### PR TITLE
Fix stale “Update Older Group Documents” prompt in Group Workspace & ensure conversation titles refresh immediately after edit

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -77,7 +77,7 @@ executor.init_app(app)
 
 app.config['SECRET_KEY'] = os.getenv("SECRET_KEY")
 app.config['SESSION_TYPE'] = 'filesystem'
-app.config['VERSION'] = '0.208.004'
+app.config['VERSION'] = '0.210.007'
 Session(app)
 
 CLIENTS = {}

--- a/application/single_app/route_backend_documents.py
+++ b/application/single_app/route_backend_documents.py
@@ -544,7 +544,7 @@ def register_route_backend_documents(app):
     @login_required
     @user_required
     @enabled_required("enable_user_workspace")
-    def api_upgrade_legacy_documents():
+    def api_upgrade_legacy_user_documents():
         user_id = get_current_user_id()
         # returns how many docs were updated
         count = upgrade_legacy_documents(user_id)

--- a/application/single_app/route_backend_group_documents.py
+++ b/application/single_app/route_backend_group_documents.py
@@ -484,8 +484,7 @@ def register_route_backend_group_documents(app):
             'message': 'Group metadata extraction has been queued. Check document status periodically.',
             'document_id': document_id
         }), 200
-
-
+        
     @app.route('/api/group_documents/upgrade_legacy', methods=['POST'])
     @login_required
     @user_required
@@ -504,14 +503,12 @@ def register_route_backend_group_documents(app):
         role = get_user_role_in_group(group_doc, user_id)
         if role not in ["Owner","Admin","DocumentManager"]:
             return jsonify({'error':'Insufficient permissions'}), 403
-
+        # returns how many docs were updated
         try:
             # your existing function, but pass group_id
-            updated_count, failed_count = upgrade_legacy_documents(user_id=user_id, group_id=active_group_id)
+            count = upgrade_legacy_documents(user_id=user_id, group_id=active_group_id)
             return jsonify({
-                'updated_count': updated_count,
-                'failed_count': failed_count,
-                'message': f'Updated {updated_count}, failed {failed_count}'
+                "message": f"Upgraded {count} group document(s) to the new format."
             }), 200
         except Exception as e:
             return jsonify({'error': str(e)}), 500

--- a/application/single_app/route_frontend_workspace.py
+++ b/application/single_app/route_frontend_workspace.py
@@ -21,11 +21,23 @@ def register_route_frontend_workspace(app):
             print("User not authenticated.")
             return redirect(url_for('login'))
         
-        legacy_docs_from_cosmos = list(cosmos_user_documents_container.query_items(
-            query="SELECT VALUE COUNT(1) FROM c WHERE c.user_id = @user_id AND NOT IS_DEFINED(c.percentage_complete)",
-            parameters=[{"name":"@user_id","value":user_id}],
-            enable_cross_partition_query=True
-        ))
+        query = """
+            SELECT VALUE COUNT(1)
+            FROM c 
+            WHERE c.user_id = @user_id
+                AND NOT IS_DEFINED(c.percentage_complete)
+        """
+        parameters = [
+            {"name": "@user_id", "value": user_id}
+        ]
+
+        legacy_docs_from_cosmos = list(
+            cosmos_user_documents_container.query_items(
+                query=query,
+                parameters=parameters,
+                enable_cross_partition_query=True
+            )
+        )
         legacy_count = legacy_docs_from_cosmos[0] if legacy_docs_from_cosmos else 0
                 
         return render_template(

--- a/application/single_app/static/js/chat/chat-conversations.js
+++ b/application/single_app/static/js/chat/chat-conversations.js
@@ -200,7 +200,7 @@ export function enterEditMode(convoItem, convo, dropdownBtn, rightDiv) {
       // *** Call update API and get potentially updated convo data (including classification) ***
       const updatedConvoData = await updateConversationTitle(convo.id, newTitle);
       convo.title = updatedConvoData.title || newTitle; // Update local title
-
+      convoItem.setAttribute('data-conversation-title', convo.title);
       // *** Update local classification data if returned from API ***
       if (updatedConvoData.classification) {
           convoItem.dataset.classifications = JSON.stringify(updatedConvoData.classification);

--- a/application/single_app/templates/group_workspaces.html
+++ b/application/single_app/templates/group_workspaces.html
@@ -568,15 +568,12 @@ app_settings.app_title }} {% endblock %} {% block head %}
 <script src="https://cdn.jsdelivr.net/npm/simplemde/dist/simplemde.min.js"></script>
 <!-- Pass backend flags to JS -->
 <script>
-  window.classification_categories = JSON.parse(
-    "{{ settings.document_classification_categories|tojson(indent=None)|safe }}" ||
-      "[]"
-  );
-  if (!Array.isArray(window.classification_categories)) {
-    window.classification_categories = [];
-  }
-  window.enable_document_classification =
-    "{{ enable_document_classification | tojson }}";
+  window.classification_categories = JSON.parse('{{ settings.document_classification_categories|tojson(indent=None)|safe }}' || '[]');
+    if (!Array.isArray(window.classification_categories)) {
+        window.classification_categories = [];
+    }
+
+  window.enable_document_classification = "{{ enable_document_classification | tojson }}";
   window.enable_extract_meta_data = "{{ enable_extract_meta_data | tojson }}";
   window.enable_video_file_support = "{{ enable_video_file_support | tojson }}";
   window.enable_audio_file_support = "{{ enable_audio_file_support | tojson }}";
@@ -637,19 +634,23 @@ app_settings.app_title }} {% endblock %} {% block head %}
     "group-docs-search-input"
   );
   const groupDocsClassificationFilterSelect =
-    window.enable_document_classification === true
+    window.enable_document_classification === true ||
+    window.enable_document_classification === "true"
       ? document.getElementById("group-docs-classification-filter")
       : null;
   const groupDocsAuthorFilterInput =
-    window.enable_extract_meta_data === true
+    window.enable_extract_meta_data === true ||
+    window.enable_extract_meta_data === "true"
       ? document.getElementById("group-docs-author-filter")
       : null;
   const groupDocsKeywordsFilterInput =
-    window.enable_extract_meta_data === true
+    window.enable_extract_meta_data === true ||
+    window.enable_extract_meta_data === "true"
       ? document.getElementById("group-docs-keywords-filter")
       : null;
   const groupDocsAbstractFilterInput =
-    window.enable_extract_meta_data === true
+    window.enable_extract_meta_data === true ||
+    window.enable_extract_meta_data === "true"
       ? document.getElementById("group-docs-abstract-filter")
       : null;
   const groupDocsApplyFiltersBtn = document.getElementById(
@@ -1050,6 +1051,13 @@ app_settings.app_title }} {% endblock %} {% block head %}
   function fetchGroupDocuments() {
     if (!groupDocumentsTableBody || !activeGroupId) return; // Need table and active group
 
+    const placeholder = document.getElementById("group-legacy-update-prompt-placeholder");
+    if (placeholder) {
+      // remove old alert div if present
+      const old = placeholder.querySelector("#group-legacy-update-alert");
+      if (old) old.remove();
+    }
+
     // Show loading state
     groupDocumentsTableBody.innerHTML = `<tr class="table-loading-row"><td colspan="4"><div class="spinner-border spinner-border-sm me-2" role="status"></div> Loading group documents...</td></tr>`;
     if (groupDocsPaginationContainer)
@@ -1083,6 +1091,9 @@ app_settings.app_title }} {% endblock %} {% block head %}
       .then((data) => {
         if (data.needs_legacy_update_check) {
           showGroupLegacyUpdatePrompt();
+        } else {
+          const placeholder = document.getElementById("group-legacy-update-prompt-placeholder");
+          placeholder?.querySelector("#group-legacy-update-alert")?.remove();
         }
         groupDocumentsTableBody.innerHTML = ""; // Clear loading/existing rows
         if (!data.documents || data.documents.length === 0) {


### PR DESCRIPTION
**Description:**  
This PR addresses two issues:

1. **Legacy‑docs prompt never clears when switching groups**  
   Once the “Update Older Group Documents” alert appears for a group with legacy documents, it would remain visible even after switching to a group that has no legacy docs.  
2. **Edited conversation title doesn’t update header without full refresh**  
   After renaming a conversation in-place, the header (`#current-conversation-title`) still showed the old title because the underlying `data-conversation-title` attribute wasn’t updated.

---

### Root Causes

- **Group Workspace:**  
  - `fetchGroupDocuments()` would inject the legacy‑update alert whenever `needs_legacy_update_check` was `true`, but never removed it when that flag was `false`.
- **Chat Conversations:**  
  - The save handler updated the `convo.title` in memory, but `selectConversation()` reads from the DOM’s `data-conversation-title` attribute, which remained stale.

---

### Changes

#### 1. Group Workspace script (`group_workspaces.html` → inline JS)

```diff
   function fetchGroupDocuments() {
-    if (!groupDocumentsTableBody || !activeGroupId) return;
+    if (!groupDocumentsTableBody || !activeGroupId) return;

+    // ─── Clear any existing legacy‑update alert ───
+    const placeholder = document.getElementById("group-legacy-update-prompt-placeholder");
+    const existingAlert = placeholder?.querySelector("#group-legacy-update-alert");
+    if (existingAlert) existingAlert.remove();

     // … loading state, fetch params …
     fetch(`/api/group_documents?${params.toString()}`)
       .then(r => r.json())
       .then(data => {
-        if (data.needs_legacy_update_check) {
-          showGroupLegacyUpdatePrompt();
-        }
+        if (data.needs_legacy_update_check) {
+          showGroupLegacyUpdatePrompt();
+        } else {
+          // Ensure it's gone if this group has no legacy docs
+          placeholder?.querySelector("#group-legacy-update-alert")?.remove();
+        }

         // … render document rows & pagination …
```

- **What this does:**  
  - On every load, we first remove any old alert from the placeholder.  
  - We only re-inject via `showGroupLegacyUpdatePrompt()` when `needs_legacy_update_check` is true; otherwise we explicitly remove it again.

#### 2. Chat‑Conversations script (`chat-conversations.js`)

```diff
   saveBtn.addEventListener("click", async (e) => {
     // … after successfully saving …
     const updatedConvoData = await updateConversationTitle(convo.id, newTitle);
     convo.title = updatedConvoData.title || newTitle;

+    // ─── Update the data attribute so selectConversation() picks up the new title ───
+    convoItem.setAttribute("data-conversation-title", convo.title);

     // … handle classifications …
     exitEditMode(convoItem, convo, dropdownBtn, rightDiv, dateSpan, saveBtn, cancelBtn);

     if (currentConversationId === convo.id) {
       selectConversation(convo.id);
     }
```

- **What this does:**  
  - Right after we update the in-memory `convo.title`, we also sync the DOM attribute `data-conversation-title`.  
  - Now `selectConversation()` will read the new value immediately and refresh the header without a page reload.