### PR TITLE
Fix user search authentication & enable Enter‑to‑search in “Add Member” modal

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -77,7 +77,7 @@ executor.init_app(app)
 
 app.config['SECRET_KEY'] = os.getenv("SECRET_KEY")
 app.config['SESSION_TYPE'] = 'filesystem'
-app.config['VERSION'] = '0.210.007'
+app.config['VERSION'] = '0.210.009'
 Session(app)
 
 CLIENTS = {}

--- a/application/single_app/route_backend_users.py
+++ b/application/single_app/route_backend_users.py
@@ -18,9 +18,9 @@ def register_route_backend_users(app):
         if not query:
             return jsonify([]), 200
 
-        token = session.get("access_token")
+        token = get_valid_access_token()
         if not token:
-            return jsonify({"error": "No access token in session"}), 401
+            return jsonify({"error": "Could not acquire access token"}), 401
 
         user_endpoint = "https://graph.microsoft.com/v1.0/users"
         headers = {

--- a/artifacts/open_api/openapi.yaml
+++ b/artifacts/open_api/openapi.yaml
@@ -2382,7 +2382,7 @@ components:
           default: false
         doc_scope:
           type: string
-          enum: [user, group, user_and_group] # Assuming possible values
+          enum: [all, group, personal]
           nullable: true
         active_group_id:
           type: string


### PR DESCRIPTION
**Description:**  
This PR addresses two related issues in the “Manage Group” flow:

1. **Backend**: The `/api/userSearch` endpoint was always returning 401 because it looked for a non‑existent `session["access_token"]`. We now use the existing MSAL cache helper (`get_valid_access_token()`) to silently acquire/refresh the Graph API token.

2. **Frontend**:  
   - Replaced `$.get` with `$.ajax` in `searchUsers()` to inspect HTTP status codes and:
     - Redirect to `/login` on 401 (session expired).  
     - Surface server‑returned `error` messages when available.  
   - Added an Enter‑key listener on the user‑search input so pressing Enter triggers the same search as clicking “Search”.

---

**Changes:**  
- **`route_backend_users.py`**  
  - Import `get_valid_access_token` from `functions_authentication`.  
  - Replace `session.get("access_token")` with `get_valid_access_token()`.  
  - Return 401 if token acquisition fails.  

- **`manage_group.js`**  
  - Refactor `searchUsers()` to use `$.ajax({ … })` instead of `$.get(…)`.  
  - In `.fail()`, handle `jqXHR.status === 401` by redirecting to `/login`.  
  - Display `responseJSON.error` or fallback alert.  
  - Add `keydown` handler on `#userSearchTerm` to run `searchUsers()` when Enter is pressed.  