### PR TITLE
Bugfix - MAG Video Indexer API & Tweak to Speech Service Defaults

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -124,6 +124,9 @@ if AZURE_ENVIRONMENT == "custom":
 else:
     AUTHORITY = f"https://login.microsoftonline.us/{TENANT_ID}"
 
+# Commercial Azure Video Indexer Endpoint
+video_indexer_endpoint = "https://api.videoindexer.ai"
+
 WORD_CHUNK_SIZE = 400
 
 if AZURE_ENVIRONMENT == "usgovernment":
@@ -132,6 +135,8 @@ if AZURE_ENVIRONMENT == "usgovernment":
     authority = AzureAuthorityHosts.AZURE_GOVERNMENT
     credential_scopes=[resource_manager + "/.default"]
     cognitive_services_scope = "https://cognitiveservices.azure.us/.default"
+    # Microsoft Azure Governement Video Indexer Endpoint
+    video_indexer_endpoint = "https://api.videoindexer.ai.azure.us"
 elif AZURE_ENVIRONMENT == "custom":
     resource_manager = CUSTOM_RESOURCE_MANAGER_URL_VALUE
     authority = CUSTOM_IDENTITY_URL_VALUE

--- a/application/single_app/functions_settings.py
+++ b/application/single_app/functions_settings.py
@@ -161,7 +161,7 @@ def get_settings():
         'enable_external_healthcheck': False,
 
         # Video file settings with Azure Video Indexer Settings
-        'video_indexer_endpoint': 'https://api.videoindexer.ai',
+        'video_indexer_endpoint': video_indexer_endpoint,
         'video_indexer_location': '',
         'video_indexer_account_id': '',
         'video_indexer_api_key': '',
@@ -172,8 +172,8 @@ def get_settings():
         'video_index_timeout': 600,
 
         # Audio file settings with Azure speech service
-        "speech_service_endpoint": "https://eastus.api.cognitive.microsoft.com",
-        "speech_service_location": "eastus",
+        "speech_service_endpoint": '',
+        "speech_service_location": '',
         "speech_service_locale": "en-US",
         "speech_service_key": ""
     }

--- a/application/single_app/route_frontend_admin_settings.py
+++ b/application/single_app/route_frontend_admin_settings.py
@@ -353,7 +353,7 @@ def register_route_frontend_admin_settings(app):
                 'default_system_prompt': form_data.get('default_system_prompt', '').strip(),
 
                 # Video file settings with Azure Video Indexer Settings
-                'video_indexer_endpoint': form_data.get('video_indexer_endpoint', 'https://api.videoindexer.ai').strip(),
+                'video_indexer_endpoint': form_data.get('video_indexer_endpoint', video_indexer_endpoint).strip(),
                 'video_indexer_location': form_data.get('video_indexer_location', '').strip(),
                 'video_indexer_account_id': form_data.get('video_indexer_account_id', '').strip(),
                 'video_indexer_api_key': form_data.get('video_indexer_api_key', '').strip(),

--- a/application/single_app/templates/admin_settings.html
+++ b/application/single_app/templates/admin_settings.html
@@ -665,6 +665,7 @@
                         <div class="mb-3">
                             <label for="gpt_model" class="form-label">Azure OpenAI GPT Model Selection</label>
                             <br><small>Each selected model will be available in the Chat UI as an option for the User. You can select multiple models.</small>
+                            <br><small>Save Pending Changes to settings before clicking Fetch Models</small>
                             <div id="gpt_models_list" class="mt-2 mb-3">
                                 
                             </div>
@@ -806,6 +807,7 @@
                             <div id="embedding_models_list" class="mt-2 mb-3">
                                 
                             </div>
+                            <small>Save pending changes to settings before clicking Fetch Embedding Models</small>
                             
                             <input type="hidden" name="embedding_model_json" id="embedding_model_json" />
 

--- a/application/single_app/templates/admin_settings.html
+++ b/application/single_app/templates/admin_settings.html
@@ -1261,7 +1261,8 @@
                             <label for="speech_service_endpoint" class="form-label">Endpoint</label>
                             <input type="text" class="form-control"
                                 id="speech_service_endpoint" name="speech_service_endpoint"
-                                value="{{ settings.speech_service_endpoint or '' }}">
+                                value="{{ settings.speech_service_endpoint or '' }}"
+                                placeholder="https://<location>.cognitiveservices.azure.<com or us>/">
                         </div>
 
                         <div class="mb-3">

--- a/application/single_app/templates/admin_settings.html
+++ b/application/single_app/templates/admin_settings.html
@@ -1173,14 +1173,14 @@
 
                         <div class="mb-3">
                             <label for="video_indexer_endpoint" class="form-label">Endpoint</label>
-                            <input type="text" readonly class="form-control"
+                            <input type="text" class="form-control"
                                 id="video_indexer_endpoint" name="video_indexer_endpoint"
                                 value="{{ settings.video_indexer_endpoint or 'https://api.videoindexer.ai' }}">
                         </div>
 
                         <div class="mb-3">
                             <label for="video_indexer_arm_api_version" class="form-label">ARM API Version</label>
-                            <input type="text" readonly class="form-control"
+                            <input type="text" class="form-control"
                                 id="video_indexer_arm_api_version" name="video_indexer_arm_api_version"
                                 value="{{ settings.video_indexer_arm_api_version or '2021-11-10-preview' }}">
                         </div>


### PR DESCRIPTION
Added logic to change the video indexer api based on commercial or government cloud, and also added ability for admin to change/update the default values in the admin settings. Originally the endpoint and api version have "readonly" constraints in the form control and default to the commercial endpoint, so it's not possible to change the endpoint or API version in the admin settings UI.

Removed the hardcoded speech service endpoint and location (currently defaulting to commercial/eastus) and instead added a placeholder to show endpoint format within the field.

Added text reminders to the GPT admin settings tabs to save pending settings before fetching models. 

Speech service endpoint placeholder
<img width="1592" height="633" alt="image" src="https://github.com/user-attachments/assets/0c349ffa-fe8c-4010-b0f4-348446e24e03" />

GPT Save pending changes reminder text
<img width="1613" height="768" alt="image" src="https://github.com/user-attachments/assets/6ebf7c9e-de5e-4f75-a98d-6af8daa2899f" />

Embeddings Save pending changes reminder text
<img width="1606" height="692" alt="image" src="https://github.com/user-attachments/assets/c486f86d-b2d6-4d46-90d8-63027a707784" />

