### PR TITLE
fix for bug 485

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,17 @@
 <!-- BEGIN RELEASE_NOTES.MD BLOCK -->
 # Feature Release
 
+### **(v0.229.063)**
+
+#### Bug Fixes
+
+*   **Admin Plugins Modal Load Fix**
+    *   Fixed issue where Admin Plugins modal would fail to load when using sidenav navigation.
+    *   **Root Cause**: JavaScript code attempted to access DOM elements that didn't exist in sidenav navigation.
+    *   **Solution**: Corrected DOM element checks to ensure compatibility with both top-nav and sidenav layouts.
+    *   **User Experience**: Admins can now access the Plugins modal reglardless of navigation style.
+    *   (Ref: `admin_plugins.js`, DOM existence checks)
+
 ### **(v0.229.062)**
 
 #### Bug Fixes

--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -88,7 +88,7 @@ load_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.229.062"
+VERSION = "0.229.063"
 
 
 SECRET_KEY = os.getenv('SECRET_KEY', 'dev-secret-key-change-in-production')

--- a/application/single_app/static/js/admin/admin_plugins.js
+++ b/application/single_app/static/js/admin/admin_plugins.js
@@ -4,7 +4,7 @@ import { renderPluginsTable as sharedRenderPluginsTable, validatePluginManifest 
 
 // Main logic
 document.addEventListener('DOMContentLoaded', function () {
-    if (!document.getElementById('agents-tab')) return;
+    if (!document.getElementById('actions-configuration')) return;
 
     // Load and render plugins table
     loadPlugins();


### PR DESCRIPTION
Closes #485 

Fixes the issue when using sidenav that the admin plugin modal does not open and the plugins table does not load.