### PR TITLE
Add banner color text picker to admin settings

### DIFF
--- a/application/external_apps/databaseseeder/artifacts/admin_settings.json
+++ b/application/external_apps/databaseseeder/artifacts/admin_settings.json
@@ -131,6 +131,7 @@
     "speech_service_key": "",
     "classification_banner_enabled": true,
     "classification_banner_text": "Classification",
+    "classification_banner_text_color": "#ffffff",
     "classification_banner_color": "#ffc107",
     "enable_dark_mode_default": false,
     "enable_left_nav_default": true,

--- a/application/single_app/route_frontend_admin_settings.py
+++ b/application/single_app/route_frontend_admin_settings.py
@@ -152,6 +152,8 @@ def register_route_frontend_admin_settings(app):
             settings['classification_banner_text'] = ''
         if 'classification_banner_color' not in settings:
             settings['classification_banner_color'] = '#ffc107'  # Bootstrap warning color
+        if 'classification_banner_text_color' not in settings:
+            settings['classification_banner_text_color'] = '#ffffff'
         
         # --- Add defaults for left nav ---
         if 'enable_left_nav_default' not in settings:
@@ -354,6 +356,7 @@ def register_route_frontend_admin_settings(app):
             # --- Extract banner fields from form_data ---
             classification_banner_enabled = form_data.get('classification_banner_enabled') == 'on'
             classification_banner_text = form_data.get('classification_banner_text', '').strip()
+            classification_banner_text_color = form_data.get('classification_banner_text_color', '#ffffff').strip()
             classification_banner_color = form_data.get('classification_banner_color', '#ffc107').strip()
 
             # --- Application Insights Logging Toggle ---
@@ -649,6 +652,7 @@ def register_route_frontend_admin_settings(app):
                 # --- Banner fields ---
                 'classification_banner_enabled': classification_banner_enabled,
                 'classification_banner_text': classification_banner_text,
+                'classification_banner_text_color': classification_banner_text_color,
                 'classification_banner_color': classification_banner_color,
             }
             

--- a/application/single_app/templates/admin_settings.html
+++ b/application/single_app/templates/admin_settings.html
@@ -1094,15 +1094,23 @@
                             value="{{ settings.classification_banner_text }}">
                     </div>
                     <div class="mb-2">
+                        <label for="classification_banner_text_color" class="form-label">Banner Text Color</label>
+                        <input type="color" class="form-control form-control-color" id="classification_banner_text_color" name="classification_banner_text_color"
+                            value="{{ settings.classification_banner_text_color or '#ffffff' }}" style="width: 3rem; height: 2rem;">
+                    </div>
+                    <div class="mb-2">
                         <label for="classification_banner_color" class="form-label">Banner Color</label>
                         <input type="color" class="form-control form-control-color" id="classification_banner_color" name="classification_banner_color"
                             value="{{ settings.classification_banner_color or '#ffc107' }}" style="width: 3rem; height: 2rem;">
                     </div>
                     <div class="mb-2">
-                        <span id="classification-banner-preview"
-                              style="display:inline-block; padding:0.5em 1em; border-radius:0.3em; font-weight:bold; color:#fff; background:{{ settings.classification_banner_color or '#ffc107' }};">
-                            {{ settings.classification_banner_text or 'Banner Preview' }}
-                        </span>
+                        <label class="form-label">Preview</label>
+                        <div>
+                            <span id="classification-banner-preview"
+                                  style="display:inline-block; padding:0.5em 1em; border-radius:0.3em; font-weight:bold; color:{{ settings.classification_banner_text_color or '#ffffff' }}; background:{{ settings.classification_banner_color or '#ffc107' }};">
+                                {{ settings.classification_banner_text or 'Banner Preview' }}
+                            </span>
+                        </div>
                     </div>
                 </div>
 
@@ -2856,12 +2864,13 @@
     // Live preview for banner in admin
     document.addEventListener('DOMContentLoaded', function() {
         const textInput = document.getElementById('classification_banner_text');
+        const textColorInput = document.getElementById('classification_banner_text_color');
         const colorInput = document.getElementById('classification_banner_color');
         const preview = document.getElementById('classification-banner-preview');
         function updatePreview() {
             preview.textContent = textInput.value || 'Banner Preview';
             preview.style.background = colorInput.value;
-            preview.style.color = '#fff'; // Always white text for preview
+            preview.style.color = textColorInput.value;
         }
         if (textInput && colorInput && preview) {
             textInput.addEventListener('input', updatePreview);

--- a/application/single_app/templates/base.html
+++ b/application/single_app/templates/base.html
@@ -215,7 +215,7 @@
 <body class="d-flex flex-column min-vh-100{% if app_settings.classification_banner_enabled and app_settings.classification_banner_text %} has-classification-banner{% endif %}">
   {% if app_settings.classification_banner_enabled and app_settings.classification_banner_text %}
     <div id="classification-banner"
-         style="background: {{ app_settings.classification_banner_color or '#ffc107' }}; color: #fff; display: flex; align-items: center; justify-content: center; text-align: center; font-weight: bold; padding: 0; height: 40px; font-size: 1.1em; letter-spacing: 0.5px; position: fixed; top: 0; left: 0; width: 100%; z-index: 1051;">
+         style="background: {{ app_settings.classification_banner_color or '#ffc107' }}; color: {{ app_settings.classification_banner_text_color or '#ffffff' }}; display: flex; align-items: center; justify-content: center; text-align: center; font-weight: bold; padding: 0; height: 40px; font-size: 1.1em; letter-spacing: 0.5px; position: fixed; top: 0; left: 0; width: 100%; z-index: 1051;">
       {{ app_settings.classification_banner_text }}
     </div>
   {% endif %}


### PR DESCRIPTION
When picking a color for the classification banner, this is always set to white as hardcoded value "#fff". When selecting certain color shades (ex. bright yellow) this banner is unreadable. This change would allow the user to select the color of the text to go along with the paired background color. This may be typically white or black, however this picker allows the user more flexibility with styling and further compliance.