### PR TITLE
Remove opencensus requirement

### DIFF
--- a/application/single_app/requirements.txt
+++ b/application/single_app/requirements.txt
@@ -1,7 +1,6 @@
 # requirements.txt
 pandas==2.2.3
 azure-monitor-query==1.4.1
-opencensus-ext-azure==1.1.15
 Flask==2.2.5
 Flask-WTF==1.2.1
 gunicorn


### PR DESCRIPTION
App is updated to use opentelemetry.  This PR removes the opencensus dependency.