### PR TITLE
Updated searchUsers() function messages

### DIFF
--- a/application/single_app/static/js/group/manage_group.js
+++ b/application/single_app/static/js/group/manage_group.js
@@ -556,23 +556,44 @@ function rejectRequest(requestId) {
 }
 
 // Search users for manual add
+// Search users for manual add
 function searchUsers() {
   const term = $("#userSearchTerm").val().trim();
   if (!term) {
-    alert("Enter a name or email to search.");
+    // Show inline validation error
+    $("#searchStatus").text("⚠️ Please enter a name or email to search");
+    $("#searchStatus").removeClass("text-muted text-success").addClass("text-warning");
+    $("#userSearchTerm").addClass("is-invalid");
     return;
   }
+  
+  // Clear any previous validation states
+  $("#userSearchTerm").removeClass("is-invalid");
+  $("#searchStatus").removeClass("text-warning text-danger text-success").addClass("text-muted");
   $("#searchStatus").text("Searching...");
   $("#searchUsersBtn").prop("disabled", true);
 
   $.get("/api/userSearch", { query: term })
-    .done(renderUserSearchResults)
+    .done(function(users) {
+      renderUserSearchResults(users);
+      // Show success status
+      if (users && users.length > 0) {
+        $("#searchStatus").text(`✓ Found ${users.length} user(s)`);
+        $("#searchStatus").removeClass("text-muted text-warning text-danger").addClass("text-success");
+      } else {
+        $("#searchStatus").text("No users found");
+        $("#searchStatus").removeClass("text-muted text-warning text-success").addClass("text-muted");
+      }
+    })
     .fail(function (jq) {
       const err = jq.responseJSON?.error || jq.statusText;
-      alert("User search failed: " + err);
+      // Show inline error
+      $("#searchStatus").text(`❌ Search failed: ${err}`);
+      $("#searchStatus").removeClass("text-muted text-warning text-success").addClass("text-danger");
+      // Also show toast for critical errors
+      showToast("User search failed: " + err, "danger");
     })
     .always(function () {
-      $("#searchStatus").text("");
       $("#searchUsersBtn").prop("disabled", false);
     });
 }


### PR DESCRIPTION
Updated searchUsers() function with inline and toast messages instead of alerts based on comment request in previous PR: https://github.com/microsoft/simplechat/pull/608#discussion_r2701900020

Instead of alert pop up, search messages now show primarily inline, with only errors creating a toast in addition to the inline message.

Empty search message
<img width="493" height="657" alt="image" src="https://github.com/user-attachments/assets/ab301c80-f08d-45da-adac-2ad33dedd74c" />

No users found message
<img width="489" height="643" alt="image" src="https://github.com/user-attachments/assets/a7a735c2-963d-475a-8bbc-67154a28a190" />

One or more users found message
<img width="484" height="752" alt="image" src="https://github.com/user-attachments/assets/09fbfbd2-1af2-4b7e-8445-257b3a567f1d" />

