### PR TITLE
Bugfix - removed hardcoded references to commercial cognitive service scope

### DIFF
--- a/application/single_app/route_backend_chats.py
+++ b/application/single_app/route_backend_chats.py
@@ -2716,7 +2716,7 @@ def register_route_backend_chats(app):
                             credential = DefaultAzureCredential()
                             token_provider = get_bearer_token_provider(
                                 credential,
-                                "https://cognitiveservices.azure.com/.default"
+                                cognitive_services_scope
                             )
                             gpt_client = AzureOpenAI(
                                 api_version=api_version,

--- a/application/single_app/semantic_kernel_plugins/smart_http_plugin.py
+++ b/application/single_app/semantic_kernel_plugins/smart_http_plugin.py
@@ -560,6 +560,7 @@ class SmartHttpPlugin:
             from functions_settings import get_settings
             from openai import AzureOpenAI
             from azure.identity import DefaultAzureCredential, get_bearer_token_provider
+            from config import cognitive_services_scope
             
             settings = get_settings()
             
@@ -580,7 +581,6 @@ class SmartHttpPlugin:
                 )
             else:
                 if settings.get('azure_openai_gpt_authentication_type') == 'managed_identity':
-                    cognitive_services_scope = "https://cognitiveservices.azure.com/.default"
                     token_provider = get_bearer_token_provider(
                         DefaultAzureCredential(), 
                         cognitive_services_scope


### PR DESCRIPTION
Bugfix - removed hardcoded references to commercial cognitive services scope in the chat_stream_api and smart_http_plugin and replaced with variable from config.py so they work in MAG and custom clouds.

Related issue: https://github.com/microsoft/simplechat/issues/616#issue-3835164022

Error in MAG when chatting with streaming enabled before the change in this PR:
<img width="896" height="570" alt="image" src="https://github.com/user-attachments/assets/899ae543-441f-4595-b596-bcaf0c19ccea" />

Working properly in MAG after change:
<img width="894" height="463" alt="image" src="https://github.com/user-attachments/assets/a0080559-db05-4c3b-aef7-ae77e7cf28a3" />
