### PR TITLE
bugfix - fixed content safety client creation w/ APIM & managed identity

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -651,7 +651,7 @@ def initialize_clients(settings):
             azure_apim_content_safety_endpoint = settings.get("azure_apim_content_safety_endpoint")
             azure_apim_content_safety_subscription_key = settings.get("azure_apim_content_safety_subscription_key")
 
-            if safety_endpoint and safety_key:
+            if safety_endpoint:
                 try:
                     if enable_content_safety_apim:
                         content_safety_client = ContentSafetyClient(


### PR DESCRIPTION
A logic bug in config.py prevents the content_safety_client from being created unless a content safety API key is present in the settings because the if condition required both the endpoint and the key before continuing to client creation:
https://github.com/microsoft/simplechat/blob/cebd8f7002309b381065215b9713295afd7cc597/application/single_app/config.py#L648
<img width="963" height="658" alt="image" src="https://github.com/user-attachments/assets/75187819-80cf-4426-8184-5b07bd9866d0" />

This bugfix simply removes the "and safety_key" from the condition so the clients can be created properly whether the authentication uses API key, managed identity, or APIM.

Tested using the prompt from Microsoft's docs here: https://microsoft.github.io/TechExcel-Operationalize-LLMs-with-LLMOps-automation/docs/01_intro_to_llms/01_03.html#:~:text=and%20select%20Run-,Test,-.

Behavior before change:
<img width="1027" height="637" alt="image" src="https://github.com/user-attachments/assets/b57f76b1-b0c0-453c-800c-3423ab3b0bb6" />

Behavior after change:
<img width="914" height="699" alt="image" src="https://github.com/user-attachments/assets/0aa05ab5-a139-48de-880b-3f5357d472a9" />
