### PR TITLE
Add Dockerfile and update devcontainer configuration for Python envir…

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,3 @@
+FROM mcr.microsoft.com/devcontainers/base:ubuntu
+# Install the xz-utils package
+RUN apt-get update && apt-get install -y xz-utils

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,14 @@
 {
 	"name": "Python 3",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/python:0-3.11",
+	//"image": "mcr.microsoft.com/devcontainers/python:0-3.11",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"args": {
+			"VARIANT": "3.11"
+		}
+	},
+	// Features to add to the dev container. More info: https://containers.dev/features.
 	"features": {
 		"ghcr.io/devcontainers/features/docker-in-docker:2": {
 			"version": "latest"
@@ -14,18 +21,16 @@
 			"installBicep": true,
 			"installUsingPython": true,
 			"version": "2.72.0",
-			"bicepVersion": "latest"			
+			"bicepVersion": "latest"
 		},
 		"ghcr.io/devcontainers/features/terraform:1": {},
 		"ghcr.io/devcontainers/features/powershell:1": {},
 		"ghcr.io/azure/azure-dev/azd:latest": {}
 	},
-	// Features to add to the dev container. More info: https://containers.dev/features.
-	// "features": {},
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "pip3 install --user -r application/single_app/requirements.txt",
+	"postCreateCommand": "python3 -m venv .venv && .venv/bin/pip install -r application/single_app/requirements.txt",
 	// Configure tool-specific properties.
 	"customizations": {
 		"vscode": {
@@ -36,7 +41,10 @@
 				"ms-vscode.azurecli",
 				"HashiCorp.terraform",
 				"ms-vscode.powershell"
-			]
+			],
+			"settings": {
+				"python.defaultInterpreterPath": "${containerWorkspaceFolder}/.venv/bin/python"
+			}
 		}
 	}
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.

--- a/deployers/azure.yaml
+++ b/deployers/azure.yaml
@@ -62,7 +62,8 @@ hooks:
             
             echo ""
             echo "[2/4] Installing Python dependencies..."
-            if python3 -m pip install --user -r ./bicep/requirements.txt > /dev/null 2>&1; then
+
+            if python3 -m venv .venv && .venv/bin/pip install -r ./bicep/requirements.txt > /dev/null 2>&1; then
                 echo "✓ Dependencies installed successfully"
             else
                 echo "✗ ERROR: Failed to install Python dependencies" >&2
@@ -71,7 +72,7 @@ hooks:
             
             echo ""
             echo "[3/4] Running post-deployment configuration..."
-            if python3 ./bicep/postconfig.py; then
+            if .venv/bin/python3 ./bicep/postconfig.py; then
                 echo "✓ Post-deployment configuration completed"
             else
                 echo "✗ ERROR: Post-deployment configuration failed" >&2

--- a/deployers/bicep/README.md
+++ b/deployers/bicep/README.md
@@ -121,6 +121,8 @@ Using the bash terminal in Visual Studio Code
 
 `azd config set cloud.name AzureCloud` - If you work with other Azure clouds, you may need to update your cloud like `azd config set cloud.name AzureUSGovernment` - more information here - [Use Azure Developer CLI in sovereign clouds | Microsoft Learn](https://learn.microsoft.com/en-us/azure/developer/azure-developer-cli/sovereign-clouds)
 
+`az login` - this will open a browser window shta the user with Owner level permissions to the target subscription will need to authenticate with.
+
 `azd auth login` - this will open a browser window that the user with Owner level permissions to the target subscription will need to authenticate with.
 
 `azd env new <environment>` - Use the same value for the \<environment\> that was used in the application registration.


### PR DESCRIPTION
This pull request updates the development container and deployment scripts to improve Python environment management and dependency installation. The main changes include switching to a custom Dockerfile for the dev container, ensuring dependencies are installed in a virtual environment, and updating post-deployment commands to consistently use the virtual environment's Python interpreter.

**Development environment improvements:**

* Switched the dev container setup from using a prebuilt Python image to building from a custom Dockerfile (`.devcontainer/Dockerfile`), which now installs the `xz-utils` package. [[1]](diffhunk://#diff-13bd9d7a30bf46656bc81f1ad5b908a627f9247be3f7d76df862b0578b534fc6R1-R3) [[2]](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L6-R13)
* Updated the devcontainer configuration to build with a specific Python version, and set up the Python virtual environment (`.venv`) for dependency management. The `postCreateCommand` now creates a virtual environment and installs requirements into it, and VS Code is configured to use the virtual environment's Python interpreter by default (`.devcontainer/devcontainer.json`). [[1]](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L6-R13) [[2]](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L23-R33) [[3]](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L39-R47)

**Deployment script improvements:**

* Modified the Azure deployment hook to install Python dependencies into a virtual environment instead of user space, and ensured post-deployment scripts are run using the virtual environment's Python interpreter (`deployers/azure.yaml`). [[1]](diffhunk://#diff-c75e70d8ac942dee2a7d9e0679b9bee4e3838fbf339819d1da620b7960a8834fL65-R66) [[2]](diffhunk://#diff-c75e70d8ac942dee2a7d9e0679b9bee4e3838fbf339819d1da620b7960a8834fL74-R75)

**Documentation:**

* Added a step to the Bicep deployment README instructing users to run `az login` before authenticating with `azd` (`deployers/bicep/README.md`)