### PR TITLE
Upgrade requests requirement

### DIFF
--- a/application/single_app/requirements.txt
+++ b/application/single_app/requirements.txt
@@ -5,7 +5,7 @@ Flask==3.1.3
 Flask-WTF==1.2.1
 gunicorn==25.0.3
 Werkzeug==3.1.6
-requests==2.33.0
+requests==2.33.1
 openai==1.109.1
 docx2txt==0.8
 olefile==0.47

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -8,6 +8,10 @@ For feature-focused and fix-focused drill-downs by version, see [Features by Ver
 
 #### Bug Fixes
 
+*   **Requests Runtime Dependency Upgrade**
+    *   Updated the runtime HTTP client dependency from `requests==2.33.0` to `requests==2.33.1` in the main application requirements to keep deployment environments aligned with the latest pinned patch release.
+    *   (Ref: `application/single_app/requirements.txt`)
+
 *   **Speech and Video Indexer Setup Guidance Alignment**
     *   Fixed stale admin guidance around Azure AI Video Indexer and shared Azure Speech configuration so managed-identity setup no longer points admins toward legacy Video Indexer API keys or incomplete Speech instructions.
     *   The admin experience now reflects the shared Speech resource model, adds Speech Resource ID helper fields, and keeps managed-identity voice-response requirements aligned with runtime behavior.


### PR DESCRIPTION
- Improved malformed header handling
- More importantly, 2.33.1 is available in the airgap mirror and 2.33.0 is not.