### PR TITLE
Disable BuildKit for dev image publishers

### DIFF
--- a/.github/workflows/docker_image_publish_dev.yml
+++ b/.github/workflows/docker_image_publish_dev.yml
@@ -36,6 +36,8 @@ jobs:
 
     - uses: actions/checkout@v3
     - name: Build the Docker image
+      env:
+        DOCKER_BUILDKIT: "0"
       run:         
         docker build . --file application/single_app/Dockerfile --tag ${{ secrets.ACR_LOGIN_SERVER }}/simple-chat-dev:$(date +'%Y-%m-%d')_${BRANCH_TAG}_$GITHUB_RUN_NUMBER;
         docker tag ${{ secrets.ACR_LOGIN_SERVER }}/simple-chat-dev:$(date +'%Y-%m-%d')_${BRANCH_TAG}_$GITHUB_RUN_NUMBER ${{ secrets.ACR_LOGIN_SERVER }}/simple-chat-dev:latest;
@@ -68,6 +70,8 @@ jobs:
         
     - uses: actions/checkout@v3
     - name: Build the Docker image
+      env:
+        DOCKER_BUILDKIT: "0"
       run:         
         docker build . --file application/single_app/Dockerfile --tag ${{ secrets.ACR_LOGIN_SERVER_NADOYLE }}/simple-chat-dev:$(date +'%Y-%m-%d')_${BRANCH_TAG}_$GITHUB_RUN_NUMBER;
         docker tag ${{ secrets.ACR_LOGIN_SERVER_NADOYLE }}/simple-chat-dev:$(date +'%Y-%m-%d')_${BRANCH_TAG}_$GITHUB_RUN_NUMBER ${{ secrets.ACR_LOGIN_SERVER_NADOYLE }}/simple-chat-dev:latest;

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -1,7 +1,5 @@
 <!-- BEGIN release_notes.md BLOCK -->
 
-This page tracks notable Simple Chat releases and organizes the detailed change log by version. The timeline below provides a quick visual overview of the current release progression through v0.250.006, and the per-version entries continue immediately after it.
-
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](/explanation/features/) and [Fixes by Version](/explanation/fixes/).
 
 ### **(v0.250.001)**


### PR DESCRIPTION
## Summary
- Disable BuildKit for the Development/Staging Docker image publisher workflow jobs.
- Keep the existing docker build/tag/push flow unchanged while using the classic Docker builder for these GitHub-hosted jobs.
- No application version bump per release unblock scope.

## Validation
- git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check -- .github/workflows/docker_image_publish_dev.yml
- VS Code diagnostics for .github/workflows/docker_image_publish_dev.yml