### PR TITLE
Restore azd config in staging workflow

### DIFF
--- a/.github/workflows/staging-azd-ui-tests.yml
+++ b/.github/workflows/staging-azd-ui-tests.yml
@@ -48,6 +48,7 @@ jobs:
       SIMPLECHAT_UI_AUTH_RESOURCE: ${{ vars.SIMPLECHAT_UI_AUTH_RESOURCE }}
       PLAYWRIGHT_SERVICE_URL: ${{ vars.PLAYWRIGHT_SERVICE_URL }}
       AZD_ENV_FILE_B64: ${{ secrets.AZD_ENV_FILE_B64 }}
+      AZD_CONFIG_FILE_B64: ${{ secrets.AZD_CONFIG_FILE_B64 }}
       SIMPLECHAT_UI_STORAGE_STATE_B64: ${{ secrets.SIMPLECHAT_UI_STORAGE_STATE_B64 }}
       SIMPLECHAT_UI_ADMIN_STORAGE_STATE_B64: ${{ secrets.SIMPLECHAT_UI_ADMIN_STORAGE_STATE_B64 }}
       SIMPLECHAT_UI_ARTIFACT_DIR: ui_tests/artifacts
@@ -113,6 +114,10 @@ jobs:
 
           if [[ -n "${AZD_ENV_FILE_B64:-}" ]]; then
             printf '%s' "$AZD_ENV_FILE_B64" | base64 -d > ".azure/$AZURE_ENV_NAME/.env"
+          fi
+
+          if [[ -n "${AZD_CONFIG_FILE_B64:-}" ]]; then
+            printf '%s' "$AZD_CONFIG_FILE_B64" | base64 -d > ".azure/$AZURE_ENV_NAME/config.json"
           fi
 
           cat > .azure/config.json <<EOF


### PR DESCRIPTION
## Summary
- Restores the Staging azd per-environment config.json from AZD_CONFIG_FILE_B64 during the staging AZD/UI workflow.
- Allows staging-specific infra parameters such as cosmosCapacityMode=serverless to be honored by azd up.
- Keeps .env restoration unchanged.

## Validation
- git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check -- .github/workflows/staging-azd-ui-tests.yml
- VS Code diagnostics for .github/workflows/staging-azd-ui-tests.yml
- Confirmed Staging environment secret AZD_CONFIG_FILE_B64 exists.