### PR TITLE
Sync staging azd config restore to Staging

### DIFF
--- a/.github/workflows/staging-azd-ui-tests.yml
+++ b/.github/workflows/staging-azd-ui-tests.yml
@@ -48,6 +48,7 @@ jobs:
       SIMPLECHAT_UI_AUTH_RESOURCE: ${{ vars.SIMPLECHAT_UI_AUTH_RESOURCE }}
       PLAYWRIGHT_SERVICE_URL: ${{ vars.PLAYWRIGHT_SERVICE_URL }}
       AZD_ENV_FILE_B64: ${{ secrets.AZD_ENV_FILE_B64 }}
+      AZD_CONFIG_FILE_B64: ${{ secrets.AZD_CONFIG_FILE_B64 }}
       SIMPLECHAT_UI_STORAGE_STATE_B64: ${{ secrets.SIMPLECHAT_UI_STORAGE_STATE_B64 }}
       SIMPLECHAT_UI_ADMIN_STORAGE_STATE_B64: ${{ secrets.SIMPLECHAT_UI_ADMIN_STORAGE_STATE_B64 }}
       SIMPLECHAT_UI_ARTIFACT_DIR: ui_tests/artifacts
@@ -113,6 +114,10 @@ jobs:
 
           if [[ -n "${AZD_ENV_FILE_B64:-}" ]]; then
             printf '%s' "$AZD_ENV_FILE_B64" | base64 -d > ".azure/$AZURE_ENV_NAME/.env"
+          fi
+
+          if [[ -n "${AZD_CONFIG_FILE_B64:-}" ]]; then
+            printf '%s' "$AZD_CONFIG_FILE_B64" | base64 -d > ".azure/$AZURE_ENV_NAME/config.json"
           fi
 
           cat > .azure/config.json <<EOF


### PR DESCRIPTION
## Summary
- Flows PR #931 from Development into Staging.
- Restores the Staging azd per-environment config.json from AZD_CONFIG_FILE_B64 during the staging AZD/UI workflow.
- Allows staging-specific infra parameters such as cosmosCapacityMode=serverless to be honored by azd up.

## Validation
- PR #931 checks passed before merge into Development.
- Staging environment secret AZD_CONFIG_FILE_B64 is present.
- Local staging azd config reads infra.parameters.cosmosCapacityMode as serverless.