### PR TITLE
update-app-polling - Fix anonymous notification polling 401 spam.

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -95,7 +95,7 @@ load_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.250.014"
+VERSION = "0.250.015"
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')
 SESSION_COOKIE_HTTPONLY = os.getenv('SESSION_COOKIE_HTTPONLY', 'true').lower() != 'false'

--- a/application/single_app/templates/base.html
+++ b/application/single_app/templates/base.html
@@ -700,8 +700,10 @@
   <script src="{{ url_for('static', filename='js/sidebar-resize.js') }}"></script>
   <!-- Profile Image JavaScript -->
   <script src="{{ url_for('static', filename='js/profile-image.js') }}"></script>
-  <!-- Notifications JavaScript (for badge polling on all pages) -->
+  {% if session.get('user') %}
+  <!-- Notifications JavaScript (for badge polling on authenticated pages) -->
   <script src="{{ url_for('static', filename='js/notifications.js') }}"></script>
+  {% endif %}
   {% if session.get('user') and app_settings.enable_speech_to_text_input %}
   <script src="{{ url_for('static', filename='js/form-voice-input.js') }}?v={{ config['VERSION'] }}"></script>
   {% endif %}

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,15 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](/explanation/features/) and [Fixes by Version](/explanation/fixes/).
 
+### **(v0.250.015)**
+
+#### Bug Fixes
+
+*   **Anonymous Notification Polling 401 Log Reduction**
+    *   Stopped loading the notification polling script for unauthenticated sessions, preventing the login screen from repeatedly calling `/api/notifications/count` after idle timeout or before sign-in.
+    *   This reduces expected 401 noise in App Service log streams and Application Insights while preserving notification badge polling for authenticated users.
+    *   (Ref: notification polling, idle timeout, `base.html`, `notifications.js`, `test_notification_polling_redirect_guard.py`)
+
 ### **(v0.250.010)**
 
 #### New Features

--- a/functional_tests/test_notification_polling_redirect_guard.py
+++ b/functional_tests/test_notification_polling_redirect_guard.py
@@ -2,11 +2,12 @@
 # test_notification_polling_redirect_guard.py
 """
 Functional test for notification polling redirect guards.
-Version: 0.241.095
-Implemented in: 0.241.095
+Version: 0.250.015
+Implemented in: 0.250.015
 
-This test ensures notification polling stops after auth-like or repeated fetch
-failures so the browser does not spam redirect-loop errors in the console.
+This test ensures notification polling only loads for authenticated sessions and
+stops after auth-like or repeated fetch failures so the browser does not spam
+redirect-loop errors in the console or 401s in the backend log stream.
 """
 
 from pathlib import Path
@@ -21,9 +22,12 @@ def read_text(relative_path: str) -> str:
 
 def test_notification_polling_redirect_guard_contract() -> None:
     config_content = read_text('application/single_app/config.py')
+    base_template_content = read_text('application/single_app/templates/base.html')
     notifications_js_content = read_text('application/single_app/static/js/notifications.js')
 
-    assert 'VERSION = "0.241.095"' in config_content
+    assert 'VERSION = "0.250.015"' in config_content
+    assert "{% if session.get('user') %}\n  <!-- Notifications JavaScript (for badge polling on authenticated pages) -->" in base_template_content
+    assert "<script src=\"{{ url_for('static', filename='js/notifications.js') }}\"></script>" in base_template_content
     assert 'const MAX_NOTIFICATION_POLL_FAILURES = 3;' in notifications_js_content
     assert 'let notificationPollingDisabled = false;' in notifications_js_content
     assert 'function disableNotificationPolling(reason) {' in notifications_js_content

--- a/ui_tests/test_notifications_polling_redirect_guard.py
+++ b/ui_tests/test_notifications_polling_redirect_guard.py
@@ -1,11 +1,12 @@
 # test_notifications_polling_redirect_guard.py
 """
 UI test for notification polling redirect guards.
-Version: 0.241.095
-Implemented in: 0.241.095
+Version: 0.250.015
+Implemented in: 0.250.015
 
-This test ensures an auth-like notification polling response disables further
-notification polling for the current page session instead of retrying forever.
+This test ensures notification polling is limited to authenticated pages and an
+auth-like notification polling response disables further notification polling for
+the current page session instead of retrying forever.
 """
 
 import json


### PR DESCRIPTION
## Summary

- Prevents unauthenticated pages from loading the notification polling script.
- Stops the login screen from repeatedly calling `/api/notifications/count` after idle timeout or before sign-in.
- Updates version, release notes, and notification polling regression coverage.

## Validation

- `git diff --check`
- `python -m py_compile application/single_app/config.py functional_tests/test_notification_polling_redirect_guard.py ui_tests/test_notifications_polling_redirect_guard.py`
- `python -m compileall -q application/single_app`
- `python scripts/check_xss_sinks.py --full-file application/single_app/templates/base.html`
- `pytest functional_tests/test_notification_polling_redirect_guard.py`

## Notes

- Local UI test execution was blocked because the environment did not provide the `playwright` pytest fixture.