### PR TITLE
Add admin Cosmos DB JSON document query and editor

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -96,7 +96,7 @@ load_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.250.047"
+VERSION = "0.250.051"
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')
 SESSION_COOKIE_HTTPONLY = os.getenv('SESSION_COOKIE_HTTPONLY', 'true').lower() != 'false'

--- a/application/single_app/functions_data_management.py
+++ b/application/single_app/functions_data_management.py
@@ -2,10 +2,13 @@
 """Data Management settings, schedules, and durable job records."""
 
 import copy
+import hashlib
 import json
 import logging
 import os
+import re
 import socket
+import time
 import tempfile
 import uuid
 from datetime import datetime, timedelta, timezone
@@ -130,6 +133,10 @@ DATA_MANAGEMENT_DEFAULT_SETTINGS = {
 class DataManagementSettingsValidationError(ValueError):
     """Raised when Data Management settings fail admin-safe validation."""
 
+
+class DataManagementCosmosEditorError(ValueError):
+    """Raised when Cosmos editor input is unsafe or incomplete."""
+
 DATA_MANAGEMENT_FRONTEND_SECRET_FIELDS = {
     "backup_storage_connection_string",
     "encryption_key_reference",
@@ -192,6 +199,77 @@ DATA_MANAGEMENT_COSMOS_ARTIFACTS = [
     {"name": "group_workspace_identities", "container_attr": "cosmos_group_workspace_identities_container", "container_name_attr": "cosmos_group_workspace_identities_container_name", "partition_key_path": "/group_id", "category": "identities"},
     {"name": "public_workspace_identities", "container_attr": "cosmos_public_workspace_identities_container", "container_name_attr": "cosmos_public_workspace_identities_container_name", "partition_key_path": "/public_workspace_id", "category": "identities"},
     {"name": "global_workspace_identities", "container_attr": "cosmos_global_workspace_identities_container", "container_name_attr": "cosmos_global_workspace_identities_container_name", "partition_key_path": "/id", "category": "identities"},
+]
+
+DATA_MANAGEMENT_COSMOS_EDITOR_EMPTY_QUERY = "SELECT * FROM c"
+DATA_MANAGEMENT_COSMOS_EDITOR_EMPTY_QUERY_LIMIT = 100
+DATA_MANAGEMENT_COSMOS_EDITOR_MAX_PAGE_SIZE = 100
+DATA_MANAGEMENT_COSMOS_EDITOR_MAX_QUERY_LENGTH = 4000
+DATA_MANAGEMENT_COSMOS_EDITOR_CONFIRMATION_PHRASE = "I understand this can damage system data"
+DATA_MANAGEMENT_COSMOS_EDITOR_CONTAINER_DEFINITIONS = [
+    ("conversations", "cosmos_conversations_container", "cosmos_conversations_container_name", "/id", "conversations"),
+    ("messages", "cosmos_messages_container", "cosmos_messages_container_name", "/conversation_id", "conversations"),
+    ("tabular_export_runs", "cosmos_tabular_export_runs_container", "cosmos_tabular_export_runs_container_name", "/user_id", "exports"),
+    ("data_management_jobs", "cosmos_data_management_jobs_container", "cosmos_data_management_jobs_container_name", "/id", "data_management"),
+    ("data_management_job_items", "cosmos_data_management_job_items_container", "cosmos_data_management_job_items_container_name", "/job_id", "data_management"),
+    ("personal_workflows", "cosmos_personal_workflows_container", "cosmos_personal_workflows_container_name", "/user_id", "workflows"),
+    ("personal_workflow_runs", "cosmos_personal_workflow_runs_container", "cosmos_personal_workflow_runs_container_name", "/user_id", "workflows"),
+    ("personal_workflow_run_items", "cosmos_personal_workflow_run_items_container", "cosmos_personal_workflow_run_items_container_name", "/run_id", "workflows"),
+    ("group_workflows", "cosmos_group_workflows_container", "cosmos_group_workflows_container_name", "/group_id", "workflows"),
+    ("group_workflow_runs", "cosmos_group_workflow_runs_container", "cosmos_group_workflow_runs_container_name", "/group_id", "workflows"),
+    ("group_workflow_run_items", "cosmos_group_workflow_run_items_container", "cosmos_group_workflow_run_items_container_name", "/run_id", "workflows"),
+    ("group_conversations", "cosmos_group_conversations_container", "cosmos_group_conversations_container_name", "/id", "conversations"),
+    ("group_messages", "cosmos_group_messages_container", "cosmos_group_messages_container_name", "/conversation_id", "conversations"),
+    ("collaboration_conversations", "cosmos_collaboration_conversations_container", "cosmos_collaboration_conversations_container_name", "/id", "collaboration"),
+    ("collaboration_messages", "cosmos_collaboration_messages_container", "cosmos_collaboration_messages_container_name", "/conversation_id", "collaboration"),
+    ("collaboration_user_state", "cosmos_collaboration_user_state_container", "cosmos_collaboration_user_state_container_name", "/user_id", "collaboration"),
+    ("settings", "cosmos_settings_container", "cosmos_settings_container_name", "/id", "settings"),
+    ("custom_pages", "cosmos_custom_pages_container", "cosmos_custom_pages_container_name", "/id", "settings"),
+    ("groups", "cosmos_groups_container", "cosmos_groups_container_name", "/id", "workspaces"),
+    ("public_workspaces", "cosmos_public_workspaces_container", "cosmos_public_workspaces_container_name", "/id", "workspaces"),
+    ("documents", "cosmos_user_documents_container", "cosmos_user_documents_container_name", "/id", "documents"),
+    ("group_documents", "cosmos_group_documents_container", "cosmos_group_documents_container_name", "/id", "documents"),
+    ("public_documents", "cosmos_public_documents_container", "cosmos_public_documents_container_name", "/id", "documents"),
+    ("document_access_index", "cosmos_document_access_index_container", "cosmos_document_access_index_container_name", "/scope_key", "documents"),
+    ("personal_file_sync_sources", "cosmos_personal_file_sync_sources_container", "cosmos_personal_file_sync_sources_container_name", "/user_id", "file_sync"),
+    ("group_file_sync_sources", "cosmos_group_file_sync_sources_container", "cosmos_group_file_sync_sources_container_name", "/group_id", "file_sync"),
+    ("public_file_sync_sources", "cosmos_public_file_sync_sources_container", "cosmos_public_file_sync_sources_container_name", "/public_workspace_id", "file_sync"),
+    ("personal_workspace_identities", "cosmos_personal_workspace_identities_container", "cosmos_personal_workspace_identities_container_name", "/user_id", "identities"),
+    ("group_workspace_identities", "cosmos_group_workspace_identities_container", "cosmos_group_workspace_identities_container_name", "/group_id", "identities"),
+    ("public_workspace_identities", "cosmos_public_workspace_identities_container", "cosmos_public_workspace_identities_container_name", "/public_workspace_id", "identities"),
+    ("global_workspace_identities", "cosmos_global_workspace_identities_container", "cosmos_global_workspace_identities_container_name", "/global_id", "identities"),
+    ("personal_file_sync_items", "cosmos_personal_file_sync_items_container", "cosmos_personal_file_sync_items_container_name", "/source_id", "file_sync"),
+    ("group_file_sync_items", "cosmos_group_file_sync_items_container", "cosmos_group_file_sync_items_container_name", "/source_id", "file_sync"),
+    ("public_file_sync_items", "cosmos_public_file_sync_items_container", "cosmos_public_file_sync_items_container_name", "/source_id", "file_sync"),
+    ("personal_file_sync_runs", "cosmos_personal_file_sync_runs_container", "cosmos_personal_file_sync_runs_container_name", "/source_id", "file_sync"),
+    ("group_file_sync_runs", "cosmos_group_file_sync_runs_container", "cosmos_group_file_sync_runs_container_name", "/source_id", "file_sync"),
+    ("public_file_sync_runs", "cosmos_public_file_sync_runs_container", "cosmos_public_file_sync_runs_container_name", "/source_id", "file_sync"),
+    ("user_settings", "cosmos_user_settings_container", "cosmos_user_settings_container_name", "/id", "settings"),
+    ("safety", "cosmos_safety_container", "cosmos_safety_container_name", "/id", "safety"),
+    ("feedback", "cosmos_feedback_container", "cosmos_feedback_container_name", "/id", "feedback"),
+    ("archived_conversations", "cosmos_archived_conversations_container", "cosmos_archived_conversations_container_name", "/id", "archive"),
+    ("archived_messages", "cosmos_archived_messages_container", "cosmos_archived_messages_container_name", "/conversation_id", "archive"),
+    ("prompts", "cosmos_user_prompts_container", "cosmos_user_prompts_container_name", "/id", "prompts"),
+    ("group_prompts", "cosmos_group_prompts_container", "cosmos_group_prompts_container_name", "/id", "prompts"),
+    ("public_prompts", "cosmos_public_prompts_container", "cosmos_public_prompts_container_name", "/id", "prompts"),
+    ("file_processing", "cosmos_file_processing_container", "cosmos_file_processing_container_name", "/document_id", "documents"),
+    ("personal_agents", "cosmos_personal_agents_container", "cosmos_personal_agents_container_name", "/user_id", "agents"),
+    ("personal_actions", "cosmos_personal_actions_container", "cosmos_personal_actions_container_name", "/user_id", "actions"),
+    ("group_agents", "cosmos_group_agents_container", "cosmos_group_agents_container_name", "/group_id", "agents"),
+    ("group_actions", "cosmos_group_actions_container", "cosmos_group_actions_container_name", "/group_id", "actions"),
+    ("global_agents", "cosmos_global_agents_container", "cosmos_global_agents_container_name", "/id", "agents"),
+    ("global_actions", "cosmos_global_actions_container", "cosmos_global_actions_container_name", "/id", "actions"),
+    ("governance_policies", "cosmos_governance_policies_container", "cosmos_governance_policies_container_name", "/id", "governance"),
+    ("governance_item_policies", "cosmos_governance_item_policies_container", "cosmos_governance_item_policies_container_name", "/id", "governance"),
+    ("agent_templates", "cosmos_agent_templates_container", "cosmos_agent_templates_container_name", "/id", "agents"),
+    ("agent_facts", "cosmos_agent_facts_container", "cosmos_agent_facts_container_name", "/scope_id", "agents"),
+    ("search_cache", "cosmos_search_cache_container", "cosmos_search_cache_container_name", "/user_id", "cache"),
+    ("activity_logs", "cosmos_activity_logs_container", "cosmos_activity_logs_container_name", "/user_id", "activity"),
+    ("notifications", "cosmos_notifications_container", "cosmos_notifications_container_name", "/user_id", "notifications"),
+    ("approvals", "cosmos_approvals_container", "cosmos_approvals_container_name", "/group_id", "approvals"),
+    ("msgraph_pending_actions", "cosmos_msgraph_pending_actions_container", "cosmos_msgraph_pending_actions_container_name", "/user_id", "actions"),
+    ("thoughts", "cosmos_thoughts_container", "cosmos_thoughts_container_name", "/user_id", "thoughts"),
+    ("archive_thoughts", "cosmos_archived_thoughts_container", "cosmos_archived_thoughts_container_name", "/user_id", "archive"),
 ]
 
 DATA_MANAGEMENT_SEARCH_ARTIFACTS = [
@@ -1638,6 +1716,402 @@ def _strip_cosmos_system_fields(document):
         for key, value in document.items()
         if not key.startswith("_")
     }
+
+
+def _format_cosmos_editor_label(container_name):
+    return _safe_text(container_name).replace("_", " ").title()
+
+
+def _cosmos_editor_partition_key_field(partition_key_path):
+    normalized_path = _safe_text(partition_key_path)
+    if not normalized_path.startswith("/"):
+        raise DataManagementCosmosEditorError("Cosmos editor container metadata has an invalid partition key path.")
+    path_parts = [part for part in normalized_path.strip("/").split("/") if part]
+    if not path_parts:
+        raise DataManagementCosmosEditorError("Cosmos editor container metadata has an invalid partition key path.")
+    return path_parts[-1]
+
+
+def _get_document_path_value(document, path):
+    if not isinstance(document, dict):
+        return None
+    path_parts = [part for part in _safe_text(path).strip("/").split("/") if part]
+    current_value = document
+    for path_part in path_parts:
+        if not isinstance(current_value, dict) or path_part not in current_value:
+            return None
+        current_value = current_value.get(path_part)
+    return current_value
+
+
+def _build_cosmos_editor_container_metadata():
+    containers = []
+    seen_container_names = set()
+    for logical_name, container_attr, container_name_attr, partition_key_path, category in DATA_MANAGEMENT_COSMOS_EDITOR_CONTAINER_DEFINITIONS:
+        container_name = _safe_text(getattr(app_config, container_name_attr, logical_name))
+        if not container_name or container_name in seen_container_names or not hasattr(app_config, container_attr):
+            continue
+        seen_container_names.add(container_name)
+        containers.append({
+            "id": container_name,
+            "name": container_name,
+            "logical_name": logical_name,
+            "display_name": _format_cosmos_editor_label(container_name),
+            "category": category,
+            "container_attr": container_attr,
+            "container_name_attr": container_name_attr,
+            "partition_key_path": partition_key_path,
+            "partition_key_field": _cosmos_editor_partition_key_field(partition_key_path),
+            "max_page_size": DATA_MANAGEMENT_COSMOS_EDITOR_MAX_PAGE_SIZE,
+            "empty_query_limit": DATA_MANAGEMENT_COSMOS_EDITOR_EMPTY_QUERY_LIMIT,
+            "editable": True,
+        })
+    return sorted(containers, key=lambda container: (container["category"], container["display_name"]))
+
+
+def get_data_management_cosmos_editor_containers():
+    return [
+        {
+            "id": container["id"],
+            "name": container["name"],
+            "display_name": container["display_name"],
+            "category": container["category"],
+            "partition_key_path": container["partition_key_path"],
+            "partition_key_field": container["partition_key_field"],
+            "max_page_size": container["max_page_size"],
+            "empty_query_limit": container["empty_query_limit"],
+            "editable": container["editable"],
+        }
+        for container in _build_cosmos_editor_container_metadata()
+    ]
+
+
+def _get_cosmos_editor_container_metadata(container_name):
+    safe_container_name = _safe_text(container_name)
+    if not safe_container_name:
+        raise DataManagementCosmosEditorError("Choose a Cosmos DB container.")
+    for container in _build_cosmos_editor_container_metadata():
+        if safe_container_name in {container["id"], container["name"], container["logical_name"]}:
+            return container
+    raise DataManagementCosmosEditorError("The selected Cosmos DB container is not available for Data Management editing.")
+
+
+def _get_cosmos_editor_container(container_name):
+    metadata = _get_cosmos_editor_container_metadata(container_name)
+    return metadata, getattr(app_config, metadata["container_attr"])
+
+
+def _hash_cosmos_editor_query(query_text):
+    if not query_text:
+        return ""
+    return hashlib.sha256(query_text.encode("utf-8")).hexdigest()
+
+
+def _normalize_cosmos_editor_query(query_text):
+    query = _safe_text(query_text)
+    if not query:
+        return DATA_MANAGEMENT_COSMOS_EDITOR_EMPTY_QUERY, True
+    if len(query) > DATA_MANAGEMENT_COSMOS_EDITOR_MAX_QUERY_LENGTH:
+        raise DataManagementCosmosEditorError("Cosmos query text is too long.")
+    if ";" in query:
+        raise DataManagementCosmosEditorError("Run one SELECT query at a time without semicolons.")
+    if not re.match(r"^\s*SELECT\b", query, re.IGNORECASE):
+        raise DataManagementCosmosEditorError("Cosmos editor queries must start with SELECT.")
+    return query, False
+
+
+def log_data_management_cosmos_editor_activity(admin_user_id, admin_email, action, status, message, details=None):
+    now = _now_iso()
+    safe_action = _safe_text(action)
+    safe_admin_user_id = _safe_text(admin_user_id, "unknown") or "unknown"
+    activity_record = {
+        "id": str(uuid.uuid4()),
+        "user_id": safe_admin_user_id,
+        "activity_type": "data_management",
+        "timestamp": now,
+        "created_at": now,
+        "action": safe_action,
+        "description": _safe_text(message) or safe_action,
+        "workspace_type": "admin",
+        "workspace_context": {
+            "action": safe_action,
+            "tool": "cosmos_json_editor",
+        },
+        "additional_context": {
+            "tool": "cosmos_json_editor",
+            "status": _safe_text(status),
+            "details": _sanitize_activity_value(details if isinstance(details, dict) else {}),
+        },
+        "admin": {
+            "user_id": safe_admin_user_id,
+            "email": _safe_text(admin_email, "unknown") or "unknown",
+        },
+    }
+
+    try:
+        app_config.cosmos_activity_logs_container.create_item(body=activity_record)
+    except Exception as exc:
+        log_event(
+            "[DataManagement] Failed to write Cosmos editor activity record.",
+            {"action": safe_action, "status": status, "error": str(exc)},
+            level=logging.WARNING,
+        )
+
+
+def _summarize_cosmos_editor_item(item, container_metadata):
+    if not isinstance(item, dict):
+        preview_text = _safe_text(item)
+        return {
+            "id": None,
+            "partition_key": None,
+            "etag": None,
+            "timestamp": None,
+            "selectable": False,
+            "preview": preview_text[:200],
+        }
+
+    document_id = item.get("id")
+    partition_key_value = _get_document_path_value(item, container_metadata["partition_key_path"])
+    preview_fields = []
+    for field_name in ("name", "display_name", "title", "type", "user_id", "group_id", "public_workspace_id", "created_at", "updated_at"):
+        field_value = item.get(field_name)
+        if field_value is not None:
+            preview_fields.append(f"{field_name}: {_safe_text(field_value)[:80]}")
+        if len(preview_fields) >= 3:
+            break
+
+    return {
+        "id": _safe_text(document_id) if document_id is not None else None,
+        "partition_key": partition_key_value,
+        "etag": item.get("_etag"),
+        "timestamp": item.get("_ts"),
+        "selectable": document_id is not None and partition_key_value is not None,
+        "preview": "; ".join(preview_fields) if preview_fields else _safe_text(document_id)[:200],
+    }
+
+
+def query_data_management_cosmos_editor_documents(container_name, query_text=None, page_size=None, continuation_token=None, admin_user_id=None, admin_email=None):
+    container_metadata, container = _get_cosmos_editor_container(container_name)
+    query, is_empty_query = _normalize_cosmos_editor_query(query_text)
+    safe_page_size = _safe_int(
+        page_size,
+        default=DATA_MANAGEMENT_COSMOS_EDITOR_MAX_PAGE_SIZE,
+        minimum=1,
+        maximum=DATA_MANAGEMENT_COSMOS_EDITOR_MAX_PAGE_SIZE,
+    )
+    safe_continuation_token = None if is_empty_query else _safe_text(continuation_token) or None
+    started_at = time.perf_counter()
+
+    query_iterable = container.query_items(
+        query=query,
+        enable_cross_partition_query=True,
+        max_item_count=safe_page_size,
+    )
+    if hasattr(query_iterable, "by_page"):
+        page_iterator = query_iterable.by_page(continuation_token=safe_continuation_token)
+        try:
+            page_items = list(next(page_iterator))
+        except StopIteration:
+            page_items = []
+        next_continuation_token = None if is_empty_query else getattr(page_iterator, "continuation_token", None)
+    else:
+        page_items = list(query_iterable)[:safe_page_size]
+        next_continuation_token = None
+
+    duration_ms = int((time.perf_counter() - started_at) * 1000)
+    items = [
+        _summarize_cosmos_editor_item(item, container_metadata)
+        for item in page_items
+    ]
+    result = {
+        "container": get_data_management_cosmos_editor_container_public_metadata(container_metadata),
+        "query": {
+            "mode": "empty" if is_empty_query else "custom",
+            "page_size": safe_page_size,
+            "query_hash": _hash_cosmos_editor_query(query if not is_empty_query else ""),
+            "empty_query_limit_applied": is_empty_query,
+        },
+        "items": items,
+        "count": len(items),
+        "continuation_token": next_continuation_token,
+        "has_more": bool(next_continuation_token),
+        "duration_ms": duration_ms,
+    }
+    log_data_management_cosmos_editor_activity(
+        admin_user_id,
+        admin_email,
+        "cosmos_editor_query_executed",
+        "success",
+        "Executed a Cosmos DB editor query.",
+        {
+            "container": container_metadata["name"],
+            "query_mode": result["query"]["mode"],
+            "page_size": safe_page_size,
+            "returned_count": len(items),
+            "has_more": bool(next_continuation_token),
+            "duration_ms": duration_ms,
+            "query_hash": result["query"]["query_hash"],
+        },
+    )
+    return result
+
+
+def get_data_management_cosmos_editor_container_public_metadata(container_metadata):
+    return {
+        "id": container_metadata["id"],
+        "name": container_metadata["name"],
+        "display_name": container_metadata["display_name"],
+        "category": container_metadata["category"],
+        "partition_key_path": container_metadata["partition_key_path"],
+        "partition_key_field": container_metadata["partition_key_field"],
+        "max_page_size": container_metadata["max_page_size"],
+        "empty_query_limit": container_metadata["empty_query_limit"],
+        "editable": container_metadata["editable"],
+    }
+
+
+def get_data_management_cosmos_editor_document(container_name, document_id, partition_key_value, admin_user_id=None, admin_email=None):
+    container_metadata, container = _get_cosmos_editor_container(container_name)
+    safe_document_id = _safe_text(document_id)
+    if not safe_document_id:
+        raise DataManagementCosmosEditorError("Choose a Cosmos DB document.")
+    if partition_key_value is None:
+        raise DataManagementCosmosEditorError("The selected document is missing its partition key value.")
+
+    document = container.read_item(item=safe_document_id, partition_key=partition_key_value)
+    current_partition_key_value = _get_document_path_value(document, container_metadata["partition_key_path"])
+    result = {
+        "container": get_data_management_cosmos_editor_container_public_metadata(container_metadata),
+        "document": document,
+        "id": safe_document_id,
+        "partition_key": current_partition_key_value,
+        "etag": document.get("_etag") if isinstance(document, dict) else None,
+    }
+    log_data_management_cosmos_editor_activity(
+        admin_user_id,
+        admin_email,
+        "cosmos_editor_document_opened",
+        "success",
+        "Opened a Cosmos DB document in the editor.",
+        {
+            "container": container_metadata["name"],
+            "document_id": safe_document_id,
+            "partition_key_path": container_metadata["partition_key_path"],
+        },
+    )
+    return result
+
+
+def _summarize_cosmos_editor_changes(original_document, updated_document):
+    if not isinstance(original_document, dict) or not isinstance(updated_document, dict):
+        return {"changed_paths": [], "changed_count": 0, "added_count": 0, "removed_count": 0, "updated_count": 0}
+
+    changed_paths = []
+    added_count = 0
+    removed_count = 0
+    updated_count = 0
+
+    def compare_values(original_value, updated_value, path):
+        nonlocal added_count, removed_count, updated_count
+        if isinstance(original_value, dict) and isinstance(updated_value, dict):
+            all_keys = sorted(set(original_value.keys()) | set(updated_value.keys()))
+            for key in all_keys:
+                if key.startswith("_"):
+                    continue
+                child_path = f"{path}.{key}" if path else key
+                if key not in original_value:
+                    added_count += 1
+                    changed_paths.append(child_path)
+                    continue
+                if key not in updated_value:
+                    removed_count += 1
+                    changed_paths.append(child_path)
+                    continue
+                compare_values(original_value.get(key), updated_value.get(key), child_path)
+            return
+        if original_value != updated_value:
+            updated_count += 1
+            changed_paths.append(path)
+
+    compare_values(original_document, updated_document, "")
+    return {
+        "changed_paths": changed_paths[:50],
+        "changed_count": len(changed_paths),
+        "added_count": added_count,
+        "removed_count": removed_count,
+        "updated_count": updated_count,
+        "truncated": len(changed_paths) > 50,
+    }
+
+
+def _validate_cosmos_editor_save_confirmation(confirmation_accepted, confirmation_phrase):
+    if confirmation_accepted is not True:
+        raise DataManagementCosmosEditorError("Confirm that you understand this Cosmos DB edit can damage system data.")
+    if _safe_text(confirmation_phrase) != DATA_MANAGEMENT_COSMOS_EDITOR_CONFIRMATION_PHRASE:
+        raise DataManagementCosmosEditorError("Type the required confirmation phrase before saving this Cosmos DB document.")
+
+
+def save_data_management_cosmos_editor_document(container_name, document_id, partition_key_value, etag, document, confirmation_accepted=False, confirmation_phrase="", admin_user_id=None, admin_email=None):
+    container_metadata, container = _get_cosmos_editor_container(container_name)
+    safe_document_id = _safe_text(document_id)
+    safe_etag = _safe_text(etag)
+    if not safe_document_id:
+        raise DataManagementCosmosEditorError("Choose a Cosmos DB document before saving.")
+    if partition_key_value is None:
+        raise DataManagementCosmosEditorError("The selected document is missing its partition key value.")
+    if not safe_etag:
+        raise DataManagementCosmosEditorError("The selected document is missing its ETag. Refresh the document before saving.")
+    if not isinstance(document, dict):
+        raise DataManagementCosmosEditorError("Cosmos DB document JSON must be an object.")
+
+    _validate_cosmos_editor_save_confirmation(confirmation_accepted, confirmation_phrase)
+
+    if _safe_text(document.get("id")) != safe_document_id:
+        raise DataManagementCosmosEditorError("Document id cannot be changed in the Cosmos DB editor.")
+    updated_partition_key_value = _get_document_path_value(document, container_metadata["partition_key_path"])
+    if updated_partition_key_value != partition_key_value:
+        raise DataManagementCosmosEditorError("Document partition key value cannot be changed in the Cosmos DB editor.")
+
+    original_document = container.read_item(item=safe_document_id, partition_key=partition_key_value)
+    change_summary = _summarize_cosmos_editor_changes(original_document, document)
+    clean_document = _strip_cosmos_system_fields(copy.deepcopy(document))
+    replace_target = safe_document_id
+    if isinstance(original_document, dict) and original_document.get("_self"):
+        replace_target = original_document
+    saved_document = container.replace_item(
+        item=replace_target,
+        body=clean_document,
+        etag=safe_etag,
+        match_condition=MatchConditions.IfNotModified,
+    )
+
+    result = {
+        "container": get_data_management_cosmos_editor_container_public_metadata(container_metadata),
+        "document": saved_document,
+        "id": safe_document_id,
+        "partition_key": _get_document_path_value(saved_document, container_metadata["partition_key_path"]),
+        "etag": saved_document.get("_etag") if isinstance(saved_document, dict) else None,
+        "change_summary": change_summary,
+    }
+    log_data_management_cosmos_editor_activity(
+        admin_user_id,
+        admin_email,
+        "cosmos_editor_document_saved",
+        "success",
+        "Saved a Cosmos DB document from the Data Management editor.",
+        {
+            "container": container_metadata["name"],
+            "document_id": safe_document_id,
+            "partition_key_path": container_metadata["partition_key_path"],
+            "changed_count": change_summary["changed_count"],
+            "added_count": change_summary["added_count"],
+            "removed_count": change_summary["removed_count"],
+            "updated_count": change_summary["updated_count"],
+            "changed_paths": change_summary["changed_paths"],
+            "changed_paths_truncated": change_summary["truncated"],
+        },
+    )
+    return result
 
 
 def _save_data_management_job(job):

--- a/application/single_app/route_backend_data_management.py
+++ b/application/single_app/route_backend_data_management.py
@@ -281,7 +281,7 @@ def register_route_backend_data_management(bp):
                 "Rejected a Cosmos DB editor query.",
                 {"container": payload.get("container"), "error": str(exc)},
             )
-            return jsonify({"success": False, "error": str(exc)}), 400
+            return jsonify({"success": False, "error": "Cosmos DB editor query was rejected."}), 400
         except Exception as exc:
             log_event(
                 "[DataManagement] Cosmos editor query failed.",

--- a/application/single_app/route_backend_data_management.py
+++ b/application/single_app/route_backend_data_management.py
@@ -359,7 +359,7 @@ def register_route_backend_data_management(bp):
                 "Rejected a Cosmos DB editor save request.",
                 {"container": payload.get("container"), "document_id": payload.get("id"), "error": str(exc)},
             )
-            return jsonify({"success": False, "error": str(exc)}), 400
+            return jsonify({"success": False, "error": "Cosmos DB document save request was rejected."}), 400
         except Exception as exc:
             status_code = _cosmos_editor_error_status(exc, default_status=400)
             log_event(

--- a/application/single_app/route_backend_data_management.py
+++ b/application/single_app/route_backend_data_management.py
@@ -312,12 +312,17 @@ def register_route_backend_data_management(bp):
                 admin_email=admin_email,
             )
         except DataManagementCosmosEditorError as exc:
+            log_event(
+                "[DataManagement] Cosmos editor document open rejected.",
+                {"container": payload.get("container"), "document_id": payload.get("id"), "error": str(exc)},
+                level=logging.WARNING,
+            )
             _log_cosmos_editor_failure(
                 "cosmos_editor_document_rejected",
                 "Rejected a Cosmos DB editor document open request.",
                 {"container": payload.get("container"), "document_id": payload.get("id"), "error": str(exc)},
             )
-            return jsonify({"success": False, "error": str(exc)}), 400
+            return jsonify({"success": False, "error": "Cosmos DB document request was invalid."}), 400
         except Exception as exc:
             status_code = _cosmos_editor_error_status(exc, default_status=400)
             log_event(

--- a/application/single_app/route_backend_data_management.py
+++ b/application/single_app/route_backend_data_management.py
@@ -13,16 +13,22 @@ from functions_data_management import (
     DATA_MANAGEMENT_OPERATION_DRY_RUN,
     DATA_MANAGEMENT_OPERATION_MIGRATION,
     DATA_MANAGEMENT_OPERATION_RESTORE,
+    DataManagementCosmosEditorError,
     DataManagementSettingsValidationError,
     generate_data_management_encryption_key,
+    get_data_management_cosmos_editor_containers,
+    get_data_management_cosmos_editor_document,
     get_data_management_backup_summary,
     get_data_management_job_detail,
     get_data_management_jobs,
     get_data_management_migration_catalog,
     get_data_management_settings,
+    log_data_management_cosmos_editor_activity,
     queue_data_management_job,
+    query_data_management_cosmos_editor_documents,
     sanitize_data_management_job_for_admin,
     sanitize_data_management_settings_for_admin,
+    save_data_management_cosmos_editor_document,
     summarize_data_management_migration_plan,
     submit_data_management_job,
     test_backup_storage_connection,
@@ -56,6 +62,32 @@ def _log_data_management_admin_action(action, description, additional_context=No
             {"action": action, "error": str(exc)},
             level=logging.WARNING,
         )
+
+
+def _get_cosmos_editor_payload():
+    payload = request.get_json(silent=True) or {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _cosmos_editor_error_status(exc, default_status=400):
+    status_code = getattr(exc, "status_code", None)
+    if status_code == 404:
+        return 404
+    if status_code == 412:
+        return 409
+    return default_status
+
+
+def _log_cosmos_editor_failure(action, message, details=None):
+    admin_user_id, admin_email = _get_admin_context()
+    log_data_management_cosmos_editor_activity(
+        admin_user_id,
+        admin_email,
+        action,
+        "failed",
+        message,
+        details=details or {},
+    )
 
 
 def register_route_backend_data_management(bp):
@@ -200,6 +232,155 @@ def register_route_backend_data_management(bp):
             )
             return jsonify({"success": False, "error": "Target Enhanced Citation Storage connection test failed."}), 400
         return jsonify(result), 200
+
+    @bp.route("/api/admin/data-management/cosmos-editor/containers", methods=["GET"])
+    @swagger_route(security=get_auth_security())
+    @login_required
+    @admin_required
+    def list_admin_data_management_cosmos_editor_containers():
+        return jsonify({
+            "success": True,
+            "containers": get_data_management_cosmos_editor_containers(),
+        }), 200
+
+    @bp.route("/api/admin/data-management/cosmos-editor/danger-acknowledgement", methods=["POST"])
+    @swagger_route(security=get_auth_security())
+    @login_required
+    @admin_required
+    def acknowledge_admin_data_management_cosmos_editor_danger():
+        admin_user_id, admin_email = _get_admin_context()
+        log_data_management_cosmos_editor_activity(
+            admin_user_id,
+            admin_email,
+            "cosmos_editor_danger_acknowledged",
+            "success",
+            "Acknowledged the Cosmos DB editor danger prompt.",
+            {"prompt": "interface_entry"},
+        )
+        return jsonify({"success": True}), 200
+
+    @bp.route("/api/admin/data-management/cosmos-editor/query", methods=["POST"])
+    @swagger_route(security=get_auth_security())
+    @login_required
+    @admin_required
+    def query_admin_data_management_cosmos_editor_documents():
+        payload = _get_cosmos_editor_payload()
+        admin_user_id, admin_email = _get_admin_context()
+        try:
+            result = query_data_management_cosmos_editor_documents(
+                payload.get("container"),
+                query_text=payload.get("query"),
+                page_size=payload.get("page_size"),
+                continuation_token=payload.get("continuation_token"),
+                admin_user_id=admin_user_id,
+                admin_email=admin_email,
+            )
+        except DataManagementCosmosEditorError as exc:
+            _log_cosmos_editor_failure(
+                "cosmos_editor_query_rejected",
+                "Rejected a Cosmos DB editor query.",
+                {"container": payload.get("container"), "error": str(exc)},
+            )
+            return jsonify({"success": False, "error": str(exc)}), 400
+        except Exception as exc:
+            log_event(
+                "[DataManagement] Cosmos editor query failed.",
+                {"container": payload.get("container"), "error": str(exc)},
+                level=logging.WARNING,
+            )
+            _log_cosmos_editor_failure(
+                "cosmos_editor_query_failed",
+                "Cosmos DB editor query failed.",
+                {"container": payload.get("container"), "status_code": getattr(exc, "status_code", None), "error": str(exc)},
+            )
+            return jsonify({"success": False, "error": "Cosmos DB editor query failed."}), _cosmos_editor_error_status(exc)
+        return jsonify({"success": True, **result}), 200
+
+    @bp.route("/api/admin/data-management/cosmos-editor/document", methods=["POST"])
+    @swagger_route(security=get_auth_security())
+    @login_required
+    @admin_required
+    def get_admin_data_management_cosmos_editor_document():
+        payload = _get_cosmos_editor_payload()
+        admin_user_id, admin_email = _get_admin_context()
+        try:
+            result = get_data_management_cosmos_editor_document(
+                payload.get("container"),
+                payload.get("id"),
+                payload.get("partition_key"),
+                admin_user_id=admin_user_id,
+                admin_email=admin_email,
+            )
+        except DataManagementCosmosEditorError as exc:
+            _log_cosmos_editor_failure(
+                "cosmos_editor_document_rejected",
+                "Rejected a Cosmos DB editor document open request.",
+                {"container": payload.get("container"), "document_id": payload.get("id"), "error": str(exc)},
+            )
+            return jsonify({"success": False, "error": str(exc)}), 400
+        except Exception as exc:
+            status_code = _cosmos_editor_error_status(exc, default_status=400)
+            log_event(
+                "[DataManagement] Cosmos editor document open failed.",
+                {"container": payload.get("container"), "document_id": payload.get("id"), "error": str(exc)},
+                level=logging.WARNING,
+            )
+            _log_cosmos_editor_failure(
+                "cosmos_editor_document_failed",
+                "Cosmos DB editor document open failed.",
+                {"container": payload.get("container"), "document_id": payload.get("id"), "status_code": getattr(exc, "status_code", None), "error": str(exc)},
+            )
+            error_message = "Cosmos DB document was not found." if status_code == 404 else "Cosmos DB document could not be opened."
+            return jsonify({"success": False, "error": error_message}), status_code
+        return jsonify({"success": True, **result}), 200
+
+    @bp.route("/api/admin/data-management/cosmos-editor/document", methods=["PUT"])
+    @swagger_route(security=get_auth_security())
+    @login_required
+    @admin_required
+    def save_admin_data_management_cosmos_editor_document():
+        payload = _get_cosmos_editor_payload()
+        admin_user_id, admin_email = _get_admin_context()
+        try:
+            result = save_data_management_cosmos_editor_document(
+                payload.get("container"),
+                payload.get("id"),
+                payload.get("partition_key"),
+                payload.get("etag"),
+                payload.get("document"),
+                confirmation_accepted=payload.get("confirmation_accepted") is True,
+                confirmation_phrase=payload.get("confirmation_phrase"),
+                admin_user_id=admin_user_id,
+                admin_email=admin_email,
+            )
+        except DataManagementCosmosEditorError as exc:
+            _log_cosmos_editor_failure(
+                "cosmos_editor_save_rejected",
+                "Rejected a Cosmos DB editor save request.",
+                {"container": payload.get("container"), "document_id": payload.get("id"), "error": str(exc)},
+            )
+            return jsonify({"success": False, "error": str(exc)}), 400
+        except Exception as exc:
+            status_code = _cosmos_editor_error_status(exc, default_status=400)
+            log_event(
+                "[DataManagement] Cosmos editor save failed.",
+                {"container": payload.get("container"), "document_id": payload.get("id"), "error": str(exc)},
+                level=logging.WARNING,
+                exceptionTraceback=True,
+            )
+            _log_cosmos_editor_failure(
+                "cosmos_editor_save_failed",
+                "Cosmos DB editor save failed.",
+                {"container": payload.get("container"), "document_id": payload.get("id"), "status_code": getattr(exc, "status_code", None), "error": str(exc)},
+            )
+            if status_code == 409:
+                error_message = "Cosmos DB document changed after it was opened. Refresh before saving again."
+            elif status_code == 404:
+                error_message = "Cosmos DB document was not found."
+            else:
+                error_message = "Cosmos DB document could not be saved."
+            return jsonify({"success": False, "error": error_message}), status_code
+        return jsonify({"success": True, **result}), 200
 
     @bp.route("/api/admin/data-management/jobs", methods=["GET"])
     @swagger_route(security=get_auth_security())

--- a/application/single_app/static/css/styles.css
+++ b/application/single_app/static/css/styles.css
@@ -1240,3 +1240,19 @@ main {
     border-left-color: #495057;
     color: #adb5bd;
 }
+
+/* Cosmos editor modal */
+#data-management-cosmos-editor-results-modal .cosmos-editor-results-modal-body {
+    overflow-x: hidden;
+}
+
+#data-management-cosmos-editor-results-modal .cosmos-editor-results-list {
+    max-height: calc(100vh - 18rem);
+    overflow-y: auto;
+}
+
+@media (max-width: 991.98px) {
+    #data-management-cosmos-editor-results-modal .cosmos-editor-results-list {
+        max-height: 18rem;
+    }
+}

--- a/application/single_app/static/js/admin/admin_data_management.js
+++ b/application/single_app/static/js/admin/admin_data_management.js
@@ -6,6 +6,7 @@ const redactedValue = "***REDACTED***";
 const backupStorageAuthManagedIdentity = "managed_identity";
 const backupStorageAuthConnectionString = "connection_string";
 const targetCosmosDatabaseName = "SimpleChat";
+const cosmosEditorConfirmationPhrase = "I understand this can damage system data";
 const elements = {};
 let dataManagementModified = false;
 let storedBackupConnectionStringAvailable = false;
@@ -15,6 +16,12 @@ let currentJobDetailId = null;
 let jobDetailRefreshTimer = null;
 let jobDetailRefreshInFlight = false;
 let refreshListsWhenJobCompletes = false;
+let cosmosEditorUnlocked = false;
+let cosmosEditorContainers = [];
+let cosmosEditorContinuationToken = null;
+let cosmosEditorResultCount = 0;
+let cosmosEditorSelectedDocument = null;
+let cosmosEditorPendingDocument = null;
 
 const jobDetailRefreshIntervalMs = 4000;
 const activeJobStatuses = new Set(["queued", "running"]);
@@ -35,6 +42,8 @@ document.addEventListener("DOMContentLoaded", () => {
     loadDataManagementSettings();
     loadDataManagementBackups();
     loadDataManagementJobs();
+    initializeCosmosEditorLockedState();
+    loadCosmosEditorContainers();
 });
 
 function bindElements() {
@@ -135,6 +144,35 @@ function bindElements() {
         "data-management-job-artifacts-tbody",
         "data-management-job-manifest-detail",
         "data-management-job-warnings",
+        "data-management-cosmos-editor-section",
+        "data-management-cosmos-editor-open-danger-btn",
+        "data-management-cosmos-editor-locked-message",
+        "data-management-cosmos-editor-workspace",
+        "data_management_cosmos_editor_container",
+        "data-management-cosmos-editor-container-help",
+        "data_management_cosmos_editor_page_size",
+        "data_management_cosmos_editor_query",
+        "data-management-cosmos-editor-run-query-btn",
+        "data-management-cosmos-editor-next-page-btn",
+        "data-management-cosmos-editor-refresh-document-btn",
+        "data-management-cosmos-editor-query-status",
+        "data-management-cosmos-editor-results-list",
+        "data-management-cosmos-editor-document-meta",
+        "data-management-cosmos-editor-save-btn",
+        "data_management_cosmos_editor_document_json",
+        "data-management-cosmos-editor-document-help",
+        "data-management-cosmos-editor-danger-modal",
+        "data_management_cosmos_editor_danger_accept",
+        "data-management-cosmos-editor-accept-danger-btn",
+        "data-management-cosmos-editor-save-modal",
+        "data-management-cosmos-editor-save-subtitle",
+        "data-management-cosmos-editor-save-summary",
+        "data_management_cosmos_editor_confirmation_phrase",
+        "data-management-cosmos-editor-confirm-save-btn",
+        "data-management-cosmos-editor-results-modal",
+        "data-management-cosmos-editor-modal-title",
+        "data-management-cosmos-editor-modal-subtitle",
+        "data-management-cosmos-editor-modal-status",
     ];
 
     ids.forEach((id) => {
@@ -182,6 +220,17 @@ function bindEvents() {
     elements.dataManagementRefreshJobsBtn?.addEventListener("click", loadDataManagementJobs);
     elements.dataManagementJobDetailModal?.addEventListener("hidden.bs.modal", () => stopJobDetailAutoRefresh({ clearJob: true }));
     elements.dataManagementKeyVaultLink?.addEventListener("click", openKeyVaultSettings);
+    elements.dataManagementCosmosEditorOpenDangerBtn?.addEventListener("click", showCosmosEditorDangerModal);
+    elements.datamanagementcosmoseditordangeraccept?.addEventListener("change", updateCosmosEditorDangerAcceptState);
+    elements.dataManagementCosmosEditorAcceptDangerBtn?.addEventListener("click", acceptCosmosEditorDanger);
+    elements.datamanagementcosmoseditorcontainer?.addEventListener("change", () => resetCosmosEditorQueryState({ clearResults: true, clearDocument: true }));
+    elements.datamanagementcosmoseditorquery?.addEventListener("input", () => resetCosmosEditorQueryState({ clearResults: false, clearDocument: true }));
+    elements.dataManagementCosmosEditorRunQueryBtn?.addEventListener("click", () => queryCosmosEditorDocuments(false));
+    elements.dataManagementCosmosEditorNextPageBtn?.addEventListener("click", () => queryCosmosEditorDocuments(true));
+    elements.dataManagementCosmosEditorRefreshDocumentBtn?.addEventListener("click", refreshCosmosEditorDocument);
+    elements.dataManagementCosmosEditorSaveBtn?.addEventListener("click", openCosmosEditorSaveModal);
+    elements.datamanagementcosmoseditorconfirmationphrase?.addEventListener("input", updateCosmosEditorConfirmSaveState);
+    elements.dataManagementCosmosEditorConfirmSaveBtn?.addEventListener("click", saveCosmosEditorDocument);
     bindDataManagementChangeTracking();
     setStorageAuthVisibility();
     setMigrationTargetVisibility();
@@ -210,6 +259,9 @@ function bindMigrationPickerEvents() {
 
 function bindDataManagementChangeTracking() {
     elements.tabPane?.querySelectorAll("input, select, textarea").forEach((element) => {
+        if (element.closest("[data-ignore-data-management-change='true']")) {
+            return;
+        }
         const eventName = element.type === "checkbox" || element.type === "radio" || element.tagName === "SELECT" ? "change" : "input";
         element.addEventListener(eventName, markDataManagementModified);
     });
@@ -266,6 +318,14 @@ function setBusy(button, isBusy, busyLabel = "Working...") {
     }
     button.removeAttribute("aria-busy");
     button.disabled = false;
+}
+
+function setButtonDisabled(button, disabled) {
+    if (!button) {
+        return;
+    }
+    button.disabled = Boolean(disabled);
+    button.setAttribute("aria-disabled", String(Boolean(disabled)));
 }
 
 function setValue(element, value) {
@@ -558,6 +618,475 @@ async function requestJson(url, options = {}) {
         throw new Error(data.error || `Request failed with status ${response.status}`);
     }
     return data;
+}
+
+function initializeCosmosEditorLockedState() {
+    setElementVisible(elements.dataManagementCosmosEditorWorkspace, cosmosEditorUnlocked);
+    setElementVisible(elements.dataManagementCosmosEditorLockedMessage, !cosmosEditorUnlocked);
+    setButtonDisabled(elements.dataManagementCosmosEditorRunQueryBtn, !cosmosEditorUnlocked || cosmosEditorContainers.length === 0);
+    setButtonDisabled(elements.dataManagementCosmosEditorNextPageBtn, true);
+    setButtonDisabled(elements.dataManagementCosmosEditorRefreshDocumentBtn, true);
+    setButtonDisabled(elements.dataManagementCosmosEditorSaveBtn, true);
+    if (elements.datamanagementcosmoseditorcontainer) {
+        elements.datamanagementcosmoseditorcontainer.disabled = !cosmosEditorUnlocked;
+    }
+    if (elements.datamanagementcosmoseditorpagesize) {
+        elements.datamanagementcosmoseditorpagesize.disabled = !cosmosEditorUnlocked;
+    }
+    if (elements.datamanagementcosmoseditorquery) {
+        elements.datamanagementcosmoseditorquery.disabled = !cosmosEditorUnlocked;
+    }
+    if (elements.datamanagementcosmoseditordocumentjson) {
+        elements.datamanagementcosmoseditordocumentjson.disabled = true;
+    }
+}
+
+function showCosmosEditorDangerModal() {
+    if (cosmosEditorUnlocked) {
+        setElementVisible(elements.dataManagementCosmosEditorWorkspace, true);
+        return;
+    }
+    if (elements.datamanagementcosmoseditordangeraccept) {
+        elements.datamanagementcosmoseditordangeraccept.checked = false;
+    }
+    updateCosmosEditorDangerAcceptState();
+    if (elements.dataManagementCosmosEditorDangerModal && window.bootstrap?.Modal) {
+        window.bootstrap.Modal.getOrCreateInstance(elements.dataManagementCosmosEditorDangerModal).show();
+    }
+}
+
+function updateCosmosEditorDangerAcceptState() {
+    setButtonDisabled(
+        elements.dataManagementCosmosEditorAcceptDangerBtn,
+        !elements.datamanagementcosmoseditordangeraccept?.checked
+    );
+}
+
+async function acceptCosmosEditorDanger() {
+    if (!elements.datamanagementcosmoseditordangeraccept?.checked) {
+        return;
+    }
+    setBusy(elements.dataManagementCosmosEditorAcceptDangerBtn, true, "Unlocking...");
+    try {
+        await requestJson("/api/admin/data-management/cosmos-editor/danger-acknowledgement", {
+            method: "POST",
+            body: "{}",
+        });
+        cosmosEditorUnlocked = true;
+        initializeCosmosEditorLockedState();
+        setStatus("Cosmos DB JSON editor unlocked for this page session.", "warning");
+        showToast("Cosmos DB JSON editor unlocked.", "warning");
+        if (elements.dataManagementCosmosEditorDangerModal && window.bootstrap?.Modal) {
+            window.bootstrap.Modal.getOrCreateInstance(elements.dataManagementCosmosEditorDangerModal).hide();
+        }
+    } catch (error) {
+        setStatus(error.message || "Cosmos DB editor could not be unlocked.", "danger");
+        showToast(error.message || "Cosmos DB editor could not be unlocked.", "danger");
+    } finally {
+        setBusy(elements.dataManagementCosmosEditorAcceptDangerBtn, false);
+        updateCosmosEditorDangerAcceptState();
+    }
+}
+
+async function loadCosmosEditorContainers() {
+    const select = elements.datamanagementcosmoseditorcontainer;
+    if (!select) {
+        return;
+    }
+    try {
+        const data = await requestJson("/api/admin/data-management/cosmos-editor/containers", { method: "GET" });
+        cosmosEditorContainers = Array.isArray(data.containers) ? data.containers : [];
+        renderCosmosEditorContainerOptions();
+    } catch (error) {
+        cosmosEditorContainers = [];
+        renderCosmosEditorContainerOptions(error.message || "Cosmos DB containers could not be loaded.");
+    }
+}
+
+function renderCosmosEditorContainerOptions(errorMessage = "") {
+    const select = elements.datamanagementcosmoseditorcontainer;
+    if (!select) {
+        return;
+    }
+    select.replaceChildren();
+    const placeholder = document.createElement("option");
+    placeholder.value = "";
+    placeholder.textContent = errorMessage || "Choose a container";
+    select.appendChild(placeholder);
+    cosmosEditorContainers.forEach((container) => {
+        const option = document.createElement("option");
+        option.value = container.name;
+        option.textContent = `${container.display_name || container.name} (${container.partition_key_path})`;
+        select.appendChild(option);
+    });
+    setButtonDisabled(elements.dataManagementCosmosEditorRunQueryBtn, !cosmosEditorUnlocked || cosmosEditorContainers.length === 0);
+    updateCosmosEditorContainerHelp();
+}
+
+function updateCosmosEditorContainerHelp() {
+    const container = getSelectedCosmosEditorContainer();
+    if (!container) {
+        setText(elements.dataManagementCosmosEditorContainerHelp, "Choose a known SimpleChat Cosmos DB container.");
+        return;
+    }
+    setText(
+        elements.dataManagementCosmosEditorContainerHelp,
+        `Category: ${formatActivityLabel(container.category)}. Partition key: ${container.partition_key_path}.`
+    );
+}
+
+function getSelectedCosmosEditorContainer() {
+    const selectedName = getValue(elements.datamanagementcosmoseditorcontainer);
+    return cosmosEditorContainers.find((container) => container.name === selectedName) || null;
+}
+
+function setCosmosEditorQueryStatus(message) {
+    setText(elements.dataManagementCosmosEditorQueryStatus, message);
+    setText(elements.dataManagementCosmosEditorModalStatus, message);
+}
+
+function showCosmosEditorResultsModal() {
+    const selectedContainer = getSelectedCosmosEditorContainer();
+    if (selectedContainer) {
+        setText(elements.dataManagementCosmosEditorModalTitle, `${selectedContainer.display_name || selectedContainer.name} Results`);
+        setText(
+            elements.dataManagementCosmosEditorModalSubtitle,
+            `Container: ${selectedContainer.name}; partition key: ${selectedContainer.partition_key_path}`
+        );
+    }
+    if (elements.dataManagementCosmosEditorResultsModal && window.bootstrap?.Modal) {
+        window.bootstrap.Modal.getOrCreateInstance(elements.dataManagementCosmosEditorResultsModal).show();
+    }
+}
+
+function resetCosmosEditorQueryState(options = {}) {
+    cosmosEditorContinuationToken = null;
+    if (options.clearResults) {
+        cosmosEditorResultCount = 0;
+        renderCosmosEditorResultMessage("Run a query to list documents.");
+    }
+    if (options.clearDocument) {
+        clearCosmosEditorDocument();
+    }
+    updateCosmosEditorContainerHelp();
+    setButtonDisabled(elements.dataManagementCosmosEditorNextPageBtn, true);
+}
+
+function clearCosmosEditorDocument() {
+    cosmosEditorSelectedDocument = null;
+    cosmosEditorPendingDocument = null;
+    setValue(elements.datamanagementcosmoseditordocumentjson, "");
+    if (elements.datamanagementcosmoseditordocumentjson) {
+        elements.datamanagementcosmoseditordocumentjson.disabled = true;
+        elements.datamanagementcosmoseditordocumentjson.setAttribute("aria-disabled", "true");
+    }
+    setText(elements.dataManagementCosmosEditorDocumentMeta, "Select a result to load JSON.");
+    setButtonDisabled(elements.dataManagementCosmosEditorRefreshDocumentBtn, true);
+    setButtonDisabled(elements.dataManagementCosmosEditorSaveBtn, true);
+}
+
+async function queryCosmosEditorDocuments(useContinuation) {
+    if (!cosmosEditorUnlocked) {
+        showCosmosEditorDangerModal();
+        return;
+    }
+    const selectedContainer = getSelectedCosmosEditorContainer();
+    if (!selectedContainer) {
+        showToast("Choose a Cosmos DB container first.", "warning");
+        return;
+    }
+    if (useContinuation && !cosmosEditorContinuationToken) {
+        return;
+    }
+
+    const triggerButton = useContinuation ? elements.dataManagementCosmosEditorNextPageBtn : elements.dataManagementCosmosEditorRunQueryBtn;
+    setBusy(triggerButton, true, useContinuation ? "Loading..." : "Querying...");
+    setCosmosEditorQueryStatus(useContinuation ? "Loading next page..." : "Running query...");
+    try {
+        const data = await requestJson("/api/admin/data-management/cosmos-editor/query", {
+            method: "POST",
+            body: JSON.stringify({
+                container: selectedContainer.name,
+                query: getValue(elements.datamanagementcosmoseditorquery),
+                page_size: getNumberValue(elements.datamanagementcosmoseditorpagesize, 100),
+                continuation_token: useContinuation ? cosmosEditorContinuationToken : null,
+            }),
+        });
+        if (!useContinuation) {
+            clearCosmosEditorDocument();
+            cosmosEditorResultCount = 0;
+        }
+        renderCosmosEditorResults(data, useContinuation);
+        cosmosEditorContinuationToken = data.continuation_token || null;
+        setButtonDisabled(elements.dataManagementCosmosEditorNextPageBtn, !cosmosEditorContinuationToken);
+        const modeLabel = data.query?.mode === "empty" ? "empty browse" : "custom SELECT";
+        const pageNote = data.has_more ? "More results are available." : "No more results returned.";
+        setCosmosEditorQueryStatus(`${formatNumber(cosmosEditorResultCount)} loaded from ${modeLabel} query. ${pageNote}`);
+        showCosmosEditorResultsModal();
+    } catch (error) {
+        setCosmosEditorQueryStatus(error.message || "Cosmos DB query failed.");
+        showToast(error.message || "Cosmos DB query failed.", "danger");
+    } finally {
+        setBusy(triggerButton, false);
+        setButtonDisabled(elements.dataManagementCosmosEditorRunQueryBtn, !cosmosEditorUnlocked || cosmosEditorContainers.length === 0);
+        setButtonDisabled(elements.dataManagementCosmosEditorNextPageBtn, !cosmosEditorContinuationToken);
+    }
+}
+
+function renderCosmosEditorResults(data, append) {
+    const resultsList = elements.dataManagementCosmosEditorResultsList;
+    if (!resultsList) {
+        return;
+    }
+    const items = Array.isArray(data.items) ? data.items : [];
+    if (!append) {
+        resultsList.replaceChildren();
+    }
+    if (!items.length && !append) {
+        renderCosmosEditorResultMessage("No documents matched this query.");
+        return;
+    }
+    items.forEach((item) => {
+        cosmosEditorResultCount += 1;
+        resultsList.appendChild(createCosmosEditorResultButton(item, cosmosEditorResultCount));
+    });
+}
+
+function renderCosmosEditorResultMessage(message) {
+    const resultsList = elements.dataManagementCosmosEditorResultsList;
+    if (!resultsList) {
+        return;
+    }
+    const messageElement = document.createElement("div");
+    messageElement.className = "list-group-item text-muted";
+    messageElement.textContent = message;
+    resultsList.replaceChildren(messageElement);
+}
+
+function createCosmosEditorResultButton(item, index) {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "list-group-item list-group-item-action py-2";
+    button.disabled = item.selectable !== true;
+
+    const header = document.createElement("div");
+    header.className = "d-flex justify-content-between align-items-start gap-2";
+    const title = document.createElement("div");
+    title.className = "small fw-semibold text-break";
+    title.textContent = item.id || "Non-document projection";
+    const indexBadge = createBadge(formatNumber(index), item.selectable === true ? "bg-light text-dark border" : "bg-secondary");
+    header.append(title, indexBadge);
+    const partition = document.createElement("div");
+    partition.className = "small text-muted text-break";
+    partition.textContent = item.partition_key !== null && item.partition_key !== undefined
+        ? `Partition key: ${formatDetailValue(item.partition_key)}`
+        : "Projection is missing the partition key.";
+    const preview = document.createElement("div");
+    preview.className = "small text-muted";
+    const previewText = item.preview || "No preview fields available.";
+    preview.textContent = previewText.length > 120 ? `${previewText.slice(0, 117)}...` : previewText;
+    button.append(header, partition, preview);
+    if (item.selectable === true) {
+        button.addEventListener("click", () => openCosmosEditorDocument(item));
+    }
+    return button;
+}
+
+async function openCosmosEditorDocument(item) {
+    const selectedContainer = getSelectedCosmosEditorContainer();
+    if (!selectedContainer || !item?.id) {
+        return;
+    }
+    setText(elements.dataManagementCosmosEditorDocumentMeta, "Loading selected document...");
+    try {
+        const data = await requestJson("/api/admin/data-management/cosmos-editor/document", {
+            method: "POST",
+            body: JSON.stringify({
+                container: selectedContainer.name,
+                id: item.id,
+                partition_key: item.partition_key,
+            }),
+        });
+        renderCosmosEditorDocument(data);
+    } catch (error) {
+        clearCosmosEditorDocument();
+        setText(elements.dataManagementCosmosEditorDocumentMeta, error.message || "Document could not be opened.");
+        showToast(error.message || "Document could not be opened.", "danger");
+    }
+}
+
+function renderCosmosEditorDocument(data) {
+    const documentJson = data.document && typeof data.document === "object" ? data.document : {};
+    cosmosEditorSelectedDocument = {
+        container: data.container?.name || getValue(elements.datamanagementcosmoseditorcontainer),
+        id: data.id,
+        partitionKey: data.partition_key,
+        etag: data.etag,
+        originalDocument: documentJson,
+    };
+    setValue(elements.datamanagementcosmoseditordocumentjson, JSON.stringify(documentJson, null, 2));
+    if (elements.datamanagementcosmoseditordocumentjson) {
+        elements.datamanagementcosmoseditordocumentjson.disabled = false;
+        elements.datamanagementcosmoseditordocumentjson.setAttribute("aria-disabled", "false");
+    }
+    setText(
+        elements.dataManagementCosmosEditorDocumentMeta,
+        `Container: ${cosmosEditorSelectedDocument.container}; id: ${cosmosEditorSelectedDocument.id}; ETag: ${cosmosEditorSelectedDocument.etag || "not returned"}`
+    );
+    setButtonDisabled(elements.dataManagementCosmosEditorRefreshDocumentBtn, false);
+    setButtonDisabled(elements.dataManagementCosmosEditorSaveBtn, false);
+}
+
+function refreshCosmosEditorDocument() {
+    if (!cosmosEditorSelectedDocument) {
+        return;
+    }
+    openCosmosEditorDocument({
+        id: cosmosEditorSelectedDocument.id,
+        partition_key: cosmosEditorSelectedDocument.partitionKey,
+        selectable: true,
+    });
+}
+
+function parseCosmosEditorDocumentJson() {
+    const rawJson = getValue(elements.datamanagementcosmoseditordocumentjson);
+    const parsedDocument = JSON.parse(rawJson);
+    if (!parsedDocument || typeof parsedDocument !== "object" || Array.isArray(parsedDocument)) {
+        throw new Error("Cosmos DB document JSON must be an object.");
+    }
+    return parsedDocument;
+}
+
+function openCosmosEditorSaveModal() {
+    if (!cosmosEditorSelectedDocument) {
+        return;
+    }
+    let parsedDocument;
+    try {
+        parsedDocument = parseCosmosEditorDocumentJson();
+    } catch (error) {
+        showToast(error.message || "Document JSON is invalid.", "danger");
+        return;
+    }
+
+    cosmosEditorPendingDocument = parsedDocument;
+    const summary = summarizeCosmosEditorChanges(cosmosEditorSelectedDocument.originalDocument, parsedDocument);
+    renderCosmosEditorSaveSummary(summary);
+    setText(
+        elements.dataManagementCosmosEditorSaveSubtitle,
+        `Container: ${cosmosEditorSelectedDocument.container}; id: ${cosmosEditorSelectedDocument.id}`
+    );
+    setValue(elements.datamanagementcosmoseditorconfirmationphrase, "");
+    updateCosmosEditorConfirmSaveState();
+    if (elements.dataManagementCosmosEditorSaveModal && window.bootstrap?.Modal) {
+        window.bootstrap.Modal.getOrCreateInstance(elements.dataManagementCosmosEditorSaveModal).show();
+    }
+}
+
+function summarizeCosmosEditorChanges(originalDocument, updatedDocument) {
+    const changedPaths = [];
+    let addedCount = 0;
+    let removedCount = 0;
+    let updatedCount = 0;
+
+    function compareValues(originalValue, updatedValue, path) {
+        if (isPlainObject(originalValue) && isPlainObject(updatedValue)) {
+            const keys = Array.from(new Set([...Object.keys(originalValue), ...Object.keys(updatedValue)])).sort();
+            keys.forEach((key) => {
+                if (key.startsWith("_")) {
+                    return;
+                }
+                const childPath = path ? `${path}.${key}` : key;
+                if (!Object.prototype.hasOwnProperty.call(originalValue, key)) {
+                    addedCount += 1;
+                    changedPaths.push(childPath);
+                    return;
+                }
+                if (!Object.prototype.hasOwnProperty.call(updatedValue, key)) {
+                    removedCount += 1;
+                    changedPaths.push(childPath);
+                    return;
+                }
+                compareValues(originalValue[key], updatedValue[key], childPath);
+            });
+            return;
+        }
+        if (JSON.stringify(originalValue) !== JSON.stringify(updatedValue)) {
+            updatedCount += 1;
+            changedPaths.push(path);
+        }
+    }
+
+    compareValues(originalDocument || {}, updatedDocument || {}, "");
+    return {
+        changedPaths,
+        changedCount: changedPaths.length,
+        addedCount,
+        removedCount,
+        updatedCount,
+    };
+}
+
+function isPlainObject(value) {
+    return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function renderCosmosEditorSaveSummary(summary) {
+    const container = elements.dataManagementCosmosEditorSaveSummary;
+    if (!container) {
+        return;
+    }
+    const wrapper = document.createElement("div");
+    wrapper.className = "vstack gap-2";
+    wrapper.append(
+        createDetailBlock("Changed paths", formatNumber(summary.changedCount)),
+        createDetailBlock("Added / removed / updated", `${formatNumber(summary.addedCount)} / ${formatNumber(summary.removedCount)} / ${formatNumber(summary.updatedCount)}`)
+    );
+    const paths = document.createElement("div");
+    paths.className = "small text-muted text-break";
+    paths.textContent = summary.changedPaths.length
+        ? summary.changedPaths.slice(0, 20).join(", ")
+        : "No value changes detected. Saving will still refresh the document ETag.";
+    wrapper.appendChild(paths);
+    container.replaceChildren(wrapper);
+}
+
+function updateCosmosEditorConfirmSaveState() {
+    const phraseMatches = getValue(elements.datamanagementcosmoseditorconfirmationphrase) === cosmosEditorConfirmationPhrase;
+    setButtonDisabled(elements.dataManagementCosmosEditorConfirmSaveBtn, !phraseMatches);
+}
+
+async function saveCosmosEditorDocument() {
+    if (!cosmosEditorSelectedDocument || !cosmosEditorPendingDocument) {
+        return;
+    }
+    setBusy(elements.dataManagementCosmosEditorConfirmSaveBtn, true, "Saving...");
+    try {
+        const data = await requestJson("/api/admin/data-management/cosmos-editor/document", {
+            method: "PUT",
+            body: JSON.stringify({
+                container: cosmosEditorSelectedDocument.container,
+                id: cosmosEditorSelectedDocument.id,
+                partition_key: cosmosEditorSelectedDocument.partitionKey,
+                etag: cosmosEditorSelectedDocument.etag,
+                document: cosmosEditorPendingDocument,
+                confirmation_accepted: true,
+                confirmation_phrase: cosmosEditorConfirmationPhrase,
+            }),
+        });
+        if (elements.dataManagementCosmosEditorSaveModal && window.bootstrap?.Modal) {
+            window.bootstrap.Modal.getOrCreateInstance(elements.dataManagementCosmosEditorSaveModal).hide();
+        }
+        renderCosmosEditorDocument(data);
+        setStatus("Cosmos DB document saved. The edit was recorded in Activity Logs.", "success");
+        showToast("Cosmos DB document saved.", "success");
+    } catch (error) {
+        setStatus(error.message || "Cosmos DB document could not be saved.", "danger");
+        showToast(error.message || "Cosmos DB document could not be saved.", "danger");
+    } finally {
+        setBusy(elements.dataManagementCosmosEditorConfirmSaveBtn, false);
+        updateCosmosEditorConfirmSaveState();
+    }
 }
 
 async function loadDataManagementSettings() {

--- a/application/single_app/templates/_sidebar_nav.html
+++ b/application/single_app/templates/_sidebar_nav.html
@@ -647,6 +647,11 @@
                 </a>
               </li>
               <li class="nav-item">
+                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="data-management" data-section="data-management-cosmos-editor-section">
+                  <i class="bi bi-database-exclamation me-2" style="font-size: 0.8em;"></i><span class="nav-text">Cosmos Editor</span>
+                </a>
+              </li>
+              <li class="nav-item">
                 <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="data-management" data-section="data-management-backup-inventory-section">
                   <i class="bi bi-box-seam me-2" style="font-size: 0.8em;"></i><span class="nav-text">Backup Inventory</span>
                 </a>

--- a/application/single_app/templates/admin_settings.html
+++ b/application/single_app/templates/admin_settings.html
@@ -5136,6 +5136,54 @@
                     </div>
                 </div>
 
+                <div class="card p-4 mb-4 border-danger shadow-sm" id="data-management-cosmos-editor-section" data-ignore-data-management-change="true">
+                    <div class="d-flex flex-wrap align-items-start justify-content-between gap-3 mb-3">
+                        <div>
+                            <h4 class="mb-1"><i class="bi bi-database-exclamation me-2"></i>Cosmos DB JSON Editor</h4>
+                            <p class="text-muted mb-0 small">Query SimpleChat Cosmos DB containers, inspect one document, and save JSON changes with ETag protection.</p>
+                        </div>
+                        <button type="button" class="btn btn-danger" id="data-management-cosmos-editor-open-danger-btn">
+                            <i class="bi bi-unlock me-1"></i>Unlock Editor
+                        </button>
+                    </div>
+                    <div class="alert alert-danger mb-3" role="alert">
+                        This tool can modify production Cosmos DB documents directly. Use it only for targeted admin repair or investigation after you understand the impact.
+                    </div>
+                    <div class="alert alert-warning mb-3" id="data-management-cosmos-editor-locked-message" role="status">
+                        The Cosmos DB JSON editor is locked. Acknowledge the danger prompt before querying or editing data.
+                    </div>
+                    <div class="d-none" id="data-management-cosmos-editor-workspace">
+                        <div class="row g-3">
+                            <div class="col-lg-4">
+                                <label class="form-label" for="data_management_cosmos_editor_container">Container</label>
+                                <select class="form-select" id="data_management_cosmos_editor_container">
+                                    <option value="">Loading containers...</option>
+                                </select>
+                                <div class="form-text" id="data-management-cosmos-editor-container-help">Choose a known SimpleChat Cosmos DB container.</div>
+                            </div>
+                            <div class="col-lg-2">
+                                <label class="form-label" for="data_management_cosmos_editor_page_size">Page size</label>
+                                <input class="form-control" type="number" id="data_management_cosmos_editor_page_size" min="1" max="100" value="100">
+                                <div class="form-text">Max 100 per request.</div>
+                            </div>
+                            <div class="col-lg-6">
+                                <label class="form-label" for="data_management_cosmos_editor_query">SELECT query</label>
+                                <textarea class="form-control font-monospace" id="data_management_cosmos_editor_query" rows="4" placeholder="Leave empty to browse the first 100 documents. Custom queries must start with SELECT."></textarea>
+                                <div class="form-text">Empty query returns only the first 100 documents. Custom SELECT queries can page beyond 100 with Next Page.</div>
+                            </div>
+                        </div>
+                        <div class="d-flex flex-wrap align-items-center gap-2 mt-3">
+                            <button type="button" class="btn btn-primary" id="data-management-cosmos-editor-run-query-btn">
+                                <i class="bi bi-search me-1"></i>Run Query
+                            </button>
+                            <span class="small text-muted" id="data-management-cosmos-editor-query-status">No query has run yet.</span>
+                        </div>
+                        <div class="form-text mt-2">
+                            Query results and the JSON editor open in a modal so the Data Management page stays compact.
+                        </div>
+                    </div>
+                </div>
+
                 <div class="card p-4 mb-4 border-primary shadow-sm" id="data-management-backup-inventory-section">
                     <div class="d-flex flex-wrap align-items-start justify-content-between gap-3 mb-3">
                         <div>
@@ -5225,6 +5273,137 @@
                                 </tr>
                             </tbody>
                         </table>
+                    </div>
+                </div>
+
+                <div class="modal fade" id="data-management-cosmos-editor-danger-modal" tabindex="-1" aria-labelledby="data-management-cosmos-editor-danger-title" aria-hidden="true">
+                    <div class="modal-dialog modal-lg">
+                        <div class="modal-content border-danger">
+                            <div class="modal-header bg-danger text-white">
+                                <div>
+                                    <h5 class="modal-title" id="data-management-cosmos-editor-danger-title">Cosmos DB JSON Editor Warning</h5>
+                                    <p class="mb-0 small text-white-50">This interface can change live application data.</p>
+                                </div>
+                                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+                            </div>
+                            <div class="modal-body">
+                                <div class="alert alert-danger" role="alert">
+                                    Incorrect edits can break authentication, workspaces, chat history, documents, automations, or activity log integrity. Use this editor only when safer admin tools cannot solve the problem.
+                                </div>
+                                <ul class="mb-3">
+                                    <li>Run targeted SELECT queries and page results instead of loading large containers at once.</li>
+                                    <li>Do not change <code>id</code> or the container partition key value.</li>
+                                    <li>Review JSON carefully before saving. Saves are audited in Activity Logs.</li>
+                                </ul>
+                                <div class="form-check">
+                                    <input class="form-check-input" type="checkbox" id="data_management_cosmos_editor_danger_accept">
+                                    <label class="form-check-label fw-semibold" for="data_management_cosmos_editor_danger_accept">
+                                        I understand this editor can damage overall system health.
+                                    </label>
+                                </div>
+                            </div>
+                            <div class="modal-footer">
+                                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                                <button type="button" class="btn btn-danger" id="data-management-cosmos-editor-accept-danger-btn" disabled aria-disabled="true">
+                                    I Understand, Unlock Editor
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="modal fade" id="data-management-cosmos-editor-results-modal" tabindex="-1" aria-labelledby="data-management-cosmos-editor-modal-title" aria-hidden="true">
+                    <div class="modal-dialog modal-xl modal-dialog-scrollable">
+                        <div class="modal-content">
+                            <div class="modal-header">
+                                <div>
+                                    <h5 class="modal-title" id="data-management-cosmos-editor-modal-title">Cosmos DB Query Results</h5>
+                                    <p class="text-muted small mb-0" id="data-management-cosmos-editor-modal-subtitle">Run a query to load document summaries.</p>
+                                    <p class="text-muted small mb-0" id="data-management-cosmos-editor-modal-status">No query has run yet.</p>
+                                </div>
+                                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                            </div>
+                            <div class="modal-body cosmos-editor-results-modal-body">
+                                <div class="row g-3">
+                                    <div class="col-lg-4">
+                                        <div class="border rounded h-100">
+                                            <div class="border-bottom px-3 py-2 bg-light">
+                                                <h6 class="mb-0">Results</h6>
+                                            </div>
+                                            <div class="list-group list-group-flush cosmos-editor-results-list" id="data-management-cosmos-editor-results-list" aria-label="Cosmos DB query results">
+                                                <div class="list-group-item text-muted">Run a query to list documents.</div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col-lg-8">
+                                        <div class="border rounded h-100">
+                                            <div class="border-bottom px-3 py-2 bg-light">
+                                                <div class="d-flex flex-wrap align-items-center justify-content-between gap-2">
+                                                    <div>
+                                                        <h6 class="mb-0">Document JSON</h6>
+                                                        <div class="small text-muted" id="data-management-cosmos-editor-document-meta">Select a result to load JSON.</div>
+                                                    </div>
+                                                    <div class="d-flex flex-wrap gap-2">
+                                                        <button type="button" class="btn btn-outline-secondary btn-sm" id="data-management-cosmos-editor-refresh-document-btn" disabled aria-disabled="true">
+                                                            <i class="bi bi-arrow-clockwise me-1"></i>Refresh Document
+                                                        </button>
+                                                        <button type="button" class="btn btn-danger btn-sm" id="data-management-cosmos-editor-save-btn" disabled aria-disabled="true">
+                                                            <i class="bi bi-save me-1"></i>Save JSON
+                                                        </button>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                            <div class="p-3">
+                                                <textarea class="form-control font-monospace" id="data_management_cosmos_editor_document_json" rows="20" spellcheck="false" disabled aria-disabled="true" placeholder="Selected document JSON appears here." style="min-height: 58vh;"></textarea>
+                                                <div class="form-text" id="data-management-cosmos-editor-document-help">The editor blocks id and partition key changes. Saves use the ETag from the loaded document.</div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="modal-footer d-flex flex-wrap justify-content-between gap-2">
+                                <div class="small text-muted">Custom SELECT queries can page beyond the first request when Cosmos returns a continuation token.</div>
+                                <div class="d-flex flex-wrap gap-2">
+                                    <button type="button" class="btn btn-outline-primary" id="data-management-cosmos-editor-next-page-btn" disabled aria-disabled="true">
+                                        <i class="bi bi-arrow-right-circle me-1"></i>Next Page
+                                    </button>
+                                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="modal fade" id="data-management-cosmos-editor-save-modal" tabindex="-1" aria-labelledby="data-management-cosmos-editor-save-title" aria-hidden="true">
+                    <div class="modal-dialog modal-lg">
+                        <div class="modal-content border-danger">
+                            <div class="modal-header">
+                                <div>
+                                    <h5 class="modal-title" id="data-management-cosmos-editor-save-title">Confirm Cosmos DB Document Save</h5>
+                                    <p class="text-muted small mb-0" id="data-management-cosmos-editor-save-subtitle">Review the change summary before saving.</p>
+                                </div>
+                                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                            </div>
+                            <div class="modal-body">
+                                <div class="alert alert-danger" role="alert">
+                                    Saving replaces the selected Cosmos DB document with the JSON currently in the editor. This action is audited and cannot be undone from this screen.
+                                </div>
+                                <div class="border rounded p-3 mb-3" id="data-management-cosmos-editor-save-summary">
+                                    No changes summarized yet.
+                                </div>
+                                <label class="form-label" for="data_management_cosmos_editor_confirmation_phrase">Type the confirmation phrase to enable saving</label>
+                                <input class="form-control" type="text" id="data_management_cosmos_editor_confirmation_phrase" autocomplete="off" aria-describedby="data-management-cosmos-editor-confirmation-help">
+                                <div class="form-text" id="data-management-cosmos-editor-confirmation-help">
+                                    Required phrase: <code>I understand this can damage system data</code>
+                                </div>
+                            </div>
+                            <div class="modal-footer">
+                                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                                <button type="button" class="btn btn-danger" id="data-management-cosmos-editor-confirm-save-btn" disabled aria-disabled="true">
+                                    Save Cosmos Document
+                                </button>
+                            </div>
+                        </div>
                     </div>
                 </div>
 

--- a/docs/explanation/features/COSMOS_DB_JSON_EDITOR.md
+++ b/docs/explanation/features/COSMOS_DB_JSON_EDITOR.md
@@ -1,0 +1,85 @@
+# Cosmos DB JSON Editor
+
+Implemented in version: **0.250.048**
+Refined in version: **0.250.049**
+Save-path fix in version: **0.250.050**
+Results scrolling refined in version: **0.250.051**
+
+## Overview and Purpose
+
+The Cosmos DB JSON Editor adds an admin-only Data Management tool for targeted SimpleChat Cosmos DB inspection and repair. It lets administrators choose a known SimpleChat container, run a paged read-only query, select a result, edit the full JSON document, and save it back after explicit danger confirmation.
+
+Related issue:
+- microsoft/simplechat#1006
+
+Related config update:
+- `application/single_app/config.py` reports version `0.250.051`.
+
+Dependencies:
+- `application/single_app/functions_data_management.py`
+- `application/single_app/route_backend_data_management.py`
+- `application/single_app/templates/_sidebar_nav.html`
+- `application/single_app/templates/admin_settings.html`
+- `application/single_app/static/js/admin/admin_data_management.js`
+
+## Technical Specifications
+
+Architecture overview:
+- The UI lives in the existing Admin Settings > Data Management tab.
+- The container dropdown is populated from a backend allowlist of SimpleChat Cosmos containers and partition key metadata.
+- Empty queries run as `SELECT * FROM c`, respect the selected page size up to the 100-document cap, and do not expose continuation paging.
+- Custom queries must start with `SELECT`, are capped to 100 results per request, and use Cosmos continuation tokens for Next Page.
+- Query results return lightweight summaries in a modal with an independently scrollable results pane. Selecting a result loads the full document by `id` and partition key in the modal editor pane.
+- Saves require the loaded ETag and use `MatchConditions.IfNotModified` to prevent overwriting a document that changed after it was opened.
+- Saves replace the loaded document through the SDK-supported item/link target and do not pass unsupported transport kwargs to `replace_item`.
+- The backend rejects attempts to change `id` or the selected container partition key value.
+- Cosmos editor actions are recorded as Data Management activity records, including query execution, document open, save success, rejected attempts, and failures.
+
+Security controls:
+- Every editor endpoint is under `/api/admin/data-management/cosmos-editor/...`.
+- Routes require `@swagger_route(security=get_auth_security())`, `@login_required`, and `@admin_required`.
+- The browser interface is locked behind a Bootstrap danger modal for each page session.
+- Saves require a second Bootstrap confirmation modal and the phrase `I understand this can damage system data`.
+- Activity logs store metadata and changed paths, not full document bodies.
+- The frontend uses safe DOM APIs and `textContent`; no unsafe HTML injection sinks are used.
+
+## Usage Instructions
+
+How to use:
+1. Open Admin Settings.
+2. Select Data Management.
+3. In Cosmos DB JSON Editor, select Unlock Editor.
+4. Read and accept the danger prompt.
+5. Choose a container.
+6. Leave the query empty to browse up to the selected page size, capped at 100 documents, or enter a targeted `SELECT` query.
+7. Run the query to open the results modal.
+8. Select a result to load the full JSON document.
+9. Edit the JSON.
+10. Select Save JSON, review the change summary, type the confirmation phrase, and save.
+
+Paging behavior:
+- Empty browse mode intentionally stops after one page and uses the selected page size up to 100 documents.
+- Custom SELECT mode returns up to 100 documents per page and enables Next Page when Cosmos returns a continuation token.
+
+## Testing and Validation
+
+Functional coverage:
+- `functional_tests/test_data_management_security_patterns.py`
+
+UI coverage:
+- `ui_tests/test_admin_data_management_settings_ui.py`
+
+Validation focus:
+- admin-only route protection
+- SELECT-only query validation
+- page-size cap and continuation-token workflow
+- danger gate and save confirmation workflow
+- immutable `id` and partition key enforcement
+- ETag-based optimistic concurrency
+- Activity Log audit coverage for editor operations
+
+## Known Limitations
+
+- This tool edits one document at a time and intentionally does not support bulk updates.
+- Query parameters are not yet exposed in the UI; administrators should write complete targeted SELECT statements.
+- The editor is intended for expert administrative repair and investigation, not routine content management.

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,41 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](/explanation/features/) and [Fixes by Version](/explanation/fixes/).
 
+### **(v0.250.051)**
+
+#### User Interface Enhancements
+
+*   **Cosmos Editor Independent Results Scrolling**
+    *   Cosmos editor query results now use a dedicated scroll area inside the results modal, so long result lists do not stretch the rest of the modal.
+    *   Added a smaller results-list cap for narrower screens while keeping the document editor and modal footer accessible.
+    *   (Ref: microsoft/simplechat#1006, `admin_settings.html`, `styles.css`, Cosmos DB JSON Editor)
+
+### **(v0.250.049)**
+
+#### Bug Fixes
+
+*   **Cosmos Editor Page Size Enforcement**
+    *   Empty Cosmos editor browse mode now respects the selected page size up to the 100-document cap instead of always requesting 100 items.
+    *   This keeps small page-size selections useful for compact validation and targeted inspection.
+    *   (Ref: microsoft/simplechat#1006, Cosmos DB JSON Editor, `functions_data_management.py`)
+
+#### User Interface Enhancements
+
+*   **Cosmos Editor Results Modal**
+    *   Moved Cosmos editor query results and the JSON document editor into a large scrollable modal opened by Run Query.
+    *   Kept the Data Management card focused on unlock, container selection, page size, and query setup while the modal provides compact result rows, a scrollable results pane, document refresh, Next Page, and Save JSON controls.
+    *   (Ref: microsoft/simplechat#1006, `admin_settings.html`, `admin_data_management.js`, `COSMOS_DB_JSON_EDITOR.md`)
+
+### **(v0.250.048)**
+
+#### New Features
+
+*   **Admin Cosmos DB JSON Editor**
+    *   Added an admin-only Data Management tool for selecting SimpleChat Cosmos DB containers, running paged SELECT queries, opening individual documents, editing JSON, and saving changes with ETag concurrency protection.
+    *   Empty browse mode is capped at the first 100 documents, while custom SELECT queries page beyond 100 through continuation tokens without returning oversized result sets in one request.
+    *   The interface is protected by danger acknowledgements, blocks `id` and partition key edits, and records editor actions plus save summaries in Activity Logs.
+    *   (Ref: microsoft/simplechat#1006, `COSMOS_DB_JSON_EDITOR.md`, `functions_data_management.py`, `route_backend_data_management.py`, `admin_settings.html`, `admin_data_management.js`)
+
 ### **(v0.250.047)**
 
 #### Bug Fixes

--- a/functional_tests/test_data_management_security_patterns.py
+++ b/functional_tests/test_data_management_security_patterns.py
@@ -2,14 +2,21 @@
 # test_data_management_security_patterns.py
 """
 Functional test for Data Management security patterns.
-Version: 0.241.231
+Version: 0.250.051
 Implemented in: 0.241.211
-Updated in: 0.241.231
+Updated in: 0.250.051
 
 This test ensures Data Management admin routes require authenticated admin
 access, secrets stay redacted in frontend responses, and the admin browser
 controller avoids XSS-prone rendering sinks. It also verifies the migration
-target database name is fixed to SimpleChat.
+target database name is fixed to SimpleChat and the Cosmos DB JSON editor
+uses SELECT-only, paged, ETag-protected writes with Activity Log audit records.
+Version 0.250.049 adds selected page-size enforcement for empty browse mode
+and moves results/editing into a scrollable modal.
+Version 0.250.050 verifies Cosmos editor saves do not pass unsupported
+partition_key kwargs into the Python Cosmos SDK replace_item call.
+Version 0.250.051 keeps version coverage aligned with the Cosmos editor
+results-pane scroll refinement.
 """
 
 import ast
@@ -59,7 +66,7 @@ def test_version_and_container_registration():
     """Validate the Data Management version and Cosmos job container registrations."""
     config_source = read_text(CONFIG_FILE)
 
-    assert 'VERSION = "0.241.231"' in config_source
+    assert 'VERSION = "0.250.051"' in config_source
     assert 'cosmos_data_management_jobs_container_name = "data_management_jobs"' in config_source
     assert 'partition_key=PartitionKey(path="/id")' in config_source
     assert 'cosmos_data_management_job_items_container_name = "data_management_job_items"' in config_source
@@ -69,7 +76,7 @@ def test_version_and_container_registration():
 def test_admin_routes_require_login_admin_and_swagger_security():
     """Validate every Data Management route has the required admin security stack."""
     routes = route_functions_with_decorators()
-    assert len(routes) == 13
+    assert len(routes) == 18
 
     for function_name, decorators in routes:
         assert "swagger_route" in decorators, f"{function_name} missing swagger_route"
@@ -87,6 +94,11 @@ def test_admin_routes_require_login_admin_and_swagger_security():
     assert '/api/admin/data-management/target/cosmos/test' in source
     assert '/api/admin/data-management/target/search/test' in source
     assert '/api/admin/data-management/target/enhanced-citation-storage/test' in source
+    assert '/api/admin/data-management/cosmos-editor/containers' in source
+    assert '/api/admin/data-management/cosmos-editor/danger-acknowledgement' in source
+    assert '/api/admin/data-management/cosmos-editor/query' in source
+    assert '/api/admin/data-management/cosmos-editor/document' in source
+    assert 'save_data_management_cosmos_editor_document(' in source
     assert 'current_app._get_current_object()' in source
 
 
@@ -135,6 +147,57 @@ def test_settings_secrets_are_redacted_for_frontend():
     assert 'summarize_backup_artifacts(artifacts)' in source
     assert 'sanitized[field_name] = DATA_MANAGEMENT_REDACTED_VALUE' in source
     assert 'if payload.get(secret_field) == DATA_MANAGEMENT_REDACTED_VALUE:' in source
+
+
+def test_cosmos_editor_backend_safety_contract():
+    """Validate the Cosmos DB JSON editor backend uses read paging, guarded saves, and audit logs."""
+    source = read_text(FUNCTIONS_FILE)
+    route_source = read_text(ROUTE_FILE)
+
+    for marker in [
+        'DATA_MANAGEMENT_COSMOS_EDITOR_EMPTY_QUERY = "SELECT * FROM c"',
+        'DATA_MANAGEMENT_COSMOS_EDITOR_EMPTY_QUERY_LIMIT = 100',
+        'DATA_MANAGEMENT_COSMOS_EDITOR_MAX_PAGE_SIZE = 100',
+        'DATA_MANAGEMENT_COSMOS_EDITOR_CONFIRMATION_PHRASE = "I understand this can damage system data"',
+        'DATA_MANAGEMENT_COSMOS_EDITOR_CONTAINER_DEFINITIONS',
+        'def get_data_management_cosmos_editor_containers',
+        'def query_data_management_cosmos_editor_documents',
+        'def get_data_management_cosmos_editor_document',
+        'def save_data_management_cosmos_editor_document',
+        'def log_data_management_cosmos_editor_activity',
+        'if not re.match(r"^\\s*SELECT\\b", query, re.IGNORECASE):',
+        'safe_page_size = _safe_int(',
+        'safe_continuation_token = None if is_empty_query else _safe_text(continuation_token) or None',
+        'page_iterator = query_iterable.by_page(continuation_token=safe_continuation_token)',
+        '"empty_query_limit_applied": is_empty_query',
+        '"selectable": document_id is not None and partition_key_value is not None',
+        'Document id cannot be changed in the Cosmos DB editor.',
+        'Document partition key value cannot be changed in the Cosmos DB editor.',
+        'replace_target = safe_document_id',
+        'if isinstance(original_document, dict) and original_document.get("_self"):',
+        'replace_target = original_document',
+        'item=replace_target,',
+        'match_condition=MatchConditions.IfNotModified',
+        '"cosmos_editor_document_saved"',
+        '"changed_paths": change_summary["changed_paths"]',
+        '"activity_type": "data_management"',
+    ]:
+        assert marker in source
+    replace_call = re.search(
+        r"saved_document = container\.replace_item\((?P<args>.*?)\n    \)",
+        source,
+        flags=re.DOTALL,
+    )
+    assert replace_call
+    assert "partition_key=" not in replace_call.group("args")
+
+    for marker in [
+        'cosmos_editor_danger_acknowledged',
+        'cosmos_editor_query_rejected',
+        'cosmos_editor_save_rejected',
+        'Cosmos DB document changed after it was opened. Refresh before saving again.',
+    ]:
+        assert marker in route_source
 
 
 def test_admin_javascript_uses_safe_dom_patterns():
@@ -189,6 +252,15 @@ def test_admin_javascript_uses_safe_dom_patterns():
         'Stored connection string saved. You can test storage without re-entering it.',
         'backup_storage_blob_endpoint: backupStorageAuthenticationType === backupStorageAuthManagedIdentity ? getValue(elements.datamanagementblobendpoint) : "",',
         'backup_storage_connection_string: backupStorageAuthenticationType === backupStorageAuthConnectionString ? getValue(elements.datamanagementconnectionstring) : "",',
+        'loadCosmosEditorContainers',
+        'queryCosmosEditorDocuments(false)',
+        'cosmosEditorContinuationToken',
+        'showCosmosEditorResultsModal',
+        'dataManagementCosmosEditorResultsModal',
+        'openCosmosEditorSaveModal',
+        'saveCosmosEditorDocument',
+        'confirmation_phrase: cosmosEditorConfirmationPhrase',
+        'closest("[data-ignore-data-management-change',
     ]:
         assert required_snippet in source
 
@@ -229,6 +301,24 @@ def test_admin_ui_exposes_data_management_without_external_assets():
         'id="data-management-migration-workflow-section"',
         'id="data-management-migration-summary"',
         'id="data-management-execute-migration-btn"',
+        'id="data-management-cosmos-editor-section"',
+        'id="data-management-cosmos-editor-open-danger-btn"',
+        'id="data-management-cosmos-editor-locked-message"',
+        'id="data-management-cosmos-editor-workspace"',
+        'id="data_management_cosmos_editor_container"',
+        'id="data_management_cosmos_editor_query"',
+        'id="data-management-cosmos-editor-run-query-btn"',
+        'id="data-management-cosmos-editor-results-modal"',
+        'id="data-management-cosmos-editor-modal-status"',
+        'id="data-management-cosmos-editor-next-page-btn"',
+        'id="data_management_cosmos_editor_document_json"',
+        'id="data-management-cosmos-editor-danger-modal"',
+        'id="data_management_cosmos_editor_danger_accept"',
+        'id="data-management-cosmos-editor-save-modal"',
+        'id="data_management_cosmos_editor_confirmation_phrase"',
+        'Cosmos DB JSON Editor',
+        'I understand this editor can damage overall system health.',
+        'I understand this can damage system data',
         'id="data-management-advanced-scope-drawer"',
         'Advanced backup scope',
         'Modify them at your own risk',
@@ -280,6 +370,7 @@ def test_admin_ui_exposes_data_management_without_external_assets():
     assert 'cdn.jsdelivr.net' not in read_text(ADMIN_JS)
     assert 'data-tab="data-management"' in sidebar
     assert 'data-section="data-management-backup-section"' in sidebar
+    assert 'data-section="data-management-cosmos-editor-section"' in sidebar
     assert 'data-section="data-management-backup-inventory-section"' in sidebar
     assert 'data-section="data-management-migration-section"' in sidebar
 
@@ -288,6 +379,7 @@ if __name__ == "__main__":
     test_version_and_container_registration()
     test_admin_routes_require_login_admin_and_swagger_security()
     test_settings_secrets_are_redacted_for_frontend()
+    test_cosmos_editor_backend_safety_contract()
     test_admin_javascript_uses_safe_dom_patterns()
     test_admin_ui_exposes_data_management_without_external_assets()
     print("Data Management security pattern tests passed")

--- a/ui_tests/test_admin_data_management_settings_ui.py
+++ b/ui_tests/test_admin_data_management_settings_ui.py
@@ -1,13 +1,17 @@
 # test_admin_data_management_settings_ui.py
 """
 UI test for Admin Settings Data Management controls.
-Version: 0.241.221
+Version: 0.250.051
 Implemented in: 0.241.211
 Updated in: 0.241.221
+Updated in: 0.250.051
 
 This test ensures admins can discover the Data Management tab, see the
 operational-business-hours warning, and access the backup, encryption,
-migration, backup inventory, and job-history controls without unsafe frontend rendering.
+migration, Cosmos DB JSON editor, backup inventory, and job-history controls without unsafe frontend rendering.
+Version 0.250.049 moves query results and document editing into a scrollable modal.
+Version 0.250.050 keeps this coverage aligned with the Cosmos editor save-path fix.
+Version 0.250.051 verifies the Cosmos editor results list scrolls independently.
 """
 
 import os
@@ -26,6 +30,7 @@ except ModuleNotFoundError:
 REPO_ROOT = Path(__file__).resolve().parents[1]
 ADMIN_TEMPLATE = REPO_ROOT / "application" / "single_app" / "templates" / "admin_settings.html"
 ADMIN_JS = REPO_ROOT / "application" / "single_app" / "static" / "js" / "admin" / "admin_data_management.js"
+STYLES_CSS = REPO_ROOT / "application" / "single_app" / "static" / "css" / "styles.css"
 BASE_URL = os.getenv("SIMPLECHAT_UI_BASE_URL", "").rstrip("/")
 STORAGE_STATE = os.getenv("SIMPLECHAT_UI_ADMIN_STORAGE_STATE") or os.getenv("SIMPLECHAT_UI_STORAGE_STATE", "")
 
@@ -34,6 +39,7 @@ def test_admin_data_management_controls_render_from_template():
     """Validate the Data Management controls are present in the admin template."""
     template = ADMIN_TEMPLATE.read_text(encoding="utf-8")
     js_source = ADMIN_JS.read_text(encoding="utf-8")
+    css_source = STYLES_CSS.read_text(encoding="utf-8")
 
     required_ids = [
         "data-management-tab",
@@ -95,6 +101,32 @@ def test_admin_data_management_controls_render_from_template():
         "data-management-migration-summary",
         "data-management-migration-preview-btn",
         "data-management-execute-migration-btn",
+        "data-management-cosmos-editor-section",
+        "data-management-cosmos-editor-open-danger-btn",
+        "data-management-cosmos-editor-locked-message",
+        "data-management-cosmos-editor-workspace",
+        "data_management_cosmos_editor_container",
+        "data-management-cosmos-editor-container-help",
+        "data_management_cosmos_editor_page_size",
+        "data_management_cosmos_editor_query",
+        "data-management-cosmos-editor-run-query-btn",
+        "data-management-cosmos-editor-results-modal",
+        "data-management-cosmos-editor-modal-title",
+        "data-management-cosmos-editor-modal-subtitle",
+        "data-management-cosmos-editor-modal-status",
+        "data-management-cosmos-editor-next-page-btn",
+        "data-management-cosmos-editor-refresh-document-btn",
+        "data-management-cosmos-editor-results-list",
+        "data-management-cosmos-editor-document-meta",
+        "data-management-cosmos-editor-save-btn",
+        "data_management_cosmos_editor_document_json",
+        "data-management-cosmos-editor-danger-modal",
+        "data_management_cosmos_editor_danger_accept",
+        "data-management-cosmos-editor-accept-danger-btn",
+        "data-management-cosmos-editor-save-modal",
+        "data-management-cosmos-editor-save-summary",
+        "data_management_cosmos_editor_confirmation_phrase",
+        "data-management-cosmos-editor-confirm-save-btn",
         "data-management-backup-operations-section",
         "data-management-run-full-backup-btn",
         "data-management-run-partial-backup-btn",
@@ -121,6 +153,18 @@ def test_admin_data_management_controls_render_from_template():
     assert 'id="data-management-save-settings-btn" disabled aria-disabled="true"' in template
     assert '<h4 class="mb-1">Backup</h4>' in template
     assert '<h4 class="mb-1">Migration</h4>' in template
+    assert "Cosmos DB JSON Editor" in template
+    assert "Query results and the JSON editor open in a modal" in template
+    assert "modal-xl modal-dialog-scrollable" in template
+    assert "cosmos-editor-results-modal-body" in template
+    assert "cosmos-editor-results-list" in template
+    assert 'style="max-height: 62vh;"' not in template
+    assert "#data-management-cosmos-editor-results-modal .cosmos-editor-results-modal-body" in css_source
+    assert "#data-management-cosmos-editor-results-modal .cosmos-editor-results-list" in css_source
+    assert "max-height: calc(100vh - 18rem);" in css_source
+    assert "overflow-y: auto;" in css_source
+    assert "I understand this editor can damage overall system health." in template
+    assert "Required phrase: <code>I understand this can damage system data</code>" in template
     assert '<h4 class="mb-1">Backup Inventory</h4>' in template
     assert 'aria-label="Backup inventory filters"' in template
     assert '<span>Available backups</span>' in template
@@ -152,6 +196,15 @@ def test_admin_data_management_controls_render_from_template():
     assert 'buildMigrationPlan' in js_source
     assert 'queueMigration(false)' in js_source
     assert 'loadMigrationCatalog(targetType)' in js_source
+    assert 'loadCosmosEditorContainers' in js_source
+    assert 'queryCosmosEditorDocuments(false)' in js_source
+    assert 'cosmosEditorContinuationToken' in js_source
+    assert 'showCosmosEditorResultsModal' in js_source
+    assert 'setCosmosEditorQueryStatus' in js_source
+    assert 'openCosmosEditorSaveModal' in js_source
+    assert 'confirmation_phrase: cosmosEditorConfirmationPhrase' in js_source
+    assert 'The edit was recorded in Activity Logs.' in js_source
+    assert 'closest("[data-ignore-data-management-change' in js_source
     assert 'testTargetCosmos' in js_source
     assert 'testTargetSearch' in js_source
     assert 'testTargetEnhancedCitationStorage' in js_source
@@ -214,6 +267,12 @@ def test_admin_data_management_tab_browser_workflow():
         expect(page.locator("#data-management-test-target-search-btn")).to_be_visible()
         expect(page.locator("#data-management-migration-workflow-section")).to_be_visible()
         expect(page.locator("#data-management-execute-migration-btn")).to_be_visible()
+        expect(page.locator("#data-management-cosmos-editor-section")).to_be_visible()
+        expect(page.locator("#data-management-cosmos-editor-locked-message")).to_be_visible()
+        expect(page.locator("#data-management-cosmos-editor-workspace")).to_have_class(re.compile(r"\bd-none\b"))
+        expect(page.locator("#data-management-cosmos-editor-danger-modal")).to_be_attached()
+        expect(page.locator("#data-management-cosmos-editor-results-modal")).to_be_attached()
+        expect(page.locator("#data-management-cosmos-editor-save-modal")).to_be_attached()
         expect(page.locator("#data-management-save-settings-btn")).to_be_visible()
         expect(page.locator("#data-management-save-settings-btn")).to_be_disabled()
         expect(page.locator("#data-management-save-settings-btn")).to_contain_text("Saved")


### PR DESCRIPTION
## Summary

- Adds an admin-only Cosmos DB JSON document query and editor under Admin Settings > Data Management.
- Supports querying configured Cosmos containers, viewing JSON documents, editing allowed documents, and saving updates through backend validation.
- Adds UI affordances and styling for the JSON editor experience in the Data Management area.
- Adds security-pattern coverage for data management routes and UI coverage for the admin Data Management settings screen.

Fixes #1006

## Validation

- `git diff --check`
- Python compile check for changed Python files
- `node --check application/single_app/static/js/admin/admin_data_management.js`
- `python scripts/check_swagger_routes.py ...`
- XSS changed-line check: passed for 6 files
- Broken access control changed-line check: passed for 3 files
- Route policy coverage tests:
  - `functional_tests/route_tests/test_route_blueprint_policy_inventory.py`
  - `functional_tests/route_tests/test_route_unauthenticated_policy_contract.py`
  - `functional_tests/route_tests/test_route_policy_test_coverage.py`
- `python functional_tests/test_data_management_security_patterns.py`
- `python -m pytest -rs ui_tests/test_admin_data_management_settings_ui.py`

## Test Notes

- `ui_tests/test_admin_data_management_settings_ui.py`: 1 passed, 1 skipped.
- Skipped test reason: `Set SIMPLECHAT_UI_BASE_URL to run this UI test.`

## Documentation and Release Notes

- Added `docs/explanation/features/COSMOS_DB_JSON_EDITOR.md`.
- Updated `docs/explanation/release_notes.md` under version `0.250.051`.
- `application/single_app/config.py` version is `0.250.051`.

## Security Notes

- No sensitive filename hits for `.env`, secrets, tokens, sessions, keys, connection strings, or local settings artifacts.
- XSS guardrail passed.
- Broken access control guardrail passed.
- Route decorator and route policy coverage passed.