### PR TITLE
Add Phase 1 chat orchestration foundation

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -96,7 +96,7 @@ load_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.250.057"
+VERSION = "0.250.058"
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')
 SESSION_COOKIE_HTTPONLY = os.getenv('SESSION_COOKIE_HTTPONLY', 'true').lower() != 'false'

--- a/application/single_app/functions_chat_orchestration.py
+++ b/application/single_app/functions_chat_orchestration.py
@@ -1,0 +1,478 @@
+# functions_chat_orchestration.py
+"""Deterministic Phase 1 planning helpers for coordinated chat turns."""
+
+import re
+import uuid
+from collections.abc import Mapping
+
+
+ORCHESTRATION_PLAN_VERSION = 1
+ORCHESTRATION_GUIDANCE_MARKER = '[Turn Orchestration Guidance]'
+
+IMAGE_CREATION_PATTERNS = (
+    re.compile(
+        r'\b(?:create|generate|make|design|draw|render|illustrate|produce|build)\b'
+        r'[^.!?\n]{0,100}\b(?:image|picture|illustration|graphic|infographic|sketch|poster|visual|'
+        r'logo|diagram|timeline|map|storyboard|concept\s+art)\b',
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r'\b(?:image|picture|illustration|graphic|infographic|sketch|poster|visual|logo|diagram|timeline|'
+        r'map|storyboard|concept\s+art)\b'
+        r'[^.!?\n]{0,100}\b(?:create|generate|make|design|draw|render|produce|build)\b',
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r'\bturn\b[^.!?\n]{0,80}\binto\b[^.!?\n]{0,40}'
+        r'\b(?:an?\s+)?(?:image|picture|illustration|graphic|infographic|sketch|poster|visual)\b',
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r'\b(?:draw|sketch|illustrate)\s+(?:an?|the|this|that|my|our)\s+'
+        r'(?!\b(?:chart|conclusion|attention|comparison|difference|distinction|graph|implications?|'
+        r'inferences?|insights?|lessons?|plot|table)\b)',
+        re.IGNORECASE,
+    ),
+    re.compile(r'\bvisuali[sz]e\b[^.!?\n]{0,100}\b(?:as|with|showing|depicting)\b', re.IGNORECASE),
+)
+
+GROUNDING_REQUEST_PATTERN = re.compile(
+    r'\bground(?:ed|ing)?\s+(?:this|it|the\s+\w+)?\s*(?:in|on)\b',
+    re.IGNORECASE,
+)
+
+EVIDENCE_SOURCE_PATTERNS = (
+    (
+        'enterprise_data',
+        re.compile(
+            r'\b(?:microsoft\s*365|m365|microsoft\s+graph|graph\s+profile|'
+            r'(?:use|using|query|from)\s+(?:microsoft\s+)?graph|'
+            r'(?:my|our)\s+(?:calendar|email|mail|profile|role|collaborators?|'
+            r'work\s+life|work\s+history|values|priorities|responsibilities|organization))\b',
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        'structured_data',
+        re.compile(
+            r'\b(?:sql|database|data\s+warehouse|warehouse\s+data|lakehouse|'
+            r'databricks|snowflake)\b',
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        'business_system',
+        re.compile(r'\b(?:crm|salesforce|service\s*now|dynamics\s*365|workday)\b', re.IGNORECASE),
+    ),
+    (
+        'public_web',
+        re.compile(
+            r'\b(?:linkedin|public\s+profile|public\s+web|web\s+search|search\s+the\s+web|'
+            r'online\s+sources?|publicly\s+available)\b',
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        'workspace_search',
+        re.compile(
+            r'\b(?:(?:my|our|the)\s+workspace|workspace\s+(?:documents?|files?|knowledge)|'
+            r'selected\s+(?:documents?|files?)|uploaded\s+(?:documents?|files?))\b',
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        'conversation_evidence',
+        re.compile(
+            r'\b(?:earlier\s+(?:messages?|sources?|citations?)|previous\s+(?:messages?|sources?|citations?)|'
+            r'conversation\s+history|prior\s+(?:messages?|sources?|citations?)|cited\s+documents?)\b'
+            r'|\b(?:information|context|messages?|sources?|citations?)\s+above\b',
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        'selected_images',
+        re.compile(
+            r'\b(?:(?:selected|attached|uploaded|reference)\s+(?:image|photo|picture|headshot)|'
+            r'(?:this|the)\s+(?:image|photo|picture|headshot)\s+as\s+(?:an?\s+)?reference)\b',
+            re.IGNORECASE,
+        ),
+    ),
+)
+
+EVIDENCE_SOURCE_SATISFIERS = {
+    'public_web': {
+        'web_search',
+        'url_access',
+        'source_review',
+        'deep_research',
+    },
+    'workspace_search': {
+        'selected_documents',
+        'workspace_search',
+        'user_workspace_context',
+        'conversation_documents',
+    },
+}
+
+
+def _coerce_bool(value):
+    if isinstance(value, str):
+        return value.strip().lower() == 'true'
+    return bool(value)
+
+
+def _normalize_ids(values):
+    if values is None:
+        return []
+    if isinstance(values, str):
+        values = [values]
+
+    normalized = []
+    for value in values:
+        identifier = str(value or '').strip()
+        if identifier and identifier not in normalized:
+            normalized.append(identifier)
+    return normalized
+
+
+def _nonnegative_int(value):
+    try:
+        return max(0, int(value or 0))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _selected_agent_identifier(selected_agent):
+    if isinstance(selected_agent, Mapping):
+        return str(
+            selected_agent.get('id')
+            or selected_agent.get('agent_id')
+            or selected_agent.get('name')
+            or ''
+        ).strip()
+    return str(selected_agent or '').strip()
+
+
+def _selected_action_type(selected_action):
+    if isinstance(selected_action, Mapping):
+        return str(selected_action.get('type') or selected_action.get('action_type') or '').strip().lower()
+    return str(selected_action or '').strip().lower()
+
+
+def _selected_prompt_identifier(prompt_info):
+    if not isinstance(prompt_info, Mapping):
+        return ''
+    return str(
+        prompt_info.get('id')
+        or prompt_info.get('prompt_id')
+        or prompt_info.get('name')
+        or prompt_info.get('title')
+        or ''
+    ).strip()
+
+
+def user_requested_image_generation(user_message):
+    """Return whether the message asks to create an image-like output."""
+    normalized_message = str(user_message or '').strip()
+    if not normalized_message:
+        return False
+    return any(pattern.search(normalized_message) for pattern in IMAGE_CREATION_PATTERNS)
+
+
+def detect_requested_evidence_sources(user_message):
+    """Return source-neutral evidence hints explicitly present in the message."""
+    normalized_message = str(user_message or '').strip()
+    requested_sources = []
+    for source_type, pattern in EVIDENCE_SOURCE_PATTERNS:
+        if pattern.search(normalized_message):
+            requested_sources.append(source_type)
+    return requested_sources
+
+
+def _build_source(source_type, origin, metadata=None):
+    return {
+        'id': source_type,
+        'origin': origin,
+        'required': True,
+        'status': 'planned',
+        'metadata': dict(metadata or {}),
+    }
+
+
+def _build_collection_step(source):
+    if source['id'] == 'selected_action':
+        step_type = 'execute'
+    elif source['id'] == 'evidence_discovery':
+        step_type = 'plan'
+    else:
+        step_type = 'collect'
+    return {
+        'id': f"{step_type}_{source['id']}",
+        'type': step_type,
+        'capability': source['id'],
+        'origin': source['origin'],
+        'required': source['required'],
+        'status': 'pending',
+        'depends_on': [],
+    }
+
+
+def _source_requirement_is_already_covered(source_type, source_types):
+    if source_type in source_types:
+        return True
+    return bool(EVIDENCE_SOURCE_SATISFIERS.get(source_type, set()).intersection(source_types))
+
+
+def build_turn_orchestration_plan(
+    user_message,
+    *,
+    run_id=None,
+    conversation_id=None,
+    selected_agent=None,
+    selected_action=None,
+    selected_document_ids=None,
+    conversation_document_ids=None,
+    assigned_knowledge_enabled=False,
+    document_scope=None,
+    active_group_ids=None,
+    active_public_workspace_ids=None,
+    tags=None,
+    hybrid_search_enabled=False,
+    web_search_enabled=False,
+    url_access_enabled=False,
+    source_review_enabled=False,
+    deep_research_enabled=False,
+    user_workspace_context_enabled=False,
+    selected_image_reference_count=0,
+    prior_citation_count=0,
+    image_generation_available=False,
+    model_deployment=None,
+    model_id=None,
+    model_endpoint_id=None,
+    model_provider=None,
+    reasoning_effort=None,
+    prompt_info=None,
+):
+    """Build a JSON-serializable, immutable-by-convention plan snapshot for one turn."""
+    selected_document_ids = _normalize_ids(selected_document_ids)
+    conversation_document_ids = _normalize_ids(conversation_document_ids)
+    active_group_ids = _normalize_ids(active_group_ids)
+    active_public_workspace_ids = _normalize_ids(active_public_workspace_ids)
+    selected_tags = _normalize_ids(tags)
+    selected_agent_id = _selected_agent_identifier(selected_agent)
+    selected_action_type = _selected_action_type(selected_action)
+    selected_prompt_id = _selected_prompt_identifier(prompt_info)
+    selected_image_reference_count = _nonnegative_int(selected_image_reference_count)
+    selected_sources = []
+
+    if selected_agent_id:
+        selected_sources.append(_build_source('selected_agent', 'selection', {'agent_id': selected_agent_id}))
+    if selected_action_type and selected_action_type != 'none':
+        selected_sources.append(
+            _build_source('selected_action', 'selection', {'action_type': selected_action_type})
+        )
+    if selected_document_ids:
+        selected_sources.append(
+            _build_source('selected_documents', 'selection', {'count': len(selected_document_ids)})
+        )
+    if _coerce_bool(hybrid_search_enabled):
+        selected_sources.append(_build_source('workspace_search', 'selection'))
+    if _coerce_bool(web_search_enabled):
+        selected_sources.append(_build_source('web_search', 'selection'))
+    if _coerce_bool(url_access_enabled):
+        selected_sources.append(_build_source('url_access', 'selection'))
+    if _coerce_bool(source_review_enabled) and not _coerce_bool(deep_research_enabled):
+        selected_sources.append(_build_source('source_review', 'selection'))
+    if _coerce_bool(deep_research_enabled):
+        selected_sources.append(_build_source('deep_research', 'selection'))
+    if _coerce_bool(user_workspace_context_enabled):
+        selected_sources.append(_build_source('user_workspace_context', 'selection'))
+    if selected_image_reference_count:
+        selected_sources.append(
+            _build_source(
+                'selected_images',
+                'selection',
+                {'count': selected_image_reference_count},
+            )
+        )
+
+    requested_source_types = detect_requested_evidence_sources(user_message)
+    grounding_language_detected = bool(GROUNDING_REQUEST_PATTERN.search(str(user_message or '')))
+    selected_source_types = [source['id'] for source in selected_sources]
+    requested_sources = list(selected_sources)
+    if conversation_document_ids:
+        requested_sources.append(
+            _build_source(
+                'conversation_documents',
+                'conversation',
+                {'count': len(conversation_document_ids)},
+            )
+        )
+    if _coerce_bool(assigned_knowledge_enabled):
+        requested_sources.append(_build_source('assigned_knowledge', 'agent_configuration'))
+
+    existing_source_types = [source['id'] for source in requested_sources]
+    if grounding_language_detected and not requested_source_types and not requested_sources:
+        requested_source_types.append('unspecified_grounding')
+        requested_sources.append(
+            _build_source(
+                'evidence_discovery',
+                'request',
+                {'requirement': 'unspecified_grounding'},
+            )
+        )
+        existing_source_types.append('evidence_discovery')
+    for source_type in requested_source_types:
+        if source_type == 'unspecified_grounding':
+            continue
+        if not _source_requirement_is_already_covered(source_type, existing_source_types):
+            metadata = {}
+            if source_type == 'conversation_evidence':
+                metadata['available_citation_count'] = _nonnegative_int(prior_citation_count)
+            requested_sources.append(_build_source(source_type, 'request', metadata))
+            existing_source_types.append(source_type)
+
+    image_generation_requested = user_requested_image_generation(user_message)
+    requires_evidence_before_finalization = bool(requested_sources)
+    grounded_image_generation_requested = bool(
+        image_generation_requested
+        and (requires_evidence_before_finalization or grounding_language_detected)
+    )
+
+    reason_codes = []
+    if selected_sources:
+        reason_codes.append('selected_capability')
+    if requested_source_types or grounding_language_detected:
+        reason_codes.append('evidence_requested')
+    if grounded_image_generation_requested:
+        reason_codes.append('grounded_image_generation')
+
+    collection_steps = [_build_collection_step(source) for source in requested_sources]
+    collection_step_ids = {step['capability']: step['id'] for step in collection_steps}
+    selected_action_step = next(
+        (step for step in collection_steps if step['capability'] == 'selected_action'),
+        None,
+    )
+    if selected_action_step:
+        selected_action_step['depends_on'] = [
+            collection_step_ids[source_type]
+            for source_type in (
+                'selected_agent',
+                'selected_documents',
+                'conversation_documents',
+                'assigned_knowledge',
+            )
+            if source_type in collection_step_ids
+        ]
+    finalizer_capability = (
+        'image_proposal'
+        if image_generation_requested and _coerce_bool(image_generation_available)
+        else 'response'
+    )
+    finalizer_step = {
+        'id': f'finalize_{finalizer_capability}',
+        'type': 'finalize',
+        'capability': finalizer_capability,
+        'origin': 'orchestrator',
+        'required': True,
+        'status': 'pending',
+        'depends_on': [step['id'] for step in collection_steps],
+    }
+
+    warnings = []
+    if image_generation_requested and not _coerce_bool(image_generation_available):
+        warnings.append('image_generation_unavailable')
+
+    selection_snapshot = {
+        'conversation_id': str(conversation_id or '').strip() or None,
+        'agent_id': selected_agent_id or None,
+        'action_type': selected_action_type if selected_action_type and selected_action_type != 'none' else None,
+        'selected_document_ids': selected_document_ids,
+        'document_scope': str(document_scope or '').strip() or None,
+        'active_group_ids': active_group_ids,
+        'active_public_workspace_ids': active_public_workspace_ids,
+        'tags': selected_tags,
+        'conversation_document_ids': conversation_document_ids,
+        'toggles': {
+            'workspace_search': _coerce_bool(hybrid_search_enabled),
+            'web_search': _coerce_bool(web_search_enabled),
+            'url_access': _coerce_bool(url_access_enabled),
+            'source_review': _coerce_bool(source_review_enabled),
+            'deep_research': _coerce_bool(deep_research_enabled),
+            'user_workspace_context': _coerce_bool(user_workspace_context_enabled),
+        },
+        'selected_image_reference_count': selected_image_reference_count,
+        'model': {
+            'deployment': str(model_deployment or '').strip() or None,
+            'model_id': str(model_id or '').strip() or None,
+            'endpoint_id': str(model_endpoint_id or '').strip() or None,
+            'provider': str(model_provider or '').strip() or None,
+            'reasoning_effort': str(reasoning_effort or '').strip() or None,
+        },
+        'prompt_id': selected_prompt_id or None,
+    }
+
+    return {
+        'version': ORCHESTRATION_PLAN_VERSION,
+        'run_id': str(run_id or uuid.uuid4()),
+        'selection_snapshot': selection_snapshot,
+        'mode': 'coordinated' if collection_steps else 'direct',
+        'task_type': 'image_generation' if image_generation_requested else 'answer',
+        'task_profile': (
+            'grounded_image_generation'
+            if grounded_image_generation_requested
+            else 'image_generation'
+            if image_generation_requested
+            else 'grounded_answer'
+            if collection_steps
+            else 'direct_answer'
+        ),
+        'image_generation_requested': image_generation_requested,
+        'grounded_image_generation_requested': grounded_image_generation_requested,
+        'requires_evidence_before_finalization': requires_evidence_before_finalization,
+        'reason_codes': reason_codes,
+        'selected_capabilities': selected_source_types,
+        'evidence_requirements': requested_source_types,
+        'requested_evidence_sources': [source['id'] for source in requested_sources],
+        'sources': requested_sources,
+        'steps': [*collection_steps, finalizer_step],
+        'finalizer': finalizer_capability,
+        'policy': {
+            'selected_capabilities_are_required': True,
+            'allow_governed_read_only_discovery': True,
+            'allow_bounded_replanning': True,
+            'central_finalizer_required': True,
+            'approval_required_for': [
+                'side_effect',
+                'sensitive_access',
+                'budget_overflow',
+            ],
+        },
+        'warnings': warnings,
+    }
+
+
+def build_turn_orchestration_guidance_message(plan):
+    """Build finalizer guidance for a coordinated plan."""
+    if not isinstance(plan, Mapping) or plan.get('mode') != 'coordinated':
+        return ''
+
+    source_labels = ', '.join(str(source) for source in plan.get('requested_evidence_sources') or [])
+    requirement_labels = ', '.join(str(requirement) for requirement in plan.get('evidence_requirements') or [])
+    guidance = [
+        ORCHESTRATION_GUIDANCE_MARKER,
+        f'Required source attempts for this turn: {source_labels or "none"}.',
+        f'Evidence requirements inferred from the request: {requirement_labels or "none beyond selected sources"}.',
+        'Use the results from every attempted source when producing the final response.',
+        'Do not silently ignore a selected source. If a source was skipped, unavailable, unauthorized, failed, or returned no evidence, state that clearly.',
+        'Use only supported facts, preserve material source conflicts, and identify partial results instead of filling evidence gaps with assumptions.',
+    ]
+
+    if plan.get('grounded_image_generation_requested'):
+        guidance.extend([
+            'This is a grounded image-generation task.',
+            'Do not emit a simpleimage proposal until the required evidence sources have been attempted.',
+            'Do not claim that requested evidence is unavailable until the relevant selected or available source has been attempted.',
+        ])
+
+    return '\n'.join(guidance)

--- a/application/single_app/functions_image_generation.py
+++ b/application/single_app/functions_image_generation.py
@@ -14,6 +14,7 @@ from azure.identity import DefaultAzureCredential, get_bearer_token_provider
 
 from config import AzureOpenAI, cognitive_services_scope, cosmos_messages_container
 from functions_appinsights import log_event
+from functions_chat_orchestration import user_requested_image_generation
 from functions_image_messages import build_image_message_documents, decode_image_content
 
 
@@ -58,7 +59,10 @@ def user_request_supports_image_proposals(user_message):
     if not normalized_message:
         return False
 
-    return any(marker in normalized_message for marker in IMAGE_PROPOSAL_REQUEST_MARKERS)
+    return (
+        any(marker in normalized_message for marker in IMAGE_PROPOSAL_REQUEST_MARKERS)
+        or user_requested_image_generation(normalized_message)
+    )
 
 
 def build_image_proposal_guidance_message():

--- a/application/single_app/route_backend_chats.py
+++ b/application/single_app/route_backend_chats.py
@@ -107,6 +107,10 @@ from functions_chart_operations import (
 from functions_conversation_cache import invalidate_conversation_cache_for_item
 from functions_conversation_metadata import collect_conversation_metadata, update_conversation_with_metadata
 from functions_conversation_unread import mark_conversation_unread
+from functions_chat_orchestration import (
+    build_turn_orchestration_guidance_message,
+    build_turn_orchestration_plan,
+)
 from functions_image_messages import build_image_message_documents, decode_image_content
 from functions_icon_utils import normalize_icon_payload
 from functions_image_generation import (
@@ -4940,6 +4944,18 @@ def maybe_append_chart_tool_system_message(conversation_history, user_message, s
     return insert_system_message_after_existing_system_messages(
         conversation_history,
         build_chart_tool_usage_system_message(),
+    )
+
+
+def maybe_append_turn_orchestration_system_message(conversation_history, orchestration_plan):
+    """Add coordination guidance for a planned multi-source turn."""
+    guidance = build_turn_orchestration_guidance_message(orchestration_plan)
+    if not guidance:
+        return conversation_history
+
+    return insert_system_message_after_existing_system_messages(
+        conversation_history,
+        guidance,
     )
 
 
@@ -11679,6 +11695,7 @@ def register_route_backend_chats(bp):
         selected_document_ids = data.get('selected_document_ids', [])
         if not selected_document_ids and selected_document_id:
             selected_document_ids = [selected_document_id]
+        requested_selected_document_ids = list(selected_document_ids or [])
 
         requested_action = data.get('document_action') if isinstance(data.get('document_action'), dict) else {}
         debug_print(
@@ -11699,6 +11716,14 @@ def register_route_backend_chats(bp):
                 'window_unit': 'pages',
                 'max_retries_per_window': 1,
             }
+        requested_action_document_ids = _normalize_conversation_task_document_ids(
+            requested_action.get('document_ids')
+        )
+        requested_selected_document_ids = (
+            requested_action_document_ids
+            if requested_action_document_ids
+            else requested_selected_document_ids
+        )
         request_agent_info = data.get('agent_info') if isinstance(data.get('agent_info'), dict) else {}
         canonical_request_agent = _resolve_canonical_chat_agent(user_id, settings, request_agent_info)
         assigned_knowledge_filters = (
@@ -11853,6 +11878,44 @@ def register_route_backend_chats(bp):
         conversation_id = conversation_item.get('id')
         g.conversation_id = conversation_id
 
+        assigned_knowledge_planned = bool(
+            assigned_knowledge_filters
+            and assigned_knowledge_filters.get('has_workspace_knowledge')
+        )
+        turn_orchestration_plan = build_turn_orchestration_plan(
+            user_message,
+            conversation_id=conversation_id,
+            selected_agent=request_agent_info,
+            selected_action=normalized_action,
+            selected_document_ids=requested_selected_document_ids,
+            conversation_document_ids=auto_linked_chat_upload_document_ids,
+            assigned_knowledge_enabled=assigned_knowledge_planned,
+            document_scope=document_scope,
+            active_group_ids=active_group_ids,
+            active_public_workspace_ids=active_public_workspace_ids,
+            tags=data.get('tags'),
+            user_workspace_context_enabled=data.get('user_workspace_context_enabled'),
+            image_generation_available=image_generation_is_enabled(settings),
+            model_deployment=data.get('model_deployment'),
+            model_id=data.get('model_id'),
+            model_endpoint_id=data.get('model_endpoint_id'),
+            model_provider=data.get('model_provider'),
+            reasoning_effort=data.get('reasoning_effort'),
+            prompt_info=data.get('prompt_info'),
+        )
+        log_event(
+            '[Orchestration] Document action turn plan created',
+            extra={
+                'conversation_id': conversation_id,
+                'user_id': user_id,
+                'run_id': turn_orchestration_plan.get('run_id'),
+                'mode': turn_orchestration_plan.get('mode'),
+                'task_profile': turn_orchestration_plan.get('task_profile'),
+                'action_type': normalized_action.get('type'),
+                'source_count': len(turn_orchestration_plan.get('sources') or []),
+            },
+        )
+
         previous_thread_id = _get_latest_chat_thread_id(conversation_id)
         current_thread_id = str(uuid.uuid4())
         user_message_id = f"{conversation_id}_user_{int(time.time())}_{random.randint(1000,9999)}"
@@ -11867,6 +11930,7 @@ def register_route_backend_chats(bp):
             assigned_knowledge_filters=assigned_knowledge_filters,
             streaming_enabled=callable(publish_background_event),
         )
+        user_metadata['orchestration'] = turn_orchestration_plan
         if auto_linked_chat_upload_document_ids:
             user_metadata['workspace_search']['auto_linked_chat_upload_document_ids'] = auto_linked_chat_upload_document_ids
             user_metadata['workspace_search']['auto_linked_chat_upload_document_count'] = len(auto_linked_chat_upload_document_ids)
@@ -12109,6 +12173,7 @@ def register_route_backend_chats(bp):
             'metadata': {
                 'token_usage': execution_result.get('token_usage'),
                 'user_info': response_message_context.get('user_info'),
+                'orchestration': turn_orchestration_plan,
                 'capability_usage': document_action_capability_usage,
                 'thread_info': {
                     'thread_id': response_message_context.get('thread_id'),
@@ -16300,6 +16365,16 @@ def register_route_backend_chats(bp):
                 if isinstance(user_workspace_context_requested, str):
                     user_workspace_context_requested = user_workspace_context_requested.lower() == 'true'
                 user_workspace_context_requested = bool(user_workspace_context_requested)
+                requested_selected_document_ids = list(selected_document_ids or [])
+                requested_document_scope = document_scope
+                requested_active_group_ids = list(active_group_ids or [])
+                requested_active_public_workspace_ids = list(active_public_workspace_ids or [])
+                requested_tags_filter = list(tags_filter or [])
+                requested_hybrid_search_enabled = bool(hybrid_search_enabled)
+                requested_web_search_enabled = bool(web_search_enabled)
+                requested_url_access_enabled = bool(url_access_enabled)
+                requested_source_review_enabled = bool(source_review_enabled)
+                requested_deep_research_enabled = bool(deep_research_enabled)
                 prompt_urls = extract_urls_from_text(user_message)
                 url_access_requested = bool(url_access_enabled)
                 if url_access_requested:
@@ -16675,6 +16750,54 @@ def register_route_backend_chats(bp):
                     selected_document_id = effective_selected_document_id
                     document_scope = effective_document_scope
 
+                prior_grounded_document_refs = _normalize_prior_grounded_document_refs(conversation_item)
+                assigned_knowledge_planned = bool(
+                    assigned_knowledge_filters
+                    and (
+                        assigned_knowledge_filters.get('has_workspace_knowledge')
+                        or assigned_knowledge_url_review_urls
+                        or assigned_knowledge_deep_research_urls
+                    )
+                )
+                turn_orchestration_plan = build_turn_orchestration_plan(
+                    user_message,
+                    conversation_id=conversation_id,
+                    selected_agent=request_agent_info,
+                    selected_action=data.get('document_action'),
+                    selected_document_ids=requested_selected_document_ids,
+                    conversation_document_ids=auto_linked_chat_upload_document_ids,
+                    assigned_knowledge_enabled=assigned_knowledge_planned,
+                    document_scope=requested_document_scope,
+                    active_group_ids=requested_active_group_ids,
+                    active_public_workspace_ids=requested_active_public_workspace_ids,
+                    tags=requested_tags_filter,
+                    hybrid_search_enabled=requested_hybrid_search_enabled,
+                    web_search_enabled=requested_web_search_enabled,
+                    url_access_enabled=requested_url_access_enabled,
+                    source_review_enabled=requested_source_review_enabled,
+                    deep_research_enabled=requested_deep_research_enabled,
+                    user_workspace_context_enabled=user_workspace_context_requested,
+                    prior_citation_count=len(prior_grounded_document_refs),
+                    image_generation_available=image_generation_is_enabled(settings),
+                    model_deployment=frontend_gpt_model,
+                    model_id=frontend_model_id,
+                    model_endpoint_id=frontend_model_endpoint_id,
+                    model_provider=frontend_model_provider,
+                    reasoning_effort=reasoning_effort,
+                    prompt_info=data.get('prompt_info'),
+                )
+                log_event(
+                    '[Orchestration] Turn plan created',
+                    extra={
+                        'conversation_id': conversation_id,
+                        'user_id': user_id,
+                        'run_id': turn_orchestration_plan.get('run_id'),
+                        'mode': turn_orchestration_plan.get('mode'),
+                        'task_profile': turn_orchestration_plan.get('task_profile'),
+                        'source_count': len(turn_orchestration_plan.get('sources') or []),
+                    },
+                )
+
                 # Determine chat type
                 actual_chat_type = 'personal_single_user'
                 if conversation_item.get('chat_type'):
@@ -16826,6 +16949,7 @@ def register_route_backend_chats(bp):
                 if agent_selection_metadata:
                     user_metadata['agent_selection'] = agent_selection_metadata
 
+                user_metadata['orchestration'] = turn_orchestration_plan
                 user_metadata['chat_context'] = {
                     'conversation_id': conversation_id
                 }
@@ -18191,6 +18315,10 @@ def register_route_backend_chats(bp):
                     user_message,
                     selected_agent,
                 )
+                conversation_history_for_api = maybe_append_turn_orchestration_system_message(
+                    conversation_history_for_api,
+                    turn_orchestration_plan,
+                )
                 conversation_history_for_api = maybe_append_image_proposal_system_message(
                     conversation_history_for_api,
                     user_message,
@@ -18257,6 +18385,7 @@ def register_route_backend_chats(bp):
                                     'streaming': 'Enabled',
                                 },
                                 'history_context': history_debug_info,
+                                'orchestration': turn_orchestration_plan,
                                 'capability_usage': build_streaming_capability_usage(),
                                 'source_review': compact_source_review_result_for_metadata(source_review_result),
                                 'deep_research': deep_research_result,
@@ -18305,7 +18434,10 @@ def register_route_backend_chats(bp):
                             'agent_name': agent_name_used if use_agent_streaming else None,
                             'agent_icon': agent_icon_used if use_agent_streaming else None,
                             'agent_tags': agent_tags_used if use_agent_streaming else [],
-                            'metadata': cancel_metadata,
+                            'metadata': {
+                                **cancel_metadata,
+                                'orchestration': turn_orchestration_plan,
+                            },
                             'thoughts_enabled': thought_tracker.enabled,
                         },
                     )
@@ -18839,6 +18971,7 @@ def register_route_backend_chats(bp):
                                 'streaming': 'Enabled',
                             },
                             'history_context': history_debug_info,
+                            'orchestration': turn_orchestration_plan,
                             'capability_usage': build_streaming_capability_usage(),
                             'agent_runtime': agent_runtime_metadata or None,
                             'source_review': compact_source_review_result_for_metadata(source_review_result),
@@ -19055,6 +19188,7 @@ def register_route_backend_chats(bp):
                                 'error': error_msg,
                                 'reasoning_effort': reasoning_effort,
                                 'history_context': history_debug_info,
+                                'orchestration': turn_orchestration_plan,
                                 'capability_usage': build_streaming_capability_usage(),
                                 'source_review': compact_source_review_result_for_metadata(source_review_result),
                                 'deep_research': deep_research_result,
@@ -19072,7 +19206,16 @@ def register_route_backend_chats(bp):
                         except Exception as ex:
                             pass
 
-                    yield f"data: {json.dumps({'error': error_msg, 'partial_content': accumulated_content})}\n\n"
+                    partial_error_payload = {
+                        'error': error_msg,
+                        'partial_content': accumulated_content,
+                        'metadata': {
+                            'incomplete': True,
+                            'error': error_msg,
+                            'orchestration': turn_orchestration_plan,
+                        },
+                    }
+                    yield f"data: {json.dumps(partial_error_payload)}\n\n"
 
             except Exception as e:
                 import traceback

--- a/docs/explanation/features/CHAT_TURN_ORCHESTRATION.md
+++ b/docs/explanation/features/CHAT_TURN_ORCHESTRATION.md
@@ -1,0 +1,116 @@
+# Chat Turn Orchestration Foundation
+
+Implemented in version: **0.250.058**  
+Associated issue: **[#1021](https://github.com/microsoft/simplechat/issues/1021)**
+
+## Overview
+
+Chat turn orchestration coordinates the capabilities and context available when a user submits a message. Its purpose is to turn the current request, selected chat controls, relevant conversation lineage, and governed capabilities into one direct or coordinated plan before the response is finalized.
+
+Grounded image generation is the first proving workflow. The core plan is output-neutral so later phases can reuse it for answers, reports, presentations, analyses, exports, and other agent-driven work.
+
+## Phase 1 Behavior
+
+Every supported chat turn receives a JSON-serializable plan:
+
+- A simple request receives a direct plan with one response finalizer step.
+- A request with selected capabilities or named evidence receives a coordinated plan.
+- User-selected capabilities are represented as required attempts for that submitted turn.
+- Conversation-linked documents and agent-assigned knowledge retain distinct source origins.
+- The finalizer depends on the planned collection and execution steps.
+- Coordinated turns receive guidance to use attempted sources, disclose skipped or failed sources, preserve conflicts, and avoid unsupported claims.
+- Grounded image requests receive a prompt-level gate instructing the finalizer not to emit a `simpleimage` proposal until required evidence sources have been attempted or explicitly failed.
+
+## Turn Snapshot
+
+The plan records a compact snapshot of submitted controls that downstream code treats as immutable, including:
+
+- Conversation ID.
+- Selected agent and document action.
+- Selected document IDs and document scope.
+- Authorized group and public workspace scopes.
+- Selected tags and conversation-linked task documents.
+- Workspace Search, Web Search, URL Access, Deep Research, and user-workspace-context toggles.
+- Selected image reference count when available.
+- Model deployment, endpoint, provider, and reasoning effort.
+- Selected prompt identifier without persisting the prompt payload in orchestration metadata.
+
+Stored IDs are execution references, not authorization decisions. Existing access checks remain authoritative, and later executors must revalidate access at each data boundary.
+
+## Plan Structure
+
+The initial plan contains:
+
+- `run_id`, version, mode, task type, and task profile.
+- Conventionally immutable `selection_snapshot`.
+- Selected capabilities and requested evidence sources.
+- Inferred evidence requirements, retained separately when a selected source already satisfies them.
+- Source origin, required state, and planned status.
+- Collection, execution, and finalizer steps with dependencies.
+- Policy defaults for selected inputs, governed read-only discovery, bounded replanning, central finalization, and approval-required operations.
+- Warnings such as unavailable image generation.
+
+Initial task profiles are:
+
+- `direct_answer`
+- `grounded_answer`
+- `image_generation`
+- `grounded_image_generation`
+
+## Integration
+
+Phase 1 is integrated with:
+
+- Standard streaming chat turns.
+- Analyze and Compare document-action chat turns.
+- User message metadata.
+- Successful, cancelled, and partial-error assistant message metadata on the standard streaming path.
+- Existing image proposal guidance.
+- Existing capability-usage metadata.
+
+The plan is intentionally dependency-light and rules-based so direct requests do not incur an extra planning-model call.
+
+## Security And Governance
+
+- Caller-supplied IDs are never treated as proof of authorization.
+- Existing conversation, document, group, public workspace, agent, and action authorization remains in force.
+- The plan stores compact metadata rather than raw tool payloads or source content.
+- Prompt content is not copied into orchestration metadata.
+- Selected capabilities are required attempts, but unavailable or unauthorized sources must be represented explicitly rather than bypassing access controls.
+- Side effects, sensitive access, and budget overflow are marked as approval-required policy classes for later runtime enforcement.
+
+## Dependencies
+
+- Existing chat streaming and document-action routes.
+- Existing authorized chat scope resolution.
+- Existing agent selection and assigned knowledge handling.
+- Existing workspace, web, source-review, history, citation, and artifact systems.
+- Existing image proposal finalizer guidance.
+
+## Testing And Validation
+
+Functional coverage is in `functional_tests/test_chat_turn_orchestration_plan.py` and validates:
+
+- Direct versus coordinated plans.
+- Complete submitted-control snapshots.
+- Selected agent, action, document, and search dependencies.
+- Conversation and assigned-knowledge source origins.
+- M365/Graph, SQL, CRM, workspace, public web, and prior-citation evidence detection.
+- Grounded image classification.
+- Generic image generation without false grounding.
+- Selected-image Q&A without false generation.
+- Standard streaming and document-action route wiring.
+
+## Known Limitations
+
+Phase 1 records and gates plans but does not yet provide the complete orchestration runtime.
+
+- Planned steps are not yet scheduled through a generic execution graph.
+- Arbitrary governed tools are not yet discovered automatically.
+- Capability outputs do not yet share one normalized result/evidence ledger.
+- A selected agent can still own response streaming instead of returning structured evidence to a separate central finalizer.
+- Plan status does not yet provide complete per-step execution reconciliation.
+- The legacy non-streaming compatibility path does not yet use the generic plan contract.
+- The live chat payload does not yet expose a dedicated selected-image-reference list; selected workspace images are represented as documents, and explicit headshot/reference intent can be detected from the message until a reference control is wired.
+
+These limitations are addressed by the evidence ledger, capability adapter, executor, central synthesis, and runtime phases.

--- a/docs/explanation/features/index.md
+++ b/docs/explanation/features/index.md
@@ -22,6 +22,7 @@ category: Version History
 
 - [Action Type Governance](v0.242.064/ACTION_TYPE_GOVERNANCE.md)
 - [Agents Page Customization](v0.241.229/AGENTS_PAGE_CUSTOMIZATION.md)
+- [Chat Turn Orchestration Foundation](CHAT_TURN_ORCHESTRATION.md)
 - [Microsoft Graph Send Mail Action](MSGRAPH_SEND_MAIL_ACTION.md)
 - [Snowflake Action](v0.250.006/SNOWFLAKE_ACTION.md)
 

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,16 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](/explanation/features/) and [Fixes by Version](/explanation/fixes/).
 
+### **(v0.250.058)**
+
+#### New Features
+
+*   **Chat Turn Orchestration Foundation**
+    *   Added a lightweight direct-or-coordinated plan for standard streaming and Analyze/Compare chat turns, capturing selected agents, actions, documents, retrieval modes, conversation-linked context, model choices, and evidence requirements.
+    *   Selected capabilities are represented as required attempts, equivalent source requirements share execution steps, and coordinated finalizers receive guidance to use available results, disclose missing sources, preserve conflicts, and avoid unsupported claims.
+    *   Grounded image generation is the first proving profile, with finalizer instructions to withhold image proposals until requested evidence sources have been attempted or explicitly failed; simple questions and generic image requests retain direct one-step plans.
+    *   (Ref: microsoft/simplechat#1021, `functions_chat_orchestration.py`, `route_backend_chats.py`, `CHAT_TURN_ORCHESTRATION.md`)
+
 ### **(v0.250.057)**
 
 #### Bug Fixes

--- a/functional_tests/test_chat_turn_orchestration_plan.py
+++ b/functional_tests/test_chat_turn_orchestration_plan.py
@@ -1,0 +1,403 @@
+#!/usr/bin/env python3
+# test_chat_turn_orchestration_plan.py
+"""
+Functional test for the chat turn orchestration planning foundation.
+Version: 0.250.058
+Implemented in: 0.250.058
+
+This test ensures every turn receives a direct or coordinated plan, selected
+capabilities are required attempts, and grounded image generation remains a
+task profile rather than the core orchestration abstraction.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SINGLE_APP_ROOT = REPO_ROOT / 'application' / 'single_app'
+ROUTE_BACKEND_CHATS = SINGLE_APP_ROOT / 'route_backend_chats.py'
+CONFIG_FILE = SINGLE_APP_ROOT / 'config.py'
+sys.path.insert(0, str(SINGLE_APP_ROOT))
+
+from functions_chat_orchestration import (  # noqa: E402
+    ORCHESTRATION_GUIDANCE_MARKER,
+    build_turn_orchestration_guidance_message,
+    build_turn_orchestration_plan,
+)
+
+
+def test_simple_request_uses_direct_plan():
+    plan = build_turn_orchestration_plan(
+        'Explain recursion with a short example.',
+        run_id='run-direct',
+        image_generation_available=True,
+    )
+
+    assert plan['mode'] == 'direct'
+    assert plan['task_profile'] == 'direct_answer'
+    assert plan['requires_evidence_before_finalization'] is False
+    assert plan['requested_evidence_sources'] == []
+    assert plan['steps'] == [{
+        'id': 'finalize_response',
+        'type': 'finalize',
+        'capability': 'response',
+        'origin': 'orchestrator',
+        'required': True,
+        'status': 'pending',
+        'depends_on': [],
+    }]
+    assert build_turn_orchestration_guidance_message(plan) == ''
+
+
+def test_selected_capabilities_are_required_attempts():
+    plan = build_turn_orchestration_plan(
+        'Compare the evidence and summarize it.',
+        run_id='run-selected',
+        conversation_id='conversation-1',
+        selected_agent={'id': 'agent-1', 'name': 'Research Agent'},
+        selected_action={'type': 'comparison'},
+        selected_document_ids=['doc-1', 'doc-2'],
+        document_scope='group',
+        active_group_ids=['group-1'],
+        tags=['roadmap'],
+        web_search_enabled=True,
+        model_deployment='gpt-4.1',
+        model_id='model-1',
+        model_endpoint_id='endpoint-1',
+        model_provider='azure_openai',
+        reasoning_effort='medium',
+        prompt_info={'id': 'prompt-1', 'content': 'must not be persisted in the plan'},
+    )
+
+    assert plan['mode'] == 'coordinated'
+    assert plan['task_profile'] == 'grounded_answer'
+    assert plan['selected_capabilities'] == [
+        'selected_agent',
+        'selected_action',
+        'selected_documents',
+        'web_search',
+    ]
+    assert all(source['required'] for source in plan['sources'])
+    assert all(source['origin'] == 'selection' for source in plan['sources'])
+    assert plan['steps'][-1]['depends_on'] == [
+        'collect_selected_agent',
+        'execute_selected_action',
+        'collect_selected_documents',
+        'collect_web_search',
+    ]
+    selected_action_step = next(
+        step for step in plan['steps'] if step['id'] == 'execute_selected_action'
+    )
+    assert selected_action_step['depends_on'] == [
+        'collect_selected_agent',
+        'collect_selected_documents',
+    ]
+    assert plan['policy']['central_finalizer_required'] is True
+    assert plan['selection_snapshot'] == {
+        'conversation_id': 'conversation-1',
+        'agent_id': 'agent-1',
+        'action_type': 'comparison',
+        'selected_document_ids': ['doc-1', 'doc-2'],
+        'document_scope': 'group',
+        'active_group_ids': ['group-1'],
+        'active_public_workspace_ids': [],
+        'tags': ['roadmap'],
+        'conversation_document_ids': [],
+        'toggles': {
+            'workspace_search': False,
+            'web_search': True,
+            'url_access': False,
+            'source_review': False,
+            'deep_research': False,
+            'user_workspace_context': False,
+        },
+        'selected_image_reference_count': 0,
+        'model': {
+            'deployment': 'gpt-4.1',
+            'model_id': 'model-1',
+            'endpoint_id': 'endpoint-1',
+            'provider': 'azure_openai',
+            'reasoning_effort': 'medium',
+        },
+        'prompt_id': 'prompt-1',
+    }
+    assert 'must not be persisted' not in json.dumps(plan)
+
+
+def test_grounded_image_is_a_coordinated_task_profile():
+    plan = build_turn_orchestration_plan(
+        'Create a whiteboard sketch of my work life grounded in M365 and my public LinkedIn profile.',
+        run_id='run-grounded-image',
+        selected_image_reference_count=1,
+        image_generation_available=True,
+    )
+
+    assert plan['task_type'] == 'image_generation'
+    assert plan['task_profile'] == 'grounded_image_generation'
+    assert plan['image_generation_requested'] is True
+    assert plan['grounded_image_generation_requested'] is True
+    assert plan['requires_evidence_before_finalization'] is True
+    assert plan['requested_evidence_sources'] == [
+        'selected_images',
+        'enterprise_data',
+        'public_web',
+    ]
+    assert plan['finalizer'] == 'image_proposal'
+
+    guidance = build_turn_orchestration_guidance_message(plan)
+    assert ORCHESTRATION_GUIDANCE_MARKER in guidance
+    assert 'Do not emit a simpleimage proposal until' in guidance
+    assert 'selected_images, enterprise_data, public_web' in guidance
+
+
+def test_generic_image_request_does_not_require_evidence():
+    prompts = [
+        'Create a cat picture in a watercolor style.',
+        'Draw a landscape.',
+        'Generate a logo from this text.',
+        'Create a logo based on my description.',
+    ]
+
+    for index, prompt in enumerate(prompts):
+        plan = build_turn_orchestration_plan(
+            prompt,
+            run_id=f'run-simple-image-{index}',
+            image_generation_available=True,
+        )
+
+        assert plan['mode'] == 'direct'
+        assert plan['task_profile'] == 'image_generation'
+        assert plan['grounded_image_generation_requested'] is False
+        assert plan['requested_evidence_sources'] == []
+        assert plan['finalizer'] == 'image_proposal'
+
+
+def test_selected_image_question_is_not_generation():
+    plan = build_turn_orchestration_plan(
+        'What is this image about?',
+        run_id='run-image-question',
+        selected_image_reference_count=1,
+        image_generation_available=True,
+    )
+
+    assert plan['task_type'] == 'answer'
+    assert plan['task_profile'] == 'grounded_answer'
+    assert plan['image_generation_requested'] is False
+    assert plan['grounded_image_generation_requested'] is False
+    assert plan['requested_evidence_sources'] == ['selected_images']
+
+
+def test_grounding_in_prior_messages_uses_conversation_evidence():
+    plan = build_turn_orchestration_plan(
+        'Create an infographic and ground it in the information above.',
+        run_id='run-prior-grounding',
+        prior_citation_count=2,
+        image_generation_available=True,
+    )
+
+    assert plan['mode'] == 'coordinated'
+    assert plan['task_profile'] == 'grounded_image_generation'
+    assert plan['evidence_requirements'] == ['conversation_evidence']
+    assert plan['requested_evidence_sources'] == ['conversation_evidence']
+    assert plan['sources'][0]['metadata']['available_citation_count'] == 2
+
+
+def test_unspecified_grounding_requires_evidence_discovery():
+    plan = build_turn_orchestration_plan(
+        'Create an image grounded in verified facts.',
+        run_id='run-unspecified-grounding',
+        image_generation_available=True,
+    )
+
+    assert plan['mode'] == 'coordinated'
+    assert plan['task_profile'] == 'grounded_image_generation'
+    assert plan['evidence_requirements'] == ['unspecified_grounding']
+    assert plan['requested_evidence_sources'] == ['evidence_discovery']
+    assert plan['steps'][0] == {
+        'id': 'plan_evidence_discovery',
+        'type': 'plan',
+        'capability': 'evidence_discovery',
+        'origin': 'request',
+        'required': True,
+        'status': 'pending',
+        'depends_on': [],
+    }
+    assert plan['steps'][-1]['depends_on'] == ['plan_evidence_discovery']
+
+
+def test_non_image_enterprise_request_is_still_coordinated():
+    prompts = [
+        ('Use my Microsoft 365 calendar to summarize my priorities this week.', 'enterprise_data'),
+        ('Draw insights from the SQL data.', 'structured_data'),
+        ('Draw a chart from the SQL data.', 'structured_data'),
+    ]
+
+    for index, (prompt, expected_source) in enumerate(prompts):
+        plan = build_turn_orchestration_plan(
+            prompt,
+            run_id=f'run-enterprise-answer-{index}',
+            image_generation_available=True,
+        )
+
+        assert plan['mode'] == 'coordinated'
+        assert plan['task_type'] == 'answer'
+        assert plan['task_profile'] == 'grounded_answer'
+        assert plan['requested_evidence_sources'] == [expected_source]
+        assert plan['finalizer'] == 'response'
+
+
+def test_connector_detection_is_source_neutral():
+    scenarios = [
+        ('Create an infographic using customer churn from SQL.', 'structured_data'),
+        ('Create a diagram based on our Salesforce pipeline.', 'business_system'),
+        ('Create a team visual using Graph.', 'enterprise_data'),
+        ('Create a profile image using my LinkedIn public profile.', 'public_web'),
+    ]
+
+    for index, (prompt, expected_source) in enumerate(scenarios):
+        plan = build_turn_orchestration_plan(
+            prompt,
+            run_id=f'run-connector-{index}',
+            image_generation_available=True,
+        )
+
+        assert plan['task_profile'] == 'grounded_image_generation'
+        assert expected_source in plan['requested_evidence_sources']
+
+
+def test_selected_sources_cover_equivalent_evidence_requirements():
+    web_plan = build_turn_orchestration_plan(
+        'Create a profile visual using my LinkedIn public profile.',
+        run_id='run-web-alias',
+        web_search_enabled=True,
+        image_generation_available=True,
+    )
+    assert web_plan['requested_evidence_sources'] == ['web_search']
+    assert web_plan['evidence_requirements'] == ['public_web']
+    assert [step['id'] for step in web_plan['steps']] == [
+        'collect_web_search',
+        'finalize_image_proposal',
+    ]
+
+    workspace_plan = build_turn_orchestration_plan(
+        'Summarize the selected documents.',
+        run_id='run-workspace-alias',
+        selected_document_ids=['doc-1'],
+    )
+    assert workspace_plan['requested_evidence_sources'] == ['selected_documents']
+    assert workspace_plan['evidence_requirements'] == ['workspace_search']
+
+
+def test_string_zero_image_count_does_not_create_selected_image_source():
+    plan = build_turn_orchestration_plan(
+        'What happened?',
+        run_id='run-zero-image-count',
+        selected_image_reference_count='0',
+    )
+
+    assert plan['mode'] == 'direct'
+    assert plan['selection_snapshot']['selected_image_reference_count'] == 0
+    assert 'selected_images' not in plan['requested_evidence_sources']
+
+
+def test_plan_is_json_serializable():
+    plan = build_turn_orchestration_plan(
+        'Use the previous citations and selected documents to draft a brief.',
+        run_id='run-json',
+        selected_document_ids=['doc-1'],
+        prior_citation_count=3,
+    )
+
+    serialized = json.dumps(plan)
+    assert 'conversation_evidence' in serialized
+    conversation_source = next(
+        source for source in plan['sources'] if source['id'] == 'conversation_evidence'
+    )
+    assert conversation_source['metadata']['available_citation_count'] == 3
+
+
+def test_context_sources_are_distinct_from_user_selections():
+    plan = build_turn_orchestration_plan(
+        'Draft the response from the available context.',
+        run_id='run-context',
+        selected_agent={'id': 'agent-1'},
+        conversation_document_ids=['upload-1'],
+        assigned_knowledge_enabled=True,
+    )
+
+    assert plan['selected_capabilities'] == ['selected_agent']
+    source_origins = {source['id']: source['origin'] for source in plan['sources']}
+    assert source_origins == {
+        'selected_agent': 'selection',
+        'conversation_documents': 'conversation',
+        'assigned_knowledge': 'agent_configuration',
+    }
+
+
+def test_attached_headshot_is_detected_as_requested_image_evidence():
+    plan = build_turn_orchestration_plan(
+        'Create a sketch of my role using the attached headshot as a reference.',
+        run_id='run-headshot',
+        image_generation_available=True,
+    )
+
+    assert plan['task_profile'] == 'grounded_image_generation'
+    assert plan['requested_evidence_sources'] == ['enterprise_data', 'selected_images']
+
+
+def test_streaming_chat_path_persists_and_applies_plan():
+    route_source = ROUTE_BACKEND_CHATS.read_text(encoding='utf-8')
+    config_source = CONFIG_FILE.read_text(encoding='utf-8')
+
+    assert 'VERSION = "0.250.058"' in config_source
+    assert 'turn_orchestration_plan = build_turn_orchestration_plan(' in route_source
+    assert 'requested_action_document_ids = _normalize_conversation_task_document_ids(' in route_source
+    assert 'requested_action_document_ids\n            if requested_action_document_ids' in route_source
+    assert 'requested_document_scope = document_scope' in route_source
+    assert 'document_scope=requested_document_scope,' in route_source
+    assert 'active_group_ids=requested_active_group_ids,' in route_source
+    assert 'active_public_workspace_ids=requested_active_public_workspace_ids,' in route_source
+    assert 'tags=requested_tags_filter,' in route_source
+    assert route_source.count("user_metadata['orchestration'] = turn_orchestration_plan") >= 2
+    assert "'orchestration': turn_orchestration_plan," in route_source
+    assert 'conversation_history_for_api = maybe_append_turn_orchestration_system_message(' in route_source
+    assert "'[Orchestration] Document action turn plan created'" in route_source
+    assert "partial_error_payload = {" in route_source
+
+
+if __name__ == '__main__':
+    tests = [
+        test_simple_request_uses_direct_plan,
+        test_selected_capabilities_are_required_attempts,
+        test_grounded_image_is_a_coordinated_task_profile,
+        test_generic_image_request_does_not_require_evidence,
+        test_selected_image_question_is_not_generation,
+        test_grounding_in_prior_messages_uses_conversation_evidence,
+        test_unspecified_grounding_requires_evidence_discovery,
+        test_non_image_enterprise_request_is_still_coordinated,
+        test_connector_detection_is_source_neutral,
+        test_selected_sources_cover_equivalent_evidence_requirements,
+        test_string_zero_image_count_does_not_create_selected_image_source,
+        test_plan_is_json_serializable,
+        test_context_sources_are_distinct_from_user_selections,
+        test_attached_headshot_is_detected_as_requested_image_evidence,
+        test_streaming_chat_path_persists_and_applies_plan,
+    ]
+    results = []
+
+    for test in tests:
+        print(f'\nRunning {test.__name__}...')
+        try:
+            test()
+            print('Passed')
+            results.append(True)
+        except Exception as exc:
+            print(f'Failed: {exc}')
+            results.append(False)
+
+    passed = sum(results)
+    total = len(results)
+    print(f'\nResults: {passed}/{total} tests passed')
+    sys.exit(0 if all(results) else 1)

--- a/functional_tests/test_image_proposal_pipeline.py
+++ b/functional_tests/test_image_proposal_pipeline.py
@@ -2,7 +2,7 @@
 # test_image_proposal_pipeline.py
 """
 Functional test for opt-in chat image proposal pipeline.
-Version: 0.241.138
+Version: 0.250.058
 Implemented in: 0.241.138
 
 This test ensures the reusable image proposal helpers normalize model-authored
@@ -62,6 +62,8 @@ def test_image_proposal_guidance_and_gating():
     assert image_generation_is_enabled({'enable_image_generation': True}) is True
     assert image_generation_is_enabled({'enable_image_generation': False}) is False
     assert user_request_supports_image_proposals('Create a classroom timeline slide deck') is True
+    assert user_request_supports_image_proposals('Draw a landscape') is True
+    assert user_request_supports_image_proposals('Draw insights from the SQL data') is False
     assert user_request_supports_image_proposals('What is the capital of France?') is False
 
 


### PR DESCRIPTION
## Summary

Introduces the generic Phase 1 foundation for coordinating SimpleChat capabilities per submitted chat turn. Grounded image generation is the first proving profile, while the planner and metadata contracts remain output-neutral.

This PR intentionally targets `feature/orchestration` so the phased capability can be integrated and tested without exposing an incomplete orchestration workflow in `Development`.

## Changes

- Adds deterministic direct and coordinated turn plans without an additional planning-model call for simple requests.
- Captures a compact submitted-control snapshot for selected agents, document actions, documents and scopes, retrieval modes, conversation-linked documents, assigned knowledge, model selection, reasoning effort, and prompt identity.
- Separates inferred evidence requirements from deduplicated source attempts and records source origin, required state, execution dependencies, finalizer dependencies, and policy defaults.
- Integrates orchestration metadata with standard streaming and Analyze/Compare document-action paths, including success, cancellation, and partial-error metadata.
- Adds coordinated finalizer guidance for required source attempts, partial results, conflicts, and unsupported claims.
- Aligns image proposal guidance with the orchestration image-intent detector while keeping chart and analytical requests outside image generation.
- Uses grounded image generation as the initial task profile, including evidence discovery when grounding is requested without a named source.
- Adds feature documentation, release notes, and version `0.250.058`.

## Validation

- `functional_tests/test_chat_turn_orchestration_plan.py`: 15/15 passed
- `functional_tests/test_image_proposal_pipeline.py`: 3/3 passed
- `functional_tests/test_chat_streaming_sse_metadata_fix.py`: 3/3 passed
- Route policy contracts: 12/12 passed
- Python `py_compile`: passed
- VS Code diagnostics: clean
- Scoped broken-access-control scan: passed
- `git diff --check`: clean

## Known Follow-Up Work

- Add the shared result/evidence ledger.
- Adapt history, prior citations and cited documents, workspace, web/research, agents, and actions to generic executor contracts.
- Move selected agents beneath a true central finalizer for coordinated turns.
- Add generic scheduling, per-step reconciliation, governed capability discovery, retries, bounded replanning, budgets, and durable resume.
- Add a dedicated selected-image-reference request field; selected workspace images currently arrive as documents and explicit reference intent is inferred from the message.

Refs #1021