### PR TITLE
Add Phase 2 result and evidence ledger

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -96,7 +96,7 @@ load_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.250.058"
+VERSION = "0.250.059"
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')
 SESSION_COOKIE_HTTPONLY = os.getenv('SESSION_COOKIE_HTTPONLY', 'true').lower() != 'false'

--- a/application/single_app/functions_evidence_ledger.py
+++ b/application/single_app/functions_evidence_ledger.py
@@ -1,0 +1,1060 @@
+# functions_evidence_ledger.py
+"""Output-neutral result and evidence ledger helpers for chat orchestration."""
+
+import json
+import uuid
+from collections.abc import Mapping
+from datetime import datetime, timezone
+from urllib.parse import urlsplit, urlunsplit
+
+
+EVIDENCE_LEDGER_VERSION = 1
+EVIDENCE_LEDGER_GUIDANCE_MARKER = '[Turn Evidence Ledger]'
+
+SOURCE_STATUSES = frozenset({
+    'not_requested',
+    'planned',
+    'pending',
+    'running',
+    'succeeded',
+    'partial',
+    'not_found',
+    'not_available',
+    'failed',
+    'unauthorized',
+    'skipped',
+    'cancelled',
+})
+AUTHORIZATION_STATUSES = frozenset({
+    'pending',
+    'authorized',
+    'denied',
+    'not_required',
+})
+REQUIREMENT_STATUSES = frozenset({
+    'pending',
+    'satisfied',
+    'partial',
+    'unsatisfied',
+    'not_required',
+})
+FACT_CONFIDENCE_LEVELS = frozenset({
+    'source_supported',
+    'derived_from_sources',
+    'user_provided',
+    'placeholder',
+    'unsupported',
+})
+RESULT_STATUSES = frozenset({'succeeded', 'partial', 'failed'})
+CONFLICT_STATUSES = frozenset({'unresolved', 'resolved'})
+LEDGER_STATUSES = frozenset({
+    'collecting',
+    'ready',
+    'partial',
+    'failed',
+    'completed',
+    'cancelled',
+})
+
+SENSITIVE_METADATA_KEY_PARTS = (
+    'connection',
+    'credential',
+    'endpoint',
+    'key',
+    'password',
+    'secret',
+    'token',
+)
+REQUIREMENT_SOURCE_TYPES = {
+    'public_web': (
+        'public_web',
+        'web_search',
+        'url_access',
+        'source_review',
+        'deep_research',
+    ),
+    'workspace_search': (
+        'workspace_search',
+        'selected_documents',
+        'user_workspace_context',
+        'conversation_documents',
+    ),
+    'conversation_evidence': (
+        'conversation_evidence',
+        'conversation_history',
+        'chat_upload',
+        'prior_citations',
+    ),
+    'selected_images': ('selected_images', 'selected_image'),
+    'unspecified_grounding': ('evidence_discovery',),
+}
+MODEL_LEDGER_SECTIONS = (
+    'requirements',
+    'sources',
+    'missing_or_failed',
+    'conflicts',
+    'unsupported_facts',
+    'facts',
+    'results',
+    'citations',
+    'artifacts',
+)
+COMPACTION_INSERTION_ORDER = (
+    'requirements',
+    'sources',
+    'citations',
+    'artifacts',
+    'facts',
+    'unsupported_facts',
+    'results',
+    'conflicts',
+    'missing_or_failed',
+)
+
+
+def _normalize_identifier(value, field_name):
+    identifier = str(value or '').strip()
+    if not identifier:
+        raise ValueError(f'{field_name} is required')
+    return identifier
+
+
+def _normalize_ids(values):
+    if values is None:
+        return []
+    if isinstance(values, str):
+        values = [values]
+
+    normalized = []
+    for value in values:
+        identifier = str(value or '').strip()
+        if identifier and identifier not in normalized:
+            normalized.append(identifier)
+    return normalized
+
+
+def _normalize_text(value, field_name, *, required=False, max_chars=4000):
+    normalized = str(value or '').strip()
+    if required and not normalized:
+        raise ValueError(f'{field_name} is required')
+    if len(normalized) > max_chars:
+        return f'{normalized[:max_chars - 3]}...'
+    return normalized
+
+
+def _validate_choice(value, allowed_values, field_name):
+    normalized = _normalize_identifier(value, field_name).lower()
+    if normalized not in allowed_values:
+        expected = ', '.join(sorted(allowed_values))
+        raise ValueError(f'{field_name} must be one of: {expected}')
+    return normalized
+
+
+def _sanitize_uri(value):
+    normalized = _normalize_text(value, 'uri', max_chars=2000)
+    if not normalized:
+        return ''
+    try:
+        parsed = urlsplit(normalized)
+    except ValueError:
+        return ''
+    if parsed.scheme.lower() not in {'http', 'https'}:
+        if parsed.scheme:
+            return ''
+        return urlunsplit(('', parsed.netloc, parsed.path, '', ''))
+    return urlunsplit((parsed.scheme, parsed.netloc, parsed.path, '', ''))
+
+
+def _sanitize_reference(value):
+    normalized = _normalize_text(value, 'reference', max_chars=1000)
+    if (
+        normalized.startswith(('http://', 'https://', '/', '//'))
+        or '?' in normalized
+        or '#' in normalized
+    ):
+        return _sanitize_uri(normalized)
+    return normalized
+
+
+def _looks_sensitive_string(value):
+    normalized = value.strip().lower()
+    return (
+        normalized.startswith('bearer ')
+        or 'accountkey=' in normalized
+        or 'sharedaccesssignature=' in normalized
+        or 'sig=' in normalized and ('https://' in normalized or 'http://' in normalized)
+    )
+
+
+def _sanitize_metadata_value(value, *, depth=0):
+    """Return bounded metadata, omitting binary values and nesting beyond five levels."""
+    if depth > 5 or isinstance(value, (bytes, bytearray, memoryview)):
+        return None
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+    if isinstance(value, str):
+        if _looks_sensitive_string(value):
+            return None
+        normalized = _normalize_text(value, 'metadata value', max_chars=1000)
+        if normalized.startswith(('http://', 'https://')):
+            return _sanitize_uri(normalized)
+        return normalized
+    if isinstance(value, Mapping):
+        sanitized = {}
+        for key, nested_value in value.items():
+            normalized_key = str(key or '').strip()
+            compact_key = ''.join(character for character in normalized_key.lower() if character.isalnum())
+            if not normalized_key or any(part in compact_key for part in SENSITIVE_METADATA_KEY_PARTS):
+                continue
+            safe_value = _sanitize_metadata_value(nested_value, depth=depth + 1)
+            if safe_value is not None:
+                sanitized[normalized_key] = safe_value
+        return sanitized
+    if isinstance(value, (list, tuple, set)):
+        sanitized = []
+        for item in list(value)[:50]:
+            safe_value = _sanitize_metadata_value(item, depth=depth + 1)
+            if safe_value is not None:
+                sanitized.append(safe_value)
+        return sanitized
+    return None
+
+
+def _sanitize_metadata(metadata):
+    if metadata is None:
+        return {}
+    if not isinstance(metadata, Mapping):
+        raise ValueError('metadata must be a mapping')
+    return _sanitize_metadata_value(metadata) or {}
+
+
+def _require_ledger(ledger):
+    if not isinstance(ledger, dict) or ledger.get('version') != EVIDENCE_LEDGER_VERSION:
+        raise ValueError('ledger must be a supported evidence ledger')
+    for section in MODEL_LEDGER_SECTIONS:
+        if not isinstance(ledger.get(section), list):
+            raise ValueError(f'ledger section {section} must be a list')
+
+
+def _find_entry(ledger, section, entry_id):
+    return next(
+        (entry for entry in ledger.get(section, []) if entry.get('id') == entry_id),
+        None,
+    )
+
+
+def _next_identifier(ledger, section, prefix, requested_id=None):
+    if requested_id is not None:
+        identifier = _normalize_identifier(requested_id, f'{prefix}_id')
+        if _find_entry(ledger, section, identifier):
+            raise ValueError(f'{prefix}_id already exists: {identifier}')
+        return identifier
+
+    existing_ids = {entry.get('id') for entry in ledger.get(section, [])}
+    index = len(existing_ids) + 1
+    identifier = f'{prefix}_{index}'
+    while identifier in existing_ids:
+        index += 1
+        identifier = f'{prefix}_{index}'
+    return identifier
+
+
+def _require_known_ids(ledger, section, identifiers, field_name):
+    normalized = _normalize_ids(identifiers)
+    known_ids = {entry.get('id') for entry in ledger.get(section, [])}
+    unknown_ids = [identifier for identifier in normalized if identifier not in known_ids]
+    if unknown_ids:
+        raise ValueError(f'{field_name} contains unknown ids: {", ".join(unknown_ids)}')
+    return normalized
+
+
+def _requirement_source_types(requirement_id):
+    return list(REQUIREMENT_SOURCE_TYPES.get(requirement_id, (requirement_id,)))
+
+
+def _humanize_identifier(identifier):
+    return identifier.replace('_', ' ').strip().capitalize()
+
+
+def create_evidence_ledger(
+    task_type,
+    conversation_id,
+    user_message_id,
+    requested_output,
+    *,
+    task_profile=None,
+    run_id=None,
+    created_at=None,
+    orchestration_mode='coordinated',
+    plan_version=None,
+):
+    """Create an empty JSON-serializable result and evidence ledger."""
+    if not isinstance(requested_output, Mapping):
+        raise ValueError('requested_output must be a mapping')
+
+    normalized_mode = _validate_choice(
+        orchestration_mode,
+        frozenset({'direct', 'coordinated'}),
+        'orchestration_mode',
+    )
+    ledger_status = 'collecting' if normalized_mode == 'coordinated' else 'ready'
+    return {
+        'version': EVIDENCE_LEDGER_VERSION,
+        'run_id': str(run_id or uuid.uuid4()),
+        'task_type': _normalize_identifier(task_type, 'task_type'),
+        'task_profile': _normalize_text(task_profile, 'task_profile') or None,
+        'orchestration_mode': normalized_mode,
+        'plan_version': plan_version,
+        'conversation_id': _normalize_text(conversation_id, 'conversation_id') or None,
+        'user_message_id': _normalize_text(user_message_id, 'user_message_id') or None,
+        'created_at': _normalize_text(created_at, 'created_at')
+        or datetime.now(timezone.utc).isoformat(),
+        'requested_output': _sanitize_metadata(requested_output),
+        'status': ledger_status,
+        'requirements': [],
+        'sources': [],
+        'facts': [],
+        'unsupported_facts': [],
+        'results': [],
+        'citations': [],
+        'artifacts': [],
+        'conflicts': [],
+        'missing_or_failed': [],
+    }
+
+
+def create_evidence_ledger_from_plan(
+    plan,
+    *,
+    user_message_id,
+    conversation_id=None,
+    requested_output=None,
+    created_at=None,
+):
+    """Initialize a ledger from an immutable orchestration plan."""
+    if not isinstance(plan, Mapping):
+        raise ValueError('plan must be a mapping')
+
+    selection_snapshot = plan.get('selection_snapshot')
+    if not isinstance(selection_snapshot, Mapping):
+        selection_snapshot = {}
+    effective_conversation_id = conversation_id or selection_snapshot.get('conversation_id')
+    effective_requested_output = requested_output or {
+        'type': plan.get('finalizer') or 'response',
+        'task_type': plan.get('task_type') or 'answer',
+    }
+    ledger = create_evidence_ledger(
+        plan.get('task_type') or 'answer',
+        effective_conversation_id,
+        user_message_id,
+        effective_requested_output,
+        task_profile=plan.get('task_profile'),
+        run_id=plan.get('run_id'),
+        created_at=created_at,
+        orchestration_mode=plan.get('mode') or 'direct',
+        plan_version=plan.get('version'),
+    )
+
+    for requirement_id in _normalize_ids(plan.get('evidence_requirements')):
+        add_evidence_requirement(
+            ledger,
+            _humanize_identifier(requirement_id),
+            _requirement_source_types(requirement_id),
+            requirement_id=requirement_id,
+        )
+
+    for source in plan.get('sources') or []:
+        if not isinstance(source, Mapping):
+            continue
+        source_id = _normalize_identifier(source.get('id'), 'source id')
+        source_type = str(source.get('type') or source_id).strip()
+        requirement_ids = [
+            requirement['id']
+            for requirement in ledger['requirements']
+            if source_type in requirement.get('source_types', [])
+        ]
+        add_evidence_source(
+            ledger,
+            source_type,
+            source.get('status') or 'planned',
+            source_id=source_id,
+            origin=source.get('origin'),
+            required=source.get('required', True),
+            requirement_ids=requirement_ids,
+            metadata=source.get('metadata'),
+            authorization_status='pending',
+        )
+
+    return ledger
+
+
+def add_evidence_requirement(
+    ledger,
+    description,
+    source_types,
+    *,
+    required=True,
+    requirement_id=None,
+    status='pending',
+):
+    """Add an evidence requirement and return its normalized entry."""
+    _require_ledger(ledger)
+    normalized_status = _validate_choice(status, REQUIREMENT_STATUSES, 'requirement status')
+    identifier = _next_identifier(
+        ledger,
+        'requirements',
+        'requirement',
+        requested_id=requirement_id,
+    )
+    entry = {
+        'id': identifier,
+        'description': _normalize_text(description, 'description', required=True),
+        'source_types': _normalize_ids(source_types),
+        'required': bool(required),
+        'status': normalized_status,
+    }
+    if not entry['source_types']:
+        raise ValueError('source_types must contain at least one source type')
+    ledger['requirements'].append(entry)
+    return entry
+
+
+def _reconcile_requirement_statuses(ledger):
+    terminal_unsatisfied_statuses = {
+        'not_found',
+        'not_available',
+        'failed',
+        'unauthorized',
+        'skipped',
+        'cancelled',
+        'not_requested',
+    }
+    for requirement in ledger['requirements']:
+        if requirement['status'] == 'not_required':
+            continue
+        requirement_id = requirement['id']
+        matching_sources = [
+            source
+            for source in ledger['sources']
+            if requirement_id in source.get('requirement_ids', [])
+        ]
+        matching_gaps = [
+            gap
+            for gap in ledger['missing_or_failed']
+            if requirement_id in gap.get('requirement_ids', [])
+        ]
+        source_statuses = {source.get('status') for source in matching_sources}
+        if 'succeeded' in source_statuses and not matching_gaps:
+            requirement['status'] = 'satisfied'
+        elif 'succeeded' in source_statuses or 'partial' in source_statuses:
+            requirement['status'] = 'partial'
+        elif matching_gaps and not source_statuses.intersection({'planned', 'pending', 'running'}):
+            requirement['status'] = 'unsatisfied'
+        elif source_statuses and source_statuses.issubset(terminal_unsatisfied_statuses):
+            requirement['status'] = 'unsatisfied'
+        else:
+            requirement['status'] = 'pending'
+
+
+def add_evidence_source(
+    ledger,
+    source_type,
+    status='planned',
+    *,
+    source_id=None,
+    origin=None,
+    required=None,
+    summary='',
+    requirement_ids=None,
+    citations=None,
+    artifacts=None,
+    metadata=None,
+    raw_metadata=None,
+    authorization_status=None,
+):
+    """Add or update a normalized evidence source without retaining raw payloads."""
+    _require_ledger(ledger)
+    del raw_metadata
+    normalized_type = _normalize_identifier(source_type, 'source_type')
+    normalized_status = _validate_choice(status, SOURCE_STATUSES, 'source status')
+    normalized_authorization = None
+    if authorization_status is not None:
+        normalized_authorization = _validate_choice(
+            authorization_status,
+            AUTHORIZATION_STATUSES,
+            'authorization_status',
+        )
+    normalized_requirement_ids = None
+    if requirement_ids is not None:
+        normalized_requirement_ids = _require_known_ids(
+            ledger,
+            'requirements',
+            requirement_ids,
+            'requirement_ids',
+        )
+    identifier = str(source_id or '').strip()
+    existing = _find_entry(ledger, 'sources', identifier) if identifier else None
+    if existing:
+        existing.update({
+            'type': normalized_type,
+            'origin': _normalize_text(origin, 'origin') or existing.get('origin'),
+            'required': existing.get('required', True) if required is None else bool(required),
+            'status': normalized_status,
+            'authorization_status': normalized_authorization or existing.get('authorization_status', 'pending'),
+            'summary': _normalize_text(summary, 'summary') or existing.get('summary', ''),
+            'requirement_ids': (
+                existing.get('requirement_ids', [])
+                if normalized_requirement_ids is None
+                else normalized_requirement_ids
+            ),
+            'metadata': {
+                **existing.get('metadata', {}),
+                **_sanitize_metadata(metadata),
+            },
+        })
+        entry = existing
+    else:
+        identifier = _next_identifier(
+            ledger,
+            'sources',
+            'source',
+            requested_id=source_id,
+        )
+        entry = {
+            'id': identifier,
+            'type': normalized_type,
+            'origin': _normalize_text(origin, 'origin') or None,
+            'required': True if required is None else bool(required),
+            'status': normalized_status,
+            'authorization_status': normalized_authorization or 'pending',
+            'summary': _normalize_text(summary, 'summary'),
+            'requirement_ids': normalized_requirement_ids or [],
+            'citation_ids': [],
+            'artifact_ids': [],
+            'metadata': _sanitize_metadata(metadata),
+        }
+        ledger['sources'].append(entry)
+
+    if normalized_status == 'unauthorized':
+        entry['authorization_status'] = 'denied'
+    elif normalized_status in {'succeeded', 'partial'} and entry['authorization_status'] == 'pending':
+        entry['authorization_status'] = 'authorized'
+
+    for citation in citations or []:
+        if not isinstance(citation, Mapping):
+            raise ValueError('citations must contain mappings')
+        citation_values = dict(citation)
+        citation_values.pop('source_id', None)
+        if 'citation_id' not in citation_values and 'id' in citation_values:
+            citation_values['citation_id'] = citation_values.pop('id')
+        add_citation(ledger, entry['id'], **citation_values)
+    for artifact in artifacts or []:
+        if not isinstance(artifact, Mapping):
+            raise ValueError('artifacts must contain mappings')
+        artifact_values = dict(artifact)
+        artifact_type = artifact_values.pop('artifact_type', None) or artifact_values.pop('type', None)
+        if 'artifact_id' not in artifact_values and 'id' in artifact_values:
+            artifact_values['artifact_id'] = artifact_values.pop('id')
+        artifact_values.setdefault('source_ids', [entry['id']])
+        add_artifact(ledger, artifact_type, **artifact_values)
+
+    _reconcile_requirement_statuses(ledger)
+    return entry
+
+
+def add_fact(
+    ledger,
+    text,
+    source_ids,
+    *,
+    requirement_ids=None,
+    confidence='source_supported',
+    fact_id=None,
+):
+    """Add a fact, keeping unsupported statements outside the supported fact list."""
+    _require_ledger(ledger)
+    normalized_confidence = _validate_choice(
+        confidence,
+        FACT_CONFIDENCE_LEVELS,
+        'confidence',
+    )
+    normalized_source_ids = _require_known_ids(
+        ledger,
+        'sources',
+        source_ids,
+        'source_ids',
+    )
+    normalized_requirement_ids = _require_known_ids(
+        ledger,
+        'requirements',
+        requirement_ids,
+        'requirement_ids',
+    )
+    if normalized_confidence in {'source_supported', 'derived_from_sources'} and not normalized_source_ids:
+        raise ValueError(f'{normalized_confidence} facts require at least one source_id')
+    denied_source_ids = [
+        source_id
+        for source_id in normalized_source_ids
+        if (
+            (_find_entry(ledger, 'sources', source_id) or {}).get('authorization_status') == 'denied'
+            or (_find_entry(ledger, 'sources', source_id) or {}).get('status') == 'unauthorized'
+        )
+    ]
+    if denied_source_ids and normalized_confidence != 'unsupported':
+        raise ValueError(
+            f'supported facts cannot use denied sources: {", ".join(denied_source_ids)}'
+        )
+
+    target_section = 'unsupported_facts' if normalized_confidence == 'unsupported' else 'facts'
+    identifier = _next_identifier(
+        ledger,
+        target_section,
+        'fact',
+        requested_id=fact_id,
+    )
+    entry = {
+        'id': identifier,
+        'text': _normalize_text(text, 'text', required=True),
+        'confidence': normalized_confidence,
+        'source_ids': normalized_source_ids,
+        'requirement_ids': normalized_requirement_ids,
+    }
+    ledger[target_section].append(entry)
+    return entry
+
+
+def add_citation(
+    ledger,
+    source_id,
+    *,
+    citation_id=None,
+    title='',
+    uri='',
+    locator='',
+    excerpt='',
+    metadata=None,
+):
+    """Add a citation linked to one authorized evidence source."""
+    _require_ledger(ledger)
+    normalized_source_id = _require_known_ids(
+        ledger,
+        'sources',
+        [source_id],
+        'source_id',
+    )[0]
+    identifier = _next_identifier(
+        ledger,
+        'citations',
+        'citation',
+        requested_id=citation_id,
+    )
+    entry = {
+        'id': identifier,
+        'source_id': normalized_source_id,
+        'title': _normalize_text(title, 'title', max_chars=1000),
+        'uri': _sanitize_uri(uri),
+        'locator': _normalize_text(locator, 'locator', max_chars=500),
+        'excerpt': _normalize_text(excerpt, 'excerpt', max_chars=2000),
+        'metadata': _sanitize_metadata(metadata),
+    }
+    ledger['citations'].append(entry)
+    source = _find_entry(ledger, 'sources', normalized_source_id)
+    source['citation_ids'].append(identifier)
+    return entry
+
+
+def add_artifact(
+    ledger,
+    artifact_type,
+    *,
+    artifact_id=None,
+    name='',
+    source_ids=None,
+    reference='',
+    metadata=None,
+):
+    """Add compact artifact lineage; direct generated artifacts may omit source_ids."""
+    _require_ledger(ledger)
+    normalized_source_ids = _require_known_ids(
+        ledger,
+        'sources',
+        source_ids,
+        'source_ids',
+    )
+    identifier = _next_identifier(
+        ledger,
+        'artifacts',
+        'artifact',
+        requested_id=artifact_id,
+    )
+    entry = {
+        'id': identifier,
+        'type': _normalize_identifier(artifact_type, 'artifact_type'),
+        'name': _normalize_text(name, 'name', max_chars=1000),
+        'source_ids': normalized_source_ids,
+        'reference': _sanitize_reference(reference),
+        'metadata': _sanitize_metadata(metadata),
+    }
+    ledger['artifacts'].append(entry)
+    for normalized_source_id in normalized_source_ids:
+        source = _find_entry(ledger, 'sources', normalized_source_id)
+        source['artifact_ids'].append(identifier)
+    return entry
+
+
+def add_result(
+    ledger,
+    result_type,
+    summary,
+    *,
+    result_id=None,
+    status='succeeded',
+    source_ids=None,
+    requirement_ids=None,
+    citation_ids=None,
+    artifact_ids=None,
+):
+    """Add a computed or executor output with normalized provenance."""
+    _require_ledger(ledger)
+    entry = {
+        'id': _next_identifier(
+            ledger,
+            'results',
+            'result',
+            requested_id=result_id,
+        ),
+        'type': _normalize_identifier(result_type, 'result_type'),
+        'status': _validate_choice(status, RESULT_STATUSES, 'result status'),
+        'summary': _normalize_text(summary, 'summary', required=True),
+        'source_ids': _require_known_ids(ledger, 'sources', source_ids, 'source_ids'),
+        'requirement_ids': _require_known_ids(
+            ledger,
+            'requirements',
+            requirement_ids,
+            'requirement_ids',
+        ),
+        'citation_ids': _require_known_ids(
+            ledger,
+            'citations',
+            citation_ids,
+            'citation_ids',
+        ),
+        'artifact_ids': _require_known_ids(
+            ledger,
+            'artifacts',
+            artifact_ids,
+            'artifact_ids',
+        ),
+    }
+    ledger['results'].append(entry)
+    return entry
+
+
+def add_conflict(
+    ledger,
+    description,
+    source_ids,
+    *,
+    conflict_id=None,
+    fact_ids=None,
+    requirement_ids=None,
+    status='unresolved',
+):
+    """Record a material evidence conflict without silently resolving it."""
+    _require_ledger(ledger)
+    entry = {
+        'id': _next_identifier(
+            ledger,
+            'conflicts',
+            'conflict',
+            requested_id=conflict_id,
+        ),
+        'description': _normalize_text(description, 'description', required=True),
+        'status': _validate_choice(status, CONFLICT_STATUSES, 'conflict status'),
+        'source_ids': _require_known_ids(ledger, 'sources', source_ids, 'source_ids'),
+        'fact_ids': _require_known_ids(ledger, 'facts', fact_ids, 'fact_ids'),
+        'requirement_ids': _require_known_ids(
+            ledger,
+            'requirements',
+            requirement_ids,
+            'requirement_ids',
+        ),
+    }
+    if len(entry['source_ids']) < 2 and len(entry['fact_ids']) < 2:
+        raise ValueError('conflicts require at least two source_ids or two fact_ids')
+    ledger['conflicts'].append(entry)
+    return entry
+
+
+def _add_missing_or_failed(
+    ledger,
+    *,
+    kind,
+    source_type,
+    status,
+    message,
+    requirement_ids=None,
+    source_id=None,
+    step_id=None,
+    entry_id=None,
+):
+    _require_ledger(ledger)
+    normalized_requirement_ids = _require_known_ids(
+        ledger,
+        'requirements',
+        requirement_ids,
+        'requirement_ids',
+    )
+    normalized_source_ids = _require_known_ids(
+        ledger,
+        'sources',
+        [source_id] if source_id else [],
+        'source_id',
+    )
+    normalized_status = _validate_choice(status, SOURCE_STATUSES, 'status')
+    entry = {
+        'id': _next_identifier(
+            ledger,
+            'missing_or_failed',
+            'gap',
+            requested_id=entry_id,
+        ),
+        'kind': kind,
+        'requirement_ids': normalized_requirement_ids,
+        'source_id': normalized_source_ids[0] if normalized_source_ids else None,
+        'source_type': _normalize_identifier(source_type, 'source_type'),
+        'status': normalized_status,
+        'message': _normalize_text(message, 'message', required=True),
+        'step_id': _normalize_text(step_id, 'step_id') or None,
+    }
+    ledger['missing_or_failed'].append(entry)
+    if normalized_source_ids:
+        source = _find_entry(ledger, 'sources', normalized_source_ids[0])
+        if source:
+            source['status'] = normalized_status
+            if normalized_status == 'unauthorized':
+                source['authorization_status'] = 'denied'
+            elif (
+                normalized_status in {'succeeded', 'partial', 'not_found', 'failed'}
+                and source.get('authorization_status') == 'pending'
+            ):
+                source['authorization_status'] = 'authorized'
+    _reconcile_requirement_statuses(ledger)
+    return entry
+
+
+def add_missing_evidence(
+    ledger,
+    requirement_id,
+    source_type,
+    status,
+    message,
+    *,
+    source_id=None,
+    missing_id=None,
+):
+    """Record evidence that was requested but unavailable or not found."""
+    return _add_missing_or_failed(
+        ledger,
+        kind='missing_evidence',
+        requirement_ids=[requirement_id] if requirement_id else [],
+        source_type=source_type,
+        source_id=source_id,
+        status=status,
+        message=message,
+        entry_id=missing_id,
+    )
+
+
+def add_execution_failure(
+    ledger,
+    source_type,
+    status,
+    message,
+    *,
+    source_id=None,
+    step_id=None,
+    requirement_ids=None,
+    failure_id=None,
+):
+    """Record an explicit executor failure, skip, denial, or cancellation."""
+    return _add_missing_or_failed(
+        ledger,
+        kind='execution_failure',
+        requirement_ids=requirement_ids,
+        source_type=source_type,
+        source_id=source_id,
+        status=status,
+        message=message,
+        step_id=step_id,
+        entry_id=failure_id,
+    )
+
+
+def set_evidence_ledger_status(ledger, status):
+    """Set the turn-level ledger status."""
+    _require_ledger(ledger)
+    ledger['status'] = _validate_choice(status, LEDGER_STATUSES, 'ledger status')
+    return ledger['status']
+
+
+def _model_safe_ledger(ledger):
+    _require_ledger(ledger)
+    model_sections = {
+        section: [_sanitize_metadata(entry) for entry in ledger.get(section, [])]
+        for section in MODEL_LEDGER_SECTIONS
+    }
+    for source in model_sections['sources']:
+        source.pop('citation_ids', None)
+        source.pop('artifact_ids', None)
+    return {
+        'version': ledger['version'],
+        'run_id': ledger.get('run_id'),
+        'task_type': ledger.get('task_type'),
+        'task_profile': ledger.get('task_profile'),
+        'orchestration_mode': ledger.get('orchestration_mode'),
+        'requested_output': _sanitize_metadata(ledger.get('requested_output')),
+        'status': ledger.get('status'),
+        **model_sections,
+    }
+
+
+def _truncate_model_strings(value, max_chars):
+    if isinstance(value, str):
+        if len(value) <= max_chars:
+            return value
+        return f'{value[:max_chars - 3]}...'
+    if isinstance(value, list):
+        return [_truncate_model_strings(item, max_chars) for item in value]
+    if isinstance(value, Mapping):
+        return {
+            key: _truncate_model_strings(nested_value, max_chars)
+            for key, nested_value in value.items()
+        }
+    return value
+
+
+def _serialize_compact_ledger(ledger):
+    return json.dumps(
+        ledger,
+        ensure_ascii=True,
+        separators=(',', ':'),
+        sort_keys=True,
+    )
+
+
+def _compacted_entry_references_are_retained(section, entry, retained_ids):
+    reference_fields = {
+        'sources': (('requirement_ids', 'requirements'),),
+        'citations': (('source_id', 'sources'),),
+        'artifacts': (('source_ids', 'sources'),),
+        'facts': (
+            ('source_ids', 'sources'),
+            ('requirement_ids', 'requirements'),
+        ),
+        'unsupported_facts': (
+            ('source_ids', 'sources'),
+            ('requirement_ids', 'requirements'),
+        ),
+        'results': (
+            ('source_ids', 'sources'),
+            ('requirement_ids', 'requirements'),
+            ('citation_ids', 'citations'),
+            ('artifact_ids', 'artifacts'),
+        ),
+        'conflicts': (
+            ('source_ids', 'sources'),
+            ('fact_ids', 'facts'),
+            ('requirement_ids', 'requirements'),
+        ),
+        'missing_or_failed': (
+            ('source_id', 'sources'),
+            ('requirement_ids', 'requirements'),
+        ),
+    }
+    for field_name, target_section in reference_fields.get(section, ()):
+        field_value = entry.get(field_name)
+        referenced_ids = _normalize_ids(field_value)
+        if not set(referenced_ids).issubset(retained_ids[target_section]):
+            return False
+    return True
+
+
+def compact_evidence_ledger_for_model(ledger, max_chars=12000):
+    """Return bounded valid JSON with raw and sensitive payload fields omitted."""
+    try:
+        normalized_max_chars = int(max_chars)
+    except (TypeError, ValueError) as exc:
+        raise ValueError('max_chars must be an integer') from exc
+    if normalized_max_chars < 512:
+        raise ValueError('max_chars must be at least 512')
+
+    model_ledger = _model_safe_ledger(ledger)
+    serialized = _serialize_compact_ledger(model_ledger)
+    if len(serialized) <= normalized_max_chars:
+        return serialized
+
+    trimmed_ledger = _truncate_model_strings(model_ledger, 320)
+    serialized = _serialize_compact_ledger(trimmed_ledger)
+    if len(serialized) <= normalized_max_chars:
+        return serialized
+
+    bounded_ledger = {
+        key: value
+        for key, value in trimmed_ledger.items()
+        if key not in MODEL_LEDGER_SECTIONS
+    }
+    bounded_ledger['compaction'] = {
+        'truncated': True,
+        'omitted': {
+            section: len(trimmed_ledger.get(section, []))
+            for section in MODEL_LEDGER_SECTIONS
+        },
+    }
+    for section in MODEL_LEDGER_SECTIONS:
+        bounded_ledger[section] = []
+
+    if len(_serialize_compact_ledger(bounded_ledger)) > normalized_max_chars:
+        bounded_ledger['requested_output'] = {
+            'type': str((bounded_ledger.get('requested_output') or {}).get('type') or 'response')[:80]
+        }
+
+    retained_ids = {section: set() for section in MODEL_LEDGER_SECTIONS}
+    for section in COMPACTION_INSERTION_ORDER:
+        for entry in trimmed_ledger.get(section, []):
+            if not _compacted_entry_references_are_retained(section, entry, retained_ids):
+                continue
+            bounded_ledger[section].append(entry)
+            bounded_ledger['compaction']['omitted'][section] -= 1
+            if len(_serialize_compact_ledger(bounded_ledger)) > normalized_max_chars:
+                bounded_ledger[section].pop()
+                bounded_ledger['compaction']['omitted'][section] += 1
+                break
+            retained_ids[section].add(entry.get('id'))
+
+    bounded_ledger['compaction']['omitted'] = {
+        section: count
+        for section, count in bounded_ledger['compaction']['omitted'].items()
+        if count
+    }
+    serialized = _serialize_compact_ledger(bounded_ledger)
+    if len(serialized) > normalized_max_chars:
+        return _serialize_compact_ledger({
+            'version': EVIDENCE_LEDGER_VERSION,
+            'status': ledger.get('status'),
+            'compaction': {'truncated': True},
+        })
+    return serialized
+
+
+def build_evidence_ledger_guidance_message(ledger, max_chars=12000):
+    """Build source-of-truth guidance for any answer or artifact finalizer."""
+    compact_ledger = compact_evidence_ledger_for_model(ledger, max_chars=max_chars)
+    return '\n'.join([
+        EVIDENCE_LEDGER_GUIDANCE_MARKER,
+        'Treat this ledger as the authority for grounded facts and normalized outputs.',
+        'Use supported facts and results with their source lineage.',
+        'Do not present unsupported_facts as factual content or fill missing evidence with assumptions.',
+        'Preserve unresolved conflicts and disclose required sources that failed, were denied, or returned no evidence.',
+        compact_ledger,
+    ])

--- a/application/single_app/route_backend_chats.py
+++ b/application/single_app/route_backend_chats.py
@@ -111,6 +111,7 @@ from functions_chat_orchestration import (
     build_turn_orchestration_guidance_message,
     build_turn_orchestration_plan,
 )
+from functions_evidence_ledger import create_evidence_ledger_from_plan
 from functions_image_messages import build_image_message_documents, decode_image_content
 from functions_icon_utils import normalize_icon_payload
 from functions_image_generation import (
@@ -11919,6 +11920,11 @@ def register_route_backend_chats(bp):
         previous_thread_id = _get_latest_chat_thread_id(conversation_id)
         current_thread_id = str(uuid.uuid4())
         user_message_id = f"{conversation_id}_user_{int(time.time())}_{random.randint(1000,9999)}"
+        turn_evidence_ledger = create_evidence_ledger_from_plan(
+            turn_orchestration_plan,
+            conversation_id=conversation_id,
+            user_message_id=user_message_id,
+        )
         user_metadata = _build_document_action_user_metadata(
             data=data,
             user_id=user_id,
@@ -11931,6 +11937,7 @@ def register_route_backend_chats(bp):
             streaming_enabled=callable(publish_background_event),
         )
         user_metadata['orchestration'] = turn_orchestration_plan
+        user_metadata['evidence_ledger'] = turn_evidence_ledger
         if auto_linked_chat_upload_document_ids:
             user_metadata['workspace_search']['auto_linked_chat_upload_document_ids'] = auto_linked_chat_upload_document_ids
             user_metadata['workspace_search']['auto_linked_chat_upload_document_count'] = len(auto_linked_chat_upload_document_ids)
@@ -12174,6 +12181,7 @@ def register_route_backend_chats(bp):
                 'token_usage': execution_result.get('token_usage'),
                 'user_info': response_message_context.get('user_info'),
                 'orchestration': turn_orchestration_plan,
+                'evidence_ledger': turn_evidence_ledger,
                 'capability_usage': document_action_capability_usage,
                 'thread_info': {
                     'thread_id': response_message_context.get('thread_id'),
@@ -16815,6 +16823,11 @@ def register_route_backend_chats(bp):
 
                 # Save user message
                 user_message_id = f"{conversation_id}_user_{int(time.time())}_{random.randint(1000,9999)}"
+                turn_evidence_ledger = create_evidence_ledger_from_plan(
+                    turn_orchestration_plan,
+                    conversation_id=conversation_id,
+                    user_message_id=user_message_id,
+                )
 
                 user_metadata = {}
                 current_user = get_current_user_info()
@@ -16950,6 +16963,7 @@ def register_route_backend_chats(bp):
                     user_metadata['agent_selection'] = agent_selection_metadata
 
                 user_metadata['orchestration'] = turn_orchestration_plan
+                user_metadata['evidence_ledger'] = turn_evidence_ledger
                 user_metadata['chat_context'] = {
                     'conversation_id': conversation_id
                 }
@@ -18386,6 +18400,7 @@ def register_route_backend_chats(bp):
                                 },
                                 'history_context': history_debug_info,
                                 'orchestration': turn_orchestration_plan,
+                                'evidence_ledger': turn_evidence_ledger,
                                 'capability_usage': build_streaming_capability_usage(),
                                 'source_review': compact_source_review_result_for_metadata(source_review_result),
                                 'deep_research': deep_research_result,
@@ -18437,6 +18452,7 @@ def register_route_backend_chats(bp):
                             'metadata': {
                                 **cancel_metadata,
                                 'orchestration': turn_orchestration_plan,
+                                'evidence_ledger': turn_evidence_ledger,
                             },
                             'thoughts_enabled': thought_tracker.enabled,
                         },
@@ -18972,6 +18988,7 @@ def register_route_backend_chats(bp):
                             },
                             'history_context': history_debug_info,
                             'orchestration': turn_orchestration_plan,
+                            'evidence_ledger': turn_evidence_ledger,
                             'capability_usage': build_streaming_capability_usage(),
                             'agent_runtime': agent_runtime_metadata or None,
                             'source_review': compact_source_review_result_for_metadata(source_review_result),
@@ -19189,6 +19206,7 @@ def register_route_backend_chats(bp):
                                 'reasoning_effort': reasoning_effort,
                                 'history_context': history_debug_info,
                                 'orchestration': turn_orchestration_plan,
+                                'evidence_ledger': turn_evidence_ledger,
                                 'capability_usage': build_streaming_capability_usage(),
                                 'source_review': compact_source_review_result_for_metadata(source_review_result),
                                 'deep_research': deep_research_result,
@@ -19213,6 +19231,7 @@ def register_route_backend_chats(bp):
                             'incomplete': True,
                             'error': error_msg,
                             'orchestration': turn_orchestration_plan,
+                            'evidence_ledger': turn_evidence_ledger,
                         },
                     }
                     yield f"data: {json.dumps(partial_error_payload)}\n\n"

--- a/docs/explanation/features/CHAT_TURN_ORCHESTRATION.md
+++ b/docs/explanation/features/CHAT_TURN_ORCHESTRATION.md
@@ -1,6 +1,6 @@
-# Chat Turn Orchestration Foundation
+# Chat Turn Orchestration
 
-Implemented in version: **0.250.058**  
+Implemented in version: **0.250.059**
 Associated issue: **[#1021](https://github.com/microsoft/simplechat/issues/1021)**
 
 ## Overview
@@ -70,11 +70,34 @@ Phase 1 is integrated with:
 
 The plan is intentionally dependency-light and rules-based so direct requests do not incur an extra planning-model call.
 
+## Phase 2 Result And Evidence Ledger
+
+Every supported turn now initializes a versioned, output-neutral result and evidence ledger after the user message ID is assigned. Standard streaming stores the same ledger beside the immutable plan on user, successful assistant, cancelled, and partial-error metadata. Analyze/Compare stores it on user and successful assistant metadata.
+
+The ledger is initialized from the plan and records:
+
+- Requested output, task type, task profile, orchestration mode, and plan/run linkage.
+- Evidence requirements and the source types that can satisfy them.
+- Planned sources with required state, origin, permission state, and requirement linkage.
+- Supported, derived, user-provided, placeholder, and unsupported fact confidence classes.
+- Normalized computed results, citations, and artifact lineage.
+- Explicit missing evidence, execution failures, authorization denials, and cancellations.
+- Unresolved or resolved conflicts that retain all contributing source and fact IDs.
+
+Unsupported statements are stored separately from supported facts. Provenance references must resolve to entries already present in the ledger, preventing finalizers from receiving facts with unknown source lineage.
+
+The contract is shared by answer, image-proposal, report, table, and future artifact finalizers. `compact_evidence_ledger_for_model()` returns bounded valid JSON without dangling provenance references, and `build_evidence_ledger_guidance_message()` provides common evidence-before-claims instructions without adding output-specific fields to the core schema.
+
+Phase 2 establishes and persists the contract. The route does not yet inject the initial planned ledger into the finalizer prompt because it contains no normalized live results and must not override evidence supplied through existing context paths. Phase 3 adapts existing conversation, document, workspace, web, research, source-review, and selected-image result structures to populate and inject it before finalization. Phase 4 applies the same contract to selected agents and actions.
+
 ## Security And Governance
 
 - Caller-supplied IDs are never treated as proof of authorization.
 - Existing conversation, document, group, public workspace, agent, and action authorization remains in force.
 - The plan stores compact metadata rather than raw tool payloads or source content.
+- The ledger records authorization status but never treats that status or a stored scope ID as an access decision; collectors and executors must revalidate access at their own boundaries.
+- Raw metadata parameters are not retained in the ledger. Binary values and metadata keys associated with credentials, secrets, tokens, keys, connection strings, or internal endpoints are omitted.
+- HTTP citation and artifact references have query strings and fragments removed so signed URLs are not persisted or sent to a model.
 - Prompt content is not copied into orchestration metadata.
 - Selected capabilities are required attempts, but unavailable or unauthorized sources must be represented explicitly rather than bypassing access controls.
 - Side effects, sensitive access, and budget overflow are marked as approval-required policy classes for later runtime enforcement.
@@ -101,13 +124,23 @@ Functional coverage is in `functional_tests/test_chat_turn_orchestration_plan.py
 - Selected-image Q&A without false generation.
 - Standard streaming and document-action route wiring.
 
+Ledger coverage is in `functional_tests/test_chat_evidence_ledger.py` and validates:
+
+- Plan-based initialization for answer and artifact task profiles.
+- Selected-image, public-web, selected-agent, and computed-output evidence.
+- Source, citation, artifact, fact, and result lineage.
+- Unsupported-fact separation, missing evidence, permission failures, and conflicts.
+- Secret, signed-URL, raw-payload, and binary-data omission.
+- Bounded model compaction that remains valid JSON.
+- Standard streaming success, cancellation, and partial-error persistence, plus document-action user and success metadata.
+
 ## Known Limitations
 
 Phase 1 records and gates plans but does not yet provide the complete orchestration runtime.
 
 - Planned steps are not yet scheduled through a generic execution graph.
 - Arbitrary governed tools are not yet discovered automatically.
-- Capability outputs do not yet share one normalized result/evidence ledger.
+- Existing capability outputs are not populated into the ledger until the Phase 3 and Phase 4 adapters are implemented; Phase 2 entries therefore begin in planned state.
 - A selected agent can still own response streaming instead of returning structured evidence to a separate central finalizer.
 - Plan status does not yet provide complete per-step execution reconciliation.
 - The legacy non-streaming compatibility path does not yet use the generic plan contract.

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,16 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](/explanation/features/) and [Fixes by Version](/explanation/fixes/).
 
+### **(v0.250.059)**
+
+#### New Features
+
+*   **Chat Result And Evidence Ledger Foundation**
+    *   Added a shared, output-neutral ledger for requirements, sources, supported and unsupported facts, computed results, citations, artifacts, conflicts, missing evidence, execution failures, and permission states.
+    *   Standard streaming now carries the same plan-linked ledger through user, success, cancellation, and partial-error metadata, while Analyze/Compare persists it on user and successful assistant messages.
+    *   Added bounded model compaction that preserves referential integrity while omitting raw payloads, binary data, credential-like metadata, and signed URL query strings.
+    *   (Ref: microsoft/simplechat#1021, `functions_evidence_ledger.py`, `route_backend_chats.py`, `CHAT_TURN_ORCHESTRATION.md`)
+
 ### **(v0.250.058)**
 
 #### New Features

--- a/functional_tests/test_chat_evidence_ledger.py
+++ b/functional_tests/test_chat_evidence_ledger.py
@@ -1,0 +1,508 @@
+#!/usr/bin/env python3
+# test_chat_evidence_ledger.py
+"""
+Functional test for the generic chat result and evidence ledger.
+Version: 0.250.059
+Implemented in: 0.250.059
+
+This test ensures orchestration evidence remains output-neutral, provenance-aware,
+permission-aware, safely compacted, and explicit about unsupported or failed evidence.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SINGLE_APP_ROOT = REPO_ROOT / 'application' / 'single_app'
+ROUTE_BACKEND_CHATS = SINGLE_APP_ROOT / 'route_backend_chats.py'
+sys.path.insert(0, str(SINGLE_APP_ROOT))
+
+from functions_chat_orchestration import build_turn_orchestration_plan  # noqa: E402
+from functions_evidence_ledger import (  # noqa: E402
+    EVIDENCE_LEDGER_GUIDANCE_MARKER,
+    add_artifact,
+    add_citation,
+    add_conflict,
+    add_evidence_requirement,
+    add_evidence_source,
+    add_execution_failure,
+    add_fact,
+    add_missing_evidence,
+    add_result,
+    build_evidence_ledger_guidance_message,
+    compact_evidence_ledger_for_model,
+    create_evidence_ledger,
+    create_evidence_ledger_from_plan,
+)
+
+
+def _assert_raises(expected_exception, callback):
+    try:
+        callback()
+    except expected_exception:
+        return
+    raise AssertionError(f'Expected {expected_exception.__name__}')
+
+
+def test_plan_initializes_output_neutral_ledger():
+    plan = build_turn_orchestration_plan(
+        'Create a whiteboard sketch grounded in my public LinkedIn profile.',
+        run_id='run-plan-ledger',
+        conversation_id='conversation-1',
+        web_search_enabled=True,
+        image_generation_available=True,
+    )
+
+    ledger = create_evidence_ledger_from_plan(
+        plan,
+        user_message_id='message-1',
+        created_at='2026-07-14T00:00:00+00:00',
+    )
+
+    assert ledger['run_id'] == plan['run_id']
+    assert ledger['task_profile'] == 'grounded_image_generation'
+    assert ledger['requested_output'] == {
+        'type': 'image_proposal',
+        'task_type': 'image_generation',
+    }
+    assert ledger['requirements'] == [{
+        'id': 'public_web',
+        'description': 'Public web',
+        'source_types': [
+            'public_web',
+            'web_search',
+            'url_access',
+            'source_review',
+            'deep_research',
+        ],
+        'required': True,
+        'status': 'pending',
+    }]
+    assert ledger['sources'][0]['id'] == 'web_search'
+    assert ledger['sources'][0]['requirement_ids'] == ['public_web']
+    assert ledger['facts'] == []
+    assert ledger['results'] == []
+    json.dumps(ledger)
+
+    discovery_plan = build_turn_orchestration_plan(
+        'Create an image grounded in verified facts.',
+        run_id='run-evidence-discovery-ledger',
+        image_generation_available=True,
+    )
+    discovery_ledger = create_evidence_ledger_from_plan(
+        discovery_plan,
+        user_message_id='message-evidence-discovery',
+    )
+    assert discovery_ledger['sources'][0]['id'] == 'evidence_discovery'
+    assert discovery_ledger['sources'][0]['requirement_ids'] == ['unspecified_grounding']
+
+
+def test_selected_image_evidence_preserves_lineage_without_secrets():
+    plan = build_turn_orchestration_plan(
+        'Create a portrait using the attached headshot as a reference.',
+        run_id='run-selected-image',
+        conversation_id='conversation-2',
+        selected_image_reference_count=1,
+        image_generation_available=True,
+    )
+    ledger = create_evidence_ledger_from_plan(plan, user_message_id='message-2')
+
+    source = add_evidence_source(
+        ledger,
+        'selected_image',
+        'succeeded',
+        source_id='selected_images',
+        summary='The selected headshot is available as a visual reference.',
+        authorization_status='authorized',
+        metadata={
+            'mime_type': 'image/png',
+            'access_token': 'must-not-survive',
+            'binary_preview': b'not-model-context',
+        },
+        raw_metadata={
+            'vision_payload': {'api_key': 'must-not-survive'},
+        },
+    )
+    citation = add_citation(
+        ledger,
+        source['id'],
+        citation_id='citation-headshot',
+        title='Selected headshot',
+        uri='https://example.test/headshot.png?sig=private-token',
+        locator='selected image',
+    )
+    artifact = add_artifact(
+        ledger,
+        'image_reference',
+        artifact_id='artifact-headshot',
+        name='Headshot reference',
+        source_ids=[source['id']],
+        reference='/artifacts/headshot?sig=private-token#fragment',
+    )
+    fact = add_fact(
+        ledger,
+        'The selected image is a head-and-shoulders portrait.',
+        [source['id']],
+        requirement_ids=['selected_images'],
+    )
+    result = add_result(
+        ledger,
+        'visual_reference_summary',
+        'One authorized portrait reference is ready for finalization.',
+        source_ids=[source['id']],
+        requirement_ids=['selected_images'],
+        citation_ids=[citation['id']],
+        artifact_ids=[artifact['id']],
+    )
+
+    serialized = json.dumps(ledger)
+    assert ledger['requirements'][0]['status'] == 'satisfied'
+    assert source['citation_ids'] == ['citation-headshot']
+    assert source['artifact_ids'] == ['artifact-headshot']
+    assert fact['source_ids'] == ['selected_images']
+    assert result['artifact_ids'] == ['artifact-headshot']
+    assert citation['uri'] == 'https://example.test/headshot.png'
+    assert artifact['reference'] == '/artifacts/headshot'
+    assert 'must-not-survive' not in serialized
+    assert 'not-model-context' not in serialized
+
+
+def test_missing_public_evidence_and_unsupported_facts_stay_separate():
+    plan = build_turn_orchestration_plan(
+        'Summarize my public LinkedIn profile.',
+        run_id='run-missing-public-profile',
+        conversation_id='conversation-3',
+    )
+    ledger = create_evidence_ledger_from_plan(plan, user_message_id='message-3')
+    source = add_evidence_source(
+        ledger,
+        'public_web',
+        'not_found',
+        source_id='public_web',
+        summary='No verified matching profile was found.',
+        authorization_status='not_required',
+    )
+    add_missing_evidence(
+        ledger,
+        'public_web',
+        'public_web',
+        'not_found',
+        'No verified LinkedIn profile was found.',
+        source_id=source['id'],
+    )
+    unsupported = add_fact(
+        ledger,
+        'The user is a product executive.',
+        [],
+        requirement_ids=['public_web'],
+        confidence='unsupported',
+    )
+
+    assert ledger['requirements'][0]['status'] == 'unsatisfied'
+    assert ledger['facts'] == []
+    assert ledger['unsupported_facts'] == [unsupported]
+    assert ledger['missing_or_failed'][0]['kind'] == 'missing_evidence'
+    guidance = build_evidence_ledger_guidance_message(ledger)
+    assert EVIDENCE_LEDGER_GUIDANCE_MARKER in guidance
+    assert 'Do not present unsupported_facts as factual content' in guidance
+    assert 'No verified LinkedIn profile was found.' in guidance
+
+
+def test_execution_failure_updates_permission_aware_source_state():
+    plan = build_turn_orchestration_plan(
+        'Use the selected agent to gather profile evidence.',
+        run_id='run-agent-denied',
+        selected_agent={'id': 'agent-1'},
+    )
+    ledger = create_evidence_ledger_from_plan(plan, user_message_id='message-4')
+
+    failure = add_execution_failure(
+        ledger,
+        'selected_agent',
+        'unauthorized',
+        'The selected agent could not access the requested profile data.',
+        source_id='selected_agent',
+        step_id='collect_selected_agent',
+    )
+
+    assert failure['kind'] == 'execution_failure'
+    assert ledger['sources'][0]['status'] == 'unauthorized'
+    assert ledger['sources'][0]['authorization_status'] == 'denied'
+    _assert_raises(
+        ValueError,
+        lambda: add_fact(
+            ledger,
+            'Denied profile content must not become a supported fact.',
+            ['selected_agent'],
+        ),
+    )
+
+
+def test_conflicts_preserve_both_supported_sources():
+    ledger = create_evidence_ledger(
+        'answer',
+        'conversation-5',
+        'message-5',
+        {'type': 'response'},
+        run_id='run-conflict',
+    )
+    add_evidence_source(
+        ledger,
+        'workspace_search',
+        'succeeded',
+        source_id='workspace-search-1',
+        authorization_status='authorized',
+    )
+    add_evidence_source(
+        ledger,
+        'web_search',
+        'succeeded',
+        source_id='web-search-1',
+        authorization_status='not_required',
+    )
+    workspace_fact = add_fact(
+        ledger,
+        'The launch date is August 1.',
+        ['workspace-search-1'],
+        fact_id='fact-workspace-date',
+    )
+    web_fact = add_fact(
+        ledger,
+        'The launch date is August 15.',
+        ['web-search-1'],
+        fact_id='fact-web-date',
+    )
+    conflict = add_conflict(
+        ledger,
+        'The workspace and public source report different launch dates.',
+        ['workspace-search-1', 'web-search-1'],
+        fact_ids=[workspace_fact['id'], web_fact['id']],
+    )
+
+    assert conflict['status'] == 'unresolved'
+    assert len(ledger['facts']) == 2
+    assert conflict['source_ids'] == ['workspace-search-1', 'web-search-1']
+
+
+def test_compaction_is_bounded_valid_json_and_omits_sensitive_payloads():
+    ledger = create_evidence_ledger(
+        'report',
+        'conversation-6',
+        'message-6',
+        {'type': 'report'},
+        run_id='run-compaction',
+    )
+    for index in range(20):
+        source_id = f'source-{index}'
+        add_evidence_source(
+            ledger,
+            'computed_output',
+            'succeeded',
+            source_id=source_id,
+            summary=f'Computed source {index}: ' + ('evidence ' * 80),
+            authorization_status='authorized',
+            metadata={
+                'row_count': index,
+                'api_key': f'secret-{index}',
+                'payload': b'binary-data',
+            },
+            raw_metadata={'connection_string': f'connection-{index}'},
+        )
+        add_fact(
+            ledger,
+            f'Computed fact {index}: ' + ('supported detail ' * 80),
+            [source_id],
+        )
+
+    compact = compact_evidence_ledger_for_model(ledger, max_chars=1800)
+    parsed = json.loads(compact)
+
+    assert len(compact) <= 1800
+    assert parsed['version'] == 1
+    assert parsed['compaction']['truncated'] is True
+    assert 'secret-' not in compact
+    assert 'connection-' not in compact
+    assert 'binary-data' not in compact
+
+
+def test_compaction_never_retains_dangling_provenance_references():
+    ledger = create_evidence_ledger(
+        'report',
+        'conversation-compact-lineage',
+        'message-compact-lineage',
+        {'type': 'report'},
+        run_id='run-compact-lineage',
+    )
+    add_evidence_requirement(
+        ledger,
+        'Use public evidence.',
+        ['web_search'],
+        requirement_id='public_web',
+    )
+    for index in range(4):
+        add_evidence_source(
+            ledger,
+            'web_search',
+            'succeeded',
+            source_id=f'source-{index}',
+            summary=f'Source {index}: ' + ('large source summary ' * 80),
+            requirement_ids=['public_web'],
+            authorization_status='not_required',
+        )
+
+    add_evidence_source(
+        ledger,
+        'web_search',
+        'succeeded',
+        source_id='source-3',
+        citations=[{
+            'citation_id': 'citation-3',
+            'title': 'Public source',
+            'uri': 'https://example.test/source-3?sig=private',
+        }],
+        artifacts=[{
+            'id': 'artifact-3',
+            'type': 'source_archive',
+            'name': 'Archived source',
+        }],
+    )
+    fact = add_fact(
+        ledger,
+        'A supported fact from the final source.',
+        ['source-3'],
+        requirement_ids=['public_web'],
+        fact_id='fact-3',
+    )
+    add_result(
+        ledger,
+        'report_section',
+        'A result linked to the final source.',
+        source_ids=['source-3'],
+        requirement_ids=['public_web'],
+        citation_ids=['citation-3'],
+        artifact_ids=['artifact-3'],
+        result_id='result-3',
+    )
+    add_conflict(
+        ledger,
+        'Two sources disagree about the supported fact.',
+        ['source-2', 'source-3'],
+        fact_ids=[fact['id'], add_fact(
+            ledger,
+            'A conflicting fact from the prior source.',
+            ['source-2'],
+            requirement_ids=['public_web'],
+            fact_id='fact-2',
+        )['id']],
+        conflict_id='conflict-1',
+    )
+    add_missing_evidence(
+        ledger,
+        'public_web',
+        'web_search',
+        'partial',
+        'One requested detail was not available.',
+        source_id='source-3',
+    )
+
+    for max_chars in range(512, 3001, 41):
+        compact = json.loads(compact_evidence_ledger_for_model(ledger, max_chars=max_chars))
+        retained_ids = {
+            section: {entry['id'] for entry in compact.get(section, [])}
+            for section in (
+                'requirements',
+                'sources',
+                'facts',
+                'citations',
+                'artifacts',
+            )
+        }
+        for source in compact.get('sources', []):
+            assert set(source['requirement_ids']).issubset(retained_ids['requirements'])
+            assert 'citation_ids' not in source
+            assert 'artifact_ids' not in source
+        for citation in compact.get('citations', []):
+            assert citation['source_id'] in retained_ids['sources']
+        for artifact in compact.get('artifacts', []):
+            assert set(artifact['source_ids']).issubset(retained_ids['sources'])
+        for compact_fact in compact.get('facts', []) + compact.get('unsupported_facts', []):
+            assert set(compact_fact['source_ids']).issubset(retained_ids['sources'])
+            assert set(compact_fact['requirement_ids']).issubset(retained_ids['requirements'])
+        for result in compact.get('results', []):
+            assert set(result['source_ids']).issubset(retained_ids['sources'])
+            assert set(result['requirement_ids']).issubset(retained_ids['requirements'])
+            assert set(result['citation_ids']).issubset(retained_ids['citations'])
+            assert set(result['artifact_ids']).issubset(retained_ids['artifacts'])
+        for conflict in compact.get('conflicts', []):
+            assert set(conflict['source_ids']).issubset(retained_ids['sources'])
+            assert set(conflict['fact_ids']).issubset(retained_ids['facts'])
+            assert set(conflict['requirement_ids']).issubset(retained_ids['requirements'])
+        for gap in compact.get('missing_or_failed', []):
+            assert not gap.get('source_id') or gap['source_id'] in retained_ids['sources']
+            assert set(gap['requirement_ids']).issubset(retained_ids['requirements'])
+
+
+def test_unknown_provenance_references_are_rejected():
+    ledger = create_evidence_ledger(
+        'answer',
+        'conversation-7',
+        'message-7',
+        {'type': 'response'},
+    )
+
+    _assert_raises(
+        ValueError,
+        lambda: add_fact(ledger, 'Unsupported provenance reference.', ['missing-source']),
+    )
+    _assert_raises(
+        ValueError,
+        lambda: add_result(
+            ledger,
+            'answer',
+            'Unknown citation reference.',
+            citation_ids=['missing-citation'],
+        ),
+    )
+
+
+def test_supported_chat_paths_persist_one_shared_ledger_per_turn():
+    route_source = ROUTE_BACKEND_CHATS.read_text(encoding='utf-8')
+
+    assert 'from functions_evidence_ledger import create_evidence_ledger_from_plan' in route_source
+    assert route_source.count('turn_evidence_ledger = create_evidence_ledger_from_plan(') == 2
+    assert route_source.count("user_metadata['evidence_ledger'] = turn_evidence_ledger") == 2
+    assert route_source.count("'evidence_ledger': turn_evidence_ledger,") >= 6
+    assert 'conversation_id=conversation_id,\n            user_message_id=user_message_id,' in route_source
+    assert 'conversation_id=conversation_id,\n                    user_message_id=user_message_id,' in route_source
+
+
+if __name__ == '__main__':
+    tests = [
+        test_plan_initializes_output_neutral_ledger,
+        test_selected_image_evidence_preserves_lineage_without_secrets,
+        test_missing_public_evidence_and_unsupported_facts_stay_separate,
+        test_execution_failure_updates_permission_aware_source_state,
+        test_conflicts_preserve_both_supported_sources,
+        test_compaction_is_bounded_valid_json_and_omits_sensitive_payloads,
+        test_compaction_never_retains_dangling_provenance_references,
+        test_unknown_provenance_references_are_rejected,
+        test_supported_chat_paths_persist_one_shared_ledger_per_turn,
+    ]
+    results = []
+
+    for test in tests:
+        print(f'\nRunning {test.__name__}...')
+        try:
+            test()
+            print('Passed')
+            results.append(True)
+        except Exception as exc:
+            print(f'Failed: {exc}')
+            results.append(False)
+
+    passed = sum(results)
+    total = len(results)
+    print(f'\nResults: {passed}/{total} tests passed')
+    sys.exit(0 if all(results) else 1)

--- a/functional_tests/test_chat_turn_orchestration_plan.py
+++ b/functional_tests/test_chat_turn_orchestration_plan.py
@@ -2,7 +2,7 @@
 # test_chat_turn_orchestration_plan.py
 """
 Functional test for the chat turn orchestration planning foundation.
-Version: 0.250.058
+Version: 0.250.059
 Implemented in: 0.250.058
 
 This test ensures every turn receives a direct or coordinated plan, selected
@@ -351,7 +351,7 @@ def test_streaming_chat_path_persists_and_applies_plan():
     route_source = ROUTE_BACKEND_CHATS.read_text(encoding='utf-8')
     config_source = CONFIG_FILE.read_text(encoding='utf-8')
 
-    assert 'VERSION = "0.250.058"' in config_source
+    assert 'VERSION = "0.250.059"' in config_source
     assert 'turn_orchestration_plan = build_turn_orchestration_plan(' in route_source
     assert 'requested_action_document_ids = _normalize_conversation_task_document_ids(' in route_source
     assert 'requested_action_document_ids\n            if requested_action_document_ids' in route_source


### PR DESCRIPTION
## Summary

Introduces the generic Phase 2 result and evidence ledger foundation for chat orchestration. The ledger is output-neutral and supports answer, image proposal, report, table, and future artifact finalizers through one provenance contract.

This PR intentionally targets `feature/orchestration`, not `Development`, so the phased orchestration work remains isolated until the vertical slice is complete.

## Changes

- Adds a versioned ledger for evidence requirements, permission-aware sources, supported and unsupported facts, normalized results, citations, artifacts, conflicts, missing evidence, and execution failures.
- Initializes each ledger from the immutable Phase 1 plan and links equivalent requirements to their planned sources, including evidence discovery for unspecified grounding.
- Enforces source, requirement, citation, artifact, result, and conflict referential integrity.
- Keeps unsupported facts separate and rejects supported facts backed by denied sources.
- Adds bounded valid-JSON compaction that preserves retained provenance relationships while omitting raw payloads, binary data, credential-like metadata, and signed URL query strings/fragments.
- Persists one plan-linked ledger on standard streaming user/success/cancel/partial-error metadata and Analyze/Compare user/success metadata.
- Updates orchestration documentation, release notes, and application version `0.250.059`.

## Phase Boundary

Phase 2 establishes and persists the shared contract. It does not adapt existing conversation, document, workspace, web, research, source-review, image, agent, or action outputs into the ledger yet, and it does not inject an empty planned ledger into finalizer prompts. Those live population and consumption paths remain Phase 3 and Phase 4 work.

## Validation

- `functional_tests/test_chat_evidence_ledger.py`: 9/9 passed
- `functional_tests/test_chat_turn_orchestration_plan.py`: 15/15 passed
- `functional_tests/test_image_proposal_pipeline.py`: 3/3 passed
- `functional_tests/test_chat_streaming_sse_metadata_fix.py`: 3/3 passed
- Route policy contracts: 12/12 passed
- Broken Access Control guardrail: passed for all changed production Python files
- XSS sink guardrail: passed for all changed production Python files
- Python compilation: passed for all changed Python files
- VS Code diagnostics: clean
- Staged `git diff --check`: clean

Refs #1021