### PR TITLE
Add Phase 6 request-scoped orchestration runtime

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -96,7 +96,7 @@ load_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.250.062"
+VERSION = "0.250.063"
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')
 SESSION_COOKIE_HTTPONLY = os.getenv('SESSION_COOKIE_HTTPONLY', 'true').lower() != 'false'

--- a/application/single_app/functions_orchestration_runtime.py
+++ b/application/single_app/functions_orchestration_runtime.py
@@ -1,0 +1,1423 @@
+# functions_orchestration_runtime.py
+"""Request-scoped execution graph runtime for chat orchestration plans."""
+
+import copy
+import json
+from collections.abc import Callable, Mapping, MutableMapping
+from concurrent.futures import CancelledError, FIRST_COMPLETED, ThreadPoolExecutor, wait
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+
+from functions_appinsights import log_event
+from functions_evidence_collectors import apply_evidence_collector_result
+from functions_evidence_ledger import (
+    add_evidence_source,
+    add_execution_failure,
+    set_evidence_ledger_status,
+)
+
+
+ORCHESTRATION_RUNTIME_VERSION = 1
+ORCHESTRATION_NODE_STATUSES = frozenset({
+    'pending',
+    'running',
+    'succeeded',
+    'partial',
+    'failed',
+    'skipped',
+    'blocked',
+    'cancelled',
+})
+ORCHESTRATION_TERMINAL_NODE_STATUSES = frozenset({
+    'succeeded',
+    'partial',
+    'failed',
+    'skipped',
+    'blocked',
+    'cancelled',
+})
+ORCHESTRATION_RUN_STATUSES = frozenset({
+    'pending',
+    'running',
+    'succeeded',
+    'partial',
+    'failed',
+    'cancelled',
+})
+ORCHESTRATION_FAILURE_NODE_STATUSES = frozenset({
+    'failed',
+    'skipped',
+    'blocked',
+    'cancelled',
+})
+ORCHESTRATION_PARALLEL_NODE_TYPES = frozenset({'collect', 'plan'})
+ORCHESTRATION_REPLAN_NODE_TYPES = frozenset({'collect', 'plan'})
+DEFAULT_MAX_PARALLEL_NODES = 1
+DEFAULT_MAX_REPLANS = 1
+DEFAULT_MAX_RUNTIME_NODES = 32
+MAX_NODE_ATTEMPTS = 3
+MAX_RUNTIME_TEXT_CHARS = 1000
+
+COLLECTOR_TO_NODE_STATUS = {
+    'not_requested': 'skipped',
+    'skipped': 'skipped',
+    'succeeded': 'succeeded',
+    'partial': 'partial',
+    'not_found': 'failed',
+    'not_available': 'failed',
+    'failed': 'failed',
+    'unauthorized': 'failed',
+}
+NODE_TO_SOURCE_STATUS = {
+    'succeeded': 'succeeded',
+    'partial': 'partial',
+    'failed': 'failed',
+    'skipped': 'skipped',
+    'blocked': 'failed',
+    'cancelled': 'cancelled',
+}
+SOURCE_TO_NODE_STATUS = {
+    'succeeded': 'succeeded',
+    'partial': 'partial',
+    'not_found': 'failed',
+    'not_available': 'failed',
+    'failed': 'failed',
+    'unauthorized': 'failed',
+    'skipped': 'skipped',
+    'cancelled': 'cancelled',
+}
+PROVENANCE_LEDGER_SECTIONS = (
+    'facts',
+    'unsupported_facts',
+    'results',
+    'citations',
+    'artifacts',
+    'missing_or_failed',
+)
+PROGRESS_MESSAGES = {
+    'conversation_evidence': 'Reviewing conversation evidence',
+    'selected_documents': 'Reviewing selected documents',
+    'selected_images': 'Reviewing selected image',
+    'workspace_search': 'Searching workspace documents',
+    'web_search': 'Searching public web',
+    'source_review': 'Reviewing source pages',
+    'deep_research': 'Reviewing source pages',
+    'selected_agent': 'Calling selected agent',
+    'selected_action': 'Calling selected action',
+    'evidence_discovery': 'Planning evidence workflow',
+    'image_proposal': 'Building image proposal',
+    'response': 'Building response',
+}
+
+
+class OrchestrationRuntimeError(ValueError):
+    """Raised when an orchestration run or execution graph is invalid."""
+
+
+def _utc_now():
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _normalize_text(value, *, max_chars=MAX_RUNTIME_TEXT_CHARS):
+    normalized = ' '.join(str(value or '').split())
+    return normalized[:max_chars].rstrip()
+
+
+def _normalize_identifier(value, field_name):
+    identifier = str(value or '').strip()
+    if not identifier:
+        raise OrchestrationRuntimeError(f'{field_name} is required')
+    return identifier
+
+
+def _normalize_identifiers(values):
+    if values is None:
+        return []
+    if isinstance(values, str):
+        values = [values]
+    normalized = []
+    for value in values:
+        identifier = str(value or '').strip()
+        if identifier and identifier not in normalized:
+            normalized.append(identifier)
+    return normalized
+
+
+def _safe_error_type(value):
+    normalized = _normalize_text(value, max_chars=120).lower().replace(' ', '_')
+    return normalized or 'execution_failed'
+
+
+@dataclass
+class OrchestrationNode:
+    """One request-scoped plan step and its runtime lifecycle."""
+
+    id: str
+    type: str
+    capability: str
+    origin: str
+    required: bool
+    depends_on: list[str] = field(default_factory=list)
+    status: str = 'pending'
+    attempt_count: int = 0
+    started_at: str | None = None
+    completed_at: str | None = None
+    error_type: str | None = None
+    user_message: str | None = None
+    debug_message: str | None = None
+
+    @classmethod
+    def from_plan_step(cls, step):
+        if not isinstance(step, Mapping):
+            raise OrchestrationRuntimeError('orchestration steps must be mappings')
+        normalized_status = str(step.get('status') or 'pending').strip().lower()
+        if normalized_status != 'pending':
+            raise OrchestrationRuntimeError('request-scoped runtime steps must start pending')
+        return cls(
+            id=_normalize_identifier(step.get('id'), 'step id'),
+            type=_normalize_identifier(step.get('type'), 'step type'),
+            capability=_normalize_identifier(step.get('capability'), 'step capability'),
+            origin=_normalize_text(step.get('origin'), max_chars=120) or 'orchestrator',
+            required=bool(step.get('required', True)),
+            depends_on=_normalize_identifiers(step.get('depends_on')),
+        )
+
+    def to_metadata(self):
+        metadata = {
+            'id': self.id,
+            'type': self.type,
+            'capability': self.capability,
+            'origin': self.origin,
+            'required': self.required,
+            'status': self.status,
+            'depends_on': list(self.depends_on),
+            'attempt_count': self.attempt_count,
+            'started_at': self.started_at,
+            'completed_at': self.completed_at,
+        }
+        if self.error_type:
+            metadata['error'] = {
+                'type': self.error_type,
+                'user_message': self.user_message,
+            }
+        return metadata
+
+
+@dataclass(frozen=True)
+class OrchestrationNodeResult:
+    """Normalized output returned by a runtime node adapter."""
+
+    status: str = 'succeeded'
+    summary: str = ''
+    collector_result: Mapping | None = None
+    additional_nodes: tuple[Mapping, ...] = ()
+    error_type: str | None = None
+    user_message: str | None = None
+    debug_message: str | None = None
+    retryable: bool = False
+    attempt_count: int = 1
+
+
+@dataclass(frozen=True)
+class OrchestrationNodeContext:
+    """Isolated context supplied to one adapter; evidence_ledger is a read-only snapshot."""
+
+    run_id: str
+    task_type: str
+    task_profile: str | None
+    original_request: str
+    node: OrchestrationNode
+    evidence_ledger: dict
+    is_cancel_requested: Callable[[], bool]
+
+
+@dataclass(frozen=True)
+class OrchestrationNodeAdapter:
+    """Trusted adapter; parallel_safe adapters must not depend on Flask request context."""
+
+    execute: Callable[[OrchestrationNodeContext], object]
+    parallel_safe: bool = False
+    read_only: bool = True
+    cancel: Callable[[OrchestrationNodeContext], None] | None = None
+    max_attempts: int = 1
+    retry_on_exception: bool = False
+
+
+@dataclass
+class OrchestrationRun:
+    """In-process execution graph linked to one immutable turn plan and ledger."""
+
+    run_id: str
+    task_type: str
+    task_profile: str | None
+    mode: str
+    plan_snapshot: dict
+    evidence_ledger: MutableMapping
+    nodes: list[OrchestrationNode]
+    policy: dict
+    max_replans: int = DEFAULT_MAX_REPLANS
+    max_nodes: int = DEFAULT_MAX_RUNTIME_NODES
+    status: str = 'pending'
+    replan_count: int = 0
+    started_at: str | None = None
+    completed_at: str | None = None
+    cancel_requested: bool = False
+    warnings: list[str] = field(default_factory=list)
+
+    @classmethod
+    def from_plan(
+        cls,
+        plan,
+        evidence_ledger,
+        *,
+        max_replans=DEFAULT_MAX_REPLANS,
+        max_nodes=DEFAULT_MAX_RUNTIME_NODES,
+    ):
+        if not isinstance(plan, Mapping):
+            raise OrchestrationRuntimeError('plan must be a mapping')
+        if not isinstance(evidence_ledger, MutableMapping):
+            raise OrchestrationRuntimeError('evidence_ledger must be a mutable mapping')
+        run_id = _normalize_identifier(plan.get('run_id'), 'run id')
+        if run_id != str(evidence_ledger.get('run_id') or '').strip():
+            raise OrchestrationRuntimeError('plan and evidence ledger run ids must match')
+        mode = str(plan.get('mode') or '').strip().lower()
+        if mode not in {'direct', 'coordinated'}:
+            raise OrchestrationRuntimeError('plan mode must be direct or coordinated')
+        if mode != str(evidence_ledger.get('orchestration_mode') or '').strip().lower():
+            raise OrchestrationRuntimeError('plan and evidence ledger modes must match')
+
+        normalized_max_replans = int(max_replans)
+        normalized_max_nodes = int(max_nodes)
+        if normalized_max_replans < 0:
+            raise OrchestrationRuntimeError('max_replans must be nonnegative')
+        if normalized_max_nodes < 1:
+            raise OrchestrationRuntimeError('max_nodes must be positive')
+
+        nodes = [OrchestrationNode.from_plan_step(step) for step in plan.get('steps') or []]
+        if not nodes:
+            raise OrchestrationRuntimeError('plan must contain at least one step')
+        if len(nodes) > normalized_max_nodes:
+            raise OrchestrationRuntimeError('plan exceeds the runtime node budget')
+        _validate_execution_graph(nodes)
+        finalizer_nodes = [node for node in nodes if node.type == 'finalize']
+        if len(finalizer_nodes) != 1:
+            raise OrchestrationRuntimeError('plan must contain exactly one finalizer step')
+
+        policy = plan.get('policy') if isinstance(plan.get('policy'), Mapping) else {}
+        return cls(
+            run_id=run_id,
+            task_type=_normalize_identifier(plan.get('task_type'), 'task type'),
+            task_profile=_normalize_text(plan.get('task_profile'), max_chars=120) or None,
+            mode=mode,
+            plan_snapshot=copy.deepcopy(dict(plan)),
+            evidence_ledger=evidence_ledger,
+            nodes=nodes,
+            policy=copy.deepcopy(dict(policy)),
+            max_replans=normalized_max_replans,
+            max_nodes=normalized_max_nodes,
+        )
+
+    def to_metadata(self):
+        node_counts = {
+            status: sum(node.status == status for node in self.nodes)
+            for status in sorted(ORCHESTRATION_NODE_STATUSES)
+            if any(node.status == status for node in self.nodes)
+        }
+        return {
+            'version': ORCHESTRATION_RUNTIME_VERSION,
+            'run_id': self.run_id,
+            'task_type': self.task_type,
+            'task_profile': self.task_profile,
+            'mode': self.mode,
+            'status': self.status,
+            'started_at': self.started_at,
+            'completed_at': self.completed_at,
+            'replan_count': self.replan_count,
+            'max_replans': self.max_replans,
+            'node_counts': node_counts,
+            'nodes': [node.to_metadata() for node in self.nodes],
+            'warnings': list(self.warnings),
+            'evidence_ledger_size_bytes': _ledger_size_bytes(self.evidence_ledger),
+        }
+
+
+def _validate_execution_graph(nodes):
+    node_ids = [node.id for node in nodes]
+    if len(node_ids) != len(set(node_ids)):
+        raise OrchestrationRuntimeError('orchestration node ids must be unique')
+    known_ids = set(node_ids)
+    for node in nodes:
+        unknown_dependencies = [
+            dependency_id
+            for dependency_id in node.depends_on
+            if dependency_id not in known_ids
+        ]
+        if unknown_dependencies:
+            raise OrchestrationRuntimeError(
+                f'node {node.id} has unknown dependencies: {", ".join(unknown_dependencies)}'
+            )
+        if node.id in node.depends_on:
+            raise OrchestrationRuntimeError(f'node {node.id} cannot depend on itself')
+
+    remaining = {node.id: set(node.depends_on) for node in nodes}
+    while remaining:
+        ready_ids = {node_id for node_id, dependencies in remaining.items() if not dependencies}
+        if not ready_ids:
+            raise OrchestrationRuntimeError('orchestration execution graph contains a cycle')
+        remaining = {
+            node_id: dependencies - ready_ids
+            for node_id, dependencies in remaining.items()
+            if node_id not in ready_ids
+        }
+
+
+def _ledger_size_bytes(ledger):
+    try:
+        return len(json.dumps(ledger, ensure_ascii=True, separators=(',', ':')).encode('utf-8'))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _normalize_adapters(adapters):
+    if not isinstance(adapters, Mapping):
+        raise OrchestrationRuntimeError('adapters must be a mapping')
+    normalized = {}
+    for key, adapter in adapters.items():
+        normalized_key = str(key or '').strip()
+        if not normalized_key:
+            raise OrchestrationRuntimeError('adapter keys must be nonempty')
+        if isinstance(adapter, OrchestrationNodeAdapter):
+            max_attempts = int(adapter.max_attempts)
+            if max_attempts < 1 or max_attempts > MAX_NODE_ATTEMPTS:
+                raise OrchestrationRuntimeError(
+                    f'adapter max_attempts must be between 1 and {MAX_NODE_ATTEMPTS}'
+                )
+            normalized[normalized_key] = OrchestrationNodeAdapter(
+                execute=adapter.execute,
+                parallel_safe=adapter.parallel_safe,
+                read_only=adapter.read_only,
+                cancel=adapter.cancel,
+                max_attempts=max_attempts if adapter.read_only else 1,
+                retry_on_exception=(
+                    bool(adapter.retry_on_exception) if adapter.read_only else False
+                ),
+            )
+        elif callable(adapter):
+            normalized[normalized_key] = OrchestrationNodeAdapter(execute=adapter)
+        else:
+            raise OrchestrationRuntimeError('adapter values must be callable runtime adapters')
+    return normalized
+
+
+def _resolve_adapter(node, adapters):
+    for key in (
+        node.id,
+        f'{node.type}.{node.capability}',
+        node.capability,
+        node.type,
+    ):
+        if key in adapters:
+            return adapters[key]
+    return None
+
+
+def _normalize_node_result(raw_result, node):
+    if raw_result is None:
+        result = OrchestrationNodeResult()
+    elif isinstance(raw_result, OrchestrationNodeResult):
+        result = raw_result
+    elif isinstance(raw_result, Mapping):
+        collector_result = raw_result.get('collector_result')
+        if collector_result is None and raw_result.get('source_type'):
+            collector_result = raw_result
+        raw_status = raw_result.get('node_status') or raw_result.get('status') or 'succeeded'
+        normalized_raw_status = str(raw_status).strip().lower()
+        normalized_status = COLLECTOR_TO_NODE_STATUS.get(
+            normalized_raw_status,
+            normalized_raw_status,
+        )
+        additional_nodes = raw_result.get('additional_nodes') or ()
+        if isinstance(additional_nodes, Mapping):
+            additional_nodes = (additional_nodes,)
+        result = OrchestrationNodeResult(
+            status=normalized_status,
+            summary=_normalize_text(raw_result.get('summary')),
+            collector_result=(
+                copy.deepcopy(dict(collector_result))
+                if isinstance(collector_result, Mapping)
+                else None
+            ),
+            additional_nodes=tuple(additional_nodes),
+            error_type=raw_result.get('error_type'),
+            user_message=raw_result.get('user_message'),
+            debug_message=raw_result.get('debug_message'),
+            retryable=bool(raw_result.get('retryable', False)),
+        )
+    else:
+        raise OrchestrationRuntimeError(
+            f'adapter for {node.id} returned an unsupported result type'
+        )
+
+    normalized_status = str(result.status or '').strip().lower()
+    if normalized_status not in ORCHESTRATION_TERMINAL_NODE_STATUSES:
+        raise OrchestrationRuntimeError(
+            f'adapter for {node.id} returned unsupported status {normalized_status or "empty"}'
+        )
+    return OrchestrationNodeResult(
+        status=normalized_status,
+        summary=_normalize_text(result.summary),
+        collector_result=(
+            copy.deepcopy(dict(result.collector_result))
+            if isinstance(result.collector_result, Mapping)
+            else None
+        ),
+        additional_nodes=tuple(result.additional_nodes or ()),
+        error_type=_safe_error_type(result.error_type) if result.error_type else None,
+        user_message=_normalize_text(result.user_message),
+        debug_message=_normalize_text(result.debug_message),
+        retryable=bool(result.retryable),
+        attempt_count=max(1, min(int(result.attempt_count), MAX_NODE_ATTEMPTS)),
+    )
+
+
+def _adapter_failure_result(node, ex, *, retryable=False):
+    return OrchestrationNodeResult(
+        status='failed',
+        error_type=type(ex).__name__,
+        user_message=f'The {node.capability.replace("_", " ")} step could not be completed.',
+        debug_message=str(ex),
+        retryable=retryable,
+    )
+
+
+def _adapter_unavailable_result(node):
+    return OrchestrationNodeResult(
+        status='failed',
+        error_type='adapter_unavailable',
+        user_message=f'The {node.capability.replace("_", " ")} capability is unavailable.',
+    )
+
+
+def _cancelled_result(node):
+    return OrchestrationNodeResult(
+        status='cancelled',
+        error_type='cancelled',
+        user_message=f'The {node.capability.replace("_", " ")} step was cancelled.',
+    )
+
+
+def _is_cancel_requested(callback):
+    if callback is None:
+        return False
+    try:
+        return bool(callback())
+    except Exception as ex:
+        log_event(
+            '[OrchestrationRuntime] Cancellation check failed',
+            {'error_type': type(ex).__name__},
+            debug_only=True,
+        )
+        return False
+
+
+def _build_node_context(run, node, original_request, cancel_requested):
+    return OrchestrationNodeContext(
+        run_id=run.run_id,
+        task_type=run.task_type,
+        task_profile=run.task_profile,
+        original_request=_normalize_text(original_request, max_chars=8000),
+        node=copy.deepcopy(node),
+        evidence_ledger=copy.deepcopy(dict(run.evidence_ledger)),
+        is_cancel_requested=lambda: _is_cancel_requested(cancel_requested),
+    )
+
+
+def _invoke_adapter(adapter, context):
+    if adapter is None:
+        return _normalize_node_result(
+            _adapter_unavailable_result(context.node),
+            context.node,
+        )
+    for attempt_number in range(1, adapter.max_attempts + 1):
+        if context.is_cancel_requested():
+            result = _normalize_node_result(_cancelled_result(context.node), context.node)
+        else:
+            try:
+                result = _normalize_node_result(adapter.execute(context), context.node)
+            except Exception as ex:
+                result = _normalize_node_result(
+                    _adapter_failure_result(
+                        context.node,
+                        ex,
+                        retryable=adapter.retry_on_exception,
+                    ),
+                    context.node,
+                )
+        result = OrchestrationNodeResult(
+            status=result.status,
+            summary=result.summary,
+            collector_result=result.collector_result,
+            additional_nodes=result.additional_nodes,
+            error_type=result.error_type,
+            user_message=result.user_message,
+            debug_message=result.debug_message,
+            retryable=result.retryable,
+            attempt_count=attempt_number,
+        )
+        if (
+            result.status != 'failed'
+            or not result.retryable
+            or attempt_number >= adapter.max_attempts
+        ):
+            return result
+        log_event(
+            '[OrchestrationRuntime] Retrying read-only node',
+            {
+                'run_id': context.run_id,
+                'node_id': context.node.id,
+                'capability': context.node.capability,
+                'attempt_count': attempt_number,
+                'max_attempts': adapter.max_attempts,
+                'error_type': result.error_type,
+            },
+        )
+    return result
+
+
+def _progress_message(node, status):
+    base_message = PROGRESS_MESSAGES.get(
+        node.capability,
+        node.capability.replace('_', ' ').capitalize(),
+    )
+    if status == 'running':
+        return base_message
+    suffix = {
+        'succeeded': 'completed',
+        'partial': 'completed with partial results',
+        'failed': 'failed',
+        'skipped': 'was skipped',
+        'blocked': 'was blocked',
+        'cancelled': 'was cancelled',
+    }.get(status, status)
+    return f'{base_message} {suffix}'
+
+
+def _emit_progress(run, node, progress_callback):
+    if progress_callback is None:
+        return
+    event = {
+        'version': ORCHESTRATION_RUNTIME_VERSION,
+        'run_id': run.run_id,
+        'node_id': node.id,
+        'node_type': node.type,
+        'capability': node.capability,
+        'status': node.status,
+        'message': _progress_message(node, node.status),
+    }
+    try:
+        progress_callback(event)
+    except Exception as ex:
+        log_event(
+            '[OrchestrationRuntime] Progress callback failed',
+            {
+                'run_id': run.run_id,
+                'node_id': node.id,
+                'error_type': type(ex).__name__,
+            },
+            debug_only=True,
+        )
+
+
+def _log_node_lifecycle(run, node):
+    log_event(
+        f'[OrchestrationRuntime] Node {node.status}',
+        {
+            'run_id': run.run_id,
+            'node_id': node.id,
+            'node_type': node.type,
+            'capability': node.capability,
+            'required': node.required,
+            'status': node.status,
+            'attempt_count': node.attempt_count,
+            'error_type': node.error_type,
+        },
+    )
+
+
+def _start_node(run, node, progress_callback):
+    node.status = 'running'
+    node.attempt_count += 1
+    node.started_at = _utc_now()
+    _emit_progress(run, node, progress_callback)
+    _log_node_lifecycle(run, node)
+
+
+def _complete_node(run, node, result, progress_callback):
+    node.status = result.status
+    node.attempt_count = max(node.attempt_count, result.attempt_count)
+    node.completed_at = _utc_now()
+    node.error_type = result.error_type
+    node.user_message = result.user_message or None
+    node.debug_message = result.debug_message or None
+    _apply_node_result_to_ledger(run, node, result)
+    _attach_existing_source_provenance(run.evidence_ledger, node)
+    _emit_progress(run, node, progress_callback)
+    _log_node_lifecycle(run, node)
+
+
+def _existing_ledger_ids(ledger):
+    return {
+        section: {
+            str(entry.get('id'))
+            for entry in ledger.get(section, [])
+            if isinstance(entry, Mapping) and entry.get('id')
+        }
+        for section in PROVENANCE_LEDGER_SECTIONS
+    }
+
+
+def _attach_node_provenance(ledger, node_id, previous_ids):
+    for section in PROVENANCE_LEDGER_SECTIONS:
+        known_ids = previous_ids.get(section, set())
+        for entry in ledger.get(section, []):
+            if not isinstance(entry, MutableMapping):
+                continue
+            if str(entry.get('id') or '') not in known_ids:
+                entry['step_id'] = node_id
+
+
+def _attach_existing_source_provenance(ledger, node):
+    source = _ledger_source(ledger, node.capability)
+    if isinstance(source, MutableMapping):
+        metadata = source.get('metadata')
+        if not isinstance(metadata, Mapping):
+            metadata = {}
+        source['metadata'] = {
+            **dict(metadata),
+            'runtime_node_id': node.id,
+        }
+
+    for section in ('facts', 'unsupported_facts', 'results', 'artifacts'):
+        for entry in ledger.get(section, []):
+            if not isinstance(entry, MutableMapping) or entry.get('step_id'):
+                continue
+            if node.capability in (entry.get('source_ids') or []):
+                entry['step_id'] = node.id
+    for entry in ledger.get('citations', []):
+        if (
+            isinstance(entry, MutableMapping)
+            and not entry.get('step_id')
+            and entry.get('source_id') == node.capability
+        ):
+            entry['step_id'] = node.id
+    for entry in ledger.get('missing_or_failed', []):
+        if (
+            isinstance(entry, MutableMapping)
+            and not entry.get('step_id')
+            and entry.get('source_id') == node.capability
+        ):
+            entry['step_id'] = node.id
+
+
+def _ledger_source(ledger, source_id):
+    return next(
+        (
+            source
+            for source in ledger.get('sources', [])
+            if isinstance(source, Mapping) and source.get('id') == source_id
+        ),
+        None,
+    )
+
+
+def _record_node_failure(run, node, result):
+    if any(
+        gap.get('step_id') == node.id
+        for gap in run.evidence_ledger.get('missing_or_failed', [])
+        if isinstance(gap, Mapping)
+    ):
+        return
+    source = _ledger_source(run.evidence_ledger, node.capability)
+    source_status = NODE_TO_SOURCE_STATUS.get(node.status, 'failed')
+    failure = add_execution_failure(
+        run.evidence_ledger,
+        node.capability,
+        source_status,
+        result.user_message
+        or f'The {node.capability.replace("_", " ")} step did not complete.',
+        source_id=node.capability if source else None,
+        step_id=node.id,
+        failure_id=f'failure_{node.id}',
+    )
+    failure['error_type'] = result.error_type or 'execution_failed'
+
+
+def _apply_node_result_to_ledger(run, node, result):
+    previous_ids = _existing_ledger_ids(run.evidence_ledger)
+    if result.collector_result is not None:
+        collector_result = copy.deepcopy(dict(result.collector_result))
+        metadata = collector_result.get('metadata')
+        if not isinstance(metadata, Mapping):
+            metadata = {}
+        collector_result['metadata'] = {
+            **dict(metadata),
+            'runtime_node_id': node.id,
+        }
+        gaps = []
+        for gap in collector_result.get('missing_or_failed') or []:
+            if isinstance(gap, Mapping):
+                normalized_gap = dict(gap)
+                normalized_gap.setdefault('step_id', node.id)
+                gaps.append(normalized_gap)
+        collector_result['missing_or_failed'] = gaps
+        apply_evidence_collector_result(
+            run.evidence_ledger,
+            collector_result,
+            source_id=node.capability,
+            origin=node.origin,
+            required=node.required,
+        )
+    elif node.type != 'finalize':
+        source = _ledger_source(run.evidence_ledger, node.capability)
+        add_evidence_source(
+            run.evidence_ledger,
+            node.capability,
+            NODE_TO_SOURCE_STATUS.get(node.status, 'failed'),
+            source_id=node.capability,
+            origin=node.origin,
+            required=node.required,
+            requirement_ids=(source or {}).get('requirement_ids'),
+            metadata={'runtime_node_id': node.id},
+        )
+
+    _attach_node_provenance(run.evidence_ledger, node.id, previous_ids)
+    if node.status in ORCHESTRATION_FAILURE_NODE_STATUSES:
+        _record_node_failure(run, node, result)
+
+
+def _dependency_blocks(node, node_by_id):
+    return any(
+        node_by_id[dependency_id].required
+        and node_by_id[dependency_id].status in ORCHESTRATION_FAILURE_NODE_STATUSES
+        for dependency_id in node.depends_on
+    )
+
+
+def _block_failed_dependents(run, progress_callback):
+    changed = True
+    while changed:
+        changed = False
+        node_by_id = {node.id: node for node in run.nodes}
+        for node in run.nodes:
+            if node.status != 'pending' or not _dependency_blocks(node, node_by_id):
+                continue
+            result = OrchestrationNodeResult(
+                status='blocked',
+                error_type='required_dependency_failed',
+                user_message=(
+                    f'The {node.capability.replace("_", " ")} step was blocked because '
+                    'a required dependency did not complete.'
+                ),
+            )
+            node.completed_at = _utc_now()
+            node.status = result.status
+            node.error_type = result.error_type
+            node.user_message = result.user_message
+            _apply_node_result_to_ledger(run, node, result)
+            _emit_progress(run, node, progress_callback)
+            _log_node_lifecycle(run, node)
+            changed = True
+
+
+def _ready_nodes(run):
+    node_by_id = {node.id: node for node in run.nodes}
+    return [
+        node
+        for node in run.nodes
+        if node.status == 'pending'
+        and all(
+            node_by_id[dependency_id].status in ORCHESTRATION_TERMINAL_NODE_STATUSES
+            for dependency_id in node.depends_on
+        )
+        and not _dependency_blocks(node, node_by_id)
+    ]
+
+
+def _parallel_eligible(node, adapter):
+    return bool(
+        adapter
+        and adapter.parallel_safe
+        and adapter.read_only
+        and node.type in ORCHESTRATION_PARALLEL_NODE_TYPES
+    )
+
+
+def _select_execution_batch(ready_nodes, adapters, max_parallel_nodes):
+    if max_parallel_nodes <= 1:
+        return ready_nodes[:1]
+    parallel_nodes = [
+        node
+        for node in ready_nodes
+        if _parallel_eligible(node, _resolve_adapter(node, adapters))
+    ]
+    if len(parallel_nodes) >= 2:
+        return parallel_nodes[:max_parallel_nodes]
+    return ready_nodes[:1]
+
+
+def _cancel_adapter(adapter, context):
+    if adapter is None or adapter.cancel is None:
+        return
+    try:
+        adapter.cancel(context)
+    except Exception as ex:
+        log_event(
+            '[OrchestrationRuntime] Adapter cancellation failed',
+            {
+                'node_id': context.node.id,
+                'error_type': type(ex).__name__,
+            },
+            debug_only=True,
+        )
+
+
+def _execute_batch(
+    run,
+    batch,
+    adapters,
+    original_request,
+    cancel_requested,
+    progress_callback,
+):
+    invocations = []
+    for node in batch:
+        if node.type == 'finalize':
+            _prepare_ledger_for_finalizer(run)
+        _start_node(run, node, progress_callback)
+        adapter = _resolve_adapter(node, adapters)
+        context = _build_node_context(run, node, original_request, cancel_requested)
+        invocations.append((node, adapter, context))
+
+    if len(invocations) == 1:
+        node, adapter, context = invocations[0]
+        result = _invoke_adapter(adapter, context)
+        if _is_cancel_requested(cancel_requested):
+            _cancel_adapter(adapter, context)
+            result = _cancelled_result(node)
+        return [(node, result)]
+
+    results = {}
+    cancellation_signalled = set()
+    with ThreadPoolExecutor(max_workers=len(invocations)) as executor:
+        future_to_invocation = {
+            executor.submit(_invoke_adapter, adapter, context): (node, adapter, context)
+            for node, adapter, context in invocations
+        }
+        pending_futures = set(future_to_invocation)
+        while pending_futures:
+            completed_futures, pending_futures = wait(
+                pending_futures,
+                timeout=0.05,
+                return_when=FIRST_COMPLETED,
+            )
+            if _is_cancel_requested(cancel_requested):
+                for future in pending_futures:
+                    node, adapter, context = future_to_invocation[future]
+                    if node.id not in cancellation_signalled:
+                        cancellation_signalled.add(node.id)
+                        future.cancel()
+                        _cancel_adapter(adapter, context)
+            for future in completed_futures:
+                node, _adapter, _context = future_to_invocation[future]
+                try:
+                    result = future.result()
+                except CancelledError:
+                    result = _cancelled_result(node)
+                results[node.id] = result
+
+    cancellation_requested = _is_cancel_requested(cancel_requested)
+    return [
+        (
+            node,
+            _cancelled_result(node) if cancellation_requested else results[node.id],
+        )
+        for node, _adapter, _context in invocations
+    ]
+
+
+def _prepare_ledger_for_finalizer(run):
+    source_nodes = [node for node in run.nodes if node.type != 'finalize']
+    if not source_nodes:
+        set_evidence_ledger_status(run.evidence_ledger, 'ready')
+        return
+    if any(
+        node.required and node.status in ORCHESTRATION_FAILURE_NODE_STATUSES
+        for node in source_nodes
+    ):
+        set_evidence_ledger_status(run.evidence_ledger, 'failed')
+    elif any(
+        node.status == 'partial'
+        or (not node.required and node.status in ORCHESTRATION_FAILURE_NODE_STATUSES)
+        for node in source_nodes
+    ):
+        set_evidence_ledger_status(run.evidence_ledger, 'partial')
+    else:
+        set_evidence_ledger_status(run.evidence_ledger, 'ready')
+
+
+def _replan_is_allowed(run):
+    return bool(run.policy.get('allow_bounded_replanning', False))
+
+
+def _downgrade_replan_node(run, node, warning):
+    if warning not in run.warnings:
+        run.warnings.append(warning)
+    if node.status == 'succeeded':
+        node.status = 'partial'
+        source = _ledger_source(run.evidence_ledger, node.capability)
+        if source:
+            source['status'] = 'partial'
+
+
+def _apply_replanned_nodes(run, node, additional_nodes):
+    if not additional_nodes:
+        return
+    if not _replan_is_allowed(run):
+        _downgrade_replan_node(run, node, 'replanning_not_allowed')
+        return
+    if run.replan_count >= run.max_replans:
+        _downgrade_replan_node(run, node, 'replan_budget_exhausted')
+        return
+    if not all(isinstance(step, Mapping) for step in additional_nodes):
+        _downgrade_replan_node(run, node, 'invalid_replan_nodes')
+        return
+
+    normalized_nodes = [OrchestrationNode.from_plan_step(step) for step in additional_nodes]
+    if any(replanned.type not in ORCHESTRATION_REPLAN_NODE_TYPES for replanned in normalized_nodes):
+        _downgrade_replan_node(run, node, 'replan_requires_read_only_nodes')
+        return
+    if len(run.nodes) + len(normalized_nodes) > run.max_nodes:
+        _downgrade_replan_node(run, node, 'runtime_node_budget_exhausted')
+        return
+
+    finalizer = next(existing for existing in run.nodes if existing.type == 'finalize')
+    insertion_index = run.nodes.index(finalizer)
+    candidate_nodes = copy.deepcopy([
+        *run.nodes[:insertion_index],
+        *normalized_nodes,
+        *run.nodes[insertion_index:],
+    ])
+    candidate_finalizer = next(
+        candidate for candidate in candidate_nodes if candidate.type == 'finalize'
+    )
+    for replanned in normalized_nodes:
+        if replanned.id not in candidate_finalizer.depends_on:
+            candidate_finalizer.depends_on.append(replanned.id)
+    try:
+        _validate_execution_graph(candidate_nodes)
+    except OrchestrationRuntimeError:
+        _downgrade_replan_node(run, node, 'invalid_replan_graph')
+        return
+    for replanned in normalized_nodes:
+        if replanned.id not in finalizer.depends_on:
+            finalizer.depends_on.append(replanned.id)
+    run.nodes[insertion_index:insertion_index] = normalized_nodes
+    run.replan_count += 1
+
+
+def _cancel_pending_nodes(run, progress_callback):
+    run.cancel_requested = True
+    for node in run.nodes:
+        if node.status != 'pending':
+            continue
+        result = _cancelled_result(node)
+        node.status = result.status
+        node.completed_at = _utc_now()
+        node.error_type = result.error_type
+        node.user_message = result.user_message
+        _apply_node_result_to_ledger(run, node, result)
+        _emit_progress(run, node, progress_callback)
+        _log_node_lifecycle(run, node)
+
+
+def _finalize_run(run):
+    if run.completed_at:
+        return
+    finalizer = next(node for node in run.nodes if node.type == 'finalize')
+    if run.cancel_requested or finalizer.status == 'cancelled':
+        run.status = 'cancelled'
+        set_evidence_ledger_status(run.evidence_ledger, 'cancelled')
+    elif finalizer.status in {'succeeded', 'partial'}:
+        degraded = finalizer.status == 'partial' or any(
+            node.status == 'partial'
+            or (not node.required and node.status in ORCHESTRATION_FAILURE_NODE_STATUSES)
+            for node in run.nodes
+            if node.type != 'finalize'
+        )
+        run.status = 'partial' if degraded else 'succeeded'
+        set_evidence_ledger_status(run.evidence_ledger, 'completed')
+    else:
+        run.status = 'failed'
+        set_evidence_ledger_status(run.evidence_ledger, 'failed')
+    run.completed_at = _utc_now()
+    log_event(
+        f'[OrchestrationRuntime] Run {run.status}',
+        {
+            'run_id': run.run_id,
+            'task_type': run.task_type,
+            'task_profile': run.task_profile,
+            'mode': run.mode,
+            'status': run.status,
+            'node_count': len(run.nodes),
+            'replan_count': run.replan_count,
+            'evidence_ledger_size_bytes': _ledger_size_bytes(run.evidence_ledger),
+        },
+    )
+
+
+def _start_run(run, *, max_parallel_nodes=DEFAULT_MAX_PARALLEL_NODES):
+    if run.status == 'running':
+        return
+    if run.status != 'pending':
+        raise OrchestrationRuntimeError('a completed orchestration run cannot restart')
+    run.status = 'running'
+    run.started_at = _utc_now()
+    log_event(
+        '[OrchestrationRuntime] Run started',
+        {
+            'run_id': run.run_id,
+            'task_type': run.task_type,
+            'task_profile': run.task_profile,
+            'mode': run.mode,
+            'node_count': len(run.nodes),
+            'max_parallel_nodes': max_parallel_nodes,
+            'max_replans': run.max_replans,
+        },
+    )
+
+
+def _find_runtime_node(run, node_id):
+    normalized_node_id = str(node_id or '').strip()
+    node = next((candidate for candidate in run.nodes if candidate.id == normalized_node_id), None)
+    if node is None:
+        raise OrchestrationRuntimeError(f'unknown orchestration node: {normalized_node_id}')
+    return node
+
+
+def reconcile_orchestration_run_from_ledger(run, *, progress_callback=None):
+    """Reconcile authorized collector outputs already applied by an existing request path."""
+    if not isinstance(run, OrchestrationRun):
+        raise OrchestrationRuntimeError('run must be an OrchestrationRun')
+    _start_run(run)
+
+    reconciled = True
+    while reconciled:
+        reconciled = False
+        _block_failed_dependents(run, progress_callback)
+        ready_ids = {node.id for node in _ready_nodes(run)}
+        for node in run.nodes:
+            if node.type == 'finalize' or node.status != 'pending' or node.id not in ready_ids:
+                continue
+            source = _ledger_source(run.evidence_ledger, node.capability)
+            source_status = str((source or {}).get('status') or '').strip().lower()
+            node_status = SOURCE_TO_NODE_STATUS.get(source_status)
+            if node_status is None:
+                continue
+            _attach_existing_source_provenance(run.evidence_ledger, node)
+            _start_node(run, node, progress_callback)
+            result = OrchestrationNodeResult(
+                status=node_status,
+                summary=_normalize_text((source or {}).get('summary')),
+                error_type=(
+                    source_status
+                    if node_status in ORCHESTRATION_FAILURE_NODE_STATUSES
+                    else None
+                ),
+                user_message=(
+                    f'The {node.capability.replace("_", " ")} source ended with '
+                    f'{source_status.replace("_", " ")} status.'
+                    if node_status in ORCHESTRATION_FAILURE_NODE_STATUSES
+                    else None
+                ),
+            )
+            _complete_node(run, node, result, progress_callback)
+            _attach_existing_source_provenance(run.evidence_ledger, node)
+            reconciled = True
+    return run
+
+
+def start_orchestration_node(run, node_id, *, progress_callback=None):
+    """Start one externally executed node after enforcing graph dependencies."""
+    if not isinstance(run, OrchestrationRun):
+        raise OrchestrationRuntimeError('run must be an OrchestrationRun')
+    reconcile_orchestration_run_from_ledger(run, progress_callback=progress_callback)
+    _block_failed_dependents(run, progress_callback)
+    node = _find_runtime_node(run, node_id)
+    if node.status != 'pending':
+        raise OrchestrationRuntimeError(
+            f'orchestration node {node.id} cannot start from {node.status}'
+        )
+    if node.id not in {ready.id for ready in _ready_nodes(run)}:
+        raise OrchestrationRuntimeError(
+            f'orchestration node {node.id} has nonterminal dependencies'
+        )
+    if node.type == 'finalize':
+        _prepare_ledger_for_finalizer(run)
+    _start_node(run, node, progress_callback)
+    return node
+
+
+def complete_orchestration_node(run, node_id, result=None, *, progress_callback=None):
+    """Complete one externally executed node and normalize its ledger lifecycle."""
+    if not isinstance(run, OrchestrationRun):
+        raise OrchestrationRuntimeError('run must be an OrchestrationRun')
+    node = _find_runtime_node(run, node_id)
+    if node.status != 'running':
+        raise OrchestrationRuntimeError(
+            f'orchestration node {node.id} cannot complete from {node.status}'
+        )
+    normalized_result = _normalize_node_result(result, node)
+    _complete_node(run, node, normalized_result, progress_callback)
+    _apply_replanned_nodes(run, node, normalized_result.additional_nodes)
+    _block_failed_dependents(run, progress_callback)
+    return node
+
+
+def cancel_orchestration_run(run, *, progress_callback=None):
+    """Mark pending and externally running nodes cancelled, then close the request run."""
+    if not isinstance(run, OrchestrationRun):
+        raise OrchestrationRuntimeError('run must be an OrchestrationRun')
+    if run.completed_at:
+        return run
+    _start_run(run)
+    run.cancel_requested = True
+    for node in run.nodes:
+        if node.status not in {'pending', 'running'}:
+            continue
+        result = _cancelled_result(node)
+        if node.status == 'running':
+            _complete_node(run, node, result, progress_callback)
+        else:
+            node.status = result.status
+            node.completed_at = _utc_now()
+            node.error_type = result.error_type
+            node.user_message = result.user_message
+            _apply_node_result_to_ledger(run, node, result)
+            _emit_progress(run, node, progress_callback)
+            _log_node_lifecycle(run, node)
+    _finalize_run(run)
+    return run
+
+
+def fail_orchestration_run(
+    run,
+    *,
+    error_type='request_failed',
+    user_message='The orchestration request could not be completed.',
+    progress_callback=None,
+):
+    """Fail active work, block pending work, and close one request-scoped run."""
+    if not isinstance(run, OrchestrationRun):
+        raise OrchestrationRuntimeError('run must be an OrchestrationRun')
+    if run.completed_at:
+        return run
+    _start_run(run)
+    normalized_error_type = _safe_error_type(error_type)
+    normalized_user_message = _normalize_text(user_message)
+    for node in run.nodes:
+        if node.status == 'running':
+            _complete_node(
+                run,
+                node,
+                OrchestrationNodeResult(
+                    status='failed',
+                    error_type=normalized_error_type,
+                    user_message=normalized_user_message,
+                ),
+                progress_callback,
+            )
+        elif node.status == 'pending':
+            node.status = 'blocked'
+            node.completed_at = _utc_now()
+            node.error_type = normalized_error_type
+            node.user_message = normalized_user_message
+            _apply_node_result_to_ledger(
+                run,
+                node,
+                OrchestrationNodeResult(
+                    status='blocked',
+                    error_type=normalized_error_type,
+                    user_message=normalized_user_message,
+                ),
+            )
+            _emit_progress(run, node, progress_callback)
+            _log_node_lifecycle(run, node)
+    _finalize_run(run)
+    return run
+
+
+def finish_orchestration_run(run):
+    """Close a fully terminal externally executed run and derive its aggregate status."""
+    if not isinstance(run, OrchestrationRun):
+        raise OrchestrationRuntimeError('run must be an OrchestrationRun')
+    if any(node.status not in ORCHESTRATION_TERMINAL_NODE_STATUSES for node in run.nodes):
+        raise OrchestrationRuntimeError('orchestration run still has nonterminal nodes')
+    _finalize_run(run)
+    return run
+
+
+def execute_orchestration_run(
+    run,
+    adapters,
+    *,
+    original_request='',
+    cancel_requested=None,
+    progress_callback=None,
+    max_parallel_nodes=DEFAULT_MAX_PARALLEL_NODES,
+):
+    """Execute one request-scoped run through injected, authorization-preserving adapters."""
+    if not isinstance(run, OrchestrationRun):
+        raise OrchestrationRuntimeError('run must be an OrchestrationRun')
+    if run.status != 'pending':
+        raise OrchestrationRuntimeError('an orchestration run can execute only once')
+    normalized_max_parallel_nodes = int(max_parallel_nodes)
+    if normalized_max_parallel_nodes < 1:
+        raise OrchestrationRuntimeError('max_parallel_nodes must be positive')
+    normalized_adapters = _normalize_adapters(adapters)
+    _start_run(run, max_parallel_nodes=normalized_max_parallel_nodes)
+
+    while any(node.status == 'pending' for node in run.nodes):
+        if _is_cancel_requested(cancel_requested):
+            _cancel_pending_nodes(run, progress_callback)
+            break
+        _block_failed_dependents(run, progress_callback)
+        ready_nodes = _ready_nodes(run)
+        if not ready_nodes:
+            if any(node.status == 'pending' for node in run.nodes):
+                raise OrchestrationRuntimeError('orchestration graph cannot make progress')
+            break
+        batch = _select_execution_batch(
+            ready_nodes,
+            normalized_adapters,
+            normalized_max_parallel_nodes,
+        )
+        completed = _execute_batch(
+            run,
+            batch,
+            normalized_adapters,
+            original_request,
+            cancel_requested,
+            progress_callback,
+        )
+        for node, result in completed:
+            _complete_node(run, node, result, progress_callback)
+            _apply_replanned_nodes(run, node, result.additional_nodes)
+        if _is_cancel_requested(cancel_requested):
+            _cancel_pending_nodes(run, progress_callback)
+            break
+
+    _block_failed_dependents(run, progress_callback)
+    if _is_cancel_requested(cancel_requested):
+        _cancel_pending_nodes(run, progress_callback)
+    _finalize_run(run)
+    return run
+
+
+def resolve_orchestration_evidence_discovery(run, *, progress_callback=None):
+    """Resolve the generic discovery node from usable authorized evidence already collected."""
+    if not isinstance(run, OrchestrationRun):
+        raise OrchestrationRuntimeError('run must be an OrchestrationRun')
+    discovery_node = next(
+        (node for node in run.nodes if node.capability == 'evidence_discovery'),
+        None,
+    )
+    if discovery_node is None or discovery_node.status != 'pending':
+        return discovery_node
+
+    evidence_source_ids = []
+    for section in ('facts', 'results', 'artifacts'):
+        for entry in run.evidence_ledger.get(section, []):
+            if not isinstance(entry, Mapping):
+                continue
+            for source_id in entry.get('source_ids') or []:
+                normalized_source_id = str(source_id or '').strip()
+                if (
+                    normalized_source_id
+                    and normalized_source_id != 'evidence_discovery'
+                    and normalized_source_id not in evidence_source_ids
+                ):
+                    evidence_source_ids.append(normalized_source_id)
+    for citation in run.evidence_ledger.get('citations', []):
+        if not isinstance(citation, Mapping):
+            continue
+        source_id = str(citation.get('source_id') or '').strip()
+        if source_id and source_id != 'evidence_discovery' and source_id not in evidence_source_ids:
+            evidence_source_ids.append(source_id)
+
+    authorized_source_ids = {
+        str(source.get('id') or '').strip()
+        for source in run.evidence_ledger.get('sources', [])
+        if isinstance(source, Mapping)
+        and source.get('authorization_status') != 'denied'
+        and str(source.get('status') or '').strip().lower() in {'succeeded', 'partial'}
+    }
+    usable_source_ids = [
+        source_id for source_id in evidence_source_ids if source_id in authorized_source_ids
+    ]
+
+    start_orchestration_node(
+        run,
+        discovery_node.id,
+        progress_callback=progress_callback,
+    )
+    if usable_source_ids:
+        collector_result = {
+            'source_type': 'evidence_discovery',
+            'status': 'succeeded',
+            'summary': (
+                f'Discovered usable authorized evidence from {len(usable_source_ids)} source(s).'
+            ),
+            'facts': [],
+            'citations': [],
+            'artifacts': [],
+            'missing_or_failed': [],
+            'metadata': {
+                'authorization_status': 'authorized',
+                'discovered_source_ids': usable_source_ids,
+            },
+        }
+        result = OrchestrationNodeResult(
+            status='succeeded',
+            summary=collector_result['summary'],
+            collector_result=collector_result,
+        )
+    else:
+        collector_result = {
+            'source_type': 'evidence_discovery',
+            'status': 'not_found',
+            'summary': 'No usable authorized evidence was discovered for the requested grounding.',
+            'facts': [],
+            'citations': [],
+            'artifacts': [],
+            'missing_or_failed': [{
+                'kind': 'missing_evidence',
+                'status': 'not_found',
+                'message': 'No usable authorized evidence was found for the requested grounding.',
+                'step_id': discovery_node.id,
+            }],
+            'metadata': {'authorization_status': 'authorized'},
+        }
+        result = OrchestrationNodeResult(
+            status='failed',
+            summary=collector_result['summary'],
+            collector_result=collector_result,
+            error_type='evidence_not_found',
+            user_message='No usable authorized evidence was found for the requested grounding.',
+        )
+    complete_orchestration_node(
+        run,
+        discovery_node.id,
+        result,
+        progress_callback=progress_callback,
+    )
+    return discovery_node

--- a/application/single_app/route_backend_chats.py
+++ b/application/single_app/route_backend_chats.py
@@ -131,6 +131,17 @@ from functions_evidence_ledger import (
     create_evidence_ledger_from_plan,
     set_evidence_ledger_status,
 )
+from functions_orchestration_runtime import (
+    OrchestrationNodeResult,
+    OrchestrationRun,
+    cancel_orchestration_run,
+    complete_orchestration_node,
+    fail_orchestration_run,
+    finish_orchestration_run,
+    reconcile_orchestration_run_from_ledger,
+    resolve_orchestration_evidence_discovery,
+    start_orchestration_node,
+)
 from functions_image_messages import build_image_message_documents, decode_image_content
 from functions_icon_utils import normalize_icon_payload
 from functions_image_generation import (
@@ -11852,7 +11863,12 @@ def register_route_backend_chats(bp):
         invalidate_conversation_cache_for_item(conversation_item, reason="conversation_created")
         return conversation_item
 
-    def execute_document_action_chat_request(data=None, publish_background_event=None, forced_action_type=None):
+    def execute_document_action_chat_request(
+        data=None,
+        publish_background_event=None,
+        forced_action_type=None,
+        cancel_requested=None,
+    ):
         settings = get_settings()
         data = data if isinstance(data, dict) else (request.get_json() or {})
         user_id = get_current_user_id()
@@ -12101,31 +12117,34 @@ def register_route_backend_chats(bp):
             conversation_id=conversation_id,
             user_message_id=user_message_id,
         )
-        action_evidence_task = None
-        if turn_orchestration_plan.get('grounded_image_generation_requested'):
-            action_evidence_task = build_agent_action_evidence_task(
-                turn_orchestration_plan,
-                turn_evidence_ledger,
-                user_message,
-                executor_type='selected_action',
-                executor_name=normalized_action.get('type'),
-                capability_metadata=normalized_action,
-                authorization_context=getattr(g, 'authorized_chat_context', None),
+        turn_orchestration_run = OrchestrationRun.from_plan(
+            turn_orchestration_plan,
+            turn_evidence_ledger,
+        )
+        reconcile_orchestration_run_from_ledger(turn_orchestration_run)
+        action_evidence_task = build_agent_action_evidence_task(
+            turn_orchestration_plan,
+            turn_evidence_ledger,
+            user_message,
+            executor_type='selected_action',
+            executor_name=normalized_action.get('type'),
+            capability_metadata=normalized_action,
+            authorization_context=getattr(g, 'authorized_chat_context', None),
+        )
+        if action_evidence_task and request_agent_info:
+            selected_agent_source = next(
+                (
+                    source
+                    for source in turn_evidence_ledger.get('sources', [])
+                    if source.get('id') == 'selected_agent'
+                ),
+                None,
             )
-            if action_evidence_task and request_agent_info:
-                selected_agent_source = next(
-                    (
-                        source
-                        for source in turn_evidence_ledger.get('sources', [])
-                        if source.get('id') == 'selected_agent'
-                    ),
-                    None,
-                )
-                if selected_agent_source:
-                    action_evidence_task['delegated_sources'].append({
-                        'source_id': 'selected_agent',
-                        'requirement_ids': [],
-                    })
+            if selected_agent_source:
+                action_evidence_task['delegated_sources'].append({
+                    'source_id': 'selected_agent',
+                    'requirement_ids': [],
+                })
         user_metadata = _build_document_action_user_metadata(
             data=data,
             user_id=user_id,
@@ -12139,6 +12158,7 @@ def register_route_backend_chats(bp):
         )
         user_metadata['orchestration'] = turn_orchestration_plan
         user_metadata['evidence_ledger'] = turn_evidence_ledger
+        user_metadata['orchestration_runtime'] = turn_orchestration_run.to_metadata()
         if auto_linked_chat_upload_document_ids:
             user_metadata['workspace_search']['auto_linked_chat_upload_document_ids'] = auto_linked_chat_upload_document_ids
             user_metadata['workspace_search']['auto_linked_chat_upload_document_count'] = len(auto_linked_chat_upload_document_ids)
@@ -12213,6 +12233,33 @@ def register_route_backend_chats(bp):
                     f"Queued {normalized_action.get('type').replace('_', ' ')} for {len(selected_document_ids)} selected document{'s' if len(selected_document_ids) != 1 else ''}"
                 )
 
+        def publish_orchestration_runtime_progress(event):
+            if callable(publish_stream_thought):
+                publish_stream_thought(event.get('message') or 'Updating orchestration progress')
+
+        def document_action_cancel_requested():
+            return bool(callable(cancel_requested) and cancel_requested())
+
+        def persist_cancelled_document_action_runtime():
+            cancel_orchestration_run(
+                turn_orchestration_run,
+                progress_callback=publish_orchestration_runtime_progress,
+            )
+            user_metadata['evidence_ledger'] = turn_evidence_ledger
+            user_metadata['orchestration_runtime'] = turn_orchestration_run.to_metadata()
+            user_message_doc['metadata'] = user_metadata
+            cosmos_messages_container.upsert_item(user_message_doc)
+            return {
+                'cancelled': True,
+                'conversation_id': conversation_id,
+                'user_message_id': user_message_id,
+                'metadata': {
+                    'orchestration': turn_orchestration_plan,
+                    'orchestration_runtime': turn_orchestration_run.to_metadata(),
+                    'evidence_ledger': turn_evidence_ledger,
+                },
+            }, 499
+
         assigned_knowledge_action_context = {}
         assigned_context_metadata = {}
         assigned_knowledge_context_citations = []
@@ -12226,6 +12273,16 @@ def register_route_backend_chats(bp):
                 )
             except SemanticSearchQuotaExceededError as exc:
                 debug_print(f'Semantic search quota exceeded during Assigned Knowledge action context search: {exc}')
+                fail_orchestration_run(
+                    turn_orchestration_run,
+                    error_type='assigned_knowledge_quota_exceeded',
+                    user_message='Assigned knowledge could not be searched within the available quota.',
+                    progress_callback=publish_orchestration_runtime_progress,
+                )
+                user_metadata['evidence_ledger'] = turn_evidence_ledger
+                user_metadata['orchestration_runtime'] = turn_orchestration_run.to_metadata()
+                user_message_doc['metadata'] = user_metadata
+                cosmos_messages_container.upsert_item(user_message_doc)
                 return {
                     'error': exc.user_message,
                     'warning_type': SEMANTIC_SEARCH_QUOTA_WARNING_TYPE,
@@ -12233,6 +12290,16 @@ def register_route_backend_chats(bp):
                 }, 503
             except Exception as exc:
                 debug_print(f'[ChatDocumentAction] Assigned Knowledge context search failed: {exc}')
+                fail_orchestration_run(
+                    turn_orchestration_run,
+                    error_type='assigned_knowledge_search_failed',
+                    user_message='Assigned knowledge could not be searched for this action.',
+                    progress_callback=publish_orchestration_runtime_progress,
+                )
+                user_metadata['evidence_ledger'] = turn_evidence_ledger
+                user_metadata['orchestration_runtime'] = turn_orchestration_run.to_metadata()
+                user_message_doc['metadata'] = user_metadata
+                cosmos_messages_container.upsert_item(user_message_doc)
                 return {
                     'error': 'There was an issue searching the assigned knowledge for this agent.'
                 }, 500
@@ -12258,10 +12325,11 @@ def register_route_backend_chats(bp):
             assigned_knowledge_action_context.get('context_block'),
             normalized_action.get('type'),
         )
-        workflow_task_prompt = append_agent_action_evidence_guidance(
-            workflow_task_prompt,
-            action_evidence_task,
-        )
+        if turn_orchestration_plan.get('grounded_image_generation_requested'):
+            workflow_task_prompt = append_agent_action_evidence_guidance(
+                workflow_task_prompt,
+                action_evidence_task,
+            )
 
         workflow_like = {
             'id': f'chat-analyze:{conversation_id}',
@@ -12295,6 +12363,8 @@ def register_route_backend_chats(bp):
         }
 
         try:
+            if document_action_cancel_requested():
+                return persist_cancelled_document_action_runtime()
             debug_print(
                 '[ChatDocumentAction] Executing action | '
                 f'user_id={user_id} | '
@@ -12311,6 +12381,8 @@ def register_route_backend_chats(bp):
                 thought_tracker=thought_tracker,
                 external_activity_callback=stream_activity_callback,
             )
+            if document_action_cancel_requested():
+                return persist_cancelled_document_action_runtime()
         except Exception as exc:
             debug_print(
                 '[ChatDocumentAction] Execution failed | '
@@ -12340,9 +12412,16 @@ def register_route_backend_chats(bp):
                     action_evidence_task,
                     action_failure_result,
                 )
-                user_metadata['evidence_ledger'] = turn_evidence_ledger
-                user_message_doc['metadata'] = user_metadata
-                cosmos_messages_container.upsert_item(user_message_doc)
+            fail_orchestration_run(
+                turn_orchestration_run,
+                error_type='document_action_failed',
+                user_message='The selected document action could not be completed.',
+                progress_callback=publish_orchestration_runtime_progress,
+            )
+            user_metadata['evidence_ledger'] = turn_evidence_ledger
+            user_metadata['orchestration_runtime'] = turn_orchestration_run.to_metadata()
+            user_message_doc['metadata'] = user_metadata
+            cosmos_messages_container.upsert_item(user_message_doc)
             return {'error': str(exc), 'conversation_id': conversation_id, 'user_message_id': user_message_id}, 500
 
         assistant_timestamp = datetime.utcnow().isoformat()
@@ -12397,10 +12476,78 @@ def register_route_backend_chats(bp):
                 action_evidence_task,
                 action_evidence_result,
             )
-            document_action_reply = build_agent_action_evidence_status_message(
-                action_evidence_result
+            if turn_orchestration_plan.get('grounded_image_generation_requested'):
+                document_action_reply = build_agent_action_evidence_status_message(
+                    action_evidence_result
+                )
+        try:
+            resolve_orchestration_evidence_discovery(
+                turn_orchestration_run,
+                progress_callback=publish_orchestration_runtime_progress,
             )
+            reconcile_orchestration_run_from_ledger(
+                turn_orchestration_run,
+                progress_callback=publish_orchestration_runtime_progress,
+            )
+            finalizer_node = next(
+                node for node in turn_orchestration_run.nodes if node.type == 'finalize'
+            )
+            if finalizer_node.status == 'pending':
+                if 'document_action_finalizer_compatibility' not in turn_orchestration_run.warnings:
+                    turn_orchestration_run.warnings.append(
+                        'document_action_finalizer_compatibility'
+                    )
+                start_orchestration_node(
+                    turn_orchestration_run,
+                    finalizer_node.id,
+                    progress_callback=publish_orchestration_runtime_progress,
+                )
+                complete_orchestration_node(
+                    turn_orchestration_run,
+                    finalizer_node.id,
+                    OrchestrationNodeResult(
+                        status='succeeded',
+                        summary='The document action produced the compatibility response.',
+                    ),
+                    progress_callback=publish_orchestration_runtime_progress,
+                )
+            finish_orchestration_run(turn_orchestration_run)
+        except Exception as runtime_error:
+            log_event(
+                '[OrchestrationRuntime] Document action runtime reconciliation failed',
+                extra={
+                    'conversation_id': conversation_id,
+                    'run_id': turn_orchestration_plan.get('run_id'),
+                    'error_type': type(runtime_error).__name__,
+                },
+                level=logging.ERROR,
+            )
+            fail_orchestration_run(
+                turn_orchestration_run,
+                error_type='runtime_reconciliation_failed',
+                user_message='The document action runtime could not reconcile all required steps.',
+                progress_callback=publish_orchestration_runtime_progress,
+            )
+            user_metadata['evidence_ledger'] = turn_evidence_ledger
+            user_metadata['orchestration_runtime'] = turn_orchestration_run.to_metadata()
+            user_message_doc['metadata'] = user_metadata
+            cosmos_messages_container.upsert_item(user_message_doc)
+            return {
+                'error': (
+                    'One or more required orchestration steps did not complete, '
+                    'so no final document-action response was created.'
+                ),
+                'partial_content': document_action_reply,
+                'conversation_id': conversation_id,
+                'user_message_id': user_message_id,
+                'metadata': {
+                    'orchestration': turn_orchestration_plan,
+                    'orchestration_runtime': turn_orchestration_run.to_metadata(),
+                    'evidence_ledger': turn_evidence_ledger,
+                },
+            }, 409
         user_metadata['evidence_ledger'] = turn_evidence_ledger
+        user_metadata['orchestration_runtime'] = turn_orchestration_run.to_metadata()
         user_message_doc['metadata'] = user_metadata
         cosmos_messages_container.upsert_item(user_message_doc)
         prepared_agent_citations = persist_agent_citation_artifacts(
@@ -12453,6 +12600,7 @@ def register_route_backend_chats(bp):
                 'token_usage': execution_result.get('token_usage'),
                 'user_info': response_message_context.get('user_info'),
                 'orchestration': turn_orchestration_plan,
+                'orchestration_runtime': turn_orchestration_run.to_metadata(),
                 'evidence_ledger': turn_evidence_ledger,
                 'capability_usage': document_action_capability_usage,
                 'thread_info': {
@@ -12581,11 +12729,16 @@ def register_route_backend_chats(bp):
             'metadata': assistant_doc.get('metadata', {}),
         }), 200
 
-    def execute_analyze_chat_request(data=None, publish_background_event=None):
+    def execute_analyze_chat_request(
+        data=None,
+        publish_background_event=None,
+        cancel_requested=None,
+    ):
         return execute_document_action_chat_request(
             data=data,
             publish_background_event=publish_background_event,
             forced_action_type=DOCUMENT_ACTION_TYPE_ANALYZE,
+            cancel_requested=cancel_requested,
         )
 
     @bp.route('/api/chat/document-action', methods=['POST'])
@@ -12627,6 +12780,9 @@ def register_route_backend_chats(bp):
                 payload, status_code = execute_document_action_chat_request(
                     data=data,
                     publish_background_event=publish_background_event,
+                    cancel_requested=(
+                        stream_session.is_cancel_requested if stream_session else None
+                    ),
                 )
                 if stream_session and stream_session.is_cancel_requested():
                     yield _build_stream_cancel_event(
@@ -12688,6 +12844,9 @@ def register_route_backend_chats(bp):
                 payload, status_code = execute_analyze_chat_request(
                     data=data,
                     publish_background_event=publish_background_event,
+                    cancel_requested=(
+                        stream_session.is_cancel_requested if stream_session else None
+                    ),
                 )
                 if stream_session and stream_session.is_cancel_requested():
                     yield _build_stream_cancel_event(
@@ -17112,6 +17271,12 @@ def register_route_backend_chats(bp):
                     conversation_id=conversation_id,
                     user_message_id=user_message_id,
                 )
+                turn_orchestration_run = OrchestrationRun.from_plan(
+                    turn_orchestration_plan,
+                    turn_evidence_ledger,
+                )
+                reconcile_orchestration_run_from_ledger(turn_orchestration_run)
+                orchestration_runtime_progress_events = []
 
                 user_metadata = {}
                 current_user = get_current_user_info()
@@ -17248,6 +17413,7 @@ def register_route_backend_chats(bp):
 
                 user_metadata['orchestration'] = turn_orchestration_plan
                 user_metadata['evidence_ledger'] = turn_evidence_ledger
+                user_metadata['orchestration_runtime'] = turn_orchestration_run.to_metadata()
                 user_metadata['chat_context'] = {
                     'conversation_id': conversation_id
                 }
@@ -17358,6 +17524,23 @@ def register_route_backend_chats(bp):
                     """Add a thought to Cosmos and return an SSE event string."""
                     thought_tracker.add_thought(step_type, content, detail)
                     return serialize_thought_event(step_type, content, thought_tracker.current_index - 1, detail=detail)
+
+                def queue_orchestration_runtime_progress(event):
+                    orchestration_runtime_progress_events.append(dict(event))
+
+                def drain_orchestration_runtime_progress():
+                    queued_events = list(orchestration_runtime_progress_events)
+                    orchestration_runtime_progress_events.clear()
+                    return [
+                        emit_thought(
+                            'orchestration',
+                            event.get('message') or 'Updating orchestration progress',
+                            detail=(
+                                f"node={event.get('node_id')}; status={event.get('status')}"
+                            ),
+                        )
+                        for event in queued_events
+                    ]
 
                 def publish_live_plugin_thought(thought_payload):
                     if not callable(publish_background_event):
@@ -18324,9 +18507,20 @@ def register_route_backend_chats(bp):
                         deep_research_enabled=bool(deep_research_enabled),
                         selected_image_references=selected_image_references,
                     )
+                    resolve_orchestration_evidence_discovery(
+                        turn_orchestration_run,
+                        progress_callback=queue_orchestration_runtime_progress,
+                    )
+                    reconcile_orchestration_run_from_ledger(
+                        turn_orchestration_run,
+                        progress_callback=queue_orchestration_runtime_progress,
+                    )
                     user_metadata['evidence_ledger'] = turn_evidence_ledger
+                    user_metadata['orchestration_runtime'] = turn_orchestration_run.to_metadata()
                     user_message_doc['metadata'] = user_metadata
                     cosmos_messages_container.upsert_item(user_message_doc)
+                    for runtime_progress_event in drain_orchestration_runtime_progress():
+                        yield runtime_progress_event
                     history_segments = build_conversation_history_segments(
                         all_messages=all_messages,
                         conversation_history_limit=conversation_history_limit,
@@ -18617,6 +18811,7 @@ def register_route_backend_chats(bp):
                         status,
                     )
                     user_metadata['evidence_ledger'] = turn_evidence_ledger
+                    user_metadata['orchestration_runtime'] = turn_orchestration_run.to_metadata()
                     user_metadata['central_synthesis'] = central_synthesis_metadata
                     user_message_doc['metadata'] = user_metadata
                     cosmos_messages_container.upsert_item(user_message_doc)
@@ -18672,6 +18867,48 @@ def register_route_backend_chats(bp):
 
                 if selected_agent_metadata:
                     user_metadata['agent_selection'] = selected_agent_metadata
+
+                selected_agent_runtime_node = next(
+                    (
+                        node
+                        for node in turn_orchestration_run.nodes
+                        if node.capability == 'selected_agent'
+                    ),
+                    None,
+                )
+                required_selected_agent_unavailable = bool(
+                    _has_chat_agent_selection(request_agent_info)
+                    and not selected_agent
+                    and selected_agent_runtime_node
+                )
+                if (
+                    required_selected_agent_unavailable
+                    and selected_agent_runtime_node.status == 'pending'
+                ):
+                    start_orchestration_node(
+                        turn_orchestration_run,
+                        selected_agent_runtime_node.id,
+                        progress_callback=queue_orchestration_runtime_progress,
+                    )
+                    complete_orchestration_node(
+                        turn_orchestration_run,
+                        selected_agent_runtime_node.id,
+                        OrchestrationNodeResult(
+                            status='failed',
+                            error_type='selected_agent_unavailable',
+                            user_message='The selected agent is unavailable for this turn.',
+                        ),
+                        progress_callback=queue_orchestration_runtime_progress,
+                    )
+                    reconcile_orchestration_run_from_ledger(
+                        turn_orchestration_run,
+                        progress_callback=queue_orchestration_runtime_progress,
+                    )
+                    user_metadata['orchestration_runtime'] = (
+                        turn_orchestration_run.to_metadata()
+                    )
+                    for runtime_progress_event in drain_orchestration_runtime_progress():
+                        yield runtime_progress_event
 
                 if (
                     selected_agent
@@ -18729,6 +18966,15 @@ def register_route_backend_chats(bp):
                 final_model_used = gpt_model  # Default to gpt_model, will be overridden if agent is used
 
                 def finalize_cancelled_stream_response():
+                    if not turn_orchestration_run.completed_at:
+                        cancel_orchestration_run(
+                            turn_orchestration_run,
+                            progress_callback=queue_orchestration_runtime_progress,
+                        )
+                    user_metadata['orchestration_runtime'] = turn_orchestration_run.to_metadata()
+                    user_metadata['evidence_ledger'] = turn_evidence_ledger
+                    user_message_doc['metadata'] = user_metadata
+                    cosmos_messages_container.upsert_item(user_message_doc)
                     if (
                         central_synthesis_metadata
                         and central_synthesis_metadata.get('status') == 'pending'
@@ -18798,6 +19044,7 @@ def register_route_backend_chats(bp):
                                 },
                                 'history_context': history_debug_info,
                                 'orchestration': turn_orchestration_plan,
+                                'orchestration_runtime': turn_orchestration_run.to_metadata(),
                                 'evidence_ledger': turn_evidence_ledger,
                                 'central_synthesis': central_synthesis_metadata,
                                 'capability_usage': build_streaming_capability_usage(),
@@ -18851,6 +19098,7 @@ def register_route_backend_chats(bp):
                             'metadata': {
                                 **cancel_metadata,
                                 'orchestration': turn_orchestration_plan,
+                                'orchestration_runtime': turn_orchestration_run.to_metadata(),
                                 'evidence_ledger': turn_evidence_ledger,
                                 'central_synthesis': central_synthesis_metadata,
                             },
@@ -18878,6 +19126,11 @@ def register_route_backend_chats(bp):
                 )
 
                 try:
+                    if required_selected_agent_unavailable:
+                        raise RuntimeError(
+                            'The selected agent is unavailable, so its required orchestration '
+                            'step could not be completed.'
+                        )
                     if (
                         turn_orchestration_plan.get('grounded_image_generation_requested')
                         and not agent_evidence_task
@@ -18888,6 +19141,17 @@ def register_route_backend_chats(bp):
                             'no image proposal was created.'
                         )
                     if use_agent_streaming and selected_agent:
+                        if (
+                            selected_agent_runtime_node
+                            and selected_agent_runtime_node.status == 'pending'
+                        ):
+                            start_orchestration_node(
+                                turn_orchestration_run,
+                                selected_agent_runtime_node.id,
+                                progress_callback=queue_orchestration_runtime_progress,
+                            )
+                            for runtime_progress_event in drain_orchestration_runtime_progress():
+                                yield runtime_progress_event
                         # Stream from agent using invoke_stream
                         yield emit_thought('agent_tool_call', f"Sending to agent '{agent_display_name_used or agent_name_used}'")
                         yield emit_thought('generation', f"Sending to '{actual_model_used}'")
@@ -19078,9 +19342,16 @@ def register_route_backend_chats(bp):
                                     agent_evidence_task,
                                     agent_failure_result,
                                 )
-                                user_metadata['evidence_ledger'] = turn_evidence_ledger
-                                user_message_doc['metadata'] = user_metadata
-                                cosmos_messages_container.upsert_item(user_message_doc)
+                            fail_orchestration_run(
+                                turn_orchestration_run,
+                                error_type='selected_agent_failed',
+                                user_message='The selected agent could not complete this turn.',
+                                progress_callback=queue_orchestration_runtime_progress,
+                            )
+                            user_metadata['evidence_ledger'] = turn_evidence_ledger
+                            user_metadata['orchestration_runtime'] = turn_orchestration_run.to_metadata()
+                            user_message_doc['metadata'] = user_metadata
+                            cosmos_messages_container.upsert_item(user_message_doc)
                             error_payload = {'error': f'Agent streaming failed: {str(stream_error)}'}
                             if isinstance(stream_error, FoundryAgentUserAuthenticationRequired):
                                 auth_response = getattr(stream_error, 'auth_response', {}) or {}
@@ -19244,6 +19515,43 @@ def register_route_backend_chats(bp):
                                 agent_evidence_task,
                                 agent_evidence_result,
                             )
+                            if (
+                                selected_agent_runtime_node
+                                and selected_agent_runtime_node.status == 'running'
+                            ):
+                                agent_evidence_status = str(
+                                    agent_evidence_result.get('status') or 'failed'
+                                ).strip().lower()
+                                agent_runtime_status = (
+                                    agent_evidence_status
+                                    if agent_evidence_status in {'succeeded', 'partial'}
+                                    else 'failed'
+                                )
+                                complete_orchestration_node(
+                                    turn_orchestration_run,
+                                    selected_agent_runtime_node.id,
+                                    OrchestrationNodeResult(
+                                        status=agent_runtime_status,
+                                        summary=agent_evidence_result.get('summary') or '',
+                                        error_type=(
+                                            agent_evidence_status
+                                            if agent_runtime_status == 'failed'
+                                            else None
+                                        ),
+                                        user_message=(
+                                            'The selected agent did not return the required evidence.'
+                                            if agent_runtime_status == 'failed'
+                                            else None
+                                        ),
+                                    ),
+                                    progress_callback=queue_orchestration_runtime_progress,
+                                )
+                                reconcile_orchestration_run_from_ledger(
+                                    turn_orchestration_run,
+                                    progress_callback=queue_orchestration_runtime_progress,
+                                )
+                                for runtime_progress_event in drain_orchestration_runtime_progress():
+                                    yield runtime_progress_event
                             evidence_status_message = build_agent_action_evidence_status_message(
                                 agent_evidence_result
                             )
@@ -19261,6 +19569,19 @@ def register_route_backend_chats(bp):
                                     'Grounded image evidence did not reach a terminal synthesis state.'
                                 )
                             persist_central_synthesis_state('pending')
+
+                            finalizer_runtime_node = next(
+                                node
+                                for node in turn_orchestration_run.nodes
+                                if node.type == 'finalize'
+                            )
+                            start_orchestration_node(
+                                turn_orchestration_run,
+                                finalizer_runtime_node.id,
+                                progress_callback=queue_orchestration_runtime_progress,
+                            )
+                            for runtime_progress_event in drain_orchestration_runtime_progress():
+                                yield runtime_progress_event
 
                             agent_executor_model_used = actual_model_used
                             yield emit_thought(
@@ -19326,9 +19647,58 @@ def register_route_backend_chats(bp):
 
                         debug_print(f"[Agent Streaming] Captured {len(agent_citations_list)} citations")
                         if not agent_evidence_task:
+                            if (
+                                selected_agent_runtime_node
+                                and selected_agent_runtime_node.status == 'running'
+                            ):
+                                complete_orchestration_node(
+                                    turn_orchestration_run,
+                                    selected_agent_runtime_node.id,
+                                    OrchestrationNodeResult(
+                                        status='succeeded',
+                                        summary='The selected agent completed the compatibility response.',
+                                    ),
+                                    progress_callback=queue_orchestration_runtime_progress,
+                                )
+                            reconcile_orchestration_run_from_ledger(
+                                turn_orchestration_run,
+                                progress_callback=queue_orchestration_runtime_progress,
+                            )
+                            if (
+                                'selected_agent_finalizer_compatibility'
+                                not in turn_orchestration_run.warnings
+                            ):
+                                turn_orchestration_run.warnings.append(
+                                    'selected_agent_finalizer_compatibility'
+                                )
+                            finalizer_runtime_node = next(
+                                node
+                                for node in turn_orchestration_run.nodes
+                                if node.type == 'finalize'
+                            )
+                            if finalizer_runtime_node.status == 'pending':
+                                start_orchestration_node(
+                                    turn_orchestration_run,
+                                    finalizer_runtime_node.id,
+                                    progress_callback=queue_orchestration_runtime_progress,
+                                )
+                            for runtime_progress_event in drain_orchestration_runtime_progress():
+                                yield runtime_progress_event
                             final_model_used = actual_model_used
 
                     else:
+                        finalizer_runtime_node = next(
+                            node
+                            for node in turn_orchestration_run.nodes
+                            if node.type == 'finalize'
+                        )
+                        start_orchestration_node(
+                            turn_orchestration_run,
+                            finalizer_runtime_node.id,
+                            progress_callback=queue_orchestration_runtime_progress,
+                        )
+                        for runtime_progress_event in drain_orchestration_runtime_progress():
+                            yield runtime_progress_event
                         # Stream from regular GPT model (non-agent)
                         yield emit_thought('generation', f"Sending to '{gpt_model}'")
                         debug_print(f"--- Streaming from GPT ({gpt_model}) ---")
@@ -19462,6 +19832,25 @@ def register_route_backend_chats(bp):
                         return
 
                     # Stream complete - save message and send final metadata
+                    finalizer_runtime_node = next(
+                        node
+                        for node in turn_orchestration_run.nodes
+                        if node.type == 'finalize'
+                    )
+                    if finalizer_runtime_node.status == 'running':
+                        complete_orchestration_node(
+                            turn_orchestration_run,
+                            finalizer_runtime_node.id,
+                            OrchestrationNodeResult(
+                                status='succeeded',
+                                summary='The central response finalizer completed.',
+                            ),
+                            progress_callback=queue_orchestration_runtime_progress,
+                        )
+                    finish_orchestration_run(turn_orchestration_run)
+                    user_metadata['orchestration_runtime'] = turn_orchestration_run.to_metadata()
+                    for runtime_progress_event in drain_orchestration_runtime_progress():
+                        yield runtime_progress_event
                     if central_synthesis_context and accumulated_content:
                         set_evidence_ledger_status(turn_evidence_ledger, 'completed')
                         central_synthesis_metadata = build_central_synthesis_metadata(
@@ -19532,6 +19921,7 @@ def register_route_backend_chats(bp):
                             },
                             'history_context': history_debug_info,
                             'orchestration': turn_orchestration_plan,
+                            'orchestration_runtime': turn_orchestration_run.to_metadata(),
                             'evidence_ledger': turn_evidence_ledger,
                             'central_synthesis': central_synthesis_metadata,
                             'capability_usage': build_streaming_capability_usage(),
@@ -19622,6 +20012,9 @@ def register_route_backend_chats(bp):
                         if selected_agent_metadata:
                             user_message_doc.setdefault('metadata', {})['agent_selection'] = selected_agent_metadata
                         user_message_doc.setdefault('metadata', {})['evidence_ledger'] = turn_evidence_ledger
+                        user_message_doc.setdefault('metadata', {})['orchestration_runtime'] = (
+                            turn_orchestration_run.to_metadata()
+                        )
                         if central_synthesis_metadata:
                             user_message_doc.setdefault('metadata', {})['central_synthesis'] = central_synthesis_metadata
                         cosmos_messages_container.upsert_item(user_message_doc)
@@ -19718,6 +20111,18 @@ def register_route_backend_chats(bp):
                     error_msg = str(e)
                     debug_print(f"Error during streaming: {error_msg}")
 
+                    if not turn_orchestration_run.completed_at:
+                        fail_orchestration_run(
+                            turn_orchestration_run,
+                            error_type='stream_execution_failed',
+                            user_message='The orchestration stream could not be completed.',
+                            progress_callback=queue_orchestration_runtime_progress,
+                        )
+                    user_metadata['orchestration_runtime'] = turn_orchestration_run.to_metadata()
+                    user_metadata['evidence_ledger'] = turn_evidence_ledger
+                    user_message_doc['metadata'] = user_metadata
+                    cosmos_messages_container.upsert_item(user_message_doc)
+
                     if (
                         central_synthesis_metadata
                         and central_synthesis_metadata.get('status') == 'pending'
@@ -19771,6 +20176,7 @@ def register_route_backend_chats(bp):
                                 'reasoning_effort': reasoning_effort,
                                 'history_context': history_debug_info,
                                 'orchestration': turn_orchestration_plan,
+                                'orchestration_runtime': turn_orchestration_run.to_metadata(),
                                 'evidence_ledger': turn_evidence_ledger,
                                 'central_synthesis': central_synthesis_metadata,
                                 'capability_usage': build_streaming_capability_usage(),
@@ -19797,6 +20203,7 @@ def register_route_backend_chats(bp):
                             'incomplete': True,
                             'error': error_msg,
                             'orchestration': turn_orchestration_plan,
+                            'orchestration_runtime': turn_orchestration_run.to_metadata(),
                             'evidence_ledger': turn_evidence_ledger,
                             'central_synthesis': central_synthesis_metadata,
                         },
@@ -19809,6 +20216,50 @@ def register_route_backend_chats(bp):
                 debug_print(f"[STREAM API ERROR] Unhandled exception: {str(e)}")
                 debug_print(f"[STREAM API ERROR] Full traceback:\n{error_traceback}")
                 yield f"data: {json.dumps({'error': f'Internal server error: {str(e)}'})}\n\n"
+            finally:
+                active_runtime = locals().get('turn_orchestration_run')
+                if active_runtime and not active_runtime.completed_at:
+                    try:
+                        runtime_progress_callback = locals().get(
+                            'queue_orchestration_runtime_progress'
+                        )
+                        if stream_session and stream_session.is_cancel_requested():
+                            cancel_orchestration_run(
+                                active_runtime,
+                                progress_callback=runtime_progress_callback,
+                            )
+                        else:
+                            fail_orchestration_run(
+                                active_runtime,
+                                error_type='stream_ended_before_runtime_completion',
+                                user_message=(
+                                    'The stream ended before all orchestration steps completed.'
+                                ),
+                                progress_callback=runtime_progress_callback,
+                            )
+                        active_user_metadata = locals().get('user_metadata')
+                        active_user_message_doc = locals().get('user_message_doc')
+                        active_evidence_ledger = locals().get('turn_evidence_ledger')
+                        if (
+                            isinstance(active_user_metadata, dict)
+                            and isinstance(active_user_message_doc, dict)
+                        ):
+                            active_user_metadata['orchestration_runtime'] = (
+                                active_runtime.to_metadata()
+                            )
+                            if active_evidence_ledger is not None:
+                                active_user_metadata['evidence_ledger'] = active_evidence_ledger
+                            active_user_message_doc['metadata'] = active_user_metadata
+                            cosmos_messages_container.upsert_item(active_user_message_doc)
+                    except Exception as runtime_cleanup_error:
+                        log_event(
+                            '[OrchestrationRuntime] Failed to close an incomplete stream run',
+                            extra={
+                                'run_id': active_runtime.run_id,
+                                'error_type': type(runtime_cleanup_error).__name__,
+                            },
+                            level=logging.ERROR,
+                        )
 
         return build_background_stream_response(generate, stream_session=stream_session)
 

--- a/docs/explanation/features/CHAT_TURN_ORCHESTRATION.md
+++ b/docs/explanation/features/CHAT_TURN_ORCHESTRATION.md
@@ -1,6 +1,6 @@
 # Chat Turn Orchestration
 
-Implemented in version: **0.250.062**
+Implemented in version: **0.250.063**
 Associated issue: **[#1021](https://github.com/microsoft/simplechat/issues/1021)**
 
 ## Overview
@@ -165,6 +165,38 @@ Model-only grounded-image turns replace legacy augmented history with the isolat
 
 The `simpleimage` proposal schema now supports optional `evidenceIds`, `sourceSummary`, `missingEvidence`, and `referenceImageIds`. Python and browser normalizers bound and deduplicate these fields. At approval, evidence IDs must exist in the authorized source assistant message's ledger, and reference image IDs must identify `image_reference` artifacts in that ledger. Unbound or invented lineage IDs are removed before generation metadata is persisted. Image generation remains opt-in and starts only after user approval.
 
+## Phase 6 Request-Scoped Orchestration Runtime
+
+Phase 6 adds `functions_orchestration_runtime.py`, an in-process execution graph that binds one immutable plan to its matching evidence ledger for the lifetime of a chat request. Direct and coordinated turns now share the same `OrchestrationRun` contract. The runtime validates matching run IDs and modes, unique node IDs, known dependencies, acyclic graphs, a single finalizer, and bounded node and replan budgets before execution.
+
+Runtime nodes retain the Phase 1 step fields and add lifecycle metadata for:
+
+- `pending`
+- `running`
+- `succeeded`
+- `partial`
+- `failed`
+- `skipped`
+- `blocked`
+- `cancelled`
+
+The runtime supports two execution modes over the same graph:
+
+- Injected adapters can execute dependency-light operations directly. Sequential execution is the default. Independent adapters run in bounded parallel only when they are explicitly marked read-only, parallel-safe, and independent of Flask request context.
+- Existing chat-route operations continue through their established authorization and request-context boundaries, then reconcile their normalized ledger source states into the same runtime graph. This avoids duplicating retrieval or moving identity-sensitive work into worker threads.
+
+Read-only adapters can opt into at most three cancellation-aware attempts. Write-capable or otherwise non-read-only adapters remain single-attempt even if configured otherwise. Bounded replanning accepts only collection or planning nodes, revalidates the complete graph including finalizer dependencies, enforces the run's replan and node budgets, and records rejected follow-ups as explicit partial warnings.
+
+Required-node failures block dependent finalizers. Optional failures and partial nodes permit a clearly partial run when the finalizer can still produce a supported result. A finalizer cannot start until every dependency is terminal, and selected agents that cannot be resolved no longer silently fall back to the base model. Generic evidence discovery resolves only after authorized collectors have run; it succeeds when usable authorized evidence exists and fails closed with node-linked missing evidence otherwise.
+
+The standard streaming and Analyze/Compare paths persist compact `orchestration_runtime` metadata beside the plan and ledger. Source metadata records the responsible runtime node, and normalized facts, results, citations, artifacts, and gaps receive `step_id` provenance where applicable. Existing thought channels display concise node progress, while Application Insights receives run and node lifecycle, attempt count, status, and compact ledger-size telemetry without raw evidence or sensitive payloads.
+
+### Cancellation And Terminal Cleanup
+
+Standard streaming uses `ActiveConversationStreamSession.is_cancel_requested()` as the runtime cancellation signal. Cancellation marks pending nodes and externally running nodes cancelled, prevents pending synthesis, preserves useful partial evidence, and stores a terminal runtime snapshot even when no assistant content was emitted. A final generator cleanup also fails or cancels any run left active by an early return.
+
+Streaming document actions check cancellation before and after their existing workflow call. The underlying Analyze/Compare workflow remains non-preemptive, so a cancellation received during that call discards its result before assistant persistence and closes the runtime when control returns. Required runtime failures return an explicit conflict response rather than persisting a final document-action answer.
+
 ## Security And Governance
 
 - Caller-supplied IDs are never treated as proof of authorization.
@@ -187,6 +219,10 @@ The `simpleimage` proposal schema now supports optional `evidenceIds`, `sourceSu
 - Agent/action task payloads describe the principal as `current_user` and omit caller-provided private identity and scope IDs.
 - Only tool invocations created after the current-turn baseline are eligible for executor evidence provenance.
 - Credential-bearing tool result fields and authorization strings are redacted before bounded fact summaries are recorded.
+- Runtime adapters receive a copied ledger snapshot and return structured results; they cannot mutate the shared ledger from parallel workers.
+- Parallel execution is opt-in for read-only, request-context-independent adapters. Existing Flask-scoped collectors, agents, and actions remain inside their current authenticated request boundaries.
+- Runtime metadata excludes raw adapter results, raw evidence, debug exception text, and caller-supplied authorization identifiers.
+- Runtime source reconciliation consumes only evidence already normalized by the established authorization-aware collectors and executors.
 - Side effects, sensitive access, and budget overflow are marked as approval-required policy classes for later runtime enforcement.
 
 ## Dependencies
@@ -197,6 +233,8 @@ The `simpleimage` proposal schema now supports optional `evidenceIds`, `sourceSu
 - Existing workspace, web, source-review, history, citation, and artifact systems.
 - Existing image proposal finalizer guidance.
 - Generic central synthesis request and output-profile contracts.
+- Request-scoped `OrchestrationRun` scheduling and lifecycle helpers.
+- Existing `ActiveConversationStreamSession` cancellation, replay, heartbeat, and reattach behavior.
 
 ## Testing And Validation
 
@@ -255,17 +293,34 @@ Central synthesis coverage is in `functional_tests/test_central_synthesis_contra
 
 The existing desktop/mobile Playwright coverage in `ui_tests/test_chat_inline_image_proposal_cards.py` also verifies that normalized provenance metadata survives card rendering, prompt editing, and the approval request.
 
+Runtime coverage is in `functional_tests/test_orchestration_runtime.py` and validates:
+
+- Direct and coordinated turns share one run contract.
+- Dependency ordering and bounded parallel execution for independent read-only collectors.
+- Required versus optional failure behavior and finalizer isolation.
+- Cancellation of pending synthesis, including the final aggregate closure checkpoint.
+- Read-only retry limits and single-attempt write behavior.
+- Bounded replanning, node-budget enforcement, and cycle rejection.
+- Authorized evidence discovery success and fail-closed missing evidence.
+- Runtime-node provenance across normalized ledger entries.
+- Conversation, document, image, workspace, web, source-review, agent, action, response, and image-proposal node categories.
+- Standard streaming and document-action lifecycle, progress, cancellation, terminal cleanup, and metadata persistence wiring.
+
+The stream heartbeat, background execution, lifecycle observability, new-conversation reattach, and stop-control contracts also validate that runtime cancellation preserves the existing SSE protocol and replay behavior.
+
 ## Known Limitations
 
-Phase 1 records and gates plans but does not yet provide the complete orchestration runtime.
+Phase 6 provides the request-scoped in-process runtime, with these deliberate boundaries:
 
-- Planned steps are not yet scheduled through a generic execution graph.
 - Arbitrary governed tools are not yet discovered automatically.
+- Runs are not stored in a durable queue or Cosmos run store and cannot resume after process loss.
+- Parallel runtime adapters must be request-context independent; the live chat route currently reconciles its existing authorized collectors sequentially.
+- Cancellation of synchronous model, agent, and document-action SDK calls is best effort. Pending finalization is prevented, but an in-flight non-cooperative call may return before its result can be discarded.
 - The legacy non-streaming compatibility path does not yet use Phase 3 collectors.
-- Outside the grounded-image proving profile, selected agents retain their existing response-streaming behavior until central synthesis is generalized.
-- Analyze and Compare actions normalize and persist grounded-image evidence but still return the Phase 4 evidence-status handoff; using that ledger in central synthesis is a later output-profile integration.
-- Central synthesis currently uses a synchronous completion after selected-agent evidence collection; resilient scheduling, retry, cancellation during that finalizer call, and durable resume belong to Phase 6.
-- Plan status does not yet provide complete per-step execution reconciliation.
+- Outside the grounded-image proving profile, selected agents retain their existing response-streaming behavior. The runtime records this compatibility finalizer until central synthesis is generalized.
+- Analyze and Compare actions participate in runtime lifecycle and evidence normalization but retain their existing compatibility response finalizer. Grounded-image actions still return the evidence-status handoff rather than invoking central synthesis.
+- Phase 7 review, approval, intervention, and technical-detail UI is not included; Phase 6 reuses concise thought/progress events.
+- Automatic write, sensitive, consequential, or over-budget steps remain prohibited without a later approval runtime.
 - The live chat payload does not yet expose a dedicated selected-image-reference list; selected workspace images are represented as documents, and explicit headshot/reference intent can be detected from the message until a reference control is wired.
 
-These limitations are addressed by the evidence ledger, capability adapter, executor, central synthesis, and runtime phases.
+Durable persistence, intervention UX, broader finalizers, and generalized artifact generation remain later roadmap phases.

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,16 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](/explanation/features/) and [Fixes by Version](/explanation/fixes/).
 
+### **(v0.250.063)**
+
+#### New Features
+
+*   **Request-Scoped Chat Orchestration Runtime**
+    *   Added an in-process `OrchestrationRun` execution graph for direct and coordinated turns, with validated dependencies, terminal node lifecycle, required/optional failure policy, finalizer gating, bounded read-only retries, safe parallel adapters, and bounded replanning.
+    *   Existing authorized conversation, document, image, workspace, web, source-review, agent, and action outputs now reconcile into the same graph and retain runtime-node provenance in the shared evidence ledger.
+    *   Standard streaming and document-action paths persist compact runtime metadata, emit concise node progress, fail closed when required steps do not complete, and integrate cancellation with the existing heartbeat, replay, reattach, and stop-control contracts.
+    *   (Ref: microsoft/simplechat#1021, `functions_orchestration_runtime.py`, `route_backend_chats.py`, `test_orchestration_runtime.py`, `CHAT_TURN_ORCHESTRATION.md`)
+
 ### **(v0.250.062)**
 
 #### New Features

--- a/functional_tests/test_agent_action_evidence_contract.py
+++ b/functional_tests/test_agent_action_evidence_contract.py
@@ -2,7 +2,7 @@
 # test_agent_action_evidence_contract.py
 """
 Functional test for the generic agent/action evidence collection contract.
-Version: 0.250.062
+Version: 0.250.063
 Implemented in: 0.250.061
 
 This test ensures selected agents and actions collect governed evidence into the

--- a/functional_tests/test_central_synthesis_contract.py
+++ b/functional_tests/test_central_synthesis_contract.py
@@ -2,7 +2,7 @@
 # test_central_synthesis_contract.py
 """
 Functional test for the generic central synthesis contract.
-Version: 0.250.062
+Version: 0.250.063
 Implemented in: 0.250.062
 
 This test ensures grounded image proposals are finalized only from completed,

--- a/functional_tests/test_chat_evidence_collectors.py
+++ b/functional_tests/test_chat_evidence_collectors.py
@@ -2,7 +2,7 @@
 # test_chat_evidence_collectors.py
 """
 Functional test for generic chat source collectors.
-Version: 0.250.060
+Version: 0.250.063
 Implemented in: 0.250.060
 
 This test ensures existing authorized context and retrieval outputs are normalized

--- a/functional_tests/test_chat_evidence_ledger.py
+++ b/functional_tests/test_chat_evidence_ledger.py
@@ -2,7 +2,7 @@
 # test_chat_evidence_ledger.py
 """
 Functional test for the generic chat result and evidence ledger.
-Version: 0.250.061
+Version: 0.250.063
 Implemented in: 0.250.059
 
 This test ensures orchestration evidence remains output-neutral, provenance-aware,

--- a/functional_tests/test_chat_stream_background_execution.py
+++ b/functional_tests/test_chat_stream_background_execution.py
@@ -2,7 +2,7 @@
 # test_chat_stream_background_execution.py
 """
 Functional test for chat stream background execution.
-Version: 0.239.185
+Version: 0.250.063
 Implemented in: 0.239.129
 
 This test ensures that the streaming chat route runs its SSE generator through
@@ -18,7 +18,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 ROUTE_FILE = ROOT / "application" / "single_app" / "route_backend_chats.py"
 CONFIG_FILE = ROOT / "application" / "single_app" / "config.py"
-FIX_DOC_FILE = ROOT / "docs" / "explanation" / "fixes" / "CHAT_STREAM_BACKGROUND_EXECUTION_FIX.md"
+FIX_DOC_FILE = ROOT / "docs" / "explanation" / "fixes" / "v0.241.001" / "CHAT_STREAM_BACKGROUND_EXECUTION_FIX.md"
 
 
 def assert_contains(file_path: Path, expected: str) -> None:
@@ -38,12 +38,12 @@ def test_chat_stream_background_execution() -> None:
     assert_contains(ROUTE_FILE, "def publish_background_event(event_text):")
     assert_contains(ROUTE_FILE, "event_iterator = event_generator_factory(")
     assert_contains(ROUTE_FILE, "for event in event_iterator:")
-    assert_contains(ROUTE_FILE, "stream_bridge.detach_consumer()")
+    assert_contains(ROUTE_FILE, "stream_bridge.detach_consumer(reason='client_disconnect', update_session=True)")
     assert_contains(ROUTE_FILE, "CHAT_STREAM_REGISTRY = ActiveConversationStreamRegistry()")
     assert_contains(ROUTE_FILE, "return build_background_stream_response(generate_compatibility_response, stream_session=stream_session)")
     assert_contains(ROUTE_FILE, "return build_background_stream_response(generate, stream_session=stream_session)")
 
-    assert_contains(CONFIG_FILE, 'VERSION = "0.239.185"')
+    assert_contains(CONFIG_FILE, 'VERSION = "0.250.063"')
     assert_contains(FIX_DOC_FILE, "Fixed/Implemented in version: **0.239.129**")
 
     print("Chat stream background execution checks passed!")

--- a/functional_tests/test_chat_stream_heartbeat_reattach.py
+++ b/functional_tests/test_chat_stream_heartbeat_reattach.py
@@ -2,7 +2,7 @@
 # test_chat_stream_heartbeat_reattach.py
 """
 Functional test for chat stream heartbeat and reattach support.
-Version: 0.239.185
+Version: 0.250.063
 Implemented in: 0.239.183
 
 This test ensures long-running chat streams emit keep-alive heartbeat frames,
@@ -21,7 +21,7 @@ APP_CACHE_FILE = ROOT / "application" / "single_app" / "app_settings_cache.py"
 STREAMING_FILE = ROOT / "application" / "single_app" / "static" / "js" / "chat" / "chat-streaming.js"
 CONVERSATIONS_FILE = ROOT / "application" / "single_app" / "static" / "js" / "chat" / "chat-conversations.js"
 CONFIG_FILE = ROOT / "application" / "single_app" / "config.py"
-FIX_DOC_FILE = ROOT / "docs" / "explanation" / "fixes" / "CHAT_STREAM_HEARTBEAT_REATTACH_FIX.md"
+FIX_DOC_FILE = ROOT / "docs" / "explanation" / "fixes" / "v0.241.001" / "CHAT_STREAM_HEARTBEAT_REATTACH_FIX.md"
 
 
 def assert_contains(file_path: Path, expected: str) -> None:
@@ -42,9 +42,10 @@ def test_chat_stream_heartbeat_and_reattach() -> None:
     assert_contains(ROUTE_FILE, "yield ': keep-alive\\n\\n'")
     assert_contains(ROUTE_FILE, "class ActiveConversationStreamSession:")
     assert_contains(ROUTE_FILE, "CHAT_STREAM_REGISTRY = ActiveConversationStreamRegistry()")
-    assert_contains(ROUTE_FILE, "@app.route('/api/chat/stream/status/<conversation_id>', methods=['GET'])")
-    assert_contains(ROUTE_FILE, "@app.route('/api/chat/stream/reattach/<conversation_id>', methods=['GET'])")
-    assert_contains(ROUTE_FILE, "stream_with_context(stream_session.iter_events())")
+    assert_contains(ROUTE_FILE, "@bp.route('/api/chat/stream/status/<conversation_id>', methods=['GET'])")
+    assert_contains(ROUTE_FILE, "@bp.route('/api/chat/stream/reattach/<conversation_id>', methods=['GET'])")
+    assert_contains(ROUTE_FILE, "for event in stream_session.iter_events():")
+    assert_contains(ROUTE_FILE, "stream_with_context(consume_reattach_stream())")
     assert_contains(ROUTE_FILE, "import app_settings_cache")
     assert_contains(ROUTE_FILE, "app_settings_cache.initialize_stream_session_cache(")
     assert_contains(ROUTE_FILE, "app_settings_cache.append_stream_session_event(")
@@ -56,7 +57,7 @@ def test_chat_stream_heartbeat_and_reattach() -> None:
     assert_contains(APP_CACHE_FILE, "def append_stream_session_event_redis(cache_key, event_text, ttl_seconds=None):")
     assert_contains(APP_CACHE_FILE, "def get_stream_session_events_mem(cache_key, start_index=0):")
 
-    assert_contains(STREAMING_FILE, "export async function reattachStreamingConversation(conversationId)")
+    assert_contains(STREAMING_FILE, "export async function reattachStreamingConversation(conversationId, options = {})")
     assert_contains(STREAMING_FILE, "fetch(`/api/chat/stream/status/${conversationId}`")
     assert_contains(STREAMING_FILE, "fetch(`/api/chat/stream/reattach/${conversationId}`")
     assert_not_contains(STREAMING_FILE, "5 * 60 * 1000")
@@ -64,7 +65,7 @@ def test_chat_stream_heartbeat_and_reattach() -> None:
     assert_contains(CONVERSATIONS_FILE, "await loadMessages(conversationId);")
     assert_contains(CONVERSATIONS_FILE, "await streamingModule.reattachStreamingConversation(conversationId);")
 
-    assert_contains(CONFIG_FILE, 'VERSION = "0.239.185"')
+    assert_contains(CONFIG_FILE, 'VERSION = "0.250.063"')
     assert_contains(FIX_DOC_FILE, "Fixed/Implemented in version: **0.239.183**")
     assert_contains(FIX_DOC_FILE, "Redis-backed session metadata and event replay")
 

--- a/functional_tests/test_chat_stream_lifecycle_observability.py
+++ b/functional_tests/test_chat_stream_lifecycle_observability.py
@@ -2,7 +2,7 @@
 # test_chat_stream_lifecycle_observability.py
 """
 Functional test for chat stream lifecycle observability.
-Version: 0.241.111
+Version: 0.250.063
 Implemented in: 0.241.109
 
 This test ensures long-running chat streams persist lifecycle state for
@@ -19,7 +19,7 @@ ROUTE_FILE = ROOT / "application" / "single_app" / "route_backend_chats.py"
 STREAMING_FILE = ROOT / "application" / "single_app" / "static" / "js" / "chat" / "chat-streaming.js"
 CONFIG_FILE = ROOT / "application" / "single_app" / "config.py"
 FIX_DOC_FILE = ROOT / "docs" / "explanation" / "fixes" / "v0.241.109" / "CHAT_STREAM_LIFECYCLE_OBSERVABILITY_FIX.md"
-CURRENT_VERSION = "0.241.111"
+CURRENT_VERSION = "0.250.063"
 
 
 def assert_contains(file_path: Path, expected: str) -> None:
@@ -40,7 +40,7 @@ def test_chat_stream_lifecycle_observability() -> None:
     assert_contains(ROUTE_FILE, "def mark_reattached(self):")
     assert_contains(ROUTE_FILE, "self._stream_session.note_keepalive(source='bridge')")
     assert_contains(ROUTE_FILE, "self.note_keepalive(source='session')")
-    assert_contains(ROUTE_FILE, "@app.route('/api/chat/stream/client-event', methods=['POST'])")
+    assert_contains(ROUTE_FILE, "@bp.route('/api/chat/stream/client-event', methods=['POST'])")
     assert_contains(ROUTE_FILE, "def chat_stream_client_event_api():")
     assert_contains(ROUTE_FILE, "stream_status = stream_session.get_status_snapshot() if stream_session else _build_stream_status_payload(None)")
     assert_contains(ROUTE_FILE, "stream_session.mark_reattached()")

--- a/functional_tests/test_chat_stream_new_conversation_reattach.py
+++ b/functional_tests/test_chat_stream_new_conversation_reattach.py
@@ -2,7 +2,7 @@
 # test_chat_stream_new_conversation_reattach.py
 """
 Functional test for new-conversation chat stream reattach support.
-Version: 0.239.191
+Version: 0.250.063
 Implemented in: 0.239.191
 
 This test ensures the streaming chat route finalizes a conversation id before
@@ -18,7 +18,7 @@ ROOT = Path(__file__).resolve().parents[1]
 ROUTE_FILE = ROOT / "application" / "single_app" / "route_backend_chats.py"
 STREAMING_FILE = ROOT / "application" / "single_app" / "static" / "js" / "chat" / "chat-streaming.js"
 CONFIG_FILE = ROOT / "application" / "single_app" / "config.py"
-FIX_DOC_FILE = ROOT / "docs" / "explanation" / "fixes" / "CHAT_STREAM_NEW_CONVERSATION_REATTACH_FIX.md"
+FIX_DOC_FILE = ROOT / "docs" / "explanation" / "fixes" / "v0.241.001" / "CHAT_STREAM_NEW_CONVERSATION_REATTACH_FIX.md"
 
 
 def assert_contains(file_path: Path, expected: str) -> None:
@@ -43,7 +43,7 @@ def test_chat_stream_new_conversation_reattach() -> None:
     assert_contains(STREAMING_FILE, "if (allowRecovery) {")
     assert_contains(STREAMING_FILE, "allowRecovery: false,")
 
-    assert_contains(CONFIG_FILE, 'VERSION = "0.239.191"')
+    assert_contains(CONFIG_FILE, 'VERSION = "0.250.063"')
     assert_contains(FIX_DOC_FILE, "Fixed/Implemented in version: **0.239.191**")
     assert_contains(FIX_DOC_FILE, "finalizes a conversation id before registering the stream session")
 

--- a/functional_tests/test_chat_stream_stop_control.py
+++ b/functional_tests/test_chat_stream_stop_control.py
@@ -2,7 +2,7 @@
 # test_chat_stream_stop_control.py
 """
 Functional test for chat stream stop control.
-Version: 0.241.098
+Version: 0.250.063
 Implemented in: 0.241.097
 
 This test ensures chat streams expose a user-scoped cancellation endpoint,
@@ -35,32 +35,37 @@ def test_chat_stream_stop_control_wiring() -> None:
     route_content = read_text("application/single_app/route_backend_chats.py")
     collaboration_content = read_text("application/single_app/route_backend_collaboration.py")
     streaming_content = read_text("application/single_app/static/js/chat/chat-streaming.js")
+    chats_css_content = read_text("application/single_app/static/css/chats.css")
     collaboration_js_content = read_text("application/single_app/static/js/chat/chat-collaboration.js")
     feature_doc_content = read_text("docs/explanation/features/v0.241.097/CHAT_STREAM_STOP_CONTROL.md")
 
-    assert_contains(config_content, 'VERSION = "0.241.098"', "config version")
+    assert_contains(config_content, 'VERSION = "0.250.063"', "config version")
 
     assert_contains(route_content, "STREAM_STATUS_CANCEL_REQUESTED = 'cancel_requested'", "chat route")
     assert_contains(route_content, "STREAM_STATUS_CANCELED = 'canceled'", "chat route")
     assert_contains(route_content, "def request_cancel(self, reason='user_requested'):", "chat stream session")
     assert_contains(route_content, "def is_cancel_requested(self):", "chat stream session")
     assert_contains(route_content, "def _build_stream_cancel_event(", "cancel event builder")
-    assert_contains(route_content, "@app.route('/api/chat/stream/cancel/<conversation_id>', methods=['POST'])", "chat cancel route")
+    assert_contains(route_content, "@bp.route('/api/chat/stream/cancel/<conversation_id>', methods=['POST'])", "chat cancel route")
     assert_contains(route_content, "if stream_cancel_requested():", "stream cancellation checkpoints")
     assert_contains(route_content, "yield finalize_cancelled_stream_response()", "cancelled stream finalization")
+    assert_contains(route_content, "cancel_orchestration_run(", "orchestration runtime cancellation")
+    assert_contains(route_content, "def persist_cancelled_document_action_runtime():", "document action cancellation persistence")
+    assert_contains(route_content, "stream_session.is_cancel_requested if stream_session else None", "document action cancellation callback")
 
     assert_contains(
         collaboration_content,
-        "@app.route('/api/collaboration/conversations/<conversation_id>/stream/cancel', methods=['POST'])",
+        "@bp.route('/api/collaboration/conversations/<conversation_id>/stream/cancel', methods=['POST'])",
         "collaboration cancel route",
     )
     assert_contains(collaboration_content, "source_conversation_id = str((conversation_doc or {}).get('source_conversation_id')", "source conversation lookup")
     assert_contains(collaboration_content, "CHAT_STREAM_REGISTRY.get_session(", "collaboration source stream lookup")
     assert_contains(collaboration_content, "stream_payload.get('cancelled') or stream_payload.get('canceled')", "collaboration cancel transform")
 
-    assert_contains(streaming_content, "className = 'btn btn-sm btn-danger stream-stop-btn", "message-local Stop button")
+    assert_contains(streaming_content, "className = 'btn btn-sm stream-stop-btn", "message-local Stop button")
     assert_contains(streaming_content, "rounded-circle p-0 border-0", "compact icon-only Stop button")
-    assert_contains(streaming_content, "stopButton.style.width = '1.65rem'", "fixed-size Stop button")
+    assert_contains(chats_css_content, ".stream-stop-btn {", "Stop button styles")
+    assert_contains(chats_css_content, "width: 1.65rem", "fixed-size Stop button")
     assert_contains(streaming_content, "async function requestStreamCancellation", "frontend cancel request")
     assert_contains(streaming_content, "fetch(streamContext.cancelEndpoint", "cancel endpoint POST")
     assert_contains(streaming_content, "finalizeCancelledStreamingMessage", "cancelled UI finalizer")

--- a/functional_tests/test_chat_turn_orchestration_plan.py
+++ b/functional_tests/test_chat_turn_orchestration_plan.py
@@ -2,7 +2,7 @@
 # test_chat_turn_orchestration_plan.py
 """
 Functional test for the chat turn orchestration planning foundation.
-Version: 0.250.062
+Version: 0.250.063
 Implemented in: 0.250.058
 
 This test ensures every turn receives a direct or coordinated plan, selected
@@ -351,7 +351,7 @@ def test_streaming_chat_path_persists_and_applies_plan():
     route_source = ROUTE_BACKEND_CHATS.read_text(encoding='utf-8')
     config_source = CONFIG_FILE.read_text(encoding='utf-8')
 
-    assert 'VERSION = "0.250.062"' in config_source
+    assert 'VERSION = "0.250.063"' in config_source
     assert 'turn_orchestration_plan = build_turn_orchestration_plan(' in route_source
     assert 'requested_action_document_ids = _normalize_conversation_task_document_ids(' in route_source
     assert 'requested_action_document_ids\n            if requested_action_document_ids' in route_source

--- a/functional_tests/test_image_proposal_pipeline.py
+++ b/functional_tests/test_image_proposal_pipeline.py
@@ -2,7 +2,7 @@
 # test_image_proposal_pipeline.py
 """
 Functional test for opt-in chat image proposal pipeline.
-Version: 0.250.062
+Version: 0.250.063
 Implemented in: 0.241.138
 
 This test ensures the reusable image proposal helpers normalize model-authored

--- a/functional_tests/test_orchestration_runtime.py
+++ b/functional_tests/test_orchestration_runtime.py
@@ -1,0 +1,776 @@
+#!/usr/bin/env python3
+# test_orchestration_runtime.py
+"""
+Functional test for the request-scoped orchestration runtime.
+Version: 0.250.063
+Implemented in: 0.250.063
+
+This test ensures direct and coordinated plans execute through one bounded graph
+with dependency ordering, safe parallelism, cancellation, failure policy,
+replanning, finalizer isolation, and runtime-node evidence provenance.
+"""
+
+import json
+import sys
+import threading
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SINGLE_APP_ROOT = REPO_ROOT / 'application' / 'single_app'
+ROUTE_BACKEND_CHATS = SINGLE_APP_ROOT / 'route_backend_chats.py'
+sys.path.insert(0, str(SINGLE_APP_ROOT))
+
+from functions_chat_orchestration import build_turn_orchestration_plan  # noqa: E402
+from functions_evidence_ledger import (  # noqa: E402
+    add_evidence_source,
+    add_fact,
+    create_evidence_ledger_from_plan,
+)
+from functions_orchestration_runtime import (  # noqa: E402
+    OrchestrationNodeAdapter,
+    OrchestrationNodeResult,
+    OrchestrationRun,
+    complete_orchestration_node,
+    execute_orchestration_run,
+    finish_orchestration_run,
+    reconcile_orchestration_run_from_ledger,
+    resolve_orchestration_evidence_discovery,
+    start_orchestration_node,
+)
+
+
+def _build_run(run_id, message, **plan_options):
+    plan = build_turn_orchestration_plan(message, run_id=run_id, **plan_options)
+    ledger = create_evidence_ledger_from_plan(
+        plan,
+        user_message_id=f'{run_id}-message',
+    )
+    return plan, ledger, OrchestrationRun.from_plan(plan, ledger)
+
+
+def _collector_result(source_type, fact_text, *, fact_id, status='succeeded'):
+    return {
+        'source_type': source_type,
+        'status': status,
+        'summary': f'{source_type} completed.',
+        'facts': [{
+            'id': fact_id,
+            'text': fact_text,
+            'confidence': 'source_supported',
+        }],
+        'citations': [],
+        'artifacts': [],
+        'missing_or_failed': [],
+        'metadata': {'authorization_status': 'authorized'},
+        'raw_executor_payload': 'must-not-reach-finalizer',
+    }
+
+
+def _node(run, node_id):
+    return next(node for node in run.nodes if node.id == node_id)
+
+
+def test_direct_and_coordinated_turns_share_run_contract():
+    _plan, ledger, run = _build_run(
+        'runtime-direct',
+        'Explain dependency graphs in one paragraph.',
+    )
+    progress_events = []
+
+    execute_orchestration_run(
+        run,
+        {'response': lambda _context: OrchestrationNodeResult(status='succeeded')},
+        original_request='Explain dependency graphs in one paragraph.',
+        progress_callback=progress_events.append,
+    )
+
+    assert run.status == 'succeeded'
+    assert ledger['status'] == 'completed'
+    assert run.to_metadata()['mode'] == 'direct'
+    assert _node(run, 'finalize_response').status == 'succeeded'
+    assert [event['status'] for event in progress_events] == ['running', 'succeeded']
+
+
+def test_dependencies_parallel_collectors_and_node_provenance():
+    _plan, ledger, run = _build_run(
+        'runtime-ordering',
+        'Use the selected agent, action, and public web evidence.',
+        selected_agent={'id': 'agent-1'},
+        selected_action={'type': 'analysis'},
+        web_search_enabled=True,
+    )
+    parallel_barrier = threading.Barrier(2)
+    execution_events = []
+
+    def collect_agent(_context):
+        execution_events.append('agent_started')
+        parallel_barrier.wait(timeout=2)
+        execution_events.append('agent_finished')
+        return _collector_result(
+            'selected_agent',
+            'The selected agent returned an authorized profile fact.',
+            fact_id='fact-agent',
+        )
+
+    def collect_web(_context):
+        execution_events.append('web_started')
+        parallel_barrier.wait(timeout=2)
+        execution_events.append('web_finished')
+        return _collector_result(
+            'web_search',
+            'The public source returned a supported market fact.',
+            fact_id='fact-web',
+        )
+
+    def execute_action(context):
+        assert any(fact.get('id') == 'fact-agent' for fact in context.evidence_ledger['facts'])
+        execution_events.append('action_started')
+        return _collector_result(
+            'selected_action',
+            'The selected action computed an authorized result.',
+            fact_id='fact-action',
+        )
+
+    def finalize(context):
+        serialized_ledger = json.dumps(context.evidence_ledger)
+        assert context.evidence_ledger['status'] == 'ready'
+        assert 'must-not-reach-finalizer' not in serialized_ledger
+        assert all(
+            fact.get('step_id')
+            for fact in context.evidence_ledger.get('facts', [])
+        )
+        execution_events.append('finalizer_started')
+        return OrchestrationNodeResult(status='succeeded')
+
+    execute_orchestration_run(
+        run,
+        {
+            'selected_agent': OrchestrationNodeAdapter(
+                execute=collect_agent,
+                parallel_safe=True,
+            ),
+            'web_search': OrchestrationNodeAdapter(
+                execute=collect_web,
+                parallel_safe=True,
+            ),
+            'selected_action': OrchestrationNodeAdapter(
+                execute=execute_action,
+                read_only=False,
+            ),
+            'response': OrchestrationNodeAdapter(
+                execute=finalize,
+                read_only=False,
+            ),
+        },
+        original_request='Use the selected agent, action, and public web evidence.',
+        max_parallel_nodes=2,
+    )
+
+    assert run.status == 'succeeded'
+    assert execution_events.index('agent_started') < execution_events.index('agent_finished')
+    assert execution_events.index('web_started') < execution_events.index('web_finished')
+    assert execution_events.index('action_started') > execution_events.index('agent_finished')
+    assert execution_events.index('action_started') > execution_events.index('web_finished')
+    assert execution_events[-1] == 'finalizer_started'
+    assert {fact['id']: fact['step_id'] for fact in ledger['facts']} == {
+        'fact-agent': 'collect_selected_agent',
+        'fact-web': 'collect_web_search',
+        'fact-action': 'execute_selected_action',
+    }
+
+
+def test_optional_failure_allows_partial_finalization_without_secret_leakage():
+    plan, ledger, _run = _build_run(
+        'runtime-optional-failure',
+        'Use the selected agent and public web evidence.',
+        selected_agent={'id': 'agent-1'},
+        web_search_enabled=True,
+    )
+    next(source for source in plan['sources'] if source['id'] == 'web_search')['required'] = False
+    next(step for step in plan['steps'] if step['id'] == 'collect_web_search')['required'] = False
+    run = OrchestrationRun.from_plan(plan, ledger)
+    finalizer_called = []
+
+    def fail_web(_context):
+        raise RuntimeError('secret-token-value')
+
+    def finalize(context):
+        finalizer_called.append(True)
+        assert context.evidence_ledger['status'] == 'partial'
+        assert 'secret-token-value' not in json.dumps(context.evidence_ledger)
+        return OrchestrationNodeResult(status='succeeded')
+
+    execute_orchestration_run(
+        run,
+        {
+            'selected_agent': lambda _context: _collector_result(
+                'selected_agent',
+                'The agent supplied supported evidence.',
+                fact_id='fact-agent-optional',
+            ),
+            'web_search': fail_web,
+            'response': finalize,
+        },
+        original_request='Use the selected agent and public web evidence.',
+    )
+
+    assert finalizer_called == [True]
+    assert run.status == 'partial'
+    assert _node(run, 'collect_web_search').status == 'failed'
+    assert next(
+        gap for gap in ledger['missing_or_failed']
+        if gap.get('step_id') == 'collect_web_search'
+    )['error_type'] == 'runtimeerror'
+    assert 'secret-token-value' not in json.dumps(run.to_metadata())
+
+
+def test_required_failure_blocks_finalizer():
+    _plan, ledger, run = _build_run(
+        'runtime-required-failure',
+        'Use the selected agent and public web evidence.',
+        selected_agent={'id': 'agent-1'},
+        web_search_enabled=True,
+    )
+    finalizer_called = []
+
+    execute_orchestration_run(
+        run,
+        {
+            'selected_agent': lambda _context: _collector_result(
+                'selected_agent',
+                'The agent supplied supported evidence.',
+                fact_id='fact-agent-required',
+            ),
+            'web_search': lambda _context: OrchestrationNodeResult(
+                status='failed',
+                error_type='tool_unavailable',
+                user_message='Public web evidence was unavailable.',
+            ),
+            'response': lambda _context: finalizer_called.append(True),
+        },
+        original_request='Use the selected agent and public web evidence.',
+    )
+
+    assert finalizer_called == []
+    assert run.status == 'failed'
+    assert ledger['status'] == 'failed'
+    assert _node(run, 'finalize_response').status == 'blocked'
+    assert _node(run, 'finalize_response').error_type == 'required_dependency_failed'
+
+
+def test_read_only_retries_are_bounded_and_writes_remain_single_attempt():
+    _plan, _ledger, run = _build_run(
+        'runtime-read-retry',
+        'Use public web evidence.',
+        web_search_enabled=True,
+    )
+    read_attempts = []
+
+    def retry_web(_context):
+        read_attempts.append(len(read_attempts) + 1)
+        if len(read_attempts) == 1:
+            return OrchestrationNodeResult(
+                status='failed',
+                error_type='temporary_service_failure',
+                user_message='The read-only source was temporarily unavailable.',
+                retryable=True,
+            )
+        return _collector_result(
+            'web_search',
+            'The retried public source returned supported evidence.',
+            fact_id='fact-retried-web',
+        )
+
+    execute_orchestration_run(
+        run,
+        {
+            'web_search': OrchestrationNodeAdapter(
+                execute=retry_web,
+                read_only=True,
+                max_attempts=3,
+            ),
+            'response': lambda _context: OrchestrationNodeResult(status='succeeded'),
+        },
+        original_request='Use public web evidence.',
+    )
+
+    assert read_attempts == [1, 2]
+    assert _node(run, 'collect_web_search').attempt_count == 2
+    assert run.status == 'succeeded'
+
+    _write_plan, _write_ledger, write_run = _build_run(
+        'runtime-write-no-retry',
+        'Use the selected action.',
+        selected_action={'type': 'analysis'},
+    )
+    write_attempts = []
+
+    def fail_write(_context):
+        write_attempts.append(len(write_attempts) + 1)
+        return OrchestrationNodeResult(
+            status='failed',
+            error_type='temporary_write_failure',
+            retryable=True,
+        )
+
+    execute_orchestration_run(
+        write_run,
+        {
+            'selected_action': OrchestrationNodeAdapter(
+                execute=fail_write,
+                read_only=False,
+                max_attempts=3,
+            ),
+            'response': lambda _context: OrchestrationNodeResult(status='succeeded'),
+        },
+        original_request='Use the selected action.',
+    )
+
+    assert write_attempts == [1]
+    assert _node(write_run, 'execute_selected_action').attempt_count == 1
+    assert write_run.status == 'failed'
+
+
+def test_cancellation_stops_pending_synthesis():
+    _plan, ledger, run = _build_run(
+        'runtime-cancellation',
+        'Use the selected agent and public web evidence.',
+        selected_agent={'id': 'agent-1'},
+        web_search_enabled=True,
+    )
+    cancellation_state = {'requested': False}
+    web_called = []
+    finalizer_called = []
+
+    def collect_agent(_context):
+        cancellation_state['requested'] = True
+        return _collector_result(
+            'selected_agent',
+            'The agent supplied evidence before cancellation.',
+            fact_id='fact-agent-cancelled',
+        )
+
+    execute_orchestration_run(
+        run,
+        {
+            'selected_agent': collect_agent,
+            'web_search': lambda _context: web_called.append(True),
+            'response': lambda _context: finalizer_called.append(True),
+        },
+        original_request='Use the selected agent and public web evidence.',
+        cancel_requested=lambda: cancellation_state['requested'],
+    )
+
+    assert run.status == 'cancelled'
+    assert ledger['status'] == 'cancelled'
+    assert web_called == []
+    assert finalizer_called == []
+    assert _node(run, 'collect_web_search').status == 'cancelled'
+    assert _node(run, 'finalize_response').status == 'cancelled'
+
+
+def test_cancellation_wins_before_aggregate_run_closure():
+    _plan, ledger, run = _build_run(
+        'runtime-final-cancellation',
+        'Explain the final cancellation checkpoint.',
+    )
+    cancellation_checks = {'count': 0}
+
+    def cancellation_requested():
+        cancellation_checks['count'] += 1
+        return cancellation_checks['count'] >= 4
+
+    execute_orchestration_run(
+        run,
+        {'response': lambda _context: OrchestrationNodeResult(status='succeeded')},
+        original_request='Explain the final cancellation checkpoint.',
+        cancel_requested=cancellation_requested,
+    )
+
+    assert run.status == 'cancelled'
+    assert ledger['status'] == 'cancelled'
+
+
+def test_bounded_replanning_adds_read_only_work_before_finalizer():
+    _plan, ledger, run = _build_run(
+        'runtime-replanning',
+        'Create a summary grounded in whatever evidence is needed.',
+    )
+    finalizer_contexts = []
+
+    def plan_evidence(_context):
+        return OrchestrationNodeResult(
+            status='succeeded',
+            additional_nodes=({
+                'id': 'collect_source_review',
+                'type': 'collect',
+                'capability': 'source_review',
+                'origin': 'replan',
+                'required': False,
+                'status': 'pending',
+                'depends_on': ['plan_evidence_discovery'],
+            },),
+        )
+
+    def collect_source_review(_context):
+        result = _collector_result(
+            'source_review',
+            'The follow-up source review returned supported evidence.',
+            fact_id='fact-source-review',
+        )
+        return OrchestrationNodeResult(
+            status='succeeded',
+            collector_result=result,
+            additional_nodes=({
+                'id': 'collect_unbounded_followup',
+                'type': 'collect',
+                'capability': 'web_search',
+                'origin': 'replan',
+                'required': False,
+                'status': 'pending',
+                'depends_on': ['collect_source_review'],
+            },),
+        )
+
+    def finalize(context):
+        finalizer_contexts.append(context)
+        assert context.evidence_ledger['status'] == 'partial'
+        assert any(
+            fact.get('id') == 'fact-source-review'
+            for fact in context.evidence_ledger['facts']
+        )
+        return OrchestrationNodeResult(status='succeeded')
+
+    execute_orchestration_run(
+        run,
+        {
+            'evidence_discovery': plan_evidence,
+            'source_review': collect_source_review,
+            'response': finalize,
+        },
+        original_request='Create a summary grounded in whatever evidence is needed.',
+    )
+
+    assert len(finalizer_contexts) == 1
+    assert run.replan_count == 1
+    assert run.status == 'partial'
+    assert 'replan_budget_exhausted' in run.warnings
+    assert _node(run, 'collect_source_review').status == 'partial'
+    assert all(node.id != 'collect_unbounded_followup' for node in run.nodes)
+    assert 'collect_source_review' in _node(run, 'finalize_response').depends_on
+
+
+def test_cycles_are_rejected_before_execution():
+    plan, ledger, _run = _build_run(
+        'runtime-cycle',
+        'Use public web evidence.',
+        web_search_enabled=True,
+    )
+    plan['steps'][0]['depends_on'] = ['finalize_response']
+    try:
+        OrchestrationRun.from_plan(plan, ledger)
+    except ValueError as ex:
+        assert 'cycle' in str(ex)
+    else:
+        raise AssertionError('Expected cyclic orchestration graph to be rejected')
+
+
+def test_replanning_cannot_create_a_finalizer_cycle():
+    _plan, _ledger, run = _build_run(
+        'runtime-replan-cycle',
+        'Create a summary grounded in whatever evidence is needed.',
+    )
+
+    execute_orchestration_run(
+        run,
+        {
+            'evidence_discovery': lambda _context: OrchestrationNodeResult(
+                status='succeeded',
+                additional_nodes=({
+                    'id': 'collect_invalid_followup',
+                    'type': 'collect',
+                    'capability': 'source_review',
+                    'origin': 'replan',
+                    'required': False,
+                    'status': 'pending',
+                    'depends_on': ['finalize_response'],
+                },),
+            ),
+            'response': lambda _context: OrchestrationNodeResult(status='succeeded'),
+        },
+        original_request='Create a summary grounded in whatever evidence is needed.',
+    )
+
+    assert run.status == 'partial'
+    assert run.replan_count == 0
+    assert 'invalid_replan_graph' in run.warnings
+    assert all(node.id != 'collect_invalid_followup' for node in run.nodes)
+
+
+def test_evidence_discovery_resolves_only_from_usable_authorized_evidence():
+    _plan, ledger, run = _build_run(
+        'runtime-discovery-success',
+        'Create a summary grounded in whatever evidence is available.',
+    )
+    add_evidence_source(
+        ledger,
+        'conversation_history',
+        'succeeded',
+        source_id='conversation_history',
+        required=False,
+        authorization_status='authorized',
+    )
+    add_fact(
+        ledger,
+        'The user previously supplied an authorized project constraint.',
+        ['conversation_history'],
+        confidence='user_provided',
+        fact_id='fact-discovered-history',
+    )
+
+    resolve_orchestration_evidence_discovery(run)
+
+    assert _node(run, 'plan_evidence_discovery').status == 'succeeded'
+    discovery_source = next(
+        source for source in ledger['sources'] if source['id'] == 'evidence_discovery'
+    )
+    assert discovery_source['status'] == 'succeeded'
+    assert discovery_source['metadata']['discovered_source_ids'] == ['conversation_history']
+
+    _empty_plan, empty_ledger, empty_run = _build_run(
+        'runtime-discovery-empty',
+        'Create a summary grounded in whatever evidence is available.',
+    )
+    resolve_orchestration_evidence_discovery(empty_run)
+    reconcile_orchestration_run_from_ledger(empty_run)
+
+    assert _node(empty_run, 'plan_evidence_discovery').status == 'failed'
+    assert _node(empty_run, 'finalize_response').status == 'blocked'
+    assert empty_ledger['missing_or_failed'][0]['step_id'] == 'plan_evidence_discovery'
+
+
+def test_external_stream_lifecycle_uses_same_graph_and_provenance():
+    _plan, ledger, run = _build_run(
+        'runtime-external-stream',
+        'Use the selected agent and public web evidence.',
+        selected_agent={'id': 'agent-1'},
+        web_search_enabled=True,
+    )
+    for source_id, fact_id in (
+        ('selected_agent', 'fact-external-agent'),
+        ('web_search', 'fact-external-web'),
+    ):
+        source = next(item for item in ledger['sources'] if item['id'] == source_id)
+        add_evidence_source(
+            ledger,
+            source_id,
+            'succeeded',
+            source_id=source_id,
+            summary=f'{source_id} completed in the existing request path.',
+            requirement_ids=source.get('requirement_ids'),
+            authorization_status='authorized',
+        )
+        add_fact(
+            ledger,
+            f'{source_id} returned externally collected evidence.',
+            [source_id],
+            requirement_ids=source.get('requirement_ids'),
+            fact_id=fact_id,
+        )
+
+    progress_events = []
+    reconcile_orchestration_run_from_ledger(run, progress_callback=progress_events.append)
+    start_orchestration_node(
+        run,
+        'finalize_response',
+        progress_callback=progress_events.append,
+    )
+    assert ledger['status'] == 'ready'
+    complete_orchestration_node(
+        run,
+        'finalize_response',
+        OrchestrationNodeResult(status='succeeded'),
+        progress_callback=progress_events.append,
+    )
+    finish_orchestration_run(run)
+
+    assert run.status == 'succeeded'
+    assert ledger['status'] == 'completed'
+    assert _node(run, 'collect_selected_agent').status == 'succeeded'
+    assert _node(run, 'collect_web_search').status == 'succeeded'
+    assert {fact['id']: fact['step_id'] for fact in ledger['facts']} == {
+        'fact-external-agent': 'collect_selected_agent',
+        'fact-external-web': 'collect_web_search',
+    }
+    assert progress_events[-1]['node_id'] == 'finalize_response'
+    assert progress_events[-1]['status'] == 'succeeded'
+
+
+def test_initial_adapter_categories_share_image_finalizer_graph():
+    plan, ledger, run = _build_run(
+        'runtime-initial-adapters',
+        'Create an image grounded in conversation history, selected documents, '
+        'the selected image, workspace documents, and public web sources.',
+        selected_agent={'id': 'agent-1'},
+        selected_action={'type': 'analysis'},
+        selected_document_ids=['document-1'],
+        hybrid_search_enabled=True,
+        web_search_enabled=True,
+        source_review_enabled=True,
+        selected_image_reference_count=1,
+        image_generation_available=True,
+    )
+    expected_capabilities = {
+        'conversation_evidence',
+        'selected_documents',
+        'selected_images',
+        'workspace_search',
+        'web_search',
+        'source_review',
+        'selected_agent',
+        'selected_action',
+    }
+    assert expected_capabilities.issubset({node.capability for node in run.nodes})
+
+    for source in plan['sources']:
+        source_id = source['id']
+        ledger_source = next(item for item in ledger['sources'] if item['id'] == source_id)
+        add_evidence_source(
+            ledger,
+            source_id,
+            'succeeded',
+            source_id=source_id,
+            origin=source.get('origin'),
+            required=source.get('required', True),
+            requirement_ids=ledger_source.get('requirement_ids'),
+            authorization_status='authorized',
+        )
+        add_fact(
+            ledger,
+            f'{source_id} supplied authorized runtime evidence.',
+            [source_id],
+            requirement_ids=ledger_source.get('requirement_ids'),
+            fact_id=f'fact-{source_id}',
+        )
+
+    reconcile_orchestration_run_from_ledger(run)
+    start_orchestration_node(run, 'finalize_image_proposal')
+    complete_orchestration_node(
+        run,
+        'finalize_image_proposal',
+        OrchestrationNodeResult(status='succeeded'),
+    )
+    finish_orchestration_run(run)
+
+    assert run.status == 'succeeded'
+    assert all(
+        node.status == 'succeeded'
+        for node in run.nodes
+        if node.capability in expected_capabilities
+    )
+    assert _node(run, 'finalize_image_proposal').status == 'succeeded'
+    assert ledger['status'] == 'completed'
+
+
+def test_chat_routes_persist_and_gate_request_scoped_runtime():
+    route_source = ROUTE_BACKEND_CHATS.read_text(encoding='utf-8')
+
+    assert route_source.count('turn_orchestration_run = OrchestrationRun.from_plan(') >= 2
+    assert "user_metadata['orchestration_runtime'] = turn_orchestration_run.to_metadata()" in route_source
+    assert "'orchestration_runtime': turn_orchestration_run.to_metadata()," in route_source
+    assert 'resolve_orchestration_evidence_discovery(' in route_source
+    assert 'reconcile_orchestration_run_from_ledger(' in route_source
+    assert 'start_orchestration_node(' in route_source
+    assert 'complete_orchestration_node(' in route_source
+    assert 'finish_orchestration_run(turn_orchestration_run)' in route_source
+    assert 'cancel_orchestration_run(' in route_source
+    assert 'fail_orchestration_run(' in route_source
+    assert 'stream_session.is_cancel_requested if stream_session else None' in route_source
+    assert "error_type='stream_ended_before_runtime_completion'" in route_source
+    assert 'active_runtime and not active_runtime.completed_at' in route_source
+    assert "'partial_content': document_action_reply," in route_source
+    assert "}, 409" in route_source
+    assert route_source.count("user_message_doc['metadata'] = user_metadata") >= 8
+    cancel_runtime_index = route_source.index(
+        'cancel_orchestration_run(',
+        route_source.index('def finalize_cancelled_stream_response():'),
+    )
+    cancel_persist_index = route_source.index(
+        'cosmos_messages_container.upsert_item(user_message_doc)',
+        cancel_runtime_index,
+    )
+    stream_failure_index = route_source.index(
+        "error_type='stream_execution_failed'",
+        cancel_persist_index,
+    )
+    stream_failure_persist_index = route_source.index(
+        'cosmos_messages_container.upsert_item(user_message_doc)',
+        stream_failure_index,
+    )
+    assert cancel_runtime_index < cancel_persist_index < stream_failure_index
+    assert stream_failure_index < stream_failure_persist_index
+
+    streaming_plan_index = route_source.rindex(
+        'turn_orchestration_plan = build_turn_orchestration_plan('
+    )
+    streaming_ledger_index = route_source.index(
+        'turn_evidence_ledger = create_evidence_ledger_from_plan(',
+        streaming_plan_index,
+    )
+    streaming_runtime_index = route_source.index(
+        'turn_orchestration_run = OrchestrationRun.from_plan(',
+        streaming_ledger_index,
+    )
+    collector_index = route_source.index(
+        'populate_evidence_ledger_from_chat_sources(',
+        streaming_runtime_index,
+    )
+    discovery_index = route_source.index(
+        'resolve_orchestration_evidence_discovery(',
+        collector_index,
+    )
+    reconcile_index = route_source.index(
+        'reconcile_orchestration_run_from_ledger(',
+        discovery_index,
+    )
+    finalizer_start_index = route_source.index(
+        'start_orchestration_node(',
+        reconcile_index,
+    )
+    finalizer_finish_index = route_source.index(
+        'finish_orchestration_run(turn_orchestration_run)',
+        finalizer_start_index,
+    )
+    assert (
+        streaming_plan_index
+        < streaming_ledger_index
+        < streaming_runtime_index
+        < collector_index
+        < discovery_index
+        < reconcile_index
+        < finalizer_start_index
+        < finalizer_finish_index
+    )
+
+
+if __name__ == '__main__':
+    tests = [
+        test_direct_and_coordinated_turns_share_run_contract,
+        test_dependencies_parallel_collectors_and_node_provenance,
+        test_optional_failure_allows_partial_finalization_without_secret_leakage,
+        test_required_failure_blocks_finalizer,
+        test_read_only_retries_are_bounded_and_writes_remain_single_attempt,
+        test_cancellation_stops_pending_synthesis,
+        test_cancellation_wins_before_aggregate_run_closure,
+        test_bounded_replanning_adds_read_only_work_before_finalizer,
+        test_cycles_are_rejected_before_execution,
+        test_replanning_cannot_create_a_finalizer_cycle,
+        test_evidence_discovery_resolves_only_from_usable_authorized_evidence,
+        test_external_stream_lifecycle_uses_same_graph_and_provenance,
+        test_initial_adapter_categories_share_image_finalizer_graph,
+        test_chat_routes_persist_and_gate_request_scoped_runtime,
+    ]
+    for test in tests:
+        test()
+    print(f'Orchestration runtime checks passed: {len(tests)}/{len(tests)}')


### PR DESCRIPTION
## Summary

- add a request-scoped, in-process `OrchestrationRun` execution graph shared by direct and coordinated turns, with DAG validation, terminal node lifecycle, required/optional failure policy, finalizer gating, bounded read-only retries, opt-in safe parallelism, and bounded replanning
- reconcile existing authorized conversation, document, image, workspace, web, source-review, agent, and action outputs into the runtime without moving Flask-scoped authorization work into worker threads
- integrate standard streaming and document actions with node progress, selected-agent required-attempt enforcement, evidence-discovery gating, cancellation, terminal cleanup, provenance, and compact persisted runtime metadata
- update version `0.250.063`, orchestration documentation, release notes, and stream lifecycle regression contracts

## Validation

- Phase 1-6 orchestration and compatibility checks: 84/84 passed
- stream heartbeat, background execution, lifecycle, reattach, and stop-control checks: 5/5 passed
- route policy contracts: 12/12 passed
- Python compilation and VS Code diagnostics: clean
- full-file Broken Access Control and XSS scans: passed
- staged whitespace validation: clean

## Phase Boundary

- runtime remains in-process and request-scoped; no durable queue or process-loss resume
- synchronous SDK cancellation remains best effort, with pending finalization blocked and late results discarded where possible
- non-grounded selected-agent and Analyze/Compare paths retain compatibility finalizers until central synthesis expands to those output profiles

Refs #1021