### PR TITLE
Add Phase 7 orchestration progress and approval UX

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -96,7 +96,7 @@ load_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.250.063"
+VERSION = "0.250.064"
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')
 SESSION_COOKIE_HTTPONLY = os.getenv('SESSION_COOKIE_HTTPONLY', 'true').lower() != 'false'

--- a/application/single_app/functions_image_generation.py
+++ b/application/single_app/functions_image_generation.py
@@ -25,6 +25,25 @@ IMAGE_PROPOSAL_TEXT_MAX_LENGTH = 600
 IMAGE_PROPOSAL_ID_MAX_LENGTH = 120
 IMAGE_PROPOSAL_METADATA_ID_MAX_LENGTH = 160
 IMAGE_PROPOSAL_METADATA_MAX_ITEMS = 24
+IMAGE_PROPOSAL_APPROVAL_REVIEW_VERSION = 1
+
+IMAGE_PROPOSAL_SOURCE_LABELS = {
+    'assigned_knowledge': 'Assigned Knowledge',
+    'conversation_documents': 'Conversation Documents',
+    'conversation_history': 'Conversation History',
+    'deep_research': 'Deep Research',
+    'document_action': 'Selected Action',
+    'prior_citations': 'Prior Citations',
+    'selected_action': 'Selected Action',
+    'selected_agent': 'Selected Agent',
+    'selected_documents': 'Selected Documents',
+    'selected_image': 'Selected Image',
+    'selected_images': 'Selected Image',
+    'source_review': 'Source Review',
+    'user_message': 'User Provided',
+    'web_search': 'Web Search',
+    'workspace_search': 'Workspace Search',
+}
 
 IMAGE_PROPOSAL_REQUEST_MARKERS = (
     'image',
@@ -290,6 +309,210 @@ def constrain_image_proposal_to_evidence_ledger(proposal, evidence_ledger):
         normalized_proposal.pop('referenceImageIds', None)
 
     return normalized_proposal
+
+
+def _image_proposal_source_label(source_type):
+    normalized_type = _normalize_metadata_id(source_type).lower()
+    if normalized_type in IMAGE_PROPOSAL_SOURCE_LABELS:
+        return IMAGE_PROPOSAL_SOURCE_LABELS[normalized_type]
+    return _trim_text(normalized_type.replace('_', ' ').title(), 80) or 'Evidence Source'
+
+
+def _image_proposal_entry_source_ids(entry):
+    source_ids = _normalize_metadata_list(entry.get('source_ids'), identifiers=True)
+    source_id = _normalize_metadata_id(entry.get('source_id'))
+    if source_id and source_id not in source_ids:
+        source_ids.append(source_id)
+    return source_ids
+
+
+def build_image_proposal_approval_review(
+    evidence_ledger,
+    orchestration_runtime=None,
+    proposal=None,
+):
+    """Build a bounded user-facing approval state from authorized turn metadata."""
+    if not isinstance(evidence_ledger, dict):
+        return {
+            'version': IMAGE_PROPOSAL_APPROVAL_REVIEW_VERSION,
+            'state': 'ready',
+            'can_approve': True,
+            'requires_confirmation': False,
+            'ledger_status': 'unavailable',
+            'runtime_status': 'unavailable',
+            'message': 'Review the image proposal before generation.',
+            'sources': [],
+            'missing_evidence': [],
+            'reference_images': [],
+        }
+
+    runtime = orchestration_runtime if isinstance(orchestration_runtime, dict) else {}
+    normalized_proposal = proposal if isinstance(proposal, dict) else {}
+    ledger_status = _normalize_metadata_id(evidence_ledger.get('status')).lower() or 'unknown'
+    runtime_status = _normalize_metadata_id(runtime.get('status')).lower() or 'unavailable'
+    requirements = [
+        entry
+        for entry in (evidence_ledger.get('requirements') or [])
+        if isinstance(entry, dict)
+    ]
+    sources = [
+        entry
+        for entry in (evidence_ledger.get('sources') or [])
+        if isinstance(entry, dict)
+    ]
+
+    retained_evidence_ids = set(_normalize_metadata_list(
+        normalized_proposal.get('evidenceIds', normalized_proposal.get('evidence_ids')),
+        identifiers=True,
+    ))
+    retained_reference_ids = set(_normalize_metadata_list(
+        normalized_proposal.get('referenceImageIds', normalized_proposal.get('reference_image_ids')),
+        identifiers=True,
+    ))
+    supported_entries = []
+    for section in ('facts', 'citations', 'artifacts'):
+        supported_entries.extend(
+            entry
+            for entry in (evidence_ledger.get(section) or [])
+            if isinstance(entry, dict)
+        )
+    supported_entries.extend(
+        entry
+        for entry in (evidence_ledger.get('results') or [])
+        if isinstance(entry, dict) and entry.get('status') in {'succeeded', 'partial'}
+    )
+
+    selected_entry_ids = retained_evidence_ids | retained_reference_ids
+    used_source_ids = {
+        source_id
+        for entry in supported_entries
+        if selected_entry_ids and _normalize_metadata_id(entry.get('id')) in selected_entry_ids
+        for source_id in _image_proposal_entry_source_ids(entry)
+    }
+    source_summaries = []
+    for source in sources[:IMAGE_PROPOSAL_METADATA_MAX_ITEMS]:
+        source_id = _normalize_metadata_id(source.get('id'))
+        source_type = _normalize_metadata_id(source.get('type')).lower() or 'evidence_source'
+        source_status = _normalize_metadata_id(source.get('status')).lower() or 'unknown'
+        source_summaries.append({
+            'id': source_id,
+            'type': source_type,
+            'label': _image_proposal_source_label(source_type),
+            'status': source_status,
+            'required': bool(source.get('required')),
+            'used': source_id in used_source_ids,
+        })
+
+    missing_evidence = []
+    for gap in evidence_ledger.get('missing_or_failed') or []:
+        if not isinstance(gap, dict):
+            continue
+        message = _trim_text(gap.get('message'), IMAGE_PROPOSAL_TEXT_MAX_LENGTH)
+        if message and message not in missing_evidence:
+            missing_evidence.append(message)
+        if len(missing_evidence) >= IMAGE_PROPOSAL_METADATA_MAX_ITEMS:
+            break
+    for requirement in requirements:
+        requirement_status = _normalize_metadata_id(requirement.get('status')).lower()
+        if requirement_status not in {'pending', 'partial', 'unsatisfied'}:
+            continue
+        description = _trim_text(requirement.get('description'), IMAGE_PROPOSAL_TEXT_MAX_LENGTH)
+        if description and description not in missing_evidence:
+            missing_evidence.append(description)
+        if len(missing_evidence) >= IMAGE_PROPOSAL_METADATA_MAX_ITEMS:
+            break
+
+    reference_images = []
+    for artifact in evidence_ledger.get('artifacts') or []:
+        if not isinstance(artifact, dict) or artifact.get('type') != 'image_reference':
+            continue
+        artifact_id = _normalize_metadata_id(artifact.get('id'))
+        if artifact_id not in retained_reference_ids:
+            continue
+        reference_images.append({
+            'id': artifact_id,
+            'name': _trim_text(artifact.get('name'), 160) or 'Selected image',
+            'reference_id': _normalize_metadata_id(artifact.get('reference')),
+            'document_id': _normalize_metadata_id(artifact.get('document_id')),
+            'message_id': _normalize_metadata_id(artifact.get('message_id')),
+        })
+        if len(reference_images) >= IMAGE_PROPOSAL_METADATA_MAX_ITEMS:
+            break
+
+    blocking_reasons = []
+    confirmation_reasons = []
+    if ledger_status in {'collecting', 'pending', 'running'}:
+        blocking_reasons.append('Evidence collection is still in progress.')
+    elif ledger_status == 'cancelled':
+        blocking_reasons.append('The evidence review was cancelled.')
+    elif ledger_status not in {'ready', 'partial', 'completed'}:
+        blocking_reasons.append('The evidence review did not complete successfully.')
+
+    if runtime_status in {'pending', 'running'}:
+        blocking_reasons.append('The orchestration workflow is still running.')
+    elif runtime_status == 'cancelled':
+        blocking_reasons.append('The orchestration workflow was cancelled.')
+    elif runtime_status == 'failed':
+        blocking_reasons.append('The orchestration workflow failed.')
+    elif runtime_status not in {'unavailable', 'succeeded', 'partial'}:
+        blocking_reasons.append('The orchestration workflow is not ready for approval.')
+
+    required_pending = any(
+        bool(requirement.get('required'))
+        and _normalize_metadata_id(requirement.get('status')).lower() == 'pending'
+        for requirement in requirements
+    )
+    if required_pending:
+        blocking_reasons.append('Required evidence is still pending.')
+
+    required_cancelled = any(
+        bool(source.get('required'))
+        and _normalize_metadata_id(source.get('status')).lower() == 'cancelled'
+        for source in sources
+    )
+    if required_cancelled:
+        blocking_reasons.append('A required evidence source was cancelled.')
+
+    has_supported_evidence = bool(supported_entries)
+    required_incomplete = any(
+        bool(requirement.get('required'))
+        and _normalize_metadata_id(requirement.get('status')).lower() in {'partial', 'unsatisfied'}
+        for requirement in requirements
+    )
+    if ledger_status == 'partial' or runtime_status == 'partial' or required_incomplete:
+        if (
+            has_supported_evidence
+            and ledger_status in {'ready', 'partial', 'completed'}
+            and not blocking_reasons
+        ):
+            confirmation_reasons.append(
+                'Some requested evidence was not available. Review the missing evidence before continuing.'
+            )
+        elif not blocking_reasons:
+            blocking_reasons.append('Required evidence is incomplete and cannot be approved.')
+
+    if blocking_reasons:
+        state = 'blocked'
+        message = blocking_reasons[0]
+    elif confirmation_reasons:
+        state = 'confirmation_required'
+        message = confirmation_reasons[0]
+    else:
+        state = 'ready'
+        message = 'Evidence review complete. Review the image proposal before generation.'
+
+    return {
+        'version': IMAGE_PROPOSAL_APPROVAL_REVIEW_VERSION,
+        'state': state,
+        'can_approve': state != 'blocked',
+        'requires_confirmation': state == 'confirmation_required',
+        'ledger_status': ledger_status,
+        'runtime_status': runtime_status,
+        'message': message,
+        'sources': source_summaries,
+        'missing_evidence': missing_evidence,
+        'reference_images': reference_images,
+    }
 
 
 def resolve_image_generation_client(settings):

--- a/application/single_app/functions_orchestration_runtime.py
+++ b/application/single_app/functions_orchestration_runtime.py
@@ -605,12 +605,20 @@ def _progress_message(node, status):
 def _emit_progress(run, node, progress_callback):
     if progress_callback is None:
         return
+    node_index = next(
+        index
+        for index, runtime_node in enumerate(run.nodes)
+        if runtime_node.id == node.id
+    )
     event = {
         'version': ORCHESTRATION_RUNTIME_VERSION,
         'run_id': run.run_id,
         'node_id': node.id,
+        'node_index': node_index,
+        'node_count': len(run.nodes),
         'node_type': node.type,
         'capability': node.capability,
+        'required': node.required,
         'status': node.status,
         'message': _progress_message(node, node.status),
     }

--- a/application/single_app/route_backend_chats.py
+++ b/application/single_app/route_backend_chats.py
@@ -145,6 +145,7 @@ from functions_orchestration_runtime import (
 from functions_image_messages import build_image_message_documents, decode_image_content
 from functions_icon_utils import normalize_icon_payload
 from functions_image_generation import (
+    build_image_proposal_approval_review,
     build_grounded_image_synthesis_profile,
     build_image_proposal_guidance_message,
     constrain_image_proposal_to_evidence_ledger,
@@ -11747,6 +11748,60 @@ def register_route_backend_chats(bp):
 
         return user_metadata
 
+    def _build_orchestration_stream_thought_payloads(event):
+        event = event if isinstance(event, dict) else {}
+        node_id = str(event.get('node_id') or '').strip()[:160]
+        node_type = str(event.get('node_type') or '').strip()[:80]
+        capability = str(event.get('capability') or '').strip()[:120]
+        status = str(event.get('status') or '').strip().lower()[:40]
+        run_id = str(event.get('run_id') or '').strip()[:160]
+        message = str(event.get('message') or 'Updating orchestration progress').strip()[:1000]
+        try:
+            node_index = max(0, min(int(event.get('node_index') or 0), 1000))
+        except (TypeError, ValueError):
+            node_index = 0
+        try:
+            node_count = max(node_index + 1, min(int(event.get('node_count') or 0), 1000))
+        except (TypeError, ValueError):
+            node_count = node_index + 1
+        approval_required = capability == 'image_proposal' and status == 'succeeded'
+        visible_node_count = node_count + 1 if approval_required else node_count
+        activity = {
+            'kind': 'orchestration_node',
+            'run_id': run_id,
+            'node_id': node_id,
+            'node_index': node_index,
+            'node_count': visible_node_count,
+            'node_type': node_type,
+            'capability': capability,
+            'status': status,
+            'required': bool(event.get('required')),
+        }
+        payloads = [{
+            'step_type': 'orchestration_progress',
+            'content': message,
+            'detail': f'node={node_id}; status={status}',
+            'activity': activity,
+        }]
+        if approval_required:
+            payloads.append({
+                'step_type': 'approval_required',
+                'content': 'Awaiting image proposal approval',
+                'detail': 'Review the evidence and proposal before generation.',
+                'activity': {
+                    'kind': 'orchestration_node',
+                    'run_id': run_id,
+                    'node_id': f'{node_id}:approval',
+                    'node_index': node_count,
+                    'node_count': visible_node_count,
+                    'node_type': 'approval',
+                    'capability': 'approval_required',
+                    'status': 'running',
+                    'required': True,
+                },
+            })
+        return payloads
+
     def _build_document_action_stream_activity_callback(publish_background_event, assistant_message_id):
         if not callable(publish_background_event) or not assistant_message_id:
             return None, None
@@ -12234,8 +12289,9 @@ def register_route_backend_chats(bp):
                 )
 
         def publish_orchestration_runtime_progress(event):
-            if callable(publish_stream_thought):
-                publish_stream_thought(event.get('message') or 'Updating orchestration progress')
+            if callable(stream_activity_callback):
+                for thought_payload in _build_orchestration_stream_thought_payloads(event):
+                    stream_activity_callback(thought_payload)
 
         def document_action_cancel_requested():
             return bool(callable(cancel_requested) and cancel_requested())
@@ -12903,6 +12959,7 @@ def register_route_backend_chats(bp):
                 or ''
             ).strip()
             source_evidence_ledger = None
+            source_orchestration_runtime = None
             if source_assistant_message_id:
                 try:
                     source_message = cosmos_messages_container.read_item(
@@ -12919,12 +12976,28 @@ def register_route_backend_chats(bp):
                         else {}
                     )
                     source_evidence_ledger = source_metadata.get('evidence_ledger')
+                    source_orchestration_runtime = source_metadata.get('orchestration_runtime')
                 except CosmosResourceNotFoundError:
-                    source_assistant_message_id = ''
+                    return jsonify({'error': 'Source assistant message not found'}), 404
             proposal = constrain_image_proposal_to_evidence_ledger(
                 proposal,
                 source_evidence_ledger,
             )
+            approval_review = build_image_proposal_approval_review(
+                source_evidence_ledger,
+                source_orchestration_runtime,
+                proposal,
+            )
+            if approval_review['state'] == 'blocked':
+                return jsonify({
+                    'error': approval_review['message'],
+                    'approval_review': approval_review,
+                }), 409
+            if approval_review['requires_confirmation'] and data.get('confirm_partial') is not True:
+                return jsonify({
+                    'error': approval_review['message'],
+                    'approval_review': approval_review,
+                }), 409
 
             image_result = generate_chat_image_message(
                 settings=settings,
@@ -12948,6 +13021,7 @@ def register_route_backend_chats(bp):
                 response_metadata['image_proposal'] = image_doc_metadata['image_proposal']
             image_result.update({
                 'conversation_title': conversation_item.get('title'),
+                'approval_review': approval_review,
                 'image_message': {
                     'id': image_doc.get('id') or image_result.get('message_id'),
                     'conversation_id': conversation_id,
@@ -12964,6 +13038,8 @@ def register_route_backend_chats(bp):
             return jsonify(image_result), 200
         except CosmosResourceNotFoundError:
             return jsonify({'error': 'Conversation or source message not found'}), 404
+        except LookupError:
+            return jsonify({'error': 'Conversation not found'}), 404
         except PermissionError as exc:
             return jsonify({'error': str(exc)}), 403
         except ValueError as exc:
@@ -17520,10 +17596,16 @@ def register_route_backend_chats(bp):
 
                     return f"data: {json.dumps(payload)}\n\n"
 
-                def emit_thought(step_type, content, detail=None):
+                def emit_thought(step_type, content, detail=None, activity=None):
                     """Add a thought to Cosmos and return an SSE event string."""
-                    thought_tracker.add_thought(step_type, content, detail)
-                    return serialize_thought_event(step_type, content, thought_tracker.current_index - 1, detail=detail)
+                    thought_tracker.add_thought(step_type, content, detail, activity=activity)
+                    return serialize_thought_event(
+                        step_type,
+                        content,
+                        thought_tracker.current_index - 1,
+                        detail=detail,
+                        activity=activity,
+                    )
 
                 def queue_orchestration_runtime_progress(event):
                     orchestration_runtime_progress_events.append(dict(event))
@@ -17531,16 +17613,16 @@ def register_route_backend_chats(bp):
                 def drain_orchestration_runtime_progress():
                     queued_events = list(orchestration_runtime_progress_events)
                     orchestration_runtime_progress_events.clear()
-                    return [
-                        emit_thought(
-                            'orchestration',
-                            event.get('message') or 'Updating orchestration progress',
-                            detail=(
-                                f"node={event.get('node_id')}; status={event.get('status')}"
-                            ),
-                        )
-                        for event in queued_events
-                    ]
+                    thought_events = []
+                    for event in queued_events:
+                        for thought_payload in _build_orchestration_stream_thought_payloads(event):
+                            thought_events.append(emit_thought(
+                                thought_payload['step_type'],
+                                thought_payload['content'],
+                                detail=thought_payload.get('detail'),
+                                activity=thought_payload.get('activity'),
+                            ))
+                    return thought_events
 
                 def publish_live_plugin_thought(thought_payload):
                     if not callable(publish_background_event):

--- a/application/single_app/static/css/chats.css
+++ b/application/single_app/static/css/chats.css
@@ -2895,6 +2895,67 @@ ol {
   line-height: 1.35;
 }
 
+.sc-inline-image-proposal-evidence {
+  border-top: 1px solid rgba(100, 116, 139, 0.18);
+}
+
+.sc-inline-image-proposal-source-badge {
+  line-height: 1.35;
+  max-width: 100%;
+  overflow-wrap: anywhere;
+  text-align: left;
+  white-space: normal;
+}
+
+.sc-inline-image-proposal-reference {
+  flex: 0 0 5.5rem;
+  max-width: 5.5rem;
+}
+
+.sc-inline-image-proposal-reference-preview {
+  align-items: center;
+  aspect-ratio: 1;
+  background: rgba(var(--bs-secondary-bg-rgb), 0.7);
+  border: 1px solid rgba(100, 116, 139, 0.2);
+  border-radius: 0.5rem;
+  display: flex;
+  justify-content: center;
+  overflow: hidden;
+  width: 100%;
+}
+
+.sc-inline-image-proposal-reference-image {
+  height: 100%;
+  object-fit: cover;
+  width: 100%;
+}
+
+.sc-inline-image-proposal-reference-fallback {
+  color: var(--bs-secondary-color);
+  font-size: 1.5rem;
+}
+
+.sc-inline-image-proposal-reference figcaption,
+.sc-inline-image-proposal-missing,
+.sc-inline-image-proposal-evidence-details,
+.sc-inline-image-proposal-approval-notice {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.sc-inline-image-proposal-evidence-details summary {
+  cursor: pointer;
+  width: fit-content;
+}
+
+.sc-inline-image-proposal[data-approval-review-state="blocked"] .sc-inline-image-proposal-card {
+  border-color: rgba(100, 116, 139, 0.38) !important;
+}
+
+.sc-inline-image-proposal[data-approval-review-state="confirmation_required"] .sc-inline-image-proposal-card {
+  border-color: rgba(180, 83, 9, 0.42) !important;
+}
+
 .sc-inline-image-proposal-prompt-preview {
   max-height: 9rem;
   overflow: auto;
@@ -2945,6 +3006,18 @@ ol {
 [data-bs-theme="dark"] .sc-inline-image-proposal-prompt-preview {
   background: #111827 !important;
   border-color: rgba(148, 163, 184, 0.32) !important;
+}
+
+@media (max-width: 575.98px) {
+  .sc-inline-image-proposal-actions .btn {
+    flex: 1 1 auto;
+    min-height: 2.75rem;
+  }
+
+  .sc-inline-image-proposal-reference {
+    flex-basis: 4.75rem;
+    max-width: 4.75rem;
+  }
 }
 
 .inline-image-gallery-card {
@@ -3946,6 +4019,36 @@ mark.search-highlight {
     padding: 0.5rem 0;
 }
 
+.orchestration-progress-card {
+  align-items: stretch;
+  max-width: 42rem;
+  width: 100%;
+}
+
+.orchestration-progress-card > .card {
+  width: 100%;
+}
+
+.orchestration-progress-current,
+.orchestration-progress-step {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.orchestration-progress-steps {
+  max-height: 18rem;
+  overflow-y: auto;
+  padding-right: 0.25rem;
+}
+
+.orchestration-progress-step + .orchestration-progress-step {
+  border-top: 1px solid rgba(100, 116, 139, 0.16);
+}
+
+.orchestration-progress-step > i {
+  flex: 0 0 auto;
+}
+
 .streaming-thinking-placeholder {
   min-width: 0;
 }
@@ -4186,4 +4289,8 @@ mark.search-highlight {
 
 [data-bs-theme="dark"] .thoughts-container {
     border-top-color: #495057 !important;
+}
+
+[data-bs-theme="dark"] .orchestration-progress-step + .orchestration-progress-step {
+  border-top-color: rgba(148, 163, 184, 0.2);
 }

--- a/application/single_app/static/js/chat/chat-inline-image-proposals.js
+++ b/application/single_app/static/js/chat/chat-inline-image-proposals.js
@@ -8,6 +8,23 @@ const IMAGE_PROPOSAL_TEXT_MAX_LENGTH = 600;
 const IMAGE_PROPOSAL_METADATA_ID_MAX_LENGTH = 160;
 const IMAGE_PROPOSAL_METADATA_MAX_ITEMS = 24;
 const IMAGE_PROPOSAL_TOKEN_PREFIX = '@@SC_INLINE_IMAGE_PROPOSAL_';
+const IMAGE_PROPOSAL_SOURCE_LABELS = Object.freeze({
+    assigned_knowledge: 'Assigned Knowledge',
+    conversation_documents: 'Conversation Documents',
+    conversation_history: 'Conversation History',
+    deep_research: 'Deep Research',
+    document_action: 'Selected Action',
+    prior_citations: 'Prior Citations',
+    selected_action: 'Selected Action',
+    selected_agent: 'Selected Agent',
+    selected_documents: 'Selected Documents',
+    selected_image: 'Selected Image',
+    selected_images: 'Selected Image',
+    source_review: 'Source Review',
+    user_message: 'User Provided',
+    web_search: 'Web Search',
+    workspace_search: 'Workspace Search',
+});
 const imageProposalQueue = [];
 const imageProposalQueuePromises = new WeakMap();
 let imageProposalQueueActive = false;
@@ -83,6 +100,242 @@ function createElement(tagName, className = '', textContent = '') {
         element.textContent = textContent;
     }
     return element;
+}
+
+function getObjectEntries(value) {
+    return Array.isArray(value) ? value.filter(entry => entry && typeof entry === 'object') : [];
+}
+
+function getEvidenceSourceLabel(sourceType) {
+    const normalizedType = sanitizeMetadataId(sourceType).toLowerCase();
+    if (IMAGE_PROPOSAL_SOURCE_LABELS[normalizedType]) {
+        return IMAGE_PROPOSAL_SOURCE_LABELS[normalizedType];
+    }
+    return sanitizeText(normalizedType.replaceAll('_', ' ').replace(/\b\w/g, character => character.toUpperCase()), 80)
+        || 'Evidence Source';
+}
+
+function getEvidenceEntrySourceIds(entry) {
+    const sourceIds = sanitizeMetadataList(entry?.source_ids, sanitizeMetadataId);
+    const sourceId = sanitizeMetadataId(entry?.source_id);
+    if (sourceId && !sourceIds.includes(sourceId)) {
+        sourceIds.push(sourceId);
+    }
+    return sourceIds;
+}
+
+function normalizeApprovalReview(rawReview) {
+    if (!rawReview || typeof rawReview !== 'object' || Array.isArray(rawReview)) {
+        return null;
+    }
+
+    const state = ['ready', 'confirmation_required', 'blocked'].includes(rawReview.state)
+        ? rawReview.state
+        : 'blocked';
+    const sources = getObjectEntries(rawReview.sources).slice(0, IMAGE_PROPOSAL_METADATA_MAX_ITEMS).map(source => ({
+        id: sanitizeMetadataId(source.id),
+        type: sanitizeMetadataId(source.type).toLowerCase() || 'evidence_source',
+        label: getEvidenceSourceLabel(source.type),
+        status: sanitizeMetadataId(source.status).toLowerCase() || 'unknown',
+        required: Boolean(source.required),
+        used: Boolean(source.used),
+    }));
+    const referenceImages = getObjectEntries(rawReview.reference_images || rawReview.referenceImages)
+        .slice(0, IMAGE_PROPOSAL_METADATA_MAX_ITEMS)
+        .map(reference => ({
+            id: sanitizeMetadataId(reference.id),
+            name: sanitizeText(reference.name, 160) || 'Selected image',
+            referenceId: sanitizeMetadataId(reference.reference_id || reference.referenceId),
+            documentId: sanitizeMetadataId(reference.document_id || reference.documentId),
+            messageId: sanitizeMetadataId(reference.message_id || reference.messageId),
+        }));
+
+    return {
+        version: 1,
+        state,
+        canApprove: state !== 'blocked',
+        requiresConfirmation: state === 'confirmation_required',
+        ledgerStatus: sanitizeMetadataId(rawReview.ledger_status || rawReview.ledgerStatus).toLowerCase() || 'unavailable',
+        runtimeStatus: sanitizeMetadataId(rawReview.runtime_status || rawReview.runtimeStatus).toLowerCase() || 'unavailable',
+        message: sanitizeText(rawReview.message) || 'Review the image proposal before generation.',
+        sources,
+        missingEvidence: sanitizeMetadataList(
+            rawReview.missing_evidence || rawReview.missingEvidence,
+            value => sanitizeText(value),
+        ),
+        referenceImages,
+    };
+}
+
+function buildImageProposalApprovalReview(messageElement, spec) {
+    const metadata = messageElement?.__simpleChatImageProposalReviewMetadata;
+    const explicitReview = normalizeApprovalReview(metadata?.image_proposal_approval_review);
+    if (explicitReview) {
+        return explicitReview;
+    }
+
+    const ledger = metadata?.evidence_ledger;
+    const runtime = metadata?.orchestration_runtime;
+    if (!ledger || typeof ledger !== 'object' || Array.isArray(ledger)) {
+        const isStreaming = messageElement?.dataset?.messageComplete === 'false';
+        return {
+            version: 1,
+            state: isStreaming ? 'blocked' : 'ready',
+            canApprove: !isStreaming,
+            requiresConfirmation: false,
+            ledgerStatus: 'unavailable',
+            runtimeStatus: 'unavailable',
+            message: isStreaming
+                ? 'Evidence review is still in progress.'
+                : 'Review the image proposal before generation.',
+            sources: [],
+            missingEvidence: [],
+            referenceImages: [],
+        };
+    }
+
+    const ledgerStatus = sanitizeMetadataId(ledger.status).toLowerCase() || 'unknown';
+    const runtimeStatus = sanitizeMetadataId(runtime?.status).toLowerCase() || 'unavailable';
+    const requirements = getObjectEntries(ledger.requirements);
+    const sources = getObjectEntries(ledger.sources);
+    const retainedEvidenceIds = new Set(sanitizeMetadataList(spec.evidenceIds, sanitizeMetadataId));
+    const retainedReferenceIds = new Set(sanitizeMetadataList(spec.referenceImageIds, sanitizeMetadataId));
+    const selectedEntryIds = new Set([...retainedEvidenceIds, ...retainedReferenceIds]);
+    const supportedEntries = [
+        ...getObjectEntries(ledger.facts),
+        ...getObjectEntries(ledger.citations),
+        ...getObjectEntries(ledger.artifacts),
+        ...getObjectEntries(ledger.results).filter(entry => ['succeeded', 'partial'].includes(entry.status)),
+    ];
+    const usedSourceIds = new Set();
+    supportedEntries.forEach(entry => {
+        const entryId = sanitizeMetadataId(entry.id);
+        if (selectedEntryIds.size === 0 || !selectedEntryIds.has(entryId)) {
+            return;
+        }
+        getEvidenceEntrySourceIds(entry).forEach(sourceId => usedSourceIds.add(sourceId));
+    });
+
+    const sourceSummaries = sources.slice(0, IMAGE_PROPOSAL_METADATA_MAX_ITEMS).map(source => {
+        const sourceId = sanitizeMetadataId(source.id);
+        const sourceType = sanitizeMetadataId(source.type).toLowerCase() || 'evidence_source';
+        return {
+            id: sourceId,
+            type: sourceType,
+            label: getEvidenceSourceLabel(sourceType),
+            status: sanitizeMetadataId(source.status).toLowerCase() || 'unknown',
+            required: Boolean(source.required),
+            used: usedSourceIds.has(sourceId),
+        };
+    });
+
+    const missingEvidence = [];
+    getObjectEntries(ledger.missing_or_failed).forEach(gap => {
+        const message = sanitizeText(gap.message);
+        if (message && !missingEvidence.includes(message)) {
+            missingEvidence.push(message);
+        }
+    });
+    requirements.forEach(requirement => {
+        const requirementStatus = sanitizeMetadataId(requirement.status).toLowerCase();
+        const description = sanitizeText(requirement.description);
+        if (
+            ['pending', 'partial', 'unsatisfied'].includes(requirementStatus)
+            && description
+            && !missingEvidence.includes(description)
+        ) {
+            missingEvidence.push(description);
+        }
+    });
+
+    const referenceImages = getObjectEntries(ledger.artifacts)
+        .filter(artifact => artifact.type === 'image_reference')
+        .filter(artifact => retainedReferenceIds.has(sanitizeMetadataId(artifact.id)))
+        .slice(0, IMAGE_PROPOSAL_METADATA_MAX_ITEMS)
+        .map(artifact => ({
+            id: sanitizeMetadataId(artifact.id),
+            name: sanitizeText(artifact.name, 160) || 'Selected image',
+            referenceId: sanitizeMetadataId(artifact.reference),
+            documentId: sanitizeMetadataId(artifact.document_id),
+            messageId: sanitizeMetadataId(artifact.message_id),
+        }));
+
+    const blockingReasons = [];
+    const confirmationReasons = [];
+    if (['collecting', 'pending', 'running'].includes(ledgerStatus)) {
+        blockingReasons.push('Evidence collection is still in progress.');
+    } else if (ledgerStatus === 'cancelled') {
+        blockingReasons.push('The evidence review was cancelled.');
+    } else if (!['ready', 'partial', 'completed'].includes(ledgerStatus)) {
+        blockingReasons.push('The evidence review did not complete successfully.');
+    }
+
+    if (['pending', 'running'].includes(runtimeStatus)) {
+        blockingReasons.push('The orchestration workflow is still running.');
+    } else if (runtimeStatus === 'cancelled') {
+        blockingReasons.push('The orchestration workflow was cancelled.');
+    } else if (runtimeStatus === 'failed') {
+        blockingReasons.push('The orchestration workflow failed.');
+    } else if (!['unavailable', 'succeeded', 'partial'].includes(runtimeStatus)) {
+        blockingReasons.push('The orchestration workflow is not ready for approval.');
+    }
+
+    const requiredPending = requirements.some(requirement => (
+        Boolean(requirement.required) && sanitizeMetadataId(requirement.status).toLowerCase() === 'pending'
+    ));
+    if (requiredPending) {
+        blockingReasons.push('Required evidence is still pending.');
+    }
+
+    const requiredCancelled = sources.some(source => (
+        Boolean(source.required) && sanitizeMetadataId(source.status).toLowerCase() === 'cancelled'
+    ));
+    if (requiredCancelled) {
+        blockingReasons.push('A required evidence source was cancelled.');
+    }
+
+    const requiredIncomplete = requirements.some(requirement => (
+        Boolean(requirement.required)
+        && ['partial', 'unsatisfied'].includes(sanitizeMetadataId(requirement.status).toLowerCase())
+    ));
+    if (ledgerStatus === 'partial' || runtimeStatus === 'partial' || requiredIncomplete) {
+        if (
+            supportedEntries.length > 0
+            && ['ready', 'partial', 'completed'].includes(ledgerStatus)
+            && blockingReasons.length === 0
+        ) {
+            confirmationReasons.push('Some requested evidence was not available. Review the missing evidence before continuing.');
+        } else if (blockingReasons.length === 0) {
+            blockingReasons.push('Required evidence is incomplete and cannot be approved.');
+        }
+    }
+
+    const state = blockingReasons.length > 0
+        ? 'blocked'
+        : confirmationReasons.length > 0
+            ? 'confirmation_required'
+            : 'ready';
+    return {
+        version: 1,
+        state,
+        canApprove: state !== 'blocked',
+        requiresConfirmation: state === 'confirmation_required',
+        ledgerStatus,
+        runtimeStatus,
+        message: blockingReasons[0]
+            || confirmationReasons[0]
+            || 'Evidence review complete. Review the image proposal before generation.',
+        sources: sourceSummaries,
+        missingEvidence: missingEvidence.slice(0, IMAGE_PROPOSAL_METADATA_MAX_ITEMS),
+        referenceImages,
+    };
+}
+
+function getImageProposalApprovalReview(container, spec) {
+    if (container.__simpleChatImageProposalApprovalReview) {
+        return container.__simpleChatImageProposalApprovalReview;
+    }
+    return buildImageProposalApprovalReview(container.closest('.message'), spec);
 }
 
 function parseImageProposalPayload(payloadText) {
@@ -331,10 +584,11 @@ function setCardState(container, state, message = '') {
 }
 
 function reenableProposalControls(container) {
-    container.querySelectorAll('button, textarea').forEach(control => {
+    container.querySelectorAll('button, textarea, input').forEach(control => {
         control.disabled = false;
     });
     setButtonLoading(container.querySelector('.sc-inline-image-proposal-approve'), false);
+    syncApprovalControls(container);
 }
 
 function renderGeneratedImageResult(container, spec, imageResult) {
@@ -365,6 +619,12 @@ function renderGeneratedImageResult(container, spec, imageResult) {
     const metaList = createProposalMetaList(spec);
     if (metaList.childElementCount > 0) {
         cardBody.appendChild(metaList);
+    }
+
+    const approvalReview = getImageProposalApprovalReview(container, spec);
+    const evidenceReview = createEvidenceReviewSection(spec, approvalReview);
+    if (evidenceReview) {
+        cardBody.appendChild(evidenceReview);
     }
 
     const resultWrapper = createElement('div', 'sc-inline-image-proposal-result mt-2');
@@ -438,8 +698,22 @@ async function runImageProposalGeneration(container) {
         return false;
     }
 
+    const approvalReview = getImageProposalApprovalReview(container, spec);
+    const confirmationControl = container.querySelector('.sc-inline-image-proposal-confirm-partial');
+    if (approvalReview.state === 'blocked') {
+        reenableProposalControls(container);
+        setCardState(container, 'blocked', approvalReview.message);
+        return false;
+    }
+    if (approvalReview.requiresConfirmation && !confirmationControl?.checked) {
+        reenableProposalControls(container);
+        setCardState(container, 'pending', 'Confirm that you want to continue with the available evidence.');
+        confirmationControl?.focus();
+        return false;
+    }
+
     const approveButton = container.querySelector('.sc-inline-image-proposal-approve');
-    const actionButtons = container.querySelectorAll('button, textarea');
+    const actionButtons = container.querySelectorAll('button, textarea, input');
     actionButtons.forEach(control => {
         control.disabled = true;
     });
@@ -455,6 +729,7 @@ async function runImageProposalGeneration(container) {
             body: JSON.stringify({
                 conversation_id: conversationId,
                 assistant_message_id: getAssistantMessageId(container),
+                confirm_partial: approvalReview.requiresConfirmation && confirmationControl?.checked === true,
                 proposal: {
                     ...spec,
                     prompt,
@@ -463,6 +738,12 @@ async function runImageProposalGeneration(container) {
         });
         const result = await response.json().catch(() => ({}));
         if (!response.ok) {
+            const refreshedReview = normalizeApprovalReview(result.approval_review);
+            if (refreshedReview) {
+                container.__simpleChatImageProposalApprovalReview = refreshedReview;
+                renderImageProposalCard(container, spec, refreshedReview);
+                return false;
+            }
             throw new Error(result.error || `Image generation failed (${response.status})`);
         }
 
@@ -536,7 +817,22 @@ function approveImageProposal(container) {
         return Promise.resolve(false);
     }
 
-    const actionButtons = container.querySelectorAll('button, textarea');
+    const spec = decodeContainerSpec(container);
+    const approvalReview = spec ? getImageProposalApprovalReview(container, spec) : null;
+    const confirmationControl = container.querySelector('.sc-inline-image-proposal-confirm-partial');
+    if (!approvalReview || approvalReview.state === 'blocked') {
+        setCardState(container, 'blocked', approvalReview?.message || 'This proposal is not ready for approval.');
+        syncApprovalControls(container);
+        return Promise.resolve(false);
+    }
+    if (approvalReview.requiresConfirmation && !confirmationControl?.checked) {
+        setCardState(container, 'pending', 'Confirm that you want to continue with the available evidence.');
+        confirmationControl?.focus();
+        syncApprovalControls(container);
+        return Promise.resolve(false);
+    }
+
+    const actionButtons = container.querySelectorAll('button, textarea, input');
     actionButtons.forEach(control => {
         control.disabled = true;
     });
@@ -553,7 +849,7 @@ function approveImageProposal(container) {
 
 function cancelImageProposal(container) {
     container.classList.add('sc-inline-image-proposal-cancelled');
-    container.querySelectorAll('button, textarea').forEach(control => {
+    container.querySelectorAll('button, textarea, input').forEach(control => {
         control.disabled = true;
     });
     setCardState(container, 'cancelled', 'Image proposal dismissed.');
@@ -597,7 +893,180 @@ function createProposalMetaList(spec) {
     return list;
 }
 
-function renderImageProposalCard(container, spec) {
+function getSourceBadgeState(source) {
+    if (source.used) {
+        return { className: 'text-bg-success', label: 'used' };
+    }
+    if (source.status === 'succeeded') {
+        return { className: 'text-bg-light border', label: 'reviewed' };
+    }
+    if (source.status === 'partial') {
+        return { className: 'text-bg-warning', label: 'partial' };
+    }
+    if (['planned', 'pending', 'running'].includes(source.status)) {
+        return { className: 'text-bg-info', label: 'reviewing' };
+    }
+    return { className: 'text-bg-secondary', label: 'unavailable' };
+}
+
+function createReferenceImageTray(referenceImages) {
+    const tray = createElement('div', 'sc-inline-image-proposal-reference-tray d-flex flex-wrap gap-2 mt-2');
+    referenceImages.forEach(reference => {
+        const figure = createElement('figure', 'sc-inline-image-proposal-reference mb-0');
+        const preview = createElement('div', 'sc-inline-image-proposal-reference-preview');
+        const fallback = createElement('span', 'sc-inline-image-proposal-reference-fallback d-none');
+        const fallbackIcon = createElement('i', 'bi bi-image');
+        fallbackIcon.setAttribute('aria-hidden', 'true');
+        fallback.appendChild(fallbackIcon);
+
+        if (reference.messageId) {
+            const image = document.createElement('img');
+            image.className = 'sc-inline-image-proposal-reference-image';
+            image.src = `/api/image/${encodeURIComponent(reference.messageId)}`;
+            image.alt = `Reference image: ${reference.name}`;
+            image.loading = 'lazy';
+            image.addEventListener('error', () => {
+                image.classList.add('d-none');
+                fallback.classList.remove('d-none');
+            }, { once: true });
+            preview.appendChild(image);
+        } else {
+            fallback.classList.remove('d-none');
+        }
+        preview.appendChild(fallback);
+        figure.appendChild(preview);
+        figure.appendChild(createElement('figcaption', 'small text-muted mt-1', reference.name));
+        tray.appendChild(figure);
+    });
+    return tray;
+}
+
+function createEvidenceReviewSection(spec, approvalReview) {
+    const missingEvidence = sanitizeMetadataList(
+        [...(spec.missingEvidence || []), ...(approvalReview.missingEvidence || [])],
+        value => sanitizeText(value),
+    );
+    const hasReviewContent = Boolean(
+        spec.sourceSummary
+        || spec.evidenceIds?.length
+        || approvalReview.sources.length
+        || missingEvidence.length
+        || approvalReview.referenceImages.length
+    );
+    if (!hasReviewContent) {
+        return null;
+    }
+
+    const section = createElement('section', 'sc-inline-image-proposal-evidence mt-3 pt-3');
+    section.setAttribute('aria-label', 'Image proposal evidence review');
+    section.appendChild(createElement('div', 'small fw-semibold mb-2', 'Evidence review'));
+
+    if (approvalReview.sources.length > 0) {
+        const sourceList = createElement('div', 'sc-inline-image-proposal-sources d-flex flex-wrap gap-2');
+        sourceList.setAttribute('aria-label', 'Evidence sources');
+        approvalReview.sources.forEach(source => {
+            const badgeState = getSourceBadgeState(source);
+            const badge = createElement(
+                'span',
+                `badge ${badgeState.className} sc-inline-image-proposal-source-badge`,
+                `${source.label} · ${badgeState.label}`,
+            );
+            sourceList.appendChild(badge);
+        });
+        section.appendChild(sourceList);
+    }
+
+    if (approvalReview.referenceImages.length > 0) {
+        const referenceHeading = createElement('div', 'small fw-semibold mt-3', 'Reference images');
+        section.appendChild(referenceHeading);
+        section.appendChild(createReferenceImageTray(approvalReview.referenceImages));
+    }
+
+    if (missingEvidence.length > 0) {
+        const missingAlert = createElement('div', 'alert alert-warning py-2 px-3 mt-3 mb-0 sc-inline-image-proposal-missing');
+        missingAlert.setAttribute('role', 'note');
+        missingAlert.appendChild(createElement('div', 'small fw-semibold', 'Missing evidence'));
+        const list = createElement('ul', 'small mb-0 mt-1 ps-3');
+        missingEvidence.forEach(message => {
+            list.appendChild(createElement('li', '', message));
+        });
+        missingAlert.appendChild(list);
+        section.appendChild(missingAlert);
+    }
+
+    const details = createElement('details', 'sc-inline-image-proposal-evidence-details mt-2');
+    details.appendChild(createElement('summary', 'small text-primary', 'Review evidence details'));
+    const detailBody = createElement('div', 'small text-muted mt-2');
+    if (spec.sourceSummary) {
+        detailBody.appendChild(createElement('p', 'mb-1', spec.sourceSummary));
+    }
+    if (spec.evidenceIds?.length) {
+        const evidenceCount = spec.evidenceIds.length;
+        detailBody.appendChild(createElement(
+            'p',
+            'mb-0',
+            `${evidenceCount} evidence record${evidenceCount === 1 ? '' : 's'} linked to this proposal.`,
+        ));
+    }
+    details.appendChild(detailBody);
+    section.appendChild(details);
+    return section;
+}
+
+function createApprovalNotice(container, approvalReview, spec) {
+    if (approvalReview.state === 'ready') {
+        return null;
+    }
+
+    const noticeClass = approvalReview.state === 'blocked' ? 'alert-secondary' : 'alert-warning';
+    const notice = createElement('div', `alert ${noticeClass} py-2 px-3 mb-2 sc-inline-image-proposal-approval-notice`);
+    const index = container.getAttribute('data-image-proposal-index') || '0';
+    const messageId = sanitizeVisualId(getAssistantMessageId(container)) || 'message';
+    const visualId = sanitizeVisualId(spec?.visualId) || 'proposal';
+    notice.id = `inline-image-proposal-notice-${messageId}-${index}-${visualId}`;
+    notice.setAttribute('role', 'status');
+    notice.setAttribute('aria-live', 'polite');
+    notice.setAttribute('aria-atomic', 'true');
+    notice.appendChild(createElement('div', 'small', approvalReview.message));
+    if (!approvalReview.requiresConfirmation) {
+        return notice;
+    }
+
+    const confirmation = createElement('div', 'form-check mt-2');
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.className = 'form-check-input sc-inline-image-proposal-confirm-partial';
+    checkbox.id = `inline-image-proposal-confirm-${messageId}-${index}-${visualId}`;
+    const label = createElement('label', 'form-check-label small', 'Continue using only the available evidence.');
+    label.setAttribute('for', checkbox.id);
+    checkbox.addEventListener('change', () => {
+        syncApprovalControls(container);
+        const liveStatus = container.querySelector('.sc-inline-image-proposal-approval-live');
+        if (liveStatus) {
+            liveStatus.textContent = checkbox.checked
+                ? 'Approval is now available using the current evidence.'
+                : 'Approval requires confirmation to use the current evidence.';
+        }
+    });
+    confirmation.appendChild(checkbox);
+    confirmation.appendChild(label);
+    notice.appendChild(confirmation);
+    return notice;
+}
+
+function syncApprovalControls(container) {
+    const approveButton = container.querySelector('.sc-inline-image-proposal-approve');
+    const confirmationControl = container.querySelector('.sc-inline-image-proposal-confirm-partial');
+    const approvalReview = container.__simpleChatImageProposalApprovalReview;
+    if (!approveButton || !approvalReview) {
+        return;
+    }
+    approveButton.disabled = approvalReview.state === 'blocked'
+        || (approvalReview.requiresConfirmation && !confirmationControl?.checked);
+    approveButton.setAttribute('aria-disabled', approveButton.disabled ? 'true' : 'false');
+}
+
+function renderImageProposalCard(container, spec, providedApprovalReview = null) {
     const generatedImageResult = findGeneratedImageResultForSpec(container, spec);
     if (generatedImageResult && renderGeneratedImageResult(container, spec, generatedImageResult)) {
         return;
@@ -605,6 +1074,9 @@ function renderImageProposalCard(container, spec) {
 
     container.replaceChildren();
     container.setAttribute('data-image-proposal-hydrated', 'true');
+    const approvalReview = providedApprovalReview || buildImageProposalApprovalReview(container.closest('.message'), spec);
+    container.__simpleChatImageProposalApprovalReview = approvalReview;
+    container.setAttribute('data-approval-review-state', approvalReview.state);
 
     const card = createElement('div', 'sc-inline-image-proposal-card card border-0 shadow-sm');
     const cardBody = createElement('div', 'card-body p-3');
@@ -627,6 +1099,11 @@ function renderImageProposalCard(container, spec) {
         cardBody.appendChild(metaList);
     }
 
+    const evidenceReview = createEvidenceReviewSection(spec, approvalReview);
+    if (evidenceReview) {
+        cardBody.appendChild(evidenceReview);
+    }
+
     const promptPanel = createElement('div', 'sc-inline-image-proposal-prompt-panel d-none mb-2');
     const promptLabel = createElement('label', 'small fw-semibold mb-1', 'Prompt');
     const promptEditor = createElement('textarea', 'sc-inline-image-proposal-prompt-editor form-control form-control-sm');
@@ -643,10 +1120,22 @@ function renderImageProposalCard(container, spec) {
     const status = createElement('div', 'sc-inline-image-proposal-status-text small text-muted mb-2 d-none');
     cardBody.appendChild(status);
 
+    const approvalNotice = createApprovalNotice(container, approvalReview, spec);
+    if (approvalNotice) {
+        cardBody.appendChild(approvalNotice);
+    }
+
     const actions = createElement('div', 'sc-inline-image-proposal-actions d-flex flex-wrap gap-2');
-    const approveButton = createElement('button', 'btn btn-sm btn-primary sc-inline-image-proposal-approve', 'Approve');
+    const approveButton = createElement(
+        'button',
+        'btn btn-sm btn-primary sc-inline-image-proposal-approve',
+        approvalReview.requiresConfirmation ? 'Approve with available evidence' : 'Approve',
+    );
     approveButton.type = 'button';
     approveButton.title = 'Generate this image';
+    if (approvalNotice) {
+        approveButton.setAttribute('aria-describedby', approvalNotice.id);
+    }
     const editButton = createElement('button', 'btn btn-sm btn-outline-secondary sc-inline-image-proposal-edit', 'Edit');
     editButton.type = 'button';
     editButton.title = 'Edit the image prompt';
@@ -665,14 +1154,21 @@ function renderImageProposalCard(container, spec) {
     actions.appendChild(approveButton);
     actions.appendChild(editButton);
     actions.appendChild(cancelButton);
+    const approvalLive = createElement('span', 'visually-hidden sc-inline-image-proposal-approval-live');
+    approvalLive.setAttribute('role', 'status');
+    approvalLive.setAttribute('aria-live', 'polite');
+    approvalLive.setAttribute('aria-atomic', 'true');
+    actions.appendChild(approvalLive);
     cardBody.appendChild(actions);
     card.appendChild(cardBody);
     container.appendChild(card);
+    syncApprovalControls(container);
 }
 
 function getPendingProposalContainers(scopeRoot) {
     return Array.from(scopeRoot.querySelectorAll('.sc-inline-image-proposal[data-image-proposal-state="pending"]'))
-        .filter(container => !container.classList.contains('sc-inline-image-proposal-status'));
+        .filter(container => !container.classList.contains('sc-inline-image-proposal-status'))
+        .filter(container => container.getAttribute('data-approval-review-state') === 'ready');
 }
 
 function createBulkActions(messageElement, pendingContainers) {
@@ -756,7 +1252,11 @@ export function injectInlineImageProposalHtml(html = '', blocks = []) {
     return renderedHtml;
 }
 
-export function hydrateInlineImageProposals(root = document) {
+export function hydrateInlineImageProposals(root = document, messageMetadata = null) {
+    const messageElement = root.matches?.('.message') ? root : root.closest?.('.message');
+    if (messageElement && messageMetadata && typeof messageMetadata === 'object') {
+        messageElement.__simpleChatImageProposalReviewMetadata = messageMetadata;
+    }
     const proposalContainers = root.querySelectorAll('.sc-inline-image-proposal:not([data-image-proposal-state="status"])');
     proposalContainers.forEach(container => {
         const spec = decodeContainerSpec(container);
@@ -765,11 +1265,19 @@ export function hydrateInlineImageProposals(root = document) {
             return;
         }
 
-        if (container.getAttribute('data-image-proposal-hydrated') === 'true' && container.querySelector('.sc-inline-image-proposal-card')) {
+        const approvalReview = buildImageProposalApprovalReview(container.closest('.message'), spec);
+        const reviewSignature = JSON.stringify(approvalReview);
+        if (
+            container.getAttribute('data-image-proposal-hydrated') === 'true'
+            && container.querySelector('.sc-inline-image-proposal-card')
+            && container.__simpleChatImageProposalApprovalReviewSignature === reviewSignature
+        ) {
+            container.__simpleChatImageProposalApprovalReview = approvalReview;
             return;
         }
 
-        renderImageProposalCard(container, spec);
+        container.__simpleChatImageProposalApprovalReviewSignature = reviewSignature;
+        renderImageProposalCard(container, spec, approvalReview);
     });
 
     refreshImageProposalBulkActions(root);

--- a/application/single_app/static/js/chat/chat-messages.js
+++ b/application/single_app/static/js/chat/chat-messages.js
@@ -4962,7 +4962,7 @@ export function appendMessage(
       applyMaskedState(messageDiv, fullMessageObject.metadata);
     } else {
       hydrateInlineCharts(messageDiv);
-      hydrateInlineImageProposals(messageDiv);
+      hydrateInlineImageProposals(messageDiv, fullMessageObject?.metadata || null);
     }
 
     // --- Attach Event Listeners specifically for AI message ---
@@ -8013,7 +8013,7 @@ function applyMaskedState(messageDiv, metadata = {}) {
   }
 
   hydrateInlineCharts(messageDiv);
-  hydrateInlineImageProposals(messageDiv);
+  hydrateInlineImageProposals(messageDiv, nextMetadata);
   updateMaskControls(messageDiv, nextMetadata);
 }
 

--- a/application/single_app/static/js/chat/chat-thoughts.js
+++ b/application/single_app/static/js/chat/chat-thoughts.js
@@ -10,6 +10,7 @@ let activeStreamingThoughtTargetId = null;
 let activeStreamingServerMessageId = null;
 const streamingAgentActivityStates = new Map();
 const streamingSourceReviewStates = new Map();
+const streamingOrchestrationProgressStates = new Map();
 const progressDetailsExpandedStates = new Map();
 let progressDetailsToggleListenerAttached = false;
 
@@ -27,10 +28,216 @@ function getThoughtIcon(stepType) {
         'url_access': 'bi-link-45deg',
         'document_analysis': 'bi-journal-richtext',
         'agent_tool_call': 'bi-robot',
+        'orchestration_progress': 'bi-diagram-3',
+        'approval_required': 'bi-person-check',
         'generation': 'bi-lightning',
         'content_safety': 'bi-shield-check'
     };
     return iconMap[stepType] || 'bi-stars';
+}
+
+const ORCHESTRATION_CAPABILITY_PRESENTATION = Object.freeze({
+    approval_required: { label: 'Awaiting approval', icon: 'bi-person-check' },
+    conversation_evidence: { label: 'Reviewing conversation evidence', icon: 'bi-chat-square-text' },
+    deep_research: { label: 'Reviewing sources', icon: 'bi-binoculars' },
+    evidence_discovery: { label: 'Planning evidence workflow', icon: 'bi-diagram-3' },
+    image_proposal: { label: 'Building image proposal', icon: 'bi-image' },
+    response: { label: 'Building response', icon: 'bi-lightning' },
+    selected_action: { label: 'Calling selected action', icon: 'bi-lightning-charge' },
+    selected_agent: { label: 'Calling selected agent', icon: 'bi-robot' },
+    selected_documents: { label: 'Reviewing selected documents', icon: 'bi-files' },
+    selected_image: { label: 'Reviewing selected image', icon: 'bi-image' },
+    selected_images: { label: 'Reviewing selected image', icon: 'bi-image' },
+    source_review: { label: 'Reviewing sources', icon: 'bi-journal-check' },
+    web_search: { label: 'Searching public web', icon: 'bi-globe' },
+    workspace_search: { label: 'Searching workspace documents', icon: 'bi-search' },
+});
+
+const ORCHESTRATION_TERMINAL_STATUSES = new Set([
+    'succeeded',
+    'partial',
+    'failed',
+    'skipped',
+    'blocked',
+    'cancelled',
+]);
+
+function createOrchestrationProgressState() {
+    return {
+        runId: '',
+        totalCount: 0,
+        nodes: new Map(),
+        latestNodeId: '',
+    };
+}
+
+function resetStreamingOrchestrationProgressState(targetMessageId = null) {
+    if (targetMessageId) {
+        streamingOrchestrationProgressStates.delete(targetMessageId);
+    }
+}
+
+function getStreamingOrchestrationProgressState(targetMessageId) {
+    if (!targetMessageId) {
+        return null;
+    }
+    if (!streamingOrchestrationProgressStates.has(targetMessageId)) {
+        streamingOrchestrationProgressStates.set(targetMessageId, createOrchestrationProgressState());
+    }
+    return streamingOrchestrationProgressStates.get(targetMessageId);
+}
+
+function isOrchestrationProgressThought(thoughtData) {
+    return thoughtData?.activity?.kind === 'orchestration_node';
+}
+
+function getOrchestrationCapabilityPresentation(capability) {
+    const normalizedCapability = String(capability || '').trim().toLowerCase();
+    if (ORCHESTRATION_CAPABILITY_PRESENTATION[normalizedCapability]) {
+        return ORCHESTRATION_CAPABILITY_PRESENTATION[normalizedCapability];
+    }
+    const label = normalizedCapability
+        .replaceAll('_', ' ')
+        .replace(/\b\w/g, character => character.toUpperCase());
+    return {
+        label: label || 'Processing request',
+        icon: 'bi-stars',
+    };
+}
+
+function updateOrchestrationProgressState(state, thoughtData) {
+    if (!state || !isOrchestrationProgressThought(thoughtData)) {
+        return state;
+    }
+
+    const activity = thoughtData.activity;
+    const runId = String(activity.run_id || '').trim();
+    if (state.runId && runId && state.runId !== runId) {
+        state.nodes.clear();
+        state.latestNodeId = '';
+        state.totalCount = 0;
+    }
+    if (runId) {
+        state.runId = runId;
+    }
+
+    const nodeId = String(activity.node_id || `step-${thoughtData.step_index ?? state.nodes.size}`).trim();
+    const previousNode = state.nodes.get(nodeId) || {};
+    const nodeIndex = Number(activity.node_index);
+    const nodeCount = Number(activity.node_count);
+    state.nodes.set(nodeId, {
+        ...previousNode,
+        id: nodeId,
+        order: Number.isFinite(nodeIndex) && nodeIndex >= 0
+            ? nodeIndex
+            : previousNode.order ?? state.nodes.size,
+        type: String(activity.node_type || previousNode.type || '').trim().toLowerCase(),
+        capability: String(activity.capability || previousNode.capability || '').trim().toLowerCase(),
+        status: String(activity.status || previousNode.status || 'pending').trim().toLowerCase(),
+        required: Boolean(activity.required ?? previousNode.required),
+        content: String(thoughtData.content || previousNode.content || '').trim(),
+        detail: String(thoughtData.detail || previousNode.detail || '').trim(),
+    });
+    if (Number.isFinite(nodeCount) && nodeCount > 0) {
+        state.totalCount = Math.max(state.totalCount, Math.round(nodeCount));
+    }
+    state.totalCount = Math.max(state.totalCount, state.nodes.size);
+    state.latestNodeId = nodeId;
+    return state;
+}
+
+function buildOrchestrationProgressStateFromThoughts(thoughts) {
+    const state = createOrchestrationProgressState();
+    (thoughts || []).forEach(thought => updateOrchestrationProgressState(state, thought));
+    return state;
+}
+
+function hasOrchestrationProgress(state) {
+    return Boolean(state && state.nodes.size > 0);
+}
+
+function getOrchestrationStatusPresentation(status) {
+    const statusMap = {
+        blocked: { label: 'Blocked', icon: 'bi-slash-circle text-danger' },
+        cancelled: { label: 'Cancelled', icon: 'bi-x-circle text-muted' },
+        failed: { label: 'Failed', icon: 'bi-x-circle-fill text-danger' },
+        partial: { label: 'Partial', icon: 'bi-exclamation-circle-fill text-warning' },
+        pending: { label: 'Pending', icon: 'bi-circle text-muted' },
+        running: { label: 'In progress', icon: 'bi-arrow-repeat text-info' },
+        skipped: { label: 'Skipped', icon: 'bi-dash-circle text-muted' },
+        succeeded: { label: 'Complete', icon: 'bi-check-circle-fill text-success' },
+    };
+    return statusMap[status] || statusMap.pending;
+}
+
+function renderOrchestrationProgress(state) {
+    const nodes = Array.from(state.nodes.values()).sort((left, right) => left.order - right.order);
+    const totalCount = Math.max(state.totalCount, nodes.length);
+    const finishedCount = nodes.filter(node => ORCHESTRATION_TERMINAL_STATUSES.has(node.status)).length;
+    const failedCount = nodes.filter(node => ['failed', 'blocked', 'cancelled'].includes(node.status)).length;
+    const partialCount = nodes.filter(node => node.status === 'partial').length;
+    const awaitingApproval = nodes.some(node => node.capability === 'approval_required' && node.status === 'running');
+    const isCompleted = totalCount > 0 && nodes.length >= totalCount && finishedCount === totalCount;
+    const percent = awaitingApproval
+        ? 95
+        : isCompleted
+            ? 100
+            : Math.max(8, Math.min(94, Math.round((finishedCount / Math.max(totalCount, 1)) * 100)));
+    const currentNode = [...nodes].reverse().find(node => node.status === 'running')
+        || state.nodes.get(state.latestNodeId)
+        || nodes[nodes.length - 1];
+    const currentPresentation = getOrchestrationCapabilityPresentation(currentNode?.capability);
+    const summaryParts = [`${finishedCount}/${totalCount} steps finished`];
+    if (partialCount > 0) {
+        summaryParts.push(`${partialCount} partial`);
+    }
+    if (failedCount > 0) {
+        summaryParts.push(`${failedCount} unavailable`);
+    }
+
+    const overallStatus = awaitingApproval
+        ? 'awaiting_approval'
+        : isCompleted
+            ? (failedCount > 0 || partialCount > 0 ? 'completed_with_failures' : 'completed')
+            : 'running';
+    const badgeClass = awaitingApproval
+        ? 'text-bg-warning'
+        : isCompleted
+            ? (failedCount > 0 || partialCount > 0 ? 'text-bg-warning' : 'text-bg-success')
+            : 'text-bg-light border';
+    const badgeText = awaitingApproval ? 'Approval' : isCompleted ? 'Complete' : `${percent}%`;
+    const rows = nodes.map(node => {
+        const capabilityPresentation = getOrchestrationCapabilityPresentation(node.capability);
+        const statusPresentation = getOrchestrationStatusPresentation(node.status);
+        return `<li class="orchestration-progress-step d-flex align-items-start gap-2 py-1" data-orchestration-node-id="${escapeHtml(node.id)}" data-orchestration-node-status="${escapeHtml(node.status)}">
+            <i class="bi ${statusPresentation.icon} mt-1" aria-hidden="true"></i>
+            <div class="flex-grow-1 min-w-0">
+                <div class="small fw-semibold text-body">${escapeHtml(capabilityPresentation.label)}</div>
+                <div class="small text-muted">${escapeHtml(statusPresentation.label)}</div>
+            </div>
+            <i class="bi ${capabilityPresentation.icon} text-muted" aria-hidden="true"></i>
+        </li>`;
+    }).join('');
+
+    return `<div class="streaming-thought-display orchestration-progress-card" data-orchestration-progress-state="${escapeHtml(overallStatus)}" data-orchestration-progress-percent="${percent}" role="status" aria-live="polite" aria-atomic="true">
+        <div class="card border-info-subtle shadow-sm">
+            <div class="card-body py-3 px-3">
+                <div class="d-flex align-items-start justify-content-between gap-2 mb-2">
+                    <div class="d-flex align-items-start gap-2 min-w-0">
+                        <i class="bi bi-diagram-3 text-info mt-1" aria-hidden="true"></i>
+                        <div class="min-w-0">
+                            <div class="small fw-semibold text-body">Orchestration progress</div>
+                            <div class="small text-muted orchestration-progress-current">${escapeHtml(currentPresentation.label)}</div>
+                        </div>
+                    </div>
+                    <span class="badge ${badgeClass}">${escapeHtml(badgeText)}</span>
+                </div>
+                <div class="small text-muted mb-2">${escapeHtml(summaryParts.join(' | '))}</div>
+                ${renderProgressBar(percent, isCompleted ? overallStatus : 'running', failedCount + partialCount, 'Orchestration progress')}
+                <ol class="orchestration-progress-steps list-unstyled mb-0 mt-2">${rows}</ol>
+            </div>
+        </div>
+    </div>`;
 }
 
 function normalizeProgressPercent(value) {
@@ -418,6 +625,9 @@ function hasAgentActivity(state) {
 
 function updateAgentActivityState(state, thoughtData, preserveMaxPercent = true) {
     if (!state || !thoughtData) {
+        return state;
+    }
+    if (isOrchestrationProgressThought(thoughtData)) {
         return state;
     }
 
@@ -995,6 +1205,7 @@ export function beginStreamingThoughtSession(targetMessageId) {
 
     resetStreamingAgentActivityState(activeStreamingThoughtTargetId);
     resetStreamingSourceReviewState(activeStreamingThoughtTargetId);
+    resetStreamingOrchestrationProgressState(activeStreamingThoughtTargetId);
     resetStreamingPlaceholderState(getStreamingMessageElement(activeStreamingThoughtTargetId));
 }
 
@@ -1006,6 +1217,7 @@ export function clearStreamingThoughtSession(targetMessageId = null) {
     const messageIdToReset = targetMessageId || activeStreamingThoughtTargetId;
     resetStreamingAgentActivityState(messageIdToReset);
     resetStreamingSourceReviewState(messageIdToReset);
+    resetStreamingOrchestrationProgressState(messageIdToReset);
     resetStreamingPlaceholderState(getStreamingMessageElement(messageIdToReset));
 
     activeStreamingThoughtTargetId = null;
@@ -1020,6 +1232,7 @@ export function markStreamingThoughtContentStarted(targetMessageId) {
 
     resetStreamingAgentActivityState(targetMessageId);
     resetStreamingSourceReviewState(targetMessageId);
+    resetStreamingOrchestrationProgressState(targetMessageId);
     messageElement.dataset.streamingHasContent = 'true';
     delete messageElement.dataset.streamingThoughtIndex;
     delete messageElement.dataset.streamingThoughtSignature;
@@ -1110,6 +1323,21 @@ export function handleStreamingThought(thoughtData, targetMessageId = null) {
     const contentElement = messageElement.querySelector('.message-text');
     if (!contentElement) return;
 
+    if (isOrchestrationProgressThought(thoughtData)) {
+        const orchestrationState = getStreamingOrchestrationProgressState(activeStreamingThoughtTargetId);
+        updateOrchestrationProgressState(orchestrationState, thoughtData);
+        if (hasOrchestrationProgress(orchestrationState)) {
+            if (typeof DOMPurify === 'undefined') {
+                return;
+            }
+            const safeOrchestrationProgressHtml = DOMPurify.sanitize(
+                renderOrchestrationProgress(orchestrationState),
+            );
+            contentElement.innerHTML = safeOrchestrationProgressHtml;
+            return;
+        }
+    }
+
     if (thoughtData.progress && typeof thoughtData.progress === 'object') {
         contentElement.innerHTML = renderDocumentAnalysisProgress(thoughtData);
         return;
@@ -1132,12 +1360,17 @@ export function handleStreamingThought(thoughtData, targetMessageId = null) {
     }
 
     const icon = getThoughtIcon(thoughtData.step_type);
+    if (typeof DOMPurify === 'undefined') {
+        contentElement.textContent = String(thoughtData.content || 'Processing request');
+        return;
+    }
     // Replace entire content with styled thought indicator (visually distinct from AI response)
-    contentElement.innerHTML = `<div class="streaming-thought-display">
+    const safeStreamingThoughtHtml = DOMPurify.sanitize(`<div class="streaming-thought-display">
         <span class="badge bg-info bg-opacity-10 text-info border border-info-subtle px-3 py-2 animate-pulse" style="font-size: 0.85rem; font-weight: 500;">
             <i class="bi ${icon} me-2"></i>${escapeHtml(thoughtData.content)}
         </span>
-    </div>`;
+    </div>`);
+    contentElement.innerHTML = safeStreamingThoughtHtml;
 }
 
 // ---------------------------------------------------------------------------
@@ -1252,6 +1485,11 @@ function renderThoughtsList(thoughts) {
     const latestProgressThought = [...thoughts].reverse().find(thought => thought.progress && typeof thought.progress === 'object');
     const sourceReviewState = buildSourceReviewProgressStateFromThoughts(thoughts);
     const agentActivityState = buildAgentActivityStateFromThoughts(thoughts);
+    const orchestrationState = buildOrchestrationProgressStateFromThoughts(thoughts);
+
+    if (hasOrchestrationProgress(orchestrationState)) {
+        summaryCards.push(renderOrchestrationProgress(orchestrationState));
+    }
 
     if (hasSourceReviewProgress(sourceReviewState)) {
         summaryCards.push(renderSourceReviewProgress(sourceReviewState));
@@ -1270,6 +1508,9 @@ function renderThoughtsList(thoughts) {
     }
 
     thoughts.forEach(t => {
+        if (hasOrchestrationProgress(orchestrationState) && isOrchestrationProgressThought(t)) {
+            return;
+        }
         const icon = getThoughtIcon(t.step_type);
         const durationStr = t.duration_ms != null ? `<span class="text-muted ms-2">(${t.duration_ms}ms)</span>` : '';
         html += `<div class="thought-step small py-1">

--- a/docs/explanation/features/CHAT_TURN_ORCHESTRATION.md
+++ b/docs/explanation/features/CHAT_TURN_ORCHESTRATION.md
@@ -1,6 +1,6 @@
 # Chat Turn Orchestration
 
-Implemented in version: **0.250.063**
+Implemented in version: **0.250.064**
 Associated issue: **[#1021](https://github.com/microsoft/simplechat/issues/1021)**
 
 ## Overview
@@ -197,6 +197,28 @@ Standard streaming uses `ActiveConversationStreamSession.is_cancel_requested()` 
 
 Streaming document actions check cancellation before and after their existing workflow call. The underlying Analyze/Compare workflow remains non-preemptive, so a cancellation received during that call discards its result before assistant persistence and closes the runtime when control returns. Required runtime failures return an explicit conflict response rather than persisting a final document-action answer.
 
+## Phase 7 Progress, Evidence Review, And Approval
+
+Phase 7 keeps orchestration inside the existing chat experience. Runtime node events now retain bounded `run_id`, `node_id`, node type, capability, required state, and lifecycle status in the existing thought stream. The browser groups updates for the same node, preserves first-seen execution order, and presents capability-specific labels for planning, selected images, workspace evidence, public web, selected agents/actions, source review, finalization, and image approval. Live progress uses `role="status"` and `aria-live="polite"`; completed progress remains available behind the existing collapsed Thoughts control without exposing model reasoning, raw evidence, or debug details.
+
+Grounded image proposal cards now derive a compact review from authorized assistant-message metadata and show:
+
+- Canonical source badges with used, reviewed, partial, reviewing, or unavailable state.
+- Concise source summaries and linked evidence-record counts.
+- Explicit missing-evidence notes, including requested sources that returned no usable evidence.
+- Selected reference-image previews when an authorized conversation image message can be served through the existing same-origin image route.
+- Responsive evidence and approval controls for desktop and mobile layouts.
+
+Approval has three states:
+
+- `ready`: evidence and runtime state are terminal and the proposal can be approved normally.
+- `confirmation_required`: a terminal partial outcome still contains supported evidence; the user must acknowledge that generation will use only the available evidence.
+- `blocked`: evidence or orchestration is active, cancelled, failed, or lacks usable support.
+
+The browser state is explanatory, not authoritative. The generation route reauthorizes the personal conversation, reads the exact source assistant message from that conversation, constrains proposal evidence and reference IDs to its persisted ledger, rebuilds the approval review, and validates the literal partial-confirmation boolean immediately before generation. A supplied source message that cannot be read from the authorized conversation fails instead of silently creating an unbound request. Model-authored source labels and arbitrary image URLs are not trusted.
+
+Users can edit or dismiss a proposal before generation, explicitly acknowledge a partial proposal, or stop the active chat stream through the existing cancellation control. These interventions remain scoped to the current request and proposal; Phase 7 does not add an admin approval queue or permit automatic write, sensitive, consequential, or over-budget actions.
+
 ## Security And Governance
 
 - Caller-supplied IDs are never treated as proof of authorization.
@@ -214,6 +236,9 @@ Streaming document actions check cancellation before and after their existing wo
 - Unsupported fact text is excluded from central synthesis payloads while explicit missing and conflict records remain available to the finalizer.
 - Central synthesis payload delimiters are escaped and source/user content is treated as data rather than executable instructions.
 - Proposal evidence and reference-image IDs are revalidated against the authorized source assistant message's persisted ledger before approval.
+- Approval state is recalculated from the authorized source ledger and runtime immediately before generation; a browser acknowledgment cannot override active, failed, cancelled, or supportless evidence.
+- Evidence badges use canonical server-known source types, and reference previews use only the existing authenticated same-origin image route for message-backed references.
+- Evidence summaries and missing-evidence notes are rendered as text, so source or model content cannot create executable markup.
 - Prompt content is not copied into orchestration metadata.
 - Selected capabilities are required attempts, but unavailable or unauthorized sources must be represented explicitly rather than bypassing access controls.
 - Agent/action task payloads describe the principal as `current_user` and omit caller-provided private identity and scope IDs.
@@ -293,6 +318,8 @@ Central synthesis coverage is in `functional_tests/test_central_synthesis_contra
 
 The existing desktop/mobile Playwright coverage in `ui_tests/test_chat_inline_image_proposal_cards.py` also verifies that normalized provenance metadata survives card rendering, prompt editing, and the approval request.
 
+Phase 7 proposal coverage additionally validates canonical source badges, missing-evidence disclosure, same-origin reference previews, inert markup-like evidence, normal approval, explicit partial-evidence acknowledgment, blocked approval, live accessibility state, 44px mobile actions, and responsive desktop/mobile behavior. `functional_tests/test_image_proposal_pipeline.py` validates the matching server review contract for ready, terminal-partial, active, cancelled, failed, and supportless states. `functional_tests/test_image_proposal_approval_route.py` directly validates owner access, foreign and missing conversations, cross-partition source messages, cross-turn and forged lineage removal, strict partial confirmation, and legacy no-ledger compatibility. `functional_tests/test_central_synthesis_contract.py` verifies that the authorized generation route wires the review after lineage constraints.
+
 Runtime coverage is in `functional_tests/test_orchestration_runtime.py` and validates:
 
 - Direct and coordinated turns share one run contract.
@@ -304,13 +331,15 @@ Runtime coverage is in `functional_tests/test_orchestration_runtime.py` and vali
 - Authorized evidence discovery success and fail-closed missing evidence.
 - Runtime-node provenance across normalized ledger entries.
 - Conversation, document, image, workspace, web, source-review, agent, action, response, and image-proposal node categories.
-- Standard streaming and document-action lifecycle, progress, cancellation, terminal cleanup, and metadata persistence wiring.
+- Standard streaming and document-action lifecycle, structured progress, cancellation, terminal cleanup, and metadata persistence wiring.
+
+Desktop/mobile coverage in `ui_tests/test_streaming_thought_progression.py` validates ordered node updates, capability labels, approval waiting, `aria-live` semantics, session isolation, and the existing collapsed completed-thought behavior.
 
 The stream heartbeat, background execution, lifecycle observability, new-conversation reattach, and stop-control contracts also validate that runtime cancellation preserves the existing SSE protocol and replay behavior.
 
 ## Known Limitations
 
-Phase 6 provides the request-scoped in-process runtime, with these deliberate boundaries:
+Phase 7 provides request-scoped progress, review, and image-proposal approval, with these deliberate boundaries:
 
 - Arbitrary governed tools are not yet discovered automatically.
 - Runs are not stored in a durable queue or Cosmos run store and cannot resume after process loss.
@@ -319,8 +348,9 @@ Phase 6 provides the request-scoped in-process runtime, with these deliberate bo
 - The legacy non-streaming compatibility path does not yet use Phase 3 collectors.
 - Outside the grounded-image proving profile, selected agents retain their existing response-streaming behavior. The runtime records this compatibility finalizer until central synthesis is generalized.
 - Analyze and Compare actions participate in runtime lifecycle and evidence normalization but retain their existing compatibility response finalizer. Grounded-image actions still return the evidence-status handoff rather than invoking central synthesis.
-- Phase 7 review, approval, intervention, and technical-detail UI is not included; Phase 6 reuses concise thought/progress events.
-- Automatic write, sensitive, consequential, or over-budget steps remain prohibited without a later approval runtime.
+- Approval review currently governs the grounded-image proving profile. Automatic write, sensitive, consequential, or over-budget steps remain prohibited until a generalized approval runtime is added.
+- Progress is live before response content begins and remains available through the collapsed Thoughts view after completion; it does not expose chain-of-thought or adapter debug details.
+- Reference thumbnails are shown only for authorized conversation image messages. Document-backed image evidence remains labeled when no existing same-origin preview route applies.
 - The live chat payload does not yet expose a dedicated selected-image-reference list; selected workspace images are represented as documents, and explicit headshot/reference intent can be detected from the message until a reference control is wired.
 
-Durable persistence, intervention UX, broader finalizers, and generalized artifact generation remain later roadmap phases.
+Durable run persistence, process-loss resume, generalized consequential-action approval, broader finalizers, and generalized artifact generation remain later roadmap phases.

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,17 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](/explanation/features/) and [Fixes by Version](/explanation/fixes/).
 
+### **(v0.250.064)**
+
+#### User Interface Enhancements
+
+*   **Chat Orchestration Progress, Evidence Review, And Approval**
+    *   Added ordered, accessible chat progress for orchestration planning, selected sources, workspace and web evidence, agents/actions, source review, image proposal synthesis, and approval waiting.
+    *   Grounded image proposal cards now show canonical source badges, missing-evidence notes, linked evidence details, and authorized reference-image previews on desktop and mobile.
+    *   Approval is blocked while evidence is active, cancelled, failed, or unsupported; terminal partial outcomes require an explicit acknowledgment that is revalidated against the authorized source assistant message before generation.
+    *   Existing prompt editing, proposal dismissal, and stream cancellation provide request-scoped intervention without exposing chain-of-thought, raw evidence, or arbitrary image URLs.
+    *   (Ref: microsoft/simplechat#1021, `chat-thoughts.js`, `chat-inline-image-proposals.js`, `functions_image_generation.py`, `route_backend_chats.py`, `CHAT_TURN_ORCHESTRATION.md`)
+
 ### **(v0.250.063)**
 
 #### New Features

--- a/functional_tests/test_agent_action_evidence_contract.py
+++ b/functional_tests/test_agent_action_evidence_contract.py
@@ -2,7 +2,7 @@
 # test_agent_action_evidence_contract.py
 """
 Functional test for the generic agent/action evidence collection contract.
-Version: 0.250.063
+Version: 0.250.064
 Implemented in: 0.250.061
 
 This test ensures selected agents and actions collect governed evidence into the

--- a/functional_tests/test_central_synthesis_contract.py
+++ b/functional_tests/test_central_synthesis_contract.py
@@ -2,7 +2,7 @@
 # test_central_synthesis_contract.py
 """
 Functional test for the generic central synthesis contract.
-Version: 0.250.063
+Version: 0.250.064
 Implemented in: 0.250.062
 
 This test ensures grounded image proposals are finalized only from completed,
@@ -346,6 +346,10 @@ def test_streaming_route_centralizes_both_grounded_image_paths():
     assert 'synthesis_response = gpt_client.chat.completions.create(**synthesis_params)' in route_source
     assert "set_evidence_ledger_status(turn_evidence_ledger, 'completed')" in route_source
     assert 'constrain_image_proposal_to_evidence_ledger(' in route_source
+    assert 'approval_review = build_image_proposal_approval_review(' in route_source
+    assert "if approval_review['state'] == 'blocked':" in route_source
+    assert "data.get('confirm_partial') is not True" in route_source
+    assert "return jsonify({'error': 'Source assistant message not found'}), 404" in route_source
     assert "persist_central_synthesis_state('pending')" in route_source
     assert "persist_central_synthesis_state('failed')" in route_source
     assert "persist_central_synthesis_state('cancelled')" in route_source

--- a/functional_tests/test_chat_evidence_collectors.py
+++ b/functional_tests/test_chat_evidence_collectors.py
@@ -2,7 +2,7 @@
 # test_chat_evidence_collectors.py
 """
 Functional test for generic chat source collectors.
-Version: 0.250.063
+Version: 0.250.064
 Implemented in: 0.250.060
 
 This test ensures existing authorized context and retrieval outputs are normalized

--- a/functional_tests/test_chat_evidence_ledger.py
+++ b/functional_tests/test_chat_evidence_ledger.py
@@ -2,7 +2,7 @@
 # test_chat_evidence_ledger.py
 """
 Functional test for the generic chat result and evidence ledger.
-Version: 0.250.063
+Version: 0.250.064
 Implemented in: 0.250.059
 
 This test ensures orchestration evidence remains output-neutral, provenance-aware,

--- a/functional_tests/test_chat_stream_background_execution.py
+++ b/functional_tests/test_chat_stream_background_execution.py
@@ -2,7 +2,7 @@
 # test_chat_stream_background_execution.py
 """
 Functional test for chat stream background execution.
-Version: 0.250.063
+Version: 0.250.064
 Implemented in: 0.239.129
 
 This test ensures that the streaming chat route runs its SSE generator through
@@ -43,7 +43,7 @@ def test_chat_stream_background_execution() -> None:
     assert_contains(ROUTE_FILE, "return build_background_stream_response(generate_compatibility_response, stream_session=stream_session)")
     assert_contains(ROUTE_FILE, "return build_background_stream_response(generate, stream_session=stream_session)")
 
-    assert_contains(CONFIG_FILE, 'VERSION = "0.250.063"')
+    assert_contains(CONFIG_FILE, 'VERSION = "0.250.064"')
     assert_contains(FIX_DOC_FILE, "Fixed/Implemented in version: **0.239.129**")
 
     print("Chat stream background execution checks passed!")

--- a/functional_tests/test_chat_stream_heartbeat_reattach.py
+++ b/functional_tests/test_chat_stream_heartbeat_reattach.py
@@ -2,7 +2,7 @@
 # test_chat_stream_heartbeat_reattach.py
 """
 Functional test for chat stream heartbeat and reattach support.
-Version: 0.250.063
+Version: 0.250.064
 Implemented in: 0.239.183
 
 This test ensures long-running chat streams emit keep-alive heartbeat frames,
@@ -65,7 +65,7 @@ def test_chat_stream_heartbeat_and_reattach() -> None:
     assert_contains(CONVERSATIONS_FILE, "await loadMessages(conversationId);")
     assert_contains(CONVERSATIONS_FILE, "await streamingModule.reattachStreamingConversation(conversationId);")
 
-    assert_contains(CONFIG_FILE, 'VERSION = "0.250.063"')
+    assert_contains(CONFIG_FILE, 'VERSION = "0.250.064"')
     assert_contains(FIX_DOC_FILE, "Fixed/Implemented in version: **0.239.183**")
     assert_contains(FIX_DOC_FILE, "Redis-backed session metadata and event replay")
 

--- a/functional_tests/test_chat_stream_lifecycle_observability.py
+++ b/functional_tests/test_chat_stream_lifecycle_observability.py
@@ -2,7 +2,7 @@
 # test_chat_stream_lifecycle_observability.py
 """
 Functional test for chat stream lifecycle observability.
-Version: 0.250.063
+Version: 0.250.064
 Implemented in: 0.241.109
 
 This test ensures long-running chat streams persist lifecycle state for
@@ -19,7 +19,7 @@ ROUTE_FILE = ROOT / "application" / "single_app" / "route_backend_chats.py"
 STREAMING_FILE = ROOT / "application" / "single_app" / "static" / "js" / "chat" / "chat-streaming.js"
 CONFIG_FILE = ROOT / "application" / "single_app" / "config.py"
 FIX_DOC_FILE = ROOT / "docs" / "explanation" / "fixes" / "v0.241.109" / "CHAT_STREAM_LIFECYCLE_OBSERVABILITY_FIX.md"
-CURRENT_VERSION = "0.250.063"
+CURRENT_VERSION = "0.250.064"
 
 
 def assert_contains(file_path: Path, expected: str) -> None:

--- a/functional_tests/test_chat_stream_new_conversation_reattach.py
+++ b/functional_tests/test_chat_stream_new_conversation_reattach.py
@@ -2,7 +2,7 @@
 # test_chat_stream_new_conversation_reattach.py
 """
 Functional test for new-conversation chat stream reattach support.
-Version: 0.250.063
+Version: 0.250.064
 Implemented in: 0.239.191
 
 This test ensures the streaming chat route finalizes a conversation id before
@@ -43,7 +43,7 @@ def test_chat_stream_new_conversation_reattach() -> None:
     assert_contains(STREAMING_FILE, "if (allowRecovery) {")
     assert_contains(STREAMING_FILE, "allowRecovery: false,")
 
-    assert_contains(CONFIG_FILE, 'VERSION = "0.250.063"')
+    assert_contains(CONFIG_FILE, 'VERSION = "0.250.064"')
     assert_contains(FIX_DOC_FILE, "Fixed/Implemented in version: **0.239.191**")
     assert_contains(FIX_DOC_FILE, "finalizes a conversation id before registering the stream session")
 

--- a/functional_tests/test_chat_stream_stop_control.py
+++ b/functional_tests/test_chat_stream_stop_control.py
@@ -2,7 +2,7 @@
 # test_chat_stream_stop_control.py
 """
 Functional test for chat stream stop control.
-Version: 0.250.063
+Version: 0.250.064
 Implemented in: 0.241.097
 
 This test ensures chat streams expose a user-scoped cancellation endpoint,
@@ -39,7 +39,7 @@ def test_chat_stream_stop_control_wiring() -> None:
     collaboration_js_content = read_text("application/single_app/static/js/chat/chat-collaboration.js")
     feature_doc_content = read_text("docs/explanation/features/v0.241.097/CHAT_STREAM_STOP_CONTROL.md")
 
-    assert_contains(config_content, 'VERSION = "0.250.063"', "config version")
+    assert_contains(config_content, 'VERSION = "0.250.064"', "config version")
 
     assert_contains(route_content, "STREAM_STATUS_CANCEL_REQUESTED = 'cancel_requested'", "chat route")
     assert_contains(route_content, "STREAM_STATUS_CANCELED = 'canceled'", "chat route")

--- a/functional_tests/test_chat_turn_orchestration_plan.py
+++ b/functional_tests/test_chat_turn_orchestration_plan.py
@@ -2,7 +2,7 @@
 # test_chat_turn_orchestration_plan.py
 """
 Functional test for the chat turn orchestration planning foundation.
-Version: 0.250.063
+Version: 0.250.064
 Implemented in: 0.250.058
 
 This test ensures every turn receives a direct or coordinated plan, selected
@@ -351,7 +351,7 @@ def test_streaming_chat_path_persists_and_applies_plan():
     route_source = ROUTE_BACKEND_CHATS.read_text(encoding='utf-8')
     config_source = CONFIG_FILE.read_text(encoding='utf-8')
 
-    assert 'VERSION = "0.250.063"' in config_source
+    assert 'VERSION = "0.250.064"' in config_source
     assert 'turn_orchestration_plan = build_turn_orchestration_plan(' in route_source
     assert 'requested_action_document_ids = _normalize_conversation_task_document_ids(' in route_source
     assert 'requested_action_document_ids\n            if requested_action_document_ids' in route_source

--- a/functional_tests/test_image_proposal_approval_route.py
+++ b/functional_tests/test_image_proposal_approval_route.py
@@ -1,0 +1,383 @@
+#!/usr/bin/env python3
+# test_image_proposal_approval_route.py
+"""
+Functional test for the image proposal approval route.
+Version: 0.250.064
+Implemented in: 0.250.064
+
+This test ensures proposal generation reauthorizes the personal conversation
+and source assistant message, constrains evidence and reference lineage, and
+enforces blocked and partial-confirmation states before image generation.
+"""
+
+import copy
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+from flask import Flask
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SINGLE_APP_ROOT = REPO_ROOT / 'application' / 'single_app'
+if str(SINGLE_APP_ROOT) not in sys.path:
+    sys.path.insert(0, str(SINGLE_APP_ROOT))
+
+
+class DummyNotFoundError(Exception):
+    """Raised when an in-memory Cosmos item cannot be read."""
+
+
+class FakeConversationContainer:
+    """Store personal conversations by their id and partition key."""
+
+    def __init__(self, items):
+        self.items = {item['id']: copy.deepcopy(item) for item in items}
+        self.upserted_items = []
+
+    def read_item(self, item=None, partition_key=None, *args, **kwargs):
+        item_id = item if item is not None else args[0]
+        stored_item = self.items.get(item_id)
+        if stored_item is None or partition_key != item_id:
+            raise DummyNotFoundError(item_id)
+        return copy.deepcopy(stored_item)
+
+    def upsert_item(self, item):
+        stored_item = copy.deepcopy(item)
+        self.items[stored_item['id']] = stored_item
+        self.upserted_items.append(stored_item)
+        return copy.deepcopy(stored_item)
+
+
+class FakeMessageContainer:
+    """Store assistant messages under their conversation partition."""
+
+    def __init__(self, items):
+        self.items = {
+            (item['conversation_id'], item['id']): copy.deepcopy(item)
+            for item in items
+        }
+        self.read_count = 0
+
+    def read_item(self, item=None, partition_key=None, *args, **kwargs):
+        self.read_count += 1
+        item_id = item if item is not None else args[0]
+        stored_item = self.items.get((partition_key, item_id))
+        if stored_item is None:
+            raise DummyNotFoundError(item_id)
+        return copy.deepcopy(stored_item)
+
+    def set_item(self, item):
+        self.items[(item['conversation_id'], item['id'])] = copy.deepcopy(item)
+
+
+def _evidence_metadata(
+    *,
+    ledger_status='ready',
+    runtime_status='succeeded',
+    requirement_status='satisfied',
+    source_status='succeeded',
+    include_supported_fact=True,
+):
+    ledger = {
+        'version': 1,
+        'status': ledger_status,
+        'requirements': [{
+            'id': 'profile_evidence',
+            'description': 'Verified profile evidence',
+            'required': True,
+            'status': requirement_status,
+        }],
+        'sources': [{
+            'id': 'selected_agent',
+            'type': 'selected_agent',
+            'status': source_status,
+            'required': True,
+            'authorization_status': 'authorized',
+        }],
+        'facts': [],
+        'results': [],
+        'citations': [],
+        'artifacts': [{
+            'id': 'artifact-headshot',
+            'type': 'image_reference',
+            'name': 'Authorized headshot',
+            'reference': 'conversation-owner_image_1_2_3',
+            'message_id': 'conversation-owner_image_1_2_3',
+            'source_ids': ['selected_agent'],
+        }],
+        'missing_or_failed': [],
+    }
+    if include_supported_fact:
+        ledger['facts'].append({
+            'id': 'fact-profile-role',
+            'text': 'The profile includes a verified role.',
+            'source_ids': ['selected_agent'],
+        })
+    return {
+        'evidence_ledger': ledger,
+        'orchestration_runtime': {
+            'version': 1,
+            'status': runtime_status,
+        },
+    }
+
+
+def _assistant_message(conversation_id, message_id='assistant-source', metadata=None):
+    return {
+        'id': message_id,
+        'conversation_id': conversation_id,
+        'role': 'assistant',
+        'content': 'Grounded image proposal.',
+        'metadata': metadata or _evidence_metadata(),
+    }
+
+
+def _approval_payload(conversation_id='conversation-owner', **overrides):
+    payload = {
+        'conversation_id': conversation_id,
+        'assistant_message_id': 'assistant-source',
+        'proposal': {
+            'version': 1,
+            'visualId': 'profile-visual',
+            'title': 'Profile visual',
+            'prompt': 'Create a grounded profile illustration.',
+            'evidenceIds': ['fact-profile-role', 'forged-fact'],
+            'referenceImageIds': ['artifact-headshot', 'foreign-image-reference'],
+        },
+    }
+    payload.update(overrides)
+    return payload
+
+
+@pytest.fixture
+def approval_route_app(monkeypatch):
+    """Register the production route with in-memory authorization dependencies."""
+    monkeypatch.chdir(SINGLE_APP_ROOT)
+    route_backend_chats = importlib.import_module('route_backend_chats')
+    user_state = {'id': 'user-owner'}
+    generated_requests = []
+
+    conversation_container = FakeConversationContainer([
+        {'id': 'conversation-owner', 'user_id': 'user-owner', 'title': 'Owner conversation'},
+        {'id': 'conversation-foreign', 'user_id': 'user-foreign', 'title': 'Foreign conversation'},
+    ])
+    other_run_metadata = _evidence_metadata()
+    other_run_metadata['evidence_ledger']['run_id'] = 'other-run'
+    other_run_metadata['evidence_ledger']['facts'] = [{
+        'id': 'fact-other-run',
+        'text': 'Evidence from another assistant turn.',
+        'source_ids': ['selected_agent'],
+    }]
+    message_container = FakeMessageContainer([
+        _assistant_message('conversation-owner'),
+        _assistant_message(
+            'conversation-owner',
+            message_id='assistant-other-run',
+            metadata=other_run_metadata,
+        ),
+        _assistant_message('conversation-foreign', message_id='assistant-foreign'),
+    ])
+
+    def generate_image(**kwargs):
+        generated_requests.append(copy.deepcopy(kwargs))
+        proposal = copy.deepcopy(kwargs['proposal'])
+        message_id = 'conversation-owner_image_9_8_7'
+        return {
+            'reply': 'Image loading...',
+            'image_url': f'/api/image/{message_id}',
+            'conversation_id': kwargs['conversation_id'],
+            'model_deployment_name': 'mock-image-model',
+            'message_id': message_id,
+            'image_message': {
+                'id': message_id,
+                'prompt': kwargs['prompt'],
+                'created_at': '2026-07-15T12:00:00Z',
+                'timestamp': '2026-07-15T12:00:00Z',
+                'metadata': {'image_proposal': proposal},
+            },
+        }
+
+    monkeypatch.setattr(route_backend_chats, 'login_required', lambda func: func)
+    monkeypatch.setattr(route_backend_chats, 'user_required', lambda func: func)
+    monkeypatch.setattr(
+        route_backend_chats,
+        'swagger_route',
+        lambda **kwargs: (lambda func: func),
+    )
+    monkeypatch.setattr(route_backend_chats, 'get_auth_security', lambda: {})
+    monkeypatch.setattr(route_backend_chats, 'get_current_user_id', lambda: user_state['id'])
+    monkeypatch.setattr(route_backend_chats, 'get_current_user_info', lambda: {})
+    monkeypatch.setattr(
+        route_backend_chats,
+        'get_settings',
+        lambda: {'enable_image_generation': True},
+    )
+    monkeypatch.setattr(
+        route_backend_chats,
+        'cosmos_conversations_container',
+        conversation_container,
+    )
+    monkeypatch.setattr(
+        route_backend_chats,
+        'cosmos_messages_container',
+        message_container,
+    )
+    monkeypatch.setattr(route_backend_chats, 'CosmosResourceNotFoundError', DummyNotFoundError)
+    monkeypatch.setattr(route_backend_chats, 'generate_chat_image_message', generate_image)
+    monkeypatch.setattr(
+        route_backend_chats,
+        'invalidate_conversation_cache_for_item',
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(route_backend_chats, 'log_event', lambda *args, **kwargs: None)
+
+    app = Flask(__name__)
+    app.config['TESTING'] = True
+    route_backend_chats.register_route_backend_chats(app)
+    app.config['approval_route_state'] = {
+        'conversations': conversation_container,
+        'messages': message_container,
+        'generated_requests': generated_requests,
+        'user': user_state,
+    }
+    return app
+
+
+def test_owner_approval_constrains_forged_lineage(approval_route_app):
+    """Verify valid owner approval retains only source-ledger lineage."""
+    with approval_route_app.test_client() as client:
+        response = client.post(
+            '/api/chat/image-proposals/generate',
+            json=_approval_payload(),
+        )
+
+    state = approval_route_app.config['approval_route_state']
+    assert response.status_code == 200
+    assert len(state['generated_requests']) == 1
+    generated_proposal = state['generated_requests'][0]['proposal']
+    assert generated_proposal['evidenceIds'] == ['fact-profile-role']
+    assert generated_proposal['referenceImageIds'] == ['artifact-headshot']
+    assert response.get_json()['approval_review']['state'] == 'ready'
+
+
+def test_other_turn_lineage_is_removed_from_selected_source_message(approval_route_app):
+    """Verify same-conversation evidence from another turn cannot cross ledgers."""
+    payload = _approval_payload()
+    payload['proposal']['evidenceIds'] = ['fact-other-run']
+
+    with approval_route_app.test_client() as client:
+        response = client.post('/api/chat/image-proposals/generate', json=payload)
+
+    state = approval_route_app.config['approval_route_state']
+    assert response.status_code == 200
+    assert 'evidenceIds' not in state['generated_requests'][0]['proposal']
+
+
+def test_legacy_proposal_without_source_ledger_remains_approvable(approval_route_app):
+    """Verify legacy ungrounded proposals retain their existing opt-in flow."""
+    with approval_route_app.test_client() as client:
+        response = client.post(
+            '/api/chat/image-proposals/generate',
+            json=_approval_payload(assistant_message_id=''),
+        )
+
+    state = approval_route_app.config['approval_route_state']
+    generated_proposal = state['generated_requests'][0]['proposal']
+    assert response.status_code == 200
+    assert response.get_json()['approval_review']['ledger_status'] == 'unavailable'
+    assert 'evidenceIds' not in generated_proposal
+    assert 'referenceImageIds' not in generated_proposal
+
+
+def test_foreign_conversation_is_rejected_before_source_read(approval_route_app):
+    """Verify conversation ownership gates all dependent source-message reads."""
+    state = approval_route_app.config['approval_route_state']
+    initial_read_count = state['messages'].read_count
+
+    with approval_route_app.test_client() as client:
+        response = client.post(
+            '/api/chat/image-proposals/generate',
+            json=_approval_payload(conversation_id='conversation-foreign'),
+        )
+
+    assert response.status_code == 403
+    assert state['messages'].read_count == initial_read_count
+    assert state['generated_requests'] == []
+
+
+def test_missing_conversation_and_cross_partition_source_return_not_found(approval_route_app):
+    """Verify missing objects cannot downgrade into unbound image generation."""
+    with approval_route_app.test_client() as client:
+        missing_conversation = client.post(
+            '/api/chat/image-proposals/generate',
+            json=_approval_payload(conversation_id='conversation-missing'),
+        )
+        foreign_source = client.post(
+            '/api/chat/image-proposals/generate',
+            json=_approval_payload(assistant_message_id='assistant-foreign'),
+        )
+
+    state = approval_route_app.config['approval_route_state']
+    assert missing_conversation.status_code == 404
+    assert foreign_source.status_code == 404
+    assert state['generated_requests'] == []
+
+
+def test_active_to_partial_transition_requires_literal_confirmation(approval_route_app):
+    """Verify active evidence blocks and terminal partial evidence needs boolean true."""
+    state = approval_route_app.config['approval_route_state']
+    active_message = _assistant_message(
+        'conversation-owner',
+        metadata=_evidence_metadata(
+            ledger_status='collecting',
+            runtime_status='running',
+            requirement_status='pending',
+            source_status='running',
+            include_supported_fact=False,
+        ),
+    )
+    state['messages'].set_item(active_message)
+
+    with approval_route_app.test_client() as client:
+        blocked = client.post(
+            '/api/chat/image-proposals/generate',
+            json=_approval_payload(confirm_partial=True),
+        )
+
+        partial_message = _assistant_message(
+            'conversation-owner',
+            metadata=_evidence_metadata(
+                ledger_status='partial',
+                runtime_status='partial',
+                requirement_status='unsatisfied',
+                source_status='partial',
+            ),
+        )
+        partial_message['metadata']['evidence_ledger']['missing_or_failed'].append({
+            'status': 'not_found',
+            'message': 'The requested public profile could not be verified.',
+        })
+        state['messages'].set_item(partial_message)
+
+        missing_confirmation = client.post(
+            '/api/chat/image-proposals/generate',
+            json=_approval_payload(),
+        )
+        string_confirmation = client.post(
+            '/api/chat/image-proposals/generate',
+            json=_approval_payload(confirm_partial='true'),
+        )
+        confirmed = client.post(
+            '/api/chat/image-proposals/generate',
+            json=_approval_payload(confirm_partial=True),
+        )
+
+    assert blocked.status_code == 409
+    assert blocked.get_json()['approval_review']['state'] == 'blocked'
+    assert missing_confirmation.status_code == 409
+    assert string_confirmation.status_code == 409
+    assert missing_confirmation.get_json()['approval_review']['state'] == 'confirmation_required'
+    assert confirmed.status_code == 200
+    assert len(state['generated_requests']) == 1

--- a/functional_tests/test_image_proposal_pipeline.py
+++ b/functional_tests/test_image_proposal_pipeline.py
@@ -2,12 +2,13 @@
 # test_image_proposal_pipeline.py
 """
 Functional test for opt-in chat image proposal pipeline.
-Version: 0.250.063
-Implemented in: 0.241.138
+Version: 0.250.064
+Implemented in: 0.250.064
 
 This test ensures the reusable image proposal helpers normalize model-authored
-proposal JSON, gate proposal guidance behind image generation settings, and
-produce inline fenced simpleimage schemas used by the chat renderer.
+proposal JSON, derive approval states from authorized orchestration evidence,
+gate proposal guidance behind image generation settings, and produce inline
+fenced simpleimage schemas used by the chat renderer.
 """
 
 import os
@@ -20,6 +21,7 @@ if APP_ROOT not in sys.path:
 
 from functions_image_generation import (  # noqa: E402
     INLINE_IMAGE_PROPOSAL_BLOCK_LANGUAGE,
+    build_image_proposal_approval_review,
     build_image_proposal_guidance_message,
     image_generation_is_enabled,
     normalize_image_proposal,
@@ -88,11 +90,149 @@ def test_invalid_proposal_rejected():
     raise AssertionError('Expected missing prompt to raise ValueError')
 
 
+def _approval_ledger(status='ready', requirement_status='satisfied', include_fact=True):
+    ledger = {
+        'version': 1,
+        'status': status,
+        'requirements': [{
+            'id': 'profile_evidence',
+            'description': 'Verified profile evidence',
+            'required': True,
+            'status': requirement_status,
+        }],
+        'sources': [{
+            'id': 'selected_agent',
+            'type': 'selected_agent',
+            'status': 'succeeded' if requirement_status == 'satisfied' else 'partial',
+            'required': True,
+            'authorization_status': 'authorized',
+        }],
+        'facts': [],
+        'results': [],
+        'citations': [],
+        'artifacts': [{
+            'id': 'artifact-headshot',
+            'type': 'image_reference',
+            'name': 'Selected headshot',
+            'reference': 'message-headshot',
+            'message_id': 'message-headshot',
+            'source_ids': ['selected_agent'],
+        }],
+        'missing_or_failed': [],
+    }
+    if include_fact:
+        ledger['facts'].append({
+            'id': 'fact-profile-role',
+            'text': 'The profile includes a verified role.',
+            'source_ids': ['selected_agent'],
+        })
+    return ledger
+
+
+def test_image_proposal_approval_review_ready():
+    """Validate source and reference summaries for terminal supported evidence."""
+    review = build_image_proposal_approval_review(
+        _approval_ledger(),
+        {'status': 'succeeded'},
+        {
+            'evidenceIds': ['fact-profile-role'],
+            'referenceImageIds': ['artifact-headshot'],
+        },
+    )
+
+    assert review['state'] == 'ready'
+    assert review['can_approve'] is True
+    assert review['requires_confirmation'] is False
+    assert review['sources'] == [{
+        'id': 'selected_agent',
+        'type': 'selected_agent',
+        'label': 'Selected Agent',
+        'status': 'succeeded',
+        'required': True,
+        'used': True,
+    }]
+    assert review['reference_images'] == [{
+        'id': 'artifact-headshot',
+        'name': 'Selected headshot',
+        'reference_id': 'message-headshot',
+        'document_id': '',
+        'message_id': 'message-headshot',
+    }]
+
+    unlinked_review = build_image_proposal_approval_review(
+        _approval_ledger(),
+        {'status': 'succeeded'},
+    )
+    assert unlinked_review['sources'][0]['used'] is False
+    assert unlinked_review['reference_images'] == []
+
+
+def test_image_proposal_approval_review_requires_partial_confirmation():
+    """Validate terminal partial evidence remains opt-in with an acknowledgment."""
+    ledger = _approval_ledger(status='partial', requirement_status='unsatisfied')
+    ledger['missing_or_failed'].append({
+        'status': 'not_found',
+        'message': 'LinkedIn profile was requested but not verified.',
+    })
+
+    review = build_image_proposal_approval_review(ledger, {'status': 'partial'})
+
+    assert review['state'] == 'confirmation_required'
+    assert review['can_approve'] is True
+    assert review['requires_confirmation'] is True
+    assert review['missing_evidence'] == [
+        'LinkedIn profile was requested but not verified.',
+        'Verified profile evidence',
+    ]
+
+    completed_review = build_image_proposal_approval_review(
+        _approval_ledger(status='completed', requirement_status='unsatisfied'),
+        {'status': 'partial'},
+    )
+    assert completed_review['state'] == 'confirmation_required'
+
+
+def test_image_proposal_approval_review_blocks_unfinished_or_unsupported_runs():
+    """Validate active, cancelled, failed, and supportless evidence cannot proceed."""
+    collecting = build_image_proposal_approval_review(
+        _approval_ledger(status='collecting', requirement_status='pending'),
+        {'status': 'running'},
+    )
+    cancelled = build_image_proposal_approval_review(
+        _approval_ledger(status='cancelled', requirement_status='unsatisfied'),
+        {'status': 'cancelled'},
+    )
+    failed = build_image_proposal_approval_review(
+        _approval_ledger(status='failed', requirement_status='unsatisfied'),
+        {'status': 'failed'},
+    )
+    unsupported = build_image_proposal_approval_review(
+        _approval_ledger(
+            status='partial',
+            requirement_status='unsatisfied',
+            include_fact=False,
+        ) | {'artifacts': []},
+        {'status': 'partial'},
+    )
+
+    assert collecting['state'] == 'blocked'
+    assert cancelled['state'] == 'blocked'
+    assert failed['state'] == 'blocked'
+    assert unsupported['state'] == 'blocked'
+    assert all(
+        review['can_approve'] is False
+        for review in (collecting, cancelled, failed, unsupported)
+    )
+
+
 if __name__ == '__main__':
     tests = [
         test_normalize_image_proposal,
         test_image_proposal_guidance_and_gating,
         test_invalid_proposal_rejected,
+        test_image_proposal_approval_review_ready,
+        test_image_proposal_approval_review_requires_partial_confirmation,
+        test_image_proposal_approval_review_blocks_unfinished_or_unsupported_runs,
     ]
     results = []
     for test in tests:

--- a/functional_tests/test_orchestration_runtime.py
+++ b/functional_tests/test_orchestration_runtime.py
@@ -2,12 +2,13 @@
 # test_orchestration_runtime.py
 """
 Functional test for the request-scoped orchestration runtime.
-Version: 0.250.063
+Version: 0.250.064
 Implemented in: 0.250.063
 
 This test ensures direct and coordinated plans execute through one bounded graph
 with dependency ordering, safe parallelism, cancellation, failure policy,
-replanning, finalizer isolation, and runtime-node evidence provenance.
+replanning, finalizer isolation, runtime-node evidence provenance, and bounded
+structured progress for the chat UI.
 """
 
 import json
@@ -90,6 +91,27 @@ def test_direct_and_coordinated_turns_share_run_contract():
     assert run.to_metadata()['mode'] == 'direct'
     assert _node(run, 'finalize_response').status == 'succeeded'
     assert [event['status'] for event in progress_events] == ['running', 'succeeded']
+    assert all(event['required'] is True for event in progress_events)
+    assert [event['node_index'] for event in progress_events] == [0, 0]
+    assert [event['node_count'] for event in progress_events] == [1, 1]
+
+
+def test_chat_streams_preserve_structured_orchestration_progress():
+    """Validate both stream paths retain bounded node progress and approval state."""
+    route_source = ROUTE_BACKEND_CHATS.read_text(encoding='utf-8')
+
+    assert "'kind': 'orchestration_node'" in route_source
+    assert "'step_type': 'orchestration_progress'" in route_source
+    assert "'capability': capability" in route_source
+    assert "'node_index': node_index" in route_source
+    assert "'node_count': visible_node_count" in route_source
+    assert "'required': bool(event.get('required'))" in route_source
+    assert "'step_type': 'approval_required'" in route_source
+    assert "'capability': 'approval_required'" in route_source
+    assert route_source.count(
+        'for thought_payload in _build_orchestration_stream_thought_payloads(event):'
+    ) == 2
+    assert 'thought_tracker.add_thought(step_type, content, detail, activity=activity)' in route_source
 
 
 def test_dependencies_parallel_collectors_and_node_provenance():

--- a/ui_tests/test_chat_inline_image_proposal_cards.py
+++ b/ui_tests/test_chat_inline_image_proposal_cards.py
@@ -1,15 +1,16 @@
 # test_chat_inline_image_proposal_cards.py
 """
 UI test for inline image proposal approval cards in chat.
-Version: 0.250.062
-Implemented in: 0.241.137
+Version: 0.250.064
+Implemented in: 0.250.064
 
 This test ensures assistant-authored simpleimage blocks render as opt-in image
-proposal cards with clean streaming placeholders, hidden prompts, provenance
-metadata, approve, approve-all, edit, cancel, inline result, saved-result hydration,
-and bulk-action alignment workflows.
+proposal cards with clean streaming placeholders, evidence review, approval
+gating, hidden prompts, approve-all, edit, cancel, inline result, saved-result
+hydration, and responsive bulk-action alignment workflows.
 """
 
+import base64
 import json
 import os
 
@@ -46,39 +47,85 @@ def _proposal_block(index, title=None, prompt=None, metadata=None):
     return f"```simpleimage\n{json.dumps(proposal)}\n```"
 
 
-def _append_custom_ai_message(page, message_id, content, generated_image_proposals=None):
+def _append_custom_ai_message(page, message_id, content, generated_image_proposals=None, metadata=None):
     page.evaluate(
-        """
-        async ({ messageId, content, generatedImageProposals }) => {
-            const chatMessages = window.chatMessages && typeof window.chatMessages.appendMessage === 'function'
-                ? window.chatMessages
-                : await import('/static/js/chat/chat-messages.js');
-            chatMessages.appendMessage(
-                'AI',
-                content,
-                'image-proposal-ui-test',
-                messageId,
-                false,
-                [],
-                [],
-                [],
-                null,
-                null,
-                {
-                    id: messageId,
-                    role: 'assistant',
+        r"""
+        async ({ messageId, content, generatedImageProposals, metadata }) => {
+            if (document.getElementById('chatbox')) {
+                const chatMessages = window.chatMessages && typeof window.chatMessages.appendMessage === 'function'
+                    ? window.chatMessages
+                    : await import('/static/js/chat/chat-messages.js');
+                chatMessages.appendMessage(
+                    'AI',
                     content,
-                    conversation_id: 'ui-image-proposal-conversation',
-                    generated_image_proposals: generatedImageProposals || []
-                },
-                false
+                    'image-proposal-ui-test',
+                    messageId,
+                    false,
+                    [],
+                    [],
+                    [],
+                    null,
+                    null,
+                    {
+                        id: messageId,
+                        role: 'assistant',
+                        content,
+                        conversation_id: 'ui-image-proposal-conversation',
+                        generated_image_proposals: generatedImageProposals || [],
+                        metadata: metadata || {}
+                    },
+                    false
+                );
+                return;
+            }
+
+            const proposals = await import('/static/js/chat/chat-inline-image-proposals.js');
+            let harness = document.getElementById('phase7-chat-harness');
+            if (!harness) {
+                harness = document.createElement('main');
+                harness.id = 'phase7-chat-harness';
+                harness.className = 'container py-3';
+                document.body.replaceChildren(harness);
+            }
+
+            const messageElement = document.createElement('article');
+            messageElement.className = 'message ai-message';
+            messageElement.dataset.messageId = messageId;
+            messageElement.dataset.conversationId = 'ui-image-proposal-conversation';
+            messageElement.dataset.messageComplete = 'true';
+            const messageText = document.createElement('div');
+            messageText.className = 'message-text';
+            const extracted = proposals.extractInlineImageProposalBlocks(content);
+            const escapedMarkdown = extracted.markdown
+                .replace(/[&<>"']/g, character => ({
+                    '&': '&amp;',
+                    '<': '&lt;',
+                    '>': '&gt;',
+                    '"': '&quot;',
+                    "'": '&#39;'
+                })[character])
+                .replace(/\n/g, '<br>');
+            const safeProposalHtml = DOMPurify.sanitize(
+                proposals.injectInlineImageProposalHtml(
+                    escapedMarkdown,
+                    extracted.blocks,
+                ),
             );
+            messageText.innerHTML = safeProposalHtml;
+            messageElement.appendChild(messageText);
+            harness.appendChild(messageElement);
+            proposals.attachGeneratedImageProposalResults(
+                messageElement,
+                generatedImageProposals || [],
+            );
+            proposals.hydrateInlineImageProposals(messageElement, metadata || {});
         }
         """,
         {
             'messageId': message_id,
             'content': content,
             'generatedImageProposals': generated_image_proposals or [],
+            'metadata': metadata or {},
         },
     )
 
@@ -118,6 +165,77 @@ def _install_approval_route(page, requests):
     page.route('**/api/chat/image-proposals/generate', handle_approval)
 
 
+def _install_image_route(page):
+    transparent_png = base64.b64decode(
+        'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII='
+    )
+
+    def handle_image(route):
+        route.fulfill(status=200, content_type='image/png', body=transparent_png)
+
+    page.route('**/api/image/*', handle_image)
+
+
+def _orchestration_metadata(status='ready', runtime_status='succeeded'):
+    requirement_status = 'satisfied' if status == 'ready' else 'unsatisfied'
+    return {
+        'evidence_ledger': {
+            'version': 1,
+            'status': status,
+            'requirements': [
+                {
+                    'id': 'profile_evidence',
+                    'description': 'Verified profile evidence',
+                    'required': True,
+                    'status': requirement_status,
+                },
+            ],
+            'sources': [
+                {
+                    'id': 'selected_agent',
+                    'type': 'selected_agent',
+                    'status': 'succeeded' if status == 'ready' else 'partial',
+                    'required': True,
+                },
+                {
+                    'id': 'web_search',
+                    'type': 'web_search',
+                    'status': 'not_found' if status == 'partial' else 'succeeded',
+                    'required': status == 'partial',
+                },
+            ],
+            'facts': [
+                {
+                    'id': 'fact-profile-role',
+                    'source_ids': ['selected_agent'],
+                },
+            ],
+            'results': [],
+            'citations': [],
+            'artifacts': [
+                {
+                    'id': 'artifact-headshot',
+                    'type': 'image_reference',
+                    'name': 'Selected headshot',
+                    'reference': 'ui-image-proposal-conversation_image_1_2_3',
+                    'message_id': 'ui-image-proposal-conversation_image_1_2_3',
+                    'source_ids': ['selected_agent'],
+                },
+            ],
+            'missing_or_failed': ([
+                {
+                    'status': 'not_found',
+                    'message': 'LinkedIn profile was requested but not verified. <img src=x onerror=fail()>',
+                },
+            ] if status == 'partial' else []),
+        },
+        'orchestration_runtime': {
+            'version': 1,
+            'status': runtime_status,
+        },
+    }
+
+
 @pytest.mark.ui
 @pytest.mark.parametrize('viewport', [{'width': 1440, 'height': 900}, {'width': 390, 'height': 844}])
 def test_chat_inline_image_proposal_cards(viewport):
@@ -133,7 +251,12 @@ def test_chat_inline_image_proposal_cards(viewport):
         context = _create_context(browser, viewport)
         page = context.new_page()
         _install_approval_route(page, requests)
+        _install_image_route(page)
         page.goto(chat_url, wait_until='domcontentloaded')
+        if page.locator('link[href="/static/css/chats.css"]').count() == 0:
+            page.add_style_tag(url='/static/css/chats.css')
+        if page.evaluate("typeof window.DOMPurify === 'undefined'"):
+            page.add_script_tag(url='/static/js/chat/purify.min.js')
 
         bulk_message_id = 'ui-image-proposal-bulk'
         _append_custom_ai_message(
@@ -219,6 +342,93 @@ def test_chat_inline_image_proposal_cards(viewport):
             'artifact-headshot',
             'photo-reference',
         ]
+
+        partial_message_id = 'ui-image-proposal-partial-evidence'
+        _append_custom_ai_message(
+            page,
+            partial_message_id,
+            'A grounded visual with partial evidence.\n\n' + _proposal_block(
+                7,
+                metadata={
+                    'evidenceIds': ['fact-profile-role'],
+                    'sourceSummary': 'Selected agent evidence and an authorized headshot.',
+                    'missingEvidence': ['A public profile could not be verified.'],
+                    'referenceImageIds': ['artifact-headshot'],
+                },
+            ),
+            metadata=_orchestration_metadata(status='partial', runtime_status='partial'),
+        )
+        partial_message = page.locator(f'[data-message-id="{partial_message_id}"]')
+        expect(partial_message.locator('.sc-inline-image-proposal-source-badge')).to_contain_text([
+            'Selected Agent · used',
+            'Web Search · unavailable',
+        ])
+        expect(partial_message.locator('.sc-inline-image-proposal-missing')).to_contain_text(
+            'LinkedIn profile was requested but not verified.'
+        )
+        expect(partial_message.locator('.sc-inline-image-proposal-reference-image')).to_have_attribute(
+            'src',
+            '/api/image/ui-image-proposal-conversation_image_1_2_3',
+        )
+        expect(partial_message.locator('.sc-inline-image-proposal-reference-image')).to_have_attribute(
+            'alt',
+            'Reference image: Selected headshot',
+        )
+        expect(partial_message.locator('img[src="x"]')).to_have_count(0)
+        expect(partial_message.locator('.sc-inline-image-proposal-evidence-details')).to_contain_text(
+            'Review evidence details'
+        )
+        partial_approve = partial_message.locator('.sc-inline-image-proposal-approve')
+        expect(partial_approve).to_be_disabled()
+        partial_message.locator('.sc-inline-image-proposal-confirm-partial').check()
+        expect(partial_approve).to_be_enabled()
+        expect(partial_approve).to_have_attribute('aria-disabled', 'false')
+        notice_id = partial_approve.get_attribute('aria-describedby')
+        assert notice_id
+        expect(partial_message.locator(f'#{notice_id}')).to_have_attribute('aria-live', 'polite')
+        expect(partial_message.locator('.sc-inline-image-proposal-approval-live')).to_contain_text(
+            'Approval is now available'
+        )
+        partial_layout = partial_message.locator('.sc-inline-image-proposal-card').evaluate(
+            """
+            element => ({
+                overflows: element.scrollWidth > element.clientWidth,
+                right: element.getBoundingClientRect().right,
+                viewportWidth: window.innerWidth,
+                actionOverflows: element.querySelector('.sc-inline-image-proposal-actions').scrollWidth
+                    > element.querySelector('.sc-inline-image-proposal-actions').clientWidth,
+                actionHeights: Array.from(
+                    element.querySelectorAll('.sc-inline-image-proposal-actions .btn')
+                ).map(button => button.getBoundingClientRect().height)
+            })
+            """
+        )
+        assert partial_layout['overflows'] is False
+        assert partial_layout['actionOverflows'] is False
+        assert partial_layout['right'] <= partial_layout['viewportWidth'] + 1
+        if viewport['width'] <= 575:
+            assert all(height >= 44 for height in partial_layout['actionHeights'])
+        partial_approve.click()
+        expect(partial_message.locator('.sc-inline-image-proposal-approved')).to_have_count(1)
+        assert requests[-1]['confirm_partial'] is True
+
+        blocked_message_id = 'ui-image-proposal-blocked-evidence'
+        blocked_metadata = _orchestration_metadata(status='collecting', runtime_status='running')
+        blocked_metadata['evidence_ledger']['requirements'][0]['status'] = 'pending'
+        blocked_metadata['evidence_ledger']['sources'][0]['status'] = 'running'
+        _append_custom_ai_message(
+            page,
+            blocked_message_id,
+            'A proposal waiting for evidence.\n\n' + _proposal_block(8),
+            metadata=blocked_metadata,
+        )
+        blocked_message = page.locator(f'[data-message-id="{blocked_message_id}"]')
+        expect(blocked_message.locator('.sc-inline-image-proposal-approve')).to_be_disabled()
+        expect(blocked_message.locator('.sc-inline-image-proposal-approval-notice')).to_contain_text(
+            'Evidence collection is still in progress.'
+        )
+        expect(blocked_message.locator('.sc-inline-image-proposal-confirm-partial')).to_have_count(0)
+        expect(blocked_message.locator('.sc-inline-image-proposal-reference')).to_have_count(0)
 
         completed_message_id = 'ui-image-proposal-completed'
         _append_custom_ai_message(

--- a/ui_tests/test_streaming_thought_progression.py
+++ b/ui_tests/test_streaming_thought_progression.py
@@ -1,12 +1,12 @@
 # test_streaming_thought_progression.py
 """
 UI test for streaming thought progression.
-Version: 0.239.185
-Implemented in: 0.239.185
+Version: 0.250.064
+Implemented in: 0.250.064
 
 This test ensures the live streaming placeholder keeps advancing to the latest
-thought for the active assistant message and does not inherit stale thought
-state when a new message starts.
+thought and ordered orchestration step for the active assistant message, remains
+accessible, and does not inherit stale state when a new message starts.
 """
 
 import os
@@ -27,19 +27,28 @@ def _require_ui_env():
 
 
 @pytest.mark.ui
-def test_streaming_thought_progression_and_session_isolation(playwright):
+@pytest.mark.parametrize('viewport', [
+    {'width': 1440, 'height': 900},
+    {'width': 390, 'height': 844},
+])
+def test_streaming_thought_progression_and_session_isolation(playwright, viewport):
     """Validate live thought progression and stale-session isolation in the browser."""
     _require_ui_env()
 
     browser = playwright.chromium.launch()
     context = browser.new_context(
         storage_state=STORAGE_STATE,
-        viewport={"width": 1440, "height": 900},
+        viewport=viewport,
+        ignore_https_errors=True,
     )
     page = context.new_page()
 
     try:
         page.goto(f"{BASE_URL}/chats", wait_until="domcontentloaded")
+        if page.locator('link[href="/static/css/chats.css"]').count() == 0:
+            page.add_style_tag(url='/static/css/chats.css')
+        if page.evaluate("typeof window.DOMPurify === 'undefined'"):
+            page.add_script_tag(url='/static/js/chat/purify.min.js')
 
         result = page.evaluate(
             """
@@ -48,15 +57,23 @@ def test_streaming_thought_progression_and_session_isolation(playwright):
                 const {
                     beginStreamingThoughtSession,
                     clearStreamingThoughtSession,
+                    createThoughtsToggleHtml,
                     handleStreamingThought,
                     markStreamingThoughtContentStarted,
                 } = thoughtsModule;
 
                 function createPlaceholder(messageId, initialText = 'Streaming...') {
+                        let harness = document.getElementById('phase7-thought-harness');
+                        if (!harness) {
+                            harness = document.createElement('main');
+                            harness.id = 'phase7-thought-harness';
+                            harness.className = 'container py-3';
+                            document.body.replaceChildren(harness);
+                        }
                     const wrapper = document.createElement('div');
                     wrapper.setAttribute('data-message-id', messageId);
                     wrapper.innerHTML = `<div class="message-text">${initialText}</div>`;
-                    document.body.appendChild(wrapper);
+                        harness.appendChild(wrapper);
                     return wrapper;
                 }
 
@@ -99,6 +116,100 @@ def test_streaming_thought_progression_and_session_isolation(playwright):
                     content: 'Late thought should be ignored'
                 }, 'temp-new');
                 const afterContentStarted = newPlaceholder.querySelector('.message-text').textContent;
+                const serverMessageId = newPlaceholder.dataset.streamingServerMessageId || null;
+                const thoughtIndexAfterContent = newPlaceholder.dataset.streamingThoughtIndex || null;
+
+                clearStreamingThoughtSession('temp-new');
+                const orchestrationPlaceholder = createPlaceholder('temp-orchestration');
+                beginStreamingThoughtSession('temp-orchestration');
+                const capabilities = [
+                    ['evidence_discovery', 'plan-evidence', 'Planning evidence workflow'],
+                    ['selected_images', 'selected-images', 'Reviewing selected image'],
+                    ['workspace_search', 'workspace-search', 'Searching workspace documents'],
+                    ['web_search', 'web-search', 'Searching public web'],
+                    ['selected_agent', 'selected-agent', 'Calling selected agent'],
+                    ['source_review', 'source-review', 'Reviewing sources'],
+                    ['image_proposal', 'image-proposal', 'Building image proposal'],
+                ];
+                let stepIndex = 0;
+                const orchestrationPercents = [];
+                capabilities.forEach(([capability, nodeId, content], nodeIndex) => {
+                    ['running', 'succeeded'].forEach(status => {
+                        handleStreamingThought({
+                            message_id: 'assistant-orchestration',
+                            step_index: stepIndex,
+                            step_type: 'orchestration_progress',
+                            content,
+                            activity: {
+                                kind: 'orchestration_node',
+                                run_id: 'run-orchestration',
+                                node_id: nodeId,
+                                node_index: nodeIndex,
+                                node_count: 8,
+                                node_type: capability === 'image_proposal' ? 'finalize' : 'collect',
+                                capability,
+                                status,
+                                required: true,
+                            },
+                        }, 'temp-orchestration');
+                        orchestrationPercents.push(Number(
+                            orchestrationPlaceholder.querySelector('.orchestration-progress-card').dataset.orchestrationProgressPercent
+                        ));
+                        stepIndex += 1;
+                    });
+                });
+                handleStreamingThought({
+                    message_id: 'assistant-orchestration',
+                    step_index: stepIndex,
+                    step_type: 'approval_required',
+                    content: 'Awaiting image proposal approval',
+                    activity: {
+                        kind: 'orchestration_node',
+                        run_id: 'run-orchestration',
+                        node_id: 'image-proposal:approval',
+                        node_index: 7,
+                        node_count: 8,
+                        node_type: 'approval',
+                        capability: 'approval_required',
+                        status: 'running',
+                        required: true,
+                    },
+                }, 'temp-orchestration');
+
+                const orchestrationCard = orchestrationPlaceholder.querySelector('.orchestration-progress-card');
+                const orchestrationLabels = Array.from(
+                    orchestrationCard.querySelectorAll('.orchestration-progress-step .fw-semibold')
+                ).map(element => element.textContent.trim());
+                const orchestrationStatuses = Array.from(
+                    orchestrationCard.querySelectorAll('.orchestration-progress-step')
+                ).map(element => element.dataset.orchestrationNodeStatus);
+
+                clearStreamingThoughtSession('temp-orchestration');
+                const isolatedPlaceholder = createPlaceholder('temp-orchestration-isolated');
+                beginStreamingThoughtSession('temp-orchestration-isolated');
+                handleStreamingThought({
+                    message_id: 'assistant-orchestration-isolated',
+                    step_index: 0,
+                    step_type: 'orchestration_progress',
+                    content: 'Searching public web',
+                    activity: {
+                        kind: 'orchestration_node',
+                        run_id: 'run-isolated',
+                        node_id: 'web-search',
+                        node_type: 'collect',
+                        capability: 'web_search',
+                        status: 'running',
+                        required: true,
+                    },
+                }, 'temp-orchestration-isolated');
+                const isolatedLabels = Array.from(
+                    isolatedPlaceholder.querySelectorAll('.orchestration-progress-step .fw-semibold')
+                ).map(element => element.textContent.trim());
+                window.appSettings = {
+                    ...(window.appSettings || {}),
+                    enable_thoughts: true,
+                };
+                const thoughtsMarkup = createThoughtsToggleHtml('assistant-complete');
 
                 return {
                     beforeThought,
@@ -106,8 +217,21 @@ def test_streaming_thought_progression_and_session_isolation(playwright):
                     afterSecondThought,
                     afterContentStarted,
                     oldPlaceholderText: oldPlaceholder.querySelector('.message-text').textContent,
-                    serverMessageId: newPlaceholder.dataset.streamingServerMessageId || null,
-                    thoughtIndexAfterContent: newPlaceholder.dataset.streamingThoughtIndex || null,
+                    serverMessageId,
+                    thoughtIndexAfterContent,
+                    orchestrationLabels,
+                    orchestrationStatuses,
+                    orchestrationPercents,
+                    orchestrationState: orchestrationCard.dataset.orchestrationProgressState,
+                    orchestrationPercent: orchestrationCard.dataset.orchestrationProgressPercent,
+                    ariaLive: orchestrationCard.getAttribute('aria-live'),
+                    ariaRole: orchestrationCard.getAttribute('role'),
+                    currentOrchestrationStep: orchestrationCard.querySelector('.orchestration-progress-current').textContent.trim(),
+                    orchestrationOverflows: orchestrationCard.scrollWidth > orchestrationCard.clientWidth,
+                    orchestrationRight: orchestrationCard.getBoundingClientRect().right,
+                    viewportWidth: window.innerWidth,
+                    isolatedLabels,
+                    completedThoughtsCollapsed: thoughtsMarkup.containerHtml.includes('d-none'),
                 };
             }
             """
@@ -122,6 +246,28 @@ def test_streaming_thought_progression_and_session_isolation(playwright):
         assert result['oldPlaceholderText'] != result['afterFirstThought']
         assert result['serverMessageId'] == 'assistant-new'
         assert result['thoughtIndexAfterContent'] is None
+        assert result['orchestrationLabels'] == [
+            'Planning evidence workflow',
+            'Reviewing selected image',
+            'Searching workspace documents',
+            'Searching public web',
+            'Calling selected agent',
+            'Reviewing sources',
+            'Building image proposal',
+            'Awaiting approval',
+        ]
+        assert result['orchestrationStatuses'] == (['succeeded'] * 7) + ['running']
+        assert result['orchestrationPercents'] == sorted(result['orchestrationPercents'])
+        assert result['orchestrationPercents'][-1] < 100
+        assert result['orchestrationState'] == 'awaiting_approval'
+        assert result['orchestrationPercent'] == '95'
+        assert result['ariaLive'] == 'polite'
+        assert result['ariaRole'] == 'status'
+        assert result['currentOrchestrationStep'] == 'Awaiting approval'
+        assert result['orchestrationOverflows'] is False
+        assert result['orchestrationRight'] <= result['viewportWidth'] + 1
+        assert result['isolatedLabels'] == ['Searching public web']
+        assert result['completedThoughtsCollapsed'] is True
     finally:
         context.close()
         browser.close()


### PR DESCRIPTION
## Summary
- add ordered, monotonic, accessible orchestration progress for planning, evidence sources, agents/actions, finalization, and image approval handoff
- add grounded-image evidence review with canonical source badges, missing-evidence notes, proposal-linked reference previews, responsive controls, and partial-evidence acknowledgment
- enforce approval server-side against the exact authorized source assistant message, including active/failed/cancelled/supportless blocking, strict boolean confirmation, and forged or cross-turn lineage removal
- update orchestration documentation, release notes, and app version to `0.250.064`

## Validation
- Phase 1-7 orchestration and approval contracts: 85/85 passed
- stream lifecycle, chat compatibility, collaboration, tabular, and route-policy contracts: 28/28 passed
- live desktop/mobile Playwright proposal and progress scenarios: 4/4 passed against the local HTTPS app
- Python compilation, JavaScript syntax, editor diagnostics, and whitespace checks: clean
- full-file and PR-diff Broken Access Control/XSS guardrails: passed

## Security And UX Notes
- conversation ownership is revalidated before source-message reads
- source messages remain bound to the authorized conversation partition
- browser approval state is explanatory; the generation route recalculates and enforces the authoritative state
- reference previews use only the authenticated same-origin image route and proposal-retained reference IDs
- progress exposes bounded capability/status metadata, not chain-of-thought or raw evidence

Refs #1021