### PR TITLE
Suppress successful source status notes

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -96,7 +96,7 @@ load_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.250.064"
+VERSION = "0.250.065"
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')
 SESSION_COOKIE_HTTPONLY = os.getenv('SESSION_COOKIE_HTTPONLY', 'true').lower() != 'false'

--- a/application/single_app/functions_chat_orchestration.py
+++ b/application/single_app/functions_chat_orchestration.py
@@ -464,7 +464,8 @@ def build_turn_orchestration_guidance_message(plan):
         f'Required source attempts for this turn: {source_labels or "none"}.',
         f'Evidence requirements inferred from the request: {requirement_labels or "none beyond selected sources"}.',
         'Use the results from every attempted source when producing the final response.',
-        'Do not silently ignore a selected source. If a source was skipped, unavailable, unauthorized, failed, or returned no evidence, state that clearly.',
+        'Do not add a source-status note or list sources merely to report successful attempts.',
+        'Only mention source execution status when a required source was skipped, unavailable, unauthorized, failed, returned no evidence, or produced partial results.',
         'Use only supported facts, preserve material source conflicts, and identify partial results instead of filling evidence gaps with assumptions.',
     ]
 

--- a/functional_tests/test_chat_turn_orchestration_plan.py
+++ b/functional_tests/test_chat_turn_orchestration_plan.py
@@ -2,7 +2,7 @@
 # test_chat_turn_orchestration_plan.py
 """
 Functional test for the chat turn orchestration planning foundation.
-Version: 0.250.064
+Version: 0.250.065
 Implemented in: 0.250.058
 
 This test ensures every turn receives a direct or coordinated plan, selected
@@ -124,6 +124,11 @@ def test_selected_capabilities_are_required_attempts():
         'prompt_id': 'prompt-1',
     }
     assert 'must not be persisted' not in json.dumps(plan)
+
+    guidance = build_turn_orchestration_guidance_message(plan)
+    assert 'Do not add a source-status note or list sources merely to report successful attempts.' in guidance
+    assert 'Only mention source execution status when a required source was skipped' in guidance
+    assert 'or produced partial results.' in guidance
 
 
 def test_grounded_image_is_a_coordinated_task_profile():
@@ -351,7 +356,7 @@ def test_streaming_chat_path_persists_and_applies_plan():
     route_source = ROUTE_BACKEND_CHATS.read_text(encoding='utf-8')
     config_source = CONFIG_FILE.read_text(encoding='utf-8')
 
-    assert 'VERSION = "0.250.064"' in config_source
+    assert 'VERSION = "0.250.065"' in config_source
     assert 'turn_orchestration_plan = build_turn_orchestration_plan(' in route_source
     assert 'requested_action_document_ids = _normalize_conversation_task_document_ids(' in route_source
     assert 'requested_action_document_ids\n            if requested_action_document_ids' in route_source


### PR DESCRIPTION
## Summary

- Prevent coordinated finalizers from adding success-only source-status notes to otherwise useful answers.
- Continue disclosing skipped, unavailable, unauthorized, failed, empty, or partial required sources.
- Add focused regression coverage and bump the application version to `0.250.065`.

## Validation

- `15 passed` in `functional_tests/test_chat_turn_orchestration_plan.py`
- Modified Python files compile successfully.
- VS Code diagnostics and whitespace validation are clean.

Follow-up to #1035.
Refs #1021