### PR TITLE
Add governed capability discovery and user choice

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -96,7 +96,7 @@ load_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.250.065"
+VERSION = "0.250.066"
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')
 SESSION_COOKIE_HTTPONLY = os.getenv('SESSION_COOKIE_HTTPONLY', 'true').lower() != 'false'

--- a/application/single_app/functions_chat_capabilities.py
+++ b/application/single_app/functions_chat_capabilities.py
@@ -1,0 +1,504 @@
+# functions_chat_capabilities.py
+"""Governed built-in capability discovery for chat orchestration."""
+
+import re
+from collections.abc import Mapping
+
+from functions_chat_orchestration import user_requested_image_generation
+
+
+CAPABILITY_INVENTORY_VERSION = 1
+CAPABILITY_RECOMMENDATION_VERSION = 1
+CONTINUE_WITHOUT_CAPABILITIES_OPTION_ID = 'continue_without_capabilities'
+
+CAPABILITY_STATES = {
+    'selected',
+    'unselected',
+    'unavailable',
+    'unauthorized',
+    'policy_blocked',
+}
+GOVERNANCE_MODES = {'manual_only', 'recommend', 'auto_read_only', 'blocked'}
+DEFAULT_CAPABILITY_GOVERNANCE_MODES = {
+    'workspace_search': 'recommend',
+    'analyze': 'recommend',
+    'compare': 'recommend',
+    'image': 'recommend',
+    'web_search': 'recommend',
+    'url_access': 'recommend',
+    'deep_research': 'recommend',
+}
+
+CAPABILITY_DEFINITIONS = {
+    'workspace_search': {
+        'label': 'Workspace Search',
+        'category': 'retrieval',
+        'risk_class': 'internal_read',
+        'cost_class': 'low',
+        'latency_class': 'seconds',
+        'evidence_types': ['workspace_documents', 'authorized_knowledge'],
+        'input_requirements': ['authorized_workspace_scope'],
+        'external_data': False,
+        'read_only': True,
+        'default_requires_user_choice': True,
+    },
+    'analyze': {
+        'label': 'Analyze',
+        'category': 'analysis',
+        'risk_class': 'internal_read',
+        'cost_class': 'standard',
+        'latency_class': 'seconds',
+        'evidence_types': ['document_findings', 'calculated_results'],
+        'input_requirements': ['authorized_document_target'],
+        'external_data': False,
+        'read_only': True,
+        'default_requires_user_choice': True,
+    },
+    'compare': {
+        'label': 'Compare',
+        'category': 'analysis',
+        'risk_class': 'internal_read',
+        'cost_class': 'standard',
+        'latency_class': 'seconds',
+        'evidence_types': ['document_differences', 'document_consistency'],
+        'input_requirements': ['two_authorized_document_targets'],
+        'external_data': False,
+        'read_only': True,
+        'default_requires_user_choice': True,
+    },
+    'image': {
+        'label': 'Image',
+        'category': 'generation',
+        'risk_class': 'generated_content',
+        'cost_class': 'standard',
+        'latency_class': 'seconds',
+        'evidence_types': ['visual_output'],
+        'input_requirements': [],
+        'external_data': False,
+        'read_only': False,
+        'default_requires_user_choice': True,
+    },
+    'web_search': {
+        'label': 'Web Search',
+        'category': 'retrieval',
+        'risk_class': 'external_read',
+        'cost_class': 'standard',
+        'latency_class': 'seconds',
+        'evidence_types': ['public_web', 'current_information'],
+        'input_requirements': [],
+        'external_data': True,
+        'read_only': True,
+        'default_requires_user_choice': True,
+    },
+    'url_access': {
+        'label': 'URL Access',
+        'category': 'retrieval',
+        'risk_class': 'external_read',
+        'cost_class': 'standard',
+        'latency_class': 'seconds',
+        'evidence_types': ['supplied_url_content'],
+        'input_requirements': ['user_supplied_url'],
+        'external_data': True,
+        'read_only': True,
+        'default_requires_user_choice': True,
+    },
+    'deep_research': {
+        'label': 'Deep Research',
+        'category': 'retrieval',
+        'risk_class': 'external_read',
+        'cost_class': 'extended',
+        'latency_class': 'minutes',
+        'evidence_types': ['public_web', 'current_information', 'authoritative_sources'],
+        'input_requirements': [],
+        'external_data': True,
+        'read_only': True,
+        'default_requires_user_choice': True,
+        'bundle': ['deep_research', 'web_search'],
+    },
+}
+
+URL_PATTERN = re.compile(r'https?://[^\s<>\"]+', re.IGNORECASE)
+CURRENT_INFORMATION_PATTERN = re.compile(
+    r'\b(?:current|currently|latest|recent|recently|today|tonight|tomorrow|this\s+(?:week|month|year)|'
+    r'up[- ]to[- ]date|as\s+of\s+20\d{2}|20(?:2[6-9]|[3-9]\d))\b',
+    re.IGNORECASE,
+)
+LOCAL_AUTHORITATIVE_PATTERN = re.compile(
+    r'\b(?:law|laws|legal|regulation|regulations|regulatory|ordinance|ordinances|zoning|permit|permits|'
+    r'policy|policies|schedule|schedules|official\s+records?|county|municipal|property|parcel|'
+    r'city\s+rules?|state\s+rules?)\b',
+    re.IGNORECASE,
+)
+INHERENTLY_CURRENT_AUTHORITY_PATTERN = re.compile(
+    r'\b(?:regulation|regulations|regulatory|ordinance|ordinances|zoning|permit|permits|'
+    r'official\s+records?|county|municipal|city\s+rules?|state\s+rules?|property\s+rules?|parcel)\b',
+    re.IGNORECASE,
+)
+WORKSPACE_EVIDENCE_PATTERN = re.compile(
+    r'\b(?:(?:my|our)\s+(?:workspace|documents?|files?|uploads?)|workspace\s+(?:documents?|files?|knowledge)|'
+    r'selected\s+(?:documents?|files?)|uploaded\s+(?:documents?|files?))\b',
+    re.IGNORECASE,
+)
+DOCUMENT_ANALYSIS_PATTERN = re.compile(
+    r'\b(?:analy[sz]e|extract|calculate|compute|summari[sz]e|findings?|themes?|trends?|structured\s+findings?)\b',
+    re.IGNORECASE,
+)
+DOCUMENT_COMPARISON_PATTERN = re.compile(
+    r'\b(?:compare|comparison|differences?|tradeoffs?|trade-offs?|consisten(?:cy|t)|changes?\s+between|'
+    r'versus|vs\.?|across\s+(?:the\s+)?documents?)\b',
+    re.IGNORECASE,
+)
+MULTI_SOURCE_RESEARCH_PATTERN = re.compile(
+    r'\b(?:deep\s+research|comprehensive\s+research|investigate|multiple\s+sources?|multi-source|'
+    r'authoritative\s+sources?|source-intensive|due\s+diligence)\b',
+    re.IGNORECASE,
+)
+
+REQUIREMENT_CAPABILITY_PREFERENCES = {
+    'current_public_information': ['web_search', 'deep_research'],
+    'current_authoritative_sources': ['deep_research', 'web_search'],
+    'supplied_url_review': ['url_access'],
+    'workspace_evidence': ['workspace_search'],
+    'document_analysis': ['analyze'],
+    'multi_document_comparison': ['compare'],
+    'visual_output': ['image'],
+    'multi_source_public_research': ['deep_research', 'web_search'],
+}
+
+
+def _coerce_bool(value, default=False):
+    if value is None:
+        return default
+    if isinstance(value, str):
+        return value.strip().lower() == 'true'
+    return bool(value)
+
+
+def _bounded_reason(value):
+    normalized = re.sub(r'[^a-z0-9_]+', '_', str(value or '').strip().lower()).strip('_')
+    return normalized[:80] or None
+
+
+def _normalize_governance_mode(value):
+    normalized = str(value or 'recommend').strip().lower()
+    return normalized if normalized in GOVERNANCE_MODES else 'blocked'
+
+
+def normalize_capability_governance_modes(settings_or_modes=None):
+    """Normalize per-capability policy while failing closed on invalid values."""
+    raw_modes = settings_or_modes
+    if isinstance(settings_or_modes, Mapping) and 'chat_capability_governance' in settings_or_modes:
+        raw_modes = settings_or_modes.get('chat_capability_governance')
+    raw_modes = raw_modes if isinstance(raw_modes, Mapping) else {}
+    normalized = {}
+    for capability_id, default_mode in DEFAULT_CAPABILITY_GOVERNANCE_MODES.items():
+        raw_value = raw_modes.get(capability_id, default_mode)
+        if isinstance(raw_value, Mapping):
+            raw_value = raw_value.get('mode')
+        normalized[capability_id] = _normalize_governance_mode(raw_value)
+    return normalized
+
+
+def build_governed_capability_inventory(*, selected_capability_ids=None, resolved_capabilities=None):
+    """Build a fail-closed inventory from server-resolved capability decisions."""
+    selected_ids = {
+        str(capability_id or '').strip().lower()
+        for capability_id in (selected_capability_ids or [])
+        if str(capability_id or '').strip().lower() in CAPABILITY_DEFINITIONS
+    }
+    resolved_capabilities = resolved_capabilities if isinstance(resolved_capabilities, Mapping) else {}
+    entries = []
+
+    for capability_id, definition in CAPABILITY_DEFINITIONS.items():
+        resolved = resolved_capabilities.get(capability_id)
+        resolved = resolved if isinstance(resolved, Mapping) else {}
+        enabled = _coerce_bool(resolved.get('enabled'), default=False)
+        available = enabled and _coerce_bool(resolved.get('available'), default=False)
+        authorized = _coerce_bool(resolved.get('authorized'), default=False)
+        governance_mode = _normalize_governance_mode(resolved.get('governance_mode'))
+        policy_allowed = governance_mode != 'blocked' and _coerce_bool(
+            resolved.get('policy_allowed'),
+            default=True,
+        )
+        input_ready = _coerce_bool(resolved.get('input_ready'), default=True)
+        selected = capability_id in selected_ids
+
+        if not available:
+            state = 'unavailable'
+        elif not authorized:
+            state = 'unauthorized'
+        elif not policy_allowed:
+            state = 'policy_blocked'
+        elif selected:
+            state = 'selected'
+        else:
+            state = 'unselected'
+
+        discoverable = bool(
+            state == 'unselected'
+            and input_ready
+            and governance_mode in {'recommend', 'auto_read_only'}
+            and _coerce_bool(resolved.get('discoverable'), default=True)
+        )
+        auto_use_allowed = bool(
+            discoverable
+            and governance_mode == 'auto_read_only'
+            and capability_id == 'workspace_search'
+            and definition['read_only']
+            and not definition['external_data']
+        )
+        requires_user_choice = bool(
+            discoverable
+            and not auto_use_allowed
+            and definition['default_requires_user_choice']
+        )
+
+        entry = {
+            'id': capability_id,
+            'label': definition['label'],
+            'category': definition['category'],
+            'state': state,
+            'selected': selected,
+            'available': available,
+            'authorized': authorized,
+            'discoverable': discoverable,
+            'auto_use_allowed': auto_use_allowed,
+            'requires_user_choice': requires_user_choice,
+            'external_data': definition['external_data'],
+            'risk_class': definition['risk_class'],
+            'cost_class': definition['cost_class'],
+            'latency_class': definition['latency_class'],
+            'evidence_types': list(definition['evidence_types']),
+            'input_requirements': list(definition['input_requirements']),
+            'input_ready': input_ready,
+            'scope': 'current_user',
+            'governance_mode': governance_mode,
+        }
+        if definition.get('bundle'):
+            entry['bundle'] = list(definition['bundle'])
+        if state in {'unavailable', 'unauthorized', 'policy_blocked'}:
+            reason = _bounded_reason(resolved.get('reason')) or state
+            entry['diagnostic_reason'] = reason
+        entries.append(entry)
+
+    return {
+        'version': CAPABILITY_INVENTORY_VERSION,
+        'capabilities': entries,
+    }
+
+
+def classify_capability_requirements(user_message, *, authorized_document_count=0):
+    """Classify common capability requirements without a planning-model call."""
+    message = str(user_message or '').strip()
+    if not message:
+        return []
+
+    try:
+        document_count = max(0, int(authorized_document_count or 0))
+    except (TypeError, ValueError):
+        document_count = 0
+
+    requirements = []
+
+    def add_requirement(requirement_id, reason_code, *, required_inputs=None):
+        if any(item['id'] == requirement_id for item in requirements):
+            return
+        requirements.append({
+            'id': requirement_id,
+            'reason_code': reason_code,
+            'required_inputs': list(required_inputs or []),
+        })
+
+    has_current_signal = bool(CURRENT_INFORMATION_PATTERN.search(message))
+    has_authoritative_signal = bool(LOCAL_AUTHORITATIVE_PATTERN.search(message))
+    if has_authoritative_signal and (
+        has_current_signal or INHERENTLY_CURRENT_AUTHORITY_PATTERN.search(message)
+    ):
+        add_requirement('current_authoritative_sources', 'current_authoritative_sources')
+    elif has_current_signal:
+        add_requirement('current_public_information', 'current_public_information')
+
+    if URL_PATTERN.search(message):
+        add_requirement('supplied_url_review', 'user_supplied_url_requires_review')
+    if WORKSPACE_EVIDENCE_PATTERN.search(message):
+        add_requirement('workspace_evidence', 'workspace_evidence_requested')
+    if DOCUMENT_ANALYSIS_PATTERN.search(message) and document_count >= 1:
+        add_requirement('document_analysis', 'document_analysis_requested')
+    if DOCUMENT_COMPARISON_PATTERN.search(message):
+        if document_count >= 2:
+            add_requirement('multi_document_comparison', 'multi_document_comparison')
+        else:
+            add_requirement(
+                'multi_document_comparison',
+                'comparison_targets_required',
+                required_inputs=['two_authorized_document_targets'],
+            )
+    if user_requested_image_generation(message):
+        add_requirement('visual_output', 'visual_output_materially_helpful')
+    if MULTI_SOURCE_RESEARCH_PATTERN.search(message):
+        add_requirement('multi_source_public_research', 'multi_source_public_research')
+
+    return requirements
+
+
+def build_capability_recommendation(inventory, requirements):
+    """Build one bounded proposal for unresolved deterministic requirements."""
+    if not isinstance(inventory, Mapping):
+        return None
+    inventory_entries = inventory.get('capabilities')
+    if not isinstance(inventory_entries, list):
+        return None
+
+    entries_by_id = {
+        entry.get('id'): entry
+        for entry in inventory_entries
+        if isinstance(entry, Mapping) and entry.get('id') in CAPABILITY_DEFINITIONS
+    }
+    selected_ids = {
+        capability_id
+        for capability_id, entry in entries_by_id.items()
+        if entry.get('state') == 'selected'
+    }
+    option_ids = []
+    requirement_ids = []
+    reason_codes = []
+    required_inputs = []
+
+    def candidate_is_eligible(capability_id):
+        entry = entries_by_id.get(capability_id)
+        if not (
+            entry
+            and entry.get('state') == 'unselected'
+            and entry.get('discoverable') is True
+        ):
+            return False
+        for effective_capability_id in entry.get('bundle') or []:
+            effective_entry = entries_by_id.get(effective_capability_id)
+            if not effective_entry or effective_entry.get('state') not in {'selected', 'unselected'}:
+                return False
+        return True
+
+    for requirement in requirements or []:
+        if not isinstance(requirement, Mapping):
+            continue
+        requirement_id = str(requirement.get('id') or '').strip()
+        preferences = REQUIREMENT_CAPABILITY_PREFERENCES.get(requirement_id, [])
+        if not preferences or selected_ids.intersection(preferences):
+            continue
+
+        eligible_ids = [
+            capability_id
+            for capability_id in preferences
+            if candidate_is_eligible(capability_id)
+        ]
+        if not eligible_ids:
+            continue
+
+        requirement_inputs = [
+            str(value or '').strip()
+            for value in (requirement.get('required_inputs') or [])
+            if str(value or '').strip()
+        ]
+        if requirement_inputs and requirement_id == 'multi_document_comparison':
+            continue
+
+        requirement_ids.append(requirement_id)
+        reason_code = _bounded_reason(requirement.get('reason_code'))
+        if reason_code and reason_code not in reason_codes:
+            reason_codes.append(reason_code)
+        for input_requirement in requirement_inputs:
+            if input_requirement not in required_inputs:
+                required_inputs.append(input_requirement)
+        for capability_id in eligible_ids:
+            if capability_id not in option_ids:
+                option_ids.append(capability_id)
+
+    if not option_ids:
+        return None
+
+    options = []
+    for capability_id in option_ids:
+        entry = entries_by_id[capability_id]
+        option = {
+            'id': capability_id,
+            'capability_ids': [capability_id],
+            'label': entry['label'],
+            'latency_class': entry['latency_class'],
+            'cost_class': entry['cost_class'],
+            'external_data': entry['external_data'],
+            'requires_user_choice': entry['requires_user_choice'],
+        }
+        if entry.get('bundle'):
+            option['effective_capability_ids'] = list(entry['bundle'])
+        options.append(option)
+
+    options.append({
+        'id': CONTINUE_WITHOUT_CAPABILITIES_OPTION_ID,
+        'capability_ids': [],
+        'label': 'Continue without additional capabilities',
+        'latency_class': 'immediate',
+        'cost_class': 'none',
+        'external_data': False,
+        'requires_user_choice': True,
+    })
+
+    return {
+        'version': CAPABILITY_RECOMMENDATION_VERSION,
+        'status': 'pending',
+        'requirement_ids': requirement_ids,
+        'reason_codes': reason_codes,
+        'recommended_option_id': option_ids[0],
+        'options': options,
+        'required_inputs': required_inputs,
+    }
+
+
+def match_governed_capabilities(inventory, requirements):
+    """Separate policy-approved automatic discovery from user-choice recommendations."""
+    inventory_entries = (
+        inventory.get('capabilities')
+        if isinstance(inventory, Mapping)
+        else None
+    )
+    if not isinstance(inventory_entries, list):
+        return {
+            'auto_capability_ids': [],
+            'recommendation': None,
+        }
+
+    automatic_ids = []
+    for requirement in requirements or []:
+        if not isinstance(requirement, Mapping):
+            continue
+        requirement_id = str(requirement.get('id') or '').strip()
+        for capability_id in REQUIREMENT_CAPABILITY_PREFERENCES.get(requirement_id, []):
+            entry = next(
+                (
+                    capability
+                    for capability in inventory_entries
+                    if isinstance(capability, Mapping)
+                    and capability.get('id') == capability_id
+                ),
+                None,
+            )
+            if entry and entry.get('auto_use_allowed') is True:
+                if capability_id not in automatic_ids:
+                    automatic_ids.append(capability_id)
+                break
+
+    recommendation_inventory = {
+        'version': inventory.get('version'),
+        'capabilities': [
+            dict(entry)
+            for entry in inventory_entries
+            if not isinstance(entry, Mapping)
+            or entry.get('id') not in automatic_ids
+        ],
+    }
+    return {
+        'auto_capability_ids': automatic_ids,
+        'recommendation': build_capability_recommendation(
+            recommendation_inventory,
+            requirements,
+        ),
+    }

--- a/application/single_app/functions_chat_capability_choices.py
+++ b/application/single_app/functions_chat_capability_choices.py
@@ -1,0 +1,527 @@
+# functions_chat_capability_choices.py
+"""Durable capability proposal, decision, and resume contracts."""
+
+import copy
+import re
+import uuid
+from collections.abc import Mapping
+from datetime import datetime, timedelta, timezone
+
+from functions_chat_capabilities import CONTINUE_WITHOUT_CAPABILITIES_OPTION_ID
+
+
+CAPABILITY_CHOICE_VERSION = 1
+CAPABILITY_PROVENANCE_VERSION = 1
+DEFAULT_CAPABILITY_CHOICE_TTL_SECONDS = 86400
+MAX_CAPABILITY_CHOICE_TTL_SECONDS = 604800
+CAPABILITY_RESUME_LEASE_SECONDS = 1800
+CAPABILITY_PROPOSAL_STATUSES = {
+    'pending',
+    'approved',
+    'declined',
+    'expired',
+    'invalidated',
+}
+CAPABILITY_RESUME_STATUSES = {
+    'not_requested',
+    'pending',
+    'running',
+    'completed',
+    'failed',
+}
+STREET_ADDRESS_PATTERN = re.compile(
+    r'\b\d{1,6}\s+(?:[A-Za-z0-9][A-Za-z0-9.\'-]*\s+){0,6}'
+    r'(?:Street|St|Road|Rd|Avenue|Ave|Boulevard|Blvd|Lane|Ln|Drive|Dr|Court|Ct|Way|'
+    r'Place|Pl|Parkway|Pkwy)\b(?:\s*,\s*[A-Za-z .\'-]+)?(?:\s+[A-Z]{2})?(?:\s+\d{5}(?:-\d{4})?)?',
+    re.IGNORECASE,
+)
+EMAIL_PATTERN = re.compile(r'\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b', re.IGNORECASE)
+PHONE_PATTERN = re.compile(r'(?<!\d)(?:\+?1[ .-]?)?\(?\d{3}\)?[ .-]\d{3}[ .-]\d{4}(?!\d)')
+ACCOUNT_IDENTIFIER_PATTERN = re.compile(
+    r'\b(?:account|parcel|customer|member|case)\s*(?:id|number|no\.?|#)\s*[:#-]?\s*[A-Z0-9-]{4,}\b',
+    re.IGNORECASE,
+)
+PARCEL_LOOKUP_PATTERN = re.compile(
+    r'\b(?:parcel|property\s+(?:record|records|assessment|assessor)|tax\s+record|this\s+address|'
+    r'at\s+the\s+(?:property|address))\b',
+    re.IGNORECASE,
+)
+
+
+class CapabilityChoiceError(ValueError):
+    """Raised when a capability proposal or decision is invalid."""
+
+    def __init__(self, message, *, code='invalid_capability_choice'):
+        super().__init__(message)
+        self.code = code
+
+
+def _utc_now():
+    return datetime.now(timezone.utc)
+
+
+def _parse_timestamp(value):
+    normalized = str(value or '').strip()
+    if not normalized:
+        return None
+    try:
+        parsed = datetime.fromisoformat(normalized.replace('Z', '+00:00'))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _normalize_identifier(value, field_name):
+    normalized = str(value or '').strip()
+    if not normalized or len(normalized) > 200:
+        raise CapabilityChoiceError(f'{field_name} is required', code=f'invalid_{field_name}')
+    return normalized
+
+
+def _normalize_identifiers(values, *, max_items=16):
+    if values is None:
+        return []
+    if isinstance(values, str):
+        values = [values]
+    normalized = []
+    for value in values:
+        identifier = str(value or '').strip()
+        if not identifier or len(identifier) > 200 or identifier in normalized:
+            continue
+        normalized.append(identifier)
+        if len(normalized) >= max_items:
+            break
+    return normalized
+
+
+def _normalize_options(options):
+    normalized_options = []
+    seen_option_ids = set()
+    for raw_option in options or []:
+        if not isinstance(raw_option, Mapping):
+            continue
+        option_id = _normalize_identifier(raw_option.get('id'), 'option_id')
+        if option_id in seen_option_ids:
+            raise CapabilityChoiceError('proposal option IDs must be unique', code='duplicate_option_id')
+        seen_option_ids.add(option_id)
+        capability_ids = _normalize_identifiers(raw_option.get('capability_ids'), max_items=8)
+        effective_ids = _normalize_identifiers(
+            raw_option.get('effective_capability_ids') or capability_ids,
+            max_items=8,
+        )
+        if option_id == CONTINUE_WITHOUT_CAPABILITIES_OPTION_ID:
+            capability_ids = []
+            effective_ids = []
+        elif not capability_ids:
+            raise CapabilityChoiceError(
+                'capability options must name at least one capability',
+                code='missing_option_capability',
+            )
+        normalized_options.append({
+            'id': option_id,
+            'capability_ids': capability_ids,
+            'effective_capability_ids': effective_ids,
+            'label': ' '.join(str(raw_option.get('label') or option_id).split())[:120],
+            'latency_class': str(raw_option.get('latency_class') or 'unknown').strip()[:40],
+            'cost_class': str(raw_option.get('cost_class') or 'unknown').strip()[:40],
+            'external_data': bool(raw_option.get('external_data')),
+            'requires_user_choice': True,
+            'external_query_mode': str(
+                raw_option.get('external_query_mode') or 'minimized'
+            ).strip().lower()[:40],
+            'sensitive_input_types': _normalize_identifiers(
+                raw_option.get('sensitive_input_types'),
+                max_items=8,
+            ),
+        })
+    if not normalized_options:
+        raise CapabilityChoiceError('proposal options are required', code='missing_options')
+    return normalized_options
+
+
+def build_minimized_external_query(user_message, *, include_sensitive_inputs=False):
+    """Build a current-message-only query while omitting unnecessary personal data."""
+    query = ' '.join(str(user_message or '').split())
+    omitted_types = []
+    replacements = (
+        (STREET_ADDRESS_PATTERN, 'street_address'),
+        (EMAIL_PATTERN, 'email_address'),
+        (PHONE_PATTERN, 'phone_number'),
+        (ACCOUNT_IDENTIFIER_PATTERN, 'account_identifier'),
+    )
+    if not include_sensitive_inputs:
+        for pattern, sensitive_type in replacements:
+            if pattern.search(query):
+                query = pattern.sub(' ', query)
+                omitted_types.append(sensitive_type)
+    query = re.sub(r'\s+([,.;:!?])', r'\1', query)
+    query = re.sub(r'\s{2,}', ' ', query).strip(' ,;:-')
+    return {
+        'query': query[:1000],
+        'source': 'current_message_only',
+        'omitted_sensitive_input_types': omitted_types,
+        'parcel_specific': bool(PARCEL_LOOKUP_PATTERN.search(str(user_message or ''))),
+        'conversation_history_included': False,
+        'workspace_content_included': False,
+    }
+
+
+def add_sensitive_external_query_options(recommendation, user_message):
+    """Add explicit address-bearing alternatives only for parcel-specific requests."""
+    if not isinstance(recommendation, Mapping):
+        return recommendation
+    minimized_query = build_minimized_external_query(user_message)
+    if (
+        not minimized_query['parcel_specific']
+        or 'street_address' not in minimized_query['omitted_sensitive_input_types']
+    ):
+        return copy.deepcopy(dict(recommendation))
+
+    updated = copy.deepcopy(dict(recommendation))
+    updated_options = []
+    sensitive_recommended_option_id = None
+    for option in updated.get('options') or []:
+        if not isinstance(option, Mapping):
+            continue
+        normalized_option = dict(option)
+        if normalized_option.get('external_data') and normalized_option.get('capability_ids'):
+            normalized_option['external_query_mode'] = 'minimized'
+            updated_options.append(normalized_option)
+            sensitive_option = dict(normalized_option)
+            sensitive_option['id'] = f"{normalized_option['id']}_with_sensitive_inputs"
+            sensitive_option['label'] = f"{normalized_option.get('label') or 'Search'} with supplied address"
+            sensitive_option['external_query_mode'] = 'include_approved_sensitive_inputs'
+            sensitive_option['sensitive_input_types'] = ['street_address']
+            updated_options.append(sensitive_option)
+            if normalized_option.get('id') == updated.get('recommended_option_id'):
+                sensitive_recommended_option_id = sensitive_option['id']
+        else:
+            updated_options.append(normalized_option)
+    updated['options'] = updated_options
+    if sensitive_recommended_option_id:
+        updated['recommended_option_id'] = sensitive_recommended_option_id
+    updated['sensitive_data_notice_required'] = True
+    return updated
+
+
+def build_capability_choice_proposal(
+    recommendation,
+    *,
+    run_id,
+    conversation_id,
+    user_message_id,
+    assistant_message_id=None,
+    now=None,
+    ttl_seconds=DEFAULT_CAPABILITY_CHOICE_TTL_SECONDS,
+):
+    """Create one bounded, durable proposal linked to an exact user turn."""
+    if not isinstance(recommendation, Mapping):
+        raise CapabilityChoiceError('recommendation is required', code='missing_recommendation')
+    current_time = now or _utc_now()
+    if current_time.tzinfo is None:
+        current_time = current_time.replace(tzinfo=timezone.utc)
+    try:
+        normalized_ttl = int(ttl_seconds)
+    except (TypeError, ValueError):
+        normalized_ttl = DEFAULT_CAPABILITY_CHOICE_TTL_SECONDS
+    normalized_ttl = max(60, min(normalized_ttl, MAX_CAPABILITY_CHOICE_TTL_SECONDS))
+    proposal_id = str(assistant_message_id or uuid.uuid4())
+    options = _normalize_options(recommendation.get('options'))
+    option_ids = {option['id'] for option in options}
+    recommended_option_id = _normalize_identifier(
+        recommendation.get('recommended_option_id'),
+        'recommended_option_id',
+    )
+    if recommended_option_id not in option_ids:
+        raise CapabilityChoiceError(
+            'recommended option must be allowlisted',
+            code='invalid_recommended_option',
+        )
+    return {
+        'version': CAPABILITY_CHOICE_VERSION,
+        'proposal_id': proposal_id,
+        'run_id': _normalize_identifier(run_id, 'run_id'),
+        'conversation_id': _normalize_identifier(conversation_id, 'conversation_id'),
+        'user_message_id': _normalize_identifier(user_message_id, 'user_message_id'),
+        'assistant_message_id': proposal_id,
+        'status': 'pending',
+        'requirement_ids': _normalize_identifiers(recommendation.get('requirement_ids')),
+        'reason_codes': _normalize_identifiers(recommendation.get('reason_codes')),
+        'recommended_option_id': recommended_option_id,
+        'options': options,
+        'created_at': current_time.isoformat(),
+        'expires_at': (current_time + timedelta(seconds=normalized_ttl)).isoformat(),
+        'decision': None,
+        'resume': {
+            'status': 'not_requested',
+            'execution_id': None,
+            'child_run_id': None,
+            'assistant_message_id': None,
+            'claimed_at': None,
+            'lease_expires_at': None,
+            'completed_at': None,
+            'error_type': None,
+        },
+    }
+
+
+def get_capability_choice_option(proposal, option_id):
+    normalized_option_id = str(option_id or '').strip()
+    return next(
+        (
+            dict(option)
+            for option in (proposal.get('options') or [])
+            if isinstance(option, Mapping) and option.get('id') == normalized_option_id
+        ),
+        None,
+    )
+
+
+def capability_choice_is_expired(proposal, *, now=None):
+    current_time = now or _utc_now()
+    if current_time.tzinfo is None:
+        current_time = current_time.replace(tzinfo=timezone.utc)
+    expires_at = _parse_timestamp(proposal.get('expires_at'))
+    return expires_at is None or current_time >= expires_at
+
+
+def apply_capability_choice_decision(proposal, option_id, *, actor_user_id, now=None):
+    """Apply an allowlisted decision once and return an idempotent replay thereafter."""
+    if not isinstance(proposal, Mapping):
+        raise CapabilityChoiceError('proposal is required', code='invalid_proposal')
+    updated = copy.deepcopy(dict(proposal))
+    current_time = now or _utc_now()
+    if current_time.tzinfo is None:
+        current_time = current_time.replace(tzinfo=timezone.utc)
+    normalized_option_id = _normalize_identifier(option_id, 'option_id')
+    actor_user_id = _normalize_identifier(actor_user_id, 'actor_user_id')
+    existing_decision = updated.get('decision') if isinstance(updated.get('decision'), Mapping) else None
+    if existing_decision:
+        if existing_decision.get('option_id') != normalized_option_id:
+            raise CapabilityChoiceError(
+                'this proposal already has a different decision',
+                code='decision_conflict',
+            )
+        return updated, True
+
+    status = str(updated.get('status') or '').strip().lower()
+    if status != 'pending':
+        raise CapabilityChoiceError(
+            'this capability proposal is no longer pending',
+            code=f'proposal_{status or "invalid"}',
+        )
+    if capability_choice_is_expired(updated, now=current_time):
+        updated['status'] = 'expired'
+        raise CapabilityChoiceError('this capability proposal has expired', code='proposal_expired')
+
+    option = get_capability_choice_option(updated, normalized_option_id)
+    if option is None:
+        raise CapabilityChoiceError(
+            'option_id is not valid for this proposal',
+            code='option_not_allowlisted',
+        )
+    capability_ids = list(option.get('capability_ids') or [])
+    decision_status = 'declined' if not capability_ids else 'approved'
+    updated['status'] = decision_status
+    updated['decision'] = {
+        'option_id': normalized_option_id,
+        'status': decision_status,
+        'capability_ids': capability_ids,
+        'effective_capability_ids': list(option.get('effective_capability_ids') or capability_ids),
+        'external_query_mode': option.get('external_query_mode') or 'minimized',
+        'sensitive_input_types': list(option.get('sensitive_input_types') or []),
+        'actor_user_id': actor_user_id,
+        'decided_at': current_time.isoformat(),
+    }
+    updated['resume'] = {
+        'status': 'pending',
+        'execution_id': None,
+        'child_run_id': None,
+        'assistant_message_id': None,
+        'claimed_at': None,
+        'lease_expires_at': None,
+        'completed_at': None,
+        'error_type': None,
+    }
+    return updated, False
+
+
+def revalidate_capability_choice(proposal, inventory):
+    """Reject approved capabilities that are no longer offerable at resume time."""
+    decision = proposal.get('decision') if isinstance(proposal, Mapping) else None
+    if not isinstance(decision, Mapping):
+        raise CapabilityChoiceError('proposal has no decision', code='decision_missing')
+    if decision.get('status') == 'declined':
+        return True
+    inventory_entries = (
+        inventory.get('capabilities')
+        if isinstance(inventory, Mapping)
+        else None
+    )
+    entries_by_id = {
+        entry.get('id'): entry
+        for entry in (inventory_entries or [])
+        if isinstance(entry, Mapping) and entry.get('id')
+    }
+    approved_capability_ids = set(decision.get('capability_ids') or [])
+    effective_capability_ids = set(
+        decision.get('effective_capability_ids') or approved_capability_ids
+    )
+    for capability_id in effective_capability_ids:
+        entry = entries_by_id.get(capability_id)
+        if not entry:
+            raise CapabilityChoiceError(
+                'an approved capability is no longer in the governed inventory',
+                code='capability_missing',
+            )
+        if entry.get('state') not in {'selected', 'unselected'}:
+            raise CapabilityChoiceError(
+                'an approved capability is no longer available or authorized',
+                code=f"capability_{entry.get('state') or 'invalid'}",
+            )
+        if (
+            capability_id in approved_capability_ids
+            and entry.get('state') == 'unselected'
+            and entry.get('discoverable') is not True
+        ):
+            raise CapabilityChoiceError(
+                'an approved capability is no longer discoverable',
+                code='capability_policy_blocked',
+            )
+    return True
+
+
+def claim_capability_choice_resume(proposal, *, now=None, execution_id=None, child_run_id=None):
+    """Claim one resume execution while allowing idempotent completed replays."""
+    updated = copy.deepcopy(dict(proposal))
+    current_time = now or _utc_now()
+    if current_time.tzinfo is None:
+        current_time = current_time.replace(tzinfo=timezone.utc)
+    proposal_status = str(updated.get('status') or '').strip().lower()
+    if proposal_status not in {'approved', 'declined'}:
+        raise CapabilityChoiceError(
+            'this capability proposal cannot be resumed',
+            code=f'proposal_{proposal_status or "invalid"}',
+        )
+    resume = updated.get('resume') if isinstance(updated.get('resume'), Mapping) else {}
+    resume_status = str(resume.get('status') or 'not_requested').strip().lower()
+    if resume_status == 'completed':
+        return updated, True
+    if resume_status == 'running':
+        lease_expires_at = _parse_timestamp(resume.get('lease_expires_at'))
+        if lease_expires_at and current_time < lease_expires_at:
+            raise CapabilityChoiceError(
+                'this capability decision is already being resumed',
+                code='resume_in_progress',
+            )
+    if resume_status not in {'pending', 'failed', 'running'}:
+        raise CapabilityChoiceError(
+            'this capability decision is not ready to resume',
+            code='resume_not_ready',
+        )
+    execution_id = str(execution_id or uuid.uuid4())
+    child_run_id = str(child_run_id or uuid.uuid4())
+    updated['resume'] = {
+        'status': 'running',
+        'execution_id': execution_id,
+        'child_run_id': child_run_id,
+        'assistant_message_id': None,
+        'claimed_at': current_time.isoformat(),
+        'lease_expires_at': (
+            current_time + timedelta(seconds=CAPABILITY_RESUME_LEASE_SECONDS)
+        ).isoformat(),
+        'completed_at': None,
+        'error_type': None,
+    }
+    return updated, False
+
+
+def complete_capability_choice_resume(
+    proposal,
+    *,
+    execution_id,
+    assistant_message_id,
+    now=None,
+):
+    """Mark the exact claimed resume execution complete."""
+    updated = copy.deepcopy(dict(proposal))
+    resume = updated.get('resume') if isinstance(updated.get('resume'), Mapping) else {}
+    if resume.get('status') == 'completed':
+        if resume.get('assistant_message_id') == assistant_message_id:
+            return updated, True
+        raise CapabilityChoiceError('resume already completed', code='resume_completed')
+    if resume.get('status') != 'running' or resume.get('execution_id') != execution_id:
+        raise CapabilityChoiceError('resume claim does not match', code='resume_claim_mismatch')
+    current_time = now or _utc_now()
+    if current_time.tzinfo is None:
+        current_time = current_time.replace(tzinfo=timezone.utc)
+    updated['resume'] = {
+        **dict(resume),
+        'status': 'completed',
+        'assistant_message_id': _normalize_identifier(
+            assistant_message_id,
+            'assistant_message_id',
+        ),
+        'completed_at': current_time.isoformat(),
+        'lease_expires_at': None,
+        'error_type': None,
+    }
+    return updated, False
+
+
+def fail_capability_choice_resume(proposal, *, execution_id, error_type, now=None):
+    """Release the exact resume claim for an authorized retry after failure."""
+    updated = copy.deepcopy(dict(proposal))
+    resume = updated.get('resume') if isinstance(updated.get('resume'), Mapping) else {}
+    if resume.get('status') != 'running' or resume.get('execution_id') != execution_id:
+        return updated, True
+    current_time = now or _utc_now()
+    if current_time.tzinfo is None:
+        current_time = current_time.replace(tzinfo=timezone.utc)
+    updated['resume'] = {
+        **dict(resume),
+        'status': 'failed',
+        'lease_expires_at': None,
+        'completed_at': current_time.isoformat(),
+        'error_type': re.sub(
+            r'[^a-z0-9_]+',
+            '_',
+            str(error_type or 'resume_failed').strip().lower(),
+        )[:120],
+    }
+    return updated, False
+
+
+def build_capability_provenance(
+    *,
+    selection_snapshot,
+    capability_inventory,
+    proposal=None,
+    decisions=None,
+    effective_capabilities=None,
+):
+    """Keep submitted, proposed, decided, and effective capability facts separate."""
+    return {
+        'version': CAPABILITY_PROVENANCE_VERSION,
+        'selection_snapshot': copy.deepcopy(dict(selection_snapshot or {})),
+        'capability_inventory': copy.deepcopy(dict(capability_inventory or {})),
+        'proposed_capabilities': (
+            copy.deepcopy(dict(proposal)) if isinstance(proposal, Mapping) else None
+        ),
+        'capability_decisions': [
+            copy.deepcopy(dict(decision))
+            for decision in (decisions or [])
+            if isinstance(decision, Mapping)
+        ],
+        'effective_capabilities': [
+            {
+                'id': str(item.get('id') or '').strip(),
+                'origin': str(item.get('origin') or '').strip(),
+                'required': bool(item.get('required', True)),
+            }
+            for item in (effective_capabilities or [])
+            if isinstance(item, Mapping) and str(item.get('id') or '').strip()
+        ],
+    }

--- a/application/single_app/functions_chat_capability_persistence.py
+++ b/application/single_app/functions_chat_capability_persistence.py
@@ -1,0 +1,339 @@
+# functions_chat_capability_persistence.py
+"""Conditional persistence helpers for durable chat capability choices."""
+
+import copy
+from collections.abc import Mapping
+from datetime import datetime, timezone
+
+from azure.core import MatchConditions
+
+from functions_chat_capability_choices import (
+    CapabilityChoiceError,
+    apply_capability_choice_decision,
+    capability_choice_is_expired,
+    claim_capability_choice_resume,
+    complete_capability_choice_resume,
+    fail_capability_choice_resume,
+    revalidate_capability_choice,
+)
+
+
+CAPABILITY_PROPOSAL_METADATA_KEY = 'capability_proposal'
+CAPABILITY_PROVENANCE_METADATA_KEY = 'capability_provenance'
+MAX_CONDITIONAL_WRITE_ATTEMPTS = 3
+
+
+def _normalize_identifier(value, field_name):
+    normalized = str(value or '').strip()
+    if not normalized or len(normalized) > 200:
+        raise CapabilityChoiceError(f'{field_name} is required', code=f'invalid_{field_name}')
+    return normalized
+
+
+def read_capability_proposal_message(container, *, conversation_id, proposal_id):
+    """Read and validate an exact assistant proposal from its conversation partition."""
+    conversation_id = _normalize_identifier(conversation_id, 'conversation_id')
+    proposal_id = _normalize_identifier(proposal_id, 'proposal_id')
+    message = container.read_item(item=proposal_id, partition_key=conversation_id)
+    if message.get('conversation_id') != conversation_id:
+        raise CapabilityChoiceError(
+            'proposal does not belong to this conversation',
+            code='proposal_conversation_mismatch',
+        )
+    if message.get('role') != 'assistant':
+        raise CapabilityChoiceError(
+            'capability proposal must be an assistant message',
+            code='proposal_role_invalid',
+        )
+    metadata = message.get('metadata') if isinstance(message.get('metadata'), Mapping) else {}
+    proposal = metadata.get(CAPABILITY_PROPOSAL_METADATA_KEY)
+    if not isinstance(proposal, Mapping):
+        raise CapabilityChoiceError(
+            'capability proposal metadata is missing',
+            code='proposal_metadata_missing',
+        )
+    if proposal.get('proposal_id') != proposal_id:
+        raise CapabilityChoiceError(
+            'proposal identifier does not match the stored message',
+            code='proposal_id_mismatch',
+        )
+    if proposal.get('conversation_id') != conversation_id:
+        raise CapabilityChoiceError(
+            'stored proposal conversation does not match',
+            code='proposal_conversation_mismatch',
+        )
+    return message, copy.deepcopy(dict(proposal))
+
+
+def _replace_proposal_message(container, message, proposal):
+    updated_message = copy.deepcopy(dict(message))
+    updated_metadata = (
+        copy.deepcopy(dict(updated_message.get('metadata')))
+        if isinstance(updated_message.get('metadata'), Mapping)
+        else {}
+    )
+    updated_metadata[CAPABILITY_PROPOSAL_METADATA_KEY] = copy.deepcopy(dict(proposal))
+    provenance = updated_metadata.get(CAPABILITY_PROVENANCE_METADATA_KEY)
+    if isinstance(provenance, Mapping):
+        updated_provenance = copy.deepcopy(dict(provenance))
+        if not isinstance(updated_provenance.get('proposed_capabilities'), Mapping):
+            updated_provenance['proposed_capabilities'] = copy.deepcopy(dict(proposal))
+        decision = proposal.get('decision')
+        updated_provenance['capability_decisions'] = (
+            [copy.deepcopy(dict(decision))]
+            if isinstance(decision, Mapping)
+            else []
+        )
+        updated_metadata[CAPABILITY_PROVENANCE_METADATA_KEY] = updated_provenance
+    updated_message['metadata'] = updated_metadata
+    return container.replace_item(
+        item=updated_message['id'],
+        body=updated_message,
+        etag=message.get('_etag'),
+        match_condition=MatchConditions.IfNotModified,
+    )
+
+
+def _is_conditional_conflict(exc):
+    return getattr(exc, 'status_code', None) in {409, 412}
+
+
+def persist_capability_decision(
+    container,
+    *,
+    conversation_id,
+    proposal_id,
+    option_id,
+    actor_user_id,
+    refreshed_inventory,
+    now=None,
+):
+    """Persist one allowlisted decision using optimistic concurrency."""
+    last_conflict = None
+    for _ in range(MAX_CONDITIONAL_WRITE_ATTEMPTS):
+        message, proposal = read_capability_proposal_message(
+            container,
+            conversation_id=conversation_id,
+            proposal_id=proposal_id,
+        )
+        if proposal.get('status') == 'pending' and capability_choice_is_expired(proposal, now=now):
+            expired_proposal = copy.deepcopy(proposal)
+            expired_proposal['status'] = 'expired'
+            expired_proposal['invalidated_at'] = _transition_timestamp(now)
+            expired_proposal['invalidation_reason'] = 'proposal_expired'
+            try:
+                _replace_proposal_message(container, message, expired_proposal)
+            except Exception as exc:
+                if _is_conditional_conflict(exc):
+                    last_conflict = exc
+                    continue
+                raise
+            raise CapabilityChoiceError(
+                'this capability proposal has expired',
+                code='proposal_expired',
+            )
+        updated, idempotent = apply_capability_choice_decision(
+            proposal,
+            option_id,
+            actor_user_id=actor_user_id,
+            now=now,
+        )
+        try:
+            revalidate_capability_choice(updated, refreshed_inventory)
+        except CapabilityChoiceError as validation_error:
+            invalidated = _build_invalidated_proposal(updated, validation_error.code, now=now)
+            try:
+                _replace_proposal_message(container, message, invalidated)
+            except Exception as exc:
+                if _is_conditional_conflict(exc):
+                    last_conflict = exc
+                    continue
+                raise
+            raise
+        if idempotent:
+            return message, updated, True
+        try:
+            saved_message = _replace_proposal_message(container, message, updated)
+            return saved_message, updated, False
+        except Exception as exc:
+            if not _is_conditional_conflict(exc):
+                raise
+            last_conflict = exc
+    raise CapabilityChoiceError(
+        'the capability proposal changed while the decision was being saved',
+        code='decision_write_conflict',
+    ) from last_conflict
+
+
+def persist_capability_resume_claim(
+    container,
+    *,
+    conversation_id,
+    proposal_id,
+    refreshed_inventory,
+    now=None,
+    execution_id=None,
+    child_run_id=None,
+):
+    """Revalidate and conditionally claim one resume execution."""
+    last_conflict = None
+    for _ in range(MAX_CONDITIONAL_WRITE_ATTEMPTS):
+        message, proposal = read_capability_proposal_message(
+            container,
+            conversation_id=conversation_id,
+            proposal_id=proposal_id,
+        )
+        resume_state = proposal.get('resume') if isinstance(proposal.get('resume'), Mapping) else {}
+        if (
+            resume_state.get('status') != 'completed'
+            and capability_choice_is_expired(proposal, now=now)
+        ):
+            invalidated = _build_invalidated_proposal(proposal, 'proposal_expired', now=now)
+            try:
+                _replace_proposal_message(container, message, invalidated)
+            except Exception as exc:
+                if _is_conditional_conflict(exc):
+                    last_conflict = exc
+                    continue
+                raise
+            raise CapabilityChoiceError(
+                'this capability proposal has expired',
+                code='proposal_expired',
+            )
+        try:
+            revalidate_capability_choice(proposal, refreshed_inventory)
+        except CapabilityChoiceError as validation_error:
+            invalidated = _build_invalidated_proposal(proposal, validation_error.code, now=now)
+            try:
+                _replace_proposal_message(container, message, invalidated)
+            except Exception as exc:
+                if _is_conditional_conflict(exc):
+                    last_conflict = exc
+                    continue
+                raise
+            raise
+        updated, idempotent = claim_capability_choice_resume(
+            proposal,
+            now=now,
+            execution_id=execution_id,
+            child_run_id=child_run_id,
+        )
+        if idempotent:
+            return message, updated, True
+        try:
+            saved_message = _replace_proposal_message(container, message, updated)
+            return saved_message, updated, False
+        except Exception as exc:
+            if not _is_conditional_conflict(exc):
+                raise
+            last_conflict = exc
+    raise CapabilityChoiceError(
+        'the capability proposal changed while resume was being claimed',
+        code='resume_write_conflict',
+    ) from last_conflict
+
+
+def persist_capability_resume_completion(
+    container,
+    *,
+    conversation_id,
+    proposal_id,
+    execution_id,
+    assistant_message_id,
+    now=None,
+):
+    """Conditionally mark the exact claimed resume execution complete."""
+    return _persist_resume_transition(
+        container,
+        conversation_id=conversation_id,
+        proposal_id=proposal_id,
+        transition=lambda proposal: complete_capability_choice_resume(
+            proposal,
+            execution_id=execution_id,
+            assistant_message_id=assistant_message_id,
+            now=now,
+        ),
+        conflict_code='resume_completion_write_conflict',
+    )
+
+
+def persist_capability_resume_failure(
+    container,
+    *,
+    conversation_id,
+    proposal_id,
+    execution_id,
+    error_type,
+    now=None,
+):
+    """Conditionally release the exact failed resume execution for retry."""
+    return _persist_resume_transition(
+        container,
+        conversation_id=conversation_id,
+        proposal_id=proposal_id,
+        transition=lambda proposal: fail_capability_choice_resume(
+            proposal,
+            execution_id=execution_id,
+            error_type=error_type,
+            now=now,
+        ),
+        conflict_code='resume_failure_write_conflict',
+    )
+
+
+def _persist_resume_transition(
+    container,
+    *,
+    conversation_id,
+    proposal_id,
+    transition,
+    conflict_code,
+):
+    last_conflict = None
+    for _ in range(MAX_CONDITIONAL_WRITE_ATTEMPTS):
+        message, proposal = read_capability_proposal_message(
+            container,
+            conversation_id=conversation_id,
+            proposal_id=proposal_id,
+        )
+        updated, idempotent = transition(proposal)
+        if idempotent:
+            return message, updated, True
+        try:
+            saved_message = _replace_proposal_message(container, message, updated)
+            return saved_message, updated, False
+        except Exception as exc:
+            if not _is_conditional_conflict(exc):
+                raise
+            last_conflict = exc
+    raise CapabilityChoiceError(
+        'the capability proposal changed while resume state was being saved',
+        code=conflict_code,
+    ) from last_conflict
+
+
+def _transition_timestamp(now=None):
+    current_time = now or datetime.now(timezone.utc)
+    if current_time.tzinfo is None:
+        current_time = current_time.replace(tzinfo=timezone.utc)
+    return current_time.astimezone(timezone.utc).isoformat()
+
+
+def _build_invalidated_proposal(proposal, reason, *, now=None):
+    invalidated = copy.deepcopy(dict(proposal))
+    invalidated['status'] = 'invalidated'
+    invalidated['invalidated_at'] = _transition_timestamp(now)
+    invalidated['invalidation_reason'] = str(reason or 'capability_invalidated').strip()[:120]
+    decision = invalidated.get('decision')
+    if isinstance(decision, Mapping):
+        invalidated_decision = copy.deepcopy(dict(decision))
+        invalidated_decision['status'] = 'invalidated'
+        invalidated['decision'] = invalidated_decision
+    resume = invalidated.get('resume')
+    if isinstance(resume, Mapping):
+        invalidated_resume = copy.deepcopy(dict(resume))
+        invalidated_resume['status'] = 'failed'
+        invalidated_resume['lease_expires_at'] = None
+        invalidated_resume['error_type'] = invalidated['invalidation_reason']
+        invalidated['resume'] = invalidated_resume
+    return invalidated

--- a/application/single_app/functions_chat_orchestration.py
+++ b/application/single_app/functions_chat_orchestration.py
@@ -1,6 +1,7 @@
 # functions_chat_orchestration.py
 """Deterministic Phase 1 planning helpers for coordinated chat turns."""
 
+import copy
 import re
 import uuid
 from collections.abc import Mapping
@@ -252,6 +253,9 @@ def build_turn_orchestration_plan(
     model_provider=None,
     reasoning_effort=None,
     prompt_info=None,
+    capability_origins=None,
+    selection_snapshot_override=None,
+    parent_run_id=None,
 ):
     """Build a JSON-serializable, immutable-by-convention plan snapshot for one turn."""
     selected_document_ids = _normalize_ids(selected_document_ids)
@@ -263,28 +267,46 @@ def build_turn_orchestration_plan(
     selected_action_type = _selected_action_type(selected_action)
     selected_prompt_id = _selected_prompt_identifier(prompt_info)
     selected_image_reference_count = _nonnegative_int(selected_image_reference_count)
+    capability_origins = capability_origins if isinstance(capability_origins, Mapping) else {}
     selected_sources = []
+
+    def capability_origin(capability_id):
+        origin = str(capability_origins.get(capability_id) or 'selection').strip().lower()
+        if origin not in {'selection', 'discovery_auto', 'discovery_approved'}:
+            return 'selection'
+        return origin
 
     if selected_agent_id:
         selected_sources.append(_build_source('selected_agent', 'selection', {'agent_id': selected_agent_id}))
     if selected_action_type and selected_action_type != 'none':
+        selected_action_capability = (
+            'compare'
+            if selected_action_type in {'compare', 'comparison'}
+            else 'analyze'
+            if selected_action_type == 'analyze'
+            else 'selected_action'
+        )
         selected_sources.append(
-            _build_source('selected_action', 'selection', {'action_type': selected_action_type})
+            _build_source(
+                'selected_action',
+                capability_origin(selected_action_capability),
+                {'action_type': selected_action_type},
+            )
         )
     if selected_document_ids:
         selected_sources.append(
             _build_source('selected_documents', 'selection', {'count': len(selected_document_ids)})
         )
     if _coerce_bool(hybrid_search_enabled):
-        selected_sources.append(_build_source('workspace_search', 'selection'))
+        selected_sources.append(_build_source('workspace_search', capability_origin('workspace_search')))
     if _coerce_bool(web_search_enabled):
-        selected_sources.append(_build_source('web_search', 'selection'))
+        selected_sources.append(_build_source('web_search', capability_origin('web_search')))
     if _coerce_bool(url_access_enabled):
-        selected_sources.append(_build_source('url_access', 'selection'))
+        selected_sources.append(_build_source('url_access', capability_origin('url_access')))
     if _coerce_bool(source_review_enabled) and not _coerce_bool(deep_research_enabled):
-        selected_sources.append(_build_source('source_review', 'selection'))
+        selected_sources.append(_build_source('source_review', capability_origin('url_access')))
     if _coerce_bool(deep_research_enabled):
-        selected_sources.append(_build_source('deep_research', 'selection'))
+        selected_sources.append(_build_source('deep_research', capability_origin('deep_research')))
     if _coerce_bool(user_workspace_context_enabled):
         selected_sources.append(_build_source('user_workspace_context', 'selection'))
     if selected_image_reference_count:
@@ -298,7 +320,12 @@ def build_turn_orchestration_plan(
 
     requested_source_types = detect_requested_evidence_sources(user_message)
     grounding_language_detected = bool(GROUNDING_REQUEST_PATTERN.search(str(user_message or '')))
-    selected_source_types = [source['id'] for source in selected_sources]
+    selected_source_types = [
+        source['id']
+        for source in selected_sources
+        if source['origin'] == 'selection'
+    ]
+    effective_source_types = [source['id'] for source in selected_sources]
     requested_sources = list(selected_sources)
     if conversation_document_ids:
         requested_sources.append(
@@ -340,8 +367,12 @@ def build_turn_orchestration_plan(
     )
 
     reason_codes = []
-    if selected_sources:
+    if selected_source_types:
         reason_codes.append('selected_capability')
+    if any(source['origin'] == 'discovery_auto' for source in selected_sources):
+        reason_codes.append('governed_capability_discovery')
+    if any(source['origin'] == 'discovery_approved' for source in selected_sources):
+        reason_codes.append('approved_capability_discovery')
     if requested_source_types or grounding_language_detected:
         reason_codes.append('evidence_requested')
     if grounded_image_generation_requested:
@@ -369,11 +400,16 @@ def build_turn_orchestration_plan(
         if image_generation_requested and _coerce_bool(image_generation_available)
         else 'response'
     )
+    image_capability_origin = (
+        capability_origin('image')
+        if image_generation_requested and 'image' in capability_origins
+        else None
+    )
     finalizer_step = {
         'id': f'finalize_{finalizer_capability}',
         'type': 'finalize',
         'capability': finalizer_capability,
-        'origin': 'orchestrator',
+        'origin': image_capability_origin or 'orchestrator',
         'required': True,
         'status': 'pending',
         'depends_on': [step['id'] for step in collection_steps],
@@ -411,8 +447,16 @@ def build_turn_orchestration_plan(
         },
         'prompt_id': selected_prompt_id or None,
     }
+    if isinstance(selection_snapshot_override, Mapping):
+        selection_snapshot = copy.deepcopy(dict(selection_snapshot_override))
 
-    return {
+    effective_capability_types = list(effective_source_types)
+    if image_capability_origin and 'image' not in effective_capability_types:
+        effective_capability_types.append('image')
+    if image_capability_origin == 'selection' and 'image' not in selected_source_types:
+        selected_source_types.append('image')
+
+    plan = {
         'version': ORCHESTRATION_PLAN_VERSION,
         'run_id': str(run_id or uuid.uuid4()),
         'selection_snapshot': selection_snapshot,
@@ -432,6 +476,7 @@ def build_turn_orchestration_plan(
         'requires_evidence_before_finalization': requires_evidence_before_finalization,
         'reason_codes': reason_codes,
         'selected_capabilities': selected_source_types,
+        'effective_capabilities': effective_capability_types,
         'evidence_requirements': requested_source_types,
         'requested_evidence_sources': [source['id'] for source in requested_sources],
         'sources': requested_sources,
@@ -450,6 +495,10 @@ def build_turn_orchestration_plan(
         },
         'warnings': warnings,
     }
+    normalized_parent_run_id = str(parent_run_id or '').strip()
+    if normalized_parent_run_id:
+        plan['parent_run_id'] = normalized_parent_run_id
+    return plan
 
 
 def build_turn_orchestration_guidance_message(plan):

--- a/application/single_app/functions_orchestration_runtime.py
+++ b/application/single_app/functions_orchestration_runtime.py
@@ -39,6 +39,7 @@ ORCHESTRATION_TERMINAL_NODE_STATUSES = frozenset({
 ORCHESTRATION_RUN_STATUSES = frozenset({
     'pending',
     'running',
+    'awaiting_user_choice',
     'succeeded',
     'partial',
     'failed',

--- a/application/single_app/functions_settings.py
+++ b/application/single_app/functions_settings.py
@@ -1155,6 +1155,18 @@ def get_settings(use_cosmos=False, include_source=False):
             }
         },
 
+        # Server-authoritative orchestration discovery policy for built-in chat capabilities
+        'chat_capability_governance': {
+            'workspace_search': 'recommend',
+            'analyze': 'recommend',
+            'compare': 'recommend',
+            'image': 'recommend',
+            'web_search': 'recommend',
+            'url_access': 'recommend',
+            'deep_research': 'recommend',
+        },
+        'chat_capability_choice_ttl_seconds': 86400,
+
         # URL Access and Deep Research (bounded source-page inspection for web evidence)
         'enable_url_access': False,
         'url_access_max_chat_urls_per_turn': 10,

--- a/application/single_app/route_backend_chats.py
+++ b/application/single_app/route_backend_chats.py
@@ -36,6 +36,7 @@ from functions_model_endpoint_runtime import (
 import builtins
 import asyncio, types
 import ast
+import copy
 import csv
 import io
 import inspect
@@ -110,6 +111,26 @@ from functions_conversation_unread import mark_conversation_unread
 from functions_chat_orchestration import (
     build_turn_orchestration_guidance_message,
     build_turn_orchestration_plan,
+)
+from functions_chat_capabilities import (
+    build_governed_capability_inventory,
+    classify_capability_requirements,
+    match_governed_capabilities,
+    normalize_capability_governance_modes,
+)
+from functions_chat_capability_choices import (
+    CapabilityChoiceError,
+    add_sensitive_external_query_options,
+    build_capability_choice_proposal,
+    build_capability_provenance,
+    build_minimized_external_query,
+)
+from functions_chat_capability_persistence import (
+    persist_capability_decision,
+    persist_capability_resume_claim,
+    persist_capability_resume_completion,
+    persist_capability_resume_failure,
+    read_capability_proposal_message,
 )
 from functions_central_synthesis import (
     build_central_synthesis_metadata,
@@ -2419,6 +2440,706 @@ def _authorize_personal_conversation_access(user_id, conversation_id):
         raise PermissionError('You can only access your own conversations')
 
     return conversation_item
+
+
+def _get_selected_builtin_chat_capability_ids(data):
+    """Return submitted built-in selections without treating inactive controls as denials."""
+    data = data if isinstance(data, Mapping) else {}
+    selected = []
+
+    def coerce_bool(value):
+        if isinstance(value, str):
+            return value.strip().lower() == 'true'
+        return bool(value)
+
+    def append_selected(capability_id, value):
+        if coerce_bool(value) and capability_id not in selected:
+            selected.append(capability_id)
+
+    append_selected('workspace_search', data.get('hybrid_search'))
+    append_selected('web_search', data.get('web_search_enabled'))
+    append_selected('url_access', data.get('url_access_enabled'))
+    append_selected(
+        'deep_research',
+        data.get('deep_research_enabled') or data.get('source_review_enabled'),
+    )
+    append_selected('image', data.get('image_generation'))
+
+    document_action = data.get('document_action') if isinstance(data.get('document_action'), Mapping) else {}
+    action_type = str(document_action.get('type') or '').strip().lower()
+    if action_type == DOCUMENT_ACTION_TYPE_ANALYZE:
+        selected.append('analyze')
+    elif action_type == DOCUMENT_ACTION_TYPE_COMPARISON:
+        selected.append('compare')
+    return selected
+
+
+def _get_policy_blocked_selected_capability_ids(settings, data):
+    governance_modes = normalize_capability_governance_modes(settings)
+    return [
+        capability_id
+        for capability_id in _get_selected_builtin_chat_capability_ids(data)
+        if governance_modes.get(capability_id) == 'blocked'
+    ]
+
+
+def _get_rejected_selected_capability_entries(inventory, selected_capability_ids):
+    selected_ids = set(selected_capability_ids or [])
+    entries = inventory.get('capabilities') if isinstance(inventory, Mapping) else []
+    return [
+        entry
+        for entry in entries or []
+        if isinstance(entry, Mapping)
+        and entry.get('id') in selected_ids
+        and entry.get('state') in {'unavailable', 'unauthorized', 'policy_blocked'}
+    ]
+
+
+def _build_selected_capability_rejection_message(entries):
+    capability_labels = [
+        str(entry.get('label') or entry.get('id') or 'Capability').strip()
+        for entry in entries or []
+    ]
+    return (
+        'The selected capability is not currently available or permitted: '
+        f"{', '.join(capability_labels)}."
+    )
+
+
+def _web_search_capability_is_configured(settings):
+    if not settings.get('enable_web_search'):
+        return False
+    web_search_agent = settings.get('web_search_agent')
+    web_search_agent = web_search_agent if isinstance(web_search_agent, Mapping) else {}
+    other_settings = web_search_agent.get('other_settings')
+    other_settings = other_settings if isinstance(other_settings, Mapping) else {}
+    foundry_settings = other_settings.get('azure_ai_foundry')
+    foundry_settings = foundry_settings if isinstance(foundry_settings, Mapping) else {}
+    return bool(str(foundry_settings.get('agent_id') or '').strip())
+
+
+def _resolve_server_chat_capability_inventory(
+    *,
+    settings,
+    user_id,
+    user_email,
+    user_roles,
+    user_message,
+    selected_capability_ids,
+    authorized_document_count=0,
+):
+    """Resolve built-in capability state from trusted configuration and identity context."""
+    governance_modes = normalize_capability_governance_modes(settings)
+    enabled_document_actions = get_enabled_document_action_types(settings=settings)
+    prompt_urls = extract_urls_from_text(user_message)
+    web_search_configured = _web_search_capability_is_configured(settings)
+    url_access_admin_enabled = bool(settings.get('enable_url_access'))
+    url_access_authorized = is_url_access_enabled_for_user(
+        settings,
+        user_roles=user_roles,
+    )
+    deep_research_admin_enabled = bool(
+        settings.get('enable_source_review')
+        and settings.get('enable_deep_source_review', True)
+    )
+    deep_research_authorized = is_source_review_enabled_for_user(
+        settings,
+        user_id,
+        user_email=user_email,
+        user_roles=user_roles,
+    )
+    workspace_search_available = bool(
+        CLIENTS.get('search_client_user')
+        and str(settings.get('azure_ai_search_endpoint') or '').strip()
+    )
+    try:
+        normalized_document_count = max(0, int(authorized_document_count or 0))
+    except (TypeError, ValueError):
+        normalized_document_count = 0
+
+    resolved_capabilities = {
+        'workspace_search': {
+            'enabled': True,
+            'available': workspace_search_available,
+            'authorized': bool(user_id),
+            'governance_mode': governance_modes['workspace_search'],
+            'input_ready': bool(user_id),
+            'reason': 'search_client_unavailable' if not workspace_search_available else None,
+        },
+        'analyze': {
+            'enabled': DOCUMENT_ACTION_TYPE_ANALYZE in enabled_document_actions,
+            'available': DOCUMENT_ACTION_TYPE_ANALYZE in enabled_document_actions,
+            'authorized': bool(user_id),
+            'governance_mode': governance_modes['analyze'],
+            'input_ready': normalized_document_count >= 1,
+            'reason': 'authorized_document_target_required' if normalized_document_count < 1 else None,
+        },
+        'compare': {
+            'enabled': DOCUMENT_ACTION_TYPE_COMPARISON in enabled_document_actions,
+            'available': DOCUMENT_ACTION_TYPE_COMPARISON in enabled_document_actions,
+            'authorized': bool(user_id),
+            'governance_mode': governance_modes['compare'],
+            'input_ready': normalized_document_count >= 2,
+            'reason': 'two_authorized_document_targets_required' if normalized_document_count < 2 else None,
+        },
+        'image': {
+            'enabled': image_generation_is_enabled(settings),
+            'available': image_generation_is_enabled(settings),
+            'authorized': bool(user_id),
+            'governance_mode': governance_modes['image'],
+            'input_ready': True,
+            'reason': 'image_generation_unavailable' if not image_generation_is_enabled(settings) else None,
+        },
+        'web_search': {
+            'enabled': bool(settings.get('enable_web_search')),
+            'available': web_search_configured,
+            'authorized': bool(user_id),
+            'governance_mode': governance_modes['web_search'],
+            'input_ready': True,
+            'reason': 'web_search_not_configured' if not web_search_configured else None,
+        },
+        'url_access': {
+            'enabled': url_access_admin_enabled,
+            'available': url_access_admin_enabled,
+            'authorized': url_access_authorized,
+            'governance_mode': governance_modes['url_access'],
+            'input_ready': bool(prompt_urls),
+            'reason': (
+                'url_access_role_required'
+                if url_access_admin_enabled and not url_access_authorized
+                else 'supplied_url_required'
+                if not prompt_urls
+                else None
+            ),
+        },
+        'deep_research': {
+            'enabled': deep_research_admin_enabled,
+            'available': bool(deep_research_admin_enabled and web_search_configured),
+            'authorized': deep_research_authorized,
+            'governance_mode': governance_modes['deep_research'],
+            'input_ready': True,
+            'reason': (
+                'deep_research_role_required'
+                if deep_research_admin_enabled and not deep_research_authorized
+                else 'deep_research_not_configured'
+                if not (deep_research_admin_enabled and web_search_configured)
+                else None
+            ),
+        },
+    }
+    return build_governed_capability_inventory(
+        selected_capability_ids=selected_capability_ids,
+        resolved_capabilities=resolved_capabilities,
+    )
+
+
+def _build_server_capability_discovery(
+    *,
+    settings,
+    user_id,
+    user_email,
+    user_roles,
+    user_message,
+    selected_capability_ids,
+    authorized_document_count=0,
+):
+    inventory = _resolve_server_chat_capability_inventory(
+        settings=settings,
+        user_id=user_id,
+        user_email=user_email,
+        user_roles=user_roles,
+        user_message=user_message,
+        selected_capability_ids=selected_capability_ids,
+        authorized_document_count=authorized_document_count,
+    )
+    requirements = classify_capability_requirements(
+        user_message,
+        authorized_document_count=authorized_document_count,
+    )
+    match = match_governed_capabilities(inventory, requirements)
+    recommendation = add_sensitive_external_query_options(
+        match.get('recommendation'),
+        user_message,
+    )
+    return {
+        'inventory': inventory,
+        'requirements': requirements,
+        'auto_capability_ids': list(match.get('auto_capability_ids') or []),
+        'recommendation': recommendation,
+    }
+
+
+def _build_capability_resume_request(data, *, canonical_agent=None):
+    """Persist only bounded identifiers needed to reconstruct the authorized turn."""
+    source = data if isinstance(data, Mapping) else {}
+    prompt_info = source.get('prompt_info') if isinstance(source.get('prompt_info'), Mapping) else {}
+    agent_info = canonical_agent if isinstance(canonical_agent, Mapping) else source.get('agent_info')
+    agent_info = agent_info if isinstance(agent_info, Mapping) else {}
+    document_action = source.get('document_action') if isinstance(source.get('document_action'), Mapping) else {}
+
+    def coerce_bool(value):
+        if isinstance(value, str):
+            return value.strip().lower() == 'true'
+        return bool(value)
+
+    return {
+        'hybrid_search': coerce_bool(source.get('hybrid_search')),
+        'user_workspace_context_enabled': coerce_bool(source.get('user_workspace_context_enabled')),
+        'web_search_enabled': coerce_bool(source.get('web_search_enabled')),
+        'url_access_enabled': coerce_bool(source.get('url_access_enabled')),
+        'source_review_enabled': coerce_bool(source.get('source_review_enabled')),
+        'deep_research_enabled': coerce_bool(source.get('deep_research_enabled')),
+        'image_generation': coerce_bool(source.get('image_generation')),
+        'selected_document_id': str(source.get('selected_document_id') or '').strip() or None,
+        'selected_document_ids': _normalize_conversation_task_document_ids(
+            source.get('selected_document_ids')
+        ),
+        'conversation_task_document_ids': _normalize_conversation_task_document_ids(
+            source.get('conversation_task_document_ids')
+        ),
+        'doc_scope': str(source.get('doc_scope') or '').strip() or None,
+        'tags': [
+            str(tag).strip()
+            for tag in (source.get('tags') or [])
+            if str(tag).strip()
+        ][:50],
+        'chat_type': str(source.get('chat_type') or 'user').strip()[:40],
+        'active_group_ids': _normalize_conversation_task_document_ids(
+            source.get('active_group_ids') or source.get('active_group_id')
+        ),
+        'active_public_workspace_ids': _normalize_conversation_task_document_ids(
+            source.get('active_public_workspace_ids') or source.get('active_public_workspace_id')
+        ),
+        'model_deployment': str(source.get('model_deployment') or '').strip() or None,
+        'model_id': str(source.get('model_id') or '').strip() or None,
+        'model_endpoint_id': str(source.get('model_endpoint_id') or '').strip() or None,
+        'model_provider': str(source.get('model_provider') or '').strip() or None,
+        'model_icon': _normalize_model_icon_payload(source.get('model_icon')),
+        'reasoning_effort': str(source.get('reasoning_effort') or '').strip() or None,
+        'prompt_info': (
+            {
+                'id': str(prompt_info.get('id') or '').strip(),
+                'name': str(prompt_info.get('name') or '').strip()[:120],
+            }
+            if str(prompt_info.get('id') or '').strip()
+            else None
+        ),
+        'agent_info': (
+            {
+                'id': str(agent_info.get('id') or agent_info.get('agent_id') or '').strip(),
+                'name': str(agent_info.get('name') or agent_info.get('selected_agent') or '').strip()[:120],
+            }
+            if str(agent_info.get('id') or agent_info.get('agent_id') or '').strip()
+            else None
+        ),
+        'document_action': {
+            'type': str(document_action.get('type') or '').strip().lower(),
+            'document_ids': _normalize_conversation_task_document_ids(document_action.get('document_ids')),
+            'left_document_id': str(document_action.get('left_document_id') or '').strip(),
+            'right_document_ids': _normalize_conversation_task_document_ids(document_action.get('right_document_ids')),
+            'doc_scope': str(document_action.get('doc_scope') or source.get('doc_scope') or '').strip(),
+            'active_group_ids': _normalize_conversation_task_document_ids(document_action.get('active_group_ids')),
+            'active_public_workspace_id': _normalize_conversation_task_document_ids(
+                document_action.get('active_public_workspace_id')
+            ),
+            'window_unit': 'pages',
+            'max_retries_per_window': 1,
+        } if document_action else None,
+    }
+
+
+def _apply_effective_capabilities_to_request(request_data, effective_capability_ids):
+    updated = dict(request_data or {})
+    effective_ids = set(effective_capability_ids or [])
+    if 'workspace_search' in effective_ids:
+        updated['hybrid_search'] = True
+    if 'web_search' in effective_ids:
+        updated['web_search_enabled'] = True
+    if 'url_access' in effective_ids:
+        updated['url_access_enabled'] = True
+        updated['source_review_enabled'] = True
+    if 'deep_research' in effective_ids:
+        updated['web_search_enabled'] = True
+        updated['source_review_enabled'] = True
+        updated['deep_research_enabled'] = True
+    selected_document_ids = _normalize_conversation_task_document_ids(
+        updated.get('selected_document_ids')
+    )
+    if 'analyze' in effective_ids:
+        updated['document_action'] = {
+            'type': DOCUMENT_ACTION_TYPE_ANALYZE,
+            'document_ids': selected_document_ids,
+            'doc_scope': updated.get('doc_scope'),
+            'active_group_ids': updated.get('active_group_ids') or [],
+            'active_public_workspace_id': updated.get('active_public_workspace_ids') or [],
+            'window_unit': 'pages',
+            'max_retries_per_window': 1,
+        }
+    if 'compare' in effective_ids and len(selected_document_ids) >= 2:
+        updated['document_action'] = {
+            'type': DOCUMENT_ACTION_TYPE_COMPARISON,
+            'document_ids': selected_document_ids,
+            'left_document_id': selected_document_ids[0],
+            'right_document_ids': selected_document_ids[1:],
+            'doc_scope': updated.get('doc_scope'),
+            'active_group_ids': updated.get('active_group_ids') or [],
+            'active_public_workspace_id': updated.get('active_public_workspace_ids') or [],
+            'window_unit': 'pages',
+            'max_retries_per_window': 1,
+        }
+    return updated
+
+
+def _load_authorized_capability_proposal_context(
+    *,
+    settings,
+    user_id,
+    user_email,
+    user_roles,
+    conversation_id,
+    proposal_id,
+):
+    """Reauthorize one persisted proposal and rebuild its governed inventory."""
+    conversation_item = _authorize_personal_conversation_access(user_id, conversation_id)
+    proposal_message, proposal = read_capability_proposal_message(
+        cosmos_messages_container,
+        conversation_id=conversation_id,
+        proposal_id=proposal_id,
+    )
+    user_message_id = str(proposal.get('user_message_id') or '').strip()
+    if not user_message_id:
+        raise CapabilityChoiceError(
+            'proposal source user message is missing',
+            code='proposal_user_message_missing',
+        )
+    try:
+        user_message_doc = cosmos_messages_container.read_item(
+            item=user_message_id,
+            partition_key=conversation_id,
+        )
+    except CosmosResourceNotFoundError as exc:
+        raise CapabilityChoiceError(
+            'proposal source user message no longer exists',
+            code='proposal_user_message_missing',
+        ) from exc
+    if (
+        user_message_doc.get('conversation_id') != conversation_id
+        or user_message_doc.get('role') != 'user'
+        or (user_message_doc.get('metadata') or {}).get('is_deleted') is True
+    ):
+        raise CapabilityChoiceError(
+            'proposal source user message is invalid',
+            code='proposal_user_message_invalid',
+        )
+    user_metadata = (
+        user_message_doc.get('metadata')
+        if isinstance(user_message_doc.get('metadata'), Mapping)
+        else {}
+    )
+    original_plan = (
+        user_metadata.get('orchestration')
+        if isinstance(user_metadata.get('orchestration'), Mapping)
+        else {}
+    )
+    source_provenance = (
+        user_metadata.get('capability_provenance')
+        if isinstance(user_metadata.get('capability_provenance'), Mapping)
+        else {}
+    )
+    source_proposal = (
+        source_provenance.get('proposed_capabilities')
+        if isinstance(source_provenance.get('proposed_capabilities'), Mapping)
+        else {}
+    )
+    source_run_id = str(
+        source_proposal.get('run_id')
+        or original_plan.get('run_id')
+        or ''
+    ).strip()
+    if (
+        source_run_id != str(proposal.get('run_id') or '').strip()
+        or (
+            source_proposal
+            and str(source_proposal.get('proposal_id') or '').strip() != proposal_id
+        )
+    ):
+        raise CapabilityChoiceError(
+            'proposal is not linked to the source turn run',
+            code='proposal_run_mismatch',
+        )
+    proposal_metadata = (
+        proposal_message.get('metadata')
+        if isinstance(proposal_message.get('metadata'), Mapping)
+        else {}
+    )
+    resume_request = proposal_metadata.get('capability_resume_request')
+    if not isinstance(resume_request, Mapping):
+        raise CapabilityChoiceError(
+            'proposal resume request is missing',
+            code='proposal_resume_request_missing',
+        )
+    resume_request = copy.deepcopy(dict(resume_request))
+    resume_request['conversation_id'] = conversation_id
+    resume_request['message'] = str(user_message_doc.get('content') or '')
+
+    scope_context = _get_authorized_chat_scope_context(
+        user_id,
+        active_group_ids=resume_request.get('active_group_ids') or [],
+        active_public_workspace_ids=resume_request.get('active_public_workspace_ids') or [],
+    )
+    resume_request['active_group_ids'] = list(scope_context.get('active_group_ids') or [])
+    resume_request['active_group_id'] = scope_context.get('active_group_id')
+    resume_request['active_public_workspace_ids'] = list(
+        scope_context.get('active_public_workspace_ids') or []
+    )
+    resume_request['active_public_workspace_id'] = scope_context.get('active_public_workspace_id')
+
+    authorized_documents = _resolve_authorized_chat_selected_documents(
+        resume_request.get('selected_document_ids') or [],
+        user_id=user_id,
+        document_scope=resume_request.get('doc_scope') or 'all',
+        active_group_ids=resume_request['active_group_ids'],
+        active_public_workspace_ids=resume_request['active_public_workspace_ids'],
+    )
+    conversation_task_document_ids = _normalize_conversation_task_document_ids(
+        resume_request.get('conversation_task_document_ids')
+    )
+    authorized_task_documents = []
+    if conversation_task_document_ids:
+        proposed_capability_ids = {
+            capability_id
+            for option in proposal.get('options') or []
+            if isinstance(option, Mapping)
+            for capability_id in option.get('capability_ids') or []
+        }
+        task_action_type = (
+            DOCUMENT_ACTION_TYPE_COMPARISON
+            if 'compare' in proposed_capability_ids
+            else DOCUMENT_ACTION_TYPE_ANALYZE
+        )
+        task_resolution = _resolve_conversation_task_documents(
+            user_id=user_id,
+            conversation_id=conversation_id,
+            document_action_type=task_action_type,
+            candidate_document_ids=conversation_task_document_ids,
+        )
+        if not task_resolution.get('blocked'):
+            authorized_task_documents = [
+                document
+                for document in task_resolution.get('documents') or []
+                if isinstance(document, Mapping)
+            ]
+            resume_request['conversation_task_document_ids'] = list(
+                task_resolution.get('document_ids') or []
+            )
+            resume_request['doc_scope'] = _merge_document_scope_with_conversation_task_documents(
+                resume_request.get('doc_scope') or 'personal',
+                authorized_task_documents,
+            )
+    authorized_document_ids = {
+        str(document.get('id') or document.get('document_id') or '').strip()
+        for document in authorized_documents
+        if isinstance(document, Mapping)
+    }
+    resume_request['selected_document_ids'] = [
+        document_id
+        for document_id in _normalize_conversation_task_document_ids(
+            resume_request.get('selected_document_ids')
+        )
+        if document_id in authorized_document_ids
+    ]
+    for document_id in resume_request.get('conversation_task_document_ids') or []:
+        if document_id not in resume_request['selected_document_ids']:
+            resume_request['selected_document_ids'].append(document_id)
+    resume_request['selected_document_id'] = (
+        resume_request['selected_document_ids'][0]
+        if len(resume_request['selected_document_ids']) == 1
+        else None
+    )
+    selected_capability_ids = _get_selected_builtin_chat_capability_ids(resume_request)
+    refreshed_inventory = _resolve_server_chat_capability_inventory(
+        settings=settings,
+        user_id=user_id,
+        user_email=user_email,
+        user_roles=user_roles,
+        user_message=resume_request['message'],
+        selected_capability_ids=selected_capability_ids,
+        authorized_document_count=len(authorized_documents) + len(authorized_task_documents),
+    )
+    provenance = (
+        proposal_metadata.get('capability_provenance')
+        if isinstance(proposal_metadata.get('capability_provenance'), Mapping)
+        else {}
+    )
+    return {
+        'conversation_item': conversation_item,
+        'proposal_message': proposal_message,
+        'proposal': proposal,
+        'user_message_doc': user_message_doc,
+        'resume_request': resume_request,
+        'scope_context': scope_context,
+        'authorized_documents': authorized_documents + authorized_task_documents,
+        'inventory': refreshed_inventory,
+        'provenance': copy.deepcopy(dict(provenance)),
+    }
+
+
+def _claim_authorized_capability_resume(
+    *,
+    settings,
+    user_id,
+    user_email,
+    user_roles,
+    conversation_id,
+    proposal_id,
+):
+    """Claim one durable resume and return a server-authored execution request."""
+    context = _load_authorized_capability_proposal_context(
+        settings=settings,
+        user_id=user_id,
+        user_email=user_email,
+        user_roles=user_roles,
+        conversation_id=conversation_id,
+        proposal_id=proposal_id,
+    )
+    pending_decision = (
+        context['proposal'].get('decision')
+        if isinstance(context['proposal'].get('decision'), Mapping)
+        else {}
+    )
+    pending_effective_capability_ids = list(
+        pending_decision.get('effective_capability_ids') or []
+    )
+    authorized_document_count = len(context.get('authorized_documents') or [])
+    if 'analyze' in pending_effective_capability_ids and authorized_document_count < 1:
+        raise CapabilityChoiceError(
+            'Analyze no longer has an authorized document target.',
+            code='capability_input_unavailable',
+        )
+    if 'compare' in pending_effective_capability_ids and authorized_document_count < 2:
+        raise CapabilityChoiceError(
+            'Compare no longer has two authorized document targets.',
+            code='capability_input_unavailable',
+        )
+    stored_resume = (
+        context['proposal'].get('resume')
+        if isinstance(context['proposal'].get('resume'), Mapping)
+        else {}
+    )
+    stored_execution_id = str(stored_resume.get('execution_id') or '').strip()
+    if stored_execution_id and stored_resume.get('status') in {'running', 'failed'}:
+        try:
+            completed_rows = list(cosmos_messages_container.query_items(
+                query=(
+                    'SELECT TOP 1 * FROM c '
+                    'WHERE c.conversation_id = @conversation_id '
+                    'AND c.role = "assistant" '
+                    'AND c.metadata.capability_resume.proposal_id = @proposal_id '
+                    'AND c.metadata.capability_resume.execution_id = @execution_id '
+                    'ORDER BY c.timestamp DESC'
+                ),
+                parameters=[
+                    {'name': '@conversation_id', 'value': conversation_id},
+                    {'name': '@proposal_id', 'value': proposal_id},
+                    {'name': '@execution_id', 'value': stored_execution_id},
+                ],
+                partition_key=conversation_id,
+            ))
+            completed_assistant = next(
+                (
+                    message
+                    for message in completed_rows
+                    if str(message.get('id') or '').strip()
+                ),
+                None,
+            )
+            if completed_assistant:
+                _, completed_proposal, _ = persist_capability_resume_completion(
+                    cosmos_messages_container,
+                    conversation_id=conversation_id,
+                    proposal_id=proposal_id,
+                    execution_id=stored_execution_id,
+                    assistant_message_id=completed_assistant['id'],
+                )
+                context['proposal'] = completed_proposal
+                context['already_completed'] = True
+                return context
+        except CapabilityChoiceError:
+            raise
+        except Exception as reconciliation_error:
+            log_event(
+                '[CapabilityDiscovery] Resume completion reconciliation failed',
+                extra={
+                    'conversation_id': conversation_id,
+                    'proposal_id': proposal_id,
+                    'error_type': type(reconciliation_error).__name__,
+                },
+                level=logging.WARNING,
+            )
+    _, claimed_proposal, idempotent = persist_capability_resume_claim(
+        cosmos_messages_container,
+        conversation_id=conversation_id,
+        proposal_id=proposal_id,
+        refreshed_inventory=context['inventory'],
+    )
+    if idempotent:
+        context['proposal'] = claimed_proposal
+        context['already_completed'] = True
+        return context
+
+    decision = (
+        claimed_proposal.get('decision')
+        if isinstance(claimed_proposal.get('decision'), Mapping)
+        else {}
+    )
+    effective_capability_ids = list(decision.get('effective_capability_ids') or [])
+    request_data = _apply_effective_capabilities_to_request(
+        context['resume_request'],
+        effective_capability_ids,
+    )
+    external_query_mode = str(decision.get('external_query_mode') or 'minimized').strip().lower()
+    if any(
+        capability_id in {'web_search', 'url_access', 'deep_research'}
+        for capability_id in effective_capability_ids
+    ):
+        external_query = build_minimized_external_query(
+            request_data.get('message'),
+            include_sensitive_inputs=(
+                external_query_mode == 'include_approved_sensitive_inputs'
+            ),
+        )
+        request_data['_server_external_query'] = external_query['query']
+
+    capability_origins = {
+        str(item.get('id') or '').strip(): str(item.get('origin') or '').strip()
+        for item in (context['provenance'].get('effective_capabilities') or [])
+        if isinstance(item, Mapping)
+        and str(item.get('origin') or '').strip() == 'discovery_auto'
+    }
+    for capability_id in effective_capability_ids:
+        capability_origins[capability_id] = 'discovery_approved'
+    request_data['_capability_resume_context'] = {
+        'proposal_id': proposal_id,
+        'parent_run_id': claimed_proposal.get('run_id'),
+        'child_run_id': (claimed_proposal.get('resume') or {}).get('child_run_id'),
+        'execution_id': (claimed_proposal.get('resume') or {}).get('execution_id'),
+        'user_message_id': claimed_proposal.get('user_message_id'),
+        'selection_snapshot': copy.deepcopy(
+            context['provenance'].get('selection_snapshot') or {}
+        ),
+        'capability_origins': capability_origins,
+        'capability_inventory': copy.deepcopy(context['inventory']),
+        'decision': copy.deepcopy(decision),
+        'original_proposal': copy.deepcopy(
+            context['provenance'].get('proposed_capabilities') or claimed_proposal
+        ),
+        'effective_capability_ids': effective_capability_ids,
+        'existing_user_message': copy.deepcopy(context['user_message_doc']),
+    }
+    context['proposal'] = claimed_proposal
+    context['request_data'] = request_data
+    context['already_completed'] = False
+    return context
 
 
 def _resolve_or_create_authorized_personal_conversation(user_id, conversation_id):
@@ -11930,6 +12651,24 @@ def register_route_backend_chats(bp):
         if not user_id:
             return {'error': 'User not authenticated'}, 401
 
+        blocked_selected_capabilities = _get_policy_blocked_selected_capability_ids(
+            settings,
+            data,
+        )
+        if blocked_selected_capabilities:
+            return {
+                'error': _build_selected_capability_rejection_message([
+                    {'id': capability_id}
+                    for capability_id in blocked_selected_capabilities
+                ])
+            }, 403
+
+        capability_resume_context = (
+            data.get('_capability_resume_context')
+            if isinstance(data.get('_capability_resume_context'), Mapping)
+            else None
+        )
+
         user_message = str(data.get('message') or '').strip()
         if not user_message:
             return {'error': 'Message is required'}, 400
@@ -12130,8 +12869,67 @@ def register_route_backend_chats(bp):
             assigned_knowledge_filters
             and assigned_knowledge_filters.get('has_workspace_knowledge')
         )
+        authorized_action_documents = _resolve_authorized_chat_selected_documents(
+            selected_document_ids,
+            user_id=user_id,
+            document_scope=document_scope,
+            active_group_ids=active_group_ids,
+            active_public_workspace_ids=active_public_workspace_ids,
+        )
+        selected_builtin_capability_ids = (
+            [
+                capability.get('id')
+                for capability in (
+                    capability_resume_context.get('capability_inventory', {}).get('capabilities', [])
+                    if capability_resume_context
+                    else []
+                )
+                if isinstance(capability, Mapping)
+                and capability.get('state') == 'selected'
+            ]
+            if capability_resume_context
+            else _get_selected_builtin_chat_capability_ids(data)
+        )
+        action_capability_inventory = (
+            copy.deepcopy(capability_resume_context.get('capability_inventory') or {})
+            if capability_resume_context
+            else _resolve_server_chat_capability_inventory(
+                settings=settings,
+                user_id=user_id,
+                user_email=(get_current_user_info() or {}).get('email'),
+                user_roles=(session.get('user') or {}).get('roles', []),
+                user_message=user_message,
+                selected_capability_ids=selected_builtin_capability_ids,
+                authorized_document_count=len(authorized_action_documents),
+            )
+        )
+        rejected_selected_capabilities = _get_rejected_selected_capability_entries(
+            action_capability_inventory,
+            selected_builtin_capability_ids,
+        )
+        if rejected_selected_capabilities:
+            return {
+                'error': _build_selected_capability_rejection_message(
+                    rejected_selected_capabilities
+                )
+            }, 403
+        capability_origins = (
+            dict(capability_resume_context.get('capability_origins') or {})
+            if capability_resume_context
+            else {}
+        )
         turn_orchestration_plan = build_turn_orchestration_plan(
             user_message,
+            run_id=(
+                capability_resume_context.get('child_run_id')
+                if capability_resume_context
+                else None
+            ),
+            parent_run_id=(
+                capability_resume_context.get('parent_run_id')
+                if capability_resume_context
+                else None
+            ),
             conversation_id=conversation_id,
             selected_agent=request_agent_info,
             selected_action=normalized_action,
@@ -12150,6 +12948,41 @@ def register_route_backend_chats(bp):
             model_provider=data.get('model_provider'),
             reasoning_effort=data.get('reasoning_effort'),
             prompt_info=data.get('prompt_info'),
+            capability_origins=capability_origins,
+            selection_snapshot_override=(
+                capability_resume_context.get('selection_snapshot')
+                if capability_resume_context
+                else None
+            ),
+        )
+        effective_capability_entries = [
+            {'id': capability_id, 'origin': 'selection', 'required': True}
+            for capability_id in selected_builtin_capability_ids
+        ]
+        for capability_id, origin in capability_origins.items():
+            if capability_id and not any(
+                entry['id'] == capability_id
+                for entry in effective_capability_entries
+            ):
+                effective_capability_entries.append({
+                    'id': capability_id,
+                    'origin': origin,
+                    'required': True,
+                })
+        turn_capability_provenance = build_capability_provenance(
+            selection_snapshot=turn_orchestration_plan.get('selection_snapshot'),
+            capability_inventory=action_capability_inventory,
+            decisions=(
+                [capability_resume_context.get('decision')]
+                if capability_resume_context
+                else []
+            ),
+            proposal=(
+                capability_resume_context.get('original_proposal')
+                if capability_resume_context
+                else None
+            ),
+            effective_capabilities=effective_capability_entries,
         )
         log_event(
             '[Orchestration] Document action turn plan created',
@@ -12164,9 +12997,39 @@ def register_route_backend_chats(bp):
             },
         )
 
-        previous_thread_id = _get_latest_chat_thread_id(conversation_id)
-        current_thread_id = str(uuid.uuid4())
-        user_message_id = f"{conversation_id}_user_{int(time.time())}_{random.randint(1000,9999)}"
+        existing_user_message = (
+            capability_resume_context.get('existing_user_message')
+            if capability_resume_context
+            else None
+        )
+        existing_user_metadata = (
+            existing_user_message.get('metadata')
+            if isinstance(existing_user_message, Mapping)
+            and isinstance(existing_user_message.get('metadata'), Mapping)
+            else {}
+        )
+        existing_thread_info = (
+            existing_user_metadata.get('thread_info')
+            if isinstance(existing_user_metadata.get('thread_info'), Mapping)
+            else {}
+        )
+        previous_thread_id = (
+            existing_thread_info.get('previous_thread_id')
+            if capability_resume_context
+            else _get_latest_chat_thread_id(conversation_id)
+        )
+        current_thread_id = (
+            str(existing_thread_info.get('thread_id') or '').strip()
+            if capability_resume_context
+            else str(uuid.uuid4())
+        )
+        user_message_id = (
+            str(capability_resume_context.get('user_message_id') or '').strip()
+            if capability_resume_context
+            else f"{conversation_id}_user_{int(time.time())}_{random.randint(1000,9999)}"
+        )
+        if not current_thread_id or not user_message_id:
+            return {'error': 'Capability resume source turn is incomplete.'}, 409
         turn_evidence_ledger = create_evidence_ledger_from_plan(
             turn_orchestration_plan,
             conversation_id=conversation_id,
@@ -12200,7 +13063,7 @@ def register_route_backend_chats(bp):
                     'source_id': 'selected_agent',
                     'requirement_ids': [],
                 })
-        user_metadata = _build_document_action_user_metadata(
+        generated_user_metadata = _build_document_action_user_metadata(
             data=data,
             user_id=user_id,
             conversation_id=conversation_id,
@@ -12211,26 +13074,46 @@ def register_route_backend_chats(bp):
             assigned_knowledge_filters=assigned_knowledge_filters,
             streaming_enabled=callable(publish_background_event),
         )
+        if capability_resume_context:
+            user_metadata = copy.deepcopy(dict(existing_user_metadata))
+            if isinstance(user_metadata.get('orchestration'), Mapping):
+                user_metadata.setdefault(
+                    'orchestration_parent',
+                    copy.deepcopy(dict(user_metadata['orchestration'])),
+                )
+            user_metadata.update(generated_user_metadata)
+        else:
+            user_metadata = generated_user_metadata
         user_metadata['orchestration'] = turn_orchestration_plan
         user_metadata['evidence_ledger'] = turn_evidence_ledger
         user_metadata['orchestration_runtime'] = turn_orchestration_run.to_metadata()
+        user_metadata['capability_provenance'] = turn_capability_provenance
         if auto_linked_chat_upload_document_ids:
             user_metadata['workspace_search']['auto_linked_chat_upload_document_ids'] = auto_linked_chat_upload_document_ids
             user_metadata['workspace_search']['auto_linked_chat_upload_document_count'] = len(auto_linked_chat_upload_document_ids)
             user_metadata['document_action']['auto_linked_chat_upload_document_ids'] = auto_linked_chat_upload_document_ids
-        user_message_doc = make_json_serializable({
-            'id': user_message_id,
-            'conversation_id': conversation_id,
-            'role': 'user',
-            'content': user_message,
-            'timestamp': datetime.utcnow().isoformat(),
-            'model_deployment_name': data.get('model_deployment'),
-            'metadata': user_metadata,
-        })
+        user_message_doc = make_json_serializable(
+            {
+                **(
+                    copy.deepcopy(dict(existing_user_message))
+                    if isinstance(existing_user_message, Mapping)
+                    else {
+                        'id': user_message_id,
+                        'conversation_id': conversation_id,
+                        'role': 'user',
+                        'content': user_message,
+                        'timestamp': datetime.utcnow().isoformat(),
+                        'model_deployment_name': data.get('model_deployment'),
+                    }
+                ),
+                'metadata': user_metadata,
+            }
+        )
         cosmos_messages_container.upsert_item(user_message_doc)
 
-        try:
-            document_action_activity_context = {
+        if not capability_resume_context:
+            try:
+                document_action_activity_context = {
                 key: value
                 for key, value in {
                     'conversation_source': 'document_action_chat',
@@ -12241,24 +13124,27 @@ def register_route_backend_chats(bp):
                 }.items()
                 if value not in (None, '', [])
             }
-            log_chat_activity(
-                user_id=user_id,
-                conversation_id=conversation_id,
-                message_type='user_message',
-                message_length=len(user_message) if user_message else 0,
-                has_document_search=False,
-                has_image_generation=False,
-                document_scope=document_scope,
-                chat_context=(user_metadata.get('chat_context') or {}).get('chat_type'),
-                workspace_type=(user_metadata.get('chat_context') or {}).get('chat_type'),
-                group_id=active_group_ids[0] if document_scope == 'group' and active_group_ids else None,
-                public_workspace_id=active_public_workspace_ids[0] if document_scope == 'public' and active_public_workspace_ids else None,
-                additional_context=document_action_activity_context,
-            )
-        except Exception as e:
-            debug_print(f"Activity logging error: {e}")
+                log_chat_activity(
+                    user_id=user_id,
+                    conversation_id=conversation_id,
+                    message_type='user_message',
+                    message_length=len(user_message) if user_message else 0,
+                    has_document_search=False,
+                    has_image_generation=False,
+                    document_scope=document_scope,
+                    chat_context=(user_metadata.get('chat_context') or {}).get('chat_type'),
+                    workspace_type=(user_metadata.get('chat_context') or {}).get('chat_type'),
+                    group_id=active_group_ids[0] if document_scope == 'group' and active_group_ids else None,
+                    public_workspace_id=active_public_workspace_ids[0] if document_scope == 'public' and active_public_workspace_ids else None,
+                    additional_context=document_action_activity_context,
+                )
+            except Exception as e:
+                debug_print(f"Activity logging error: {e}")
 
-        title_updated = _set_initial_conversation_title(conversation_item, user_message)
+        title_updated = bool(
+            not capability_resume_context
+            and _set_initial_conversation_title(conversation_item, user_message)
+        )
         if title_updated:
             conversation_item['last_updated'] = datetime.utcnow().isoformat()
             cosmos_conversations_container.upsert_item(conversation_item)
@@ -12658,6 +13544,16 @@ def register_route_backend_chats(bp):
                 'orchestration': turn_orchestration_plan,
                 'orchestration_runtime': turn_orchestration_run.to_metadata(),
                 'evidence_ledger': turn_evidence_ledger,
+                'capability_provenance': turn_capability_provenance,
+                'capability_resume': (
+                    {
+                        'proposal_id': capability_resume_context.get('proposal_id'),
+                        'parent_run_id': capability_resume_context.get('parent_run_id'),
+                        'execution_id': capability_resume_context.get('execution_id'),
+                    }
+                    if capability_resume_context
+                    else None
+                ),
                 'capability_usage': document_action_capability_usage,
                 'thread_info': {
                     'thread_id': response_message_context.get('thread_id'),
@@ -12815,6 +13711,53 @@ def register_route_backend_chats(bp):
             return jsonify({'error': 'User not authenticated'}), 401
 
         data = request.get_json() or {}
+        capability_resume_claim = None
+        capability_resume_proposal_id = str(
+            data.get('capability_resume_proposal_id') or ''
+        ).strip()
+        if capability_resume_proposal_id:
+            resume_conversation_id = str(data.get('conversation_id') or '').strip()
+            if not resume_conversation_id:
+                return jsonify({'error': 'conversation_id is required for capability resume'}), 400
+            current_user_info = get_current_user_info() or {}
+            current_user_roles = (session.get('user') or {}).get('roles', [])
+            try:
+                capability_resume_claim = _claim_authorized_capability_resume(
+                    settings=get_settings(),
+                    user_id=user_id,
+                    user_email=current_user_info.get('email'),
+                    user_roles=current_user_roles,
+                    conversation_id=resume_conversation_id,
+                    proposal_id=capability_resume_proposal_id,
+                )
+                if not capability_resume_claim.get('already_completed'):
+                    data = capability_resume_claim['request_data']
+            except CosmosResourceNotFoundError:
+                return jsonify({'error': 'Capability proposal not found'}), 404
+            except LookupError:
+                return jsonify({'error': 'Conversation not found'}), 404
+            except PermissionError:
+                return jsonify({'error': 'Forbidden'}), 403
+            except CapabilityChoiceError as exc:
+                log_event(
+                    '[CapabilityDiscovery] Document resume rejected',
+                    extra={
+                        'conversation_id': resume_conversation_id,
+                        'proposal_id': capability_resume_proposal_id,
+                        'reason_code': exc.code,
+                    },
+                    level=logging.WARNING,
+                )
+                status_code = 409 if (
+                    exc.code.startswith('capability_')
+                    or exc.code in {
+                        'proposal_expired',
+                        'resume_in_progress',
+                        'resume_not_ready',
+                        'resume_write_conflict',
+                    }
+                ) else 400
+                return jsonify({'error': str(exc), 'code': exc.code}), status_code
         conversation_id = getattr(g, 'conversation_id', None) or data.get('conversation_id')
         if conversation_id is not None:
             conversation_id = str(conversation_id).strip() or None
@@ -12824,9 +13767,46 @@ def register_route_backend_chats(bp):
         g.conversation_id = conversation_id
         stream_session = CHAT_STREAM_REGISTRY.start_session(user_id, conversation_id)
 
+        if capability_resume_claim and capability_resume_claim.get('already_completed'):
+            completed_proposal = capability_resume_claim.get('proposal') or {}
+            completed_resume = completed_proposal.get('resume') or {}
+
+            def replay_completed_document_capability_resume():
+                yield f"data: {json.dumps(make_json_serializable({
+                    'done': True,
+                    'conversation_id': conversation_id,
+                    'message_id': completed_resume.get('assistant_message_id'),
+                    'user_message_id': completed_proposal.get('user_message_id'),
+                    'full_content': '',
+                    'reload_messages': True,
+                    'capability_resume': {
+                        'proposal_id': capability_resume_proposal_id,
+                        'status': 'completed',
+                        'idempotent': True,
+                    },
+                }))}\n\n"
+
+            return build_background_stream_response(
+                replay_completed_document_capability_resume,
+                stream_session=stream_session,
+            )
+
         def generate_document_action_response(publish_background_event=None):
+            resume_context = (
+                data.get('_capability_resume_context')
+                if isinstance(data.get('_capability_resume_context'), Mapping)
+                else None
+            )
             try:
                 if stream_session and stream_session.is_cancel_requested():
+                    if resume_context:
+                        persist_capability_resume_failure(
+                            cosmos_messages_container,
+                            conversation_id=conversation_id,
+                            proposal_id=resume_context.get('proposal_id'),
+                            execution_id=resume_context.get('execution_id'),
+                            error_type='cancelled',
+                        )
                     yield _build_stream_cancel_event(
                         conversation_id,
                         reason=stream_session.get_cancel_reason(),
@@ -12841,6 +13821,14 @@ def register_route_backend_chats(bp):
                     ),
                 )
                 if stream_session and stream_session.is_cancel_requested():
+                    if resume_context:
+                        persist_capability_resume_failure(
+                            cosmos_messages_container,
+                            conversation_id=conversation_id,
+                            proposal_id=resume_context.get('proposal_id'),
+                            execution_id=resume_context.get('execution_id'),
+                            error_type='cancelled',
+                        )
                     yield _build_stream_cancel_event(
                         payload.get('conversation_id') or conversation_id,
                         user_message_id=payload.get('user_message_id'),
@@ -12851,12 +13839,49 @@ def register_route_backend_chats(bp):
                     )
                     return
                 if status_code >= 400:
+                    if resume_context:
+                        persist_capability_resume_failure(
+                            cosmos_messages_container,
+                            conversation_id=conversation_id,
+                            proposal_id=resume_context.get('proposal_id'),
+                            execution_id=resume_context.get('execution_id'),
+                            error_type='document_action_failed',
+                        )
                     error_message = payload.get('error') or f'Document action failed ({status_code})'
                     yield f"data: {json.dumps({'error': error_message, 'conversation_id': payload.get('conversation_id')})}\n\n"
                     return
 
+                if resume_context:
+                    persist_capability_resume_completion(
+                        cosmos_messages_container,
+                        conversation_id=conversation_id,
+                        proposal_id=resume_context.get('proposal_id'),
+                        execution_id=resume_context.get('execution_id'),
+                        assistant_message_id=payload.get('message_id'),
+                    )
+                    log_event(
+                        '[CapabilityDiscovery] Document orchestration resumed',
+                        extra={
+                            'conversation_id': conversation_id,
+                            'proposal_id': resume_context.get('proposal_id'),
+                            'parent_run_id': resume_context.get('parent_run_id'),
+                            'child_run_id': resume_context.get('child_run_id'),
+                        },
+                    )
+
                 yield f"data: {json.dumps(normalize_terminal_chat_payload(payload))}\n\n"
             except Exception as document_action_error:
+                if resume_context:
+                    try:
+                        persist_capability_resume_failure(
+                            cosmos_messages_container,
+                            conversation_id=conversation_id,
+                            proposal_id=resume_context.get('proposal_id'),
+                            execution_id=resume_context.get('execution_id'),
+                            error_type=type(document_action_error).__name__,
+                        )
+                    except Exception:
+                        pass
                 yield f"data: {json.dumps({'error': str(document_action_error), 'conversation_id': conversation_id})}\n\n"
 
         return build_background_stream_response(generate_document_action_response, stream_session=stream_session)
@@ -13061,6 +14086,109 @@ def register_route_backend_chats(bp):
             )
             return jsonify({'error': error_message}), status_code
 
+    @bp.route('/api/chat/capability-proposals/<proposal_id>/decision', methods=['POST'])
+    @swagger_route(security=get_auth_security())
+    @login_required
+    @user_required
+    def decide_chat_capability_proposal(proposal_id):
+        """Apply one authenticated turn-scoped capability decision idempotently."""
+        data = request.get_json(silent=True) or {}
+        user_id = get_current_user_id()
+        if not user_id:
+            return jsonify({'error': 'User not authenticated'}), 401
+        conversation_id = str(data.get('conversation_id') or '').strip()
+        option_id = str(data.get('option_id') or '').strip()
+        if not conversation_id or not option_id:
+            return jsonify({'error': 'conversation_id and option_id are required'}), 400
+        current_user_info = get_current_user_info() or {}
+        current_user_roles = (session.get('user') or {}).get('roles', [])
+        try:
+            settings = get_settings()
+            context = _load_authorized_capability_proposal_context(
+                settings=settings,
+                user_id=user_id,
+                user_email=current_user_info.get('email'),
+                user_roles=current_user_roles,
+                conversation_id=conversation_id,
+                proposal_id=proposal_id,
+            )
+            _, proposal, idempotent = persist_capability_decision(
+                cosmos_messages_container,
+                conversation_id=conversation_id,
+                proposal_id=proposal_id,
+                option_id=option_id,
+                actor_user_id=user_id,
+                refreshed_inventory=context['inventory'],
+            )
+            decision = proposal.get('decision') or {}
+            effective_capability_ids = list(decision.get('effective_capability_ids') or [])
+            resume_endpoint = (
+                '/api/chat/document-action/stream'
+                if {'analyze', 'compare'}.intersection(effective_capability_ids)
+                else '/api/chat/stream'
+            )
+            log_event(
+                '[CapabilityDiscovery] Recommendation decision persisted',
+                extra={
+                    'conversation_id': conversation_id,
+                    'proposal_id': proposal_id,
+                    'run_id': proposal.get('run_id'),
+                    'decision_status': decision.get('status'),
+                    'option_id': decision.get('option_id'),
+                    'idempotent': idempotent,
+                },
+            )
+            return jsonify({
+                'success': True,
+                'conversation_id': conversation_id,
+                'proposal_id': proposal_id,
+                'status': proposal.get('status'),
+                'decision': {
+                    'option_id': decision.get('option_id'),
+                    'status': decision.get('status'),
+                },
+                'resume_status': (proposal.get('resume') or {}).get('status'),
+                'resume_endpoint': resume_endpoint,
+                'idempotent': idempotent,
+            }), 200
+        except CosmosResourceNotFoundError:
+            return jsonify({'error': 'Capability proposal not found'}), 404
+        except LookupError:
+            return jsonify({'error': 'Conversation not found'}), 404
+        except PermissionError:
+            return jsonify({'error': 'Forbidden'}), 403
+        except CapabilityChoiceError as exc:
+            conflict_codes = {
+                'decision_conflict',
+                'decision_write_conflict',
+                'proposal_expired',
+                'proposal_approved',
+                'proposal_declined',
+            }
+            log_event(
+                '[CapabilityDiscovery] Recommendation decision rejected',
+                extra={
+                    'conversation_id': conversation_id,
+                    'proposal_id': proposal_id,
+                    'reason_code': exc.code,
+                },
+                level=logging.WARNING,
+            )
+            status_code = 409 if exc.code in conflict_codes or exc.code.startswith('capability_') else 400
+            return jsonify({'error': str(exc), 'code': exc.code}), status_code
+        except Exception as exc:
+            log_event(
+                '[CapabilityDiscovery] Proposal decision failed',
+                extra={
+                    'conversation_id': conversation_id,
+                    'proposal_id': proposal_id,
+                    'error_type': type(exc).__name__,
+                },
+                level=logging.ERROR,
+                exceptionTraceback=True,
+            )
+            return jsonify({'error': 'Capability decision could not be saved'}), 500
+
     @bp.route('/api/chat', methods=['POST'])
     @swagger_route(security=get_auth_security())
     @login_required
@@ -13075,6 +14203,18 @@ def register_route_backend_chats(bp):
                 return jsonify({
                     'error': 'User not authenticated'
                 }), 401
+
+            blocked_selected_capabilities = _get_policy_blocked_selected_capability_ids(
+                settings,
+                data,
+            )
+            if blocked_selected_capabilities:
+                return jsonify({
+                    'error': _build_selected_capability_rejection_message([
+                        {'id': capability_id}
+                        for capability_id in blocked_selected_capabilities
+                    ])
+                }), 403
 
             # Extract agent_info early to guide GPT initialization decisions
             request_agent_info = data.get('agent_info')
@@ -13594,6 +14734,71 @@ def register_route_backend_chats(bp):
                 selected_document_id = effective_selected_document_id
                 document_scope = effective_document_scope
 
+            compatibility_selected_capability_ids = _get_selected_builtin_chat_capability_ids(data)
+            compatibility_authorized_documents = _resolve_authorized_chat_selected_documents(
+                selected_document_ids,
+                user_id=user_id,
+                document_scope=document_scope or effective_document_scope or 'all',
+                active_group_ids=active_group_ids,
+                active_public_workspace_ids=active_public_workspace_ids,
+            )
+            compatibility_capability_inventory = _resolve_server_chat_capability_inventory(
+                settings=settings,
+                user_id=user_id,
+                user_email=current_user_email,
+                user_roles=current_user_roles,
+                user_message=user_message,
+                selected_capability_ids=compatibility_selected_capability_ids,
+                authorized_document_count=(
+                    len(compatibility_authorized_documents)
+                    + len(auto_linked_chat_upload_document_ids)
+                ),
+            )
+            compatibility_rejected_capabilities = _get_rejected_selected_capability_entries(
+                compatibility_capability_inventory,
+                compatibility_selected_capability_ids,
+            )
+            if compatibility_rejected_capabilities:
+                return jsonify({
+                    'error': _build_selected_capability_rejection_message(
+                        compatibility_rejected_capabilities
+                    )
+                }), 403
+            compatibility_selection_snapshot = {
+                'conversation_id': conversation_id,
+                'capability_ids': list(compatibility_selected_capability_ids),
+                'selected_document_ids': [
+                    str(document.get('id') or document.get('document_id') or '').strip()
+                    for document in compatibility_authorized_documents
+                    if isinstance(document, Mapping)
+                    and str(document.get('id') or document.get('document_id') or '').strip()
+                ],
+                'conversation_document_ids': list(auto_linked_chat_upload_document_ids),
+                'document_scope': document_scope or effective_document_scope,
+                'active_group_ids': list(active_group_ids or []),
+                'active_public_workspace_ids': list(active_public_workspace_ids or []),
+                'toggles': {
+                    'workspace_search': bool(hybrid_search_enabled),
+                    'web_search': bool(web_search_enabled),
+                    'url_access': bool(url_access_enabled),
+                    'source_review': bool(source_review_enabled),
+                    'deep_research': bool(deep_research_enabled),
+                    'image': bool(image_gen_enabled),
+                },
+            }
+            compatibility_capability_provenance = build_capability_provenance(
+                selection_snapshot=compatibility_selection_snapshot,
+                capability_inventory=compatibility_capability_inventory,
+                effective_capabilities=[
+                    {
+                        'id': capability_id,
+                        'origin': 'selection',
+                        'required': True,
+                    }
+                    for capability_id in compatibility_selected_capability_ids
+                ],
+            )
+
             # Clear plugin invocations at start of message processing to ensure
             # each message only shows citations for tools executed during that specific interaction
             plugin_logger = get_plugin_logger()
@@ -13923,6 +15128,10 @@ def register_route_backend_chats(bp):
                 cosmos_conversations_container.upsert_item(conversation_item) # Update timestamp and potentially title
                 invalidate_conversation_cache_for_item(conversation_item, reason="conversation_title_initialized")
 
+            user_metadata['capability_provenance'] = compatibility_capability_provenance
+            user_message_doc['metadata'] = user_metadata
+            cosmos_messages_container.upsert_item(user_message_doc)
+
             assistant_message_id, thought_tracker, assistant_thread_attempt, response_message_context = _initialize_assistant_response_tracking(
                 conversation_id=conversation_id,
                 user_message_id=user_message_id,
@@ -14024,6 +15233,9 @@ def register_route_backend_chats(bp):
                             content=blocked_msg_content.strip(),
                             response_context=response_message_context,
                             thread_attempt=assistant_thread_attempt,
+                        )
+                        safety_doc.setdefault('metadata', {})['capability_provenance'] = (
+                            compatibility_capability_provenance
                         )
                         cosmos_messages_container.upsert_item(safety_doc)
 
@@ -14804,6 +16016,7 @@ def register_route_backend_chats(bp):
                         'model_deployment_name': image_gen_model,
                         'metadata': {
                             'user_info': user_info_for_image,
+                            'capability_provenance': compatibility_capability_provenance,
                             'thread_info': {
                                 'thread_id': user_thread_id,
                                 'previous_thread_id': user_previous_thread_id,
@@ -14855,7 +16068,10 @@ def register_route_backend_chats(bp):
                         'conversation_title': conversation_item['title'],
                         'model_deployment_name': image_gen_model,
                         'message_id': image_message_id,
-                        'user_message_id': user_message_id
+                        'user_message_id': user_message_id,
+                        'metadata': {
+                            'capability_provenance': compatibility_capability_provenance,
+                        },
                     }), 200
                 except Exception as e:
                     debug_print(f"Image generation error: {str(e)}")
@@ -16343,6 +17559,7 @@ def register_route_backend_chats(bp):
                         'streaming': 'Disabled',
                     },
                     'history_context': history_debug_info,
+                    'capability_provenance': compatibility_capability_provenance,
                     'capability_usage': assistant_capability_usage,
                     'agent_runtime': agent_runtime_metadata or None,
                     'source_review': compact_source_review_result_for_metadata(source_review_result),
@@ -16551,6 +17768,64 @@ def register_route_backend_chats(bp):
         except Exception as e:
             return jsonify({'error': f'Failed to parse request: {str(e)}'}), 400
 
+        blocked_selected_capabilities = _get_policy_blocked_selected_capability_ids(
+            settings,
+            data,
+        )
+        if blocked_selected_capabilities:
+            return jsonify({
+                'error': _build_selected_capability_rejection_message([
+                    {'id': capability_id}
+                    for capability_id in blocked_selected_capabilities
+                ])
+            }), 403
+
+        capability_resume_claim = None
+        capability_resume_proposal_id = str(
+            (data or {}).get('capability_resume_proposal_id') or ''
+        ).strip()
+        if capability_resume_proposal_id:
+            resume_conversation_id = str((data or {}).get('conversation_id') or '').strip()
+            if not resume_conversation_id:
+                return jsonify({'error': 'conversation_id is required for capability resume'}), 400
+            try:
+                capability_resume_claim = _claim_authorized_capability_resume(
+                    settings=settings,
+                    user_id=user_id,
+                    user_email=current_user_email,
+                    user_roles=current_user_roles,
+                    conversation_id=resume_conversation_id,
+                    proposal_id=capability_resume_proposal_id,
+                )
+                if not capability_resume_claim.get('already_completed'):
+                    data = capability_resume_claim['request_data']
+            except CosmosResourceNotFoundError:
+                return jsonify({'error': 'Capability proposal not found'}), 404
+            except LookupError:
+                return jsonify({'error': 'Conversation not found'}), 404
+            except PermissionError:
+                return jsonify({'error': 'Forbidden'}), 403
+            except CapabilityChoiceError as exc:
+                log_event(
+                    '[CapabilityDiscovery] Chat resume rejected',
+                    extra={
+                        'conversation_id': resume_conversation_id,
+                        'proposal_id': capability_resume_proposal_id,
+                        'reason_code': exc.code,
+                    },
+                    level=logging.WARNING,
+                )
+                status_code = 409 if (
+                    exc.code.startswith('capability_')
+                    or exc.code in {
+                        'proposal_expired',
+                        'resume_in_progress',
+                        'resume_not_ready',
+                        'resume_write_conflict',
+                    }
+                ) else 400
+                return jsonify({'error': str(exc), 'code': exc.code}), status_code
+
         retry_user_message_id = data.get('retry_user_message_id') or data.get('edited_user_message_id')
         retry_thread_id = data.get('retry_thread_id')
         retry_thread_attempt = data.get('retry_thread_attempt')
@@ -16586,6 +17861,30 @@ def register_route_backend_chats(bp):
         data['active_public_workspace_ids'] = list(initial_scope_context['active_public_workspace_ids'])
         data['active_public_workspace_id'] = initial_scope_context['active_public_workspace_id']
         stream_session = CHAT_STREAM_REGISTRY.start_session(user_id, finalized_conversation_id)
+
+        if capability_resume_claim and capability_resume_claim.get('already_completed'):
+            completed_proposal = capability_resume_claim.get('proposal') or {}
+            completed_resume = completed_proposal.get('resume') or {}
+
+            def replay_completed_capability_resume():
+                yield f"data: {json.dumps(make_json_serializable({
+                    'done': True,
+                    'conversation_id': finalized_conversation_id,
+                    'message_id': completed_resume.get('assistant_message_id'),
+                    'user_message_id': completed_proposal.get('user_message_id'),
+                    'full_content': '',
+                    'reload_messages': True,
+                    'capability_resume': {
+                        'proposal_id': capability_resume_proposal_id,
+                        'status': 'completed',
+                        'idempotent': True,
+                    },
+                }))}\n\n"
+
+            return build_background_stream_response(
+                replay_completed_capability_resume,
+                stream_session=stream_session,
+            )
 
         request_message = (data.get('message') or '').strip()
         request_preview = request_message[:120] + '...' if len(request_message) > 120 else request_message
@@ -16639,6 +17938,7 @@ def register_route_backend_chats(bp):
                 'kernel_fallback_notice': payload.get('kernel_fallback_notice'),
                 'thoughts_enabled': payload.get('thoughts_enabled', False),
                 'blocked': payload.get('blocked', False),
+                'metadata': payload.get('metadata', {}),
             })
 
         def generate_compatibility_response():
@@ -16713,6 +18013,11 @@ def register_route_backend_chats(bp):
 
                 # Extract request parameters (same as non-streaming endpoint)
                 user_message = data.get('message', '')
+                capability_resume_context = (
+                    data.get('_capability_resume_context')
+                    if isinstance(data.get('_capability_resume_context'), Mapping)
+                    else None
+                )
                 conversation_id = finalized_conversation_id
                 hybrid_search_enabled = data.get('hybrid_search')
                 web_search_enabled = data.get('web_search_enabled')
@@ -16852,7 +18157,10 @@ def register_route_backend_chats(bp):
 
                 # Initialize variables
                 search_query = user_message
-                web_search_query_text = build_web_search_query_text(user_message)
+                external_retrieval_message = str(
+                    data.get('_server_external_query') or user_message
+                ).strip()
+                web_search_query_text = build_web_search_query_text(external_retrieval_message)
                 hybrid_citations_list = []
                 agent_citations_list = []
                 web_search_citations_list = []
@@ -17286,33 +18594,239 @@ def register_route_backend_chats(bp):
                         or assigned_knowledge_deep_research_urls
                     )
                 )
-                turn_orchestration_plan = build_turn_orchestration_plan(
-                    user_message,
-                    conversation_id=conversation_id,
-                    selected_agent=request_agent_info,
-                    selected_action=data.get('document_action'),
-                    selected_document_ids=requested_selected_document_ids,
-                    conversation_document_ids=auto_linked_chat_upload_document_ids,
-                    assigned_knowledge_enabled=assigned_knowledge_planned,
-                    document_scope=requested_document_scope,
+                discovery_authorized_documents = _resolve_authorized_chat_selected_documents(
+                    requested_selected_document_ids,
+                    user_id=user_id,
+                    document_scope=requested_document_scope or effective_document_scope or 'all',
                     active_group_ids=requested_active_group_ids,
                     active_public_workspace_ids=requested_active_public_workspace_ids,
-                    tags=requested_tags_filter,
-                    hybrid_search_enabled=requested_hybrid_search_enabled,
-                    web_search_enabled=requested_web_search_enabled,
-                    url_access_enabled=requested_url_access_enabled,
-                    source_review_enabled=requested_source_review_enabled,
-                    deep_research_enabled=requested_deep_research_enabled,
-                    user_workspace_context_enabled=user_workspace_context_requested,
-                    prior_citation_count=len(prior_grounded_document_refs),
-                    image_generation_available=image_generation_is_enabled(settings),
-                    model_deployment=frontend_gpt_model,
-                    model_id=frontend_model_id,
-                    model_endpoint_id=frontend_model_endpoint_id,
-                    model_provider=frontend_model_provider,
-                    reasoning_effort=reasoning_effort,
-                    prompt_info=data.get('prompt_info'),
                 )
+                discovery_document_ids = {
+                    str(document.get('id') or document.get('document_id') or '').strip()
+                    for document in discovery_authorized_documents
+                    if isinstance(document, Mapping)
+                }
+                for document in task_resolution.get('documents') or []:
+                    if not isinstance(document, Mapping):
+                        continue
+                    document_id = str(document.get('id') or document.get('document_id') or '').strip()
+                    if document_id:
+                        discovery_document_ids.add(document_id)
+
+                selected_builtin_capability_ids = (
+                    [
+                        capability.get('id')
+                        for capability in (
+                            capability_resume_context.get('capability_inventory', {}).get('capabilities', [])
+                            if capability_resume_context
+                            else []
+                        )
+                        if isinstance(capability, Mapping)
+                        and capability.get('state') == 'selected'
+                    ]
+                    if capability_resume_context
+                    else _get_selected_builtin_chat_capability_ids(data)
+                )
+                if capability_resume_context:
+                    capability_discovery = {
+                        'inventory': copy.deepcopy(
+                            capability_resume_context.get('capability_inventory') or {}
+                        ),
+                        'requirements': classify_capability_requirements(
+                            user_message,
+                            authorized_document_count=len(discovery_document_ids),
+                        ),
+                        'auto_capability_ids': [
+                            capability_id
+                            for capability_id, origin in (
+                                capability_resume_context.get('capability_origins') or {}
+                            ).items()
+                            if origin == 'discovery_auto'
+                        ],
+                        'recommendation': None,
+                    }
+                else:
+                    capability_discovery = _build_server_capability_discovery(
+                        settings=settings,
+                        user_id=user_id,
+                        user_email=current_user_email,
+                        user_roles=current_user_roles,
+                        user_message=user_message,
+                        selected_capability_ids=selected_builtin_capability_ids,
+                        authorized_document_count=len(discovery_document_ids),
+                    )
+                inventory_entries = capability_discovery.get('inventory', {}).get('capabilities', [])
+                log_event(
+                    '[CapabilityDiscovery] Governed capability inventory built',
+                    extra={
+                        'conversation_id': conversation_id,
+                        'capability_count': len(inventory_entries),
+                        'selected_count': sum(
+                            capability.get('state') == 'selected'
+                            for capability in inventory_entries
+                            if isinstance(capability, Mapping)
+                        ),
+                        'discoverable_count': sum(
+                            capability.get('discoverable') is True
+                            for capability in inventory_entries
+                            if isinstance(capability, Mapping)
+                        ),
+                        'requirement_count': len(
+                            capability_discovery.get('requirements') or []
+                        ),
+                    },
+                )
+                rejected_selected_capabilities = _get_rejected_selected_capability_entries(
+                    capability_discovery.get('inventory'),
+                    selected_builtin_capability_ids,
+                )
+                if rejected_selected_capabilities:
+                    log_event(
+                        '[CapabilityDiscovery] Selected capability rejected',
+                        extra={
+                            'conversation_id': conversation_id,
+                            'capability_count': len(rejected_selected_capabilities),
+                            'states': sorted({
+                                str(entry.get('state') or '')
+                                for entry in rejected_selected_capabilities
+                            }),
+                        },
+                        level=logging.WARNING,
+                    )
+                    yield f"data: {json.dumps({
+                        'error': _build_selected_capability_rejection_message(
+                            rejected_selected_capabilities
+                        )
+                    })}\n\n"
+                    return
+
+                auto_capability_ids = list(capability_discovery.get('auto_capability_ids') or [])
+                capability_origins = (
+                    dict(capability_resume_context.get('capability_origins') or {})
+                    if capability_resume_context
+                    else {capability_id: 'discovery_auto' for capability_id in auto_capability_ids}
+                )
+                if 'workspace_search' in auto_capability_ids:
+                    hybrid_search_enabled = True
+                if 'web_search' in auto_capability_ids:
+                    web_search_enabled = True
+                if 'url_access' in auto_capability_ids:
+                    url_access_enabled = True
+                    source_review_enabled = True
+                if 'deep_research' in auto_capability_ids:
+                    web_search_enabled = True
+                    source_review_enabled = True
+                    deep_research_enabled = True
+
+                plan_kwargs = {
+                    'conversation_id': conversation_id,
+                    'selected_agent': request_agent_info,
+                    'selected_action': data.get('document_action'),
+                    'selected_document_ids': requested_selected_document_ids,
+                    'conversation_document_ids': auto_linked_chat_upload_document_ids,
+                    'assigned_knowledge_enabled': assigned_knowledge_planned,
+                    'document_scope': requested_document_scope,
+                    'active_group_ids': requested_active_group_ids,
+                    'active_public_workspace_ids': requested_active_public_workspace_ids,
+                    'tags': requested_tags_filter,
+                    'hybrid_search_enabled': (
+                        requested_hybrid_search_enabled or 'workspace_search' in auto_capability_ids
+                    ),
+                    'web_search_enabled': (
+                        requested_web_search_enabled or 'web_search' in auto_capability_ids
+                    ),
+                    'url_access_enabled': (
+                        requested_url_access_enabled or 'url_access' in auto_capability_ids
+                    ),
+                    'source_review_enabled': (
+                        requested_source_review_enabled
+                        or 'url_access' in auto_capability_ids
+                        or 'deep_research' in auto_capability_ids
+                    ),
+                    'deep_research_enabled': (
+                        requested_deep_research_enabled or 'deep_research' in auto_capability_ids
+                    ),
+                    'user_workspace_context_enabled': user_workspace_context_requested,
+                    'prior_citation_count': len(prior_grounded_document_refs),
+                    'image_generation_available': image_generation_is_enabled(settings),
+                    'model_deployment': frontend_gpt_model,
+                    'model_id': frontend_model_id,
+                    'model_endpoint_id': frontend_model_endpoint_id,
+                    'model_provider': frontend_model_provider,
+                    'reasoning_effort': reasoning_effort,
+                    'prompt_info': data.get('prompt_info'),
+                }
+                if capability_resume_context:
+                    turn_orchestration_plan = build_turn_orchestration_plan(
+                        user_message,
+                        run_id=capability_resume_context.get('child_run_id'),
+                        parent_run_id=capability_resume_context.get('parent_run_id'),
+                        capability_origins=capability_origins,
+                        selection_snapshot_override=capability_resume_context.get('selection_snapshot'),
+                        **plan_kwargs,
+                    )
+                else:
+                    if auto_capability_ids:
+                        submitted_plan_kwargs = dict(plan_kwargs)
+                        submitted_plan_kwargs.update({
+                            'hybrid_search_enabled': requested_hybrid_search_enabled,
+                            'web_search_enabled': requested_web_search_enabled,
+                            'url_access_enabled': requested_url_access_enabled,
+                            'source_review_enabled': requested_source_review_enabled,
+                            'deep_research_enabled': requested_deep_research_enabled,
+                        })
+                        submitted_plan = build_turn_orchestration_plan(
+                            user_message,
+                            **submitted_plan_kwargs,
+                        )
+                        turn_orchestration_plan = build_turn_orchestration_plan(
+                            user_message,
+                            run_id=submitted_plan.get('run_id'),
+                            capability_origins=capability_origins,
+                            selection_snapshot_override=submitted_plan.get('selection_snapshot'),
+                            **plan_kwargs,
+                        )
+                    else:
+                        turn_orchestration_plan = build_turn_orchestration_plan(
+                            user_message,
+                            **plan_kwargs,
+                        )
+
+                effective_capability_entries = [
+                    {
+                        'id': capability_id,
+                        'origin': 'selection',
+                        'required': True,
+                    }
+                    for capability_id in selected_builtin_capability_ids
+                ]
+                for capability_id, origin in capability_origins.items():
+                    if not capability_id or any(
+                        entry['id'] == capability_id
+                        for entry in effective_capability_entries
+                    ):
+                        continue
+                    effective_capability_entries.append({
+                        'id': capability_id,
+                        'origin': origin,
+                        'required': True,
+                    })
+                turn_capability_provenance = build_capability_provenance(
+                    selection_snapshot=turn_orchestration_plan.get('selection_snapshot'),
+                    capability_inventory=capability_discovery.get('inventory'),
+                    decisions=(
+                        [capability_resume_context.get('decision')]
+                        if capability_resume_context
+                        else []
+                    ),
+                    proposal=(
+                        capability_resume_context.get('original_proposal')
+                        if capability_resume_context
+                        else None
+                    ),
+                    effective_capabilities=effective_capability_entries,
+                )
+                capability_recommendation = capability_discovery.get('recommendation')
                 log_event(
                     '[Orchestration] Turn plan created',
                     extra={
@@ -17341,7 +18855,11 @@ def register_route_backend_chats(bp):
                     g.conversation_group_id = conversation_group_id
 
                 # Save user message
-                user_message_id = f"{conversation_id}_user_{int(time.time())}_{random.randint(1000,9999)}"
+                user_message_id = (
+                    str(capability_resume_context.get('user_message_id') or '').strip()
+                    if capability_resume_context
+                    else f"{conversation_id}_user_{int(time.time())}_{random.randint(1000,9999)}"
+                )
                 turn_evidence_ledger = create_evidence_ledger_from_plan(
                     turn_orchestration_plan,
                     conversation_id=conversation_id,
@@ -17354,7 +18872,15 @@ def register_route_backend_chats(bp):
                 reconcile_orchestration_run_from_ledger(turn_orchestration_run)
                 orchestration_runtime_progress_events = []
 
-                user_metadata = {}
+                user_metadata = (
+                    copy.deepcopy(
+                        (
+                            capability_resume_context.get('existing_user_message') or {}
+                        ).get('metadata') or {}
+                    )
+                    if capability_resume_context
+                    else {}
+                )
                 current_user = get_current_user_info()
                 if current_user:
                     user_metadata['user_info'] = {
@@ -17365,12 +18891,17 @@ def register_route_backend_chats(bp):
                         'timestamp': datetime.utcnow().isoformat()
                     }
 
+                submitted_toggles = (
+                    turn_orchestration_plan.get('selection_snapshot', {}).get('toggles', {})
+                )
                 user_metadata['button_states'] = {
-                    'image_generation': False,
-                    'document_search': hybrid_search_enabled,
-                    'web_search': bool(web_search_enabled),
-                    'url_access': bool(url_access_enabled),
-                    'deep_research': bool(deep_research_enabled)
+                    'image_generation': bool(
+                        'image' in selected_builtin_capability_ids
+                    ),
+                    'document_search': bool(submitted_toggles.get('workspace_search')),
+                    'web_search': bool(submitted_toggles.get('web_search')),
+                    'url_access': bool(submitted_toggles.get('url_access')),
+                    'deep_research': bool(submitted_toggles.get('deep_research')),
                 }
                 user_metadata['capability_usage'] = _build_capability_usage_metadata(
                     workspace_search_enabled=hybrid_search_enabled,
@@ -17388,7 +18919,8 @@ def register_route_backend_chats(bp):
                 # Document search scope and selections
                 if hybrid_search_enabled:
                     user_metadata['workspace_search'] = {
-                        'search_enabled': True,
+                        'search_enabled': bool(submitted_toggles.get('workspace_search')),
+                        'effective_search_enabled': True,
                         'document_scope': effective_document_scope,
                         'selected_document_id': effective_selected_document_id,
                         'selected_document_ids': effective_selected_document_ids,
@@ -17487,32 +19019,55 @@ def register_route_backend_chats(bp):
                 if agent_selection_metadata:
                     user_metadata['agent_selection'] = agent_selection_metadata
 
+                if capability_resume_context and isinstance(user_metadata.get('orchestration'), Mapping):
+                    user_metadata.setdefault(
+                        'orchestration_parent',
+                        copy.deepcopy(dict(user_metadata['orchestration'])),
+                    )
                 user_metadata['orchestration'] = turn_orchestration_plan
                 user_metadata['evidence_ledger'] = turn_evidence_ledger
                 user_metadata['orchestration_runtime'] = turn_orchestration_run.to_metadata()
+                user_metadata['capability_provenance'] = turn_capability_provenance
                 user_metadata['chat_context'] = {
                     'conversation_id': conversation_id
                 }
 
                 # --- Threading Logic for Streaming ---
-                previous_thread_id = None
-                try:
-                    last_msg_query = f"""
-                        SELECT TOP 1 c.metadata.thread_info.thread_id as thread_id
-                        FROM c
-                        WHERE c.conversation_id = '{conversation_id}'
-                        ORDER BY c.timestamp DESC
-                    """
-                    last_msgs = list(cosmos_messages_container.query_items(
-                        query=last_msg_query,
-                        partition_key=conversation_id
-                    ))
-                    if last_msgs:
-                        previous_thread_id = last_msgs[0].get('thread_id')
-                except Exception as e:
-                    debug_print(f"Error fetching last message for threading: {e}")
+                existing_thread_info = (
+                    (
+                        capability_resume_context.get('existing_user_message') or {}
+                    ).get('metadata', {}).get('thread_info', {})
+                    if capability_resume_context
+                    else {}
+                )
+                previous_thread_id = existing_thread_info.get('previous_thread_id')
+                if not capability_resume_context:
+                    try:
+                        last_msg_query = f"""
+                            SELECT TOP 1 c.metadata.thread_info.thread_id as thread_id
+                            FROM c
+                            WHERE c.conversation_id = '{conversation_id}'
+                            ORDER BY c.timestamp DESC
+                        """
+                        last_msgs = list(cosmos_messages_container.query_items(
+                            query=last_msg_query,
+                            partition_key=conversation_id
+                        ))
+                        if last_msgs:
+                            previous_thread_id = last_msgs[0].get('thread_id')
+                    except Exception as e:
+                        debug_print(f"Error fetching last message for threading: {e}")
 
-                current_user_thread_id = str(uuid.uuid4())
+                current_user_thread_id = (
+                    str(existing_thread_info.get('thread_id') or '').strip()
+                    if capability_resume_context
+                    else str(uuid.uuid4())
+                )
+                if not current_user_thread_id:
+                    raise CapabilityChoiceError(
+                        'source user message thread is missing',
+                        code='proposal_thread_missing',
+                    )
                 latest_thread_id = current_user_thread_id
 
                 # Add thread information to user metadata
@@ -17523,41 +19078,50 @@ def register_route_backend_chats(bp):
                     'thread_attempt': 1
                 }
 
-                user_message_doc = {
-                    'id': user_message_id,
-                    'conversation_id': conversation_id,
-                    'role': 'user',
-                    'content': user_message,
-                    'timestamp': datetime.utcnow().isoformat(),
-                    'model_deployment_name': None,
-                    'metadata': user_metadata
-                }
+                user_message_doc = (
+                    copy.deepcopy(capability_resume_context.get('existing_user_message'))
+                    if capability_resume_context
+                    else {
+                        'id': user_message_id,
+                        'conversation_id': conversation_id,
+                        'role': 'user',
+                        'content': user_message,
+                        'timestamp': datetime.utcnow().isoformat(),
+                        'model_deployment_name': None,
+                    }
+                )
+                user_message_doc['metadata'] = user_metadata
 
                 cosmos_messages_container.upsert_item(user_message_doc)
                 debug_print(
-                    f"[Streaming] Saved user message {user_message_id} | thread_id={current_user_thread_id} | previous_thread_id={previous_thread_id}"
+                    f"[Streaming] {'Updated resumed' if capability_resume_context else 'Saved'} user message "
+                    f"{user_message_id} | thread_id={current_user_thread_id} | previous_thread_id={previous_thread_id}"
                 )
 
                 # Log activity
-                try:
-                    log_chat_activity(
-                        user_id=user_id,
-                        conversation_id=conversation_id,
-                        message_type='user_message',
-                        message_length=len(user_message) if user_message else 0,
-                        has_document_search=hybrid_search_enabled,
-                        has_image_generation=False,
-                        document_scope=effective_document_scope,
-                        chat_context=actual_chat_type,
-                        workspace_type='group' if actual_chat_type == 'group' else 'public' if actual_chat_type == 'public' else 'personal',
-                        group_id=effective_active_group_id if actual_chat_type == 'group' else None,
-                        public_workspace_id=effective_active_public_workspace_id if actual_chat_type == 'public' else None,
-                    )
-                except Exception as e:
-                    debug_print(f"Activity logging error: {e}")
+                if not capability_resume_context:
+                    try:
+                        log_chat_activity(
+                            user_id=user_id,
+                            conversation_id=conversation_id,
+                            message_type='user_message',
+                            message_length=len(user_message) if user_message else 0,
+                            has_document_search=hybrid_search_enabled,
+                            has_image_generation=False,
+                            document_scope=effective_document_scope,
+                            chat_context=actual_chat_type,
+                            workspace_type='group' if actual_chat_type == 'group' else 'public' if actual_chat_type == 'public' else 'personal',
+                            group_id=effective_active_group_id if actual_chat_type == 'group' else None,
+                            public_workspace_id=effective_active_public_workspace_id if actual_chat_type == 'public' else None,
+                        )
+                    except Exception as e:
+                        debug_print(f"Activity logging error: {e}")
 
                 # Update conversation title
-                title_updated = _set_initial_conversation_title(conversation_item, user_message)
+                title_updated = bool(
+                    not capability_resume_context
+                    and _set_initial_conversation_title(conversation_item, user_message)
+                )
 
                 conversation_item['last_updated'] = datetime.utcnow().isoformat()
                 cosmos_conversations_container.upsert_item(conversation_item)
@@ -17781,6 +19345,94 @@ def register_route_backend_chats(bp):
                         debug_print(f"[Content Safety Error - Streaming] {e}")
                     except Exception as ex:
                         debug_print(f"[Content Safety - Streaming] Unexpected error: {ex}")
+
+                if capability_recommendation and not capability_resume_context:
+                    turn_orchestration_run.status = 'awaiting_user_choice'
+                    turn_orchestration_run.started_at = datetime.utcnow().isoformat()
+                    proposal = build_capability_choice_proposal(
+                        capability_recommendation,
+                        run_id=turn_orchestration_plan.get('run_id'),
+                        conversation_id=conversation_id,
+                        user_message_id=user_message_id,
+                        assistant_message_id=assistant_message_id,
+                        ttl_seconds=settings.get('chat_capability_choice_ttl_seconds', 86400),
+                    )
+                    turn_capability_provenance = build_capability_provenance(
+                        selection_snapshot=turn_orchestration_plan.get('selection_snapshot'),
+                        capability_inventory=capability_discovery.get('inventory'),
+                        proposal=proposal,
+                        effective_capabilities=effective_capability_entries,
+                    )
+                    user_metadata['capability_provenance'] = turn_capability_provenance
+                    user_metadata['orchestration_runtime'] = turn_orchestration_run.to_metadata()
+                    user_message_doc['metadata'] = user_metadata
+                    cosmos_messages_container.upsert_item(user_message_doc)
+
+                    proposal_content = (
+                        'An additional capability could materially improve this answer. '
+                        'Choose how you want to continue.'
+                    )
+                    proposal_assistant_doc = make_json_serializable({
+                        'id': assistant_message_id,
+                        'conversation_id': conversation_id,
+                        'role': 'assistant',
+                        'content': proposal_content,
+                        'timestamp': datetime.utcnow().isoformat(),
+                        'augmented': False,
+                        'hybrid_citations': [],
+                        'web_search_citations': [],
+                        'agent_citations': [],
+                        'model_deployment_name': None,
+                        'metadata': {
+                            'awaiting_user_choice': True,
+                            'orchestration': turn_orchestration_plan,
+                            'orchestration_runtime': turn_orchestration_run.to_metadata(),
+                            'evidence_ledger': turn_evidence_ledger,
+                            'capability_proposal': proposal,
+                            'capability_provenance': turn_capability_provenance,
+                            'capability_resume_request': _build_capability_resume_request(
+                                data,
+                                canonical_agent=request_agent_info,
+                            ),
+                            'thread_info': {
+                                'thread_id': user_thread_id,
+                                'previous_thread_id': user_previous_thread_id,
+                                'active_thread': True,
+                                'thread_attempt': assistant_thread_attempt,
+                            },
+                        },
+                    })
+                    cosmos_messages_container.upsert_item(proposal_assistant_doc)
+                    conversation_item['last_updated'] = datetime.utcnow().isoformat()
+                    cosmos_conversations_container.upsert_item(conversation_item)
+                    invalidate_conversation_cache_for_item(
+                        conversation_item,
+                        reason='capability_choice_created',
+                    )
+                    orchestration_waiting_for_choice = True
+                    log_event(
+                        '[CapabilityDiscovery] Capability recommendation created',
+                        extra={
+                            'conversation_id': conversation_id,
+                            'proposal_id': proposal.get('proposal_id'),
+                            'run_id': proposal.get('run_id'),
+                            'recommended_option_id': proposal.get('recommended_option_id'),
+                            'option_count': len(proposal.get('options') or []),
+                            'requirement_count': len(proposal.get('requirement_ids') or []),
+                        },
+                    )
+                    yield f"data: {json.dumps(make_json_serializable({
+                        'done': True,
+                        'awaiting_user_choice': True,
+                        'conversation_id': conversation_id,
+                        'conversation_title': conversation_item.get('title'),
+                        'message_id': assistant_message_id,
+                        'user_message_id': user_message_id,
+                        'full_content': proposal_content,
+                        'metadata': proposal_assistant_doc.get('metadata', {}),
+                        'thoughts_enabled': thought_tracker.enabled,
+                    }))}\n\n"
+                    return
 
                 if not original_hybrid_search_enabled and not explicit_external_retrieval_requested:
                     prior_grounded_document_refs = _normalize_prior_grounded_document_refs(conversation_item)
@@ -18384,7 +20036,7 @@ def register_route_backend_chats(bp):
                         settings=settings,
                         conversation_id=conversation_id,
                         user_id=user_id,
-                        user_message=user_message,
+                        user_message=external_retrieval_message,
                         user_message_id=user_message_id,
                         chat_type=chat_type,
                         document_scope=document_scope,
@@ -18431,7 +20083,7 @@ def register_route_backend_chats(bp):
                         user_id=user_id,
                         user_email=current_user_email,
                         user_roles=current_user_roles,
-                        user_message=user_message,
+                        user_message=external_retrieval_message,
                         web_search_citations=web_search_citations_list if deep_research_enabled else [],
                         conversation_id=conversation_id,
                         source_review_planner_client=gpt_client,
@@ -20005,6 +21657,16 @@ def register_route_backend_chats(bp):
                             'orchestration': turn_orchestration_plan,
                             'orchestration_runtime': turn_orchestration_run.to_metadata(),
                             'evidence_ledger': turn_evidence_ledger,
+                            'capability_provenance': turn_capability_provenance,
+                            'capability_resume': (
+                                {
+                                    'proposal_id': capability_resume_context.get('proposal_id'),
+                                    'parent_run_id': capability_resume_context.get('parent_run_id'),
+                                    'execution_id': capability_resume_context.get('execution_id'),
+                                }
+                                if capability_resume_context
+                                else None
+                            ),
                             'central_synthesis': central_synthesis_metadata,
                             'capability_usage': build_streaming_capability_usage(),
                             'agent_runtime': agent_runtime_metadata or None,
@@ -20021,6 +21683,35 @@ def register_route_backend_chats(bp):
                         }
                     })
                     cosmos_messages_container.upsert_item(assistant_doc)
+                    if capability_resume_context:
+                        try:
+                            persist_capability_resume_completion(
+                                cosmos_messages_container,
+                                conversation_id=conversation_id,
+                                proposal_id=capability_resume_context.get('proposal_id'),
+                                execution_id=capability_resume_context.get('execution_id'),
+                                assistant_message_id=assistant_message_id,
+                            )
+                            log_event(
+                                '[CapabilityDiscovery] Orchestration resumed',
+                                extra={
+                                    'conversation_id': conversation_id,
+                                    'proposal_id': capability_resume_context.get('proposal_id'),
+                                    'parent_run_id': capability_resume_context.get('parent_run_id'),
+                                    'child_run_id': turn_orchestration_plan.get('run_id'),
+                                },
+                            )
+                        except Exception as resume_completion_error:
+                            log_event(
+                                '[CapabilityDiscovery] Resume completion persistence failed',
+                                extra={
+                                    'conversation_id': conversation_id,
+                                    'proposal_id': capability_resume_context.get('proposal_id'),
+                                    'error_type': type(resume_completion_error).__name__,
+                                },
+                                level=logging.ERROR,
+                                exceptionTraceback=True,
+                            )
                     if use_agent_streaming and agent_name_used:
                         agent_scope_for_usage = 'personal'
                         agent_group_id_for_usage = None
@@ -20099,6 +21790,9 @@ def register_route_backend_chats(bp):
                         )
                         if central_synthesis_metadata:
                             user_message_doc.setdefault('metadata', {})['central_synthesis'] = central_synthesis_metadata
+                        user_message_doc.setdefault('metadata', {})['capability_provenance'] = (
+                            turn_capability_provenance
+                        )
                         cosmos_messages_container.upsert_item(user_message_doc)
                     except Exception as e:
                         debug_print(f"Warning: Could not update streaming user message metadata: {e}")
@@ -20193,6 +21887,26 @@ def register_route_backend_chats(bp):
                     error_msg = str(e)
                     debug_print(f"Error during streaming: {error_msg}")
 
+                    if capability_resume_context:
+                        try:
+                            persist_capability_resume_failure(
+                                cosmos_messages_container,
+                                conversation_id=conversation_id,
+                                proposal_id=capability_resume_context.get('proposal_id'),
+                                execution_id=capability_resume_context.get('execution_id'),
+                                error_type=type(e).__name__,
+                            )
+                        except Exception as resume_failure_error:
+                            log_event(
+                                '[CapabilityDiscovery] Resume failure persistence failed',
+                                extra={
+                                    'conversation_id': conversation_id,
+                                    'proposal_id': capability_resume_context.get('proposal_id'),
+                                    'error_type': type(resume_failure_error).__name__,
+                                },
+                                level=logging.ERROR,
+                            )
+
                     if not turn_orchestration_run.completed_at:
                         fail_orchestration_run(
                             turn_orchestration_run,
@@ -20260,6 +21974,7 @@ def register_route_backend_chats(bp):
                                 'orchestration': turn_orchestration_plan,
                                 'orchestration_runtime': turn_orchestration_run.to_metadata(),
                                 'evidence_ledger': turn_evidence_ledger,
+                                'capability_provenance': turn_capability_provenance,
                                 'central_synthesis': central_synthesis_metadata,
                                 'capability_usage': build_streaming_capability_usage(),
                                 'source_review': compact_source_review_result_for_metadata(source_review_result),
@@ -20287,6 +22002,7 @@ def register_route_backend_chats(bp):
                             'orchestration': turn_orchestration_plan,
                             'orchestration_runtime': turn_orchestration_run.to_metadata(),
                             'evidence_ledger': turn_evidence_ledger,
+                            'capability_provenance': turn_capability_provenance,
                             'central_synthesis': central_synthesis_metadata,
                         },
                     }
@@ -20300,7 +22016,11 @@ def register_route_backend_chats(bp):
                 yield f"data: {json.dumps({'error': f'Internal server error: {str(e)}'})}\n\n"
             finally:
                 active_runtime = locals().get('turn_orchestration_run')
-                if active_runtime and not active_runtime.completed_at:
+                if (
+                    active_runtime
+                    and not active_runtime.completed_at
+                    and not locals().get('orchestration_waiting_for_choice')
+                ):
                     try:
                         runtime_progress_callback = locals().get(
                             'queue_orchestration_runtime_progress'

--- a/application/single_app/static/css/chats.css
+++ b/application/single_app/static/css/chats.css
@@ -1,5 +1,97 @@
 /* chats.css */
 
+.sc-capability-choice-card {
+  margin-top: 0.85rem;
+  padding: 0.9rem;
+  border: 1px solid rgba(13, 110, 253, 0.24);
+  border-left: 4px solid #0d6efd;
+  border-radius: 6px;
+  background: color-mix(in srgb, var(--bs-body-bg) 94%, #0d6efd 6%);
+  color: var(--bs-body-color);
+  overflow-wrap: anywhere;
+}
+
+.sc-capability-choice-header {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  margin-bottom: 0.45rem;
+}
+
+.sc-capability-choice-title {
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.35;
+  font-weight: 650;
+}
+
+.sc-capability-choice-reason,
+.sc-capability-choice-notice,
+.sc-capability-choice-sensitive-notice {
+  margin: 0 0 0.65rem;
+  font-size: 0.875rem;
+  line-height: 1.45;
+}
+
+.sc-capability-choice-notice,
+.sc-capability-choice-sensitive-notice {
+  padding: 0.55rem 0.65rem;
+  border-radius: 4px;
+}
+
+.sc-capability-choice-notice {
+  border: 1px solid rgba(13, 202, 240, 0.28);
+  background: rgba(13, 202, 240, 0.08);
+}
+
+.sc-capability-choice-sensitive-notice {
+  border: 1px solid rgba(255, 193, 7, 0.35);
+  background: rgba(255, 193, 7, 0.1);
+}
+
+.sc-capability-choice-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.55rem;
+}
+
+.sc-capability-choice-button {
+  min-height: 44px;
+  max-width: 100%;
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
+  white-space: normal;
+  text-align: center;
+}
+
+.sc-capability-choice-option-meta {
+  flex-basis: 100%;
+  font-size: 0.75rem;
+  line-height: 1.25;
+  opacity: 0.82;
+}
+
+.sc-capability-choice-status {
+  min-height: 1.35rem;
+  margin-top: 0.65rem;
+  font-size: 0.82rem;
+  line-height: 1.35;
+}
+
+@media (max-width: 575.98px) {
+  .sc-capability-choice-actions {
+    flex-direction: column;
+  }
+
+  .sc-capability-choice-button {
+    width: 100%;
+  }
+}
+/* chats.css */
+
 /* Prevent initial layout shift by disabling transitions on page load */
 .no-transitions *,
 .no-transitions #left-pane,

--- a/application/single_app/static/js/chat/chat-capability-choice.js
+++ b/application/single_app/static/js/chat/chat-capability-choice.js
@@ -1,0 +1,304 @@
+// chat-capability-choice.js
+
+const CONTINUE_OPTION_ID = 'continue_without_capabilities';
+const MAX_OPTIONS = 12;
+const REASON_LABELS = Object.freeze({
+    current_authoritative_sources: 'Current official sources could materially improve accuracy.',
+    current_public_information: 'Current public information could materially improve freshness.',
+    user_supplied_url_requires_review: 'The supplied links need review to answer from their contents.',
+    workspace_evidence_requested: 'Authorized workspace evidence could materially improve this answer.',
+    document_analysis_requested: 'Structured analysis could materially improve the findings.',
+    multi_document_comparison: 'A document comparison could materially improve the result.',
+    visual_output_materially_helpful: 'A visual output would materially help with this request.',
+    multi_source_public_research: 'Multiple authoritative sources could materially improve confidence.',
+});
+
+function normalizeIdentifier(value) {
+    return String(value || '').trim().slice(0, 200);
+}
+
+function normalizeProposal(metadata) {
+    const proposal = metadata?.capability_proposal;
+    if (!proposal || typeof proposal !== 'object') {
+        return null;
+    }
+    const proposalId = normalizeIdentifier(proposal.proposal_id);
+    const conversationId = normalizeIdentifier(proposal.conversation_id);
+    const status = normalizeIdentifier(proposal.status).toLowerCase();
+    const options = Array.isArray(proposal.options)
+        ? proposal.options.slice(0, MAX_OPTIONS).map(option => ({
+            id: normalizeIdentifier(option?.id),
+            label: String(option?.label || '').trim().slice(0, 120),
+            capabilityIds: Array.isArray(option?.capability_ids)
+                ? option.capability_ids.map(normalizeIdentifier).filter(Boolean).slice(0, 8)
+                : [],
+            latencyClass: normalizeIdentifier(option?.latency_class),
+            costClass: normalizeIdentifier(option?.cost_class),
+            externalData: option?.external_data === true,
+            sensitiveInputTypes: Array.isArray(option?.sensitive_input_types)
+                ? option.sensitive_input_types.map(normalizeIdentifier).filter(Boolean).slice(0, 8)
+                : [],
+        })).filter(option => option.id && option.label)
+        : [];
+    if (!proposalId || !conversationId || options.length === 0) {
+        return null;
+    }
+    const expiresAt = normalizeIdentifier(proposal.expires_at);
+    const expiresAtMilliseconds = Date.parse(expiresAt);
+    return {
+        proposalId,
+        conversationId,
+        status,
+        recommendedOptionId: normalizeIdentifier(proposal.recommended_option_id),
+        reasonCodes: Array.isArray(proposal.reason_codes)
+            ? proposal.reason_codes.map(normalizeIdentifier).filter(Boolean).slice(0, 12)
+            : [],
+        options,
+        decision: proposal.decision && typeof proposal.decision === 'object'
+            ? {
+                optionId: normalizeIdentifier(proposal.decision.option_id),
+                status: normalizeIdentifier(proposal.decision.status).toLowerCase(),
+            }
+            : null,
+        resume: proposal.resume && typeof proposal.resume === 'object'
+            ? {
+                status: normalizeIdentifier(proposal.resume.status).toLowerCase(),
+                assistantMessageId: normalizeIdentifier(proposal.resume.assistant_message_id),
+            }
+            : { status: 'not_requested', assistantMessageId: '' },
+        expiresAt,
+        expired: Number.isFinite(expiresAtMilliseconds) && expiresAtMilliseconds <= Date.now(),
+    };
+}
+
+function createElement(tagName, className = '', text = '') {
+    const element = document.createElement(tagName);
+    if (className) {
+        element.className = className;
+    }
+    if (text) {
+        element.textContent = text;
+    }
+    return element;
+}
+
+function appendOptionMeta(container, option) {
+    const parts = [];
+    if (option.latencyClass) {
+        parts.push(`Time: ${option.latencyClass}`);
+    }
+    if (option.costClass) {
+        parts.push(`Cost: ${option.costClass}`);
+    }
+    if (parts.length === 0) {
+        return;
+    }
+    container.appendChild(createElement('span', 'sc-capability-choice-option-meta', parts.join(' | ')));
+}
+
+function getReasonText(proposal) {
+    const reasonCode = proposal.reasonCodes.find(code => REASON_LABELS[code]);
+    return REASON_LABELS[reasonCode] || 'An additional capability could materially improve this answer.';
+}
+
+function setCardBusy(card, busy) {
+    card.dataset.submitting = busy ? 'true' : 'false';
+    card.querySelectorAll('button').forEach(button => {
+        button.disabled = busy;
+    });
+}
+
+function updateStatus(statusElement, message, tone = 'muted') {
+    statusElement.className = `sc-capability-choice-status text-${tone}`;
+    statusElement.textContent = message;
+}
+
+async function submitDecision(card, proposal, option, statusElement, onResume) {
+    if (card.dataset.submitting === 'true') {
+        return;
+    }
+    setCardBusy(card, true);
+    updateStatus(statusElement, 'Saving your choice...', 'primary');
+    try {
+        const response = await fetch(
+            `/api/chat/capability-proposals/${encodeURIComponent(proposal.proposalId)}/decision`,
+            {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                credentials: 'same-origin',
+                body: JSON.stringify({
+                    conversation_id: proposal.conversationId,
+                    option_id: option.id,
+                }),
+            },
+        );
+        const result = await response.json().catch(() => ({}));
+        if (!response.ok) {
+            throw new Error(result.error || 'Your capability choice could not be saved.');
+        }
+        updateStatus(
+            statusElement,
+            option.id === CONTINUE_OPTION_ID
+                ? 'Continuing without additional capabilities...'
+                : `Approved ${option.label}. Resuming...`,
+            'primary',
+        );
+        if (typeof onResume !== 'function') {
+            throw new Error('Chat resume is not available. Refresh this conversation to continue.');
+        }
+        await onResume({
+            conversationId: proposal.conversationId,
+            proposalId: proposal.proposalId,
+            endpoint: result.resume_endpoint || '/api/chat/stream',
+        });
+        updateStatus(
+            statusElement,
+            option.id === CONTINUE_OPTION_ID
+                ? 'Completed without additional capabilities.'
+                : `Completed with ${option.label}.`,
+            'success',
+        );
+    } catch (error) {
+        setCardBusy(card, false);
+        updateStatus(
+            statusElement,
+            error?.message || 'Your capability choice could not be saved.',
+            'danger',
+        );
+    }
+}
+
+function renderPendingOptions(card, proposal, actions, statusElement, onResume) {
+    proposal.options.forEach(option => {
+        const isRecommended = option.id === proposal.recommendedOptionId;
+        const isContinue = option.id === CONTINUE_OPTION_ID;
+        const button = createElement(
+            'button',
+            isContinue
+                ? 'btn btn-outline-secondary sc-capability-choice-button'
+                : isRecommended
+                ? 'btn btn-primary sc-capability-choice-button'
+                : 'btn btn-outline-primary sc-capability-choice-button',
+        );
+        button.type = 'button';
+        button.dataset.optionId = option.id;
+        button.setAttribute('aria-describedby', statusElement.id);
+
+        const label = createElement('span', 'sc-capability-choice-option-label', option.label);
+        button.appendChild(label);
+        if (isRecommended) {
+            button.appendChild(createElement('span', 'badge text-bg-light ms-2', 'Recommended'));
+        }
+        appendOptionMeta(button, option);
+        button.addEventListener('click', () => {
+            void submitDecision(card, proposal, option, statusElement, onResume);
+        });
+        actions.appendChild(button);
+    });
+}
+
+function renderResolvedAction(card, proposal, actions, statusElement, onResume) {
+    const selectedOption = proposal.options.find(option => option.id === proposal.decision?.optionId);
+    const selectedLabel = selectedOption?.label || 'saved choice';
+    if (proposal.resume.status === 'completed') {
+        updateStatus(statusElement, `Completed with ${selectedLabel}.`, 'success');
+        return;
+    }
+    if (proposal.resume.status === 'running') {
+        updateStatus(statusElement, `Resuming with ${selectedLabel}...`, 'primary');
+        return;
+    }
+    if (!selectedOption) {
+        updateStatus(statusElement, 'This capability choice is no longer available.', 'danger');
+        return;
+    }
+    const resumeButton = createElement(
+        'button',
+        'btn btn-primary sc-capability-choice-button',
+        proposal.resume.status === 'failed' ? 'Retry resume' : 'Resume',
+    );
+    resumeButton.type = 'button';
+    resumeButton.setAttribute('aria-describedby', statusElement.id);
+    resumeButton.addEventListener('click', () => {
+        void submitDecision(card, proposal, selectedOption, statusElement, onResume);
+    });
+    actions.appendChild(resumeButton);
+    updateStatus(
+        statusElement,
+        proposal.resume.status === 'failed'
+            ? `The previous resume attempt failed. ${selectedLabel} remains approved for this turn.`
+            : `${selectedLabel} is saved and ready to resume.`,
+        proposal.resume.status === 'failed' ? 'warning' : 'muted',
+    );
+}
+
+export function hydrateCapabilityChoice(messageElement, metadata, { onResume } = {}) {
+    if (!messageElement) {
+        return;
+    }
+    messageElement.querySelector('.sc-capability-choice-card')?.remove();
+    const proposal = normalizeProposal(metadata);
+    if (!proposal) {
+        return;
+    }
+
+    const messageText = messageElement.querySelector('.message-text');
+    if (!messageText) {
+        return;
+    }
+    const safeId = proposal.proposalId.replace(/[^A-Za-z0-9_-]/g, '').slice(0, 80) || 'proposal';
+    const titleId = `capability-choice-title-${safeId}`;
+    const statusId = `capability-choice-status-${safeId}`;
+    const card = createElement('section', 'sc-capability-choice-card');
+    card.dataset.testid = 'capability-choice-card';
+    card.setAttribute('aria-labelledby', titleId);
+
+    const header = createElement('div', 'sc-capability-choice-header');
+    const icon = createElement('i', 'bi bi-signpost-split');
+    icon.setAttribute('aria-hidden', 'true');
+    header.appendChild(icon);
+    const title = createElement('h3', 'sc-capability-choice-title', 'Choose how to continue');
+    title.id = titleId;
+    header.appendChild(title);
+    card.appendChild(header);
+    card.appendChild(createElement('p', 'sc-capability-choice-reason', getReasonText(proposal)));
+
+    const hasExternalOption = proposal.options.some(option => option.externalData);
+    if (hasExternalOption) {
+        const notice = createElement(
+            'p',
+            'sc-capability-choice-notice',
+            'External options send only the current message query. Conversation history and workspace content are not included.',
+        );
+        notice.dataset.testid = 'capability-external-data-notice';
+        card.appendChild(notice);
+    }
+    if (proposal.options.some(option => option.sensitiveInputTypes.length > 0)) {
+        const sensitiveNotice = createElement(
+            'p',
+            'sc-capability-choice-sensitive-notice',
+            'Options labeled with the supplied address explicitly approve using that address for this turn.',
+        );
+        sensitiveNotice.dataset.testid = 'capability-sensitive-data-notice';
+        card.appendChild(sensitiveNotice);
+    }
+
+    const actions = createElement('div', 'sc-capability-choice-actions');
+    const statusElement = createElement('div', 'sc-capability-choice-status text-muted');
+    statusElement.id = statusId;
+    statusElement.setAttribute('role', 'status');
+    statusElement.setAttribute('aria-live', 'polite');
+    statusElement.textContent = 'Waiting for your choice.';
+    if (proposal.status === 'pending' && proposal.expired) {
+        updateStatus(statusElement, 'This capability choice has expired.', 'muted');
+    } else if (proposal.status === 'pending') {
+        renderPendingOptions(card, proposal, actions, statusElement, onResume);
+    } else if (proposal.status === 'approved' || proposal.status === 'declined') {
+        renderResolvedAction(card, proposal, actions, statusElement, onResume);
+    } else {
+        updateStatus(statusElement, 'This capability choice is no longer available.', 'muted');
+    }
+    card.appendChild(actions);
+    card.appendChild(statusElement);
+    messageText.insertAdjacentElement('afterend', card);
+}

--- a/application/single_app/static/js/chat/chat-messages.js
+++ b/application/single_app/static/js/chat/chat-messages.js
@@ -24,6 +24,7 @@ import { areAgentsEnabled } from './chat-agents.js';
 import { createThoughtsToggleHtml, attachThoughtsToggleListener } from './chat-thoughts.js';
 import { destroyInlineCharts, extractInlineChartBlocks, hydrateInlineCharts, injectInlineChartHtml, restoreInlineChartTokens } from './chat-inline-charts.js';
 import { attachGeneratedImageProposalResults, extractInlineImageProposalBlocks, hydrateInlineImageProposals, injectInlineImageProposalHtml, restoreInlineImageProposalTokens } from './chat-inline-image-proposals.js';
+import { hydrateCapabilityChoice } from './chat-capability-choice.js';
 import { renderInlineVideoGalleries } from './chat-inline-videos.js';
 import { renderInlineImageGalleries } from './chat-inline-images.js';
 import { renderInlineAzureMaps } from './chat-inline-maps.js';
@@ -4964,6 +4965,29 @@ export function appendMessage(
       hydrateInlineCharts(messageDiv);
       hydrateInlineImageProposals(messageDiv, fullMessageObject?.metadata || null);
     }
+    hydrateCapabilityChoice(messageDiv, fullMessageObject?.metadata || null, {
+      onResume: ({ conversationId, proposalId, endpoint }) => new Promise((resolve, reject) => {
+        const started = sendMessageWithStreaming(
+          {
+            conversation_id: conversationId,
+            capability_resume_proposal_id: proposalId,
+          },
+          null,
+          conversationId,
+          {
+            endpoint,
+            allowRecovery: false,
+            onDone: resolve,
+            onError: errorMessage => reject(
+              new Error(errorMessage || 'The resumed chat could not be completed.')
+            ),
+          },
+        );
+        if (!started) {
+          reject(new Error('The resumed chat could not be started.'));
+        }
+      }),
+    });
 
     // --- Attach Event Listeners specifically for AI message ---
     attachCodeBlockCopyButtons(messageDiv.querySelector(".message-text"));

--- a/docs/explanation/features/CHAT_TURN_ORCHESTRATION.md
+++ b/docs/explanation/features/CHAT_TURN_ORCHESTRATION.md
@@ -1,6 +1,6 @@
 # Chat Turn Orchestration
 
-Implemented in version: **0.250.064**
+Implemented in version: **0.250.066**
 Associated issue: **[#1021](https://github.com/microsoft/simplechat/issues/1021)**
 
 ## Overview
@@ -219,6 +219,49 @@ The browser state is explanatory, not authoritative. The generation route reauth
 
 Users can edit or dismiss a proposal before generation, explicitly acknowledge a partial proposal, or stop the active chat stream through the existing cancellation control. These interventions remain scoped to the current request and proposal; Phase 7 does not add an admin approval queue or permit automatic write, sensitive, consequential, or over-budget actions.
 
+## Phase 8A Governed Capability Discovery And User Choice
+
+Phase 8A gives the authenticated server a bounded inventory of built-in chat capabilities before execution. The initial inventory covers Workspace Search, Analyze, Compare, Image, Web Search, URL Access, and Deep Research. It contains only planning metadata such as category, state, governance mode, risk, latency, cost, evidence types, required inputs, and current-user scope. It does not include secrets, connection settings, raw prompt or agent instructions, inaccessible catalog entries, or browser-supplied authorization claims.
+
+Capability states remain distinct:
+
+- `selected` is an explicit submitted mandate and remains a required attempt.
+- `unselected` is available and authorized, so policy may allow deterministic discovery or recommendation.
+- `approved` and `declined` are persisted turn-scoped decisions for a proposal.
+- `unavailable`, `unauthorized`, and `policy_blocked` capabilities are not offered or executed.
+
+An inactive toolbar control is therefore not treated as a denial. Per-capability modes under `chat_capability_governance` are `manual_only`, `recommend`, `auto_read_only`, and `blocked`. Only internal, read-only capabilities can use `auto_read_only`; external retrieval still requires a user choice. Invalid governance values fail closed as blocked. `chat_capability_choice_ttl_seconds` controls the bounded pending-choice lifetime and defaults to one day.
+
+### Deterministic Matching
+
+Common requirements are classified without a planning-model call. Initial classes cover current public information, current official/local rules, user-supplied URLs, workspace evidence, document analysis, multi-document comparison, explicit visual output, and multi-source public research. A recommendation is created only when an eligible capability can materially improve freshness, completeness, confidence, evidence quality, or requested output.
+
+Simple timeless questions keep their direct one-step plan. Analyze requires at least one reauthorized document target, Compare requires at least two, URL Access requires a supplied URL, and Image is proposed only for explicit visual creation intent. Current local-law and official-record requests prefer Deep Research when available and retain Web Search as a bounded alternative. Unselected-agent discovery is intentionally deferred to Phase 8B; selected agents continue through canonical server resolution and the existing required-attempt contract.
+
+### Durable Choice And Resume
+
+When consent is needed, the server persists one normal assistant message with an `awaiting_user_choice` checkpoint and ends SSE. The proposal records its exact conversation, source user message, parent run, requirement/reason codes, allowlisted options, recommendation, creation and expiry times, decision, and resume lease. Refreshing the conversation reconstructs the same card from message metadata; no process-local waiter is required.
+
+The decision route:
+
+1. Reauthorizes personal conversation ownership.
+2. Reads the exact proposal and source user message from the conversation partition.
+3. Validates parent-run and source-turn linkage.
+4. Accepts only a literal option ID present in the persisted proposal.
+5. Rebuilds capability configuration, role authorization, scopes, and document targets.
+6. Uses an ETag conditional replacement so duplicate clicks replay idempotently and conflicting choices cannot both win.
+7. Persists approved, declined, expired, or invalidated terminal state.
+
+Resume requests contain only the conversation and proposal IDs. The server reconstructs the original bounded request, reauthorizes scopes and linked chat-upload documents, applies approved capabilities with `discovery_approved` origin, and creates a child run linked to the parent. A decline creates no capability source and finalizes once without another recommendation loop. Selected, proposed, decided, and effective capability provenance remain separate; approved or automatic discovery is never rewritten as `selection`.
+
+Resume execution uses a conditional lease. A duplicate live claim is rejected, a failed or cancelled claim can be retried, and completed output is replayed without another capability call. If a process stops after persisting the resumed assistant but before marking the proposal complete, the next request reconciles that exact assistant by proposal and execution IDs before considering another claim.
+
+### External Data Minimization
+
+Discovered external retrieval preserves the existing current-message-only boundary. Conversation history, retrieved workspace content, and unrelated context are not appended to Web Search or Deep Research requests. The server removes detected street addresses, email addresses, phone numbers, and account-like identifiers from the default external query. Parcel-specific requests receive a separate, clearly labeled option whose selection explicitly approves including the supplied address for that turn. Capability choices do not change saved toolbar defaults.
+
+The inline choice card renders server fields through DOM text APIs, provides one recommended option, alternatives, and a continue-without-capabilities path, associates external/sensitive notices with the workflow, uses `aria-live` for status, and maintains at least 44-pixel actions on mobile.
+
 ## Security And Governance
 
 - Caller-supplied IDs are never treated as proof of authorization.
@@ -249,6 +292,11 @@ Users can edit or dismiss a proposal before generation, explicitly acknowledge a
 - Runtime metadata excludes raw adapter results, raw evidence, debug exception text, and caller-supplied authorization identifiers.
 - Runtime source reconciliation consumes only evidence already normalized by the established authorization-aware collectors and executors.
 - Side effects, sensitive access, and budget overflow are marked as approval-required policy classes for later runtime enforcement.
+- Capability inventory availability and authorization come from current server configuration, role claims, authorized scopes, and revalidated document targets rather than toolbar state.
+- Pending proposals, decisions, resume leases, parent/child linkage, and effective origins are stored in the authorized conversation partition with ETag concurrency.
+- A proposal approval never substitutes for collector or executor authorization; configuration and object access are checked again immediately before resume and at execution boundaries.
+- Browser decision payloads cannot add capabilities, run IDs, user IDs, document IDs, or scope IDs. Effective execution is reconstructed from the persisted allowlist.
+- Discovered external queries use current-message-only minimized text. Sensitive address use requires selection of the separately labeled sensitive-input option.
 
 ## Dependencies
 
@@ -260,6 +308,8 @@ Users can edit or dismiss a proposal before generation, explicitly acknowledge a
 - Generic central synthesis request and output-profile contracts.
 - Request-scoped `OrchestrationRun` scheduling and lifecycle helpers.
 - Existing `ActiveConversationStreamSession` cancellation, replay, heartbeat, and reattach behavior.
+- Cosmos message ETags for idempotent capability decisions and resume leases.
+- Existing role-aware Web Search, URL Access, Deep Research, image-generation, document-action, and authorized document/scope checks.
 
 ## Testing And Validation
 
@@ -337,12 +387,20 @@ Desktop/mobile coverage in `ui_tests/test_streaming_thought_progression.py` vali
 
 The stream heartbeat, background execution, lifecycle observability, new-conversation reattach, and stop-control contracts also validate that runtime cancellation preserves the existing SSE protocol and replay behavior.
 
+Phase 8A capability coverage is in:
+
+- `functional_tests/test_chat_capability_discovery.py` for inventory states, deterministic matching, target gates, and unavailable/unauthorized/policy-blocked filtering.
+- `functional_tests/test_chat_capability_choice_contract.py` for allowlisted decisions, expiry, decline, external-query minimization, sensitive-input options, provenance, and resume lifecycle.
+- `functional_tests/test_chat_capability_choice_persistence.py` for ETag conflicts, duplicate decisions, single execution claims, and persisted expired/invalidated states.
+- `functional_tests/test_chat_capability_choice_route.py` for conversation ownership, exact source-turn linkage, forged options, post-approval revocation, server request reconstruction, parent/child replay, and process-loss reconciliation.
+- `ui_tests/test_chat_capability_choice_card.py` for persisted rendering, keyboard interaction, external notices, exact decision/resume payloads, `aria-live`, desktop/mobile overflow, and 44-pixel controls.
+
 ## Known Limitations
 
-Phase 7 provides request-scoped progress, review, and image-proposal approval, with these deliberate boundaries:
+Phase 8A adds durable built-in capability choice, with these deliberate boundaries:
 
-- Arbitrary governed tools are not yet discovered automatically.
-- Runs are not stored in a durable queue or Cosmos run store and cannot resume after process loss.
+- Governed discovery of unselected agents is deferred to Phase 8B and will reuse this inventory/proposal contract.
+- Active runs and evidence ledgers are not stored in a durable queue or dedicated run store. Pending capability choices survive process loss, and persisted resumed assistants reconcile safely, but an in-flight model/tool operation still relies on existing stream execution and retry behavior.
 - Parallel runtime adapters must be request-context independent; the live chat route currently reconciles its existing authorized collectors sequentially.
 - Cancellation of synchronous model, agent, and document-action SDK calls is best effort. Pending finalization is prevented, but an in-flight non-cooperative call may return before its result can be discarded.
 - The legacy non-streaming compatibility path does not yet use Phase 3 collectors.
@@ -353,4 +411,4 @@ Phase 7 provides request-scoped progress, review, and image-proposal approval, w
 - Reference thumbnails are shown only for authorized conversation image messages. Document-backed image evidence remains labeled when no existing same-origin preview route applies.
 - The live chat payload does not yet expose a dedicated selected-image-reference list; selected workspace images are represented as documents, and explicit headshot/reference intent can be detected from the message until a reference control is wired.
 
-Durable run persistence, process-loss resume, generalized consequential-action approval, broader finalizers, and generalized artifact generation remain later roadmap phases.
+Generalized durable run execution, consequential/write approval, broader finalizers, and generalized artifact generation remain later roadmap phases.

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,17 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](/explanation/features/) and [Fixes by Version](/explanation/fixes/).
 
+### **(v0.250.066)**
+
+#### New Features
+
+*   **Governed Chat Capability Discovery And User Choice**
+    *   Added a server-authoritative inventory and deterministic requirement matching for Workspace Search, Analyze, Compare, Image, Web Search, URL Access, and Deep Research while keeping simple timeless questions on the direct path.
+    *   Unselected authorized capabilities can now be recommended through one persisted inline choice card; selected capabilities remain required, declined capabilities are prohibited for the turn, and unavailable, unauthorized, or policy-blocked capabilities are never offered.
+    *   Capability decisions and resume claims are authenticated, ETag-protected, idempotent, linked to the exact source turn, and revalidated against current configuration, roles, scopes, and document access before child-run execution.
+    *   External discovery sends a minimized current-message-only query, omits detected personal identifiers by default, and requires a separately labeled choice before including a supplied address for parcel-specific research.
+    *   (Ref: microsoft/simplechat#1021, `functions_chat_capabilities.py`, `functions_chat_capability_choices.py`, `functions_chat_capability_persistence.py`, `route_backend_chats.py`, `chat-capability-choice.js`, `CHAT_TURN_ORCHESTRATION.md`)
+
 ### **(v0.250.064)**
 
 #### User Interface Enhancements

--- a/functional_tests/test_chat_capability_choice_contract.py
+++ b/functional_tests/test_chat_capability_choice_contract.py
@@ -1,0 +1,382 @@
+#!/usr/bin/env python3
+# test_chat_capability_choice_contract.py
+"""
+Functional test for durable chat capability decisions and resume claims.
+Version: 0.250.066
+Implemented in: 0.250.066
+
+This test ensures capability proposals are bounded, decisions are allowlisted
+and idempotent, resume claims cannot execute twice, and external queries omit
+unapproved personal data.
+"""
+
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SINGLE_APP_ROOT = REPO_ROOT / 'application' / 'single_app'
+sys.path.insert(0, str(SINGLE_APP_ROOT))
+
+from functions_chat_capabilities import (  # noqa: E402
+    build_capability_recommendation,
+    build_governed_capability_inventory,
+    classify_capability_requirements,
+)
+from functions_chat_capability_choices import (  # noqa: E402
+    CapabilityChoiceError,
+    add_sensitive_external_query_options,
+    apply_capability_choice_decision,
+    build_capability_choice_proposal,
+    build_capability_provenance,
+    build_minimized_external_query,
+    claim_capability_choice_resume,
+    complete_capability_choice_resume,
+    fail_capability_choice_resume,
+    revalidate_capability_choice,
+)
+
+
+NOW = datetime(2026, 7, 15, 12, 0, tzinfo=timezone.utc)
+
+
+def _inventory(*, web_state='unselected', deep_state='unselected'):
+    resolved = {
+        capability_id: {
+            'enabled': True,
+            'available': True,
+            'authorized': True,
+            'governance_mode': 'recommend',
+        }
+        for capability_id in (
+            'workspace_search',
+            'analyze',
+            'compare',
+            'image',
+            'web_search',
+            'url_access',
+            'deep_research',
+        )
+    }
+    if web_state != 'unselected':
+        if web_state == 'unavailable':
+            resolved['web_search']['available'] = False
+        elif web_state == 'unauthorized':
+            resolved['web_search']['authorized'] = False
+        elif web_state == 'policy_blocked':
+            resolved['web_search']['governance_mode'] = 'blocked'
+    if deep_state != 'unselected':
+        if deep_state == 'unavailable':
+            resolved['deep_research']['available'] = False
+        elif deep_state == 'unauthorized':
+            resolved['deep_research']['authorized'] = False
+        elif deep_state == 'policy_blocked':
+            resolved['deep_research']['governance_mode'] = 'blocked'
+    return build_governed_capability_inventory(resolved_capabilities=resolved)
+
+
+def _proposal(inventory=None, now=NOW):
+    inventory = inventory or _inventory()
+    requirements = classify_capability_requirements(
+        'What are the current Fairfax County zoning rules?'
+    )
+    recommendation = build_capability_recommendation(inventory, requirements)
+    return build_capability_choice_proposal(
+        recommendation,
+        run_id='parent-run',
+        conversation_id='conversation-1',
+        user_message_id='user-message-1',
+        assistant_message_id='proposal-1',
+        now=now,
+    )
+
+
+def test_approval_is_allowlisted_and_idempotent():
+    proposal = _proposal()
+    approved, idempotent = apply_capability_choice_decision(
+        proposal,
+        'deep_research',
+        actor_user_id='user-1',
+        now=NOW,
+    )
+    replayed, replay_idempotent = apply_capability_choice_decision(
+        approved,
+        'deep_research',
+        actor_user_id='user-1',
+        now=NOW + timedelta(seconds=1),
+    )
+
+    assert approved['status'] == 'approved'
+    assert approved['decision']['capability_ids'] == ['deep_research']
+    assert approved['decision']['effective_capability_ids'] == [
+        'deep_research',
+        'web_search',
+    ]
+    assert approved['resume']['status'] == 'pending'
+    assert idempotent is False
+    assert replay_idempotent is True
+    assert replayed == approved
+
+
+def test_decline_is_durable_and_conflicting_decision_is_rejected():
+    proposal = _proposal()
+    declined, _ = apply_capability_choice_decision(
+        proposal,
+        'continue_without_capabilities',
+        actor_user_id='user-1',
+        now=NOW,
+    )
+
+    assert declined['status'] == 'declined'
+    assert declined['decision']['capability_ids'] == []
+    try:
+        apply_capability_choice_decision(
+            declined,
+            'web_search',
+            actor_user_id='user-1',
+            now=NOW,
+        )
+        raise AssertionError('conflicting decisions must fail')
+    except CapabilityChoiceError as exc:
+        assert exc.code == 'decision_conflict'
+
+
+def test_forged_and_expired_choices_are_rejected():
+    proposal = _proposal()
+    try:
+        apply_capability_choice_decision(
+            proposal,
+            'forged_capability',
+            actor_user_id='user-1',
+            now=NOW,
+        )
+        raise AssertionError('forged options must fail')
+    except CapabilityChoiceError as exc:
+        assert exc.code == 'option_not_allowlisted'
+
+    try:
+        apply_capability_choice_decision(
+            proposal,
+            'web_search',
+            actor_user_id='user-1',
+            now=NOW + timedelta(days=2),
+        )
+        raise AssertionError('expired proposals must fail')
+    except CapabilityChoiceError as exc:
+        assert exc.code == 'proposal_expired'
+
+
+def test_revalidation_rejects_revoked_capability():
+    proposal = _proposal()
+    approved, _ = apply_capability_choice_decision(
+        proposal,
+        'web_search',
+        actor_user_id='user-1',
+        now=NOW,
+    )
+    assert revalidate_capability_choice(approved, _inventory()) is True
+
+    try:
+        revalidate_capability_choice(
+            approved,
+            _inventory(web_state='unauthorized'),
+        )
+        raise AssertionError('revoked capabilities must fail revalidation')
+    except CapabilityChoiceError as exc:
+        assert exc.code == 'capability_unauthorized'
+
+    deep_approved, _ = apply_capability_choice_decision(
+        _proposal(),
+        'deep_research',
+        actor_user_id='user-1',
+        now=NOW,
+    )
+    blocked_bundle_inventory = _inventory()
+    web_search_entry = next(
+        entry
+        for entry in blocked_bundle_inventory['capabilities']
+        if entry['id'] == 'web_search'
+    )
+    web_search_entry.update({
+        'state': 'policy_blocked',
+        'discoverable': False,
+    })
+    try:
+        revalidate_capability_choice(deep_approved, blocked_bundle_inventory)
+        raise AssertionError('blocked bundle dependencies must fail revalidation')
+    except CapabilityChoiceError as exc:
+        assert exc.code == 'capability_policy_blocked'
+
+
+def test_resume_claim_and_completion_are_idempotent():
+    approved, _ = apply_capability_choice_decision(
+        _proposal(),
+        'web_search',
+        actor_user_id='user-1',
+        now=NOW,
+    )
+    claimed, claim_idempotent = claim_capability_choice_resume(
+        approved,
+        now=NOW,
+        execution_id='execution-1',
+        child_run_id='child-run-1',
+    )
+    assert claim_idempotent is False
+    assert claimed['resume']['status'] == 'running'
+
+    try:
+        claim_capability_choice_resume(
+            claimed,
+            now=NOW + timedelta(seconds=1),
+            execution_id='execution-2',
+        )
+        raise AssertionError('a live resume lease must prevent duplicate execution')
+    except CapabilityChoiceError as exc:
+        assert exc.code == 'resume_in_progress'
+
+    completed, completed_idempotent = complete_capability_choice_resume(
+        claimed,
+        execution_id='execution-1',
+        assistant_message_id='assistant-1',
+        now=NOW + timedelta(seconds=2),
+    )
+    replayed, replay_idempotent = claim_capability_choice_resume(
+        completed,
+        now=NOW + timedelta(seconds=3),
+    )
+    assert completed_idempotent is False
+    assert replay_idempotent is True
+    assert replayed['resume']['assistant_message_id'] == 'assistant-1'
+
+
+def test_failed_resume_can_be_reclaimed_after_release():
+    approved, _ = apply_capability_choice_decision(
+        _proposal(),
+        'web_search',
+        actor_user_id='user-1',
+        now=NOW,
+    )
+    claimed, _ = claim_capability_choice_resume(
+        approved,
+        now=NOW,
+        execution_id='execution-1',
+    )
+    failed, idempotent = fail_capability_choice_resume(
+        claimed,
+        execution_id='execution-1',
+        error_type='network failure',
+        now=NOW + timedelta(seconds=1),
+    )
+    reclaimed, _ = claim_capability_choice_resume(
+        failed,
+        now=NOW + timedelta(seconds=2),
+        execution_id='execution-2',
+    )
+
+    assert idempotent is False
+    assert failed['resume']['status'] == 'failed'
+    assert failed['resume']['error_type'] == 'network_failure'
+    assert reclaimed['resume']['execution_id'] == 'execution-2'
+
+
+def test_external_query_omits_unapproved_personal_data():
+    message = (
+        'Check current Fairfax County zoning and parcel records for '
+        '1234 Main Street, Fairfax VA 22030. Email me at person@example.com.'
+    )
+    minimized = build_minimized_external_query(message)
+    approved = build_minimized_external_query(
+        message,
+        include_sensitive_inputs=True,
+    )
+
+    assert '1234 Main Street' not in minimized['query']
+    assert 'person@example.com' not in minimized['query']
+    assert minimized['source'] == 'current_message_only'
+    assert minimized['conversation_history_included'] is False
+    assert minimized['workspace_content_included'] is False
+    assert 'street_address' in minimized['omitted_sensitive_input_types']
+    assert '1234 Main Street' in approved['query']
+
+
+def test_parcel_lookup_adds_explicit_sensitive_option():
+    recommendation = build_capability_recommendation(
+        _inventory(),
+        classify_capability_requirements(
+            'Check current parcel rules for 1234 Main Street, Fairfax VA 22030.'
+        ),
+    )
+    updated = add_sensitive_external_query_options(
+        recommendation,
+        'Check current parcel rules for 1234 Main Street, Fairfax VA 22030.',
+    )
+    option_ids = [option['id'] for option in updated['options']]
+
+    assert 'deep_research' in option_ids
+    assert 'deep_research_with_sensitive_inputs' in option_ids
+    assert updated['recommended_option_id'] == 'deep_research_with_sensitive_inputs'
+    sensitive_option = next(
+        option
+        for option in updated['options']
+        if option['id'] == 'deep_research_with_sensitive_inputs'
+    )
+    assert sensitive_option['sensitive_input_types'] == ['street_address']
+
+
+def test_provenance_keeps_each_stage_separate():
+    proposal = _proposal()
+    approved, _ = apply_capability_choice_decision(
+        proposal,
+        'web_search',
+        actor_user_id='user-1',
+        now=NOW,
+    )
+    provenance = build_capability_provenance(
+        selection_snapshot={'toggles': {'web_search': False}},
+        capability_inventory=_inventory(),
+        proposal=proposal,
+        decisions=[approved['decision']],
+        effective_capabilities=[
+            {'id': 'web_search', 'origin': 'discovery_approved', 'required': True},
+        ],
+    )
+
+    assert provenance['selection_snapshot']['toggles']['web_search'] is False
+    assert provenance['proposed_capabilities']['status'] == 'pending'
+    assert provenance['capability_decisions'][0]['status'] == 'approved'
+    assert provenance['effective_capabilities'] == [{
+        'id': 'web_search',
+        'origin': 'discovery_approved',
+        'required': True,
+    }]
+
+
+if __name__ == '__main__':
+    tests = [
+        test_approval_is_allowlisted_and_idempotent,
+        test_decline_is_durable_and_conflicting_decision_is_rejected,
+        test_forged_and_expired_choices_are_rejected,
+        test_revalidation_rejects_revoked_capability,
+        test_resume_claim_and_completion_are_idempotent,
+        test_failed_resume_can_be_reclaimed_after_release,
+        test_external_query_omits_unapproved_personal_data,
+        test_parcel_lookup_adds_explicit_sensitive_option,
+        test_provenance_keeps_each_stage_separate,
+    ]
+    results = []
+
+    for test in tests:
+        print(f'\nRunning {test.__name__}...')
+        try:
+            test()
+            print('Passed')
+            results.append(True)
+        except Exception as exc:
+            print(f'Failed: {exc}')
+            results.append(False)
+
+    passed = sum(results)
+    total = len(results)
+    print(f'\nResults: {passed}/{total} tests passed')
+    sys.exit(0 if all(results) else 1)

--- a/functional_tests/test_chat_capability_choice_persistence.py
+++ b/functional_tests/test_chat_capability_choice_persistence.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python3
+# test_chat_capability_choice_persistence.py
+"""
+Functional test for conditional capability-choice persistence.
+Version: 0.250.066
+Implemented in: 0.250.066
+
+This test ensures persisted decisions and resume claims use exact conversation
+partitions, honor ETags, and cannot execute the same capability choice twice.
+"""
+
+import copy
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SINGLE_APP_ROOT = REPO_ROOT / 'application' / 'single_app'
+sys.path.insert(0, str(SINGLE_APP_ROOT))
+
+from functions_chat_capabilities import (  # noqa: E402
+    build_capability_recommendation,
+    build_governed_capability_inventory,
+    classify_capability_requirements,
+)
+from functions_chat_capability_choices import (  # noqa: E402
+    CapabilityChoiceError,
+    build_capability_choice_proposal,
+    build_capability_provenance,
+)
+from functions_chat_capability_persistence import (  # noqa: E402
+    persist_capability_decision,
+    persist_capability_resume_claim,
+    persist_capability_resume_completion,
+    read_capability_proposal_message,
+)
+
+
+NOW = datetime(2026, 7, 15, 12, 0, tzinfo=timezone.utc)
+
+
+class ConditionalConflict(Exception):
+    status_code = 412
+
+
+class FakeContainer:
+    def __init__(self, message):
+        self.message = copy.deepcopy(message)
+        self.version = 1
+        self.replace_count = 0
+        self.force_one_conflict = False
+        self.message['_etag'] = str(self.version)
+
+    def read_item(self, *, item, partition_key):
+        if item != self.message['id'] or partition_key != self.message['conversation_id']:
+            raise KeyError(item)
+        return copy.deepcopy(self.message)
+
+    def replace_item(self, *, item, body, etag, match_condition):
+        del match_condition
+        if self.force_one_conflict:
+            self.force_one_conflict = False
+            raise ConditionalConflict()
+        if item != self.message['id'] or etag != self.message['_etag']:
+            raise ConditionalConflict()
+        self.version += 1
+        self.replace_count += 1
+        self.message = copy.deepcopy(body)
+        self.message['_etag'] = str(self.version)
+        return copy.deepcopy(self.message)
+
+
+def _inventory():
+    resolved = {
+        capability_id: {
+            'enabled': True,
+            'available': True,
+            'authorized': True,
+            'governance_mode': 'recommend',
+        }
+        for capability_id in (
+            'workspace_search', 'analyze', 'compare', 'image',
+            'web_search', 'url_access', 'deep_research',
+        )
+    }
+    return build_governed_capability_inventory(resolved_capabilities=resolved)
+
+
+def _container():
+    inventory = _inventory()
+    recommendation = build_capability_recommendation(
+        inventory,
+        classify_capability_requirements('What are the current county rules?'),
+    )
+    proposal = build_capability_choice_proposal(
+        recommendation,
+        run_id='run-1',
+        conversation_id='conversation-1',
+        user_message_id='user-message-1',
+        assistant_message_id='proposal-1',
+        now=NOW,
+    )
+    provenance = build_capability_provenance(
+        selection_snapshot={'toggles': {'web_search': False}},
+        capability_inventory=inventory,
+        proposal=proposal,
+        effective_capabilities=[],
+    )
+    return FakeContainer({
+        'id': 'proposal-1',
+        'conversation_id': 'conversation-1',
+        'role': 'assistant',
+        'content': 'Choose how to continue.',
+        'metadata': {
+            'capability_proposal': proposal,
+            'capability_provenance': provenance,
+        },
+    })
+
+
+def test_decision_retries_conditional_conflict_and_replays_idempotently():
+    container = _container()
+    container.force_one_conflict = True
+    _, approved, idempotent = persist_capability_decision(
+        container,
+        conversation_id='conversation-1',
+        proposal_id='proposal-1',
+        option_id='web_search',
+        actor_user_id='user-1',
+        refreshed_inventory=_inventory(),
+        now=NOW,
+    )
+    _, replayed, replay_idempotent = persist_capability_decision(
+        container,
+        conversation_id='conversation-1',
+        proposal_id='proposal-1',
+        option_id='web_search',
+        actor_user_id='user-1',
+        refreshed_inventory=_inventory(),
+        now=NOW,
+    )
+
+    assert approved['status'] == 'approved'
+    assert idempotent is False
+    assert replay_idempotent is True
+    assert replayed == approved
+    assert container.replace_count == 1
+    assert container.message['metadata']['capability_provenance']['capability_decisions'][0]['option_id'] == 'web_search'
+
+
+def test_conflicting_decision_never_replaces_message():
+    container = _container()
+    persist_capability_decision(
+        container,
+        conversation_id='conversation-1',
+        proposal_id='proposal-1',
+        option_id='web_search',
+        actor_user_id='user-1',
+        refreshed_inventory=_inventory(),
+        now=NOW,
+    )
+    try:
+        persist_capability_decision(
+            container,
+            conversation_id='conversation-1',
+            proposal_id='proposal-1',
+            option_id='deep_research',
+            actor_user_id='user-1',
+            refreshed_inventory=_inventory(),
+            now=NOW,
+        )
+        raise AssertionError('conflicting choice must fail')
+    except CapabilityChoiceError as exc:
+        assert exc.code == 'decision_conflict'
+    assert container.replace_count == 1
+
+
+def test_resume_claim_is_single_execution_and_completion_is_durable():
+    container = _container()
+    persist_capability_decision(
+        container,
+        conversation_id='conversation-1',
+        proposal_id='proposal-1',
+        option_id='web_search',
+        actor_user_id='user-1',
+        refreshed_inventory=_inventory(),
+        now=NOW,
+    )
+    _, claimed, _ = persist_capability_resume_claim(
+        container,
+        conversation_id='conversation-1',
+        proposal_id='proposal-1',
+        refreshed_inventory=_inventory(),
+        now=NOW,
+        execution_id='execution-1',
+        child_run_id='child-run-1',
+    )
+    assert claimed['resume']['status'] == 'running'
+
+    try:
+        persist_capability_resume_claim(
+            container,
+            conversation_id='conversation-1',
+            proposal_id='proposal-1',
+            refreshed_inventory=_inventory(),
+            now=NOW,
+            execution_id='execution-2',
+        )
+        raise AssertionError('duplicate live claim must fail')
+    except CapabilityChoiceError as exc:
+        assert exc.code == 'resume_in_progress'
+
+    _, completed, _ = persist_capability_resume_completion(
+        container,
+        conversation_id='conversation-1',
+        proposal_id='proposal-1',
+        execution_id='execution-1',
+        assistant_message_id='assistant-1',
+        now=NOW,
+    )
+    assert completed['resume']['status'] == 'completed'
+    assert completed['resume']['assistant_message_id'] == 'assistant-1'
+
+
+def test_exact_partition_and_message_shape_are_enforced():
+    container = _container()
+    try:
+        read_capability_proposal_message(
+            container,
+            conversation_id='conversation-2',
+            proposal_id='proposal-1',
+        )
+        raise AssertionError('foreign partitions must fail')
+    except KeyError:
+        pass
+
+    container.message['role'] = 'user'
+    try:
+        read_capability_proposal_message(
+            container,
+            conversation_id='conversation-1',
+            proposal_id='proposal-1',
+        )
+        raise AssertionError('non-assistant proposal messages must fail')
+    except CapabilityChoiceError as exc:
+        assert exc.code == 'proposal_role_invalid'
+
+
+def test_expired_and_revoked_states_are_persisted():
+    expired_container = _container()
+    expired_container.message['metadata']['capability_proposal']['expires_at'] = (
+        NOW - timedelta(seconds=1)
+    ).isoformat()
+    try:
+        persist_capability_decision(
+            expired_container,
+            conversation_id='conversation-1',
+            proposal_id='proposal-1',
+            option_id='web_search',
+            actor_user_id='user-1',
+            refreshed_inventory=_inventory(),
+            now=NOW,
+        )
+        raise AssertionError('expired proposal must fail')
+    except CapabilityChoiceError as exc:
+        assert exc.code == 'proposal_expired'
+    assert expired_container.message['metadata']['capability_proposal']['status'] == 'expired'
+
+    revoked_container = _container()
+    revoked_inventory = copy.deepcopy(_inventory())
+    web_search = next(
+        capability
+        for capability in revoked_inventory['capabilities']
+        if capability['id'] == 'web_search'
+    )
+    web_search.update({
+        'state': 'unauthorized',
+        'authorized': False,
+        'discoverable': False,
+    })
+    try:
+        persist_capability_decision(
+            revoked_container,
+            conversation_id='conversation-1',
+            proposal_id='proposal-1',
+            option_id='web_search',
+            actor_user_id='user-1',
+            refreshed_inventory=revoked_inventory,
+            now=NOW,
+        )
+        raise AssertionError('revoked proposal must fail')
+    except CapabilityChoiceError as exc:
+        assert exc.code == 'capability_unauthorized'
+    stored_proposal = revoked_container.message['metadata']['capability_proposal']
+    assert stored_proposal['status'] == 'invalidated'
+    assert stored_proposal['decision']['status'] == 'invalidated'
+    assert stored_proposal['invalidation_reason'] == 'capability_unauthorized'
+
+
+def test_approved_choice_expires_before_unclaimed_resume():
+    container = _container()
+    persist_capability_decision(
+        container,
+        conversation_id='conversation-1',
+        proposal_id='proposal-1',
+        option_id='web_search',
+        actor_user_id='user-1',
+        refreshed_inventory=_inventory(),
+        now=NOW,
+    )
+    try:
+        persist_capability_resume_claim(
+            container,
+            conversation_id='conversation-1',
+            proposal_id='proposal-1',
+            refreshed_inventory=_inventory(),
+            now=NOW + timedelta(days=2),
+        )
+        raise AssertionError('expired approved choice must not resume')
+    except CapabilityChoiceError as exc:
+        assert exc.code == 'proposal_expired'
+    proposal = container.message['metadata']['capability_proposal']
+    assert proposal['status'] == 'invalidated'
+    assert proposal['resume']['status'] == 'failed'
+    assert proposal['invalidation_reason'] == 'proposal_expired'
+
+
+if __name__ == '__main__':
+    tests = [
+        test_decision_retries_conditional_conflict_and_replays_idempotently,
+        test_conflicting_decision_never_replaces_message,
+        test_resume_claim_is_single_execution_and_completion_is_durable,
+        test_exact_partition_and_message_shape_are_enforced,
+        test_expired_and_revoked_states_are_persisted,
+        test_approved_choice_expires_before_unclaimed_resume,
+    ]
+    results = []
+
+    for test in tests:
+        print(f'\nRunning {test.__name__}...')
+        try:
+            test()
+            print('Passed')
+            results.append(True)
+        except Exception as exc:
+            print(f'Failed: {exc}')
+            results.append(False)
+
+    passed = sum(results)
+    total = len(results)
+    print(f'\nResults: {passed}/{total} tests passed')
+    sys.exit(0 if all(results) else 1)

--- a/functional_tests/test_chat_capability_choice_route.py
+++ b/functional_tests/test_chat_capability_choice_route.py
@@ -1,0 +1,556 @@
+#!/usr/bin/env python3
+# test_chat_capability_choice_route.py
+"""
+Functional test for authenticated chat capability decisions.
+Version: 0.250.066
+Implemented in: 0.250.066
+
+This test ensures proposal decisions reauthorize the exact personal
+conversation and source turn, reject forged or stale choices, revalidate
+capability authorization, and remain idempotent under duplicate clicks.
+"""
+
+import copy
+import importlib
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+from flask import Flask
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SINGLE_APP_ROOT = REPO_ROOT / 'application' / 'single_app'
+if str(SINGLE_APP_ROOT) not in sys.path:
+    sys.path.insert(0, str(SINGLE_APP_ROOT))
+
+from functions_chat_capabilities import (  # noqa: E402
+    build_capability_recommendation,
+    build_governed_capability_inventory,
+    classify_capability_requirements,
+)
+from functions_chat_capability_choices import (  # noqa: E402
+    build_capability_choice_proposal,
+    build_capability_provenance,
+)
+
+
+class DummyNotFoundError(Exception):
+    """Raised when an in-memory Cosmos item cannot be read."""
+
+
+class ConditionalConflict(Exception):
+    """Represent a Cosmos ETag conflict."""
+
+    status_code = 412
+
+
+class FakeConversationContainer:
+    def __init__(self, items):
+        self.items = {item['id']: copy.deepcopy(item) for item in items}
+
+    def read_item(self, item=None, partition_key=None, *args, **kwargs):
+        del kwargs
+        item_id = item if item is not None else args[0]
+        stored = self.items.get(item_id)
+        if stored is None or partition_key != item_id:
+            raise DummyNotFoundError(item_id)
+        return copy.deepcopy(stored)
+
+
+class FakeMessageContainer:
+    def __init__(self, items):
+        self.items = {
+            (item['conversation_id'], item['id']): copy.deepcopy(item)
+            for item in items
+        }
+        self.versions = {key: 1 for key in self.items}
+        self.read_count = 0
+        self.replace_count = 0
+        for key, item in self.items.items():
+            item['_etag'] = str(self.versions[key])
+
+    def read_item(self, item=None, partition_key=None, *args, **kwargs):
+        del kwargs
+        self.read_count += 1
+        item_id = item if item is not None else args[0]
+        stored = self.items.get((partition_key, item_id))
+        if stored is None:
+            raise DummyNotFoundError(item_id)
+        return copy.deepcopy(stored)
+
+    def replace_item(self, *, item, body, etag, match_condition):
+        del match_condition
+        key = (body.get('conversation_id'), item)
+        stored = self.items.get(key)
+        if stored is None or stored.get('_etag') != etag:
+            raise ConditionalConflict()
+        self.versions[key] += 1
+        saved = copy.deepcopy(body)
+        saved['_etag'] = str(self.versions[key])
+        self.items[key] = saved
+        self.replace_count += 1
+        return copy.deepcopy(saved)
+
+    def query_items(self, *, query, parameters, partition_key, **kwargs):
+        del query, kwargs
+        parameter_values = {
+            parameter['name']: parameter['value']
+            for parameter in parameters
+        }
+        proposal_id = parameter_values.get('@proposal_id')
+        execution_id = parameter_values.get('@execution_id')
+        matches = []
+        for (conversation_id, _), message in self.items.items():
+            metadata = message.get('metadata') if isinstance(message.get('metadata'), dict) else {}
+            resume = metadata.get('capability_resume') if isinstance(metadata.get('capability_resume'), dict) else {}
+            if (
+                conversation_id == partition_key
+                and message.get('role') == 'assistant'
+                and resume.get('proposal_id') == proposal_id
+                and resume.get('execution_id') == execution_id
+            ):
+                matches.append(copy.deepcopy(message))
+        return matches[:1]
+
+    def set_item(self, item):
+        key = (item['conversation_id'], item['id'])
+        self.versions[key] = self.versions.get(key, 0) + 1
+        stored = copy.deepcopy(item)
+        stored['_etag'] = str(self.versions[key])
+        self.items[key] = stored
+
+
+def _inventory(*, web_authorized=True):
+    resolved = {
+        capability_id: {
+            'enabled': True,
+            'available': True,
+            'authorized': True,
+            'governance_mode': 'recommend',
+        }
+        for capability_id in (
+            'workspace_search', 'analyze', 'compare', 'image',
+            'web_search', 'url_access', 'deep_research',
+        )
+    }
+    resolved['web_search']['authorized'] = web_authorized
+    return build_governed_capability_inventory(resolved_capabilities=resolved)
+
+
+def _proposal_documents(*, expires_at=None):
+    inventory = _inventory()
+    recommendation = build_capability_recommendation(
+        inventory,
+        classify_capability_requirements('What are the current county rules?'),
+    )
+    now = datetime.now(timezone.utc)
+    proposal = build_capability_choice_proposal(
+        recommendation,
+        run_id='parent-run-1',
+        conversation_id='conversation-owner',
+        user_message_id='user-message-1',
+        assistant_message_id='proposal-1',
+        now=now,
+    )
+    if expires_at:
+        proposal['expires_at'] = expires_at
+    provenance = build_capability_provenance(
+        selection_snapshot={
+            'conversation_id': 'conversation-owner',
+            'toggles': {
+                'workspace_search': False,
+                'web_search': False,
+                'url_access': False,
+                'source_review': False,
+                'deep_research': False,
+            },
+        },
+        capability_inventory=inventory,
+        proposal=proposal,
+        effective_capabilities=[],
+    )
+    user_message = {
+        'id': 'user-message-1',
+        'conversation_id': 'conversation-owner',
+        'role': 'user',
+        'content': 'What are the current county rules?',
+        'metadata': {
+            'orchestration': {'run_id': 'parent-run-1'},
+            'capability_provenance': copy.deepcopy(provenance),
+            'thread_info': {
+                'thread_id': 'thread-1',
+                'previous_thread_id': None,
+            },
+        },
+    }
+    assistant_message = {
+        'id': 'proposal-1',
+        'conversation_id': 'conversation-owner',
+        'role': 'assistant',
+        'content': 'Choose how to continue.',
+        'metadata': {
+            'capability_proposal': proposal,
+            'capability_provenance': provenance,
+            'capability_resume_request': {
+                'hybrid_search': False,
+                'web_search_enabled': False,
+                'url_access_enabled': False,
+                'source_review_enabled': False,
+                'deep_research_enabled': False,
+                'selected_document_ids': [],
+                'active_group_ids': [],
+                'active_public_workspace_ids': [],
+                'doc_scope': 'personal',
+                'chat_type': 'user',
+            },
+        },
+    }
+    return user_message, assistant_message
+
+
+@pytest.fixture
+def capability_route_app(monkeypatch):
+    monkeypatch.chdir(SINGLE_APP_ROOT)
+    route_backend_chats = importlib.import_module('route_backend_chats')
+    user_state = {'id': 'user-owner'}
+    inventory_state = {'web_authorized': True}
+    user_message, proposal_message = _proposal_documents()
+    conversations = FakeConversationContainer([
+        {'id': 'conversation-owner', 'user_id': 'user-owner'},
+        {'id': 'conversation-foreign', 'user_id': 'user-foreign'},
+    ])
+    messages = FakeMessageContainer([user_message, proposal_message])
+
+    monkeypatch.setattr(route_backend_chats, 'login_required', lambda func: func)
+    monkeypatch.setattr(route_backend_chats, 'user_required', lambda func: func)
+    monkeypatch.setattr(
+        route_backend_chats,
+        'swagger_route',
+        lambda **kwargs: (lambda func: func),
+    )
+    monkeypatch.setattr(route_backend_chats, 'get_auth_security', lambda: {})
+    monkeypatch.setattr(route_backend_chats, 'get_current_user_id', lambda: user_state['id'])
+    monkeypatch.setattr(route_backend_chats, 'get_current_user_info', lambda: {'email': 'owner@example.com'})
+    monkeypatch.setattr(route_backend_chats, 'get_settings', lambda: {})
+    monkeypatch.setattr(route_backend_chats, 'cosmos_conversations_container', conversations)
+    monkeypatch.setattr(route_backend_chats, 'cosmos_messages_container', messages)
+    monkeypatch.setattr(route_backend_chats, 'CosmosResourceNotFoundError', DummyNotFoundError)
+    monkeypatch.setattr(
+        route_backend_chats,
+        '_get_authorized_chat_scope_context',
+        lambda *args, **kwargs: {
+            'active_group_ids': [],
+            'active_group_id': None,
+            'active_public_workspace_ids': [],
+            'active_public_workspace_id': None,
+        },
+    )
+    monkeypatch.setattr(
+        route_backend_chats,
+        '_resolve_authorized_chat_selected_documents',
+        lambda *args, **kwargs: [],
+    )
+    monkeypatch.setattr(
+        route_backend_chats,
+        '_resolve_server_chat_capability_inventory',
+        lambda **kwargs: _inventory(web_authorized=inventory_state['web_authorized']),
+    )
+    monkeypatch.setattr(route_backend_chats, 'log_event', lambda *args, **kwargs: None)
+
+    app = Flask(__name__)
+    app.config['TESTING'] = True
+    app.secret_key = 'capability-route-test'
+    route_backend_chats.register_route_backend_chats(app)
+    app.config['capability_route_state'] = {
+        'route_module': route_backend_chats,
+        'messages': messages,
+        'user': user_state,
+        'inventory': inventory_state,
+    }
+    return app
+
+
+def _decision(client, option_id='web_search', conversation_id='conversation-owner', **extra):
+    return client.post(
+        '/api/chat/capability-proposals/proposal-1/decision',
+        json={
+            'conversation_id': conversation_id,
+            'option_id': option_id,
+            **extra,
+        },
+    )
+
+
+def test_owner_decision_is_idempotent_and_ignores_capability_claims(capability_route_app):
+    with capability_route_app.test_client() as client:
+        first = _decision(client, capabilities=['deep_research'])
+        duplicate = _decision(client, capabilities=['deep_research'])
+
+    state = capability_route_app.config['capability_route_state']
+    stored = state['messages'].items[('conversation-owner', 'proposal-1')]
+    assert first.status_code == 200
+    assert duplicate.status_code == 200
+    assert first.get_json()['idempotent'] is False
+    assert duplicate.get_json()['idempotent'] is True
+    assert stored['metadata']['capability_proposal']['decision']['capability_ids'] == ['web_search']
+    assert state['messages'].replace_count == 1
+
+
+def test_forged_and_conflicting_options_are_rejected(capability_route_app):
+    with capability_route_app.test_client() as client:
+        forged = _decision(client, option_id='forged_capability')
+        approved = _decision(client, option_id='web_search')
+        conflicting = _decision(client, option_id='deep_research')
+
+    assert forged.status_code == 400
+    assert forged.get_json()['code'] == 'option_not_allowlisted'
+    assert approved.status_code == 200
+    assert conflicting.status_code == 409
+    assert conflicting.get_json()['code'] == 'decision_conflict'
+
+
+def test_foreign_conversation_is_rejected_before_proposal_read(capability_route_app):
+    state = capability_route_app.config['capability_route_state']
+    initial_reads = state['messages'].read_count
+    with capability_route_app.test_client() as client:
+        response = _decision(client, conversation_id='conversation-foreign')
+
+    assert response.status_code == 403
+    assert state['messages'].read_count == initial_reads
+
+
+def test_cross_turn_and_deleted_source_messages_are_rejected(capability_route_app):
+    state = capability_route_app.config['capability_route_state']
+    user_key = ('conversation-owner', 'user-message-1')
+    source_message = copy.deepcopy(state['messages'].items[user_key])
+    source_message['metadata']['orchestration']['run_id'] = 'other-run'
+    source_message['metadata']['capability_provenance']['proposed_capabilities']['run_id'] = 'other-run'
+    state['messages'].set_item(source_message)
+    with capability_route_app.test_client() as client:
+        cross_turn = _decision(client)
+    assert cross_turn.status_code == 400
+    assert cross_turn.get_json()['code'] == 'proposal_run_mismatch'
+
+    source_message['metadata']['orchestration']['run_id'] = 'parent-run-1'
+    source_message['metadata']['capability_provenance']['proposed_capabilities']['run_id'] = 'parent-run-1'
+    source_message['metadata']['is_deleted'] = True
+    state['messages'].set_item(source_message)
+    with capability_route_app.test_client() as client:
+        deleted = _decision(client)
+    assert deleted.status_code == 400
+    assert deleted.get_json()['code'] == 'proposal_user_message_invalid'
+
+
+def test_expired_and_revoked_capabilities_cannot_be_approved(capability_route_app):
+    state = capability_route_app.config['capability_route_state']
+    proposal_key = ('conversation-owner', 'proposal-1')
+    proposal_message = copy.deepcopy(state['messages'].items[proposal_key])
+    proposal_message['metadata']['capability_proposal']['expires_at'] = (
+        datetime.now(timezone.utc) - timedelta(minutes=1)
+    ).isoformat()
+    state['messages'].set_item(proposal_message)
+    with capability_route_app.test_client() as client:
+        expired = _decision(client)
+    assert expired.status_code == 409
+    assert expired.get_json()['code'] == 'proposal_expired'
+
+    user_message, fresh_proposal = _proposal_documents()
+    state['messages'].set_item(user_message)
+    state['messages'].set_item(fresh_proposal)
+    state['inventory']['web_authorized'] = False
+    with capability_route_app.test_client() as client:
+        revoked = _decision(client)
+    assert revoked.status_code == 409
+    assert revoked.get_json()['code'] == 'capability_unauthorized'
+
+
+def test_resume_claim_reconstructs_effective_capabilities_server_side(capability_route_app):
+    state = capability_route_app.config['capability_route_state']
+    route_backend_chats = state['route_module']
+    with capability_route_app.test_client() as client:
+        approved = _decision(client, capabilities=['deep_research'])
+    assert approved.status_code == 200
+
+    context = route_backend_chats._claim_authorized_capability_resume(
+        settings={},
+        user_id='user-owner',
+        user_email='owner@example.com',
+        user_roles=[],
+        conversation_id='conversation-owner',
+        proposal_id='proposal-1',
+    )
+    request_data = context['request_data']
+    resume_context = request_data['_capability_resume_context']
+    assert request_data['web_search_enabled'] is True
+    assert request_data['deep_research_enabled'] is False
+    assert request_data['_server_external_query'] == 'What are the current county rules?'
+    assert resume_context['effective_capability_ids'] == ['web_search']
+    assert resume_context['capability_origins'] == {
+        'web_search': 'discovery_approved',
+    }
+    assert resume_context['selection_snapshot']['toggles']['web_search'] is False
+
+    with pytest.raises(route_backend_chats.CapabilityChoiceError) as duplicate_claim:
+        route_backend_chats._claim_authorized_capability_resume(
+            settings={},
+            user_id='user-owner',
+            user_email='owner@example.com',
+            user_roles=[],
+            conversation_id='conversation-owner',
+            proposal_id='proposal-1',
+        )
+    assert duplicate_claim.value.code == 'resume_in_progress'
+
+
+def test_resume_revalidates_revocation_after_approval(capability_route_app):
+    state = capability_route_app.config['capability_route_state']
+    route_backend_chats = state['route_module']
+    with capability_route_app.test_client() as client:
+        approved = _decision(client)
+    assert approved.status_code == 200
+
+    state['inventory']['web_authorized'] = False
+    with pytest.raises(route_backend_chats.CapabilityChoiceError) as revoked_claim:
+        route_backend_chats._claim_authorized_capability_resume(
+            settings={},
+            user_id='user-owner',
+            user_email='owner@example.com',
+            user_roles=[],
+            conversation_id='conversation-owner',
+            proposal_id='proposal-1',
+        )
+    assert revoked_claim.value.code == 'capability_unauthorized'
+
+
+def test_parent_proposal_linkage_survives_child_run_metadata(capability_route_app):
+    state = capability_route_app.config['capability_route_state']
+    route_backend_chats = state['route_module']
+    with capability_route_app.test_client() as client:
+        approved = _decision(client)
+    assert approved.status_code == 200
+
+    user_key = ('conversation-owner', 'user-message-1')
+    user_message = copy.deepcopy(state['messages'].items[user_key])
+    user_message['metadata']['orchestration_parent'] = copy.deepcopy(
+        user_message['metadata']['orchestration']
+    )
+    user_message['metadata']['orchestration'] = {
+        'run_id': 'child-run-1',
+        'parent_run_id': 'parent-run-1',
+    }
+    state['messages'].set_item(user_message)
+
+    context = route_backend_chats._load_authorized_capability_proposal_context(
+        settings={},
+        user_id='user-owner',
+        user_email='owner@example.com',
+        user_roles=[],
+        conversation_id='conversation-owner',
+        proposal_id='proposal-1',
+    )
+    assert context['proposal']['run_id'] == 'parent-run-1'
+    assert context['provenance']['proposed_capabilities']['run_id'] == 'parent-run-1'
+
+
+def test_persisted_assistant_reconciles_process_loss_without_duplicate_execution(capability_route_app):
+    state = capability_route_app.config['capability_route_state']
+    route_backend_chats = state['route_module']
+    with capability_route_app.test_client() as client:
+        approved = _decision(client)
+    assert approved.status_code == 200
+
+    claimed = route_backend_chats._claim_authorized_capability_resume(
+        settings={},
+        user_id='user-owner',
+        user_email='owner@example.com',
+        user_roles=[],
+        conversation_id='conversation-owner',
+        proposal_id='proposal-1',
+    )
+    resume_context = claimed['request_data']['_capability_resume_context']
+    state['messages'].set_item({
+        'id': 'resumed-assistant-1',
+        'conversation_id': 'conversation-owner',
+        'role': 'assistant',
+        'content': 'Completed before proposal state was updated.',
+        'timestamp': datetime.now(timezone.utc).isoformat(),
+        'metadata': {
+            'capability_resume': {
+                'proposal_id': 'proposal-1',
+                'execution_id': resume_context['execution_id'],
+            },
+        },
+    })
+
+    reconciled = route_backend_chats._claim_authorized_capability_resume(
+        settings={},
+        user_id='user-owner',
+        user_email='owner@example.com',
+        user_roles=[],
+        conversation_id='conversation-owner',
+        proposal_id='proposal-1',
+    )
+    assert reconciled['already_completed'] is True
+    assert reconciled['proposal']['resume']['status'] == 'completed'
+    assert reconciled['proposal']['resume']['assistant_message_id'] == 'resumed-assistant-1'
+
+
+def test_policy_blocked_submitted_capability_is_rejected_before_execution(capability_route_app):
+    route_backend_chats = capability_route_app.config['capability_route_state']['route_module']
+    blocked = route_backend_chats._get_policy_blocked_selected_capability_ids(
+        {
+            'chat_capability_governance': {
+                'web_search': 'blocked',
+            },
+        },
+        {'web_search_enabled': True},
+    )
+    assert blocked == ['web_search']
+    assert 'not currently available or permitted' in (
+        route_backend_chats._build_selected_capability_rejection_message([
+            {'id': 'web_search', 'label': 'Web Search'},
+        ])
+    )
+
+
+def test_effective_capabilities_reconstruct_each_execution_mode(capability_route_app):
+    route_backend_chats = capability_route_app.config['capability_route_state']['route_module']
+    base_request = {
+        'selected_document_ids': ['document-1', 'document-2'],
+        'active_group_ids': [],
+        'active_public_workspace_ids': [],
+        'doc_scope': 'personal',
+    }
+    retrieval_request = route_backend_chats._apply_effective_capabilities_to_request(
+        base_request,
+        ['workspace_search', 'web_search', 'url_access', 'deep_research'],
+    )
+    assert retrieval_request['hybrid_search'] is True
+    assert retrieval_request['web_search_enabled'] is True
+    assert retrieval_request['url_access_enabled'] is True
+    assert retrieval_request['source_review_enabled'] is True
+    assert retrieval_request['deep_research_enabled'] is True
+
+    analyze_request = route_backend_chats._apply_effective_capabilities_to_request(
+        base_request,
+        ['analyze'],
+    )
+    assert analyze_request['document_action']['type'] == 'analyze'
+    assert analyze_request['document_action']['document_ids'] == [
+        'document-1',
+        'document-2',
+    ]
+
+    compare_request = route_backend_chats._apply_effective_capabilities_to_request(
+        base_request,
+        ['compare'],
+    )
+    assert compare_request['document_action']['type'] == 'comparison'
+    assert compare_request['document_action']['left_document_id'] == 'document-1'
+    assert compare_request['document_action']['right_document_ids'] == ['document-2']
+
+
+if __name__ == '__main__':
+    raise SystemExit(pytest.main([__file__, '-q']))

--- a/functional_tests/test_chat_capability_discovery.py
+++ b/functional_tests/test_chat_capability_discovery.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+# test_chat_capability_discovery.py
+"""
+Functional test for governed chat capability discovery and recommendation.
+Version: 0.250.066
+Implemented in: 0.250.066
+
+This test ensures server-resolved capability states remain distinct and only
+authorized, available, discoverable capabilities can be recommended.
+"""
+
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SINGLE_APP_ROOT = REPO_ROOT / 'application' / 'single_app'
+sys.path.insert(0, str(SINGLE_APP_ROOT))
+
+from functions_chat_capabilities import (  # noqa: E402
+    CONTINUE_WITHOUT_CAPABILITIES_OPTION_ID,
+    build_capability_recommendation,
+    build_governed_capability_inventory,
+    classify_capability_requirements,
+)
+
+
+def _resolved_capabilities(*, deep_research=True, web_search=True):
+    return {
+        'workspace_search': {
+            'enabled': True,
+            'available': True,
+            'authorized': True,
+            'governance_mode': 'recommend',
+        },
+        'analyze': {
+            'enabled': True,
+            'available': True,
+            'authorized': True,
+            'governance_mode': 'recommend',
+        },
+        'compare': {
+            'enabled': True,
+            'available': True,
+            'authorized': True,
+            'governance_mode': 'recommend',
+        },
+        'image': {
+            'enabled': True,
+            'available': True,
+            'authorized': True,
+            'governance_mode': 'manual_only',
+        },
+        'web_search': {
+            'enabled': web_search,
+            'available': web_search,
+            'authorized': True,
+            'governance_mode': 'recommend',
+        },
+        'url_access': {
+            'enabled': True,
+            'available': True,
+            'authorized': True,
+            'governance_mode': 'recommend',
+        },
+        'deep_research': {
+            'enabled': deep_research,
+            'available': deep_research,
+            'authorized': True,
+            'governance_mode': 'recommend',
+        },
+    }
+
+
+def _entry(inventory, capability_id):
+    return next(
+        item for item in inventory['capabilities'] if item['id'] == capability_id
+    )
+
+
+def test_inventory_preserves_selection_and_governed_states():
+    resolved = _resolved_capabilities()
+    resolved['compare']['authorized'] = False
+    resolved['image']['governance_mode'] = 'blocked'
+    resolved['url_access']['available'] = False
+    inventory = build_governed_capability_inventory(
+        selected_capability_ids=['workspace_search'],
+        resolved_capabilities=resolved,
+    )
+
+    assert _entry(inventory, 'workspace_search')['state'] == 'selected'
+    assert _entry(inventory, 'workspace_search')['selected'] is True
+    assert _entry(inventory, 'web_search')['state'] == 'unselected'
+    assert _entry(inventory, 'web_search')['discoverable'] is True
+    assert _entry(inventory, 'compare')['state'] == 'unauthorized'
+    assert _entry(inventory, 'compare')['discoverable'] is False
+    assert _entry(inventory, 'image')['state'] == 'policy_blocked'
+    assert _entry(inventory, 'url_access')['state'] == 'unavailable'
+
+
+def test_inventory_fails_closed_without_server_resolution():
+    inventory = build_governed_capability_inventory(
+        selected_capability_ids=['web_search'],
+        resolved_capabilities={},
+    )
+
+    web_search = _entry(inventory, 'web_search')
+    assert web_search['selected'] is True
+    assert web_search['state'] == 'unavailable'
+    assert web_search['discoverable'] is False
+
+
+def test_only_workspace_search_can_be_automatically_discovered():
+    resolved = _resolved_capabilities()
+    resolved['workspace_search']['governance_mode'] = 'auto_read_only'
+    resolved['analyze']['governance_mode'] = 'auto_read_only'
+    resolved['compare']['governance_mode'] = 'auto_read_only'
+    inventory = build_governed_capability_inventory(
+        resolved_capabilities=resolved,
+    )
+
+    assert _entry(inventory, 'workspace_search')['auto_use_allowed'] is True
+    assert _entry(inventory, 'analyze')['auto_use_allowed'] is False
+    assert _entry(inventory, 'analyze')['requires_user_choice'] is True
+    assert _entry(inventory, 'compare')['auto_use_allowed'] is False
+    assert _entry(inventory, 'compare')['requires_user_choice'] is True
+
+
+def test_simple_timeless_question_has_no_recommendation():
+    inventory = build_governed_capability_inventory(
+        resolved_capabilities=_resolved_capabilities(),
+    )
+    requirements = classify_capability_requirements(
+        'Explain recursion with a short example.'
+    )
+
+    assert requirements == []
+    assert build_capability_recommendation(inventory, requirements) is None
+
+
+def test_local_current_rules_offer_deep_research_and_web_search():
+    inventory = build_governed_capability_inventory(
+        resolved_capabilities=_resolved_capabilities(),
+    )
+    requirements = classify_capability_requirements(
+        'What are the current Virginia and Fairfax County property rules?'
+    )
+    recommendation = build_capability_recommendation(inventory, requirements)
+
+    assert requirements == [{
+        'id': 'current_authoritative_sources',
+        'reason_code': 'current_authoritative_sources',
+        'required_inputs': [],
+    }]
+    assert recommendation['recommended_option_id'] == 'deep_research'
+    assert [option['id'] for option in recommendation['options']] == [
+        'deep_research',
+        'web_search',
+        CONTINUE_WITHOUT_CAPABILITIES_OPTION_ID,
+    ]
+
+    timeless_wording_requirements = classify_capability_requirements(
+        'What are the Fairfax County zoning and property rules?'
+    )
+    assert timeless_wording_requirements[0]['id'] == 'current_authoritative_sources'
+
+
+def test_local_current_rules_offer_only_available_capabilities():
+    web_only_inventory = build_governed_capability_inventory(
+        resolved_capabilities=_resolved_capabilities(deep_research=False),
+    )
+    requirements = classify_capability_requirements(
+        'Check the current Fairfax County zoning rules.'
+    )
+    web_only = build_capability_recommendation(web_only_inventory, requirements)
+    assert [option['id'] for option in web_only['options']] == [
+        'web_search',
+        CONTINUE_WITHOUT_CAPABILITIES_OPTION_ID,
+    ]
+
+    no_research_inventory = build_governed_capability_inventory(
+        resolved_capabilities=_resolved_capabilities(
+            deep_research=False,
+            web_search=False,
+        ),
+    )
+    assert build_capability_recommendation(no_research_inventory, requirements) is None
+
+
+def test_selected_capability_resolves_matching_requirement():
+    inventory = build_governed_capability_inventory(
+        selected_capability_ids=['web_search'],
+        resolved_capabilities=_resolved_capabilities(),
+    )
+    requirements = classify_capability_requirements(
+        'What is the latest stable Python release?'
+    )
+
+    assert build_capability_recommendation(inventory, requirements) is None
+
+
+def test_analyze_and_compare_require_authorized_targets():
+    inventory = build_governed_capability_inventory(
+        resolved_capabilities=_resolved_capabilities(),
+    )
+
+    no_targets = classify_capability_requirements(
+        'Analyze and compare the documents.',
+        authorized_document_count=0,
+    )
+    no_target_recommendation = build_capability_recommendation(inventory, no_targets)
+    assert no_target_recommendation is None
+
+    one_target = classify_capability_requirements(
+        'Analyze this document.',
+        authorized_document_count=1,
+    )
+    one_target_recommendation = build_capability_recommendation(inventory, one_target)
+    assert one_target_recommendation['recommended_option_id'] == 'analyze'
+
+    two_targets = classify_capability_requirements(
+        'Compare these documents for differences.',
+        authorized_document_count=2,
+    )
+    two_target_recommendation = build_capability_recommendation(inventory, two_targets)
+    assert two_target_recommendation['recommended_option_id'] == 'compare'
+
+
+def test_image_is_recommended_only_for_explicit_visual_output():
+    resolved = _resolved_capabilities()
+    resolved['image']['governance_mode'] = 'recommend'
+    inventory = build_governed_capability_inventory(
+        resolved_capabilities=resolved,
+    )
+
+    assert build_capability_recommendation(
+        inventory,
+        classify_capability_requirements('Explain why diagrams can help learning.'),
+    ) is None
+    recommendation = build_capability_recommendation(
+        inventory,
+        classify_capability_requirements('Create an infographic about recursion.'),
+    )
+    assert recommendation['recommended_option_id'] == 'image'
+    diagram_recommendation = build_capability_recommendation(
+        inventory,
+        classify_capability_requirements('Turn this explanation into an image.'),
+    )
+    assert diagram_recommendation['recommended_option_id'] == 'image'
+
+
+def test_blocked_and_unauthorized_capabilities_are_never_offered():
+    resolved = _resolved_capabilities()
+    resolved['deep_research']['authorized'] = False
+    resolved['web_search']['governance_mode'] = 'blocked'
+    inventory = build_governed_capability_inventory(
+        resolved_capabilities=resolved,
+    )
+    requirements = classify_capability_requirements(
+        'Research the current county regulations using authoritative sources.'
+    )
+
+    assert build_capability_recommendation(inventory, requirements) is None
+
+    blocked_bundle = _resolved_capabilities()
+    blocked_bundle['web_search']['governance_mode'] = 'blocked'
+    blocked_bundle_inventory = build_governed_capability_inventory(
+        resolved_capabilities=blocked_bundle,
+    )
+    blocked_bundle_recommendation = build_capability_recommendation(
+        blocked_bundle_inventory,
+        requirements,
+    )
+    assert blocked_bundle_recommendation is None
+
+
+if __name__ == '__main__':
+    tests = [
+        test_inventory_preserves_selection_and_governed_states,
+        test_inventory_fails_closed_without_server_resolution,
+        test_only_workspace_search_can_be_automatically_discovered,
+        test_simple_timeless_question_has_no_recommendation,
+        test_local_current_rules_offer_deep_research_and_web_search,
+        test_local_current_rules_offer_only_available_capabilities,
+        test_selected_capability_resolves_matching_requirement,
+        test_analyze_and_compare_require_authorized_targets,
+        test_image_is_recommended_only_for_explicit_visual_output,
+        test_blocked_and_unauthorized_capabilities_are_never_offered,
+    ]
+    results = []
+
+    for test in tests:
+        print(f'\nRunning {test.__name__}...')
+        try:
+            test()
+            print('Passed')
+            results.append(True)
+        except Exception as exc:
+            print(f'Failed: {exc}')
+            results.append(False)
+
+    passed = sum(results)
+    total = len(results)
+    print(f'\nResults: {passed}/{total} tests passed')
+    sys.exit(0 if all(results) else 1)

--- a/functional_tests/test_chat_stream_background_execution.py
+++ b/functional_tests/test_chat_stream_background_execution.py
@@ -2,7 +2,7 @@
 # test_chat_stream_background_execution.py
 """
 Functional test for chat stream background execution.
-Version: 0.250.064
+Version: 0.250.066
 Implemented in: 0.239.129
 
 This test ensures that the streaming chat route runs its SSE generator through
@@ -43,7 +43,7 @@ def test_chat_stream_background_execution() -> None:
     assert_contains(ROUTE_FILE, "return build_background_stream_response(generate_compatibility_response, stream_session=stream_session)")
     assert_contains(ROUTE_FILE, "return build_background_stream_response(generate, stream_session=stream_session)")
 
-    assert_contains(CONFIG_FILE, 'VERSION = "0.250.064"')
+    assert_contains(CONFIG_FILE, 'VERSION = "0.250.066"')
     assert_contains(FIX_DOC_FILE, "Fixed/Implemented in version: **0.239.129**")
 
     print("Chat stream background execution checks passed!")

--- a/functional_tests/test_chat_stream_heartbeat_reattach.py
+++ b/functional_tests/test_chat_stream_heartbeat_reattach.py
@@ -2,7 +2,7 @@
 # test_chat_stream_heartbeat_reattach.py
 """
 Functional test for chat stream heartbeat and reattach support.
-Version: 0.250.064
+Version: 0.250.066
 Implemented in: 0.239.183
 
 This test ensures long-running chat streams emit keep-alive heartbeat frames,
@@ -65,7 +65,7 @@ def test_chat_stream_heartbeat_and_reattach() -> None:
     assert_contains(CONVERSATIONS_FILE, "await loadMessages(conversationId);")
     assert_contains(CONVERSATIONS_FILE, "await streamingModule.reattachStreamingConversation(conversationId);")
 
-    assert_contains(CONFIG_FILE, 'VERSION = "0.250.064"')
+    assert_contains(CONFIG_FILE, 'VERSION = "0.250.066"')
     assert_contains(FIX_DOC_FILE, "Fixed/Implemented in version: **0.239.183**")
     assert_contains(FIX_DOC_FILE, "Redis-backed session metadata and event replay")
 

--- a/functional_tests/test_chat_stream_lifecycle_observability.py
+++ b/functional_tests/test_chat_stream_lifecycle_observability.py
@@ -2,7 +2,7 @@
 # test_chat_stream_lifecycle_observability.py
 """
 Functional test for chat stream lifecycle observability.
-Version: 0.250.064
+Version: 0.250.066
 Implemented in: 0.241.109
 
 This test ensures long-running chat streams persist lifecycle state for
@@ -19,7 +19,7 @@ ROUTE_FILE = ROOT / "application" / "single_app" / "route_backend_chats.py"
 STREAMING_FILE = ROOT / "application" / "single_app" / "static" / "js" / "chat" / "chat-streaming.js"
 CONFIG_FILE = ROOT / "application" / "single_app" / "config.py"
 FIX_DOC_FILE = ROOT / "docs" / "explanation" / "fixes" / "v0.241.109" / "CHAT_STREAM_LIFECYCLE_OBSERVABILITY_FIX.md"
-CURRENT_VERSION = "0.250.064"
+CURRENT_VERSION = "0.250.066"
 
 
 def assert_contains(file_path: Path, expected: str) -> None:

--- a/functional_tests/test_chat_stream_new_conversation_reattach.py
+++ b/functional_tests/test_chat_stream_new_conversation_reattach.py
@@ -2,7 +2,7 @@
 # test_chat_stream_new_conversation_reattach.py
 """
 Functional test for new-conversation chat stream reattach support.
-Version: 0.250.064
+Version: 0.250.066
 Implemented in: 0.239.191
 
 This test ensures the streaming chat route finalizes a conversation id before
@@ -43,7 +43,7 @@ def test_chat_stream_new_conversation_reattach() -> None:
     assert_contains(STREAMING_FILE, "if (allowRecovery) {")
     assert_contains(STREAMING_FILE, "allowRecovery: false,")
 
-    assert_contains(CONFIG_FILE, 'VERSION = "0.250.064"')
+    assert_contains(CONFIG_FILE, 'VERSION = "0.250.066"')
     assert_contains(FIX_DOC_FILE, "Fixed/Implemented in version: **0.239.191**")
     assert_contains(FIX_DOC_FILE, "finalizes a conversation id before registering the stream session")
 

--- a/functional_tests/test_chat_stream_stop_control.py
+++ b/functional_tests/test_chat_stream_stop_control.py
@@ -2,7 +2,7 @@
 # test_chat_stream_stop_control.py
 """
 Functional test for chat stream stop control.
-Version: 0.250.064
+Version: 0.250.066
 Implemented in: 0.241.097
 
 This test ensures chat streams expose a user-scoped cancellation endpoint,
@@ -39,7 +39,7 @@ def test_chat_stream_stop_control_wiring() -> None:
     collaboration_js_content = read_text("application/single_app/static/js/chat/chat-collaboration.js")
     feature_doc_content = read_text("docs/explanation/features/v0.241.097/CHAT_STREAM_STOP_CONTROL.md")
 
-    assert_contains(config_content, 'VERSION = "0.250.064"', "config version")
+    assert_contains(config_content, 'VERSION = "0.250.066"', "config version")
 
     assert_contains(route_content, "STREAM_STATUS_CANCEL_REQUESTED = 'cancel_requested'", "chat route")
     assert_contains(route_content, "STREAM_STATUS_CANCELED = 'canceled'", "chat route")

--- a/functional_tests/test_chat_turn_orchestration_plan.py
+++ b/functional_tests/test_chat_turn_orchestration_plan.py
@@ -2,7 +2,7 @@
 # test_chat_turn_orchestration_plan.py
 """
 Functional test for the chat turn orchestration planning foundation.
-Version: 0.250.065
+Version: 0.250.066
 Implemented in: 0.250.058
 
 This test ensures every turn receives a direct or coordinated plan, selected
@@ -341,6 +341,69 @@ def test_context_sources_are_distinct_from_user_selections():
     }
 
 
+def test_discovered_capabilities_preserve_original_selection_provenance():
+    original_selection = {
+        'conversation_id': 'conversation-1',
+        'toggles': {
+            'workspace_search': False,
+            'web_search': False,
+            'url_access': False,
+            'source_review': False,
+            'deep_research': False,
+        },
+    }
+    plan = build_turn_orchestration_plan(
+        'What are the current county rules?',
+        run_id='child-run',
+        parent_run_id='parent-run',
+        conversation_id='conversation-1',
+        web_search_enabled=True,
+        deep_research_enabled=True,
+        capability_origins={
+            'web_search': 'discovery_approved',
+            'deep_research': 'discovery_approved',
+        },
+        selection_snapshot_override=original_selection,
+    )
+
+    assert plan['selection_snapshot'] == original_selection
+    assert plan['selected_capabilities'] == []
+    assert plan['effective_capabilities'] == ['web_search', 'deep_research']
+    assert {source['origin'] for source in plan['sources']} == {'discovery_approved'}
+    assert all(source['required'] for source in plan['sources'])
+    assert plan['parent_run_id'] == 'parent-run'
+    assert 'approved_capability_discovery' in plan['reason_codes']
+
+    compare_plan = build_turn_orchestration_plan(
+        'Compare the selected documents.',
+        run_id='compare-child-run',
+        selected_action={'type': 'comparison'},
+        selected_document_ids=['doc-1', 'doc-2'],
+        capability_origins={'compare': 'discovery_approved'},
+        selection_snapshot_override=original_selection,
+    )
+    selected_action_source = next(
+        source
+        for source in compare_plan['sources']
+        if source['id'] == 'selected_action'
+    )
+    assert selected_action_source['origin'] == 'discovery_approved'
+    assert selected_action_source['required'] is True
+
+    image_plan = build_turn_orchestration_plan(
+        'Create an infographic about recursion.',
+        run_id='image-child-run',
+        image_generation_available=True,
+        capability_origins={'image': 'discovery_approved'},
+        selection_snapshot_override=original_selection,
+    )
+    assert image_plan['finalizer'] == 'image_proposal'
+    assert image_plan['steps'][-1]['origin'] == 'discovery_approved'
+    assert image_plan['steps'][-1]['required'] is True
+    assert image_plan['effective_capabilities'] == ['image']
+    assert image_plan['selected_capabilities'] == []
+
+
 def test_attached_headshot_is_detected_as_requested_image_evidence():
     plan = build_turn_orchestration_plan(
         'Create a sketch of my role using the attached headshot as a reference.',
@@ -356,20 +419,30 @@ def test_streaming_chat_path_persists_and_applies_plan():
     route_source = ROUTE_BACKEND_CHATS.read_text(encoding='utf-8')
     config_source = CONFIG_FILE.read_text(encoding='utf-8')
 
-    assert 'VERSION = "0.250.065"' in config_source
+    assert 'VERSION = "0.250.066"' in config_source
     assert 'turn_orchestration_plan = build_turn_orchestration_plan(' in route_source
     assert 'requested_action_document_ids = _normalize_conversation_task_document_ids(' in route_source
     assert 'requested_action_document_ids\n            if requested_action_document_ids' in route_source
     assert 'requested_document_scope = document_scope' in route_source
-    assert 'document_scope=requested_document_scope,' in route_source
-    assert 'active_group_ids=requested_active_group_ids,' in route_source
-    assert 'active_public_workspace_ids=requested_active_public_workspace_ids,' in route_source
-    assert 'tags=requested_tags_filter,' in route_source
+    assert "'document_scope': requested_document_scope," in route_source
+    assert "'active_group_ids': requested_active_group_ids," in route_source
+    assert "'active_public_workspace_ids': requested_active_public_workspace_ids," in route_source
+    assert "'tags': requested_tags_filter," in route_source
     assert route_source.count("user_metadata['orchestration'] = turn_orchestration_plan") >= 2
     assert "'orchestration': turn_orchestration_plan," in route_source
     assert 'conversation_history_for_api = maybe_append_turn_orchestration_system_message(' in route_source
     assert "'[Orchestration] Document action turn plan created'" in route_source
     assert "partial_error_payload = {" in route_source
+    assert 'capability_discovery = _build_server_capability_discovery(' in route_source
+    assert "turn_orchestration_run.status = 'awaiting_user_choice'" in route_source
+    assert "'capability_proposal': proposal," in route_source
+    assert "@bp.route('/api/chat/capability-proposals/<proposal_id>/decision'" in route_source
+    assert '_claim_authorized_capability_resume(' in route_source
+    assert 'persist_capability_resume_completion(' in route_source
+    assert "data.get('_server_external_query') or user_message" in route_source
+    assert 'compatibility_capability_inventory = _resolve_server_chat_capability_inventory(' in route_source
+    assert "user_metadata['capability_provenance'] = compatibility_capability_provenance" in route_source
+    assert "'capability_provenance': compatibility_capability_provenance," in route_source
 
 
 if __name__ == '__main__':
@@ -387,6 +460,7 @@ if __name__ == '__main__':
         test_string_zero_image_count_does_not_create_selected_image_source,
         test_plan_is_json_serializable,
         test_context_sources_are_distinct_from_user_selections,
+        test_discovered_capabilities_preserve_original_selection_provenance,
         test_attached_headshot_is_detected_as_requested_image_evidence,
         test_streaming_chat_path_persists_and_applies_plan,
     ]

--- a/functional_tests/test_orchestration_runtime.py
+++ b/functional_tests/test_orchestration_runtime.py
@@ -2,7 +2,7 @@
 # test_orchestration_runtime.py
 """
 Functional test for the request-scoped orchestration runtime.
-Version: 0.250.064
+Version: 0.250.066
 Implemented in: 0.250.063
 
 This test ensures direct and coordinated plans execute through one bounded graph
@@ -710,7 +710,9 @@ def test_chat_routes_persist_and_gate_request_scoped_runtime():
     assert 'fail_orchestration_run(' in route_source
     assert 'stream_session.is_cancel_requested if stream_session else None' in route_source
     assert "error_type='stream_ended_before_runtime_completion'" in route_source
-    assert 'active_runtime and not active_runtime.completed_at' in route_source
+    assert 'and not active_runtime.completed_at' in route_source
+    assert "and not locals().get('orchestration_waiting_for_choice')" in route_source
+    assert "turn_orchestration_run.status = 'awaiting_user_choice'" in route_source
     assert "'partial_content': document_action_reply," in route_source
     assert "}, 409" in route_source
     assert route_source.count("user_message_doc['metadata'] = user_metadata") >= 8

--- a/ui_tests/test_chat_capability_choice_card.py
+++ b/ui_tests/test_chat_capability_choice_card.py
@@ -1,0 +1,339 @@
+# test_chat_capability_choice_card.py
+"""
+UI test for governed capability choice cards in chat.
+Version: 0.250.066
+Implemented in: 0.250.066
+
+This test ensures persisted capability proposals hydrate on desktop and mobile,
+expose accessible notices and controls, submit only allowlisted identifiers,
+and resume through the server-authored stream endpoint.
+"""
+
+import json
+import os
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CHAT_MESSAGES_FILE = REPO_ROOT / 'application' / 'single_app' / 'static' / 'js' / 'chat' / 'chat-messages.js'
+
+
+def _get_chat_test_url():
+    chat_url = os.getenv('SIMPLECHAT_PLAYWRIGHT_CHAT_URL', '').strip()
+    if not chat_url:
+        pytest.skip('Set SIMPLECHAT_PLAYWRIGHT_CHAT_URL to run capability choice UI tests.')
+    return chat_url
+
+
+def _create_context(browser, viewport):
+    context_kwargs = {'viewport': viewport, 'ignore_https_errors': True}
+    storage_state_path = os.getenv('SIMPLECHAT_PLAYWRIGHT_STORAGE_STATE', '').strip()
+    if storage_state_path:
+        context_kwargs['storage_state'] = storage_state_path
+    return browser.new_context(**context_kwargs)
+
+
+def _proposal_metadata(status='pending', resume_status='not_requested'):
+    created_at = datetime.now(timezone.utc)
+    return {
+        'awaiting_user_choice': status == 'pending',
+        'capability_proposal': {
+            'version': 1,
+            'proposal_id': 'ui-capability-proposal-1',
+            'run_id': 'ui-parent-run-1',
+            'conversation_id': 'ui-capability-conversation',
+            'user_message_id': 'ui-capability-user-1',
+            'assistant_message_id': 'ui-capability-proposal-1',
+            'status': status,
+            'requirement_ids': ['current_authoritative_sources'],
+            'reason_codes': ['current_authoritative_sources'],
+            'recommended_option_id': 'deep_research',
+            'options': [
+                {
+                    'id': 'deep_research',
+                    'capability_ids': ['deep_research'],
+                    'effective_capability_ids': ['deep_research', 'web_search'],
+                    'label': 'Deep Research',
+                    'latency_class': 'minutes',
+                    'cost_class': 'extended',
+                    'external_data': True,
+                },
+                {
+                    'id': 'web_search',
+                    'capability_ids': ['web_search'],
+                    'effective_capability_ids': ['web_search'],
+                    'label': 'Web Search',
+                    'latency_class': 'seconds',
+                    'cost_class': 'standard',
+                    'external_data': True,
+                },
+                {
+                    'id': 'continue_without_capabilities',
+                    'capability_ids': [],
+                    'effective_capability_ids': [],
+                    'label': 'Continue without additional capabilities',
+                    'latency_class': 'immediate',
+                    'cost_class': 'none',
+                    'external_data': False,
+                },
+            ],
+            'decision': (
+                {
+                    'option_id': 'deep_research',
+                    'status': 'approved',
+                    'capability_ids': ['deep_research'],
+                    'effective_capability_ids': ['deep_research', 'web_search'],
+                }
+                if status == 'approved'
+                else None
+            ),
+            'resume': {
+                'status': resume_status,
+                'assistant_message_id': None,
+            },
+            'created_at': created_at.isoformat(),
+            'expires_at': (created_at + timedelta(days=1)).isoformat(),
+        },
+    }
+
+
+def _append_proposal_message(page, message_id, metadata):
+    page.evaluate(
+        r"""
+        async ({ messageId, metadata }) => {
+            if (document.getElementById('chatbox')) {
+                const chatMessages = window.chatMessages && typeof window.chatMessages.appendMessage === 'function'
+                    ? window.chatMessages
+                    : await import('/static/js/chat/chat-messages.js');
+                chatMessages.appendMessage(
+                    'AI',
+                    'An additional capability could materially improve this answer. Choose how you want to continue.',
+                    null,
+                    messageId,
+                    false,
+                    [],
+                    [],
+                    [],
+                    null,
+                    null,
+                    {
+                        id: messageId,
+                        role: 'assistant',
+                        conversation_id: 'ui-capability-conversation',
+                        metadata,
+                    },
+                    false,
+                );
+                return;
+            }
+
+            if (!document.querySelector('link[data-capability-choice-test-css]')) {
+                const stylesheet = document.createElement('link');
+                stylesheet.rel = 'stylesheet';
+                stylesheet.href = '/static/css/chats.css?capability-choice-test=1';
+                stylesheet.dataset.capabilityChoiceTestCss = 'true';
+                document.head.appendChild(stylesheet);
+                await new Promise(resolve => {
+                    stylesheet.addEventListener('load', resolve, { once: true });
+                    stylesheet.addEventListener('error', resolve, { once: true });
+                });
+            }
+            const capabilityChoice = await import('/static/js/chat/chat-capability-choice.js');
+            let harness = document.getElementById('phase8a-capability-choice-harness');
+            if (!harness) {
+                harness = document.createElement('main');
+                harness.id = 'phase8a-capability-choice-harness';
+                harness.className = 'container py-3';
+                document.body.replaceChildren(harness);
+            }
+            const messageElement = document.createElement('article');
+            messageElement.className = 'message ai-message';
+            messageElement.dataset.messageId = messageId;
+            messageElement.dataset.conversationId = 'ui-capability-conversation';
+            const messageText = document.createElement('div');
+            messageText.className = 'message-text';
+            messageText.textContent = 'An additional capability could materially improve this answer.';
+            messageElement.appendChild(messageText);
+            harness.appendChild(messageElement);
+            capabilityChoice.hydrateCapabilityChoice(messageElement, metadata, {
+                onResume: async ({ conversationId, proposalId, endpoint }) => {
+                    const response = await fetch(endpoint, {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        credentials: 'same-origin',
+                        body: JSON.stringify({
+                            conversation_id: conversationId,
+                            capability_resume_proposal_id: proposalId,
+                        }),
+                    });
+                    const streamText = await response.text();
+                    const dataLine = streamText.split('\n').find(line => line.startsWith('data:'));
+                    const payload = dataLine ? JSON.parse(dataLine.slice(5).trim()) : {};
+                    const assistant = document.createElement('article');
+                    assistant.dataset.messageId = payload.message_id || 'ui-capability-resumed-assistant';
+                    assistant.textContent = payload.full_content || '';
+                    harness.appendChild(assistant);
+                },
+            });
+        }
+        """,
+        {'messageId': message_id, 'metadata': metadata},
+    )
+
+
+def test_capability_resume_waits_for_stream_terminal_event():
+    source = CHAT_MESSAGES_FILE.read_text(encoding='utf-8')
+
+    assert 'onResume: ({ conversationId, proposalId, endpoint }) => new Promise(' in source
+    assert 'onDone: resolve,' in source
+    assert "onError: errorMessage => reject(" in source
+
+
+@pytest.mark.ui
+@pytest.mark.parametrize(
+    'viewport',
+    [
+        {'width': 1280, 'height': 900},
+        {'width': 390, 'height': 844},
+    ],
+)
+def test_capability_choice_card_decision_and_resume(viewport):
+    from playwright.sync_api import expect, sync_playwright
+
+    chat_url = _get_chat_test_url()
+    decision_requests = []
+    resume_requests = []
+
+    with sync_playwright() as playwright:
+        browser = playwright.chromium.launch(headless=True)
+        context = _create_context(browser, viewport)
+        page = context.new_page()
+
+        def handle_decision(route):
+            decision_requests.append(json.loads(route.request.post_data or '{}'))
+            route.fulfill(
+                status=200,
+                content_type='application/json',
+                body=json.dumps({
+                    'success': True,
+                    'conversation_id': 'ui-capability-conversation',
+                    'proposal_id': 'ui-capability-proposal-1',
+                    'status': 'approved',
+                    'decision': {
+                        'option_id': 'deep_research',
+                        'status': 'approved',
+                    },
+                    'resume_status': 'pending',
+                    'resume_endpoint': '/api/chat/stream',
+                }),
+            )
+
+        def handle_resume(route):
+            resume_requests.append(json.loads(route.request.post_data or '{}'))
+            route.fulfill(
+                status=200,
+                content_type='text/event-stream',
+                body=(
+                    'data: '
+                    + json.dumps({
+                        'done': True,
+                        'conversation_id': 'ui-capability-conversation',
+                        'message_id': 'ui-capability-resumed-assistant',
+                        'user_message_id': 'ui-capability-user-1',
+                        'full_content': 'Resumed with current official sources.',
+                        'metadata': {},
+                    })
+                    + '\n\n'
+                ),
+            )
+
+        page.route('**/api/chat/capability-proposals/*/decision', handle_decision)
+        page.route('**/api/chat/stream', handle_resume)
+        page.goto(chat_url, wait_until='domcontentloaded')
+
+        _append_proposal_message(
+            page,
+            'ui-capability-proposal-1',
+            _proposal_metadata(),
+        )
+        message = page.locator('[data-message-id="ui-capability-proposal-1"]')
+        card = message.get_by_test_id('capability-choice-card')
+        expect(card).to_be_visible()
+        expect(card.get_by_role('heading', name='Choose how to continue')).to_be_visible()
+        expect(card.get_by_test_id('capability-external-data-notice')).to_contain_text(
+            'Conversation history and workspace content are not included.'
+        )
+        expect(card.get_by_role('button', name='Deep Research')).to_contain_text('Recommended')
+        expect(card.get_by_role('button', name='Web Search')).to_be_enabled()
+        expect(card.get_by_role('button', name='Continue without additional capabilities')).to_be_enabled()
+        status_id = card.get_by_role('button', name='Deep Research').get_attribute('aria-describedby')
+        assert status_id
+        expect(card.locator(f'#{status_id}')).to_have_attribute('aria-live', 'polite')
+
+        layout = card.evaluate(
+            """
+            element => ({
+                overflows: element.scrollWidth > element.clientWidth,
+                right: element.getBoundingClientRect().right,
+                viewportWidth: window.innerWidth,
+                buttonHeights: Array.from(element.querySelectorAll('button')).map(
+                    button => button.getBoundingClientRect().height
+                )
+            })
+            """
+        )
+        assert layout['overflows'] is False
+        assert layout['right'] <= layout['viewportWidth'] + 1
+        assert all(height >= 44 for height in layout['buttonHeights'])
+
+        deep_research_button = card.get_by_role('button', name='Deep Research')
+        deep_research_button.focus()
+        deep_research_button.press('Enter')
+        expect(page.locator('[data-message-id="ui-capability-resumed-assistant"]')).to_contain_text(
+            'Resumed with current official sources.'
+        )
+        expect(card.get_by_role('status')).to_contain_text('Completed with Deep Research.')
+        assert decision_requests == [{
+            'conversation_id': 'ui-capability-conversation',
+            'option_id': 'deep_research',
+        }]
+        assert resume_requests == [{
+            'conversation_id': 'ui-capability-conversation',
+            'capability_resume_proposal_id': 'ui-capability-proposal-1',
+        }]
+
+        _append_proposal_message(
+            page,
+            'ui-capability-proposal-refresh',
+            _proposal_metadata(status='approved', resume_status='pending'),
+        )
+        refreshed_card = page.locator(
+            '[data-message-id="ui-capability-proposal-refresh"]'
+        ).get_by_test_id('capability-choice-card')
+        expect(refreshed_card.get_by_role('button', name='Resume')).to_be_visible()
+        expect(refreshed_card.get_by_role('status')).to_contain_text(
+            'Deep Research is saved and ready to resume.'
+        )
+
+        expired_metadata = _proposal_metadata()
+        expired_metadata['capability_proposal']['expires_at'] = (
+            datetime.now(timezone.utc) - timedelta(minutes=1)
+        ).isoformat()
+        _append_proposal_message(
+            page,
+            'ui-capability-proposal-expired',
+            expired_metadata,
+        )
+        expired_card = page.locator(
+            '[data-message-id="ui-capability-proposal-expired"]'
+        ).get_by_test_id('capability-choice-card')
+        expect(expired_card.get_by_role('button')).to_have_count(0)
+        expect(expired_card.get_by_role('status')).to_contain_text(
+            'This capability choice has expired.'
+        )
+
+        context.close()
+        browser.close()


### PR DESCRIPTION
## Summary

- Add a server-authoritative governed inventory for Workspace Search, Analyze, Compare, Image, Web Search, URL Access, and Deep Research.
- Classify common evidence requirements deterministically so simple timeless questions remain on the direct path without an additional planning-model call.
- Preserve selected, proposed, decided, declined, and effective capability provenance separately; discovered capabilities retain `discovery_auto` or `discovery_approved` origins and remain required attempts.
- Persist one inline `awaiting_user_choice` checkpoint, end SSE, and resume through authenticated ETag-protected decision and execution claims.
- Reauthorize the personal conversation, exact source turn, scopes, linked uploads, document targets, capability configuration, role policy, and bundle dependencies before resume.
- Minimize approved external queries to current-message-only text, omit detected personal identifiers by default, and require a separately labeled option before including a supplied address for parcel-specific research.
- Add accessible desktop/mobile choice-card hydration that survives refresh, supports keyboard interaction, and waits for the resumed SSE terminal event before announcing completion.
- Update orchestration documentation, release notes, and application version to `0.250.066`.

## Security And Reliability

- Browser payloads can submit only the conversation, persisted proposal, and allowlisted option IDs; they cannot add effective capabilities, run IDs, identities, scopes, or document targets.
- Decisions, expiry/invalidation, resume leases, completion, and failure transitions use Cosmos ETags.
- Duplicate same-option decisions replay idempotently; conflicting decisions and live duplicate resume claims are rejected.
- Process-loss reconciliation discovers an already-persisted resumed assistant by proposal and execution IDs before allowing another claim.
- Unavailable, unauthorized, policy-blocked, missing-input, expired, and revoked capabilities fail closed and persist bounded terminal state.
- Unselected-agent discovery remains deferred to Phase 8B; no raw agent instructions or inaccessible catalog entries enter planner metadata.

## Validation

- Final standalone matrix: 19/19 suites passed across planning, discovery, durable choice, ETag persistence, runtime, evidence, central synthesis, image proposal, stream lifecycle, SSE metadata, and route policy.
- Authenticated Flask route suites: 17/17 passed for capability decisions/resume and image proposal approval.
- Playwright: 5/5 passed across capability choice and existing image proposal desktop/mobile workflows.
- Python compilation and JavaScript `node --check`: passed.
- Broken Access Control scans: passed for all changed backend files and full new capability modules.
- XSS scans: passed for the new card/backend slice; the `chat-messages.js` diff adds only a local import and callback-backed hydrator and does not touch its known legacy sinks.
- Route policy contracts: 12/12 passed.
- Staged whitespace validation: passed.

## Phase Boundary

Phase 8A makes pending choices and resume claims durable. Generalized durable execution for in-flight model/tool work, consequential/write approval, and governed discovery of unselected agents remain later phases.

Refs #1021