### PR TITLE
Add versioned Latest Features navigation hide preference

### DIFF
--- a/application/single_app/.gitignore
+++ b/application/single_app/.gitignore
@@ -195,6 +195,6 @@ cython_debug/
 #  refer to https://docs.cursor.com/context/ignore-files
 .cursorignore
 .cursorindexingignore
-
+.env.*
 
 deploy.zip

--- a/application/single_app/app.py
+++ b/application/single_app/app.py
@@ -29,6 +29,7 @@ from semantic_kernel_loader import initialize_semantic_kernel
 from functions_authentication import *
 from functions_content import *
 from functions_documents import *
+from functions_latest_features_nav import should_hide_latest_features_nav
 from functions_search import *
 from functions_settings import *
 from functions_appinsights import *
@@ -115,6 +116,7 @@ executor = Executor()
 executor.init_app(app)
 app.config['SESSION_TYPE'] = SESSION_TYPE
 app.config['VERSION'] = VERSION
+app.config['IS_DEVELOPMENT'] = IS_DEVELOPMENT
 app.config['SECRET_KEY'] = SECRET_KEY
 app.config['SESSION_COOKIE_SAMESITE'] = SESSION_COOKIE_SAMESITE
 app.config['SESSION_COOKIE_HTTPONLY'] = SESSION_COOKIE_HTTPONLY
@@ -572,19 +574,29 @@ def inject_settings():
         log_event(f"[CustomPages] Error injecting custom page navigation: {e}", level=logging.ERROR, exceptionTraceback=True)
     # Inject per-user settings if logged in
     user_settings = {}
+    latest_features_nav_hidden = IS_DEVELOPMENT
     try:
         user_id = get_current_user_id()
         if user_id:
             from functions_settings import get_user_ui_settings
             user_settings = get_user_ui_settings(user_id) or {}
+            latest_features_nav_hidden = should_hide_latest_features_nav(
+                user_settings,
+                VERSION,
+                is_development=IS_DEVELOPMENT
+            )
     except Exception as e:
         print(f"Error injecting user settings: {e}")
         log_event(f"Error injecting user settings: {e}", level=logging.ERROR)
         user_settings = {}
+        latest_features_nav_hidden = IS_DEVELOPMENT
     return dict(
         app_settings=public_settings,
         user_settings=user_settings,
         custom_pages_nav=custom_pages_nav,
+        latest_features_current_version=VERSION,
+        latest_features_nav_hidden=latest_features_nav_hidden,
+        latest_features_nav_hidden_by_development=IS_DEVELOPMENT,
         idle_timeout_enabled=idle_timeout_enabled,
         idle_timeout_minutes=idle_timeout_minutes,
         idle_warning_minutes=idle_warning_minutes

--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -32,6 +32,7 @@ import ffmpeg as ffmpeg_py
 import glob
 import jwt
 import pandas
+from functions_latest_features_nav import is_development_env_enabled
 
 # Add dotenv import
 from dotenv import load_dotenv
@@ -96,7 +97,8 @@ load_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.250.057"
+VERSION = "0.250.059"
+IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')
 SESSION_COOKIE_HTTPONLY = os.getenv('SESSION_COOKIE_HTTPONLY', 'true').lower() != 'false'

--- a/application/single_app/functions_latest_features_nav.py
+++ b/application/single_app/functions_latest_features_nav.py
@@ -1,0 +1,50 @@
+# functions_latest_features_nav.py
+
+import os
+
+
+LATEST_FEATURES_HIDDEN_VERSION_SETTING = "latestFeaturesHiddenVersion"
+
+
+def is_development_env_enabled(value=None):
+    """Return True only when the development env flag is explicitly true."""
+    raw_value = os.getenv("is_development", "") if value is None else value
+    return str(raw_value or "").strip().lower() == "true"
+
+
+def normalize_latest_features_hidden_version(value):
+    """Normalize a hidden-version setting value for storage and comparison."""
+    if value is None:
+        return None
+
+    normalized_value = str(value).strip()
+    return normalized_value or None
+
+
+def extract_latest_features_hidden_version(user_settings_payload):
+    """Extract the hidden-version value from either a settings dict or user settings document."""
+    if not isinstance(user_settings_payload, dict):
+        return None
+
+    settings = user_settings_payload.get("settings")
+    if isinstance(settings, dict):
+        return normalize_latest_features_hidden_version(
+            settings.get(LATEST_FEATURES_HIDDEN_VERSION_SETTING)
+        )
+
+    return normalize_latest_features_hidden_version(
+        user_settings_payload.get(LATEST_FEATURES_HIDDEN_VERSION_SETTING)
+    )
+
+
+def should_hide_latest_features_nav(user_settings_payload, current_version, is_development=False):
+    """Determine whether Latest Features nav entries should be hidden."""
+    if bool(is_development):
+        return True
+
+    normalized_current_version = normalize_latest_features_hidden_version(current_version)
+    if not normalized_current_version:
+        return False
+
+    hidden_version = extract_latest_features_hidden_version(user_settings_payload)
+    return hidden_version == normalized_current_version

--- a/application/single_app/functions_settings.py
+++ b/application/single_app/functions_settings.py
@@ -9,6 +9,7 @@ from functions_appinsights import log_event
 from functions_cosmos_throughput import get_default_cosmos_throughput_settings
 from functions_document_actions import get_default_document_action_capabilities
 from functions_icon_utils import normalize_icon_payload
+from functions_latest_features_nav import LATEST_FEATURES_HIDDEN_VERSION_SETTING
 from functions_service_health import get_default_service_health
 import app_settings_cache
 import inspect
@@ -33,6 +34,7 @@ USER_UI_SETTINGS_KEYS = (
     "notifications_per_page",
     "sidebarToggleStyle",
     "sidebarMenuState",
+    LATEST_FEATURES_HIDDEN_VERSION_SETTING,
 )
 ADMIN_SETTINGS_SECRET_REDACTED_VALUE = "***REDACTED***"
 ADMIN_SETTINGS_FORM_SECRET_FIELDS = (

--- a/application/single_app/route_backend_users.py
+++ b/application/single_app/route_backend_users.py
@@ -18,6 +18,10 @@ from functions_group import (
     get_user_role_in_group,
     update_active_group_for_user,
 )
+from functions_latest_features_nav import (
+    LATEST_FEATURES_HIDDEN_VERSION_SETTING,
+    normalize_latest_features_hidden_version,
+)
 from functions_public_workspaces import update_active_public_workspace_for_user
 from functions_settings import *
 from swagger_wrapper import swagger_route, get_auth_security
@@ -503,6 +507,7 @@ def register_route_backend_users(bp):
                     'navbar_layout', 'chatLayout', 'showChatTitle', 'chatSplitSizes',
                     'deepResearchDefaultEnabled',
                     'sidebarToggleStyle', 'sidebarMenuState',
+                    LATEST_FEATURES_HIDDEN_VERSION_SETTING,
                     # Microphone permission settings
                     'microphonePermissionPreference', 'microphonePermissionState',
                     # Text-to-speech settings
@@ -556,6 +561,14 @@ def register_route_backend_users(bp):
                             normalized_sidebar_menu_state[key] = value.strip().lower() == "true"
 
                     settings_to_update["sidebarMenuState"] = normalized_sidebar_menu_state
+
+                if LATEST_FEATURES_HIDDEN_VERSION_SETTING in settings_to_update:
+                    hidden_version = normalize_latest_features_hidden_version(
+                        settings_to_update.get(LATEST_FEATURES_HIDDEN_VERSION_SETTING)
+                    )
+                    if hidden_version is not None and hidden_version != VERSION:
+                        return jsonify({"error": "Invalid Latest Features hidden version"}), 400
+                    settings_to_update[LATEST_FEATURES_HIDDEN_VERSION_SETTING] = hidden_version
 
                 active_group_updated = False
                 active_public_workspace_updated = False

--- a/application/single_app/static/js/latest-features-nav.js
+++ b/application/single_app/static/js/latest-features-nav.js
@@ -1,0 +1,265 @@
+// latest-features-nav.js
+
+(function () {
+    const config = window.simplechatLatestFeaturesNav || {};
+    const settingKey = config.settingKey || 'latestFeaturesHiddenVersion';
+
+    function getCurrentVersion() {
+        return String(config.currentVersion || '').trim();
+    }
+
+    function isHiddenByDevelopment() {
+        return Boolean(config.hiddenByDevelopment);
+    }
+
+    function getUserSettingsCache() {
+        if (!window.simplechatUserSettings || typeof window.simplechatUserSettings !== 'object') {
+            window.simplechatUserSettings = {};
+        }
+
+        return window.simplechatUserSettings;
+    }
+
+    function getHiddenVersion() {
+        const settings = getUserSettingsCache();
+        return String(settings[settingKey] || '').trim();
+    }
+
+    function setHiddenVersionCache(hiddenVersion) {
+        const settings = getUserSettingsCache();
+        settings[settingKey] = hiddenVersion || null;
+    }
+
+    function showLatestFeaturesToast(message, type = 'success') {
+        if (typeof window.showToastMessage === 'function') {
+            window.showToastMessage(message, type);
+            return;
+        }
+
+        if (typeof bootstrap === 'undefined' || !bootstrap.Toast) {
+            return;
+        }
+
+        let toastContainer = document.getElementById('latest-features-toast-container');
+        if (!toastContainer) {
+            toastContainer = document.createElement('div');
+            toastContainer.id = 'latest-features-toast-container';
+            toastContainer.className = 'toast-container position-fixed bottom-0 end-0 p-3';
+            toastContainer.setAttribute('aria-live', 'polite');
+            toastContainer.setAttribute('aria-atomic', 'true');
+            document.body.appendChild(toastContainer);
+        }
+
+        const toast = document.createElement('div');
+        const bgClass = type === 'danger' ? 'bg-danger' : type === 'info' ? 'bg-info' : 'bg-success';
+        toast.className = `toast align-items-center text-white ${bgClass} border-0`;
+        toast.setAttribute('role', 'alert');
+
+        const toastBodyRow = document.createElement('div');
+        toastBodyRow.className = 'd-flex';
+
+        const toastBody = document.createElement('div');
+        toastBody.className = 'toast-body';
+        toastBody.textContent = message;
+
+        const closeButton = document.createElement('button');
+        closeButton.type = 'button';
+        closeButton.className = 'btn-close btn-close-white me-2 m-auto';
+        closeButton.setAttribute('data-bs-dismiss', 'toast');
+        closeButton.setAttribute('aria-label', 'Close');
+
+        toastBodyRow.appendChild(toastBody);
+        toastBodyRow.appendChild(closeButton);
+        toast.appendChild(toastBodyRow);
+        toastContainer.appendChild(toast);
+
+        const toastInstance = new bootstrap.Toast(toast);
+        toast.addEventListener('hidden.bs.toast', function () {
+            toast.remove();
+        });
+        toastInstance.show();
+    }
+
+    async function saveHiddenVersion(hiddenVersion) {
+        const response = await fetch('/api/user/settings', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            credentials: 'same-origin',
+            body: JSON.stringify({
+                settings: {
+                    [settingKey]: hiddenVersion || null
+                }
+            })
+        });
+
+        if (!response.ok) {
+            throw new Error('Unable to save Latest Features navigation preference.');
+        }
+
+        setHiddenVersionCache(hiddenVersion);
+    }
+
+    function hasVisibleSupportDestination(section) {
+        const destinations = section.querySelectorAll('[data-support-menu-destination]');
+        for (const destination of destinations) {
+            if (!destination.classList.contains('d-none')) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    function updateSupportSections() {
+        document.querySelectorAll('[data-support-menu-nav-section]').forEach(function (section) {
+            section.classList.toggle('d-none', !hasVisibleSupportDestination(section));
+        });
+    }
+
+    function hideLatestFeaturesNavItems() {
+        document.querySelectorAll('[data-latest-features-nav-item]').forEach(function (item) {
+            item.classList.add('d-none');
+        });
+        updateSupportSections();
+    }
+
+    function showLatestFeaturesNavItems() {
+        if (isHiddenByDevelopment()) {
+            return;
+        }
+
+        document.querySelectorAll('[data-latest-features-nav-item]').forEach(function (item) {
+            item.classList.remove('d-none');
+        });
+        document.querySelectorAll('[data-support-menu-nav-section]').forEach(function (section) {
+            section.classList.remove('d-none');
+        });
+    }
+
+    function setProfileStatusMessage(message, type = 'muted') {
+        const status = document.getElementById('latest-features-nav-preference-status');
+        if (!status) {
+            return;
+        }
+
+        const classMap = {
+            muted: 'text-muted',
+            info: 'text-info',
+            success: 'text-success',
+            danger: 'text-danger'
+        };
+        status.textContent = message || '';
+        status.className = `preference-status small mt-3 ${classMap[type] || classMap.muted}`;
+    }
+
+    function renderProfileLatestFeaturesStatus() {
+        const badge = document.getElementById('latest-features-nav-status-badge');
+        const detail = document.getElementById('latest-features-nav-status-detail');
+        const unhideButton = document.getElementById('unhide-latest-features-nav-btn');
+        if (!badge || !detail) {
+            return;
+        }
+
+        const currentVersion = getCurrentVersion();
+        const hiddenVersion = getHiddenVersion();
+        const hiddenForCurrentVersion = Boolean(currentVersion && hiddenVersion === currentVersion);
+
+        badge.className = 'badge';
+        if (isHiddenByDevelopment()) {
+            badge.classList.add('bg-warning', 'text-dark');
+            badge.textContent = 'Hidden in development';
+            detail.textContent = 'Latest Features navigation is hidden because the is_development environment flag is true.';
+        } else if (hiddenForCurrentVersion) {
+            badge.classList.add('bg-secondary');
+            badge.textContent = 'Hidden';
+            detail.textContent = `Latest Features navigation is hidden for version ${currentVersion}.`;
+        } else {
+            badge.classList.add('bg-success');
+            badge.textContent = 'Visible';
+            detail.textContent = hiddenVersion
+                ? `Latest Features navigation is visible because your saved hide preference was for version ${hiddenVersion}, and the current version is ${currentVersion}.`
+                : `Latest Features navigation is visible for version ${currentVersion}.`;
+        }
+
+        if (unhideButton) {
+            unhideButton.classList.toggle('d-none', !hiddenForCurrentVersion);
+            unhideButton.disabled = false;
+        }
+    }
+
+    async function handleHideLatestFeatures(event) {
+        event.preventDefault();
+        event.stopPropagation();
+
+        const currentVersion = getCurrentVersion();
+        if (!currentVersion) {
+            showLatestFeaturesToast('Unable to hide Latest Features because the app version is unavailable.', 'danger');
+            return;
+        }
+
+        const actionButton = event.currentTarget;
+        actionButton.disabled = true;
+        try {
+            await saveHiddenVersion(currentVersion);
+            hideLatestFeaturesNavItems();
+            renderProfileLatestFeaturesStatus();
+            showLatestFeaturesToast('Latest Features navigation is hidden for this version.', 'success');
+        } catch (error) {
+            console.error('Error hiding Latest Features navigation:', error);
+            showLatestFeaturesToast('Failed to hide Latest Features navigation. Please try again.', 'danger');
+        } finally {
+            actionButton.disabled = false;
+        }
+    }
+
+    async function handleUnhideLatestFeatures() {
+        const unhideButton = document.getElementById('unhide-latest-features-nav-btn');
+        if (!unhideButton) {
+            return;
+        }
+
+        const originalText = unhideButton.textContent;
+        unhideButton.disabled = true;
+        unhideButton.textContent = 'Saving...';
+        setProfileStatusMessage('Restoring Latest Features navigation...', 'info');
+
+        try {
+            await saveHiddenVersion(null);
+            showLatestFeaturesNavItems();
+            renderProfileLatestFeaturesStatus();
+            setProfileStatusMessage('Latest Features navigation has been restored.', 'success');
+            showLatestFeaturesToast('Latest Features navigation restored.', 'success');
+        } catch (error) {
+            console.error('Error restoring Latest Features navigation:', error);
+            setProfileStatusMessage('Failed to restore Latest Features navigation. Please try again.', 'danger');
+            showLatestFeaturesToast('Failed to restore Latest Features navigation. Please try again.', 'danger');
+        } finally {
+            unhideButton.disabled = false;
+            unhideButton.textContent = originalText;
+        }
+    }
+
+    function initializeLatestFeaturesNavPreferences() {
+        document.querySelectorAll('[data-latest-features-hide-action]').forEach(function (button) {
+            button.addEventListener('click', handleHideLatestFeatures);
+        });
+
+        const unhideButton = document.getElementById('unhide-latest-features-nav-btn');
+        if (unhideButton) {
+            unhideButton.addEventListener('click', handleUnhideLatestFeatures);
+        }
+
+        renderProfileLatestFeaturesStatus();
+    }
+
+    document.addEventListener('DOMContentLoaded', initializeLatestFeaturesNavPreferences);
+
+    window.SimpleChatLatestFeaturesNav = {
+        hideLatestFeaturesNavItems,
+        renderProfileLatestFeaturesStatus,
+        saveHiddenVersion,
+        showLatestFeaturesNavItems
+    };
+})();

--- a/application/single_app/templates/_sidebar_nav.html
+++ b/application/single_app/templates/_sidebar_nav.html
@@ -5,6 +5,7 @@
 {% set sidebar_menu_state_raw = user_settings.get('settings', {}).get('sidebarMenuState', {}) %}
 {% set sidebar_menu_state = sidebar_menu_state_raw if sidebar_menu_state_raw is mapping else {} %}
 {% set sidebar_settings = settings if settings is defined else app_settings %}
+{% set latest_features_nav_is_hidden = latest_features_nav_hidden | default(false) %}
 <div id="sidebar-nav" class="d-flex flex-column vh-100 bg-light border-end sidebar-expanded" style="width: var(--sidebar-width, 260px); min-width: var(--sidebar-min-width, 220px); position: fixed; left: 0; top: 0; z-index: 1040; transition: transform 0.3s ease;">
 
   <div id="sidebar-resize-handle" class="sidebar-resize-handle" aria-label="Resize sidebar" role="separator" tabindex="0">
@@ -308,11 +309,11 @@
     <!-- Support Menu Section - Only show when a signed-in app user can access at least one support destination -->
     {% set support_menu_role_allowed = session.get('user') and session['user'].get('roles') and ('Admin' in session['user']['roles'] or 'User' in session['user']['roles']) %}
     {% if support_menu_role_allowed and app_settings.enable_support_menu %}
-    {% set show_support_latest_features = app_settings.enable_support_latest_features and app_settings.support_latest_features_has_visible_items %}
+    {% set show_support_latest_features = app_settings.enable_support_latest_features and app_settings.support_latest_features_has_visible_items and not latest_features_nav_is_hidden %}
     {% set show_support_send_feedback = app_settings.enable_support_send_feedback and app_settings.support_feedback_recipient_configured %}
     {% if show_support_latest_features or show_support_send_feedback %}
     {% set support_menu_expanded = sidebar_menu_state.get('support', true) %}
-    <div class="overflow-auto">
+    <div class="overflow-auto" data-support-menu-nav-section>
       <div id="support-menu-toggle" class="mt-2 mb-1 ps-3 pe-2 text-muted small d-flex align-items-center" style="font-weight: 500; letter-spacing: 0.02em; cursor: pointer; user-select: none;" role="button" tabindex="0" aria-controls="support-menu-links-section" aria-expanded="{{ 'true' if support_menu_expanded else 'false' }}" data-sidebar-menu-key="support" data-sidebar-menu-target="support-menu-links-section" data-sidebar-menu-caret="support-menu-caret">
         <span class="nav-text">{{ app_settings.support_menu_name or 'Support' }}</span>
         <i id="support-menu-caret" class="bi bi-caret-down-fill ms-2 transition" style="font-size: 0.9em; transition: transform 0.2s;{% if not support_menu_expanded %} transform: rotate(-90deg);{% endif %}"></i>
@@ -320,16 +321,35 @@
       <div id="support-menu-links-section"{% if not support_menu_expanded %} class="d-none"{% endif %} aria-hidden="{{ 'false' if support_menu_expanded else 'true' }}">
         <ul class="nav flex-column mb-2">
           {% if show_support_latest_features %}
-          <li class="nav-item">
-            <a class="nav-link d-flex align-items-center" href="{{ url_for('frontend_support.support_latest_features') }}">
+          <li class="nav-item d-flex align-items-center latest-features-nav-item" data-latest-features-nav-item data-support-menu-destination>
+            <a class="nav-link d-flex align-items-center flex-grow-1" href="{{ url_for('frontend_support.support_latest_features') }}">
               <i class="bi bi-lightning-charge me-2" style="font-size: 0.8em;"></i>
               <span class="nav-text">Latest Features</span>
               <span class="badge bg-warning text-dark text-uppercase ms-2">New</span>
             </a>
+            <div class="dropdown latest-features-hide-menu me-2">
+              <button
+                type="button"
+                class="btn btn-sm btn-link nav-link p-1 latest-features-options-toggle"
+                data-bs-toggle="dropdown"
+                aria-expanded="false"
+                aria-label="Latest Features options"
+                title="Latest Features options"
+              >
+                <i class="bi bi-three-dots" aria-hidden="true"></i>
+              </button>
+              <ul class="dropdown-menu dropdown-menu-end">
+                <li>
+                  <button type="button" class="dropdown-item latest-features-hide-action" data-latest-features-hide-action>
+                    Hide Latest Features
+                  </button>
+                </li>
+              </ul>
+            </div>
           </li>
           {% endif %}
           {% if show_support_send_feedback %}
-          <li class="nav-item">
+          <li class="nav-item" data-support-menu-destination>
             <a class="nav-link d-flex align-items-center" href="{{ url_for('frontend_support.support_send_feedback') }}">
               <i class="bi bi-envelope-paper me-2" style="font-size: 0.8em;"></i>
               <span class="nav-text">Send Feedback</span>
@@ -410,10 +430,33 @@
       </div>
       <div id="admin-settings-section"{% if not admin_settings_menu_expanded %} class="d-none"{% endif %} aria-hidden="{{ 'false' if admin_settings_menu_expanded else 'true' }}">
         <ul class="nav flex-column mb-2">
-          <li class="nav-item">
-            <a class="nav-link d-flex align-items-center admin-nav-tab" href="#" data-tab="latest-features">
-              <i class="bi bi-lightning-charge me-2"></i><span class="nav-text">Latest Features</span><span class="badge bg-warning text-dark text-uppercase ms-2">New</span>
-            </a>
+          {% if not latest_features_nav_is_hidden %}
+          <li class="nav-item latest-features-nav-item" data-latest-features-nav-item>
+            <div class="d-flex align-items-center">
+              <a class="nav-link d-flex align-items-center admin-nav-tab flex-grow-1" href="#" data-tab="latest-features">
+                <i class="bi bi-lightning-charge me-2"></i><span class="nav-text">Latest Features</span><span class="badge bg-warning text-dark text-uppercase ms-2">New</span>
+              </a>
+              <div class="dropdown latest-features-hide-menu me-2">
+                <button
+                  type="button"
+                  class="btn btn-sm btn-link nav-link p-1 latest-features-options-toggle"
+                  data-bs-toggle="dropdown"
+                  aria-expanded="false"
+                  aria-label="Latest Features options"
+                  title="Latest Features options"
+                  data-sidebar-menu-ignore="true"
+                >
+                  <i class="bi bi-three-dots" aria-hidden="true"></i>
+                </button>
+                <ul class="dropdown-menu dropdown-menu-end">
+                  <li>
+                    <button type="button" class="dropdown-item latest-features-hide-action" data-latest-features-hide-action>
+                      Hide Latest Features
+                    </button>
+                  </li>
+                </ul>
+              </div>
+            </div>
             <ul class="nav flex-column ms-3" style="display: none;" id="latest-features-submenu">
               {% for release_group in admin_latest_feature_release_groups %}
                 {% if release_group.id == 'current_release' %}
@@ -439,6 +482,7 @@
               {% endfor %}
             </ul>
           </li>
+          {% endif %}
           <li class="nav-item">
             <a class="nav-link d-flex align-items-center admin-nav-tab" href="#" data-tab="general">
               <i class="bi bi-gear me-2"></i><span class="nav-text">General</span>

--- a/application/single_app/templates/_sidebar_short_nav.html
+++ b/application/single_app/templates/_sidebar_short_nav.html
@@ -4,6 +4,7 @@
 {% set sidebar_menu_state_raw = user_settings.get('settings', {}).get('sidebarMenuState', {}) %}
 {% set sidebar_menu_state = sidebar_menu_state_raw if sidebar_menu_state_raw is mapping else {} %}
 {% set sidebar_settings = settings if settings is defined else app_settings %}
+{% set latest_features_nav_is_hidden = latest_features_nav_hidden | default(false) %}
 <div id="sidebar-nav" class="d-flex flex-column bg-light border-end sidebar-expanded chat-sidebar-nav offcanvas-lg offcanvas-start" tabindex="-1" aria-labelledby="chatSidebarDrawerLabel" data-navigation-drawer="chat-rail">
 
   <div class="offcanvas-header chat-sidebar-mobile-header">
@@ -114,11 +115,11 @@
     <!-- Support Menu Section - Only show when a signed-in app user can access at least one support destination -->
     {% set support_menu_role_allowed = session.get('user') and session['user'].get('roles') and ('Admin' in session['user']['roles'] or 'User' in session['user']['roles']) %}
     {% if support_menu_role_allowed and app_settings.enable_support_menu %}
-    {% set show_support_latest_features = app_settings.enable_support_latest_features and app_settings.support_latest_features_has_visible_items %}
+    {% set show_support_latest_features = app_settings.enable_support_latest_features and app_settings.support_latest_features_has_visible_items and not latest_features_nav_is_hidden %}
     {% set show_support_send_feedback = app_settings.enable_support_send_feedback and app_settings.support_feedback_recipient_configured %}
     {% if show_support_latest_features or show_support_send_feedback %}
     {% set support_menu_expanded = sidebar_menu_state.get('support', true) %}
-    <div class="overflow-auto">
+    <div class="overflow-auto" data-support-menu-nav-section>
       <div id="support-menu-toggle" class="mt-2 mb-1 ps-3 pe-2 text-muted small d-flex align-items-center" style="font-weight: 500; letter-spacing: 0.02em; cursor: pointer; user-select: none;" role="button" tabindex="0" aria-controls="support-menu-links-section" aria-expanded="{{ 'true' if support_menu_expanded else 'false' }}" data-sidebar-menu-key="support" data-sidebar-menu-target="support-menu-links-section" data-sidebar-menu-caret="support-menu-caret">
         <span class="nav-text">{{ app_settings.support_menu_name or 'Support' }}</span>
         <i id="support-menu-caret" class="bi bi-caret-down-fill ms-2 transition" style="font-size: 0.9em; transition: transform 0.2s;{% if not support_menu_expanded %} transform: rotate(-90deg);{% endif %}"></i>
@@ -126,16 +127,35 @@
       <div id="support-menu-links-section"{% if not support_menu_expanded %} class="d-none"{% endif %} aria-hidden="{{ 'false' if support_menu_expanded else 'true' }}">
         <ul class="nav flex-column mb-2">
           {% if show_support_latest_features %}
-          <li class="nav-item">
-            <a class="nav-link d-flex align-items-center" href="{{ url_for('frontend_support.support_latest_features') }}">
+          <li class="nav-item d-flex align-items-center latest-features-nav-item" data-latest-features-nav-item data-support-menu-destination>
+            <a class="nav-link d-flex align-items-center flex-grow-1" href="{{ url_for('frontend_support.support_latest_features') }}">
               <i class="bi bi-lightning-charge me-2" style="font-size: 0.8em;"></i>
               <span class="nav-text">Latest Features</span>
               <span class="badge bg-warning text-dark text-uppercase ms-2">New</span>
             </a>
+            <div class="dropdown latest-features-hide-menu me-2">
+              <button
+                type="button"
+                class="btn btn-sm btn-link nav-link p-1 latest-features-options-toggle"
+                data-bs-toggle="dropdown"
+                aria-expanded="false"
+                aria-label="Latest Features options"
+                title="Latest Features options"
+              >
+                <i class="bi bi-three-dots" aria-hidden="true"></i>
+              </button>
+              <ul class="dropdown-menu dropdown-menu-end">
+                <li>
+                  <button type="button" class="dropdown-item latest-features-hide-action" data-latest-features-hide-action>
+                    Hide Latest Features
+                  </button>
+                </li>
+              </ul>
+            </div>
           </li>
           {% endif %}
           {% if show_support_send_feedback %}
-          <li class="nav-item">
+          <li class="nav-item" data-support-menu-destination>
             <a class="nav-link d-flex align-items-center" href="{{ url_for('frontend_support.support_send_feedback') }}">
               <i class="bi bi-envelope-paper me-2" style="font-size: 0.8em;"></i>
               <span class="nav-text">Send Feedback</span>

--- a/application/single_app/templates/_top_nav.html
+++ b/application/single_app/templates/_top_nav.html
@@ -1,4 +1,5 @@
 {% set is_chat_page = request.endpoint == 'frontend_chats.chats' %}
+{% set latest_features_nav_is_hidden = latest_features_nav_hidden | default(false) %}
 <nav class="navbar navbar-expand-lg navbar-light bg-light fixed-top top-nav-bar{% if is_chat_page %} top-nav-bar-chat{% endif %}">
     <div class="container-fluid top-nav-shell{% if is_chat_page %} top-nav-shell-chat{% endif %}">
         <div class="top-nav-brand">
@@ -94,21 +95,32 @@
             {% if session.get('user') and session['user'].get('roles') and ('Admin' in session['user']['roles'] or 'User' in session['user']['roles']) %}
                 {% set support_menu_role_allowed = 'Admin' in session['user']['roles'] or 'User' in session['user']['roles'] %}
                 {% if support_menu_role_allowed and app_settings.enable_support_menu %}
-                    {% set show_support_latest_features = app_settings.enable_support_latest_features and app_settings.support_latest_features_has_visible_items %}
+                    {% set show_support_latest_features = app_settings.enable_support_latest_features and app_settings.support_latest_features_has_visible_items and not latest_features_nav_is_hidden %}
                     {% set show_support_send_feedback = app_settings.enable_support_send_feedback and app_settings.support_feedback_recipient_configured %}
                     {% if show_support_latest_features or show_support_send_feedback %}
-                        <div class="nav-item dropdown">
+                        <div class="nav-item dropdown" data-support-menu-nav-section>
                             <a class="nav-link dropdown-toggle" href="#" id="supportMenuDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
                                 {{ app_settings.support_menu_name or 'Support' }}
                             </a>
                             <div class="dropdown-menu" aria-labelledby="supportMenuDropdown">
                                 {% if show_support_latest_features %}
-                                    <a class="dropdown-item" href="{{ url_for('frontend_support.support_latest_features') }}">
-                                        Latest Features
-                                    </a>
+                                    <div class="d-flex align-items-center latest-features-nav-item" data-latest-features-nav-item data-support-menu-destination>
+                                        <a class="dropdown-item flex-grow-1 pe-2" href="{{ url_for('frontend_support.support_latest_features') }}">
+                                            Latest Features
+                                        </a>
+                                        <button
+                                            type="button"
+                                            class="btn btn-sm btn-link text-muted p-1 me-2 latest-features-hide-action"
+                                            data-latest-features-hide-action
+                                            aria-label="Hide Latest Features"
+                                            title="Hide Latest Features"
+                                        >
+                                            <i class="bi bi-three-dots" aria-hidden="true"></i>
+                                        </button>
+                                    </div>
                                 {% endif %}
                                 {% if show_support_send_feedback %}
-                                    <a class="dropdown-item" href="{{ url_for('frontend_support.support_send_feedback') }}">
+                                    <a class="dropdown-item" href="{{ url_for('frontend_support.support_send_feedback') }}" data-support-menu-destination>
                                         Send Feedback
                                     </a>
                                 {% endif %}
@@ -310,21 +322,34 @@
 
             {% set support_menu_role_allowed = 'Admin' in session['user']['roles'] or 'User' in session['user']['roles'] %}
             {% if support_menu_role_allowed and app_settings.enable_support_menu %}
-                {% set show_support_latest_features = app_settings.enable_support_latest_features and app_settings.support_latest_features_has_visible_items %}
+                {% set show_support_latest_features = app_settings.enable_support_latest_features and app_settings.support_latest_features_has_visible_items and not latest_features_nav_is_hidden %}
                 {% set show_support_send_feedback = app_settings.enable_support_send_feedback and app_settings.support_feedback_recipient_configured %}
                 {% if show_support_latest_features or show_support_send_feedback %}
+                    <div data-support-menu-nav-section>
                     <div class="top-nav-mobile-section-label">{{ app_settings.support_menu_name or 'Support' }}</div>
                     <div class="list-group list-group-flush top-nav-mobile-list">
                         {% if show_support_latest_features %}
-                            <a class="list-group-item list-group-item-action" href="{{ url_for('frontend_support.support_latest_features') }}">
-                                <i class="bi bi-stars me-2"></i>Latest Features
-                            </a>
+                            <div class="list-group-item d-flex align-items-center latest-features-nav-item" data-latest-features-nav-item data-support-menu-destination>
+                                <a class="flex-grow-1 text-decoration-none text-body" href="{{ url_for('frontend_support.support_latest_features') }}">
+                                    <i class="bi bi-stars me-2"></i>Latest Features
+                                </a>
+                                <button
+                                    type="button"
+                                    class="btn btn-sm btn-link text-muted p-1 latest-features-hide-action"
+                                    data-latest-features-hide-action
+                                    aria-label="Hide Latest Features"
+                                    title="Hide Latest Features"
+                                >
+                                    <i class="bi bi-three-dots" aria-hidden="true"></i>
+                                </button>
+                            </div>
                         {% endif %}
                         {% if show_support_send_feedback %}
-                            <a class="list-group-item list-group-item-action" href="{{ url_for('frontend_support.support_send_feedback') }}">
+                            <a class="list-group-item list-group-item-action" href="{{ url_for('frontend_support.support_send_feedback') }}" data-support-menu-destination>
                                 <i class="bi bi-chat-left-text me-2"></i>Send Feedback
                             </a>
                         {% endif %}
+                    </div>
                     </div>
                 {% endif %}
             {% endif %}

--- a/application/single_app/templates/base.html
+++ b/application/single_app/templates/base.html
@@ -650,6 +650,11 @@
     const appSettings = {{ app_settings|tojson }};
     window.appSettings = appSettings;
     window.simplechatUserSettings = {{ user_settings.get('settings', {}) | tojson }};
+    window.simplechatLatestFeaturesNav = {{ {
+      'currentVersion': latest_features_current_version | default(config['VERSION']),
+      'hiddenByDevelopment': latest_features_nav_hidden_by_development | default(false),
+      'settingKey': 'latestFeaturesHiddenVersion'
+    } | tojson }};
   </script>
 
   <!-- Prism.js syntax highlighting script -->
@@ -698,6 +703,7 @@
   <script src="{{ url_for('static', filename='js/navigation.js') }}"></script>
   <script src="{{ url_for('static', filename='js/sidebar.js') }}"></script>
   <script src="{{ url_for('static', filename='js/sidebar-resize.js') }}"></script>
+  <script src="{{ url_for('static', filename='js/latest-features-nav.js') }}?v={{ config['VERSION'] }}"></script>
   <!-- Profile Image JavaScript -->
   <script src="{{ url_for('static', filename='js/profile-image.js') }}"></script>
   {% if session.get('user') %}

--- a/application/single_app/templates/profile.html
+++ b/application/single_app/templates/profile.html
@@ -743,6 +743,8 @@
         >
 
     {% set sidebar_toggle_style = user_settings.get('settings', {}).get('sidebarToggleStyle', 'large') %}
+    {% set latest_features_hidden_version = user_settings.get('settings', {}).get('latestFeaturesHiddenVersion') %}
+    {% set latest_features_hidden_for_current_version = latest_features_hidden_version == config['VERSION'] %}
     <div class="section-card" id="navigation-preferences">
         <div class="d-flex flex-column flex-lg-row align-items-lg-start justify-content-between gap-3">
             <div class="d-flex gap-3 align-items-start">
@@ -795,6 +797,60 @@
         </div>
 
         <div id="navigation-preference-status" class="preference-status small mt-3 text-muted"></div>
+    </div>
+
+    <div class="section-card" id="latest-features-nav-preferences">
+        <div class="d-flex flex-column flex-lg-row align-items-lg-start justify-content-between gap-3">
+            <div class="d-flex gap-3 align-items-start">
+                <span class="preference-card-icon">
+                    <i class="bi bi-lightning-charge"></i>
+                </span>
+                <div>
+                    <h5 class="mb-2"><i class="bi bi-stars me-2"></i>Latest Features Navigation</h5>
+                    <p class="text-muted mb-2">Hide or restore Latest Features shortcuts in the left and top navigation for this app version.</p>
+                    <p class="small text-muted mb-0">When SimpleChat updates to a new version, Latest Features is shown again automatically.</p>
+                </div>
+            </div>
+            <span
+                id="latest-features-nav-status-badge"
+                class="badge {% if latest_features_nav_hidden_by_development | default(false) %}bg-warning text-dark{% elif latest_features_hidden_for_current_version %}bg-secondary{% else %}bg-success{% endif %}"
+            >
+                {% if latest_features_nav_hidden_by_development | default(false) %}
+                    Hidden in development
+                {% elif latest_features_hidden_for_current_version %}
+                    Hidden
+                {% else %}
+                    Visible
+                {% endif %}
+            </span>
+        </div>
+
+        <div class="row g-3 align-items-center mt-1">
+            <div class="col-lg-8">
+                <p id="latest-features-nav-status-detail" class="small text-muted mt-3 mb-0">
+                    {% if latest_features_nav_hidden_by_development | default(false) %}
+                        Latest Features navigation is hidden because the is_development environment flag is true.
+                    {% elif latest_features_hidden_for_current_version %}
+                        Latest Features navigation is hidden for version {{ config['VERSION'] }}.
+                    {% elif latest_features_hidden_version %}
+                        Latest Features navigation is visible because your saved hide preference was for version {{ latest_features_hidden_version }}, and the current version is {{ config['VERSION'] }}.
+                    {% else %}
+                        Latest Features navigation is visible for version {{ config['VERSION'] }}.
+                    {% endif %}
+                </p>
+            </div>
+            <div class="col-lg-4 text-lg-end">
+                <button
+                    type="button"
+                    class="btn btn-outline-primary {% if not latest_features_hidden_for_current_version %}d-none{% endif %}"
+                    id="unhide-latest-features-nav-btn"
+                >
+                    <i class="bi bi-eye me-1"></i>Unhide Latest Features
+                </button>
+            </div>
+        </div>
+
+        <div id="latest-features-nav-preference-status" class="preference-status small mt-3 text-muted"></div>
     </div>
 
     <div class="section-card" id="tutorial-preferences">

--- a/docs/explanation/features/LATEST_FEATURES_NAVIGATION_HIDE_PREFERENCE.md
+++ b/docs/explanation/features/LATEST_FEATURES_NAVIGATION_HIDE_PREFERENCE.md
@@ -1,0 +1,36 @@
+# Latest Features Navigation Hide Preference
+
+Implemented in version: **0.250.059**
+
+## Overview
+
+The Latest Features Navigation Hide Preference lets users hide Latest Features navigation entries for the current SimpleChat version. The preference is versioned, so Latest Features navigation automatically returns when the app version changes and new release information is available.
+
+## Dependencies
+
+- Current app version from `application/single_app/config.py`
+- Visibility helpers in `application/single_app/functions_latest_features_nav.py`
+- User settings allow-list in `application/single_app/functions_settings.py`
+- User settings update route in `application/single_app/route_backend_users.py`
+- Navigation templates in `_top_nav.html`, `_sidebar_nav.html`, and `_sidebar_short_nav.html`
+- Profile Settings controls in `application/single_app/templates/profile.html`
+- Browser behavior in `application/single_app/static/js/latest-features-nav.js`
+
+## Technical Specifications
+
+The feature stores a `latestFeaturesHiddenVersion` value in user UI settings. Navigation rendering compares that stored value with the current `VERSION` from `config.py`; matching values hide Latest Features entries, while older values are ignored so users see the navigation again after a version bump.
+
+The backend normalizes incoming hidden-version values before saving them, and the frontend updates the visible navigation state after hide or unhide actions complete. A development-only `is_development=true` environment override can force Latest Features navigation to hide during local validation without changing stored user settings.
+
+## Usage Instructions
+
+Users can hide Latest Features from the navigation action menu. They can restore the entries from Profile Settings in the Latest Features Navigation section. No administrator configuration is required.
+
+## Testing and Validation
+
+- Functional coverage: `functional_tests/test_latest_features_nav_hide_preference.py`
+- Existing latest-features coverage updated: `functional_tests/test_latest_features_action_links.py`
+- UI coverage: `ui_tests/test_latest_features_nav_hide_preference.py`
+- Release note: `docs/explanation/release_notes.md` under version `0.250.059`
+
+Known limitation: local UI validation requires `SIMPLECHAT_UI_BASE_URL` and an authenticated Playwright storage-state file.

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,16 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](/explanation/features/) and [Fixes by Version](/explanation/fixes/).
 
+### **(v0.250.058)**
+
+#### New Features
+
+*   **Versioned Latest Features Navigation Hide Preference**
+    *   Users can now hide Latest Features navigation entries for the current SimpleChat version from the ellipsis action and restore them from Profile Settings.
+    *   The hidden state is version-aware, so Latest Features automatically appears again after the app version changes.
+    *   Added a development-only `is_development=true` environment override that hides Latest Features nav entries without affecting production behavior when unset or false.
+    *   (Ref: microsoft/simplechat#987, `latestFeaturesHiddenVersion`, `_sidebar_nav.html`, `_top_nav.html`, `profile.html`, `latest-features-nav.js`)
+
 ### **(v0.250.057)**
 
 #### Bug Fixes

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,7 +2,7 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](/explanation/features/) and [Fixes by Version](/explanation/fixes/).
 
-### **(v0.250.058)**
+### **(v0.250.059)**
 
 #### New Features
 

--- a/functional_tests/test_latest_features_action_links.py
+++ b/functional_tests/test_latest_features_action_links.py
@@ -2,7 +2,7 @@
 # test_latest_features_action_links.py
 """
 Functional test for latest-features action links.
-Version: 0.241.003
+Version: 0.250.058
 Implemented in: 0.241.003
 
 This test ensures the latest-features configuration exposes direct in-app
@@ -40,7 +40,7 @@ def assert_markers(file_path: Path, markers: list[str]) -> None:
 def test_latest_features_action_links() -> bool:
     print("Testing latest-features action links and launch intents...")
 
-    assert 'VERSION = "0.241.003"' in read_text(CONFIG_FILE), "Config version marker is not current."
+    assert 'VERSION = "0.250.058"' in read_text(CONFIG_FILE), "Config version marker is not current."
 
     assert_markers(
         FUNCTIONS_SETTINGS_FILE,

--- a/functional_tests/test_latest_features_action_links.py
+++ b/functional_tests/test_latest_features_action_links.py
@@ -2,7 +2,7 @@
 # test_latest_features_action_links.py
 """
 Functional test for latest-features action links.
-Version: 0.250.058
+Version: 0.250.059
 Implemented in: 0.241.003
 
 This test ensures the latest-features configuration exposes direct in-app
@@ -40,7 +40,7 @@ def assert_markers(file_path: Path, markers: list[str]) -> None:
 def test_latest_features_action_links() -> bool:
     print("Testing latest-features action links and launch intents...")
 
-    assert 'VERSION = "0.250.058"' in read_text(CONFIG_FILE), "Config version marker is not current."
+    assert 'VERSION = "0.250.059"' in read_text(CONFIG_FILE), "Config version marker is not current."
 
     assert_markers(
         FUNCTIONS_SETTINGS_FILE,

--- a/functional_tests/test_latest_features_nav_hide_preference.py
+++ b/functional_tests/test_latest_features_nav_hide_preference.py
@@ -2,8 +2,8 @@
 # test_latest_features_nav_hide_preference.py
 """
 Functional test for versioned Latest Features navigation hiding.
-Version: 0.250.058
-Implemented in: 0.250.058
+Version: 0.250.059
+Implemented in: 0.250.059
 
 This test ensures that Latest Features navigation entries hide only for the
 current version or explicit development override, and that the settings,
@@ -26,7 +26,7 @@ from functions_latest_features_nav import (  # noqa: E402
 )
 
 
-CURRENT_VERSION = "0.250.058"
+CURRENT_VERSION = "0.250.059"
 PREVIOUS_VERSION = "0.250.057"
 
 

--- a/functional_tests/test_latest_features_nav_hide_preference.py
+++ b/functional_tests/test_latest_features_nav_hide_preference.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+# test_latest_features_nav_hide_preference.py
+"""
+Functional test for versioned Latest Features navigation hiding.
+Version: 0.250.058
+Implemented in: 0.250.058
+
+This test ensures that Latest Features navigation entries hide only for the
+current version or explicit development override, and that the settings,
+templates, and JavaScript wiring are present.
+"""
+
+from pathlib import Path
+import sys
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+APP_DIR = REPO_ROOT / "application" / "single_app"
+sys.path.insert(0, str(APP_DIR))
+
+from functions_latest_features_nav import (  # noqa: E402
+    LATEST_FEATURES_HIDDEN_VERSION_SETTING,
+    is_development_env_enabled,
+    normalize_latest_features_hidden_version,
+    should_hide_latest_features_nav,
+)
+
+
+CURRENT_VERSION = "0.250.058"
+PREVIOUS_VERSION = "0.250.057"
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def assert_contains(path: Path, markers: list[str]) -> None:
+    content = read_text(path)
+    missing_markers = [marker for marker in markers if marker not in content]
+    assert not missing_markers, f"Missing markers in {path.name}: {missing_markers}"
+
+
+def test_latest_features_nav_helper_logic():
+    """Validate current-version and development override visibility rules."""
+    print("Testing Latest Features nav helper logic...")
+
+    assert LATEST_FEATURES_HIDDEN_VERSION_SETTING == "latestFeaturesHiddenVersion"
+    assert normalize_latest_features_hidden_version(None) is None
+    assert normalize_latest_features_hidden_version("") is None
+    assert normalize_latest_features_hidden_version(f"  {CURRENT_VERSION}  ") == CURRENT_VERSION
+
+    assert is_development_env_enabled("true") is True
+    assert is_development_env_enabled(" TRUE ") is True
+    assert is_development_env_enabled("false") is False
+    assert is_development_env_enabled("") is False
+    assert is_development_env_enabled("yes") is False
+
+    assert should_hide_latest_features_nav({}, CURRENT_VERSION) is False
+    assert should_hide_latest_features_nav(
+        {"settings": {LATEST_FEATURES_HIDDEN_VERSION_SETTING: CURRENT_VERSION}},
+        CURRENT_VERSION,
+    ) is True
+    assert should_hide_latest_features_nav(
+        {"settings": {LATEST_FEATURES_HIDDEN_VERSION_SETTING: PREVIOUS_VERSION}},
+        CURRENT_VERSION,
+    ) is False
+    assert should_hide_latest_features_nav(
+        {"settings": {LATEST_FEATURES_HIDDEN_VERSION_SETTING: PREVIOUS_VERSION}},
+        CURRENT_VERSION,
+        is_development=True,
+    ) is True
+
+    print("Latest Features nav helper logic passed")
+    return True
+
+
+def test_latest_features_nav_wiring():
+    """Validate backend, template, and JavaScript wiring markers."""
+    print("Testing Latest Features nav wiring markers...")
+
+    config_file = APP_DIR / "config.py"
+    app_file = APP_DIR / "app.py"
+    functions_settings_file = APP_DIR / "functions_settings.py"
+    route_backend_users_file = APP_DIR / "route_backend_users.py"
+    base_template = APP_DIR / "templates" / "base.html"
+    top_nav_template = APP_DIR / "templates" / "_top_nav.html"
+    sidebar_template = APP_DIR / "templates" / "_sidebar_nav.html"
+    short_sidebar_template = APP_DIR / "templates" / "_sidebar_short_nav.html"
+    profile_template = APP_DIR / "templates" / "profile.html"
+    latest_features_js = APP_DIR / "static" / "js" / "latest-features-nav.js"
+
+    assert_contains(
+        config_file,
+        [
+            f'VERSION = "{CURRENT_VERSION}"',
+            "IS_DEVELOPMENT = is_development_env_enabled()",
+        ],
+    )
+    assert_contains(
+        app_file,
+        [
+            "app.config['IS_DEVELOPMENT'] = IS_DEVELOPMENT",
+            "latest_features_nav_hidden=latest_features_nav_hidden",
+            "latest_features_nav_hidden_by_development=IS_DEVELOPMENT",
+        ],
+    )
+    assert_contains(
+        functions_settings_file,
+        [
+            "LATEST_FEATURES_HIDDEN_VERSION_SETTING",
+            "USER_UI_SETTINGS_KEYS",
+        ],
+    )
+    assert_contains(
+        route_backend_users_file,
+        [
+            "normalize_latest_features_hidden_version",
+            "Invalid Latest Features hidden version",
+        ],
+    )
+    assert_contains(
+        base_template,
+        [
+            "window.simplechatLatestFeaturesNav",
+            "js/latest-features-nav.js",
+        ],
+    )
+    for template in (top_nav_template, sidebar_template, short_sidebar_template):
+        assert_contains(
+            template,
+            [
+                "latest_features_nav_is_hidden",
+                "data-latest-features-nav-item",
+                "data-latest-features-hide-action",
+            ],
+        )
+    assert_contains(
+        sidebar_template,
+        [
+            "{% if not latest_features_nav_is_hidden %}",
+            'data-tab="latest-features"',
+        ],
+    )
+    assert_contains(
+        profile_template,
+        [
+            'id="latest-features-nav-preferences"',
+            'id="unhide-latest-features-nav-btn"',
+            "latest_features_nav_hidden_by_development",
+        ],
+    )
+    assert_contains(
+        latest_features_js,
+        [
+            "// latest-features-nav.js",
+            "hideLatestFeaturesNavItems",
+            "showLatestFeaturesNavItems",
+            "latestFeaturesHiddenVersion",
+        ],
+    )
+
+    print("Latest Features nav wiring markers passed")
+    return True
+
+
+if __name__ == "__main__":
+    tests = [
+        test_latest_features_nav_helper_logic,
+        test_latest_features_nav_wiring,
+    ]
+    results = []
+    for test in tests:
+        print(f"\nRunning {test.__name__}...")
+        results.append(test())
+
+    success = all(results)
+    print(f"\nResults: {sum(results)}/{len(results)} tests passed")
+    sys.exit(0 if success else 1)

--- a/ui_tests/test_latest_features_nav_hide_preference.py
+++ b/ui_tests/test_latest_features_nav_hide_preference.py
@@ -1,0 +1,108 @@
+# test_latest_features_nav_hide_preference.py
+"""
+UI test for Latest Features navigation hide preference.
+Version: 0.250.058
+Implemented in: 0.250.058
+
+This test ensures an authenticated user can clear a versioned Latest Features
+navigation hide preference from the profile Settings page.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+from playwright.sync_api import expect
+
+
+BASE_URL = os.getenv("SIMPLECHAT_UI_BASE_URL", "").rstrip("/")
+STORAGE_STATE = os.getenv("SIMPLECHAT_UI_STORAGE_STATE", "")
+ADMIN_STORAGE_STATE = os.getenv("SIMPLECHAT_UI_ADMIN_STORAGE_STATE", "")
+CURRENT_VERSION = "0.250.058"
+
+
+def _require_base_url():
+    if not BASE_URL:
+        pytest.skip("Set SIMPLECHAT_UI_BASE_URL to run this UI test.")
+
+
+def _get_storage_state_path():
+    for candidate in (STORAGE_STATE, ADMIN_STORAGE_STATE):
+        if candidate and Path(candidate).exists():
+            return candidate
+    pytest.skip("Set SIMPLECHAT_UI_STORAGE_STATE or SIMPLECHAT_UI_ADMIN_STORAGE_STATE to a valid authenticated Playwright storage state file.")
+
+
+def _get_user_settings(page):
+    return page.evaluate(
+        """
+        async () => {
+            const response = await fetch('/api/user/settings');
+            const data = await response.json();
+            return data.settings || {};
+        }
+        """
+    )
+
+
+def _set_latest_features_hidden_version(page, hidden_version):
+    return page.evaluate(
+        """
+        async (hiddenVersion) => {
+            const response = await fetch('/api/user/settings', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    settings: {
+                        latestFeaturesHiddenVersion: hiddenVersion
+                    }
+                })
+            });
+            return response.ok;
+        }
+        """,
+        hidden_version,
+    )
+
+
+@pytest.mark.ui
+def test_profile_can_unhide_latest_features_navigation(playwright):
+    """Validate the profile Settings page restores Latest Features navigation."""
+    _require_base_url()
+    storage_state = _get_storage_state_path()
+
+    browser = playwright.chromium.launch()
+    context = browser.new_context(
+        storage_state=storage_state,
+        viewport={"width": 1440, "height": 900},
+    )
+    page = context.new_page()
+    original_hidden_version = None
+
+    try:
+        response = page.goto(f"{BASE_URL}/profile?tab=settings", wait_until="domcontentloaded")
+        assert response is not None, "Expected a navigation response when loading /profile."
+        if response.status in {401, 403, 404}:
+            pytest.skip("Profile page was not available for the configured session.")
+
+        assert response.ok, f"Expected /profile to load successfully, got HTTP {response.status}."
+        expect(page.get_by_role("heading", name="Latest Features Navigation")).to_be_visible()
+
+        original_hidden_version = _get_user_settings(page).get("latestFeaturesHiddenVersion")
+        assert _set_latest_features_hidden_version(page, CURRENT_VERSION), "Expected Latest Features hide preference update to succeed."
+
+        page.reload(wait_until="domcontentloaded")
+        expect(page.locator("#latest-features-nav-status-badge")).to_contain_text("Hidden")
+        expect(page.locator("#unhide-latest-features-nav-btn")).to_be_visible()
+
+        page.locator("#unhide-latest-features-nav-btn").click()
+        expect(page.locator("#latest-features-nav-status-badge")).to_contain_text("Visible")
+        expect(page.locator("#latest-features-nav-preference-status")).to_contain_text("restored")
+
+        saved_settings = _get_user_settings(page)
+        assert saved_settings.get("latestFeaturesHiddenVersion") in {None, ""}, "Expected Latest Features hide preference to be cleared."
+    finally:
+        if original_hidden_version == CURRENT_VERSION:
+            _set_latest_features_hidden_version(page, original_hidden_version)
+        context.close()
+        browser.close()

--- a/ui_tests/test_latest_features_nav_hide_preference.py
+++ b/ui_tests/test_latest_features_nav_hide_preference.py
@@ -1,8 +1,8 @@
 # test_latest_features_nav_hide_preference.py
 """
 UI test for Latest Features navigation hide preference.
-Version: 0.250.058
-Implemented in: 0.250.058
+Version: 0.250.059
+Implemented in: 0.250.059
 
 This test ensures an authenticated user can clear a versioned Latest Features
 navigation hide preference from the profile Settings page.
@@ -18,7 +18,7 @@ from playwright.sync_api import expect
 BASE_URL = os.getenv("SIMPLECHAT_UI_BASE_URL", "").rstrip("/")
 STORAGE_STATE = os.getenv("SIMPLECHAT_UI_STORAGE_STATE", "")
 ADMIN_STORAGE_STATE = os.getenv("SIMPLECHAT_UI_ADMIN_STORAGE_STATE", "")
-CURRENT_VERSION = "0.250.058"
+CURRENT_VERSION = "0.250.059"
 
 
 def _require_base_url():


### PR DESCRIPTION
## Summary

- Adds a version-aware Latest Features navigation hide preference backed by `latestFeaturesHiddenVersion` user UI settings.
- Hides Latest Features nav entries only for the current `config.py` version, with automatic reappearance after a version bump.
- Adds Profile Settings controls to restore the Latest Features navigation entries.
- Adds a development-only `is_development=true` override for local validation.
- Adds feature documentation and release notes for version `0.250.059`.

Fixes #987

## Validation

Passed:

- `git diff --check origin/Development...HEAD`
- `git diff --check`
- Python compile check for `application/single_app` and changed tests
- `python scripts/check_swagger_routes.py` for changed Python route/application files
- Route policy inventory, unauthenticated policy contract, and route policy coverage tests
- XSS changed-line sink scan
- Broken access-control changed-line scan
- `node --check application/single_app/static/js/latest-features-nav.js`
- `functional_tests/test_latest_features_action_links.py`
- `functional_tests/test_latest_features_nav_hide_preference.py`

Skipped:

- `ui_tests/test_latest_features_nav_hide_preference.py` ran under pytest but skipped because local `SIMPLECHAT_UI_BASE_URL` and authenticated Playwright storage state were not configured.

## Documentation And Release Notes

- Added `docs/explanation/features/LATEST_FEATURES_NAVIGATION_HIDE_PREFERENCE.md`.
- Updated `docs/explanation/release_notes.md` under `v0.250.059`.

## Security Notes

- No changed paths matched `.env`, secret, token, session, connection-string, storage-key, or generated local artifact patterns.
- Route decorator/policy, XSS, and broken-access-control checks passed.