### PR TITLE
Phase 2: honor explicit mixed-source Chat selections

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -97,7 +97,7 @@ load_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.250.062"
+VERSION = "0.250.064"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/foundry_agent_runtime.py
+++ b/application/single_app/foundry_agent_runtime.py
@@ -42,6 +42,8 @@ FOUNDRY_METADATA_VALUE_MAX_LENGTH = 512
 FOUNDRY_INTERNAL_METADATA_KEYS = {
     "active_group_ids",
     "active_public_workspace_ids",
+    "document_context_requested",
+    "selection_mode",
     "selected_document_ids",
 }
 FOUNDRY_FILE_SEARCHABLE_CONTEXT_MAX_CHARS = 6000
@@ -1222,6 +1224,9 @@ def _looks_like_document_context_message(text: str) -> bool:
         "chat-uploaded file",
         "selected document",
         "tabular analysis",
+        "mixed-source evidence handoff",
+        "evidence_envelopes",
+        "[workflow document search context]",
     )
     return any(marker in normalized for marker in markers)
 
@@ -1237,7 +1242,13 @@ def _build_foundry_workflow_input_text(
         if not text:
             continue
         if not include_document_context and _looks_like_document_context_message(text):
-            continue
+            workflow_task_marker = "[Workflow task]"
+            workflow_task_index = text.rfind(workflow_task_marker)
+            if workflow_task_index < 0:
+                continue
+            text = text[workflow_task_index + len(workflow_task_marker):].strip()
+            if not text:
+                continue
         role_value = getattr(message, "role", "user")
         role = str(role_value).strip().lower() or "user"
         if role.startswith("authorrole."):
@@ -1800,6 +1811,8 @@ def _collect_foundry_response_file_inputs(
     foundry_settings: Dict[str, Any],
     metadata: Dict[str, Any],
 ) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    if not _coerce_bool(foundry_settings.get("include_document_context"), True):
+        return [], []
     if not _coerce_bool(foundry_settings.get("include_file_inputs"), True):
         return [], []
 

--- a/application/single_app/functions_mixed_source_orchestration.py
+++ b/application/single_app/functions_mixed_source_orchestration.py
@@ -90,6 +90,8 @@ EVIDENCE_COVERAGE_MAX_BYTES = 4096
 EVIDENCE_JSON_MAX_DEPTH = 4
 EVIDENCE_JSON_MAX_COLLECTION_ITEMS = 20
 EVIDENCE_JSON_MAX_STRING_BYTES = 1024
+MIXED_SOURCE_HANDOFF_MAX_BYTES = 49152
+MIXED_SOURCE_HANDOFF_MAX_ENVELOPES = 20
 
 
 def normalize_selection_mode(selection_mode, default=SELECTION_MODE_SELECTED):
@@ -106,6 +108,146 @@ def normalize_selection_mode(selection_mode, default=SELECTION_MODE_SELECTED):
             f"selection_mode must be one of: {', '.join(sorted(SELECTION_MODES))}"
         )
     return normalized_mode
+
+
+def normalize_document_context_request(
+    selection_mode=None,
+    selected_document_ids=None,
+    document_context_requested=None,
+    hybrid_search=False,
+):
+    """Validate the Phase 2 request contract and derive effective context intent."""
+    normalized_document_ids = []
+    seen_document_ids = set()
+    for document_id in _normalize_identifier_list(selected_document_ids):
+        if document_id == "all" or document_id in seen_document_ids:
+            continue
+        seen_document_ids.add(document_id)
+        normalized_document_ids.append(document_id)
+
+    normalized_hybrid_search = _normalize_boolean(
+        hybrid_search,
+        field_name="hybrid_search",
+    )
+    normalized_context_requested = _normalize_optional_boolean(
+        document_context_requested,
+        field_name="document_context_requested",
+    )
+    has_explicit_selection_mode = str(selection_mode or "").strip() != ""
+
+    if normalized_document_ids:
+        normalized_selection_mode = normalize_selection_mode(
+            selection_mode,
+            default=SELECTION_MODE_SELECTED,
+        )
+        if normalized_selection_mode != SELECTION_MODE_SELECTED:
+            raise ValueError(
+                "selection_mode must be selected when selected_document_ids are provided"
+            )
+        normalized_context_requested = True
+    elif has_explicit_selection_mode:
+        normalized_selection_mode = normalize_selection_mode(selection_mode)
+        if normalized_selection_mode == SELECTION_MODE_SELECTED:
+            raise ValueError(
+                "selection_mode selected requires at least one selected_document_id"
+            )
+        if (
+            normalized_selection_mode in {SELECTION_MODE_ALL, SELECTION_MODE_RELEVANCE}
+            and normalized_context_requested is None
+        ):
+            normalized_context_requested = True
+    elif normalized_context_requested is True or normalized_hybrid_search:
+        normalized_selection_mode = SELECTION_MODE_RELEVANCE
+        normalized_context_requested = True
+    else:
+        normalized_selection_mode = None
+        normalized_context_requested = False
+
+    return {
+        "selection_mode": normalized_selection_mode,
+        "selected_document_ids": normalized_document_ids,
+        "document_context_requested": bool(normalized_context_requested),
+        "hybrid_search": normalized_hybrid_search,
+        "explicit_selection": bool(normalized_document_ids),
+    }
+
+
+def should_run_tabular_evidence(user_question, has_narrative_sources=False):
+    """Return whether a mixed-source question needs tabular data or schema evidence."""
+    normalized_question = " ".join(str(user_question or "").strip().lower().split())
+    if not normalized_question:
+        return True
+
+    tabular_markers = (
+        "calculate", "calculation", "count", "average", "mean", "median",
+        "minimum", "maximum", "total", "sum", "percentage", "percent",
+        "rows", "columns", "spreadsheet", "workbook", "worksheet", "sheet",
+        "csv", "xlsx", "xls", "table", "tabular", "data set", "dataset",
+        "trend", "group by", "how many", "highest", "lowest",
+    )
+    collective_markers = (
+        "both files", "both documents", "all files", "all documents",
+        "all selected", "each file", "each document", "each source",
+        "across the files", "across the documents", "across the sources",
+        "mixed sources",
+    )
+    narrative_markers = (
+        "pdf", "docx", "word document", "presentation", "powerpoint",
+        "paragraph", "section", "policy", "procedure", "contract",
+        "agreement", "memo", "letter", "narrative", "prose", "report",
+    )
+
+    if any(marker in normalized_question for marker in tabular_markers):
+        return True
+    if any(marker in normalized_question for marker in collective_markers):
+        return True
+    if has_narrative_sources and any(
+        marker in normalized_question for marker in narrative_markers
+    ):
+        return False
+    if normalized_question in {"summarize", "summary", "summarize the selected sources"}:
+        return True
+    if has_narrative_sources:
+        return False
+    return True
+
+
+def build_tabular_file_contexts_from_manifest(tabular_sources):
+    """Build canonical per-file contexts for the existing tabular runner."""
+    contexts = []
+    seen_source_identities = set()
+    for raw_source in list(tabular_sources or []):
+        source = raw_source if isinstance(raw_source, dict) else {}
+        if (
+            source.get("authorization_status") != AUTHORIZATION_STATUS_AUTHORIZED
+            or source.get("source_kind") != SOURCE_KIND_TABULAR
+        ):
+            continue
+
+        document_id = str(source.get("document_id") or "").strip()
+        file_name = str(source.get("file_name") or "").strip()
+        scope = str(source.get("scope") or "").strip().lower()
+        if not document_id or not file_name or scope not in SOURCE_SCOPES:
+            continue
+        source_hint = "workspace" if scope == SOURCE_SCOPE_PERSONAL else scope
+        source_identity = (
+            document_id,
+            source_hint,
+            str(source.get("scope_id") or "").strip(),
+        )
+        if source_identity in seen_source_identities:
+            continue
+        seen_source_identities.add(source_identity)
+        contexts.append({
+            "document_id": document_id,
+            "file_name": file_name,
+            "source_hint": source_hint,
+            "group_id": source.get("group_id"),
+            "public_workspace_id": source.get("public_workspace_id"),
+            "conversation_id": source.get("conversation_id"),
+            "storage_locator": dict(source.get("storage_locator") or {}),
+        })
+    return contexts
 
 
 def classify_source_kind(file_name, document_item=None):
@@ -152,6 +294,28 @@ def _normalize_identifier_list(values):
     ]
 
 
+def _normalize_boolean(value, field_name):
+    if isinstance(value, bool):
+        return value
+    if value in (None, ""):
+        return False
+    if isinstance(value, int) and value in (0, 1):
+        return bool(value)
+    if isinstance(value, str):
+        normalized_value = value.strip().lower()
+        if normalized_value in {"true", "1"}:
+            return True
+        if normalized_value in {"false", "0"}:
+            return False
+    raise ValueError(f"{field_name} must be a boolean")
+
+
+def _normalize_optional_boolean(value, field_name):
+    if value is None or value == "":
+        return None
+    return _normalize_boolean(value, field_name=field_name)
+
+
 def _safe_file_name(file_name):
     return str(file_name or "").replace("\\", "/").split("/")[-1].strip()
 
@@ -169,6 +333,7 @@ def _unresolved_manifest_entry(document_id):
         "public_workspace_id": None,
         "conversation_id": None,
         "source_version": None,
+        "storage_locator": None,
         "authorization_status": AUTHORIZATION_STATUS_UNRESOLVED,
     }
 
@@ -199,9 +364,20 @@ def _build_authorized_manifest_entry(document_id, user_id, document_context):
 
     if scope == SOURCE_SCOPE_PERSONAL:
         scope_id = str(document_item.get("user_id") or user_id or "").strip()
+        if scope_id != str(user_id or "").strip() and not any(
+            str(shared_entry or "").strip() == f"{user_id},approved"
+            for shared_entry in document_item.get("shared_user_ids", []) or []
+        ):
+            return _unresolved_manifest_entry(document_id)
     elif scope == SOURCE_SCOPE_GROUP:
         group_id = str(document_context.get("group_id") or "").strip() or None
         scope_id = group_id
+        document_group_id = str(document_item.get("group_id") or "").strip()
+        if document_group_id != group_id and not any(
+            str(shared_entry or "").strip() == f"{group_id},approved"
+            for shared_entry in document_item.get("shared_group_ids", []) or []
+        ):
+            return _unresolved_manifest_entry(document_id)
     elif scope == SOURCE_SCOPE_PUBLIC:
         public_workspace_id = str(
             document_context.get("public_workspace_id") or ""
@@ -226,6 +402,37 @@ def _build_authorized_manifest_entry(document_id, user_id, document_context):
     if source_version is not None and not isinstance(source_version, (str, int, float)):
         source_version = str(source_version)
 
+    storage_locator = None
+    if scope != SOURCE_SCOPE_CHAT:
+        try:
+            from functions_documents import get_document_blob_storage_info
+
+            blob_container, blob_path = get_document_blob_storage_info(
+                document_item,
+                user_id=(
+                    document_item.get("user_id")
+                    if scope == SOURCE_SCOPE_PERSONAL
+                    else None
+                ),
+                group_id=(
+                    document_item.get("group_id")
+                    if scope == SOURCE_SCOPE_GROUP
+                    else None
+                ),
+                public_workspace_id=(
+                    document_item.get("public_workspace_id")
+                    if scope == SOURCE_SCOPE_PUBLIC
+                    else None
+                ),
+            )
+            if blob_container and blob_path:
+                storage_locator = {
+                    "container": str(blob_container),
+                    "blob_path": str(blob_path),
+                }
+        except Exception:
+            storage_locator = None
+
     return {
         "document_id": document_id,
         "display_name": display_name,
@@ -238,6 +445,7 @@ def _build_authorized_manifest_entry(document_id, user_id, document_context):
         "public_workspace_id": public_workspace_id,
         "conversation_id": conversation_id,
         "source_version": source_version,
+        "storage_locator": storage_locator,
         "authorization_status": AUTHORIZATION_STATUS_AUTHORIZED,
     }
 
@@ -257,6 +465,7 @@ def resolve_authorized_source_manifest(
     conversation_id=None,
     active_group_ids=None,
     active_public_workspace_ids=None,
+    doc_scope="all",
     context_resolver=None,
 ):
     """Resolve each unique requested ID once into an ordered, authorized manifest."""
@@ -307,6 +516,9 @@ def resolve_authorized_source_manifest(
         active_public_workspace_ids
     )
     normalized_conversation_id = str(conversation_id or "").strip() or None
+    normalized_doc_scope = str(doc_scope or "all").strip().lower()
+    if normalized_doc_scope not in {"all", "personal", "group", "public"}:
+        raise ValueError("doc_scope must be all, personal, group, or public")
 
     resolved_contexts = None
     if context_resolver is None:
@@ -314,7 +526,7 @@ def resolve_authorized_source_manifest(
             resolved_contexts = _default_document_context_batch_resolver(
                 document_ids=unique_document_ids,
                 user_id=normalized_user_id,
-                doc_scope="all",
+                doc_scope=normalized_doc_scope,
                 active_group_ids=normalized_active_group_ids,
                 active_public_workspace_id=normalized_public_workspace_ids,
                 conversation_id=normalized_conversation_id,
@@ -338,13 +550,20 @@ def resolve_authorized_source_manifest(
                 document_context = context_resolver(
                     document_id=document_id,
                     user_id=normalized_user_id,
-                    doc_scope="all",
+                    doc_scope=normalized_doc_scope,
                     active_group_ids=normalized_active_group_ids,
                     active_public_workspace_id=normalized_public_workspace_ids,
                     conversation_id=normalized_conversation_id,
                 )
             except Exception:
                 resolution_error_count += 1
+        if (
+            isinstance(document_context, dict)
+            and normalized_doc_scope != "all"
+            and str(document_context.get("scope") or "").strip().lower()
+            != normalized_doc_scope
+        ):
+            document_context = None
         manifest.append(
             _build_authorized_manifest_entry(
                 document_id,
@@ -682,3 +901,295 @@ def serialize_evidence_envelope(envelope):
     if len(serialized_envelope.encode("utf-8")) > EVIDENCE_ENVELOPE_MAX_BYTES:
         raise ValueError("Evidence envelope exceeds its serialized size bound")
     return serialized_envelope
+
+
+def build_narrative_evidence_envelopes(
+    narrative_sources,
+    search_results,
+    selection_mode,
+):
+    """Normalize bounded narrative search results into one envelope per source."""
+    normalized_selection_mode = normalize_selection_mode(
+        selection_mode,
+        default=SELECTION_MODE_RELEVANCE,
+    )
+    results_by_document_id = {}
+    for raw_result in list(search_results or []):
+        result = raw_result if isinstance(raw_result, dict) else {}
+        document_id = str(result.get("document_id") or "").strip()
+        if not document_id:
+            continue
+        results_by_document_id.setdefault(document_id, []).append(result)
+
+    envelopes = []
+    for source in list(narrative_sources or []):
+        source = source if isinstance(source, dict) else {}
+        document_id = str(source.get("document_id") or "").strip()
+        if not document_id:
+            continue
+        source_results = results_by_document_id.get(document_id, [])
+        evidence = []
+        citations = []
+        for result in source_results:
+            evidence.append({
+                "chunk_text": result.get("chunk_text"),
+                "page_number": result.get("page_number"),
+                "chunk_sequence": result.get("chunk_sequence"),
+                "score": result.get("score"),
+            })
+            citations.append({
+                "citation_id": result.get("id") or result.get("chunk_id"),
+                "page_number": result.get("page_number"),
+                "chunk_sequence": result.get("chunk_sequence"),
+            })
+
+        result_count = len(source_results)
+        envelopes.append(build_evidence_envelope(
+            document_id=document_id,
+            source_kind=SOURCE_KIND_NARRATIVE,
+            engine=EVIDENCE_ENGINE_HYBRID_SEARCH,
+            status=(
+                EVIDENCE_STATUS_COMPLETED
+                if result_count
+                else EVIDENCE_STATUS_PARTIAL
+            ),
+            summary=(
+                f"Retrieved {result_count} bounded narrative excerpt(s)."
+                if result_count
+                else "No relevant narrative excerpts were returned."
+            ),
+            evidence=evidence,
+            citations=citations,
+            coverage={
+                "selection_mode": normalized_selection_mode,
+                "terminal": True,
+                "result_count": result_count,
+            },
+            error=(
+                None
+                if result_count
+                else "Narrative retrieval returned no relevant excerpts."
+            ),
+        ))
+    return envelopes
+
+
+def execute_tabular_evidence_sources(
+    tabular_sources,
+    execute_source,
+    selection_mode,
+    execute=True,
+):
+    """Execute the existing tabular runner once per source and require terminal coverage."""
+    normalized_selection_mode = normalize_selection_mode(
+        selection_mode,
+        default=SELECTION_MODE_RELEVANCE,
+    )
+    if execute and not callable(execute_source):
+        raise TypeError("execute_source must be callable")
+
+    envelopes = []
+    completed_count = 0
+    failed_count = 0
+    skipped_count = 0
+    for raw_source in list(tabular_sources or []):
+        source = raw_source if isinstance(raw_source, dict) else {}
+        document_id = str(source.get("document_id") or "").strip()
+        if not document_id:
+            continue
+
+        if not execute:
+            skipped_count += 1
+            envelopes.append(build_evidence_envelope(
+                document_id=document_id,
+                source_kind=SOURCE_KIND_TABULAR,
+                engine=EVIDENCE_ENGINE_TABULAR_TOOLS,
+                status=EVIDENCE_STATUS_SKIPPED,
+                summary="Tabular processing was not needed for this narrative-only request.",
+                coverage={
+                    "selection_mode": normalized_selection_mode,
+                    "terminal": True,
+                    "reason": "narrative_only_request",
+                },
+            ))
+            continue
+
+        try:
+            raw_result = execute_source(source)
+            result = raw_result if isinstance(raw_result, dict) else {}
+            summary = str(result.get("summary") or "").strip()
+            if not summary:
+                raise ValueError("Tabular execution returned no bounded summary")
+            completed_count += 1
+            envelopes.append(build_evidence_envelope(
+                document_id=document_id,
+                source_kind=SOURCE_KIND_TABULAR,
+                engine=EVIDENCE_ENGINE_TABULAR_TOOLS,
+                status=EVIDENCE_STATUS_COMPLETED,
+                summary=summary,
+                evidence=result.get("evidence"),
+                citations=result.get("citations"),
+                generated_artifacts=result.get("generated_artifacts"),
+                coverage={
+                    "selection_mode": normalized_selection_mode,
+                    "terminal": True,
+                    **dict(result.get("coverage") or {}),
+                },
+            ))
+        except Exception:
+            failed_count += 1
+            envelopes.append(build_evidence_envelope(
+                document_id=document_id,
+                source_kind=SOURCE_KIND_TABULAR,
+                engine=EVIDENCE_ENGINE_TABULAR_TOOLS,
+                status=EVIDENCE_STATUS_FAILED,
+                summary="Tabular evidence could not be completed for this source.",
+                coverage={
+                    "selection_mode": normalized_selection_mode,
+                    "terminal": True,
+                },
+                error="Tabular evidence could not be completed.",
+            ))
+
+    log_event(
+        "[MixedSourceChatSearch] Tabular source execution reached terminal coverage.",
+        extra={
+            "selection_mode": normalized_selection_mode,
+            "tabular_candidate_count": len(list(tabular_sources or [])),
+            "tabular_completed_count": completed_count,
+            "tabular_failed_count": failed_count,
+            "tabular_skipped_count": skipped_count,
+        },
+        level=logging.INFO,
+    )
+    return envelopes
+
+
+def build_mixed_source_evidence_handoff(
+    manifest,
+    evidence_envelopes,
+    selection_mode,
+):
+    """Build one bounded synthesis handoff from Phase 1 evidence envelopes."""
+    normalized_selection_mode = normalize_selection_mode(
+        selection_mode,
+        default=SELECTION_MODE_RELEVANCE,
+    )
+    manifest_entries = [entry for entry in list(manifest or []) if isinstance(entry, dict)]
+    all_envelopes = [
+        envelope
+        for envelope in list(evidence_envelopes or [])
+        if isinstance(envelope, dict)
+    ]
+    envelopes = all_envelopes[:MIXED_SOURCE_HANDOFF_MAX_ENVELOPES]
+    envelope_by_document_id = {
+        str(envelope.get("document_id") or "").strip(): envelope
+        for envelope in all_envelopes
+        if str(envelope.get("document_id") or "").strip()
+    }
+    evidence_omitted_count = max(0, len(all_envelopes) - len(envelopes))
+
+    source_coverage = []
+    failed_count = 0
+    partial_count = 0
+    skipped_count = 0
+    completed_count = 0
+    for source_index, entry in enumerate(manifest_entries, start=1):
+        document_id = str(entry.get("document_id") or "").strip()
+        envelope = envelope_by_document_id.get(document_id)
+        if entry.get("authorization_status") != AUTHORIZATION_STATUS_AUTHORIZED:
+            status = EVIDENCE_STATUS_FAILED
+            source_label = f"Unavailable selected source {source_index}"
+        elif entry.get("source_kind") == SOURCE_KIND_UNSUPPORTED:
+            status = EVIDENCE_STATUS_FAILED
+            source_label = str(entry.get("display_name") or f"Unsupported source {source_index}")
+        elif envelope:
+            status = envelope.get("status") or EVIDENCE_STATUS_FAILED
+            source_label = str(entry.get("display_name") or f"Source {source_index}")
+        else:
+            status = EVIDENCE_STATUS_FAILED
+            source_label = str(entry.get("display_name") or f"Source {source_index}")
+
+        if status == EVIDENCE_STATUS_COMPLETED:
+            completed_count += 1
+        elif status == EVIDENCE_STATUS_PARTIAL:
+            partial_count += 1
+        elif status == EVIDENCE_STATUS_SKIPPED:
+            skipped_count += 1
+        else:
+            failed_count += 1
+        source_coverage.append({
+            "source": _truncate_utf8(source_label, 128),
+            "source_kind": entry.get("source_kind"),
+            "status": status,
+        })
+
+    coverage = {
+        "selection_mode": normalized_selection_mode,
+        "requested_source_count": len(manifest_entries),
+        "completed_source_count": completed_count,
+        "partial_source_count": partial_count,
+        "failed_source_count": failed_count,
+        "skipped_source_count": skipped_count,
+        "partial_coverage": bool(
+            failed_count or partial_count or evidence_omitted_count
+        ),
+        "evidence_omitted_count": evidence_omitted_count,
+        "sources": source_coverage,
+    }
+    payload = {
+        "coverage": coverage,
+        "evidence_envelopes": envelopes,
+    }
+    serialized_payload = json.dumps(
+        payload,
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+    )
+    if len(serialized_payload.encode("utf-8")) > MIXED_SOURCE_HANDOFF_MAX_BYTES:
+        payload["evidence_envelopes"] = [
+            {
+                "document_id": envelope.get("document_id"),
+                "source_kind": envelope.get("source_kind"),
+                "engine": envelope.get("engine"),
+                "status": envelope.get("status"),
+                "summary": _truncate_utf8(envelope.get("summary"), 512),
+                "coverage": {
+                    "selection_mode": (envelope.get("coverage") or {}).get("selection_mode"),
+                    "terminal": bool((envelope.get("coverage") or {}).get("terminal")),
+                    "result_count": (envelope.get("coverage") or {}).get("result_count"),
+                    "tool_call_count": (envelope.get("coverage") or {}).get("tool_call_count"),
+                },
+            }
+            for envelope in envelopes
+        ]
+        payload["coverage"]["handoff_compacted"] = True
+        payload["coverage"]["partial_coverage"] = True
+        payload["coverage"]["evidence_compacted_count"] = len(envelopes)
+        serialized_payload = json.dumps(
+            payload,
+            allow_nan=False,
+            ensure_ascii=False,
+            separators=(",", ":"),
+        )
+    if len(serialized_payload.encode("utf-8")) > MIXED_SOURCE_HANDOFF_MAX_BYTES:
+        raise ValueError("Mixed-source evidence handoff exceeds its size bound")
+
+    partial_coverage_instruction = (
+        "State clearly that source coverage was partial and identify unavailable authorized source labels."
+        if coverage["partial_coverage"]
+        else "Do not claim that selected sources were omitted."
+    )
+    return {
+        "role": "system",
+        "content": (
+            "Use the mixed-source evidence handoff below with the other bounded narrative excerpts "
+            "and computed tabular results. Synthesize one answer. Preserve narrative source citations "
+            "and tabular tool citations; do not convert computed table facts into unsupported narrative claims. "
+            "When selection_mode is selected, current selected-source evidence supersedes prior document "
+            "grounding; do not use prior source claims to fill missing current coverage. "
+            f"{partial_coverage_instruction}\n\n{serialized_payload}"
+        ),
+        "mixed_source_coverage": coverage,
+    }

--- a/application/single_app/functions_search_service.py
+++ b/application/single_app/functions_search_service.py
@@ -45,6 +45,9 @@ SUMMARY_DEFAULT_CHUNK_WINDOW = 20
 SUMMARY_MAX_WINDOW_SIZE = 50
 CHAT_UPLOAD_CHUNK_WORD_SIZE = 400
 CHAT_UPLOAD_CHUNK_WORD_OVERLAP = 40
+MIXED_SOURCE_TABULAR_CANDIDATE_TOP_N = 36
+MIXED_SOURCE_TABULAR_CANDIDATE_LIMIT = 6
+MIXED_SOURCE_TABULAR_EXTENSIONS = frozenset({".csv", ".xls", ".xlsx", ".xlsm"})
 
 
 def _coerce_positive_int(value, default_value, min_value=1, max_value=None):
@@ -553,6 +556,7 @@ def build_search_request(
     active_group_ids=None,
     active_public_workspace_id=None,
     enable_file_sharing=True,
+    include_all_public_workspaces=False,
 ):
     normalized_query = str(query or "").strip()
     if not normalized_query:
@@ -592,7 +596,11 @@ def build_search_request(
         active_public_workspace_id=active_public_workspace_id,
     )
     if resolved_public_workspace_ids and normalized_scope in ("all", "public"):
-        search_request["active_public_workspace_id"] = resolved_public_workspace_ids[0]
+        search_request["active_public_workspace_id"] = (
+            resolved_public_workspace_ids
+            if include_all_public_workspaces
+            else resolved_public_workspace_ids[0]
+        )
 
     return search_request
 
@@ -608,6 +616,7 @@ def search_documents(
     active_group_ids=None,
     active_public_workspace_id=None,
     enable_file_sharing=True,
+    include_all_public_workspaces=False,
 ):
     search_request = build_search_request(
         query=query,
@@ -620,6 +629,7 @@ def search_documents(
         active_group_ids=active_group_ids,
         active_public_workspace_id=active_public_workspace_id,
         enable_file_sharing=enable_file_sharing,
+        include_all_public_workspaces=include_all_public_workspaces,
     )
     results = hybrid_search(**search_request) or []
     unique_document_ids = {
@@ -639,6 +649,70 @@ def search_documents(
         "result_count": len(results),
         "document_count": len(unique_document_ids),
         "results": results,
+    }
+
+
+def search_relevant_tabular_candidates(
+    query,
+    user_id,
+    doc_scope="all",
+    document_ids=None,
+    tags_filter=None,
+    active_group_ids=None,
+    active_public_workspace_id=None,
+    max_candidates=MIXED_SOURCE_TABULAR_CANDIDATE_LIMIT,
+):
+    """Find a bounded set of authorized table candidates from indexed schema chunks."""
+    normalized_limit = _coerce_positive_int(
+        max_candidates,
+        MIXED_SOURCE_TABULAR_CANDIDATE_LIMIT,
+        min_value=1,
+        max_value=MIXED_SOURCE_TABULAR_CANDIDATE_LIMIT,
+    )
+    candidate_query = (
+        f"{str(query or '').strip()}\n"
+        "Relevant spreadsheet, workbook, worksheet, CSV, table schema, columns, and data fields."
+    ).strip()
+    search_result = search_documents(
+        query=candidate_query,
+        user_id=user_id,
+        top_n=MIXED_SOURCE_TABULAR_CANDIDATE_TOP_N,
+        doc_scope=doc_scope,
+        document_ids=document_ids,
+        tags_filter=tags_filter,
+        active_group_ids=active_group_ids,
+        active_public_workspace_id=active_public_workspace_id,
+        include_all_public_workspaces=True,
+    )
+
+    candidate_document_ids = []
+    seen_document_ids = set()
+    for result in search_result.get("results") or []:
+        file_name = str(result.get("file_name") or "").strip()
+        if os.path.splitext(file_name)[1].lower() not in MIXED_SOURCE_TABULAR_EXTENSIONS:
+            continue
+        document_id = str(result.get("document_id") or "").strip()
+        if not document_id or document_id in seen_document_ids:
+            continue
+        seen_document_ids.add(document_id)
+        candidate_document_ids.append(document_id)
+        if len(candidate_document_ids) >= normalized_limit:
+            break
+
+    log_event(
+        "[MixedSourceChatSearch] Completed bounded authorized tabular candidate search.",
+        extra={
+            "candidate_search_result_count": search_result.get("result_count", 0),
+            "tabular_candidate_count": len(candidate_document_ids),
+            "candidate_limit": normalized_limit,
+        },
+        level=logging.INFO,
+    )
+    return {
+        "document_ids": candidate_document_ids,
+        "candidate_count": len(candidate_document_ids),
+        "search_result_count": search_result.get("result_count", 0),
+        "query": search_result.get("query"),
     }
 
 

--- a/application/single_app/functions_settings.py
+++ b/application/single_app/functions_settings.py
@@ -215,6 +215,19 @@ def is_mixed_source_manifest_enabled(settings):
     return bool((settings or {}).get('enable_mixed_source_manifest', False))
 
 
+def is_mixed_source_chat_search_enabled(settings):
+    """Return whether Phase 2 mixed-source Chat and Search behavior is enabled."""
+    return bool((settings or {}).get('enable_mixed_source_chat_search', False))
+
+
+def is_mixed_source_relevance_candidates_enabled(settings):
+    """Return whether Phase 2 relevance-mode table candidates are enabled."""
+    return bool(
+        (settings or {}).get('enable_mixed_source_chat_search', False)
+        and (settings or {}).get('enable_mixed_source_relevance_candidates', False)
+    )
+
+
 CHAT_FILE_UPLOAD_APP_ROLE = "ChatFileUploadUser"
 WORKFLOW_USER_APP_ROLE = "WorkflowUser"
 DOCUMENT_INTELLIGENCE_PDF_IMAGE_EXTRACTION_MODES = {"read", "layout", "auto"}
@@ -765,6 +778,8 @@ def get_settings(use_cosmos=False, include_source=False):
         'enable_tabular_processing_plugin': False,
         'enable_multi_agent_orchestration': False,
         'enable_mixed_source_manifest': False,
+        'enable_mixed_source_chat_search': False,
+        'enable_mixed_source_relevance_candidates': False,
         'max_rounds_per_agent': 1,
         'workflow_max_auto_invoke_attempts': 60,
         'enable_semantic_kernel': False,

--- a/application/single_app/functions_tabular_analysis.py
+++ b/application/single_app/functions_tabular_analysis.py
@@ -12,6 +12,7 @@ without changing workflow callers again.
 def _load_chat_helper(helper_name):
     # Import lazily because route_backend_chats imports functions_workflow_runner during app startup.
     from route_backend_chats import (
+        _execute_mixed_source_tabular_evidence,
         augment_tabular_invocations_with_related_document_evidence,
         build_tabular_computed_results_system_message,
         build_tabular_related_document_evidence_summary,
@@ -21,6 +22,7 @@ def _load_chat_helper(helper_name):
     )
 
     helpers = {
+        'execute_mixed_source_tabular_evidence': _execute_mixed_source_tabular_evidence,
         'augment_tabular_invocations_with_related_document_evidence': augment_tabular_invocations_with_related_document_evidence,
         'build_tabular_computed_results_system_message': build_tabular_computed_results_system_message,
         'build_tabular_related_document_evidence_summary': build_tabular_related_document_evidence_summary,
@@ -29,6 +31,10 @@ def _load_chat_helper(helper_name):
         'run_tabular_analysis_with_thought_tracking': run_tabular_analysis_with_thought_tracking,
     }
     return helpers[helper_name]
+
+
+def execute_mixed_source_tabular_evidence(*args, **kwargs):
+    return _load_chat_helper('execute_mixed_source_tabular_evidence')(*args, **kwargs)
 
 
 def augment_tabular_invocations_with_related_document_evidence(*args, **kwargs):

--- a/application/single_app/functions_workflow_runner.py
+++ b/application/single_app/functions_workflow_runner.py
@@ -78,7 +78,12 @@ from functions_message_artifacts import (
     build_agent_citation_artifact_documents,
     make_json_serializable,
 )
-from functions_mixed_source_orchestration import resolve_authorized_source_manifest
+from functions_mixed_source_orchestration import (
+    build_mixed_source_evidence_handoff,
+    build_narrative_evidence_envelopes,
+    partition_source_manifest,
+    resolve_authorized_source_manifest,
+)
 from model_endpoint_clients import (
     MODEL_ENDPOINT_PROTOCOL_AZURE_OPENAI,
 )
@@ -86,12 +91,17 @@ from functions_model_endpoint_runtime import build_model_endpoint_sync_chat_clie
 from functions_notifications import create_workflow_priority_notification
 from functions_personal_workflows import save_personal_workflow_run, save_personal_workflow_run_item
 from functions_public_workspaces import get_user_visible_public_workspace_ids_from_settings
-from functions_search_service import resolve_document_context, search_documents
+from functions_search_service import (
+    resolve_document_context,
+    search_documents,
+    search_relevant_tabular_candidates,
+)
 from functions_search import normalize_search_id_list, normalize_search_scope, normalize_search_top_n
 from functions_simplechat_operations import upload_generated_analysis_artifact_for_current_user
 from functions_settings import (
     get_settings,
     get_user_settings,
+    is_mixed_source_chat_search_enabled,
     is_mixed_source_manifest_enabled,
     is_tabular_processing_enabled,
     normalize_model_endpoints,
@@ -3515,6 +3525,8 @@ def _create_assistant_message(conversation, workflow, result, trigger_source, ru
             'workspace_type': workspace_type,
             'group_id': group_id or None,
             'token_usage': result.get('token_usage'),
+            'generated_analysis_artifacts': list(result.get('generated_analysis_artifacts') or []),
+            'generated_tabular_outputs': list(result.get('generated_tabular_outputs') or []),
             'source_review': source_review_metadata,
             'workflow': {
                 'workflow_id': workflow.get('id'),
@@ -3527,6 +3539,7 @@ def _create_assistant_message(conversation, workflow, result, trigger_source, ru
                 'model_binding_summary': workflow.get('model_binding_summary') or {},
                 'document_action': document_action,
                 'document_search': result.get('document_search') or {},
+                'mixed_source_coverage': result.get('mixed_source_coverage') or {},
                 'analyze': workflow.get('analyze') or {},
                 'analysis_coverage': result.get('analysis_coverage') or {},
             },
@@ -4023,20 +4036,86 @@ def _format_workflow_search_results(results):
 def _build_workflow_search_prompt(task_prompt, search_context):
     task_prompt = str(task_prompt or '').strip()
     retrieved_content = str((search_context or {}).get('retrieved_content') or '').strip()
-    if not retrieved_content:
+    evidence_messages = [
+        str((message or {}).get('content') or '').strip()
+        for message in list((search_context or {}).get('evidence_messages') or [])
+        if str((message or {}).get('content') or '').strip()
+    ]
+    if not retrieved_content and not evidence_messages:
         return task_prompt
 
-    return (
+    prompt_sections = [
         '[Workflow document search context]\n'
-        'Use the retrieved document excerpts below as grounding for the workflow task. '
-        'When the excerpts are insufficient, say what is missing instead of guessing.\n\n'
-        f'{retrieved_content}\n\n'
-        '[Workflow task]\n'
-        f'{task_prompt}'
-    ).strip()
+        'Use the bounded native-engine evidence below as grounding for the workflow task. '
+        'When the evidence is insufficient or source coverage is partial, say what is missing instead of guessing.'
+    ]
+    if retrieved_content:
+        prompt_sections.append(
+            f'[Narrative excerpts]\n{retrieved_content}'
+        )
+    if evidence_messages:
+        prompt_sections.append(
+            '[Computed and coverage evidence]\n'
+            + '\n\n'.join(evidence_messages)
+        )
+    prompt_sections.append(f'[Workflow task]\n{task_prompt}')
+    return '\n\n'.join(prompt_sections).strip()
 
 
-def _prepare_workflow_search_context(workflow, action_config, settings, thought_tracker=None, run_id=None):
+@contextmanager
+def _workflow_mixed_source_execution_context(user_id, conversation_id, manifest):
+    """Bind tabular tools to scope IDs from a freshly authorized manifest."""
+    group_ids = []
+    public_workspace_ids = []
+    for source in list(manifest or []):
+        if source.get('authorization_status') != 'authorized':
+            continue
+        group_id = str(source.get('group_id') or '').strip()
+        public_workspace_id = str(source.get('public_workspace_id') or '').strip()
+        if group_id and group_id not in group_ids:
+            group_ids.append(group_id)
+        if public_workspace_id and public_workspace_id not in public_workspace_ids:
+            public_workspace_ids.append(public_workspace_id)
+
+    with _ensure_execution_context(user_id):
+        previous_conversation_id = getattr(g, 'conversation_id', None) if hasattr(g, 'conversation_id') else None
+        previous_authorized_chat_context = getattr(g, 'authorized_chat_context', None) if hasattr(g, 'authorized_chat_context') else None
+        g.conversation_id = conversation_id
+        g.authorized_chat_context = {
+            'user_id': user_id,
+            'conversation_id': conversation_id,
+            'active_group_ids': group_ids,
+            'active_group_id': group_ids[0] if len(group_ids) == 1 else None,
+            'active_public_workspace_ids': public_workspace_ids,
+            'active_public_workspace_id': (
+                public_workspace_ids[0]
+                if len(public_workspace_ids) == 1
+                else None
+            ),
+            'fact_memory_scope_id': group_ids[0] if len(group_ids) == 1 else user_id,
+            'fact_memory_scope_type': 'group' if len(group_ids) == 1 else 'user',
+        }
+        try:
+            yield
+        finally:
+            if previous_conversation_id is None and hasattr(g, 'conversation_id'):
+                delattr(g, 'conversation_id')
+            else:
+                g.conversation_id = previous_conversation_id
+            if previous_authorized_chat_context is None and hasattr(g, 'authorized_chat_context'):
+                delattr(g, 'authorized_chat_context')
+            else:
+                g.authorized_chat_context = previous_authorized_chat_context
+
+
+def _prepare_workflow_search_context(
+    workflow,
+    action_config,
+    settings,
+    conversation_id='',
+    thought_tracker=None,
+    run_id=None,
+):
     if not _is_document_search_workflow(action_config):
         return {'workflow': workflow, 'citations': [], 'result_count': 0, 'document_count': 0, 'query': None}
 
@@ -4049,20 +4128,163 @@ def _prepare_workflow_search_context(workflow, action_config, settings, thought_
     if not query:
         return {'workflow': workflow, 'citations': [], 'result_count': 0, 'document_count': 0, 'query': None}
 
-    search_top_n = normalize_search_top_n(max(12, len(document_ids) * 3 if document_ids else 12))
-    search_result = search_documents(
-        query=query,
-        user_id=str(workflow.get('user_id') or '').strip(),
-        top_n=search_top_n,
-        doc_scope=resolved_action.get('doc_scope') or 'all',
-        document_ids=document_ids,
-        active_group_ids=resolved_action.get('active_group_ids'),
-        active_public_workspace_id=resolved_action.get('active_public_workspace_id'),
+    user_id = str(workflow.get('user_id') or '').strip()
+    manifest_doc_scope = resolved_action.get('doc_scope') or 'all'
+    manifest_group_ids = list(resolved_action.get('active_group_ids') or [])
+    manifest_public_workspace_ids = list(
+        resolved_action.get('active_public_workspace_id') or []
     )
+    workflow_group_id = _get_workflow_group_id(workflow)
+    if workflow_group_id:
+        assert_group_role(
+            user_id,
+            workflow_group_id,
+            allowed_roles=("Owner", "Admin", "DocumentManager", "User"),
+        )
+        manifest_doc_scope = 'group'
+        manifest_group_ids = [workflow_group_id]
+        manifest_public_workspace_ids = []
+
+    scoped_action = dict(resolved_action)
+    scoped_action['doc_scope'] = manifest_doc_scope
+    scoped_action['active_group_ids'] = manifest_group_ids
+    scoped_action['active_public_workspace_id'] = manifest_public_workspace_ids
+
+    if not is_mixed_source_chat_search_enabled(settings):
+        search_top_n = normalize_search_top_n(max(12, len(document_ids) * 3 if document_ids else 12))
+        search_result = search_documents(
+            query=query,
+            user_id=user_id,
+            top_n=search_top_n,
+            doc_scope=manifest_doc_scope,
+            document_ids=document_ids,
+            active_group_ids=manifest_group_ids,
+            active_public_workspace_id=manifest_public_workspace_ids,
+        )
+        retrieved_content, citations = _format_workflow_search_results(search_result.get('results') or [])
+        prepared_workflow = _apply_runtime_document_action_config(workflow, scoped_action)
+        prepared_workflow['task_prompt'] = _build_workflow_search_prompt(workflow.get('task_prompt', ''), {
+            'retrieved_content': retrieved_content,
+        })
+
+        if thought_tracker and run_id:
+            _add_workflow_activity_thought(
+                thought_tracker,
+                prepared_workflow,
+                run_id,
+                step_type='document',
+                content='Searched selected workflow documents',
+                detail=(
+                    f"results={search_result.get('result_count', 0)} | "
+                    f"documents={search_result.get('document_count', 0)}"
+                ),
+                activity_key=f'search:{run_id}:documents',
+                kind='document_search',
+                title='Document search',
+                status='completed',
+            )
+
+        return {
+            'workflow': prepared_workflow,
+            'citations': citations,
+            'agent_citations': [],
+            'generated_tabular_outputs': [],
+            'coverage': {},
+            'result_count': search_result.get('result_count', 0),
+            'document_count': search_result.get('document_count', 0),
+            'query': search_result.get('query'),
+        }
+
+    manifest = resolve_authorized_source_manifest(
+        document_ids,
+        user_id=user_id,
+        selection_mode='selected',
+        conversation_id=conversation_id,
+        active_group_ids=manifest_group_ids,
+        active_public_workspace_ids=manifest_public_workspace_ids,
+        doc_scope=manifest_doc_scope,
+    )
+    partitions = partition_source_manifest(manifest)
+    narrative_sources = list(partitions.get('narrative_sources') or [])
+    tabular_sources = list(partitions.get('tabular_sources') or [])
+    narrative_document_ids = [
+        str(source.get('document_id') or '').strip()
+        for source in narrative_sources
+        if str(source.get('document_id') or '').strip()
+    ]
+    authorized_document_ids = narrative_document_ids + [
+        str(source.get('document_id') or '').strip()
+        for source in tabular_sources
+        if str(source.get('document_id') or '').strip()
+    ]
+
+    manifest_group_ids = []
+    manifest_public_workspace_ids = []
+    for source in narrative_sources + tabular_sources:
+        group_id = str(source.get('group_id') or '').strip()
+        public_workspace_id = str(source.get('public_workspace_id') or '').strip()
+        if group_id and group_id not in manifest_group_ids:
+            manifest_group_ids.append(group_id)
+        if public_workspace_id and public_workspace_id not in manifest_public_workspace_ids:
+            manifest_public_workspace_ids.append(public_workspace_id)
+
+    search_top_n = normalize_search_top_n(
+        max(12, len(narrative_document_ids) * 3 if narrative_document_ids else 12)
+    )
+    search_result = {
+        'results': [],
+        'result_count': 0,
+        'document_count': 0,
+        'query': query,
+    }
+    if narrative_document_ids:
+        search_result = search_documents(
+            query=query,
+            user_id=user_id,
+            top_n=search_top_n,
+            doc_scope=manifest_doc_scope,
+            document_ids=narrative_document_ids,
+            active_group_ids=manifest_group_ids,
+            active_public_workspace_id=manifest_public_workspace_ids,
+            include_all_public_workspaces=True,
+        )
     retrieved_content, citations = _format_workflow_search_results(search_result.get('results') or [])
-    prepared_workflow = _apply_runtime_document_action_config(workflow, resolved_action)
+    evidence_envelopes = build_narrative_evidence_envelopes(
+        narrative_sources,
+        search_result.get('results') or [],
+        'selected',
+    )
+
+    from functions_tabular_analysis import execute_mixed_source_tabular_evidence
+
+    with _workflow_mixed_source_execution_context(user_id, conversation_id, manifest):
+        tabular_result = execute_mixed_source_tabular_evidence(
+            tabular_sources=tabular_sources,
+            selection_mode='selected',
+            has_narrative_sources=bool(narrative_sources),
+            user_question=query,
+            user_id=user_id,
+            conversation_id=conversation_id,
+            gpt_model=_resolve_tabular_document_action_model_name(workflow, settings),
+            settings=settings,
+            thought_tracker=thought_tracker,
+        )
+    evidence_envelopes.extend(tabular_result.get('evidence_envelopes') or [])
+    mixed_source_handoff = build_mixed_source_evidence_handoff(
+        manifest,
+        evidence_envelopes,
+        'selected',
+    )
+
+    prepared_action = dict(resolved_action)
+    prepared_action['document_ids'] = authorized_document_ids
+    prepared_action['doc_scope'] = manifest_doc_scope
+    prepared_action['active_group_ids'] = manifest_group_ids
+    prepared_action['active_public_workspace_id'] = manifest_public_workspace_ids
+    prepared_workflow = _apply_runtime_document_action_config(workflow, prepared_action)
     prepared_workflow['task_prompt'] = _build_workflow_search_prompt(workflow.get('task_prompt', ''), {
-        'retrieved_content': retrieved_content,
+        'retrieved_content': '',
+        'evidence_messages': [mixed_source_handoff],
     })
 
     if thought_tracker and run_id:
@@ -4074,7 +4296,8 @@ def _prepare_workflow_search_context(workflow, action_config, settings, thought_
             content='Searched selected workflow documents',
             detail=(
                 f"results={search_result.get('result_count', 0)} | "
-                f"documents={search_result.get('document_count', 0)}"
+                f"narrative_documents={len(narrative_sources)} | "
+                f"tabular_documents={len(tabular_sources)}"
             ),
             activity_key=f'search:{run_id}:documents',
             kind='document_search',
@@ -4085,10 +4308,46 @@ def _prepare_workflow_search_context(workflow, action_config, settings, thought_
     return {
         'workflow': prepared_workflow,
         'citations': citations,
+        'agent_citations': list(tabular_result.get('agent_citations') or []),
+        'generated_tabular_outputs': list(tabular_result.get('generated_outputs') or []),
+        'coverage': mixed_source_handoff.get('mixed_source_coverage') or {},
         'result_count': search_result.get('result_count', 0),
-        'document_count': search_result.get('document_count', 0),
+        'document_count': len(authorized_document_ids),
         'query': search_result.get('query'),
     }
+
+
+def _attach_workflow_search_context(execution_result, workflow_search_context):
+    """Merge mixed Search evidence into either a workflow model or agent result."""
+    execution_result = execution_result if isinstance(execution_result, dict) else {}
+    search_context = workflow_search_context if isinstance(workflow_search_context, dict) else {}
+    if not search_context:
+        return execution_result
+
+    existing_agent_citations = list(execution_result.get('agent_citations') or [])
+    existing_agent_citations.extend(list(search_context.get('agent_citations') or []))
+    existing_outputs = list(execution_result.get('generated_tabular_outputs') or [])
+    existing_outputs.extend(list(search_context.get('generated_tabular_outputs') or []))
+    hybrid_citations = list(search_context.get('citations') or [])
+    coverage = search_context.get('coverage') if isinstance(search_context.get('coverage'), dict) else {}
+    execution_result.update({
+        'hybrid_citations': hybrid_citations,
+        'agent_citations': existing_agent_citations,
+        'generated_tabular_outputs': existing_outputs,
+        'mixed_source_coverage': coverage,
+        'augmented': bool(
+            hybrid_citations
+            or existing_agent_citations
+            or coverage.get('requested_source_count')
+        ),
+        'document_search': {
+            'query': search_context.get('query'),
+            'result_count': search_context.get('result_count', 0),
+            'document_count': search_context.get('document_count', 0),
+            'partial_coverage': bool(coverage.get('partial_coverage')),
+        },
+    })
+    return execution_result
 
 
 def _apply_runtime_document_action_config(workflow, action_config):
@@ -5713,6 +5972,7 @@ def run_personal_workflow(workflow, trigger_source='manual', user_roles=None, ac
                 execution_workflow,
                 document_action,
                 settings,
+                conversation_id=conversation.get('id'),
                 thought_tracker=thought_tracker,
                 run_id=run_id,
             )
@@ -5751,16 +6011,10 @@ def run_personal_workflow(workflow, trigger_source='manual', user_roles=None, ac
                 thought_tracker=thought_tracker,
                 url_access_context=url_access_context,
             )
-            if workflow_search_context:
-                execution_result.update({
-                    'hybrid_citations': workflow_search_context.get('citations') or [],
-                    'augmented': bool(workflow_search_context.get('citations')),
-                    'document_search': {
-                        'query': workflow_search_context.get('query'),
-                        'result_count': workflow_search_context.get('result_count', 0),
-                        'document_count': workflow_search_context.get('document_count', 0),
-                    },
-                })
+            execution_result = _attach_workflow_search_context(
+                execution_result,
+                workflow_search_context,
+            )
         else:
             execution_result = _execute_model_workflow(
                 execution_workflow,
@@ -5769,16 +6023,10 @@ def run_personal_workflow(workflow, trigger_source='manual', user_roles=None, ac
                 thought_tracker=thought_tracker,
                 url_access_context=url_access_context,
             )
-            if workflow_search_context:
-                execution_result.update({
-                    'hybrid_citations': workflow_search_context.get('citations') or [],
-                    'augmented': bool(workflow_search_context.get('citations')),
-                    'document_search': {
-                        'query': workflow_search_context.get('query'),
-                        'result_count': workflow_search_context.get('result_count', 0),
-                        'document_count': workflow_search_context.get('document_count', 0),
-                    },
-                })
+            execution_result = _attach_workflow_search_context(
+                execution_result,
+                workflow_search_context,
+            )
         execution_result = _attach_workflow_url_access_result(execution_result, url_access_context)
 
         assistant_doc = _create_assistant_message(

--- a/application/single_app/route_backend_chats.py
+++ b/application/single_app/route_backend_chats.py
@@ -37,7 +37,16 @@ from functions_model_endpoint_runtime import (
     build_model_endpoint_sync_chat_client,
     build_semantic_kernel_chat_service_for_model,
 )
-from functions_mixed_source_orchestration import resolve_authorized_source_manifest
+from functions_mixed_source_orchestration import (
+    build_mixed_source_evidence_handoff,
+    build_narrative_evidence_envelopes,
+    build_tabular_file_contexts_from_manifest,
+    execute_tabular_evidence_sources,
+    normalize_document_context_request,
+    partition_source_manifest,
+    resolve_authorized_source_manifest,
+    should_run_tabular_evidence,
+)
 import builtins
 import asyncio, types
 import ast
@@ -60,6 +69,7 @@ from config import *
 from flask import Response, copy_current_request_context, g, has_request_context, stream_with_context
 from functions_authentication import *
 from functions_search import *
+from functions_search_service import search_relevant_tabular_candidates
 from functions_service_health import (
     SEMANTIC_SEARCH_QUOTA_WARNING_TYPE,
     SemanticSearchQuotaExceededError,
@@ -181,6 +191,7 @@ ASSIGNED_KNOWLEDGE_DOCUMENT_ACTION_MAP = {
 }
 ASSIGNED_KNOWLEDGE_CONTEXT_TOP_N = 12
 ASSIGNED_KNOWLEDGE_CONTEXT_EXCERPT_MAX_CHARS = 1800
+MIXED_SOURCE_CHAT_RELEVANCE_SOURCE_LIMIT = 48
 FOUNDRY_SELECTED_AGENT_TYPES = {'aifoundry', 'new_foundry', 'foundry_workflow'}
 FOUNDRY_AGENT_PLUGIN_NAMES = {
     'aifoundry': 'azure_ai_foundry',
@@ -326,6 +337,180 @@ def _maybe_resolve_chat_source_manifest(
             level=logging.WARNING,
         )
         return []
+
+
+def _normalize_chat_document_context_contract(
+    settings,
+    data,
+    selected_document_ids,
+    hybrid_search_enabled,
+):
+    """Normalize Phase 2 context intent while preserving flag-off compatibility."""
+    normalized_document_ids = _normalize_conversation_task_document_ids(
+        selected_document_ids
+    )
+    if not is_mixed_source_chat_search_enabled(settings):
+        return {
+            'selection_mode': 'selected' if normalized_document_ids else 'relevance',
+            'selected_document_ids': normalized_document_ids,
+            'document_context_requested': bool(hybrid_search_enabled),
+            'hybrid_search': bool(hybrid_search_enabled),
+            'explicit_selection': False,
+        }
+
+    return normalize_document_context_request(
+        selection_mode=data.get('selection_mode'),
+        selected_document_ids=normalized_document_ids,
+        document_context_requested=data.get('document_context_requested'),
+        hybrid_search=hybrid_search_enabled,
+    )
+
+
+def _resolve_chat_mixed_source_manifest(
+    settings,
+    user_id,
+    conversation_id,
+    document_ids,
+    selection_mode,
+    active_group_ids=None,
+    active_public_workspace_ids=None,
+):
+    """Resolve a fresh Phase 1 manifest for Phase 2 Chat evidence preparation."""
+    if not is_mixed_source_chat_search_enabled(settings):
+        return []
+    normalized_document_ids = _normalize_conversation_task_document_ids(document_ids)
+    if not normalized_document_ids:
+        return []
+    return resolve_authorized_source_manifest(
+        normalized_document_ids,
+        user_id=user_id,
+        selection_mode=selection_mode,
+        conversation_id=conversation_id,
+        active_group_ids=active_group_ids,
+        active_public_workspace_ids=active_public_workspace_ids,
+    )
+
+
+def _get_manifest_partition_document_ids(manifest_partitions, partition_name):
+    partitions = manifest_partitions if isinstance(manifest_partitions, dict) else {}
+    return [
+        str(source.get('document_id') or '').strip()
+        for source in partitions.get(partition_name) or []
+        if str(source.get('document_id') or '').strip()
+    ]
+
+
+def _resolve_chat_mixed_source_partition(
+    settings,
+    user_id,
+    conversation_id,
+    document_ids,
+    selection_mode,
+    active_group_ids=None,
+    active_public_workspace_ids=None,
+):
+    """Resolve and partition one current authorization-safe source manifest."""
+    manifest = _resolve_chat_mixed_source_manifest(
+        settings,
+        user_id,
+        conversation_id,
+        document_ids,
+        selection_mode,
+        active_group_ids=active_group_ids,
+        active_public_workspace_ids=active_public_workspace_ids,
+    )
+    partitions = partition_source_manifest(manifest)
+    return {
+        'manifest': manifest,
+        'partitions': partitions,
+        'narrative_document_ids': _get_manifest_partition_document_ids(
+            partitions,
+            'narrative_sources',
+        ),
+        'tabular_sources': list(partitions.get('tabular_sources') or []),
+    }
+
+
+def _resolve_chat_mixed_source_relevance_context(
+    *,
+    settings,
+    user_id,
+    conversation_id,
+    query,
+    search_results,
+    document_scope,
+    candidate_document_ids=None,
+    tags_filter=None,
+    active_group_ids=None,
+    active_public_workspace_ids=None,
+):
+    """Add bounded schema candidates and reauthorize all relevance-derived sources."""
+    if not is_mixed_source_chat_search_enabled(settings):
+        return {
+            'manifest': [],
+            'partitions': {},
+            'narrative_document_ids': [],
+            'tabular_sources': [],
+            'search_results': list(search_results or []),
+            'tabular_candidate_count': 0,
+        }
+
+    relevance_candidates_enabled = is_mixed_source_relevance_candidates_enabled(settings)
+    candidate_result = {
+        'document_ids': [],
+        'candidate_count': 0,
+    }
+    if relevance_candidates_enabled:
+        candidate_result = search_relevant_tabular_candidates(
+            query=query,
+            user_id=user_id,
+            doc_scope=document_scope,
+            document_ids=candidate_document_ids,
+            tags_filter=tags_filter,
+            active_group_ids=active_group_ids,
+            active_public_workspace_id=active_public_workspace_ids,
+        )
+    relevance_document_ids = []
+    seen_document_ids = set()
+    for result in list(search_results or []):
+        document_id = str((result or {}).get('document_id') or '').strip()
+        if document_id and document_id not in seen_document_ids:
+            seen_document_ids.add(document_id)
+            relevance_document_ids.append(document_id)
+        if len(relevance_document_ids) >= (
+            MIXED_SOURCE_CHAT_RELEVANCE_SOURCE_LIMIT - 6
+        ):
+            break
+    for document_id in candidate_result.get('document_ids') or []:
+        normalized_document_id = str(document_id or '').strip()
+        if normalized_document_id and normalized_document_id not in seen_document_ids:
+            seen_document_ids.add(normalized_document_id)
+            relevance_document_ids.append(normalized_document_id)
+        if len(relevance_document_ids) >= MIXED_SOURCE_CHAT_RELEVANCE_SOURCE_LIMIT:
+            break
+
+    resolved_context = _resolve_chat_mixed_source_partition(
+        settings,
+        user_id,
+        conversation_id,
+        relevance_document_ids,
+        'relevance',
+        active_group_ids=active_group_ids,
+        active_public_workspace_ids=active_public_workspace_ids,
+    )
+    narrative_document_id_set = set(
+        resolved_context.get('narrative_document_ids') or []
+    )
+    resolved_context['search_results'] = [
+        result
+        for result in list(search_results or [])
+        if str((result or {}).get('document_id') or '').strip()
+        in narrative_document_id_set
+    ]
+    resolved_context['tabular_candidate_count'] = int(
+        candidate_result.get('candidate_count') or 0
+    )
+    return resolved_context
 
 
 def _source_review_metadata_used(source_review_result):
@@ -9508,6 +9693,17 @@ async def run_tabular_sk_analysis(user_question, tabular_filenames, user_id,
             file_source_hint = file_context.get('source_hint', source_hint)
             file_group_id = file_context.get('group_id')
             file_public_workspace_id = file_context.get('public_workspace_id')
+            storage_locator = file_context.get('storage_locator')
+            if isinstance(storage_locator, dict):
+                locator_container = str(storage_locator.get('container') or '').strip()
+                locator_blob_path = str(storage_locator.get('blob_path') or '').strip()
+                if locator_container and locator_blob_path:
+                    tabular_plugin.remember_resolved_blob_location(
+                        file_source_hint,
+                        fname,
+                        locator_container,
+                        locator_blob_path,
+                    )
             schema_source_context = {'source': file_source_hint}
             if file_group_id:
                 schema_source_context['group_id'] = file_group_id
@@ -10460,12 +10656,8 @@ async def run_tabular_sk_analysis(user_question, tabular_filenames, user_id,
         log_event(f"[Tabular SK Analysis] Error: {e}", level=logging.WARNING, exceptionTraceback=True)
         return None
 
-def collect_tabular_sk_citations(user_id, conversation_id):
-    """Collect plugin invocations from the tabular SK analysis and convert to citation format."""
-    from semantic_kernel_plugins.plugin_invocation_logger import get_plugin_logger
-
-    plugin_logger = get_plugin_logger()
-    plugin_invocations = plugin_logger.get_invocations_for_conversation(user_id, conversation_id)
+def _build_tabular_sk_citations_from_invocations(plugin_invocations):
+    """Convert selected tabular invocations to the existing tool-citation shape."""
     plugin_invocations = filter_tabular_citation_invocations(plugin_invocations)
 
     if not plugin_invocations:
@@ -10510,8 +10702,252 @@ def collect_tabular_sk_citations(user_id, conversation_id):
         }
         citations.append(citation)
 
-    log_event(f"[Tabular SK Citations] Collected {len(citations)} tool execution citations", level=logging.INFO)
     return citations
+
+
+def collect_tabular_sk_citations(user_id, conversation_id):
+    """Collect plugin invocations from the tabular SK analysis and convert to citation format."""
+    plugin_logger = get_plugin_logger()
+    plugin_invocations = plugin_logger.get_invocations_for_conversation(user_id, conversation_id)
+    citations = _build_tabular_sk_citations_from_invocations(plugin_invocations)
+    log_event(
+        f"[Tabular SK Citations] Collected {len(citations)} tool execution citations",
+        level=logging.INFO,
+    )
+    return citations
+
+
+def _execute_mixed_source_tabular_evidence(
+    *,
+    tabular_sources,
+    selection_mode,
+    has_narrative_sources,
+    user_question,
+    user_id,
+    conversation_id,
+    gpt_model,
+    settings,
+    thought_tracker=None,
+    live_thought_callback=None,
+    model_context=None,
+):
+    """Run the existing tabular engine once per manifest source with terminal coverage."""
+    source_contexts = build_tabular_file_contexts_from_manifest(tabular_sources)
+    if has_request_context():
+        authorized_context = dict(getattr(g, 'authorized_chat_context', {}) or {})
+        authorized_blob_locations = []
+        for file_context in source_contexts:
+            storage_locator = file_context.get('storage_locator')
+            if not isinstance(storage_locator, dict):
+                continue
+            locator_container = str(storage_locator.get('container') or '').strip()
+            locator_blob_path = str(storage_locator.get('blob_path') or '').strip()
+            if locator_container and locator_blob_path:
+                authorized_blob_locations.append([locator_container, locator_blob_path])
+        authorized_context['authorized_blob_locations'] = authorized_blob_locations
+        g.authorized_chat_context = authorized_context
+    context_by_document_id = {
+        context['document_id']: context
+        for context in source_contexts
+    }
+    system_messages = []
+    agent_citations = []
+    generated_outputs = []
+    all_invocations = []
+    if not is_tabular_processing_enabled(settings):
+        def fail_unavailable_tabular_source(source):
+            del source
+            raise RuntimeError('Tabular processing is unavailable')
+
+        return {
+            'evidence_envelopes': execute_tabular_evidence_sources(
+                tabular_sources,
+                fail_unavailable_tabular_source,
+                selection_mode,
+            ),
+            'system_messages': [],
+            'agent_citations': [],
+            'generated_outputs': [],
+            'invocations': [],
+            'executed': False,
+        }
+
+    execute_tabular = should_run_tabular_evidence(
+        user_question,
+        has_narrative_sources=has_narrative_sources,
+    )
+    plugin_logger = get_plugin_logger()
+
+    def publish_post_processing_thought(thought_payload):
+        payload = thought_payload if isinstance(thought_payload, dict) else {}
+        if thought_tracker is not None:
+            thought_tracker.add_thought(
+                payload.get('step_type', 'tabular_analysis'),
+                payload.get('content', ''),
+                detail=payload.get('detail'),
+                activity=payload.get('activity'),
+            )
+        if callable(live_thought_callback):
+            live_payload = dict(payload)
+            if thought_tracker is not None:
+                live_payload['message_id'] = getattr(thought_tracker, 'message_id', None)
+                live_payload['step_index'] = thought_tracker.current_index - 1
+            live_thought_callback(live_payload)
+
+    def execute_source(source):
+        document_id = str(source.get('document_id') or '').strip()
+        file_context = context_by_document_id.get(document_id)
+        if not file_context:
+            raise ValueError('Authorized tabular source context is unavailable')
+
+        baseline_invocation_count = len(
+            plugin_logger.get_invocations_for_conversation(
+                user_id,
+                conversation_id,
+                limit=1000,
+            )
+        )
+        execution_mode = get_tabular_execution_mode(user_question)
+        tabular_analysis, streamed_tool_thoughts = asyncio.run(
+            run_tabular_analysis_with_thought_tracking(
+                user_question=user_question,
+                tabular_filenames={file_context['file_name']},
+                tabular_file_contexts=[file_context],
+                user_id=user_id,
+                conversation_id=conversation_id,
+                gpt_model=gpt_model,
+                settings=settings,
+                source_hint=file_context.get('source_hint', 'workspace'),
+                group_id=file_context.get('group_id'),
+                public_workspace_id=file_context.get('public_workspace_id'),
+                execution_mode=execution_mode,
+                thought_tracker=thought_tracker,
+                live_thought_callback=live_thought_callback,
+                model_context=model_context,
+            )
+        )
+        if not str(tabular_analysis or '').strip():
+            raise ValueError('Tabular execution returned no computed results')
+
+        invocations_after = plugin_logger.get_invocations_for_conversation(
+            user_id,
+            conversation_id,
+            limit=1000,
+        )
+        source_invocations = get_new_plugin_invocations(
+            invocations_after,
+            baseline_invocation_count,
+        )
+        if execution_mode == 'schema_summary':
+            successful_source_invocations = [
+                invocation
+                for invocation in source_invocations
+                if getattr(invocation, 'function_name', '') == 'describe_tabular_file'
+                and not get_tabular_invocation_error_message(invocation)
+            ]
+        else:
+            successful_source_invocations, _ = split_tabular_analysis_invocations(
+                source_invocations
+            )
+        if not successful_source_invocations:
+            raise ValueError('Tabular execution returned no successful native tool calls')
+        all_invocations.extend(source_invocations)
+        related_document_summary = ''
+        related_document_stats = augment_tabular_invocations_with_related_document_evidence(
+            source_invocations,
+            user_question,
+            user_id,
+            conversation_id=conversation_id,
+        )
+        if related_document_stats.get('augmented_row_count'):
+            related_document_summary = build_tabular_related_document_evidence_summary(
+                source_invocations,
+            )
+
+        if thought_tracker is not None and not streamed_tool_thoughts:
+            for thought_content, thought_detail in get_tabular_tool_thought_payloads(
+                source_invocations
+            ):
+                thought_tracker.add_thought(
+                    'tabular_analysis',
+                    thought_content,
+                    thought_detail,
+                )
+        if thought_tracker is not None:
+            for thought_content, thought_detail in get_tabular_status_thought_payloads(
+                source_invocations,
+                analysis_succeeded=True,
+            ):
+                thought_tracker.add_thought(
+                    'tabular_analysis',
+                    thought_content,
+                    thought_detail,
+                )
+
+        generated_output = asyncio.run(maybe_create_tabular_generated_output(
+            user_question=user_question,
+            invocations=source_invocations,
+            gpt_model=gpt_model,
+            settings=settings,
+            conversation_id=conversation_id,
+            thought_callback=publish_post_processing_thought,
+            user_id=user_id,
+            model_context=model_context,
+        ))
+        if generated_output:
+            generated_outputs.append(generated_output)
+
+        source_citations = _build_tabular_sk_citations_from_invocations(
+            source_invocations
+        )
+        agent_citations.extend(source_citations)
+        chart_citations = build_tabular_inline_chart_citations(
+            user_question,
+            source_invocations,
+        )
+        agent_citations.extend(chart_citations)
+        system_messages.append({
+            'role': 'system',
+            'content': build_tabular_computed_results_system_message(
+                'an authorized selected tabular source',
+                str(tabular_analysis).strip(),
+                related_document_evidence_summary=related_document_summary,
+            ),
+        })
+        if generated_output:
+            system_messages.append({
+                'role': 'system',
+                'content': _build_tabular_generated_output_system_message(generated_output),
+            })
+
+        return {
+            'summary': str(tabular_analysis).strip(),
+            'evidence': [
+                get_tabular_invocation_compact_payload(invocation, max_rows=5)
+                for invocation in source_invocations
+            ],
+            'citations': source_citations,
+            'generated_artifacts': [generated_output] if generated_output else [],
+            'coverage': {
+                'tool_call_count': len(source_invocations),
+                'execution_mode': execution_mode,
+            },
+        }
+
+    evidence_envelopes = execute_tabular_evidence_sources(
+        tabular_sources,
+        execute_source,
+        selection_mode,
+        execute=execute_tabular,
+    )
+    return {
+        'evidence_envelopes': evidence_envelopes,
+        'system_messages': system_messages,
+        'agent_citations': agent_citations,
+        'generated_outputs': generated_outputs,
+        'invocations': all_invocations,
+        'executed': execute_tabular,
+    }
 
 
 def is_tabular_filename(filename):
@@ -13206,6 +13642,38 @@ def register_route_backend_chats(bp):
                 deep_research_enabled = deep_research_enabled.lower() == 'true'
             if isinstance(image_gen_enabled, str):
                 image_gen_enabled = image_gen_enabled.lower() == 'true'
+            try:
+                document_context_contract = _normalize_chat_document_context_contract(
+                    settings,
+                    data,
+                    selected_document_ids,
+                    hybrid_search_enabled,
+                )
+            except ValueError as contract_error:
+                return jsonify({'error': str(contract_error)}), 400
+            selected_document_ids = list(
+                document_context_contract.get('selected_document_ids') or []
+            )
+            requested_selected_document_ids = list(selected_document_ids)
+            selected_document_id = (
+                selected_document_ids[0]
+                if len(selected_document_ids) == 1
+                else None
+            )
+            selection_mode = document_context_contract.get('selection_mode')
+            document_context_requested = bool(
+                document_context_contract.get('document_context_requested')
+            )
+            request_has_explicit_document_selection = bool(
+                document_context_contract.get('explicit_selection')
+            )
+            request_document_context_enabled = bool(
+                hybrid_search_enabled
+                or (
+                    is_mixed_source_chat_search_enabled(settings)
+                    and document_context_requested
+                )
+            )
             user_workspace_context_requested = data.get('user_workspace_context_enabled')
             if isinstance(user_workspace_context_requested, str):
                 user_workspace_context_requested = user_workspace_context_requested.lower() == 'true'
@@ -13273,7 +13741,7 @@ def register_route_backend_chats(bp):
             assigned_knowledge_deep_research_urls = []
             if assigned_knowledge_filters:
                 assigned_knowledge_user_context_active = (
-                    user_workspace_context_requested
+                    (user_workspace_context_requested or document_context_requested)
                     and _assigned_knowledge_allows_user_workspace_context(assigned_knowledge_filters)
                     and _assigned_knowledge_allows_document_action(
                         assigned_knowledge_filters,
@@ -13332,6 +13800,15 @@ def register_route_backend_chats(bp):
                         deep_research_enabled = True
                 g.assigned_knowledge_context = assigned_knowledge_filters
                 g.assigned_knowledge_user_context_active = assigned_knowledge_user_context_active
+
+            mixed_source_explicit_selection = bool(
+                is_mixed_source_chat_search_enabled(settings)
+                and request_has_explicit_document_selection
+                and (
+                    not assigned_knowledge_filters
+                    or assigned_knowledge_user_context_active
+                )
+            )
 
             explicit_external_retrieval_requested = _is_explicit_external_retrieval_requested(
                 web_search_enabled=web_search_enabled,
@@ -13503,11 +13980,14 @@ def register_route_backend_chats(bp):
             _set_authorized_chat_request_context(user_id, conversation_id, scope_context)
 
             auto_linked_chat_upload_document_ids = []
-            auto_merge_chat_upload_workspace_context = _should_auto_merge_chat_upload_workspace_context(
-                explicit_external_retrieval_requested,
-                hybrid_search_enabled,
-                assigned_knowledge_filters=assigned_knowledge_filters,
-                assigned_knowledge_user_context_active=assigned_knowledge_user_context_active,
+            auto_merge_chat_upload_workspace_context = (
+                not mixed_source_explicit_selection
+                and _should_auto_merge_chat_upload_workspace_context(
+                    explicit_external_retrieval_requested,
+                    hybrid_search_enabled,
+                    assigned_knowledge_filters=assigned_knowledge_filters,
+                    assigned_knowledge_user_context_active=assigned_knowledge_user_context_active,
+                )
             )
             if auto_merge_chat_upload_workspace_context:
                 chat_upload_context = _resolve_chat_upload_workspace_context(
@@ -13566,12 +14046,76 @@ def register_route_backend_chats(bp):
                 selected_document_id = effective_selected_document_id
                 document_scope = effective_document_scope
 
-            _maybe_resolve_chat_source_manifest(
-                settings,
-                user_id,
-                conversation_id,
-                effective_selected_document_ids,
-                scope_context,
+            mixed_source_manifest = []
+            mixed_source_partitions = {}
+            mixed_source_narrative_document_ids = []
+            mixed_source_tabular_sources = []
+            mixed_source_evidence_envelopes = []
+            if mixed_source_explicit_selection:
+                try:
+                    mixed_source_manifest = _resolve_chat_mixed_source_manifest(
+                        settings,
+                        user_id,
+                        conversation_id,
+                        effective_selected_document_ids,
+                        'selected',
+                        active_group_ids=effective_active_group_ids,
+                        active_public_workspace_ids=effective_active_public_workspace_ids,
+                    )
+                except ValueError as manifest_error:
+                    return jsonify({'error': str(manifest_error)}), 400
+                mixed_source_partitions = partition_source_manifest(
+                    mixed_source_manifest
+                )
+                mixed_source_narrative_document_ids = _get_manifest_partition_document_ids(
+                    mixed_source_partitions,
+                    'narrative_sources',
+                )
+                mixed_source_tabular_sources = list(
+                    mixed_source_partitions.get('tabular_sources') or []
+                )
+                authorized_selected_document_ids = [
+                    str(source.get('document_id') or '').strip()
+                    for source in (
+                        list(mixed_source_partitions.get('narrative_sources') or [])
+                        + mixed_source_tabular_sources
+                    )
+                    if str(source.get('document_id') or '').strip()
+                ]
+                effective_selected_document_ids = authorized_selected_document_ids
+                effective_selected_document_id = (
+                    authorized_selected_document_ids[0]
+                    if len(authorized_selected_document_ids) == 1
+                    else None
+                )
+                log_event(
+                    '[MixedSourceChatSearch] Activated explicit selected-source context.',
+                    extra={
+                        'selection_mode': 'selected',
+                        'requested_source_count': len(mixed_source_manifest),
+                        'authorized_source_count': len(authorized_selected_document_ids),
+                        'narrative_source_count': len(mixed_source_narrative_document_ids),
+                        'tabular_source_count': len(mixed_source_tabular_sources),
+                        'omitted_source_count': len(
+                            mixed_source_partitions.get('unresolved_sources') or []
+                        ),
+                    },
+                    level=logging.INFO,
+                )
+            else:
+                _maybe_resolve_chat_source_manifest(
+                    settings,
+                    user_id,
+                    conversation_id,
+                    effective_selected_document_ids,
+                    scope_context,
+                )
+            request_document_context_enabled = bool(
+                hybrid_search_enabled
+                or (
+                    is_mixed_source_chat_search_enabled(settings)
+                    and document_context_requested
+                )
             )
 
             # Clear plugin invocations at start of message processing to ensure
@@ -13671,13 +14215,13 @@ def register_route_backend_chats(bp):
                 # Button states and selections
                 user_metadata['button_states'] = {
                     'image_generation': image_gen_enabled,
-                    'document_search': hybrid_search_enabled,
+                    'document_search': request_document_context_enabled,
                     'web_search': bool(web_search_enabled),
                     'url_access': bool(url_access_enabled),
                     'deep_research': bool(deep_research_enabled)
                 }
                 user_metadata['capability_usage'] = _build_capability_usage_metadata(
-                    workspace_search_enabled=hybrid_search_enabled,
+                    workspace_search_enabled=request_document_context_enabled,
                     document_action_type=DOCUMENT_ACTION_TYPE_NONE,
                     document_scope=effective_document_scope,
                     selected_document_ids=effective_selected_document_ids,
@@ -13690,12 +14234,18 @@ def register_route_backend_chats(bp):
                 )
 
                 # Document search scope and selections
-                if hybrid_search_enabled:
+                if request_document_context_enabled:
                     user_metadata['workspace_search'] = {
                         'search_enabled': True,
+                        'selection_mode': selection_mode,
+                        'document_context_requested': document_context_requested,
+                        'hybrid_search_preference': bool(hybrid_search_enabled),
                         'document_scope': effective_document_scope,
                         'selected_document_id': effective_selected_document_id,
                         'selected_document_ids': effective_selected_document_ids,
+                        'requested_document_ids': requested_selected_document_ids,
+                        'active_group_ids': effective_active_group_ids,
+                        'active_public_workspace_ids': effective_active_public_workspace_ids,
                         'tags': tags_filter,
                         'classification': classifications_to_send
                     }
@@ -13884,7 +14434,7 @@ def register_route_backend_chats(bp):
                         conversation_id=conversation_id,
                         message_type='user_message',
                         message_length=len(user_message) if user_message else 0,
-                        has_document_search=hybrid_search_enabled,
+                        has_document_search=request_document_context_enabled,
                         has_image_generation=image_gen_enabled,
                         document_scope=document_scope,
                         chat_context=actual_chat_type,
@@ -14029,7 +14579,11 @@ def register_route_backend_chats(bp):
                 except Exception as ex:
                     debug_print(f"[Content Safety] Unexpected error: {ex}")
 
-            if not original_hybrid_search_enabled and not explicit_external_retrieval_requested:
+            if (
+                not original_hybrid_search_enabled
+                and not explicit_external_retrieval_requested
+                and not mixed_source_explicit_selection
+            ):
                 prior_grounded_document_refs = _normalize_prior_grounded_document_refs(conversation_item)
                 if prior_grounded_document_refs:
                     thought_tracker.add_thought(
@@ -14143,13 +14697,64 @@ def register_route_backend_chats(bp):
                         'history_context',
                         'No prior grounded documents were available; using conversation history only'
                     )
+            if (
+                is_mixed_source_chat_search_enabled(settings)
+                and history_grounded_search_used
+            ):
+                history_context = _resolve_chat_mixed_source_partition(
+                    settings,
+                    user_id,
+                    conversation_id,
+                    effective_selected_document_ids,
+                    'history',
+                    active_group_ids=effective_active_group_ids,
+                    active_public_workspace_ids=effective_active_public_workspace_ids,
+                )
+                mixed_source_manifest = history_context.get('manifest') or []
+                mixed_source_partitions = history_context.get('partitions') or {}
+                mixed_source_narrative_document_ids = list(
+                    history_context.get('narrative_document_ids') or []
+                )
+                mixed_source_tabular_sources = list(
+                    history_context.get('tabular_sources') or []
+                )
+                effective_selected_document_ids = (
+                    mixed_source_narrative_document_ids
+                    + _get_manifest_partition_document_ids(
+                        mixed_source_partitions,
+                        'tabular_sources',
+                    )
+                )
+                effective_selected_document_id = (
+                    effective_selected_document_ids[0]
+                    if len(effective_selected_document_ids) == 1
+                    else None
+                )
         # region 4 - Augmentation
             # ---------------------------------------------------------------------
             # 4) Augmentation (Search, etc.) - Run *before* final history prep
             # ---------------------------------------------------------------------
 
             # Hybrid Search
-            if hybrid_search_enabled or history_grounded_search_used:
+            mixed_source_document_context_active = bool(
+                (hybrid_search_enabled or history_grounded_search_used)
+                if not is_mixed_source_chat_search_enabled(settings)
+                else (
+                    document_context_requested
+                    or hybrid_search_enabled
+                    or history_grounded_search_used
+                )
+            )
+            combined_documents = []
+            mixed_source_narrative_search_active = bool(
+                mixed_source_document_context_active
+                and (
+                    not is_mixed_source_chat_search_enabled(settings)
+                    or not mixed_source_manifest
+                    or mixed_source_narrative_document_ids
+                )
+            )
+            if mixed_source_narrative_search_active:
 
                 # Optional: Summarize recent history *for search* (uses its own limit)
                 if hybrid_search_enabled and enable_summarize_content_history_for_search:
@@ -14264,8 +14869,14 @@ def register_route_backend_chats(bp):
                     ):
                         search_args["active_public_workspace_id"] = effective_active_public_workspace_id
 
-                    if effective_selected_document_ids:
-                        search_args["document_ids"] = effective_selected_document_ids
+                    search_document_ids = (
+                        mixed_source_narrative_document_ids
+                        if is_mixed_source_chat_search_enabled(settings)
+                        and mixed_source_manifest
+                        else effective_selected_document_ids
+                    )
+                    if search_document_ids:
+                        search_args["document_ids"] = search_document_ids
                     elif effective_selected_document_id:
                         search_args["document_id"] = effective_selected_document_id
                     if auto_linked_chat_upload_document_ids:
@@ -14300,6 +14911,40 @@ def register_route_backend_chats(bp):
                     else:
                         # Public scope now automatically searches all visible public workspaces
                         search_results = hybrid_search(**search_args) # Assuming hybrid_search handles None document_id
+
+                    if (
+                        is_mixed_source_chat_search_enabled(settings)
+                        and not mixed_source_explicit_selection
+                        and not history_grounded_search_used
+                    ):
+                        relevance_context = _resolve_chat_mixed_source_relevance_context(
+                            settings=settings,
+                            user_id=user_id,
+                            conversation_id=conversation_id,
+                            query=search_query,
+                            search_results=search_results,
+                            document_scope=effective_document_scope,
+                            candidate_document_ids=(
+                                assigned_knowledge_filters.get('document_ids')
+                                if assigned_knowledge_filters
+                                and assigned_knowledge_filters.get('has_workspace_knowledge')
+                                else None
+                            ),
+                            tags_filter=tags_filter,
+                            active_group_ids=effective_active_group_ids,
+                            active_public_workspace_ids=effective_active_public_workspace_ids,
+                        )
+                        mixed_source_manifest = relevance_context.get('manifest') or []
+                        mixed_source_partitions = relevance_context.get('partitions') or {}
+                        mixed_source_narrative_document_ids = list(
+                            relevance_context.get('narrative_document_ids') or []
+                        )
+                        mixed_source_tabular_sources = list(
+                            relevance_context.get('tabular_sources') or []
+                        )
+                        search_results = list(
+                            relevance_context.get('search_results') or []
+                        )
                 except SemanticSearchQuotaExceededError as e:
                     debug_print(f"Semantic search quota exceeded during hybrid search: {e}")
                     return jsonify({
@@ -14314,7 +14959,6 @@ def register_route_backend_chats(bp):
                         'error': 'There was an issue with the embedding process. Please check with an admin on embedding configuration.'
                     }), 500
 
-                combined_documents = []
                 if search_results:
                     unique_doc_names = set(doc.get('file_name', 'Unknown') for doc in search_results)
                     thought_tracker.add_thought('search', f"Found {len(search_results)} results from {len(unique_doc_names)} documents")
@@ -14375,11 +15019,12 @@ def register_route_backend_chats(bp):
                     # Construct system prompt for search results
                     system_prompt_search = build_search_augmentation_system_prompt(retrieved_content)
                     # Add this to a temporary list, don't save to DB yet
-                    system_messages_for_augmentation.append({
-                        'role': 'system',
-                        'content': system_prompt_search,
-                        'documents': combined_documents # Keep track of docs used
-                    })
+                    if not is_mixed_source_chat_search_enabled(settings):
+                        system_messages_for_augmentation.append({
+                            'role': 'system',
+                            'content': system_prompt_search,
+                            'documents': combined_documents # Keep track of docs used
+                        })
 
                     # Loop through each source document/chunk used for this message
                     for source_doc in combined_documents:
@@ -14595,7 +15240,13 @@ def register_route_backend_chats(bp):
             # Update message-level chat_type based on actual document usage for this message
             # This must happen after document search is completed so search_results is populated
             message_chat_type = None
-            if (hybrid_search_enabled or history_grounded_search_used) and search_results and len(search_results) > 0:
+            mixed_source_has_authorized_evidence_sources = bool(
+                mixed_source_narrative_document_ids
+                or mixed_source_tabular_sources
+            )
+            if mixed_source_document_context_active and (
+                search_results or mixed_source_has_authorized_evidence_sources
+            ):
                 # Documents were actually used for this message
                 if effective_document_scope == 'group':
                     message_chat_type = 'group'
@@ -14653,8 +15304,10 @@ def register_route_backend_chats(bp):
 
             source_review_used = _source_review_metadata_used(source_review_result)
             user_metadata['capability_usage'] = _build_capability_usage_metadata(
-                workspace_search_enabled=hybrid_search_enabled or history_grounded_search_used,
-                workspace_search_used=bool(search_results),
+                workspace_search_enabled=mixed_source_document_context_active,
+                workspace_search_used=bool(
+                    search_results or mixed_source_has_authorized_evidence_sources
+                ),
                 workspace_search_result_count=len(search_results or []),
                 document_action_type=DOCUMENT_ACTION_TYPE_NONE,
                 document_scope=effective_document_scope,
@@ -14863,7 +15516,11 @@ def register_route_backend_chats(bp):
 
             workspace_tabular_file_contexts = []
             workspace_tabular_files = set()
-            if (hybrid_search_enabled or history_grounded_search_used) and is_tabular_processing_enabled(settings):
+            if (
+                not is_mixed_source_chat_search_enabled(settings)
+                and (hybrid_search_enabled or history_grounded_search_used)
+                and is_tabular_processing_enabled(settings)
+            ):
                 workspace_tabular_file_contexts = collect_workspace_tabular_file_contexts(
                     combined_documents=combined_documents,
                     selected_document_ids=effective_selected_document_ids,
@@ -14887,7 +15544,88 @@ def register_route_backend_chats(bp):
                     activity=thought_payload.get('activity'),
                 )
 
-            if (hybrid_search_enabled or history_grounded_search_used) and workspace_tabular_files and is_tabular_processing_enabled(settings):
+            if (
+                is_mixed_source_chat_search_enabled(settings)
+                and mixed_source_document_context_active
+                and mixed_source_manifest
+            ):
+                effective_mixed_source_selection_mode = (
+                    'selected'
+                    if mixed_source_explicit_selection
+                    else 'history'
+                    if history_grounded_search_used
+                    else 'relevance'
+                )
+                mixed_source_evidence_envelopes.extend(
+                    build_narrative_evidence_envelopes(
+                        mixed_source_partitions.get('narrative_sources') or [],
+                        search_results,
+                        effective_mixed_source_selection_mode,
+                    )
+                )
+                mixed_source_tabular_result = _execute_mixed_source_tabular_evidence(
+                    tabular_sources=mixed_source_tabular_sources,
+                    selection_mode=effective_mixed_source_selection_mode,
+                    has_narrative_sources=bool(mixed_source_narrative_document_ids),
+                    user_question=user_message,
+                    user_id=user_id,
+                    conversation_id=conversation_id,
+                    gpt_model=gpt_model,
+                    settings=settings,
+                    thought_tracker=thought_tracker,
+                    model_context=tabular_model_context,
+                )
+                mixed_source_evidence_envelopes.extend(
+                    mixed_source_tabular_result.get('evidence_envelopes') or []
+                )
+                agent_citations_list.extend(
+                    mixed_source_tabular_result.get('agent_citations') or []
+                )
+                generated_tabular_outputs_list.extend(
+                    mixed_source_tabular_result.get('generated_outputs') or []
+                )
+                generated_analysis_artifacts_list.extend(
+                    mixed_source_tabular_result.get('generated_outputs') or []
+                )
+                mixed_source_handoff = build_mixed_source_evidence_handoff(
+                    mixed_source_manifest,
+                    mixed_source_evidence_envelopes,
+                    effective_mixed_source_selection_mode,
+                )
+                system_messages_for_augmentation.append(mixed_source_handoff)
+                mixed_source_coverage = mixed_source_handoff.get(
+                    'mixed_source_coverage',
+                    {},
+                )
+                user_metadata['mixed_source_coverage'] = mixed_source_coverage
+                user_message_doc['metadata'] = user_metadata
+                cosmos_messages_container.upsert_item(user_message_doc)
+                log_event(
+                    '[MixedSourceChatSearch] Prepared bounded mixed-source synthesis evidence.',
+                    extra={
+                        'selection_mode': effective_mixed_source_selection_mode,
+                        'narrative_result_count': len(search_results or []),
+                        'tabular_candidate_count': len(mixed_source_tabular_sources),
+                        'tabular_completed_count': sum(
+                            1
+                            for envelope in mixed_source_evidence_envelopes
+                            if envelope.get('source_kind') == 'tabular'
+                            and envelope.get('status') == 'completed'
+                        ),
+                        'mixed_synthesis_count': 1,
+                        'partial_coverage': bool(
+                            mixed_source_coverage.get('partial_coverage')
+                        ),
+                    },
+                    level=logging.INFO,
+                )
+
+            if (
+                not is_mixed_source_chat_search_enabled(settings)
+                and (hybrid_search_enabled or history_grounded_search_used)
+                and workspace_tabular_files
+                and is_tabular_processing_enabled(settings)
+            ):
                 tabular_source_hint = determine_tabular_source_hint(
                     effective_document_scope,
                     active_group_id=effective_active_group_id,
@@ -15150,7 +15888,10 @@ def register_route_backend_chats(bp):
                     gpt_model=gpt_model,
                     user_message_id=user_message_id,
                     fallback_user_message=user_message,
-                    include_assistant_citation_context=not explicit_external_retrieval_requested,
+                    include_assistant_citation_context=(
+                        not explicit_external_retrieval_requested
+                        and not mixed_source_explicit_selection
+                    ),
                 )
                 summary_of_older = history_segments['summary_of_older']
                 chat_tabular_files = history_segments['chat_tabular_files']
@@ -15227,7 +15968,14 @@ def register_route_backend_chats(bp):
                 final_api_source_refs.extend(history_debug_info.get('history_message_source_refs', []))
 
                 # --- Mini SK analysis for tabular files uploaded directly to chat ---
-                if chat_tabular_files and is_tabular_processing_enabled(settings):
+                if (
+                    chat_tabular_files
+                    and is_tabular_processing_enabled(settings)
+                    and not (
+                        is_mixed_source_chat_search_enabled(settings)
+                        and (mixed_source_explicit_selection or mixed_source_tabular_sources)
+                    )
+                ):
                     chat_tabular_filenames_str = ", ".join(chat_tabular_files)
                     chat_tabular_execution_mode = get_tabular_execution_mode(user_message)
                     log_event(
@@ -15390,6 +16138,10 @@ def register_route_backend_chats(bp):
                 original_hybrid_search_enabled,
                 prior_grounded_document_refs,
                 explicit_external_retrieval_requested,
+                current_document_context_requested=(
+                    is_mixed_source_chat_search_enabled(settings)
+                    and document_context_requested
+                ),
             ):
                 history_grounding_message = build_history_grounding_system_message()
                 insert_idx = 0
@@ -15828,10 +16580,12 @@ def register_route_backend_chats(bp):
                                 'user_id': user_id,
                                 'message_id': user_message_id,
                                 'chat_type': chat_type,
-                                'document_scope': document_scope,
+                                'document_scope': effective_document_scope,
                                 'group_id': active_group_id if chat_type == 'group' else None,
                                 'hybrid_search_enabled': hybrid_search_enabled,
-                                'selected_document_id': selected_document_id,
+                                'selection_mode': selection_mode,
+                                'document_context_requested': mixed_source_document_context_active,
+                                'selected_document_id': effective_selected_document_id,
                                 'selected_document_ids': effective_selected_document_ids,
                                 'active_group_ids': effective_active_group_ids,
                                 'active_public_workspace_ids': effective_active_public_workspace_ids,
@@ -16272,8 +17026,10 @@ def register_route_backend_chats(bp):
             )
             source_review_used = _source_review_metadata_used(source_review_result)
             assistant_capability_usage = _build_capability_usage_metadata(
-                workspace_search_enabled=hybrid_search_enabled or history_grounded_search_used,
-                workspace_search_used=bool(search_results),
+                workspace_search_enabled=mixed_source_document_context_active,
+                workspace_search_used=bool(
+                    search_results or mixed_source_has_authorized_evidence_sources
+                ),
                 workspace_search_result_count=len(hybrid_citations_list or []),
                 document_action_type=DOCUMENT_ACTION_TYPE_NONE,
                 document_scope=effective_document_scope,
@@ -16430,7 +17186,7 @@ def register_route_backend_chats(bp):
                     document_scope=effective_document_scope,
                     selected_document_id=effective_selected_document_id,
                     model_deployment=actual_model_used,
-                    hybrid_search_enabled=hybrid_search_enabled or history_grounded_search_used,
+                    hybrid_search_enabled=mixed_source_document_context_active,
                     image_gen_enabled=image_gen_enabled,
                     selected_documents=combined_documents if 'combined_documents' in locals() else None,
                     selected_agent=selected_agent_name,
@@ -16867,6 +17623,39 @@ def register_route_backend_chats(bp):
                     source_review_enabled = source_review_enabled.lower() == 'true'
                 if isinstance(deep_research_enabled, str):
                     deep_research_enabled = deep_research_enabled.lower() == 'true'
+                try:
+                    document_context_contract = _normalize_chat_document_context_contract(
+                        settings,
+                        data,
+                        selected_document_ids,
+                        hybrid_search_enabled,
+                    )
+                except ValueError as contract_error:
+                    yield f"data: {json.dumps({'error': str(contract_error)})}\n\n"
+                    return
+                selected_document_ids = list(
+                    document_context_contract.get('selected_document_ids') or []
+                )
+                requested_selected_document_ids = list(selected_document_ids)
+                selected_document_id = (
+                    selected_document_ids[0]
+                    if len(selected_document_ids) == 1
+                    else None
+                )
+                selection_mode = document_context_contract.get('selection_mode')
+                document_context_requested = bool(
+                    document_context_contract.get('document_context_requested')
+                )
+                request_has_explicit_document_selection = bool(
+                    document_context_contract.get('explicit_selection')
+                )
+                request_document_context_enabled = bool(
+                    hybrid_search_enabled
+                    or (
+                        is_mixed_source_chat_search_enabled(settings)
+                        and document_context_requested
+                    )
+                )
                 user_workspace_context_requested = data.get('user_workspace_context_enabled')
                 if isinstance(user_workspace_context_requested, str):
                     user_workspace_context_requested = user_workspace_context_requested.lower() == 'true'
@@ -16931,7 +17720,7 @@ def register_route_backend_chats(bp):
                 assigned_knowledge_deep_research_urls = []
                 if assigned_knowledge_filters:
                     assigned_knowledge_user_context_active = (
-                        user_workspace_context_requested
+                        (user_workspace_context_requested or document_context_requested)
                         and _assigned_knowledge_allows_user_workspace_context(assigned_knowledge_filters)
                         and _assigned_knowledge_allows_document_action(
                             assigned_knowledge_filters,
@@ -16996,6 +17785,16 @@ def register_route_backend_chats(bp):
                         f"public_workspaces={len(effective_active_public_workspace_ids)} | "
                         f"tags={len(tags_filter)}"
                     )
+                mixed_source_explicit_selection = bool(
+                    is_mixed_source_chat_search_enabled(settings)
+                    and request_has_explicit_document_selection
+                    and (
+                        not assigned_knowledge_filters
+                        or assigned_knowledge_user_context_active
+                    )
+                )
+                mixed_source_document_context_active = request_document_context_enabled
+                mixed_source_has_authorized_evidence_sources = False
                 explicit_external_retrieval_requested = _is_explicit_external_retrieval_requested(
                     web_search_enabled=web_search_enabled,
                     url_access_enabled=url_access_enabled,
@@ -17013,8 +17812,10 @@ def register_route_backend_chats(bp):
                 def build_streaming_capability_usage():
                     source_review_was_used = _source_review_metadata_used(source_review_result)
                     return _build_capability_usage_metadata(
-                        workspace_search_enabled=hybrid_search_enabled or history_grounded_search_used,
-                        workspace_search_used=bool(search_results),
+                        workspace_search_enabled=mixed_source_document_context_active,
+                        workspace_search_used=bool(
+                            search_results or mixed_source_has_authorized_evidence_sources
+                        ),
                         workspace_search_result_count=len(hybrid_citations_list or []),
                         document_action_type=DOCUMENT_ACTION_TYPE_NONE,
                         document_scope=effective_document_scope,
@@ -17181,11 +17982,14 @@ def register_route_backend_chats(bp):
                         return
 
                 auto_linked_chat_upload_document_ids = []
-                auto_merge_chat_upload_workspace_context = _should_auto_merge_chat_upload_workspace_context(
-                    explicit_external_retrieval_requested,
-                    hybrid_search_enabled,
-                    assigned_knowledge_filters=assigned_knowledge_filters,
-                    assigned_knowledge_user_context_active=assigned_knowledge_user_context_active,
+                auto_merge_chat_upload_workspace_context = (
+                    not mixed_source_explicit_selection
+                    and _should_auto_merge_chat_upload_workspace_context(
+                        explicit_external_retrieval_requested,
+                        hybrid_search_enabled,
+                        assigned_knowledge_filters=assigned_knowledge_filters,
+                        assigned_knowledge_user_context_active=assigned_knowledge_user_context_active,
+                    )
                 )
                 if auto_merge_chat_upload_workspace_context:
                     chat_upload_context = _resolve_chat_upload_workspace_context(
@@ -17246,12 +18050,73 @@ def register_route_backend_chats(bp):
                     selected_document_id = effective_selected_document_id
                     document_scope = effective_document_scope
 
-                _maybe_resolve_chat_source_manifest(
-                    settings,
-                    user_id,
-                    conversation_id,
-                    effective_selected_document_ids,
-                    scope_context,
+                mixed_source_manifest = []
+                mixed_source_partitions = {}
+                mixed_source_narrative_document_ids = []
+                mixed_source_tabular_sources = []
+                mixed_source_evidence_envelopes = []
+                if mixed_source_explicit_selection:
+                    try:
+                        explicit_context = _resolve_chat_mixed_source_partition(
+                            settings,
+                            user_id,
+                            conversation_id,
+                            effective_selected_document_ids,
+                            'selected',
+                            active_group_ids=effective_active_group_ids,
+                            active_public_workspace_ids=effective_active_public_workspace_ids,
+                        )
+                    except ValueError as manifest_error:
+                        yield f"data: {json.dumps({'error': str(manifest_error)})}\n\n"
+                        return
+                    mixed_source_manifest = explicit_context.get('manifest') or []
+                    mixed_source_partitions = explicit_context.get('partitions') or {}
+                    mixed_source_narrative_document_ids = list(
+                        explicit_context.get('narrative_document_ids') or []
+                    )
+                    mixed_source_tabular_sources = list(
+                        explicit_context.get('tabular_sources') or []
+                    )
+                    effective_selected_document_ids = (
+                        mixed_source_narrative_document_ids
+                        + _get_manifest_partition_document_ids(
+                            mixed_source_partitions,
+                            'tabular_sources',
+                        )
+                    )
+                    effective_selected_document_id = (
+                        effective_selected_document_ids[0]
+                        if len(effective_selected_document_ids) == 1
+                        else None
+                    )
+                    log_event(
+                        '[MixedSourceChatSearch] Activated streaming explicit selected-source context.',
+                        extra={
+                            'selection_mode': 'selected',
+                            'requested_source_count': len(mixed_source_manifest),
+                            'authorized_source_count': len(effective_selected_document_ids),
+                            'narrative_source_count': len(mixed_source_narrative_document_ids),
+                            'tabular_source_count': len(mixed_source_tabular_sources),
+                            'omitted_source_count': len(
+                                mixed_source_partitions.get('unresolved_sources') or []
+                            ),
+                        },
+                        level=logging.INFO,
+                    )
+                else:
+                    _maybe_resolve_chat_source_manifest(
+                        settings,
+                        user_id,
+                        conversation_id,
+                        effective_selected_document_ids,
+                        scope_context,
+                    )
+                request_document_context_enabled = bool(
+                    hybrid_search_enabled
+                    or (
+                        is_mixed_source_chat_search_enabled(settings)
+                        and document_context_requested
+                    )
                 )
 
                 # Determine chat type
@@ -17285,13 +18150,13 @@ def register_route_backend_chats(bp):
 
                 user_metadata['button_states'] = {
                     'image_generation': False,
-                    'document_search': hybrid_search_enabled,
+                    'document_search': request_document_context_enabled,
                     'web_search': bool(web_search_enabled),
                     'url_access': bool(url_access_enabled),
                     'deep_research': bool(deep_research_enabled)
                 }
                 user_metadata['capability_usage'] = _build_capability_usage_metadata(
-                    workspace_search_enabled=hybrid_search_enabled,
+                    workspace_search_enabled=request_document_context_enabled,
                     document_action_type=DOCUMENT_ACTION_TYPE_NONE,
                     document_scope=effective_document_scope,
                     selected_document_ids=effective_selected_document_ids,
@@ -17304,12 +18169,16 @@ def register_route_backend_chats(bp):
                 )
 
                 # Document search scope and selections
-                if hybrid_search_enabled:
+                if request_document_context_enabled:
                     user_metadata['workspace_search'] = {
                         'search_enabled': True,
+                        'selection_mode': selection_mode,
+                        'document_context_requested': document_context_requested,
+                        'hybrid_search_preference': bool(hybrid_search_enabled),
                         'document_scope': effective_document_scope,
                         'selected_document_id': effective_selected_document_id,
                         'selected_document_ids': effective_selected_document_ids,
+                        'requested_document_ids': requested_selected_document_ids,
                         'active_group_ids': effective_active_group_ids,
                         'active_public_workspace_ids': effective_active_public_workspace_ids,
                         'classification': classifications_to_send
@@ -17460,7 +18329,7 @@ def register_route_backend_chats(bp):
                         conversation_id=conversation_id,
                         message_type='user_message',
                         message_length=len(user_message) if user_message else 0,
-                        has_document_search=hybrid_search_enabled,
+                        has_document_search=request_document_context_enabled,
                         has_image_generation=False,
                         document_scope=effective_document_scope,
                         chat_context=actual_chat_type,
@@ -17674,7 +18543,11 @@ def register_route_backend_chats(bp):
                     except Exception as ex:
                         debug_print(f"[Content Safety - Streaming] Unexpected error: {ex}")
 
-                if not original_hybrid_search_enabled and not explicit_external_retrieval_requested:
+                if (
+                    not original_hybrid_search_enabled
+                    and not explicit_external_retrieval_requested
+                    and not mixed_source_explicit_selection
+                ):
                     prior_grounded_document_refs = _normalize_prior_grounded_document_refs(conversation_item)
                     if prior_grounded_document_refs:
                         yield emit_thought(
@@ -17789,9 +18662,60 @@ def register_route_backend_chats(bp):
                             'No prior grounded documents were available; using conversation history only'
                         )
 
+                if (
+                    is_mixed_source_chat_search_enabled(settings)
+                    and history_grounded_search_used
+                ):
+                    history_context = _resolve_chat_mixed_source_partition(
+                        settings,
+                        user_id,
+                        conversation_id,
+                        effective_selected_document_ids,
+                        'history',
+                        active_group_ids=effective_active_group_ids,
+                        active_public_workspace_ids=effective_active_public_workspace_ids,
+                    )
+                    mixed_source_manifest = history_context.get('manifest') or []
+                    mixed_source_partitions = history_context.get('partitions') or {}
+                    mixed_source_narrative_document_ids = list(
+                        history_context.get('narrative_document_ids') or []
+                    )
+                    mixed_source_tabular_sources = list(
+                        history_context.get('tabular_sources') or []
+                    )
+                    effective_selected_document_ids = (
+                        mixed_source_narrative_document_ids
+                        + _get_manifest_partition_document_ids(
+                            mixed_source_partitions,
+                            'tabular_sources',
+                        )
+                    )
+                    effective_selected_document_id = (
+                        effective_selected_document_ids[0]
+                        if len(effective_selected_document_ids) == 1
+                        else None
+                    )
+
                 # Hybrid search (if enabled)
                 combined_documents = []
-                if hybrid_search_enabled or history_grounded_search_used:
+                mixed_source_document_context_active = bool(
+                    (hybrid_search_enabled or history_grounded_search_used)
+                    if not is_mixed_source_chat_search_enabled(settings)
+                    else (
+                        document_context_requested
+                        or hybrid_search_enabled
+                        or history_grounded_search_used
+                    )
+                )
+                mixed_source_narrative_search_active = bool(
+                    mixed_source_document_context_active
+                    and (
+                        not is_mixed_source_chat_search_enabled(settings)
+                        or not mixed_source_manifest
+                        or mixed_source_narrative_document_ids
+                    )
+                )
+                if mixed_source_narrative_search_active:
                     debug_print(
                         "[Streaming] Starting hybrid search | "
                         f"conversation_id={conversation_id} | doc_scope={effective_document_scope} | "
@@ -17834,8 +18758,14 @@ def register_route_backend_chats(bp):
                         ):
                             search_args['active_public_workspace_id'] = effective_active_public_workspace_id
 
-                        if effective_selected_document_ids:
-                            search_args['document_ids'] = effective_selected_document_ids
+                        search_document_ids = (
+                            mixed_source_narrative_document_ids
+                            if is_mixed_source_chat_search_enabled(settings)
+                            and mixed_source_manifest
+                            else effective_selected_document_ids
+                        )
+                        if search_document_ids:
+                            search_args['document_ids'] = search_document_ids
                         elif effective_selected_document_id:
                             search_args['document_id'] = effective_selected_document_id
                         if auto_linked_chat_upload_document_ids:
@@ -17865,6 +18795,40 @@ def register_route_backend_chats(bp):
                                 search_results = assigned_search_results
                         else:
                             search_results = hybrid_search(**search_args)
+
+                        if (
+                            is_mixed_source_chat_search_enabled(settings)
+                            and not mixed_source_explicit_selection
+                            and not history_grounded_search_used
+                        ):
+                            relevance_context = _resolve_chat_mixed_source_relevance_context(
+                                settings=settings,
+                                user_id=user_id,
+                                conversation_id=conversation_id,
+                                query=search_query,
+                                search_results=search_results,
+                                document_scope=effective_document_scope,
+                                candidate_document_ids=(
+                                    assigned_knowledge_filters.get('document_ids')
+                                    if assigned_knowledge_filters
+                                    and assigned_knowledge_filters.get('has_workspace_knowledge')
+                                    else None
+                                ),
+                                tags_filter=tags_filter,
+                                active_group_ids=effective_active_group_ids,
+                                active_public_workspace_ids=effective_active_public_workspace_ids,
+                            )
+                            mixed_source_manifest = relevance_context.get('manifest') or []
+                            mixed_source_partitions = relevance_context.get('partitions') or {}
+                            mixed_source_narrative_document_ids = list(
+                                relevance_context.get('narrative_document_ids') or []
+                            )
+                            mixed_source_tabular_sources = list(
+                                relevance_context.get('tabular_sources') or []
+                            )
+                            search_results = list(
+                                relevance_context.get('search_results') or []
+                            )
                         debug_print(
                             f"[Streaming] Hybrid search completed | results={len(search_results) if search_results else 0}"
                         )
@@ -18070,11 +19034,12 @@ def register_route_backend_chats(bp):
                         retrieved_content = "\n\n".join(retrieved_texts)
                         system_prompt_search = build_search_augmentation_system_prompt(retrieved_content)
 
-                        system_messages_for_augmentation.append({
-                            'role': 'system',
-                            'content': system_prompt_search,
-                            'documents': combined_documents
-                        })
+                        if not is_mixed_source_chat_search_enabled(settings):
+                            system_messages_for_augmentation.append({
+                                'role': 'system',
+                                'content': system_prompt_search,
+                                'documents': combined_documents
+                            })
 
                         hybrid_citations_list.sort(key=_build_hybrid_citation_sort_key, reverse=True)
                     elif history_grounded_search_used:
@@ -18103,7 +19068,11 @@ def register_route_backend_chats(bp):
 
                 workspace_tabular_file_contexts = []
                 workspace_tabular_files = set()
-                if (hybrid_search_enabled or history_grounded_search_used) and is_tabular_processing_enabled(settings):
+                if (
+                    not is_mixed_source_chat_search_enabled(settings)
+                    and (hybrid_search_enabled or history_grounded_search_used)
+                    and is_tabular_processing_enabled(settings)
+                ):
                     workspace_tabular_file_contexts = collect_workspace_tabular_file_contexts(
                         combined_documents=combined_documents,
                         selected_document_ids=effective_selected_document_ids,
@@ -18119,7 +19088,93 @@ def register_route_backend_chats(bp):
                         file_context['file_name'] for file_context in workspace_tabular_file_contexts
                     }
 
-                if (hybrid_search_enabled or history_grounded_search_used) and workspace_tabular_files and is_tabular_processing_enabled(settings):
+                if (
+                    is_mixed_source_chat_search_enabled(settings)
+                    and mixed_source_document_context_active
+                    and mixed_source_manifest
+                ):
+                    effective_mixed_source_selection_mode = (
+                        'selected'
+                        if mixed_source_explicit_selection
+                        else 'history'
+                        if history_grounded_search_used
+                        else 'relevance'
+                    )
+                    mixed_source_evidence_envelopes.extend(
+                        build_narrative_evidence_envelopes(
+                            mixed_source_partitions.get('narrative_sources') or [],
+                            search_results,
+                            effective_mixed_source_selection_mode,
+                        )
+                    )
+                    mixed_source_tabular_result = _execute_mixed_source_tabular_evidence(
+                        tabular_sources=mixed_source_tabular_sources,
+                        selection_mode=effective_mixed_source_selection_mode,
+                        has_narrative_sources=bool(mixed_source_narrative_document_ids),
+                        user_question=user_message,
+                        user_id=user_id,
+                        conversation_id=conversation_id,
+                        gpt_model=gpt_model,
+                        settings=settings,
+                        thought_tracker=thought_tracker,
+                        live_thought_callback=publish_live_plugin_thought,
+                        model_context=tabular_model_context,
+                    )
+                    mixed_source_evidence_envelopes.extend(
+                        mixed_source_tabular_result.get('evidence_envelopes') or []
+                    )
+                    agent_citations_list.extend(
+                        mixed_source_tabular_result.get('agent_citations') or []
+                    )
+                    generated_tabular_outputs_list.extend(
+                        mixed_source_tabular_result.get('generated_outputs') or []
+                    )
+                    generated_analysis_artifacts_list.extend(
+                        mixed_source_tabular_result.get('generated_outputs') or []
+                    )
+                    mixed_source_handoff = build_mixed_source_evidence_handoff(
+                        mixed_source_manifest,
+                        mixed_source_evidence_envelopes,
+                        effective_mixed_source_selection_mode,
+                    )
+                    system_messages_for_augmentation.append(mixed_source_handoff)
+                    mixed_source_coverage = mixed_source_handoff.get(
+                        'mixed_source_coverage',
+                        {},
+                    )
+                    mixed_source_has_authorized_evidence_sources = bool(
+                        mixed_source_narrative_document_ids
+                        or mixed_source_tabular_sources
+                    )
+                    user_metadata['mixed_source_coverage'] = mixed_source_coverage
+                    user_message_doc['metadata'] = user_metadata
+                    cosmos_messages_container.upsert_item(user_message_doc)
+                    log_event(
+                        '[MixedSourceChatSearch] Prepared streaming bounded mixed-source synthesis evidence.',
+                        extra={
+                            'selection_mode': effective_mixed_source_selection_mode,
+                            'narrative_result_count': len(search_results or []),
+                            'tabular_candidate_count': len(mixed_source_tabular_sources),
+                            'tabular_completed_count': sum(
+                                1
+                                for envelope in mixed_source_evidence_envelopes
+                                if envelope.get('source_kind') == 'tabular'
+                                and envelope.get('status') == 'completed'
+                            ),
+                            'mixed_synthesis_count': 1,
+                            'partial_coverage': bool(
+                                mixed_source_coverage.get('partial_coverage')
+                            ),
+                        },
+                        level=logging.INFO,
+                    )
+
+                if (
+                    not is_mixed_source_chat_search_enabled(settings)
+                    and (hybrid_search_enabled or history_grounded_search_used)
+                    and workspace_tabular_files
+                    and is_tabular_processing_enabled(settings)
+                ):
                     tabular_source_hint = determine_tabular_source_hint(
                         effective_document_scope,
                         active_group_id=effective_active_group_id,
@@ -18391,7 +19446,9 @@ def register_route_backend_chats(bp):
 
                 # Update message chat type
                 message_chat_type = None
-                if (hybrid_search_enabled or history_grounded_search_used) and search_results and len(search_results) > 0:
+                if mixed_source_document_context_active and (
+                    search_results or mixed_source_has_authorized_evidence_sources
+                ):
                     if effective_document_scope == 'group':
                         message_chat_type = 'group'
                     elif effective_document_scope == 'public':
@@ -18403,8 +19460,10 @@ def register_route_backend_chats(bp):
 
                 source_review_used = _source_review_metadata_used(source_review_result)
                 user_metadata['capability_usage'] = _build_capability_usage_metadata(
-                    workspace_search_enabled=hybrid_search_enabled or history_grounded_search_used,
-                    workspace_search_used=bool(search_results),
+                    workspace_search_enabled=mixed_source_document_context_active,
+                    workspace_search_used=bool(
+                        search_results or mixed_source_has_authorized_evidence_sources
+                    ),
                     workspace_search_result_count=len(search_results or []),
                     document_action_type=DOCUMENT_ACTION_TYPE_NONE,
                     document_scope=effective_document_scope,
@@ -18446,7 +19505,10 @@ def register_route_backend_chats(bp):
                         gpt_model=gpt_model,
                         user_message_id=user_message_id,
                         fallback_user_message=user_message,
-                        include_assistant_citation_context=not explicit_external_retrieval_requested,
+                        include_assistant_citation_context=(
+                            not explicit_external_retrieval_requested
+                            and not mixed_source_explicit_selection
+                        ),
                     )
                     summary_of_older = history_segments['summary_of_older']
                     chat_tabular_files = history_segments['chat_tabular_files']
@@ -18473,7 +19535,14 @@ def register_route_backend_chats(bp):
                     final_api_source_refs.extend(history_debug_info.get('history_message_source_refs', []))
 
                     # --- Mini SK analysis for tabular files uploaded directly to chat ---
-                    if chat_tabular_files and is_tabular_processing_enabled(settings):
+                    if (
+                        chat_tabular_files
+                        and is_tabular_processing_enabled(settings)
+                        and not (
+                            is_mixed_source_chat_search_enabled(settings)
+                            and (mixed_source_explicit_selection or mixed_source_tabular_sources)
+                        )
+                    ):
                         chat_tabular_filenames_str = ", ".join(chat_tabular_files)
                         chat_tabular_execution_mode = get_tabular_execution_mode(user_message)
                         log_event(
@@ -18645,6 +19714,10 @@ def register_route_backend_chats(bp):
                     original_hybrid_search_enabled,
                     prior_grounded_document_refs,
                     explicit_external_retrieval_requested,
+                    current_document_context_requested=(
+                        is_mixed_source_chat_search_enabled(settings)
+                        and document_context_requested
+                    ),
                 ):
                     history_grounding_message = build_history_grounding_system_message()
                     insert_idx = 0
@@ -18987,6 +20060,8 @@ def register_route_backend_chats(bp):
                                             'document_scope': effective_document_scope,
                                             'group_id': effective_active_group_id if chat_type == 'group' else None,
                                             'hybrid_search_enabled': hybrid_search_enabled,
+                                            'selection_mode': selection_mode,
+                                            'document_context_requested': mixed_source_document_context_active,
                                             'selected_document_id': effective_selected_document_id,
                                             'selected_document_ids': effective_selected_document_ids,
                                             'active_group_ids': effective_active_group_ids,
@@ -19519,7 +20594,7 @@ def register_route_backend_chats(bp):
                             document_scope=effective_document_scope,
                             selected_document_id=effective_selected_document_id,
                             model_deployment=final_model_used if use_agent_streaming else gpt_model,
-                            hybrid_search_enabled=hybrid_search_enabled or history_grounded_search_used,
+                            hybrid_search_enabled=mixed_source_document_context_active,
                             image_gen_enabled=False,
                             selected_documents=combined_documents if combined_documents else None,
                             selected_agent=agent_name_used if use_agent_streaming else None,
@@ -20516,11 +21591,13 @@ def should_apply_history_grounding_message(
     original_hybrid_search_enabled,
     prior_grounded_document_refs,
     explicit_external_retrieval_requested=False,
+    current_document_context_requested=False,
 ):
     """Apply bounded grounding only when prior grounded docs exist for this conversation."""
     return (
         not bool(original_hybrid_search_enabled)
         and not bool(explicit_external_retrieval_requested)
+        and not bool(current_document_context_requested)
         and bool(prior_grounded_document_refs)
     )
 

--- a/application/single_app/route_backend_collaboration.py
+++ b/application/single_app/route_backend_collaboration.py
@@ -307,6 +307,8 @@ def _build_collaboration_stream_request_payload(data, source_conversation_id, me
         'message': message_content,
         'conversation_id': source_conversation_id,
         'hybrid_search': bool(data.get('hybrid_search')),
+        'selection_mode': data.get('selection_mode'),
+        'document_context_requested': data.get('document_context_requested'),
         'web_search_enabled': bool(data.get('web_search_enabled')),
         'selected_document_id': data.get('selected_document_id'),
         'selected_document_ids': data.get('selected_document_ids') or [],

--- a/application/single_app/route_backend_conversations.py
+++ b/application/single_app/route_backend_conversations.py
@@ -171,6 +171,67 @@ def _normalize_workspace_document_delete_ids(raw_document_ids):
     return normalized_document_ids
 
 
+def _build_replayed_document_context(original_metadata):
+    """Rebuild document-context intent from stored metadata for retry and edit."""
+    metadata = original_metadata if isinstance(original_metadata, dict) else {}
+    workspace_search = metadata.get('workspace_search')
+    if not isinstance(workspace_search, dict):
+        workspace_search = metadata.get('document_search')
+    workspace_search = workspace_search if isinstance(workspace_search, dict) else {}
+
+    selected_document_ids = (
+        workspace_search.get('requested_document_ids')
+        or workspace_search.get('selected_document_ids')
+        or []
+    )
+    if not isinstance(selected_document_ids, list):
+        selected_document_ids = [selected_document_ids]
+    selected_document_ids = [
+        str(document_id or '').strip()
+        for document_id in selected_document_ids
+        if str(document_id or '').strip()
+    ]
+    selected_document_id = str(
+        workspace_search.get('selected_document_id')
+        or workspace_search.get('document_id')
+        or ''
+    ).strip()
+    if selected_document_id and selected_document_id not in selected_document_ids:
+        selected_document_ids.insert(0, selected_document_id)
+
+    selection_mode = str(workspace_search.get('selection_mode') or '').strip().lower()
+    if selection_mode not in {'selected', 'all', 'history', 'relevance'}:
+        selection_mode = 'selected' if selected_document_ids else 'relevance'
+    document_context_requested = workspace_search.get('document_context_requested')
+    if not isinstance(document_context_requested, bool):
+        document_context_requested = bool(
+            workspace_search.get('search_enabled')
+            or workspace_search.get('enabled')
+            or selected_document_ids
+        )
+
+    return {
+        'hybrid_search': bool(
+            workspace_search.get('hybrid_search_preference')
+            if 'hybrid_search_preference' in workspace_search
+            else workspace_search.get('enabled')
+            or workspace_search.get('search_enabled')
+        ),
+        'selection_mode': selection_mode,
+        'document_context_requested': document_context_requested,
+        'selected_document_id': selected_document_ids[0] if selected_document_ids else None,
+        'selected_document_ids': selected_document_ids,
+        'doc_scope': workspace_search.get('document_scope') or workspace_search.get('scope'),
+        'top_n': workspace_search.get('top_n'),
+        'classifications': (
+            workspace_search.get('classification')
+            or workspace_search.get('classifications')
+        ),
+        'active_group_ids': workspace_search.get('active_group_ids') or [],
+        'active_public_workspace_ids': workspace_search.get('active_public_workspace_ids') or [],
+    }
+
+
 def _get_requested_workspace_document_delete_ids_for_conversation(payload, conversation_id):
     if not isinstance(payload, dict):
         return []
@@ -2641,16 +2702,13 @@ def register_route_backend_conversations(bp):
                 "message_retry_created",
             )
             # Build chat request parameters from original message metadata
+            replayed_document_context = _build_replayed_document_context(original_metadata)
             chat_request = {
                 'message': user_content,
                 'conversation_id': conversation_id,
                 'model_deployment': selected_model or original_metadata.get('model_selection', {}).get('selected_model'),
                 'reasoning_effort': reasoning_effort or original_metadata.get('reasoning_effort'),
-                'hybrid_search': original_metadata.get('document_search', {}).get('enabled', False),
-                'selected_document_id': original_metadata.get('document_search', {}).get('document_id'),
-                'doc_scope': original_metadata.get('document_search', {}).get('scope'),
-                'top_n': original_metadata.get('document_search', {}).get('top_n'),
-                'classifications': original_metadata.get('document_search', {}).get('classifications'),
+                **replayed_document_context,
                 'image_generation': original_metadata.get('image_generation', {}).get('enabled', False),
                 'active_group_id': original_metadata.get('chat_context', {}).get('group_id'),
                 'active_public_workspace_id': original_metadata.get('chat_context', {}).get('public_workspace_id'),
@@ -2864,16 +2922,13 @@ def register_route_backend_conversations(bp):
             )
             # Build chat request parameters from original message metadata
             # Keep all original settings (model, reasoning, doc search, etc.)
+            replayed_document_context = _build_replayed_document_context(original_metadata)
             chat_request = {
                 'message': edited_content,  # Use edited content
                 'conversation_id': conversation_id,
                 'model_deployment': original_metadata.get('model_selection', {}).get('selected_model'),
                 'reasoning_effort': original_metadata.get('reasoning_effort'),
-                'hybrid_search': original_metadata.get('document_search', {}).get('enabled', False),
-                'selected_document_id': original_metadata.get('document_search', {}).get('document_id'),
-                'doc_scope': original_metadata.get('document_search', {}).get('scope'),
-                'top_n': original_metadata.get('document_search', {}).get('top_n'),
-                'classifications': original_metadata.get('document_search', {}).get('classifications'),
+                **replayed_document_context,
                 'image_generation': original_metadata.get('image_generation', {}).get('enabled', False),
                 'active_group_id': original_metadata.get('chat_context', {}).get('group_id'),
                 'active_public_workspace_id': original_metadata.get('chat_context', {}).get('public_workspace_id'),

--- a/application/single_app/semantic_kernel_plugins/tabular_processing_plugin.py
+++ b/application/single_app/semantic_kernel_plugins/tabular_processing_plugin.py
@@ -234,6 +234,14 @@ class TabularProcessingPlugin:
             for workspace_id in (authorized_context.get('active_public_workspace_ids') or [])
             if str(workspace_id or '').strip()
         ]
+        authorized_blob_locations = [
+            [str(location[0]), str(location[1])]
+            for location in authorized_context.get('authorized_blob_locations') or []
+            if isinstance(location, (list, tuple))
+            and len(location) == 2
+            and str(location[0] or '').strip()
+            and str(location[1] or '').strip()
+        ]
 
         return {
             'user_id': authorized_user_id,
@@ -244,6 +252,7 @@ class TabularProcessingPlugin:
             'active_public_workspace_id': (
                 str(authorized_context.get('active_public_workspace_id') or '').strip() or None
             ),
+            'authorized_blob_locations': authorized_blob_locations,
         }
 
     def _resolve_authorized_scope_arguments(
@@ -346,6 +355,14 @@ class TabularProcessingPlugin:
 
     def _is_authorized_blob_location(self, container_name: str, blob_path: str, authorized_context: dict) -> bool:
         """Ensure remembered blob locations still fall within the caller's authorized request scope."""
+        exact_authorized_locations = {
+            (str(location[0]), str(location[1]))
+            for location in authorized_context.get('authorized_blob_locations') or []
+            if isinstance(location, (list, tuple)) and len(location) == 2
+        }
+        if (str(container_name or ''), str(blob_path or '')) in exact_authorized_locations:
+            return True
+
         source = self._infer_source_from_container(container_name)
         blob_parts = [part for part in str(blob_path or '').split('/') if part]
         if not source or not blob_parts:

--- a/application/single_app/static/js/chat/chat-messages.js
+++ b/application/single_app/static/js/chat/chat-messages.js
@@ -6102,6 +6102,8 @@ export function buildChatRequestPayload(finalMessageToSend, conversationId = cur
       .filter(value => value);
     selectedDocumentId = selectedDocumentIds.length > 0 ? selectedDocumentIds[0] : null;
   }
+  const selectionMode = selectedDocumentIds.length > 0 ? 'selected' : 'relevance';
+  const documentContextRequested = hybridSearchEnabled || selectedDocumentIds.length > 0;
 
   let imageGenEnabled = false;
   const igbtn = document.getElementById('image-generate-btn');
@@ -6216,6 +6218,8 @@ export function buildChatRequestPayload(finalMessageToSend, conversationId = cur
     message: finalMessageToSend,
     conversation_id: conversationId,
     hybrid_search: hybridSearchEnabled,
+    selection_mode: selectionMode,
+    document_context_requested: documentContextRequested,
     user_workspace_context_enabled: userWorkspaceContextEnabled,
     web_search_enabled: webSearchEnabled,
     url_access_enabled: urlAccessEnabled,
@@ -6277,6 +6281,13 @@ export function buildCollaborativeInvocationTarget(messageData = {}, explicitInv
     messageData.agent_info
     && (messageData.agent_info.id || messageData.agent_info.name || messageData.agent_info.display_name)
   );
+  const workspaceContextInvocationRequested = Boolean(
+    messageData.hybrid_search
+    || (
+      messageData.document_context_requested
+      && window.appSettings?.enable_mixed_source_chat_search
+    )
+  );
   const sourceMode = messageData.image_generation
     ? 'image_generation'
     : hasAgentTarget
@@ -6287,7 +6298,7 @@ export function buildCollaborativeInvocationTarget(messageData = {}, explicitInv
     ? 'url_access'
     : messageData.web_search_enabled
     ? 'web_search'
-    : messageData.hybrid_search
+    : workspaceContextInvocationRequested
     ? 'workspace'
     : messageData.prompt_info
     ? 'prompt'

--- a/application/single_app/templates/chats.html
+++ b/application/single_app/templates/chats.html
@@ -1487,6 +1487,7 @@
         enable_multi_model_endpoints: {{ enable_multi_model_endpoints|tojson }},
         enable_thoughts: {{ settings.enable_thoughts|tojson }},
         enable_collaborative_conversations: {{ settings.enable_collaborative_conversations|tojson }},
+        enable_mixed_source_chat_search: {{ app_settings.enable_mixed_source_chat_search|default(false, true)|tojson }},
         documentActionCapabilities: {{ settings.document_action_capabilities|default({}, true)|tojson|safe }}
     };
 

--- a/docs/explanation/features/MIXED_SOURCE_CHAT_AND_SEARCH_CONSISTENCY.md
+++ b/docs/explanation/features/MIXED_SOURCE_CHAT_AND_SEARCH_CONSISTENCY.md
@@ -1,0 +1,164 @@
+# Mixed-Source Chat and Search Consistency
+
+Implemented in version: **0.250.064**
+
+GitHub issue: [#1057](https://github.com/microsoft/simplechat/issues/1057)
+
+Parent initiative: [#1055](https://github.com/microsoft/simplechat/issues/1055)
+
+Phase 1 dependency: [#1056](https://github.com/microsoft/simplechat/issues/1056)
+
+## Overview
+
+SimpleChat Chat and workflow Search now treat explicit document selections as authoritative context even when the Search Documents panel is closed. Narrative documents continue through bounded hybrid retrieval, while selected or relevance-chosen CSV and Excel sources use the existing tabular planner and tool runner. Both branches normalize their results into the bounded evidence-envelope contract introduced in Phase 1 and provide one coverage-aware synthesis handoff to the selected model or agent.
+
+This is Phase 2 of the mixed-source orchestration initiative. Explicit-selection behavior changes only when the independent `enable_mixed_source_chat_search` flag is enabled. Relevance-derived table candidates use a second default-off rollout stage.
+
+## Purpose
+
+Previously, the browser could send valid `selected_document_ids` with `hybrid_search: false` after the Search Documents panel closed. Standard Chat, streaming Chat, and tabular execution then treated the panel-derived toggle as the authority and ignored the explicit selection. Workflow Search retrieved narrative chunks but did not run selected tables through tabular tools.
+
+Phase 2 separates source intent from retrieval preference and gives every explicit selected source a terminal coverage state without turning Chat or Search into exhaustive catalog analysis.
+
+## Dependencies
+
+- The Phase 1 authorized source manifest, capability partition, selection mode, and bounded evidence envelope from `functions_mixed_source_orchestration.py`
+- Existing authorization-aware document resolution in `functions_search_service.py`
+- Existing hybrid search, tabular planning, tool invocation, citation, generated-output, model, agent, and workflow runners
+- Existing conversation history sufficiency and authorized grounding revalidation helpers
+- Structured telemetry through `functions_appinsights.log_event(...)`
+
+No new authorization model, tabular runner, synthesis contract, route, storage container, or persisted source-reuse mechanism is introduced.
+
+## Technical Specifications
+
+### Request Contract
+
+The shared Chat payload now sends:
+
+- `selection_mode`: `selected` for one or more explicit IDs; otherwise `relevance`
+- `selected_document_ids`: the ordered explicit selection
+- `document_context_requested`: true whenever explicit IDs exist, even if the panel is closed
+- `hybrid_search`: the existing panel-derived compatibility and retrieval preference
+
+The backend validates contradictory values and fails closed. Explicit IDs force selected mode and document context. With the rollout flag disabled, the legacy toggle-gated behavior remains active.
+
+Collaboration streaming and retry/edit replay preserve the same fields. Replayed IDs remain untrusted hints and are reauthorized before use.
+
+### Effective Context Order
+
+Chat resolves evidence in this order:
+
+1. A fresh authorized manifest for the current explicit selection
+2. Freshly reauthorized conversation grounding only when there is no current selection and the history assessor requires new evidence
+3. Relevance-bounded catalog candidates
+
+Current explicit selections suppress stale conversation source guidance, automatic source expansion, and duplicate chat-upload table execution. History-sufficient turns still answer from existing conversation context without rerunning retrieval or tabular tools. Phase 2 does not persist a new follow-up source-selection record.
+
+### Native Engine Dispatch
+
+The manifest is partitioned once by source capability:
+
+- Narrative sources are sent to bounded hybrid retrieval using only their authorized IDs.
+- Explicit tabular sources are sent one at a time through the existing tabular planner and runner so each table reaches a completed, failed, or intentionally skipped terminal state.
+- A tabular source is completed only after the existing runner records at least one successful native tabular tool call. Nonempty model text without tool coverage fails closed.
+- Clearly narrative-only prompts may skip row-level processing for a selected table; collective summaries, schema questions, calculations, and table-oriented prompts invoke the tabular path.
+- Unauthorized, unresolved, and unsupported sources never reach an engine and contribute only scrubbed failure coverage.
+
+The manifest carries an internal request-scoped storage locator for authorized tabular records. The existing tabular plugin accepts that exact location only when it appears in the current request authorization context, preserving archived revision identity and approved shared-document access without authorizing arbitrary blob prefixes. The locator is not logged or included in synthesis evidence.
+
+Tabular tool citations, inline chart citations, and generated outputs continue through their existing channels. Narrative excerpts continue through hybrid citations.
+
+### Bounded Relevance Candidates
+
+All Documents Chat and Search remain relevance-bounded. When `enable_mixed_source_relevance_candidates` is also enabled, a second authorized search over indexed schema-rich chunks considers spreadsheet, workbook, worksheet, CSV, column, and table terms. It requests at most 36 results and admits at most six unique tabular document candidates.
+
+Candidate IDs are resolved again through the Phase 1 manifest before tabular execution. Assigned-knowledge searches remain constrained to their trusted document allowlist. No code enumerates or processes the entire authorized catalog.
+
+### Evidence and Synthesis
+
+Narrative and tabular results are normalized into the Phase 1 evidence envelope. The final bounded handoff records:
+
+- Selection origin: selected, history, or relevance
+- Native engine and terminal status for each source
+- Bounded narrative excerpts and citation identifiers
+- Bounded computed tabular summaries and tool citations
+- Missing, unauthorized, unsupported, skipped, or failed coverage
+- Whether the final answer must state partial coverage
+
+The same handoff reaches standard Chat, streaming Chat, local model runners, local agent runners, Foundry-backed runners, and model or agent workflow Search.
+
+### Diagnostics
+
+Phase 2 emits aggregate structured diagnostics for:
+
+- Explicit-selection activations
+- Narrative result counts
+- Tabular candidate, completed, failed, and skipped counts
+- Mixed synthesis count
+- Selected, history, and relevance decisions
+- Partial coverage and authorization/failure omissions
+
+Diagnostics do not include document IDs, filenames, content, blob paths, prompts, evidence, credentials, or raw configuration.
+
+### API Endpoints
+
+No routes are added or moved. Existing Chat, streaming Chat, collaboration, retry/edit, and workflow execution paths consume the new internal request fields.
+
+### Configuration
+
+- `enable_mixed_source_chat_search`: default off; enables Phase 2 Chat and Search behavior.
+- `enable_mixed_source_relevance_candidates`: default off and effective only when the Phase 2 flag is enabled; activates relevance-derived table candidates after explicit-selection telemetry is stable.
+- `enable_mixed_source_manifest`: remains the independent Phase 1 shadow flag and is not a prerequisite for Phase 2.
+
+Disabling the Phase 2 flag restores legacy toggle-gated Chat and narrative-only workflow Search behavior without a data migration.
+
+## Security
+
+- Personal sources are reauthorized through current ownership or approved sharing checks.
+- Group sources are reauthorized against current group membership.
+- Public sources are reauthorized against currently visible public workspaces.
+- Chat-upload sources require ownership of the active conversation.
+- Caller-supplied scope, workspace IDs, ownership fields, CSS state, and persisted metadata are never accepted as authorization decisions.
+- Missing and unauthorized sources retain the same scrubbed unresolved shape, preventing a metadata enumeration oracle.
+- Workflow tabular tool context is derived from the freshly authorized manifest, not from workflow payload scope values.
+- Browser rendering and payload changes introduce no HTML sinks, external runtime assets, or raw settings exposure.
+
+## Usage
+
+Enable `enable_mixed_source_chat_search` in application settings. Users may select narrative and tabular documents, close the Search Documents panel, and send a standard Chat prompt. The explicit selection remains active. Workflow Search uses the same mixed-source behavior for selected or bounded recent targets. After explicit-selection telemetry is stable, enable `enable_mixed_source_relevance_candidates` to allow bounded relevance-derived tables to compete outside the initial chunk hits.
+
+Disable the flag to roll back to the legacy `hybrid_search` gate while retaining the Phase 1 contracts.
+
+## Testing and Validation
+
+- Functional coverage: `functional_tests/test_mixed_source_chat_search_consistency.py`
+- Shared contract coverage: `functional_tests/test_mixed_source_manifest_contracts.py`
+- Browser payload coverage: `ui_tests/test_chat_mixed_source_selection_payload.py`
+- Existing workflow, history-grounding, selected-document authorization, route-policy, broken-access-control, and XSS guardrails remain part of the validation gate.
+
+Coverage includes panel-open/panel-closed equivalence, standard/streaming shared execution, PDF plus XLSX, DOCX plus CSV in both orders, calculations, narrative-only prompts, per-table terminal coverage, partial failure, personal/group/public/chat-upload scopes, workflow model and agent runners, relevant tables outside initial hits, collaboration/replay/Foundry propagation, diagnostics privacy, and flag-off rollback.
+
+## Performance
+
+- Initial narrative retrieval remains bounded by existing Chat and Search limits.
+- The metadata/schema candidate stage is capped at 36 search results and six tabular candidates.
+- Only planner-selected relevance candidates receive tabular analytical calls.
+- Explicit tables run independently to guarantee terminal coverage; evidence is bounded before final synthesis.
+- Exhaustive rows remain in existing generated artifacts and checkpoints rather than model context.
+
+## Known Limitations and Scope Guardrails
+
+Phase 2 does not implement:
+
+- Exhaustive Analyze All Documents semantics from Phase 3 (#1058)
+- Cross-format Compare from Phase 4 (#1059)
+- New persisted follow-up source reuse from Phase 5 (#1060)
+- Full route-to-service extraction, broader hardening, or rollout completion from Phase 6 (#1061)
+- Per-document workflow-mode changes
+
+Chat and Search remain relevance-bounded. Analyze and Compare behavior is otherwise unchanged by this phase.
+
+## Related Version Update
+
+`application/single_app/config.py` was updated from **0.250.062** to **0.250.064** after preserving a concurrent application version increment while completing the Phase 2 delivery associated with #1057.

--- a/docs/explanation/fixes/COSMOS_MIGRATION_JSON_PROPERTY_AND_SKIP_REPORTING_FIX.md
+++ b/docs/explanation/fixes/COSMOS_MIGRATION_JSON_PROPERTY_AND_SKIP_REPORTING_FIX.md
@@ -1,0 +1,65 @@
+# Cosmos Migration JSON Property, Skip Reporting, and Throttling Recovery Fix
+
+Fixed in version: **0.250.064**
+
+## Issue
+
+The Cosmos DB migration stopped while parsing a document-feed response when a
+source document contained a JSON property whose name was an empty string.
+PowerShell's default `ConvertFrom-Json` object conversion rejects that valid
+JSON shape. Any individual destination write failure also stopped the entire
+migration without leaving a durable document-level audit record. A sustained
+Cosmos DB HTTP 429 response similarly ended the run after its request retry
+budget was exhausted, requiring an administrator to restart it manually.
+
+## Root Cause
+
+Cosmos document responses and writable document clones were converted to
+`PSCustomObject`. That representation cannot preserve empty or case-distinct
+JSON property names. Parallel write failures were emitted as events, but the
+parent migration treated every failed event as fatal.
+
+## Technical Details
+
+- Document feeds and document write responses use
+  `ConvertFrom-Json -AsHashtable`, preserving empty, nested-empty, and
+  case-distinct property names.
+- Writable document clones use the same ordered hash-table representation and
+  remove only Cosmos-managed properties before serialization.
+- Document preparation failures and document-scoped HTTP 400, 409, 413, and
+  422 write failures are skipped without stopping later documents.
+- Authentication, connectivity, exhausted transient retries, feed failures,
+  and other systemic errors remain fatal.
+- Exhausted HTTP 429 document writes enter bounded automatic recovery. The
+  script pauses with a per-second progress countdown, then retries only the
+  throttled documents. `MaxThrottleRecoveryPauses` defaults to `5`, and
+  `ThrottleRecoveryPauseSeconds` defaults to `60`. Once the pause budget is
+  exhausted, the failure explains the affected container/document count and
+  recommends lowering `MaxConcurrentDocuments`, increasing destination RU
+  capacity, or rerunning with the same state file.
+- Each affected container records `ErrorSkippedCount` and structured
+  `SkippedDocuments` entries in the migration state JSON. Completed containers
+  store them under `result`; interrupted or failed containers retain the latest
+  audit under `progress`.
+- The final summary records the aggregate count and prints an admin warning
+  with the state path. If a later systemic error stops the run, the ordinary
+  migration failure message and an admin review warning are shown, while any
+  earlier document skips remain in the failed container's
+  `progress.SkippedDocuments` list.
+
+Files modified:
+
+- `scripts/Migration-Cosmos.ps1`
+- `functional_tests/test_cosmos_migration_document_skip_reporting.py`
+- `application/single_app/config.py`
+
+## Validation
+
+The focused functional test runs the bounded parallel-write path against a
+mock Cosmos REST API. It verifies that a document containing empty and
+case-distinct property names is copied unchanged, a rejected document is
+recorded, a later document still copies, the state counts are correct, and the
+completion output directs the admin to the audit details.
+
+The application version in `application/single_app/config.py` was updated to
+`0.250.064` with this fix.

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,23 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](/explanation/features/) and [Fixes by Version](/explanation/fixes/).
 
+### **(v0.250.064)**
+
+#### New Features
+
+*   **Mixed-Source Chat and Search Consistency**
+    *   Explicit document selections now remain authoritative when the Search Documents panel is closed, with `hybrid_search` retained only as a compatibility and retrieval preference.
+    *   Standard and streaming Chat plus workflow Search now reauthorize and partition selected narrative and tabular sources, run each through its native bounded engine, and synthesize one response with narrative citations, tabular tool citations, and partial-coverage reporting.
+    *   All Documents remains relevance-bounded through an independently staged, capped authorized schema-candidate search; both `enable_mixed_source_chat_search` and the later `enable_mixed_source_relevance_candidates` stage default off for rollback compatibility.
+    *   (Ref: microsoft/simplechat#1057, parent microsoft/simplechat#1055, Phase 1 microsoft/simplechat#1056, `functions_mixed_source_orchestration.py`, `route_backend_chats.py`, `functions_workflow_runner.py`, `MIXED_SOURCE_CHAT_AND_SEARCH_CONSISTENCY.md`)
+
+#### Bug Fixes
+
+*   **Cosmos Migration JSON and Throttling Recovery**
+    *   Preserved empty and case-distinct JSON property names during Cosmos document migration, recorded nonfatal document write skips in migration state, and continued later documents.
+    *   Added bounded automatic recovery for exhausted HTTP 429 document writes, with pause progress, resumed throttled documents, and durable state reporting.
+    *   (Ref: `scripts/Migration-Cosmos.ps1`, `Migration-State.ps1`, `test_cosmos_migration_document_skip_reporting.py`, `COSMOS_MIGRATION_JSON_PROPERTY_AND_SKIP_REPORTING_FIX.md`)
+
 ### **(v0.250.062)**
 
 #### New Features

--- a/functional_tests/test_cosmos_migration_document_skip_reporting.py
+++ b/functional_tests/test_cosmos_migration_document_skip_reporting.py
@@ -1,0 +1,392 @@
+# test_cosmos_migration_document_skip_reporting.py
+#!/usr/bin/env python3
+"""
+Functional test for Cosmos migration JSON property and skip reporting.
+Version: 0.250.064
+Implemented in: 0.250.064
+
+This test ensures documents with empty or case-distinct JSON property names
+are copied correctly and document-scoped write failures are recorded without
+stopping later writes.
+"""
+
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "Migration-Cosmos.ps1"
+
+
+def _powershell_single_quote(value: Path) -> str:
+    """Escape a path for a PowerShell single-quoted string."""
+    return str(value).replace("'", "''")
+
+
+def test_cosmos_migration_document_skip_reporting() -> None:
+    """Exercise empty-name JSON fields and nonfatal write rejection reporting."""
+    powershell = shutil.which("pwsh")
+    if not powershell:
+        raise AssertionError("PowerShell 7 is required to test the migration script.")
+
+    with tempfile.TemporaryDirectory(prefix="simplechat-cosmos-skip-") as temp_dir:
+        state_path = Path(temp_dir) / "migration-state.json"
+        harness = r'''
+$ErrorActionPreference = "Stop"
+$scriptPath = '__SCRIPT_PATH__'
+$statePath = '__STATE_PATH__'
+$global:mockFatalWrites = $false
+$global:mockThrottleResponsesRemaining = 0
+$global:mockSleepRecords = [System.Collections.Generic.List[object]]::new()
+
+function Start-Sleep {
+    [CmdletBinding()]
+    param(
+        [int]$Milliseconds,
+        [int]$Seconds
+    )
+
+    $global:mockSleepRecords.Add([pscustomobject]@{
+        Milliseconds = $Milliseconds
+        Seconds = $Seconds
+    })
+}
+
+function Invoke-WebRequest {
+    [CmdletBinding()]
+    param(
+        [string]$Method,
+        [string]$Uri,
+        [hashtable]$Headers,
+        [AllowNull()]
+        [string]$Body,
+        [string]$ContentType,
+        [switch]$SkipHttpErrorCheck
+    )
+
+    $isSource = $Uri.StartsWith("https://source-cosmos.")
+    $isDestination = $Uri.StartsWith("https://destination-cosmos.")
+    if (-not $isSource -and -not $isDestination) {
+        throw "Unexpected endpoint: $Uri"
+    }
+
+    if ($Method -eq "GET" -and $Uri -match "/dbs/SimpleChat$") {
+        return [pscustomobject]@{
+            StatusCode = 200
+            Headers = @{}
+            Content = '{"id":"SimpleChat"}'
+        }
+    }
+
+    if ($Method -eq "GET" -and $Uri -match "/dbs/SimpleChat/colls$") {
+        return [pscustomobject]@{
+            StatusCode = 200
+            Headers = @{}
+            Content = '{"DocumentCollections":[{"id":"documents","partitionKey":{"paths":["/tenant"],"kind":"Hash","version":2},"statistics":[{"documentCount":4}]}]}'
+        }
+    }
+
+    if (
+        $Method -eq "GET" -and
+        $isSource -and
+        $Uri -match "/dbs/SimpleChat/colls/documents/docs$"
+    ) {
+        return [pscustomobject]@{
+            StatusCode = 200
+            Headers = @{}
+            Content = '{"Documents":[{"id":"empty-key-doc","tenant":"a","":"root-empty","Name":"upper","name":"lower","nested":{"":"nested-empty"},"_rid":"remove"},{"id":"bad-doc","tenant":"b","content":"reject"},{"tenant":"missing-id","content":"cannot write"},{"id":"after-doc","tenant":"c","content":"continues"}],"_count":4}'
+        }
+    }
+
+    if (
+        $Method -eq "POST" -and
+        $isDestination -and
+        $Uri -match "/dbs/SimpleChat/colls/documents/docs$"
+    ) {
+        $document = $Body | ConvertFrom-Json -AsHashtable -Depth 100
+        if ($global:mockFatalWrites -and $document.id -eq "after-doc") {
+            return [pscustomobject]@{
+                StatusCode = 503
+                Headers = @{}
+                Content = '{"code":"ServiceUnavailable","message":"mock outage"}'
+            }
+        }
+        if ($document.id -eq "empty-key-doc") {
+            if (
+                $document[""] -ne "root-empty" -or
+                $document.Name -ne "upper" -or
+                $document.name -ne "lower" -or
+                $document.nested[""] -ne "nested-empty" -or
+                $document.Contains("_rid")
+            ) {
+                throw "The empty-name document was not preserved correctly: $Body"
+            }
+        }
+        if ($document.id -eq "bad-doc") {
+            return [pscustomobject]@{
+                StatusCode = 400
+                Headers = @{}
+                Content = '{"code":"BadRequest","message":"mock rejected document"}'
+            }
+        }
+        if (
+            $document.id -eq "after-doc" -and
+            $global:mockThrottleResponsesRemaining -gt 0
+        ) {
+            $global:mockThrottleResponsesRemaining--
+            return [pscustomobject]@{
+                StatusCode = 429
+                Headers = @{}
+                Content = '{"code":"TooManyRequests","message":"mock throttling"}'
+            }
+        }
+        return [pscustomobject]@{
+            StatusCode = 201
+            Headers = @{}
+            Content = $Body
+        }
+    }
+
+    throw "Unexpected mock request: $Method $Uri"
+}
+
+$parameters = @{
+    SourceCosmosAccount = "source-cosmos"
+    SourceResourceGroup = "source-rg"
+    SourceSubscriptionId = "00000000-0000-0000-0000-000000000001"
+    SourceDatabaseName = "SimpleChat"
+    SourcePrimaryKey = "c291cmNlLWtleQ=="
+    DestinationCosmosAccount = "destination-cosmos"
+    DestinationResourceGroup = "destination-rg"
+    DestinationSubscriptionId = "00000000-0000-0000-0000-000000000002"
+    DestinationDatabaseName = "SimpleChat"
+    DestinationPrimaryKey = "ZGVzdGluYXRpb24ta2V5"
+    Containers = @("documents")
+    DifferentialMigration = $true
+    ShowProgress = $false
+    PageSize = 100
+    MaxConcurrentDocuments = 2
+    MaxRetryCount = 2
+    StateFilePath = $statePath
+}
+
+$migrationOutput = @(& $scriptPath @parameters 3>&1 6>&1)
+$outputText = $migrationOutput | Out-String
+$state = [IO.File]::ReadAllText($statePath) |
+    ConvertFrom-Json -AsHashtable -Depth 100
+$result = $state.resources.documents.result
+$badSkippedDocument = @($result.SkippedDocuments | Where-Object {
+    $_.DocumentId -eq "bad-doc"
+})[0]
+$missingIdSkippedDocument = @($result.SkippedDocuments | Where-Object {
+    $_.DocumentId -eq "<missing id>"
+})[0]
+
+if ($state.status -ne "completed") {
+    throw "Migration state was not completed: $($state.status)"
+}
+if (
+    $result.ProcessedCount -ne 4 -or
+    $result.CopiedCount -ne 2 -or
+    $result.SkippedCount -ne 2 -or
+    $result.ErrorSkippedCount -ne 2
+) {
+    throw "Unexpected result counts: $($result | ConvertTo-Json -Compress)"
+}
+if (
+    $badSkippedDocument.ContainerName -ne "documents" -or
+    $badSkippedDocument.Stage -ne "Write" -or
+    $badSkippedDocument.Attempt -ne 1 -or
+    $badSkippedDocument.StatusCode -ne 400 -or
+    $badSkippedDocument.Reason -notmatch "mock rejected document" -or
+    [string]::IsNullOrWhiteSpace($badSkippedDocument.RecordedUtc) -or
+    $missingIdSkippedDocument.ContainerName -ne "documents" -or
+    $missingIdSkippedDocument.Stage -ne "Preparation" -or
+    $null -ne $missingIdSkippedDocument.StatusCode -or
+    $missingIdSkippedDocument.Reason -notmatch "without a valid id" -or
+    [string]::IsNullOrWhiteSpace($missingIdSkippedDocument.RecordedUtc)
+) {
+    throw "Skipped document details were incomplete: $($result.SkippedDocuments | ConvertTo-Json -Compress)"
+}
+if ($state.summary.ErrorSkippedCount -ne 2) {
+    throw "Migration summary did not include the error-skipped count."
+}
+if (
+    $outputText -notmatch "Admin review required: 2 document" -or
+    $outputText -notmatch "result\.SkippedDocuments" -or
+    $outputText -notmatch "entries in '[^']+migration-state\.json'"
+) {
+    throw "The final admin warning was missing or incomplete: $outputText"
+}
+
+$resumeOutput = @(& $scriptPath @parameters 3>&1 6>&1) | Out-String
+$resumedState = [IO.File]::ReadAllText($statePath) |
+    ConvertFrom-Json -AsHashtable -Depth 100
+if (
+    $resumedState.status -ne "completed" -or
+    $resumedState.resumeCount -ne 1 -or
+    $resumedState.summary.ErrorSkippedCount -ne 2 -or
+    $resumeOutput -notmatch "Skipping completed container from migration state: documents" -or
+    $resumeOutput -notmatch "Admin review required: 2 document"
+) {
+    throw "Resumed migration did not preserve skipped-document reporting: $resumeOutput"
+}
+
+$sequentialStatePath = "$statePath.sequential.json"
+$parameters.StateFilePath = $sequentialStatePath
+$parameters.MaxConcurrentDocuments = 1
+$sequentialOutput = @(& $scriptPath @parameters 3>&1 6>&1) | Out-String
+$sequentialState = [IO.File]::ReadAllText($sequentialStatePath) |
+    ConvertFrom-Json -AsHashtable -Depth 100
+$sequentialResult = $sequentialState.resources.documents.result
+if (
+    $sequentialState.status -ne "completed" -or
+    $sequentialResult.ProcessedCount -ne 4 -or
+    $sequentialResult.CopiedCount -ne 2 -or
+    $sequentialResult.SkippedCount -ne 2 -or
+    $sequentialResult.ErrorSkippedCount -ne 2 -or
+    @($sequentialResult.SkippedDocuments | Where-Object {
+        $_.DocumentId -eq "bad-doc"
+    }).Count -ne 1 -or
+    @($sequentialResult.SkippedDocuments | Where-Object {
+        $_.DocumentId -eq "<missing id>"
+    }).Count -ne 1
+) {
+    throw "Sequential migration did not copy and record skips correctly: $($sequentialResult | ConvertTo-Json -Compress)"
+}
+if ($sequentialOutput -notmatch "Admin review required: 2 document") {
+    throw "Sequential migration did not warn the admin about its skipped document."
+}
+
+$recoveryStatePath = "$statePath.recovery.json"
+$parameters.StateFilePath = $recoveryStatePath
+$parameters.MaxConcurrentDocuments = 1
+$parameters.MaxRetryCount = 2
+$parameters.MaxThrottleRecoveryPauses = 2
+$parameters.ThrottleRecoveryPauseSeconds = 1
+$global:mockSleepRecords.Clear()
+$global:mockThrottleResponsesRemaining = 2
+$recoveryOutput = @(& $scriptPath @parameters 3>&1 6>&1) | Out-String
+$recoveryState = [IO.File]::ReadAllText($recoveryStatePath) |
+    ConvertFrom-Json -AsHashtable -Depth 100
+$recoveryResult = $recoveryState.resources.documents.result
+if (
+    $recoveryState.status -ne "completed" -or
+    $recoveryResult.CopiedCount -ne 2 -or
+    $recoveryResult.ThrottleRecoveryPauseCount -ne 1 -or
+    $global:mockThrottleResponsesRemaining -ne 0 -or
+    @($global:mockSleepRecords | Where-Object { $_.Seconds -eq 1 }).Count -ne 1
+) {
+    throw "Exhausted 429 retries did not recover correctly: $($recoveryResult | ConvertTo-Json -Compress)"
+}
+if ($recoveryOutput -notmatch "Recovery pause 1/2 begins now") {
+    throw "Throttling recovery warning was missing: $recoveryOutput"
+}
+
+$exhaustedRecoveryStatePath = "$statePath.recovery-exhausted.json"
+$parameters.StateFilePath = $exhaustedRecoveryStatePath
+$parameters.MaxThrottleRecoveryPauses = 1
+$global:mockSleepRecords.Clear()
+$global:mockThrottleResponsesRemaining = 4
+$exhaustedRecoveryError = $null
+try {
+    & $scriptPath @parameters -ErrorAction Stop 3>&1 6>&1 | Out-Null
+}
+catch {
+    $exhaustedRecoveryError = $_
+}
+if (
+    $null -eq $exhaustedRecoveryError -or
+    $exhaustedRecoveryError.Exception.Message -notmatch "throttling recovery exhausted" -or
+    $exhaustedRecoveryError.Exception.Message -notmatch "1 recovery pause" -or
+    $exhaustedRecoveryError.Exception.Message -notmatch "Reduce -MaxConcurrentDocuments" -or
+    @($global:mockSleepRecords | Where-Object { $_.Seconds -eq 1 }).Count -ne 1
+) {
+    throw "Throttling recovery exhaustion was not reported cleanly: $exhaustedRecoveryError"
+}
+$exhaustedRecoveryState = [IO.File]::ReadAllText($exhaustedRecoveryStatePath) |
+    ConvertFrom-Json -AsHashtable -Depth 100
+if (
+    $exhaustedRecoveryState.status -ne "failed" -or
+    $exhaustedRecoveryState.lastError -notmatch "throttling recovery exhausted"
+) {
+    throw "Throttling recovery exhaustion did not persist failed state."
+}
+
+$fatalStatePath = "$statePath.fatal.json"
+$parameters.StateFilePath = $fatalStatePath
+$parameters.MaxRetryCount = 1
+$global:mockFatalWrites = $true
+$fatalError = $null
+$fatalOutput = [System.Collections.Generic.List[string]]::new()
+try {
+    & $scriptPath @parameters -ErrorAction Stop 3>&1 6>&1 |
+        ForEach-Object { $fatalOutput.Add([string]$_) }
+}
+catch {
+    $fatalError = $_
+}
+finally {
+    $global:mockFatalWrites = $false
+}
+if ($null -eq $fatalError -or $fatalError.Exception.Message -notmatch "HTTP 503") {
+    throw "A systemic destination failure was incorrectly skipped: $fatalError"
+}
+$fatalOutputText = $fatalOutput -join "`n"
+if (
+    $fatalOutputText -notmatch "Admin review required: 2 document" -or
+    $fatalOutputText -notmatch "progress\.SkippedDocuments"
+) {
+    throw "The failed migration did not warn the admin about earlier document skips: $fatalOutputText"
+}
+$fatalState = [IO.File]::ReadAllText($fatalStatePath) |
+    ConvertFrom-Json -AsHashtable -Depth 100
+if (
+    $fatalState.status -ne "failed" -or
+    $fatalState.resources.documents.status -ne "failed" -or
+    $fatalState.lastError -notmatch "HTTP 503" -or
+    $fatalState.resources.documents.progress.ErrorSkippedCount -ne 2 -or
+    @($fatalState.resources.documents.progress.SkippedDocuments | Where-Object {
+        $_.DocumentId -eq "bad-doc" -and $_.StatusCode -eq 400
+    }).Count -ne 1 -or
+    @($fatalState.resources.documents.progress.SkippedDocuments | Where-Object {
+        $_.DocumentId -eq "<missing id>" -and $_.Stage -eq "Preparation"
+    }).Count -ne 1
+) {
+    throw "Systemic destination failure was not persisted as failed state: $($fatalState | ConvertTo-Json -Compress -Depth 100)"
+}
+'''
+        harness = harness.replace(
+            "__SCRIPT_PATH__", _powershell_single_quote(SCRIPT_PATH)
+        ).replace("__STATE_PATH__", _powershell_single_quote(state_path))
+
+        result = subprocess.run(
+            [
+                powershell,
+                "-NoLogo",
+                "-NoProfile",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-Command",
+                harness,
+            ],
+            cwd=REPO_ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    if result.returncode != 0:
+        print(result.stdout)
+        print(result.stderr, file=sys.stderr)
+        raise AssertionError(
+            f"Cosmos migration skip-reporting harness failed with exit code {result.returncode}."
+        )
+
+
+if __name__ == "__main__":
+    test_cosmos_migration_document_skip_reporting()
+    print("Cosmos migration document skip-reporting test passed.")

--- a/functional_tests/test_mixed_source_chat_search_consistency.py
+++ b/functional_tests/test_mixed_source_chat_search_consistency.py
@@ -1,0 +1,807 @@
+#!/usr/bin/env python3
+# test_mixed_source_chat_search_consistency.py
+"""
+Functional test for mixed-source Chat and Search consistency.
+Version: 0.250.064
+Implemented in: 0.250.064
+
+This test ensures Phase 2 of #1057 consumes the Phase 1 #1056 contracts for
+standard and streaming Chat plus workflow Search without implementing later
+phases from the parent initiative #1055.
+"""
+
+import ast
+import asyncio
+import json
+import logging
+import os
+import sys
+import types
+from contextlib import nullcontext
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+APP_ROOT = REPO_ROOT / "application" / "single_app"
+ROUTE_PATH = APP_ROOT / "route_backend_chats.py"
+WORKFLOW_PATH = APP_ROOT / "functions_workflow_runner.py"
+SEARCH_SERVICE_PATH = APP_ROOT / "functions_search_service.py"
+CONVERSATIONS_PATH = APP_ROOT / "route_backend_conversations.py"
+COLLABORATION_PATH = APP_ROOT / "route_backend_collaboration.py"
+FOUNDRY_PATH = APP_ROOT / "foundry_agent_runtime.py"
+SETTINGS_PATH = APP_ROOT / "functions_settings.py"
+sys.path.insert(0, str(APP_ROOT))
+
+import functions_mixed_source_orchestration as orchestration  # pyright: ignore[reportMissingImports]
+
+
+def _read(path):
+    return path.read_text(encoding="utf-8")
+
+
+def _load_functions(path, function_names, namespace):
+    tree = ast.parse(_read(path), filename=str(path))
+    selected_nodes = [
+        node
+        for node in tree.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name in function_names
+    ]
+    assert {node.name for node in selected_nodes} == set(function_names)
+    module = ast.Module(body=selected_nodes, type_ignores=[])
+    ast.fix_missing_locations(module)
+    exec(compile(module, str(path), "exec"), namespace)
+    return namespace
+
+
+def _source(document_id, file_name, source_kind, scope="personal", scope_id="user-1"):
+    return {
+        "document_id": document_id,
+        "display_name": file_name,
+        "file_name": file_name,
+        "extension": os.path.splitext(file_name)[1].lower(),
+        "source_kind": source_kind,
+        "scope": scope,
+        "scope_id": scope_id,
+        "group_id": scope_id if scope == "group" else None,
+        "public_workspace_id": scope_id if scope == "public" else None,
+        "conversation_id": scope_id if scope == "chat" else None,
+        "source_version": 1,
+        "authorization_status": "authorized",
+    }
+
+
+class FakeInvocation:
+    def __init__(self, file_name):
+        self.plugin_name = "TabularProcessingPlugin"
+        self.function_name = "count_rows"
+        self.parameters = {"filename": file_name}
+        self.result = json.dumps({"filename": file_name, "count": 42})
+        self.duration_ms = 5
+        self.timestamp = "2026-07-22T00:00:00Z"
+        self.success = True
+        self.error_message = None
+        self.user_id = "user-1"
+
+
+class FakePluginLogger:
+    def __init__(self):
+        self.invocations = []
+
+    def get_invocations_for_conversation(self, user_id, conversation_id, limit=1000):
+        del user_id, conversation_id, limit
+        return list(self.invocations)
+
+
+def _load_shared_tabular_executor(failing_file_name=None, emit_tool_invocation=True):
+    plugin_logger = FakePluginLogger()
+    runner_calls = []
+
+    async def run_tabular_analysis_with_thought_tracking(**kwargs):
+        file_name = next(iter(kwargs["tabular_filenames"]))
+        runner_calls.append({
+            "file_name": file_name,
+            "source_hint": kwargs.get("source_hint"),
+            "group_id": kwargs.get("group_id"),
+            "public_workspace_id": kwargs.get("public_workspace_id"),
+        })
+        if file_name == failing_file_name:
+            raise RuntimeError("deterministic test failure")
+        if emit_tool_invocation:
+            plugin_logger.invocations.append(FakeInvocation(file_name))
+        return f"Computed count for {file_name}: 42", False
+
+    async def no_generated_output(**kwargs):
+        del kwargs
+        return None
+
+    namespace = {
+        "asyncio": asyncio,
+        "has_request_context": lambda: False,
+        "build_tabular_file_contexts_from_manifest": orchestration.build_tabular_file_contexts_from_manifest,
+        "is_tabular_processing_enabled": lambda settings: settings.get("tabular", True),
+        "should_run_tabular_evidence": orchestration.should_run_tabular_evidence,
+        "get_plugin_logger": lambda: plugin_logger,
+        "execute_tabular_evidence_sources": orchestration.execute_tabular_evidence_sources,
+        "get_tabular_execution_mode": lambda question: (
+            "schema_summary" if "worksheet" in question.lower() else "analysis"
+        ),
+        "run_tabular_analysis_with_thought_tracking": run_tabular_analysis_with_thought_tracking,
+        "get_new_plugin_invocations": lambda invocations, baseline: invocations[baseline:],
+        "split_tabular_analysis_invocations": lambda invocations: (list(invocations), []),
+        "get_tabular_invocation_error_message": lambda invocation: None,
+        "augment_tabular_invocations_with_related_document_evidence": lambda *args, **kwargs: {},
+        "build_tabular_related_document_evidence_summary": lambda invocations: "",
+        "get_tabular_tool_thought_payloads": lambda invocations: [],
+        "get_tabular_status_thought_payloads": lambda invocations, analysis_succeeded: [],
+        "maybe_create_tabular_generated_output": no_generated_output,
+        "_build_tabular_sk_citations_from_invocations": lambda invocations: [
+            {
+                "tool_name": "Tabular count",
+                "function_name": invocation.function_name,
+                "file_name": invocation.parameters["filename"],
+            }
+            for invocation in invocations
+        ],
+        "build_tabular_inline_chart_citations": lambda question, invocations: [],
+        "build_tabular_computed_results_system_message": lambda label, analysis, **kwargs: analysis,
+        "_build_tabular_generated_output_system_message": lambda output: str(output),
+        "get_tabular_invocation_compact_payload": lambda invocation, max_rows=5: {
+            "file_name": invocation.parameters["filename"],
+            "function_name": invocation.function_name,
+            "max_rows": max_rows,
+        },
+    }
+    _load_functions(
+        ROUTE_PATH,
+        {"_execute_mixed_source_tabular_evidence"},
+        namespace,
+    )
+    return namespace["_execute_mixed_source_tabular_evidence"], runner_calls
+
+
+def test_selected_context_is_equivalent_with_panel_open_or_closed():
+    selected_ids = ["narrative-pdf", "table-xlsx"]
+    panel_open = orchestration.normalize_document_context_request(
+        selection_mode="selected",
+        selected_document_ids=selected_ids,
+        document_context_requested=True,
+        hybrid_search=True,
+    )
+    panel_closed = orchestration.normalize_document_context_request(
+        selection_mode="selected",
+        selected_document_ids=selected_ids,
+        document_context_requested=True,
+        hybrid_search=False,
+    )
+
+    for contract in (panel_open, panel_closed):
+        assert contract["selection_mode"] == "selected"
+        assert contract["selected_document_ids"] == selected_ids
+        assert contract["document_context_requested"] is True
+        assert contract["explicit_selection"] is True
+    assert panel_open["hybrid_search"] is True
+    assert panel_closed["hybrid_search"] is False
+
+
+def test_mixed_format_orders_and_calculation_tools_have_terminal_coverage():
+    execute_tabular, runner_calls = _load_shared_tabular_executor()
+    pairs = (
+        (
+            _source("narrative-pdf", "report.pdf", "narrative"),
+            _source("table-xlsx", "data.xlsx", "tabular"),
+        ),
+        (
+            _source("narrative-docx", "brief.docx", "narrative"),
+            _source("table-csv", "facts.csv", "tabular"),
+        ),
+    )
+
+    for narrative_source, tabular_source in pairs:
+        for manifest in (
+            [narrative_source, tabular_source],
+            [tabular_source, narrative_source],
+        ):
+            partitions = orchestration.partition_source_manifest(manifest)
+            result = execute_tabular(
+                tabular_sources=partitions["tabular_sources"],
+                selection_mode="selected",
+                has_narrative_sources=True,
+                user_question="Calculate the total row count from every selected table.",
+                user_id="user-1",
+                conversation_id="conversation-1",
+                gpt_model="test-model",
+                settings={"tabular": True},
+            )
+            envelopes = result["evidence_envelopes"]
+            assert len(envelopes) == 1
+            assert envelopes[0]["status"] == "completed"
+            assert envelopes[0]["coverage"]["terminal"] is True
+            assert envelopes[0]["coverage"]["tool_call_count"] == 1
+            assert result["agent_citations"][0]["function_name"] == "count_rows"
+
+    called_files = [call["file_name"] for call in runner_calls]
+    assert called_files.count("data.xlsx") == 2
+    assert called_files.count("facts.csv") == 2
+
+
+def test_narrative_only_prompt_skips_rows_and_explicit_failure_is_partial():
+    tabular_source = _source("table-xlsx", "data.xlsx", "tabular")
+    execute_tabular, runner_calls = _load_shared_tabular_executor()
+    skipped = execute_tabular(
+        tabular_sources=[tabular_source],
+        selection_mode="selected",
+        has_narrative_sources=True,
+        user_question="What policy does the PDF state?",
+        user_id="user-1",
+        conversation_id="conversation-1",
+        gpt_model="test-model",
+        settings={"tabular": True},
+    )
+    assert runner_calls == []
+    assert skipped["evidence_envelopes"][0]["status"] == "skipped"
+    assert skipped["evidence_envelopes"][0]["coverage"]["terminal"] is True
+
+    generic_narrative = execute_tabular(
+        tabular_sources=[tabular_source],
+        selection_mode="selected",
+        has_narrative_sources=True,
+        user_question="What does the introduction say?",
+        user_id="user-1",
+        conversation_id="conversation-1",
+        gpt_model="test-model",
+        settings={"tabular": True},
+    )
+    assert runner_calls == []
+    assert generic_narrative["evidence_envelopes"][0]["status"] == "skipped"
+
+    failing_executor, failure_calls = _load_shared_tabular_executor(
+        failing_file_name="broken.csv"
+    )
+    manifest = [
+        _source("narrative-docx", "brief.docx", "narrative"),
+        _source("working-csv", "working.csv", "tabular"),
+        _source("broken-csv", "broken.csv", "tabular"),
+    ]
+    tabular_result = failing_executor(
+        tabular_sources=orchestration.partition_source_manifest(manifest)["tabular_sources"],
+        selection_mode="selected",
+        has_narrative_sources=True,
+        user_question="Calculate totals for all selected tables.",
+        user_id="user-1",
+        conversation_id="conversation-1",
+        gpt_model="test-model",
+        settings={"tabular": True},
+    )
+    assert [call["file_name"] for call in failure_calls] == ["working.csv", "broken.csv"]
+    assert [envelope["status"] for envelope in tabular_result["evidence_envelopes"]] == [
+        "completed",
+        "failed",
+    ]
+    handoff = orchestration.build_mixed_source_evidence_handoff(
+        manifest,
+        tabular_result["evidence_envelopes"],
+        "selected",
+    )
+    assert handoff["mixed_source_coverage"]["partial_coverage"] is True
+    assert handoff["mixed_source_coverage"]["failed_source_count"] == 2
+
+    zero_tool_executor, _ = _load_shared_tabular_executor(
+        emit_tool_invocation=False
+    )
+    zero_tool_result = zero_tool_executor(
+        tabular_sources=[tabular_source],
+        selection_mode="selected",
+        has_narrative_sources=False,
+        user_question="Calculate the total.",
+        user_id="user-1",
+        conversation_id="conversation-1",
+        gpt_model="test-model",
+        settings={"tabular": True},
+    )
+    assert zero_tool_result["evidence_envelopes"][0]["status"] == "failed"
+    assert zero_tool_result["evidence_envelopes"][0]["coverage"]["terminal"] is True
+
+
+def test_personal_group_public_and_chat_tabular_contexts_use_canonical_scope():
+    sources = [
+        _source("personal-csv", "personal.csv", "tabular"),
+        _source("group-xlsx", "group.xlsx", "tabular", "group", "group-1"),
+        _source("public-xls", "public.xls", "tabular", "public", "public-1"),
+        _source("chat-csv", "chat.csv", "tabular", "chat", "conversation-1"),
+    ]
+    contexts = orchestration.build_tabular_file_contexts_from_manifest(sources)
+    assert [context["source_hint"] for context in contexts] == [
+        "workspace",
+        "group",
+        "public",
+        "chat",
+    ]
+    assert contexts[1]["group_id"] == "group-1"
+    assert contexts[2]["public_workspace_id"] == "public-1"
+    assert contexts[3]["conversation_id"] == "conversation-1"
+
+
+def test_relevance_candidate_stage_finds_table_beyond_initial_hits_and_stays_bounded():
+    captured_requests = []
+    search_results = [
+        {
+            "document_id": f"narrative-{index}",
+            "file_name": f"note-{index}.pdf",
+        }
+        for index in range(20)
+    ] + [
+        {
+            "document_id": f"table-{index}",
+            "file_name": f"table-{index}.xlsx",
+        }
+        for index in range(10)
+    ]
+
+    namespace = {
+        "MIXED_SOURCE_TABULAR_CANDIDATE_LIMIT": 6,
+        "MIXED_SOURCE_TABULAR_CANDIDATE_TOP_N": 36,
+        "MIXED_SOURCE_TABULAR_EXTENSIONS": frozenset({".csv", ".xls", ".xlsx", ".xlsm"}),
+        "_coerce_positive_int": lambda value, default, min_value=1, max_value=None: min(
+            max(int(value or default), min_value),
+            max_value or int(value or default),
+        ),
+        "search_documents": lambda **kwargs: (
+            captured_requests.append(kwargs)
+            or {
+                "results": search_results,
+                "result_count": len(search_results),
+                "query": kwargs["query"],
+            }
+        ),
+        "os": os,
+        "log_event": lambda *args, **kwargs: None,
+        "logging": logging,
+    }
+    _load_functions(
+        SEARCH_SERVICE_PATH,
+        {"search_relevant_tabular_candidates"},
+        namespace,
+    )
+    result = namespace["search_relevant_tabular_candidates"](
+        query="quarterly revenue",
+        user_id="user-1",
+        document_ids=["authorized-catalog-hint"],
+        max_candidates=99,
+    )
+
+    assert captured_requests[0]["top_n"] == 36
+    assert captured_requests[0]["document_ids"] == ["authorized-catalog-hint"]
+    assert captured_requests[0]["include_all_public_workspaces"] is True
+    assert result["document_ids"] == [f"table-{index}" for index in range(6)]
+    assert "table-0" not in [item["document_id"] for item in search_results[:12]]
+
+
+def _load_workflow_search_helpers(flag_enabled, manifest, search_calls, tabular_calls):
+    namespace = {
+        "DOCUMENT_ACTION_TARGET_MODE_RECENT": "recent",
+        "_get_workflow_group_id": lambda workflow: str(workflow.get("group_id") or ""),
+        "assert_group_role": lambda *args, **kwargs: None,
+        "_is_document_search_workflow": lambda action: action.get("type") == "search",
+        "_resolve_recent_document_action_targets": lambda workflow, action, settings: dict(action),
+        "normalize_search_id_list": lambda values: list(values or []),
+        "is_mixed_source_chat_search_enabled": lambda settings: flag_enabled,
+        "normalize_search_top_n": lambda value: int(value),
+        "search_documents": lambda **kwargs: (
+            search_calls.append(kwargs)
+            or {
+                "results": [
+                    {
+                        "document_id": "narrative-doc",
+                        "chunk_text": "Narrative evidence",
+                        "file_name": "brief.docx",
+                        "id": "chunk-1",
+                        "page_number": 1,
+                    }
+                ],
+                "result_count": 1,
+                "document_count": 1,
+                "query": kwargs["query"],
+            }
+        ),
+        "_format_workflow_search_results": lambda results: (
+            "Narrative evidence",
+            [{"document_id": "narrative-doc", "citation_id": "chunk-1"}],
+        ),
+        "_apply_runtime_document_action_config": lambda workflow, action: {
+            **workflow,
+            "document_action": dict(action),
+        },
+        "resolve_authorized_source_manifest": lambda *args, **kwargs: list(manifest),
+        "partition_source_manifest": orchestration.partition_source_manifest,
+        "build_narrative_evidence_envelopes": orchestration.build_narrative_evidence_envelopes,
+        "_workflow_mixed_source_execution_context": lambda *args, **kwargs: nullcontext(),
+        "_resolve_tabular_document_action_model_name": lambda workflow, settings: "test-model",
+        "build_mixed_source_evidence_handoff": orchestration.build_mixed_source_evidence_handoff,
+        "_add_workflow_activity_thought": lambda *args, **kwargs: None,
+    }
+    _load_functions(
+        WORKFLOW_PATH,
+        {"_build_workflow_search_prompt", "_prepare_workflow_search_context", "_attach_workflow_search_context"},
+        namespace,
+    )
+
+    tabular_stub = types.ModuleType("functions_tabular_analysis")
+
+    def execute_mixed_source_tabular_evidence(**kwargs):
+        tabular_calls.append(kwargs)
+        source = kwargs["tabular_sources"][0]
+        return {
+            "evidence_envelopes": [orchestration.build_evidence_envelope(
+                document_id=source["document_id"],
+                source_kind="tabular",
+                engine="tabular_tools",
+                status="completed",
+                summary="Computed total: 42",
+                citations=[{"tool_name": "count_rows"}],
+                coverage={"terminal": True, "tool_call_count": 1},
+            )],
+            "system_messages": [{"role": "system", "content": "UNBOUNDED_DUPLICATE"}],
+            "agent_citations": [{"tool_name": "count_rows"}],
+            "generated_outputs": [{"id": "artifact-1"}],
+        }
+
+    tabular_stub.execute_mixed_source_tabular_evidence = execute_mixed_source_tabular_evidence
+    return namespace, tabular_stub
+
+
+def test_workflow_search_uses_mixed_evidence_for_model_and_agent_with_flag_rollback():
+    manifest = [
+        _source("narrative-doc", "brief.docx", "narrative"),
+        _source("table-doc", "facts.csv", "tabular"),
+    ]
+    search_calls = []
+    tabular_calls = []
+    namespace, tabular_stub = _load_workflow_search_helpers(
+        True,
+        manifest,
+        search_calls,
+        tabular_calls,
+    )
+    previous_tabular_module = sys.modules.get("functions_tabular_analysis")
+    sys.modules["functions_tabular_analysis"] = tabular_stub
+    try:
+        context = namespace["_prepare_workflow_search_context"](
+            {
+                "user_id": "user-1",
+                "task_prompt": "Calculate totals and summarize the brief.",
+                "runner_type": "model",
+            },
+            {
+                "type": "search",
+                "target_mode": "selected",
+                "document_ids": ["narrative-doc", "table-doc"],
+                "doc_scope": "all",
+            },
+            {"enable_mixed_source_chat_search": True},
+            conversation_id="conversation-1",
+        )
+    finally:
+        if previous_tabular_module is None:
+            sys.modules.pop("functions_tabular_analysis", None)
+        else:
+            sys.modules["functions_tabular_analysis"] = previous_tabular_module
+
+    assert search_calls[0]["document_ids"] == ["narrative-doc"]
+    assert search_calls[0]["include_all_public_workspaces"] is True
+    assert [source["document_id"] for source in tabular_calls[0]["tabular_sources"]] == [
+        "table-doc"
+    ]
+    assert "Computed total: 42" in context["workflow"]["task_prompt"]
+    assert "UNBOUNDED_DUPLICATE" not in context["workflow"]["task_prompt"]
+    assert context["coverage"]["partial_coverage"] is False
+
+    attach = namespace["_attach_workflow_search_context"]
+    model_result = attach({"reply": "model", "provider": "model"}, context)
+    agent_result = attach(
+        {
+            "reply": "agent",
+            "provider": "agent",
+            "agent_citations": [{"tool_name": "agent_tool"}],
+        },
+        context,
+    )
+    assert model_result["agent_citations"] == [{"tool_name": "count_rows"}]
+    assert agent_result["agent_citations"] == [
+        {"tool_name": "agent_tool"},
+        {"tool_name": "count_rows"},
+    ]
+    assert model_result["generated_tabular_outputs"] == [{"id": "artifact-1"}]
+    assert agent_result["document_search"]["document_count"] == 2
+
+    legacy_search_calls = []
+    legacy_tabular_calls = []
+    legacy_namespace, legacy_stub = _load_workflow_search_helpers(
+        False,
+        manifest,
+        legacy_search_calls,
+        legacy_tabular_calls,
+    )
+    previous_tabular_module = sys.modules.get("functions_tabular_analysis")
+    sys.modules["functions_tabular_analysis"] = legacy_stub
+    try:
+        legacy_context = legacy_namespace["_prepare_workflow_search_context"](
+            {"user_id": "user-1", "task_prompt": "legacy", "runner_type": "model"},
+            {
+                "type": "search",
+                "target_mode": "selected",
+                "document_ids": ["narrative-doc", "table-doc"],
+                "doc_scope": "all",
+            },
+            {"enable_mixed_source_chat_search": False},
+            conversation_id="conversation-1",
+        )
+    finally:
+        if previous_tabular_module is None:
+            sys.modules.pop("functions_tabular_analysis", None)
+        else:
+            sys.modules["functions_tabular_analysis"] = previous_tabular_module
+    assert legacy_search_calls[0]["document_ids"] == ["narrative-doc", "table-doc"]
+    assert legacy_tabular_calls == []
+    assert legacy_context["coverage"] == {}
+
+
+def test_group_workflow_search_forces_stored_group_scope():
+    group_manifest = [
+        _source("group-narrative", "brief.docx", "narrative", "group", "group-safe"),
+        _source("group-table", "facts.csv", "tabular", "group", "group-safe"),
+    ]
+    search_calls = []
+    tabular_calls = []
+    namespace, tabular_stub = _load_workflow_search_helpers(
+        True,
+        group_manifest,
+        search_calls,
+        tabular_calls,
+    )
+    manifest_calls = []
+    role_calls = []
+    namespace["resolve_authorized_source_manifest"] = lambda *args, **kwargs: (
+        manifest_calls.append((args, kwargs)) or list(group_manifest)
+    )
+    namespace["assert_group_role"] = lambda *args, **kwargs: role_calls.append(
+        (args, kwargs)
+    )
+
+    previous_tabular_module = sys.modules.get("functions_tabular_analysis")
+    sys.modules["functions_tabular_analysis"] = tabular_stub
+    try:
+        context = namespace["_prepare_workflow_search_context"](
+            {
+                "user_id": "user-1",
+                "group_id": "group-safe",
+                "task_prompt": "Calculate totals and summarize the brief.",
+                "runner_type": "model",
+            },
+            {
+                "type": "search",
+                "target_mode": "selected",
+                "document_ids": ["group-narrative", "group-table"],
+                "doc_scope": "personal",
+                "active_group_ids": ["group-attacker"],
+                "active_public_workspace_id": ["public-attacker"],
+            },
+            {"enable_mixed_source_chat_search": True},
+            conversation_id="conversation-1",
+        )
+    finally:
+        if previous_tabular_module is None:
+            sys.modules.pop("functions_tabular_analysis", None)
+        else:
+            sys.modules["functions_tabular_analysis"] = previous_tabular_module
+
+    assert role_calls[0][0][:2] == ("user-1", "group-safe")
+    manifest_kwargs = manifest_calls[0][1]
+    assert manifest_kwargs["doc_scope"] == "group"
+    assert manifest_kwargs["active_group_ids"] == ["group-safe"]
+    assert manifest_kwargs["active_public_workspace_ids"] == []
+    prepared_action = context["workflow"]["document_action"]
+    assert prepared_action["doc_scope"] == "group"
+    assert prepared_action["active_group_ids"] == ["group-safe"]
+    assert prepared_action["active_public_workspace_id"] == []
+
+
+def test_replay_collaboration_foundry_and_chat_path_contracts():
+    replay_namespace = {}
+    _load_functions(
+        CONVERSATIONS_PATH,
+        {"_build_replayed_document_context"},
+        replay_namespace,
+    )
+    replay = replay_namespace["_build_replayed_document_context"]({
+        "workspace_search": {
+            "search_enabled": True,
+            "selection_mode": "selected",
+            "document_context_requested": True,
+            "hybrid_search_preference": False,
+            "requested_document_ids": ["doc-1", "temporarily-unavailable"],
+            "selected_document_ids": ["doc-1", "doc-2"],
+            "document_scope": "all",
+            "active_group_ids": ["group-1"],
+        }
+    })
+    assert replay["hybrid_search"] is False
+    assert replay["selection_mode"] == "selected"
+    assert replay["document_context_requested"] is True
+    assert replay["selected_document_ids"] == ["doc-1", "temporarily-unavailable"]
+
+    collaboration_namespace = {}
+    _load_functions(
+        COLLABORATION_PATH,
+        {"_build_collaboration_stream_request_payload"},
+        collaboration_namespace,
+    )
+    forwarded = collaboration_namespace["_build_collaboration_stream_request_payload"](
+        {
+            "hybrid_search": False,
+            "selection_mode": "selected",
+            "document_context_requested": True,
+            "selected_document_ids": ["doc-1"],
+        },
+        "conversation-1",
+        "Question",
+    )
+    assert forwarded["selection_mode"] == "selected"
+    assert forwarded["document_context_requested"] is True
+    assert forwarded["selected_document_ids"] == ["doc-1"]
+
+    chat_source = _read(ROUTE_PATH)
+    template_source = _read(APP_ROOT / "templates" / "chats.html")
+    frontend_source = _read(APP_ROOT / "static" / "js" / "chat" / "chat-messages.js")
+    assert "'active_group_ids': effective_active_group_ids" in chat_source
+    assert "'active_public_workspace_ids': effective_active_public_workspace_ids" in chat_source
+    assert "'requested_document_ids': requested_selected_document_ids" in chat_source
+    assert "enable_mixed_source_chat_search:" in template_source
+    assert "workspaceContextInvocationRequested" in frontend_source
+    assert "messageData.hybrid_search" in frontend_source
+    assert "window.appSettings?.enable_mixed_source_chat_search" in frontend_source
+
+    foundry_tree = ast.parse(_read(FOUNDRY_PATH), filename=str(FOUNDRY_PATH))
+    internal_keys = next(
+        ast.literal_eval(node.value)
+        for node in foundry_tree.body
+        if isinstance(node, ast.Assign)
+        and any(
+            isinstance(target, ast.Name) and target.id == "FOUNDRY_INTERNAL_METADATA_KEYS"
+            for target in node.targets
+        )
+    )
+    assert {
+        "selected_document_ids",
+        "selection_mode",
+        "document_context_requested",
+    }.issubset(internal_keys)
+
+    route_source = chat_source
+    assert route_source.count("_normalize_chat_document_context_contract(") == 3
+    assert route_source.count("_execute_mixed_source_tabular_evidence(") == 3
+    assert route_source.count("build_mixed_source_evidence_handoff(") == 2
+    assert route_source.count("and not mixed_source_explicit_selection") >= 4
+    assert route_source.count("'selected_document_id': effective_selected_document_id") >= 2
+    assert route_source.count("'document_scope': effective_document_scope") >= 2
+    assert "if hybrid_search_enabled or history_grounded_search_used" not in route_source
+
+
+def test_flag_defaults_off_and_diagnostics_are_privacy_safe():
+    settings_source = _read(SETTINGS_PATH)
+    assert "'enable_mixed_source_chat_search': False" in settings_source
+    assert "'enable_mixed_source_relevance_candidates': False" in settings_source
+    assert "enable_mixed_source_manifest" not in _read(ROUTE_PATH)[
+        _read(ROUTE_PATH).find("def _normalize_chat_document_context_contract"):
+        _read(ROUTE_PATH).find("def _resolve_chat_mixed_source_manifest")
+    ]
+
+    captured_events = []
+    original_log_event = orchestration.log_event
+    orchestration.log_event = lambda message, **kwargs: captured_events.append(
+        {"message": message, **kwargs}
+    )
+    try:
+        orchestration.execute_tabular_evidence_sources(
+            [_source("sensitive-document-id", "sensitive-name.csv", "tabular")],
+            lambda source: {"summary": "bounded result"},
+            "selected",
+        )
+    finally:
+        orchestration.log_event = original_log_event
+
+    serialized_events = json.dumps(captured_events, sort_keys=True)
+    assert "sensitive-document-id" not in serialized_events
+    assert "sensitive-name.csv" not in serialized_events
+    assert "bounded result" not in serialized_events
+
+
+def test_relevance_table_rollout_is_independently_gated():
+    route_source = _read(ROUTE_PATH)
+    settings_source = _read(SETTINGS_PATH)
+    assert "def is_mixed_source_relevance_candidates_enabled" in settings_source
+    assert "if relevance_candidates_enabled:" in route_source
+    assert "candidate_result = search_relevant_tabular_candidates(" in route_source
+
+
+def test_foundry_context_opt_out_and_compacted_handoff_are_safe():
+    foundry_namespace = {
+        "List": List,
+        "Optional": Optional,
+        "ChatMessageContent": object,
+        "FoundryAgentInvocationError": RuntimeError,
+        "_extract_message_text": lambda message: str(message),
+    }
+    _load_functions(
+        FOUNDRY_PATH,
+        {"_looks_like_document_context_message", "_build_foundry_workflow_input_text"},
+        foundry_namespace,
+    )
+    build_input = foundry_namespace["_build_foundry_workflow_input_text"]
+    pure_evidence = (
+        "Use the mixed-source evidence handoff below.\n"
+        '{"evidence_envelopes":[{"summary":"secret evidence"}]}'
+    )
+    workflow_prompt = (
+        "[Workflow document search context]\n"
+        f"{pure_evidence}\n\n"
+        "[Workflow task]\nWrite the user-facing answer."
+    )
+    assert "secret evidence" not in build_input(
+        [pure_evidence, "Current user question"],
+        include_document_context=False,
+    )
+    packed_workflow = build_input(
+        [workflow_prompt],
+        include_document_context=False,
+    )
+    assert "secret evidence" not in packed_workflow
+    assert "Write the user-facing answer." in packed_workflow
+
+    file_input_namespace = {
+        "Any": Any,
+        "Dict": Dict,
+        "List": List,
+        "Tuple": Tuple,
+        "_coerce_bool": lambda value, default=True: bool(value),
+    }
+    _load_functions(
+        FOUNDRY_PATH,
+        {"_collect_foundry_response_file_inputs"},
+        file_input_namespace,
+    )
+    assert file_input_namespace["_collect_foundry_response_file_inputs"](
+        {"include_document_context": False, "include_file_inputs": True},
+        {"selected_document_ids": ["sensitive-document"]},
+    ) == ([], [])
+
+    manifest = []
+    envelopes = []
+    for source_index in range(12):
+        document_id = f"table-{source_index}"
+        manifest.append(_source(document_id, f"table-{source_index}.csv", "tabular"))
+        envelopes.append(orchestration.build_evidence_envelope(
+            document_id=document_id,
+            source_kind="tabular",
+            engine="tabular_tools",
+            status="completed",
+            summary="s" * 4000,
+            evidence=[{"rows": "x" * 1500} for _ in range(10)],
+            citations=[{"tool": "count_rows", "payload": "y" * 1000}],
+            coverage={"terminal": True, "tool_call_count": 1},
+        ))
+    handoff = orchestration.build_mixed_source_evidence_handoff(
+        manifest,
+        envelopes,
+        "selected",
+    )
+    assert handoff["mixed_source_coverage"]["handoff_compacted"] is True
+    assert handoff["mixed_source_coverage"]["partial_coverage"] is True
+    assert handoff["mixed_source_coverage"]["evidence_compacted_count"] == 12
+
+    plugin_source = _read(
+        APP_ROOT / "semantic_kernel_plugins" / "tabular_processing_plugin.py"
+    )
+    assert "authorized_blob_locations" in plugin_source
+    assert "exact_authorized_locations" in plugin_source

--- a/functional_tests/test_mixed_source_manifest_contracts.py
+++ b/functional_tests/test_mixed_source_manifest_contracts.py
@@ -2,12 +2,13 @@
 # test_mixed_source_manifest_contracts.py
 """
 Functional test for authorized mixed-source manifest and evidence contracts.
-Version: 0.250.062
-Implemented in: 0.250.062
+Version: 0.250.064
+Implemented in: 0.250.062; Phase 2 request/evidence coverage added in 0.250.064
 
 This test ensures Phase 1 of #1056 resolves requested sources once through
 current authorization boundaries, preserves ordering, partitions mixed source
-types, and bounds engine-neutral evidence without implementing #1057-#1061.
+types, and bounds engine-neutral evidence. It also validates the shared Phase 2
+request and evidence primitives for #1057 without implementing #1058-#1061.
 Parent initiative: #1055.
 """
 
@@ -486,6 +487,275 @@ def test_selection_mode_normalization():
         raise AssertionError("Invalid selection_mode must fail validation")
 
 
+def test_phase_2_document_context_request_contract():
+    selected_panel_open = orchestration.normalize_document_context_request(
+        selection_mode="selected",
+        selected_document_ids=["personal-pdf", "personal-xlsx"],
+        document_context_requested=True,
+        hybrid_search=True,
+    )
+    selected_panel_closed = orchestration.normalize_document_context_request(
+        selection_mode="selected",
+        selected_document_ids=["personal-pdf", "personal-xlsx"],
+        document_context_requested=True,
+        hybrid_search=False,
+    )
+
+    assert selected_panel_open["selection_mode"] == "selected"
+    assert selected_panel_closed["selection_mode"] == "selected"
+    assert selected_panel_open["selected_document_ids"] == selected_panel_closed[
+        "selected_document_ids"
+    ]
+    assert selected_panel_open["document_context_requested"] is True
+    assert selected_panel_closed["document_context_requested"] is True
+    assert selected_panel_open["explicit_selection"] is True
+    assert selected_panel_closed["explicit_selection"] is True
+    assert selected_panel_open["hybrid_search"] is True
+    assert selected_panel_closed["hybrid_search"] is False
+
+    legacy_toggle_request = orchestration.normalize_document_context_request(
+        hybrid_search=True,
+    )
+    assert legacy_toggle_request == {
+        "selection_mode": "relevance",
+        "selected_document_ids": [],
+        "document_context_requested": True,
+        "hybrid_search": True,
+        "explicit_selection": False,
+    }
+
+    idle_relevance_request = orchestration.normalize_document_context_request(
+        selection_mode="relevance",
+        selected_document_ids=[],
+        document_context_requested=False,
+        hybrid_search=False,
+    )
+    assert idle_relevance_request["document_context_requested"] is False
+    assert idle_relevance_request["selection_mode"] == "relevance"
+
+    for invalid_request in (
+        {
+            "selection_mode": "history",
+            "selected_document_ids": ["personal-pdf"],
+        },
+        {
+            "selection_mode": "selected",
+            "selected_document_ids": [],
+        },
+        {
+            "document_context_requested": "sometimes",
+        },
+    ):
+        try:
+            orchestration.normalize_document_context_request(**invalid_request)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("Invalid Phase 2 request contracts must fail closed")
+
+
+def test_phase_2_evidence_execution_and_partial_coverage():
+    manifest = [
+        {
+            "document_id": "personal-pdf",
+            "display_name": "Narrative",
+            "source_kind": "narrative",
+            "authorization_status": "authorized",
+        },
+        {
+            "document_id": "personal-xlsx",
+            "display_name": "Table",
+            "source_kind": "tabular",
+            "authorization_status": "authorized",
+        },
+        {
+            "document_id": "missing-source",
+            "display_name": None,
+            "source_kind": "unresolved",
+            "authorization_status": "unresolved",
+        },
+    ]
+    narrative_envelopes = orchestration.build_narrative_evidence_envelopes(
+        [manifest[0]],
+        [{
+            "document_id": "personal-pdf",
+            "chunk_text": "Bounded narrative evidence",
+            "id": "citation-1",
+            "page_number": 2,
+            "score": 0.9,
+        }],
+        "selected",
+    )
+    executor_calls = []
+    tabular_envelopes = orchestration.execute_tabular_evidence_sources(
+        [manifest[1]],
+        lambda source: executor_calls.append(source["document_id"]) or {
+            "summary": "Computed total: 42",
+            "evidence": [{"total": 42}],
+            "citations": [{"tool_name": "count_rows"}],
+            "coverage": {"tool_call_count": 1},
+        },
+        "selected",
+    )
+    handoff = orchestration.build_mixed_source_evidence_handoff(
+        manifest,
+        narrative_envelopes + tabular_envelopes,
+        "selected",
+    )
+
+    assert executor_calls == ["personal-xlsx"]
+    assert narrative_envelopes[0]["status"] == "completed"
+    assert tabular_envelopes[0]["status"] == "completed"
+    assert tabular_envelopes[0]["coverage"]["terminal"] is True
+    assert handoff["mixed_source_coverage"]["partial_coverage"] is True
+    assert handoff["mixed_source_coverage"]["failed_source_count"] == 1
+    assert "missing-source" not in handoff["content"]
+    assert "Unavailable selected source 3" in handoff["content"]
+
+
+def test_phase_2_narrative_only_tabular_skip_is_terminal():
+    assert orchestration.should_run_tabular_evidence(
+        "Calculate the total and average from the spreadsheet.",
+        has_narrative_sources=True,
+    ) is True
+    assert orchestration.should_run_tabular_evidence(
+        "Summarize all selected documents.",
+        has_narrative_sources=True,
+    ) is True
+    assert orchestration.should_run_tabular_evidence(
+        "What policy does the PDF state?",
+        has_narrative_sources=True,
+    ) is False
+
+    executor_calls = []
+    envelopes = orchestration.execute_tabular_evidence_sources(
+        [{"document_id": "personal-xlsx"}],
+        lambda source: executor_calls.append(source),
+        "selected",
+        execute=False,
+    )
+    assert executor_calls == []
+    assert envelopes[0]["status"] == "skipped"
+    assert envelopes[0]["coverage"]["terminal"] is True
+
+
+def test_phase_2_manifest_builds_cross_scope_tabular_contexts():
+    contexts = orchestration.build_tabular_file_contexts_from_manifest([
+        {
+            "document_id": "personal-csv",
+            "file_name": "personal.csv",
+            "source_kind": "tabular",
+            "scope": "personal",
+            "scope_id": "user-1",
+            "authorization_status": "authorized",
+        },
+        {
+            "document_id": "group-xlsx",
+            "file_name": "group.xlsx",
+            "source_kind": "tabular",
+            "scope": "group",
+            "scope_id": "group-a",
+            "group_id": "group-a",
+            "authorization_status": "authorized",
+        },
+        {
+            "document_id": "public-xls",
+            "file_name": "public.xls",
+            "source_kind": "tabular",
+            "scope": "public",
+            "scope_id": "public-a",
+            "public_workspace_id": "public-a",
+            "authorization_status": "authorized",
+        },
+        {
+            "document_id": "chat-csv",
+            "file_name": "chat.csv",
+            "source_kind": "tabular",
+            "scope": "chat",
+            "scope_id": "conversation-1",
+            "conversation_id": "conversation-1",
+            "authorization_status": "authorized",
+        },
+        {
+            "document_id": "unauthorized-csv",
+            "file_name": None,
+            "source_kind": "unresolved",
+            "scope": None,
+            "authorization_status": "unresolved",
+        },
+    ])
+
+    assert [context["source_hint"] for context in contexts] == [
+        "workspace",
+        "group",
+        "public",
+        "chat",
+    ]
+    assert contexts[1]["group_id"] == "group-a"
+    assert contexts[2]["public_workspace_id"] == "public-a"
+    assert contexts[3]["conversation_id"] == "conversation-1"
+    assert all(context["document_id"] != "unauthorized-csv" for context in contexts)
+
+
+def test_restrictive_manifest_scope_fails_closed_and_preserves_storage_locator():
+    contexts = {
+        "personal-table": {
+            "scope": "personal",
+            "document": {
+                "id": "personal-table",
+                "user_id": "user-1",
+                "file_name": "shared.xlsx",
+            },
+        },
+        "group-table": {
+            "scope": "group",
+            "group_id": "group-1",
+            "document": {
+                "id": "group-table",
+                "group_id": "group-1",
+                "file_name": "archive.xlsx",
+                "version": 2,
+                "blob_container": "group-documents",
+                "blob_path": "group-1/family-1/group-table/archive.xlsx",
+                "blob_path_mode": "archived_revision",
+            },
+        },
+        "chat-table": {
+            "scope": "chat",
+            "conversation_id": "conversation-1",
+            "document": {
+                "id": "chat-table",
+                "conversation_id": "conversation-1",
+                "file_name": "chat.csv",
+            },
+        },
+    }
+
+    def resolver(**kwargs):
+        assert kwargs["doc_scope"] == "group"
+        return contexts.get(kwargs["document_id"])
+
+    manifest = orchestration.resolve_authorized_source_manifest(
+        ["personal-table", "group-table", "chat-table"],
+        user_id="user-1",
+        selection_mode="selected",
+        conversation_id="conversation-1",
+        active_group_ids=["group-1"],
+        doc_scope="group",
+        context_resolver=resolver,
+    )
+
+    assert manifest[0]["authorization_status"] == "unresolved"
+    assert manifest[1]["scope"] == "group"
+    assert manifest[1]["storage_locator"] == {
+        "container": "group-documents",
+        "blob_path": "group-1/family-1/group-table/archive.xlsx",
+    }
+    assert manifest[2]["authorization_status"] == "unresolved"
+    tabular_contexts = orchestration.build_tabular_file_contexts_from_manifest(manifest)
+    assert tabular_contexts[0]["storage_locator"] == manifest[1]["storage_locator"]
+
+
 def test_batch_authorization_snapshot_and_source_limit():
     search_service, state, _, _ = build_authorized_resolver_fixture()
     state["group_authorization_count"] = 0
@@ -669,6 +939,11 @@ def run_tests():
         test_unresolved_and_unsupported_do_not_erase_valid_sources,
         test_personal_group_public_and_chat_authorization,
         test_selection_mode_normalization,
+        test_phase_2_document_context_request_contract,
+        test_phase_2_evidence_execution_and_partial_coverage,
+        test_phase_2_narrative_only_tabular_skip_is_terminal,
+        test_phase_2_manifest_builds_cross_scope_tabular_contexts,
+        test_restrictive_manifest_scope_fails_closed_and_preserves_storage_locator,
         test_batch_authorization_snapshot_and_source_limit,
         test_evidence_envelope_serialization_and_bounds,
         test_manifest_diagnostics_are_aggregate_only,

--- a/scripts/Migration-AISearch.ps1
+++ b/scripts/Migration-AISearch.ps1
@@ -1,0 +1,1308 @@
+# Migration-AISearch.ps1
+#Requires -Version 7.0
+
+[CmdletBinding()]
+param(
+    [string]$SourceSearchService = "<source-search-service>",
+
+    [string]$SourceResourceGroup = "<source-resource-group>",
+
+    [string]$SourceSubscriptionId = "<source-subscription-id>",
+
+    [string]$SourceAdminKey = "",
+
+    [string]$DestinationSearchService = "<destination-search-service>",
+
+    [string]$DestinationResourceGroup = "<destination-resource-group>",
+
+    [string]$DestinationSubscriptionId = "<destination-subscription-id>",
+
+    [string]$DestinationAdminKey = "",
+
+    [bool]$DifferentialMigration = $false,
+
+    [bool]$ShowProgress = $true,
+
+    [ValidateRange(1, 100000)]
+    [int]$ProgressUpdateInterval = 100,
+
+    [ValidateRange(1, 1000)]
+    [int]$BatchSize = 100,
+
+    [ValidateRange(1, 64)]
+    [int]$MaxConcurrentBatches = 30,
+
+    [ValidateRange(1024, 16777216)]
+    [int]$MaxBatchBytes = 15000000,
+
+    [ValidateRange(1, 1000)]
+    [int]$PageSize = 100,
+
+    [ValidateRange(1, 10)]
+    [int]$MaxRetryCount = 5,
+
+    [ValidateRange(30, 3600)]
+    [int]$RequestTimeoutSeconds = 300,
+
+    [string]$ApiVersion = "2026-04-01",
+
+    [string]$ManagementApiVersion = "2025-05-01",
+
+    # Optional parameters for testing against Azure Government or other sovereign clouds.
+    [string]$SearchDnsSuffix = "search.windows.net",
+
+    [string]$StateFilePath = "",
+
+    [switch]$ResetState
+)
+
+$ErrorActionPreference = "Stop"
+. (Join-Path $PSScriptRoot "Migration-State.ps1")
+
+function Get-AISearchProgressPercent {
+    param(
+        [long]$ProcessedCount,
+        [long]$TotalCount
+    )
+
+    if ($TotalCount -le 0) {
+        return 100
+    }
+
+    return [int][Math]::Min(
+        100,
+        [Math]::Floor(([double]$ProcessedCount / [double]$TotalCount) * 100)
+    )
+}
+
+function Write-AISearchProgress {
+    param(
+        [int]$Id,
+        [int]$ParentId = -1,
+        [string]$Activity,
+        [string]$Status = "",
+        [string]$CurrentOperation = "",
+        [int]$PercentComplete = -1,
+        [switch]$Completed
+    )
+
+    if (-not $ShowProgress) {
+        return
+    }
+
+    $progressParameters = @{
+        Id = $Id
+        ParentId = $ParentId
+        Activity = $Activity
+    }
+
+    if ($Completed) {
+        $progressParameters.Completed = $true
+    }
+    else {
+        $progressParameters.Status = $Status
+        $progressParameters.PercentComplete = $PercentComplete
+        if (-not [string]::IsNullOrWhiteSpace($CurrentOperation)) {
+            $progressParameters.CurrentOperation = $CurrentOperation
+        }
+    }
+
+    Write-Progress @progressParameters
+}
+
+function Write-AISearchCountProgress {
+    param(
+        [int]$Id,
+        [int]$ParentId = -1,
+        [string]$Activity,
+        [string]$Phase,
+        [long]$ProcessedCount,
+        [long]$TotalCount,
+        [string]$CurrentOperation = ""
+    )
+
+    $percentComplete = Get-AISearchProgressPercent `
+        -ProcessedCount $ProcessedCount `
+        -TotalCount $TotalCount
+    $remainingCount = [Math]::Max(0, $TotalCount - $ProcessedCount)
+    $status = "$Phase`: $ProcessedCount/$TotalCount | Remaining: $remainingCount | $percentComplete%"
+
+    Write-AISearchProgress `
+        -Id $Id `
+        -ParentId $ParentId `
+        -Activity $Activity `
+        -Status $status `
+        -CurrentOperation $CurrentOperation `
+        -PercentComplete $percentComplete
+}
+
+function Test-AISearchProgressCheckpoint {
+    param(
+        [long]$ProcessedCount,
+        [long]$TotalCount
+    )
+
+    return (
+        $ProcessedCount -eq 1 -or
+        $ProcessedCount -eq $TotalCount -or
+        ($ProcessedCount % $ProgressUpdateInterval) -eq 0
+    )
+}
+
+function Get-AISearchAdminKey {
+    param(
+        [string]$ProvidedKey,
+        [string]$SubscriptionId,
+        [string]$ResourceGroupName,
+        [string]$ServiceName
+    )
+
+    if (-not [string]::IsNullOrWhiteSpace($ProvidedKey)) {
+        return $ProvidedKey
+    }
+
+    Set-AzContext -SubscriptionId $SubscriptionId | Out-Null
+    $encodedResourceGroupName = [Uri]::EscapeDataString($ResourceGroupName)
+    $encodedServiceName = [Uri]::EscapeDataString($ServiceName)
+    $keyPath = "/subscriptions/$SubscriptionId/resourceGroups/$encodedResourceGroupName/providers/Microsoft.Search/searchServices/$encodedServiceName/listAdminKeys?api-version=$ManagementApiVersion"
+    $keyResponse = Invoke-AzRestMethod -Method "POST" -Path $keyPath
+
+    if ($keyResponse.StatusCode -ne 200) {
+        throw "Admin key lookup failed for AI Search service '$ServiceName' with HTTP $($keyResponse.StatusCode)."
+    }
+
+    $keyPair = $keyResponse.Content | ConvertFrom-Json
+    if ([string]::IsNullOrWhiteSpace($keyPair.primaryKey)) {
+        throw "The primary admin key for AI Search service '$ServiceName' could not be resolved."
+    }
+
+    return $keyPair.primaryKey
+}
+
+function New-AISearchUri {
+    param(
+        [string]$Endpoint,
+        [string]$RelativePath
+    )
+
+    return "{0}/{1}?api-version={2}" -f $Endpoint.Trim().TrimEnd("/"), $RelativePath.Trim().TrimStart("/"), $ApiVersion.Trim()
+}
+
+function Invoke-AISearchRequest {
+    param(
+        [ValidateSet("GET", "POST", "PUT")]
+        [string]$Method,
+        [string]$Uri,
+        [string]$AdminKey,
+        [AllowNull()]
+        [object]$Body = $null
+    )
+
+    $headers = @{
+        "api-key" = $AdminKey
+        "Accept" = "application/json"
+    }
+
+    $invokeParameters = @{
+        Method = $Method
+        Uri = $Uri
+        Headers = $headers
+        TimeoutSec = $RequestTimeoutSeconds
+        ErrorAction = "Stop"
+    }
+
+    if ($null -ne $Body) {
+        $invokeParameters.ContentType = "application/json"
+        $invokeParameters.Body = $Body | ConvertTo-Json -Depth 100 -Compress
+    }
+
+    for ($attempt = 1; $attempt -le $MaxRetryCount; $attempt++) {
+        try {
+            return Invoke-RestMethod @invokeParameters
+        }
+        catch {
+            $statusCode = $null
+            if ($null -ne $_.Exception.Response) {
+                $statusCode = [int]$_.Exception.Response.StatusCode
+            }
+
+            $requestTimedOut = $_.Exception.Message -match '(?i)timed out|timeout'
+            $retryable = $statusCode -in @(409, 422, 429, 503) -or $requestTimedOut
+            if (-not $retryable -or $attempt -eq $MaxRetryCount) {
+                throw
+            }
+
+            $retryDelaySeconds = [Math]::Pow(2, $attempt - 1)
+            $failureDescription = if ($requestTimedOut) { "timed out" } else { "returned HTTP $statusCode" }
+            Write-Warning "AI Search request $failureDescription. Retrying in $retryDelaySeconds second(s)."
+            Start-Sleep -Seconds $retryDelaySeconds
+        }
+    }
+}
+
+function ConvertTo-AISearchWritableDefinition {
+    param(
+        [object]$Definition
+    )
+
+    $copy = $Definition | ConvertTo-Json -Depth 100 | ConvertFrom-Json -Depth 100
+    foreach ($property in @($copy.PSObject.Properties)) {
+        if ($property.Name.StartsWith("@odata.", [System.StringComparison]::Ordinal)) {
+            $copy.PSObject.Properties.Remove($property.Name)
+        }
+    }
+
+    $definitionJson = $copy | ConvertTo-Json -Depth 100 -Compress
+    if ($definitionJson.Contains('"<redacted>"')) {
+        throw "The definition for '$($copy.name)' contains a redacted secret and cannot be recreated automatically."
+    }
+
+    return $copy
+}
+
+function Get-AISearchKeyField {
+    param(
+        [object]$IndexDefinition
+    )
+
+    $keyFields = @($IndexDefinition.fields | Where-Object { $_.key -eq $true })
+    if ($keyFields.Count -ne 1) {
+        throw "AI Search index '$($IndexDefinition.name)' must have exactly one key field."
+    }
+
+    return $keyFields[0]
+}
+
+function Get-AISearchDocumentCount {
+    param(
+        [string]$Endpoint,
+        [string]$AdminKey,
+        [string]$IndexName
+    )
+
+    $encodedIndexName = [Uri]::EscapeDataString($IndexName)
+    $countUri = New-AISearchUri -Endpoint $Endpoint -RelativePath "indexes/$encodedIndexName/docs/`$count"
+    return [long](Invoke-AISearchRequest -Method "GET" -Uri $countUri -AdminKey $AdminKey)
+}
+
+function Get-AISearchDocuments {
+    param(
+        [string]$Endpoint,
+        [string]$AdminKey,
+        [object]$IndexDefinition,
+        [switch]$KeysOnly,
+        [long]$TotalCount = 0,
+        [string]$ProgressActivity = "",
+        [string]$ProgressPhase = "Documents",
+        [string]$StartAfterKey = "",
+        [long]$InitialProcessedCount = 0
+    )
+
+    $keyField = Get-AISearchKeyField -IndexDefinition $IndexDefinition
+    $encodedIndexName = [Uri]::EscapeDataString($IndexDefinition.name)
+    $searchUri = New-AISearchUri -Endpoint $Endpoint -RelativePath "indexes/$encodedIndexName/docs/search"
+    $supportsKeysetPagination = $keyField.filterable -eq $true -and $keyField.sortable -eq $true
+    $skip = 0
+    if (-not [string]::IsNullOrEmpty($StartAfterKey) -and -not $supportsKeysetPagination) {
+        throw "Index '$($IndexDefinition.name)' cannot resume by key because its key field is not filterable and sortable."
+    }
+    $lastKey = if ([string]::IsNullOrEmpty($StartAfterKey)) { $null } else { $StartAfterKey }
+    $migrationComplete = $false
+    $pageNumber = 0
+    $emittedCount = $InitialProcessedCount
+
+    while (-not $migrationComplete) {
+        $requestBody = [ordered]@{
+            search = "*"
+            top = $PageSize
+            count = $true
+        }
+
+        if ($KeysOnly) {
+            $requestBody.select = $keyField.name
+        }
+
+        if ($supportsKeysetPagination) {
+            $requestBody.orderby = "$($keyField.name) asc"
+            if ($null -ne $lastKey) {
+                $escapedLastKey = ([string]$lastKey).Replace("'", "''")
+                $requestBody.filter = "$($keyField.name) gt '$escapedLastKey'"
+            }
+        }
+        else {
+            $requestBody.skip = $skip
+        }
+
+        $requestUri = $searchUri
+        $logicalPageCount = 0
+        $logicalPageLastKey = $lastKey
+
+        do {
+            $pageNumber++
+            if (-not [string]::IsNullOrWhiteSpace($ProgressActivity)) {
+                Write-AISearchCountProgress `
+                    -Id 1 `
+                    -ParentId 0 `
+                    -Activity $ProgressActivity `
+                    -Phase $ProgressPhase `
+                    -ProcessedCount $emittedCount `
+                    -TotalCount $TotalCount `
+                    -CurrentOperation "Requesting page $pageNumber (up to $PageSize documents; timeout: $RequestTimeoutSeconds seconds)"
+            }
+
+            $requestStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+            $response = Invoke-AISearchRequest `
+                -Method "POST" `
+                -Uri $requestUri `
+                -AdminKey $AdminKey `
+                -Body $requestBody
+            $requestStopwatch.Stop()
+
+            $documents = @($response.value)
+            if ($pageNumber -eq 1 -or ($pageNumber % 10) -eq 0 -or $documents.Count -lt $PageSize) {
+                $elapsedSeconds = [Math]::Round($requestStopwatch.Elapsed.TotalSeconds, 1)
+                Write-Host "Fetched $ProgressPhase page $pageNumber for index '$($IndexDefinition.name)': $($documents.Count) document(s) in $elapsedSeconds second(s)."
+            }
+            foreach ($document in $documents) {
+                Write-Output $document
+                $emittedCount++
+            }
+
+            $logicalPageCount += $documents.Count
+            if ($documents.Count -gt 0) {
+                $logicalPageLastKey = $documents[-1].PSObject.Properties[$keyField.name].Value
+            }
+
+            $nextLink = $response.PSObject.Properties["@odata.nextLink"].Value
+            $nextPageParameters = $response.PSObject.Properties["@search.nextPageParameters"].Value
+            if ($null -ne $nextLink -and $null -ne $nextPageParameters) {
+                $requestUri = $nextLink
+                $requestBody = $nextPageParameters
+            }
+            else {
+                $requestUri = $null
+            }
+        } while ($null -ne $requestUri)
+
+        if ($logicalPageCount -lt $PageSize) {
+            $migrationComplete = $true
+            continue
+        }
+
+        if ($supportsKeysetPagination) {
+            if ($logicalPageLastKey -eq $lastKey) {
+                throw "Keyset pagination did not advance for index '$($IndexDefinition.name)'."
+            }
+            $lastKey = $logicalPageLastKey
+        }
+        else {
+            $skip += $logicalPageCount
+            if ($skip -gt 100000) {
+                throw "Index '$($IndexDefinition.name)' exceeds skip-based paging limits. Its key field must be filterable and sortable to migrate more than 100,000 documents."
+            }
+        }
+    }
+}
+
+function ConvertTo-AISearchWriteDocument {
+    param(
+        [object]$Document,
+        [ValidateSet("upload", "mergeOrUpload")]
+        [string]$Action
+    )
+
+    $writeDocument = [ordered]@{
+        "@search.action" = $Action
+    }
+
+    foreach ($property in $Document.PSObject.Properties) {
+        if (-not $property.Name.StartsWith("@search.", [System.StringComparison]::Ordinal)) {
+            $writeDocument[$property.Name] = $property.Value
+        }
+    }
+
+    return [pscustomobject]$writeDocument
+}
+
+function Send-AISearchDocumentBatch {
+    param(
+        [string]$Endpoint,
+        [string]$AdminKey,
+        [string]$IndexName,
+        [System.Collections.Generic.List[object]]$Documents
+    )
+
+    if ($Documents.Count -eq 0) {
+        return 0
+    }
+
+    $encodedIndexName = [Uri]::EscapeDataString($IndexName)
+    $indexUri = New-AISearchUri -Endpoint $Endpoint -RelativePath "indexes/$encodedIndexName/docs/index"
+    for ($attempt = 1; $attempt -le $MaxRetryCount; $attempt++) {
+        $response = Invoke-AISearchRequest `
+            -Method "POST" `
+            -Uri $indexUri `
+            -AdminKey $AdminKey `
+            -Body @{ value = @($Documents) }
+
+        $failedDocuments = @($response.value | Where-Object { $_.status -ne $true })
+        if ($failedDocuments.Count -eq 0) {
+            return $Documents.Count
+        }
+
+        $permanentFailures = @($failedDocuments | Where-Object {
+            [int]$_.statusCode -notin @(409, 422, 429, 503)
+        })
+        if ($permanentFailures.Count -gt 0 -or $attempt -eq $MaxRetryCount) {
+            $failureSummary = $failedDocuments | ForEach-Object {
+                "key=$($_.key), status=$($_.statusCode), error=$($_.errorMessage)"
+            }
+            throw "Document indexing failed for index '$IndexName': $($failureSummary -join '; ')"
+        }
+
+        $retryDelaySeconds = [Math]::Pow(2, $attempt - 1)
+        Write-Warning "Document indexing returned transient failures for '$IndexName'. Retrying the batch in $retryDelaySeconds second(s)."
+        Start-Sleep -Seconds $retryDelaySeconds
+    }
+}
+
+function New-AISearchDocumentBatchWorkItem {
+    param(
+        [System.Collections.Generic.List[object]]$Documents,
+        [long]$Sequence
+    )
+
+    $documentArray = @($Documents.ToArray())
+    return [pscustomobject]@{
+        Sequence = $Sequence
+        DocumentCount = $documentArray.Count
+        Documents = $documentArray
+        Body = @{ value = $documentArray } | ConvertTo-Json -Depth 100 -Compress
+    }
+}
+
+function Invoke-AISearchParallelDocumentBatches {
+    param(
+        [Parameter(ValueFromPipeline)]
+        [object]$WorkItem,
+        [string]$Endpoint,
+        [string]$AdminKey,
+        [string]$IndexName
+    )
+
+    begin {
+        $workItems = [System.Collections.Generic.List[object]]::new()
+    }
+    process {
+        $workItems.Add($WorkItem)
+    }
+    end {
+        if ($workItems.Count -eq 0) {
+            return
+        }
+
+        $encodedIndexName = [Uri]::EscapeDataString($IndexName)
+        $indexUri = New-AISearchUri `
+            -Endpoint $Endpoint `
+            -RelativePath "indexes/$encodedIndexName/docs/index"
+        $retryLimit = $MaxRetryCount
+        $requestTimeout = $RequestTimeoutSeconds
+        $invokeRestMethodCommand = Get-Command "Invoke-RestMethod" -ErrorAction "Stop"
+        $invokeRestMethodOverrideDefinition = if (
+            $invokeRestMethodCommand.CommandType -eq "Function"
+        ) {
+            $invokeRestMethodCommand.Definition
+        }
+        else {
+            ""
+        }
+        $startSleepCommand = Get-Command "Start-Sleep" -ErrorAction "Stop"
+        $startSleepOverrideDefinition = if ($startSleepCommand.CommandType -eq "Function") {
+            $startSleepCommand.Definition
+        }
+        else {
+            ""
+        }
+
+        $workItems | ForEach-Object -Parallel {
+            $currentWorkItem = $_
+            if (-not [string]::IsNullOrWhiteSpace($using:invokeRestMethodOverrideDefinition)) {
+                Set-Item `
+                    -Path "Function:Invoke-RestMethod" `
+                    -Value ([scriptblock]::Create($using:invokeRestMethodOverrideDefinition))
+            }
+            if (-not [string]::IsNullOrWhiteSpace($using:startSleepOverrideDefinition)) {
+                Set-Item `
+                    -Path "Function:Start-Sleep" `
+                    -Value ([scriptblock]::Create($using:startSleepOverrideDefinition))
+            }
+
+            $headers = @{
+                "api-key" = $using:AdminKey
+                "Accept" = "application/json"
+            }
+            for ($attempt = 1; $attempt -le $using:retryLimit; $attempt++) {
+                try {
+                    $response = Invoke-RestMethod `
+                        -Method "POST" `
+                        -Uri $using:indexUri `
+                        -Headers $headers `
+                        -ContentType "application/json" `
+                        -Body $currentWorkItem.Body `
+                        -TimeoutSec $using:requestTimeout `
+                        -ErrorAction "Stop"
+                }
+                catch {
+                    $statusCode = 0
+                    if ($null -ne $_.Exception.Response) {
+                        try {
+                            $statusCode = [int]$_.Exception.Response.StatusCode
+                        }
+                        catch {
+                            $statusCode = 0
+                        }
+                    }
+
+                    $requestTimedOut = $_.Exception.Message -match '(?i)timed out|timeout'
+                    $retryable = $statusCode -in @(409, 422, 429, 503) -or $requestTimedOut
+                    if ($retryable -and $attempt -lt $using:retryLimit) {
+                        $retryDelaySeconds = [int][Math]::Pow(2, $attempt - 1)
+                        Start-Sleep -Seconds $retryDelaySeconds
+                        continue
+                    }
+
+                    [pscustomobject]@{
+                        Sequence = $currentWorkItem.Sequence
+                        DocumentCount = $currentWorkItem.DocumentCount
+                        Succeeded = $false
+                        ErrorMessage = "AI Search batch request failed after $attempt attempt(s): $($_.Exception.Message)"
+                    }
+                    return
+                }
+
+                $failedDocuments = @($response.value | Where-Object { $_.status -ne $true })
+                if ($failedDocuments.Count -eq 0) {
+                    [pscustomobject]@{
+                        Sequence = $currentWorkItem.Sequence
+                        DocumentCount = $currentWorkItem.DocumentCount
+                        Succeeded = $true
+                        ErrorMessage = ""
+                    }
+                    return
+                }
+
+                $permanentFailures = @($failedDocuments | Where-Object {
+                    [int]$_.statusCode -notin @(409, 422, 429, 503)
+                })
+                if ($permanentFailures.Count -gt 0 -or $attempt -eq $using:retryLimit) {
+                    $failureSummary = $failedDocuments | ForEach-Object {
+                        "key=$($_.key), status=$($_.statusCode), error=$($_.errorMessage)"
+                    }
+                    [pscustomobject]@{
+                        Sequence = $currentWorkItem.Sequence
+                        DocumentCount = $currentWorkItem.DocumentCount
+                        Succeeded = $false
+                        ErrorMessage = "Document indexing failed for index '$using:IndexName': $($failureSummary -join '; ')"
+                    }
+                    return
+                }
+
+                $retryDelaySeconds = [int][Math]::Pow(2, $attempt - 1)
+                Start-Sleep -Seconds $retryDelaySeconds
+            }
+        } -ThrottleLimit $MaxConcurrentBatches
+    }
+}
+
+function Send-AISearchDocumentBatchWindow {
+    param(
+        [System.Collections.Generic.List[object]]$WorkItems,
+        [string]$Endpoint,
+        [string]$AdminKey,
+        [string]$IndexName
+    )
+
+    if ($WorkItems.Count -eq 0) {
+        return 0
+    }
+
+    if ($MaxConcurrentBatches -eq 1) {
+        $copiedCount = 0
+        foreach ($workItem in $WorkItems) {
+            $documents = [System.Collections.Generic.List[object]]::new()
+            foreach ($document in @($workItem.Documents)) {
+                $documents.Add($document)
+            }
+            $copiedCount += Send-AISearchDocumentBatch `
+                -Endpoint $Endpoint `
+                -AdminKey $AdminKey `
+                -IndexName $IndexName `
+                -Documents $documents
+        }
+        return $copiedCount
+    }
+
+    $batchResults = @(
+        $WorkItems.ToArray() |
+            Invoke-AISearchParallelDocumentBatches `
+                -Endpoint $Endpoint `
+                -AdminKey $AdminKey `
+                -IndexName $IndexName |
+            Sort-Object Sequence
+    )
+    if ($batchResults.Count -ne $WorkItems.Count) {
+        throw "AI Search parallel batch processing returned $($batchResults.Count) result(s) for $($WorkItems.Count) batch(es)."
+    }
+
+    $failedBatch = @($batchResults | Where-Object { -not $_.Succeeded } | Select-Object -First 1)
+    if ($failedBatch.Count -gt 0) {
+        throw $failedBatch[0].ErrorMessage
+    }
+
+    return [long](($batchResults | Measure-Object -Property DocumentCount -Sum).Sum)
+}
+
+function Copy-AISearchSynonymMaps {
+    param(
+        [string]$SourceEndpoint,
+        [string]$SourceKey,
+        [string]$DestinationEndpoint,
+        [string]$DestinationKey
+    )
+
+    $sourceUri = New-AISearchUri -Endpoint $SourceEndpoint -RelativePath "synonymmaps"
+    $destinationUri = New-AISearchUri -Endpoint $DestinationEndpoint -RelativePath "synonymmaps"
+    $sourceMaps = @((Invoke-AISearchRequest -Method "GET" -Uri $sourceUri -AdminKey $SourceKey).value)
+    $destinationMaps = @((Invoke-AISearchRequest -Method "GET" -Uri $destinationUri -AdminKey $DestinationKey).value)
+    $destinationMapNames = @{}
+    foreach ($synonymMap in $destinationMaps) {
+        $destinationMapNames[$synonymMap.name] = $true
+    }
+
+    foreach ($synonymMap in $sourceMaps) {
+        if ($DifferentialMigration -and $destinationMapNames.ContainsKey($synonymMap.name)) {
+            Write-Host "Skipping existing synonym map: $($synonymMap.name)"
+            continue
+        }
+
+        $writableMap = ConvertTo-AISearchWritableDefinition -Definition $synonymMap
+        $encodedMapName = [Uri]::EscapeDataString($synonymMap.name)
+        $mapUri = New-AISearchUri -Endpoint $DestinationEndpoint -RelativePath "synonymmaps/$encodedMapName"
+        Invoke-AISearchRequest -Method "PUT" -Uri $mapUri -AdminKey $DestinationKey -Body $writableMap | Out-Null
+        Write-Host "Migrated synonym map: $($synonymMap.name)"
+    }
+}
+
+function Update-AISearchDocumentCheckpoint {
+    param(
+        [object]$StateContext,
+        [string]$ResourceName,
+        [object]$KeyField,
+        [long]$SourceDocumentCount,
+        [AllowNull()]
+        [object]$LastCommittedKey,
+        [long]$ProcessedCount,
+        [long]$CopiedCount,
+        [long]$SkippedCount,
+        [long]$BatchCount
+    )
+
+    Update-MigrationResourceCheckpoint `
+        -Context $StateContext `
+        -ResourceName $ResourceName `
+        -Progress ([ordered]@{
+            phase = "source_documents"
+            keyField = $KeyField.name
+            resumeSupported = ($KeyField.filterable -eq $true -and $KeyField.sortable -eq $true)
+            sourceDocumentCount = $SourceDocumentCount
+            lastCommittedKey = $LastCommittedKey
+            processedCount = $ProcessedCount
+            copiedCount = $CopiedCount
+            skippedCount = $SkippedCount
+            batchCount = $BatchCount
+        })
+}
+
+function Copy-AISearchIndexDocuments {
+    param(
+        [object]$SourceIndex,
+        [AllowNull()]
+        [object]$DestinationIndex,
+        [bool]$DestinationIndexExisted,
+        [string]$SourceEndpoint,
+        [string]$SourceKey,
+        [string]$DestinationEndpoint,
+        [string]$DestinationKey,
+        [object]$StateContext,
+        [string]$ResourceName
+    )
+
+    $sourceKeyField = Get-AISearchKeyField -IndexDefinition $SourceIndex
+    $indexActivity = "Index '$($SourceIndex.name)' documents"
+    $sourceDocumentCount = Get-AISearchDocumentCount `
+        -Endpoint $SourceEndpoint `
+        -AdminKey $SourceKey `
+        -IndexName $SourceIndex.name
+    $resumeSupported = $sourceKeyField.filterable -eq $true -and $sourceKeyField.sortable -eq $true
+    $processedCount = 0
+    $copiedCount = 0
+    $skippedCount = 0
+    $batchCount = 0
+    $lastCommittedKey = $null
+    $resumeAfterKey = ""
+
+    $resourceCheckpoint = Get-MigrationResourceCheckpoint `
+        -Context $StateContext `
+        -ResourceName $ResourceName
+    if ($null -eq $resourceCheckpoint) {
+        throw "Migration state for index '$($SourceIndex.name)' was not initialized."
+    }
+
+    $storedProgress = $resourceCheckpoint["progress"]
+    if ($null -ne $storedProgress -and $storedProgress.Count -gt 0) {
+        if ($storedProgress["keyField"] -ne $sourceKeyField.name) {
+            throw "Index '$($SourceIndex.name)' changed key fields after checkpointing. Use -ResetState to start over."
+        }
+        if ([bool]$storedProgress["resumeSupported"] -ne $resumeSupported) {
+            throw "Index '$($SourceIndex.name)' changed keyset paging capabilities after checkpointing. Use -ResetState to start over."
+        }
+
+        if ([long]$storedProgress["sourceDocumentCount"] -ne $sourceDocumentCount) {
+            Write-Warning "Source document count changed for index '$($SourceIndex.name)'. Restarting this index from the beginning."
+        }
+        elseif (
+            $resumeSupported -and
+            -not [string]::IsNullOrEmpty([string]$storedProgress["lastCommittedKey"])
+        ) {
+            $lastCommittedKey = [string]$storedProgress["lastCommittedKey"]
+            $resumeAfterKey = $lastCommittedKey
+            $processedCount = [long]$storedProgress["processedCount"]
+            $copiedCount = [long]$storedProgress["copiedCount"]
+            $skippedCount = [long]$storedProgress["skippedCount"]
+            $batchCount = [long]$storedProgress["batchCount"]
+            Write-Host "Resuming index '$($SourceIndex.name)' after committed key '$lastCommittedKey' ($processedCount/$sourceDocumentCount processed)."
+        }
+        elseif ([long]$storedProgress["processedCount"] -gt 0) {
+            Write-Warning "Index '$($SourceIndex.name)' has no safe keyset checkpoint. Restarting this index from the beginning."
+        }
+    }
+
+    Update-AISearchDocumentCheckpoint `
+        -StateContext $StateContext `
+        -ResourceName $ResourceName `
+        -KeyField $sourceKeyField `
+        -SourceDocumentCount $sourceDocumentCount `
+        -LastCommittedKey $lastCommittedKey `
+        -ProcessedCount $processedCount `
+        -CopiedCount $copiedCount `
+        -SkippedCount $skippedCount `
+        -BatchCount $batchCount
+    $existingKeys = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
+
+    if ($DifferentialMigration -and $DestinationIndexExisted) {
+        $destinationKeyField = Get-AISearchKeyField -IndexDefinition $DestinationIndex
+        if ($destinationKeyField.name -ne $sourceKeyField.name) {
+            throw "Index '$($SourceIndex.name)' uses different source and destination key fields."
+        }
+
+        $destinationDocumentCount = Get-AISearchDocumentCount `
+            -Endpoint $DestinationEndpoint `
+            -AdminKey $DestinationKey `
+            -IndexName $DestinationIndex.name
+        $destinationKeysRead = 0
+        Write-Host "Reading destination keys for differential migration: $($SourceIndex.name)"
+        Write-AISearchCountProgress `
+            -Id 1 `
+            -ParentId 0 `
+            -Activity $indexActivity `
+            -Phase "Destination keys" `
+            -ProcessedCount 0 `
+            -TotalCount $destinationDocumentCount `
+            -CurrentOperation "Comparing destination document keys"
+        Get-AISearchDocuments `
+            -Endpoint $DestinationEndpoint `
+            -AdminKey $DestinationKey `
+            -IndexDefinition $DestinationIndex `
+            -KeysOnly `
+            -TotalCount $destinationDocumentCount `
+            -ProgressActivity $indexActivity `
+            -ProgressPhase "Destination keys" | ForEach-Object {
+            $destinationDocument = $_
+            $keyValue = [string]$destinationDocument.PSObject.Properties[$destinationKeyField.name].Value
+            [void]$existingKeys.Add($keyValue)
+            $destinationKeysRead++
+            if (Test-AISearchProgressCheckpoint `
+                -ProcessedCount $destinationKeysRead `
+                -TotalCount $destinationDocumentCount) {
+                Write-AISearchCountProgress `
+                    -Id 1 `
+                    -ParentId 0 `
+                    -Activity $indexActivity `
+                    -Phase "Destination keys" `
+                    -ProcessedCount $destinationKeysRead `
+                    -TotalCount $destinationDocumentCount `
+                    -CurrentOperation "Comparing destination document keys"
+            }
+        }
+    }
+
+    $nonRetrievableFields = @($SourceIndex.fields | Where-Object { $_.retrievable -eq $false })
+    if ($nonRetrievableFields.Count -gt 0) {
+        $fieldNames = $nonRetrievableFields.name -join ", "
+        Write-Warning "Index '$($SourceIndex.name)' has non-retrievable fields that cannot be copied: $fieldNames"
+    }
+
+    $action = "upload"
+    $batch = [System.Collections.Generic.List[object]]::new()
+    $pendingBatches = [System.Collections.Generic.List[object]]::new()
+    $batchBytes = 12
+    $pendingDocumentCount = 0
+    $lastProcessedKey = $lastCommittedKey
+    $nextBatchSequence = $batchCount + 1
+
+    Write-AISearchCountProgress `
+        -Id 1 `
+        -ParentId 0 `
+        -Activity $indexActivity `
+        -Phase "Source documents" `
+        -ProcessedCount $processedCount `
+        -TotalCount $sourceDocumentCount `
+        -CurrentOperation "Copied: $copiedCount | Skipped: $skippedCount | Batches: $batchCount | Buffered: 0"
+
+    Get-AISearchDocuments `
+        -Endpoint $SourceEndpoint `
+        -AdminKey $SourceKey `
+        -IndexDefinition $SourceIndex `
+        -TotalCount $sourceDocumentCount `
+        -ProgressActivity $indexActivity `
+        -ProgressPhase "Source documents" `
+        -StartAfterKey $resumeAfterKey `
+        -InitialProcessedCount $processedCount | ForEach-Object {
+        $sourceDocument = $_
+        $keyValue = [string]$sourceDocument.PSObject.Properties[$sourceKeyField.name].Value
+        $documentAlreadyExists = $DifferentialMigration -and $existingKeys.Contains($keyValue)
+        $writeDocument = $null
+        $documentBytes = 0
+        if (-not $documentAlreadyExists) {
+            $writeDocument = ConvertTo-AISearchWriteDocument -Document $sourceDocument -Action $action
+            $documentJson = $writeDocument | ConvertTo-Json -Depth 100 -Compress
+            $documentBytes = [System.Text.Encoding]::UTF8.GetByteCount($documentJson)
+            if ($documentBytes -gt $MaxBatchBytes) {
+                throw "Document '$keyValue' in index '$($SourceIndex.name)' exceeds the configured maximum batch payload size."
+            }
+        }
+
+        $windowFlushed = $false
+        if (
+            -not $documentAlreadyExists -and
+            $batch.Count -gt 0 -and
+            ($batchBytes + $documentBytes + 1) -gt $MaxBatchBytes
+        ) {
+            $pendingBatches.Add((New-AISearchDocumentBatchWorkItem `
+                -Documents $batch `
+                -Sequence $nextBatchSequence))
+            $nextBatchSequence++
+            $pendingDocumentCount += $batch.Count
+            $batch.Clear()
+            $batchBytes = 12
+            if ($pendingBatches.Count -ge $MaxConcurrentBatches) {
+                $completedBatchCount = $pendingBatches.Count
+                $copiedCount += Send-AISearchDocumentBatchWindow `
+                    -WorkItems $pendingBatches `
+                    -Endpoint $DestinationEndpoint `
+                    -AdminKey $DestinationKey `
+                    -IndexName $SourceIndex.name
+                $batchCount += $completedBatchCount
+                $pendingBatches.Clear()
+                $pendingDocumentCount = 0
+                $lastCommittedKey = $lastProcessedKey
+                Update-AISearchDocumentCheckpoint `
+                    -StateContext $StateContext `
+                    -ResourceName $ResourceName `
+                    -KeyField $sourceKeyField `
+                    -SourceDocumentCount $sourceDocumentCount `
+                    -LastCommittedKey $lastCommittedKey `
+                    -ProcessedCount $processedCount `
+                    -CopiedCount $copiedCount `
+                    -SkippedCount $skippedCount `
+                    -BatchCount $batchCount
+                $windowFlushed = $true
+            }
+        }
+
+        $processedCount++
+        $lastProcessedKey = $keyValue
+        if ($documentAlreadyExists) {
+            $skippedCount++
+        }
+        else {
+            $batch.Add($writeDocument)
+            $batchBytes += $documentBytes + 1
+        }
+
+        if ($batch.Count -ge $BatchSize) {
+            $pendingBatches.Add((New-AISearchDocumentBatchWorkItem `
+                -Documents $batch `
+                -Sequence $nextBatchSequence))
+            $nextBatchSequence++
+            $pendingDocumentCount += $batch.Count
+            $batch.Clear()
+            $batchBytes = 12
+        }
+
+        if ($pendingBatches.Count -ge $MaxConcurrentBatches) {
+            $completedBatchCount = $pendingBatches.Count
+            $copiedCount += Send-AISearchDocumentBatchWindow `
+                -WorkItems $pendingBatches `
+                -Endpoint $DestinationEndpoint `
+                -AdminKey $DestinationKey `
+                -IndexName $SourceIndex.name
+            $batchCount += $completedBatchCount
+            $pendingBatches.Clear()
+            $pendingDocumentCount = 0
+            $lastCommittedKey = $lastProcessedKey
+            Update-AISearchDocumentCheckpoint `
+                -StateContext $StateContext `
+                -ResourceName $ResourceName `
+                -KeyField $sourceKeyField `
+                -SourceDocumentCount $sourceDocumentCount `
+                -LastCommittedKey $lastCommittedKey `
+                -ProcessedCount $processedCount `
+                -CopiedCount $copiedCount `
+                -SkippedCount $skippedCount `
+                -BatchCount $batchCount
+            $windowFlushed = $true
+        }
+
+        $checkpointDue = Test-AISearchProgressCheckpoint `
+            -ProcessedCount $processedCount `
+            -TotalCount $sourceDocumentCount
+        if ($checkpointDue -and $batch.Count -eq 0 -and $pendingBatches.Count -eq 0) {
+            $lastCommittedKey = $lastProcessedKey
+            Update-AISearchDocumentCheckpoint `
+                -StateContext $StateContext `
+                -ResourceName $ResourceName `
+                -KeyField $sourceKeyField `
+                -SourceDocumentCount $sourceDocumentCount `
+                -LastCommittedKey $lastCommittedKey `
+                -ProcessedCount $processedCount `
+                -CopiedCount $copiedCount `
+                -SkippedCount $skippedCount `
+                -BatchCount $batchCount
+        }
+
+        if ($windowFlushed -or $checkpointDue) {
+            $bufferedCount = $batch.Count + $pendingDocumentCount
+            Write-AISearchCountProgress `
+                -Id 1 `
+                -ParentId 0 `
+                -Activity $indexActivity `
+                -Phase "Source documents" `
+                -ProcessedCount $processedCount `
+                -TotalCount $sourceDocumentCount `
+                -CurrentOperation "Copied: $copiedCount | Skipped: $skippedCount | Batches: $batchCount | Buffered: $bufferedCount"
+        }
+    }
+
+    if ($batch.Count -gt 0) {
+        $pendingBatches.Add((New-AISearchDocumentBatchWorkItem `
+            -Documents $batch `
+            -Sequence $nextBatchSequence))
+        $pendingDocumentCount += $batch.Count
+        $batch.Clear()
+        $batchBytes = 12
+    }
+
+    if ($pendingBatches.Count -gt 0) {
+        $completedBatchCount = $pendingBatches.Count
+        $copiedCount += Send-AISearchDocumentBatchWindow `
+            -WorkItems $pendingBatches `
+            -Endpoint $DestinationEndpoint `
+            -AdminKey $DestinationKey `
+            -IndexName $SourceIndex.name
+        $batchCount += $completedBatchCount
+        $pendingBatches.Clear()
+        $pendingDocumentCount = 0
+    }
+
+    $lastCommittedKey = $lastProcessedKey
+    Update-AISearchDocumentCheckpoint `
+        -StateContext $StateContext `
+        -ResourceName $ResourceName `
+        -KeyField $sourceKeyField `
+        -SourceDocumentCount $sourceDocumentCount `
+        -LastCommittedKey $lastCommittedKey `
+        -ProcessedCount $processedCount `
+        -CopiedCount $copiedCount `
+        -SkippedCount $skippedCount `
+        -BatchCount $batchCount
+
+    Write-AISearchCountProgress `
+        -Id 1 `
+        -ParentId 0 `
+        -Activity $indexActivity `
+        -Phase "Source documents" `
+        -ProcessedCount $processedCount `
+        -TotalCount $sourceDocumentCount `
+        -CurrentOperation "Copied: $copiedCount | Skipped: $skippedCount | Batches: $batchCount | Buffered: 0"
+    Write-AISearchProgress -Id 1 -ParentId 0 -Activity $indexActivity -Completed
+    Write-Host "Completed index '$($SourceIndex.name)': copied=$copiedCount, skipped=$skippedCount"
+    return [pscustomobject]@{
+        CopiedCount = $copiedCount
+        SkippedCount = $skippedCount
+        ProcessedCount = $processedCount
+        TotalCount = $sourceDocumentCount
+        BatchCount = $batchCount
+    }
+}
+
+$migrationState = $null
+$activeMigrationResource = $null
+
+try {
+    $SourceSearchService = $SourceSearchService.Trim()
+    $SourceResourceGroup = $SourceResourceGroup.Trim()
+    $SourceSubscriptionId = $SourceSubscriptionId.Trim()
+    $DestinationSearchService = $DestinationSearchService.Trim()
+    $DestinationResourceGroup = $DestinationResourceGroup.Trim()
+    $DestinationSubscriptionId = $DestinationSubscriptionId.Trim()
+    $SearchDnsSuffix = $SearchDnsSuffix.Trim().TrimEnd(".")
+    $ApiVersion = $ApiVersion.Trim()
+    $ManagementApiVersion = $ManagementApiVersion.Trim()
+    $SourceAdminKey = $SourceAdminKey.Trim()
+    $DestinationAdminKey = $DestinationAdminKey.Trim()
+    if ([string]::IsNullOrWhiteSpace($StateFilePath)) {
+        $StateFilePath = Join-Path $PSScriptRoot "Migration-AISearch.state.json"
+    }
+
+    foreach ($serviceName in @($SourceSearchService, $DestinationSearchService)) {
+        if ($serviceName -notmatch '^(?!.*--)[a-z0-9](?:[a-z0-9-]{0,58}[a-z0-9])$') {
+            throw "AI Search service name '$serviceName' must contain 2-60 lowercase letters, numbers, or single hyphens."
+        }
+    }
+    if ([string]::IsNullOrWhiteSpace($SearchDnsSuffix)) {
+        throw "SearchDnsSuffix cannot be empty."
+    }
+
+    $sourceEndpoint = "https://$SourceSearchService.$SearchDnsSuffix"
+    $destinationEndpoint = "https://$DestinationSearchService.$SearchDnsSuffix"
+    $parsedEndpoint = $null
+    foreach ($endpoint in @($sourceEndpoint, $destinationEndpoint)) {
+        if (-not [Uri]::TryCreate($endpoint, [UriKind]::Absolute, [ref]$parsedEndpoint)) {
+            throw "AI Search endpoint '$endpoint' is not a valid absolute URI."
+        }
+    }
+
+    Write-AISearchProgress `
+        -Id 0 `
+        -Activity "AI Search migration" `
+        -Status "Connecting and discovering source resources" `
+        -CurrentOperation "Resolving credentials" `
+        -PercentComplete -1
+
+    if ([string]::Equals($sourceEndpoint, $destinationEndpoint, [System.StringComparison]::OrdinalIgnoreCase)) {
+        throw "Source and destination AI Search services must be different."
+    }
+
+    $migrationMode = if ($DifferentialMigration) { "differential" } else { "full" }
+    $stateConfiguration = [ordered]@{
+        sourceService = $SourceSearchService
+        sourceResourceGroup = $SourceResourceGroup
+        sourceSubscriptionId = $SourceSubscriptionId
+        destinationService = $DestinationSearchService
+        destinationResourceGroup = $DestinationResourceGroup
+        destinationSubscriptionId = $DestinationSubscriptionId
+        mode = $migrationMode
+        searchApiVersion = $ApiVersion
+        managementApiVersion = $ManagementApiVersion
+        searchDnsSuffix = $SearchDnsSuffix
+    }
+    $migrationState = Initialize-MigrationState `
+        -MigrationType "ai_search" `
+        -StateFilePath $StateFilePath `
+        -Configuration $stateConfiguration `
+        -Reset:$ResetState
+    Write-Host "Migration state: $($migrationState.Path)"
+
+    if ([string]::IsNullOrWhiteSpace($SourceAdminKey) -or [string]::IsNullOrWhiteSpace($DestinationAdminKey)) {
+        foreach ($requiredCommand in @("Connect-AzAccount", "Set-AzContext", "Invoke-AzRestMethod")) {
+            if (-not (Get-Command $requiredCommand -ErrorAction SilentlyContinue)) {
+                throw "The Az.Accounts command '$requiredCommand' is required when admin keys are not supplied."
+            }
+        }
+
+        Connect-AzAccount | Out-Null
+    }
+
+    $resolvedSourceKey = Get-AISearchAdminKey `
+        -ProvidedKey $SourceAdminKey `
+        -SubscriptionId $SourceSubscriptionId `
+        -ResourceGroupName $SourceResourceGroup `
+        -ServiceName $SourceSearchService
+    $resolvedDestinationKey = Get-AISearchAdminKey `
+        -ProvidedKey $DestinationAdminKey `
+        -SubscriptionId $DestinationSubscriptionId `
+        -ResourceGroupName $DestinationResourceGroup `
+        -ServiceName $DestinationSearchService
+
+    Write-Host "Starting $migrationMode AI Search migration. Destination-only indexes and documents will not be deleted."
+    Write-Host "Document batch concurrency: $MaxConcurrentBatches"
+
+    $synonymMapResource = "synonymmaps"
+    if (Test-MigrationResourceCompleted `
+        -Context $migrationState `
+        -ResourceName $synonymMapResource) {
+        Write-Host "Skipping completed synonym maps from migration state."
+    }
+    else {
+        Start-MigrationResourceCheckpoint `
+            -Context $migrationState `
+            -ResourceName $synonymMapResource
+        $activeMigrationResource = $synonymMapResource
+        Copy-AISearchSynonymMaps `
+            -SourceEndpoint $sourceEndpoint `
+            -SourceKey $resolvedSourceKey `
+            -DestinationEndpoint $destinationEndpoint `
+            -DestinationKey $resolvedDestinationKey
+        Complete-MigrationResourceCheckpoint `
+            -Context $migrationState `
+            -ResourceName $synonymMapResource
+        $activeMigrationResource = $null
+    }
+
+    $sourceIndexesUri = New-AISearchUri -Endpoint $sourceEndpoint -RelativePath "indexes"
+    $destinationIndexesUri = New-AISearchUri -Endpoint $destinationEndpoint -RelativePath "indexes"
+    $sourceIndexes = @((Invoke-AISearchRequest -Method "GET" -Uri $sourceIndexesUri -AdminKey $resolvedSourceKey).value)
+    $destinationIndexes = @((Invoke-AISearchRequest -Method "GET" -Uri $destinationIndexesUri -AdminKey $resolvedDestinationKey).value)
+    $destinationIndexesByName = @{}
+    foreach ($destinationIndex in $destinationIndexes) {
+        $destinationIndexesByName[$destinationIndex.name] = $destinationIndex
+    }
+
+    $completedIndexCount = 0
+    $totalCopiedCount = 0
+    $totalSkippedCount = 0
+    $indexNumber = 0
+    Write-AISearchCountProgress `
+        -Id 0 `
+        -Activity "AI Search migration" `
+        -Phase "Indexes" `
+        -ProcessedCount 0 `
+        -TotalCount $sourceIndexes.Count `
+        -CurrentOperation "Ready to migrate $($sourceIndexes.Count) index(es)"
+
+    foreach ($sourceIndex in $sourceIndexes) {
+        $indexNumber++
+        $resourceName = "index:$($sourceIndex.name)"
+        Write-AISearchCountProgress `
+            -Id 0 `
+            -Activity "AI Search migration" `
+            -Phase "Indexes" `
+            -ProcessedCount $completedIndexCount `
+            -TotalCount $sourceIndexes.Count `
+            -CurrentOperation "Current index: $indexNumber/$($sourceIndexes.Count) - $($sourceIndex.name)"
+
+        if (Test-MigrationResourceCompleted `
+            -Context $migrationState `
+            -ResourceName $resourceName) {
+            $checkpoint = Get-MigrationResourceCheckpoint `
+                -Context $migrationState `
+                -ResourceName $resourceName
+            $completedIndexCount++
+            $totalCopiedCount += [long]$checkpoint["result"]["CopiedCount"]
+            $totalSkippedCount += [long]$checkpoint["result"]["SkippedCount"]
+            Write-Host "Skipping completed index from migration state: $($sourceIndex.name)"
+            Write-AISearchCountProgress `
+                -Id 0 `
+                -Activity "AI Search migration" `
+                -Phase "Indexes" `
+                -ProcessedCount $completedIndexCount `
+                -TotalCount $sourceIndexes.Count `
+                -CurrentOperation "Documents copied: $totalCopiedCount | Skipped: $totalSkippedCount"
+            continue
+        }
+
+        Start-MigrationResourceCheckpoint `
+            -Context $migrationState `
+            -ResourceName $resourceName
+        $activeMigrationResource = $resourceName
+        $destinationIndexExisted = $destinationIndexesByName.ContainsKey($sourceIndex.name)
+        $destinationIndex = if ($destinationIndexExisted) {
+            $destinationIndexesByName[$sourceIndex.name]
+        }
+        else {
+            $null
+        }
+
+        if (-not $destinationIndexExisted -or -not $DifferentialMigration) {
+            $writableIndex = ConvertTo-AISearchWritableDefinition -Definition $sourceIndex
+            $encodedIndexName = [Uri]::EscapeDataString($sourceIndex.name)
+            $destinationIndexUri = New-AISearchUri -Endpoint $destinationEndpoint -RelativePath "indexes/$encodedIndexName"
+            Invoke-AISearchRequest `
+                -Method "PUT" `
+                -Uri $destinationIndexUri `
+                -AdminKey $resolvedDestinationKey `
+                -Body $writableIndex | Out-Null
+            Write-Host "Migrated index definition: $($sourceIndex.name)"
+        }
+        else {
+            Write-Host "Keeping existing destination index definition: $($sourceIndex.name)"
+        }
+
+        $indexResult = Copy-AISearchIndexDocuments `
+            -SourceIndex $sourceIndex `
+            -DestinationIndex $destinationIndex `
+            -DestinationIndexExisted $destinationIndexExisted `
+            -SourceEndpoint $sourceEndpoint `
+            -SourceKey $resolvedSourceKey `
+            -DestinationEndpoint $destinationEndpoint `
+            -DestinationKey $resolvedDestinationKey `
+            -StateContext $migrationState `
+            -ResourceName $resourceName
+
+        Complete-MigrationResourceCheckpoint `
+            -Context $migrationState `
+            -ResourceName $resourceName `
+            -Result $indexResult
+        $activeMigrationResource = $null
+        $completedIndexCount++
+        $totalCopiedCount += $indexResult.CopiedCount
+        $totalSkippedCount += $indexResult.SkippedCount
+        Write-AISearchCountProgress `
+            -Id 0 `
+            -Activity "AI Search migration" `
+            -Phase "Indexes" `
+            -ProcessedCount $completedIndexCount `
+            -TotalCount $sourceIndexes.Count `
+            -CurrentOperation "Documents copied: $totalCopiedCount | Skipped: $totalSkippedCount"
+    }
+
+    Complete-MigrationState `
+        -Context $migrationState `
+        -Summary ([ordered]@{
+            IndexCount = $completedIndexCount
+            CopiedCount = $totalCopiedCount
+            SkippedCount = $totalSkippedCount
+        })
+    Write-Host "AI Search migration completed successfully. Indexes processed: $($sourceIndexes.Count), documents copied: $totalCopiedCount, documents skipped: $totalSkippedCount"
+}
+catch {
+    $migrationErrorMessage = $_.Exception.Message
+    if ($null -ne $migrationState) {
+        try {
+            Set-MigrationStateFailure `
+                -Context $migrationState `
+                -ResourceName $activeMigrationResource `
+                -ErrorMessage $migrationErrorMessage
+        }
+        catch {
+            Write-Warning "Failed to update migration state after an error: $($_.Exception.Message)"
+        }
+    }
+    Write-Error "AI Search migration failed: $migrationErrorMessage" -ErrorAction Continue
+    throw
+}
+finally {
+    Write-AISearchProgress -Id 1 -ParentId 0 -Activity "Index documents" -Completed
+    Write-AISearchProgress -Id 0 -Activity "AI Search migration" -Completed
+}

--- a/scripts/Migration-Cosmos.ps1
+++ b/scripts/Migration-Cosmos.ps1
@@ -1,0 +1,2152 @@
+# Migration-Cosmos.ps1
+#Requires -Version 7.0
+
+[CmdletBinding()]
+param(
+    [string]$SourceCosmosAccount = "<source-cosmos-account>",
+
+    [string]$SourceResourceGroup = "<source-resource-group> ",
+
+    [string]$SourceSubscriptionId = "<source-subscription-id>",
+
+    [string]$SourceDatabaseName = "SimpleChat",
+
+    [string]$SourcePrimaryKey = "<source-primary-key>",
+
+    [string]$DestinationCosmosAccount = "<destination-cosmos-account>",
+
+    [string]$DestinationResourceGroup = "<destination-resource-group>",
+
+    [string]$DestinationSubscriptionId = "<destination-subscription-id>",
+
+    [string]$DestinationDatabaseName = "SimpleChat",
+
+    [string]$DestinationPrimaryKey = "<destination-primary-key>",
+
+    [AllowEmptyCollection()]
+    [string[]]$Containers = @(),
+
+    [bool]$DifferentialMigration = $true,
+
+    [bool]$ShowProgress = $true,
+
+    [ValidateRange(1, 100000)]
+    [int]$ProgressUpdateInterval = 100,
+
+    [ValidateRange(1, 1000)]
+    [int]$PageSize = 100,
+
+    [ValidateRange(1, 64)]
+    [int]$MaxConcurrentDocuments = 60,
+
+    [ValidateRange(1, 10)]
+    [int]$MaxRetryCount = 5,
+
+    [ValidateRange(0, 20)]
+    [int]$MaxThrottleRecoveryPauses = 5,
+
+    [ValidateRange(1, 3600)]
+    [int]$ThrottleRecoveryPauseSeconds = 60,
+
+    [string]$CosmosApiVersion = "2020-07-15",
+
+    [string]$ManagementApiVersion = "2025-04-15",
+
+    [string]$CosmosDnsSuffix = "documents.azure.com",
+
+    [string]$StateFilePath = "",
+
+    [switch]$ResetState
+)
+
+$ErrorActionPreference = "Stop"
+. (Join-Path $PSScriptRoot "Migration-State.ps1")
+$adminSettingsContainerName = "settings"
+$adminSettingsDocumentId = "app_settings"
+$excludedMigrationContainerNames = [string[]]@("file_processing")
+
+function Get-CosmosMigrationProgressPercent {
+    param(
+        [long]$ProcessedCount,
+        [long]$TotalCount
+    )
+
+    if ($TotalCount -le 0) {
+        return 100
+    }
+
+    return [int][Math]::Min(
+        100,
+        [Math]::Floor(([double]$ProcessedCount / [double]$TotalCount) * 100)
+    )
+}
+
+function Write-CosmosMigrationProgress {
+    param(
+        [int]$Id,
+        [int]$ParentId = -1,
+        [string]$Activity,
+        [string]$Status = "",
+        [string]$CurrentOperation = "",
+        [int]$PercentComplete = -1,
+        [switch]$Completed
+    )
+
+    if (-not $ShowProgress) {
+        return
+    }
+
+    $progressParameters = @{
+        Id = $Id
+        ParentId = $ParentId
+        Activity = $Activity
+    }
+
+    if ($Completed) {
+        $progressParameters.Completed = $true
+    }
+    else {
+        $progressParameters.Status = $Status
+        $progressParameters.PercentComplete = $PercentComplete
+        if (-not [string]::IsNullOrWhiteSpace($CurrentOperation)) {
+            $progressParameters.CurrentOperation = $CurrentOperation
+        }
+    }
+
+    Write-Progress @progressParameters
+}
+
+function Write-CosmosMigrationCountProgress {
+    param(
+        [int]$Id,
+        [int]$ParentId = -1,
+        [string]$Activity,
+        [string]$Phase,
+        [long]$ProcessedCount,
+        [long]$TotalCount,
+        [string]$CurrentOperation = ""
+    )
+
+    $percentComplete = Get-CosmosMigrationProgressPercent `
+        -ProcessedCount $ProcessedCount `
+        -TotalCount $TotalCount
+    $remainingCount = [Math]::Max(0, $TotalCount - $ProcessedCount)
+    $status = "$Phase`: $ProcessedCount/$TotalCount | Remaining: $remainingCount | $percentComplete%"
+
+    Write-CosmosMigrationProgress `
+        -Id $Id `
+        -ParentId $ParentId `
+        -Activity $Activity `
+        -Status $status `
+        -CurrentOperation $CurrentOperation `
+        -PercentComplete $percentComplete
+}
+
+function Test-CosmosMigrationProgressCheckpoint {
+    param(
+        [long]$ProcessedCount,
+        [long]$TotalCount = -1
+    )
+
+    return (
+        $ProcessedCount -eq 1 -or
+        ($TotalCount -gt 0 -and $ProcessedCount -eq $TotalCount) -or
+        ($ProcessedCount % $ProgressUpdateInterval) -eq 0
+    )
+}
+
+function Get-CosmosProgressDocumentLabel {
+    param(
+        [AllowNull()]
+        [object]$DocumentId,
+        [int]$MaximumLength = 96
+    )
+
+    $label = [string]$DocumentId
+    if ([string]::IsNullOrWhiteSpace($label)) {
+        return "<missing id>"
+    }
+    if ($label.Length -le $MaximumLength) {
+        return $label
+    }
+    return "$($label.Substring(0, $MaximumLength - 3))..."
+}
+
+function New-CosmosSkippedDocumentRecord {
+    param(
+        [string]$ContainerName,
+        [long]$Sequence,
+        [AllowNull()]
+        [object]$DocumentId,
+        [ValidateSet("Preparation", "Write")]
+        [string]$Stage,
+        [AllowNull()]
+        [object]$Attempt = $null,
+        [AllowNull()]
+        [object]$StatusCode = $null,
+        [string]$Reason
+    )
+
+    $normalizedDocumentId = [string]$DocumentId
+    if ([string]::IsNullOrWhiteSpace($normalizedDocumentId)) {
+        $normalizedDocumentId = "<missing id>"
+    }
+    $normalizedReason = ([string]$Reason).Trim()
+    if ([string]::IsNullOrWhiteSpace($normalizedReason)) {
+        $normalizedReason = "No error details were returned."
+    }
+    if ($normalizedReason.Length -gt 2000) {
+        $normalizedReason = $normalizedReason.Substring(0, 2000)
+    }
+
+    return [pscustomobject][ordered]@{
+        ContainerName = $ContainerName
+        Sequence = $Sequence
+        DocumentId = $normalizedDocumentId
+        Stage = $Stage
+        Attempt = $Attempt
+        StatusCode = $StatusCode
+        Reason = $normalizedReason
+        RecordedUtc = [DateTime]::UtcNow.ToString(
+            "o",
+            [System.Globalization.CultureInfo]::InvariantCulture
+        )
+    }
+}
+
+function Test-CosmosDocumentWriteFailureCanBeSkipped {
+    param(
+        [int]$StatusCode
+    )
+
+    return $StatusCode -in @(400, 409, 413, 422)
+}
+
+function Update-CosmosDocumentSkipCheckpoint {
+    param(
+        [AllowNull()]
+        [object]$Context,
+        [string]$ResourceName,
+        [long]$ProcessedCount,
+        [long]$CopiedCount,
+        [long]$SkippedCount,
+        [long]$RetryCount,
+        [object[]]$SkippedDocuments
+    )
+
+    if ($null -eq $Context) {
+        return
+    }
+
+    Update-MigrationResourceCheckpoint `
+        -Context $Context `
+        -ResourceName $ResourceName `
+        -Progress ([ordered]@{
+            ProcessedCount = $ProcessedCount
+            CopiedCount = $CopiedCount
+            SkippedCount = $SkippedCount
+            RetryCount = $RetryCount
+            ErrorSkippedCount = $SkippedDocuments.Count
+            SkippedDocuments = @($SkippedDocuments)
+        })
+}
+
+function Get-CosmosRecordedErrorSkippedCount {
+    param(
+        [AllowNull()]
+        [object]$Context
+    )
+
+    if ($null -eq $Context) {
+        return 0
+    }
+
+    $recordedCount = 0L
+    foreach ($checkpoint in $Context.Data["resources"].Values) {
+        $countSource = if ($checkpoint["status"] -eq "completed") {
+            $checkpoint["result"]
+        }
+        else {
+            $checkpoint["progress"]
+        }
+        if (
+            $countSource -is [System.Collections.IDictionary] -and
+            $countSource.Contains("ErrorSkippedCount")
+        ) {
+            $recordedCount += [long]$countSource["ErrorSkippedCount"]
+        }
+    }
+    return $recordedCount
+}
+
+function Get-NormalizedCosmosContainerSelection {
+    param(
+        [AllowNull()]
+        [string[]]$ContainerNames
+    )
+
+    $normalizedNames = [System.Collections.Generic.List[string]]::new()
+    $seenNames = [System.Collections.Generic.HashSet[string]]::new(
+        [System.StringComparer]::Ordinal
+    )
+    foreach ($containerName in @($ContainerNames)) {
+        $normalizedName = ([string]$containerName).Trim()
+        if ([string]::IsNullOrWhiteSpace($normalizedName)) {
+            throw "Containers cannot contain an empty container name."
+        }
+        if (
+            $normalizedName.Length -gt 255 -or
+            $normalizedName.IndexOfAny([char[]]'\/\?#') -ge 0
+        ) {
+            throw "Cosmos DB container name '$normalizedName' contains an unsupported character or exceeds 255 characters."
+        }
+        if (-not $seenNames.Add($normalizedName)) {
+            throw "Cosmos DB container '$normalizedName' is listed more than once."
+        }
+        $normalizedNames.Add($normalizedName)
+    }
+    return $normalizedNames.ToArray()
+}
+
+function Select-CosmosMigrationContainers {
+    param(
+        [object[]]$SourceContainers,
+        [string[]]$RequestedContainerNames,
+        [string]$DatabaseName
+    )
+
+    $migratableSourceContainers = @(
+        $SourceContainers | Where-Object {
+            $excludedMigrationContainerNames -cnotcontains [string]$_.id
+        }
+    )
+    $effectiveRequestedContainerNames = @(
+        $RequestedContainerNames | Where-Object {
+            $excludedMigrationContainerNames -cnotcontains $_
+        }
+    )
+    $skippedContainerNames = if ($RequestedContainerNames.Count -eq 0) {
+        @(
+            $SourceContainers | Where-Object {
+                $excludedMigrationContainerNames -ccontains [string]$_.id
+            } | ForEach-Object { [string]$_.id }
+        )
+    }
+    else {
+        @(
+            $RequestedContainerNames | Where-Object {
+                $excludedMigrationContainerNames -ccontains $_
+            }
+        )
+    }
+    if ($skippedContainerNames.Count -gt 0) {
+        Write-Host "Skipping log-only Cosmos DB container(s): $($skippedContainerNames -join ', ')"
+    }
+
+    if ($RequestedContainerNames.Count -eq 0) {
+        return $migratableSourceContainers
+    }
+    if ($effectiveRequestedContainerNames.Count -eq 0) {
+        return @()
+    }
+
+    $sourceContainersByName = [System.Collections.Generic.Dictionary[string, object]]::new(
+        [System.StringComparer]::Ordinal
+    )
+    foreach ($sourceContainer in $migratableSourceContainers) {
+        $sourceContainersByName[[string]$sourceContainer.id] = $sourceContainer
+    }
+
+    $selectedContainers = [System.Collections.Generic.List[object]]::new()
+    $missingContainerNames = [System.Collections.Generic.List[string]]::new()
+    foreach ($containerName in $effectiveRequestedContainerNames) {
+        if ($sourceContainersByName.ContainsKey($containerName)) {
+            $selectedContainers.Add($sourceContainersByName[$containerName])
+        }
+        else {
+            $missingContainerNames.Add($containerName)
+        }
+    }
+    if ($missingContainerNames.Count -gt 0) {
+        throw "Requested Cosmos DB container(s) were not found in source database '$DatabaseName': $($missingContainerNames -join ', ')."
+    }
+    return $selectedContainers.ToArray()
+}
+
+function Test-CosmosMigrationConfiguration {
+    $configuredValues = [ordered]@{
+        SourceCosmosAccount = $SourceCosmosAccount
+        SourceResourceGroup = $SourceResourceGroup
+        SourceSubscriptionId = $SourceSubscriptionId
+        SourceDatabaseName = $SourceDatabaseName
+        DestinationCosmosAccount = $DestinationCosmosAccount
+        DestinationResourceGroup = $DestinationResourceGroup
+        DestinationSubscriptionId = $DestinationSubscriptionId
+        DestinationDatabaseName = $DestinationDatabaseName
+    }
+    foreach ($entry in $configuredValues.GetEnumerator()) {
+        if (
+            [string]::IsNullOrWhiteSpace($entry.Value) -or
+            $entry.Value -match '^<[^>]+>$'
+        ) {
+            throw "Set '$($entry.Key)' in the script or supply it as a parameter."
+        }
+    }
+
+    foreach ($accountName in @($SourceCosmosAccount, $DestinationCosmosAccount)) {
+        if ($accountName -notmatch '^[a-z0-9](?:[a-z0-9-]{1,42}[a-z0-9])$') {
+            throw "Cosmos DB account name '$accountName' must contain 3-44 lowercase letters, numbers, or hyphens and cannot start or end with a hyphen."
+        }
+    }
+
+    foreach ($subscriptionId in @($SourceSubscriptionId, $DestinationSubscriptionId)) {
+        $parsedSubscriptionId = [Guid]::Empty
+        if (-not [Guid]::TryParse($subscriptionId, [ref]$parsedSubscriptionId)) {
+            throw "Subscription ID '$subscriptionId' must be a valid GUID."
+        }
+    }
+
+    foreach ($databaseName in @($SourceDatabaseName, $DestinationDatabaseName)) {
+        if ($databaseName.Length -gt 255 -or $databaseName.IndexOfAny([char[]]'\/\?#') -ge 0) {
+            throw "Cosmos DB database name '$databaseName' contains an unsupported character or exceeds 255 characters."
+        }
+    }
+
+    if (
+        [string]::Equals(
+            $SourceCosmosAccount,
+            $DestinationCosmosAccount,
+            [System.StringComparison]::OrdinalIgnoreCase
+        ) -and
+        [string]::Equals(
+            $SourceDatabaseName,
+            $DestinationDatabaseName,
+            [System.StringComparison]::Ordinal
+        )
+    ) {
+        throw "Source and destination Cosmos DB account/database pairs must be different."
+    }
+}
+
+function Get-CosmosAccountPrimaryKey {
+    param(
+        [string]$ProvidedKey,
+        [string]$SubscriptionId,
+        [string]$ResourceGroupName,
+        [string]$AccountName
+    )
+
+    if (-not [string]::IsNullOrWhiteSpace($ProvidedKey)) {
+        return $ProvidedKey.Trim()
+    }
+
+    Set-AzContext -SubscriptionId $SubscriptionId | Out-Null
+    $encodedResourceGroupName = [Uri]::EscapeDataString($ResourceGroupName)
+    $encodedAccountName = [Uri]::EscapeDataString($AccountName)
+    $keyPath = "/subscriptions/$SubscriptionId/resourceGroups/$encodedResourceGroupName/providers/Microsoft.DocumentDB/databaseAccounts/$encodedAccountName/listKeys?api-version=$ManagementApiVersion"
+    $keyResponse = Invoke-AzRestMethod -Method "POST" -Path $keyPath
+
+    if ($keyResponse.StatusCode -ne 200) {
+        throw "Primary key lookup failed for Cosmos DB account '$AccountName' with HTTP $($keyResponse.StatusCode)."
+    }
+
+    $keyPair = $keyResponse.Content | ConvertFrom-Json
+    if ([string]::IsNullOrWhiteSpace($keyPair.primaryMasterKey)) {
+        throw "The primary key for Cosmos DB account '$AccountName' could not be resolved."
+    }
+
+    return $keyPair.primaryMasterKey
+}
+
+function New-CosmosAuthorizationHeader {
+    param(
+        [string]$Method,
+        [string]$ResourceType,
+        [string]$ResourceLink,
+        [string]$RequestDate,
+        [string]$PrimaryKey
+    )
+
+    try {
+        $keyBytes = [Convert]::FromBase64String($PrimaryKey)
+    }
+    catch {
+        throw "A supplied Cosmos DB primary key is not valid Base64."
+    }
+
+    $payload = "{0}`n{1}`n{2}`n{3}`n`n" -f `
+        $Method.ToLowerInvariant(), `
+        $ResourceType.ToLowerInvariant(), `
+        $ResourceLink, `
+        $RequestDate.ToLowerInvariant()
+    $hmac = [System.Security.Cryptography.HMACSHA256]::new($keyBytes)
+    try {
+        $hash = $hmac.ComputeHash([System.Text.Encoding]::UTF8.GetBytes($payload))
+    }
+    finally {
+        $hmac.Dispose()
+    }
+
+    $signature = [Convert]::ToBase64String($hash)
+    return [Uri]::EscapeDataString("type=master&ver=1.0&sig=$signature")
+}
+
+function ConvertTo-CosmosRequestPath {
+    param(
+        [string]$ResourcePath
+    )
+
+    $encodedSegments = foreach ($segment in $ResourcePath.Split('/')) {
+        [Uri]::EscapeDataString($segment)
+    }
+    return $encodedSegments -join '/'
+}
+
+function Get-CosmosResponseHeaderValue {
+    param(
+        [AllowNull()]
+        [object]$Headers,
+        [string]$Name
+    )
+
+    if ($null -eq $Headers) {
+        return ""
+    }
+
+    if ($Headers -is [System.Collections.IDictionary]) {
+        foreach ($headerName in $Headers.Keys) {
+            if ([string]::Equals([string]$headerName, $Name, [System.StringComparison]::OrdinalIgnoreCase)) {
+                return @($Headers[$headerName]) -join ','
+            }
+        }
+        return ""
+    }
+
+    foreach ($header in $Headers) {
+        if ([string]::Equals([string]$header.Key, $Name, [System.StringComparison]::OrdinalIgnoreCase)) {
+            return @($header.Value) -join ','
+        }
+    }
+    return ""
+}
+
+function Get-CosmosStatisticsDocumentCount {
+    param(
+        [AllowNull()]
+        [object]$Resource
+    )
+
+    if ($null -eq $Resource) {
+        return -1
+    }
+
+    $statisticsProperty = $Resource.PSObject.Properties["statistics"]
+    if ($null -eq $statisticsProperty -or $null -eq $statisticsProperty.Value) {
+        return -1
+    }
+
+    $documentCounts = @(
+        @($statisticsProperty.Value) | Where-Object { $null -ne $_ } | ForEach-Object {
+            $documentCountProperty = $_.PSObject.Properties["documentCount"]
+            if ($null -ne $documentCountProperty -and $null -ne $documentCountProperty.Value) {
+                [long]$documentCountProperty.Value
+            }
+        }
+    )
+    if ($documentCounts.Count -eq 0) {
+        return -1
+    }
+    return [long](($documentCounts | Measure-Object -Sum).Sum)
+}
+
+function Get-CosmosContainerDocumentCount {
+    param(
+        [object]$ContainerDefinition,
+        [string]$SubscriptionId,
+        [string]$ResourceGroupName,
+        [string]$AccountName,
+        [string]$DatabaseName
+    )
+
+    $embeddedCount = Get-CosmosStatisticsDocumentCount -Resource $ContainerDefinition
+    if ($embeddedCount -ge 0) {
+        return $embeddedCount
+    }
+
+    $encodedResourceGroupName = [Uri]::EscapeDataString($ResourceGroupName)
+    $encodedAccountName = [Uri]::EscapeDataString($AccountName)
+    $encodedDatabaseName = [Uri]::EscapeDataString($DatabaseName)
+    $encodedContainerName = [Uri]::EscapeDataString([string]$ContainerDefinition.id)
+    $managementPath = "/subscriptions/$SubscriptionId/resourceGroups/$encodedResourceGroupName/providers/Microsoft.DocumentDB/databaseAccounts/$encodedAccountName/sqlDatabases/$encodedDatabaseName/containers/${encodedContainerName}?api-version=$ManagementApiVersion"
+    $managementResource = $null
+
+    if (Get-Command "Invoke-AzRestMethod" -ErrorAction "SilentlyContinue") {
+        try {
+            $response = Invoke-AzRestMethod -Method "GET" -Path $managementPath
+            if ($response.StatusCode -eq 200) {
+                $managementResource = ($response.Content | ConvertFrom-Json -Depth 100).properties.resource
+            }
+        }
+        catch {
+            Write-Verbose "PowerShell ARM document-count lookup failed for '$($ContainerDefinition.id)': $($_.Exception.Message)"
+        }
+    }
+
+    if ($null -eq $managementResource -and (Get-Command "az" -ErrorAction "SilentlyContinue")) {
+        try {
+            $managementUrl = "https://management.azure.com$managementPath"
+            $azOutput = & az rest `
+                --method get `
+                --url $managementUrl `
+                --output json 2>$null
+            if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($azOutput)) {
+                $managementResource = ($azOutput | ConvertFrom-Json -Depth 100).properties.resource
+            }
+        }
+        catch {
+            Write-Verbose "Azure CLI document-count lookup failed for '$($ContainerDefinition.id)': $($_.Exception.Message)"
+        }
+    }
+
+    $managementCount = Get-CosmosStatisticsDocumentCount -Resource $managementResource
+    if ($managementCount -lt 0) {
+        Write-Verbose "Document total is unavailable for container '$($ContainerDefinition.id)'."
+    }
+    return $managementCount
+}
+
+function Write-CosmosDocumentProgress {
+    param(
+        [string]$Activity,
+        [long]$ProcessedCount,
+        [long]$TotalCount,
+        [string]$CurrentOperation
+    )
+
+    if ($TotalCount -ge 0) {
+        Write-CosmosMigrationCountProgress `
+            -Id 1 `
+            -ParentId 0 `
+            -Activity $Activity `
+            -Phase "Source documents" `
+            -ProcessedCount $ProcessedCount `
+            -TotalCount $TotalCount `
+            -CurrentOperation $CurrentOperation
+        return
+    }
+
+    Write-CosmosMigrationProgress `
+        -Id 1 `
+        -ParentId 0 `
+        -Activity $Activity `
+        -Status "Source documents completed: $ProcessedCount | Total: unavailable" `
+        -PercentComplete -1 `
+        -CurrentOperation $CurrentOperation
+}
+
+function Invoke-CosmosThrottleRecoveryPause {
+    param(
+        [string]$Activity,
+        [string]$ContainerName,
+        [int]$PauseNumber,
+        [int]$ThrottledDocumentCount
+    )
+
+    Write-Warning "Cosmos DB returned HTTP 429 for $ThrottledDocumentCount document(s) in container '$ContainerName' after $MaxRetryCount request attempt(s). Recovery pause $PauseNumber/$MaxThrottleRecoveryPauses begins now; retrying only the throttled document(s) in $ThrottleRecoveryPauseSeconds second(s)."
+    for ($remainingSeconds = $ThrottleRecoveryPauseSeconds; $remainingSeconds -gt 0; $remainingSeconds--) {
+        Write-CosmosMigrationProgress `
+            -Id 1 `
+            -ParentId 0 `
+            -Activity $Activity `
+            -Status "Cosmos DB throttling recovery pause $PauseNumber/$MaxThrottleRecoveryPauses" `
+            -CurrentOperation "$remainingSeconds second(s) until retrying $ThrottledDocumentCount throttled document(s)" `
+            -PercentComplete -1
+        Start-Sleep -Seconds 1
+    }
+}
+
+function New-CosmosThrottleRecoveryExhaustedError {
+    param(
+        [string]$ContainerName,
+        [object[]]$ThrottledWorkItems,
+        [int]$PauseCount
+    )
+
+    $sampleDocument = $ThrottledWorkItems[0]
+    return "Cosmos DB throttling recovery exhausted in container '$ContainerName'. $($ThrottledWorkItems.Count) document(s) still returned HTTP 429 after $MaxRetryCount request attempt(s) and $PauseCount recovery pause(s) of $ThrottleRecoveryPauseSeconds second(s). Example document: '$($sampleDocument.DocumentId)'. Reduce -MaxConcurrentDocuments, increase destination RU capacity, or rerun with the same state file after capacity is available."
+}
+
+function Invoke-CosmosRestRequest {
+    param(
+        [string]$Endpoint,
+        [string]$PrimaryKey,
+        [ValidateSet("GET", "POST", "PUT")]
+        [string]$Method,
+        [string]$ResourcePath,
+        [string]$ResourceType,
+        [string]$ResourceLink,
+        [AllowNull()]
+        [string]$Body = $null,
+        [hashtable]$AdditionalHeaders = @{},
+        [int[]]$AllowedStatusCodes = @(200),
+        [switch]$PreserveJsonPropertyNames
+    )
+
+    $encodedPath = ConvertTo-CosmosRequestPath -ResourcePath $ResourcePath
+    $requestUri = "$($Endpoint.TrimEnd('/'))/$encodedPath"
+
+    for ($attempt = 1; $attempt -le $MaxRetryCount; $attempt++) {
+        $requestDate = [DateTime]::UtcNow.ToString(
+            "r",
+            [System.Globalization.CultureInfo]::InvariantCulture
+        )
+        $requestHeaders = @{
+            "Accept" = "application/json"
+            "Authorization" = New-CosmosAuthorizationHeader `
+                -Method $Method `
+                -ResourceType $ResourceType `
+                -ResourceLink $ResourceLink `
+                -RequestDate $requestDate `
+                -PrimaryKey $PrimaryKey
+            "x-ms-date" = $requestDate
+            "x-ms-version" = $CosmosApiVersion
+        }
+        $contentType = ""
+        foreach ($headerName in $AdditionalHeaders.Keys) {
+            if ([string]::Equals(
+                $headerName,
+                "Content-Type",
+                [System.StringComparison]::OrdinalIgnoreCase
+            )) {
+                $contentType = [string]$AdditionalHeaders[$headerName]
+                continue
+            }
+            $requestHeaders[$headerName] = $AdditionalHeaders[$headerName]
+        }
+
+        $invokeParameters = @{
+            Method = $Method
+            Uri = $requestUri
+            Headers = $requestHeaders
+            SkipHttpErrorCheck = $true
+            ErrorAction = "Stop"
+        }
+        if ($null -ne $Body) {
+            $invokeParameters.Body = $Body
+        }
+        if (-not [string]::IsNullOrWhiteSpace($contentType)) {
+            $invokeParameters.ContentType = $contentType
+        }
+
+        try {
+            $response = Invoke-WebRequest @invokeParameters
+        }
+        catch {
+            if ($attempt -eq $MaxRetryCount) {
+                throw
+            }
+
+            $retryDelayMilliseconds = [int]([Math]::Pow(2, $attempt - 1) * 1000)
+            Write-Warning "Cosmos DB request failed before receiving a response. Retrying in $retryDelayMilliseconds millisecond(s)."
+            Start-Sleep -Milliseconds $retryDelayMilliseconds
+            continue
+        }
+
+        $statusCode = [int]$response.StatusCode
+        if ($AllowedStatusCodes -contains $statusCode) {
+            $responseBody = $null
+            $responseContent = [string]$response.Content
+            if (-not [string]::IsNullOrWhiteSpace($responseContent)) {
+                $responseBody = if ($PreserveJsonPropertyNames) {
+                    $responseContent |
+                        ConvertFrom-Json -AsHashtable -Depth 100
+                }
+                else {
+                    $responseContent | ConvertFrom-Json -Depth 100
+                }
+            }
+            return [pscustomobject]@{
+                StatusCode = $statusCode
+                Headers = $response.Headers
+                Body = $responseBody
+                Content = $responseContent
+            }
+        }
+
+        $retryable = $statusCode -in @(408, 429, 449, 500, 503)
+        if ($retryable -and $attempt -lt $MaxRetryCount) {
+            $retryAfterHeader = Get-CosmosResponseHeaderValue `
+                -Headers $response.Headers `
+                -Name "x-ms-retry-after-ms"
+            $retryAfterMilliseconds = 0
+            if (-not [int]::TryParse($retryAfterHeader, [ref]$retryAfterMilliseconds)) {
+                $retryAfterMilliseconds = [int]([Math]::Pow(2, $attempt - 1) * 1000)
+            }
+            $retryAfterMilliseconds = [Math]::Max(1, $retryAfterMilliseconds)
+            Write-Warning "Cosmos DB request returned HTTP $statusCode. Retrying in $retryAfterMilliseconds millisecond(s)."
+            Start-Sleep -Milliseconds $retryAfterMilliseconds
+            continue
+        }
+
+        $errorContent = [string]$response.Content
+        if ($errorContent.Length -gt 1000) {
+            $errorContent = $errorContent.Substring(0, 1000)
+        }
+        throw "Cosmos DB request '$Method $ResourcePath' failed with HTTP $statusCode. $errorContent"
+    }
+}
+
+function Get-CosmosDatabase {
+    param(
+        [string]$Endpoint,
+        [string]$PrimaryKey,
+        [string]$DatabaseName
+    )
+
+    $resourceLink = "dbs/$DatabaseName"
+    return Invoke-CosmosRestRequest `
+        -Endpoint $Endpoint `
+        -PrimaryKey $PrimaryKey `
+        -Method "GET" `
+        -ResourcePath $resourceLink `
+        -ResourceType "dbs" `
+        -ResourceLink $resourceLink `
+        -AllowedStatusCodes @(200, 404)
+}
+
+function New-CosmosDatabaseIfMissing {
+    param(
+        [string]$Endpoint,
+        [string]$PrimaryKey,
+        [string]$DatabaseName
+    )
+
+    $databaseResponse = Get-CosmosDatabase `
+        -Endpoint $Endpoint `
+        -PrimaryKey $PrimaryKey `
+        -DatabaseName $DatabaseName
+    if ($databaseResponse.StatusCode -eq 200) {
+        return
+    }
+
+    $body = @{ id = $DatabaseName } | ConvertTo-Json -Compress
+    Invoke-CosmosRestRequest `
+        -Endpoint $Endpoint `
+        -PrimaryKey $PrimaryKey `
+        -Method "POST" `
+        -ResourcePath "dbs" `
+        -ResourceType "dbs" `
+        -ResourceLink "" `
+        -Body $body `
+        -AdditionalHeaders @{ "Content-Type" = "application/json" } `
+        -AllowedStatusCodes @(201) | Out-Null
+    Write-Host "Created destination database: $DatabaseName"
+}
+
+function Get-CosmosContainers {
+    param(
+        [string]$Endpoint,
+        [string]$PrimaryKey,
+        [string]$DatabaseName
+    )
+
+    $databaseLink = "dbs/$DatabaseName"
+    $continuation = ""
+    do {
+        $headers = @{
+            "x-ms-max-item-count" = [string]$PageSize
+        }
+        if (-not [string]::IsNullOrWhiteSpace($continuation)) {
+            $headers["x-ms-continuation"] = $continuation
+        }
+        $response = Invoke-CosmosRestRequest `
+            -Endpoint $Endpoint `
+            -PrimaryKey $PrimaryKey `
+            -Method "GET" `
+            -ResourcePath "$databaseLink/colls" `
+            -ResourceType "colls" `
+            -ResourceLink $databaseLink `
+            -AdditionalHeaders $headers
+        foreach ($container in @($response.Body.DocumentCollections)) {
+            Write-Output $container
+        }
+        $continuation = Get-CosmosResponseHeaderValue `
+            -Headers $response.Headers `
+            -Name "x-ms-continuation"
+    } while (-not [string]::IsNullOrWhiteSpace($continuation))
+}
+
+function ConvertTo-CosmosNonNullJsonValue {
+    param(
+        [AllowNull()]
+        [object]$Value
+    )
+
+    if ($null -eq $Value) {
+        return $null
+    }
+    if (
+        $Value -is [string] -or
+        $Value -is [ValueType]
+    ) {
+        return $Value
+    }
+    if ($Value -is [System.Collections.IDictionary]) {
+        $convertedDictionary = [ordered]@{}
+        foreach ($key in $Value.Keys) {
+            if ($null -ne $Value[$key]) {
+                $convertedDictionary[[string]$key] = ConvertTo-CosmosNonNullJsonValue `
+                    -Value $Value[$key]
+            }
+        }
+        return $convertedDictionary
+    }
+    if ($Value -is [System.Collections.IEnumerable]) {
+        $convertedItems = [System.Collections.Generic.List[object]]::new()
+        foreach ($item in $Value) {
+            if ($null -ne $item) {
+                $convertedItems.Add((ConvertTo-CosmosNonNullJsonValue -Value $item))
+            }
+        }
+        return ,$convertedItems.ToArray()
+    }
+
+    $convertedObject = [ordered]@{}
+    foreach ($property in $Value.PSObject.Properties) {
+        if ($null -ne $property.Value) {
+            $convertedObject[$property.Name] = ConvertTo-CosmosNonNullJsonValue `
+                -Value $property.Value
+        }
+    }
+    return $convertedObject
+}
+
+function ConvertTo-CosmosWritableResource {
+    param(
+        [object]$Resource
+    )
+
+    $partitionKey = [ordered]@{
+        paths = @($Resource.partitionKey.paths)
+    }
+    if (-not [string]::IsNullOrWhiteSpace([string]$Resource.partitionKey.kind)) {
+        $partitionKey.kind = [string]$Resource.partitionKey.kind
+    }
+    if ($null -ne $Resource.partitionKey.version) {
+        $partitionKey.version = $Resource.partitionKey.version
+    }
+
+    $writableResource = [ordered]@{
+        id = [string]$Resource.id
+        partitionKey = $partitionKey
+    }
+    $optionalWritableProperties = @(
+        "indexingPolicy",
+        "defaultTtl",
+        "uniqueKeyPolicy",
+        "conflictResolutionPolicy",
+        "analyticalStorageTtl",
+        "computedProperties",
+        "clientEncryptionPolicy",
+        "geospatialConfig",
+        "changeFeedPolicy",
+        "vectorEmbeddingPolicy",
+        "fullTextPolicy"
+    )
+    foreach ($propertyName in $optionalWritableProperties) {
+        $property = $Resource.PSObject.Properties[$propertyName]
+        if ($null -ne $property -and $null -ne $property.Value) {
+            $writableResource[$propertyName] = ConvertTo-CosmosNonNullJsonValue `
+                -Value $property.Value
+        }
+    }
+    return [pscustomobject]$writableResource
+}
+
+function Get-CosmosPartitionKeyDefinitionJson {
+    param(
+        [object]$Container
+    )
+
+    $partitionKey = [ordered]@{
+        paths = @($Container.partitionKey.paths)
+        kind = [string]$Container.partitionKey.kind
+        version = $Container.partitionKey.version
+    }
+    return $partitionKey | ConvertTo-Json -Depth 10 -Compress
+}
+
+function Assert-CosmosContainerCompatibility {
+    param(
+        [object]$SourceContainer,
+        [object]$DestinationContainer
+    )
+
+    $sourcePartitionKey = Get-CosmosPartitionKeyDefinitionJson -Container $SourceContainer
+    $destinationPartitionKey = Get-CosmosPartitionKeyDefinitionJson -Container $DestinationContainer
+    if ($sourcePartitionKey -ne $destinationPartitionKey) {
+        throw "Container '$($SourceContainer.id)' has incompatible source and destination partition key definitions. Cosmos DB partition keys cannot be changed in place."
+    }
+}
+
+function Sync-CosmosContainerDefinition {
+    param(
+        [object]$SourceContainer,
+        [AllowNull()]
+        [object]$DestinationContainer,
+        [string]$DestinationEndpoint,
+        [string]$DestinationKey,
+        [string]$DestinationDatabase
+    )
+
+    $databaseLink = "dbs/$DestinationDatabase"
+    $containerLink = "$databaseLink/colls/$($SourceContainer.id)"
+    $writableContainer = ConvertTo-CosmosWritableResource -Resource $SourceContainer
+    $containerBody = $writableContainer | ConvertTo-Json -Depth 100 -Compress
+    Write-Verbose "Writable container definition for '$($SourceContainer.id)': $containerBody"
+
+    if ($null -eq $DestinationContainer) {
+        Invoke-CosmosRestRequest `
+            -Endpoint $DestinationEndpoint `
+            -PrimaryKey $DestinationKey `
+            -Method "POST" `
+            -ResourcePath "$databaseLink/colls" `
+            -ResourceType "colls" `
+            -ResourceLink $databaseLink `
+            -Body $containerBody `
+            -AdditionalHeaders @{ "Content-Type" = "application/json" } `
+            -AllowedStatusCodes @(201) | Out-Null
+        Write-Host "Created destination container: $($SourceContainer.id)"
+        return
+    }
+
+    Assert-CosmosContainerCompatibility `
+        -SourceContainer $SourceContainer `
+        -DestinationContainer $DestinationContainer
+    if ($DifferentialMigration) {
+        Write-Host "Keeping existing destination container definition: $($SourceContainer.id)"
+        return
+    }
+
+    Invoke-CosmosRestRequest `
+        -Endpoint $DestinationEndpoint `
+        -PrimaryKey $DestinationKey `
+        -Method "PUT" `
+        -ResourcePath $containerLink `
+        -ResourceType "colls" `
+        -ResourceLink $containerLink `
+        -Body $containerBody `
+        -AdditionalHeaders @{ "Content-Type" = "application/json" } `
+        -AllowedStatusCodes @(200) | Out-Null
+    Write-Host "Updated destination container definition: $($SourceContainer.id)"
+}
+
+function Invoke-CosmosDocumentFeedPage {
+    param(
+        [string]$Endpoint,
+        [string]$PrimaryKey,
+        [string]$DatabaseName,
+        [string]$ContainerName,
+        [string]$Continuation = ""
+    )
+
+    $containerLink = "dbs/$DatabaseName/colls/$ContainerName"
+    $headers = @{
+        "x-ms-max-item-count" = [string]$PageSize
+    }
+    if (-not [string]::IsNullOrWhiteSpace($Continuation)) {
+        $headers["x-ms-continuation"] = $Continuation
+    }
+
+    return Invoke-CosmosRestRequest `
+        -Endpoint $Endpoint `
+        -PrimaryKey $PrimaryKey `
+        -Method "GET" `
+        -ResourcePath "$containerLink/docs" `
+        -ResourceType "docs" `
+        -ResourceLink $containerLink `
+        -AdditionalHeaders $headers `
+        -PreserveJsonPropertyNames
+}
+
+function Get-CosmosDocuments {
+    param(
+        [string]$Endpoint,
+        [string]$PrimaryKey,
+        [string]$DatabaseName,
+        [string]$ContainerName,
+        [bool]$ExcludeAdminSettings
+    )
+
+    $continuation = ""
+
+    do {
+        $response = Invoke-CosmosDocumentFeedPage `
+            -Endpoint $Endpoint `
+            -PrimaryKey $PrimaryKey `
+            -DatabaseName $DatabaseName `
+            -ContainerName $ContainerName `
+            -Continuation $continuation
+        foreach ($document in @($response.Body.Documents)) {
+            if (
+                $ExcludeAdminSettings -and
+                [string]::Equals(
+                    [string]$document.id,
+                    $adminSettingsDocumentId,
+                    [System.StringComparison]::Ordinal
+                )
+            ) {
+                continue
+            }
+            Write-Output $document
+        }
+        $continuation = Get-CosmosResponseHeaderValue `
+            -Headers $response.Headers `
+            -Name "x-ms-continuation"
+    } while (-not [string]::IsNullOrWhiteSpace($continuation))
+}
+
+function Get-CosmosPropertyPathValue {
+    param(
+        [object]$Document,
+        [string]$Path
+    )
+
+    $current = $Document
+    $segments = $Path.TrimStart('/').Split('/')
+    foreach ($encodedSegment in $segments) {
+        $segment = $encodedSegment.Replace('~1', '/').Replace('~0', '~')
+        if ($current -is [System.Collections.IDictionary]) {
+            if (-not $current.Contains($segment)) {
+                return [pscustomobject]@{ Exists = $false; Value = $null }
+            }
+            $current = $current[$segment]
+            continue
+        }
+
+        $property = $current.PSObject.Properties[$segment]
+        if ($null -eq $property) {
+            return [pscustomobject]@{ Exists = $false; Value = $null }
+        }
+        $current = $property.Value
+    }
+
+    return [pscustomobject]@{ Exists = $true; Value = $current }
+}
+
+function Get-CosmosPartitionKeyHeader {
+    param(
+        [object]$Document,
+        [object]$ContainerDefinition
+    )
+
+    $partitionKeyValues = [System.Collections.Generic.List[object]]::new()
+    foreach ($path in @($ContainerDefinition.partitionKey.paths)) {
+        $pathValue = Get-CosmosPropertyPathValue -Document $Document -Path $path
+        if ($pathValue.Exists) {
+            $partitionKeyValues.Add($pathValue.Value)
+        }
+        else {
+            $partitionKeyValues.Add([pscustomobject]@{})
+        }
+    }
+    return ConvertTo-Json -InputObject $partitionKeyValues.ToArray() -Depth 100 -Compress
+}
+
+function ConvertTo-CosmosWritableDocument {
+    param(
+        [object]$Document
+    )
+
+    $copy = $Document |
+        ConvertTo-Json -Depth 100 |
+        ConvertFrom-Json -AsHashtable -Depth 100
+    foreach ($propertyName in @("_rid", "_self", "_etag", "_attachments", "_ts")) {
+        [void]$copy.Remove($propertyName)
+    }
+    return $copy
+}
+
+function Send-CosmosDocument {
+    param(
+        [object]$Document,
+        [object]$ContainerDefinition,
+        [string]$Endpoint,
+        [string]$PrimaryKey,
+        [string]$DatabaseName
+    )
+
+    $writableDocument = ConvertTo-CosmosWritableDocument -Document $Document
+    if ([string]::IsNullOrWhiteSpace([string]$writableDocument.id)) {
+        throw "Container '$($ContainerDefinition.id)' contains a document without a valid id."
+    }
+
+    $containerLink = "dbs/$DatabaseName/colls/$($ContainerDefinition.id)"
+    $headers = @{
+        "Content-Type" = "application/json"
+        "x-ms-documentdb-partitionkey" = Get-CosmosPartitionKeyHeader `
+            -Document $writableDocument `
+            -ContainerDefinition $ContainerDefinition
+    }
+    $allowedStatusCodes = @(201)
+    if (-not $DifferentialMigration) {
+        $headers["x-ms-documentdb-is-upsert"] = "true"
+        $allowedStatusCodes = @(200, 201)
+    }
+
+    $response = Invoke-CosmosRestRequest `
+        -Endpoint $Endpoint `
+        -PrimaryKey $PrimaryKey `
+        -Method "POST" `
+        -ResourcePath "$containerLink/docs" `
+        -ResourceType "docs" `
+        -ResourceLink $containerLink `
+        -Body ($writableDocument | ConvertTo-Json -Depth 100 -Compress) `
+        -AdditionalHeaders $headers `
+        -AllowedStatusCodes ($allowedStatusCodes + @(409)) `
+        -PreserveJsonPropertyNames
+    if ($response.StatusCode -eq 409) {
+        if (-not $DifferentialMigration) {
+            throw "Full migration received an unexpected HTTP 409 conflict for document '$($writableDocument.id)' in container '$($ContainerDefinition.id)'."
+        }
+        return "Skipped"
+    }
+    return "Copied"
+}
+
+function New-CosmosDocumentWriteWorkItem {
+    param(
+        [object]$Document,
+        [object]$ContainerDefinition,
+        [long]$Sequence
+    )
+
+    $writableDocument = ConvertTo-CosmosWritableDocument -Document $Document
+    if ([string]::IsNullOrWhiteSpace([string]$writableDocument.id)) {
+        throw "Container '$($ContainerDefinition.id)' contains a document without a valid id."
+    }
+
+    return [pscustomobject]@{
+        Sequence = $Sequence
+        DocumentId = [string]$writableDocument.id
+        DocumentLabel = Get-CosmosProgressDocumentLabel -DocumentId $writableDocument.id
+        Body = $writableDocument | ConvertTo-Json -Depth 100 -Compress
+        PartitionKeyHeader = Get-CosmosPartitionKeyHeader `
+            -Document $writableDocument `
+            -ContainerDefinition $ContainerDefinition
+    }
+}
+
+function Invoke-CosmosParallelDocumentWrites {
+    param(
+        [Parameter(ValueFromPipeline)]
+        [object]$WorkItem,
+        [string]$Endpoint,
+        [string]$PrimaryKey,
+        [string]$DatabaseName,
+        [string]$ContainerName
+    )
+
+    begin {
+        $workItems = [System.Collections.Generic.List[object]]::new()
+    }
+    process {
+        $workItems.Add($WorkItem)
+    }
+    end {
+        if ($workItems.Count -eq 0) {
+            return
+        }
+
+        $resourceLink = "dbs/$DatabaseName/colls/$ContainerName"
+        $encodedDatabaseName = [Uri]::EscapeDataString($DatabaseName)
+        $encodedContainerName = [Uri]::EscapeDataString($ContainerName)
+        $requestUri = "$($Endpoint.TrimEnd('/'))/dbs/$encodedDatabaseName/colls/$encodedContainerName/docs"
+        $keyBytes = [Convert]::FromBase64String($PrimaryKey)
+        $apiVersion = $CosmosApiVersion
+        $retryLimit = $MaxRetryCount
+        $useUpsert = -not $DifferentialMigration
+        $invokeWebRequestCommand = Get-Command "Invoke-WebRequest" -ErrorAction "Stop"
+        $invokeWebRequestOverrideDefinition = if ($invokeWebRequestCommand.CommandType -eq "Function") {
+            $invokeWebRequestCommand.Definition
+        }
+        else {
+            ""
+        }
+
+        $workItems | ForEach-Object -Parallel {
+            $currentWorkItem = $_
+            if (-not [string]::IsNullOrWhiteSpace($using:invokeWebRequestOverrideDefinition)) {
+                Set-Item `
+                    -Path "Function:Invoke-WebRequest" `
+                    -Value ([scriptblock]::Create($using:invokeWebRequestOverrideDefinition))
+            }
+            [pscustomobject]@{
+                EventType = "Started"
+                Sequence = $currentWorkItem.Sequence
+                DocumentId = $currentWorkItem.DocumentId
+                DocumentLabel = $currentWorkItem.DocumentLabel
+                Attempt = 1
+                StatusCode = 0
+                RetryDelayMilliseconds = 0
+                Result = ""
+                ErrorMessage = ""
+            }
+
+            for ($attempt = 1; $attempt -le $using:retryLimit; $attempt++) {
+                $requestDate = [DateTime]::UtcNow.ToString(
+                    "r",
+                    [System.Globalization.CultureInfo]::InvariantCulture
+                )
+                $signaturePayload = "post`ndocs`n$using:resourceLink`n$($requestDate.ToLowerInvariant())`n`n"
+                $hmac = [System.Security.Cryptography.HMACSHA256]::new($using:keyBytes)
+                try {
+                    $hash = $hmac.ComputeHash(
+                        [System.Text.Encoding]::UTF8.GetBytes($signaturePayload)
+                    )
+                }
+                finally {
+                    $hmac.Dispose()
+                }
+                $signature = [Convert]::ToBase64String($hash)
+                $authorization = [Uri]::EscapeDataString(
+                    "type=master&ver=1.0&sig=$signature"
+                )
+                $headers = @{
+                    "Accept" = "application/json"
+                    "Authorization" = $authorization
+                    "x-ms-date" = $requestDate
+                    "x-ms-version" = $using:apiVersion
+                    "x-ms-documentdb-partitionkey" = $currentWorkItem.PartitionKeyHeader
+                }
+                if ($using:useUpsert) {
+                    $headers["x-ms-documentdb-is-upsert"] = "true"
+                }
+
+                try {
+                    $response = Invoke-WebRequest `
+                        -Method "POST" `
+                        -Uri $using:requestUri `
+                        -Headers $headers `
+                        -ContentType "application/json" `
+                        -Body $currentWorkItem.Body `
+                        -SkipHttpErrorCheck `
+                        -ErrorAction "Stop"
+                }
+                catch {
+                    if ($attempt -eq $using:retryLimit) {
+                        [pscustomobject]@{
+                            EventType = "Failed"
+                            Sequence = $currentWorkItem.Sequence
+                            DocumentId = $currentWorkItem.DocumentId
+                            DocumentLabel = $currentWorkItem.DocumentLabel
+                            Attempt = $attempt
+                            StatusCode = 0
+                            RetryDelayMilliseconds = 0
+                            Result = ""
+                            ErrorMessage = $_.Exception.Message
+                        }
+                        return
+                    }
+
+                    $retryDelayMilliseconds = [int]([Math]::Pow(2, $attempt - 1) * 1000)
+                    [pscustomobject]@{
+                        EventType = "Retrying"
+                        Sequence = $currentWorkItem.Sequence
+                        DocumentId = $currentWorkItem.DocumentId
+                        DocumentLabel = $currentWorkItem.DocumentLabel
+                        Attempt = $attempt
+                        StatusCode = 0
+                        RetryDelayMilliseconds = $retryDelayMilliseconds
+                        Result = ""
+                        ErrorMessage = $_.Exception.Message
+                    }
+                    Start-Sleep -Milliseconds $retryDelayMilliseconds
+                    continue
+                }
+
+                $statusCode = [int]$response.StatusCode
+                $successfulWrite = $statusCode -in @(200, 201)
+                $differentialConflict = -not $using:useUpsert -and $statusCode -eq 409
+                if ($successfulWrite -or $differentialConflict) {
+                    [pscustomobject]@{
+                        EventType = "Completed"
+                        Sequence = $currentWorkItem.Sequence
+                        DocumentId = $currentWorkItem.DocumentId
+                        DocumentLabel = $currentWorkItem.DocumentLabel
+                        Attempt = $attempt
+                        StatusCode = $statusCode
+                        RetryDelayMilliseconds = 0
+                        Result = if ($differentialConflict) { "Skipped" } else { "Copied" }
+                        ErrorMessage = ""
+                    }
+                    return
+                }
+
+                $retryable = $statusCode -in @(408, 429, 449, 500, 503)
+                if ($retryable -and $attempt -lt $using:retryLimit) {
+                    $retryAfterHeader = @($response.Headers["x-ms-retry-after-ms"]) -join ","
+                    $retryDelayMilliseconds = 0
+                    if (-not [int]::TryParse($retryAfterHeader, [ref]$retryDelayMilliseconds)) {
+                        $retryDelayMilliseconds = [int]([Math]::Pow(2, $attempt - 1) * 1000)
+                    }
+                    $retryDelayMilliseconds = [Math]::Max(1, $retryDelayMilliseconds)
+                    [pscustomobject]@{
+                        EventType = "Retrying"
+                        Sequence = $currentWorkItem.Sequence
+                        DocumentId = $currentWorkItem.DocumentId
+                        DocumentLabel = $currentWorkItem.DocumentLabel
+                        Attempt = $attempt
+                        StatusCode = $statusCode
+                        RetryDelayMilliseconds = $retryDelayMilliseconds
+                        Result = ""
+                        ErrorMessage = ""
+                    }
+                    Start-Sleep -Milliseconds $retryDelayMilliseconds
+                    continue
+                }
+
+                $errorContent = [string]$response.Content
+                if ($errorContent.Length -gt 1000) {
+                    $errorContent = $errorContent.Substring(0, 1000)
+                }
+                [pscustomobject]@{
+                    EventType = "Failed"
+                    Sequence = $currentWorkItem.Sequence
+                    DocumentId = $currentWorkItem.DocumentId
+                    DocumentLabel = $currentWorkItem.DocumentLabel
+                    Attempt = $attempt
+                    StatusCode = $statusCode
+                    RetryDelayMilliseconds = 0
+                    Result = ""
+                    ErrorMessage = "HTTP $statusCode. $errorContent"
+                }
+                return
+            }
+        } -ThrottleLimit $MaxConcurrentDocuments
+    }
+}
+
+function Invoke-CosmosParallelDocumentBatch {
+    param(
+        [object[]]$WorkItems,
+        [string]$Activity,
+        [string]$DestinationEndpoint,
+        [string]$DestinationKey,
+        [string]$DestinationDatabase,
+        [string]$ContainerName,
+        [long]$SourceDocumentCount,
+        [long]$InitialProcessedCount,
+        [long]$InitialCopiedCount,
+        [long]$InitialSkippedCount,
+        [long]$InitialRetryCount,
+        [int]$InitialThrottleRecoveryPauseCount = 0,
+        [object[]]$InitialSkippedDocuments = @(),
+        [AllowNull()]
+        [object]$MigrationState,
+        [string]$MigrationResourceName
+    )
+
+    $processedCount = $InitialProcessedCount
+    $copiedCount = $InitialCopiedCount
+    $skippedCount = $InitialSkippedCount
+    $retryCount = $InitialRetryCount
+    $throttleRecoveryPauseCount = $InitialThrottleRecoveryPauseCount
+    $inFlightCount = 0
+    $skippedDocuments = [System.Collections.Generic.List[object]]::new()
+    foreach ($skippedDocument in $InitialSkippedDocuments) {
+        $skippedDocuments.Add($skippedDocument)
+    }
+
+    $workItemsBySequence = @{}
+    foreach ($workItem in $WorkItems) {
+        $workItemsBySequence[[long]$workItem.Sequence] = $workItem
+    }
+    $pendingWorkItems = @($WorkItems)
+
+    while ($pendingWorkItems.Count -gt 0) {
+        $throttledWorkItems = [System.Collections.Generic.List[object]]::new()
+        $pendingWorkItems |
+            Invoke-CosmosParallelDocumentWrites `
+                -Endpoint $DestinationEndpoint `
+                -PrimaryKey $DestinationKey `
+                -DatabaseName $DestinationDatabase `
+                -ContainerName $ContainerName |
+            ForEach-Object {
+            $writeEvent = $_
+            $updateDocumentProgress = Test-CosmosMigrationProgressCheckpoint `
+                -ProcessedCount $writeEvent.Sequence
+            switch ($writeEvent.EventType) {
+                "Started" {
+                    $inFlightCount++
+                    if ($updateDocumentProgress) {
+                        Write-CosmosDocumentProgress `
+                            -Activity $Activity `
+                            -ProcessedCount $processedCount `
+                            -TotalCount $SourceDocumentCount `
+                            -CurrentOperation "Copying document $($writeEvent.Sequence)`: '$($writeEvent.DocumentLabel)' | Copied: $copiedCount | Skipped: $skippedCount"
+                    }
+                }
+                "Retrying" {
+                    $retryCount++
+                }
+                "Completed" {
+                    $inFlightCount = [Math]::Max(0, $inFlightCount - 1)
+                    $processedCount++
+                    if ($writeEvent.Result -eq "Skipped") {
+                        $skippedCount++
+                    }
+                    else {
+                        $copiedCount++
+                    }
+                    if ($updateDocumentProgress) {
+                        Write-CosmosDocumentProgress `
+                            -Activity $Activity `
+                            -ProcessedCount $processedCount `
+                            -TotalCount $SourceDocumentCount `
+                            -CurrentOperation "$($writeEvent.Result) document $($writeEvent.Sequence)`: '$($writeEvent.DocumentLabel)' | Copied: $copiedCount | Skipped: $skippedCount"
+                    }
+                }
+                "Failed" {
+                    if ($writeEvent.StatusCode -eq 429) {
+                        $inFlightCount = [Math]::Max(0, $inFlightCount - 1)
+                        $throttledWorkItems.Add(
+                            $workItemsBySequence[[long]$writeEvent.Sequence]
+                        )
+                        return
+                    }
+                    if (-not (Test-CosmosDocumentWriteFailureCanBeSkipped `
+                        -StatusCode $writeEvent.StatusCode)) {
+                        throw "Document '$($writeEvent.DocumentId)' in container '$ContainerName' failed after $($writeEvent.Attempt) attempt(s): $($writeEvent.ErrorMessage)"
+                    }
+                    $inFlightCount = [Math]::Max(0, $inFlightCount - 1)
+                    $processedCount++
+                    $skippedCount++
+                    $skippedDocument = New-CosmosSkippedDocumentRecord `
+                        -ContainerName $ContainerName `
+                        -Sequence $writeEvent.Sequence `
+                        -DocumentId $writeEvent.DocumentId `
+                        -Stage "Write" `
+                        -Attempt $writeEvent.Attempt `
+                        -StatusCode $writeEvent.StatusCode `
+                        -Reason $writeEvent.ErrorMessage
+                    $skippedDocuments.Add($skippedDocument)
+                    Update-CosmosDocumentSkipCheckpoint `
+                        -Context $MigrationState `
+                        -ResourceName $MigrationResourceName `
+                        -ProcessedCount $processedCount `
+                        -CopiedCount $copiedCount `
+                        -SkippedCount $skippedCount `
+                        -RetryCount $retryCount `
+                        -SkippedDocuments $skippedDocuments.ToArray()
+                    Write-Warning "Skipped document '$($writeEvent.DocumentLabel)' in container '$ContainerName' after a write error. Details were recorded in migration state."
+                    if ($updateDocumentProgress) {
+                        Write-CosmosDocumentProgress `
+                            -Activity $Activity `
+                            -ProcessedCount $processedCount `
+                            -TotalCount $SourceDocumentCount `
+                            -CurrentOperation "Skipped document $($writeEvent.Sequence) after a write error: '$($writeEvent.DocumentLabel)' | Copied: $copiedCount | Skipped: $skippedCount"
+                    }
+                }
+                default {
+                    throw "Unexpected parallel document event '$($writeEvent.EventType)'."
+                }
+            }
+        }
+
+        if ($throttledWorkItems.Count -eq 0) {
+            break
+        }
+        if ($throttleRecoveryPauseCount -ge $MaxThrottleRecoveryPauses) {
+            throw (New-CosmosThrottleRecoveryExhaustedError `
+                -ContainerName $ContainerName `
+                -ThrottledWorkItems $throttledWorkItems.ToArray() `
+                -PauseCount $throttleRecoveryPauseCount)
+        }
+
+        $throttleRecoveryPauseCount++
+        Invoke-CosmosThrottleRecoveryPause `
+            -Activity $Activity `
+            -ContainerName $ContainerName `
+            -PauseNumber $throttleRecoveryPauseCount `
+            -ThrottledDocumentCount $throttledWorkItems.Count
+        $pendingWorkItems = $throttledWorkItems.ToArray()
+    }
+
+    return [pscustomobject]@{
+        ProcessedCount = $processedCount
+        CopiedCount = $copiedCount
+        SkippedCount = $skippedCount
+        RetryCount = $retryCount
+        ThrottleRecoveryPauseCount = $throttleRecoveryPauseCount
+        ErrorSkippedCount = $skippedDocuments.Count
+        SkippedDocuments = $skippedDocuments.ToArray()
+    }
+}
+
+function Copy-CosmosContainerDocuments {
+    param(
+        [object]$SourceContainer,
+        [string]$SourceEndpoint,
+        [string]$SourceKey,
+        [string]$SourceDatabase,
+        [string]$DestinationEndpoint,
+        [string]$DestinationKey,
+        [string]$DestinationDatabase,
+        [AllowNull()]
+        [object]$MigrationState,
+        [string]$MigrationResourceName
+    )
+
+    $excludeAdminSettings = [string]::Equals(
+        $SourceContainer.id,
+        $adminSettingsContainerName,
+        [System.StringComparison]::Ordinal
+    )
+    $activity = "Container '$($SourceContainer.id)' documents"
+    $copiedCount = 0
+    $skippedCount = 0
+    $processedCount = 0
+    $retryCount = 0
+    $throttleRecoveryPauseCount = 0
+    $skippedDocuments = [System.Collections.Generic.List[object]]::new()
+    $sourceDocumentCount = Get-CosmosContainerDocumentCount `
+        -ContainerDefinition $SourceContainer `
+        -SubscriptionId $SourceSubscriptionId `
+        -ResourceGroupName $SourceResourceGroup `
+        -AccountName $SourceCosmosAccount `
+        -DatabaseName $SourceDatabase
+    if ($excludeAdminSettings -and $sourceDocumentCount -gt 0) {
+        $sourceDocumentCount--
+    }
+
+    Update-CosmosDocumentSkipCheckpoint `
+        -Context $MigrationState `
+        -ResourceName $MigrationResourceName `
+        -ProcessedCount 0 `
+        -CopiedCount 0 `
+        -SkippedCount 0 `
+        -RetryCount 0 `
+        -SkippedDocuments @()
+
+    Write-CosmosDocumentProgress `
+        -Activity $activity `
+        -ProcessedCount 0 `
+        -TotalCount $sourceDocumentCount `
+        -CurrentOperation "Copied: 0 | Skipped: 0"
+
+    if ($MaxConcurrentDocuments -eq 1) {
+        Get-CosmosDocuments `
+            -Endpoint $SourceEndpoint `
+            -PrimaryKey $SourceKey `
+            -DatabaseName $SourceDatabase `
+            -ContainerName $SourceContainer.id `
+            -ExcludeAdminSettings $excludeAdminSettings |
+        ForEach-Object {
+            $document = $_
+            $nextDocumentNumber = $processedCount + 1
+            $documentLabel = Get-CosmosProgressDocumentLabel -DocumentId $document.id
+            $updateDocumentProgress = Test-CosmosMigrationProgressCheckpoint `
+                -ProcessedCount $nextDocumentNumber `
+                -TotalCount $sourceDocumentCount
+            if ($updateDocumentProgress) {
+                Write-CosmosDocumentProgress `
+                    -Activity $activity `
+                    -ProcessedCount $processedCount `
+                    -TotalCount $sourceDocumentCount `
+                    -CurrentOperation "Copying document $nextDocumentNumber`: '$documentLabel' | Copied: $copiedCount | Skipped: $skippedCount"
+            }
+
+            try {
+                [void](New-CosmosDocumentWriteWorkItem `
+                    -Document $document `
+                    -ContainerDefinition $SourceContainer `
+                    -Sequence $nextDocumentNumber)
+            }
+            catch {
+                $skippedDocument = New-CosmosSkippedDocumentRecord `
+                    -ContainerName $SourceContainer.id `
+                    -Sequence $nextDocumentNumber `
+                    -DocumentId $document.id `
+                    -Stage "Preparation" `
+                    -Reason $_.Exception.Message
+                $skippedDocuments.Add($skippedDocument)
+                $processedCount++
+                $skippedCount++
+                Update-CosmosDocumentSkipCheckpoint `
+                    -Context $MigrationState `
+                    -ResourceName $MigrationResourceName `
+                    -ProcessedCount $processedCount `
+                    -CopiedCount $copiedCount `
+                    -SkippedCount $skippedCount `
+                    -RetryCount $retryCount `
+                    -SkippedDocuments $skippedDocuments.ToArray()
+                Write-Warning "Skipped document '$documentLabel' in container '$($SourceContainer.id)' after a preparation error. Details were recorded in migration state."
+                if ($updateDocumentProgress) {
+                    Write-CosmosDocumentProgress `
+                        -Activity $activity `
+                        -ProcessedCount $processedCount `
+                        -TotalCount $sourceDocumentCount `
+                        -CurrentOperation "Skipped document $processedCount after a preparation error: '$documentLabel' | Copied: $copiedCount | Skipped: $skippedCount"
+                }
+                return
+            }
+
+            $result = ""
+            do {
+                try {
+                    $result = Send-CosmosDocument `
+                        -Document $document `
+                        -ContainerDefinition $SourceContainer `
+                        -Endpoint $DestinationEndpoint `
+                        -PrimaryKey $DestinationKey `
+                        -DatabaseName $DestinationDatabase
+                }
+                catch {
+                $errorMessage = $_.Exception.Message
+                $statusCode = $null
+                if ($errorMessage -match '\bHTTP (?<StatusCode>[1-5][0-9]{2})\b') {
+                    $statusCode = [int]$Matches.StatusCode
+                }
+                if ($statusCode -eq 429) {
+                    if ($throttleRecoveryPauseCount -ge $MaxThrottleRecoveryPauses) {
+                        throw (New-CosmosThrottleRecoveryExhaustedError `
+                            -ContainerName $SourceContainer.id `
+                            -ThrottledWorkItems @([pscustomobject]@{
+                                DocumentId = $document.id
+                            }) `
+                            -PauseCount $throttleRecoveryPauseCount)
+                    }
+                    $throttleRecoveryPauseCount++
+                    Invoke-CosmosThrottleRecoveryPause `
+                        -Activity $activity `
+                        -ContainerName $SourceContainer.id `
+                        -PauseNumber $throttleRecoveryPauseCount `
+                        -ThrottledDocumentCount 1
+                    continue
+                }
+                if (
+                    $null -eq $statusCode -or
+                    -not (Test-CosmosDocumentWriteFailureCanBeSkipped `
+                        -StatusCode $statusCode)
+                ) {
+                    throw
+                }
+                $skippedDocument = New-CosmosSkippedDocumentRecord `
+                    -ContainerName $SourceContainer.id `
+                    -Sequence $nextDocumentNumber `
+                    -DocumentId $document.id `
+                    -Stage "Write" `
+                    -Attempt 1 `
+                    -StatusCode $statusCode `
+                    -Reason $errorMessage
+                $skippedDocuments.Add($skippedDocument)
+                Update-CosmosDocumentSkipCheckpoint `
+                    -Context $MigrationState `
+                    -ResourceName $MigrationResourceName `
+                    -ProcessedCount ($processedCount + 1) `
+                    -CopiedCount $copiedCount `
+                    -SkippedCount ($skippedCount + 1) `
+                    -RetryCount $retryCount `
+                    -SkippedDocuments $skippedDocuments.ToArray()
+                Write-Warning "Skipped document '$documentLabel' in container '$($SourceContainer.id)' after a write error. Details were recorded in migration state."
+                $result = "Skipped after a write error"
+                }
+            } while ([string]::IsNullOrWhiteSpace($result))
+
+            $processedCount++
+            if ($result -like "Skipped*") {
+                $skippedCount++
+            }
+            else {
+                $copiedCount++
+            }
+
+            if ($updateDocumentProgress) {
+                Write-CosmosDocumentProgress `
+                    -Activity $activity `
+                    -ProcessedCount $processedCount `
+                    -TotalCount $sourceDocumentCount `
+                    -CurrentOperation "$result document $processedCount`: '$documentLabel' | Copied: $copiedCount | Skipped: $skippedCount"
+            }
+        }
+    }
+    else {
+        $scheduledCount = 0
+        $writeBatchSize = [Math]::Min(
+            $PageSize,
+            [Math]::Max($MaxConcurrentDocuments, $MaxConcurrentDocuments * 4)
+        )
+        $workItems = [System.Collections.Generic.List[object]]::new()
+
+        Get-CosmosDocuments `
+            -Endpoint $SourceEndpoint `
+            -PrimaryKey $SourceKey `
+            -DatabaseName $SourceDatabase `
+            -ContainerName $SourceContainer.id `
+            -ExcludeAdminSettings $excludeAdminSettings |
+        ForEach-Object {
+            $document = $_
+            $scheduledCount++
+            try {
+                $workItems.Add((New-CosmosDocumentWriteWorkItem `
+                    -Document $document `
+                    -ContainerDefinition $SourceContainer `
+                    -Sequence $scheduledCount))
+            }
+            catch {
+                $processedCount++
+                $skippedCount++
+                $documentLabel = Get-CosmosProgressDocumentLabel -DocumentId $document.id
+                $skippedDocument = New-CosmosSkippedDocumentRecord `
+                    -ContainerName $SourceContainer.id `
+                    -Sequence $scheduledCount `
+                    -DocumentId $document.id `
+                    -Stage "Preparation" `
+                    -Reason $_.Exception.Message
+                $skippedDocuments.Add($skippedDocument)
+                Update-CosmosDocumentSkipCheckpoint `
+                    -Context $MigrationState `
+                    -ResourceName $MigrationResourceName `
+                    -ProcessedCount $processedCount `
+                    -CopiedCount $copiedCount `
+                    -SkippedCount $skippedCount `
+                    -RetryCount $retryCount `
+                    -SkippedDocuments $skippedDocuments.ToArray()
+                Write-Warning "Skipped document '$documentLabel' in container '$($SourceContainer.id)' after a preparation error. Details were recorded in migration state."
+            }
+
+            if ($workItems.Count -ge $writeBatchSize) {
+                $batchResult = Invoke-CosmosParallelDocumentBatch `
+                    -WorkItems $workItems.ToArray() `
+                    -Activity $activity `
+                    -DestinationEndpoint $DestinationEndpoint `
+                    -DestinationKey $DestinationKey `
+                    -DestinationDatabase $DestinationDatabase `
+                    -ContainerName $SourceContainer.id `
+                    -SourceDocumentCount $sourceDocumentCount `
+                    -InitialProcessedCount $processedCount `
+                    -InitialCopiedCount $copiedCount `
+                    -InitialSkippedCount $skippedCount `
+                    -InitialRetryCount $retryCount `
+                    -InitialThrottleRecoveryPauseCount $throttleRecoveryPauseCount `
+                    -InitialSkippedDocuments $skippedDocuments.ToArray() `
+                    -MigrationState $MigrationState `
+                    -MigrationResourceName $MigrationResourceName
+                $processedCount = $batchResult.ProcessedCount
+                $copiedCount = $batchResult.CopiedCount
+                $skippedCount = $batchResult.SkippedCount
+                $retryCount = $batchResult.RetryCount
+                $throttleRecoveryPauseCount = $batchResult.ThrottleRecoveryPauseCount
+                $skippedDocuments.Clear()
+                foreach ($batchSkippedDocument in @($batchResult.SkippedDocuments)) {
+                    $skippedDocuments.Add($batchSkippedDocument)
+                }
+                $workItems.Clear()
+            }
+        }
+
+        if ($workItems.Count -gt 0) {
+            $batchResult = Invoke-CosmosParallelDocumentBatch `
+                -WorkItems $workItems.ToArray() `
+                -Activity $activity `
+                -DestinationEndpoint $DestinationEndpoint `
+                -DestinationKey $DestinationKey `
+                -DestinationDatabase $DestinationDatabase `
+                -ContainerName $SourceContainer.id `
+                -SourceDocumentCount $sourceDocumentCount `
+                -InitialProcessedCount $processedCount `
+                -InitialCopiedCount $copiedCount `
+                -InitialSkippedCount $skippedCount `
+                -InitialRetryCount $retryCount `
+                -InitialThrottleRecoveryPauseCount $throttleRecoveryPauseCount `
+                -InitialSkippedDocuments $skippedDocuments.ToArray() `
+                -MigrationState $MigrationState `
+                -MigrationResourceName $MigrationResourceName
+            $processedCount = $batchResult.ProcessedCount
+            $copiedCount = $batchResult.CopiedCount
+            $skippedCount = $batchResult.SkippedCount
+            $retryCount = $batchResult.RetryCount
+            $throttleRecoveryPauseCount = $batchResult.ThrottleRecoveryPauseCount
+            $skippedDocuments.Clear()
+            foreach ($batchSkippedDocument in @($batchResult.SkippedDocuments)) {
+                $skippedDocuments.Add($batchSkippedDocument)
+            }
+        }
+    }
+
+    $finalTotalCount = if ($sourceDocumentCount -ge 0) {
+        $sourceDocumentCount
+    }
+    else {
+        $processedCount
+    }
+    Write-CosmosMigrationCountProgress `
+        -Id 1 `
+        -ParentId 0 `
+        -Activity $activity `
+        -Phase "Source documents" `
+        -ProcessedCount $processedCount `
+        -TotalCount $finalTotalCount `
+        -CurrentOperation "Copied: $copiedCount | Skipped: $skippedCount"
+    Write-CosmosMigrationProgress -Id 1 -ParentId 0 -Activity $activity -Completed
+    Write-Host "Completed container '$($SourceContainer.id)': copied=$copiedCount, skipped=$skippedCount, throttling recovery pauses=$throttleRecoveryPauseCount"
+    return [pscustomobject]@{
+        CopiedCount = $copiedCount
+        SkippedCount = $skippedCount
+        ProcessedCount = $processedCount
+        TotalCount = $finalTotalCount
+        RetryCount = $retryCount
+        ThrottleRecoveryPauseCount = $throttleRecoveryPauseCount
+        ErrorSkippedCount = $skippedDocuments.Count
+        SkippedDocuments = $skippedDocuments.ToArray()
+    }
+}
+
+$SourceCosmosAccount = $SourceCosmosAccount.Trim()
+$SourceResourceGroup = $SourceResourceGroup.Trim()
+$SourceSubscriptionId = $SourceSubscriptionId.Trim()
+$SourceDatabaseName = $SourceDatabaseName.Trim()
+$DestinationCosmosAccount = $DestinationCosmosAccount.Trim()
+$DestinationResourceGroup = $DestinationResourceGroup.Trim()
+$DestinationSubscriptionId = $DestinationSubscriptionId.Trim()
+$DestinationDatabaseName = $DestinationDatabaseName.Trim()
+$CosmosApiVersion = $CosmosApiVersion.Trim()
+$ManagementApiVersion = $ManagementApiVersion.Trim()
+$CosmosDnsSuffix = $CosmosDnsSuffix.Trim().Trim('.')
+$requestedContainerNames = @(Get-NormalizedCosmosContainerSelection -ContainerNames $Containers)
+if ([string]::IsNullOrWhiteSpace($StateFilePath)) {
+    $StateFilePath = Join-Path $PSScriptRoot "Migration-Cosmos.state.json"
+}
+$sourceEndpoint = "https://$SourceCosmosAccount.$CosmosDnsSuffix"
+$destinationEndpoint = "https://$DestinationCosmosAccount.$CosmosDnsSuffix"
+$migrationMode = if ($DifferentialMigration) { "differential" } else { "full" }
+$migrationState = $null
+$activeMigrationResource = $null
+
+try {
+    Test-CosmosMigrationConfiguration
+
+    Write-CosmosMigrationProgress `
+        -Id 0 `
+        -Activity "Cosmos DB migration" `
+        -Status "Connecting and discovering source resources" `
+        -CurrentOperation "Resolving credentials" `
+        -PercentComplete -1
+
+    if ([string]::IsNullOrWhiteSpace($SourcePrimaryKey) -or [string]::IsNullOrWhiteSpace($DestinationPrimaryKey)) {
+        foreach ($requiredCommand in @("Connect-AzAccount", "Set-AzContext", "Invoke-AzRestMethod")) {
+            if (-not (Get-Command $requiredCommand -ErrorAction SilentlyContinue)) {
+                throw "The Az.Accounts command '$requiredCommand' is required when primary keys are not supplied."
+            }
+        }
+        Connect-AzAccount | Out-Null
+    }
+
+    $resolvedSourceKey = Get-CosmosAccountPrimaryKey `
+        -ProvidedKey $SourcePrimaryKey `
+        -SubscriptionId $SourceSubscriptionId `
+        -ResourceGroupName $SourceResourceGroup `
+        -AccountName $SourceCosmosAccount
+    $resolvedDestinationKey = Get-CosmosAccountPrimaryKey `
+        -ProvidedKey $DestinationPrimaryKey `
+        -SubscriptionId $DestinationSubscriptionId `
+        -ResourceGroupName $DestinationResourceGroup `
+        -AccountName $DestinationCosmosAccount
+
+    $sourceDatabase = Get-CosmosDatabase `
+        -Endpoint $sourceEndpoint `
+        -PrimaryKey $resolvedSourceKey `
+        -DatabaseName $SourceDatabaseName
+    if ($sourceDatabase.StatusCode -ne 200) {
+        throw "Source database '$SourceDatabaseName' does not exist in Cosmos DB account '$SourceCosmosAccount'."
+    }
+
+    $allSourceContainers = @(Get-CosmosContainers `
+        -Endpoint $sourceEndpoint `
+        -PrimaryKey $resolvedSourceKey `
+        -DatabaseName $SourceDatabaseName)
+    $sourceContainers = @(Select-CosmosMigrationContainers `
+        -SourceContainers $allSourceContainers `
+        -RequestedContainerNames $requestedContainerNames `
+        -DatabaseName $SourceDatabaseName)
+    $stateContainerNames = [string[]]@($sourceContainers | ForEach-Object { [string]$_.id })
+    [Array]::Sort($stateContainerNames, [System.StringComparer]::Ordinal)
+    $selectionMode = if ($requestedContainerNames.Count -eq 0) { "all" } else { "explicit" }
+    $stateConfiguration = [ordered]@{
+        sourceAccount = $SourceCosmosAccount
+        sourceResourceGroup = $SourceResourceGroup
+        sourceSubscriptionId = $SourceSubscriptionId
+        sourceDatabase = $SourceDatabaseName
+        destinationAccount = $DestinationCosmosAccount
+        destinationResourceGroup = $DestinationResourceGroup
+        destinationSubscriptionId = $DestinationSubscriptionId
+        destinationDatabase = $DestinationDatabaseName
+        containers = @($stateContainerNames)
+        containerSelectionMode = $selectionMode
+        mode = $migrationMode
+        cosmosApiVersion = $CosmosApiVersion
+        cosmosDnsSuffix = $CosmosDnsSuffix
+        excludedAdminSettingsDocument = "$adminSettingsContainerName/$adminSettingsDocumentId"
+    }
+    $migrationState = Initialize-MigrationState `
+        -MigrationType "cosmos" `
+        -StateFilePath $StateFilePath `
+        -Configuration $stateConfiguration `
+        -Reset:$ResetState
+    Write-Host "Migration state: $($migrationState.Path)"
+
+    New-CosmosDatabaseIfMissing `
+        -Endpoint $destinationEndpoint `
+        -PrimaryKey $resolvedDestinationKey `
+        -DatabaseName $DestinationDatabaseName
+
+    Write-Host "Starting $migrationMode Cosmos DB migration. Destination-only containers and documents will not be deleted."
+    Write-Host "Document write concurrency: $MaxConcurrentDocuments"
+    Write-Host "Preserving destination admin app settings. '$adminSettingsContainerName/$adminSettingsDocumentId' will not be migrated."
+    if ($selectionMode -eq "explicit") {
+        Write-Host "Selected containers: $($stateContainerNames -join ', ')"
+    }
+    $destinationContainers = @(Get-CosmosContainers `
+        -Endpoint $destinationEndpoint `
+        -PrimaryKey $resolvedDestinationKey `
+        -DatabaseName $DestinationDatabaseName)
+    $destinationContainersByName = @{}
+    foreach ($destinationContainer in $destinationContainers) {
+        $destinationContainersByName[$destinationContainer.id] = $destinationContainer
+    }
+
+    $completedContainerCount = 0
+    $totalCopiedCount = 0
+    $totalSkippedCount = 0
+    $totalErrorSkippedCount = 0
+    $totalThrottleRecoveryPauseCount = 0
+    $containerNumber = 0
+    Write-CosmosMigrationCountProgress `
+        -Id 0 `
+        -Activity "Cosmos DB migration" `
+        -Phase "Containers" `
+        -ProcessedCount 0 `
+        -TotalCount $sourceContainers.Count `
+        -CurrentOperation "Ready to migrate $($sourceContainers.Count) container(s)"
+
+    foreach ($sourceContainer in $sourceContainers) {
+        $containerNumber++
+        $resourceName = [string]$sourceContainer.id
+        Write-CosmosMigrationCountProgress `
+            -Id 0 `
+            -Activity "Cosmos DB migration" `
+            -Phase "Containers" `
+            -ProcessedCount $completedContainerCount `
+            -TotalCount $sourceContainers.Count `
+            -CurrentOperation "Current container: $containerNumber/$($sourceContainers.Count) - $($sourceContainer.id)"
+
+        if (Test-MigrationResourceCompleted `
+            -Context $migrationState `
+            -ResourceName $resourceName) {
+            $checkpoint = Get-MigrationResourceCheckpoint `
+                -Context $migrationState `
+                -ResourceName $resourceName
+            $completedContainerCount++
+            $totalCopiedCount += [long]$checkpoint["result"]["CopiedCount"]
+            $totalSkippedCount += [long]$checkpoint["result"]["SkippedCount"]
+            $totalErrorSkippedCount += [long]$checkpoint["result"]["ErrorSkippedCount"]
+            $totalThrottleRecoveryPauseCount += [long]$checkpoint["result"]["ThrottleRecoveryPauseCount"]
+            Write-Host "Skipping completed container from migration state: $resourceName"
+            Write-CosmosMigrationCountProgress `
+                -Id 0 `
+                -Activity "Cosmos DB migration" `
+                -Phase "Containers" `
+                -ProcessedCount $completedContainerCount `
+                -TotalCount $sourceContainers.Count `
+                -CurrentOperation "Documents copied: $totalCopiedCount | Skipped: $totalSkippedCount"
+            continue
+        }
+
+        Start-MigrationResourceCheckpoint `
+            -Context $migrationState `
+            -ResourceName $resourceName
+        $activeMigrationResource = $resourceName
+
+        $destinationContainer = if ($destinationContainersByName.ContainsKey($sourceContainer.id)) {
+            $destinationContainersByName[$sourceContainer.id]
+        }
+        else {
+            $null
+        }
+        Sync-CosmosContainerDefinition `
+            -SourceContainer $sourceContainer `
+            -DestinationContainer $destinationContainer `
+            -DestinationEndpoint $destinationEndpoint `
+            -DestinationKey $resolvedDestinationKey `
+            -DestinationDatabase $DestinationDatabaseName
+
+        $containerResult = Copy-CosmosContainerDocuments `
+            -SourceContainer $sourceContainer `
+            -SourceEndpoint $sourceEndpoint `
+            -SourceKey $resolvedSourceKey `
+            -SourceDatabase $SourceDatabaseName `
+            -DestinationEndpoint $destinationEndpoint `
+            -DestinationKey $resolvedDestinationKey `
+            -DestinationDatabase $DestinationDatabaseName `
+            -MigrationState $migrationState `
+            -MigrationResourceName $resourceName
+        Complete-MigrationResourceCheckpoint `
+            -Context $migrationState `
+            -ResourceName $resourceName `
+            -Result $containerResult
+        $activeMigrationResource = $null
+        $completedContainerCount++
+        $totalCopiedCount += $containerResult.CopiedCount
+        $totalSkippedCount += $containerResult.SkippedCount
+        $totalErrorSkippedCount += $containerResult.ErrorSkippedCount
+        $totalThrottleRecoveryPauseCount += $containerResult.ThrottleRecoveryPauseCount
+
+        Write-CosmosMigrationCountProgress `
+            -Id 0 `
+            -Activity "Cosmos DB migration" `
+            -Phase "Containers" `
+            -ProcessedCount $completedContainerCount `
+            -TotalCount $sourceContainers.Count `
+            -CurrentOperation "Documents copied: $totalCopiedCount | Skipped: $totalSkippedCount"
+    }
+
+    Complete-MigrationState `
+        -Context $migrationState `
+        -Summary ([ordered]@{
+            ContainerCount = $completedContainerCount
+            CopiedCount = $totalCopiedCount
+            SkippedCount = $totalSkippedCount
+            ErrorSkippedCount = $totalErrorSkippedCount
+            ThrottleRecoveryPauseCount = $totalThrottleRecoveryPauseCount
+        })
+    Write-Host "Cosmos DB migration completed. Containers processed: $completedContainerCount, documents copied: $totalCopiedCount, documents skipped: $totalSkippedCount, throttling recovery pauses: $totalThrottleRecoveryPauseCount"
+    if ($totalErrorSkippedCount -gt 0) {
+        Write-Warning "Admin review required: $totalErrorSkippedCount document(s) were skipped because of preparation or write errors. Review each container's result.SkippedDocuments entries in '$($migrationState.Path)'."
+    }
+}
+catch {
+    $migrationErrorMessage = $_.Exception.Message
+    if ($null -ne $migrationState) {
+        try {
+            Set-MigrationStateFailure `
+                -Context $migrationState `
+                -ResourceName $activeMigrationResource `
+                -ErrorMessage $migrationErrorMessage
+        }
+        catch {
+            Write-Warning "Failed to update migration state after an error: $($_.Exception.Message)"
+        }
+    }
+    $recordedErrorSkippedCount = Get-CosmosRecordedErrorSkippedCount `
+        -Context $migrationState
+    if ($recordedErrorSkippedCount -gt 0) {
+        Write-Warning "Admin review required: $recordedErrorSkippedCount document(s) were skipped before the migration stopped. Review completed containers' result.SkippedDocuments and interrupted containers' progress.SkippedDocuments entries in '$($migrationState.Path)'."
+    }
+    Write-Error "Cosmos DB migration failed: $migrationErrorMessage" -ErrorAction Continue
+    throw
+}
+finally {
+    Write-CosmosMigrationProgress -Id 1 -ParentId 0 -Activity "Container documents" -Completed
+    Write-CosmosMigrationProgress -Id 0 -Activity "Cosmos DB migration" -Completed
+}

--- a/scripts/Migration-State.ps1
+++ b/scripts/Migration-State.ps1
@@ -1,0 +1,323 @@
+# Migration-State.ps1
+
+function Get-MigrationStateUtcTimestamp {
+    return [DateTime]::UtcNow.ToString(
+        "o",
+        [System.Globalization.CultureInfo]::InvariantCulture
+    )
+}
+
+function Get-MigrationStateFingerprint {
+    param(
+        [System.Collections.IDictionary]$Configuration
+    )
+
+    $configurationJson = ConvertTo-Json `
+        -InputObject $Configuration `
+        -Depth 100 `
+        -Compress
+    $sha256 = [System.Security.Cryptography.SHA256]::Create()
+    try {
+        $hash = $sha256.ComputeHash(
+            [System.Text.Encoding]::UTF8.GetBytes($configurationJson)
+        )
+    }
+    finally {
+        $sha256.Dispose()
+    }
+    return [Convert]::ToHexString($hash).ToLowerInvariant()
+}
+
+function ConvertTo-MigrationStateResult {
+    param(
+        [AllowNull()]
+        [object]$Result
+    )
+
+    $converted = [ordered]@{}
+    if ($null -eq $Result) {
+        return $converted
+    }
+
+    if ($Result -is [System.Collections.IDictionary]) {
+        foreach ($key in $Result.Keys) {
+            $converted[[string]$key] = $Result[$key]
+        }
+        return $converted
+    }
+
+    foreach ($property in $Result.PSObject.Properties) {
+        $converted[$property.Name] = $property.Value
+    }
+    return $converted
+}
+
+function Save-MigrationState {
+    param(
+        [object]$Context
+    )
+
+    $Context.Data["updatedUtc"] = Get-MigrationStateUtcTimestamp
+    $stateDirectory = [IO.Path]::GetDirectoryName($Context.Path)
+    if (-not [string]::IsNullOrWhiteSpace($stateDirectory)) {
+        [IO.Directory]::CreateDirectory($stateDirectory) | Out-Null
+    }
+
+    $temporaryPath = "$($Context.Path).$PID.tmp"
+    $stateJson = ConvertTo-Json `
+        -InputObject $Context.Data `
+        -Depth 100
+    try {
+        [IO.File]::WriteAllText(
+            $temporaryPath,
+            "$stateJson`n",
+            [System.Text.UTF8Encoding]::new($false)
+        )
+        [IO.File]::Move($temporaryPath, $Context.Path, $true)
+    }
+    finally {
+        if ([IO.File]::Exists($temporaryPath)) {
+            [IO.File]::Delete($temporaryPath)
+        }
+    }
+}
+
+function Initialize-MigrationState {
+    param(
+        [string]$MigrationType,
+        [string]$StateFilePath,
+        [System.Collections.IDictionary]$Configuration,
+        [switch]$Reset
+    )
+
+    if ([string]::IsNullOrWhiteSpace($StateFilePath)) {
+        throw "StateFilePath cannot be empty when migration state tracking is enabled."
+    }
+
+    $absoluteStatePath = [IO.Path]::GetFullPath(
+        [Environment]::ExpandEnvironmentVariables($StateFilePath.Trim())
+    )
+    if ($Reset -and [IO.File]::Exists($absoluteStatePath)) {
+        [IO.File]::Delete($absoluteStatePath)
+    }
+
+    $fingerprint = Get-MigrationStateFingerprint -Configuration $Configuration
+    if ([IO.File]::Exists($absoluteStatePath)) {
+        try {
+            $state = [IO.File]::ReadAllText($absoluteStatePath) |
+                ConvertFrom-Json -AsHashtable -Depth 100
+        }
+        catch {
+            throw "Migration state file '$absoluteStatePath' is not valid JSON. Use -ResetState after preserving it for investigation."
+        }
+
+        if ([int]$state["schemaVersion"] -ne 1) {
+            throw "Migration state file '$absoluteStatePath' uses an unsupported schema version."
+        }
+        if (-not [string]::Equals(
+            [string]$state["migrationType"],
+            $MigrationType,
+            [System.StringComparison]::Ordinal
+        )) {
+            throw "Migration state file '$absoluteStatePath' belongs to a different migration type."
+        }
+        if (-not [string]::Equals(
+            [string]$state["configurationFingerprint"],
+            $fingerprint,
+            [System.StringComparison]::Ordinal
+        )) {
+            throw "Migration state file '$absoluteStatePath' does not match the current source, destination, or mode. Use a different -StateFilePath or pass -ResetState."
+        }
+        if ($null -eq $state["resources"]) {
+            $state["resources"] = [ordered]@{}
+        }
+        $state["status"] = "in_progress"
+        $state["lastError"] = $null
+        $state["currentResource"] = $null
+        $state["resumeCount"] = [int]$state["resumeCount"] + 1
+    }
+    else {
+        $timestamp = Get-MigrationStateUtcTimestamp
+        $state = [ordered]@{
+            schemaVersion = 1
+            migrationType = $MigrationType
+            configurationFingerprint = $fingerprint
+            configuration = $Configuration
+            status = "in_progress"
+            createdUtc = $timestamp
+            updatedUtc = $timestamp
+            completedUtc = $null
+            resumeCount = 0
+            currentResource = $null
+            lastError = $null
+            resources = [ordered]@{}
+            summary = [ordered]@{}
+        }
+    }
+
+    $context = [pscustomobject]@{
+        Path = $absoluteStatePath
+        Data = $state
+    }
+    Save-MigrationState -Context $context
+    return $context
+}
+
+function Get-MigrationResourceCheckpoint {
+    param(
+        [object]$Context,
+        [string]$ResourceName
+    )
+
+    $resources = $Context.Data["resources"]
+    if ($resources.Contains($ResourceName)) {
+        return $resources[$ResourceName]
+    }
+    return $null
+}
+
+function Test-MigrationResourceCompleted {
+    param(
+        [object]$Context,
+        [string]$ResourceName
+    )
+
+    $checkpoint = Get-MigrationResourceCheckpoint `
+        -Context $Context `
+        -ResourceName $ResourceName
+    return (
+        $null -ne $checkpoint -and
+        [string]::Equals(
+            [string]$checkpoint["status"],
+            "completed",
+            [System.StringComparison]::Ordinal
+        )
+    )
+}
+
+function Start-MigrationResourceCheckpoint {
+    param(
+        [object]$Context,
+        [string]$ResourceName
+    )
+
+    $existingCheckpoint = Get-MigrationResourceCheckpoint `
+        -Context $Context `
+        -ResourceName $ResourceName
+    $attempt = if ($null -eq $existingCheckpoint) {
+        1
+    }
+    else {
+        [int]$existingCheckpoint["attempt"] + 1
+    }
+    $progress = if (
+        $null -ne $existingCheckpoint -and
+        $null -ne $existingCheckpoint["progress"]
+    ) {
+        $existingCheckpoint["progress"]
+    }
+    else {
+        [ordered]@{}
+    }
+    $timestamp = Get-MigrationStateUtcTimestamp
+    $Context.Data["resources"][$ResourceName] = [ordered]@{
+        status = "in_progress"
+        attempt = $attempt
+        startedUtc = $timestamp
+        updatedUtc = $timestamp
+        completedUtc = $null
+        lastError = $null
+        progress = $progress
+        result = [ordered]@{}
+    }
+    $Context.Data["currentResource"] = $ResourceName
+    Save-MigrationState -Context $Context
+}
+
+function Update-MigrationResourceCheckpoint {
+    param(
+        [object]$Context,
+        [string]$ResourceName,
+        [System.Collections.IDictionary]$Progress
+    )
+
+    $checkpoint = Get-MigrationResourceCheckpoint `
+        -Context $Context `
+        -ResourceName $ResourceName
+    if ($null -eq $checkpoint) {
+        throw "Migration resource '$ResourceName' was updated before it was started."
+    }
+    if ($checkpoint["status"] -eq "completed") {
+        throw "Migration resource '$ResourceName' cannot be updated after completion."
+    }
+
+    $checkpoint["progress"] = ConvertTo-MigrationStateResult -Result $Progress
+    $checkpoint["updatedUtc"] = Get-MigrationStateUtcTimestamp
+    Save-MigrationState -Context $Context
+}
+
+function Complete-MigrationResourceCheckpoint {
+    param(
+        [object]$Context,
+        [string]$ResourceName,
+        [AllowNull()]
+        [object]$Result = $null
+    )
+
+    $checkpoint = Get-MigrationResourceCheckpoint `
+        -Context $Context `
+        -ResourceName $ResourceName
+    if ($null -eq $checkpoint) {
+        throw "Migration resource '$ResourceName' was completed before it was started."
+    }
+
+    $timestamp = Get-MigrationStateUtcTimestamp
+    $checkpoint["status"] = "completed"
+    $checkpoint["updatedUtc"] = $timestamp
+    $checkpoint["completedUtc"] = $timestamp
+    $checkpoint["lastError"] = $null
+    $checkpoint["result"] = ConvertTo-MigrationStateResult -Result $Result
+    $Context.Data["currentResource"] = $null
+    Save-MigrationState -Context $Context
+}
+
+function Set-MigrationStateFailure {
+    param(
+        [object]$Context,
+        [AllowNull()]
+        [string]$ResourceName,
+        [string]$ErrorMessage
+    )
+
+    $timestamp = Get-MigrationStateUtcTimestamp
+    if (-not [string]::IsNullOrWhiteSpace($ResourceName)) {
+        $checkpoint = Get-MigrationResourceCheckpoint `
+            -Context $Context `
+            -ResourceName $ResourceName
+        if ($null -ne $checkpoint -and $checkpoint["status"] -ne "completed") {
+            $checkpoint["status"] = "failed"
+            $checkpoint["updatedUtc"] = $timestamp
+            $checkpoint["lastError"] = $ErrorMessage
+        }
+    }
+    $Context.Data["status"] = "failed"
+    $Context.Data["currentResource"] = $ResourceName
+    $Context.Data["lastError"] = $ErrorMessage
+    Save-MigrationState -Context $Context
+}
+
+function Complete-MigrationState {
+    param(
+        [object]$Context,
+        [AllowNull()]
+        [object]$Summary = $null
+    )
+
+    $timestamp = Get-MigrationStateUtcTimestamp
+    $Context.Data["status"] = "completed"
+    $Context.Data["completedUtc"] = $timestamp
+    $Context.Data["currentResource"] = $null
+    $Context.Data["lastError"] = $null
+    $Context.Data["summary"] = ConvertTo-MigrationStateResult -Result $Summary
+    Save-MigrationState -Context $Context
+}

--- a/scripts/Migration-StorageAccount.ps1
+++ b/scripts/Migration-StorageAccount.ps1
@@ -1,0 +1,315 @@
+# Migration-StorageAccount.ps1
+#Requires -Version 7.0
+
+[CmdletBinding()]
+param(
+    [string]$SourceStorageAccount = "<source-account>",
+
+    [string]$SourceSubscriptionId = "<source-subscription-id>",
+
+    [string]$DestinationStorageAccount = "<destination-account>",
+
+    [string]$DestinationSubscriptionId = "<destination-subscription-id>",
+
+    [ValidateNotNullOrEmpty()]
+    [string[]]$Containers = @(
+        "user-documents",
+        "group-documents",
+        "public-documents",
+        "group-chat",
+        "personal-chat"
+    ),
+
+    [bool]$DifferentialMigration = $true,
+
+    [bool]$ShowProgress = $true,
+
+    [ValidateRange(1, 168)]
+    [int]$SasExpiryHours = 48,
+
+    [string]$StateFilePath = "",
+
+    [switch]$ResetState
+)
+
+$ErrorActionPreference = "Stop"
+. (Join-Path $PSScriptRoot "Migration-State.ps1")
+
+function Write-StorageMigrationProgress {
+    param(
+        [int]$CompletedCount,
+        [int]$TotalCount,
+        [string]$CurrentContainer = "",
+        [switch]$Completed
+    )
+
+    if (-not $ShowProgress) {
+        return
+    }
+
+    if ($Completed) {
+        Write-Progress -Id 0 -Activity "Storage account migration" -Completed
+        return
+    }
+
+    $percentComplete = if ($TotalCount -eq 0) {
+        100
+    }
+    else {
+        [int][Math]::Floor(($CompletedCount / $TotalCount) * 100)
+    }
+    $remainingCount = [Math]::Max(0, $TotalCount - $CompletedCount)
+    $progressParameters = @{
+        Id = 0
+        Activity = "Storage account migration"
+        Status = "Containers: $CompletedCount/$TotalCount | Remaining: $remainingCount | $percentComplete%"
+        PercentComplete = $percentComplete
+    }
+    if (-not [string]::IsNullOrWhiteSpace($CurrentContainer)) {
+        $progressParameters.CurrentOperation = "Current container: $CurrentContainer"
+    }
+
+    Write-Progress @progressParameters
+}
+
+function Test-StorageMigrationConfiguration {
+    $configuredValues = [ordered]@{
+        SourceStorageAccount = $SourceStorageAccount
+        SourceSubscriptionId = $SourceSubscriptionId
+        DestinationStorageAccount = $DestinationStorageAccount
+        DestinationSubscriptionId = $DestinationSubscriptionId
+    }
+    foreach ($entry in $configuredValues.GetEnumerator()) {
+        if (
+            [string]::IsNullOrWhiteSpace($entry.Value) -or
+            $entry.Value -match '^<[^>]+>$'
+        ) {
+            throw "Set '$($entry.Key)' in the script or supply it as a parameter."
+        }
+    }
+
+    foreach ($accountName in @($SourceStorageAccount, $DestinationStorageAccount)) {
+        if ($accountName -notmatch '^[a-z0-9]{3,24}$') {
+            throw "Storage account name '$accountName' must contain 3-24 lowercase letters or numbers."
+        }
+    }
+
+    foreach ($subscriptionId in @($SourceSubscriptionId, $DestinationSubscriptionId)) {
+        $parsedSubscriptionId = [Guid]::Empty
+        if (-not [Guid]::TryParse($subscriptionId, [ref]$parsedSubscriptionId)) {
+            throw "Subscription ID '$subscriptionId' must be a valid GUID."
+        }
+    }
+
+    if ([string]::Equals(
+        $SourceStorageAccount,
+        $DestinationStorageAccount,
+        [System.StringComparison]::OrdinalIgnoreCase
+    )) {
+        throw "Source and destination storage accounts must be different."
+    }
+
+    $containerNames = [System.Collections.Generic.HashSet[string]]::new(
+        [System.StringComparer]::Ordinal
+    )
+    foreach ($container in $Containers) {
+        if (
+            [string]::IsNullOrWhiteSpace($container) -or
+            $container -notmatch '^(?!.*--)[a-z0-9](?:[a-z0-9-]{1,61}[a-z0-9])$'
+        ) {
+            throw "Container name '$container' is not a valid Azure Blob container name."
+        }
+        if (-not $containerNames.Add($container)) {
+            throw "Container '$container' is listed more than once."
+        }
+    }
+}
+
+$migrationMode = if ($DifferentialMigration) { "differential" } else { "full" }
+if ([string]::IsNullOrWhiteSpace($StateFilePath)) {
+    $StateFilePath = Join-Path $PSScriptRoot "Migration-StorageAccount.state.json"
+}
+$migrationState = $null
+$activeMigrationResource = $null
+
+try {
+    Test-StorageMigrationConfiguration
+
+    $stateConfiguration = [ordered]@{
+        sourceAccount = $SourceStorageAccount
+        sourceSubscriptionId = $SourceSubscriptionId
+        destinationAccount = $DestinationStorageAccount
+        destinationSubscriptionId = $DestinationSubscriptionId
+        containers = @($Containers)
+        mode = $migrationMode
+    }
+    $migrationState = Initialize-MigrationState `
+        -MigrationType "storage" `
+        -StateFilePath $StateFilePath `
+        -Configuration $stateConfiguration `
+        -Reset:$ResetState
+    Write-Host "Migration state: $($migrationState.Path)"
+
+    foreach ($requiredCommand in @(
+        "Connect-AzAccount",
+        "Set-AzContext",
+        "New-AzStorageContext",
+        "Get-AzStorageContainer",
+        "New-AzStorageContainer",
+        "New-AzStorageContainerSASToken",
+        "azcopy"
+    )) {
+        if (-not (Get-Command $requiredCommand -ErrorAction SilentlyContinue)) {
+            throw "Required command '$requiredCommand' is not available."
+        }
+    }
+
+    Connect-AzAccount | Out-Null
+
+    Set-AzContext -SubscriptionId $SourceSubscriptionId | Out-Null
+    $sourceContext = New-AzStorageContext `
+        -StorageAccountName $SourceStorageAccount `
+        -UseConnectedAccount
+
+    Set-AzContext -SubscriptionId $DestinationSubscriptionId | Out-Null
+    $destinationContext = New-AzStorageContext `
+        -StorageAccountName $DestinationStorageAccount `
+        -UseConnectedAccount
+
+    $completedContainerCount = 0
+    Write-Host "Starting $migrationMode storage account migration. Destination-only blobs will not be deleted."
+    Write-StorageMigrationProgress `
+        -CompletedCount 0 `
+        -TotalCount $Containers.Count
+
+    foreach ($container in $Containers) {
+        Write-StorageMigrationProgress `
+            -CompletedCount $completedContainerCount `
+            -TotalCount $Containers.Count `
+            -CurrentContainer $container
+        Write-Host "Migrating container in $migrationMode mode: $container"
+
+        if (Test-MigrationResourceCompleted `
+            -Context $migrationState `
+            -ResourceName $container) {
+            $completedContainerCount++
+            Write-Host "Skipping completed container from migration state: $container"
+            Write-StorageMigrationProgress `
+                -CompletedCount $completedContainerCount `
+                -TotalCount $Containers.Count `
+                -CurrentContainer $container
+            continue
+        }
+
+        Start-MigrationResourceCheckpoint `
+            -Context $migrationState `
+            -ResourceName $container
+        $activeMigrationResource = $container
+
+        Set-AzContext -SubscriptionId $SourceSubscriptionId | Out-Null
+        $sourceContainer = Get-AzStorageContainer `
+            -Name $container `
+            -Context $sourceContext
+        if ($null -eq $sourceContainer) {
+            throw "Source container '$container' does not exist in storage account '$SourceStorageAccount'."
+        }
+
+        $sasStartTime = (Get-Date).ToUniversalTime().AddMinutes(-15)
+        $sasExpiryTime = (Get-Date).ToUniversalTime().AddHours($SasExpiryHours)
+        $sourceSasUrl = New-AzStorageContainerSASToken `
+            -Name $container `
+            -Context $sourceContext `
+            -Permission "rlt" `
+            -Protocol HttpsOnly `
+            -StartTime $sasStartTime `
+            -ExpiryTime $sasExpiryTime `
+            -FullUri
+
+        Set-AzContext -SubscriptionId $DestinationSubscriptionId | Out-Null
+        $destinationContainer = Get-AzStorageContainer `
+            -Name $container `
+            -Context $destinationContext
+        if ($null -eq $destinationContainer) {
+            New-AzStorageContainer `
+                -Name $container `
+                -Context $destinationContext | Out-Null
+            Write-Host "Created destination container: $container"
+        }
+
+        $destinationSasUrl = New-AzStorageContainerSASToken `
+            -Name $container `
+            -Context $destinationContext `
+            -Permission "racwdlt" `
+            -Protocol HttpsOnly `
+            -StartTime $sasStartTime `
+            -ExpiryTime $sasExpiryTime `
+            -FullUri
+
+        if ($DifferentialMigration) {
+            $azCopyArguments = @(
+                "sync"
+                $sourceSasUrl
+                $destinationSasUrl
+                "--recursive=true"
+                "--delete-destination=false"
+                "--s2s-preserve-blob-tags=true"
+            )
+        }
+        else {
+            $azCopyArguments = @(
+                "copy"
+                $sourceSasUrl
+                $destinationSasUrl
+                "--recursive=true"
+                "--overwrite=true"
+                "--s2s-preserve-properties=true"
+                "--s2s-preserve-blob-tags=true"
+            )
+        }
+
+        & azcopy @azCopyArguments
+
+        if ($LASTEXITCODE -ne 0) {
+            throw "AzCopy failed for container '$container' with exit code $LASTEXITCODE."
+        }
+
+        Complete-MigrationResourceCheckpoint `
+            -Context $migrationState `
+            -ResourceName $container `
+            -Result ([ordered]@{
+                Mode = $migrationMode
+            })
+        $activeMigrationResource = $null
+        $completedContainerCount++
+        Write-StorageMigrationProgress `
+            -CompletedCount $completedContainerCount `
+            -TotalCount $Containers.Count `
+            -CurrentContainer $container
+    }
+
+    Complete-MigrationState `
+        -Context $migrationState `
+        -Summary ([ordered]@{
+            ContainerCount = $completedContainerCount
+        })
+    Write-Host "Storage account migration completed successfully. Containers processed: $completedContainerCount"
+}
+catch {
+    $migrationErrorMessage = $_.Exception.Message
+    if ($null -ne $migrationState) {
+        try {
+            Set-MigrationStateFailure `
+                -Context $migrationState `
+                -ResourceName $activeMigrationResource `
+                -ErrorMessage $migrationErrorMessage
+        }
+        catch {
+            Write-Warning "Failed to update migration state after an error: $($_.Exception.Message)"
+        }
+    }
+    Write-Error "Storage account migration failed: $migrationErrorMessage" -ErrorAction Continue
+    throw
+}
+finally {
+    Write-StorageMigrationProgress -CompletedCount 0 -TotalCount 0 -Completed
+}

--- a/ui_tests/test_chat_mixed_source_selection_payload.py
+++ b/ui_tests/test_chat_mixed_source_selection_payload.py
@@ -1,0 +1,195 @@
+# test_chat_mixed_source_selection_payload.py
+"""
+UI test for explicit mixed-source Chat payload consistency.
+Version: 0.250.064
+Implemented in: 0.250.064
+
+This test ensures Phase 2 issue #1057 sends the Phase 1 #1056 selection
+contract with the Search Documents panel open and closed. Parent: #1055.
+"""
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+
+BASE_URL = os.getenv("SIMPLECHAT_UI_BASE_URL", "").rstrip("/")
+STORAGE_STATE = os.getenv("SIMPLECHAT_UI_STORAGE_STATE", "")
+
+
+def _fulfill_json(route, payload, status=200):
+    route.fulfill(
+        status=status,
+        content_type="application/json",
+        body=json.dumps(payload),
+    )
+
+
+def _fulfill_stream(route, payload, status=200):
+    route.fulfill(
+        status=status,
+        content_type="text/event-stream",
+        headers={"Cache-Control": "no-cache"},
+        body=f"data: {json.dumps(payload)}\n\n",
+    )
+
+
+def _select_mixed_documents(page):
+    page.locator("#document-select").evaluate(
+        """
+        select => {
+            const selectedIds = ['narrative-pdf', 'table-xlsx'];
+            Array.from(select.options).forEach(option => {
+                option.selected = selectedIds.includes(option.value);
+            });
+            select.dispatchEvent(new Event('change', { bubbles: true }));
+            window.dispatchEvent(new CustomEvent('chat:document-selection-changed', {
+                detail: { documentIds: selectedIds },
+            }));
+        }
+        """
+    )
+
+
+@pytest.mark.ui
+def test_selected_documents_request_context_with_panel_open_and_closed():
+    """Validate that panel state changes retrieval preference, not selected context."""
+    if not BASE_URL:
+        pytest.skip("Set SIMPLECHAT_UI_BASE_URL to run this UI test.")
+    if not STORAGE_STATE or not Path(STORAGE_STATE).exists():
+        pytest.skip("Set SIMPLECHAT_UI_STORAGE_STATE to a valid authenticated Playwright storage state file.")
+
+    playwright_module = pytest.importorskip("playwright.sync_api")
+    expect = playwright_module.expect
+    playwright_context = playwright_module.sync_playwright().start()
+
+    browser = playwright_context.chromium.launch()
+    context = browser.new_context(
+        storage_state=STORAGE_STATE,
+        viewport={"width": 1440, "height": 900},
+    )
+    page = context.new_page()
+    captured_payloads = []
+
+    def handle_user_settings(route):
+        if route.request.method == "GET":
+            _fulfill_json(route, {"selected_agent": None, "settings": {"enable_agents": False}})
+            return
+        if route.request.method == "POST":
+            _fulfill_json(route, {"success": True})
+            return
+        route.continue_()
+
+    page.route("**/api/user/settings", handle_user_settings)
+    page.route(
+        "**/api/get_conversations",
+        lambda route: _fulfill_json(
+            route,
+            {
+                "conversations": [{
+                    "id": "mixed-source-payload-conversation",
+                    "title": "Mixed Source Payload",
+                    "last_updated": "2026-07-22T10:00:00Z",
+                    "classification": [],
+                    "context": [],
+                    "chat_type": "new",
+                    "is_pinned": False,
+                    "is_hidden": False,
+                    "has_unread_assistant_response": False,
+                }]
+            },
+        ),
+    )
+    page.route(
+        "**/conversation/mixed-source-payload-conversation/messages?*",
+        lambda route: _fulfill_json(route, {"messages": []}),
+    )
+    page.route(
+        "**/api/documents?page_size=1000",
+        lambda route: _fulfill_json(
+            route,
+            {
+                "documents": [
+                    {
+                        "id": "narrative-pdf",
+                        "title": "Narrative Report",
+                        "file_name": "narrative-report.pdf",
+                        "tags": [],
+                        "document_classification": "",
+                    },
+                    {
+                        "id": "table-xlsx",
+                        "title": "Source Data",
+                        "file_name": "source-data.xlsx",
+                        "tags": [],
+                        "document_classification": "",
+                    },
+                ]
+            },
+        ),
+    )
+    page.route("**/api/group_documents?*", lambda route: _fulfill_json(route, {"documents": []}))
+    page.route("**/api/public_workspace_documents?page_size=1000", lambda route: _fulfill_json(route, {"documents": []}))
+    page.route("**/api/documents/tags", lambda route: _fulfill_json(route, {"tags": []}))
+    page.route("**/api/group_documents/tags?*", lambda route: _fulfill_json(route, {"tags": []}))
+    page.route("**/api/public_workspace_documents/tags?*", lambda route: _fulfill_json(route, {"tags": []}))
+    page.route("**/api/chat/stream/client-event", lambda route: _fulfill_json(route, {"success": True}))
+    page.route(
+        "**/api/conversations/mixed-source-payload-conversation/mark-read",
+        lambda route: _fulfill_json(route, {"success": True}),
+    )
+
+    def handle_standard_stream(route):
+        payload = route.request.post_data_json or {}
+        captured_payloads.append(payload)
+        response_index = len(captured_payloads)
+        _fulfill_stream(
+            route,
+            {
+                "content": f"Mixed source response {response_index}",
+                "full_content": f"Mixed source response {response_index}",
+                "done": True,
+                "conversation_id": "mixed-source-payload-conversation",
+                "message_id": f"mixed-source-assistant-{response_index}",
+                "role": "assistant",
+            },
+        )
+
+    page.route("**/api/chat/stream", handle_standard_stream)
+
+    try:
+        response = page.goto(f"{BASE_URL}/chats", wait_until="networkidle")
+        assert response is not None and response.ok
+        expect(page.locator("#user-input")).to_be_visible()
+
+        workspace_toggle = page.locator("#search-documents-btn")
+        workspace_toggle.click()
+        expect(page.locator("#search-documents-container")).to_be_visible()
+        _select_mixed_documents(page)
+
+        page.locator("#user-input").fill("Summarize the report and calculate the table total")
+        page.locator("#send-btn").click()
+        expect(page.locator("[data-message-id='mixed-source-assistant-1']")).to_be_visible()
+
+        workspace_toggle.click()
+        expect(page.locator("#search-documents-container")).to_be_hidden()
+        page.locator("#user-input").fill("Repeat the same mixed-source request")
+        page.locator("#send-btn").click()
+        expect(page.locator("[data-message-id='mixed-source-assistant-2']")).to_be_visible()
+
+        assert len(captured_payloads) == 2
+        open_payload, closed_payload = captured_payloads
+        for payload in (open_payload, closed_payload):
+            assert payload["selection_mode"] == "selected"
+            assert payload["selected_document_ids"] == ["narrative-pdf", "table-xlsx"]
+            assert payload["selected_document_id"] == "narrative-pdf"
+            assert payload["document_context_requested"] is True
+
+        assert open_payload["hybrid_search"] is True
+        assert closed_payload["hybrid_search"] is False
+    finally:
+        context.close()
+        browser.close()
+        playwright_context.stop()


### PR DESCRIPTION
## Summary

- Make explicit Chat document selections authoritative regardless of whether the Search Documents panel is open, while retaining `hybrid_search` as a compatibility/retrieval preference.
- Reuse the Phase 1 authorized manifest, partitions, bounded evidence envelopes, and privacy-safe diagnostics across standard Chat, streaming Chat, local/Foundry model and agent paths, collaboration, retry/edit replay, and workflow Search.
- Route narrative sources through bounded retrieval and tabular sources through the existing native tabular runner with per-source terminal coverage, exact authorized revision/blob identity, tool-citation evidence, and partial-coverage synthesis.
- Add two default-off rollout flags: `enable_mixed_source_chat_search` for explicit selections and `enable_mixed_source_relevance_candidates` for the later capped relevance candidate stage.
- Keep Chat/Search relevance-bounded; no exhaustive Analyze, cross-format Compare, persisted follow-up source reuse, or Phase 3-6 behavior is included.
- Add the Cosmos migration scripts and recovery hardening: preserve unusual JSON property names, record nonfatal document skips, and resume bounded HTTP 429 write recovery using durable migration state.
- Bump the combined application release to `0.250.064`, with Phase 2 and migration documentation plus release notes.

## Security

- Reauthorize personal, group, public, and chat-upload sources at object boundaries; group workflows force their stored authorized group scope.
- Require exact approved shares before source manifests expose shared personal/group documents.
- Keep authorized archived/shared blob locators request-scoped and plugin-validated; never emit them into evidence, prompts, or diagnostics.
- Foundry `include_document_context=false` now excludes both mixed-source evidence text and file attachments.
- Diagnostics remain aggregate-only and exclude source IDs, filenames, content, paths, prompts, credentials, and raw configuration.

## Validation

- `51 passed, 1 skipped` across focused mixed-source, workflow, Foundry, migration, and UI collection suites. The UI test skips only when no authenticated `SIMPLECHAT_UI_BASE_URL` and storage state are configured.
- `1 passed` focused Cosmos migration document-skip/reporting test.
- `12 passed` route-policy tests.
- Full-file broken-access-control scan passed for 10 files.
- Full-file XSS scan passed for 11 files.
- Python compilation, `node --check`, editor diagnostics for changed files, and CRLF-aware whitespace checks passed.
- Independent reviews were performed and all substantive findings were repaired.

## Scope

Phase 2 only for #1057. The relevance-table candidate stage is explicitly default-off until telemetry confirms coverage and latency. The migration scripts are included as the concurrent `0.250.064` release work.

Fixes #1057
Refs #1055
Refs #1056