### PR TITLE
Fix CSV artifacts for non-tabular documents

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -97,7 +97,7 @@ load_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.250.064"
+VERSION = "0.250.065"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/functions_assistant_table_exports.py
+++ b/application/single_app/functions_assistant_table_exports.py
@@ -9,6 +9,57 @@ from typing import Any, Dict, List, Optional
 
 
 ASSISTANT_TABLE_EXPORT_PREVIEW_ROWS = 3
+CSV_FENCE_LANGUAGES = {'', 'csv', 'md', 'markdown', 'plaintext', 'text', 'text/csv', 'txt'}
+CSV_OUTPUT_REQUEST_PATTERNS = (
+    re.compile(
+        r'\b(?:build|create|download|export|generate|make|prepare|save)\b'
+        r'.{0,120}\b(?:a\s+)?csv(?:\s+(?:file|format|output))?\b'
+    ),
+    re.compile(
+        r'\b(?:respond|return|provide|output)\b'
+        r'(?:(?!\bfrom\b).){0,80}\b(?:as|in|to\s+)?(?:a\s+)?csv\b'
+    ),
+    re.compile(
+        r'\b(?:convert|format|put|turn)\b.{0,80}\b(?:as|in|into|to)\s+(?:a\s+)?csv\b'
+    ),
+    re.compile(r'\b(?:get|give)\s+(?:me\s+)?(?:a|the)\s+csv\b'),
+    re.compile(
+        r'\b(?:need|want)\s+(?:(?:a|the)\s+)?(?:direct\s+)?csv'
+        r'(?:\s+(?:file|format|output))?\b'
+    ),
+    re.compile(
+        r'\b(?:need|want)\b.{0,40}\b(?:results?|output|answer|response|fields?|rows?|data|this|that|it)\b'
+        r'.{0,40}\b(?:as|in)\s+csv\b'
+    ),
+    re.compile(r'\bcsv\s+(?:output|version)\b'),
+    re.compile(r'^\s*(?:a\s+)?csv\s+file\s*(?:,?\s*please)?[.!?]?\s*$'),
+    re.compile(
+        r'\b(?:build|create|download|export|generate|make|prepare|save|turn)\b'
+        r'.{0,80}\bspreadsheet\b'
+    ),
+)
+CSV_PROSE_PREFIXES = (
+    'below ',
+    'csv data',
+    'for clarity',
+    'for context',
+    'here are ',
+    'here is ',
+    'i extracted ',
+    'i found ',
+    'in summary',
+    'sure ',
+    'the following ',
+    'the requested ',
+    'the export ',
+    'this csv ',
+    'this export ',
+    'your csv ',
+)
+SIGNED_NUMBER_PATTERN = re.compile(
+    r'[+-]?(?:(?:\d{1,3}(?:,\d{3})+|\d+)(?:\.\d*)?|\.\d+)(?:e[+-]?\d+)?',
+    flags=re.IGNORECASE,
+)
 
 TABLE_EXPORT_REQUEST_MARKERS = (
     'turn that into a csv',
@@ -85,15 +136,13 @@ TABLE_EXPORT_REQUEST_MARKERS = (
     'table for me',
     'in table format',
     'download table',
-    'table file',
-    'spreadsheet',
-    'csv file',
     'download csv',
     'save csv',
     'make a csv',
     'make csv',
     'create a csv',
     'create csv',
+    'csv version',
 )
 
 
@@ -103,7 +152,37 @@ def assistant_table_export_requested(user_question: str) -> bool:
     if not normalized_question:
         return False
 
-    return any(marker in normalized_question for marker in TABLE_EXPORT_REQUEST_MARKERS)
+    csv_markers = tuple(marker for marker in TABLE_EXPORT_REQUEST_MARKERS if 'csv' in marker)
+    table_markers = tuple(marker for marker in TABLE_EXPORT_REQUEST_MARKERS if 'csv' not in marker)
+    question_clauses = [
+        clause.strip()
+        for clause in re.split(r'[;.!?]+', normalized_question)
+        if clause.strip()
+    ]
+
+    for question_clause in question_clauses:
+        if 'csv' not in question_clause:
+            continue
+        csv_request_negated = bool(re.search(
+            r"\b(?:do\s+not|don't|dont|never)\b.{0,80}\bcsv\b"
+            r'|\b(?:not|no|without)\s+(?:a\s+)?csv\b',
+            question_clause,
+        ))
+        if csv_request_negated:
+            continue
+        if any(marker in question_clause for marker in csv_markers):
+            return True
+        if any(pattern.search(question_clause) for pattern in CSV_OUTPUT_REQUEST_PATTERNS):
+            return True
+
+    return (
+        any(marker in normalized_question for marker in table_markers)
+        or any(
+            pattern.search(normalized_question)
+            for pattern in CSV_OUTPUT_REQUEST_PATTERNS
+            if 'spreadsheet' in pattern.pattern
+        )
+    )
 
 
 def build_assistant_table_csv_export(user_question: str, assistant_content: str) -> Optional[Dict[str, Any]]:
@@ -130,14 +209,19 @@ def build_assistant_table_csv_export(user_question: str, assistant_content: str)
 
 
 def extract_assistant_table_entries(assistant_content: str) -> List[Dict[str, str]]:
-    """Extract table rows from Markdown pipe tables or tab-separated assistant output."""
+    """Extract table rows from Markdown, tab-separated, or CSV assistant output."""
     normalized_content = str(assistant_content or '').replace('\r\n', '\n').replace('\r', '\n')
     if not normalized_content.strip():
         return []
 
+    fenced_csv_rows = _extract_fenced_comma_separated_table_entries(normalized_content)
+    if fenced_csv_rows:
+        return fenced_csv_rows
+
     candidates = [
         _extract_markdown_table_entries(normalized_content),
         _extract_tab_separated_table_entries(normalized_content),
+        _extract_comma_separated_table_entries(normalized_content),
     ]
     return max(candidates, key=len, default=[])
 
@@ -169,6 +253,30 @@ def build_assistant_table_csv(table_rows: List[Dict[str, Any]]) -> str:
                 serialized_row[column_name] = _serialize_table_cell(table_row.get(column_name))
         writer.writerow(serialized_row)
     return output_buffer.getvalue()
+
+
+def build_safe_csv_headers(header_cells: List[Any]) -> List[str]:
+    """Return non-empty, formula-safe, unique CSV headers in source order."""
+    headers = []
+    seen_headers = set()
+    for index, header_cell in enumerate(header_cells or []):
+        base_header = neutralize_csv_spreadsheet_formula(_clean_table_cell(header_cell)) or f'Column {index + 1}'
+        header = base_header
+        occurrence_count = 2
+        while header.casefold() in seen_headers:
+            header = f'{base_header} {occurrence_count}'
+            occurrence_count += 1
+        seen_headers.add(header.casefold())
+        headers.append(header)
+    return headers
+
+
+def neutralize_csv_spreadsheet_formula(value: Any) -> str:
+    """Prefix spreadsheet formula-like text while preserving signed numbers."""
+    serialized_value = '' if value is None else str(value)
+    if _spreadsheet_formula_candidate(serialized_value):
+        return f"'{serialized_value}"
+    return serialized_value
 
 
 def _extract_markdown_table_entries(content: str) -> List[Dict[str, str]]:
@@ -213,6 +321,198 @@ def _extract_tab_separated_table_entries(content: str) -> List[Dict[str, str]]:
             best_entries = block_entries
 
     return best_entries
+
+
+def _extract_comma_separated_table_entries(content: str) -> List[Dict[str, str]]:
+    fenced_candidates = []
+    unfenced_sections = []
+    previous_end = 0
+    fence_pattern = re.compile(
+        r'```[ \t]*(?P<language>[^\n`]*)\n(?P<body>.*?)```',
+        flags=re.IGNORECASE | re.DOTALL,
+    )
+
+    for fence_match in fence_pattern.finditer(content):
+        unfenced_sections.append(content[previous_end:fence_match.start()])
+        language = str(fence_match.group('language') or '').strip().casefold()
+        if language in CSV_FENCE_LANGUAGES:
+            fenced_candidates.extend(_parse_csv_table_candidates(fence_match.group('body'), trusted=True))
+        previous_end = fence_match.end()
+    unfenced_sections.append(content[previous_end:])
+
+    if fenced_candidates:
+        return max(fenced_candidates, key=len, default=[])
+
+    candidates = []
+    for section in unfenced_sections:
+        candidates.extend(_parse_csv_table_candidates(section, trusted=False))
+
+    return max(candidates, key=len, default=[])
+
+
+def _extract_fenced_comma_separated_table_entries(content: str) -> List[Dict[str, str]]:
+    explicit_csv_candidates = []
+    generic_fenced_candidates = []
+    fence_pattern = re.compile(
+        r'```[ \t]*(?P<language>[^\n`]*)\n(?P<body>.*?)```',
+        flags=re.IGNORECASE | re.DOTALL,
+    )
+    for fence_match in fence_pattern.finditer(content):
+        language = str(fence_match.group('language') or '').strip().casefold()
+        if language in CSV_FENCE_LANGUAGES:
+            parsed_candidates = _parse_csv_table_candidates(fence_match.group('body'), trusted=True)
+            if language in {'csv', 'text/csv'}:
+                explicit_csv_candidates.extend(parsed_candidates)
+            else:
+                generic_fenced_candidates.extend(parsed_candidates)
+    if explicit_csv_candidates:
+        return max(explicit_csv_candidates, key=len, default=[])
+    return max(generic_fenced_candidates, key=len, default=[])
+
+
+def _parse_csv_table_candidates(content: str, trusted: bool = False) -> List[List[Dict[str, str]]]:
+    if ',' not in str(content or ''):
+        return []
+
+    try:
+        parsed_rows = list(csv.reader(io.StringIO(content), strict=True))
+    except csv.Error:
+        return []
+
+    candidates = []
+    current_rows = []
+    current_width = None
+    for parsed_row in parsed_rows:
+        if not trusted and _is_csv_source_citation_row(parsed_row):
+            candidate_rows = _trim_trailing_csv_narration_rows(current_rows)
+            if len(candidate_rows) >= 2:
+                candidates.append(_build_csv_table_entries(candidate_rows, trusted=trusted))
+            current_rows = []
+            current_width = None
+            continue
+
+        row_width = len(parsed_row)
+        if row_width < 2:
+            if len(current_rows) >= 2:
+                candidates.append(_build_csv_table_entries(current_rows, trusted=trusted))
+            current_rows = []
+            current_width = None
+            continue
+
+        if current_width is not None and row_width != current_width:
+            if len(current_rows) >= 2:
+                candidates.append(_build_csv_table_entries(current_rows, trusted=trusted))
+            current_rows = []
+
+        current_rows.append(parsed_row)
+        current_width = row_width
+
+    if len(current_rows) >= 2:
+        candidates.append(_build_csv_table_entries(current_rows, trusted=trusted))
+
+    return [candidate for candidate in candidates if candidate]
+
+
+def _build_csv_table_entries(parsed_rows: List[List[str]], trusted: bool = False) -> List[Dict[str, str]]:
+    if len(parsed_rows) < 2:
+        return []
+
+    if trusted:
+        header_index = 0
+    else:
+        header_index = next(
+            (
+                row_index
+                for row_index, parsed_row in enumerate(parsed_rows[:-1])
+                if _is_likely_csv_header_row(parsed_row)
+            ),
+            None,
+        )
+    if header_index is None:
+        return []
+
+    table_rows = parsed_rows[header_index:]
+    headers = _build_unique_headers(table_rows[0])
+    if len(headers) < 2:
+        return []
+
+    entries = []
+    for parsed_row in table_rows[1:]:
+        if not trusted and _is_csv_source_citation_row(parsed_row):
+            break
+        normalized_row = _coerce_row_length(parsed_row, len(headers))
+        if not any(str(cell or '').strip() for cell in normalized_row):
+            continue
+        entries.append({
+            header: _clean_csv_cell(normalized_row[index])
+            for index, header in enumerate(headers)
+        })
+    return entries
+
+
+def _is_likely_csv_header_row(parsed_row: List[str]) -> bool:
+    cleaned_cells = [_clean_csv_cell(cell) for cell in parsed_row]
+    if len(cleaned_cells) < 2 or any(not cell for cell in cleaned_cells):
+        return False
+
+    if _is_likely_csv_preamble_row(parsed_row) or _is_csv_source_citation_row(parsed_row):
+        return False
+
+    return all('\n' not in cell for cell in cleaned_cells)
+
+
+def _is_likely_csv_discourse_row(parsed_row: List[str]) -> bool:
+    if not parsed_row:
+        return False
+
+    first_cell = _clean_csv_cell(parsed_row[0]).casefold()
+    return first_cell.startswith(CSV_PROSE_PREFIXES)
+
+
+def _is_likely_csv_preamble_row(parsed_row: List[str]) -> bool:
+    if _is_likely_csv_discourse_row(parsed_row):
+        return True
+
+    cleaned_cells = [_clean_csv_cell(cell) for cell in parsed_row]
+    combined_text = ', '.join(cell for cell in cleaned_cells if cell)
+    word_count = len(re.findall(r"\b[\w'-]+\b", combined_text))
+    return (
+        len(cleaned_cells) == 2
+        and word_count >= 5
+        and cleaned_cells[-1].rstrip().endswith(('.', '!'))
+        and not any(re.search(r'\d', cell) for cell in cleaned_cells)
+    )
+
+
+def _trim_trailing_csv_narration_rows(parsed_rows: List[List[str]]) -> List[List[str]]:
+    trimmed_rows = list(parsed_rows or [])
+    while len(trimmed_rows) > 1 and _is_likely_csv_trailing_narration_row(trimmed_rows[-1]):
+        trimmed_rows.pop()
+    return trimmed_rows
+
+
+def _is_likely_csv_trailing_narration_row(parsed_row: List[str]) -> bool:
+    cleaned_cells = [_clean_csv_cell(cell) for cell in parsed_row]
+    if len(cleaned_cells) != 2 or not _is_likely_csv_discourse_row(parsed_row):
+        return False
+
+    combined_text = ', '.join(cell for cell in cleaned_cells if cell)
+    word_count = len(re.findall(r"\b[\w'-]+\b", combined_text))
+    return word_count >= 5 and cleaned_cells[-1].rstrip().endswith(('.', '!'))
+
+
+def _is_csv_source_citation_row(parsed_row: List[str]) -> bool:
+    if not parsed_row:
+        return False
+
+    first_cell = _clean_csv_cell(parsed_row[0])
+    return bool(re.match(
+        r'^\s*(?:[-*+>\u2022\u25e6\u25aa\u2023]\s*)?'
+        r'(?:(?:\[\s*\d+\s*\]|\(\s*\d+\s*\)|\d+[.)])\s*)?'
+        r'[\[(]?\s*(?:sources?|citations?)\s*[\])]?\s*:',
+        first_cell,
+        flags=re.IGNORECASE,
+    ))
 
 
 def _parse_markdown_table_block(table_block: List[str]) -> List[Dict[str, str]]:
@@ -321,17 +621,7 @@ def _is_markdown_separator_row(row: List[str]) -> bool:
 
 
 def _build_unique_headers(header_cells: List[str]) -> List[str]:
-    headers = []
-    seen_headers = {}
-    for index, header_cell in enumerate(header_cells or []):
-        header = _clean_table_cell(header_cell) or f'Column {index + 1}'
-        normalized_header = header.casefold()
-        occurrence_count = seen_headers.get(normalized_header, 0)
-        seen_headers[normalized_header] = occurrence_count + 1
-        if occurrence_count:
-            header = f'{header} {occurrence_count + 1}'
-        headers.append(header)
-    return headers
+    return build_safe_csv_headers(header_cells)
 
 
 def _coerce_row_length(row: List[str], target_length: int) -> List[str]:
@@ -353,12 +643,25 @@ def _clean_table_cell(value: Any) -> str:
     return cleaned
 
 
+def _clean_csv_cell(value: Any) -> str:
+    return str(value or '').replace('\r\n', '\n').replace('\r', '\n').strip()
+
+
 def _serialize_table_cell(value: Any) -> str:
     if value is None:
         return ''
     if isinstance(value, (dict, list)):
-        return str(value)
-    return str(value)
+        return neutralize_csv_spreadsheet_formula(str(value))
+    return neutralize_csv_spreadsheet_formula(str(value))
+
+
+def _spreadsheet_formula_candidate(value: Any) -> bool:
+    normalized_value = str(value or '').lstrip()
+    if not normalized_value or normalized_value[0] not in ('=', '+', '-', '@'):
+        return False
+    if normalized_value[0] in ('+', '-') and SIGNED_NUMBER_PATTERN.fullmatch(normalized_value):
+        return False
+    return True
 
 
 def _build_assistant_table_export_file_name() -> str:

--- a/application/single_app/functions_tabular_generated_exports.py
+++ b/application/single_app/functions_tabular_generated_exports.py
@@ -34,6 +34,7 @@ from config import (
     storage_account_user_documents_container_name,
 )
 from functions_appinsights import log_event
+from functions_assistant_table_exports import build_safe_csv_headers, neutralize_csv_spreadsheet_formula
 from functions_tabular_csv_query import (
     iter_tabular_csv_query_rows,
     validate_tabular_csv_query_expression,
@@ -232,13 +233,13 @@ def _serialize_generated_output_value(value):
     if value is None:
         return ''
     if isinstance(value, (dict, list)):
-        return json.dumps(value, default=str, ensure_ascii=False)
+        return neutralize_csv_spreadsheet_formula(json.dumps(value, default=str, ensure_ascii=False))
     if hasattr(value, 'isoformat') and not isinstance(value, str):
         try:
-            return value.isoformat()
+            return neutralize_csv_spreadsheet_formula(value.isoformat())
         except TypeError:
             pass
-    return str(value)
+    return neutralize_csv_spreadsheet_formula(value)
 
 
 def _normalize_source_identity_label(value):
@@ -513,14 +514,15 @@ def _build_generated_output_csv(entries):
     if not ordered_columns:
         ordered_columns = ['value']
 
+    safe_ordered_columns = build_safe_csv_headers(ordered_columns)
     output_buffer = io.StringIO()
-    writer = csv.DictWriter(output_buffer, fieldnames=ordered_columns)
+    writer = csv.DictWriter(output_buffer, fieldnames=safe_ordered_columns)
     writer.writeheader()
     for entry in entries or []:
         serialized_row = {}
         if isinstance(entry, dict):
-            for field_name in ordered_columns:
-                serialized_row[field_name] = _serialize_generated_output_value(entry.get(field_name))
+            for field_name, safe_field_name in zip(ordered_columns, safe_ordered_columns):
+                serialized_row[safe_field_name] = _serialize_generated_output_value(entry.get(field_name))
         writer.writerow(serialized_row)
     return output_buffer.getvalue()
 
@@ -2143,8 +2145,10 @@ def _write_ordered_output_stream(run, output_stream):
         raise ValueError('Generated output schema is missing source row order')
 
     csv_writer = None
+    safe_output_schema = None
     if output_format == 'csv':
-        csv_writer = csv.DictWriter(output_stream, fieldnames=output_schema, lineterminator='\n')
+        safe_output_schema = build_safe_csv_headers(output_schema)
+        csv_writer = csv.DictWriter(output_stream, fieldnames=safe_output_schema, lineterminator='\n')
         csv_writer.writeheader()
     else:
         output_stream.write('[\n')
@@ -2179,8 +2183,8 @@ def _write_ordered_output_stream(run, output_stream):
             }
             if csv_writer:
                 csv_writer.writerow({
-                    field_name: _serialize_generated_output_value(field_value)
-                    for field_name, field_value in ordered_entry.items()
+                    safe_field_name: _serialize_generated_output_value(ordered_entry.get(field_name))
+                    for field_name, safe_field_name in zip(output_schema, safe_output_schema)
                 })
             else:
                 if written_row_count:
@@ -2463,6 +2467,31 @@ def _checkpoint_generated_batch_results(run, generated_results):
     return batch_results
 
 
+def _build_passthrough_batch_results(run, batch_requests):
+    """Create checkpoint entries directly when rows are already final export output."""
+    expected_output_schema = list(run.get('output_schema') or [])
+    generated_results = []
+    for batch_request in batch_requests:
+        batch_started_at = time.monotonic()
+        batch_entries, output_schema = _normalize_generated_batch_entries(
+            batch_request['rows'],
+            batch_request['rows'],
+            expected_output_schema=expected_output_schema,
+        )
+        if not expected_output_schema:
+            expected_output_schema = output_schema
+        generated_results.append({
+            'batch_number': batch_request['batch_number'],
+            'batch_entries': batch_entries,
+            'batch_summary': _build_generated_batch_summary(batch_entries),
+            'batch_row_count': len(batch_entries),
+            'elapsed_seconds': time.monotonic() - batch_started_at,
+            'mismatch_count': 0,
+            'output_schema': output_schema,
+        })
+    return generated_results
+
+
 def _advance_run_progress_for_window(run, batch_results, completed_batches, processed_rows, window_start, window_end):
     for batch_number in range(window_start, window_end + 1):
         batch_result = batch_results.get(batch_number)
@@ -2516,11 +2545,13 @@ def process_tabular_generated_output_run(run_id, user_id):
             minimum=1,
             maximum=TABULAR_EXPORT_MAX_BATCH_CONCURRENCY,
         )
-        chat_service = _build_chat_service(
-            run.get('gpt_model'),
-            settings,
-            model_context=run.get('model_context'),
-        )
+        chat_service = None
+        if not run.get('passthrough_input_rows'):
+            chat_service = _build_chat_service(
+                run.get('gpt_model'),
+                settings,
+                model_context=run.get('model_context'),
+            )
         completed_batches = _safe_int(run.get('completed_batches'))
         processed_rows = _safe_int(run.get('processed_rows'))
         batch_count = _safe_int(run.get('batch_count'))
@@ -2580,20 +2611,23 @@ def process_tabular_generated_output_run(run_id, user_id):
                     },
                     debug_only=True,
                 )
-                generated_results, generation_error = asyncio.run(
-                    _generate_batch_window_entries(
-                        chat_service,
-                        run.get('user_question'),
-                        batch_requests,
-                        batch_count,
-                        run.get('source_file_name'),
-                        run.get('selected_sheet'),
-                        retry_attempts,
-                        normalized_run_id,
-                        batch_concurrency,
-                        expected_output_schema=run.get('output_schema'),
+                if run.get('passthrough_input_rows'):
+                    generated_results = _build_passthrough_batch_results(run, batch_requests)
+                else:
+                    generated_results, generation_error = asyncio.run(
+                        _generate_batch_window_entries(
+                            chat_service,
+                            run.get('user_question'),
+                            batch_requests,
+                            batch_count,
+                            run.get('source_file_name'),
+                            run.get('selected_sheet'),
+                            retry_attempts,
+                            normalized_run_id,
+                            batch_concurrency,
+                            expected_output_schema=run.get('output_schema'),
+                        )
                     )
-                )
                 _raise_if_tabular_export_canceled(run)
                 batch_results.update(_checkpoint_generated_batch_results(run, generated_results))
 
@@ -2655,6 +2689,7 @@ def queue_tabular_generated_output_run(
     settings=None,
     model_context=None,
     source_descriptor=None,
+    passthrough_input_rows=False,
 ):
     """Stage batch input blobs, create a run record, and submit background processing."""
     normalized_user_id = str(user_id or '').strip()
@@ -2756,6 +2791,7 @@ def queue_tabular_generated_output_run(
         'output_format': normalized_output_format,
         'gpt_model': str(gpt_model or '').strip(),
         'model_context': model_context if isinstance(model_context, dict) else {},
+        'passthrough_input_rows': bool(passthrough_input_rows),
         'generated_file_name': generated_file_name,
         'row_count': staged_row_count,
         'batch_count': staged_batch_count,

--- a/application/single_app/functions_workflow_runner.py
+++ b/application/single_app/functions_workflow_runner.py
@@ -43,6 +43,7 @@ from config import (
 )
 from functions_activity_logging import log_conversation_creation, log_token_usage, log_workflow_run
 from functions_appinsights import log_event
+from functions_assistant_table_exports import build_safe_csv_headers, neutralize_csv_spreadsheet_formula
 from functions_chart_operations import append_proactive_chart_guidance
 from functions_collaboration import (
     create_collaboration_message_notifications,
@@ -803,13 +804,13 @@ def _serialize_document_analysis_csv_value(value):
     if value is None:
         return ''
     if isinstance(value, (dict, list)):
-        return json.dumps(value, ensure_ascii=False, default=str)
+        return neutralize_csv_spreadsheet_formula(json.dumps(value, ensure_ascii=False, default=str))
     if hasattr(value, 'isoformat') and not isinstance(value, str):
         try:
-            return value.isoformat()
+            return neutralize_csv_spreadsheet_formula(value.isoformat())
         except TypeError:
             pass
-    return str(value)
+    return neutralize_csv_spreadsheet_formula(value)
 
 
 def _add_document_analysis_source_context(row, source_context):
@@ -906,13 +907,14 @@ def _build_document_analysis_rows_csv(rows):
         for column_name in row.keys():
             add_column(column_name)
 
+    safe_ordered_columns = build_safe_csv_headers(ordered_columns)
     output_buffer = io.StringIO()
-    writer = csv.DictWriter(output_buffer, fieldnames=ordered_columns, lineterminator='\n')
+    writer = csv.DictWriter(output_buffer, fieldnames=safe_ordered_columns, lineterminator='\n')
     writer.writeheader()
     for row in rows:
         writer.writerow({
-            column_name: _serialize_document_analysis_csv_value(row.get(column_name))
-            for column_name in ordered_columns
+            safe_column_name: _serialize_document_analysis_csv_value(row.get(column_name))
+            for column_name, safe_column_name in zip(ordered_columns, safe_ordered_columns)
         })
     return output_buffer.getvalue()
 

--- a/application/single_app/route_backend_chats.py
+++ b/application/single_app/route_backend_chats.py
@@ -109,8 +109,11 @@ from functions_group import find_group_by_id, get_group_model_endpoints, get_use
 from functions_chat import *
 from functions_content import generate_embedding, generate_embeddings_batch
 from functions_assistant_table_exports import (
-    TABLE_EXPORT_REQUEST_MARKERS,
+    assistant_table_export_requested,
+    build_safe_csv_headers,
     build_assistant_table_csv_export,
+    extract_assistant_table_entries,
+    neutralize_csv_spreadsheet_formula,
 )
 from functions_chart_operations import (
     CORE_CHART_PLUGIN_NAME,
@@ -1627,6 +1630,47 @@ def maybe_create_assistant_table_generated_output(
 
     generated_file_name = export_payload.get('file_name')
     row_count = _safe_int(export_payload.get('row_count'))
+    settings = get_settings()
+    table_rows = extract_assistant_table_entries(assistant_content)
+    row_batches = _build_tabular_generated_output_row_batches(
+        table_rows,
+        settings=settings,
+    )
+    if should_queue_tabular_generated_output_background(row_count, len(row_batches), settings):
+        try:
+            background_run = queue_tabular_generated_output_run(
+                user_id=get_current_user_id(),
+                conversation_id=conversation_id,
+                user_question=user_question,
+                source_candidate={
+                    'filename': generated_file_name,
+                    'selected_sheet': '',
+                    'source_authorization': {
+                        'source': 'chat',
+                        'container': storage_account_personal_chat_container_name,
+                    },
+                },
+                output_format='csv',
+                row_batches=row_batches,
+                gpt_model='',
+                settings=settings,
+                passthrough_input_rows=True,
+            )
+            return build_background_tabular_generated_output_metadata(background_run)
+        except Exception as exc:
+            log_event(
+                '[Assistant Table Export] Failed to queue large CSV export',
+                {
+                    'conversation_id': conversation_id,
+                    'generated_file_name': generated_file_name,
+                    'row_count': row_count,
+                    'error': str(exc),
+                },
+                level=logging.ERROR,
+                exceptionTraceback=True,
+            )
+            return None
+
     try:
         upload_result = upload_generated_analysis_artifact_for_current_user(
             conversation_id=conversation_id,
@@ -4065,11 +4109,9 @@ def get_tabular_generated_output_format(user_question):
         'return json',
         'valid json',
     )
-    csv_markers = TABLE_EXPORT_REQUEST_MARKERS
-
     if any(marker in normalized_question for marker in json_markers):
         return 'json'
-    if any(marker in normalized_question for marker in csv_markers):
+    if assistant_table_export_requested(user_question):
         return 'csv'
     return None
 
@@ -4094,7 +4136,7 @@ def question_requests_tabular_generated_output(user_question):
         'each object',
         'each row',
     )
-    if requested_format == 'csv' and any(marker in normalized_question for marker in TABLE_EXPORT_REQUEST_MARKERS):
+    if requested_format == 'csv' and assistant_table_export_requested(user_question):
         return True
 
     return any(marker in normalized_question for marker in exhaustive_markers)
@@ -4163,13 +4205,13 @@ def _serialize_tabular_generated_output_value(value):
     if value is None:
         return ''
     if isinstance(value, (dict, list)):
-        return json.dumps(value, default=str, ensure_ascii=False)
+        return neutralize_csv_spreadsheet_formula(json.dumps(value, default=str, ensure_ascii=False))
     if hasattr(value, 'isoformat') and not isinstance(value, str):
         try:
-            return value.isoformat()
+            return neutralize_csv_spreadsheet_formula(value.isoformat())
         except TypeError:
             pass
-    return str(value)
+    return neutralize_csv_spreadsheet_formula(value)
 
 
 def _build_tabular_generated_output_csv(entries):
@@ -4188,14 +4230,15 @@ def _build_tabular_generated_output_csv(entries):
     if not ordered_columns:
         ordered_columns = ['value']
 
+    safe_ordered_columns = build_safe_csv_headers(ordered_columns)
     output_buffer = io.StringIO()
-    writer = csv.DictWriter(output_buffer, fieldnames=ordered_columns)
+    writer = csv.DictWriter(output_buffer, fieldnames=safe_ordered_columns)
     writer.writeheader()
     for entry in entries or []:
         serialized_row = {}
         if isinstance(entry, dict):
-            for field_name in ordered_columns:
-                serialized_row[field_name] = _serialize_tabular_generated_output_value(entry.get(field_name))
+            for field_name, safe_field_name in zip(ordered_columns, safe_ordered_columns):
+                serialized_row[safe_field_name] = _serialize_tabular_generated_output_value(entry.get(field_name))
         writer.writerow(serialized_row)
     return output_buffer.getvalue()
 

--- a/docs/explanation/fixes/NON_TABULAR_DOCUMENT_CSV_ARTIFACT_FIX.md
+++ b/docs/explanation/fixes/NON_TABULAR_DOCUMENT_CSV_ARTIFACT_FIX.md
@@ -1,0 +1,51 @@
+# Non-Tabular Document CSV Artifact Fix
+
+Fixed in version: **0.250.065**
+
+Related issue: [#1066](https://github.com/microsoft/simplechat/issues/1066)
+
+## Issue
+
+When a user selected a PDF, Word document, or other non-tabular source and explicitly requested a CSV, the assistant could return valid comma-delimited rows without creating a downloadable CSV artifact.
+
+## Root Cause
+
+The assistant table export helper recognized Markdown pipe tables and tab-separated output, but not comma-delimited output. The chat route already invoked the helper and uploaded successful results, so valid CSV text stopped at the parser boundary.
+
+## Technical Details
+
+### Files Modified
+
+- `application/single_app/functions_assistant_table_exports.py`
+- `application/single_app/route_backend_chats.py`
+- `application/single_app/functions_tabular_generated_exports.py`
+- `application/single_app/functions_workflow_runner.py`
+- `application/single_app/config.py`
+- `functional_tests/test_assistant_table_csv_artifact.py`
+- `functional_tests/test_document_analysis_lossless_artifacts.py`
+- `functional_tests/test_tabular_row_orchestration_scale.py`
+- `docs/explanation/release_notes.md`
+
+### Changes
+
+- Parse CSV from explicit CSV, text, and plaintext code fences.
+- Parse conservative comma-delimited blocks when the model returns plain CSV text.
+- Recognize broader explicit CSV phrasing through one shared intent predicate used by generic and tabular export paths.
+- Use Python's CSV parser to preserve quoted commas, escaped quotes, multiline values, and column order.
+- Exclude surrounding prose and document citation lines from generated CSV rows.
+- Neutralize spreadsheet formula prefixes in downloaded headers and values while preserving signed numeric values across assistant-table, immediate tabular, durable background, and workflow analysis CSV writers.
+- Preserve every source column when duplicate headers collide with already-suffixed header names.
+- Continue requiring an explicit CSV or table request before creating an artifact.
+- Send large assistant-derived CSV row sets through the existing checkpointed background exporter without a second model transformation; the chat displays the normal queued/running/completed status and download link.
+
+## Validation
+
+The focused functional tests cover PDF-style fenced CSV, plain CSV followed by source citations, Word-style multiline and escaped-quote values, blank lines inside quoted values, alternate text fence labels, comma-bearing prose, formula-prefixed headers and cells across every generated CSV writer, duplicate header collisions, Markdown tables, tab-separated tables, broader explicit request phrasing, non-export requests, and the bounded 30,000-row background writer.
+
+Before the fix, a valid comma-delimited response produced no export payload. After the fix, the existing artifact uploader receives normalized rows and creates a downloadable `.csv` file; large row sets use the existing background export status and checkpoint flow.
+
+## Impact
+
+Users can request a CSV from structured information contained in non-tabular documents without manually copying the model's rendered CSV text into a local file. The fix does not infer rows from prose itself; the assistant response must contain valid table-shaped output.
+
+The application version was updated in `application/single_app/config.py` from `0.250.064` to `0.250.065`.

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,15 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](/explanation/features/) and [Fixes by Version](/explanation/fixes/).
 
+### **(v0.250.065)**
+
+#### Bug Fixes
+
+*   **Non-Tabular Document CSV Artifacts**
+    *   Explicit CSV requests over PDF, Word, and other non-tabular documents now create downloadable CSV artifacts when the assistant returns valid comma-delimited rows.
+    *   CSV exports preserve quoted commas, escaped quotes, multiline values, and every source column while excluding surrounding response prose and citations and neutralizing spreadsheet formula prefixes across immediate and background export paths.
+    *   (Ref: microsoft/simplechat#1066, `functions_assistant_table_exports.py`, `route_backend_chats.py`, `functions_tabular_generated_exports.py`, `functions_workflow_runner.py`, `test_assistant_table_csv_artifact.py`, `NON_TABULAR_DOCUMENT_CSV_ARTIFACT_FIX.md`)
+
 ### **(v0.250.064)**
 
 #### New Features

--- a/functional_tests/test_assistant_table_csv_artifact.py
+++ b/functional_tests/test_assistant_table_csv_artifact.py
@@ -2,16 +2,18 @@
 #!/usr/bin/env python3
 """
 Functional test for assistant-rendered table CSV artifacts.
-Version: 0.250.061
-Implemented in: 0.241.050; exhaustive-export suppression in 0.250.060
+Version: 0.250.065
+Implemented in: 0.241.050; non-tabular document CSV parsing in 0.250.065
 
 This test ensures that explicit table-format requests with assistant-rendered
-tables and natural CSV/table conversion requests are converted into
-downloadable CSV artifact metadata for the chat UI.
+tables, including CSV rows extracted from non-tabular documents, are converted
+into downloadable CSV artifact metadata for the chat UI.
 """
 
+import ast
 import csv
 import io
+import json
 import sys
 import traceback
 from pathlib import Path
@@ -21,14 +23,18 @@ ROOT = Path(__file__).resolve().parents[1]
 APP_DIR = ROOT / 'application' / 'single_app'
 CONFIG_FILE = APP_DIR / 'config.py'
 CHAT_ROUTE_FILE = APP_DIR / 'route_backend_chats.py'
-EXPECTED_VERSION = '0.250.061'
+BACKGROUND_EXPORT_FILE = APP_DIR / 'functions_tabular_generated_exports.py'
+WORKFLOW_RUNNER_FILE = APP_DIR / 'functions_workflow_runner.py'
+EXPECTED_VERSION = '0.250.065'
 
 sys.path.append(str(APP_DIR))
 
 from functions_assistant_table_exports import (  # noqa: E402
     assistant_table_export_requested,
+    build_safe_csv_headers,
     build_assistant_table_csv_export,
     extract_assistant_table_entries,
+    neutralize_csv_spreadsheet_formula,
 )
 
 
@@ -51,6 +57,28 @@ def assert_true(condition, message):
 
 def parse_csv_rows(csv_content):
     return list(csv.DictReader(io.StringIO(csv_content)))
+
+
+def load_csv_writer_helpers(source_file, function_names):
+    module_tree = ast.parse(read_text(source_file), filename=str(source_file))
+    selected_nodes = [
+        node
+        for node in module_tree.body
+        if isinstance(node, ast.FunctionDef) and node.name in function_names
+    ]
+    if len(selected_nodes) != len(function_names):
+        raise AssertionError(f'Expected CSV writer helpers {sorted(function_names)} in {source_file.name}.')
+
+    namespace = {
+        'build_safe_csv_headers': build_safe_csv_headers,
+        'csv': csv,
+        'io': io,
+        'json': json,
+        'neutralize_csv_spreadsheet_formula': neutralize_csv_spreadsheet_formula,
+    }
+    extracted_module = ast.Module(body=selected_nodes, type_ignores=[])
+    exec(compile(extracted_module, str(source_file), 'exec'), namespace)
+    return {function_name: namespace[function_name] for function_name in function_names}
 
 
 def test_markdown_table_response_builds_csv_export():
@@ -98,6 +126,411 @@ Andy Cowley\tandy.cowley@orau.org\tDecember 11, 2025 at 1:58 PM
     assert_true(table_rows[1]['Date'] == 'December 11, 2025 at 1:58 PM', 'Expected TSV table parser to preserve the Date column.')
 
 
+def test_non_tabular_document_csv_response_builds_export():
+    print('Testing non-tabular document CSV response export creation...')
+
+    assistant_content = '''```csv
+Name,Invoice Number,Description,Notes
+Paul Lizer,DCAW1366188,"PassPark Premium Reserve - South","Includes parking, taxes, and fees"
+```
+
+Source: ParkingPrint.pdf, Page: 1
+'''
+
+    export_payload = build_assistant_table_csv_export(
+        'generate a csv from this file',
+        assistant_content,
+    )
+
+    assert_true(
+        export_payload is not None,
+        'Expected comma-delimited output from a non-tabular document to produce an export payload.',
+    )
+    csv_rows = parse_csv_rows(export_payload.get('file_content'))
+    assert_true(len(csv_rows) == 1, 'Expected the PDF citation outside the CSV block to be excluded.')
+    assert_true(csv_rows[0]['Invoice Number'] == 'DCAW1366188', 'Expected the invoice number to be preserved.')
+    assert_true(
+        csv_rows[0]['Notes'] == 'Includes parking, taxes, and fees',
+        'Expected quoted commas in generated CSV values to be preserved.',
+    )
+
+
+def test_plain_document_csv_response_excludes_surrounding_prose_and_citation():
+    print('Testing plain document CSV response boundary detection...')
+
+    assistant_content = '''I extracted the requested invoice fields, including the billed service.
+
+Name,Invoice Number,Description
+Paul Lizer,DCAW1366188,PassPark Premium Reserve - South
+(Source: ParkingPrint.pdf, Page: 1)
+
+The values reflect the uploaded file, not an external source.
+'''
+
+    export_payload = build_assistant_table_csv_export(
+        'turn this into a CSV',
+        assistant_content,
+    )
+
+    assert_true(export_payload is not None, 'Expected plain comma-delimited document output to produce an export.')
+    csv_rows = parse_csv_rows(export_payload.get('file_content'))
+    assert_true(len(csv_rows) == 1, 'Expected surrounding prose and the PDF citation to be excluded from CSV rows.')
+    assert_true(csv_rows[0]['Name'] == 'Paul Lizer', 'Expected the extracted document row to be preserved.')
+
+
+def test_document_csv_response_preserves_multiline_and_escaped_quotes():
+    print('Testing lossless document CSV value parsing...')
+
+    assistant_content = '''```csv
+Name,Description
+Contoso,"First line
+Second ""quoted"" line"
+```
+
+Source: Contract.docx, Page: 2
+'''
+
+    export_payload = build_assistant_table_csv_export(
+        'create a csv from this word file',
+        assistant_content,
+    )
+
+    assert_true(export_payload is not None, 'Expected Word-derived CSV output to produce an export.')
+    csv_rows = parse_csv_rows(export_payload.get('file_content'))
+    assert_true(
+        csv_rows[0]['Description'] == 'First line\nSecond "quoted" line',
+        'Expected multiline values and escaped quotes to survive the CSV artifact round trip.',
+    )
+
+
+def test_fenced_document_csv_preserves_sentence_shaped_rows():
+    print('Testing sentence-shaped rows inside trusted CSV fences...')
+
+    assistant_content = '''```csv
+Name,Description
+Contoso,This is a primary service contract.
+Fabrikam,This is a secondary support agreement.
+```
+'''
+
+    export_payload = build_assistant_table_csv_export('respond as CSV', assistant_content)
+
+    assert_true(export_payload is not None, 'Expected valid sentence-shaped fenced CSV rows to produce an export.')
+    csv_rows = parse_csv_rows(export_payload.get('file_content'))
+    assert_true(len(csv_rows) == 2, 'Expected trusted fenced CSV not to truncate sentence-shaped rows.')
+    assert_true(csv_rows[1]['Name'] == 'Fabrikam', 'Expected all trusted fenced rows to remain ordered.')
+
+
+def test_fenced_document_csv_wins_over_larger_markdown_table():
+    print('Testing fenced CSV precedence over larger Markdown tables...')
+
+    assistant_content = '''| Name | Value |
+| --- | --- |
+| Wrong 1 | 11 |
+| Wrong 2 | 12 |
+| Wrong 3 | 13 |
+
+```csv
+Name,Value
+Right,1
+```
+'''
+
+    export_payload = build_assistant_table_csv_export('create a CSV', assistant_content)
+
+    assert_true(export_payload is not None, 'Expected the explicit fenced CSV to produce an export.')
+    csv_rows = parse_csv_rows(export_payload.get('file_content'))
+    assert_true(len(csv_rows) == 1, 'Expected larger Markdown tables not to override explicit fenced CSV.')
+    assert_true(csv_rows[0]['Name'] == 'Right', 'Expected the fenced CSV row to be authoritative.')
+
+
+def test_explicit_csv_fence_wins_over_larger_generic_fence():
+    print('Testing explicit CSV fence precedence over generic fences...')
+
+    assistant_content = '''```text
+Name,Value
+Wrong 1,11
+Wrong 2,12
+Wrong 3,13
+```
+
+```csv
+Name,Value
+Right,1
+```
+'''
+
+    export_payload = build_assistant_table_csv_export('download CSV', assistant_content)
+
+    assert_true(export_payload is not None, 'Expected the explicitly labeled CSV fence to produce an export.')
+    csv_rows = parse_csv_rows(export_payload.get('file_content'))
+    assert_true(len(csv_rows) == 1, 'Expected generic text fences not to override explicit CSV fences.')
+    assert_true(csv_rows[0]['Name'] == 'Right', 'Expected the explicitly labeled CSV row to be authoritative.')
+
+
+def test_plain_document_csv_preserves_quoted_blank_lines_and_ignores_comma_prose():
+    print('Testing plain document CSV quoted blank lines and prose exclusion...')
+
+    assistant_content = '''I extracted the requested invoice fields, including the billed service.
+Name,Description
+Contoso,"First paragraph
+
+Second paragraph"
+Source: Contract.docx, Page: 2
+'''
+
+    export_payload = build_assistant_table_csv_export(
+        'provide the extracted rows as CSV',
+        assistant_content,
+    )
+
+    assert_true(export_payload is not None, 'Expected valid plain CSV after comma-bearing prose to produce an export.')
+    csv_rows = parse_csv_rows(export_payload.get('file_content'))
+    assert_true(list(csv_rows[0]) == ['Name', 'Description'], 'Expected prose before the header to be excluded.')
+    assert_true(
+        csv_rows[0]['Description'] == 'First paragraph\n\nSecond paragraph',
+        'Expected blank lines inside quoted CSV values to be preserved.',
+    )
+
+
+def test_plain_document_csv_preserves_long_headers_and_sentence_values():
+    print('Testing long headers and sentence-shaped values in plain CSV...')
+
+    assistant_content = '''Official Full Legal Name Used for Payroll and Tax Reporting,Primary Work Location Description
+Alice,This is a complete sentence.
+Here is the requested information.,Open
+'''
+
+    export_payload = build_assistant_table_csv_export('return the results in CSV', assistant_content)
+
+    assert_true(export_payload is not None, 'Expected valid plain CSV with long headers to produce an export.')
+    csv_rows = parse_csv_rows(export_payload.get('file_content'))
+    assert_true(len(csv_rows) == 2, 'Expected sentence-shaped plain CSV values not to truncate data rows.')
+    assert_true(
+        list(csv_rows[0]) == [
+            'Official Full Legal Name Used for Payroll and Tax Reporting',
+            'Primary Work Location Description',
+        ],
+        'Expected the earliest structural header not to be replaced by a shorter data row.',
+    )
+    assert_true(
+        csv_rows[0]['Official Full Legal Name Used for Payroll and Tax Reporting'] == 'Alice',
+        'Expected the first data row to remain intact.',
+    )
+    assert_true(
+        csv_rows[1]['Official Full Legal Name Used for Payroll and Tax Reporting'] == 'Here is the requested information.',
+        'Expected discourse-like first-column values to remain valid data.',
+    )
+
+
+def test_plain_document_csv_excludes_prose_and_short_page_citations():
+    print('Testing plain document CSV prose and short citation boundaries...')
+
+    assistant_content = '''For clarity, see below
+Name,Description
+Contoso,Primary contract
+For context, this came from page one.
+Source: Contract.docx, p. 2
+'''
+
+    export_payload = build_assistant_table_csv_export(
+        'CSV version, please',
+        assistant_content,
+    )
+
+    assert_true(export_payload is not None, 'Expected CSV-version phrasing to produce an export.')
+    csv_rows = parse_csv_rows(export_payload.get('file_content'))
+    assert_true(len(csv_rows) == 1, 'Expected comma-bearing prose and short page citations to be excluded.')
+    assert_true(list(csv_rows[0]) == ['Name', 'Description'], 'Expected the actual CSV header to be selected.')
+
+
+def test_plain_document_csv_excludes_generic_prose_and_non_page_citations():
+    print('Testing generic prose and non-page citation boundaries...')
+
+    assistant_content = '''CSV data, ready for download.
+Name,Description
+Contoso,Primary contract
+In summary, the extraction is complete.
+(Source: Contract.docx, Section: Fees)
+'''
+
+    export_payload = build_assistant_table_csv_export(
+        'download this as CSV',
+        assistant_content,
+    )
+
+    assert_true(export_payload is not None, 'Expected plain CSV surrounded by generic prose to produce an export.')
+    csv_rows = parse_csv_rows(export_payload.get('file_content'))
+    assert_true(len(csv_rows) == 1, 'Expected generic prose and non-page citations to be excluded.')
+    assert_true(list(csv_rows[0]) == ['Name', 'Description'], 'Expected generic prose not to become CSV headers.')
+
+
+def test_plain_document_csv_normalizes_preambles_and_citation_variants():
+    print('Testing scored preambles and citation variants...')
+
+    citation_rows = (
+        'Sources: Contract.docx, Section: Fees',
+        '[Source: Contract.docx, Section: Fees]',
+        '[1] Source: Contract.docx, Section: Fees',
+        '(1) Source: Contract.docx, Section: Fees',
+        '[Source]: Contract.docx, Section: Fees',
+        '(Citation): Contract.docx, Section: Fees',
+        '* Citation: Contract.docx, Section: Fees',
+        'Citation: Contract.docx, Section: Fees',
+        '- (Source: Contract.docx, Section: Fees)',
+    )
+    for citation_row in citation_rows:
+        assistant_content = f'''The requested export is ready, with the fields below
+Name,Description
+Contoso,Primary contract
+{citation_row}
+'''
+        export_payload = build_assistant_table_csv_export('put the extracted fields in CSV', assistant_content)
+        assert_true(export_payload is not None, f'Expected CSV before citation variant {citation_row!r}.')
+        csv_rows = parse_csv_rows(export_payload.get('file_content'))
+        assert_true(len(csv_rows) == 1, f'Expected citation variant {citation_row!r} to be excluded.')
+        assert_true(list(csv_rows[0]) == ['Name', 'Description'], 'Expected the scored table header to beat prose.')
+
+
+def test_document_csv_supports_alternate_text_fences():
+    print('Testing alternate CSV fence labels...')
+
+    for fence_language in ('txt', 'text/csv', 'markdown', 'md'):
+        assistant_content = f'''```{fence_language}
+Name,Amount
+Contoso,42
+```
+'''
+        export_payload = build_assistant_table_csv_export(
+            'return CSV for this Word document',
+            assistant_content,
+        )
+        assert_true(export_payload is not None, f'Expected the {fence_language} fence to support valid CSV output.')
+
+
+def test_document_csv_neutralizes_spreadsheet_formulas():
+    print('Testing spreadsheet formula neutralization...')
+
+    assistant_content = '''```csv
+Name,Value
+External input,"=HYPERLINK(""https://example.invalid"",""Open"")"
+Command,@SUM(1+1)
+Balance,-42.50
+Grouped balance,"-1,234.50"
+```
+'''
+
+    export_payload = build_assistant_table_csv_export(
+        'output the extracted values in CSV format',
+        assistant_content,
+    )
+
+    assert_true(export_payload is not None, 'Expected formula-prefixed document values to produce a safe export.')
+    csv_rows = parse_csv_rows(export_payload.get('file_content'))
+    assert_true(csv_rows[0]['Value'].startswith("'="), 'Expected equals-prefixed formulas to be neutralized.')
+    assert_true(csv_rows[1]['Value'].startswith("'@"), 'Expected at-prefixed formulas to be neutralized.')
+    assert_true(csv_rows[2]['Value'] == '-42.50', 'Expected signed numeric values to remain numeric text.')
+    assert_true(csv_rows[3]['Value'] == '-1,234.50', 'Expected grouped signed numeric values to remain numeric text.')
+
+
+def test_document_csv_accepts_punctuation_and_duplicate_headers():
+    print('Testing punctuation and duplicate CSV headers...')
+
+    assistant_content = '''```csv
+Invoice No.,Approved?,Amount,Amount
+DCAW1366188,Yes,10,20
+```
+'''
+
+    export_payload = build_assistant_table_csv_export(
+        'Can I get a CSV of this?',
+        assistant_content,
+    )
+
+    assert_true(export_payload is not None, 'Expected punctuation and duplicate headers to produce an export.')
+    csv_rows = parse_csv_rows(export_payload.get('file_content'))
+    assert_true(
+        list(csv_rows[0]) == ['Invoice No.', 'Approved?', 'Amount', 'Amount 2'],
+        'Expected punctuation to be preserved and duplicate headers to be disambiguated.',
+    )
+
+
+def test_document_csv_preserves_header_suffix_collisions():
+    print('Testing generated header suffix collisions...')
+
+    assistant_content = '''```csv
+Amount,Amount,Amount 2
+10,20,30
+```
+'''
+
+    export_payload = build_assistant_table_csv_export('create a CSV', assistant_content)
+
+    assert_true(export_payload is not None, 'Expected colliding duplicate headers to produce an export.')
+    csv_rows = parse_csv_rows(export_payload.get('file_content'))
+    assert_true(len(csv_rows[0]) == 3, 'Expected all colliding header columns to remain present.')
+    assert_true(list(csv_rows[0].values()) == ['10', '20', '30'], 'Expected no colliding column value to be overwritten.')
+
+
+def test_document_csv_neutralizes_formula_headers_without_losing_rows():
+    print('Testing formula-like CSV header parsing...')
+
+    assistant_content = '''```csv
+=Name,Value
+Alice,1
+Bob,2
+```
+'''
+
+    export_payload = build_assistant_table_csv_export('I need the results in CSV', assistant_content)
+
+    assert_true(export_payload is not None, 'Expected formula-like headers to produce a safe export.')
+    csv_rows = parse_csv_rows(export_payload.get('file_content'))
+    assert_true(len(csv_rows) == 2, 'Expected formula header safety not to discard the first data row.')
+    assert_true("'=Name" in csv_rows[0], 'Expected the formula-like header to be neutralized.')
+    assert_true(csv_rows[0]["'=Name"] == 'Alice', 'Expected the first data row to remain intact.')
+
+
+def test_all_generated_csv_writers_neutralize_formulas():
+    print('Testing formula safety across generated CSV writers...')
+
+    writer_specs = (
+        (
+            CHAT_ROUTE_FILE,
+            {'_serialize_tabular_generated_output_value', '_build_tabular_generated_output_csv'},
+            '_build_tabular_generated_output_csv',
+        ),
+        (
+            BACKGROUND_EXPORT_FILE,
+            {'_serialize_generated_output_value', '_build_generated_output_csv'},
+            '_build_generated_output_csv',
+        ),
+        (
+            WORKFLOW_RUNNER_FILE,
+            {'_serialize_document_analysis_csv_value', '_build_document_analysis_rows_csv'},
+            '_build_document_analysis_rows_csv',
+        ),
+    )
+    entries = [
+        {
+            '=Header': '=WEBSERVICE("https://example.invalid")',
+            'Amount': '-1,234.50',
+            'Count': 0,
+            'Enabled': False,
+        },
+    ]
+
+    for source_file, function_names, writer_name in writer_specs:
+        helpers = load_csv_writer_helpers(source_file, function_names)
+        csv_content = helpers[writer_name](entries)
+        csv_rows = parse_csv_rows(csv_content)
+        safe_header = next(header for header in csv_rows[0] if header.startswith("'="))
+        assert_true(csv_rows[0][safe_header].startswith("'="), f'Expected {source_file.name} to neutralize formula values.')
+        assert_true(csv_rows[0]['Amount'] == '-1,234.50', f'Expected {source_file.name} to preserve signed numbers.')
+        assert_true(csv_rows[0]['Count'] == '0', f'Expected {source_file.name} to preserve zero values.')
+        assert_true(csv_rows[0]['Enabled'] == 'False', f'Expected {source_file.name} to preserve boolean values.')
+
+
 def test_non_table_requests_do_not_create_exports():
     print('Testing non-table request exclusion...')
 
@@ -114,6 +547,20 @@ def test_non_table_requests_do_not_create_exports():
         build_assistant_table_csv_export('summarize these contacts', assistant_content) is None,
         'Expected non-table requests not to create CSV exports even when a table is present.',
     )
+    for non_export_request in (
+        "Don't respond as CSV; summarize this document.",
+        'I do not want CSV output.',
+        'Get the totals from CSV and explain them.',
+        'Get the totals from the CSV file and explain them.',
+        'Summarize this CSV file.',
+        'Analyze this spreadsheet.',
+        'I need to analyze the CSV file and explain the totals.',
+        'Please provide JSON, not CSV.',
+    ):
+        assert_true(
+            assistant_table_export_requested(non_export_request) is False,
+            f'Expected {non_export_request!r} not to request a CSV artifact.',
+        )
 
 
 def test_natural_table_request_phrase_is_recognized():
@@ -151,6 +598,20 @@ def test_natural_csv_and_create_table_phrases_are_recognized():
         'turn this into csv',
         'convert that to csv',
         'export as csv',
+        'provide the extracted rows as CSV',
+        'return CSV for this Word document',
+        'output the invoice fields in CSV format',
+        'give me a CSV',
+        'Can I get a CSV of this?',
+        'CSV version, please',
+        'Please respond as CSV',
+        'I need the results in CSV',
+        'Put the extracted fields in CSV',
+        'I want CSV output',
+        'I need a direct CSV file.',
+        'Do not summarize; create a CSV.',
+        'CSV file, please.',
+        'Make a spreadsheet from this document.',
         'create a table of the days of the week',
     ]
 
@@ -173,12 +634,28 @@ def test_chat_route_wires_assistant_table_artifacts():
 
     assert_true(current_version == EXPECTED_VERSION, f'Expected config.py version {EXPECTED_VERSION}.')
     assert_true(
-        'TABLE_EXPORT_REQUEST_MARKERS' in chat_route_content,
-        'Expected route_backend_chats.py to reuse assistant table export request markers.',
+        'assistant_table_export_requested' in chat_route_content,
+        'Expected route_backend_chats.py to reuse the shared assistant table export intent predicate.',
     )
     assert_true(
         'def maybe_create_assistant_table_generated_output(' in chat_route_content,
         'Expected route_backend_chats.py to expose assistant table artifact creation.',
+    )
+    assert_true(
+        'should_queue_tabular_generated_output_background(row_count, len(row_batches), settings)' in chat_route_content,
+        'Expected large assistant-derived CSV artifacts to use the durable background export threshold.',
+    )
+    assert_true(
+        'queue_tabular_generated_output_run(' in chat_route_content,
+        'Expected large assistant-derived CSV artifacts to queue through the background tabular exporter.',
+    )
+    assert_true(
+        'passthrough_input_rows=True' in chat_route_content,
+        'Expected large assistant-derived CSV artifacts to avoid a second model transformation.',
+    )
+    assert_true(
+        "'background_export': True" in read_text(BACKGROUND_EXPORT_FILE),
+        'Expected queued assistant exports to reuse standard background-export metadata.',
     )
     assert_true(
         'document_generated_analysis_artifacts.append(assistant_table_generated_output)' in chat_route_content,
@@ -189,8 +666,8 @@ def test_chat_route_wires_assistant_table_artifacts():
         'Expected normal and streaming assistant messages to include assistant table CSV artifacts.',
     )
     assert_true(
-        'csv_markers = TABLE_EXPORT_REQUEST_MARKERS' in chat_route_content,
-        'Expected tabular output intent detection to use shared CSV/table request markers.',
+        'if assistant_table_export_requested(user_question):' in chat_route_content,
+        'Expected tabular output format detection to use the shared CSV/table intent predicate.',
     )
     assert_true(
         "requested_format == 'csv'" in chat_route_content,
@@ -202,6 +679,23 @@ def run_tests() -> bool:
     tests = [
         test_markdown_table_response_builds_csv_export,
         test_tab_separated_table_response_builds_rows,
+        test_non_tabular_document_csv_response_builds_export,
+        test_plain_document_csv_response_excludes_surrounding_prose_and_citation,
+        test_document_csv_response_preserves_multiline_and_escaped_quotes,
+        test_fenced_document_csv_preserves_sentence_shaped_rows,
+        test_fenced_document_csv_wins_over_larger_markdown_table,
+        test_explicit_csv_fence_wins_over_larger_generic_fence,
+        test_plain_document_csv_preserves_quoted_blank_lines_and_ignores_comma_prose,
+        test_plain_document_csv_preserves_long_headers_and_sentence_values,
+        test_plain_document_csv_excludes_prose_and_short_page_citations,
+        test_plain_document_csv_excludes_generic_prose_and_non_page_citations,
+        test_plain_document_csv_normalizes_preambles_and_citation_variants,
+        test_document_csv_supports_alternate_text_fences,
+        test_document_csv_neutralizes_spreadsheet_formulas,
+        test_document_csv_accepts_punctuation_and_duplicate_headers,
+        test_document_csv_preserves_header_suffix_collisions,
+        test_document_csv_neutralizes_formula_headers_without_losing_rows,
+        test_all_generated_csv_writers_neutralize_formulas,
         test_non_table_requests_do_not_create_exports,
         test_natural_table_request_phrase_is_recognized,
         test_natural_csv_and_create_table_phrases_are_recognized,

--- a/functional_tests/test_document_analysis_lossless_artifacts.py
+++ b/functional_tests/test_document_analysis_lossless_artifacts.py
@@ -2,10 +2,11 @@
 # test_document_analysis_lossless_artifacts.py
 """
 Functional test for document analysis lossless artifacts.
-Version: 0.241.197
+Version: 0.250.065
 Implemented in: 0.241.040
 Updated in: 0.241.065
 Updated in: 0.241.197
+Updated in: 0.250.065
 
 This test ensures exhaustive/table-style document analysis preserves raw window
 outputs and can build both structured CSV rows and Markdown raw-note artifacts
@@ -21,6 +22,7 @@ import json
 import logging
 import os
 import re
+import sys
 import traceback
 from contextlib import contextmanager
 from typing import Any, Callable, Dict, List, Optional
@@ -40,6 +42,13 @@ WORKFLOW_RUNNER_PATH = os.path.join(
     'functions_workflow_runner.py',
 )
 CONFIG_PATH = os.path.join(REPO_ROOT, 'application', 'single_app', 'config.py')
+APP_ROOT = os.path.join(REPO_ROOT, 'application', 'single_app')
+sys.path.append(APP_ROOT)
+
+from functions_assistant_table_exports import (  # noqa: E402
+    build_safe_csv_headers,
+    neutralize_csv_spreadsheet_formula,
+)
 
 
 def assert_equal(actual, expected, label):
@@ -67,6 +76,7 @@ def load_module_functions(file_path, extra_globals=None):
     namespace = {
         '__builtins__': __builtins__,
         'Any': Any,
+        'build_safe_csv_headers': build_safe_csv_headers,
         'Callable': Callable,
         'Dict': Dict,
         'List': List,
@@ -76,6 +86,7 @@ def load_module_functions(file_path, extra_globals=None):
         'io': io,
         'json': json,
         'logging': logging,
+        'neutralize_csv_spreadsheet_formula': neutralize_csv_spreadsheet_formula,
         'os': os,
         're': re,
     }
@@ -449,7 +460,7 @@ def test_json_artifact_requires_explicit_json_request():
 
 def test_version_alignment():
     print('Testing version alignment...')
-    assert_equal(read_config_version(), '0.241.197', 'config version')
+    assert_equal(read_config_version(), '0.250.065', 'config version')
     print('Version alignment verified.')
 
 

--- a/functional_tests/test_tabular_row_orchestration_scale.py
+++ b/functional_tests/test_tabular_row_orchestration_scale.py
@@ -1,8 +1,8 @@
 # test_tabular_row_orchestration_scale.py
 """
 Functional test for scalable per-row tabular orchestration.
-Version: 0.250.061
-Implemented in: 0.250.060
+Version: 0.250.065
+Implemented in: 0.250.060; generated CSV formula safety in 0.250.065
 
 This test ensures generated exports preserve source identity and row order while
 enforcing one stable output schema across independently generated batches.
@@ -26,10 +26,17 @@ from typing import Any, Dict, Optional
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+APP_ROOT = REPO_ROOT / 'application' / 'single_app'
 EXPORT_MODULE = REPO_ROOT / 'application' / 'single_app' / 'functions_tabular_generated_exports.py'
 CHAT_ROUTE = REPO_ROOT / 'application' / 'single_app' / 'route_backend_chats.py'
 SIMPLECHAT_OPERATIONS = REPO_ROOT / 'application' / 'single_app' / 'functions_simplechat_operations.py'
 CSV_QUERY_MODULE = REPO_ROOT / 'application' / 'single_app' / 'functions_tabular_csv_query.py'
+sys.path.append(str(APP_ROOT))
+
+from functions_assistant_table_exports import (  # noqa: E402
+    build_safe_csv_headers,
+    neutralize_csv_spreadsheet_formula,
+)
 CONTRACT_FUNCTIONS = {
     '_normalize_source_identity_label',
     '_select_source_row_identity',
@@ -246,8 +253,10 @@ def _load_stream_writer(download_json_blob):
         raise AssertionError('Missing bounded output stream writer')
 
     namespace = {
+        'build_safe_csv_headers': build_safe_csv_headers,
         'csv': csv,
         'json': json,
+        'neutralize_csv_spreadsheet_formula': neutralize_csv_spreadsheet_formula,
         '_safe_int': lambda value: int(value or 0),
         '_output_blob_path': lambda user_id, conversation_id, run_id, batch_number: batch_number,
         '_download_json_blob': download_json_blob,
@@ -806,6 +815,39 @@ def test_streaming_finalizer_writes_30000_rows_in_bounded_chunks():
     assert output_sink.max_write_chars < 1000
 
 
+def test_streaming_finalizer_neutralizes_csv_formulas():
+    """Durable CSV assembly neutralizes formula-like headers and values."""
+    def download_batch(batch_number):
+        assert batch_number == 1
+        return [
+            {
+                'source_row_number': 1,
+                'source_row_identity': 'SC-1',
+                '=Result': '=WEBSERVICE("https://example.invalid")',
+                'Amount': '-1,234.50',
+            }
+        ]
+
+    write_output = _load_stream_writer(download_batch)
+    output_stream = io.StringIO()
+    run = {
+        'id': 'run-formula-safety',
+        'user_id': 'user-1',
+        'conversation_id': 'conversation-1',
+        'output_format': 'csv',
+        'row_count': 1,
+        'batch_count': 1,
+        'output_schema': ['source_row_number', 'source_row_identity', '=Result', 'Amount'],
+    }
+
+    written_rows = write_output(run, output_stream)
+    csv_rows = list(csv.DictReader(io.StringIO(output_stream.getvalue())))
+
+    assert written_rows == 1
+    assert csv_rows[0]["'=Result"].startswith("'=")
+    assert csv_rows[0]['Amount'] == '-1,234.50'
+
+
 def test_streaming_finalizer_rejects_source_order_gaps():
     """An ordinal gap fails final validation before the artifact is published."""
     def download_batch(batch_number):
@@ -1202,6 +1244,7 @@ def main():
         test_paginated_candidate_rejects_gaps,
         test_paginated_candidate_rejects_mixed_source_versions,
         test_streaming_finalizer_writes_30000_rows_in_bounded_chunks,
+        test_streaming_finalizer_neutralizes_csv_formulas,
         test_streaming_finalizer_rejects_source_order_gaps,
         test_csv_query_source_reader_scales_and_resumes,
         test_worker_revalidates_conversation_and_workspace_authorization,


### PR DESCRIPTION
Fixes #1066. Adds downloadable CSV artifacts for valid CSV rows returned from non-tabular documents, and queues large assistant-derived CSVs through the existing checkpointed background export flow.