### PR TITLE
Phase 3: mixed-source combined Analyze

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -97,7 +97,7 @@ load_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.250.065"
+VERSION = "0.250.066"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/functions_settings.py
+++ b/application/single_app/functions_settings.py
@@ -220,6 +220,19 @@ def is_mixed_source_chat_search_enabled(settings):
     return bool((settings or {}).get('enable_mixed_source_chat_search', False))
 
 
+def is_mixed_source_analyze_enabled(settings):
+    """Return whether Phase 3 explicit mixed-source Analyze behavior is enabled."""
+    return bool((settings or {}).get('enable_mixed_source_analyze', False))
+
+
+def is_mixed_source_analyze_all_enabled(settings):
+    """Return whether the separately staged exhaustive Analyze All behavior is enabled."""
+    return bool(
+        (settings or {}).get('enable_mixed_source_analyze', False)
+        and (settings or {}).get('enable_mixed_source_analyze_all', False)
+    )
+
+
 def is_mixed_source_relevance_candidates_enabled(settings):
     """Return whether Phase 2 relevance-mode table candidates are enabled."""
     return bool(
@@ -780,6 +793,8 @@ def get_settings(use_cosmos=False, include_source=False):
         'enable_mixed_source_manifest': False,
         'enable_mixed_source_chat_search': False,
         'enable_mixed_source_relevance_candidates': False,
+        'enable_mixed_source_analyze': False,
+        'enable_mixed_source_analyze_all': False,
         'max_rounds_per_agent': 1,
         'workflow_max_auto_invoke_attempts': 60,
         'enable_semantic_kernel': False,

--- a/application/single_app/functions_workflow_runner.py
+++ b/application/single_app/functions_workflow_runner.py
@@ -80,6 +80,12 @@ from functions_message_artifacts import (
     make_json_serializable,
 )
 from functions_mixed_source_orchestration import (
+    EVIDENCE_ENGINE_DOCUMENT_ANALYSIS,
+    EVIDENCE_ENGINE_TABULAR_TOOLS,
+    EVIDENCE_STATUS_COMPLETED,
+    EVIDENCE_STATUS_FAILED,
+    SELECTION_MODE_SELECTED,
+    build_evidence_envelope,
     build_mixed_source_evidence_handoff,
     build_narrative_evidence_envelopes,
     partition_source_manifest,
@@ -1804,6 +1810,233 @@ def _build_tabular_comparison_action_prompt(comparison_prompt, left_document, ri
         '\n\n'.join(section for section in prompt_sections if section),
         force=True,
     )
+
+
+def _build_mixed_source_analyze_reduction_prompt(analysis_prompt, handoff):
+    """Build the one bounded collective reduction prompt for combined Analyze."""
+    return (
+        'Answer the exact Analyze request using only the bounded evidence handoff below. '
+        'Treat computed tabular facts as tool-backed calculations and narrative facts as document excerpts. '
+        'Identify cross-source relationships only where the evidence supports them. Keep facts source-separated when needed. '
+        'Explicitly state missing, failed, unsupported, unresolved, or unprocessed evidence and never claim coverage for it.\n\n'
+        f'Analyze request:\n{str(analysis_prompt or "").strip()}\n\n'
+        f'Bounded evidence handoff:\n{json.dumps(handoff, ensure_ascii=False, separators=(",", ":"))}'
+    )
+
+
+def _build_mixed_source_analysis_coverage(handoff):
+    """Expose terminal coverage for every manifest entry with engine/status totals."""
+    coverage = dict((handoff or {}).get('mixed_source_coverage') or {})
+    engine_status_totals = {}
+    for envelope in list((handoff or {}).get('evidence_envelopes') or []):
+        engine = str(envelope.get('engine') or 'unknown')
+        status = str(envelope.get('status') or 'failed')
+        engine_status_totals.setdefault(engine, {})[status] = (
+            engine_status_totals.setdefault(engine, {}).get(status, 0) + 1
+        )
+    coverage['engine_status_totals'] = engine_status_totals
+    coverage['document_count'] = coverage.get('requested_source_count', 0)
+    coverage['progress_meta'] = {
+        'phase': 'complete',
+        'phase_label': 'Complete' if not coverage.get('partial_coverage') else 'Partial',
+        'phase_detail': 'Mixed-source Analyze completed with terminal source coverage',
+        'status': 'partial' if coverage.get('partial_coverage') else 'completed',
+        'percent_override': 100,
+    }
+    return coverage
+
+
+def _raise_legacy_mixed_source_analyze_limitation(
+    analysis_config,
+    user_id,
+    conversation_id='',
+):
+    """Fail closed rather than silently treating tables as narrative evidence on rollback."""
+    requested_ids, _ = _get_document_action_source_ids(analysis_config)
+    if len(requested_ids) < 2:
+        return
+    manifest = resolve_authorized_source_manifest(
+        requested_ids,
+        user_id=user_id,
+        selection_mode=SELECTION_MODE_SELECTED,
+        conversation_id=conversation_id,
+        active_group_ids=analysis_config.get('active_group_ids'),
+        active_public_workspace_ids=analysis_config.get('active_public_workspace_id'),
+        doc_scope=analysis_config.get('doc_scope', 'all'),
+    )
+    partitions = partition_source_manifest(manifest)
+    if partitions['narrative_sources'] and partitions['tabular_sources']:
+        raise ValueError(
+            'Mixed narrative and tabular Analyze is temporarily unavailable while mixed-source Analyze is disabled.'
+        )
+
+
+def _execute_mixed_source_analyze_workflow(
+    workflow,
+    analysis_config,
+    settings,
+    invoke_prompt,
+    conversation_id='',
+    activity_callback=None,
+    thought_tracker=None,
+    live_thought_callback=None,
+    max_documents=None,
+):
+    """Run combined Analyze cohorts natively, then reduce bounded evidence once."""
+    user_id = str(workflow.get('user_id') or '').strip()
+    requested_ids, _ = _get_document_action_source_ids(analysis_config)
+    requested_selection_mode = str(
+        analysis_config.get('selection_mode')
+        or analysis_config.get('target_mode')
+        or SELECTION_MODE_SELECTED
+    ).strip().lower()
+    if requested_selection_mode == 'all':
+        raise ValueError(
+            'Analyze All Documents is temporarily unavailable until exhaustive authorized catalog enumeration is enabled.'
+        )
+    if max_documents is not None and len(requested_ids) > int(max_documents):
+        raise ValueError(
+            f'Analyze supports up to {int(max_documents)} authorized documents at a time.'
+        )
+    if callable(activity_callback):
+        activity_callback({'type': 'mixed_source_progress', 'phase': 'resolving_sources', 'label': 'Resolving sources'})
+    manifest = resolve_authorized_source_manifest(
+        requested_ids,
+        user_id=user_id,
+        selection_mode=SELECTION_MODE_SELECTED,
+        conversation_id=conversation_id,
+        active_group_ids=analysis_config.get('active_group_ids'),
+        active_public_workspace_ids=analysis_config.get('active_public_workspace_id'),
+        doc_scope=analysis_config.get('doc_scope', 'all'),
+    )
+    partitions = partition_source_manifest(manifest)
+    evidence_envelopes = []
+    generated_tabular_outputs = []
+    tabular_agent_citations = []
+
+    narrative_sources = partitions['narrative_sources']
+    if narrative_sources:
+        if callable(activity_callback):
+            activity_callback({'type': 'mixed_source_progress', 'phase': 'analyzing_narrative', 'label': 'Analyzing narrative documents'})
+        try:
+            narrative_result = run_document_analysis(
+                user_id=user_id,
+                analysis_prompt=workflow.get('task_prompt', ''),
+                document_ids=[source.get('document_id') for source in narrative_sources],
+                invoke_prompt=invoke_prompt,
+                doc_scope=analysis_config.get('doc_scope'),
+                active_group_ids=analysis_config.get('active_group_ids'),
+                active_public_workspace_id=analysis_config.get('active_public_workspace_id'),
+                conversation_id=conversation_id,
+                window_unit=analysis_config.get('window_unit'),
+                window_size=analysis_config.get('window_size'),
+                window_percent=analysis_config.get('window_percent'),
+                max_retries_per_window=analysis_config.get('max_retries_per_window'),
+                activity_callback=activity_callback,
+                max_documents=max_documents,
+                include_coverage_summary=False,
+            )
+            documents_by_id = {
+                str(document.get('document_id') or ''): document
+                for document in list((narrative_result.get('coverage') or {}).get('documents') or [])
+            }
+            narrative_items_by_id = {
+                str(item.get('document_id') or ''): item
+                for item in list(narrative_result.get('document_analysis_items') or [])
+                if str(item.get('document_id') or '').strip()
+            }
+            for source in narrative_sources:
+                document_id = source.get('document_id')
+                document_coverage = documents_by_id.get(str(document_id), {})
+                narrative_item = narrative_items_by_id.get(str(document_id), {})
+                failed_windows = int(document_coverage.get('failed_windows') or 0)
+                total_windows = int(document_coverage.get('total_windows') or 0)
+                processed_windows = int(document_coverage.get('processed_windows') or 0)
+                status = (
+                    EVIDENCE_STATUS_COMPLETED
+                    if total_windows and processed_windows == total_windows and not failed_windows
+                    else ('partial' if processed_windows else EVIDENCE_STATUS_FAILED)
+                )
+                evidence_envelopes.append(build_evidence_envelope(
+                    document_id=document_id,
+                    source_kind='narrative',
+                    engine=EVIDENCE_ENGINE_DOCUMENT_ANALYSIS,
+                    status=status,
+                    summary=str(narrative_item.get('text') or ''),
+                    citations=[],
+                    generated_artifacts=[],
+                    coverage={'terminal': True, 'processed_windows': processed_windows, 'total_windows': total_windows, 'failed_windows': failed_windows},
+                    error='Narrative analysis could not be completed.' if status == EVIDENCE_STATUS_FAILED else None,
+                ))
+        except Exception:
+            for source in narrative_sources:
+                evidence_envelopes.append(build_evidence_envelope(
+                    document_id=source.get('document_id'), source_kind='narrative',
+                    engine=EVIDENCE_ENGINE_DOCUMENT_ANALYSIS, status=EVIDENCE_STATUS_FAILED,
+                    summary='Narrative evidence could not be completed for this source.',
+                    coverage={'terminal': True}, error='Narrative analysis could not be completed.',
+                ))
+
+    tabular_sources = partitions['tabular_sources']
+    if tabular_sources:
+        if callable(activity_callback):
+            activity_callback({'type': 'mixed_source_progress', 'phase': 'analyzing_tabular', 'label': 'Analyzing tabular documents'})
+        for source in tabular_sources:
+            tabular_config = dict(analysis_config)
+            tabular_config['document_ids'] = [source.get('document_id')]
+            tabular_payload = _maybe_execute_tabular_document_action(
+                DOCUMENT_ACTION_TYPE_ANALYZE, workflow, tabular_config, settings,
+                conversation_id=conversation_id, invoke_prompt=invoke_prompt,
+                thought_tracker=thought_tracker, live_thought_callback=live_thought_callback,
+            )
+            if not tabular_payload:
+                evidence_envelopes.append(build_evidence_envelope(
+                    document_id=source.get('document_id'), source_kind='tabular',
+                    engine=EVIDENCE_ENGINE_TABULAR_TOOLS, status=EVIDENCE_STATUS_FAILED,
+                    summary='Tabular evidence could not be completed for this source.',
+                    coverage={'terminal': True}, error='Tabular analysis could not be completed.',
+                ))
+                continue
+            tabular_result = tabular_payload.get('result') or {}
+            evidence_envelopes.append(build_evidence_envelope(
+                document_id=source.get('document_id'), source_kind='tabular',
+                engine=EVIDENCE_ENGINE_TABULAR_TOOLS, status=EVIDENCE_STATUS_COMPLETED,
+                summary=str(tabular_result.get('analysis_reply') or tabular_result.get('reply') or ''),
+                citations=list(tabular_payload.get('agent_citations') or []),
+                generated_artifacts=list(tabular_payload.get('generated_tabular_outputs') or []),
+                coverage={'terminal': True, 'tool_call_count': 1},
+            ))
+            generated_tabular_outputs.extend(tabular_payload.get('generated_tabular_outputs') or [])
+            tabular_agent_citations.extend(tabular_payload.get('agent_citations') or [])
+
+    handoff = build_mixed_source_evidence_handoff(manifest, evidence_envelopes, SELECTION_MODE_SELECTED)
+    if callable(activity_callback):
+        activity_callback({'type': 'mixed_source_progress', 'phase': 'combining_findings', 'label': 'Combining findings'})
+    collective_reply = str(invoke_prompt(
+        _build_mixed_source_analyze_reduction_prompt(workflow.get('task_prompt', ''), handoff),
+        stage='mixed_source_reduction', metadata={'requested_source_count': len(manifest)},
+    ) or '').strip()
+    if not collective_reply:
+        collective_reply = 'The selected sources could not be combined into a final analysis.'
+    coverage = _build_mixed_source_analysis_coverage(handoff)
+    if callable(activity_callback):
+        activity_callback({
+            'type': 'mixed_source_progress',
+            'phase': 'complete',
+            'label': coverage['progress_meta']['phase_label'],
+            'status': coverage['progress_meta']['status'],
+        })
+    return {
+        'reply': collective_reply,
+        'analysis_reply': collective_reply,
+        'coverage': coverage,
+        'documents': list(coverage.get('sources') or []),
+        'document_ids': [source.get('document_id') for source in manifest],
+        'mixed_source_manifest': manifest,
+        'mixed_source_evidence': handoff.get('evidence_envelopes') or [],
+        'generated_tabular_outputs': generated_tabular_outputs,
+        'agent_citations': tabular_agent_citations,
+    }
 
 
 def _build_workflow_generation_prompt(task_prompt):
@@ -5128,6 +5361,13 @@ def _execute_document_analysis_workflow(
 
         return _combine_per_document_analysis_results(per_document_results)
 
+    if not bool(settings.get('enable_mixed_source_analyze', False)):
+        _raise_legacy_mixed_source_analyze_limitation(
+            analysis_config,
+            user_id,
+            conversation_id=conversation_id,
+        )
+
     token_usage_aggregate = _create_token_usage_aggregate()
 
     if workflow.get('runner_type') == 'agent':
@@ -5195,19 +5435,29 @@ def _execute_document_analysis_workflow(
                     _accumulate_token_usage(token_usage_aggregate, result)
                     return str(result)
 
-                tabular_action_payload = _maybe_execute_tabular_document_action(
-                    DOCUMENT_ACTION_TYPE_ANALYZE,
-                    workflow,
-                    analysis_config,
-                    settings,
-                    conversation_id=conversation_id,
-                    invoke_prompt=invoke_prompt,
-                    thought_tracker=thought_tracker,
-                    live_thought_callback=external_activity_callback,
-                )
+                mixed_source_enabled = bool(settings.get('enable_mixed_source_analyze', False))
+                tabular_action_payload = None
+                if mixed_source_enabled:
+                    analysis_result = _execute_mixed_source_analyze_workflow(
+                        workflow, analysis_config, settings, invoke_prompt,
+                        conversation_id=conversation_id, activity_callback=activity_callback,
+                        thought_tracker=thought_tracker, live_thought_callback=external_activity_callback,
+                        max_documents=workflow_analysis_max_documents,
+                    )
+                else:
+                    tabular_action_payload = _maybe_execute_tabular_document_action(
+                        DOCUMENT_ACTION_TYPE_ANALYZE,
+                        workflow,
+                        analysis_config,
+                        settings,
+                        conversation_id=conversation_id,
+                        invoke_prompt=invoke_prompt,
+                        thought_tracker=thought_tracker,
+                        live_thought_callback=external_activity_callback,
+                    )
                 if tabular_action_payload:
                     analysis_result = tabular_action_payload.get('result') or {}
-                else:
+                elif not mixed_source_enabled:
                     analysis_result = run_document_analysis(
                         user_id=user_id,
                         analysis_prompt=workflow.get('task_prompt', ''),
@@ -5227,11 +5477,19 @@ def _execute_document_analysis_workflow(
                     analysis_result,
                     workflow.get('task_prompt', ''),
                     conversation_id=conversation_id,
-                    primary_generated_outputs=list((tabular_action_payload or {}).get('generated_tabular_outputs') or []),
+                    primary_generated_outputs=list(
+                        (tabular_action_payload or {}).get('generated_tabular_outputs')
+                        or analysis_result.get('generated_tabular_outputs')
+                        or []
+                    ),
                 )
                 agent_citations = _build_agent_citations_from_invocations(user_id, conversation_id)
                 if not agent_citations:
-                    agent_citations = list((tabular_action_payload or {}).get('agent_citations') or [])
+                    agent_citations = list(
+                        (tabular_action_payload or {}).get('agent_citations')
+                        or analysis_result.get('agent_citations')
+                        or []
+                    )
                 alert_targets = _collect_agent_alert_targets(user_id, conversation_id)
                 token_usage = _finalize_token_usage(token_usage_aggregate)
 
@@ -5249,7 +5507,11 @@ def _execute_document_analysis_workflow(
                     'agent_name': getattr(loaded_agent, 'name', None) or requested_name,
                     'agent_display_name': getattr(loaded_agent, 'display_name', None) or selected_agent.get('display_name') or requested_name,
                     'agent_citations': agent_citations,
-                    'generated_tabular_outputs': list((tabular_action_payload or {}).get('generated_tabular_outputs') or []),
+                    'generated_tabular_outputs': list(
+                        (tabular_action_payload or {}).get('generated_tabular_outputs')
+                        or analysis_result.get('generated_tabular_outputs')
+                        or []
+                    ),
                     'alert_targets': alert_targets,
                 }
             finally:
@@ -5310,19 +5572,29 @@ def _execute_document_analysis_workflow(
             return ''
         return _extract_message_text(completion.choices[0].message.content)
 
-    tabular_action_payload = _maybe_execute_tabular_document_action(
-        DOCUMENT_ACTION_TYPE_ANALYZE,
-        workflow,
-        analysis_config,
-        settings,
-        conversation_id=conversation_id,
-        invoke_prompt=invoke_model_prompt,
-        thought_tracker=thought_tracker,
-        live_thought_callback=external_activity_callback,
-    )
+    mixed_source_enabled = bool(settings.get('enable_mixed_source_analyze', False))
+    tabular_action_payload = None
+    if mixed_source_enabled:
+        analysis_result = _execute_mixed_source_analyze_workflow(
+            workflow, analysis_config, settings, invoke_model_prompt,
+            conversation_id=conversation_id, activity_callback=activity_callback,
+            thought_tracker=thought_tracker, live_thought_callback=external_activity_callback,
+            max_documents=workflow_analysis_max_documents,
+        )
+    else:
+        tabular_action_payload = _maybe_execute_tabular_document_action(
+            DOCUMENT_ACTION_TYPE_ANALYZE,
+            workflow,
+            analysis_config,
+            settings,
+            conversation_id=conversation_id,
+            invoke_prompt=invoke_model_prompt,
+            thought_tracker=thought_tracker,
+            live_thought_callback=external_activity_callback,
+        )
     if tabular_action_payload:
         analysis_result = tabular_action_payload.get('result') or {}
-    else:
+    elif not mixed_source_enabled:
         analysis_result = run_document_analysis(
             user_id=user_id,
             analysis_prompt=workflow.get('task_prompt', ''),
@@ -5342,7 +5614,11 @@ def _execute_document_analysis_workflow(
         analysis_result,
         workflow.get('task_prompt', ''),
         conversation_id=conversation_id,
-        primary_generated_outputs=list((tabular_action_payload or {}).get('generated_tabular_outputs') or []),
+        primary_generated_outputs=list(
+            (tabular_action_payload or {}).get('generated_tabular_outputs')
+            or analysis_result.get('generated_tabular_outputs')
+            or []
+        ),
     )
     token_usage = _finalize_token_usage(token_usage_aggregate)
     debug_print(
@@ -5366,8 +5642,16 @@ def _execute_document_analysis_workflow(
         'model_deployment_name': deployment_name,
         'token_usage': token_usage,
         'provider': provider,
-        'agent_citations': list((tabular_action_payload or {}).get('agent_citations') or []),
-        'generated_tabular_outputs': list((tabular_action_payload or {}).get('generated_tabular_outputs') or []),
+        'agent_citations': list(
+            (tabular_action_payload or {}).get('agent_citations')
+            or analysis_result.get('agent_citations')
+            or []
+        ),
+        'generated_tabular_outputs': list(
+            (tabular_action_payload or {}).get('generated_tabular_outputs')
+            or analysis_result.get('generated_tabular_outputs')
+            or []
+        ),
     }
 
 

--- a/docs/explanation/features/MIXED_SOURCE_ANALYZE.md
+++ b/docs/explanation/features/MIXED_SOURCE_ANALYZE.md
@@ -1,0 +1,62 @@
+# Mixed-Source Analyze
+
+Implemented in version: **0.250.066**
+
+GitHub issue: [#1058](https://github.com/microsoft/simplechat/issues/1058)
+
+Parent initiative: [#1055](https://github.com/microsoft/simplechat/issues/1055)
+
+Prerequisites: [#1056](https://github.com/microsoft/simplechat/issues/1056) and [#1057](https://github.com/microsoft/simplechat/issues/1057)
+
+## Overview
+
+Phase 3 adds a default-off mixed-source combined Analyze coordinator for explicit document selections. It resolves one fresh authorized manifest, partitions it by native capability, and keeps the existing engines responsible for their own source types:
+
+- Narrative documents are sent only to `run_document_analysis(...)`, preserving document windows, retries, progress, citations, and narrative artifacts.
+- Tabular documents are sent one at a time to the existing tabular document-action runner, preserving tool-backed results, CSV/JSON generated outputs, background-export summary handoff, and assistant-table fallback suppression.
+- One bounded Phase 1 evidence handoff is reduced once into a collective answer that distinguishes computed table facts from narrative excerpts and declares terminal coverage gaps.
+
+No separate authorization model, manifest resolver, tabular runner, evidence contract, route, or persisted source-context mechanism was added.
+
+## Rollout
+
+- `enable_mixed_source_analyze`: default `false`. Enables selected combined Analyze only.
+- `enable_mixed_source_analyze_all`: default `false`. Reserved for a later independently staged exhaustive Analyze All catalog implementation after preflight-limit and performance validation.
+
+With the main flag off, the legacy execution remains available. It does not silently fall back to treating a mixed table as narrative evidence.
+
+## Execution And Coverage
+
+The coordinator publishes these stages through existing document-action activity plumbing:
+
+1. Resolving sources
+2. Analyzing narrative documents
+3. Analyzing tabular documents
+4. Combining findings
+5. Complete or partial terminal coverage
+
+Coverage is built from every fresh manifest entry. Unresolved and unsupported entries remain terminal failures in the bounded handoff without exposing their metadata. Engine/status totals are retained alongside the existing coverage fields.
+
+If narrative or tabular execution fails, completed evidence from the other branch remains available to the one reduction. The reduction is explicitly instructed not to claim coverage for omitted, failed, unresolved, unsupported, or unprocessed sources.
+
+Per-document Analyze remains unchanged: each document is executed separately through its native engine, and no collective reduction is added.
+
+## Security
+
+The coordinator uses `resolve_authorized_source_manifest(...)` for every enabled combined request. That reauthorizes personal ownership or exact approved shares, current group membership, public visibility, and chat-upload conversation ownership at the object boundary. Caller-provided scope, workspace, ownership, and selected metadata remain untrusted hints.
+
+The existing request-scoped tabular runner continues validating authorized source context. Evidence envelopes and aggregate diagnostics are bounded, and the orchestration does not log source identifiers, names, content, locations, prompts, credentials, or raw settings.
+
+## Validation
+
+- `functional_tests/test_mixed_source_analyze_workflow.py`
+- `functional_tests/test_tabular_document_actions_workflow.py`
+- Python compilation for changed modules and tests
+
+The focused coverage verifies native partitioning, bounded collective reduction instructions, partial failure coverage, default-off rollout behavior, per-document exclusion, and tabular artifact/citation propagation.
+
+## Limitations
+
+This Phase 3 increment does not enable Analyze All Documents. The current action contract exposes selected and recent targets only, so enabling an `all` mode before a dedicated exhaustive authorized catalog enumerator exists would violate the Analyze contract. The separate `enable_mixed_source_analyze_all` flag remains disabled until that enumerator, count preflight rejection, object-boundary reauthorization, and performance validation are delivered.
+
+This phase does not implement cross-format Compare (#1059), persisted follow-up source reuse, Phase 5 conversation-selection semantics, or Phase 6 route extraction and rollout completion.

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,15 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](/explanation/features/) and [Fixes by Version](/explanation/fixes/).
 
+### **(v0.250.066)**
+
+#### New Features
+
+*   **Mixed-Source Combined Analyze**
+    *   Combined Analyze can now resolve a fresh authorization-safe selected-source manifest, dispatch narrative documents to document-window analysis and tables to existing tabular analysis, then reduce their bounded evidence into one coverage-aware answer.
+    *   The default-off `enable_mixed_source_analyze` rollout preserves legacy behavior when disabled and keeps per-document Analyze as separate native executions. The separately staged `enable_mixed_source_analyze_all` flag remains off pending exhaustive catalog enumeration and performance validation.
+    *   (Ref: microsoft/simplechat#1058, parent microsoft/simplechat#1055, prerequisites microsoft/simplechat#1056 and microsoft/simplechat#1057, `functions_workflow_runner.py`, `functions_mixed_source_orchestration.py`, `MIXED_SOURCE_ANALYZE.md`)
+
 ### **(v0.250.065)**
 
 #### Bug Fixes

--- a/functional_tests/test_mixed_source_analyze_workflow.py
+++ b/functional_tests/test_mixed_source_analyze_workflow.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+# test_mixed_source_analyze_workflow.py
+"""
+Functional test for Phase 3 mixed-source combined Analyze.
+Version: 0.250.066
+Implemented in: 0.250.066
+
+This test ensures #1058 composes native narrative and tabular analysis behind
+the default-off rollout flag, retains terminal coverage after either branch
+fails, and keeps per-document execution non-collective. Parent: #1055.
+Prerequisites: #1056 and #1057.
+"""
+
+import ast
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW_RUNNER = ROOT / 'application' / 'single_app' / 'functions_workflow_runner.py'
+SETTINGS = ROOT / 'application' / 'single_app' / 'functions_settings.py'
+
+
+def test_phase_3_mixed_analyze_contracts_are_wired():
+    """Combined Analyze must resolve once, partition, run native engines, then reduce once."""
+    source = WORKFLOW_RUNNER.read_text(encoding='utf-8')
+    tree = ast.parse(source)
+    helper = next(
+        node for node in tree.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == '_execute_mixed_source_analyze_workflow'
+    )
+    helper_source = ast.get_source_segment(source, helper) or ''
+
+    assert 'resolve_authorized_source_manifest(' in helper_source
+    assert 'partition_source_manifest(manifest)' in helper_source
+    assert "partitions['narrative_sources']" in helper_source
+    assert "partitions['tabular_sources']" in helper_source
+    assert 'run_document_analysis(' in helper_source
+    assert "document_ids=[source.get('document_id') for source in narrative_sources]" in helper_source
+    assert 'narrative_items_by_id' in helper_source
+    assert "summary=str(narrative_item.get('text') or '')" in helper_source
+    assert '_maybe_execute_tabular_document_action(' in helper_source
+    assert 'build_evidence_envelope(' in helper_source
+    assert 'build_mixed_source_evidence_handoff(' in helper_source
+    assert "stage='mixed_source_reduction'" in helper_source
+    assert "requested_selection_mode == 'all'" in helper_source
+    assert 'Analyze All Documents is temporarily unavailable' in helper_source
+    assert 'len(requested_ids) > int(max_documents)' in helper_source
+    assert "'resolving_sources'" in helper_source
+    assert "'analyzing_narrative'" in helper_source
+    assert "'analyzing_tabular'" in helper_source
+    assert "'combining_findings'" in helper_source
+    assert "'phase': 'complete'" in helper_source
+    assert 'Tabular evidence could not be completed for this source.' in helper_source
+    assert 'Narrative evidence could not be completed for this source.' in helper_source
+    assert "'generated_tabular_outputs': generated_tabular_outputs" in helper_source
+    assert "'agent_citations': tabular_agent_citations" in helper_source
+
+
+def test_phase_3_flag_default_and_per_document_guard():
+    """Rollout must remain off by default and never add collective reduction to per-document mode."""
+    settings_source = SETTINGS.read_text(encoding='utf-8')
+    workflow_source = WORKFLOW_RUNNER.read_text(encoding='utf-8')
+
+    assert "'enable_mixed_source_analyze': False" in settings_source
+    assert "'enable_mixed_source_analyze_all': False" in settings_source
+    assert 'def is_mixed_source_analyze_enabled(settings):' in settings_source
+    assert 'def is_mixed_source_analyze_all_enabled(settings):' in settings_source
+    assert workflow_source.count("mixed_source_enabled = bool(settings.get('enable_mixed_source_analyze', False))") == 2
+    assert 'def _raise_legacy_mixed_source_analyze_limitation(' in workflow_source
+    assert 'Mixed narrative and tabular Analyze is temporarily unavailable while mixed-source Analyze is disabled.' in workflow_source
+    assert "or analysis_result.get('generated_tabular_outputs')" in workflow_source
+    assert "or analysis_result.get('agent_citations')" in workflow_source
+
+
+def test_phase_3_reduction_prompt_requires_evidence_separation_and_failures():
+    """The one collective prompt must distinguish native evidence and partial coverage."""
+    source = WORKFLOW_RUNNER.read_text(encoding='utf-8')
+    assert 'computed tabular facts as tool-backed calculations' in source
+    assert 'narrative facts as document excerpts' in source
+    assert 'Explicitly state missing, failed, unsupported, unresolved, or unprocessed evidence' in source
+    assert 'never claim coverage for it' in source

--- a/functional_tests/test_tabular_document_actions_workflow.py
+++ b/functional_tests/test_tabular_document_actions_workflow.py
@@ -76,8 +76,11 @@ def test_analyze_and_compare_dispatch_use_tabular_helper() -> None:
 
     workflow_runner_content = read_text(WORKFLOW_RUNNER_FILE)
 
-    assert "DOCUMENT_ACTION_TYPE_ANALYZE,\n                    workflow,\n                    analysis_config," in workflow_runner_content, (
-        "Expected analysis workflow execution to call the shared tabular document-action helper."
+    assert workflow_runner_content.count('_maybe_execute_tabular_document_action(') >= 5, (
+        "Expected analysis workflow execution to preserve the shared tabular helper for flag-off rollback."
+    )
+    assert workflow_runner_content.count('_execute_mixed_source_analyze_workflow(') >= 3, (
+        "Expected combined Analyze model and agent paths to use the Phase 3 coordinator."
     )
     assert "DOCUMENT_ACTION_TYPE_COMPARISON,\n                    workflow,\n                    comparison_config," in workflow_runner_content, (
         "Expected document comparison workflow execution to call the shared tabular document-action helper."


### PR DESCRIPTION
## Summary\n\n- Add default-off nable_mixed_source_analyze orchestration for explicit combined Analyze selections.\n- Reuse the Phase 1 authorized source manifest, capability partitions, bounded evidence envelopes, existing document-window analysis, and tabular document-action runner.\n- Run narrative and tabular cohorts through native engines, preserve tabular artifacts/citations, then perform one bounded coverage-aware collective reduction.\n- Keep per-document Analyze separate; flag-off mixed selections now fail with a clear temporary limitation rather than silently falling back to table-as-text behavior.\n- Add Phase 3 feature documentation, release note, regression coverage, and bump the application version to 