### PR TITLE
Phase 5: preserve mixed-source context across follow-up turns

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -97,7 +97,7 @@ load_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.250.067"
+VERSION = "0.250.068"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/functions_conversation_metadata.py
+++ b/application/single_app/functions_conversation_metadata.py
@@ -139,8 +139,34 @@ def _extract_document_id_from_search_result(doc):
     return chunk_identifier
 
 
-def _build_last_grounded_document_refs(document_map):
+def _build_last_grounded_document_refs(document_map, source_continuity_refs=None):
     """Build the exact reusable grounded document set for the latest search-backed turn."""
+    if isinstance(source_continuity_refs, list):
+        safe_continuity_refs = []
+        for raw_ref in source_continuity_refs[:100]:
+            if not isinstance(raw_ref, dict):
+                continue
+            document_id = str(raw_ref.get('document_id') or '').strip()
+            scope = str(raw_ref.get('scope') or '').strip().lower()
+            scope_id = str(raw_ref.get('scope_id') or '').strip()
+            if not document_id or not scope or not scope_id:
+                continue
+            safe_ref = {
+                key: raw_ref.get(key)
+                for key in (
+                    'document_id', 'scope', 'scope_id', 'group_id',
+                    'public_workspace_id', 'user_id', 'source_role',
+                    'requested_order', 'source_kind', 'engine',
+                    'source_version', 'status', 'coverage',
+                    'selection_origin', 'action_mode',
+                    'citation_count', 'artifact_count',
+                )
+                if raw_ref.get(key) is not None
+            }
+            safe_continuity_refs.append(safe_ref)
+        if safe_continuity_refs:
+            return safe_continuity_refs
+
     grounded_refs = []
 
     for document_id, doc_info in document_map.items():
@@ -273,7 +299,8 @@ def collect_conversation_metadata(user_message, conversation_id, user_id, active
                                 image_gen_enabled=False, selected_documents=None, 
                                 selected_agent=None, selected_agent_details=None, search_results=None, web_search_results=None,
                                 conversation_item=None, additional_participants=None,
-                                active_group_ids=None, active_public_workspace_id=None, active_public_workspace_ids=None):
+                                active_group_ids=None, active_public_workspace_id=None, active_public_workspace_ids=None,
+                                source_continuity_refs=None):
     """
     Collect comprehensive metadata for a conversation based on the user's interaction.
     
@@ -736,8 +763,11 @@ def collect_conversation_metadata(user_message, conversation_id, user_id, active
             current_tags[semantic_key] = semantic_tag    # Update the tags array
     conversation_item['tags'] = list(current_tags.values())
 
-    if document_map:
-        conversation_item['last_grounded_document_refs'] = _build_last_grounded_document_refs(document_map)
+    if document_map or source_continuity_refs:
+        conversation_item['last_grounded_document_refs'] = _build_last_grounded_document_refs(
+            document_map,
+            source_continuity_refs=source_continuity_refs,
+        )
 
     # --- Scope Lock Logic ---
     current_scope_locked = conversation_item.get('scope_locked')

--- a/application/single_app/functions_settings.py
+++ b/application/single_app/functions_settings.py
@@ -220,6 +220,14 @@ def is_mixed_source_chat_search_enabled(settings):
     return bool((settings or {}).get('enable_mixed_source_chat_search', False))
 
 
+def is_mixed_source_conversation_continuity_enabled(settings):
+    """Return whether Phase 5 reauthorized source-continuity metadata is enabled."""
+    return bool(
+        (settings or {}).get('enable_mixed_source_chat_search', False)
+        and (settings or {}).get('enable_mixed_source_conversation_continuity', False)
+    )
+
+
 def is_mixed_source_analyze_enabled(settings):
     """Return whether Phase 3 explicit mixed-source Analyze behavior is enabled."""
     return bool((settings or {}).get('enable_mixed_source_analyze', False))
@@ -806,6 +814,7 @@ def get_settings(use_cosmos=False, include_source=False):
         'enable_mixed_source_manifest': False,
         'enable_mixed_source_chat_search': False,
         'enable_mixed_source_relevance_candidates': False,
+        'enable_mixed_source_conversation_continuity': False,
         'enable_mixed_source_analyze': False,
         'enable_mixed_source_analyze_all': False,
         'enable_cross_format_compare': False,

--- a/application/single_app/route_backend_chats.py
+++ b/application/single_app/route_backend_chats.py
@@ -434,6 +434,100 @@ def _resolve_chat_mixed_source_partition(
     }
 
 
+def _build_mixed_source_continuity_refs(manifest, evidence_envelopes, selection_origin):
+    """Persist only compact source identity and terminal state for later reauthorization."""
+    evidence_by_document_id = {
+        str(envelope.get('document_id') or '').strip(): envelope
+        for envelope in list(evidence_envelopes or [])
+        if isinstance(envelope, dict) and str(envelope.get('document_id') or '').strip()
+    }
+    continuity_refs = []
+    for requested_order, source in enumerate(list(manifest or [])[:100]):
+        if not isinstance(source, dict) or source.get('authorization_status') != 'authorized':
+            continue
+        document_id = str(source.get('document_id') or '').strip()
+        scope = str(source.get('scope') or '').strip().lower()
+        scope_id = str(source.get('scope_id') or '').strip()
+        if not document_id or not scope or not scope_id:
+            continue
+        envelope = evidence_by_document_id.get(document_id) or {}
+        coverage = envelope.get('coverage') if isinstance(envelope.get('coverage'), dict) else {}
+        continuity_ref = {
+            'document_id': document_id,
+            'scope': scope,
+            'scope_id': scope_id,
+            'source_role': str(source.get('source_role') or 'selected'),
+            'requested_order': requested_order,
+            'source_kind': source.get('source_kind'),
+            'engine': envelope.get('engine'),
+            'source_version': source.get('source_version'),
+            'status': envelope.get('status') or 'unavailable',
+            'coverage': {
+                'partial_coverage': bool(coverage.get('partial_coverage')),
+                'evidence_envelope_truncated': bool(coverage.get('evidence_envelope_truncated')),
+                'failed': str(envelope.get('status') or '').strip().lower() in {'failed', 'unavailable'},
+            },
+            'selection_origin': selection_origin,
+            'action_mode': 'chat',
+            'citation_count': len(envelope.get('citations') or []),
+            'artifact_count': len(envelope.get('generated_artifacts') or []),
+        }
+        if scope == 'group':
+            continuity_ref['group_id'] = scope_id
+        elif scope == 'public':
+            continuity_ref['public_workspace_id'] = scope_id
+        else:
+            continuity_ref['user_id'] = scope_id
+        continuity_refs.append(continuity_ref)
+    return continuity_refs
+
+
+def _build_reauthorized_continuity_decision(prior_refs, manifest, explicit_selection):
+    """Describe a fresh manifest decision without treating persisted refs as authority."""
+    if explicit_selection:
+        return {
+            'selection_origin': 'selected',
+            'prior_source_count': 0,
+            'reauthorized_source_count': 0,
+            'unavailable_source_count': 0,
+            'source_version_changed_count': 0,
+            'requires_native_execution': False,
+        }
+
+    prior_by_document_id = {
+        str(ref.get('document_id') or '').strip(): ref
+        for ref in list(prior_refs or [])
+        if isinstance(ref, dict) and str(ref.get('document_id') or '').strip()
+    }
+    unavailable_source_count = 0
+    source_version_changed_count = 0
+    reauthorized_source_count = 0
+    for source in list(manifest or []):
+        document_id = str((source or {}).get('document_id') or '').strip()
+        prior_ref = prior_by_document_id.get(document_id)
+        if not prior_ref:
+            continue
+        if source.get('authorization_status') != 'authorized':
+            unavailable_source_count += 1
+            continue
+        reauthorized_source_count += 1
+        prior_version = prior_ref.get('source_version')
+        current_version = source.get('source_version')
+        if prior_version is not None and current_version is not None and str(prior_version) != str(current_version):
+            source_version_changed_count += 1
+
+    return {
+        'selection_origin': 'history',
+        'prior_source_count': len(prior_by_document_id),
+        'reauthorized_source_count': reauthorized_source_count,
+        'unavailable_source_count': unavailable_source_count,
+        'source_version_changed_count': source_version_changed_count,
+        'requires_native_execution': bool(
+            unavailable_source_count or source_version_changed_count
+        ),
+    }
+
+
 def _resolve_chat_mixed_source_relevance_context(
     *,
     settings,
@@ -13766,6 +13860,7 @@ def register_route_backend_chats(bp):
             history_grounded_search_used = False
             history_only_answerability = None
             prior_grounded_document_refs = []
+            continuity_decision = None
             effective_document_scope = document_scope
             effective_selected_document_ids = list(selected_document_ids or [])
             effective_selected_document_id = selected_document_id
@@ -14761,6 +14856,12 @@ def register_route_backend_chats(bp):
                 mixed_source_tabular_sources = list(
                     history_context.get('tabular_sources') or []
                 )
+                if is_mixed_source_conversation_continuity_enabled(settings):
+                    continuity_decision = _build_reauthorized_continuity_decision(
+                        prior_grounded_document_refs,
+                        mixed_source_manifest,
+                        explicit_selection=False,
+                    )
                 effective_selected_document_ids = (
                     mixed_source_narrative_document_ids
                     + _get_manifest_partition_document_ids(
@@ -15641,6 +15742,8 @@ def register_route_backend_chats(bp):
                     {},
                 )
                 user_metadata['mixed_source_coverage'] = mixed_source_coverage
+                if continuity_decision:
+                    user_metadata['source_continuity'] = continuity_decision
                 user_message_doc['metadata'] = user_metadata
                 cosmos_messages_container.upsert_item(user_message_doc)
                 log_event(
@@ -17218,6 +17321,16 @@ def register_route_backend_chats(bp):
                 selected_agent_name = None
                 if selected_agent:
                     selected_agent_name = getattr(selected_agent, 'name', None)
+                source_continuity_refs = None
+                if (
+                    is_mixed_source_conversation_continuity_enabled(settings)
+                    and mixed_source_manifest
+                ):
+                    source_continuity_refs = _build_mixed_source_continuity_refs(
+                        mixed_source_manifest,
+                        mixed_source_evidence_envelopes,
+                        effective_mixed_source_selection_mode,
+                    )
 
                 # Collect metadata for this conversation interaction
                 conversation_item = collect_conversation_metadata(
@@ -17237,7 +17350,8 @@ def register_route_backend_chats(bp):
                     search_results=search_results if 'search_results' in locals() else None,
                     conversation_item=conversation_item,
                     active_public_workspace_id=effective_active_public_workspace_id,
-                    active_public_workspace_ids=effective_active_public_workspace_ids
+                    active_public_workspace_ids=effective_active_public_workspace_ids,
+                    source_continuity_refs=source_continuity_refs,
                 )
             except Exception as e:
                 debug_print(f"Error collecting conversation metadata: {e}")
@@ -17745,6 +17859,7 @@ def register_route_backend_chats(bp):
                 history_grounded_search_used = False
                 history_only_answerability = None
                 prior_grounded_document_refs = []
+                continuity_decision = None
                 effective_document_scope = document_scope
                 effective_selected_document_ids = list(selected_document_ids or [])
                 effective_selected_document_id = selected_document_id
@@ -18726,6 +18841,12 @@ def register_route_backend_chats(bp):
                     mixed_source_tabular_sources = list(
                         history_context.get('tabular_sources') or []
                     )
+                    if is_mixed_source_conversation_continuity_enabled(settings):
+                        continuity_decision = _build_reauthorized_continuity_decision(
+                            prior_grounded_document_refs,
+                            mixed_source_manifest,
+                            explicit_selection=False,
+                        )
                     effective_selected_document_ids = (
                         mixed_source_narrative_document_ids
                         + _get_manifest_partition_document_ids(
@@ -19190,6 +19311,8 @@ def register_route_backend_chats(bp):
                         or mixed_source_tabular_sources
                     )
                     user_metadata['mixed_source_coverage'] = mixed_source_coverage
+                    if continuity_decision:
+                        user_metadata['source_continuity'] = continuity_decision
                     user_message_doc['metadata'] = user_metadata
                     cosmos_messages_container.upsert_item(user_message_doc)
                     log_event(
@@ -20628,6 +20751,16 @@ def register_route_backend_chats(bp):
                         debug_print(f"Warning: Could not update streaming user message metadata: {e}")
 
                     try:
+                        source_continuity_refs = None
+                        if (
+                            is_mixed_source_conversation_continuity_enabled(settings)
+                            and mixed_source_manifest
+                        ):
+                            source_continuity_refs = _build_mixed_source_continuity_refs(
+                                mixed_source_manifest,
+                                mixed_source_evidence_envelopes,
+                                effective_mixed_source_selection_mode,
+                            )
                         conversation_item = collect_conversation_metadata(
                             user_message=user_message,
                             conversation_id=conversation_id,
@@ -20645,7 +20778,8 @@ def register_route_backend_chats(bp):
                             search_results=search_results if search_results else None,
                             conversation_item=conversation_item,
                             active_public_workspace_id=effective_active_public_workspace_id,
-                            active_public_workspace_ids=effective_active_public_workspace_ids
+                            active_public_workspace_ids=effective_active_public_workspace_ids,
+                            source_continuity_refs=source_continuity_refs,
                         )
                     except Exception as e:
                         debug_print(f"Error collecting conversation metadata: {e}")

--- a/docs/explanation/features/MIXED_SOURCE_CONVERSATION_CONTINUITY.md
+++ b/docs/explanation/features/MIXED_SOURCE_CONVERSATION_CONTINUITY.md
@@ -1,0 +1,38 @@
+# Mixed-Source Conversation Continuity
+
+Implemented in version: **0.250.068**
+
+GitHub issue: [#1060](https://github.com/microsoft/simplechat/issues/1060)
+
+Parent initiative: [#1055](https://github.com/microsoft/simplechat/issues/1055)
+
+Prerequisites: [#1056](https://github.com/microsoft/simplechat/issues/1056), [#1057](https://github.com/microsoft/simplechat/issues/1057), [#1058](https://github.com/microsoft/simplechat/issues/1058), and [#1059](https://github.com/microsoft/simplechat/issues/1059)
+
+## Overview
+
+Phase 5 persists a compact continuity reference for the most recent mixed-source Chat grounding. It is a reauthorization hint, never an authorization decision or evidence cache. A follow-up with no current explicit selection retains the established history fallback, which resolves a new Phase 1 authorized manifest before native narrative retrieval or tabular execution.
+
+## Precedence And Authorization
+
+1. Current explicit selection is authoritative and suppresses previous continuity context.
+2. A no-selection follow-up first uses existing history when it is sufficient.
+3. When fresh grounding is needed, only the immediately relevant compact references are considered and every source is resolved through `resolve_authorized_source_manifest(...)`.
+4. Chat/Search relevance candidates remain available only under their existing bounded Phase 2 rules.
+
+The fresh resolver rechecks personal ownership or exact approved shares, group membership, public visibility, and chat-upload conversation ownership. Missing, revoked, unsupported, or unresolved sources do not become evidence. Changed source versions and partial or failed prior coverage remain terminal state and require native execution rather than treating old evidence as current.
+
+## Metadata Contract
+
+The continuity record contains document ID, canonical scope identity, source role, requested order, source kind, native engine, source version, terminal status, bounded coverage flags, selection origin, action mode, and citation/artifact counts. It never includes document content, filenames, prompts, evidence summaries, blob paths, storage locators, credentials, raw configuration, or authorization snapshots.
+
+## Rollout And Limitations
+
+`enable_mixed_source_conversation_continuity` is default-off and is effective only with `enable_mixed_source_chat_search`. Disabling it preserves existing Phase 2 history grounding and explicit-selection behavior. This phase does not add cross-conversation sharing, many-to-many Compare, target discovery, or persisted raw-evidence reuse.
+
+## Validation
+
+- `functional_tests/test_mixed_source_conversation_continuity.py`
+- `functional_tests/test_chat_history_grounded_follow_up_fix.py`
+- Python compilation and editor diagnostics for changed modules
+
+Related version update: `application/single_app/config.py` moved from **0.250.067** to **0.250.068**.

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,15 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](/explanation/features/) and [Fixes by Version](/explanation/fixes/).
 
+### **(v0.250.068)**
+
+#### New Features
+
+*   **Mixed-Source Conversation Continuity**
+    *   Chat now preserves a default-off, compact record of the most recent mixed-source grounding so follow-up turns can reauthorize those sources before native retrieval or tabular execution.
+    *   Current explicit selections remain authoritative, while changed, revoked, unresolved, partial, or failed prior sources cannot be silently reused as current evidence.
+    *   (Ref: microsoft/simplechat#1060, parent microsoft/simplechat#1055, prerequisites microsoft/simplechat#1056, microsoft/simplechat#1057, microsoft/simplechat#1058, and microsoft/simplechat#1059, `route_backend_chats.py`, `functions_conversation_metadata.py`, `MIXED_SOURCE_CONVERSATION_CONTINUITY.md`)
+
 ### **(v0.250.067)**
 
 #### New Features

--- a/functional_tests/test_document_action_conversation_scope_metadata.py
+++ b/functional_tests/test_document_action_conversation_scope_metadata.py
@@ -2,8 +2,8 @@
 # test_document_action_conversation_scope_metadata.py
 """
 Functional test for document-action conversation scope metadata.
-Version: 0.241.124
-Implemented in: 0.241.124
+Version: 0.250.068
+Implemented in: 0.241.124; Updated in: 0.250.068
 
 This test ensures Analyze and tabular document-action results can assign
 conversation workspace metadata from selected document summaries when no
@@ -20,7 +20,7 @@ ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 METADATA_FILE = os.path.join(ROOT_DIR, 'application', 'single_app', 'functions_conversation_metadata.py')
 ROUTE_FILE = os.path.join(ROOT_DIR, 'application', 'single_app', 'route_backend_chats.py')
 CONFIG_FILE = os.path.join(ROOT_DIR, 'application', 'single_app', 'config.py')
-FIX_VERSION = '0.241.124'
+FIX_VERSION = '0.250.068'
 TEST_USER_ID = 'scope-user-1'
 CRIMSON_GROUP_ID = 'crimson-group-1'
 PUBLIC_WORKSPACE_ID = 'public-workspace-1'

--- a/functional_tests/test_mixed_source_conversation_continuity.py
+++ b/functional_tests/test_mixed_source_conversation_continuity.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+# test_mixed_source_conversation_continuity.py
+"""
+Functional test for Phase 5 mixed-source conversation continuity.
+Version: 0.250.068
+Implemented in: 0.250.068
+
+This test ensures #1060 preserves compact source continuity only as a
+reauthorization hint for #1055 and prerequisite phases #1056, #1057, #1058,
+and #1059. It verifies explicit selections, source-version changes, failed
+coverage, and privacy bounds without persisting source content or locators.
+"""
+
+import ast
+import os
+
+
+ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+ROUTE_FILE = os.path.join(ROOT_DIR, 'application', 'single_app', 'route_backend_chats.py')
+METADATA_FILE = os.path.join(ROOT_DIR, 'application', 'single_app', 'functions_conversation_metadata.py')
+SETTINGS_FILE = os.path.join(ROOT_DIR, 'application', 'single_app', 'functions_settings.py')
+CONFIG_FILE = os.path.join(ROOT_DIR, 'application', 'single_app', 'config.py')
+
+
+def _read_file(file_path):
+    with open(file_path, 'r', encoding='utf-8') as file_handle:
+        return file_handle.read()
+
+
+def _load_route_helpers():
+    source = _read_file(ROUTE_FILE)
+    parsed = ast.parse(source, filename=ROUTE_FILE)
+    target_names = {
+        '_build_mixed_source_continuity_refs',
+        '_build_reauthorized_continuity_decision',
+    }
+    nodes = [
+        node for node in parsed.body
+        if isinstance(node, ast.FunctionDef) and node.name in target_names
+    ]
+    assert len(nodes) == len(target_names)
+    namespace = {}
+    exec(compile(ast.Module(body=nodes, type_ignores=[]), ROUTE_FILE, 'exec'), namespace)
+    return namespace
+
+
+def test_compact_continuity_preserves_terminal_contract_only():
+    """Persist source identity, order, engine, coverage, and references without content."""
+    print('Testing compact continuity metadata...')
+    helpers = _load_route_helpers()
+    build_refs = helpers['_build_mixed_source_continuity_refs']
+    refs = build_refs(
+        [{
+            'document_id': 'table-1', 'scope': 'group', 'scope_id': 'group-1',
+            'source_kind': 'tabular', 'source_version': 'v1',
+            'authorization_status': 'authorized', 'source_role': 'target',
+            'storage_locator': {'blob_path': 'never-persisted'},
+        }],
+        [{
+            'document_id': 'table-1', 'engine': 'tabular', 'status': 'failed',
+            'coverage': {'partial_coverage': True, 'raw_content': 'never-persisted'},
+            'citations': [{'id': 'citation-1'}], 'generated_artifacts': [{'id': 'artifact-1'}],
+        }],
+        'history',
+    )
+    assert refs == [{
+        'document_id': 'table-1', 'scope': 'group', 'scope_id': 'group-1',
+        'source_role': 'target', 'requested_order': 0, 'source_kind': 'tabular',
+        'engine': 'tabular', 'source_version': 'v1', 'status': 'failed',
+        'coverage': {'partial_coverage': True, 'evidence_envelope_truncated': False, 'failed': True},
+        'selection_origin': 'history', 'action_mode': 'chat',
+        'citation_count': 1, 'artifact_count': 1, 'group_id': 'group-1',
+    }]
+    serialized = repr(refs)
+    for prohibited_value in ('never-persisted', 'storage_locator', 'raw_content', 'blob_path'):
+        assert prohibited_value not in serialized
+    print('PASS: compact continuity metadata')
+
+
+def test_explicit_selection_overrides_and_history_requires_reauthorization():
+    """A current selection wins; stale, revoked, and changed history requires new execution."""
+    print('Testing selection precedence and reauthorization...')
+    decide = _load_route_helpers()['_build_reauthorized_continuity_decision']
+    prior_refs = [
+        {'document_id': 'narrative-1', 'source_version': 'v1'},
+        {'document_id': 'table-1', 'source_version': 'v1'},
+    ]
+    explicit = decide(prior_refs, [], explicit_selection=True)
+    assert explicit['selection_origin'] == 'selected'
+    assert explicit['prior_source_count'] == 0
+
+    history = decide(prior_refs, [
+        {'document_id': 'narrative-1', 'source_version': 'v1', 'authorization_status': 'authorized'},
+        {'document_id': 'table-1', 'source_version': 'v2', 'authorization_status': 'authorized'},
+        {'document_id': 'revoked-upload', 'source_version': 'v1', 'authorization_status': 'unresolved'},
+    ], explicit_selection=False)
+    assert history['selection_origin'] == 'history'
+    assert history['reauthorized_source_count'] == 2
+    assert history['source_version_changed_count'] == 1
+    assert history['requires_native_execution'] is True
+    assert history['unavailable_source_count'] == 0
+    print('PASS: selection precedence and reauthorization')
+
+
+def test_flag_and_standard_streaming_wiring_are_present():
+    """Both Chat paths retain flag-off rollback and only use fresh manifest results."""
+    print('Testing flag and Chat parity wiring...')
+    settings_source = _read_file(SETTINGS_FILE)
+    route_source = _read_file(ROUTE_FILE)
+    metadata_source = _read_file(METADATA_FILE)
+    config_source = _read_file(CONFIG_FILE)
+    assert "'enable_mixed_source_conversation_continuity': False" in settings_source
+    assert 'def is_mixed_source_conversation_continuity_enabled(settings):' in settings_source
+    assert route_source.count('is_mixed_source_conversation_continuity_enabled(settings)') == 4
+    assert route_source.count('_build_reauthorized_continuity_decision(') == 3
+    assert route_source.count('_build_mixed_source_continuity_refs(') == 3
+    assert route_source.count("selection_mode='history'") == 0
+    assert route_source.count("'history',") >= 2
+    assert 'source_continuity_refs=None' in metadata_source
+    assert 'source_continuity_refs=source_continuity_refs' in metadata_source
+    assert 'VERSION = "0.250.068"' in config_source
+    print('PASS: flag and Chat parity wiring')
+
+
+if __name__ == '__main__':
+    tests = [
+        test_compact_continuity_preserves_terminal_contract_only,
+        test_explicit_selection_overrides_and_history_requires_reauthorization,
+        test_flag_and_standard_streaming_wiring_are_present,
+    ]
+    for test in tests:
+        test()
+    print(f'Completed {len(tests)}/{len(tests)} Phase 5 continuity checks.')


### PR DESCRIPTION
## Summary\n- Add a default-off nable_mixed_source_conversation_continuity flag, effective only with the existing Phase 2 Chat/Search flag.\n- Persist a compact, privacy-safe continuity record through the existing conversation metadata path, with source identity, role/order, native engine, version, terminal status, aggregate coverage flags, and citation/artifact counts.\n- Keep current explicit selections authoritative. History references are reauthorized through the existing Phase 1 manifest before native evidence processing; version changes and incomplete prior coverage require fresh execution.\n- Cover compact serialization, selection precedence, revocation/version decisions, standard/streaming parity wiring, and version alignment.\n- Update feature documentation and release notes for 