### PR TITLE
Harden mixed-source orchestration and CSV exports

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -97,7 +97,7 @@ load_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.250.068"
+VERSION = "0.250.070"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/foundry_agent_runtime.py
+++ b/application/single_app/foundry_agent_runtime.py
@@ -43,8 +43,12 @@ FOUNDRY_INTERNAL_METADATA_KEYS = {
     "active_group_ids",
     "active_public_workspace_ids",
     "document_context_requested",
+    "document_scope",
+    "group_id",
     "selection_mode",
+    "selected_document_id",
     "selected_document_ids",
+    "user_id",
 }
 FOUNDRY_FILE_SEARCHABLE_CONTEXT_MAX_CHARS = 6000
 FOUNDRY_FILE_SEARCHABLE_CONTEXT_HEADER = "Attached file searchable summary"
@@ -393,6 +397,14 @@ async def execute_foundry_agent(
 ) -> FoundryAgentInvocationResult:
     """Invoke a Foundry agent using Semantic Kernel's AzureAIAgent abstraction."""
 
+    message_history = _filter_foundry_document_context_messages(
+        message_history,
+        include_document_context=_coerce_bool(
+            foundry_settings.get("include_document_context"),
+            True,
+        ),
+    )
+
     agent_id = (foundry_settings.get("agent_id") or "").strip()
     if not agent_id:
         raise FoundryAgentInvocationError(
@@ -493,6 +505,14 @@ async def execute_new_foundry_agent(
 ) -> FoundryAgentInvocationResult:
     """Invoke the new Foundry application runtime through its Responses protocol endpoint."""
 
+    message_history = _filter_foundry_document_context_messages(
+        message_history,
+        include_document_context=_coerce_bool(
+            foundry_settings.get("include_document_context"),
+            True,
+        ),
+    )
+
     application_name = _resolve_new_foundry_application_name(foundry_settings)
     endpoint = _resolve_endpoint(foundry_settings, global_settings)
     responses_api_version = (
@@ -574,6 +594,14 @@ async def execute_new_foundry_agent_stream(
     max_completion_tokens: Optional[int] = None,
 ) -> AsyncIterator[FoundryAgentStreamMessage]:
     """Stream a new Foundry application response through the Responses API."""
+
+    message_history = _filter_foundry_document_context_messages(
+        message_history,
+        include_document_context=_coerce_bool(
+            foundry_settings.get("include_document_context"),
+            True,
+        ),
+    )
 
     application_name = _resolve_new_foundry_application_name(foundry_settings)
     endpoint = _resolve_endpoint(foundry_settings, global_settings)
@@ -1229,6 +1257,38 @@ def _looks_like_document_context_message(text: str) -> bool:
         "[workflow document search context]",
     )
     return any(marker in normalized for marker in markers)
+
+
+def _filter_foundry_document_context_messages(
+    message_history: List[ChatMessageContent],
+    include_document_context: bool = True,
+) -> List[ChatMessageContent]:
+    """Remove document/evidence messages before Foundry transport when opted out."""
+    if include_document_context:
+        return list(message_history or [])
+
+    filtered_messages: List[ChatMessageContent] = []
+    workflow_task_marker = "[workflow task]"
+    for message in list(message_history or []):
+        text = _extract_message_text(message).strip()
+        if not text:
+            continue
+        if not _looks_like_document_context_message(text):
+            filtered_messages.append(message)
+            continue
+
+        marker_index = text.lower().rfind(workflow_task_marker)
+        if marker_index < 0:
+            continue
+        workflow_task = text[marker_index + len(workflow_task_marker):].strip()
+        if not workflow_task:
+            continue
+        filtered_messages.append(ChatMessageContent(
+            role=getattr(message, "role", "user"),
+            content=workflow_task,
+            metadata=getattr(message, "metadata", {}) or {},
+        ))
+    return filtered_messages
 
 
 def _build_foundry_workflow_input_text(

--- a/application/single_app/functions_document_access_index.py
+++ b/application/single_app/functions_document_access_index.py
@@ -68,6 +68,7 @@ DOCUMENT_ACCESS_CACHE_VERSION_MIN_TTL_SECONDS = 3600
 DOCUMENT_ACCESS_CACHE_VERSION_MAX_TTL_SECONDS = 86400
 DOCUMENT_ACCESS_CACHE_VERSION_TTL_MULTIPLIER = 4
 DOCUMENT_ACCESS_CACHE_VERSION_HYGIENE_BATCH_SIZE = 100
+DOCUMENT_ACCESS_BOUNDED_CATALOG_MAX_SCOPES = 25
 DOCUMENT_ACCESS_CACHE_VERSION_HYGIENE_MAX_SCAN_ITERATIONS = 5
 DOCUMENT_ACCESS_CACHE_KEY_PREFIX = 'DAI_LIST_CACHE'
 DOCUMENT_ACCESS_CACHE_VERSION_KEY_PREFIX = 'DAI_LIST_CACHE_VERSION'
@@ -2127,7 +2128,7 @@ def _query_projection_rows_for_scope_with_diagnostics(scope_key, source_scope):
         'WHERE c.type = @type '
         'AND c.source_scope = @source_scope '
         'AND c.scope_key = @scope_key '
-        'AND (c.access_granted = true OR c.approval_status = @approval_not_approved) '
+        'AND c.access_granted = true '
         'AND c.is_current_version = true '
         'AND c.projection_version = @projection_version'
     )
@@ -2139,7 +2140,6 @@ def _query_projection_rows_for_scope_with_diagnostics(scope_key, source_scope):
             {'name': '@type', 'value': DOCUMENT_ACCESS_INDEX_TYPE},
             {'name': '@source_scope', 'value': source_scope},
             {'name': '@scope_key', 'value': scope_key},
-            {'name': '@approval_not_approved', 'value': DOCUMENT_ACCESS_APPROVAL_NOT_APPROVED},
             {'name': '@projection_version', 'value': DOCUMENT_ACCESS_INDEX_SCHEMA_VERSION},
         ],
         partition_key=scope_key,
@@ -2162,7 +2162,7 @@ def _query_candidate_projection_rows_for_scope(scope_key, source_scope):
         'WHERE c.type = @type '
         'AND c.source_scope = @source_scope '
         'AND c.scope_key = @scope_key '
-        'AND (c.access_granted = true OR c.approval_status = @approval_not_approved) '
+        'AND c.access_granted = true '
         'AND c.is_current_version = true '
         'AND c.projection_version = @projection_version'
     )
@@ -2174,11 +2174,128 @@ def _query_candidate_projection_rows_for_scope(scope_key, source_scope):
             {'name': '@type', 'value': DOCUMENT_ACCESS_INDEX_TYPE},
             {'name': '@source_scope', 'value': source_scope},
             {'name': '@scope_key', 'value': scope_key},
-            {'name': '@approval_not_approved', 'value': DOCUMENT_ACCESS_APPROVAL_NOT_APPROVED},
             {'name': '@projection_version', 'value': DOCUMENT_ACCESS_INDEX_SCHEMA_VERSION},
         ],
         partition_key=scope_key,
     )
+
+
+def _query_bounded_projection_rows_for_scope(scope_key, source_scope, max_rows):
+    normalized_max_rows = max(1, min(_safe_int(max_rows), 1001))
+    query = (
+        f'SELECT TOP {normalized_max_rows} c.document_id, c.source_document_id, c.version, '
+        'c.revision_family_id, c.source_ts, c.file_name, '
+        'c.owner_user_id, c.owner_group_id, c.owner_public_workspace_id '
+        'FROM c '
+        'WHERE c.type = @type '
+        'AND c.source_scope = @source_scope '
+        'AND c.scope_key = @scope_key '
+        'AND c.access_granted = true '
+        'AND c.is_current_version = true '
+        'AND c.projection_version = @projection_version '
+        'ORDER BY c.source_ts DESC'
+    )
+    return list(cosmos_document_access_index_container.query_items(
+        query=query,
+        parameters=[
+            {'name': '@type', 'value': DOCUMENT_ACCESS_INDEX_TYPE},
+            {'name': '@source_scope', 'value': source_scope},
+            {'name': '@scope_key', 'value': scope_key},
+            {'name': '@projection_version', 'value': DOCUMENT_ACCESS_INDEX_SCHEMA_VERSION},
+        ],
+        partition_key=scope_key,
+    ))
+
+
+def enumerate_bounded_document_access_index_ids(
+    source_scope,
+    max_documents,
+    user_id=None,
+    group_ids=None,
+    public_workspace_id=None,
+    public_workspace_ids=None,
+    settings=None,
+):
+    """Return current candidate IDs only when the ready access-index catalog fits the bound."""
+    source_scope = str(source_scope or '').strip().lower()
+    if source_scope not in DOCUMENT_ACCESS_SOURCE_SCOPES:
+        return {'success': False, 'status': 'invalid_source_scope', 'document_ids': []}
+    max_documents = _safe_int(max_documents)
+    if max_documents <= 0:
+        return {'success': False, 'status': 'invalid_document_limit', 'document_ids': []}
+
+    readiness = _get_document_access_index_readiness(source_scope, settings=settings)
+    if not readiness.get('ready'):
+        return {
+            'success': False,
+            'status': readiness.get('status'),
+            'document_ids': [],
+            'readiness': readiness,
+        }
+    scope_keys = [
+        scope_key
+        for scope_key in _build_shadow_scope(
+            source_scope,
+            user_id=user_id,
+            group_ids=group_ids,
+            public_workspace_id=public_workspace_id,
+            public_workspace_ids=public_workspace_ids,
+        )
+        if scope_key
+    ]
+    if not scope_keys:
+        return {'success': False, 'status': 'missing_scope_keys', 'document_ids': []}
+    if len(scope_keys) > DOCUMENT_ACCESS_BOUNDED_CATALOG_MAX_SCOPES:
+        return {
+            'success': False,
+            'status': 'scope_limit_exceeded',
+            'document_ids': [],
+            'scope_count': len(scope_keys),
+        }
+
+    rows_by_identity = {}
+    query_limit = max_documents + 1
+    for scope_key in scope_keys:
+        for row in _query_bounded_projection_rows_for_scope(
+            scope_key,
+            source_scope,
+            query_limit,
+        ):
+            identity = _document_family_identity(row, source_scope)
+            if not identity:
+                continue
+            rows_by_identity[identity] = _prefer_projection_row(
+                rows_by_identity.get(identity),
+                row,
+            )
+            if len(rows_by_identity) > max_documents:
+                return {
+                    'success': False,
+                    'status': 'document_limit_exceeded',
+                    'document_ids': [],
+                    'document_count_lower_bound': max_documents + 1,
+                }
+
+    ordered_rows = sorted(
+        rows_by_identity.values(),
+        key=lambda row: (
+            _safe_int(row.get('source_ts')),
+            str(row.get('source_document_id') or row.get('document_id') or ''),
+        ),
+        reverse=True,
+    )
+    document_ids = [
+        str(row.get('source_document_id') or row.get('document_id') or '').strip()
+        for row in ordered_rows
+        if str(row.get('source_document_id') or row.get('document_id') or '').strip()
+    ]
+    return {
+        'success': True,
+        'status': 'bounded_catalog_ready',
+        'document_ids': document_ids,
+        'document_count': len(document_ids),
+        'scope_count': len(scope_keys),
+    }
 
 
 def _query_tag_projection_rows_for_scope(scope_key, source_scope):

--- a/application/single_app/functions_document_actions.py
+++ b/application/single_app/functions_document_actions.py
@@ -17,6 +17,7 @@ DOCUMENT_ACTION_TYPE_ANALYZE = 'analyze'
 DOCUMENT_ACTION_TYPE_COMPARISON = 'comparison'
 DOCUMENT_ACTION_ANALYSIS_MODE_COMBINED = 'combined'
 DOCUMENT_ACTION_ANALYSIS_MODE_PER_DOCUMENT = 'per_document'
+DOCUMENT_ACTION_TARGET_MODE_ALL = 'all'
 DOCUMENT_ACTION_TARGET_MODE_SELECTED = 'selected'
 DOCUMENT_ACTION_TARGET_MODE_RECENT = 'recent'
 DEFAULT_RECENT_DOCUMENT_WINDOW_MINUTES = 10
@@ -25,6 +26,7 @@ VALID_DOCUMENT_ACTION_ANALYSIS_MODES = {
     DOCUMENT_ACTION_ANALYSIS_MODE_PER_DOCUMENT,
 }
 VALID_DOCUMENT_ACTION_TARGET_MODES = {
+    DOCUMENT_ACTION_TARGET_MODE_ALL,
     DOCUMENT_ACTION_TARGET_MODE_SELECTED,
     DOCUMENT_ACTION_TARGET_MODE_RECENT,
 }
@@ -270,6 +272,8 @@ def normalize_document_action_config(
 
     if action_type == DOCUMENT_ACTION_TYPE_SEARCH:
         target_mode = normalize_document_action_target_mode(source_action.get('target_mode'))
+        if target_mode == DOCUMENT_ACTION_TARGET_MODE_ALL:
+            raise ValueError('All Documents is exhaustive only for Analyze.')
         document_ids = normalize_search_id_list(source_action.get('document_ids'))
         if resolved_max_documents is not None and len(document_ids) > resolved_max_documents:
             raise ValueError(f'Document search supports up to {resolved_max_documents} documents at a time.')
@@ -297,6 +301,19 @@ def normalize_document_action_config(
 
     if action_type == DOCUMENT_ACTION_TYPE_ANALYZE:
         target_mode = normalize_document_action_target_mode(source_action.get('target_mode'))
+        if target_mode == DOCUMENT_ACTION_TARGET_MODE_ALL:
+            normalized_action.update({
+                'doc_scope': source_action.get('doc_scope', 'all'),
+                'active_group_ids': normalize_search_id_list(source_action.get('active_group_ids')),
+                'active_public_workspace_id': normalize_search_id_list(source_action.get('active_public_workspace_id')),
+                'window_unit': source_action.get('window_unit') or 'pages',
+                'window_size': source_action.get('window_size'),
+                'window_percent': source_action.get('window_percent'),
+                'max_retries_per_window': source_action.get('max_retries_per_window', 1),
+                'analysis_mode': normalize_document_action_analysis_mode(source_action.get('analysis_mode')),
+                'target_mode': target_mode,
+            })
+            return normalized_action
         recent_targets_resolved = bool(source_action.get('recent_targets_resolved'))
         if target_mode == DOCUMENT_ACTION_TARGET_MODE_RECENT and not normalize_search_id_list(source_action.get('document_ids')):
             source_action = dict(source_action)
@@ -323,6 +340,8 @@ def normalize_document_action_config(
         return normalized_action
 
     target_mode = normalize_document_action_target_mode(source_action.get('target_mode'))
+    if target_mode == DOCUMENT_ACTION_TARGET_MODE_ALL:
+        raise ValueError('All Documents is supported only for Analyze.')
     recent_targets_resolved = bool(source_action.get('recent_targets_resolved'))
     if target_mode == DOCUMENT_ACTION_TARGET_MODE_RECENT and not recent_targets_resolved:
         normalized_action.update({

--- a/application/single_app/functions_document_analysis.py
+++ b/application/single_app/functions_document_analysis.py
@@ -8,6 +8,10 @@ from typing import Any, Callable, Dict, List, Optional
 
 from functions_appinsights import log_event
 from functions_debug import debug_print
+from functions_mixed_source_orchestration import (
+    MixedSourceCancellationError,
+    raise_if_mixed_source_cancelled,
+)
 from functions_search import normalize_search_id_list, normalize_search_scope
 
 
@@ -679,6 +683,8 @@ def _reduce_document_analysis_items(
     failed_range_labels,
     reduction_batch_size,
     max_reduction_rounds,
+    cancel_requested=None,
+    request_correlation_id=None,
 ):
     current_items = list(items or [])
     reduction_round = 1
@@ -687,6 +693,11 @@ def _reduce_document_analysis_items(
         next_items = []
         batches = _build_reduction_batches(current_items, reduction_batch_size)
         for batch_index, batch_items in enumerate(batches, start=1):
+            raise_if_mixed_source_cancelled(
+                cancel_requested,
+                'narrative_reduction',
+                request_correlation_id=request_correlation_id,
+            )
             reduction_prompt = _build_document_reduction_prompt(
                 analysis_prompt,
                 document_name,
@@ -705,6 +716,11 @@ def _reduce_document_analysis_items(
                     'item_count': len(batch_items),
                 },
             ) or '').strip()
+            raise_if_mixed_source_cancelled(
+                cancel_requested,
+                'narrative_reduction',
+                request_correlation_id=request_correlation_id,
+            )
             if not reduced_text:
                 raise RuntimeError(
                     f'Document analysis document reduction returned an empty response for {document_name} '
@@ -784,12 +800,19 @@ def run_document_analysis(
     activity_callback=None,
     max_documents=None,
     include_coverage_summary=True,
+    cancel_requested=None,
+    request_correlation_id=None,
 ):
     normalized_analysis_prompt = str(analysis_prompt or '').strip()
     if not normalized_analysis_prompt:
         raise ValueError('An analysis prompt is required for document analysis.')
     if not callable(invoke_prompt):
         raise ValueError('A callable invoke_prompt handler is required for document analysis.')
+    raise_if_mixed_source_cancelled(
+        cancel_requested,
+        'narrative_manifest',
+        request_correlation_id=request_correlation_id,
+    )
 
     build_document_chunk_windows, get_document_chunks_payload = _get_search_service_helpers()
 
@@ -861,6 +884,11 @@ def run_document_analysis(
     json_code_block_requested = analysis_intent.get('json_code_block_requested')
 
     for document_index, document_id in enumerate(targets.get('document_ids', []), start=1):
+        raise_if_mixed_source_cancelled(
+            cancel_requested,
+            'narrative_manifest',
+            request_correlation_id=request_correlation_id,
+        )
         document_payload = get_document_chunks_payload(
             document_id=document_id,
             user_id=user_id,
@@ -871,6 +899,11 @@ def run_document_analysis(
             window_unit=targets.get('window_unit'),
             window_size=targets.get('window_size'),
             window_percent=targets.get('window_percent'),
+        )
+        raise_if_mixed_source_cancelled(
+            cancel_requested,
+            'narrative_manifest',
+            request_correlation_id=request_correlation_id,
         )
         windows = build_document_chunk_windows(
             document_payload.get('chunks', []),
@@ -919,6 +952,11 @@ def run_document_analysis(
         })
 
     for document_run in document_runs:
+        raise_if_mixed_source_cancelled(
+            cancel_requested,
+            'narrative',
+            request_correlation_id=request_correlation_id,
+        )
         document_id = document_run.get('document_id')
         document_payload = document_run.get('document_payload') or {}
         document_metadata = document_payload.get('document') if isinstance(document_payload.get('document'), dict) else {}
@@ -963,6 +1001,11 @@ def run_document_analysis(
             })
 
         for window_payload in windows:
+            raise_if_mixed_source_cancelled(
+                cancel_requested,
+                'narrative',
+                request_correlation_id=request_correlation_id,
+            )
             window_range = _serialize_window_range(window_payload)
             document_summary['ranges'].append(window_range)
             window_label = _build_window_label(document_name, window_range)
@@ -1004,6 +1047,11 @@ def run_document_analysis(
             last_error = ''
             max_attempts = targets.get('max_retries_per_window', DEFAULT_MAX_RETRIES_PER_WINDOW) + 1
             for attempt_number in range(1, max_attempts + 1):
+                raise_if_mixed_source_cancelled(
+                    cancel_requested,
+                    'narrative',
+                    request_correlation_id=request_correlation_id,
+                )
                 if attempt_number > 1:
                     coverage['retries'] += 1
 
@@ -1024,9 +1072,16 @@ def run_document_analysis(
                             'attempt_number': attempt_number,
                         },
                     ) or '').strip()
+                    raise_if_mixed_source_cancelled(
+                        cancel_requested,
+                        'narrative',
+                        request_correlation_id=request_correlation_id,
+                    )
                     if not analysis_text:
                         raise ValueError('The analysis runner returned an empty response.')
                     break
+                except MixedSourceCancellationError:
+                    raise
                 except Exception as exc:
                     last_error = str(exc)
                     debug_print(
@@ -1165,6 +1220,8 @@ def run_document_analysis(
                     document_summary.get('failed_ranges', []),
                     reduction_batch_size,
                     max_reduction_rounds,
+                    cancel_requested=cancel_requested,
+                    request_correlation_id=request_correlation_id,
                 )
 
             document_result_text = str(document_result.get('text', '') or '').strip()
@@ -1264,6 +1321,11 @@ def run_document_analysis(
             next_items = []
             batches = _build_reduction_batches(current_items, reduction_batch_size)
             for batch_index, batch_items in enumerate(batches, start=1):
+                raise_if_mixed_source_cancelled(
+                    cancel_requested,
+                    'narrative_reduction',
+                    request_correlation_id=request_correlation_id,
+                )
                 reduction_step_index = completed_reduction_steps + 1
                 reduction_progress_percent = 90
                 if reduction_step_total > 0:
@@ -1316,6 +1378,11 @@ def run_document_analysis(
                         'item_count': len(batch_items),
                     },
                 ) or '').strip()
+                raise_if_mixed_source_cancelled(
+                    cancel_requested,
+                    'narrative_reduction',
+                    request_correlation_id=request_correlation_id,
+                )
                 if not reduced_text:
                     debug_print(
                         '[DocumentAnalysis] Reduction failed | '
@@ -1350,6 +1417,11 @@ def run_document_analysis(
 
         final_analysis_reply = current_items[0].get('text', '').strip()
 
+    raise_if_mixed_source_cancelled(
+        cancel_requested,
+        'narrative_finalization',
+        request_correlation_id=request_correlation_id,
+    )
     _set_progress_meta(
         coverage,
         phase='completed',

--- a/application/single_app/functions_document_comparison.py
+++ b/application/single_app/functions_document_comparison.py
@@ -5,6 +5,10 @@ import logging
 
 from functions_appinsights import log_event
 from functions_debug import debug_print
+from functions_mixed_source_orchestration import (
+    MixedSourceCancellationError,
+    raise_if_mixed_source_cancelled,
+)
 from functions_document_actions import DOCUMENT_ACTION_TYPE_COMPARISON
 from functions_document_analysis import (
     build_document_analysis_progress_snapshot,
@@ -230,6 +234,8 @@ def run_evidence_document_comparison(
     right_sources,
     invoke_prompt,
     activity_callback=None,
+    cancel_requested=None,
+    request_correlation_id=None,
 ):
     """Run the established one-left-to-many comparison over native evidence envelopes."""
     normalized_prompt = str(comparison_prompt or '').strip()
@@ -240,11 +246,26 @@ def run_evidence_document_comparison(
     right_sources = [source for source in list(right_sources or []) if isinstance(source, dict)]
     left_name = str(left_source.get('document_name') or 'Source').strip() or 'Source'
     left_summary = str(left_source.get('summary') or '').strip()
+    left_status = str(left_source.get('status') or '').strip().lower()
+    if left_status not in {'completed', 'partial'} or not left_summary:
+        raise RuntimeError('The comparison Source could not be prepared from native evidence.')
+    if cancel_requested is not None:
+        raise_if_mixed_source_cancelled(
+            cancel_requested,
+            'comparison',
+            request_correlation_id=request_correlation_id,
+        )
     comparison_items = []
     compared_targets = []
     failed_targets = []
 
     for comparison_index, right_source in enumerate(right_sources, start=1):
+        if cancel_requested is not None:
+            raise_if_mixed_source_cancelled(
+                cancel_requested,
+                'comparison',
+                request_correlation_id=request_correlation_id,
+            )
         right_name = str(right_source.get('document_name') or f'Target {comparison_index}').strip() or f'Target {comparison_index}'
         right_status = str(right_source.get('status') or '').strip().lower()
         if right_status not in {'completed', 'partial'} or not left_summary:
@@ -261,22 +282,34 @@ def run_evidence_document_comparison(
                 'comparison_index': comparison_index,
                 'comparison_count': len(right_sources),
             })
-        pairwise_text = str(invoke_prompt(
-            _build_pairwise_comparison_prompt(
-                normalized_prompt,
-                left_name,
-                right_name,
-                left_summary,
-                str(right_source.get('summary') or ''),
-            ),
-            stage='comparison',
-            metadata={
-                'comparison_index': comparison_index,
-                'comparison_count': len(right_sources),
-                'left_document_id': left_source.get('document_id'),
-                'right_document_id': right_source.get('document_id'),
-            },
-        ) or '').strip()
+        try:
+            pairwise_text = str(invoke_prompt(
+                _build_pairwise_comparison_prompt(
+                    normalized_prompt,
+                    left_name,
+                    right_name,
+                    left_summary,
+                    str(right_source.get('summary') or ''),
+                ),
+                stage='comparison',
+                metadata={
+                    'comparison_index': comparison_index,
+                    'comparison_count': len(right_sources),
+                    'left_document_id': left_source.get('document_id'),
+                    'right_document_id': right_source.get('document_id'),
+                },
+            ) or '').strip()
+            if cancel_requested is not None:
+                raise_if_mixed_source_cancelled(
+                    cancel_requested,
+                    'comparison',
+                    request_correlation_id=request_correlation_id,
+                )
+        except MixedSourceCancellationError:
+            raise
+        except Exception:
+            failed_targets.append(right_name)
+            continue
         if not pairwise_text:
             failed_targets.append(right_name)
             continue
@@ -302,11 +335,23 @@ def run_evidence_document_comparison(
     elif len(comparison_items) == 1:
         final_reply = comparison_items[0]['text']
     else:
+        if cancel_requested is not None:
+            raise_if_mixed_source_cancelled(
+                cancel_requested,
+                'comparison_reduction',
+                request_correlation_id=request_correlation_id,
+            )
         final_reply = str(invoke_prompt(
             _build_comparison_reduction_prompt(normalized_prompt, left_name, comparison_items),
             stage='comparison_reduction',
             metadata={'comparison_count': len(comparison_items), 'left_document_id': left_source.get('document_id')},
         ) or '').strip() or 'The completed target comparisons could not be reduced into a final response.'
+        if cancel_requested is not None:
+            raise_if_mixed_source_cancelled(
+                cancel_requested,
+                'comparison_reduction',
+                request_correlation_id=request_correlation_id,
+            )
 
     evidence_engines = sorted({
         str(source.get('engine') or 'unknown')
@@ -323,7 +368,7 @@ def run_evidence_document_comparison(
     )
     return {
         'reply': f'{final_reply}{coverage_note}',
-        'analysis_reply': final_reply,
+        'analysis_reply': f'{final_reply}{coverage_note}',
         'coverage': {'document_count': 1 + len(right_sources), 'partial_coverage': bool(failed_targets), 'failed_targets': failed_targets},
         'documents': [left_source, *right_sources],
         'left_document': {'document_id': left_source.get('document_id'), 'document_name': left_name},
@@ -342,6 +387,8 @@ def run_document_comparison(
     invoke_prompt,
     activity_callback=None,
     conversation_id=None,
+    cancel_requested=None,
+    request_correlation_id=None,
 ):
     normalized_prompt = str(comparison_prompt or '').strip()
     if not normalized_prompt:
@@ -356,6 +403,11 @@ def run_document_comparison(
     right_document_ids = list(action_config.get('right_document_ids') or [])
     if not left_document_id or not right_document_ids:
         raise ValueError('Document comparison requires one Source document and at least one Target document.')
+    raise_if_mixed_source_cancelled(
+        cancel_requested,
+        'comparison_manifest',
+        request_correlation_id=request_correlation_id,
+    )
 
     debug_print(
         '[DocumentComparison] Starting comparison | '
@@ -399,6 +451,11 @@ def run_document_comparison(
 
     document_summaries = {}
     for document_index, document_id in enumerate(document_order, start=1):
+        raise_if_mixed_source_cancelled(
+            cancel_requested,
+            'comparison',
+            request_correlation_id=request_correlation_id,
+        )
         document_state = document_states[document_id]
         role_label = document_state.get('role_label', 'right')
         debug_print(
@@ -458,6 +515,8 @@ def run_document_comparison(
             activity_callback=summary_activity_callback,
             max_documents=1,
             include_coverage_summary=False,
+            cancel_requested=cancel_requested,
+            request_correlation_id=request_correlation_id,
         )
         document_summaries[document_id] = summary_result
         document_state['document_name'] = (
@@ -481,6 +540,11 @@ def run_document_comparison(
     left_document_name = document_states[left_document_id].get('document_name') or left_document_id
     comparison_items = []
     for comparison_index, right_document_id in enumerate(right_document_ids, start=1):
+        raise_if_mixed_source_cancelled(
+            cancel_requested,
+            'comparison',
+            request_correlation_id=request_correlation_id,
+        )
         right_document_name = document_states[right_document_id].get('document_name') or right_document_id
         comparison_progress_percent = ((comparison_index - 1) / len(right_document_ids)) * 100 if right_document_ids else 0
         _set_comparison_progress_meta(
@@ -528,6 +592,11 @@ def run_document_comparison(
                 'right_document_id': right_document_id,
             },
         ) or '').strip()
+        raise_if_mixed_source_cancelled(
+            cancel_requested,
+            'comparison',
+            request_correlation_id=request_correlation_id,
+        )
         if not pairwise_text:
             debug_print(
                 '[DocumentComparison] Pairwise comparison failed | '
@@ -577,6 +646,11 @@ def run_document_comparison(
     if len(comparison_items) == 1:
         final_reply = comparison_items[0].get('text', '').strip()
     else:
+        raise_if_mixed_source_cancelled(
+            cancel_requested,
+            'comparison_reduction',
+            request_correlation_id=request_correlation_id,
+        )
         _set_comparison_progress_meta(
             coverage,
             phase='reducing',
@@ -612,6 +686,11 @@ def run_document_comparison(
                 'left_document_id': left_document_id,
             },
         ) or '').strip()
+        raise_if_mixed_source_cancelled(
+            cancel_requested,
+            'comparison_reduction',
+            request_correlation_id=request_correlation_id,
+        )
         if not final_reply:
             debug_print(
                 '[DocumentComparison] Comparison reduction failed | '
@@ -624,6 +703,11 @@ def run_document_comparison(
             f'comparison_count={len(comparison_items)}'
         )
 
+    raise_if_mixed_source_cancelled(
+        cancel_requested,
+        'comparison_finalization',
+        request_correlation_id=request_correlation_id,
+    )
     _set_comparison_progress_meta(
         coverage,
         phase='completed',

--- a/application/single_app/functions_documents.py
+++ b/application/single_app/functions_documents.py
@@ -4395,7 +4395,7 @@ def extract_document_metadata(document_id, user_id, group_id=None, public_worksp
                     json.dumps(meta_data),
                     user_id,
                     document_id=document_id,
-                    top_n=12,
+                    top_n=25,
                     doc_scope=document_scope
                 )
             elif document_scope == "group":
@@ -4403,7 +4403,7 @@ def extract_document_metadata(document_id, user_id, group_id=None, public_worksp
                     json.dumps(meta_data),
                     user_id,
                     document_id=document_id,
-                    top_n=12,
+                    top_n=25,
                     doc_scope=document_scope,
                     active_group_id=scope_id
                 )
@@ -4412,7 +4412,7 @@ def extract_document_metadata(document_id, user_id, group_id=None, public_worksp
                     json.dumps(meta_data),
                     user_id,
                     document_id=document_id,
-                    top_n=12,
+                    top_n=25,
                     doc_scope=document_scope,
                     active_public_workspace_id=scope_id
                 )
@@ -4424,7 +4424,7 @@ def extract_document_metadata(document_id, user_id, group_id=None, public_worksp
                         json.dumps(meta_data),
                         user_id,
                         document_id=document_id,
-                        top_n=12,
+                        top_n=50,
                         doc_scope="public",
                         active_public_workspace_id=public_workspace_id
                     )

--- a/application/single_app/functions_mixed_source_orchestration.py
+++ b/application/single_app/functions_mixed_source_orchestration.py
@@ -6,6 +6,7 @@ import logging
 import math
 import os
 import time
+import uuid
 
 from functions_appinsights import log_event
 
@@ -92,6 +93,222 @@ EVIDENCE_JSON_MAX_COLLECTION_ITEMS = 20
 EVIDENCE_JSON_MAX_STRING_BYTES = 1024
 MIXED_SOURCE_HANDOFF_MAX_BYTES = 49152
 MIXED_SOURCE_HANDOFF_MAX_ENVELOPES = 20
+MIXED_SOURCE_MODES = frozenset({"chat", "search", "analyze", "compare"})
+MIXED_SOURCE_TERMINAL_REASON_MAX_BYTES = 128
+MIXED_SOURCE_TELEMETRY_EVENTS = frozenset({
+    "authorization_failure",
+    "background_export",
+    "cancellation",
+    "continuity",
+    "native_execution",
+    "reduction",
+    "terminal_coverage",
+})
+MIXED_SOURCE_TELEMETRY_METRICS = frozenset({
+    "artifact_count",
+    "authorization_failure_count",
+    "background_export_count",
+    "cancellation_count",
+    "citation_count",
+    "completed_source_count",
+    "duplicate_evidence_count",
+    "engine_call_count",
+    "evidence_omitted_count",
+    "failed_source_count",
+    "history_rerun_count",
+    "history_reuse_count",
+    "history_source_count",
+    "latency_ms",
+    "missing_coverage_violation_count",
+    "model_request_count",
+    "narrative_source_count",
+    "partial_failure_count",
+    "partial_source_count",
+    "prompt_tokens",
+    "request_count",
+    "skipped_source_count",
+    "successful_source_count",
+    "tabular_source_count",
+    "token_request_count",
+    "total_source_count",
+    "total_tokens",
+    "unexpected_evidence_count",
+    "unsupported_source_count",
+    "unresolved_source_count",
+})
+MIXED_SOURCE_TELEMETRY_DIMENSIONS = frozenset({
+    "cancellation_phase",
+    "continuity_decision",
+    "outcome_status",
+    "selection_mode",
+})
+
+
+class MixedSourceCancellationError(RuntimeError):
+    """Stop mixed-source work without converting cancellation into source failure."""
+
+    def __init__(self, phase="unknown"):
+        self.phase = str(phase or "unknown").strip().lower() or "unknown"
+        super().__init__(f"Mixed-source execution canceled during {self.phase}.")
+
+
+class MixedSourceFinalizationError(RuntimeError):
+    """Prevent publication when a fresh manifest no longer matches execution evidence."""
+
+    def __init__(self, reason):
+        self.reason = str(reason or "finalization_failed").strip().lower()
+        super().__init__("Mixed-source evidence changed or became unavailable before publication.")
+
+
+def normalize_mixed_source_correlation_id(request_correlation_id=None):
+    """Return an internal UUID correlation value without trusting caller-shaped text."""
+    try:
+        return str(uuid.UUID(str(request_correlation_id or "").strip()))
+    except (TypeError, ValueError, AttributeError):
+        return str(uuid.uuid4())
+
+
+def raise_if_mixed_source_cancelled(
+    cancel_requested,
+    phase,
+    request_correlation_id=None,
+):
+    """Raise the shared cancellation signal when an optional predicate is set."""
+    if cancel_requested is None:
+        return
+    if not callable(cancel_requested):
+        raise TypeError("cancel_requested must be callable")
+    if not cancel_requested():
+        return
+
+    normalized_phase = str(phase or "unknown").strip().lower() or "unknown"
+    log_event(
+        "[MixedSourceLifecycle] Execution canceled.",
+        extra={
+            "request_correlation_id": normalize_mixed_source_correlation_id(
+                request_correlation_id
+            ),
+            "cancellation_phase": normalized_phase,
+        },
+        level=logging.INFO,
+    )
+    raise MixedSourceCancellationError(normalized_phase)
+
+
+def emit_mixed_source_telemetry(
+    settings,
+    event_name,
+    mode,
+    request_correlation_id=None,
+    metrics=None,
+    dimensions=None,
+):
+    """Emit only allowlisted aggregate lifecycle telemetry when explicitly enabled."""
+    if not bool((settings or {}).get("enable_mixed_source_development_telemetry", False)):
+        return False
+
+    normalized_event_name = str(event_name or "").strip().lower()
+    normalized_mode = str(mode or "").strip().lower()
+    if normalized_event_name not in MIXED_SOURCE_TELEMETRY_EVENTS:
+        raise ValueError(f"Unsupported mixed-source telemetry event: {normalized_event_name}")
+    if normalized_mode not in MIXED_SOURCE_MODES:
+        raise ValueError(f"Unsupported mixed-source telemetry mode: {normalized_mode}")
+
+    metrics = metrics if isinstance(metrics, dict) else {}
+    dimensions = dimensions if isinstance(dimensions, dict) else {}
+    unknown_metrics = set(metrics) - MIXED_SOURCE_TELEMETRY_METRICS
+    unknown_dimensions = set(dimensions) - MIXED_SOURCE_TELEMETRY_DIMENSIONS
+    if unknown_metrics or unknown_dimensions:
+        raise ValueError("Mixed-source telemetry contains non-allowlisted fields")
+
+    extra = {
+        "request_correlation_id": normalize_mixed_source_correlation_id(
+            request_correlation_id
+        ),
+        "event_name": normalized_event_name,
+        "mode": normalized_mode,
+    }
+    for field_name, raw_value in metrics.items():
+        if isinstance(raw_value, bool):
+            metric_value = int(raw_value)
+        elif isinstance(raw_value, (int, float)) and math.isfinite(raw_value):
+            metric_value = max(0, raw_value)
+        else:
+            raise ValueError("Mixed-source telemetry metrics must be finite numbers")
+        extra[field_name] = metric_value
+    for field_name, raw_value in dimensions.items():
+        extra[field_name] = _truncate_utf8(
+            str(raw_value or "").strip().lower(),
+            64,
+        )
+
+    log_event(
+        "[MixedSourceTelemetry] Aggregate lifecycle metrics.",
+        extra=extra,
+        level=logging.INFO,
+    )
+    return True
+
+
+def emit_mixed_source_coverage_telemetry(
+    settings,
+    mode,
+    coverage,
+    request_correlation_id=None,
+):
+    """Emit terminal status and source-kind counts derived from the bounded ledger."""
+    coverage = coverage if isinstance(coverage, dict) else {}
+    terminal_ledger = [
+        entry
+        for entry in list(coverage.get("terminal_ledger") or [])
+        if isinstance(entry, dict)
+    ]
+    source_kind_counts = {source_kind: 0 for source_kind in SOURCE_KINDS}
+    for entry in terminal_ledger:
+        source_kind = str(entry.get("source_kind") or "").strip().lower()
+        if source_kind in source_kind_counts:
+            source_kind_counts[source_kind] += 1
+
+    outcome_status = (
+        EVIDENCE_STATUS_PARTIAL
+        if coverage.get("partial_coverage")
+        else EVIDENCE_STATUS_COMPLETED
+    )
+    if coverage.get("successful_source_count", 0) == 0 and coverage.get(
+        "requested_source_count",
+        0,
+    ):
+        outcome_status = EVIDENCE_STATUS_FAILED
+    return emit_mixed_source_telemetry(
+        settings,
+        "terminal_coverage",
+        mode,
+        request_correlation_id=request_correlation_id,
+        metrics={
+            "total_source_count": coverage.get("requested_source_count", 0),
+            "completed_source_count": coverage.get("completed_source_count", 0),
+            "partial_source_count": coverage.get("partial_source_count", 0),
+            "failed_source_count": coverage.get("failed_source_count", 0),
+            "skipped_source_count": coverage.get("skipped_source_count", 0),
+            "successful_source_count": coverage.get("successful_source_count", 0),
+            "tabular_source_count": source_kind_counts[SOURCE_KIND_TABULAR],
+            "narrative_source_count": source_kind_counts[SOURCE_KIND_NARRATIVE],
+            "unsupported_source_count": source_kind_counts[SOURCE_KIND_UNSUPPORTED],
+            "unresolved_source_count": source_kind_counts[SOURCE_KIND_UNRESOLVED],
+            "missing_coverage_violation_count": coverage.get(
+                "missing_coverage_violation_count",
+                0,
+            ),
+            "duplicate_evidence_count": coverage.get("duplicate_evidence_count", 0),
+            "unexpected_evidence_count": coverage.get("unexpected_evidence_count", 0),
+            "evidence_omitted_count": coverage.get("evidence_omitted_count", 0),
+            "partial_failure_count": int(bool(coverage.get("partial_coverage"))),
+        },
+        dimensions={
+            "selection_mode": coverage.get("selection_mode") or "selected",
+            "outcome_status": outcome_status,
+        },
+    )
 
 
 def normalize_selection_mode(selection_mode, default=SELECTION_MODE_SELECTED):
@@ -467,8 +684,18 @@ def resolve_authorized_source_manifest(
     active_public_workspace_ids=None,
     doc_scope="all",
     context_resolver=None,
+    cancel_requested=None,
+    request_correlation_id=None,
 ):
     """Resolve each unique requested ID once into an ordered, authorized manifest."""
+    request_correlation_id = normalize_mixed_source_correlation_id(
+        request_correlation_id
+    )
+    raise_if_mixed_source_cancelled(
+        cancel_requested,
+        "manifest",
+        request_correlation_id=request_correlation_id,
+    )
     normalized_selection_mode = normalize_selection_mode(selection_mode)
     normalized_user_id = str(user_id or "").strip()
     if not normalized_user_id:
@@ -523,6 +750,11 @@ def resolve_authorized_source_manifest(
     resolved_contexts = None
     if context_resolver is None:
         try:
+            raise_if_mixed_source_cancelled(
+                cancel_requested,
+                "manifest",
+                request_correlation_id=request_correlation_id,
+            )
             resolved_contexts = _default_document_context_batch_resolver(
                 document_ids=unique_document_ids,
                 user_id=normalized_user_id,
@@ -531,6 +763,13 @@ def resolve_authorized_source_manifest(
                 active_public_workspace_id=normalized_public_workspace_ids,
                 conversation_id=normalized_conversation_id,
             )
+            raise_if_mixed_source_cancelled(
+                cancel_requested,
+                "manifest",
+                request_correlation_id=request_correlation_id,
+            )
+        except MixedSourceCancellationError:
+            raise
         except Exception:
             resolved_contexts = [None] * len(unique_document_ids)
             resolution_error_count = len(unique_document_ids)
@@ -542,6 +781,11 @@ def resolve_authorized_source_manifest(
             resolution_error_count = len(unique_document_ids)
 
     for document_index, document_id in enumerate(unique_document_ids):
+        raise_if_mixed_source_cancelled(
+            cancel_requested,
+            "manifest",
+            request_correlation_id=request_correlation_id,
+        )
         document_context = None
         if resolved_contexts is not None:
             document_context = resolved_contexts[document_index]
@@ -555,6 +799,13 @@ def resolve_authorized_source_manifest(
                     active_public_workspace_id=normalized_public_workspace_ids,
                     conversation_id=normalized_conversation_id,
                 )
+                raise_if_mixed_source_cancelled(
+                    cancel_requested,
+                    "manifest",
+                    request_correlation_id=request_correlation_id,
+                )
+            except MixedSourceCancellationError:
+                raise
             except Exception:
                 resolution_error_count += 1
         if (
@@ -596,6 +847,7 @@ def resolve_authorized_source_manifest(
             "resolution_error_count": resolution_error_count,
             "scope_distribution": scope_distribution,
             "manifest_resolution_duration_ms": duration_ms,
+            "request_correlation_id": request_correlation_id,
         },
         level=logging.INFO,
     )
@@ -742,6 +994,80 @@ def _bound_json_list(values):
     return bounded_values, was_truncated
 
 
+def deduplicate_mixed_source_references(references, reference_type="citation"):
+    """Deduplicate structured citations or artifacts while preserving first payloads."""
+    normalized_reference_type = str(reference_type or "citation").strip().lower()
+    if normalized_reference_type not in {"citation", "artifact"}:
+        raise ValueError("reference_type must be citation or artifact")
+
+    deduplicated = []
+    seen_keys = set()
+    for reference in list(references or []):
+        if not isinstance(reference, dict):
+            dedupe_key = ("scalar", str(reference))
+        elif normalized_reference_type == "artifact":
+            identity_value = (
+                reference.get("artifact_message_id")
+                or reference.get("document_id")
+                or reference.get("export_run_id")
+            )
+            dedupe_key = (
+                ("artifact_id", str(identity_value).strip())
+                if identity_value
+                else (
+                    "artifact_location",
+                    str(reference.get("file_name") or "").strip(),
+                    str(reference.get("output_format") or "").strip().lower(),
+                    str(reference.get("capability") or "").strip().lower(),
+                )
+            )
+        else:
+            identity_value = (
+                reference.get("artifact_id")
+                or reference.get("citation_id")
+                or reference.get("chunk_id")
+            )
+            plugin_name = str(reference.get("plugin_name") or "").strip()
+            function_name = str(reference.get("function_name") or "").strip()
+            tool_name = str(reference.get("tool_name") or "").strip()
+            if identity_value:
+                dedupe_key = ("citation_id", str(identity_value).strip())
+            elif plugin_name or function_name or tool_name:
+                tool_arguments = (
+                    reference.get("function_arguments")
+                    if reference.get("function_arguments") is not None
+                    else reference.get("parameters")
+                )
+                dedupe_key = (
+                    "tool_citation",
+                    plugin_name,
+                    function_name,
+                    tool_name,
+                    json.dumps(
+                        tool_arguments,
+                        allow_nan=False,
+                        default=str,
+                        ensure_ascii=False,
+                        separators=(",", ":"),
+                        sort_keys=True,
+                    ),
+                )
+            else:
+                dedupe_key = (
+                    "citation_location",
+                    str(reference.get("document_id") or "").strip(),
+                    str(reference.get("file_name") or "").strip(),
+                    str(reference.get("page_number") or "").strip(),
+                    str(reference.get("chunk_sequence") or "").strip(),
+                    str(reference.get("sheet_name") or "").strip(),
+                )
+        if dedupe_key in seen_keys:
+            continue
+        seen_keys.add(dedupe_key)
+        deduplicated.append(reference)
+    return deduplicated
+
+
 def _build_truncated_coverage(coverage, coverage_was_truncated=False):
     normalized_coverage = dict(coverage or {})
     normalized_coverage["evidence_envelope_truncated"] = True
@@ -793,8 +1119,12 @@ def build_evidence_envelope(
         raise ValueError("coverage must be a dictionary")
 
     bounded_evidence, evidence_was_truncated = _bound_json_list(evidence)
-    bounded_citations, citations_were_truncated = _bound_json_list(citations)
-    bounded_artifacts, artifacts_were_truncated = _bound_json_list(generated_artifacts)
+    bounded_citations, citations_were_truncated = _bound_json_list(
+        deduplicate_mixed_source_references(citations, reference_type="citation")
+    )
+    bounded_artifacts, artifacts_were_truncated = _bound_json_list(
+        deduplicate_mixed_source_references(generated_artifacts, reference_type="artifact")
+    )
     normalized_summary = _truncate_utf8(summary, EVIDENCE_SUMMARY_MAX_BYTES)
     normalized_error = (
         _truncate_utf8(error, EVIDENCE_ERROR_MAX_BYTES)
@@ -974,16 +1304,57 @@ def build_narrative_evidence_envelopes(
     return envelopes
 
 
+def build_failed_narrative_evidence_envelopes(
+    narrative_sources,
+    selection_mode,
+    reason="narrative_retrieval_failed",
+):
+    """Build one scrubbed terminal failure for every narrative source in a failed cohort."""
+    normalized_selection_mode = normalize_selection_mode(
+        selection_mode,
+        default=SELECTION_MODE_RELEVANCE,
+    )
+    normalized_reason = _truncate_utf8(
+        str(reason or "narrative_retrieval_failed").strip().lower(),
+        MIXED_SOURCE_TERMINAL_REASON_MAX_BYTES,
+    )
+    envelopes = []
+    for source in list(narrative_sources or []):
+        source = source if isinstance(source, dict) else {}
+        document_id = str(source.get("document_id") or "").strip()
+        if not document_id:
+            continue
+        envelopes.append(build_evidence_envelope(
+            document_id=document_id,
+            source_kind=SOURCE_KIND_NARRATIVE,
+            engine=EVIDENCE_ENGINE_HYBRID_SEARCH,
+            status=EVIDENCE_STATUS_FAILED,
+            summary="Narrative evidence could not be retrieved for this source.",
+            coverage={
+                "selection_mode": normalized_selection_mode,
+                "terminal": True,
+                "reason": normalized_reason,
+            },
+            error="Narrative retrieval could not be completed.",
+        ))
+    return envelopes
+
+
 def execute_tabular_evidence_sources(
     tabular_sources,
     execute_source,
     selection_mode,
     execute=True,
+    cancel_requested=None,
+    request_correlation_id=None,
 ):
     """Execute the existing tabular runner once per source and require terminal coverage."""
     normalized_selection_mode = normalize_selection_mode(
         selection_mode,
         default=SELECTION_MODE_RELEVANCE,
+    )
+    request_correlation_id = normalize_mixed_source_correlation_id(
+        request_correlation_id
     )
     if execute and not callable(execute_source):
         raise TypeError("execute_source must be callable")
@@ -993,6 +1364,11 @@ def execute_tabular_evidence_sources(
     failed_count = 0
     skipped_count = 0
     for raw_source in list(tabular_sources or []):
+        raise_if_mixed_source_cancelled(
+            cancel_requested,
+            "tabular",
+            request_correlation_id=request_correlation_id,
+        )
         source = raw_source if isinstance(raw_source, dict) else {}
         document_id = str(source.get("document_id") or "").strip()
         if not document_id:
@@ -1016,6 +1392,11 @@ def execute_tabular_evidence_sources(
 
         try:
             raw_result = execute_source(source)
+            raise_if_mixed_source_cancelled(
+                cancel_requested,
+                "tabular",
+                request_correlation_id=request_correlation_id,
+            )
             result = raw_result if isinstance(raw_result, dict) else {}
             summary = str(result.get("summary") or "").strip()
             if not summary:
@@ -1036,6 +1417,8 @@ def execute_tabular_evidence_sources(
                     **dict(result.get("coverage") or {}),
                 },
             ))
+        except MixedSourceCancellationError:
+            raise
         except Exception:
             failed_count += 1
             envelopes.append(build_evidence_envelope(
@@ -1059,16 +1442,269 @@ def execute_tabular_evidence_sources(
             "tabular_completed_count": completed_count,
             "tabular_failed_count": failed_count,
             "tabular_skipped_count": skipped_count,
+            "request_correlation_id": request_correlation_id,
         },
         level=logging.INFO,
     )
     return envelopes
 
 
+def _get_terminal_reason(status, source, envelope=None):
+    """Return one bounded, non-sensitive reason for a terminal non-success state."""
+    envelope = envelope if isinstance(envelope, dict) else {}
+    coverage = envelope.get("coverage") if isinstance(envelope.get("coverage"), dict) else {}
+    explicit_reason = str(coverage.get("reason") or "").strip().lower()
+    if explicit_reason:
+        return _truncate_utf8(explicit_reason, MIXED_SOURCE_TERMINAL_REASON_MAX_BYTES)
+    if source.get("authorization_status") != AUTHORIZATION_STATUS_AUTHORIZED:
+        return "source_unavailable"
+    if source.get("source_kind") == SOURCE_KIND_UNSUPPORTED:
+        return "unsupported_source"
+    if status == EVIDENCE_STATUS_SKIPPED:
+        return "bounded_policy_skip"
+    if status == EVIDENCE_STATUS_PARTIAL:
+        return "incomplete_native_coverage"
+    if status == EVIDENCE_STATUS_FAILED:
+        return "native_execution_failed"
+    return None
+
+
+def build_terminal_coverage_ledger(
+    manifest,
+    evidence_envelopes,
+    max_handoff_envelopes=MIXED_SOURCE_HANDOFF_MAX_ENVELOPES,
+):
+    """Align exactly one terminal state and bounded evidence item to each manifest source."""
+    manifest_entries = [entry for entry in list(manifest or []) if isinstance(entry, dict)]
+    raw_envelopes = [
+        envelope
+        for envelope in list(evidence_envelopes or [])
+        if isinstance(envelope, dict)
+    ]
+    manifest_document_ids = {
+        str(entry.get("document_id") or "").strip()
+        for entry in manifest_entries
+        if str(entry.get("document_id") or "").strip()
+    }
+    envelopes_by_document_id = {}
+    unexpected_evidence_count = 0
+    for envelope in raw_envelopes:
+        document_id = str(envelope.get("document_id") or "").strip()
+        if not document_id or document_id not in manifest_document_ids:
+            unexpected_evidence_count += 1
+            continue
+        envelopes_by_document_id.setdefault(document_id, []).append(envelope)
+
+    ledger_entries = []
+    aligned_envelopes = []
+    status_counts = {status: 0 for status in EVIDENCE_STATUSES}
+    missing_coverage_violation_count = 0
+    duplicate_evidence_count = 0
+    evidence_omitted_count = 0
+
+    for request_order, source in enumerate(manifest_entries):
+        document_id = str(source.get("document_id") or "").strip()
+        source_kind = str(source.get("source_kind") or SOURCE_KIND_UNRESOLVED).strip().lower()
+        source_envelopes = envelopes_by_document_id.get(document_id, [])
+        envelope = source_envelopes[0] if len(source_envelopes) == 1 else None
+        reason = None
+
+        if len(source_envelopes) > 1:
+            status = EVIDENCE_STATUS_FAILED
+            reason = "duplicate_terminal_evidence"
+            duplicate_evidence_count += len(source_envelopes) - 1
+            missing_coverage_violation_count += 1
+        elif source.get("authorization_status") != AUTHORIZATION_STATUS_AUTHORIZED:
+            status = EVIDENCE_STATUS_FAILED
+            reason = "source_unavailable"
+        elif source_kind == SOURCE_KIND_UNSUPPORTED:
+            status = EVIDENCE_STATUS_SKIPPED
+            reason = "unsupported_source"
+        elif envelope is None:
+            status = EVIDENCE_STATUS_FAILED
+            reason = "missing_terminal_evidence"
+            missing_coverage_violation_count += 1
+        elif str(envelope.get("source_kind") or "").strip().lower() != source_kind:
+            status = EVIDENCE_STATUS_FAILED
+            reason = "evidence_identity_mismatch"
+            missing_coverage_violation_count += 1
+            envelope = None
+        else:
+            status = str(envelope.get("status") or "").strip().lower()
+            if status not in EVIDENCE_STATUSES:
+                status = EVIDENCE_STATUS_FAILED
+                reason = "invalid_terminal_status"
+                missing_coverage_violation_count += 1
+                envelope = None
+            else:
+                reason = _get_terminal_reason(status, source, envelope=envelope)
+
+        status_counts[status] += 1
+        handoff_included = False
+        if envelope is not None:
+            if len(aligned_envelopes) < max(0, int(max_handoff_envelopes)):
+                aligned_envelopes.append(envelope)
+                handoff_included = True
+            else:
+                evidence_omitted_count += 1
+
+        source_role = str(
+            source.get("comparison_role")
+            or source.get("source_role")
+            or source.get("role")
+            or "selected"
+        ).strip().lower() or "selected"
+        ledger_entry = {
+            "document_id": document_id,
+            "scope": source.get("scope"),
+            "scope_id": source.get("scope_id"),
+            "source_version": source.get("source_version"),
+            "source_kind": source_kind,
+            "role": source_role,
+            "request_order": request_order,
+            "status": status,
+            "reason": reason,
+            "handoff_included": handoff_included,
+        }
+        ledger_entries.append(ledger_entry)
+
+    partial_coverage = bool(
+        status_counts[EVIDENCE_STATUS_PARTIAL]
+        or status_counts[EVIDENCE_STATUS_FAILED]
+        or status_counts[EVIDENCE_STATUS_SKIPPED]
+        or missing_coverage_violation_count
+        or duplicate_evidence_count
+        or unexpected_evidence_count
+        or evidence_omitted_count
+    )
+    return {
+        "entries": ledger_entries,
+        "evidence_envelopes": aligned_envelopes,
+        "requested_source_count": len(manifest_entries),
+        "completed_source_count": status_counts[EVIDENCE_STATUS_COMPLETED],
+        "partial_source_count": status_counts[EVIDENCE_STATUS_PARTIAL],
+        "failed_source_count": status_counts[EVIDENCE_STATUS_FAILED],
+        "skipped_source_count": status_counts[EVIDENCE_STATUS_SKIPPED],
+        "successful_source_count": (
+            status_counts[EVIDENCE_STATUS_COMPLETED]
+            + status_counts[EVIDENCE_STATUS_PARTIAL]
+        ),
+        "missing_coverage_violation_count": missing_coverage_violation_count,
+        "duplicate_evidence_count": duplicate_evidence_count,
+        "unexpected_evidence_count": unexpected_evidence_count,
+        "evidence_omitted_count": evidence_omitted_count,
+        "partial_coverage": partial_coverage,
+    }
+
+
+def evaluate_mixed_source_mode_outcome(mode, coverage_ledger):
+    """Apply the Phase 6 terminal failure policy to one aggregate-only ledger."""
+    normalized_mode = str(mode or "").strip().lower()
+    if normalized_mode not in MIXED_SOURCE_MODES:
+        raise ValueError(f"Unsupported mixed-source mode: {normalized_mode}")
+
+    coverage_ledger = coverage_ledger if isinstance(coverage_ledger, dict) else {}
+    entries = [
+        entry
+        for entry in list(coverage_ledger.get("entries") or [])
+        if isinstance(entry, dict)
+    ]
+    successful_statuses = {EVIDENCE_STATUS_COMPLETED, EVIDENCE_STATUS_PARTIAL}
+    successful_source_count = sum(
+        str(entry.get("status") or "").strip().lower() in successful_statuses
+        for entry in entries
+    )
+    partial_coverage = bool(coverage_ledger.get("partial_coverage"))
+    should_reduce = successful_source_count > 0
+    reason = None
+
+    if normalized_mode == "compare":
+        source_entry = next(
+            (
+                entry
+                for entry in entries
+                if str(entry.get("role") or "").strip().lower() in {"left", "source"}
+            ),
+            entries[0] if entries else None,
+        )
+        source_succeeded = bool(
+            source_entry
+            and str(source_entry.get("status") or "").strip().lower() in successful_statuses
+        )
+        target_entries = [entry for entry in entries if entry is not source_entry]
+        successful_target_count = sum(
+            str(entry.get("status") or "").strip().lower() in successful_statuses
+            for entry in target_entries
+        )
+        should_reduce = source_succeeded and successful_target_count > 0
+        if not source_succeeded:
+            reason = "source_preparation_failed"
+        elif not successful_target_count:
+            reason = "no_target_prepared"
+        partial_coverage = partial_coverage or successful_target_count < len(target_entries)
+
+    if not should_reduce:
+        status = EVIDENCE_STATUS_FAILED
+        reason = reason or "no_successful_source"
+    elif partial_coverage:
+        status = EVIDENCE_STATUS_PARTIAL
+    else:
+        status = EVIDENCE_STATUS_COMPLETED
+
+    return {
+        "mode": normalized_mode,
+        "status": status,
+        "should_reduce": should_reduce,
+        "successful_source_count": successful_source_count,
+        "partial_coverage": partial_coverage,
+        "reason": reason,
+    }
+
+
+def compare_reauthorized_source_manifests(execution_manifest, fresh_manifest):
+    """Return aggregate canonical-identity and version differences for authorized sources."""
+    fresh_by_document_id = {
+        str(source.get("document_id") or "").strip(): source
+        for source in list(fresh_manifest or [])
+        if isinstance(source, dict) and str(source.get("document_id") or "").strip()
+    }
+    authorization_failure_count = 0
+    source_version_changed_count = 0
+    for source in list(execution_manifest or []):
+        if (
+            not isinstance(source, dict)
+            or source.get("authorization_status") != AUTHORIZATION_STATUS_AUTHORIZED
+        ):
+            continue
+        document_id = str(source.get("document_id") or "").strip()
+        fresh_source = fresh_by_document_id.get(document_id) or {}
+        same_canonical_identity = (
+            fresh_source.get("authorization_status") == AUTHORIZATION_STATUS_AUTHORIZED
+            and str(fresh_source.get("scope") or "").strip().lower()
+            == str(source.get("scope") or "").strip().lower()
+            and str(fresh_source.get("scope_id") or "").strip()
+            == str(source.get("scope_id") or "").strip()
+        )
+        if not same_canonical_identity:
+            authorization_failure_count += 1
+            continue
+        prior_version = source.get("source_version")
+        fresh_version = fresh_source.get("source_version")
+        if prior_version != fresh_version:
+            source_version_changed_count += 1
+    return {
+        "authorization_failure_count": authorization_failure_count,
+        "source_version_changed_count": source_version_changed_count,
+    }
+
+
 def build_mixed_source_evidence_handoff(
     manifest,
     evidence_envelopes,
     selection_mode,
+    mode=None,
+    telemetry_settings=None,
+    request_correlation_id=None,
 ):
     """Build one bounded synthesis handoff from Phase 1 evidence envelopes."""
     normalized_selection_mode = normalize_selection_mode(
@@ -1076,69 +1712,51 @@ def build_mixed_source_evidence_handoff(
         default=SELECTION_MODE_RELEVANCE,
     )
     manifest_entries = [entry for entry in list(manifest or []) if isinstance(entry, dict)]
-    all_envelopes = [
-        envelope
-        for envelope in list(evidence_envelopes or [])
-        if isinstance(envelope, dict)
-    ]
-    envelopes = all_envelopes[:MIXED_SOURCE_HANDOFF_MAX_ENVELOPES]
-    envelope_by_document_id = {
-        str(envelope.get("document_id") or "").strip(): envelope
-        for envelope in all_envelopes
-        if str(envelope.get("document_id") or "").strip()
-    }
-    evidence_omitted_count = max(0, len(all_envelopes) - len(envelopes))
-
+    ledger = build_terminal_coverage_ledger(manifest_entries, evidence_envelopes)
+    envelopes = list(ledger["evidence_envelopes"])
     source_coverage = []
-    failed_count = 0
-    partial_count = 0
-    skipped_count = 0
-    completed_count = 0
-    for source_index, entry in enumerate(manifest_entries, start=1):
-        document_id = str(entry.get("document_id") or "").strip()
-        envelope = envelope_by_document_id.get(document_id)
+    for source_index, (entry, ledger_entry) in enumerate(
+        zip(manifest_entries, ledger["entries"]),
+        start=1,
+    ):
         if entry.get("authorization_status") != AUTHORIZATION_STATUS_AUTHORIZED:
-            status = EVIDENCE_STATUS_FAILED
             source_label = f"Unavailable selected source {source_index}"
         elif entry.get("source_kind") == SOURCE_KIND_UNSUPPORTED:
-            status = EVIDENCE_STATUS_FAILED
             source_label = str(entry.get("display_name") or f"Unsupported source {source_index}")
-        elif envelope:
-            status = envelope.get("status") or EVIDENCE_STATUS_FAILED
-            source_label = str(entry.get("display_name") or f"Source {source_index}")
         else:
-            status = EVIDENCE_STATUS_FAILED
             source_label = str(entry.get("display_name") or f"Source {source_index}")
-
-        if status == EVIDENCE_STATUS_COMPLETED:
-            completed_count += 1
-        elif status == EVIDENCE_STATUS_PARTIAL:
-            partial_count += 1
-        elif status == EVIDENCE_STATUS_SKIPPED:
-            skipped_count += 1
-        else:
-            failed_count += 1
         source_coverage.append({
             "source": _truncate_utf8(source_label, 128),
-            "source_kind": entry.get("source_kind"),
-            "status": status,
+            "source_kind": ledger_entry.get("source_kind"),
+            "status": ledger_entry.get("status"),
+            "reason": ledger_entry.get("reason"),
         })
 
     coverage = {
         "selection_mode": normalized_selection_mode,
-        "requested_source_count": len(manifest_entries),
-        "completed_source_count": completed_count,
-        "partial_source_count": partial_count,
-        "failed_source_count": failed_count,
-        "skipped_source_count": skipped_count,
-        "partial_coverage": bool(
-            failed_count or partial_count or evidence_omitted_count
-        ),
-        "evidence_omitted_count": evidence_omitted_count,
+        **{
+            key: value
+            for key, value in ledger.items()
+            if key not in {"entries", "evidence_envelopes"}
+        },
         "sources": source_coverage,
+        "terminal_ledger": ledger["entries"],
     }
+    prompt_terminal_ledger = []
+    for entry, ledger_entry in zip(manifest_entries, ledger["entries"]):
+        prompt_entry = dict(ledger_entry)
+        if entry.get("authorization_status") != AUTHORIZATION_STATUS_AUTHORIZED:
+            prompt_entry.update({
+                "document_id": None,
+                "scope": None,
+                "scope_id": None,
+                "source_version": None,
+            })
+        prompt_terminal_ledger.append(prompt_entry)
+    prompt_coverage = dict(coverage)
+    prompt_coverage["terminal_ledger"] = prompt_terminal_ledger
     payload = {
-        "coverage": coverage,
+        "coverage": prompt_coverage,
         "evidence_envelopes": envelopes,
     }
     serialized_payload = json.dumps(
@@ -1167,6 +1785,9 @@ def build_mixed_source_evidence_handoff(
         payload["coverage"]["handoff_compacted"] = True
         payload["coverage"]["partial_coverage"] = True
         payload["coverage"]["evidence_compacted_count"] = len(envelopes)
+        coverage["handoff_compacted"] = True
+        coverage["partial_coverage"] = True
+        coverage["evidence_compacted_count"] = len(envelopes)
         serialized_payload = json.dumps(
             payload,
             allow_nan=False,
@@ -1181,6 +1802,13 @@ def build_mixed_source_evidence_handoff(
         if coverage["partial_coverage"]
         else "Do not claim that selected sources were omitted."
     )
+    if mode:
+        emit_mixed_source_coverage_telemetry(
+            telemetry_settings,
+            mode,
+            coverage,
+            request_correlation_id=request_correlation_id,
+        )
     return {
         "role": "system",
         "content": (
@@ -1192,4 +1820,5 @@ def build_mixed_source_evidence_handoff(
             f"{partial_coverage_instruction}\n\n{serialized_payload}"
         ),
         "mixed_source_coverage": coverage,
+        "evidence_envelopes": list(payload["evidence_envelopes"]),
     }

--- a/application/single_app/functions_search.py
+++ b/application/single_app/functions_search.py
@@ -22,7 +22,7 @@ from functions_service_health import (
 logger = logging.getLogger(__name__)
 
 
-SEARCH_DEFAULT_TOP_N = 12
+SEARCH_DEFAULT_TOP_N = 25
 SEARCH_MAX_TOP_N = 500
 VALID_SEARCH_SCOPES = {"all", "personal", "group", "public"}
 BASE_SEARCH_SELECT_FIELDS = [
@@ -259,7 +259,7 @@ def _build_odata_any_eq(collection_field: str, iterator_name: str, value: Any) -
     escaped_value = _escape_odata_literal(value)
     return f"{collection_field}/any({iterator_name}: {iterator_name} eq '{escaped_value}')"
 
-def hybrid_search(query, user_id, document_id=None, document_ids=None, top_n=12, doc_scope="all", active_group_id=None, active_group_ids=None, active_public_workspace_id=None, enable_file_sharing=True, tags_filter=None, document_filter_mode="intersection", enforce_public_workspace_visibility=True):
+def hybrid_search(query, user_id, document_id=None, document_ids=None, top_n=25, doc_scope="all", active_group_id=None, active_group_ids=None, active_public_workspace_id=None, enable_file_sharing=True, tags_filter=None, document_filter_mode="intersection", enforce_public_workspace_visibility=True):
     """
     Hybrid search that queries the user doc index, group doc index, or public doc index
     depending on doc type.

--- a/application/single_app/functions_settings.py
+++ b/application/single_app/functions_settings.py
@@ -215,6 +215,11 @@ def is_mixed_source_manifest_enabled(settings):
     return bool((settings or {}).get('enable_mixed_source_manifest', False))
 
 
+def is_mixed_source_development_telemetry_enabled(settings):
+    """Return whether aggregate-only mixed-source development telemetry is enabled."""
+    return bool((settings or {}).get('enable_mixed_source_development_telemetry', False))
+
+
 def is_mixed_source_chat_search_enabled(settings):
     """Return whether Phase 2 mixed-source Chat and Search behavior is enabled."""
     return bool((settings or {}).get('enable_mixed_source_chat_search', False))
@@ -811,6 +816,7 @@ def get_settings(use_cosmos=False, include_source=False):
         'enable_fact_memory_plugin': True,
         'enable_tabular_processing_plugin': False,
         'enable_multi_agent_orchestration': False,
+        'enable_mixed_source_development_telemetry': False,
         'enable_mixed_source_manifest': False,
         'enable_mixed_source_chat_search': False,
         'enable_mixed_source_relevance_candidates': False,

--- a/application/single_app/functions_simplechat_operations.py
+++ b/application/single_app/functions_simplechat_operations.py
@@ -610,6 +610,70 @@ def upload_generated_analysis_artifact_for_current_user(
     )
 
 
+def delete_generated_chat_artifact_for_current_user(
+    conversation_id: str,
+    artifact_message_id: str,
+) -> bool:
+    """Delete one generated artifact after reauthorizing its conversation and stored identity."""
+    current_user_info = _require_current_user_info()
+    current_user_id = str(current_user_info.get("userId") or "").strip()
+    return delete_generated_chat_artifact_for_user(
+        current_user_id,
+        conversation_id,
+        artifact_message_id,
+    )
+
+
+def delete_generated_chat_artifact_for_user(
+    current_user_id: str,
+    conversation_id: str,
+    artifact_message_id: str,
+) -> bool:
+    """Delete one generated artifact for a known user after object-level authorization."""
+    current_user_id = str(current_user_id or "").strip()
+    normalized_conversation_id = str(conversation_id or "").strip()
+    normalized_message_id = str(artifact_message_id or "").strip()
+    if not current_user_id or not normalized_conversation_id or not normalized_message_id:
+        return False
+
+    try:
+        conversation_item = cosmos_conversations_container.read_item(
+            item=normalized_conversation_id,
+            partition_key=normalized_conversation_id,
+        )
+        message_item = cosmos_messages_container.read_item(
+            item=normalized_message_id,
+            partition_key=normalized_conversation_id,
+        )
+    except CosmosResourceNotFoundError:
+        return False
+
+    if str(conversation_item.get("user_id") or "").strip() != current_user_id:
+        raise PermissionError("Forbidden")
+    message_metadata = message_item.get("metadata") if isinstance(message_item.get("metadata"), dict) else {}
+    if (
+        str(message_item.get("conversation_id") or "").strip() != normalized_conversation_id
+        or message_item.get("role") != "file"
+        or not message_metadata.get("is_generated_chat_artifact")
+    ):
+        raise PermissionError("Forbidden")
+
+    delete_blob_backed_chat_message_files([message_item])
+    cosmos_messages_container.delete_item(
+        item=normalized_message_id,
+        partition_key=normalized_conversation_id,
+    )
+    log_event(
+        "[SimpleChat] Generated chat artifact rolled back after cancellation",
+        {
+            "artifact_count": 1,
+            "rollback_reason": "cancellation",
+        },
+        debug_only=True,
+    )
+    return True
+
+
 def upload_generated_analysis_artifact_for_user(
     current_user_id: str,
     conversation_id: str,

--- a/application/single_app/functions_tabular_analysis.py
+++ b/application/single_app/functions_tabular_analysis.py
@@ -2,10 +2,10 @@
 """
 Reusable tabular analysis helpers for chat and workflow execution.
 
-This module is the non-route import surface for tabular analysis behavior that
-is still implemented in route_backend_chats.py. Keeping workflow code pointed at
-this module lets the implementation move out of the chat route incrementally
-without changing workflow callers again.
+This module owns extracted tabular coordination helpers and provides the
+non-route import surface for behavior still implemented in
+route_backend_chats.py. Keeping workflow code pointed here lets the remaining
+implementation move incrementally without changing workflow callers again.
 """
 
 
@@ -16,7 +16,6 @@ def _load_chat_helper(helper_name):
         augment_tabular_invocations_with_related_document_evidence,
         build_tabular_computed_results_system_message,
         build_tabular_related_document_evidence_summary,
-        get_new_plugin_invocations,
         maybe_create_tabular_generated_output,
         run_tabular_analysis_with_thought_tracking,
     )
@@ -26,7 +25,6 @@ def _load_chat_helper(helper_name):
         'augment_tabular_invocations_with_related_document_evidence': augment_tabular_invocations_with_related_document_evidence,
         'build_tabular_computed_results_system_message': build_tabular_computed_results_system_message,
         'build_tabular_related_document_evidence_summary': build_tabular_related_document_evidence_summary,
-        'get_new_plugin_invocations': get_new_plugin_invocations,
         'maybe_create_tabular_generated_output': maybe_create_tabular_generated_output,
         'run_tabular_analysis_with_thought_tracking': run_tabular_analysis_with_thought_tracking,
     }
@@ -49,8 +47,18 @@ def build_tabular_related_document_evidence_summary(*args, **kwargs):
     return _load_chat_helper('build_tabular_related_document_evidence_summary')(*args, **kwargs)
 
 
-def get_new_plugin_invocations(*args, **kwargs):
-    return _load_chat_helper('get_new_plugin_invocations')(*args, **kwargs)
+def get_new_plugin_invocations(invocations, baseline_count):
+    """Return only the plugin invocations created after the baseline count."""
+    if not invocations:
+        return []
+
+    if baseline_count <= 0:
+        return list(invocations)
+
+    if baseline_count >= len(invocations):
+        return []
+
+    return list(invocations[baseline_count:])
 
 
 async def maybe_create_tabular_generated_output(*args, **kwargs):

--- a/application/single_app/functions_tabular_generated_exports.py
+++ b/application/single_app/functions_tabular_generated_exports.py
@@ -66,8 +66,9 @@ TABULAR_EXPORT_DEFAULT_LEASE_SECONDS = 300
 TABULAR_EXPORT_DEFAULT_STALE_SECONDS = 420
 TABULAR_EXPORT_DEFAULT_SCAN_LIMIT = 5
 TABULAR_EXPORT_DEFAULT_MAX_TRANSIENT_FAILURES = 20
-TABULAR_EXPORT_DEFAULT_BATCH_CONCURRENCY = 2
+TABULAR_EXPORT_DEFAULT_BATCH_CONCURRENCY = 3
 TABULAR_EXPORT_MAX_BATCH_CONCURRENCY = 5
+TABULAR_EXPORT_DEFAULT_BATCH_TIMEOUT_SECONDS = 300
 TABULAR_EXPORT_FINAL_SPOOL_MAX_MEMORY_BYTES = 1024 * 1024
 TABULAR_EXPORT_DEFAULT_SOURCE_CHUNK_ROWS = 1000
 TABULAR_EXPORT_DEFAULT_SOURCE_BATCH_ROWS = 50
@@ -1051,6 +1052,7 @@ async def _generate_batch_entries(
     retry_attempts,
     run_id,
     expected_output_schema=None,
+    batch_timeout_seconds=TABULAR_EXPORT_DEFAULT_BATCH_TIMEOUT_SECONDS,
 ):
     batch_number = batch_index + 1
     batch_prompt = _build_batch_prompt(
@@ -1067,6 +1069,13 @@ async def _generate_batch_entries(
     raw_response_content = ''
     mismatch_count = 0
     last_validation_error = None
+    timeout_seconds = max(
+        _safe_float(
+            batch_timeout_seconds,
+            default=TABULAR_EXPORT_DEFAULT_BATCH_TIMEOUT_SECONDS,
+        ),
+        0.001,
+    )
     for attempt_number in range(1, retry_attempts + 1):
         chat_history = SKChatHistory()
         chat_history.add_system_message(
@@ -1082,7 +1091,16 @@ async def _generate_batch_entries(
         chat_history.add_user_message(batch_prompt)
 
         execution_settings = AzureChatPromptExecutionSettings(service_id='tabular-generated-output-background')
-        result = await chat_service.get_chat_message_contents(chat_history, execution_settings)
+        try:
+            result = await asyncio.wait_for(
+                chat_service.get_chat_message_contents(chat_history, execution_settings),
+                timeout=timeout_seconds,
+            )
+        except asyncio.TimeoutError as exc:
+            raise TimeoutError(
+                f'Background structured export batch {batch_number}/{total_batches} '
+                f'timed out after {timeout_seconds:g} seconds.'
+            ) from exc
         raw_response_content = result[0].content if result and result[0].content else ''
         parsed_entries = _parse_generated_json_entries(raw_response_content) if raw_response_content else None
         parsed_entry_count = len(parsed_entries) if parsed_entries is not None else 0
@@ -1134,6 +1152,7 @@ async def _generate_batch_entries_for_window(
     retry_attempts,
     run_id,
     expected_output_schema,
+    batch_timeout_seconds,
 ):
     async with semaphore:
         batch_started_at = time.monotonic()
@@ -1148,6 +1167,7 @@ async def _generate_batch_entries_for_window(
             retry_attempts,
             run_id,
             expected_output_schema=expected_output_schema,
+            batch_timeout_seconds=batch_timeout_seconds,
         )
         return {
             'batch_number': batch_request['batch_number'],
@@ -1171,6 +1191,7 @@ async def _generate_batch_window_entries(
     run_id,
     batch_concurrency,
     expected_output_schema=None,
+    batch_timeout_seconds=TABULAR_EXPORT_DEFAULT_BATCH_TIMEOUT_SECONDS,
 ):
     semaphore = asyncio.Semaphore(max(1, batch_concurrency))
     tasks = [
@@ -1185,6 +1206,7 @@ async def _generate_batch_window_entries(
             retry_attempts,
             run_id,
             expected_output_schema,
+            batch_timeout_seconds,
         )
         for batch_request in batch_requests
     ]
@@ -2545,6 +2567,22 @@ def process_tabular_generated_output_run(run_id, user_id):
             minimum=1,
             maximum=TABULAR_EXPORT_MAX_BATCH_CONCURRENCY,
         )
+        stale_seconds = _settings_int(
+            settings,
+            'tabular_generated_output_stale_seconds',
+            TABULAR_EXPORT_DEFAULT_STALE_SECONDS,
+            minimum=60,
+        )
+        batch_timeout_seconds = min(
+            _settings_int(
+                settings,
+                'tabular_generated_output_batch_timeout_seconds',
+                TABULAR_EXPORT_DEFAULT_BATCH_TIMEOUT_SECONDS,
+                minimum=30,
+                maximum=900,
+            ),
+            max(30, stale_seconds - 30),
+        )
         chat_service = None
         if not run.get('passthrough_input_rows'):
             chat_service = _build_chat_service(
@@ -2575,6 +2613,7 @@ def process_tabular_generated_output_run(run_id, user_id):
                 'batch_count': batch_count,
                 'resume_completed_batches': completed_batches,
                 'batch_concurrency': batch_concurrency,
+                'batch_timeout_seconds': batch_timeout_seconds,
             },
             level=logging.INFO,
         )
@@ -2607,6 +2646,7 @@ def process_tabular_generated_output_run(run_id, user_id):
                         'window_end': window_end,
                         'batch_count': batch_count,
                         'batch_concurrency': batch_concurrency,
+                        'batch_timeout_seconds': batch_timeout_seconds,
                         'generation_request_count': len(batch_requests),
                     },
                     debug_only=True,
@@ -2626,6 +2666,7 @@ def process_tabular_generated_output_run(run_id, user_id):
                             normalized_run_id,
                             batch_concurrency,
                             expected_output_schema=run.get('output_schema'),
+                            batch_timeout_seconds=batch_timeout_seconds,
                         )
                     )
                 _raise_if_tabular_export_canceled(run)

--- a/application/single_app/functions_workflow_runner.py
+++ b/application/single_app/functions_workflow_runner.py
@@ -10,6 +10,7 @@ import json
 import logging
 import os
 import re
+import time
 import uuid
 from contextlib import contextmanager
 from datetime import datetime, timezone
@@ -53,6 +54,7 @@ from functions_collaboration import (
 from functions_document_actions import (
     DOCUMENT_ACTION_ANALYSIS_MODE_PER_DOCUMENT,
     DOCUMENT_ACTION_CONTEXT_WORKFLOW,
+    DOCUMENT_ACTION_TARGET_MODE_ALL,
     DOCUMENT_ACTION_TARGET_MODE_RECENT,
     DOCUMENT_ACTION_TYPE_COMPARISON,
     DOCUMENT_ACTION_TYPE_ANALYZE,
@@ -67,6 +69,12 @@ from functions_document_actions import (
     normalize_document_action_analysis_mode,
 )
 from functions_documents import select_current_documents, sort_documents
+from functions_document_access_index import (
+    DOCUMENT_ACCESS_SCOPE_GROUP,
+    DOCUMENT_ACCESS_SCOPE_PERSONAL,
+    DOCUMENT_ACCESS_SCOPE_PUBLIC,
+    enumerate_bounded_document_access_index_ids,
+)
 from functions_document_comparison import run_document_comparison, run_evidence_document_comparison
 from functions_debug import debug_print
 from functions_document_analysis import run_document_analysis
@@ -84,12 +92,21 @@ from functions_mixed_source_orchestration import (
     EVIDENCE_ENGINE_TABULAR_TOOLS,
     EVIDENCE_STATUS_COMPLETED,
     EVIDENCE_STATUS_FAILED,
+    MixedSourceCancellationError,
+    MixedSourceFinalizationError,
     SELECTION_MODE_SELECTED,
     build_evidence_envelope,
+    build_failed_narrative_evidence_envelopes,
     build_mixed_source_evidence_handoff,
+    compare_reauthorized_source_manifests,
+    evaluate_mixed_source_mode_outcome,
     build_narrative_evidence_envelopes,
+    deduplicate_mixed_source_references,
+    emit_mixed_source_telemetry,
     partition_source_manifest,
+    normalize_mixed_source_correlation_id,
     resolve_authorized_source_manifest,
+    raise_if_mixed_source_cancelled,
 )
 from model_endpoint_clients import (
     MODEL_ENDPOINT_PROTOCOL_AZURE_OPENAI,
@@ -104,7 +121,11 @@ from functions_search_service import (
     search_relevant_tabular_candidates,
 )
 from functions_search import normalize_search_id_list, normalize_search_scope, normalize_search_top_n
-from functions_simplechat_operations import upload_generated_analysis_artifact_for_current_user
+from functions_simplechat_operations import (
+    delete_generated_chat_artifact_for_current_user,
+    delete_generated_chat_artifact_for_user,
+    upload_generated_analysis_artifact_for_current_user,
+)
 from functions_settings import (
     get_settings,
     get_user_settings,
@@ -123,6 +144,7 @@ from functions_source_review import (
     validate_url_access_request,
 )
 from functions_thoughts import ThoughtTracker
+from functions_tabular_generated_exports import cancel_tabular_generated_output_run
 from semantic_kernel_loader import load_user_semantic_kernel
 from semantic_kernel_plugins.plugin_invocation_logger import get_plugin_logger, sanitize_plugin_invocation_value
 from semantic_kernel_plugins.plugin_invocation_thoughts import register_plugin_invocation_thought_callback
@@ -1023,6 +1045,8 @@ def _upload_document_analysis_generated_artifact(
     preview_rows=None,
     preview_items=None,
     preview_lines=None,
+    cancel_requested=None,
+    request_correlation_id=None,
 ):
     try:
         upload_result = upload_generated_analysis_artifact_for_current_user(
@@ -1033,6 +1057,20 @@ def _upload_document_analysis_generated_artifact(
             output_format=output_format,
             summary=summary,
         )
+        try:
+            raise_if_mixed_source_cancelled(
+                cancel_requested,
+                'artifact_publication',
+                request_correlation_id=request_correlation_id,
+            )
+        except MixedSourceCancellationError:
+            delete_generated_chat_artifact_for_current_user(
+                normalized_conversation_id,
+                (upload_result.get('message') or {}).get('id'),
+            )
+            raise
+    except MixedSourceCancellationError:
+        raise
     except Exception as exc:
         debug_print(
             '[WorkflowDocumentAnalysis] Generated artifact upload skipped | '
@@ -1111,7 +1149,14 @@ def _maybe_create_document_analysis_generated_artifacts(
     analysis_prompt,
     conversation_id='',
     primary_generated_outputs=None,
+    cancel_requested=None,
+    request_correlation_id=None,
 ):
+    raise_if_mixed_source_cancelled(
+        cancel_requested,
+        'artifact_publication',
+        request_correlation_id=request_correlation_id,
+    )
     normalized_conversation_id = str(conversation_id or '').strip()
     if not normalized_conversation_id or not has_request_context():
         return {'artifacts': [], 'assistant_reply': None}
@@ -1137,72 +1182,85 @@ def _maybe_create_document_analysis_generated_artifacts(
     if create_lossless_artifacts:
         artifacts = []
         structured_rows = _build_document_analysis_structured_rows(analysis_result)
+        try:
+            if artifact_intent.get('csv_artifact_recommended') and structured_rows:
+                csv_output = _build_document_analysis_rows_csv(structured_rows)
+                csv_file_name = _build_document_analysis_artifact_file_name(analysis_result, 'csv')
+                csv_summary = (
+                    f'Saved {len(structured_rows)} extracted analysis row(s) for {document_count} '
+                    'source document(s) as a downloadable CSV artifact.'
+                )
+                csv_artifact = _upload_document_analysis_generated_artifact(
+                    normalized_conversation_id,
+                    csv_file_name,
+                    csv_output,
+                    'csv',
+                    csv_summary,
+                    preview_rows=structured_rows[:DOCUMENT_ANALYSIS_ARTIFACT_PREVIEW_ROW_COUNT],
+                    cancel_requested=cancel_requested,
+                    request_correlation_id=request_correlation_id,
+                )
+                if csv_artifact:
+                    artifacts.append(csv_artifact)
 
-        if artifact_intent.get('csv_artifact_recommended') and structured_rows:
-            csv_output = _build_document_analysis_rows_csv(structured_rows)
-            csv_file_name = _build_document_analysis_artifact_file_name(analysis_result, 'csv')
-            csv_summary = (
-                f'Saved {len(structured_rows)} extracted analysis row(s) for {document_count} '
-                'source document(s) as a downloadable CSV artifact.'
+            markdown_output = _build_document_analysis_markdown_artifact(analysis_result)
+            should_create_markdown_artifact = bool(
+                (
+                    artifact_intent.get('markdown_analysis_artifact_recommended')
+                    or (json_payload is not None and not json_artifact_requested)
+                )
+                and markdown_output
+                and (
+                    not primary_tabular_outputs
+                    or _prompt_explicitly_requests_markdown_artifact(analysis_prompt)
+                )
             )
-            csv_artifact = _upload_document_analysis_generated_artifact(
-                normalized_conversation_id,
-                csv_file_name,
-                csv_output,
-                'csv',
-                csv_summary,
-                preview_rows=structured_rows[:DOCUMENT_ANALYSIS_ARTIFACT_PREVIEW_ROW_COUNT],
-            )
-            if csv_artifact:
-                artifacts.append(csv_artifact)
+            if should_create_markdown_artifact:
+                markdown_file_name = _build_document_analysis_artifact_file_name(analysis_result, 'md')
+                markdown_summary = (
+                    f'Saved the final analysis plus retained raw analysis notes for {document_count} '
+                    'source document(s) as a downloadable Markdown artifact.'
+                )
+                markdown_artifact = _upload_document_analysis_generated_artifact(
+                    normalized_conversation_id,
+                    markdown_file_name,
+                    markdown_output,
+                    'md',
+                    markdown_summary,
+                    preview_lines=_build_document_analysis_preview_lines(analysis_reply),
+                    cancel_requested=cancel_requested,
+                    request_correlation_id=request_correlation_id,
+                )
+                if markdown_artifact:
+                    artifacts.append(markdown_artifact)
 
-        markdown_output = _build_document_analysis_markdown_artifact(analysis_result)
-        should_create_markdown_artifact = bool(
-            (
-                artifact_intent.get('markdown_analysis_artifact_recommended')
-                or (json_payload is not None and not json_artifact_requested)
-            )
-            and markdown_output
-            and (
-                not primary_tabular_outputs
-                or _prompt_explicitly_requests_markdown_artifact(analysis_prompt)
-            )
-        )
-        if should_create_markdown_artifact:
-            markdown_file_name = _build_document_analysis_artifact_file_name(analysis_result, 'md')
-            markdown_summary = (
-                f'Saved the final analysis plus retained raw analysis notes for {document_count} '
-                'source document(s) as a downloadable Markdown artifact.'
-            )
-            markdown_artifact = _upload_document_analysis_generated_artifact(
-                normalized_conversation_id,
-                markdown_file_name,
-                markdown_output,
-                'md',
-                markdown_summary,
-                preview_lines=_build_document_analysis_preview_lines(analysis_reply),
-            )
-            if markdown_artifact:
-                artifacts.append(markdown_artifact)
-
-        if json_payload is not None and json_artifact_requested and not primary_tabular_outputs:
-            json_file_name = _build_document_analysis_artifact_file_name(analysis_result, 'json')
-            json_summary = _build_document_analysis_artifact_summary(document_count, 'json')
-            json_preview_items = []
-            if isinstance(json_payload, list):
-                json_preview_items = json_payload[:DOCUMENT_ANALYSIS_ARTIFACT_PREVIEW_ITEM_COUNT]
-            elif isinstance(json_payload, dict):
-                json_preview_items = [json_payload]
-            json_artifact = _upload_document_analysis_generated_artifact(
-                normalized_conversation_id,
-                json_file_name,
-                json.dumps(json_payload, indent=2, ensure_ascii=False),
-                'json',
-                json_summary,
-                preview_items=json_preview_items,
-            )
-            if json_artifact:
-                artifacts.append(json_artifact)
+            if json_payload is not None and json_artifact_requested and not primary_tabular_outputs:
+                json_file_name = _build_document_analysis_artifact_file_name(analysis_result, 'json')
+                json_summary = _build_document_analysis_artifact_summary(document_count, 'json')
+                json_preview_items = []
+                if isinstance(json_payload, list):
+                    json_preview_items = json_payload[:DOCUMENT_ANALYSIS_ARTIFACT_PREVIEW_ITEM_COUNT]
+                elif isinstance(json_payload, dict):
+                    json_preview_items = [json_payload]
+                json_artifact = _upload_document_analysis_generated_artifact(
+                    normalized_conversation_id,
+                    json_file_name,
+                    json.dumps(json_payload, indent=2, ensure_ascii=False),
+                    'json',
+                    json_summary,
+                    preview_items=json_preview_items,
+                    cancel_requested=cancel_requested,
+                    request_correlation_id=request_correlation_id,
+                )
+                if json_artifact:
+                    artifacts.append(json_artifact)
+        except MixedSourceCancellationError:
+            for artifact in reversed(artifacts):
+                delete_generated_chat_artifact_for_current_user(
+                    normalized_conversation_id,
+                    artifact.get('artifact_message_id'),
+                )
+            raise
 
         if artifacts or primary_tabular_outputs:
             assistant_reply = _build_document_analysis_multi_artifact_reply(
@@ -1275,6 +1333,13 @@ def _maybe_create_document_analysis_generated_artifacts(
         summary,
         preview_items=preview_items,
         preview_lines=preview_lines,
+        cancel_requested=cancel_requested,
+        request_correlation_id=request_correlation_id,
+    )
+    raise_if_mixed_source_cancelled(
+        cancel_requested,
+        'artifact_publication',
+        request_correlation_id=request_correlation_id,
     )
     if not artifact_payload:
         return {'artifacts': [], 'assistant_reply': None}
@@ -1317,7 +1382,18 @@ def _build_comparison_artifact_reply(left_document_name, right_count, output_for
     )
 
 
-def _maybe_create_comparison_generated_artifacts(comparison_result, comparison_prompt, conversation_id=''):
+def _maybe_create_comparison_generated_artifacts(
+    comparison_result,
+    comparison_prompt,
+    conversation_id='',
+    cancel_requested=None,
+    request_correlation_id=None,
+):
+    raise_if_mixed_source_cancelled(
+        cancel_requested,
+        'artifact_publication',
+        request_correlation_id=request_correlation_id,
+    )
     normalized_conversation_id = str(conversation_id or '').strip()
     if not normalized_conversation_id or not has_request_context():
         return {'artifacts': [], 'assistant_reply': None}
@@ -1363,6 +1439,11 @@ def _maybe_create_comparison_generated_artifacts(comparison_result, comparison_p
     summary = _build_comparison_artifact_summary(left_document_name, len(right_documents), output_format)
 
     try:
+        raise_if_mixed_source_cancelled(
+            cancel_requested,
+            'artifact_publication',
+            request_correlation_id=request_correlation_id,
+        )
         upload_result = upload_generated_analysis_artifact_for_current_user(
             conversation_id=normalized_conversation_id,
             file_name=file_name,
@@ -1371,6 +1452,20 @@ def _maybe_create_comparison_generated_artifacts(comparison_result, comparison_p
             output_format=output_format,
             summary=summary,
         )
+        try:
+            raise_if_mixed_source_cancelled(
+                cancel_requested,
+                'artifact_publication',
+                request_correlation_id=request_correlation_id,
+            )
+        except MixedSourceCancellationError:
+            delete_generated_chat_artifact_for_current_user(
+                normalized_conversation_id,
+                (upload_result.get('message') or {}).get('id'),
+            )
+            raise
+    except MixedSourceCancellationError:
+        raise
     except Exception as exc:
         debug_print(
             '[WorkflowDocumentComparison] Generated artifact upload skipped | '
@@ -1473,6 +1568,191 @@ def _finalize_token_usage(aggregate):
     if request_count:
         token_usage['request_count'] = request_count
     return token_usage
+
+
+def _accumulate_token_usage_summary(aggregate, token_usage):
+    """Merge an already-normalized token summary into the existing aggregate."""
+    if not isinstance(aggregate, dict) or not isinstance(token_usage, dict):
+        return
+    for key in ('prompt_tokens', 'completion_tokens', 'total_tokens'):
+        value = _coerce_token_count(token_usage.get(key))
+        if value is not None:
+            aggregate[key] = int(aggregate.get(key, 0) or 0) + value
+    request_count = _coerce_token_count(token_usage.get('request_count'))
+    if request_count is None and any(
+        token_usage.get(key) not in (None, 0, '')
+        for key in ('prompt_tokens', 'completion_tokens', 'total_tokens')
+    ):
+        request_count = 1
+    if request_count:
+        aggregate['request_count'] = int(aggregate.get('request_count', 0) or 0) + request_count
+
+
+def _emit_mixed_source_token_telemetry(
+    settings,
+    mode,
+    token_usage,
+    request_correlation_id=None,
+):
+    """Link existing aggregate token accounting to mixed-source request telemetry."""
+    token_usage = token_usage if isinstance(token_usage, dict) else {}
+    return emit_mixed_source_telemetry(
+        settings,
+        'native_execution',
+        mode,
+        request_correlation_id=request_correlation_id,
+        metrics={
+            'prompt_tokens': token_usage.get('prompt_tokens', 0),
+            'completion_tokens': token_usage.get('completion_tokens', 0),
+            'total_tokens': token_usage.get('total_tokens', 0),
+            'token_request_count': token_usage.get('request_count', 0),
+            'request_count': token_usage.get('request_count', 0),
+        },
+    )
+
+
+def _rollback_mixed_source_generated_outputs(
+    user_id,
+    conversation_id,
+    generated_outputs,
+    reason='finalization',
+):
+    """Cancel queued exports and delete exact generated artifacts by stored identity."""
+    normalized_user_id = str(user_id or '').strip()
+    normalized_conversation_id = str(conversation_id or '').strip()
+    if not normalized_user_id or not normalized_conversation_id:
+        return {'canceled_export_count': 0, 'deleted_artifact_count': 0}
+
+    export_run_ids = []
+    artifact_message_ids = []
+    for output in list(generated_outputs or []):
+        if not isinstance(output, dict):
+            continue
+        export_run_id = str(output.get('export_run_id') or '').strip()
+        artifact_message_id = str(output.get('artifact_message_id') or '').strip()
+        if export_run_id and export_run_id not in export_run_ids:
+            export_run_ids.append(export_run_id)
+        if artifact_message_id and artifact_message_id not in artifact_message_ids:
+            artifact_message_ids.append(artifact_message_id)
+
+    canceled_export_count = 0
+    deleted_artifact_count = 0
+    rollback_failure_count = 0
+    for export_run_id in export_run_ids:
+        try:
+            cancel_result = cancel_tabular_generated_output_run(
+                normalized_user_id,
+                export_run_id,
+            )
+            if isinstance(cancel_result, dict) and cancel_result.get('canceled'):
+                canceled_export_count += 1
+        except Exception:
+            rollback_failure_count += 1
+    for artifact_message_id in artifact_message_ids:
+        try:
+            if delete_generated_chat_artifact_for_user(
+                normalized_user_id,
+                normalized_conversation_id,
+                artifact_message_id,
+            ):
+                deleted_artifact_count += 1
+        except Exception:
+            rollback_failure_count += 1
+
+    log_event(
+        '[MixedSourceLifecycle] Generated output rollback completed.',
+        extra={
+            'canceled_export_count': canceled_export_count,
+            'deleted_artifact_count': deleted_artifact_count,
+            'rollback_failure_count': rollback_failure_count,
+            'rollback_reason': str(reason or 'finalization')[:64],
+        },
+        level=logging.INFO if not rollback_failure_count else logging.WARNING,
+    )
+    return {
+        'canceled_export_count': canceled_export_count,
+        'deleted_artifact_count': deleted_artifact_count,
+        'rollback_failure_count': rollback_failure_count,
+    }
+
+
+def _reauthorize_mixed_source_workflow_result(
+    workflow,
+    action_config,
+    result,
+    settings,
+    conversation_id,
+    cancel_requested=None,
+    request_correlation_id=None,
+    additional_generated_outputs=None,
+):
+    """Reauthorize a mixed result and roll back outputs before propagating failure."""
+    result = result if isinstance(result, dict) else {}
+    execution_manifest = result.get('mixed_source_manifest')
+    if not isinstance(execution_manifest, list):
+        return
+
+    user_id = str((workflow or {}).get('user_id') or '').strip()
+    requested_ids = [
+        str(source.get('document_id') or '').strip()
+        for source in execution_manifest
+        if isinstance(source, dict) and str(source.get('document_id') or '').strip()
+    ]
+    selection_mode = str(
+        (action_config or {}).get('target_mode') or SELECTION_MODE_SELECTED
+    ).strip().lower()
+    if selection_mode not in {'selected', 'all', 'history', 'relevance'}:
+        selection_mode = SELECTION_MODE_SELECTED
+
+    generated_outputs = list(result.get('generated_tabular_outputs') or [])
+    generated_outputs.extend(list(additional_generated_outputs or []))
+    try:
+        raise_if_mixed_source_cancelled(
+            cancel_requested,
+            'finalization',
+            request_correlation_id=request_correlation_id,
+        )
+        fresh_manifest = resolve_authorized_source_manifest(
+            requested_ids,
+            user_id=user_id,
+            selection_mode=selection_mode,
+            conversation_id=conversation_id,
+            active_group_ids=(action_config or {}).get('active_group_ids'),
+            active_public_workspace_ids=(action_config or {}).get('active_public_workspace_id'),
+            doc_scope=(action_config or {}).get('doc_scope', 'all'),
+            cancel_requested=cancel_requested,
+            request_correlation_id=request_correlation_id,
+        )
+        finalization_result = compare_reauthorized_source_manifests(
+            execution_manifest,
+            fresh_manifest,
+        )
+        if finalization_result['authorization_failure_count']:
+            emit_mixed_source_telemetry(
+                settings,
+                'authorization_failure',
+                (
+                    'compare'
+                    if (action_config or {}).get('type') == DOCUMENT_ACTION_TYPE_COMPARISON
+                    else 'analyze'
+                ),
+                request_correlation_id=request_correlation_id,
+                metrics={
+                    'authorization_failure_count': finalization_result['authorization_failure_count'],
+                },
+                dimensions={'outcome_status': 'failed'},
+            )
+            raise MixedSourceFinalizationError('authorization_lost')
+        if finalization_result['source_version_changed_count']:
+            raise MixedSourceFinalizationError('source_version_changed')
+    except (MixedSourceCancellationError, MixedSourceFinalizationError):
+        _rollback_mixed_source_generated_outputs(
+            user_id,
+            conversation_id,
+            generated_outputs,
+            reason='finalization',
+        )
+        raise
 
 
 def _strip_agent_citation_artifact_refs(agent_citations):
@@ -1883,8 +2163,15 @@ def _execute_mixed_source_analyze_workflow(
     thought_tracker=None,
     live_thought_callback=None,
     max_documents=None,
+    cancel_requested=None,
+    request_correlation_id=None,
+    token_usage_callback=None,
 ):
     """Run combined Analyze cohorts natively, then reduce bounded evidence once."""
+    started_at = time.perf_counter()
+    request_correlation_id = normalize_mixed_source_correlation_id(
+        request_correlation_id
+    )
     user_id = str(workflow.get('user_id') or '').strip()
     requested_ids, _ = _get_document_action_source_ids(analysis_config)
     requested_selection_mode = str(
@@ -1893,9 +2180,20 @@ def _execute_mixed_source_analyze_workflow(
         or SELECTION_MODE_SELECTED
     ).strip().lower()
     if requested_selection_mode == 'all':
-        raise ValueError(
-            'Analyze All Documents is temporarily unavailable until exhaustive authorized catalog enumeration is enabled.'
+        if not bool(settings.get('enable_mixed_source_analyze_all', False)):
+            raise ValueError(
+                'Analyze All Documents is temporarily unavailable while its rollout flag is disabled.'
+            )
+        if max_documents is None:
+            raise ValueError('Analyze All Documents requires a configured document limit.')
+        all_targets = _resolve_analyze_all_document_ids(
+            workflow,
+            analysis_config,
+            settings,
+            int(max_documents),
         )
+        analysis_config = {**analysis_config, **all_targets}
+        requested_ids = list(all_targets['document_ids'])
     if max_documents is not None and len(requested_ids) > int(max_documents):
         raise ValueError(
             f'Analyze supports up to {int(max_documents)} authorized documents at a time.'
@@ -1905,11 +2203,13 @@ def _execute_mixed_source_analyze_workflow(
     manifest = resolve_authorized_source_manifest(
         requested_ids,
         user_id=user_id,
-        selection_mode=SELECTION_MODE_SELECTED,
+        selection_mode=requested_selection_mode,
         conversation_id=conversation_id,
         active_group_ids=analysis_config.get('active_group_ids'),
         active_public_workspace_ids=analysis_config.get('active_public_workspace_id'),
         doc_scope=analysis_config.get('doc_scope', 'all'),
+        cancel_requested=cancel_requested,
+        request_correlation_id=request_correlation_id,
     )
     partitions = partition_source_manifest(manifest)
     evidence_envelopes = []
@@ -1937,6 +2237,8 @@ def _execute_mixed_source_analyze_workflow(
                 activity_callback=activity_callback,
                 max_documents=max_documents,
                 include_coverage_summary=False,
+                cancel_requested=cancel_requested,
+                request_correlation_id=request_correlation_id,
             )
             documents_by_id = {
                 str(document.get('document_id') or ''): document
@@ -1970,6 +2272,8 @@ def _execute_mixed_source_analyze_workflow(
                     coverage={'terminal': True, 'processed_windows': processed_windows, 'total_windows': total_windows, 'failed_windows': failed_windows},
                     error='Narrative analysis could not be completed.' if status == EVIDENCE_STATUS_FAILED else None,
                 ))
+        except MixedSourceCancellationError:
+            raise
         except Exception:
             for source in narrative_sources:
                 evidence_envelopes.append(build_evidence_envelope(
@@ -1990,6 +2294,9 @@ def _execute_mixed_source_analyze_workflow(
                 DOCUMENT_ACTION_TYPE_ANALYZE, workflow, tabular_config, settings,
                 conversation_id=conversation_id, invoke_prompt=invoke_prompt,
                 thought_tracker=thought_tracker, live_thought_callback=live_thought_callback,
+                cancel_requested=cancel_requested,
+                request_correlation_id=request_correlation_id,
+                token_usage_callback=token_usage_callback,
             )
             if not tabular_payload:
                 evidence_envelopes.append(build_evidence_envelope(
@@ -2011,15 +2318,58 @@ def _execute_mixed_source_analyze_workflow(
             generated_tabular_outputs.extend(tabular_payload.get('generated_tabular_outputs') or [])
             tabular_agent_citations.extend(tabular_payload.get('agent_citations') or [])
 
-    handoff = build_mixed_source_evidence_handoff(manifest, evidence_envelopes, SELECTION_MODE_SELECTED)
+    handoff = build_mixed_source_evidence_handoff(
+        manifest,
+        evidence_envelopes,
+        requested_selection_mode,
+        mode='analyze',
+        telemetry_settings=settings,
+        request_correlation_id=request_correlation_id,
+    )
+    mode_outcome = evaluate_mixed_source_mode_outcome(
+        'analyze',
+        {
+            'entries': (handoff.get('mixed_source_coverage') or {}).get('terminal_ledger') or [],
+            'partial_coverage': bool((handoff.get('mixed_source_coverage') or {}).get('partial_coverage')),
+        },
+    )
+    if not mode_outcome['should_reduce']:
+        raise RuntimeError(
+            'Mixed-source Analyze could not prepare evidence from any selected source.'
+        )
+    raise_if_mixed_source_cancelled(
+        cancel_requested,
+        'reduction',
+        request_correlation_id=request_correlation_id,
+    )
     if callable(activity_callback):
         activity_callback({'type': 'mixed_source_progress', 'phase': 'combining_findings', 'label': 'Combining findings'})
     collective_reply = str(invoke_prompt(
         _build_mixed_source_analyze_reduction_prompt(workflow.get('task_prompt', ''), handoff),
         stage='mixed_source_reduction', metadata={'requested_source_count': len(manifest)},
     ) or '').strip()
+    raise_if_mixed_source_cancelled(
+        cancel_requested,
+        'reduction',
+        request_correlation_id=request_correlation_id,
+    )
     if not collective_reply:
         collective_reply = 'The selected sources could not be combined into a final analysis.'
+    emit_mixed_source_telemetry(
+        settings,
+        'reduction',
+        'analyze',
+        request_correlation_id=request_correlation_id,
+        metrics={
+            'engine_call_count': len(evidence_envelopes),
+            'model_request_count': 1,
+            'latency_ms': round((time.perf_counter() - started_at) * 1000, 3),
+        },
+        dimensions={
+            'selection_mode': requested_selection_mode,
+            'outcome_status': mode_outcome['status'],
+        },
+    )
     coverage = _build_mixed_source_analysis_coverage(handoff)
     if callable(activity_callback):
         activity_callback({
@@ -2040,7 +2390,13 @@ def _execute_mixed_source_analyze_workflow(
         'agent_citations': tabular_agent_citations,
     }
 
-def _resolve_cross_format_comparison_manifest(comparison_config, user_id, conversation_id):
+def _resolve_cross_format_comparison_manifest(
+    comparison_config,
+    user_id,
+    conversation_id,
+    cancel_requested=None,
+    request_correlation_id=None,
+):
     """Resolve the Source and ordered Targets once for the mixed Compare decision."""
     requested_ids, role_by_document_id = _get_document_action_source_ids(comparison_config)
     manifest = resolve_authorized_source_manifest(
@@ -2051,6 +2407,8 @@ def _resolve_cross_format_comparison_manifest(comparison_config, user_id, conver
         active_group_ids=comparison_config.get('active_group_ids'),
         active_public_workspace_ids=comparison_config.get('active_public_workspace_id'),
         doc_scope=comparison_config.get('doc_scope', 'all'),
+        cancel_requested=cancel_requested,
+        request_correlation_id=request_correlation_id,
     )
     for source in manifest:
         source['comparison_role'] = role_by_document_id.get(source.get('document_id'), 'target')
@@ -2076,10 +2434,28 @@ def _execute_cross_format_comparison_workflow(
     activity_callback=None,
     thought_tracker=None,
     live_thought_callback=None,
+    cancel_requested=None,
+    request_correlation_id=None,
+    token_usage_callback=None,
 ):
     """Prepare native envelopes for a mixed Source/Target Compare, then reuse pairwise reduction."""
+    started_at = time.perf_counter()
+    request_correlation_id = normalize_mixed_source_correlation_id(
+        request_correlation_id
+    )
     user_id = str(workflow.get('user_id') or '').strip()
-    manifest = _resolve_cross_format_comparison_manifest(comparison_config, user_id, conversation_id)
+    raise_if_mixed_source_cancelled(
+        cancel_requested,
+        'manifest',
+        request_correlation_id=request_correlation_id,
+    )
+    manifest = _resolve_cross_format_comparison_manifest(
+        comparison_config,
+        user_id,
+        conversation_id,
+        cancel_requested=cancel_requested,
+        request_correlation_id=request_correlation_id,
+    )
     partitions = partition_source_manifest(manifest)
     if not (partitions['narrative_sources'] and partitions['tabular_sources']):
         return None
@@ -2112,6 +2488,8 @@ def _execute_cross_format_comparison_workflow(
                 activity_callback=activity_callback,
                 max_documents=1,
                 include_coverage_summary=False,
+                cancel_requested=cancel_requested,
+                request_correlation_id=request_correlation_id,
             )
             document_coverage = list((narrative_result.get('coverage') or {}).get('documents') or [{}])[0]
             status = EVIDENCE_STATUS_COMPLETED if not document_coverage.get('failed_windows') else 'partial'
@@ -2121,6 +2499,8 @@ def _execute_cross_format_comparison_workflow(
                 summary=str(narrative_result.get('analysis_reply') or narrative_result.get('reply') or ''),
                 coverage={'terminal': True, 'source_version': source.get('source_version'), **document_coverage},
             )
+        except MixedSourceCancellationError:
+            raise
         except Exception:
             evidence_by_id[source.get('document_id')] = build_evidence_envelope(
                 document_id=source.get('document_id'), source_kind='narrative',
@@ -2142,6 +2522,9 @@ def _execute_cross_format_comparison_workflow(
             },
             settings, conversation_id=conversation_id, invoke_prompt=invoke_prompt,
             thought_tracker=thought_tracker, live_thought_callback=live_thought_callback,
+            cancel_requested=cancel_requested,
+            request_correlation_id=request_correlation_id,
+            token_usage_callback=token_usage_callback,
         )
         tabular_result = (tabular_payload or {}).get('result') or {}
         if tabular_result.get('analysis_reply'):
@@ -2164,7 +2547,25 @@ def _execute_cross_format_comparison_workflow(
                 error='Tabular analysis could not be completed.',
             )
 
-    handoff = build_mixed_source_evidence_handoff(manifest, list(evidence_by_id.values()), SELECTION_MODE_SELECTED)
+    handoff = build_mixed_source_evidence_handoff(
+        manifest,
+        list(evidence_by_id.values()),
+        SELECTION_MODE_SELECTED,
+        mode='compare',
+        telemetry_settings=settings,
+        request_correlation_id=request_correlation_id,
+    )
+    mode_outcome = evaluate_mixed_source_mode_outcome(
+        'compare',
+        {
+            'entries': (handoff.get('mixed_source_coverage') or {}).get('terminal_ledger') or [],
+            'partial_coverage': bool((handoff.get('mixed_source_coverage') or {}).get('partial_coverage')),
+        },
+    )
+    if not mode_outcome['should_reduce']:
+        if mode_outcome.get('reason') == 'source_preparation_failed':
+            raise RuntimeError('Cross-format Compare Source could not be prepared.')
+        raise RuntimeError('Cross-format Compare could not prepare any Target evidence.')
     envelopes = {envelope.get('document_id'): envelope for envelope in handoff.get('evidence_envelopes') or []}
     def source_payload(source):
         envelope = dict(envelopes.get(source.get('document_id')) or {})
@@ -2180,12 +2581,36 @@ def _execute_cross_format_comparison_workflow(
     comparison_result = run_evidence_document_comparison(
         workflow.get('task_prompt', ''), source_payload(left_source),
         [source_payload(source) for source in target_sources], invoke_prompt, activity_callback=activity_callback,
+        cancel_requested=cancel_requested,
+        request_correlation_id=request_correlation_id,
     )
-    comparison_result['coverage'] = _build_mixed_source_analysis_coverage(handoff)
+    pairwise_coverage = dict(comparison_result.get('coverage') or {})
+    mixed_coverage = _build_mixed_source_analysis_coverage(handoff)
+    mixed_coverage['failed_targets'] = list(pairwise_coverage.get('failed_targets') or [])
+    mixed_coverage['partial_coverage'] = bool(
+        mixed_coverage.get('partial_coverage')
+        or pairwise_coverage.get('partial_coverage')
+    )
+    comparison_result['coverage'] = mixed_coverage
     comparison_result['mixed_source_manifest'] = manifest
     comparison_result['mixed_source_evidence'] = handoff.get('evidence_envelopes') or []
     comparison_result['generated_tabular_outputs'] = generated_tabular_outputs
     comparison_result['agent_citations'] = tabular_agent_citations
+    emit_mixed_source_telemetry(
+        settings,
+        'reduction',
+        'compare',
+        request_correlation_id=request_correlation_id,
+        metrics={
+            'engine_call_count': len(evidence_by_id),
+            'model_request_count': len(comparison_result.get('comparison_items') or []),
+            'latency_ms': round((time.perf_counter() - started_at) * 1000, 3),
+        },
+        dimensions={
+            'selection_mode': SELECTION_MODE_SELECTED,
+            'outcome_status': mode_outcome['status'],
+        },
+    )
     return comparison_result
 
 
@@ -2412,7 +2837,15 @@ def _maybe_execute_tabular_document_action(
     invoke_prompt=None,
     thought_tracker=None,
     live_thought_callback=None,
+    cancel_requested=None,
+    request_correlation_id=None,
+    token_usage_callback=None,
 ):
+    raise_if_mixed_source_cancelled(
+        cancel_requested,
+        'tabular',
+        request_correlation_id=request_correlation_id,
+    )
     if action_type not in {DOCUMENT_ACTION_TYPE_ANALYZE, DOCUMENT_ACTION_TYPE_COMPARISON}:
         return None
 
@@ -2431,7 +2864,11 @@ def _maybe_execute_tabular_document_action(
                     conversation_id=conversation_id,
                     active_group_ids=action_config.get('active_group_ids'),
                     active_public_workspace_ids=action_config.get('active_public_workspace_id'),
+                    cancel_requested=cancel_requested,
+                    request_correlation_id=request_correlation_id,
                 )
+            except MixedSourceCancellationError:
+                raise
             except Exception:
                 log_event(
                     '[MixedSourceManifest] Workflow shadow resolution failed.',
@@ -2481,6 +2918,11 @@ def _maybe_execute_tabular_document_action(
 
     try:
         for tabular_document in tabular_documents:
+            raise_if_mixed_source_cancelled(
+                cancel_requested,
+                'tabular',
+                request_correlation_id=request_correlation_id,
+            )
             document_baseline_invocation_count = 0
             if conversation_id:
                 document_baseline_invocation_count = len(
@@ -2511,7 +2953,13 @@ def _maybe_execute_tabular_document_action(
                     }],
                     thought_tracker=thought_tracker,
                     live_thought_callback=live_thought_callback,
+                    token_usage_callback=token_usage_callback,
                 )
+            )
+            raise_if_mixed_source_cancelled(
+                cancel_requested,
+                'tabular',
+                request_correlation_id=request_correlation_id,
             )
             if not str(tabular_analysis or '').strip():
                 raise ValueError(
@@ -2550,10 +2998,20 @@ def _maybe_execute_tabular_document_action(
                         conversation_id=conversation_id,
                         thought_callback=tabular_post_processing_thought_callback,
                         user_id=user_id,
+                        cancel_requested=cancel_requested,
+                        request_correlation_id=request_correlation_id,
+                        token_usage_callback=token_usage_callback,
                     )
+                )
+                raise_if_mixed_source_cancelled(
+                    cancel_requested,
+                    'export',
+                    request_correlation_id=request_correlation_id,
                 )
                 if generated_tabular_output:
                     generated_tabular_outputs.append(generated_tabular_output)
+    except MixedSourceCancellationError:
+        raise
     except Exception as exc:
         log_event(
             f'[WorkflowDocumentAction] Tabular document-action helper skipped: {exc}',
@@ -2577,6 +3035,11 @@ def _maybe_execute_tabular_document_action(
     tabular_agent_citations = _build_agent_citations_from_plugin_invocations(tabular_invocations)
 
     if action_type == DOCUMENT_ACTION_TYPE_ANALYZE:
+        raise_if_mixed_source_cancelled(
+            cancel_requested,
+            'reduction',
+            request_correlation_id=request_correlation_id,
+        )
         analysis_result = {
             'reply': '',
             'analysis_reply': str(invoke_prompt(
@@ -2595,6 +3058,11 @@ def _maybe_execute_tabular_document_action(
             'window_size': None,
             'window_percent': None,
         }
+        raise_if_mixed_source_cancelled(
+            cancel_requested,
+            'reduction',
+            request_correlation_id=request_correlation_id,
+        )
         if not analysis_result['analysis_reply']:
             raise RuntimeError('Tabular analysis synthesis returned an empty response.')
         analysis_result['reply'] = analysis_result['analysis_reply']
@@ -2607,6 +3075,11 @@ def _maybe_execute_tabular_document_action(
 
     left_document = tabular_documents[0] if tabular_documents else {}
     right_documents = tabular_documents[1:]
+    raise_if_mixed_source_cancelled(
+        cancel_requested,
+        'comparison_reduction',
+        request_correlation_id=request_correlation_id,
+    )
     comparison_result = {
         'reply': '',
         'analysis_reply': str(invoke_prompt(
@@ -2637,6 +3110,11 @@ def _maybe_execute_tabular_document_action(
         ],
         'comparison_items': [],
     }
+    raise_if_mixed_source_cancelled(
+        cancel_requested,
+        'comparison_reduction',
+        request_correlation_id=request_correlation_id,
+    )
     if not comparison_result['analysis_reply']:
         raise RuntimeError('Tabular comparison synthesis returned an empty response.')
     comparison_result['reply'] = comparison_result['analysis_reply']
@@ -4284,6 +4762,80 @@ def _get_recent_workflow_document_limit(action_type, settings):
     return _get_workflow_search_max_documents(settings)
 
 
+def _resolve_analyze_all_document_ids(workflow, action_config, settings, max_documents):
+    """Enumerate a bounded catalog before the manifest performs object authorization."""
+    user_id = str(workflow.get('user_id') or '').strip()
+    workflow_group_id = _get_workflow_group_id(workflow)
+    doc_scope = normalize_search_scope(action_config.get('doc_scope'))
+    active_group_ids = normalize_search_id_list(action_config.get('active_group_ids'))
+    if workflow_group_id:
+        assert_group_role(
+            user_id,
+            workflow_group_id,
+            allowed_roles=("Owner", "Admin", "DocumentManager", "User"),
+        )
+        active_group_ids = [workflow_group_id]
+        doc_scope = 'group'
+    else:
+        active_group_ids = _resolve_recent_authorized_group_ids(user_id, active_group_ids)
+
+    active_public_workspace_ids = normalize_search_id_list(
+        action_config.get('active_public_workspace_id')
+    )
+    if not workflow_group_id:
+        active_public_workspace_ids = _resolve_recent_authorized_public_workspace_ids(
+            user_id,
+            active_public_workspace_ids,
+        )
+
+    catalog_requests = []
+    if doc_scope in {'personal', 'all'} and not workflow_group_id:
+        catalog_requests.append((DOCUMENT_ACCESS_SCOPE_PERSONAL, {'user_id': user_id}))
+    if doc_scope in {'group', 'all'} and active_group_ids:
+        catalog_requests.append((DOCUMENT_ACCESS_SCOPE_GROUP, {'group_ids': active_group_ids}))
+    if doc_scope in {'public', 'all'} and active_public_workspace_ids and not workflow_group_id:
+        catalog_requests.append((
+            DOCUMENT_ACCESS_SCOPE_PUBLIC,
+            {'public_workspace_ids': active_public_workspace_ids},
+        ))
+    if not catalog_requests:
+        raise ValueError('Analyze All Documents has no authorized workspace scopes to enumerate.')
+
+    document_ids = []
+    for source_scope, scope_arguments in catalog_requests:
+        catalog_result = enumerate_bounded_document_access_index_ids(
+            source_scope,
+            max_documents,
+            settings=settings,
+            **scope_arguments,
+        )
+        if not catalog_result.get('success'):
+            if catalog_result.get('status') == 'document_limit_exceeded':
+                raise ValueError(
+                    f'Analyze All Documents exceeds the configured {max_documents}-document limit.'
+                )
+            raise RuntimeError(
+                'Analyze All Documents is temporarily unavailable until the authorized document catalog is ready.'
+            )
+        for document_id in catalog_result.get('document_ids') or []:
+            if document_id not in document_ids:
+                document_ids.append(document_id)
+        if len(document_ids) > max_documents:
+            raise ValueError(
+                f'Analyze All Documents exceeds the configured {max_documents}-document limit.'
+            )
+
+    if not document_ids:
+        raise ValueError('Analyze All Documents found no authorized documents in the selected scopes.')
+    return {
+        'document_ids': document_ids,
+        'doc_scope': doc_scope,
+        'active_group_ids': active_group_ids,
+        'active_public_workspace_id': active_public_workspace_ids,
+        'target_mode': DOCUMENT_ACTION_TARGET_MODE_ALL,
+    }
+
+
 def _collect_recent_workflow_documents(workflow, action_config, settings, max_documents):
     user_id = str(workflow.get('user_id') or '').strip()
     workflow_group_id = _get_workflow_group_id(workflow)
@@ -4500,7 +5052,11 @@ def _prepare_workflow_search_context(
     conversation_id='',
     thought_tracker=None,
     run_id=None,
+    request_correlation_id=None,
 ):
+    request_correlation_id = normalize_mixed_source_correlation_id(
+        request_correlation_id
+    )
     if not _is_document_search_workflow(action_config):
         return {'workflow': workflow, 'citations': [], 'result_count': 0, 'document_count': 0, 'query': None}
 
@@ -4588,6 +5144,7 @@ def _prepare_workflow_search_context(
         active_group_ids=manifest_group_ids,
         active_public_workspace_ids=manifest_public_workspace_ids,
         doc_scope=manifest_doc_scope,
+        request_correlation_id=request_correlation_id,
     )
     partitions = partition_source_manifest(manifest)
     narrative_sources = list(partitions.get('narrative_sources') or [])
@@ -4622,26 +5179,40 @@ def _prepare_workflow_search_context(
         'document_count': 0,
         'query': query,
     }
+    narrative_retrieval_failed = False
     if narrative_document_ids:
-        search_result = search_documents(
-            query=query,
-            user_id=user_id,
-            top_n=search_top_n,
-            doc_scope=manifest_doc_scope,
-            document_ids=narrative_document_ids,
-            active_group_ids=manifest_group_ids,
-            active_public_workspace_id=manifest_public_workspace_ids,
-            include_all_public_workspaces=True,
-        )
+        try:
+            search_result = search_documents(
+                query=query,
+                user_id=user_id,
+                top_n=search_top_n,
+                doc_scope=manifest_doc_scope,
+                document_ids=narrative_document_ids,
+                active_group_ids=manifest_group_ids,
+                active_public_workspace_id=manifest_public_workspace_ids,
+                include_all_public_workspaces=True,
+            )
+        except Exception:
+            if not tabular_sources:
+                raise
+            narrative_retrieval_failed = True
     retrieved_content, citations = _format_workflow_search_results(search_result.get('results') or [])
-    evidence_envelopes = build_narrative_evidence_envelopes(
-        narrative_sources,
-        search_result.get('results') or [],
-        'selected',
+    evidence_envelopes = (
+        build_failed_narrative_evidence_envelopes(
+            narrative_sources,
+            'selected',
+        )
+        if narrative_retrieval_failed
+        else build_narrative_evidence_envelopes(
+            narrative_sources,
+            search_result.get('results') or [],
+            'selected',
+        )
     )
 
     from functions_tabular_analysis import execute_mixed_source_tabular_evidence
 
+    native_token_usage_aggregate = _create_token_usage_aggregate()
     with _workflow_mixed_source_execution_context(user_id, conversation_id, manifest):
         tabular_result = execute_mixed_source_tabular_evidence(
             tabular_sources=tabular_sources,
@@ -4653,12 +5224,20 @@ def _prepare_workflow_search_context(
             gpt_model=_resolve_tabular_document_action_model_name(workflow, settings),
             settings=settings,
             thought_tracker=thought_tracker,
+            request_correlation_id=request_correlation_id,
         )
+    _accumulate_token_usage_summary(
+        native_token_usage_aggregate,
+        tabular_result.get('token_usage'),
+    )
     evidence_envelopes.extend(tabular_result.get('evidence_envelopes') or [])
     mixed_source_handoff = build_mixed_source_evidence_handoff(
         manifest,
         evidence_envelopes,
         'selected',
+        mode='search',
+        telemetry_settings=settings,
+        request_correlation_id=request_correlation_id,
     )
 
     prepared_action = dict(resolved_action)
@@ -4696,6 +5275,7 @@ def _prepare_workflow_search_context(
         'agent_citations': list(tabular_result.get('agent_citations') or []),
         'generated_tabular_outputs': list(tabular_result.get('generated_outputs') or []),
         'coverage': mixed_source_handoff.get('mixed_source_coverage') or {},
+        'token_usage': _finalize_token_usage(native_token_usage_aggregate),
         'result_count': search_result.get('result_count', 0),
         'document_count': len(authorized_document_ids),
         'query': search_result.get('query'),
@@ -4709,17 +5289,31 @@ def _attach_workflow_search_context(execution_result, workflow_search_context):
     if not search_context:
         return execution_result
 
-    existing_agent_citations = list(execution_result.get('agent_citations') or [])
-    existing_agent_citations.extend(list(search_context.get('agent_citations') or []))
-    existing_outputs = list(execution_result.get('generated_tabular_outputs') or [])
-    existing_outputs.extend(list(search_context.get('generated_tabular_outputs') or []))
-    hybrid_citations = list(search_context.get('citations') or [])
+    existing_agent_citations = deduplicate_mixed_source_references(
+        list(execution_result.get('agent_citations') or [])
+        + list(search_context.get('agent_citations') or []),
+        reference_type='citation',
+    )
+    existing_outputs = deduplicate_mixed_source_references(
+        list(execution_result.get('generated_tabular_outputs') or [])
+        + list(search_context.get('generated_tabular_outputs') or []),
+        reference_type='artifact',
+    )
+    hybrid_citations = deduplicate_mixed_source_references(
+        list(search_context.get('citations') or []),
+        reference_type='citation',
+    )
     coverage = search_context.get('coverage') if isinstance(search_context.get('coverage'), dict) else {}
+    merged_token_usage = _merge_token_usage_summaries([
+        execution_result,
+        {'token_usage': search_context.get('token_usage')},
+    ])
     execution_result.update({
         'hybrid_citations': hybrid_citations,
         'agent_citations': existing_agent_citations,
         'generated_tabular_outputs': existing_outputs,
         'mixed_source_coverage': coverage,
+        'token_usage': merged_token_usage or execution_result.get('token_usage'),
         'augmented': bool(
             hybrid_citations
             or existing_agent_citations
@@ -5428,7 +6022,14 @@ def _execute_document_analysis_workflow(
     external_activity_callback=None,
     action_config=None,
     url_access_context=None,
+    cancel_requested=None,
+    request_correlation_id=None,
 ):
+    raise_if_mixed_source_cancelled(
+        cancel_requested,
+        'manifest',
+        request_correlation_id=request_correlation_id,
+    )
     analysis_config = action_config if isinstance(action_config, dict) else _get_document_action_config(workflow)
     if analysis_config.get('type') != DOCUMENT_ACTION_TYPE_ANALYZE:
         raise ValueError('Document analysis is not enabled for this workflow.')
@@ -5492,6 +6093,8 @@ def _execute_document_analysis_workflow(
                     external_activity_callback=external_activity_callback,
                     action_config=per_document_action,
                     url_access_context=url_access_context,
+                    cancel_requested=cancel_requested,
+                    request_correlation_id=request_correlation_id,
                 ),
             })
 
@@ -5585,6 +6188,9 @@ def _execute_document_analysis_workflow(
                     _accumulate_token_usage(token_usage_aggregate, result)
                     return str(result)
 
+                def record_native_token_usage(token_usage):
+                    _accumulate_token_usage_summary(token_usage_aggregate, token_usage)
+
                 mixed_source_enabled = bool(settings.get('enable_mixed_source_analyze', False))
                 tabular_action_payload = None
                 if mixed_source_enabled:
@@ -5593,6 +6199,9 @@ def _execute_document_analysis_workflow(
                         conversation_id=conversation_id, activity_callback=activity_callback,
                         thought_tracker=thought_tracker, live_thought_callback=external_activity_callback,
                         max_documents=workflow_analysis_max_documents,
+                        cancel_requested=cancel_requested,
+                        request_correlation_id=request_correlation_id,
+                        token_usage_callback=record_native_token_usage,
                     )
                 else:
                     tabular_action_payload = _maybe_execute_tabular_document_action(
@@ -5604,6 +6213,9 @@ def _execute_document_analysis_workflow(
                         invoke_prompt=invoke_prompt,
                         thought_tracker=thought_tracker,
                         live_thought_callback=external_activity_callback,
+                        cancel_requested=cancel_requested,
+                        request_correlation_id=request_correlation_id,
+                        token_usage_callback=record_native_token_usage,
                     )
                 if tabular_action_payload:
                     analysis_result = tabular_action_payload.get('result') or {}
@@ -5622,15 +6234,52 @@ def _execute_document_analysis_workflow(
                         max_retries_per_window=analysis_config.get('max_retries_per_window'),
                         activity_callback=activity_callback,
                         max_documents=workflow_analysis_max_documents,
+                        cancel_requested=cancel_requested,
+                        request_correlation_id=request_correlation_id,
                     )
-                document_analysis_artifact_payload = _maybe_create_document_analysis_generated_artifacts(
+                primary_generated_outputs = list(
+                    (tabular_action_payload or {}).get('generated_tabular_outputs')
+                    or analysis_result.get('generated_tabular_outputs')
+                    or []
+                )
+                _reauthorize_mixed_source_workflow_result(
+                    workflow,
+                    analysis_config,
                     analysis_result,
-                    workflow.get('task_prompt', ''),
-                    conversation_id=conversation_id,
-                    primary_generated_outputs=list(
-                        (tabular_action_payload or {}).get('generated_tabular_outputs')
-                        or analysis_result.get('generated_tabular_outputs')
-                        or []
+                    settings,
+                    conversation_id,
+                    cancel_requested=cancel_requested,
+                    request_correlation_id=request_correlation_id,
+                    additional_generated_outputs=primary_generated_outputs,
+                )
+                try:
+                    document_analysis_artifact_payload = _maybe_create_document_analysis_generated_artifacts(
+                        analysis_result,
+                        workflow.get('task_prompt', ''),
+                        conversation_id=conversation_id,
+                        primary_generated_outputs=primary_generated_outputs,
+                        cancel_requested=cancel_requested,
+                        request_correlation_id=request_correlation_id,
+                    )
+                except MixedSourceCancellationError:
+                    _rollback_mixed_source_generated_outputs(
+                        user_id,
+                        conversation_id,
+                        primary_generated_outputs,
+                        reason='cancellation',
+                    )
+                    raise
+                _reauthorize_mixed_source_workflow_result(
+                    workflow,
+                    analysis_config,
+                    analysis_result,
+                    settings,
+                    conversation_id,
+                    cancel_requested=cancel_requested,
+                    request_correlation_id=request_correlation_id,
+                    additional_generated_outputs=(
+                        primary_generated_outputs
+                        + list(document_analysis_artifact_payload.get('artifacts') or [])
                     ),
                 )
                 agent_citations = _build_agent_citations_from_invocations(user_id, conversation_id)
@@ -5642,6 +6291,13 @@ def _execute_document_analysis_workflow(
                     )
                 alert_targets = _collect_agent_alert_targets(user_id, conversation_id)
                 token_usage = _finalize_token_usage(token_usage_aggregate)
+                if analysis_result.get('mixed_source_manifest'):
+                    _emit_mixed_source_token_telemetry(
+                        settings,
+                        'analyze',
+                        token_usage,
+                        request_correlation_id=request_correlation_id,
+                    )
 
                 return {
                     'reply': (
@@ -5722,6 +6378,9 @@ def _execute_document_analysis_workflow(
             return ''
         return _extract_message_text(completion.choices[0].message.content)
 
+    def record_native_token_usage(token_usage):
+        _accumulate_token_usage_summary(token_usage_aggregate, token_usage)
+
     mixed_source_enabled = bool(settings.get('enable_mixed_source_analyze', False))
     tabular_action_payload = None
     if mixed_source_enabled:
@@ -5730,6 +6389,9 @@ def _execute_document_analysis_workflow(
             conversation_id=conversation_id, activity_callback=activity_callback,
             thought_tracker=thought_tracker, live_thought_callback=external_activity_callback,
             max_documents=workflow_analysis_max_documents,
+            cancel_requested=cancel_requested,
+            request_correlation_id=request_correlation_id,
+            token_usage_callback=record_native_token_usage,
         )
     else:
         tabular_action_payload = _maybe_execute_tabular_document_action(
@@ -5741,6 +6403,9 @@ def _execute_document_analysis_workflow(
             invoke_prompt=invoke_model_prompt,
             thought_tracker=thought_tracker,
             live_thought_callback=external_activity_callback,
+            cancel_requested=cancel_requested,
+            request_correlation_id=request_correlation_id,
+            token_usage_callback=record_native_token_usage,
         )
     if tabular_action_payload:
         analysis_result = tabular_action_payload.get('result') or {}
@@ -5759,18 +6424,62 @@ def _execute_document_analysis_workflow(
             max_retries_per_window=analysis_config.get('max_retries_per_window'),
             activity_callback=activity_callback,
             max_documents=workflow_analysis_max_documents,
+            cancel_requested=cancel_requested,
+            request_correlation_id=request_correlation_id,
         )
-    document_analysis_artifact_payload = _maybe_create_document_analysis_generated_artifacts(
+    primary_generated_outputs = list(
+        (tabular_action_payload or {}).get('generated_tabular_outputs')
+        or analysis_result.get('generated_tabular_outputs')
+        or []
+    )
+    _reauthorize_mixed_source_workflow_result(
+        workflow,
+        analysis_config,
         analysis_result,
-        workflow.get('task_prompt', ''),
-        conversation_id=conversation_id,
-        primary_generated_outputs=list(
-            (tabular_action_payload or {}).get('generated_tabular_outputs')
-            or analysis_result.get('generated_tabular_outputs')
-            or []
+        settings,
+        conversation_id,
+        cancel_requested=cancel_requested,
+        request_correlation_id=request_correlation_id,
+        additional_generated_outputs=primary_generated_outputs,
+    )
+    try:
+        document_analysis_artifact_payload = _maybe_create_document_analysis_generated_artifacts(
+            analysis_result,
+            workflow.get('task_prompt', ''),
+            conversation_id=conversation_id,
+            primary_generated_outputs=primary_generated_outputs,
+            cancel_requested=cancel_requested,
+            request_correlation_id=request_correlation_id,
+        )
+    except MixedSourceCancellationError:
+        _rollback_mixed_source_generated_outputs(
+            user_id,
+            conversation_id,
+            primary_generated_outputs,
+            reason='cancellation',
+        )
+        raise
+    _reauthorize_mixed_source_workflow_result(
+        workflow,
+        analysis_config,
+        analysis_result,
+        settings,
+        conversation_id,
+        cancel_requested=cancel_requested,
+        request_correlation_id=request_correlation_id,
+        additional_generated_outputs=(
+            primary_generated_outputs
+            + list(document_analysis_artifact_payload.get('artifacts') or [])
         ),
     )
     token_usage = _finalize_token_usage(token_usage_aggregate)
+    if analysis_result.get('mixed_source_manifest'):
+        _emit_mixed_source_token_telemetry(
+            settings,
+            'analyze',
+            token_usage,
+            request_correlation_id=request_correlation_id,
+        )
     debug_print(
         '[WorkflowDocumentAnalysis] Completed workflow action | '
         f"workflow_id={workflow.get('id')} | "
@@ -5814,7 +6523,14 @@ def _execute_document_comparison_workflow(
     external_activity_callback=None,
     action_config=None,
     url_access_context=None,
+    cancel_requested=None,
+    request_correlation_id=None,
 ):
+    raise_if_mixed_source_cancelled(
+        cancel_requested,
+        'manifest',
+        request_correlation_id=request_correlation_id,
+    )
     comparison_config = action_config if isinstance(action_config, dict) else _get_document_action_config(workflow)
     if comparison_config.get('type') != DOCUMENT_ACTION_TYPE_COMPARISON:
         raise ValueError('Document comparison is not enabled for this workflow.')
@@ -5901,12 +6617,18 @@ def _execute_document_comparison_workflow(
                     _accumulate_token_usage(token_usage_aggregate, result)
                     return str(result)
 
+                def record_native_token_usage(token_usage):
+                    _accumulate_token_usage_summary(token_usage_aggregate, token_usage)
+
                 mixed_comparison_enabled = is_cross_format_compare_enabled(settings)
                 mixed_comparison_result = (
                     _execute_cross_format_comparison_workflow(
                         workflow, comparison_config, settings, invoke_prompt,
                         conversation_id=conversation_id, activity_callback=activity_callback,
                         thought_tracker=thought_tracker, live_thought_callback=external_activity_callback,
+                        cancel_requested=cancel_requested,
+                        request_correlation_id=request_correlation_id,
+                        token_usage_callback=record_native_token_usage,
                     ) if mixed_comparison_enabled else None
                 )
                 if not mixed_comparison_enabled:
@@ -5915,6 +6637,9 @@ def _execute_document_comparison_workflow(
                     DOCUMENT_ACTION_TYPE_COMPARISON, workflow, comparison_config, settings,
                     conversation_id=conversation_id, invoke_prompt=invoke_prompt,
                     thought_tracker=thought_tracker, live_thought_callback=external_activity_callback,
+                    cancel_requested=cancel_requested,
+                    request_correlation_id=request_correlation_id,
+                    token_usage_callback=record_native_token_usage,
                 )
                 if mixed_comparison_result:
                     comparison_result = mixed_comparison_result
@@ -5928,17 +6653,69 @@ def _execute_document_comparison_workflow(
                         invoke_prompt=invoke_prompt,
                         activity_callback=activity_callback,
                         conversation_id=conversation_id,
+                        cancel_requested=cancel_requested,
+                        request_correlation_id=request_correlation_id,
                     )
-                comparison_artifact_payload = _maybe_create_comparison_generated_artifacts(
-                    comparison_result,
-                    workflow.get('task_prompt', ''),
-                    conversation_id=conversation_id,
-                )
                 agent_citations = _build_agent_citations_from_invocations(user_id, conversation_id)
-                if not agent_citations:
-                    agent_citations = list((tabular_action_payload or {}).get('agent_citations') or [])
+                agent_citations = deduplicate_mixed_source_references(
+                    list(agent_citations or [])
+                    + list((tabular_action_payload or {}).get('agent_citations') or [])
+                    + list(comparison_result.get('agent_citations') or []),
+                    reference_type='citation',
+                )
+                generated_tabular_outputs = deduplicate_mixed_source_references(
+                    list((tabular_action_payload or {}).get('generated_tabular_outputs') or [])
+                    + list(comparison_result.get('generated_tabular_outputs') or []),
+                    reference_type='artifact',
+                )
+                _reauthorize_mixed_source_workflow_result(
+                    workflow,
+                    comparison_config,
+                    comparison_result,
+                    settings,
+                    conversation_id,
+                    cancel_requested=cancel_requested,
+                    request_correlation_id=request_correlation_id,
+                    additional_generated_outputs=generated_tabular_outputs,
+                )
+                try:
+                    comparison_artifact_payload = _maybe_create_comparison_generated_artifacts(
+                        comparison_result,
+                        workflow.get('task_prompt', ''),
+                        conversation_id=conversation_id,
+                        cancel_requested=cancel_requested,
+                        request_correlation_id=request_correlation_id,
+                    )
+                except MixedSourceCancellationError:
+                    _rollback_mixed_source_generated_outputs(
+                        user_id,
+                        conversation_id,
+                        generated_tabular_outputs,
+                        reason='cancellation',
+                    )
+                    raise
+                _reauthorize_mixed_source_workflow_result(
+                    workflow,
+                    comparison_config,
+                    comparison_result,
+                    settings,
+                    conversation_id,
+                    cancel_requested=cancel_requested,
+                    request_correlation_id=request_correlation_id,
+                    additional_generated_outputs=(
+                        generated_tabular_outputs
+                        + list(comparison_artifact_payload.get('artifacts') or [])
+                    ),
+                )
                 alert_targets = _collect_agent_alert_targets(user_id, conversation_id)
                 token_usage = _finalize_token_usage(token_usage_aggregate)
+                if comparison_result.get('mixed_source_manifest'):
+                    _emit_mixed_source_token_telemetry(
+                        settings,
+                        'compare',
+                        token_usage,
+                        request_correlation_id=request_correlation_id,
+                    )
 
                 return {
                     'reply': (
@@ -5954,7 +6731,7 @@ def _execute_document_comparison_workflow(
                     'agent_name': getattr(loaded_agent, 'name', None) or requested_name,
                     'agent_display_name': getattr(loaded_agent, 'display_name', None) or selected_agent.get('display_name') or requested_name,
                     'agent_citations': agent_citations,
-                    'generated_tabular_outputs': list((tabular_action_payload or {}).get('generated_tabular_outputs') or []),
+                    'generated_tabular_outputs': generated_tabular_outputs,
                     'alert_targets': alert_targets,
                 }
             finally:
@@ -6015,12 +6792,18 @@ def _execute_document_comparison_workflow(
             return ''
         return _extract_message_text(completion.choices[0].message.content)
 
+    def record_native_token_usage(token_usage):
+        _accumulate_token_usage_summary(token_usage_aggregate, token_usage)
+
     mixed_comparison_enabled = is_cross_format_compare_enabled(settings)
     mixed_comparison_result = (
         _execute_cross_format_comparison_workflow(
             workflow, comparison_config, settings, invoke_model_prompt,
             conversation_id=conversation_id, activity_callback=activity_callback,
             thought_tracker=thought_tracker, live_thought_callback=external_activity_callback,
+            cancel_requested=cancel_requested,
+            request_correlation_id=request_correlation_id,
+            token_usage_callback=record_native_token_usage,
         ) if mixed_comparison_enabled else None
     )
     if not mixed_comparison_enabled:
@@ -6029,6 +6812,9 @@ def _execute_document_comparison_workflow(
         DOCUMENT_ACTION_TYPE_COMPARISON, workflow, comparison_config, settings,
         conversation_id=conversation_id, invoke_prompt=invoke_model_prompt,
         thought_tracker=thought_tracker, live_thought_callback=external_activity_callback,
+        cancel_requested=cancel_requested,
+        request_correlation_id=request_correlation_id,
+        token_usage_callback=record_native_token_usage,
     )
     if mixed_comparison_result:
         comparison_result = mixed_comparison_result
@@ -6042,13 +6828,66 @@ def _execute_document_comparison_workflow(
             invoke_prompt=invoke_model_prompt,
             activity_callback=activity_callback,
             conversation_id=conversation_id,
+            cancel_requested=cancel_requested,
+            request_correlation_id=request_correlation_id,
         )
-    comparison_artifact_payload = _maybe_create_comparison_generated_artifacts(
+    agent_citations = deduplicate_mixed_source_references(
+        list((tabular_action_payload or {}).get('agent_citations') or [])
+        + list(comparison_result.get('agent_citations') or []),
+        reference_type='citation',
+    )
+    generated_tabular_outputs = deduplicate_mixed_source_references(
+        list((tabular_action_payload or {}).get('generated_tabular_outputs') or [])
+        + list(comparison_result.get('generated_tabular_outputs') or []),
+        reference_type='artifact',
+    )
+    _reauthorize_mixed_source_workflow_result(
+        workflow,
+        comparison_config,
         comparison_result,
-        workflow.get('task_prompt', ''),
-        conversation_id=conversation_id,
+        settings,
+        conversation_id,
+        cancel_requested=cancel_requested,
+        request_correlation_id=request_correlation_id,
+        additional_generated_outputs=generated_tabular_outputs,
+    )
+    try:
+        comparison_artifact_payload = _maybe_create_comparison_generated_artifacts(
+            comparison_result,
+            workflow.get('task_prompt', ''),
+            conversation_id=conversation_id,
+            cancel_requested=cancel_requested,
+            request_correlation_id=request_correlation_id,
+        )
+    except MixedSourceCancellationError:
+        _rollback_mixed_source_generated_outputs(
+            user_id,
+            conversation_id,
+            generated_tabular_outputs,
+            reason='cancellation',
+        )
+        raise
+    _reauthorize_mixed_source_workflow_result(
+        workflow,
+        comparison_config,
+        comparison_result,
+        settings,
+        conversation_id,
+        cancel_requested=cancel_requested,
+        request_correlation_id=request_correlation_id,
+        additional_generated_outputs=(
+            generated_tabular_outputs
+            + list(comparison_artifact_payload.get('artifacts') or [])
+        ),
     )
     token_usage = _finalize_token_usage(token_usage_aggregate)
+    if comparison_result.get('mixed_source_manifest'):
+        _emit_mixed_source_token_telemetry(
+            settings,
+            'compare',
+            token_usage,
+            request_correlation_id=request_correlation_id,
+        )
     debug_print(
         '[WorkflowDocumentComparison] Completed workflow action | '
         f"workflow_id={workflow.get('id')} | "
@@ -6070,8 +6909,8 @@ def _execute_document_comparison_workflow(
         'model_deployment_name': deployment_name,
         'token_usage': token_usage,
         'provider': provider,
-        'agent_citations': list((tabular_action_payload or {}).get('agent_citations') or []),
-        'generated_tabular_outputs': list((tabular_action_payload or {}).get('generated_tabular_outputs') or []),
+        'agent_citations': agent_citations,
+        'generated_tabular_outputs': generated_tabular_outputs,
     }
 
 
@@ -6083,7 +6922,17 @@ def _execute_document_action_workflow(
     thought_tracker=None,
     external_activity_callback=None,
     url_access_context=None,
+    cancel_requested=None,
+    request_correlation_id=None,
 ):
+    request_correlation_id = normalize_mixed_source_correlation_id(
+        request_correlation_id
+    )
+    raise_if_mixed_source_cancelled(
+        cancel_requested,
+        'manifest',
+        request_correlation_id=request_correlation_id,
+    )
     action_config = _get_document_action_config(workflow)
     action_config = _resolve_recent_document_action_targets(workflow, action_config, settings)
     workflow = _apply_runtime_document_action_config(workflow, action_config)
@@ -6108,6 +6957,8 @@ def _execute_document_action_workflow(
                 external_activity_callback=external_activity_callback,
                 action_config=action_config,
                 url_access_context=url_access_context,
+                cancel_requested=cancel_requested,
+                request_correlation_id=request_correlation_id,
             )
         elif action_type == DOCUMENT_ACTION_TYPE_COMPARISON:
             result = _execute_document_comparison_workflow(
@@ -6119,6 +6970,8 @@ def _execute_document_action_workflow(
                 external_activity_callback=external_activity_callback,
                 action_config=action_config,
                 url_access_context=url_access_context,
+                cancel_requested=cancel_requested,
+                request_correlation_id=request_correlation_id,
             )
         else:
             raise ValueError('No document action is enabled for this workflow.')
@@ -6133,6 +6986,11 @@ def _execute_document_action_workflow(
         )
         raise
 
+    raise_if_mixed_source_cancelled(
+        cancel_requested,
+        'finalization',
+        request_correlation_id=request_correlation_id,
+    )
     debug_print(
         '[WorkflowDocumentAction] Action completed | '
         f"workflow_id={workflow.get('id')} | "

--- a/application/single_app/route_backend_chats.py
+++ b/application/single_app/route_backend_chats.py
@@ -38,14 +38,24 @@ from functions_model_endpoint_runtime import (
     build_semantic_kernel_chat_service_for_model,
 )
 from functions_mixed_source_orchestration import (
+    MixedSourceCancellationError,
+    MixedSourceFinalizationError,
+    build_failed_narrative_evidence_envelopes,
     build_mixed_source_evidence_handoff,
     build_narrative_evidence_envelopes,
     build_tabular_file_contexts_from_manifest,
+    compare_reauthorized_source_manifests,
+    emit_mixed_source_telemetry,
     execute_tabular_evidence_sources,
+    normalize_mixed_source_correlation_id,
     normalize_document_context_request,
     partition_source_manifest,
     resolve_authorized_source_manifest,
+    raise_if_mixed_source_cancelled,
     should_run_tabular_evidence,
+)
+from functions_tabular_analysis import (
+    get_new_plugin_invocations as _shared_get_new_plugin_invocations,
 )
 import builtins
 import asyncio, types
@@ -170,6 +180,7 @@ from functions_thoughts import ThoughtTracker
 from functions_tabular_csv_query import validate_tabular_csv_query_expression
 from functions_workflow_runner import _execute_document_action_workflow
 from functions_simplechat_operations import (
+    delete_generated_chat_artifact_for_current_user,
     derive_conversation_title_from_message,
     upload_chat_image_bytes_for_user,
     upload_generated_analysis_artifact_for_current_user,
@@ -295,6 +306,37 @@ def _safe_metadata_int(value):
         return 0
 
 
+def _merge_chat_token_usage(*token_summaries):
+    """Merge observed token summaries without estimating missing provider usage."""
+    merged = {
+        'prompt_tokens': 0,
+        'completion_tokens': 0,
+        'total_tokens': 0,
+        'request_count': 0,
+    }
+    has_usage = False
+    for token_summary in token_summaries:
+        if not isinstance(token_summary, dict):
+            continue
+        summary_has_usage = False
+        for key in ('prompt_tokens', 'completion_tokens', 'total_tokens'):
+            try:
+                value = max(0, int(token_summary.get(key) or 0))
+            except (TypeError, ValueError):
+                value = 0
+            merged[key] += value
+            summary_has_usage = summary_has_usage or bool(value)
+        try:
+            request_count = max(0, int(token_summary.get('request_count') or 0))
+        except (TypeError, ValueError):
+            request_count = 0
+        if not request_count and summary_has_usage:
+            request_count = 1
+        merged['request_count'] += request_count
+        has_usage = has_usage or summary_has_usage or bool(request_count)
+    return merged if has_usage else None
+
+
 def _normalize_capability_action(document_action_type):
     normalized_action_type = str(document_action_type or DOCUMENT_ACTION_TYPE_NONE).strip().lower()
     if normalized_action_type == DOCUMENT_ACTION_TYPE_ANALYZE:
@@ -377,6 +419,8 @@ def _resolve_chat_mixed_source_manifest(
     selection_mode,
     active_group_ids=None,
     active_public_workspace_ids=None,
+    cancel_requested=None,
+    request_correlation_id=None,
 ):
     """Resolve a fresh Phase 1 manifest for Phase 2 Chat evidence preparation."""
     if not is_mixed_source_chat_search_enabled(settings):
@@ -391,6 +435,8 @@ def _resolve_chat_mixed_source_manifest(
         conversation_id=conversation_id,
         active_group_ids=active_group_ids,
         active_public_workspace_ids=active_public_workspace_ids,
+        cancel_requested=cancel_requested,
+        request_correlation_id=request_correlation_id,
     )
 
 
@@ -411,6 +457,8 @@ def _resolve_chat_mixed_source_partition(
     selection_mode,
     active_group_ids=None,
     active_public_workspace_ids=None,
+    cancel_requested=None,
+    request_correlation_id=None,
 ):
     """Resolve and partition one current authorization-safe source manifest."""
     manifest = _resolve_chat_mixed_source_manifest(
@@ -421,6 +469,8 @@ def _resolve_chat_mixed_source_partition(
         selection_mode,
         active_group_ids=active_group_ids,
         active_public_workspace_ids=active_public_workspace_ids,
+        cancel_requested=cancel_requested,
+        request_correlation_id=request_correlation_id,
     )
     partitions = partition_source_manifest(manifest)
     return {
@@ -482,6 +532,117 @@ def _build_mixed_source_continuity_refs(manifest, evidence_envelopes, selection_
     return continuity_refs
 
 
+def _reauthorize_document_action_finalization(
+    normalized_action,
+    execution_result,
+    user_id,
+    conversation_id,
+    cancel_requested=None,
+    request_correlation_id=None,
+    settings=None,
+):
+    """Reauthorize every action source and exact version before publishing output."""
+    raise_if_mixed_source_cancelled(
+        cancel_requested,
+        'finalization',
+        request_correlation_id=request_correlation_id,
+    )
+    normalized_action = normalized_action if isinstance(normalized_action, dict) else {}
+    analysis_result = (
+        execution_result.get('analysis_result')
+        if isinstance(execution_result, dict)
+        and isinstance(execution_result.get('analysis_result'), dict)
+        else {}
+    )
+    execution_manifest = analysis_result.get('mixed_source_manifest')
+    requested_ids = [
+        str(document_id or '').strip()
+        for document_id in list(normalized_action.get('document_ids') or [])
+        if str(document_id or '').strip()
+    ]
+    if not requested_ids and isinstance(execution_manifest, list):
+        requested_ids = [
+            str(source.get('document_id') or '').strip()
+            for source in execution_manifest
+            if isinstance(source, dict) and str(source.get('document_id') or '').strip()
+        ]
+    if not requested_ids:
+        return
+
+    finalization_selection_mode = str(
+        normalized_action.get('target_mode') or 'selected'
+    ).strip().lower()
+    if finalization_selection_mode not in {'selected', 'all', 'history', 'relevance'}:
+        finalization_selection_mode = 'selected'
+    fresh_manifest = resolve_authorized_source_manifest(
+        requested_ids,
+        user_id=user_id,
+        selection_mode=finalization_selection_mode,
+        conversation_id=conversation_id,
+        active_group_ids=normalized_action.get('active_group_ids'),
+        active_public_workspace_ids=normalized_action.get('active_public_workspace_id'),
+        doc_scope=normalized_action.get('doc_scope', 'all'),
+        cancel_requested=cancel_requested,
+        request_correlation_id=request_correlation_id,
+    )
+    if isinstance(execution_manifest, list):
+        _validate_reauthorized_manifest_finalization(
+            execution_manifest,
+            fresh_manifest,
+            settings=settings,
+            mode=(
+                'compare'
+                if normalized_action.get('type') == DOCUMENT_ACTION_TYPE_COMPARISON
+                else 'analyze'
+            ),
+            request_correlation_id=request_correlation_id,
+        )
+    elif len(fresh_manifest) != len(requested_ids) or any(
+        source.get('authorization_status') != 'authorized'
+        for source in fresh_manifest
+    ):
+        raise PermissionError('One or more selected sources are no longer available.')
+
+
+def _validate_reauthorized_manifest_finalization(
+    execution_manifest,
+    fresh_manifest,
+    settings=None,
+    mode='chat',
+    request_correlation_id=None,
+):
+    """Require every previously authorized source to retain identity and version."""
+    finalization_result = compare_reauthorized_source_manifests(
+        execution_manifest,
+        fresh_manifest,
+    )
+    authorization_failure_count = finalization_result['authorization_failure_count']
+    source_version_changed_count = finalization_result['source_version_changed_count']
+
+    if authorization_failure_count:
+        emit_mixed_source_telemetry(
+            settings,
+            'authorization_failure',
+            mode,
+            request_correlation_id=request_correlation_id,
+            metrics={
+                'authorization_failure_count': authorization_failure_count,
+            },
+            dimensions={'outcome_status': 'failed'},
+        )
+        raise MixedSourceFinalizationError('authorization_lost')
+    if source_version_changed_count:
+        log_event(
+            '[MixedSourceLifecycle] Finalization source version changed.',
+            extra={
+                'request_correlation_id': request_correlation_id,
+                'source_version_changed_count': source_version_changed_count,
+            },
+            level=logging.WARNING,
+        )
+        raise MixedSourceFinalizationError('source_version_changed')
+
+
 def _build_reauthorized_continuity_decision(prior_refs, manifest, explicit_selection):
     """Describe a fresh manifest decision without treating persisted refs as authority."""
     if explicit_selection:
@@ -501,6 +662,7 @@ def _build_reauthorized_continuity_decision(prior_refs, manifest, explicit_selec
     }
     unavailable_source_count = 0
     source_version_changed_count = 0
+    incomplete_prior_source_count = 0
     reauthorized_source_count = 0
     for source in list(manifest or []):
         document_id = str((source or {}).get('document_id') or '').strip()
@@ -511,6 +673,19 @@ def _build_reauthorized_continuity_decision(prior_refs, manifest, explicit_selec
             unavailable_source_count += 1
             continue
         reauthorized_source_count += 1
+        prior_status = str(prior_ref.get('status') or '').strip().lower()
+        prior_coverage = (
+            prior_ref.get('coverage')
+            if isinstance(prior_ref.get('coverage'), dict)
+            else {}
+        )
+        if (
+            prior_status not in {'completed'}
+            or prior_coverage.get('partial_coverage')
+            or prior_coverage.get('failed')
+            or prior_coverage.get('evidence_envelope_truncated')
+        ):
+            incomplete_prior_source_count += 1
         prior_version = prior_ref.get('source_version')
         current_version = source.get('source_version')
         if prior_version is not None and current_version is not None and str(prior_version) != str(current_version):
@@ -522,10 +697,66 @@ def _build_reauthorized_continuity_decision(prior_refs, manifest, explicit_selec
         'reauthorized_source_count': reauthorized_source_count,
         'unavailable_source_count': unavailable_source_count,
         'source_version_changed_count': source_version_changed_count,
+        'incomplete_prior_source_count': incomplete_prior_source_count,
         'requires_native_execution': bool(
-            unavailable_source_count or source_version_changed_count
+            unavailable_source_count
+            or source_version_changed_count
+            or incomplete_prior_source_count
         ),
     }
+
+
+def _resolve_reauthorized_continuity_decision(
+    settings,
+    user_id,
+    conversation_id,
+    prior_refs,
+    request_correlation_id=None,
+):
+    """Resolve persisted continuity hints through a fresh authorized manifest."""
+    if not is_mixed_source_conversation_continuity_enabled(settings):
+        return None
+    requested_document_ids = [
+        str(ref.get('document_id') or '').strip()
+        for ref in list(prior_refs or [])
+        if isinstance(ref, dict) and str(ref.get('document_id') or '').strip()
+    ]
+    if not requested_document_ids:
+        return None
+
+    search_parameters = build_prior_grounded_document_search_parameters(prior_refs)
+    search_parameters = revalidate_prior_grounded_document_search_parameters(
+        user_id,
+        search_parameters,
+    )
+    manifest = _resolve_chat_mixed_source_manifest(
+        settings,
+        user_id,
+        conversation_id,
+        requested_document_ids,
+        'history',
+        active_group_ids=search_parameters.get('active_group_ids'),
+        active_public_workspace_ids=search_parameters.get('active_public_workspace_ids'),
+        request_correlation_id=request_correlation_id,
+    )
+    return _build_reauthorized_continuity_decision(
+        prior_refs,
+        manifest,
+        explicit_selection=False,
+    )
+
+
+def _can_reuse_prior_grounded_history(history_assessment, continuity_decision):
+    """Return whether existing history is complete enough to avoid fresh native evidence."""
+    if (
+        isinstance(continuity_decision, dict)
+        and continuity_decision.get('requires_native_execution')
+    ):
+        return False
+    return bool(
+        isinstance(history_assessment, dict)
+        and history_assessment.get('can_answer_from_history')
+    )
 
 
 def _resolve_chat_mixed_source_relevance_context(
@@ -540,6 +771,8 @@ def _resolve_chat_mixed_source_relevance_context(
     tags_filter=None,
     active_group_ids=None,
     active_public_workspace_ids=None,
+    cancel_requested=None,
+    request_correlation_id=None,
 ):
     """Add bounded schema candidates and reauthorize all relevance-derived sources."""
     if not is_mixed_source_chat_search_enabled(settings):
@@ -594,6 +827,8 @@ def _resolve_chat_mixed_source_relevance_context(
         'relevance',
         active_group_ids=active_group_ids,
         active_public_workspace_ids=active_public_workspace_ids,
+        cancel_requested=cancel_requested,
+        request_correlation_id=request_correlation_id,
     )
     narrative_document_id_set = set(
         resolved_context.get('narrative_document_ids') or []
@@ -1435,6 +1670,124 @@ def _strip_agent_citation_artifact_refs(agent_citations):
     return compact_citations
 
 
+def _rollback_agent_citation_artifacts(conversation_id, compact_citations):
+    """Remove current-message citation artifacts and chunks after aborted publication."""
+    normalized_conversation_id = str(conversation_id or '').strip()
+    artifact_ids = []
+    for citation in list(compact_citations or []):
+        if not isinstance(citation, dict):
+            continue
+        artifact_id = str(citation.get('artifact_id') or '').strip()
+        if artifact_id and artifact_id not in artifact_ids:
+            artifact_ids.append(artifact_id)
+
+    deleted_artifact_count = 0
+    rollback_failure_count = 0
+    for artifact_id in artifact_ids:
+        try:
+            chunk_documents = list(cosmos_messages_container.query_items(
+                query='SELECT c.id FROM c WHERE c.parent_message_id = @parent_message_id',
+                parameters=[{'name': '@parent_message_id', 'value': artifact_id}],
+                partition_key=normalized_conversation_id,
+            ))
+            for chunk_document in chunk_documents:
+                chunk_id = str((chunk_document or {}).get('id') or '').strip()
+                if chunk_id:
+                    cosmos_messages_container.delete_item(
+                        item=chunk_id,
+                        partition_key=normalized_conversation_id,
+                    )
+            cosmos_messages_container.delete_item(
+                item=artifact_id,
+                partition_key=normalized_conversation_id,
+            )
+            deleted_artifact_count += 1
+        except Exception:
+            rollback_failure_count += 1
+
+    if artifact_ids:
+        log_event(
+            '[MixedSourceLifecycle] Citation artifact rollback completed.',
+            extra={
+                'citation_artifact_count': len(artifact_ids),
+                'deleted_artifact_count': deleted_artifact_count,
+                'rollback_failure_count': rollback_failure_count,
+            },
+            level=logging.INFO if not rollback_failure_count else logging.WARNING,
+        )
+    return {
+        'deleted_artifact_count': deleted_artifact_count,
+        'rollback_failure_count': rollback_failure_count,
+    }
+
+
+def _rollback_mixed_source_chat_publication(
+    user_id,
+    conversation_id,
+    generated_outputs=None,
+    compact_citations=None,
+):
+    """Cancel queued exports and remove artifacts created before mixed publication stopped."""
+    normalized_user_id = str(user_id or '').strip()
+    normalized_conversation_id = str(conversation_id or '').strip()
+    export_run_ids = []
+    artifact_message_ids = []
+    for output in list(generated_outputs or []):
+        if not isinstance(output, dict):
+            continue
+        export_run_id = str(output.get('export_run_id') or '').strip()
+        artifact_message_id = str(output.get('artifact_message_id') or '').strip()
+        if export_run_id and export_run_id not in export_run_ids:
+            export_run_ids.append(export_run_id)
+        if artifact_message_id and artifact_message_id not in artifact_message_ids:
+            artifact_message_ids.append(artifact_message_id)
+
+    canceled_export_count = 0
+    deleted_generated_artifact_count = 0
+    rollback_failure_count = 0
+    for export_run_id in export_run_ids:
+        try:
+            cancel_result = cancel_tabular_generated_output_run(
+                normalized_user_id,
+                export_run_id,
+            )
+            if isinstance(cancel_result, dict) and cancel_result.get('canceled'):
+                canceled_export_count += 1
+        except Exception:
+            rollback_failure_count += 1
+    for artifact_message_id in artifact_message_ids:
+        try:
+            if delete_generated_chat_artifact_for_current_user(
+                normalized_conversation_id,
+                artifact_message_id,
+            ):
+                deleted_generated_artifact_count += 1
+        except Exception:
+            rollback_failure_count += 1
+
+    citation_rollback = _rollback_agent_citation_artifacts(
+        normalized_conversation_id,
+        compact_citations,
+    )
+    rollback_failure_count += citation_rollback.get('rollback_failure_count', 0)
+    log_event(
+        '[MixedSourceLifecycle] Chat publication rollback completed.',
+        extra={
+            'canceled_export_count': canceled_export_count,
+            'deleted_generated_artifact_count': deleted_generated_artifact_count,
+            'deleted_citation_artifact_count': citation_rollback.get('deleted_artifact_count', 0),
+            'rollback_failure_count': rollback_failure_count,
+        },
+        level=logging.INFO if not rollback_failure_count else logging.WARNING,
+    )
+    return {
+        'canceled_export_count': canceled_export_count,
+        'deleted_generated_artifact_count': deleted_generated_artifact_count,
+        'deleted_citation_artifact_count': citation_rollback.get('deleted_artifact_count', 0),
+        'rollback_failure_count': rollback_failure_count,
+    }
+
+
 FACT_MEMORY_TYPE_FACT = 'fact'
 FACT_MEMORY_TYPE_INSTRUCTION = 'instruction'
 FACT_MEMORY_TYPE_LEGACY_DESCRIBER = 'describer'
@@ -1713,8 +2066,15 @@ def maybe_create_assistant_table_generated_output(
     assistant_content,
     conversation_id,
     existing_outputs=None,
+    cancel_requested=None,
+    request_correlation_id=None,
 ):
     """Save a CSV artifact when a table-request answer contains a parseable table."""
+    raise_if_mixed_source_cancelled(
+        cancel_requested,
+        'artifact_publication',
+        request_correlation_id=request_correlation_id,
+    )
     if _has_generated_tabular_csv_output(existing_outputs):
         return None
 
@@ -1750,7 +2110,22 @@ def maybe_create_assistant_table_generated_output(
                 settings=settings,
                 passthrough_input_rows=True,
             )
-            return build_background_tabular_generated_output_metadata(background_run)
+            background_metadata = build_background_tabular_generated_output_metadata(background_run)
+            try:
+                raise_if_mixed_source_cancelled(
+                    cancel_requested,
+                    'export',
+                    request_correlation_id=request_correlation_id,
+                )
+            except MixedSourceCancellationError:
+                cancel_tabular_generated_output_run(
+                    get_current_user_id(),
+                    background_metadata.get('export_run_id'),
+                )
+                raise
+            return background_metadata
+        except MixedSourceCancellationError:
+            raise
         except Exception as exc:
             log_event(
                 '[Assistant Table Export] Failed to queue large CSV export',
@@ -1766,6 +2141,11 @@ def maybe_create_assistant_table_generated_output(
             return None
 
     try:
+        raise_if_mixed_source_cancelled(
+            cancel_requested,
+            'artifact_publication',
+            request_correlation_id=request_correlation_id,
+        )
         upload_result = upload_generated_analysis_artifact_for_current_user(
             conversation_id=conversation_id,
             file_name=generated_file_name,
@@ -1774,6 +2154,20 @@ def maybe_create_assistant_table_generated_output(
             output_format='csv',
             summary=export_payload.get('summary'),
         )
+        try:
+            raise_if_mixed_source_cancelled(
+                cancel_requested,
+                'artifact_publication',
+                request_correlation_id=request_correlation_id,
+            )
+        except MixedSourceCancellationError:
+            delete_generated_chat_artifact_for_current_user(
+                conversation_id,
+                (upload_result.get('message') or {}).get('id'),
+            )
+            raise
+    except MixedSourceCancellationError:
+        raise
     except Exception as exc:
         log_event(
             '[Assistant Table Export] Failed to save assistant table CSV artifact',
@@ -2971,6 +3365,8 @@ def persist_agent_citation_artifacts(
     agent_citations,
     created_timestamp,
     user_info=None,
+    cancel_requested=None,
+    request_correlation_id=None,
 ):
     """Persist raw agent citation payloads outside the primary assistant message doc."""
     if not agent_citations:
@@ -2984,10 +3380,43 @@ def persist_agent_citation_artifacts(
         user_info=user_info,
     )
 
+    persisted_artifact_ids = []
     try:
+        raise_if_mixed_source_cancelled(
+            cancel_requested,
+            'artifact_publication',
+            request_correlation_id=request_correlation_id,
+        )
         for artifact_doc in artifact_docs:
+            raise_if_mixed_source_cancelled(
+                cancel_requested,
+                'artifact_publication',
+                request_correlation_id=request_correlation_id,
+            )
             cosmos_messages_container.upsert_item(artifact_doc)
+            artifact_id = str(artifact_doc.get('id') or '').strip()
+            if artifact_id:
+                persisted_artifact_ids.append(artifact_id)
+        raise_if_mixed_source_cancelled(
+            cancel_requested,
+            'artifact_publication',
+            request_correlation_id=request_correlation_id,
+        )
         return compact_citations
+    except MixedSourceCancellationError:
+        for artifact_id in reversed(persisted_artifact_ids):
+            try:
+                cosmos_messages_container.delete_item(
+                    item=artifact_id,
+                    partition_key=conversation_id,
+                )
+            except Exception:
+                log_event(
+                    '[Agent Citations] Citation rollback after cancellation failed.',
+                    extra={'citation_artifact_rollback_failure_count': 1},
+                    level=logging.WARNING,
+                )
+        raise
     except Exception as exc:
         log_event(
             f"[Agent Citations] Failed to persist assistant artifacts: {exc}",
@@ -5138,6 +5567,7 @@ async def _generate_tabular_structured_output_entries(
     user_id=None,
     conversation_id=None,
     model_context=None,
+    token_usage_callback=None,
 ):
     from semantic_kernel.contents.chat_history import ChatHistory as SKChatHistory
 
@@ -5310,6 +5740,11 @@ async def _generate_tabular_structured_output_entries(
 
             execution_settings = AzureChatPromptExecutionSettings(service_id='tabular-generated-output')
             result = await chat_service.get_chat_message_contents(chat_history, execution_settings)
+            if result:
+                _publish_tabular_response_token_usage(
+                    result[0],
+                    token_usage_callback,
+                )
             raw_response_content = result[0].content if result and result[0].content else ''
             if result and result[0].content:
                 parsed_entries = _parse_tabular_generated_json_entries(raw_response_content)
@@ -5389,8 +5824,16 @@ async def maybe_create_tabular_generated_output(
     thought_callback=None,
     user_id=None,
     model_context=None,
+    cancel_requested=None,
+    request_correlation_id=None,
+    token_usage_callback=None,
 ):
     """Build, upload, and describe a generated tabular JSON/CSV export when requested."""
+    raise_if_mixed_source_cancelled(
+        cancel_requested,
+        'export',
+        request_correlation_id=request_correlation_id,
+    )
     if not question_requests_tabular_generated_output(user_question):
         return None
 
@@ -5494,6 +5937,11 @@ async def maybe_create_tabular_generated_output(
         and not exceeds_background_threshold
     )
     if should_queue_materialized_pages:
+        raise_if_mixed_source_cancelled(
+            cancel_requested,
+            'export',
+            request_correlation_id=request_correlation_id,
+        )
         background_run = queue_tabular_generated_output_run(
             user_id=user_id,
             conversation_id=conversation_id,
@@ -5506,6 +5954,18 @@ async def maybe_create_tabular_generated_output(
             model_context=model_context,
         )
         background_metadata = build_background_tabular_generated_output_metadata(background_run)
+        try:
+            raise_if_mixed_source_cancelled(
+                cancel_requested,
+                'export',
+                request_correlation_id=request_correlation_id,
+            )
+        except MixedSourceCancellationError:
+            cancel_tabular_generated_output_run(
+                user_id,
+                background_metadata.get('export_run_id'),
+            )
+            raise
         await emit_tabular_post_processing_thought(
             thought_callback,
             f"Queued exhaustive {str(output_format or 'json').upper()} export from validated tabular pages",
@@ -5536,6 +5996,11 @@ async def maybe_create_tabular_generated_output(
     )
     if should_queue_source_backed_run:
         try:
+            raise_if_mixed_source_cancelled(
+                cancel_requested,
+                'export',
+                request_correlation_id=request_correlation_id,
+            )
             background_run = queue_tabular_generated_output_run(
                 user_id=user_id,
                 conversation_id=conversation_id,
@@ -5548,6 +6013,8 @@ async def maybe_create_tabular_generated_output(
                 model_context=model_context,
                 source_descriptor=source_descriptor,
             )
+        except MixedSourceCancellationError:
+            raise
         except Exception as exc:
             log_event(
                 '[Tabular Generated Output] Durable source-backed export queueing failed',
@@ -5566,6 +6033,18 @@ async def maybe_create_tabular_generated_output(
                 'The exhaustive export could not be queued. No partial CSV was created.',
             )
         background_metadata = build_background_tabular_generated_output_metadata(background_run)
+        try:
+            raise_if_mixed_source_cancelled(
+                cancel_requested,
+                'export',
+                request_correlation_id=request_correlation_id,
+            )
+        except MixedSourceCancellationError:
+            cancel_tabular_generated_output_run(
+                user_id,
+                background_metadata.get('export_run_id'),
+            )
+            raise
         await emit_tabular_post_processing_thought(
             thought_callback,
             f"Queued exhaustive {str(output_format or 'json').upper()} export from the authorized source query",
@@ -5623,6 +6102,11 @@ async def maybe_create_tabular_generated_output(
         return None
 
     if question_requests_tabular_structured_object_output(user_question):
+        raise_if_mixed_source_cancelled(
+            cancel_requested,
+            'export',
+            request_correlation_id=request_correlation_id,
+        )
         output_entries = await _generate_tabular_structured_output_entries(
             user_question,
             source_candidate,
@@ -5633,6 +6117,11 @@ async def maybe_create_tabular_generated_output(
             user_id=user_id,
             conversation_id=conversation_id,
             model_context=model_context,
+        )
+        raise_if_mixed_source_cancelled(
+            cancel_requested,
+            'export',
+            request_correlation_id=request_correlation_id,
         )
         if output_entries is None:
             return _build_failed_tabular_generated_output_metadata(
@@ -5690,6 +6179,18 @@ async def maybe_create_tabular_generated_output(
             'in this chat as a downloadable export.'
         ),
     )
+    try:
+        raise_if_mixed_source_cancelled(
+            cancel_requested,
+            'artifact_publication',
+            request_correlation_id=request_correlation_id,
+        )
+    except MixedSourceCancellationError:
+        delete_generated_chat_artifact_for_current_user(
+            conversation_id,
+            (upload_result.get('message') or {}).get('id'),
+        )
+        raise
 
     preview_rows = output_entries[:TABULAR_GENERATED_OUTPUT_PREVIEW_ROWS]
     uploaded_file_name = upload_result.get('message', {}).get('file_name') or generated_file_name
@@ -6589,17 +7090,8 @@ CHAT_STREAM_REGISTRY = ActiveConversationStreamRegistry()
 
 
 def get_new_plugin_invocations(invocations, baseline_count):
-    """Return only the plugin invocations created after the baseline count."""
-    if not invocations:
-        return []
-
-    if baseline_count <= 0:
-        return list(invocations)
-
-    if baseline_count >= len(invocations):
-        return []
-
-    return list(invocations[baseline_count:])
+    """Compatibility shim for existing chat-route imports and call sites."""
+    return _shared_get_new_plugin_invocations(invocations, baseline_count)
 
 
 def split_tabular_plugin_invocations(invocations):
@@ -8427,6 +8919,42 @@ def derive_tabular_follow_up_calls_from_invocations(user_question, invocations):
     return follow_up_calls[:2]
 
 
+def _extract_tabular_response_token_usage(response):
+    """Return observed token usage from a Semantic Kernel response metadata payload."""
+    metadata = getattr(response, 'metadata', None)
+    metadata = metadata if isinstance(metadata, dict) else {}
+    usage = metadata.get('usage') or metadata.get('token_usage')
+    usage = usage if isinstance(usage, dict) else {}
+
+    def as_nonnegative_int(value):
+        try:
+            return max(0, int(value or 0))
+        except (TypeError, ValueError):
+            return 0
+
+    prompt_tokens = as_nonnegative_int(usage.get('prompt_tokens'))
+    completion_tokens = as_nonnegative_int(usage.get('completion_tokens'))
+    total_tokens = as_nonnegative_int(usage.get('total_tokens'))
+    if not total_tokens and (prompt_tokens or completion_tokens):
+        total_tokens = prompt_tokens + completion_tokens
+    if not any((prompt_tokens, completion_tokens, total_tokens)):
+        return None
+    return {
+        'prompt_tokens': prompt_tokens,
+        'completion_tokens': completion_tokens,
+        'total_tokens': total_tokens,
+        'request_count': 1,
+    }
+
+
+def _publish_tabular_response_token_usage(response, token_usage_callback=None):
+    """Publish observed native model usage without changing existing return contracts."""
+    token_usage = _extract_tabular_response_token_usage(response)
+    if token_usage and callable(token_usage_callback):
+        token_usage_callback(token_usage)
+    return token_usage
+
+
 async def maybe_recover_tabular_analysis_with_llm_reviewer(chat_service, kernel,
                                                            tabular_plugin, plugin_logger,
                                                            user_question, schema_context,
@@ -8443,7 +8971,8 @@ async def maybe_recover_tabular_analysis_with_llm_reviewer(chat_service, kernel,
                                                            discovery_feedback_messages=None,
                                                            fallback_source_hint='workspace',
                                                            fallback_group_id=None,
-                                                           fallback_public_workspace_id=None):
+                                                           fallback_public_workspace_id=None,
+                                                           token_usage_callback=None):
     """Use an LLM reviewer to choose analytical tool calls when the main SK loop stalls."""
     reviewer_allowed_function_names = [
         function_name for function_name in (allowed_function_names or [])
@@ -8529,6 +9058,10 @@ async def maybe_recover_tabular_analysis_with_llm_reviewer(chat_service, kernel,
 
     reviewer_text = ''
     if reviewer_result and reviewer_result[0].content:
+        _publish_tabular_response_token_usage(
+            reviewer_result[0],
+            token_usage_callback,
+        )
         reviewer_text = reviewer_result[0].content.strip()
 
     reviewer_calls = parse_tabular_reviewer_plan(reviewer_text)
@@ -9747,7 +10280,8 @@ async def run_tabular_sk_analysis(user_question, tabular_filenames, user_id,
                                    execution_mode='analysis',
                                    tabular_file_contexts=None,
                                    thought_callback=None,
-                                   model_context=None):
+                                   model_context=None,
+                                   token_usage_callback=None):
     """Run lightweight SK with tabular analysis and attachment follow-up support.
 
     Creates a temporary Kernel with TabularProcessingPlugin plus document-search
@@ -10438,6 +10972,11 @@ async def run_tabular_sk_analysis(user_question, tabular_filenames, user_id,
                 result = await chat_service.get_chat_message_contents(
                     chat_history, execution_settings, kernel=kernel
                 )
+                if result:
+                    _publish_tabular_response_token_usage(
+                        result[0],
+                        token_usage_callback,
+                    )
             except Exception as exc:
                 synthesis_exception = exc
                 log_event(
@@ -10782,6 +11321,7 @@ async def run_tabular_sk_analysis(user_question, tabular_filenames, user_id,
                 fallback_source_hint=source_hint,
                 fallback_group_id=group_id,
                 fallback_public_workspace_id=public_workspace_id,
+                token_usage_callback=token_usage_callback,
             )
             if reviewer_recovery and reviewer_recovery.get('fallback'):
                 return reviewer_recovery['fallback']
@@ -10867,6 +11407,8 @@ def _execute_mixed_source_tabular_evidence(
     thought_tracker=None,
     live_thought_callback=None,
     model_context=None,
+    cancel_requested=None,
+    request_correlation_id=None,
 ):
     """Run the existing tabular engine once per manifest source with terminal coverage."""
     source_contexts = build_tabular_file_contexts_from_manifest(tabular_sources)
@@ -10891,6 +11433,21 @@ def _execute_mixed_source_tabular_evidence(
     agent_citations = []
     generated_outputs = []
     all_invocations = []
+    token_usage = {
+        'prompt_tokens': 0,
+        'completion_tokens': 0,
+        'total_tokens': 0,
+        'request_count': 0,
+    }
+
+    def record_token_usage(usage):
+        if not isinstance(usage, dict):
+            return
+        for key in ('prompt_tokens', 'completion_tokens', 'total_tokens', 'request_count'):
+            try:
+                token_usage[key] += max(0, int(usage.get(key) or 0))
+            except (TypeError, ValueError):
+                continue
     if not is_tabular_processing_enabled(settings):
         def fail_unavailable_tabular_source(source):
             del source
@@ -10901,12 +11458,15 @@ def _execute_mixed_source_tabular_evidence(
                 tabular_sources,
                 fail_unavailable_tabular_source,
                 selection_mode,
+                cancel_requested=cancel_requested,
+                request_correlation_id=request_correlation_id,
             ),
             'system_messages': [],
             'agent_citations': [],
             'generated_outputs': [],
             'invocations': [],
             'executed': False,
+            'token_usage': None,
         }
 
     execute_tabular = should_run_tabular_evidence(
@@ -10961,6 +11521,7 @@ def _execute_mixed_source_tabular_evidence(
                 thought_tracker=thought_tracker,
                 live_thought_callback=live_thought_callback,
                 model_context=model_context,
+                token_usage_callback=record_token_usage,
             )
         )
         if not str(tabular_analysis or '').strip():
@@ -11030,6 +11591,9 @@ def _execute_mixed_source_tabular_evidence(
             thought_callback=publish_post_processing_thought,
             user_id=user_id,
             model_context=model_context,
+            cancel_requested=cancel_requested,
+            request_correlation_id=request_correlation_id,
+            token_usage_callback=record_token_usage,
         ))
         if generated_output:
             generated_outputs.append(generated_output)
@@ -11076,6 +11640,8 @@ def _execute_mixed_source_tabular_evidence(
         execute_source,
         selection_mode,
         execute=execute_tabular,
+        cancel_requested=cancel_requested,
+        request_correlation_id=request_correlation_id,
     )
     return {
         'evidence_envelopes': evidence_envelopes,
@@ -11084,6 +11650,7 @@ def _execute_mixed_source_tabular_evidence(
         'generated_outputs': generated_outputs,
         'invocations': all_invocations,
         'executed': execute_tabular,
+        'token_usage': token_usage if token_usage['request_count'] else None,
     }
 
 
@@ -11573,7 +12140,8 @@ async def run_tabular_analysis_with_multi_file_support(user_question, tabular_fi
                                                        execution_mode='analysis',
                                                        tabular_file_contexts=None,
                                                        thought_callback=None,
-                                                       model_context=None):
+                                                       model_context=None,
+                                                       token_usage_callback=None):
     """Run deterministic multi-file helpers first, then fall back to the SK planner."""
     analysis_file_contexts = normalize_tabular_file_contexts_for_analysis(
         tabular_filenames=tabular_filenames,
@@ -11620,6 +12188,7 @@ async def run_tabular_analysis_with_multi_file_support(user_question, tabular_fi
         execution_mode=execution_mode,
         thought_callback=thought_callback,
         model_context=model_context,
+        token_usage_callback=token_usage_callback,
     )
 
 
@@ -11631,7 +12200,8 @@ async def run_tabular_analysis_with_thought_tracking(user_question, tabular_file
                                                      tabular_file_contexts=None,
                                                      thought_tracker=None,
                                                      live_thought_callback=None,
-                                                     model_context=None):
+                                                     model_context=None,
+                                                     token_usage_callback=None):
     """Run tabular analysis while streaming/persisting live tool thoughts when available."""
     plugin_logger = get_plugin_logger()
     callback_key = None
@@ -11690,6 +12260,7 @@ async def run_tabular_analysis_with_thought_tracking(user_question, tabular_file
             execution_mode=execution_mode,
             thought_callback=tabular_progress_callback,
             model_context=model_context,
+            token_usage_callback=token_usage_callback,
         )
 
         if callable(tabular_progress_callback):
@@ -12796,8 +13367,17 @@ def register_route_backend_chats(bp):
         invalidate_conversation_cache_for_item(conversation_item, reason="conversation_created")
         return conversation_item
 
-    def execute_document_action_chat_request(data=None, publish_background_event=None, forced_action_type=None):
+    def execute_document_action_chat_request(
+        data=None,
+        publish_background_event=None,
+        forced_action_type=None,
+        cancel_requested=None,
+        request_correlation_id=None,
+    ):
         settings = get_settings()
+        request_correlation_id = normalize_mixed_source_correlation_id(
+            request_correlation_id
+        )
         data = data if isinstance(data, dict) else (request.get_json() or {})
         user_id = get_current_user_id()
         if not user_id:
@@ -13169,7 +13749,22 @@ def register_route_backend_chats(bp):
                 run_id=assistant_message_id,
                 thought_tracker=thought_tracker,
                 external_activity_callback=stream_activity_callback,
+                cancel_requested=cancel_requested,
+                request_correlation_id=request_correlation_id,
             )
+        except MixedSourceCancellationError as exc:
+            if thought_tracker.enabled:
+                thought_tracker.add_thought(
+                    'cancellation',
+                    'Document action canceled before final output publication',
+                    detail=f'phase={exc.phase}',
+                )
+            return {
+                'canceled': True,
+                'conversation_id': conversation_id,
+                'user_message_id': user_message_id,
+                'request_correlation_id': request_correlation_id,
+            }, 409
         except Exception as exc:
             debug_print(
                 '[ChatDocumentAction] Execution failed | '
@@ -13191,29 +13786,121 @@ def register_route_backend_chats(bp):
             )
             return {'error': str(exc), 'conversation_id': conversation_id, 'user_message_id': user_message_id}, 500
 
+        try:
+            _reauthorize_document_action_finalization(
+                normalized_action,
+                execution_result,
+                user_id,
+                conversation_id,
+                cancel_requested=cancel_requested,
+                request_correlation_id=request_correlation_id,
+                settings=settings,
+            )
+        except MixedSourceCancellationError as exc:
+            if thought_tracker.enabled:
+                thought_tracker.add_thought(
+                    'cancellation',
+                    'Document action canceled before final output publication',
+                    detail=f'phase={exc.phase}',
+                )
+            return {
+                'canceled': True,
+                'conversation_id': conversation_id,
+                'user_message_id': user_message_id,
+                'request_correlation_id': request_correlation_id,
+            }, 409
+        except PermissionError as exc:
+            return {
+                'error': str(exc),
+                'conversation_id': conversation_id,
+                'user_message_id': user_message_id,
+            }, 403
+        except RuntimeError as exc:
+            return {
+                'error': str(exc),
+                'conversation_id': conversation_id,
+                'user_message_id': user_message_id,
+            }, 409
+
         assistant_timestamp = datetime.utcnow().isoformat()
         hybrid_citations_list = _build_document_action_hybrid_citations(execution_result)
         if assigned_knowledge_context_citations:
             hybrid_citations_list.extend(assigned_knowledge_context_citations)
             hybrid_citations_list.sort(key=_build_hybrid_citation_sort_key, reverse=True)
-        prepared_agent_citations = persist_agent_citation_artifacts(
-            conversation_id=conversation_id,
-            assistant_message_id=assistant_message_id,
-            agent_citations=execution_result.get('agent_citations') or [],
-            created_timestamp=assistant_timestamp,
-            user_info=response_message_context.get('user_info'),
-        )
+        prepared_agent_citations = []
         document_generated_analysis_artifacts = list(execution_result.get('generated_analysis_artifacts') or [])
         document_generated_tabular_outputs = list(execution_result.get('generated_tabular_outputs') or [])
-        assistant_table_generated_output = maybe_create_assistant_table_generated_output(
-            user_question=user_message,
-            assistant_content=execution_result.get('reply', ''),
-            conversation_id=conversation_id,
-            existing_outputs=document_generated_analysis_artifacts + document_generated_tabular_outputs,
-        )
-        if assistant_table_generated_output:
-            document_generated_analysis_artifacts.append(assistant_table_generated_output)
-            document_generated_tabular_outputs.append(assistant_table_generated_output)
+        try:
+            raise_if_mixed_source_cancelled(
+                cancel_requested,
+                'artifact_publication',
+                request_correlation_id=request_correlation_id,
+            )
+            prepared_agent_citations = persist_agent_citation_artifacts(
+                conversation_id=conversation_id,
+                assistant_message_id=assistant_message_id,
+                agent_citations=execution_result.get('agent_citations') or [],
+                created_timestamp=assistant_timestamp,
+                user_info=response_message_context.get('user_info'),
+                cancel_requested=cancel_requested,
+                request_correlation_id=request_correlation_id,
+            )
+            raise_if_mixed_source_cancelled(
+                cancel_requested,
+                'artifact_publication',
+                request_correlation_id=request_correlation_id,
+            )
+            assistant_table_generated_output = maybe_create_assistant_table_generated_output(
+                user_question=user_message,
+                assistant_content=execution_result.get('reply', ''),
+                conversation_id=conversation_id,
+                existing_outputs=document_generated_analysis_artifacts + document_generated_tabular_outputs,
+                cancel_requested=cancel_requested,
+                request_correlation_id=request_correlation_id,
+            )
+            if assistant_table_generated_output:
+                document_generated_analysis_artifacts.append(assistant_table_generated_output)
+                document_generated_tabular_outputs.append(assistant_table_generated_output)
+            _reauthorize_document_action_finalization(
+                normalized_action,
+                execution_result,
+                user_id,
+                conversation_id,
+                cancel_requested=cancel_requested,
+                request_correlation_id=request_correlation_id,
+                settings=settings,
+            )
+        except MixedSourceCancellationError as exc:
+            _rollback_mixed_source_chat_publication(
+                user_id,
+                conversation_id,
+                document_generated_analysis_artifacts + document_generated_tabular_outputs,
+                compact_citations=prepared_agent_citations,
+            )
+            if thought_tracker.enabled:
+                thought_tracker.add_thought(
+                    'cancellation',
+                    'Document action canceled before final output publication',
+                    detail=f'phase={exc.phase}',
+                )
+            return {
+                'canceled': True,
+                'conversation_id': conversation_id,
+                'user_message_id': user_message_id,
+                'request_correlation_id': request_correlation_id,
+            }, 409
+        except MixedSourceFinalizationError:
+            _rollback_mixed_source_chat_publication(
+                user_id,
+                conversation_id,
+                document_generated_analysis_artifacts + document_generated_tabular_outputs,
+                compact_citations=prepared_agent_citations,
+            )
+            return {
+                'error': 'Selected source state changed before final output could be published.',
+                'conversation_id': conversation_id,
+                'user_message_id': user_message_id,
+            }, 409
         generated_analysis_metadata = _build_generated_analysis_metadata(
             generated_analysis_artifacts=document_generated_analysis_artifacts,
             generated_tabular_outputs=document_generated_tabular_outputs,
@@ -13266,6 +13953,42 @@ def register_route_backend_chats(bp):
             },
         })
         cosmos_messages_container.upsert_item(assistant_doc)
+        try:
+            raise_if_mixed_source_cancelled(
+                cancel_requested,
+                'finalization',
+                request_correlation_id=request_correlation_id,
+            )
+        except MixedSourceCancellationError as exc:
+            try:
+                cosmos_messages_container.delete_item(
+                    item=assistant_message_id,
+                    partition_key=conversation_id,
+                )
+            except Exception:
+                log_event(
+                    '[MixedSourceLifecycle] Assistant rollback after cancellation failed.',
+                    extra={'assistant_message_rollback_failure_count': 1},
+                    level=logging.WARNING,
+                )
+            _rollback_mixed_source_chat_publication(
+                user_id,
+                conversation_id,
+                document_generated_analysis_artifacts + document_generated_tabular_outputs,
+                compact_citations=prepared_agent_citations,
+            )
+            if thought_tracker.enabled:
+                thought_tracker.add_thought(
+                    'cancellation',
+                    'Document action canceled before final output publication',
+                    detail=f'phase={exc.phase}',
+                )
+            return {
+                'canceled': True,
+                'conversation_id': conversation_id,
+                'user_message_id': user_message_id,
+                'request_correlation_id': request_correlation_id,
+            }, 409
 
         token_usage = execution_result.get('token_usage') if isinstance(execution_result.get('token_usage'), dict) else None
         if token_usage and token_usage.get('total_tokens'):
@@ -13372,11 +14095,18 @@ def register_route_backend_chats(bp):
             'metadata': assistant_doc.get('metadata', {}),
         }), 200
 
-    def execute_analyze_chat_request(data=None, publish_background_event=None):
+    def execute_analyze_chat_request(
+        data=None,
+        publish_background_event=None,
+        cancel_requested=None,
+        request_correlation_id=None,
+    ):
         return execute_document_action_chat_request(
             data=data,
             publish_background_event=publish_background_event,
             forced_action_type=DOCUMENT_ACTION_TYPE_ANALYZE,
+            cancel_requested=cancel_requested,
+            request_correlation_id=request_correlation_id,
         )
 
     @bp.route('/api/chat/document-action', methods=['POST'])
@@ -13405,6 +14135,7 @@ def register_route_backend_chats(bp):
         data['conversation_id'] = conversation_id
         g.conversation_id = conversation_id
         stream_session = CHAT_STREAM_REGISTRY.start_session(user_id, conversation_id)
+        request_correlation_id = normalize_mixed_source_correlation_id()
 
         def generate_document_action_response(publish_background_event=None):
             try:
@@ -13418,7 +14149,17 @@ def register_route_backend_chats(bp):
                 payload, status_code = execute_document_action_chat_request(
                     data=data,
                     publish_background_event=publish_background_event,
+                    cancel_requested=stream_session.is_cancel_requested,
+                    request_correlation_id=request_correlation_id,
                 )
+                if payload.get('canceled'):
+                    yield _build_stream_cancel_event(
+                        payload.get('conversation_id') or conversation_id,
+                        user_message_id=payload.get('user_message_id'),
+                        reason=stream_session.get_cancel_reason(),
+                        message_persisted=False,
+                    )
+                    return
                 if stream_session and stream_session.is_cancel_requested():
                     yield _build_stream_cancel_event(
                         payload.get('conversation_id') or conversation_id,
@@ -13466,6 +14207,7 @@ def register_route_backend_chats(bp):
         data['conversation_id'] = conversation_id
         g.conversation_id = conversation_id
         stream_session = CHAT_STREAM_REGISTRY.start_session(user_id, conversation_id)
+        request_correlation_id = normalize_mixed_source_correlation_id()
 
         def generate_analyze_response(publish_background_event=None):
             try:
@@ -13479,7 +14221,17 @@ def register_route_backend_chats(bp):
                 payload, status_code = execute_analyze_chat_request(
                     data=data,
                     publish_background_event=publish_background_event,
+                    cancel_requested=stream_session.is_cancel_requested,
+                    request_correlation_id=request_correlation_id,
                 )
+                if payload.get('canceled'):
+                    yield _build_stream_cancel_event(
+                        payload.get('conversation_id') or conversation_id,
+                        user_message_id=payload.get('user_message_id'),
+                        reason=stream_session.get_cancel_reason(),
+                        message_persisted=False,
+                    )
+                    return
                 if stream_session and stream_session.is_cancel_requested():
                     yield _build_stream_cancel_event(
                         payload.get('conversation_id') or conversation_id,
@@ -13752,6 +14504,7 @@ def register_route_backend_chats(bp):
             generated_analysis_artifacts_list = []
             system_messages_for_augmentation = [] # Collect system messages from search
             search_results = []
+            mixed_source_narrative_retrieval_failed = False
             selected_agent = None  # Initialize selected_agent early to prevent NameError
             # --- Configuration ---
             # History / Summarization Settings
@@ -14189,6 +14942,8 @@ def register_route_backend_chats(bp):
             mixed_source_narrative_document_ids = []
             mixed_source_tabular_sources = []
             mixed_source_evidence_envelopes = []
+            mixed_source_native_token_usage = None
+            mixed_source_request_correlation_id = normalize_mixed_source_correlation_id()
             if mixed_source_explicit_selection:
                 try:
                     mixed_source_manifest = _resolve_chat_mixed_source_manifest(
@@ -14199,6 +14954,7 @@ def register_route_backend_chats(bp):
                         'selected',
                         active_group_ids=effective_active_group_ids,
                         active_public_workspace_ids=effective_active_public_workspace_ids,
+                        request_correlation_id=mixed_source_request_correlation_id,
                     )
                 except ValueError as manifest_error:
                     return jsonify({'error': str(manifest_error)}), 400
@@ -14724,6 +15480,13 @@ def register_route_backend_chats(bp):
             ):
                 prior_grounded_document_refs = _normalize_prior_grounded_document_refs(conversation_item)
                 if prior_grounded_document_refs:
+                    continuity_decision = _resolve_reauthorized_continuity_decision(
+                        settings,
+                        user_id,
+                        conversation_id,
+                        prior_grounded_document_refs,
+                        request_correlation_id=mixed_source_request_correlation_id,
+                    )
                     thought_tracker.add_thought(
                         'history_context',
                         'Checking whether prior conversation context already answers the question',
@@ -14762,7 +15525,10 @@ def register_route_backend_chats(bp):
                             f"[History Fallback] History-only sufficiency assessment failed: {assessment_error}"
                         )
 
-                    if history_only_answerability and history_only_answerability.get('can_answer_from_history'):
+                    if _can_reuse_prior_grounded_history(
+                        history_only_answerability,
+                        continuity_decision,
+                    ):
                         thought_tracker.add_thought(
                             'history_context',
                             'Prior conversation context appears sufficient without new document retrieval',
@@ -14847,6 +15613,7 @@ def register_route_backend_chats(bp):
                     'history',
                     active_group_ids=effective_active_group_ids,
                     active_public_workspace_ids=effective_active_public_workspace_ids,
+                    request_correlation_id=mixed_source_request_correlation_id,
                 )
                 mixed_source_manifest = history_context.get('manifest') or []
                 mixed_source_partitions = history_context.get('partitions') or {}
@@ -15077,6 +15844,7 @@ def register_route_backend_chats(bp):
                             tags_filter=tags_filter,
                             active_group_ids=effective_active_group_ids,
                             active_public_workspace_ids=effective_active_public_workspace_ids,
+                            request_correlation_id=mixed_source_request_correlation_id,
                         )
                         mixed_source_manifest = relevance_context.get('manifest') or []
                         mixed_source_partitions = relevance_context.get('partitions') or {}
@@ -15091,17 +15859,32 @@ def register_route_backend_chats(bp):
                         )
                 except SemanticSearchQuotaExceededError as e:
                     debug_print(f"Semantic search quota exceeded during hybrid search: {e}")
-                    return jsonify({
-                        'error': e.user_message,
-                        'warning_type': SEMANTIC_SEARCH_QUOTA_WARNING_TYPE,
-                        'service_health_warning': True,
-                    }), 503
+                    if (
+                        is_mixed_source_chat_search_enabled(settings)
+                        and mixed_source_manifest
+                        and mixed_source_tabular_sources
+                    ):
+                        mixed_source_narrative_retrieval_failed = True
+                        search_results = []
+                    else:
+                        return jsonify({
+                            'error': e.user_message,
+                            'warning_type': SEMANTIC_SEARCH_QUOTA_WARNING_TYPE,
+                            'service_health_warning': True,
+                        }), 503
                 except Exception as e:
                     debug_print(f"Error during hybrid search: {e}")
-                    # Only treat as error if the exception is from embedding failure
-                    return jsonify({
-                        'error': 'There was an issue with the embedding process. Please check with an admin on embedding configuration.'
-                    }), 500
+                    if (
+                        is_mixed_source_chat_search_enabled(settings)
+                        and mixed_source_manifest
+                        and mixed_source_tabular_sources
+                    ):
+                        mixed_source_narrative_retrieval_failed = True
+                        search_results = []
+                    else:
+                        return jsonify({
+                            'error': 'There was an issue with the embedding process. Please check with an admin on embedding configuration.'
+                        }), 500
 
                 if search_results:
                     unique_doc_names = set(doc.get('file_name', 'Unknown') for doc in search_results)
@@ -15701,7 +16484,12 @@ def register_route_backend_chats(bp):
                     else 'relevance'
                 )
                 mixed_source_evidence_envelopes.extend(
-                    build_narrative_evidence_envelopes(
+                    build_failed_narrative_evidence_envelopes(
+                        mixed_source_partitions.get('narrative_sources') or [],
+                        effective_mixed_source_selection_mode,
+                    )
+                    if mixed_source_narrative_retrieval_failed
+                    else build_narrative_evidence_envelopes(
                         mixed_source_partitions.get('narrative_sources') or [],
                         search_results,
                         effective_mixed_source_selection_mode,
@@ -15718,10 +16506,12 @@ def register_route_backend_chats(bp):
                     settings=settings,
                     thought_tracker=thought_tracker,
                     model_context=tabular_model_context,
+                    request_correlation_id=mixed_source_request_correlation_id,
                 )
                 mixed_source_evidence_envelopes.extend(
                     mixed_source_tabular_result.get('evidence_envelopes') or []
                 )
+                mixed_source_native_token_usage = mixed_source_tabular_result.get('token_usage')
                 agent_citations_list.extend(
                     mixed_source_tabular_result.get('agent_citations') or []
                 )
@@ -15735,6 +16525,9 @@ def register_route_backend_chats(bp):
                     mixed_source_manifest,
                     mixed_source_evidence_envelopes,
                     effective_mixed_source_selection_mode,
+                    mode='chat',
+                    telemetry_settings=settings,
+                    request_correlation_id=mixed_source_request_correlation_id,
                 )
                 system_messages_for_augmentation.append(mixed_source_handoff)
                 mixed_source_coverage = mixed_source_handoff.get(
@@ -15746,6 +16539,44 @@ def register_route_backend_chats(bp):
                     user_metadata['source_continuity'] = continuity_decision
                 user_message_doc['metadata'] = user_metadata
                 cosmos_messages_container.upsert_item(user_message_doc)
+                if continuity_decision:
+                    emit_mixed_source_telemetry(
+                        settings,
+                        'continuity',
+                        'chat',
+                        request_correlation_id=mixed_source_request_correlation_id,
+                        metrics={
+                            'history_source_count': continuity_decision.get('prior_source_count', 0),
+                            'history_rerun_count': int(bool(continuity_decision.get('requires_native_execution'))),
+                            'history_reuse_count': int(not continuity_decision.get('requires_native_execution')),
+                        },
+                        dimensions={
+                            'selection_mode': effective_mixed_source_selection_mode,
+                            'continuity_decision': (
+                                'rerun'
+                                if continuity_decision.get('requires_native_execution')
+                                else 'reuse'
+                            ),
+                        },
+                    )
+                emit_mixed_source_telemetry(
+                    settings,
+                    'background_export',
+                    'chat',
+                    request_correlation_id=mixed_source_request_correlation_id,
+                    metrics={
+                        'background_export_count': sum(
+                            bool(output.get('background_export'))
+                            for output in generated_tabular_outputs_list
+                            if isinstance(output, dict)
+                        ),
+                        'artifact_count': len(generated_analysis_artifacts_list),
+                        'citation_count': len(agent_citations_list) + len(hybrid_citations_list),
+                    },
+                    dimensions={
+                        'selection_mode': effective_mixed_source_selection_mode,
+                    },
+                )
                 log_event(
                     '[MixedSourceChatSearch] Prepared bounded mixed-source synthesis evidence.',
                     extra={
@@ -17057,7 +17888,6 @@ def register_route_backend_chats(bp):
             else:
                 ai_message, final_model_used, chat_mode, kernel_fallback_notice = fallback_result
                 token_usage_data = None
-
             ai_message = _append_inline_chart_blocks_to_message(ai_message, agent_citations_list)
 
             # Emit responded thought for non-agent paths (agent paths emit their own inside callbacks)
@@ -17104,6 +17934,25 @@ def register_route_backend_chats(bp):
                         exceptionTraceback=True
                     )
 
+            token_usage_data = _merge_chat_token_usage(
+                mixed_source_native_token_usage,
+                token_usage_data,
+            )
+            if mixed_source_manifest:
+                emit_mixed_source_telemetry(
+                    settings,
+                    'native_execution',
+                    'chat',
+                    request_correlation_id=mixed_source_request_correlation_id,
+                    metrics={
+                        'prompt_tokens': (token_usage_data or {}).get('prompt_tokens', 0),
+                        'completion_tokens': (token_usage_data or {}).get('completion_tokens', 0),
+                        'total_tokens': (token_usage_data or {}).get('total_tokens', 0),
+                        'token_request_count': (token_usage_data or {}).get('request_count', 0),
+                        'request_count': (token_usage_data or {}).get('request_count', 0),
+                    },
+                )
+
         # region 7 - Save GPT Response
             # ---------------------------------------------------------------------
             # 7) Save GPT response (or error message)
@@ -17149,6 +17998,24 @@ def register_route_backend_chats(bp):
 
             # Assistant message should be part of the same thread as the user message
             # Only system/augmentation messages create new threads within a conversation
+            if mixed_source_manifest:
+                fresh_finalization_manifest = resolve_authorized_source_manifest(
+                    [source.get('document_id') for source in mixed_source_manifest],
+                    user_id=user_id,
+                    selection_mode=effective_mixed_source_selection_mode,
+                    conversation_id=conversation_id,
+                    active_group_ids=effective_active_group_ids,
+                    active_public_workspace_ids=effective_active_public_workspace_ids,
+                    doc_scope=effective_document_scope,
+                    request_correlation_id=mixed_source_request_correlation_id,
+                )
+                _validate_reauthorized_manifest_finalization(
+                    mixed_source_manifest,
+                    fresh_finalization_manifest,
+                    settings=settings,
+                    mode='chat',
+                    request_correlation_id=mixed_source_request_correlation_id,
+                )
             assistant_timestamp = datetime.utcnow().isoformat()
             prepared_agent_citations = persist_agent_citation_artifacts(
                 conversation_id=conversation_id,
@@ -17757,6 +18624,7 @@ def register_route_backend_chats(bp):
                 generated_analysis_artifacts_list = []
                 system_messages_for_augmentation = []
                 search_results = []
+                mixed_source_narrative_retrieval_failed = False
                 selected_agent = None
 
                 # Configuration
@@ -18213,6 +19081,8 @@ def register_route_backend_chats(bp):
                 mixed_source_narrative_document_ids = []
                 mixed_source_tabular_sources = []
                 mixed_source_evidence_envelopes = []
+                mixed_source_native_token_usage = None
+                mixed_source_request_correlation_id = normalize_mixed_source_correlation_id()
                 if mixed_source_explicit_selection:
                     try:
                         explicit_context = _resolve_chat_mixed_source_partition(
@@ -18223,6 +19093,8 @@ def register_route_backend_chats(bp):
                             'selected',
                             active_group_ids=effective_active_group_ids,
                             active_public_workspace_ids=effective_active_public_workspace_ids,
+                            cancel_requested=stream_cancel_requested,
+                            request_correlation_id=mixed_source_request_correlation_id,
                         )
                     except ValueError as manifest_error:
                         yield f"data: {json.dumps({'error': str(manifest_error)})}\n\n"
@@ -18708,6 +19580,13 @@ def register_route_backend_chats(bp):
                 ):
                     prior_grounded_document_refs = _normalize_prior_grounded_document_refs(conversation_item)
                     if prior_grounded_document_refs:
+                        continuity_decision = _resolve_reauthorized_continuity_decision(
+                            settings,
+                            user_id,
+                            conversation_id,
+                            prior_grounded_document_refs,
+                            request_correlation_id=mixed_source_request_correlation_id,
+                        )
                         yield emit_thought(
                             'history_context',
                             'Checking whether prior conversation context already answers the question',
@@ -18746,7 +19625,10 @@ def register_route_backend_chats(bp):
                                 f"[Streaming][History Fallback] History-only sufficiency assessment failed: {assessment_error}"
                             )
 
-                        if history_only_answerability and history_only_answerability.get('can_answer_from_history'):
+                        if _can_reuse_prior_grounded_history(
+                            history_only_answerability,
+                            continuity_decision,
+                        ):
                             yield emit_thought(
                                 'history_context',
                                 'Prior conversation context appears sufficient without new document retrieval',
@@ -18832,6 +19714,8 @@ def register_route_backend_chats(bp):
                         'history',
                         active_group_ids=effective_active_group_ids,
                         active_public_workspace_ids=effective_active_public_workspace_ids,
+                        cancel_requested=stream_cancel_requested,
+                        request_correlation_id=mixed_source_request_correlation_id,
                     )
                     mixed_source_manifest = history_context.get('manifest') or []
                     mixed_source_partitions = history_context.get('partitions') or {}
@@ -18981,6 +19865,8 @@ def register_route_backend_chats(bp):
                                 tags_filter=tags_filter,
                                 active_group_ids=effective_active_group_ids,
                                 active_public_workspace_ids=effective_active_public_workspace_ids,
+                                cancel_requested=stream_cancel_requested,
+                                request_correlation_id=mixed_source_request_correlation_id,
                             )
                             mixed_source_manifest = relevance_context.get('manifest') or []
                             mixed_source_partitions = relevance_context.get('partitions') or {}
@@ -18998,15 +19884,34 @@ def register_route_backend_chats(bp):
                         )
                     except SemanticSearchQuotaExceededError as e:
                         debug_print(f"Semantic search quota exceeded during streaming hybrid search: {e}")
-                        yield emit_thought(
-                            'search',
-                            'Workspace search warning: Semantic Ranker quota has been exceeded.',
-                            detail=e.user_message,
-                        )
-                        yield f"data: {json.dumps({'error': e.user_message, 'warning_type': SEMANTIC_SEARCH_QUOTA_WARNING_TYPE, 'service_health_warning': True})}\n\n"
-                        return
+                        if (
+                            is_mixed_source_chat_search_enabled(settings)
+                            and mixed_source_manifest
+                            and mixed_source_tabular_sources
+                        ):
+                            mixed_source_narrative_retrieval_failed = True
+                            search_results = []
+                            yield emit_thought(
+                                'search',
+                                'Narrative search was unavailable; continuing with available table evidence.',
+                            )
+                        else:
+                            yield emit_thought(
+                                'search',
+                                'Workspace search warning: Semantic Ranker quota has been exceeded.',
+                                detail=e.user_message,
+                            )
+                            yield f"data: {json.dumps({'error': e.user_message, 'warning_type': SEMANTIC_SEARCH_QUOTA_WARNING_TYPE, 'service_health_warning': True})}\n\n"
+                            return
                     except Exception as e:
                         debug_print(f"Error during hybrid search: {e}")
+                        if (
+                            is_mixed_source_chat_search_enabled(settings)
+                            and mixed_source_manifest
+                            and mixed_source_tabular_sources
+                        ):
+                            mixed_source_narrative_retrieval_failed = True
+                            search_results = []
 
                     if search_results:
                         unique_doc_names_stream = set(doc.get('file_name', 'Unknown') for doc in search_results)
@@ -19265,7 +20170,12 @@ def register_route_backend_chats(bp):
                         else 'relevance'
                     )
                     mixed_source_evidence_envelopes.extend(
-                        build_narrative_evidence_envelopes(
+                        build_failed_narrative_evidence_envelopes(
+                            mixed_source_partitions.get('narrative_sources') or [],
+                            effective_mixed_source_selection_mode,
+                        )
+                        if mixed_source_narrative_retrieval_failed
+                        else build_narrative_evidence_envelopes(
                             mixed_source_partitions.get('narrative_sources') or [],
                             search_results,
                             effective_mixed_source_selection_mode,
@@ -19283,10 +20193,13 @@ def register_route_backend_chats(bp):
                         thought_tracker=thought_tracker,
                         live_thought_callback=publish_live_plugin_thought,
                         model_context=tabular_model_context,
+                        cancel_requested=stream_cancel_requested,
+                        request_correlation_id=mixed_source_request_correlation_id,
                     )
                     mixed_source_evidence_envelopes.extend(
                         mixed_source_tabular_result.get('evidence_envelopes') or []
                     )
+                    mixed_source_native_token_usage = mixed_source_tabular_result.get('token_usage')
                     agent_citations_list.extend(
                         mixed_source_tabular_result.get('agent_citations') or []
                     )
@@ -19300,6 +20213,9 @@ def register_route_backend_chats(bp):
                         mixed_source_manifest,
                         mixed_source_evidence_envelopes,
                         effective_mixed_source_selection_mode,
+                        mode='chat',
+                        telemetry_settings=settings,
+                        request_correlation_id=mixed_source_request_correlation_id,
                     )
                     system_messages_for_augmentation.append(mixed_source_handoff)
                     mixed_source_coverage = mixed_source_handoff.get(
@@ -19315,6 +20231,44 @@ def register_route_backend_chats(bp):
                         user_metadata['source_continuity'] = continuity_decision
                     user_message_doc['metadata'] = user_metadata
                     cosmos_messages_container.upsert_item(user_message_doc)
+                    if continuity_decision:
+                        emit_mixed_source_telemetry(
+                            settings,
+                            'continuity',
+                            'chat',
+                            request_correlation_id=mixed_source_request_correlation_id,
+                            metrics={
+                                'history_source_count': continuity_decision.get('prior_source_count', 0),
+                                'history_rerun_count': int(bool(continuity_decision.get('requires_native_execution'))),
+                                'history_reuse_count': int(not continuity_decision.get('requires_native_execution')),
+                            },
+                            dimensions={
+                                'selection_mode': effective_mixed_source_selection_mode,
+                                'continuity_decision': (
+                                    'rerun'
+                                    if continuity_decision.get('requires_native_execution')
+                                    else 'reuse'
+                                ),
+                            },
+                        )
+                    emit_mixed_source_telemetry(
+                        settings,
+                        'background_export',
+                        'chat',
+                        request_correlation_id=mixed_source_request_correlation_id,
+                        metrics={
+                            'background_export_count': sum(
+                                bool(output.get('background_export'))
+                                for output in generated_tabular_outputs_list
+                                if isinstance(output, dict)
+                            ),
+                            'artifact_count': len(generated_analysis_artifacts_list),
+                            'citation_count': len(agent_citations_list) + len(hybrid_citations_list),
+                        },
+                        dimensions={
+                            'selection_mode': effective_mixed_source_selection_mode,
+                        },
+                    )
                     log_event(
                         '[MixedSourceChatSearch] Prepared streaming bounded mixed-source synthesis evidence.',
                         extra={
@@ -20032,6 +20986,24 @@ def register_route_backend_chats(bp):
                         'cancel_reason': cancel_reason,
                     }
 
+                    if mixed_source_manifest:
+                        _rollback_mixed_source_chat_publication(
+                            user_id,
+                            conversation_id,
+                            generated_analysis_artifacts_list + generated_tabular_outputs_list,
+                        )
+                        return _build_stream_cancel_event(
+                            conversation_id,
+                            user_message_id=user_message_id,
+                            reason=cancel_reason,
+                            message_persisted=False,
+                            extra_payload={
+                                'augmented': bool(system_messages_for_augmentation),
+                                'metadata': cancel_metadata,
+                                'thoughts_enabled': thought_tracker.enabled,
+                            },
+                        )
+
                     if partial_content:
                         assistant_timestamp = datetime.utcnow().isoformat()
                         prepared_agent_citations = persist_agent_citation_artifacts(
@@ -20595,6 +21567,25 @@ def register_route_backend_chats(bp):
                         yield finalize_cancelled_stream_response()
                         return
 
+                    token_usage_data = _merge_chat_token_usage(
+                        mixed_source_native_token_usage,
+                        token_usage_data,
+                    )
+                    if mixed_source_manifest:
+                        emit_mixed_source_telemetry(
+                            settings,
+                            'native_execution',
+                            'chat',
+                            request_correlation_id=mixed_source_request_correlation_id,
+                            metrics={
+                                'prompt_tokens': (token_usage_data or {}).get('prompt_tokens', 0),
+                                'completion_tokens': (token_usage_data or {}).get('completion_tokens', 0),
+                                'total_tokens': (token_usage_data or {}).get('total_tokens', 0),
+                                'token_request_count': (token_usage_data or {}).get('request_count', 0),
+                                'request_count': (token_usage_data or {}).get('request_count', 0),
+                            },
+                        )
+
                     # Stream complete - save message and send final metadata
                     accumulated_content_before_chart_append = accumulated_content
                     accumulated_content = _append_inline_chart_blocks_to_message(accumulated_content, agent_citations_list)
@@ -20607,6 +21598,30 @@ def register_route_backend_chats(bp):
                     user_info_for_assistant = response_message_context.get('user_info')
                     user_thread_id = response_message_context.get('thread_id')
                     user_previous_thread_id = response_message_context.get('previous_thread_id')
+                    if mixed_source_manifest:
+                        raise_if_mixed_source_cancelled(
+                            stream_cancel_requested,
+                            'finalization',
+                            request_correlation_id=mixed_source_request_correlation_id,
+                        )
+                        fresh_finalization_manifest = resolve_authorized_source_manifest(
+                            [source.get('document_id') for source in mixed_source_manifest],
+                            user_id=user_id,
+                            selection_mode=effective_mixed_source_selection_mode,
+                            conversation_id=conversation_id,
+                            active_group_ids=effective_active_group_ids,
+                            active_public_workspace_ids=effective_active_public_workspace_ids,
+                            doc_scope=effective_document_scope,
+                            cancel_requested=stream_cancel_requested,
+                            request_correlation_id=mixed_source_request_correlation_id,
+                        )
+                        _validate_reauthorized_manifest_finalization(
+                            mixed_source_manifest,
+                            fresh_finalization_manifest,
+                            settings=settings,
+                            mode='chat',
+                            request_correlation_id=mixed_source_request_correlation_id,
+                        )
                     assistant_timestamp = datetime.utcnow().isoformat()
                     prepared_agent_citations = persist_agent_citation_artifacts(
                         conversation_id=conversation_id,
@@ -20614,16 +21629,44 @@ def register_route_backend_chats(bp):
                         agent_citations=agent_citations_list,
                         created_timestamp=assistant_timestamp,
                         user_info=user_info_for_assistant,
+                        cancel_requested=stream_cancel_requested,
+                        request_correlation_id=mixed_source_request_correlation_id,
+                    )
+                    raise_if_mixed_source_cancelled(
+                        stream_cancel_requested,
+                        'artifact_publication',
+                        request_correlation_id=mixed_source_request_correlation_id,
                     )
                     assistant_table_generated_output = maybe_create_assistant_table_generated_output(
                         user_question=user_message,
                         assistant_content=accumulated_content,
                         conversation_id=conversation_id,
                         existing_outputs=generated_analysis_artifacts_list + generated_tabular_outputs_list,
+                        cancel_requested=stream_cancel_requested,
+                        request_correlation_id=mixed_source_request_correlation_id,
                     )
                     if assistant_table_generated_output:
                         generated_analysis_artifacts_list.append(assistant_table_generated_output)
                         generated_tabular_outputs_list.append(assistant_table_generated_output)
+                    if mixed_source_manifest:
+                        fresh_finalization_manifest = resolve_authorized_source_manifest(
+                            [source.get('document_id') for source in mixed_source_manifest],
+                            user_id=user_id,
+                            selection_mode=effective_mixed_source_selection_mode,
+                            conversation_id=conversation_id,
+                            active_group_ids=effective_active_group_ids,
+                            active_public_workspace_ids=effective_active_public_workspace_ids,
+                            doc_scope=effective_document_scope,
+                            cancel_requested=stream_cancel_requested,
+                            request_correlation_id=mixed_source_request_correlation_id,
+                        )
+                        _validate_reauthorized_manifest_finalization(
+                            mixed_source_manifest,
+                            fresh_finalization_manifest,
+                            settings=settings,
+                            mode='chat',
+                            request_correlation_id=mixed_source_request_correlation_id,
+                        )
                     generated_analysis_metadata = _build_generated_analysis_metadata(
                         generated_analysis_artifacts=generated_analysis_artifacts_list,
                         generated_tabular_outputs=generated_tabular_outputs_list,
@@ -20674,6 +21717,11 @@ def register_route_backend_chats(bp):
                         }
                     })
                     cosmos_messages_container.upsert_item(assistant_doc)
+                    raise_if_mixed_source_cancelled(
+                        stream_cancel_requested,
+                        'finalization',
+                        request_correlation_id=mixed_source_request_correlation_id,
+                    )
                     if use_agent_streaming and agent_name_used:
                         agent_scope_for_usage = 'personal'
                         agent_group_id_for_usage = None
@@ -20847,6 +21895,52 @@ def register_route_backend_chats(bp):
                     )
                     yield f"data: {json.dumps(final_data)}\n\n"
 
+                except MixedSourceCancellationError:
+                    if mixed_source_manifest:
+                        try:
+                            cosmos_messages_container.delete_item(
+                                item=assistant_message_id,
+                                partition_key=conversation_id,
+                            )
+                        except Exception:
+                            pass
+                        _rollback_mixed_source_chat_publication(
+                            user_id,
+                            conversation_id,
+                            generated_analysis_artifacts_list + generated_tabular_outputs_list,
+                            compact_citations=locals().get('prepared_agent_citations') or [],
+                        )
+                        yield _build_stream_cancel_event(
+                            conversation_id,
+                            user_message_id=user_message_id,
+                            reason=stream_session.get_cancel_reason() if stream_session else 'user_requested',
+                            message_persisted=False,
+                            extra_payload={
+                                'augmented': bool(system_messages_for_augmentation),
+                                'thoughts_enabled': thought_tracker.enabled,
+                            },
+                        )
+                        return
+                    yield finalize_cancelled_stream_response()
+                    return
+                except MixedSourceFinalizationError:
+                    if mixed_source_manifest:
+                        try:
+                            cosmos_messages_container.delete_item(
+                                item=assistant_message_id,
+                                partition_key=conversation_id,
+                            )
+                        except Exception:
+                            pass
+                        _rollback_mixed_source_chat_publication(
+                            user_id,
+                            conversation_id,
+                            generated_analysis_artifacts_list + generated_tabular_outputs_list,
+                            compact_citations=locals().get('prepared_agent_citations') or [],
+                        )
+                        yield f"data: {json.dumps({'error': 'Selected source state changed before final output could be published.', 'conversation_id': conversation_id})}\n\n"
+                        return
+                    raise
                 except Exception as e:
                     error_msg = str(e)
                     debug_print(f"Error during streaming: {error_msg}")
@@ -21567,6 +22661,17 @@ def _normalize_prior_grounded_document_refs(conversation_item):
             'scope_id': scope_id,
             'file_name': raw_ref.get('file_name') or raw_ref.get('title'),
             'classification': raw_ref.get('classification'),
+            'source_role': raw_ref.get('source_role'),
+            'requested_order': raw_ref.get('requested_order'),
+            'source_kind': raw_ref.get('source_kind'),
+            'engine': raw_ref.get('engine'),
+            'source_version': raw_ref.get('source_version'),
+            'status': raw_ref.get('status'),
+            'coverage': dict(raw_ref.get('coverage') or {}),
+            'selection_origin': raw_ref.get('selection_origin'),
+            'action_mode': raw_ref.get('action_mode'),
+            'citation_count': _safe_metadata_int(raw_ref.get('citation_count')),
+            'artifact_count': _safe_metadata_int(raw_ref.get('artifact_count')),
         }
 
         if scope == 'group':
@@ -21605,6 +22710,8 @@ def build_prior_grounded_document_search_parameters(grounded_refs):
     document_ids = []
     group_ids = []
     public_workspace_ids = []
+    chat_conversation_ids = []
+    document_scopes = {}
     scope_types = set()
 
     for ref in grounded_refs or []:
@@ -21619,6 +22726,10 @@ def build_prior_grounded_document_search_parameters(grounded_refs):
         if not scope:
             continue
         scope_types.add(scope)
+        document_scopes[document_id] = {
+            'scope': scope,
+            'scope_id': str(ref.get('scope_id') or '').strip(),
+        }
 
         if scope == 'group':
             group_id = str(ref.get('group_id') or ref.get('scope_id') or '').strip()
@@ -21628,6 +22739,10 @@ def build_prior_grounded_document_search_parameters(grounded_refs):
             public_workspace_id = str(ref.get('public_workspace_id') or ref.get('scope_id') or '').strip()
             if public_workspace_id and public_workspace_id not in public_workspace_ids:
                 public_workspace_ids.append(public_workspace_id)
+        elif scope == 'chat':
+            chat_conversation_id = str(ref.get('scope_id') or '').strip()
+            if chat_conversation_id and chat_conversation_id not in chat_conversation_ids:
+                chat_conversation_ids.append(chat_conversation_id)
 
     if len(scope_types) == 1:
         doc_scope = next(iter(scope_types))
@@ -21641,6 +22756,8 @@ def build_prior_grounded_document_search_parameters(grounded_refs):
         'active_group_id': group_ids[0] if group_ids else None,
         'active_public_workspace_ids': public_workspace_ids,
         'active_public_workspace_id': public_workspace_ids[0] if public_workspace_ids else None,
+        'chat_conversation_ids': chat_conversation_ids,
+        'document_scopes': document_scopes,
         'scope_types': sorted(scope_types),
     }
 
@@ -21656,6 +22773,13 @@ def revalidate_prior_grounded_document_search_parameters(user_id, search_paramet
     )
     allowed_group_ids = scope_context['active_group_ids']
     allowed_public_workspace_ids = scope_context['active_public_workspace_ids']
+    allowed_chat_conversation_ids = []
+    for conversation_id in normalized_parameters.get('chat_conversation_ids') or []:
+        try:
+            _authorize_personal_conversation_access(user_id, conversation_id)
+            allowed_chat_conversation_ids.append(conversation_id)
+        except (LookupError, PermissionError):
+            continue
 
     allowed_scope_types = []
     if 'personal' in scope_types:
@@ -21664,12 +22788,25 @@ def revalidate_prior_grounded_document_search_parameters(user_id, search_paramet
         allowed_scope_types.append('group')
     if allowed_public_workspace_ids:
         allowed_scope_types.append('public')
+    if allowed_chat_conversation_ids:
+        allowed_scope_types.append('chat')
 
     normalized_parameters['active_group_ids'] = allowed_group_ids
     normalized_parameters['active_group_id'] = scope_context['active_group_id']
     normalized_parameters['active_public_workspace_ids'] = allowed_public_workspace_ids
     normalized_parameters['active_public_workspace_id'] = scope_context['active_public_workspace_id']
+    normalized_parameters['chat_conversation_ids'] = allowed_chat_conversation_ids
     normalized_parameters['scope_types'] = allowed_scope_types
+    document_scopes = normalized_parameters.get('document_scopes') or {}
+    normalized_parameters['document_ids'] = [
+        document_id
+        for document_id in normalized_parameters.get('document_ids') or []
+        if (
+            (document_scopes.get(document_id) or {}).get('scope') != 'chat'
+            or (document_scopes.get(document_id) or {}).get('scope_id')
+            in allowed_chat_conversation_ids
+        )
+    ]
 
     if not allowed_scope_types:
         normalized_parameters['document_ids'] = []
@@ -21677,7 +22814,9 @@ def revalidate_prior_grounded_document_search_parameters(user_id, search_paramet
         return normalized_parameters
 
     normalized_parameters['doc_scope'] = (
-        allowed_scope_types[0] if len(allowed_scope_types) == 1 else 'all'
+        allowed_scope_types[0]
+        if len(allowed_scope_types) == 1 and allowed_scope_types[0] != 'chat'
+        else 'all'
     )
     return normalized_parameters
 

--- a/application/single_app/static/js/plugin_modal_stepper.js
+++ b/application/single_app/static/js/plugin_modal_stepper.js
@@ -2193,7 +2193,7 @@ export class PluginModalStepper {
 
   populateDocumentSearchForm(additionalFields = {}) {
     document.getElementById('document-search-scope').value = additionalFields.default_doc_scope || 'all';
-    document.getElementById('document-search-top-n').value = additionalFields.default_top_n || 12;
+    document.getElementById('document-search-top-n').value = additionalFields.default_top_n || 25;
     document.getElementById('document-search-window-unit').value = additionalFields.default_window_unit || 'pages';
     document.getElementById('document-search-window-size').value = additionalFields.default_window_size || '';
     document.getElementById('document-search-window-percent').value = additionalFields.default_window_percent || '';
@@ -5103,7 +5103,7 @@ export class PluginModalStepper {
 
     const config = this.getDocumentSearchAdditionalFields();
     document.getElementById('summary-search-scope').textContent = this.formatDocumentScope(config.default_doc_scope);
-    document.getElementById('summary-search-top-n').textContent = String(config.default_top_n || 12);
+    document.getElementById('summary-search-top-n').textContent = String(config.default_top_n || 25);
     document.getElementById('summary-search-chunk-behavior').textContent = 'Returns all chunks by default';
     document.getElementById('summary-search-windowing').textContent = this.formatDocumentSearchWindowing(config);
     document.getElementById('summary-search-window-target-length').textContent = config.default_window_target_length || '2 pages';

--- a/application/single_app/utils_cache.py
+++ b/application/single_app/utils_cache.py
@@ -303,7 +303,7 @@ def generate_search_cache_key(
     active_group_id: Optional[str] = None,
     active_group_ids: Optional[List[str]] = None,
     active_public_workspace_id: Optional[str] = None,
-    top_n: int = 12,
+    top_n: int = 25,
     enable_file_sharing: bool = True,
     tags_filter: Optional[List[str]] = None,
     document_filter_mode: str = "intersection"

--- a/docs/admin_configuration.md
+++ b/docs/admin_configuration.md
@@ -258,6 +258,8 @@ Use this section when you need to configure an area, validate it, and know what 
 2. Enable agents, choose workspace-specific or global mode, set orchestration behavior, and manage global agents or approvals if admins curate shared agents centrally.
 3. Enable action scopes and core plugins users are allowed to invoke. Save global agent/action changes, restart the web app when the tab notes it is required, and then verify the runtime action menus.
 
+Mixed-source rollout is independently reversible. Keep `enable_mixed_source_manifest`, `enable_mixed_source_chat_search`, `enable_mixed_source_analyze`, `enable_cross_format_compare`, and `enable_mixed_source_conversation_continuity` off until the preceding stage is validated. The subordinate relevance, Analyze All, one-to-many Compare, and development telemetry stages also default off. `enable_mixed_source_development_telemetry` records aggregate counts and latency only; it must never be used to capture prompts, evidence, source identifiers, filenames, or storage paths.
+
 ### Logging
 
 ![Annotated Logging controls](./images/admin-settings/logging.png)

--- a/docs/application_workflows.md
+++ b/docs/application_workflows.md
@@ -80,3 +80,11 @@ This workflow covers what happens when users upload content into personal or gro
 8. Once indexing completes, the document becomes available to hybrid retrieval in chat and workspace search.
 
 Typical chunk metadata includes document identity, filename, workspace scope, sequence numbers, page references, timestamps, and optional classification or extraction metadata.
+
+## Mixed-Source Document Actions
+
+When mixed-source flags are enabled, Chat and workflow Search remain relevance bounded. Analyze and Compare resolve an ordered authorized manifest, dispatch narrative documents to bounded window analysis and CSV/Excel documents to native tabular tools, and combine only bounded evidence summaries.
+
+Every selected or planned source ends with `completed`, `partial`, `failed`, or `skipped` plus a bounded reason. Analyze reduces only when at least one source succeeds. Compare requires a prepared Source and can continue past a failed Target. Cancellation stops active branches and prevents later reduction, citation/artifact publication, and assistant response persistence.
+
+The staged Analyze All backend enumerates current documents through the ready document access index and rejects catalogs above the configured workflow Analyze limit. Every enumerated ID is reauthorized before execution. This stage remains default off and is not newly exposed in the workflow selector in version **0.250.070**.

--- a/docs/explanation/features/CROSS_FORMAT_COMPARE.md
+++ b/docs/explanation/features/CROSS_FORMAT_COMPARE.md
@@ -39,3 +39,7 @@ The final comparison reports compared targets, failed or partial targets, partic
 ## Limitations
 
 This phase does not add many-to-many Compare, all-document discovery, persisted follow-up source reuse, Phase 5 selection semantics, or Phase 6 broad extraction and rollout completion. Table-to-table row-level assertions require a validated structured table operation; bounded prose evidence alone is not treated as row-level proof.
+
+## Phase 6 Hardening
+
+Version **0.250.070** applies the [#1061](https://github.com/microsoft/simplechat/issues/1061) failure policy: an unprepared Source fails the operation, while a failed Target or pairwise Target reduction remains visible and later valid Targets continue. Mixed Compare citations and generated tabular outputs now survive the outer model and agent return paths with stable deduplication. Cancellation prevents later pairwise work, final reduction, or artifact publication.

--- a/docs/explanation/features/MIXED_SOURCE_ANALYZE.md
+++ b/docs/explanation/features/MIXED_SOURCE_ANALYZE.md
@@ -60,3 +60,9 @@ The focused coverage verifies native partitioning, bounded collective reduction 
 This Phase 3 increment does not enable Analyze All Documents. The current action contract exposes selected and recent targets only, so enabling an `all` mode before a dedicated exhaustive authorized catalog enumerator exists would violate the Analyze contract. The separate `enable_mixed_source_analyze_all` flag remains disabled until that enumerator, count preflight rejection, object-boundary reauthorization, and performance validation are delivered.
 
 This phase does not implement cross-format Compare (#1059), persisted follow-up source reuse, Phase 5 conversation-selection semantics, or Phase 6 route extraction and rollout completion.
+
+## Phase 6 Hardening
+
+Version **0.250.070** completes the bounded backend contract for `enable_mixed_source_analyze_all` under [#1061](https://github.com/microsoft/simplechat/issues/1061). The ready document access index enumerates current candidates using the configured Analyze limit plus one, rejects over-limit catalogs without truncation, and sends every candidate through the existing authorized source manifest before execution. The flag remains default off and the workflow selector is not newly exposed pending staged production approval.
+
+Combined Analyze now reduces only when at least one source succeeds. Terminal coverage, cancellation, generated outputs, citations, and finalization reauthorization are preserved across narrative and table branches.

--- a/docs/explanation/features/MIXED_SOURCE_CHAT_AND_SEARCH_CONSISTENCY.md
+++ b/docs/explanation/features/MIXED_SOURCE_CHAT_AND_SEARCH_CONSISTENCY.md
@@ -162,3 +162,7 @@ Chat and Search remain relevance-bounded. Analyze and Compare behavior is otherw
 ## Related Version Update
 
 `application/single_app/config.py` was updated from **0.250.062** to **0.250.064** after preserving a concurrent application version increment while completing the Phase 2 delivery associated with #1057.
+
+## Phase 6 Hardening
+
+Version **0.250.070** adds manifest-aligned terminal coverage, standard/streaming failure parity, and reference deduplication under [#1061](https://github.com/microsoft/simplechat/issues/1061). When a mixed request still has successful table evidence, a narrative retrieval or quota failure becomes an explicit per-source omission instead of aborting the available native branch. Chat and Search remain relevance bounded; no full catalog enumeration was added to either mode.

--- a/docs/explanation/features/MIXED_SOURCE_CONVERSATION_CONTINUITY.md
+++ b/docs/explanation/features/MIXED_SOURCE_CONVERSATION_CONTINUITY.md
@@ -36,3 +36,7 @@ The continuity record contains document ID, canonical scope identity, source rol
 - Python compilation and editor diagnostics for changed modules
 
 Related version update: `application/single_app/config.py` moved from **0.250.067** to **0.250.068**.
+
+## Phase 6 Hardening
+
+Version **0.250.070** preserves source version, terminal status, bounded coverage, role, and order through continuity normalization. A fresh manifest decision is now evaluated before history-only reuse, so revoked, changed, partial, failed, or truncated prior grounding forces native execution even when the history assessor would otherwise reuse an earlier answer. Chat-upload hints are filtered through fresh conversation ownership.

--- a/docs/explanation/features/MIXED_SOURCE_HARDENING_EXTRACTION_AND_ROLLOUT.md
+++ b/docs/explanation/features/MIXED_SOURCE_HARDENING_EXTRACTION_AND_ROLLOUT.md
@@ -1,0 +1,112 @@
+# Mixed-Source Hardening, Extraction, and Rollout
+
+Implemented in version: **0.250.070**
+
+GitHub issue: [#1061](https://github.com/microsoft/simplechat/issues/1061)
+
+Parent initiative: [#1055](https://github.com/microsoft/simplechat/issues/1055)
+
+Prerequisites: [#1056](https://github.com/microsoft/simplechat/issues/1056), [#1057](https://github.com/microsoft/simplechat/issues/1057), [#1058](https://github.com/microsoft/simplechat/issues/1058), [#1059](https://github.com/microsoft/simplechat/issues/1059), and [#1060](https://github.com/microsoft/simplechat/issues/1060)
+
+## Overview
+
+Phase 6 consolidates the Phase 1-5 mixed-source contracts into one manifest-aligned terminal coverage ledger and applies consistent partial-failure, cancellation, finalization, reference, and observability rules to Chat, workflow Search, Analyze, Compare, and conversation continuity.
+
+The change does not replace the existing authorization resolver, narrative window engine, tabular runner, comparison engine, generated-output system, citation storage, ThoughtTracker, or token accounting. All mixed-source behavior flags remain independently default off.
+
+## Architecture
+
+### Terminal coverage ledger
+
+`functions_mixed_source_orchestration.py` now aligns exactly one terminal entry to every fresh manifest source. Each entry preserves:
+
+- Document ID
+- Canonical scope and scope ID
+- Source version
+- Source kind
+- Source or Target role
+- Original request order
+- `completed`, `partial`, `failed`, or `skipped` status
+- A bounded non-sensitive reason for non-success
+
+Evidence is filtered, deduplicated, and reordered against the fresh manifest before synthesis. Unrelated or duplicate terminal evidence fails closed, duplicate filenames remain distinct by canonical identity, unresolved source IDs are scrubbed from the model-facing handoff, and skipped or compacted evidence makes coverage partial.
+
+### Mode failure policy
+
+- **Chat** answers from available native evidence and carries explicit terminal omissions into synthesis.
+- **Search** keeps bounded available results when one native cohort fails. Narrative retrieval failure can coexist with successful table evidence.
+- **Analyze** reduces only when at least one source succeeds. Zero-success requests fail before reduction.
+- **Compare** fails when the Source cannot be prepared. Failed Target preparation or pairwise reduction remains visible while later valid Targets continue.
+
+A failed native table never falls back to generic narrative processing.
+
+### Cancellation and finalization
+
+One `MixedSourceCancellationError` and optional cancellation predicate now span manifest resolution, narrative window calls and reductions, tabular source calls, comparison pairs and reduction, generated export queue/upload, and final response publication.
+
+Cancellation is checked after blocking model/tool calls so returned content is discarded when cancellation arrives in flight. Newly queued background exports use the existing cancellation API. Newly uploaded generated artifacts and citation records are rolled back by exact stored identity. No final reduction, completed progress event, citation artifact, generated output, or assistant message is published after accepted cancellation.
+
+Every previously authorized contributing source is resolved again before standard or streaming Chat and document-action publication. Canonical scope and source version must still match. Sources that were already unresolved remain explicit partial coverage and do not become evidence.
+
+### Bounded Analyze All
+
+The existing `enable_mixed_source_analyze_all` subordinate flag now has a backend contract:
+
+1. The ready document access index enumerates current candidates with a `configured limit + 1` query.
+2. Any catalog above the configured Analyze limit is rejected without truncation.
+3. Group memberships and public visibility are refreshed before enumeration.
+4. Every candidate ID is resolved again through `resolve_authorized_source_manifest(...)` before native execution.
+
+The flag remains default off. The workflow selector is not newly exposed in this phase; activation requires deliberate staged rollout after access-index readiness and production latency/error review.
+
+### Bounded extraction
+
+`get_new_plugin_invocations(...)` moved from `route_backend_chats.py` to `functions_tabular_analysis.py`. The route retains the original symbol as a compatibility shim, while the reusable implementation no longer imports the route at runtime. No second tabular runner or broad route-to-service rewrite was introduced.
+
+## Security
+
+- The existing authorized source manifest remains the sole source resolver and authorization model.
+- Personal ownership and exact approved shares, group membership, public workspace visibility, and chat-upload conversation ownership are rechecked at execution and finalization boundaries.
+- Caller scope, active settings, selected metadata, and continuity records remain untrusted hints.
+- Continuity status, version, coverage, role, and order survive normalization. Partial, failed, truncated, changed, or revoked history forces fresh native work even if the history assessor would otherwise reuse an earlier answer.
+- Foundry `include_document_context=false` filtering remains unchanged and continues to remove mixed-source evidence and file inputs.
+- No raw settings, evidence, prompts, filenames, document IDs, blob paths, or authorization snapshots are added to frontend responses or telemetry.
+
+## Observability
+
+`enable_mixed_source_development_telemetry` is independent and default off. When enabled, an internal UUID correlation ID links manifest, native branches, terminal coverage, reduction, continuity decisions, cancellation phase, and background export/artifact counts.
+
+The emitter accepts only allowlisted aggregate counts, finite latency/token metrics, and bounded categorical dimensions. Source-shaped or other non-allowlisted fields are rejected.
+
+## Rollout And Rollback
+
+The following flags remain independently default off:
+
+- `enable_mixed_source_manifest`
+- `enable_mixed_source_chat_search`
+- `enable_mixed_source_analyze`
+- `enable_cross_format_compare`
+- `enable_mixed_source_conversation_continuity`
+
+Subordinate stages also remain off:
+
+- `enable_mixed_source_relevance_candidates`
+- `enable_mixed_source_analyze_all`
+- `enable_cross_format_compare_one_to_many`
+- `enable_mixed_source_development_telemetry`
+
+No mixed-source mode is made default on. Production rollout still requires error, omission, and latency evidence plus explicit approval.
+
+## Testing And Validation
+
+Primary behavior coverage is in `functional_tests/test_mixed_source_hardening.py`, with Phase 1-5 regression suites retained. Coverage includes manifest-aligned identity, mixed scopes and duplicate filenames, native table failure, mode-specific partial failures, failed Compare Source and Target behavior, continuity precedence, bounded Analyze All, cancellation across lifecycle phases, exact artifact rollback, finalization authorization/version loss, reference deduplication, and telemetry privacy.
+
+The release validation also includes Python compilation, Pylance/editor diagnostics, route policy tests when route code changes, broken-access-control and XSS scans, token/artifact/progress regressions, and CRLF-aware whitespace checks.
+
+## Known Limitations
+
+- Many-to-many Compare and automatic Target discovery remain out of scope.
+- Chat and Search catalog processing remains relevance bounded.
+- Analyze All remains a staged backend capability and is not default on or newly exposed in the selector.
+- Richer relational joins and persistent computed evidence caches remain future work.
+- Production telemetry evidence and explicit approval are still required before enabling mixed-source behavior by default.

--- a/docs/explanation/features/index.md
+++ b/docs/explanation/features/index.md
@@ -21,6 +21,10 @@ category: Version History
 ## Agent and Action Features
 
 - [Action Type Governance](v0.242.064/ACTION_TYPE_GOVERNANCE.md)
+- [Mixed-Source Hardening, Extraction, and Rollout](MIXED_SOURCE_HARDENING_EXTRACTION_AND_ROLLOUT.md)
+- [Mixed-Source Chat and Search Consistency](MIXED_SOURCE_CHAT_AND_SEARCH_CONSISTENCY.md)
+- [Mixed-Source Analyze](MIXED_SOURCE_ANALYZE.md)
+- [Cross-Format Compare](CROSS_FORMAT_COMPARE.md)
 - [Agents Page Customization](v0.241.229/AGENTS_PAGE_CUSTOMIZATION.md)
 - [Microsoft Graph Send Mail Action](MSGRAPH_SEND_MAIL_ACTION.md)
 - [Snowflake Action](v0.250.006/SNOWFLAKE_ACTION.md)

--- a/docs/explanation/fixes/BACKGROUND_CSV_EXPORT_THROUGHPUT_AND_TIMEOUT_FIX.md
+++ b/docs/explanation/fixes/BACKGROUND_CSV_EXPORT_THROUGHPUT_AND_TIMEOUT_FIX.md
@@ -1,0 +1,59 @@
+# Background CSV Export Throughput and Timeout Fix
+
+Fixed in version: **0.250.070**
+
+Related issue: [#1071](https://github.com/microsoft/simplechat/issues/1071)
+
+## Issue
+
+Large structured CSV exports could appear stalled while a long-running model batch
+occupied the background worker. The worker processed only two post-schema batches
+at once, and an individual model request had no export-specific timeout.
+
+## Root Cause
+
+The first batch must remain serial because it establishes the validated output
+schema used by every later batch. Once that schema existed, the background worker
+used a conservative default of two concurrent model batches. A slow or hung model
+request could hold the worker far longer than the user-facing progress state
+suggested.
+
+## Technical Details
+
+- Increased default post-schema batch concurrency from two to three, within the
+  existing maximum of five concurrent batches.
+- Added a configurable per-batch model timeout with a five-minute default.
+- Caps the batch timeout below the stale-worker threshold so a stuck request is
+  requeued before stale-worker recovery can create competing execution.
+- Treats a timed-out batch as a retryable timeout, preserving existing durable
+  checkpoints and idempotent artifact publication.
+- Retains serial schema discovery so parallel batches cannot produce incompatible
+  CSV schemas.
+
+Modified files:
+
+- `application/single_app/functions_tabular_generated_exports.py`
+- `functional_tests/test_tabular_background_generated_exports.py`
+- `application/single_app/config.py`
+
+## Validation
+
+- The focused durable-export functional suite passed 7/7 checks.
+- The suite now executes a stalled asynchronous model-call case and verifies it
+  produces a retryable timeout rather than waiting indefinitely.
+- Existing bounded concurrency, checkpointing, scheduler, and UI polling checks
+  continue to pass.
+
+## Impact
+
+For a multi-batch export, post-schema work can now use three concurrent model
+batches. This reduces the number of execution windows for common six-batch runs
+while preserving the validated schema and ordered output guarantees. A genuinely
+stuck batch is retried from its last durable checkpoint instead of indefinitely
+occupying a background worker.
+
+## Follow-up
+
+Issue #1071 tracks the broader format-neutral job framework, including
+forward-progress detection, benchmark gates, and comparable performance behavior
+for CSV, Word, and PowerPoint generation.

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,24 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](/explanation/features/) and [Fixes by Version](/explanation/fixes/).
 
+### **(v0.250.070)**
+
+#### New Features
+
+*   **Mixed-Source Hardening, Extraction, and Staged Rollout**
+    *   Added one manifest-aligned terminal coverage ledger for Chat, workflow Search, Analyze, Compare, and continuity, with consistent mode-specific partial-failure behavior and no table-to-narrative fallback.
+    *   Propagated cancellation and one privacy-safe correlation ID across manifest, native engines, reductions, exports, finalization, citations, artifacts, and token-bearing workflow execution. Fresh authorization and source versions are checked again before publication.
+    *   Added bounded, fail-closed Analyze All catalog enumeration behind its existing default-off flag, extracted reusable tabular invocation slicing with a route compatibility shim, and added independently default-off aggregate development telemetry.
+    *   All mixed-source and subordinate rollout flags remain off pending production omission/error/latency evidence and explicit approval.
+    *   (Ref: microsoft/simplechat#1061, parent microsoft/simplechat#1055, prerequisites microsoft/simplechat#1056, microsoft/simplechat#1057, microsoft/simplechat#1058, microsoft/simplechat#1059, and microsoft/simplechat#1060, `MIXED_SOURCE_HARDENING_EXTRACTION_AND_ROLLOUT.md`, `functions_mixed_source_orchestration.py`, `functions_workflow_runner.py`, `route_backend_chats.py`)
+
+#### Bug Fixes
+
+*   **Background CSV Export Throughput and Timeout Recovery**
+    *   Increased safe post-schema concurrent batch generation from two to three batches and added a bounded model-call timeout, so a stalled batch is retried from its durable checkpoint instead of holding the background worker indefinitely.
+    *   Preserved serial schema discovery, ordered output, checkpointing, authorization, and idempotent artifact publication while reducing the number of execution windows for common multi-batch exports.
+    *   (Ref: microsoft/simplechat#1071, `functions_tabular_generated_exports.py`, `test_tabular_background_generated_exports.py`, `BACKGROUND_CSV_EXPORT_THROUGHPUT_AND_TIMEOUT_FIX.md`)
+
 ### **(v0.250.068)**
 
 #### New Features

--- a/docs/latest-release/analyze-compare.md
+++ b/docs/latest-release/analyze-compare.md
@@ -5,7 +5,7 @@ description: "How chat and workspace document actions support full-document revi
 section: "Latest Release"
 ---
 
-Current release version: **0.241.183**
+Current release version: **0.250.070**
 
 Analyze and Compare give users deliberate document-action modes beyond regular workspace search.
 
@@ -39,3 +39,6 @@ Some questions need exhaustive review or side-by-side comparison instead of top-
 - Interactive chat analysis targets a deliberately bounded set of selected documents.
 - Workflow Analyze runs can cover larger repeated batches and changed synced documents.
 - Compare treats one selected document as the source baseline and compares selected target documents against it.
+- Mixed-source Analyze and cross-format Compare remain behind default-off rollout flags.
+- Every selected source has terminal coverage. Analyze requires at least one successful source, and Compare fails when its Source cannot be prepared while retaining failed Target visibility.
+- The bounded Analyze All backend remains default off and is not newly exposed in the workflow selector pending production rollout approval.

--- a/docs/reference/admin_configuration.md
+++ b/docs/reference/admin_configuration.md
@@ -215,6 +215,24 @@ Control how document citations are displayed and linked.
 4. Enable enhanced citations feature
 5. Verify citation links in chat interface
 
+#### Mixed-Source Rollout Controls
+
+Mixed-source document orchestration uses independently reversible settings. Keep every stage off until the preceding stage has acceptable omission, error, and latency metrics:
+
+| Stage | Setting | Default |
+|---|---|---|
+| Manifest diagnostics | `enable_mixed_source_manifest` | Off |
+| Chat and workflow Search | `enable_mixed_source_chat_search` | Off |
+| Combined Analyze | `enable_mixed_source_analyze` | Off |
+| Cross-format Compare | `enable_cross_format_compare` | Off |
+| Reauthorized continuity | `enable_mixed_source_conversation_continuity` | Off |
+| Relevance table candidates | `enable_mixed_source_relevance_candidates` | Off |
+| Bounded Analyze All | `enable_mixed_source_analyze_all` | Off |
+| One-to-many mixed Compare | `enable_cross_format_compare_one_to_many` | Off |
+| Aggregate development telemetry | `enable_mixed_source_development_telemetry` | Off |
+
+Analyze All requires a ready document access index and uses the configured workflow Analyze document limit. A catalog above that limit is rejected rather than truncated. Development telemetry contains allowlisted aggregate counts and timings only; source identifiers, filenames, prompts, evidence, paths, locators, credentials, and raw settings are prohibited.
+
 ### 7. Safety Configuration
 
 Configure content moderation and user feedback systems.

--- a/docs/troubleshooting/troubleshooting.md
+++ b/docs/troubleshooting/troubleshooting.md
@@ -76,3 +76,15 @@ exceptions
 
 If startup logs show an error while Flask instrumentation is initializing, disable it with the `DISABLE_FLASK_INSTRUMENTATION` environment variable. Set the value to `1` or `true`, then restart the app service so the process starts cleanly without the instrumentation hook.
 
+## Mixed-Source Partial Coverage
+
+A mixed-source answer may complete with partial coverage when one narrative retrieval, table tool call, authorization check, or comparison Target cannot complete. This is expected fail-closed behavior: a failed table is not silently treated as narrative text, and prior conversation evidence does not fill a gap in the current selection.
+
+1. Review the response coverage summary for completed, partial, failed, and skipped source counts.
+2. Confirm the relevant mixed-source mode flag is enabled and subordinate rollout flags are not being assumed.
+3. Recheck personal ownership or approved sharing, group membership, public visibility, and chat-upload conversation ownership.
+4. For Analyze All, confirm the document access index is ready and the authorized catalog does not exceed the configured workflow Analyze limit.
+5. If aggregate development telemetry is enabled, correlate `MixedSourceTelemetry` events by `request_correlation_id` and inspect only counts, mode, status, cancellation phase, and latency. Source content or identity should never appear.
+
+If cancellation occurs, no final assistant response or new generated artifact should be published. A background tabular export that was already queued is canceled through its existing export run status.
+

--- a/functional_tests/test_assistant_table_csv_artifact.py
+++ b/functional_tests/test_assistant_table_csv_artifact.py
@@ -2,7 +2,7 @@
 #!/usr/bin/env python3
 """
 Functional test for assistant-rendered table CSV artifacts.
-Version: 0.250.065
+Version: 0.250.070
 Implemented in: 0.241.050; non-tabular document CSV parsing in 0.250.065
 
 This test ensures that explicit table-format requests with assistant-rendered
@@ -25,7 +25,7 @@ CONFIG_FILE = APP_DIR / 'config.py'
 CHAT_ROUTE_FILE = APP_DIR / 'route_backend_chats.py'
 BACKGROUND_EXPORT_FILE = APP_DIR / 'functions_tabular_generated_exports.py'
 WORKFLOW_RUNNER_FILE = APP_DIR / 'functions_workflow_runner.py'
-EXPECTED_VERSION = '0.250.065'
+EXPECTED_VERSION = '0.250.070'
 
 sys.path.append(str(APP_DIR))
 

--- a/functional_tests/test_chat_document_action_user_message_metadata.py
+++ b/functional_tests/test_chat_document_action_user_message_metadata.py
@@ -1,7 +1,7 @@
 # test_chat_document_action_user_message_metadata.py
 """
 Functional test for document-action user message metadata enrichment.
-Version: 0.241.095
+Version: 0.250.070
 Implemented in: 0.241.095
 
 This test ensures analysis and document comparison user messages
@@ -23,8 +23,8 @@ def test_document_action_user_metadata_is_enriched() -> None:
     route_content = _read_workspace_file('application', 'single_app', 'route_backend_chats.py')
     config_content = _read_workspace_file('application', 'single_app', 'config.py')
 
-    assert 'VERSION = "0.241.095"' in config_content, (
-        'Expected config.py version 0.241.095 for the document-action user metadata logging fix.'
+    assert 'VERSION = "0.250.070"' in config_content, (
+        'Expected the current application version for document-action user metadata coverage.'
     )
     assert 'def _build_document_action_user_metadata(' in route_content, (
         'Expected a dedicated helper for document-action user message metadata.'
@@ -41,8 +41,8 @@ def test_document_action_user_metadata_is_enriched() -> None:
     assert "'selected_document_names': resolved_document_names," in route_content, (
         'Expected document-action user messages to record resolved selected document names.'
     )
-    assert "selected_document_summary = f'Left: {left_document_name} | Right: {right_document_summary}'" in route_content, (
-        'Expected comparison user messages to summarize left and right document selections.'
+    assert "selected_document_summary = f'Source: {left_document_name} | Targets: {right_document_summary}'" in route_content, (
+        'Expected comparison user messages to summarize Source and Target document selections.'
     )
     assert "'streaming': bool(streaming_enabled)," in route_content, (
         'Expected document-action user messages to log whether the request was streamed.'

--- a/functional_tests/test_chat_stream_stop_control.py
+++ b/functional_tests/test_chat_stream_stop_control.py
@@ -2,7 +2,7 @@
 # test_chat_stream_stop_control.py
 """
 Functional test for chat stream stop control.
-Version: 0.241.098
+Version: 0.250.070
 Implemented in: 0.241.097
 
 This test ensures chat streams expose a user-scoped cancellation endpoint,
@@ -38,29 +38,28 @@ def test_chat_stream_stop_control_wiring() -> None:
     collaboration_js_content = read_text("application/single_app/static/js/chat/chat-collaboration.js")
     feature_doc_content = read_text("docs/explanation/features/v0.241.097/CHAT_STREAM_STOP_CONTROL.md")
 
-    assert_contains(config_content, 'VERSION = "0.241.098"', "config version")
+    assert_contains(config_content, 'VERSION = "0.250.070"', "config version")
 
     assert_contains(route_content, "STREAM_STATUS_CANCEL_REQUESTED = 'cancel_requested'", "chat route")
     assert_contains(route_content, "STREAM_STATUS_CANCELED = 'canceled'", "chat route")
     assert_contains(route_content, "def request_cancel(self, reason='user_requested'):", "chat stream session")
     assert_contains(route_content, "def is_cancel_requested(self):", "chat stream session")
     assert_contains(route_content, "def _build_stream_cancel_event(", "cancel event builder")
-    assert_contains(route_content, "@app.route('/api/chat/stream/cancel/<conversation_id>', methods=['POST'])", "chat cancel route")
+    assert_contains(route_content, "@bp.route('/api/chat/stream/cancel/<conversation_id>', methods=['POST'])", "chat cancel route")
     assert_contains(route_content, "if stream_cancel_requested():", "stream cancellation checkpoints")
     assert_contains(route_content, "yield finalize_cancelled_stream_response()", "cancelled stream finalization")
 
     assert_contains(
         collaboration_content,
-        "@app.route('/api/collaboration/conversations/<conversation_id>/stream/cancel', methods=['POST'])",
+        "@bp.route('/api/collaboration/conversations/<conversation_id>/stream/cancel', methods=['POST'])",
         "collaboration cancel route",
     )
     assert_contains(collaboration_content, "source_conversation_id = str((conversation_doc or {}).get('source_conversation_id')", "source conversation lookup")
     assert_contains(collaboration_content, "CHAT_STREAM_REGISTRY.get_session(", "collaboration source stream lookup")
     assert_contains(collaboration_content, "stream_payload.get('cancelled') or stream_payload.get('canceled')", "collaboration cancel transform")
 
-    assert_contains(streaming_content, "className = 'btn btn-sm btn-danger stream-stop-btn", "message-local Stop button")
+    assert_contains(streaming_content, "className = 'btn btn-sm stream-stop-btn", "message-local Stop button")
     assert_contains(streaming_content, "rounded-circle p-0 border-0", "compact icon-only Stop button")
-    assert_contains(streaming_content, "stopButton.style.width = '1.65rem'", "fixed-size Stop button")
     assert_contains(streaming_content, "async function requestStreamCancellation", "frontend cancel request")
     assert_contains(streaming_content, "fetch(streamContext.cancelEndpoint", "cancel endpoint POST")
     assert_contains(streaming_content, "finalizeCancelledStreamingMessage", "cancelled UI finalizer")

--- a/functional_tests/test_conversation_chart_and_tabular_reuse.py
+++ b/functional_tests/test_conversation_chart_and_tabular_reuse.py
@@ -2,7 +2,7 @@
 # test_conversation_chart_and_tabular_reuse.py
 """
 Functional test for conversation chart abilities and reusable tabular analysis.
-Version: 0.241.033
+Version: 0.250.070
 Implemented in: 0.241.031; proactive chart guidance added in 0.241.033
 
 This test ensures the built-in chart plugin is loaded as a conversation-level
@@ -27,7 +27,7 @@ TABULAR_ANALYSIS_FILE = APP_ROOT / "functions_tabular_analysis.py"
 SEMANTIC_KERNEL_LOADER_FILE = APP_ROOT / "semantic_kernel_loader.py"
 CHAT_ROUTE_FILE = APP_ROOT / "route_backend_chats.py"
 WORKFLOW_RUNNER_FILE = APP_ROOT / "functions_workflow_runner.py"
-EXPECTED_VERSION = "0.241.033"
+EXPECTED_VERSION = "0.250.070"
 
 TARGET_CHART_HELPERS = {
     "user_requested_chart_visualization",

--- a/functional_tests/test_document_action_conversation_scope_metadata.py
+++ b/functional_tests/test_document_action_conversation_scope_metadata.py
@@ -2,7 +2,7 @@
 # test_document_action_conversation_scope_metadata.py
 """
 Functional test for document-action conversation scope metadata.
-Version: 0.250.068
+Version: 0.250.070
 Implemented in: 0.241.124; Updated in: 0.250.068
 
 This test ensures Analyze and tabular document-action results can assign
@@ -20,7 +20,7 @@ ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 METADATA_FILE = os.path.join(ROOT_DIR, 'application', 'single_app', 'functions_conversation_metadata.py')
 ROUTE_FILE = os.path.join(ROOT_DIR, 'application', 'single_app', 'route_backend_chats.py')
 CONFIG_FILE = os.path.join(ROOT_DIR, 'application', 'single_app', 'config.py')
-FIX_VERSION = '0.250.068'
+FIX_VERSION = '0.250.070'
 TEST_USER_ID = 'scope-user-1'
 CRIMSON_GROUP_ID = 'crimson-group-1'
 PUBLIC_WORKSPACE_ID = 'public-workspace-1'

--- a/functional_tests/test_document_action_stream_reconnect.py
+++ b/functional_tests/test_document_action_stream_reconnect.py
@@ -2,7 +2,7 @@
 # test_document_action_stream_reconnect.py
 """
 Functional test for document action stream reconnect support.
-Version: 0.241.023
+Version: 0.250.070
 Implemented in: 0.241.090
 
 This test ensures analysis and document comparison streaming
@@ -41,22 +41,22 @@ def test_document_action_stream_reconnect_wiring() -> None:
 
     document_action_stream_block = slice_between(
         route_content,
-        "@app.route('/api/chat/document-action/stream', methods=['POST'])",
-        "@app.route('/api/chat/analyze', methods=['POST'])",
+        "@bp.route('/api/chat/document-action/stream', methods=['POST'])",
+        "@bp.route('/api/chat/analyze', methods=['POST'])",
     )
     analyze_stream_block = slice_between(
         route_content,
-        "@app.route('/api/chat/analyze/stream', methods=['POST'])",
-        "@app.route('/api/chat', methods=['POST'])",
+        "@bp.route('/api/chat/analyze/stream', methods=['POST'])",
+        "@bp.route('/api/chat/image-proposals/generate', methods=['POST'])",
     )
 
-    assert 'VERSION = "0.241.023"' in config_content, (
-        "Expected config.py version 0.241.023 for the document action reconnect fix."
+    assert 'VERSION = "0.250.070"' in config_content, (
+        "Expected the current application version for document action reconnect coverage."
     )
-    assert "@app.route('/api/chat/stream/status/<conversation_id>', methods=['GET'])" in route_content, (
+    assert "@bp.route('/api/chat/stream/status/<conversation_id>', methods=['GET'])" in route_content, (
         "Expected the shared chat stream status endpoint to exist for reconnect support."
     )
-    assert "@app.route('/api/chat/stream/reattach/<conversation_id>', methods=['GET'])" in route_content, (
+    assert "@bp.route('/api/chat/stream/reattach/<conversation_id>', methods=['GET'])" in route_content, (
         "Expected the shared chat stream reattach endpoint to exist for reconnect support."
     )
 

--- a/functional_tests/test_document_action_token_usage_aggregation.py
+++ b/functional_tests/test_document_action_token_usage_aggregation.py
@@ -1,7 +1,7 @@
 # test_document_action_token_usage_aggregation.py
 """
 Functional test for document action token usage aggregation.
-Version: 0.241.023
+Version: 0.250.070
 Implemented in: 0.241.116
 
 This test ensures analysis and comparison aggregate tokens across
@@ -11,6 +11,15 @@ all internal model calls and persist the aggregate usage on assistant metadata.
 import ast
 import os
 import uuid
+
+from pathlib import Path
+
+
+sys_path = str(Path(__file__).resolve().parents[1] / 'application' / 'single_app')
+if sys_path not in os.sys.path:
+    os.sys.path.insert(0, sys_path)
+
+import functions_mixed_source_orchestration as orchestration
 
 
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -119,12 +128,17 @@ def test_document_analysis_token_aggregation():
         extra_globals={
             'DOCUMENT_ACTION_TYPE_ANALYZE': 'analyze',
             'DOCUMENT_ACTION_CONTEXT_WORKFLOW': 'workflow',
+            'raise_if_mixed_source_cancelled': orchestration.raise_if_mixed_source_cancelled,
             'get_document_action_max_documents': lambda *args, **kwargs: 10,
+            '_is_per_document_analysis_mode': lambda action: False,
+            '_raise_legacy_mixed_source_analyze_limitation': lambda *args, **kwargs: None,
             '_chain_activity_callbacks': lambda *callbacks: None,
             '_build_document_action_activity_callback': lambda *args, **kwargs: None,
             '_maybe_execute_tabular_document_action': lambda *args, **kwargs: None,
             '_maybe_create_document_analysis_generated_artifacts': lambda *args, **kwargs: {'artifacts': [], 'assistant_reply': None},
+            '_reauthorize_mixed_source_workflow_result': lambda *args, **kwargs: None,
             '_resolve_model_workflow_client': lambda *args, **kwargs: (fake_client, 'gpt-5.4', 'aoai'),
+            '_build_workflow_chat_messages': lambda prompt, **kwargs: [{'role': 'user', 'content': prompt}],
             'run_document_analysis': lambda **kwargs: (
                 kwargs['invoke_prompt']('analysis window 1', stage='window_analysis'),
                 kwargs['invoke_prompt']('analysis window 2', stage='reduction'),
@@ -193,11 +207,17 @@ def test_document_comparison_token_aggregation():
         },
         extra_globals={
             'DOCUMENT_ACTION_TYPE_COMPARISON': 'comparison',
+            'raise_if_mixed_source_cancelled': orchestration.raise_if_mixed_source_cancelled,
+            'deduplicate_mixed_source_references': orchestration.deduplicate_mixed_source_references,
+            'is_cross_format_compare_enabled': lambda settings: False,
+            '_raise_legacy_cross_format_compare_limitation': lambda *args, **kwargs: None,
             '_chain_activity_callbacks': lambda *callbacks: None,
             '_build_document_action_activity_callback': lambda *args, **kwargs: None,
             '_maybe_execute_tabular_document_action': lambda *args, **kwargs: None,
             '_maybe_create_comparison_generated_artifacts': lambda *args, **kwargs: {'artifacts': [], 'assistant_reply': None},
+            '_reauthorize_mixed_source_workflow_result': lambda *args, **kwargs: None,
             '_resolve_model_workflow_client': lambda *args, **kwargs: (fake_client, 'gpt-5.4', 'aoai'),
+            '_build_workflow_chat_messages': lambda prompt, **kwargs: [{'role': 'user', 'content': prompt}],
             'run_document_comparison': lambda **kwargs: (
                 kwargs['invoke_prompt']('summary left', stage='summary'),
                 kwargs['invoke_prompt']('summary right', stage='summary'),
@@ -260,6 +280,8 @@ def test_workflow_assistant_persists_token_usage():
         extra_globals={
             '_utc_now_iso': lambda: '2025-01-01T00:00:00+00:00',
             '_get_document_action_config': lambda workflow: workflow.get('document_action', {}),
+            '_get_workflow_scope': lambda workflow: 'personal',
+            '_get_workflow_group_id': lambda workflow: '',
             '_persist_agent_citation_artifacts': lambda **kwargs: [],
             'cosmos_messages_container': message_container,
             'cosmos_conversations_container': conversation_container,
@@ -332,7 +354,7 @@ def test_version_update():
     with open(CONFIG_PATH, 'r', encoding='utf-8') as handle:
         content = handle.read()
 
-    assert_in('VERSION = "0.241.023"', content, 'config version update')
+    assert_in('VERSION = "0.250.070"', content, 'config version update')
     print('Version update passed.')
     return True
 

--- a/functional_tests/test_mixed_source_chat_search_consistency.py
+++ b/functional_tests/test_mixed_source_chat_search_consistency.py
@@ -415,10 +415,34 @@ def _load_workflow_search_helpers(flag_enabled, manifest, search_calls, tabular_
         },
         "resolve_authorized_source_manifest": lambda *args, **kwargs: list(manifest),
         "partition_source_manifest": orchestration.partition_source_manifest,
+        "build_failed_narrative_evidence_envelopes": orchestration.build_failed_narrative_evidence_envelopes,
         "build_narrative_evidence_envelopes": orchestration.build_narrative_evidence_envelopes,
+        "deduplicate_mixed_source_references": orchestration.deduplicate_mixed_source_references,
         "_workflow_mixed_source_execution_context": lambda *args, **kwargs: nullcontext(),
         "_resolve_tabular_document_action_model_name": lambda workflow, settings: "test-model",
         "build_mixed_source_evidence_handoff": orchestration.build_mixed_source_evidence_handoff,
+        "normalize_mixed_source_correlation_id": orchestration.normalize_mixed_source_correlation_id,
+        "_create_token_usage_aggregate": lambda: {
+            "prompt_tokens": 0,
+            "completion_tokens": 0,
+            "total_tokens": 0,
+            "request_count": 0,
+        },
+        "_accumulate_token_usage_summary": lambda aggregate, usage: aggregate.update({
+            key: aggregate.get(key, 0) + int((usage or {}).get(key, 0) or 0)
+            for key in ("prompt_tokens", "completion_tokens", "total_tokens", "request_count")
+        }),
+        "_finalize_token_usage": lambda aggregate: (
+            dict(aggregate) if aggregate.get("request_count") else None
+        ),
+        "_merge_token_usage_summaries": lambda results: next(
+            (
+                dict(item.get("token_usage") or {})
+                for item in results
+                if isinstance(item, dict) and item.get("token_usage")
+            ),
+            None,
+        ),
         "_add_workflow_activity_thought": lambda *args, **kwargs: None,
     }
     _load_functions(
@@ -605,6 +629,64 @@ def test_group_workflow_search_forces_stored_group_scope():
     assert prepared_action["doc_scope"] == "group"
     assert prepared_action["active_group_ids"] == ["group-safe"]
     assert prepared_action["active_public_workspace_id"] == []
+
+
+def test_workflow_search_narrative_failure_keeps_available_table_evidence():
+    """A failed narrative cohort remains terminal while the table branch still answers."""
+    manifest = [
+        _source("narrative-doc", "brief.docx", "narrative"),
+        _source("table-doc", "facts.csv", "tabular"),
+    ]
+    search_calls = []
+    tabular_calls = []
+    namespace, tabular_stub = _load_workflow_search_helpers(
+        True,
+        manifest,
+        search_calls,
+        tabular_calls,
+    )
+
+    def fail_narrative_search(**kwargs):
+        search_calls.append(kwargs)
+        raise RuntimeError("bounded narrative failure")
+
+    namespace["search_documents"] = fail_narrative_search
+    previous_tabular_module = sys.modules.get("functions_tabular_analysis")
+    sys.modules["functions_tabular_analysis"] = tabular_stub
+    try:
+        context = namespace["_prepare_workflow_search_context"](
+            {
+                "user_id": "user-1",
+                "task_prompt": "Calculate totals and summarize the brief.",
+                "runner_type": "model",
+            },
+            {
+                "type": "search",
+                "target_mode": "selected",
+                "document_ids": ["narrative-doc", "table-doc"],
+                "doc_scope": "all",
+            },
+            {"enable_mixed_source_chat_search": True},
+            conversation_id="conversation-1",
+        )
+    finally:
+        if previous_tabular_module is None:
+            sys.modules.pop("functions_tabular_analysis", None)
+        else:
+            sys.modules["functions_tabular_analysis"] = previous_tabular_module
+
+    assert len(search_calls) == 1
+    assert len(tabular_calls) == 1
+    assert "Computed total: 42" in context["workflow"]["task_prompt"]
+    assert context["coverage"]["partial_coverage"] is True
+    statuses = {
+        entry["document_id"]: entry["status"]
+        for entry in context["coverage"]["terminal_ledger"]
+    }
+    assert statuses == {
+        "narrative-doc": "failed",
+        "table-doc": "completed",
+    }
 
 
 def test_replay_collaboration_foundry_and_chat_path_contracts():

--- a/functional_tests/test_mixed_source_conversation_continuity.py
+++ b/functional_tests/test_mixed_source_conversation_continuity.py
@@ -2,7 +2,7 @@
 # test_mixed_source_conversation_continuity.py
 """
 Functional test for Phase 5 mixed-source conversation continuity.
-Version: 0.250.068
+Version: 0.250.070
 Implemented in: 0.250.068
 
 This test ensures #1060 preserves compact source continuity only as a
@@ -111,14 +111,14 @@ def test_flag_and_standard_streaming_wiring_are_present():
     config_source = _read_file(CONFIG_FILE)
     assert "'enable_mixed_source_conversation_continuity': False" in settings_source
     assert 'def is_mixed_source_conversation_continuity_enabled(settings):' in settings_source
-    assert route_source.count('is_mixed_source_conversation_continuity_enabled(settings)') == 4
-    assert route_source.count('_build_reauthorized_continuity_decision(') == 3
+    assert route_source.count('is_mixed_source_conversation_continuity_enabled(settings)') == 5
+    assert route_source.count('_build_reauthorized_continuity_decision(') == 4
     assert route_source.count('_build_mixed_source_continuity_refs(') == 3
     assert route_source.count("selection_mode='history'") == 0
     assert route_source.count("'history',") >= 2
     assert 'source_continuity_refs=None' in metadata_source
     assert 'source_continuity_refs=source_continuity_refs' in metadata_source
-    assert 'VERSION = "0.250.068"' in config_source
+    assert 'VERSION = "0.250.070"' in config_source
     print('PASS: flag and Chat parity wiring')
 
 

--- a/functional_tests/test_mixed_source_hardening.py
+++ b/functional_tests/test_mixed_source_hardening.py
@@ -1,0 +1,1324 @@
+#!/usr/bin/env python3
+# test_mixed_source_hardening.py
+"""
+Functional tests for mixed-source hardening, extraction, and rollout.
+Version: 0.250.070
+Implemented in: 0.250.070
+
+This test ensures Phase 6 of #1061 preserves the bounded Phase 1-5 evidence
+contracts from #1056, #1057, #1058, #1059, and #1060 under parent #1055.
+"""
+
+import sys
+import ast
+import importlib.util
+import time
+import types
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+APP_ROOT = REPO_ROOT / "application" / "single_app"
+COMPARISON_PATH = APP_ROOT / "functions_document_comparison.py"
+sys.path.insert(0, str(APP_ROOT))
+
+import functions_mixed_source_orchestration as orchestration  # pyright: ignore[reportMissingImports]
+from functions_tabular_analysis import get_new_plugin_invocations  # pyright: ignore[reportMissingImports]
+
+
+def _load_evidence_comparison():
+    source = COMPARISON_PATH.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(COMPARISON_PATH))
+    names = {
+        "_build_pairwise_comparison_prompt",
+        "_build_comparison_reduction_prompt",
+        "run_evidence_document_comparison",
+    }
+    module = ast.Module(
+        body=[
+            node
+            for node in tree.body
+            if isinstance(node, ast.FunctionDef) and node.name in names
+        ],
+        type_ignores=[],
+    )
+    ast.fix_missing_locations(module)
+    namespace = {
+        "MixedSourceCancellationError": orchestration.MixedSourceCancellationError,
+        "raise_if_mixed_source_cancelled": orchestration.raise_if_mixed_source_cancelled,
+    }
+    exec(compile(module, str(COMPARISON_PATH), "exec"), namespace)
+    return namespace["run_evidence_document_comparison"]
+
+
+def _load_route_helpers(function_names, namespace=None):
+    route_path = APP_ROOT / "route_backend_chats.py"
+    source = route_path.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(route_path))
+    selected_nodes = [
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name in set(function_names)
+    ]
+    assert {node.name for node in selected_nodes} == set(function_names)
+    loaded_namespace = dict(namespace or {})
+    exec(
+        compile(ast.Module(body=selected_nodes, type_ignores=[]), str(route_path), "exec"),
+        loaded_namespace,
+    )
+    return loaded_namespace
+
+
+def _load_document_action_contract():
+    action_path = APP_ROOT / "functions_document_actions.py"
+    source = action_path.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(action_path))
+    function_names = {
+        "normalize_document_action_type",
+        "normalize_document_action_analysis_mode",
+        "normalize_document_action_target_mode",
+        "normalize_recent_document_window_minutes",
+        "_resolve_max_documents",
+        "_build_document_action_disabled_message",
+        "normalize_document_action_config",
+    }
+    function_nodes = [
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name in function_names
+    ]
+    namespace = {
+        "DOCUMENT_ACTION_TYPE_NONE": "none",
+        "DOCUMENT_ACTION_TYPE_SEARCH": "search",
+        "DOCUMENT_ACTION_TYPE_ANALYZE": "analyze",
+        "DOCUMENT_ACTION_TYPE_COMPARISON": "comparison",
+        "DOCUMENT_ACTION_ANALYSIS_MODE_COMBINED": "combined",
+        "DOCUMENT_ACTION_ANALYSIS_MODE_PER_DOCUMENT": "per_document",
+        "DOCUMENT_ACTION_TARGET_MODE_ALL": "all",
+        "DOCUMENT_ACTION_TARGET_MODE_SELECTED": "selected",
+        "DOCUMENT_ACTION_TARGET_MODE_RECENT": "recent",
+        "DEFAULT_RECENT_DOCUMENT_WINDOW_MINUTES": 10,
+        "VALID_DOCUMENT_ACTION_ANALYSIS_MODES": {"combined", "per_document"},
+        "VALID_DOCUMENT_ACTION_TARGET_MODES": {"all", "selected", "recent"},
+        "VALID_DOCUMENT_ACTION_TYPES": {"none", "search", "analyze", "comparison"},
+        "normalize_search_id_list": lambda values: [
+            str(value).strip()
+            for value in list(values or [])
+            if str(value or "").strip()
+        ],
+        "normalize_document_analysis_targets": lambda **kwargs: {
+            "document_ids": list(kwargs.get("document_ids") or []),
+            "doc_scope": kwargs.get("doc_scope") or "all",
+            "active_group_ids": list(kwargs.get("active_group_ids") or []),
+            "active_public_workspace_id": list(kwargs.get("active_public_workspace_id") or []),
+            "window_unit": kwargs.get("window_unit") or "pages",
+            "window_size": kwargs.get("window_size"),
+            "window_percent": kwargs.get("window_percent"),
+            "max_retries_per_window": kwargs.get("max_retries_per_window", 1),
+        },
+    }
+    exec(
+        compile(ast.Module(body=function_nodes, type_ignores=[]), str(action_path), "exec"),
+        namespace,
+    )
+    return namespace
+
+
+def _load_document_analysis_module():
+    analysis_path = APP_ROOT / "functions_document_analysis.py"
+    appinsights_stub = types.ModuleType("functions_appinsights")
+    appinsights_stub.log_event = lambda *args, **kwargs: None
+    debug_stub = types.ModuleType("functions_debug")
+    debug_stub.debug_print = lambda *args, **kwargs: None
+    search_stub = types.ModuleType("functions_search")
+    search_stub.normalize_search_id_list = lambda values: [
+        str(value).strip()
+        for value in list(values or [])
+        if str(value or "").strip()
+    ]
+    search_stub.normalize_search_scope = lambda value: (
+        str(value or "all").strip().lower()
+        if str(value or "all").strip().lower() in {"all", "personal", "group", "public"}
+        else "all"
+    )
+    replacements = {
+        "functions_appinsights": appinsights_stub,
+        "functions_debug": debug_stub,
+        "functions_search": search_stub,
+    }
+    originals = {name: sys.modules.get(name) for name in replacements}
+    sys.modules.update(replacements)
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "phase6_document_analysis",
+            analysis_path,
+        )
+        assert spec and spec.loader
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        for name, original in originals.items():
+            if original is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = original
+
+
+def test_handoff_exposes_the_same_bounded_envelopes_used_for_synthesis():
+    """Analyze and Compare receive the compacted envelopes represented in the prompt."""
+    manifest = [{
+        "document_id": "table-1",
+        "display_name": "table.csv",
+        "source_kind": orchestration.SOURCE_KIND_TABULAR,
+        "scope": orchestration.SOURCE_SCOPE_PERSONAL,
+        "scope_id": "user-1",
+        "source_version": 3,
+        "authorization_status": orchestration.AUTHORIZATION_STATUS_AUTHORIZED,
+    }]
+    envelope = orchestration.build_evidence_envelope(
+        document_id="table-1",
+        source_kind=orchestration.SOURCE_KIND_TABULAR,
+        engine=orchestration.EVIDENCE_ENGINE_TABULAR_TOOLS,
+        status=orchestration.EVIDENCE_STATUS_COMPLETED,
+        summary="Computed row count: 42.",
+        coverage={"terminal": True, "tool_call_count": 1},
+    )
+
+    handoff = orchestration.build_mixed_source_evidence_handoff(
+        manifest,
+        [envelope],
+        orchestration.SELECTION_MODE_SELECTED,
+    )
+
+    assert handoff["evidence_envelopes"] == [envelope]
+    assert handoff["mixed_source_coverage"]["completed_source_count"] == 1
+
+
+def test_terminal_ledger_preserves_canonical_identity_and_rejects_stale_evidence():
+    """Duplicate names stay distinct while duplicate or unrelated evidence cannot reach synthesis."""
+    manifest = [
+        {
+            "document_id": "personal-table",
+            "display_name": "duplicate.csv",
+            "source_kind": orchestration.SOURCE_KIND_TABULAR,
+            "scope": orchestration.SOURCE_SCOPE_PERSONAL,
+            "scope_id": "user-1",
+            "source_version": "v1",
+            "authorization_status": orchestration.AUTHORIZATION_STATUS_AUTHORIZED,
+        },
+        {
+            "document_id": "group-table",
+            "display_name": "duplicate.csv",
+            "source_kind": orchestration.SOURCE_KIND_TABULAR,
+            "scope": orchestration.SOURCE_SCOPE_GROUP,
+            "scope_id": "group-1",
+            "source_version": "v2",
+            "authorization_status": orchestration.AUTHORIZATION_STATUS_AUTHORIZED,
+        },
+    ]
+
+    def completed(document_id):
+        return orchestration.build_evidence_envelope(
+            document_id=document_id,
+            source_kind=orchestration.SOURCE_KIND_TABULAR,
+            engine=orchestration.EVIDENCE_ENGINE_TABULAR_TOOLS,
+            status=orchestration.EVIDENCE_STATUS_COMPLETED,
+            summary="Computed result.",
+            coverage={"terminal": True, "tool_call_count": 1},
+        )
+
+    ledger = orchestration.build_terminal_coverage_ledger(
+        manifest,
+        [
+            completed("group-table"),
+            completed("personal-table"),
+            completed("personal-table"),
+            completed("unrelated-table"),
+        ],
+    )
+
+    assert [entry["document_id"] for entry in ledger["entries"]] == [
+        "personal-table",
+        "group-table",
+    ]
+    assert [entry["scope"] for entry in ledger["entries"]] == ["personal", "group"]
+    assert [entry["source_version"] for entry in ledger["entries"]] == ["v1", "v2"]
+    assert [entry["request_order"] for entry in ledger["entries"]] == [0, 1]
+    assert ledger["entries"][0]["status"] == orchestration.EVIDENCE_STATUS_FAILED
+    assert ledger["entries"][0]["reason"] == "duplicate_terminal_evidence"
+    assert [item["document_id"] for item in ledger["evidence_envelopes"]] == ["group-table"]
+    assert ledger["duplicate_evidence_count"] == 1
+    assert ledger["unexpected_evidence_count"] == 1
+    assert ledger["partial_coverage"] is True
+
+
+def test_mode_failure_policy_requires_success_and_a_prepared_compare_source():
+    """Analyze needs one successful source; Compare needs both Source and a valid Target."""
+    all_failed = {
+        "entries": [
+            {"role": "selected", "status": orchestration.EVIDENCE_STATUS_FAILED},
+            {"role": "selected", "status": orchestration.EVIDENCE_STATUS_SKIPPED},
+        ],
+        "partial_coverage": True,
+    }
+    analyze_outcome = orchestration.evaluate_mixed_source_mode_outcome(
+        "analyze",
+        all_failed,
+    )
+    assert analyze_outcome["status"] == orchestration.EVIDENCE_STATUS_FAILED
+    assert analyze_outcome["should_reduce"] is False
+
+    failed_source = {
+        "entries": [
+            {"role": "left", "status": orchestration.EVIDENCE_STATUS_FAILED},
+            {"role": "right", "status": orchestration.EVIDENCE_STATUS_COMPLETED},
+        ],
+        "partial_coverage": True,
+    }
+    compare_outcome = orchestration.evaluate_mixed_source_mode_outcome(
+        "compare",
+        failed_source,
+    )
+    assert compare_outcome["status"] == orchestration.EVIDENCE_STATUS_FAILED
+    assert compare_outcome["should_reduce"] is False
+    assert compare_outcome["reason"] == "source_preparation_failed"
+
+    partial_targets = {
+        "entries": [
+            {"role": "left", "status": orchestration.EVIDENCE_STATUS_COMPLETED},
+            {"role": "right", "status": orchestration.EVIDENCE_STATUS_FAILED},
+            {"role": "right", "status": orchestration.EVIDENCE_STATUS_COMPLETED},
+        ],
+        "partial_coverage": True,
+    }
+    partial_outcome = orchestration.evaluate_mixed_source_mode_outcome(
+        "compare",
+        partial_targets,
+    )
+    assert partial_outcome["status"] == orchestration.EVIDENCE_STATUS_PARTIAL
+    assert partial_outcome["should_reduce"] is True
+
+
+def test_compare_failed_source_is_fatal_and_failed_target_does_not_stop_later_targets():
+    """Compare rejects an unavailable Source and keeps a failed Target visible."""
+    compare = _load_evidence_comparison()
+    prompt_calls = []
+
+    def invoke_prompt(prompt, stage="", metadata=None):
+        del prompt
+        prompt_calls.append((stage, dict(metadata or {})))
+        if (metadata or {}).get("right_document_id") == "target-failed":
+            raise RuntimeError("bounded target failure")
+        return "Compared available evidence."
+
+    try:
+        compare(
+            "Compare the sources.",
+            {
+                "document_id": "source",
+                "document_name": "Source.csv",
+                "status": "failed",
+                "summary": "Failure boilerplate must not be evidence.",
+            },
+            [{"document_id": "target", "status": "completed", "summary": "Ready."}],
+            invoke_prompt,
+        )
+    except RuntimeError as exc:
+        assert "Source" in str(exc)
+    else:
+        raise AssertionError("A failed Compare Source must fail the operation")
+
+    result = compare(
+        "Compare the sources.",
+        {
+            "document_id": "source",
+            "document_name": "Source.csv",
+            "source_kind": "tabular",
+            "engine": "tabular_tools",
+            "status": "completed",
+            "summary": "Computed source evidence.",
+        },
+        [
+            {
+                "document_id": "target-failed",
+                "document_name": "Failed.pdf",
+                "source_kind": "narrative",
+                "engine": "document_analysis",
+                "status": "completed",
+                "summary": "Prepared, but pairwise reduction fails.",
+            },
+            {
+                "document_id": "target-valid",
+                "document_name": "Valid.pdf",
+                "source_kind": "narrative",
+                "engine": "document_analysis",
+                "status": "completed",
+                "summary": "Prepared target evidence.",
+            },
+        ],
+        invoke_prompt,
+    )
+
+    assert [item["right_document_id"] for item in result["comparison_items"]] == [
+        "target-valid"
+    ]
+    assert result["coverage"]["failed_targets"] == ["Failed.pdf"]
+    assert "Failed or partial targets: 1" in result["analysis_reply"]
+
+
+def test_tabular_invocation_slicing_is_extracted_without_route_runtime_import():
+    """The reusable helper preserves retry slices without loading the Chat route."""
+    route_was_loaded = "route_backend_chats" in sys.modules
+    invocations = [object(), object(), object()]
+
+    assert get_new_plugin_invocations([], 0) == []
+    copied = get_new_plugin_invocations(invocations, 0)
+    assert copied == invocations
+    assert copied is not invocations
+    assert get_new_plugin_invocations(invocations, 1) == invocations[1:]
+    assert get_new_plugin_invocations(invocations, len(invocations)) == []
+    assert get_new_plugin_invocations(invocations, len(invocations) + 1) == []
+    assert ("route_backend_chats" in sys.modules) is route_was_loaded
+
+    tabular_source = (APP_ROOT / "functions_tabular_analysis.py").read_text(encoding="utf-8")
+    route_source = (APP_ROOT / "route_backend_chats.py").read_text(encoding="utf-8")
+    function_source = ast.get_source_segment(
+        tabular_source,
+        next(
+            node
+            for node in ast.parse(tabular_source).body
+            if isinstance(node, ast.FunctionDef)
+            and node.name == "get_new_plugin_invocations"
+        ),
+    ) or ""
+    assert "_load_chat_helper" not in function_source
+    assert "return _shared_get_new_plugin_invocations" in route_source
+
+
+def test_manifest_and_tabular_cancellation_stop_work_without_failure_downgrade():
+    """Cancellation remains a lifecycle signal and never becomes a failed envelope."""
+    resolver_calls = []
+
+    def cancel_manifest():
+        return True
+
+    try:
+        orchestration.resolve_authorized_source_manifest(
+            ["source-1"],
+            user_id="user-1",
+            context_resolver=lambda **kwargs: resolver_calls.append(kwargs),
+            cancel_requested=cancel_manifest,
+            request_correlation_id="1de45079-f43e-4de5-a2c7-1794f23d9ea4",
+        )
+    except orchestration.MixedSourceCancellationError as exc:
+        assert exc.phase == "manifest"
+    else:
+        raise AssertionError("Manifest cancellation must abort resolution")
+    assert resolver_calls == []
+
+    source = {
+        "document_id": "table-1",
+        "source_kind": orchestration.SOURCE_KIND_TABULAR,
+    }
+    execute_calls = []
+    cancel_checks = iter([False, True])
+
+    try:
+        orchestration.execute_tabular_evidence_sources(
+            [source],
+            lambda item: execute_calls.append(item) or {"summary": "Computed."},
+            orchestration.SELECTION_MODE_SELECTED,
+            cancel_requested=lambda: next(cancel_checks),
+            request_correlation_id="1de45079-f43e-4de5-a2c7-1794f23d9ea4",
+        )
+    except orchestration.MixedSourceCancellationError as exc:
+        assert exc.phase == "tabular"
+    else:
+        raise AssertionError("Tabular cancellation must abort without a failed envelope")
+    assert execute_calls == [source]
+
+
+def test_narrative_comparison_and_reduction_cancellation_stop_later_work():
+    """Cancellation after blocking calls prevents retries, later pairs, and final reductions."""
+    analysis = _load_document_analysis_module()
+    windows = [
+        {
+            "window_number": index,
+            "window_unit": "pages",
+            "start_page": index,
+            "end_page": index,
+            "start_chunk_sequence": index,
+            "end_chunk_sequence": index,
+            "page_count": 1,
+            "chunk_count": 1,
+            "chunks": [{
+                "chunk_text": f"Window {index}",
+                "page_number": index,
+                "chunk_sequence": index,
+            }],
+        }
+        for index in (1, 2)
+    ]
+    analysis._get_search_service_helpers = lambda: (
+        lambda chunks, **kwargs: list(windows),
+        lambda **kwargs: {
+            "document": {
+                "id": "narrative-1",
+                "file_name": "brief.pdf",
+                "title": "Brief",
+            },
+            "chunks": [chunk for window in windows for chunk in window["chunks"]],
+            "chunk_count": 2,
+            "scope": "personal",
+            "scope_id": "user-1",
+        },
+    )
+    narrative_state = {"cancelled": False}
+    narrative_calls = []
+    narrative_events = []
+
+    def invoke_narrative(prompt, **kwargs):
+        del prompt
+        narrative_calls.append(kwargs)
+        narrative_state["cancelled"] = True
+        return "First window result."
+
+    try:
+        analysis.run_document_analysis(
+            user_id="user-1",
+            analysis_prompt="Review every window.",
+            document_ids=["narrative-1"],
+            invoke_prompt=invoke_narrative,
+            activity_callback=narrative_events.append,
+            cancel_requested=lambda: narrative_state["cancelled"],
+        )
+    except orchestration.MixedSourceCancellationError as exc:
+        assert exc.phase == "narrative"
+    else:
+        raise AssertionError("Narrative cancellation must abort after the active model call")
+    assert len(narrative_calls) == 1
+    assert all(event.get("type") != "window_completed" for event in narrative_events)
+    assert all(not str(event.get("type") or "").startswith("reduction") for event in narrative_events)
+
+    compare = _load_evidence_comparison()
+    comparison_state = {"cancelled": False}
+    comparison_calls = []
+
+    def invoke_comparison(prompt, stage="", metadata=None):
+        del prompt
+        comparison_calls.append((stage, dict(metadata or {})))
+        comparison_state["cancelled"] = True
+        return "Pair result."
+
+    try:
+        compare(
+            "Compare.",
+            {"document_id": "source", "status": "completed", "summary": "Source."},
+            [
+                {"document_id": "target-1", "status": "completed", "summary": "One."},
+                {"document_id": "target-2", "status": "completed", "summary": "Two."},
+            ],
+            invoke_comparison,
+            cancel_requested=lambda: comparison_state["cancelled"],
+        )
+    except orchestration.MixedSourceCancellationError as exc:
+        assert exc.phase == "comparison"
+    else:
+        raise AssertionError("Comparison cancellation must stop later Targets")
+    assert [call[1].get("right_document_id") for call in comparison_calls] == ["target-1"]
+
+    reduction_state = {"armed": False, "post_pair_grace": False}
+    reduction_calls = []
+
+    def reduction_cancel_requested():
+        if not reduction_state["armed"]:
+            return False
+        if reduction_state["post_pair_grace"]:
+            reduction_state["post_pair_grace"] = False
+            return False
+        return True
+
+    def invoke_before_reduction(prompt, stage="", metadata=None):
+        del prompt
+        reduction_calls.append((stage, dict(metadata or {})))
+        if (metadata or {}).get("right_document_id") == "target-2":
+            reduction_state["armed"] = True
+            reduction_state["post_pair_grace"] = True
+        return "Pair result."
+
+    try:
+        compare(
+            "Compare.",
+            {"document_id": "source", "status": "completed", "summary": "Source."},
+            [
+                {"document_id": "target-1", "status": "completed", "summary": "One."},
+                {"document_id": "target-2", "status": "completed", "summary": "Two."},
+            ],
+            invoke_before_reduction,
+            cancel_requested=reduction_cancel_requested,
+        )
+    except orchestration.MixedSourceCancellationError as exc:
+        assert exc.phase == "comparison_reduction"
+    else:
+        raise AssertionError("Cancellation before reduction must suppress the reduction call")
+    assert [stage for stage, _ in reduction_calls] == ["comparison", "comparison"]
+
+
+def test_export_cancellation_rolls_back_queued_and_uploaded_artifacts():
+    """Cancellation after queue/upload uses existing cancellation or exact artifact rollback."""
+    queued_runs = []
+    canceled_runs = []
+    deleted_artifacts = []
+    uploaded_artifacts = []
+
+    def load_export_helpers(queue_background):
+        return _load_route_helpers(
+            {"_has_generated_tabular_csv_output", "maybe_create_assistant_table_generated_output"},
+            namespace={
+                "MixedSourceCancellationError": orchestration.MixedSourceCancellationError,
+                "raise_if_mixed_source_cancelled": orchestration.raise_if_mixed_source_cancelled,
+                "build_assistant_table_csv_export": lambda question, content: {
+                    "file_name": "answer.csv",
+                    "file_content": "name,value\nalpha,1\n",
+                    "row_count": 1,
+                    "summary": "One row.",
+                },
+                "_safe_int": lambda value: int(value or 0),
+                "get_settings": lambda: {},
+                "extract_assistant_table_entries": lambda content: [{"name": "alpha", "value": 1}],
+                "_build_tabular_generated_output_row_batches": lambda rows, settings=None: [rows],
+                "should_queue_tabular_generated_output_background": lambda *args: queue_background,
+                "queue_tabular_generated_output_run": lambda **kwargs: (
+                    queued_runs.append(kwargs) or {"id": "run-1"}
+                ),
+                "build_background_tabular_generated_output_metadata": lambda run: {
+                    "export_run_id": run["id"],
+                    "background_export": True,
+                },
+                "get_current_user_id": lambda: "user-1",
+                "storage_account_personal_chat_container_name": "chat-files",
+                "cancel_tabular_generated_output_run": lambda user_id, run_id: canceled_runs.append((user_id, run_id)),
+                "upload_generated_analysis_artifact_for_current_user": lambda **kwargs: (
+                    uploaded_artifacts.append(kwargs)
+                    or {"message": {"id": "artifact-1", "file_name": "answer.csv"}}
+                ),
+                "delete_generated_chat_artifact_for_current_user": lambda conversation_id, message_id: deleted_artifacts.append((conversation_id, message_id)),
+                "log_event": lambda *args, **kwargs: None,
+                "logging": __import__("logging"),
+            },
+        )["maybe_create_assistant_table_generated_output"]
+
+    queued_helper = load_export_helpers(queue_background=True)
+    queued_checks = iter([False, True])
+    try:
+        queued_helper(
+            "Export this table.",
+            "| name | value |\n| --- | --- |\n| alpha | 1 |",
+            "conversation-1",
+            cancel_requested=lambda: next(queued_checks),
+        )
+    except orchestration.MixedSourceCancellationError as exc:
+        assert exc.phase == "export"
+    else:
+        raise AssertionError("Queued export cancellation must abort publication")
+    assert len(queued_runs) == 1
+    assert canceled_runs == [("user-1", "run-1")]
+
+    upload_helper = load_export_helpers(queue_background=False)
+    upload_checks = iter([False, False, True])
+    try:
+        upload_helper(
+            "Export this table.",
+            "| name | value |\n| --- | --- |\n| alpha | 1 |",
+            "conversation-1",
+            cancel_requested=lambda: next(upload_checks),
+        )
+    except orchestration.MixedSourceCancellationError as exc:
+        assert exc.phase == "artifact_publication"
+    else:
+        raise AssertionError("Uploaded artifact cancellation must roll back publication")
+    assert len(uploaded_artifacts) == 1
+    assert deleted_artifacts == [("conversation-1", "artifact-1")]
+
+
+def test_citation_artifact_cancellation_rolls_back_partial_publication():
+    """Citation records written before cancellation are deleted by exact stored identity."""
+    persisted_ids = []
+    deleted_ids = []
+
+    class CitationContainer:
+        def upsert_item(self, item):
+            persisted_ids.append(item["id"])
+
+        def delete_item(self, item, partition_key):
+            deleted_ids.append((item, partition_key))
+
+    persist = _load_route_helpers(
+        {"persist_agent_citation_artifacts"},
+        namespace={
+            "build_agent_citation_artifact_documents": lambda **kwargs: (
+                [{"artifact_id": "citation-artifact-1"}],
+                [
+                    {"id": "citation-artifact-1"},
+                    {"id": "citation-artifact-2"},
+                ],
+            ),
+            "cosmos_messages_container": CitationContainer(),
+            "MixedSourceCancellationError": orchestration.MixedSourceCancellationError,
+            "raise_if_mixed_source_cancelled": orchestration.raise_if_mixed_source_cancelled,
+            "log_event": lambda *args, **kwargs: None,
+            "logging": __import__("logging"),
+            "_strip_agent_citation_artifact_refs": lambda citations: citations,
+        },
+    )["persist_agent_citation_artifacts"]
+    cancel_checks = iter([False, False, True])
+
+    try:
+        persist(
+            conversation_id="conversation-1",
+            assistant_message_id="assistant-1",
+            agent_citations=[{"tool_name": "count_rows"}],
+            created_timestamp="2026-07-23T00:00:00Z",
+            cancel_requested=lambda: next(cancel_checks),
+        )
+    except orchestration.MixedSourceCancellationError as exc:
+        assert exc.phase == "artifact_publication"
+    else:
+        raise AssertionError("Citation cancellation must abort publication")
+
+    assert persisted_ids == ["citation-artifact-1"]
+    assert deleted_ids == [("citation-artifact-1", "conversation-1")]
+
+
+def test_finalization_reauthorizes_scope_and_version_before_publication():
+    """Finalization blocks revoked/rebound/version-changed contributors but keeps prior omissions partial."""
+    helpers = _load_route_helpers(
+        {"_validate_reauthorized_manifest_finalization"},
+        namespace={
+            "compare_reauthorized_source_manifests": orchestration.compare_reauthorized_source_manifests,
+            "MixedSourceFinalizationError": orchestration.MixedSourceFinalizationError,
+            "emit_mixed_source_telemetry": lambda *args, **kwargs: False,
+            "log_event": lambda *args, **kwargs: None,
+            "logging": __import__("logging"),
+        },
+    )
+    validate = helpers["_validate_reauthorized_manifest_finalization"]
+
+    for scope, scope_id in (
+        ("personal", "user-1"),
+        ("group", "group-1"),
+        ("public", "public-1"),
+        ("chat", "conversation-1"),
+    ):
+        execution_manifest = [{
+            "document_id": f"{scope}-doc",
+            "scope": scope,
+            "scope_id": scope_id,
+            "source_version": "v1",
+            "authorization_status": "authorized",
+        }]
+        validate(execution_manifest, [dict(execution_manifest[0])])
+
+        revoked = [{
+            "document_id": f"{scope}-doc",
+            "scope": None,
+            "scope_id": None,
+            "source_version": None,
+            "authorization_status": "unresolved",
+        }]
+        try:
+            validate(execution_manifest, revoked)
+        except orchestration.MixedSourceFinalizationError as exc:
+            assert exc.reason == "authorization_lost"
+        else:
+            raise AssertionError(f"Revoked {scope} access must block final publication")
+
+    try:
+        validate(
+            [{
+                "document_id": "doc-1",
+                "scope": "personal",
+                "scope_id": "user-1",
+                "source_version": "v1",
+                "authorization_status": "authorized",
+            }],
+            [{
+                "document_id": "doc-1",
+                "scope": "personal",
+                "scope_id": "user-1",
+                "source_version": "v2",
+                "authorization_status": "authorized",
+            }],
+        )
+    except RuntimeError:
+        pass
+    else:
+        raise AssertionError("A source-version change must block final publication")
+
+    validate(
+        [{
+            "document_id": "already-missing",
+            "authorization_status": "unresolved",
+        }],
+        [{
+            "document_id": "already-missing",
+            "authorization_status": "unresolved",
+        }],
+    )
+
+    strict_version_result = orchestration.compare_reauthorized_source_manifests(
+        [{
+            "document_id": "legacy-versioned",
+            "scope": "personal",
+            "scope_id": "user-1",
+            "source_version": "v1",
+            "authorization_status": "authorized",
+        }],
+        [{
+            "document_id": "legacy-versioned",
+            "scope": "personal",
+            "scope_id": "user-1",
+            "source_version": None,
+            "authorization_status": "authorized",
+        }],
+    )
+    assert strict_version_result["source_version_changed_count"] == 1
+
+
+def test_bounded_catalog_query_uses_approved_rows_only():
+    """Analyze All candidate queries never enumerate unapproved access-index projections."""
+    access_index_path = APP_ROOT / "functions_document_access_index.py"
+    source = access_index_path.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(access_index_path))
+    query_function = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "_query_bounded_projection_rows_for_scope"
+    )
+    captured = {}
+
+    class FakeContainer:
+        def query_items(self, **kwargs):
+            captured.update(kwargs)
+            return []
+
+    namespace = {
+        "cosmos_document_access_index_container": FakeContainer(),
+        "_safe_int": lambda value: int(value or 0),
+        "DOCUMENT_ACCESS_INDEX_TYPE": "document_access_index",
+        "DOCUMENT_ACCESS_INDEX_SCHEMA_VERSION": 2,
+    }
+    exec(
+        compile(ast.Module(body=[query_function], type_ignores=[]), str(access_index_path), "exec"),
+        namespace,
+    )
+    namespace["_query_bounded_projection_rows_for_scope"](
+        "user:user-1",
+        "personal",
+        6,
+    )
+    assert "c.access_granted = true" in captured["query"]
+    assert "approval_not_approved" not in captured["query"]
+    assert all(item["name"] != "@approval_not_approved" for item in captured["parameters"])
+
+
+def test_foundry_context_opt_out_filters_mixed_evidence_for_all_runtime_shapes():
+    """The runtime strips mixed evidence before Foundry transport when context is disabled."""
+    foundry_path = APP_ROOT / "foundry_agent_runtime.py"
+    source = foundry_path.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(foundry_path))
+    function_names = {
+        "_looks_like_document_context_message",
+        "_filter_foundry_document_context_messages",
+    }
+    function_nodes = [
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name in function_names
+    ]
+
+    class FakeMessage:
+        def __init__(self, role="user", content="", metadata=None):
+            self.role = role
+            self.content = content
+            self.metadata = metadata or {}
+
+    namespace = {
+        "List": list,
+        "ChatMessageContent": FakeMessage,
+        "_extract_message_text": lambda message: str(message.content),
+    }
+    exec(
+        compile(ast.Module(body=function_nodes, type_ignores=[]), str(foundry_path), "exec"),
+        namespace,
+    )
+    filter_messages = namespace["_filter_foundry_document_context_messages"]
+    messages = [
+        FakeMessage("system", "Use the mixed-source evidence handoff below: secret evidence"),
+        FakeMessage("user", "Current user question"),
+        FakeMessage(
+            "user",
+            "[Workflow document search context]\nsecret evidence\n\n[Workflow task]\nSafe task.",
+        ),
+    ]
+    filtered = filter_messages(messages, include_document_context=False)
+    filtered_text = "\n".join(message.content for message in filtered)
+    assert "secret evidence" not in filtered_text
+    assert "Current user question" in filtered_text
+    assert "Safe task." in filtered_text
+
+
+def test_mixed_analyze_forwards_observed_native_token_usage():
+    """Native tabular usage reaches the existing workflow aggregate callback without estimates."""
+    workflow_path = APP_ROOT / "functions_workflow_runner.py"
+    source = workflow_path.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(workflow_path))
+    function_node = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "_execute_mixed_source_analyze_workflow"
+    )
+    captured_usage = []
+    manifest = [{
+        "document_id": "table-1",
+        "display_name": "table.csv",
+        "source_kind": "tabular",
+        "scope": "personal",
+        "scope_id": "user-1",
+        "source_version": 1,
+        "authorization_status": "authorized",
+    }]
+
+    def execute_tabular(*args, **kwargs):
+        kwargs["token_usage_callback"]({
+            "prompt_tokens": 11,
+            "completion_tokens": 4,
+            "total_tokens": 15,
+            "request_count": 1,
+        })
+        return {
+            "result": {"analysis_reply": "Computed."},
+            "agent_citations": [],
+            "generated_tabular_outputs": [],
+        }
+
+    namespace = {
+        "SELECTION_MODE_SELECTED": "selected",
+        "DOCUMENT_ACTION_TYPE_ANALYZE": "analyze",
+        "EVIDENCE_ENGINE_DOCUMENT_ANALYSIS": orchestration.EVIDENCE_ENGINE_DOCUMENT_ANALYSIS,
+        "EVIDENCE_ENGINE_TABULAR_TOOLS": orchestration.EVIDENCE_ENGINE_TABULAR_TOOLS,
+        "EVIDENCE_STATUS_COMPLETED": orchestration.EVIDENCE_STATUS_COMPLETED,
+        "EVIDENCE_STATUS_FAILED": orchestration.EVIDENCE_STATUS_FAILED,
+        "MixedSourceCancellationError": orchestration.MixedSourceCancellationError,
+        "_get_document_action_source_ids": lambda config: (list(config.get("document_ids") or []), {}),
+        "resolve_authorized_source_manifest": lambda *args, **kwargs: list(manifest),
+        "partition_source_manifest": orchestration.partition_source_manifest,
+        "run_document_analysis": lambda **kwargs: {},
+        "_maybe_execute_tabular_document_action": execute_tabular,
+        "build_evidence_envelope": orchestration.build_evidence_envelope,
+        "build_mixed_source_evidence_handoff": orchestration.build_mixed_source_evidence_handoff,
+        "evaluate_mixed_source_mode_outcome": orchestration.evaluate_mixed_source_mode_outcome,
+        "raise_if_mixed_source_cancelled": orchestration.raise_if_mixed_source_cancelled,
+        "normalize_mixed_source_correlation_id": orchestration.normalize_mixed_source_correlation_id,
+        "emit_mixed_source_telemetry": lambda *args, **kwargs: False,
+        "_build_mixed_source_analyze_reduction_prompt": lambda prompt, handoff: handoff["content"],
+        "_build_mixed_source_analysis_coverage": lambda handoff: handoff["mixed_source_coverage"],
+        "time": time,
+    }
+    exec(
+        compile(ast.Module(body=[function_node], type_ignores=[]), str(workflow_path), "exec"),
+        namespace,
+    )
+    namespace["_execute_mixed_source_analyze_workflow"](
+        {"user_id": "user-1", "task_prompt": "Analyze."},
+        {"document_ids": ["table-1"]},
+        {},
+        lambda *args, **kwargs: "Combined.",
+        token_usage_callback=captured_usage.append,
+    )
+    assert captured_usage == [{
+        "prompt_tokens": 11,
+        "completion_tokens": 4,
+        "total_tokens": 15,
+        "request_count": 1,
+    }]
+
+
+def test_publication_rollback_uses_exact_ids_without_source_metadata():
+    """Cancellation/finalization rollback only targets known generated outputs and citation artifacts."""
+    canceled_runs = []
+    deleted_generated = []
+    deleted_citations = []
+    helpers = _load_route_helpers(
+        {"_rollback_mixed_source_chat_publication"},
+        namespace={
+            "cancel_tabular_generated_output_run": lambda user_id, run_id: (
+                canceled_runs.append((user_id, run_id)) or {"canceled": True}
+            ),
+            "delete_generated_chat_artifact_for_current_user": lambda conversation_id, artifact_id: (
+                deleted_generated.append((conversation_id, artifact_id)) or True
+            ),
+            "_rollback_agent_citation_artifacts": lambda conversation_id, citations: (
+                deleted_citations.append((conversation_id, list(citations or [])))
+                or {"deleted_artifact_count": 1, "rollback_failure_count": 0}
+            ),
+            "log_event": lambda *args, **kwargs: None,
+            "logging": __import__("logging"),
+        },
+    )
+    result = helpers["_rollback_mixed_source_chat_publication"](
+        "user-1",
+        "conversation-1",
+        [{"export_run_id": "run-1"}, {"artifact_message_id": "artifact-1"}],
+        compact_citations=[{"artifact_id": "citation-1"}],
+    )
+    assert canceled_runs == [("user-1", "run-1")]
+    assert deleted_generated == [("conversation-1", "artifact-1")]
+    assert deleted_citations == [("conversation-1", [{"artifact_id": "citation-1"}])]
+    assert result["rollback_failure_count"] == 0
+
+
+def test_continuity_keeps_terminal_state_and_never_reuses_incomplete_evidence():
+    """Failed, partial, truncated, or version-changed hints require fresh native execution."""
+    helpers = _load_route_helpers(
+        {"_normalize_prior_grounded_document_refs", "_build_reauthorized_continuity_decision"},
+        namespace={"_safe_metadata_int": lambda value: int(value or 0)},
+    )
+    refs = helpers["_normalize_prior_grounded_document_refs"]({
+        "last_grounded_document_refs": [{
+            "document_id": "table-1",
+            "scope": "group",
+            "scope_id": "group-1",
+            "source_role": "target",
+            "requested_order": 2,
+            "source_kind": "tabular",
+            "engine": "tabular_tools",
+            "source_version": "v1",
+            "status": "partial",
+            "coverage": {"partial_coverage": True, "failed": False},
+            "citation_count": 3,
+            "artifact_count": 1,
+        }],
+    })
+    assert refs[0]["source_version"] == "v1"
+    assert refs[0]["status"] == "partial"
+    assert refs[0]["coverage"]["partial_coverage"] is True
+    assert refs[0]["requested_order"] == 2
+
+    decision = helpers["_build_reauthorized_continuity_decision"](
+        refs,
+        [{
+            "document_id": "table-1",
+            "source_version": "v1",
+            "authorization_status": "authorized",
+        }],
+        explicit_selection=False,
+    )
+    assert decision["incomplete_prior_source_count"] == 1
+    assert decision["requires_native_execution"] is True
+
+    explicit = helpers["_build_reauthorized_continuity_decision"](
+        refs,
+        [],
+        explicit_selection=True,
+    )
+    assert explicit["selection_origin"] == "selected"
+    assert explicit["prior_source_count"] == 0
+
+    reuse_helper = _load_route_helpers(
+        {"_can_reuse_prior_grounded_history"},
+    )["_can_reuse_prior_grounded_history"]
+    history_says_yes = {"can_answer_from_history": True}
+    assert reuse_helper(history_says_yes, None) is True
+    assert reuse_helper(
+        history_says_yes,
+        {"requires_native_execution": True},
+    ) is False
+
+
+def test_reference_deduplication_preserves_first_payload_and_envelope_compatibility():
+    """Hybrid, tool, and generated references keep their shape without duplicates."""
+    citation = {
+        "citation_id": "citation-1",
+        "document_id": "doc-1",
+        "page_number": 2,
+        "custom_payload": {"kept": True},
+    }
+    artifact = {
+        "artifact_message_id": "artifact-1",
+        "file_name": "result.csv",
+        "output_format": "csv",
+        "custom_payload": {"kept": True},
+    }
+    assert orchestration.deduplicate_mixed_source_references(
+        [citation, dict(citation)],
+        reference_type="citation",
+    ) == [citation]
+    assert orchestration.deduplicate_mixed_source_references(
+        [artifact, dict(artifact)],
+        reference_type="artifact",
+    ) == [artifact]
+
+    envelope = orchestration.build_evidence_envelope(
+        document_id="doc-1",
+        source_kind=orchestration.SOURCE_KIND_TABULAR,
+        engine=orchestration.EVIDENCE_ENGINE_TABULAR_TOOLS,
+        status=orchestration.EVIDENCE_STATUS_COMPLETED,
+        summary="Computed.",
+        citations=[citation, dict(citation)],
+        generated_artifacts=[artifact, dict(artifact)],
+        coverage={"terminal": True},
+    )
+    assert envelope["citations"] == [citation]
+    assert envelope["generated_artifacts"] == [artifact]
+
+
+def test_bounded_analyze_all_catalog_rejects_over_limit_without_truncation():
+    """The ready access-index catalog returns every bounded ID or no IDs on overflow."""
+    access_index_path = APP_ROOT / "functions_document_access_index.py"
+    source = access_index_path.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(access_index_path))
+    function_node = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "enumerate_bounded_document_access_index_ids"
+    )
+    query_limits = []
+    rows = [
+        {"source_document_id": "doc-1", "revision_family_id": "family-1", "source_ts": 3},
+        {"source_document_id": "doc-2", "revision_family_id": "family-2", "source_ts": 2},
+    ]
+    namespace = {
+        "DOCUMENT_ACCESS_SOURCE_SCOPES": ("personal", "group", "public"),
+        "DOCUMENT_ACCESS_BOUNDED_CATALOG_MAX_SCOPES": 25,
+        "_safe_int": lambda value: int(value or 0),
+        "_get_document_access_index_readiness": lambda *args, **kwargs: {"ready": True},
+        "_build_shadow_scope": lambda *args, **kwargs: ["user:user-1"],
+        "_query_bounded_projection_rows_for_scope": lambda scope, kind, limit: (
+            query_limits.append(limit) or list(rows)
+        ),
+        "_document_family_identity": lambda row, kind: row.get("revision_family_id"),
+        "_prefer_projection_row": lambda existing, candidate: candidate,
+    }
+    exec(
+        compile(ast.Module(body=[function_node], type_ignores=[]), str(access_index_path), "exec"),
+        namespace,
+    )
+    enumerate_ids = namespace["enumerate_bounded_document_access_index_ids"]
+
+    bounded = enumerate_ids("personal", 2, user_id="user-1")
+    assert bounded["success"] is True
+    assert bounded["document_ids"] == ["doc-1", "doc-2"]
+    assert query_limits == [3]
+
+    rows.append({
+        "source_document_id": "doc-3",
+        "revision_family_id": "family-3",
+        "source_ts": 1,
+    })
+    overflow = enumerate_ids("personal", 2, user_id="user-1")
+    assert overflow["success"] is False
+    assert overflow["status"] == "document_limit_exceeded"
+    assert overflow["document_ids"] == []
+
+
+def test_analyze_all_action_is_analyze_only_and_manifest_is_fresh():
+    """All mode requires Analyze and enumerated IDs still pass through the sole manifest resolver."""
+    action_contract = _load_document_action_contract()
+    normalize_action = action_contract["normalize_document_action_config"]
+    normalized = normalize_action({
+        "type": "analyze",
+        "target_mode": "all",
+        "doc_scope": "all",
+        "active_group_ids": ["group-1"],
+        "active_public_workspace_id": ["public-1"],
+    })
+    assert normalized["target_mode"] == "all"
+    assert normalized["document_ids"] == []
+
+    for action_type in ("search", "comparison"):
+        try:
+            normalize_action({
+                "type": action_type,
+                "target_mode": "all",
+                "left_document_id": "source",
+                "right_document_ids": ["target"],
+            })
+        except ValueError:
+            pass
+        else:
+            raise AssertionError("All Documents must remain Analyze-only")
+
+    workflow_path = APP_ROOT / "functions_workflow_runner.py"
+    workflow_source = workflow_path.read_text(encoding="utf-8")
+    workflow_tree = ast.parse(workflow_source, filename=str(workflow_path))
+    function_node = next(
+        node
+        for node in workflow_tree.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "_execute_mixed_source_analyze_workflow"
+    )
+    manifest_calls = []
+    reduction_calls = []
+    manifest = [
+        {
+            "document_id": "personal-table",
+            "display_name": "duplicate.csv",
+            "source_kind": "tabular",
+            "scope": "personal",
+            "scope_id": "user-1",
+            "source_version": 1,
+            "authorization_status": "authorized",
+        },
+        {
+            "document_id": "group-table",
+            "display_name": "duplicate.csv",
+            "source_kind": "tabular",
+            "scope": "group",
+            "scope_id": "group-1",
+            "source_version": 1,
+            "authorization_status": "authorized",
+        },
+    ]
+
+    def resolve_manifest(document_ids, **kwargs):
+        manifest_calls.append({"document_ids": list(document_ids), **kwargs})
+        return list(manifest)
+
+    def execute_tabular(action_type, workflow, action_config, settings, **kwargs):
+        document_id = action_config["document_ids"][0]
+        return {
+            "result": {"analysis_reply": f"Computed {document_id}."},
+            "agent_citations": [{"tool_name": "count_rows", "document_id": document_id}],
+            "generated_tabular_outputs": [],
+        }
+
+    namespace = {
+        "SELECTION_MODE_SELECTED": "selected",
+        "DOCUMENT_ACTION_TYPE_ANALYZE": "analyze",
+        "EVIDENCE_ENGINE_DOCUMENT_ANALYSIS": orchestration.EVIDENCE_ENGINE_DOCUMENT_ANALYSIS,
+        "EVIDENCE_ENGINE_TABULAR_TOOLS": orchestration.EVIDENCE_ENGINE_TABULAR_TOOLS,
+        "EVIDENCE_STATUS_COMPLETED": orchestration.EVIDENCE_STATUS_COMPLETED,
+        "EVIDENCE_STATUS_FAILED": orchestration.EVIDENCE_STATUS_FAILED,
+        "MixedSourceCancellationError": orchestration.MixedSourceCancellationError,
+        "_get_document_action_source_ids": lambda config: (list(config.get("document_ids") or []), {}),
+        "_resolve_analyze_all_document_ids": lambda *args, **kwargs: {
+            "document_ids": ["personal-table", "group-table"],
+            "doc_scope": "all",
+            "active_group_ids": ["group-1"],
+            "active_public_workspace_id": [],
+            "target_mode": "all",
+        },
+        "resolve_authorized_source_manifest": resolve_manifest,
+        "partition_source_manifest": orchestration.partition_source_manifest,
+        "run_document_analysis": lambda **kwargs: {},
+        "_maybe_execute_tabular_document_action": execute_tabular,
+        "build_evidence_envelope": orchestration.build_evidence_envelope,
+        "build_mixed_source_evidence_handoff": orchestration.build_mixed_source_evidence_handoff,
+        "emit_mixed_source_telemetry": orchestration.emit_mixed_source_telemetry,
+        "evaluate_mixed_source_mode_outcome": orchestration.evaluate_mixed_source_mode_outcome,
+        "normalize_mixed_source_correlation_id": orchestration.normalize_mixed_source_correlation_id,
+        "raise_if_mixed_source_cancelled": orchestration.raise_if_mixed_source_cancelled,
+        "time": time,
+        "_build_mixed_source_analyze_reduction_prompt": lambda prompt, handoff: handoff["content"],
+        "_build_mixed_source_analysis_coverage": lambda handoff: handoff["mixed_source_coverage"],
+    }
+    exec(
+        compile(ast.Module(body=[function_node], type_ignores=[]), str(workflow_path), "exec"),
+        namespace,
+    )
+    result = namespace["_execute_mixed_source_analyze_workflow"](
+        {"user_id": "user-1", "task_prompt": "Analyze all."},
+        {"target_mode": "all", "document_ids": []},
+        {"enable_mixed_source_analyze_all": True},
+        lambda prompt, **kwargs: reduction_calls.append(kwargs) or "Combined.",
+        max_documents=5,
+    )
+    assert manifest_calls[0]["document_ids"] == ["personal-table", "group-table"]
+    assert manifest_calls[0]["selection_mode"] == "all"
+    assert result["reply"] == "Combined."
+    assert result["coverage"]["completed_source_count"] == 2
+    assert len(reduction_calls) == 1
+
+
+def test_development_telemetry_is_default_off_allowlisted_and_privacy_safe():
+    """Development telemetry emits only approved aggregate fields when explicitly enabled."""
+    captured_events = []
+    original_log_event = orchestration.log_event
+    orchestration.log_event = lambda message, **kwargs: captured_events.append({
+        "message": message,
+        **kwargs,
+    })
+    try:
+        assert orchestration.emit_mixed_source_telemetry(
+            {},
+            "terminal_coverage",
+            "analyze",
+            metrics={"completed_source_count": 1},
+        ) is False
+        assert captured_events == []
+
+        assert orchestration.emit_mixed_source_telemetry(
+            {"enable_mixed_source_development_telemetry": True},
+            "terminal_coverage",
+            "analyze",
+            request_correlation_id="1de45079-f43e-4de5-a2c7-1794f23d9ea4",
+            metrics={
+                "completed_source_count": 2,
+                "failed_source_count": 1,
+                "missing_coverage_violation_count": 0,
+                "latency_ms": 12.5,
+            },
+            dimensions={
+                "selection_mode": "all",
+                "outcome_status": "partial",
+            },
+        ) is True
+    finally:
+        orchestration.log_event = original_log_event
+
+    serialized = repr(captured_events)
+    assert "sensitive-document-id" not in serialized
+    assert "secret.csv" not in serialized
+    assert "evidence text" not in serialized
+    assert captured_events[0]["extra"]["completed_source_count"] == 2
+    assert captured_events[0]["extra"]["selection_mode"] == "all"
+
+    try:
+        orchestration.emit_mixed_source_telemetry(
+            {"enable_mixed_source_development_telemetry": True},
+            "terminal_coverage",
+            "chat",
+            metrics={"document_id": 1},
+        )
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("Source-shaped telemetry fields must be rejected")
+
+
+if __name__ == "__main__":
+    test_handoff_exposes_the_same_bounded_envelopes_used_for_synthesis()
+    test_terminal_ledger_preserves_canonical_identity_and_rejects_stale_evidence()
+    test_mode_failure_policy_requires_success_and_a_prepared_compare_source()
+    test_compare_failed_source_is_fatal_and_failed_target_does_not_stop_later_targets()
+    test_tabular_invocation_slicing_is_extracted_without_route_runtime_import()
+    test_manifest_and_tabular_cancellation_stop_work_without_failure_downgrade()
+    test_narrative_comparison_and_reduction_cancellation_stop_later_work()
+    test_export_cancellation_rolls_back_queued_and_uploaded_artifacts()
+    test_citation_artifact_cancellation_rolls_back_partial_publication()
+    test_finalization_reauthorizes_scope_and_version_before_publication()
+    test_bounded_catalog_query_uses_approved_rows_only()
+    test_foundry_context_opt_out_filters_mixed_evidence_for_all_runtime_shapes()
+    test_mixed_analyze_forwards_observed_native_token_usage()
+    test_publication_rollback_uses_exact_ids_without_source_metadata()
+    test_continuity_keeps_terminal_state_and_never_reuses_incomplete_evidence()
+    test_reference_deduplication_preserves_first_payload_and_envelope_compatibility()
+    test_bounded_analyze_all_catalog_rejects_over_limit_without_truncation()
+    test_analyze_all_action_is_analyze_only_and_manifest_is_fresh()
+    test_development_telemetry_is_default_off_allowlisted_and_privacy_safe()
+    print("Mixed-source hardening functional tests passed.")

--- a/functional_tests/test_tabular_background_generated_exports.py
+++ b/functional_tests/test_tabular_background_generated_exports.py
@@ -1,14 +1,15 @@
 #!/usr/bin/env python3
 """
 Functional test for durable tabular generated-output background exports.
-Version: 0.250.061
-Implemented in: 0.241.060
+Version: 0.250.070
+Implemented in: 0.241.060; throughput and timeout hardening in: 0.250.070
 
 This test ensures that large tabular structured exports are wired through the
 durable background queue, status API, queued retry recovery, and chat progress
 UI without requiring live Azure services.
 """
 
+import asyncio
 import ast
 import sys
 from pathlib import Path
@@ -125,15 +126,74 @@ def test_export_runner_module():
 def test_background_runner_bounded_batch_concurrency():
     """Validate Phase 4 bounded model-batch concurrency in the background runner."""
     source_text = read_text(EXPORT_MODULE)
-    assert_contains(source_text, 'TABULAR_EXPORT_DEFAULT_BATCH_CONCURRENCY = 2', 'default batch concurrency')
+    assert_contains(source_text, 'TABULAR_EXPORT_DEFAULT_BATCH_CONCURRENCY = 3', 'default batch concurrency')
     assert_contains(source_text, 'TABULAR_EXPORT_MAX_BATCH_CONCURRENCY = 5', 'maximum batch concurrency')
+    assert_contains(source_text, 'TABULAR_EXPORT_DEFAULT_BATCH_TIMEOUT_SECONDS = 300', 'bounded batch timeout')
     assert_contains(source_text, 'tabular_generated_output_batch_concurrency', 'settings override for batch concurrency')
+    assert_contains(source_text, 'tabular_generated_output_batch_timeout_seconds', 'settings override for batch timeout')
     assert_contains(source_text, '_generate_batch_window_entries', 'async batch window generation helper')
     assert_contains(source_text, 'asyncio.Semaphore', 'bounded async batch semaphore')
     assert_contains(source_text, 'asyncio.gather(*tasks, return_exceptions=True)', 'bounded window gather with exception capture')
+    assert_contains(source_text, 'asyncio.wait_for(', 'bounded model-call timeout')
     assert_contains(source_text, '_checkpoint_generated_batch_results', 'checkpoint successful concurrent batches')
     assert_contains(source_text, '_advance_run_progress_for_window', 'contiguous progress advancement after batch window')
     assert_contains(source_text, 'Building background structured export batch window', 'batch window diagnostics')
+
+
+def test_background_batch_timeout_prevents_indefinite_model_wait():
+    """A stalled model call must fail as retryable timeout before a worker can hang indefinitely."""
+    module_tree = parse_python(EXPORT_MODULE)
+    helper_node = get_function(module_tree, '_generate_batch_entries')
+    if helper_node is None:
+        raise AssertionError('_generate_batch_entries was not found')
+
+    class FakeChatHistory:
+        def add_system_message(self, _message):
+            return None
+
+        def add_user_message(self, _message):
+            return None
+
+    class FakeExecutionSettings:
+        def __init__(self, service_id):
+            self.service_id = service_id
+
+    class SlowChatService:
+        async def get_chat_message_contents(self, _history, _settings):
+            await asyncio.sleep(0.01)
+            return []
+
+    namespace = {
+        'asyncio': asyncio,
+        'SKChatHistory': FakeChatHistory,
+        'AzureChatPromptExecutionSettings': FakeExecutionSettings,
+        'TABULAR_EXPORT_DEFAULT_BATCH_TIMEOUT_SECONDS': 300,
+        '_safe_float': lambda value, default=0.0: float(value) if value is not None else default,
+        '_build_batch_prompt': lambda *args, **kwargs: 'test prompt',
+    }
+    extracted_module = ast.Module(body=[helper_node], type_ignores=[])
+    ast.fix_missing_locations(extracted_module)
+    exec(compile(extracted_module, str(EXPORT_MODULE), 'exec'), namespace)
+
+    try:
+        asyncio.run(
+            namespace['_generate_batch_entries'](
+                SlowChatService(),
+                'Create a CSV.',
+                [{'name': 'Example'}],
+                0,
+                1,
+                'example.csv',
+                '',
+                1,
+                'run-1',
+                batch_timeout_seconds=0.001,
+            )
+        )
+    except TimeoutError as exc:
+        assert 'timed out after' in str(exc), exc
+    else:
+        raise AssertionError('Expected a stalled background model call to time out')
 
 
 def test_chat_route_wires_background_exports():
@@ -223,6 +283,7 @@ def main():
     tests = [
         test_export_runner_module,
         test_background_runner_bounded_batch_concurrency,
+        test_background_batch_timeout_prevents_indefinite_model_wait,
         test_chat_route_wires_background_exports,
         test_generated_export_batch_packing_phase_three,
         test_background_scheduler_and_config_registered,

--- a/functional_tests/test_tabular_document_actions_workflow.py
+++ b/functional_tests/test_tabular_document_actions_workflow.py
@@ -2,7 +2,7 @@
 # test_tabular_document_actions_workflow.py
 """
 Functional test for tabular document-action workflow support.
-Version: 0.250.062
+Version: 0.250.070
 Implemented in: 0.241.038; mixed-source manifest coverage added in 0.250.062
 
 This test ensures tabular document actions reuse the shared tabular analysis
@@ -93,8 +93,8 @@ def test_analyze_and_compare_dispatch_use_tabular_helper() -> None:
     assert "related_document_evidence_summary=left_document.get('related_document_evidence_summary') or ''" in workflow_runner_content, (
         "Expected tabular comparison prompts to carry source-document related evidence into synthesis."
     )
-    assert "'generated_tabular_outputs': list((tabular_action_payload or {}).get('generated_tabular_outputs') or [])" in workflow_runner_content, (
-        "Expected workflow execution results to expose generated tabular outputs when the shared helper is used."
+    assert "'generated_tabular_outputs': generated_tabular_outputs" in workflow_runner_content, (
+        "Expected workflow execution results to expose deduplicated generated tabular outputs."
     )
 
     print("Analyze and comparison dispatch checks passed")
@@ -190,6 +190,7 @@ def test_manifest_flag_does_not_change_workflow_dispatch() -> None:
     namespace = {
         "DOCUMENT_ACTION_TYPE_ANALYZE": "analyze",
         "DOCUMENT_ACTION_TYPE_COMPARISON": "comparison",
+        "raise_if_mixed_source_cancelled": orchestration.raise_if_mixed_source_cancelled,
         "is_tabular_processing_enabled": lambda settings: True,
         "is_mixed_source_manifest_enabled": lambda settings: bool(
             settings.get("enable_mixed_source_manifest")


### PR DESCRIPTION
## Summary
- Complete Phase 6 mixed-source hardening: manifest-aligned terminal coverage, mode-specific partial-failure handling, cancellation/finalization rollback, strict fresh authorization/version checks, and aggregate-only development telemetry.
- Add bounded, approved-access Analyze All enumeration behind the existing default-off flag and keep Chat/Search relevance-bounded.
- Preserve Foundry document-context opt-out, deduplicate mixed citations/artifacts, aggregate observed native tabular token usage, and extract the reusable tabular invocation-slicing helper with a route compatibility shim.
- Improve durable background CSV export throughput and timeout recovery while preserving checkpointing, authorization, and idempotent publication.

## Validation
- 53 Phase 1-6 mixed-source contract tests passed.
- 67 adjacent token, artifact, stream, Foundry, and metadata regressions passed.
- Route-policy, BAC, XSS, Python compilation, Pylance diagnostics, JavaScript syntax, and whitespace checks passed.

## Rollout
All mixed-source behavior flags, subordinate rollout flags, and development telemetry remain default off pending production evidence and explicit approval.

Fixes #1061
Refs #1055
Refs #1071