### PR TITLE
Add universal CSV generation across response paths

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -97,7 +97,7 @@ load_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.250.070"
+VERSION = "0.250.071"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/functions_assistant_table_exports.py
+++ b/application/single_app/functions_assistant_table_exports.py
@@ -13,24 +13,25 @@ CSV_FENCE_LANGUAGES = {'', 'csv', 'md', 'markdown', 'plaintext', 'text', 'text/c
 CSV_OUTPUT_REQUEST_PATTERNS = (
     re.compile(
         r'\b(?:build|create|download|export|generate|make|prepare|save)\b'
-        r'.{0,120}\b(?:a\s+)?csv(?:\s+(?:file|format|output))?\b'
+        r'.{0,120}\b(?:a\s+)?(?:(?:single|combined|one)\s+)?csv(?:\s+(?:file|format|output))?\b'
     ),
     re.compile(
         r'\b(?:respond|return|provide|output)\b'
-        r'(?:(?!\bfrom\b).){0,80}\b(?:as|in|to\s+)?(?:a\s+)?csv\b'
+        r'(?:(?!\bfrom\b).){0,80}\b(?:as|in|to\s+)?(?:a\s+)?(?:(?:single|combined|one)\s+)?csv\b'
     ),
     re.compile(
-        r'\b(?:convert|format|put|turn)\b.{0,80}\b(?:as|in|into|to)\s+(?:a\s+)?csv\b'
+        r'\b(?:convert|format|put|turn)\b.{0,80}\b(?:as|in|into|to)\s+(?:a\s+)?(?:(?:single|combined|one)\s+)?csv\b'
     ),
-    re.compile(r'\b(?:get|give)\s+(?:me\s+)?(?:a|the)\s+csv\b'),
+    re.compile(r'\b(?:get|give)\s+(?:me\s+)?(?:a|the|one)\s+(?:(?:single|combined)\s+)?csv\b'),
     re.compile(
-        r'\b(?:need|want)\s+(?:(?:a|the)\s+)?(?:direct\s+)?csv'
+        r'\b(?:need|want)\s+(?:(?:a|the|one)\s+)?(?:direct\s+)?(?:(?:single|combined)\s+)?csv'
         r'(?:\s+(?:file|format|output))?\b'
     ),
     re.compile(
         r'\b(?:need|want)\b.{0,40}\b(?:results?|output|answer|response|fields?|rows?|data|this|that|it)\b'
-        r'.{0,40}\b(?:as|in)\s+csv\b'
+        r'.{0,40}\b(?:as|in)\s+(?:(?:single|combined|one)\s+)?csv\b'
     ),
+    re.compile(r'\b(?:single|combined|one)\s+csv(?:\s+(?:file|format|output))?\b'),
     re.compile(r'\bcsv\s+(?:output|version)\b'),
     re.compile(r'^\s*(?:a\s+)?csv\s+file\s*(?:,?\s*please)?[.!?]?\s*$'),
     re.compile(
@@ -146,6 +147,14 @@ TABLE_EXPORT_REQUEST_MARKERS = (
 )
 
 
+CSV_EXPLICIT_ROW_SCHEMA_PATTERNS = (
+    re.compile(r'\b(?:one|a|each)\s+(?:row|record|line|entry|object)\s+(?:per|for|of)\b'),
+    re.compile(r'\b(?:one|a|each)\s+(?:file|document|source|record|item)\s+per\s+row\b'),
+    re.compile(r'\b(?:columns?|fields?)\s*(?::|=|are|should|must|include|with)\b'),
+    re.compile(r'\b(?:include|with|using)\s+(?:the\s+)?(?:columns?|fields?)\b'),
+)
+
+
 def assistant_table_export_requested(user_question: str) -> bool:
     """Return True when the user asked for table-shaped output or a CSV export."""
     normalized_question = re.sub(r'\s+', ' ', str(user_question or '').strip().casefold())
@@ -185,6 +194,29 @@ def assistant_table_export_requested(user_question: str) -> bool:
     )
 
 
+def build_csv_output_clarification_guidance(user_question: str) -> str:
+    """Return model guidance for a CSV request that may need one schema clarification."""
+    if not assistant_table_export_requested(user_question):
+        return ''
+
+    normalized_question = re.sub(r'\s+', ' ', str(user_question or '').strip().casefold())
+    if any(pattern.search(normalized_question) for pattern in CSV_EXPLICIT_ROW_SCHEMA_PATTERNS):
+        return (
+            'The user explicitly specified CSV row or column structure. Preserve that structure, '
+            'produce valid structured rows, and do not ask a clarification unless the requested '
+            'evidence itself is contradictory.'
+        )
+
+    return (
+        'The user requested a CSV artifact. If the authorized evidence and request do not establish '
+        'one stable row unit and column schema, ask exactly one concise clarification before generating '
+        'a file: whether each row should represent files, documents, or extracted records, and which '
+        'columns to include. Do not create an empty or guessed CSV. If the schema is clear from the '
+        'request or evidence, generate valid structured rows directly. If this conversation already '
+        'contains that clarification, use the user\'s latest answer instead of asking again.'
+    )
+
+
 def build_assistant_table_csv_export(user_question: str, assistant_content: str) -> Optional[Dict[str, Any]]:
     """Build CSV export metadata from the largest table found in the assistant response."""
     if not assistant_table_export_requested(user_question):
@@ -206,6 +238,41 @@ def build_assistant_table_csv_export(user_question: str, assistant_content: str)
             'in the assistant response.'
         ),
     }
+
+
+def has_generated_tabular_csv_output(generated_outputs: List[Dict[str, Any]]) -> bool:
+    """Return whether a tabular CSV result already suppresses a duplicate table export."""
+    for generated_output in generated_outputs or []:
+        if not isinstance(generated_output, dict):
+            continue
+
+        capability = str(generated_output.get('capability') or '').strip().lower()
+        if generated_output.get('suppress_assistant_table_export') and (
+            not capability or capability == 'tabular'
+        ):
+            return True
+        output_format = str(generated_output.get('output_format') or '').strip().lower()
+        file_name = str(generated_output.get('file_name') or '').strip().lower()
+        if (output_format == 'csv' or file_name.endswith('.csv')) and (
+            not capability or capability == 'tabular'
+        ):
+            return True
+
+    return False
+
+
+def get_assistant_csv_export_content(assistant_result: Any) -> str:
+    """Return the structured document-action reply when it supersedes a concise artifact reply."""
+    if not isinstance(assistant_result, dict):
+        return str(assistant_result or '')
+
+    analysis_result = assistant_result.get('analysis_result')
+    if isinstance(analysis_result, dict):
+        analysis_reply = str(analysis_result.get('analysis_reply') or '').strip()
+        if analysis_reply:
+            return analysis_reply
+
+    return str(assistant_result.get('reply') or '')
 
 
 def extract_assistant_table_entries(assistant_content: str) -> List[Dict[str, str]]:

--- a/application/single_app/functions_settings.py
+++ b/application/single_app/functions_settings.py
@@ -233,19 +233,6 @@ def is_mixed_source_conversation_continuity_enabled(settings):
     )
 
 
-def is_mixed_source_analyze_enabled(settings):
-    """Return whether Phase 3 explicit mixed-source Analyze behavior is enabled."""
-    return bool((settings or {}).get('enable_mixed_source_analyze', False))
-
-
-def is_mixed_source_analyze_all_enabled(settings):
-    """Return whether the separately staged exhaustive Analyze All behavior is enabled."""
-    return bool(
-        (settings or {}).get('enable_mixed_source_analyze', False)
-        and (settings or {}).get('enable_mixed_source_analyze_all', False)
-    )
-
-
 def is_cross_format_compare_enabled(settings):
     """Return whether Phase 4 native mixed-source Compare behavior is enabled."""
     return bool((settings or {}).get('enable_cross_format_compare', False))
@@ -821,8 +808,6 @@ def get_settings(use_cosmos=False, include_source=False):
         'enable_mixed_source_chat_search': False,
         'enable_mixed_source_relevance_candidates': False,
         'enable_mixed_source_conversation_continuity': False,
-        'enable_mixed_source_analyze': False,
-        'enable_mixed_source_analyze_all': False,
         'enable_cross_format_compare': False,
         'enable_cross_format_compare_one_to_many': False,
         'max_rounds_per_agent': 1,

--- a/application/single_app/functions_tabular_generated_exports.py
+++ b/application/single_app/functions_tabular_generated_exports.py
@@ -1243,6 +1243,46 @@ def should_queue_tabular_generated_output_background(row_count, batch_count, set
     return _safe_int(row_count) > inline_max_rows or _safe_int(batch_count) > inline_max_batches
 
 
+def build_tabular_generated_output_row_batches(rows, settings=None):
+    """Split structured rows using the shared generated-export size budget."""
+    settings = settings or {}
+    max_batch_rows = _settings_int(
+        settings,
+        'tabular_generated_output_max_batch_rows',
+        TABULAR_EXPORT_DEFAULT_SOURCE_BATCH_ROWS,
+        minimum=1,
+        maximum=100,
+    )
+    max_batch_chars = _settings_int(
+        settings,
+        'tabular_generated_output_max_batch_chars',
+        TABULAR_EXPORT_DEFAULT_SOURCE_BATCH_CHARS,
+        minimum=6000,
+        maximum=120000,
+    )
+    batches = []
+    current_batch = []
+    current_batch_chars = 0
+
+    for row in rows or []:
+        row_text = json.dumps(row, default=str, ensure_ascii=False, separators=(',', ':'))
+        if current_batch and (
+            len(current_batch) >= max_batch_rows
+            or current_batch_chars + len(row_text) > max_batch_chars
+        ):
+            batches.append(current_batch)
+            current_batch = []
+            current_batch_chars = 0
+
+        current_batch.append(row)
+        current_batch_chars += len(row_text)
+
+    if current_batch:
+        batches.append(current_batch)
+
+    return batches
+
+
 def _parse_iso_datetime(value):
     normalized_value = str(value or '').strip()
     if not normalized_value:

--- a/application/single_app/functions_workflow_runner.py
+++ b/application/single_app/functions_workflow_runner.py
@@ -41,10 +41,19 @@ from config import (
     cosmos_messages_container,
     cosmos_public_documents_container,
     cosmos_user_documents_container,
+    storage_account_personal_chat_container_name,
 )
 from functions_activity_logging import log_conversation_creation, log_token_usage, log_workflow_run
 from functions_appinsights import log_event
-from functions_assistant_table_exports import build_safe_csv_headers, neutralize_csv_spreadsheet_formula
+from functions_assistant_table_exports import (
+    build_assistant_table_csv_export,
+    build_csv_output_clarification_guidance,
+    build_safe_csv_headers,
+    extract_assistant_table_entries,
+    get_assistant_csv_export_content,
+    has_generated_tabular_csv_output,
+    neutralize_csv_spreadsheet_formula,
+)
 from functions_chart_operations import append_proactive_chart_guidance
 from functions_collaboration import (
     create_collaboration_message_notifications,
@@ -125,6 +134,7 @@ from functions_simplechat_operations import (
     delete_generated_chat_artifact_for_current_user,
     delete_generated_chat_artifact_for_user,
     upload_generated_analysis_artifact_for_current_user,
+    upload_generated_analysis_artifact_for_user,
 )
 from functions_settings import (
     get_settings,
@@ -136,6 +146,12 @@ from functions_settings import (
     is_tabular_processing_enabled,
     normalize_model_endpoints,
     resolve_model_endpoint_foundry_scope,
+)
+from functions_tabular_generated_exports import (
+    build_background_tabular_generated_output_metadata,
+    build_tabular_generated_output_row_batches,
+    queue_tabular_generated_output_run,
+    should_queue_tabular_generated_output_background,
 )
 from functions_source_review import (
     URL_ACCESS_CONTEXT_WORKFLOW,
@@ -2128,31 +2144,6 @@ def _build_mixed_source_analysis_coverage(handoff):
     return coverage
 
 
-def _raise_legacy_mixed_source_analyze_limitation(
-    analysis_config,
-    user_id,
-    conversation_id='',
-):
-    """Fail closed rather than silently treating tables as narrative evidence on rollback."""
-    requested_ids, _ = _get_document_action_source_ids(analysis_config)
-    if len(requested_ids) < 2:
-        return
-    manifest = resolve_authorized_source_manifest(
-        requested_ids,
-        user_id=user_id,
-        selection_mode=SELECTION_MODE_SELECTED,
-        conversation_id=conversation_id,
-        active_group_ids=analysis_config.get('active_group_ids'),
-        active_public_workspace_ids=analysis_config.get('active_public_workspace_id'),
-        doc_scope=analysis_config.get('doc_scope', 'all'),
-    )
-    partitions = partition_source_manifest(manifest)
-    if partitions['narrative_sources'] and partitions['tabular_sources']:
-        raise ValueError(
-            'Mixed narrative and tabular Analyze is temporarily unavailable while mixed-source Analyze is disabled.'
-        )
-
-
 def _execute_mixed_source_analyze_workflow(
     workflow,
     analysis_config,
@@ -2645,6 +2636,9 @@ def _build_workflow_chat_messages(prompt_text, url_access_context=None, apply_ge
     source_review_content = _get_workflow_url_access_system_content(url_access_context)
     if source_review_content:
         messages.append({'role': 'system', 'content': source_review_content})
+    csv_output_guidance = build_csv_output_clarification_guidance(prompt_text)
+    if csv_output_guidance:
+        messages.append({'role': 'system', 'content': csv_output_guidance})
     messages.append({'role': 'user', 'content': user_content})
     return messages
 
@@ -2652,9 +2646,14 @@ def _build_workflow_chat_messages(prompt_text, url_access_context=None, apply_ge
 def _build_workflow_agent_messages(prompt_text, url_access_context=None, apply_generation_guidance=False):
     user_content = _build_workflow_generation_prompt(prompt_text) if apply_generation_guidance else str(prompt_text or '').strip()
     source_review_content = _get_workflow_url_access_system_content(url_access_context)
-    if source_review_content:
-        user_content = f'{source_review_content}\n\n[Workflow Task]\n{user_content}'
-    return [ChatMessageContent(role='user', content=user_content)]
+    csv_output_guidance = build_csv_output_clarification_guidance(prompt_text)
+    content_sections = [
+        content
+        for content in (csv_output_guidance, source_review_content)
+        if content
+    ]
+    content_sections.append(f'[Workflow Task]\n{user_content}')
+    return [ChatMessageContent(role='user', content='\n\n'.join(content_sections))]
 
 
 def _format_workflow_url_access_error(validation_result):
@@ -4348,6 +4347,121 @@ def _add_workflow_activity_thought(
     )
 
 
+def _maybe_create_workflow_assistant_table_generated_output(
+    workflow,
+    conversation_id,
+    user_question,
+    assistant_content,
+    existing_outputs=None,
+):
+    """Persist a workflow CSV artifact from a valid structured assistant response."""
+    if has_generated_tabular_csv_output(existing_outputs):
+        return None
+
+    export_payload = build_assistant_table_csv_export(user_question, assistant_content)
+    if not export_payload:
+        return None
+
+    normalized_workflow = workflow if isinstance(workflow, dict) else {}
+    user_id = str(normalized_workflow.get('user_id') or '').strip()
+    normalized_conversation_id = str(conversation_id or '').strip()
+    if not user_id or not normalized_conversation_id:
+        return None
+
+    generated_file_name = str(export_payload.get('file_name') or '').strip()
+    row_count = int(export_payload.get('row_count') or 0)
+    table_rows = extract_assistant_table_entries(assistant_content)
+    settings = get_settings()
+    row_batches = build_tabular_generated_output_row_batches(table_rows, settings=settings)
+    if not generated_file_name or row_count <= 0 or not row_batches:
+        return None
+
+    if should_queue_tabular_generated_output_background(row_count, len(row_batches), settings):
+        try:
+            background_run = queue_tabular_generated_output_run(
+                user_id=user_id,
+                conversation_id=normalized_conversation_id,
+                user_question=user_question,
+                source_candidate={
+                    'filename': generated_file_name,
+                    'selected_sheet': '',
+                    'source_authorization': {
+                        'source': 'chat',
+                    },
+                },
+                output_format='csv',
+                row_batches=row_batches,
+                gpt_model='',
+                settings=settings,
+                passthrough_input_rows=True,
+            )
+            return build_background_tabular_generated_output_metadata(background_run)
+        except Exception as exc:
+            log_event(
+                '[Workflow Assistant Table Export] Failed to queue large CSV export',
+                {
+                    'workflow_id': normalized_workflow.get('id'),
+                    'conversation_id': normalized_conversation_id,
+                    'row_count': row_count,
+                    'error': str(exc),
+                },
+                level=logging.ERROR,
+                exceptionTraceback=True,
+            )
+            return None
+
+    try:
+        upload_result = upload_generated_analysis_artifact_for_user(
+            current_user_id=user_id,
+            conversation_id=normalized_conversation_id,
+            file_name=generated_file_name,
+            file_content=export_payload.get('file_content'),
+            capability='tabular',
+            output_format='csv',
+            summary=export_payload.get('summary'),
+        )
+    except Exception as exc:
+        log_event(
+            '[Workflow Assistant Table Export] Failed to save assistant table CSV artifact',
+            {
+                'workflow_id': normalized_workflow.get('id'),
+                'conversation_id': normalized_conversation_id,
+                'row_count': row_count,
+                'error': str(exc),
+            },
+            debug_only=True,
+        )
+        return None
+
+    uploaded_message = upload_result.get('message') or {}
+    artifact_message_id = uploaded_message.get('id')
+    if not artifact_message_id:
+        return None
+
+    uploaded_file_name = uploaded_message.get('file_name') or generated_file_name
+    log_event(
+        '[Workflow Assistant Table Export] Saved assistant table CSV artifact',
+        {
+            'workflow_id': normalized_workflow.get('id'),
+            'conversation_id': normalized_conversation_id,
+            'artifact_message_id': artifact_message_id,
+            'row_count': row_count,
+        },
+        debug_only=True,
+    )
+    return {
+        'capability': 'tabular',
+        'artifact_message_id': artifact_message_id,
+        'conversation_id': normalized_conversation_id,
+        'storage_scope': 'chat',
+        'file_name': uploaded_file_name,
+        'output_format': 'csv',
+        'row_count': row_count,
+        'preview_rows': export_payload.get('preview_rows') or [],
+        'summary': export_payload.get('summary'),
+    }
+
+
 def _create_assistant_message(conversation, workflow, result, trigger_source, run_id, user_message_doc, assistant_message_id=None):
     assistant_message_id = assistant_message_id or str(uuid.uuid4())
     timestamp = _utc_now_iso()
@@ -4355,6 +4469,18 @@ def _create_assistant_message(conversation, workflow, result, trigger_source, ru
     document_action = _get_document_action_config(workflow)
     workspace_type = _get_workflow_scope(workflow)
     group_id = _get_workflow_group_id(workflow)
+    generated_analysis_artifacts = list(result.get('generated_analysis_artifacts') or [])
+    generated_tabular_outputs = list(result.get('generated_tabular_outputs') or [])
+    assistant_table_generated_output = _maybe_create_workflow_assistant_table_generated_output(
+        workflow=workflow,
+        conversation_id=conversation.get('id'),
+        user_question=workflow.get('task_prompt', ''),
+        assistant_content=get_assistant_csv_export_content(result),
+        existing_outputs=generated_analysis_artifacts + generated_tabular_outputs,
+    )
+    if assistant_table_generated_output:
+        generated_analysis_artifacts.append(assistant_table_generated_output)
+        generated_tabular_outputs.append(assistant_table_generated_output)
     raw_agent_citations = list(result.get('agent_citations') or [])
     web_search_citations = list(result.get('web_search_citations') or [])
     source_review_metadata = result.get('source_review') if isinstance(result.get('source_review'), dict) else {}
@@ -4388,8 +4514,8 @@ def _create_assistant_message(conversation, workflow, result, trigger_source, ru
             'workspace_type': workspace_type,
             'group_id': group_id or None,
             'token_usage': result.get('token_usage'),
-            'generated_analysis_artifacts': list(result.get('generated_analysis_artifacts') or []),
-            'generated_tabular_outputs': list(result.get('generated_tabular_outputs') or []),
+            'generated_analysis_artifacts': generated_analysis_artifacts,
+            'generated_tabular_outputs': generated_tabular_outputs,
             'source_review': source_review_metadata,
             'workflow': {
                 'workflow_id': workflow.get('id'),
@@ -6114,13 +6240,6 @@ def _execute_document_analysis_workflow(
 
         return _combine_per_document_analysis_results(per_document_results)
 
-    if not bool(settings.get('enable_mixed_source_analyze', False)):
-        _raise_legacy_mixed_source_analyze_limitation(
-            analysis_config,
-            user_id,
-            conversation_id=conversation_id,
-        )
-
     token_usage_aggregate = _create_token_usage_aggregate()
 
     if workflow.get('runner_type') == 'agent':
@@ -6191,55 +6310,17 @@ def _execute_document_analysis_workflow(
                 def record_native_token_usage(token_usage):
                     _accumulate_token_usage_summary(token_usage_aggregate, token_usage)
 
-                mixed_source_enabled = bool(settings.get('enable_mixed_source_analyze', False))
-                tabular_action_payload = None
-                if mixed_source_enabled:
-                    analysis_result = _execute_mixed_source_analyze_workflow(
-                        workflow, analysis_config, settings, invoke_prompt,
-                        conversation_id=conversation_id, activity_callback=activity_callback,
-                        thought_tracker=thought_tracker, live_thought_callback=external_activity_callback,
-                        max_documents=workflow_analysis_max_documents,
-                        cancel_requested=cancel_requested,
-                        request_correlation_id=request_correlation_id,
-                        token_usage_callback=record_native_token_usage,
-                    )
-                else:
-                    tabular_action_payload = _maybe_execute_tabular_document_action(
-                        DOCUMENT_ACTION_TYPE_ANALYZE,
-                        workflow,
-                        analysis_config,
-                        settings,
-                        conversation_id=conversation_id,
-                        invoke_prompt=invoke_prompt,
-                        thought_tracker=thought_tracker,
-                        live_thought_callback=external_activity_callback,
-                        cancel_requested=cancel_requested,
-                        request_correlation_id=request_correlation_id,
-                        token_usage_callback=record_native_token_usage,
-                    )
-                if tabular_action_payload:
-                    analysis_result = tabular_action_payload.get('result') or {}
-                elif not mixed_source_enabled:
-                    analysis_result = run_document_analysis(
-                        user_id=user_id,
-                        analysis_prompt=workflow.get('task_prompt', ''),
-                        document_ids=analysis_config.get('document_ids'),
-                        invoke_prompt=invoke_prompt,
-                        doc_scope=analysis_config.get('doc_scope'),
-                        active_group_ids=analysis_config.get('active_group_ids'),
-                        active_public_workspace_id=analysis_config.get('active_public_workspace_id'),
-                        window_unit=analysis_config.get('window_unit'),
-                        window_size=analysis_config.get('window_size'),
-                        window_percent=analysis_config.get('window_percent'),
-                        max_retries_per_window=analysis_config.get('max_retries_per_window'),
-                        activity_callback=activity_callback,
-                        max_documents=workflow_analysis_max_documents,
-                        cancel_requested=cancel_requested,
-                        request_correlation_id=request_correlation_id,
-                    )
+                analysis_result = _execute_mixed_source_analyze_workflow(
+                    workflow, analysis_config, settings, invoke_prompt,
+                    conversation_id=conversation_id, activity_callback=activity_callback,
+                    thought_tracker=thought_tracker, live_thought_callback=external_activity_callback,
+                    max_documents=workflow_analysis_max_documents,
+                    cancel_requested=cancel_requested,
+                    request_correlation_id=request_correlation_id,
+                    token_usage_callback=record_native_token_usage,
+                )
                 primary_generated_outputs = list(
-                    (tabular_action_payload or {}).get('generated_tabular_outputs')
-                    or analysis_result.get('generated_tabular_outputs')
+                    analysis_result.get('generated_tabular_outputs')
                     or []
                 )
                 _reauthorize_mixed_source_workflow_result(
@@ -6285,8 +6366,7 @@ def _execute_document_analysis_workflow(
                 agent_citations = _build_agent_citations_from_invocations(user_id, conversation_id)
                 if not agent_citations:
                     agent_citations = list(
-                        (tabular_action_payload or {}).get('agent_citations')
-                        or analysis_result.get('agent_citations')
+                        analysis_result.get('agent_citations')
                         or []
                     )
                 alert_targets = _collect_agent_alert_targets(user_id, conversation_id)
@@ -6314,8 +6394,7 @@ def _execute_document_analysis_workflow(
                     'agent_display_name': getattr(loaded_agent, 'display_name', None) or selected_agent.get('display_name') or requested_name,
                     'agent_citations': agent_citations,
                     'generated_tabular_outputs': list(
-                        (tabular_action_payload or {}).get('generated_tabular_outputs')
-                        or analysis_result.get('generated_tabular_outputs')
+                        analysis_result.get('generated_tabular_outputs')
                         or []
                     ),
                     'alert_targets': alert_targets,
@@ -6381,55 +6460,17 @@ def _execute_document_analysis_workflow(
     def record_native_token_usage(token_usage):
         _accumulate_token_usage_summary(token_usage_aggregate, token_usage)
 
-    mixed_source_enabled = bool(settings.get('enable_mixed_source_analyze', False))
-    tabular_action_payload = None
-    if mixed_source_enabled:
-        analysis_result = _execute_mixed_source_analyze_workflow(
-            workflow, analysis_config, settings, invoke_model_prompt,
-            conversation_id=conversation_id, activity_callback=activity_callback,
-            thought_tracker=thought_tracker, live_thought_callback=external_activity_callback,
-            max_documents=workflow_analysis_max_documents,
-            cancel_requested=cancel_requested,
-            request_correlation_id=request_correlation_id,
-            token_usage_callback=record_native_token_usage,
-        )
-    else:
-        tabular_action_payload = _maybe_execute_tabular_document_action(
-            DOCUMENT_ACTION_TYPE_ANALYZE,
-            workflow,
-            analysis_config,
-            settings,
-            conversation_id=conversation_id,
-            invoke_prompt=invoke_model_prompt,
-            thought_tracker=thought_tracker,
-            live_thought_callback=external_activity_callback,
-            cancel_requested=cancel_requested,
-            request_correlation_id=request_correlation_id,
-            token_usage_callback=record_native_token_usage,
-        )
-    if tabular_action_payload:
-        analysis_result = tabular_action_payload.get('result') or {}
-    elif not mixed_source_enabled:
-        analysis_result = run_document_analysis(
-            user_id=user_id,
-            analysis_prompt=workflow.get('task_prompt', ''),
-            document_ids=analysis_config.get('document_ids'),
-            invoke_prompt=invoke_model_prompt,
-            doc_scope=analysis_config.get('doc_scope'),
-            active_group_ids=analysis_config.get('active_group_ids'),
-            active_public_workspace_id=analysis_config.get('active_public_workspace_id'),
-            window_unit=analysis_config.get('window_unit'),
-            window_size=analysis_config.get('window_size'),
-            window_percent=analysis_config.get('window_percent'),
-            max_retries_per_window=analysis_config.get('max_retries_per_window'),
-            activity_callback=activity_callback,
-            max_documents=workflow_analysis_max_documents,
-            cancel_requested=cancel_requested,
-            request_correlation_id=request_correlation_id,
-        )
+    analysis_result = _execute_mixed_source_analyze_workflow(
+        workflow, analysis_config, settings, invoke_model_prompt,
+        conversation_id=conversation_id, activity_callback=activity_callback,
+        thought_tracker=thought_tracker, live_thought_callback=external_activity_callback,
+        max_documents=workflow_analysis_max_documents,
+        cancel_requested=cancel_requested,
+        request_correlation_id=request_correlation_id,
+        token_usage_callback=record_native_token_usage,
+    )
     primary_generated_outputs = list(
-        (tabular_action_payload or {}).get('generated_tabular_outputs')
-        or analysis_result.get('generated_tabular_outputs')
+        analysis_result.get('generated_tabular_outputs')
         or []
     )
     _reauthorize_mixed_source_workflow_result(
@@ -6502,13 +6543,11 @@ def _execute_document_analysis_workflow(
         'token_usage': token_usage,
         'provider': provider,
         'agent_citations': list(
-            (tabular_action_payload or {}).get('agent_citations')
-            or analysis_result.get('agent_citations')
+            analysis_result.get('agent_citations')
             or []
         ),
         'generated_tabular_outputs': list(
-            (tabular_action_payload or {}).get('generated_tabular_outputs')
-            or analysis_result.get('generated_tabular_outputs')
+            analysis_result.get('generated_tabular_outputs')
             or []
         ),
     }

--- a/application/single_app/route_backend_chats.py
+++ b/application/single_app/route_backend_chats.py
@@ -120,9 +120,12 @@ from functions_chat import *
 from functions_content import generate_embedding, generate_embeddings_batch
 from functions_assistant_table_exports import (
     assistant_table_export_requested,
+    build_csv_output_clarification_guidance,
     build_safe_csv_headers,
     build_assistant_table_csv_export,
     extract_assistant_table_entries,
+    get_assistant_csv_export_content,
+    has_generated_tabular_csv_output,
     neutralize_csv_spreadsheet_formula,
 )
 from functions_chart_operations import (
@@ -189,6 +192,7 @@ from functions_tabular_generated_exports import (
     _normalize_generated_batch_entries,
     _prepare_tabular_source_rows,
     build_background_tabular_generated_output_metadata,
+    build_tabular_generated_output_row_batches,
     cancel_tabular_generated_output_run,
     get_tabular_generated_output_run_status,
     queue_tabular_generated_output_run,
@@ -2043,22 +2047,7 @@ def _maybe_create_deep_research_ledger_artifact(settings, conversation_id, ledge
 
 
 def _has_generated_tabular_csv_output(generated_outputs):
-    for generated_output in generated_outputs or []:
-        if not isinstance(generated_output, dict):
-            continue
-
-        capability = str(generated_output.get('capability') or '').strip().lower()
-        if generated_output.get('suppress_assistant_table_export') and (
-            not capability or capability == 'tabular'
-        ):
-            return True
-        output_format = str(generated_output.get('output_format') or '').strip().lower()
-        file_name = str(generated_output.get('file_name') or '').strip().lower()
-        if output_format == 'csv' or file_name.endswith('.csv'):
-            if not capability or capability == 'tabular':
-                return True
-
-    return False
+    return has_generated_tabular_csv_output(generated_outputs)
 
 
 def maybe_create_assistant_table_generated_output(
@@ -2101,7 +2090,6 @@ def maybe_create_assistant_table_generated_output(
                     'selected_sheet': '',
                     'source_authorization': {
                         'source': 'chat',
-                        'container': storage_account_personal_chat_container_name,
                     },
                 },
                 output_format='csv',
@@ -5069,30 +5057,7 @@ def _build_tabular_generated_output_file_name(source_file_name, output_format):
 
 
 def _build_tabular_generated_output_row_batches(rows, settings=None):
-    budget = _get_tabular_generated_output_batch_budget(settings)
-    max_batch_rows = budget['max_rows']
-    max_batch_chars = budget['max_chars']
-    batches = []
-    current_batch = []
-    current_batch_chars = 0
-
-    for row in rows or []:
-        row_text = _dump_tabular_generated_output_json(row)
-        if current_batch and (
-            len(current_batch) >= max_batch_rows
-            or current_batch_chars + len(row_text) > max_batch_chars
-        ):
-            batches.append(current_batch)
-            current_batch = []
-            current_batch_chars = 0
-
-        current_batch.append(row)
-        current_batch_chars += len(row_text)
-
-    if current_batch:
-        batches.append(current_batch)
-
-    return batches
+    return build_tabular_generated_output_row_batches(rows, settings=settings)
 
 
 def _build_tabular_generated_output_candidate_diagnostic(invocation):
@@ -13852,7 +13817,7 @@ def register_route_backend_chats(bp):
             )
             assistant_table_generated_output = maybe_create_assistant_table_generated_output(
                 user_question=user_message,
-                assistant_content=execution_result.get('reply', ''),
+                assistant_content=get_assistant_csv_export_content(execution_result),
                 conversation_id=conversation_id,
                 existing_outputs=document_generated_analysis_artifacts + document_generated_tabular_outputs,
                 cancel_requested=cancel_requested,
@@ -14503,6 +14468,12 @@ def register_route_backend_chats(bp):
             generated_tabular_outputs_list = []
             generated_analysis_artifacts_list = []
             system_messages_for_augmentation = [] # Collect system messages from search
+            csv_output_guidance = build_csv_output_clarification_guidance(user_message)
+            if csv_output_guidance:
+                system_messages_for_augmentation.append({
+                    'role': 'system',
+                    'content': csv_output_guidance,
+                })
             search_results = []
             mixed_source_narrative_retrieval_failed = False
             selected_agent = None  # Initialize selected_agent early to prevent NameError
@@ -18623,6 +18594,12 @@ def register_route_backend_chats(bp):
                 generated_tabular_outputs_list = []
                 generated_analysis_artifacts_list = []
                 system_messages_for_augmentation = []
+                csv_output_guidance = build_csv_output_clarification_guidance(user_message)
+                if csv_output_guidance:
+                    system_messages_for_augmentation.append({
+                        'role': 'system',
+                        'content': csv_output_guidance,
+                    })
                 search_results = []
                 mixed_source_narrative_retrieval_failed = False
                 selected_agent = None

--- a/docs/explanation/features/UNIVERSAL_CSV_GENERATION.md
+++ b/docs/explanation/features/UNIVERSAL_CSV_GENERATION.md
@@ -1,0 +1,127 @@
+# Universal CSV Generation
+
+Implemented in version: **0.250.071**
+
+GitHub issue: [#1071](https://github.com/microsoft/simplechat/issues/1071)
+
+Related config.py update: `VERSION = "0.250.071"`
+
+## Overview
+
+CSV is a shared response-output capability rather than a CSV/XLSX-only feature. When a user requests CSV and a response contains valid structured rows, SimpleChat creates one downloadable CSV artifact through the existing authorized chat-artifact contract.
+
+The finalizer is source-neutral. Native evidence adapters continue to handle PDF, Office, text, image/media-derived, CSV, XLSX, and mixed-source evidence; once a response has a valid Markdown table, tab-separated table, or CSV-shaped result, the same CSV artifact path is used.
+
+## Purpose
+
+Previously, natural requests such as "turn these into a single CSV" could miss the shared intent detector, and workflow replies did not pass through the assistant-table artifact finalizer. Analyze and Compare could also replace a structured analysis response with a concise existing-artifact message before CSV finalization.
+
+This implementation gives ordinary Chat, streaming Chat, Chat Search, selected agents, Analyze, Compare, workflows, and source-free prompts the same final structured-response CSV contract.
+
+## Dependencies
+
+- `functions_assistant_table_exports.py` for CSV intent detection, structured-row parsing, formula protection, duplicate suppression, and authoritative document-action reply selection
+- `functions_simplechat_operations.py` for owner-authorized chat artifact uploads and downloads
+- `functions_tabular_generated_exports.py` for shared row batching, durable queueing, checkpoints, cancellation, reauthorization, and final artifact publication
+- Existing mixed-source manifest and evidence-envelope contracts for selected-source authorization and coverage semantics
+- Azure Cosmos DB `tabular_export_runs` and personal chat blob storage for oversized exports
+
+## Technical Specifications
+
+### Unified Intent and Structured Rows
+
+The shared intent detector recognizes direct CSV requests plus natural variants including `single CSV`, `combined CSV`, and `one CSV`. It excludes negated requests and prompts that merely discuss an input CSV.
+
+The exporter accepts valid structured response forms:
+
+- Markdown tables
+- Tab-separated tables
+- CSV, including quoted commas, multiline values, and escaped quotes
+- CSV-shaped output in supported fenced blocks
+
+Every generated CSV uses safe headers and neutralizes spreadsheet formula-like values while preserving signed numeric text.
+
+### Row and Schema Clarification
+
+For an ambiguous CSV request, Chat and workflow model/agent prompts direct the assistant to ask exactly one concise question before generating a file: whether each row represents files, documents, or extracted records, and which columns to include. The assistant response is persisted in the conversation, so the next user turn can answer the clarification without a separate temporary state store.
+
+Explicit instructions such as `one row per document` or `columns: file name, amount` bypass that clarification. When native evidence already establishes a clear structured result, the assistant proceeds directly to valid rows and the downloadable CSV.
+
+### Response Path Finalization
+
+The common finalizer runs after the response is complete in:
+
+- Standard and streaming Chat, including Chat Search and selected agents
+- Analyze and Compare document actions
+- Personal and group workflow assistant messages
+- Source-free prompts that return valid structured rows
+
+For Analyze and Compare, the finalizer prefers `analysis_result.analysis_reply` over a concise `reply` that may only describe a separately generated artifact. That ensures a valid structured result remains exportable without changing the user-visible response.
+
+### Evidence, Coverage, and Source Types
+
+CSV finalization does not retrieve or infer source data itself. It consumes only valid rows already produced by the native evidence path. This keeps source authorization, revision handling, and selected-source coverage in the existing mixed-source orchestration layer.
+
+Explicit selections remain authoritative upstream. A generated CSV cannot silently invent unprocessed source rows: if native evidence is partial, failed, unsupported, unresolved, canceled, or revision-changed, the response coverage contract remains responsible for disclosing that state. The CSV serializer only writes validated structured rows supplied to it.
+
+### Immediate and Durable Artifacts
+
+Small result sets upload immediately through the generic chat artifact uploader. The uploader verifies that the conversation is owned by the workflow/chat user before writing the blob-backed file message.
+
+Large assistant-rendered tables use the existing durable tabular export queue:
+
+1. Rows are batched with the shared row and character budget.
+2. The queue stages passthrough rows, so it does not call a model again to serialize an already validated table.
+3. The worker reauthorizes conversation ownership before processing.
+4. The staged-chat source uses `source: chat` without pretending that staged rows are an external source blob.
+5. The existing progress card exposes status, cancellation, retry/resume, and final authorized download behavior.
+
+### Configuration
+
+The durable threshold and batch settings are shared with tabular exports:
+
+- `enable_tabular_generated_output_background_exports`
+- `tabular_generated_output_inline_max_rows`
+- `tabular_generated_output_inline_max_batches`
+- `tabular_generated_output_max_batch_rows`
+- `tabular_generated_output_max_batch_chars`
+
+## File Structure
+
+- `application/single_app/functions_assistant_table_exports.py`
+- `application/single_app/functions_tabular_generated_exports.py`
+- `application/single_app/route_backend_chats.py`
+- `application/single_app/functions_workflow_runner.py`
+- `functional_tests/test_assistant_table_csv_artifact.py`
+- `functional_tests/test_tabular_row_orchestration_scale.py`
+
+## Usage
+
+Users can request a CSV in natural language, for example:
+
+- `Turn these into a single CSV.`
+- `Save one CSV with the extracted invoice fields.`
+- `Create a combined CSV from the selected sources.`
+
+When the response contains valid structured rows, the chat displays the downloadable CSV artifact. Large results display the existing background-export status card until the authorized artifact is published.
+
+When the requested row unit or columns are unclear, the assistant asks one clarification in the conversation. Reply with the desired row unit and columns, then the normal CSV finalization path creates the artifact from the resulting structured response.
+
+## Testing and Validation
+
+- `functional_tests/test_assistant_table_csv_artifact.py` validates intent variants, non-tabular response parsing, Analyze/Compare structured-reply selection, workflow artifacts, duplicate suppression, formula safety, and immediate/background paths.
+- `functional_tests/test_tabular_row_orchestration_scale.py` validates durable row contracts, worker reauthorization, staged-chat authorization, cancellation, recovery, and idempotent publication.
+- `functional_tests/test_tabular_background_generated_exports.py` validates queue, status, and browser-contract wiring.
+
+## Performance Considerations
+
+- Small tables avoid queue overhead and upload immediately.
+- Large tables use the existing bounded row/character batch budget and checkpointed durable worker.
+- Passthrough batches avoid duplicate model inference and preserve the validated row order.
+- Worker reauthorization uses compact identifiers and does not log source row contents.
+
+## Known Limitations
+
+- A CSV artifact requires parseable structured rows. Prose-only model output does not produce an empty or fabricated CSV.
+- Clarification state is represented by the persisted assistant conversation message rather than a separate job or schema-state container.
+- Native evidence adapters and mixed-source coverage are intentionally retained as their existing specialized contracts. This feature finalizes their valid structured response output rather than replacing retrieval, document analysis, or source orchestration.

--- a/docs/explanation/features/index.md
+++ b/docs/explanation/features/index.md
@@ -42,6 +42,7 @@ category: Version History
 
 - [Microsoft Teams App SSO](v0.242.072/TEAMS_APP_SSO.md)
 - [Tabular SK Large Result Pagination](v0.242.067/TABULAR_SK_LARGE_RESULT_PAGINATION.md)
+- [Universal CSV Generation](UNIVERSAL_CSV_GENERATION.md)
 - [Model Endpoint Model Icon Picker](v0.242.060/MODEL_ENDPOINT_MODEL_ICON_PICKER.md)
 - [Deployer Capacity Defaults](v0.241.085/DEPLOYER_CAPACITY_DEFAULTS.md)
 - [Chat Inline Export Action Progress Labels](v0.241.107/CHAT_INLINE_EXPORT_ACTION_PROGRESS.md)

--- a/docs/explanation/fixes/MIXED_SOURCE_ANALYZE_GATING_REMOVAL_FIX.md
+++ b/docs/explanation/fixes/MIXED_SOURCE_ANALYZE_GATING_REMOVAL_FIX.md
@@ -1,0 +1,25 @@
+# Mixed-Source Analyze Gating Removal Fix
+
+Version: 0.250.071
+
+Fixed/Implemented in version: **0.250.071**
+
+Related config.py update: `VERSION = "0.250.071"`
+
+## Header Information
+
+- Issue description: Combined Analyze rejected a selected mixture of narrative and tabular documents when the internal mixed-source rollout setting was false.
+- Root cause analysis: The workflow runner used a default-off settings flag to choose between the native mixed-source workflow and legacy single-engine paths. The legacy path then raised an error for mixed document types.
+- Version implemented: 0.250.071
+
+## Technical Details
+
+- Files modified: `application/single_app/functions_workflow_runner.py`, `application/single_app/functions_settings.py`, `application/single_app/config.py`, `functional_tests/test_mixed_source_analyze_workflow.py`.
+- Code changes summary: Combined Analyze now always uses the existing authorization-safe mixed-source workflow for both agent and direct-model runners. The obsolete settings defaults, helpers, and legacy rejection path were removed.
+- Testing approach: Updated the focused functional test to require automatic mixed-source routing, preserve per-document behavior, and reject reintroduction of the settings flag.
+
+## Validation
+
+- Test results: `functional_tests/test_mixed_source_analyze_workflow.py` passes with all three tests successful.
+- Before/after comparison: Before the fix, a PDF/DOCX plus XLSX/CSV selection could fail with a disabled mixed-source Analyze message. After the fix, selected narrative and tabular sources are partitioned and analyzed by their native engines before a combined response is produced.
+- User experience improvements: Users can select compatible narrative and tabular documents together for Analyze without requiring an administrator or deployment setting change.

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,22 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](/explanation/features/) and [Fixes by Version](/explanation/fixes/).
 
+### **(v0.250.071)**
+
+#### New Features
+
+*   **Universal CSV Generation**
+    *   CSV requests such as "turn these into a single CSV" now use one artifact path across standard and streaming Chat, Chat Search, selected agents, Analyze, Compare, workflows, and source-free structured responses.
+    *   Ambiguous row or column requests ask one persisted conversation clarification; explicit schema instructions proceed directly. Large outputs reuse the authorized, durable background export flow.
+    *   (Ref: microsoft/simplechat#1071, `functions_assistant_table_exports.py`, `route_backend_chats.py`, `functions_workflow_runner.py`, `functions_tabular_generated_exports.py`, `UNIVERSAL_CSV_GENERATION.md`)
+
+#### Bug Fixes
+
+*   **Mixed-Source Analyze Availability**
+    *   Removed the default-off internal gate that could reject a combined Analyze selection containing both narrative and tabular documents.
+    *   Combined Analyze now automatically uses the native mixed-source workflow for selected sources, without requiring an administrator or deployment setting change.
+    *   (Ref: microsoft/simplechat#1058, `functions_workflow_runner.py`, `functions_settings.py`, `test_mixed_source_analyze_workflow.py`, `MIXED_SOURCE_ANALYZE_GATING_REMOVAL_FIX.md`)
+
 ### **(v0.250.070)**
 
 #### New Features

--- a/functional_tests/test_assistant_table_csv_artifact.py
+++ b/functional_tests/test_assistant_table_csv_artifact.py
@@ -2,8 +2,8 @@
 #!/usr/bin/env python3
 """
 Functional test for assistant-rendered table CSV artifacts.
-Version: 0.250.070
-Implemented in: 0.241.050; non-tabular document CSV parsing in 0.250.065
+Version: 0.250.071
+Implemented in: 0.241.050; non-tabular document CSV parsing in 0.250.065; universal CSV intent in 0.250.071
 
 This test ensures that explicit table-format requests with assistant-rendered
 tables, including CSV rows extracted from non-tabular documents, are converted
@@ -25,15 +25,17 @@ CONFIG_FILE = APP_DIR / 'config.py'
 CHAT_ROUTE_FILE = APP_DIR / 'route_backend_chats.py'
 BACKGROUND_EXPORT_FILE = APP_DIR / 'functions_tabular_generated_exports.py'
 WORKFLOW_RUNNER_FILE = APP_DIR / 'functions_workflow_runner.py'
-EXPECTED_VERSION = '0.250.070'
+EXPECTED_VERSION = '0.250.071'
 
 sys.path.append(str(APP_DIR))
 
 from functions_assistant_table_exports import (  # noqa: E402
     assistant_table_export_requested,
+    build_csv_output_clarification_guidance,
     build_safe_csv_headers,
     build_assistant_table_csv_export,
     extract_assistant_table_entries,
+    get_assistant_csv_export_content,
     neutralize_csv_spreadsheet_formula,
 )
 
@@ -79,6 +81,22 @@ def load_csv_writer_helpers(source_file, function_names):
     extracted_module = ast.Module(body=selected_nodes, type_ignores=[])
     exec(compile(extracted_module, str(source_file), 'exec'), namespace)
     return {function_name: namespace[function_name] for function_name in function_names}
+
+
+def load_workflow_assistant_table_export_helper(namespace):
+    module_tree = ast.parse(read_text(WORKFLOW_RUNNER_FILE), filename=str(WORKFLOW_RUNNER_FILE))
+    selected_nodes = [
+        node
+        for node in module_tree.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == '_maybe_create_workflow_assistant_table_generated_output'
+    ]
+    if len(selected_nodes) != 1:
+        raise AssertionError('Expected workflow assistant-table CSV artifact helper.')
+
+    extracted_module = ast.Module(body=selected_nodes, type_ignores=[])
+    exec(compile(extracted_module, str(WORKFLOW_RUNNER_FILE), 'exec'), namespace)
+    return namespace['_maybe_create_workflow_assistant_table_generated_output']
 
 
 def test_markdown_table_response_builds_csv_export():
@@ -153,6 +171,32 @@ Source: ParkingPrint.pdf, Page: 1
         csv_rows[0]['Notes'] == 'Includes parking, taxes, and fees',
         'Expected quoted commas in generated CSV values to be preserved.',
     )
+
+
+def test_document_action_analysis_reply_builds_csv_export():
+    print('Testing structured document-action CSV source selection...')
+
+    assistant_result = {
+        'reply': 'The detailed analysis is available in the attached artifact.',
+        'analysis_result': {
+            'analysis_reply': '''```csv
+Name,Invoice Number
+Contoso,DCAW1366188
+```''',
+        },
+    }
+    selected_content = get_assistant_csv_export_content(assistant_result)
+    export_payload = build_assistant_table_csv_export(
+        'turn these into a single CSV',
+        selected_content,
+    )
+
+    assert_true(
+        export_payload is not None,
+        'Expected a structured document-action analysis reply to produce a CSV artifact.',
+    )
+    csv_rows = parse_csv_rows(export_payload.get('file_content'))
+    assert_true(csv_rows[0]['Invoice Number'] == 'DCAW1366188', 'Expected the analysis reply row to be exported.')
 
 
 def test_plain_document_csv_response_excludes_surrounding_prose_and_citation():
@@ -626,6 +670,163 @@ def test_natural_csv_and_create_table_phrases_are_recognized():
         )
 
 
+def test_universal_csv_request_variants_are_recognized():
+    print('Testing universal CSV request variants...')
+
+    assistant_content = """| Name | Amount |
+| --- | --- |
+| Contoso | 42 |
+"""
+    request_phrases = (
+        'turn these into a single CSV',
+        'turn these into one CSV',
+        'turn these into a combined CSV',
+        'create a single CSV file',
+        'save one CSV',
+    )
+
+    for request_phrase in request_phrases:
+        assert_true(
+            assistant_table_export_requested(request_phrase),
+            f"Expected '{request_phrase}' to request a CSV artifact.",
+        )
+        assert_true(
+            build_assistant_table_csv_export(request_phrase, assistant_content) is not None,
+            f"Expected '{request_phrase}' to produce an assistant table CSV export.",
+        )
+
+
+def test_csv_schema_clarification_guidance_is_specific_and_resumable():
+    print('Testing CSV schema clarification guidance...')
+
+    ambiguous_guidance = build_csv_output_clarification_guidance('turn these into a single CSV')
+    assert_true(
+        'ask exactly one concise clarification' in ambiguous_guidance,
+        'Expected ambiguous CSV requests to instruct one schema clarification.',
+    )
+    assert_true(
+        'latest answer instead of asking again' in ambiguous_guidance,
+        'Expected a prior CSV clarification to be resumed from conversation history.',
+    )
+
+    explicit_guidance = build_csv_output_clarification_guidance(
+        'Create a CSV with one row per document and columns: file name, invoice number, amount.',
+    )
+    assert_true(
+        'explicitly specified CSV row or column structure' in explicit_guidance,
+        'Expected explicit row and column instructions to bypass a schema clarification.',
+    )
+    assert_true(
+        'ask exactly one concise clarification' not in explicit_guidance,
+        'Expected explicit schema requests not to request a clarification.',
+    )
+    assert_true(
+        build_csv_output_clarification_guidance('Summarize the selected sources.') == '',
+        'Expected non-CSV requests not to receive CSV clarification guidance.',
+    )
+
+
+def test_workflow_assistant_table_csv_artifacts_reuse_shared_contract():
+    print('Testing workflow assistant-table CSV artifact finalization...')
+
+    uploaded_requests = []
+    queue_requests = []
+    shared_namespace = {
+        'build_assistant_table_csv_export': build_assistant_table_csv_export,
+        'extract_assistant_table_entries': extract_assistant_table_entries,
+        'has_generated_tabular_csv_output': lambda outputs: any(
+            output.get('output_format') == 'csv'
+            for output in outputs or []
+            if isinstance(output, dict)
+        ),
+        'get_settings': lambda: {},
+        'build_tabular_generated_output_row_batches': lambda rows, settings=None: [rows],
+        'should_queue_tabular_generated_output_background': lambda *args: False,
+        'queue_tabular_generated_output_run': lambda **kwargs: queue_requests.append(kwargs),
+        'build_background_tabular_generated_output_metadata': lambda run: run,
+        'upload_generated_analysis_artifact_for_user': (
+            lambda **kwargs: uploaded_requests.append(kwargs) or {
+                'message': {'id': 'workflow-csv-artifact', 'file_name': kwargs['file_name']},
+            }
+        ),
+        'log_event': lambda *args, **kwargs: None,
+        'logging': type('Logging', (), {'ERROR': 'ERROR'}),
+        'storage_account_personal_chat_container_name': 'personal-chat',
+    }
+    helper = load_workflow_assistant_table_export_helper(shared_namespace)
+    workflow = {
+        'id': 'workflow-1',
+        'user_id': 'user-1',
+        'task_prompt': 'turn these into a single CSV',
+    }
+    assistant_content = '''| Name | Invoice Number |
+| --- | --- |
+| Contoso | DCAW1366188 |
+
+Source: ParkingPrint.pdf, Page: 1
+'''
+
+    artifact = helper(
+        workflow,
+        'conversation-1',
+        workflow['task_prompt'],
+        assistant_content,
+    )
+    assert_true(artifact is not None, 'Expected a workflow CSV artifact for valid assistant rows.')
+    assert_true(artifact['artifact_message_id'] == 'workflow-csv-artifact', 'Expected uploaded workflow artifact metadata.')
+    assert_true(len(uploaded_requests) == 1, 'Expected one authorized artifact upload.')
+    assert_true(uploaded_requests[0]['current_user_id'] == 'user-1', 'Expected upload to use the workflow owner.')
+    assert_true(uploaded_requests[0]['output_format'] == 'csv', 'Expected a CSV artifact upload.')
+    assert_true(
+        helper(
+            workflow,
+            'conversation-1',
+            workflow['task_prompt'],
+            assistant_content,
+            [{'capability': 'tabular', 'output_format': 'csv'}],
+        ) is None,
+        'Expected existing tabular CSV output to suppress a duplicate workflow artifact.',
+    )
+
+    background_namespace = dict(shared_namespace)
+    background_namespace.update({
+        'should_queue_tabular_generated_output_background': lambda *args: True,
+        'queue_tabular_generated_output_run': (
+            lambda **kwargs: queue_requests.append(kwargs) or {'id': 'workflow-export-run'}
+        ),
+        'build_background_tabular_generated_output_metadata': (
+            lambda run: {
+                'background_export': True,
+                'export_run_id': run['id'],
+                'suppress_assistant_table_export': True,
+            }
+        ),
+    })
+    background_helper = load_workflow_assistant_table_export_helper(background_namespace)
+    background_artifact = background_helper(
+        workflow,
+        'conversation-1',
+        workflow['task_prompt'],
+        assistant_content,
+    )
+    assert_true(background_artifact['background_export'] is True, 'Expected large workflow exports to queue durably.')
+    assert_true(queue_requests[-1]['passthrough_input_rows'] is True, 'Expected workflow rows to avoid a second model call.')
+    assert_true(
+        queue_requests[-1]['source_candidate']['source_authorization'] == {'source': 'chat'},
+        'Expected staged workflow rows to use valid chat authorization without a source blob path.',
+    )
+
+    workflow_runner_content = read_text(WORKFLOW_RUNNER_FILE)
+    assert_true(
+        'assistant_table_generated_output = _maybe_create_workflow_assistant_table_generated_output(' in workflow_runner_content,
+        'Expected workflow assistant messages to finalize shared CSV artifacts.',
+    )
+    assert_true(
+        'generated_analysis_artifacts.append(assistant_table_generated_output)' in workflow_runner_content,
+        'Expected workflow CSV metadata to reach the generic artifact UI.',
+    )
+
+
 def test_chat_route_wires_assistant_table_artifacts():
     print('Testing chat route assistant-table artifact plumbing...')
 
@@ -666,6 +867,23 @@ def test_chat_route_wires_assistant_table_artifacts():
         'Expected normal and streaming assistant messages to include assistant table CSV artifacts.',
     )
     assert_true(
+        'assistant_content=get_assistant_csv_export_content(execution_result)' in chat_route_content,
+        'Expected document-action CSV exports to use the structured analysis reply when available.',
+    )
+    assert_true(
+        'assistant_content=get_assistant_csv_export_content(result)' in read_text(WORKFLOW_RUNNER_FILE),
+        'Expected workflow CSV exports to use the structured analysis reply when available.',
+    )
+    assert_true(
+        chat_route_content.count('build_csv_output_clarification_guidance(user_message)') == 2,
+        'Expected normal and streaming Chat to apply the same CSV clarification guidance.',
+    )
+    workflow_runner_content = read_text(WORKFLOW_RUNNER_FILE)
+    assert_true(
+        workflow_runner_content.count('build_csv_output_clarification_guidance(prompt_text)') == 2,
+        'Expected workflow model and agent execution to apply CSV clarification guidance.',
+    )
+    assert_true(
         'if assistant_table_export_requested(user_question):' in chat_route_content,
         'Expected tabular output format detection to use the shared CSV/table intent predicate.',
     )
@@ -680,6 +898,7 @@ def run_tests() -> bool:
         test_markdown_table_response_builds_csv_export,
         test_tab_separated_table_response_builds_rows,
         test_non_tabular_document_csv_response_builds_export,
+        test_document_action_analysis_reply_builds_csv_export,
         test_plain_document_csv_response_excludes_surrounding_prose_and_citation,
         test_document_csv_response_preserves_multiline_and_escaped_quotes,
         test_fenced_document_csv_preserves_sentence_shaped_rows,
@@ -699,6 +918,9 @@ def run_tests() -> bool:
         test_non_table_requests_do_not_create_exports,
         test_natural_table_request_phrase_is_recognized,
         test_natural_csv_and_create_table_phrases_are_recognized,
+        test_universal_csv_request_variants_are_recognized,
+        test_csv_schema_clarification_guidance_is_specific_and_resumable,
+        test_workflow_assistant_table_csv_artifacts_reuse_shared_contract,
         test_chat_route_wires_assistant_table_artifacts,
     ]
 

--- a/functional_tests/test_document_action_conversation_scope_metadata.py
+++ b/functional_tests/test_document_action_conversation_scope_metadata.py
@@ -2,8 +2,8 @@
 # test_document_action_conversation_scope_metadata.py
 """
 Functional test for document-action conversation scope metadata.
-Version: 0.250.070
-Implemented in: 0.241.124; Updated in: 0.250.068
+Version: 0.250.071
+Implemented in: 0.241.124; Updated in: 0.250.071
 
 This test ensures Analyze and tabular document-action results can assign
 conversation workspace metadata from selected document summaries when no
@@ -20,7 +20,7 @@ ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 METADATA_FILE = os.path.join(ROOT_DIR, 'application', 'single_app', 'functions_conversation_metadata.py')
 ROUTE_FILE = os.path.join(ROOT_DIR, 'application', 'single_app', 'route_backend_chats.py')
 CONFIG_FILE = os.path.join(ROOT_DIR, 'application', 'single_app', 'config.py')
-FIX_VERSION = '0.250.070'
+FIX_VERSION = '0.250.071'
 TEST_USER_ID = 'scope-user-1'
 CRIMSON_GROUP_ID = 'crimson-group-1'
 PUBLIC_WORKSPACE_ID = 'public-workspace-1'

--- a/functional_tests/test_document_action_token_usage_aggregation.py
+++ b/functional_tests/test_document_action_token_usage_aggregation.py
@@ -1,8 +1,8 @@
 # test_document_action_token_usage_aggregation.py
 """
 Functional test for document action token usage aggregation.
-Version: 0.250.070
-Implemented in: 0.241.116
+Version: 0.250.071
+Implemented in: 0.241.116; updated for universal CSV artifacts in 0.250.071
 
 This test ensures analysis and comparison aggregate tokens across
 all internal model calls and persist the aggregate usage on assistant metadata.
@@ -130,15 +130,28 @@ def test_document_analysis_token_aggregation():
             'DOCUMENT_ACTION_CONTEXT_WORKFLOW': 'workflow',
             'raise_if_mixed_source_cancelled': orchestration.raise_if_mixed_source_cancelled,
             'get_document_action_max_documents': lambda *args, **kwargs: 10,
-            '_is_per_document_analysis_mode': lambda action: False,
+            '_is_per_document_analysis_mode': lambda *args, **kwargs: False,
             '_raise_legacy_mixed_source_analyze_limitation': lambda *args, **kwargs: None,
             '_chain_activity_callbacks': lambda *callbacks: None,
             '_build_document_action_activity_callback': lambda *args, **kwargs: None,
             '_maybe_execute_tabular_document_action': lambda *args, **kwargs: None,
             '_maybe_create_document_analysis_generated_artifacts': lambda *args, **kwargs: {'artifacts': [], 'assistant_reply': None},
             '_reauthorize_mixed_source_workflow_result': lambda *args, **kwargs: None,
+            '_execute_mixed_source_analyze_workflow': lambda workflow, action_config, settings, invoke_prompt, **kwargs: (
+                invoke_prompt('analysis window 1', stage='window_analysis'),
+                invoke_prompt('analysis window 2', stage='reduction'),
+                {
+                    'reply': 'Aggregated analysis answer',
+                    'coverage': {
+                        'processed_windows': 2,
+                        'failed_windows': 0,
+                    },
+                }
+            )[-1],
             '_resolve_model_workflow_client': lambda *args, **kwargs: (fake_client, 'gpt-5.4', 'aoai'),
-            '_build_workflow_chat_messages': lambda prompt, **kwargs: [{'role': 'user', 'content': prompt}],
+            '_build_workflow_chat_messages': lambda prompt_text, **kwargs: [
+                {'role': 'user', 'content': prompt_text},
+            ],
             'run_document_analysis': lambda **kwargs: (
                 kwargs['invoke_prompt']('analysis window 1', stage='window_analysis'),
                 kwargs['invoke_prompt']('analysis window 2', stage='reduction'),
@@ -216,8 +229,12 @@ def test_document_comparison_token_aggregation():
             '_maybe_execute_tabular_document_action': lambda *args, **kwargs: None,
             '_maybe_create_comparison_generated_artifacts': lambda *args, **kwargs: {'artifacts': [], 'assistant_reply': None},
             '_reauthorize_mixed_source_workflow_result': lambda *args, **kwargs: None,
+            'is_cross_format_compare_enabled': lambda *args, **kwargs: False,
+            '_raise_legacy_cross_format_compare_limitation': lambda *args, **kwargs: None,
             '_resolve_model_workflow_client': lambda *args, **kwargs: (fake_client, 'gpt-5.4', 'aoai'),
-            '_build_workflow_chat_messages': lambda prompt, **kwargs: [{'role': 'user', 'content': prompt}],
+            '_build_workflow_chat_messages': lambda prompt_text, **kwargs: [
+                {'role': 'user', 'content': prompt_text},
+            ],
             'run_document_comparison': lambda **kwargs: (
                 kwargs['invoke_prompt']('summary left', stage='summary'),
                 kwargs['invoke_prompt']('summary right', stage='summary'),
@@ -282,6 +299,8 @@ def test_workflow_assistant_persists_token_usage():
             '_get_document_action_config': lambda workflow: workflow.get('document_action', {}),
             '_get_workflow_scope': lambda workflow: 'personal',
             '_get_workflow_group_id': lambda workflow: '',
+            '_maybe_create_workflow_assistant_table_generated_output': lambda **kwargs: None,
+            'get_assistant_csv_export_content': lambda result: result.get('reply', ''),
             '_persist_agent_citation_artifacts': lambda **kwargs: [],
             'cosmos_messages_container': message_container,
             'cosmos_conversations_container': conversation_container,
@@ -354,7 +373,7 @@ def test_version_update():
     with open(CONFIG_PATH, 'r', encoding='utf-8') as handle:
         content = handle.read()
 
-    assert_in('VERSION = "0.250.070"', content, 'config version update')
+    assert_in('VERSION = "0.250.071"', content, 'config version update')
     print('Version update passed.')
     return True
 

--- a/functional_tests/test_mixed_source_analyze_workflow.py
+++ b/functional_tests/test_mixed_source_analyze_workflow.py
@@ -2,12 +2,12 @@
 # test_mixed_source_analyze_workflow.py
 """
 Functional test for Phase 3 mixed-source combined Analyze.
-Version: 0.250.066
-Implemented in: 0.250.066
+Version: 0.250.071
+Implemented in: 0.250.071
 
 This test ensures #1058 composes native narrative and tabular analysis behind
-the default-off rollout flag, retains terminal coverage after either branch
-fails, and keeps per-document execution non-collective. Parent: #1055.
+automatic combined Analyze routing, retains terminal coverage after either
+branch fails, and keeps per-document execution non-collective. Parent: #1055.
 Prerequisites: #1056 and #1057.
 """
 
@@ -57,20 +57,26 @@ def test_phase_3_mixed_analyze_contracts_are_wired():
     assert "'agent_citations': tabular_agent_citations" in helper_source
 
 
-def test_phase_3_flag_default_and_per_document_guard():
-    """Rollout must remain off by default and never add collective reduction to per-document mode."""
+def test_phase_3_mixed_analyze_is_automatic_and_preserves_per_document_mode():
+    """Combined Analyze must use native mixed-source execution without a feature gate."""
     settings_source = SETTINGS.read_text(encoding='utf-8')
     workflow_source = WORKFLOW_RUNNER.read_text(encoding='utf-8')
+    tree = ast.parse(workflow_source)
+    runner = next(
+        node for node in tree.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == '_execute_document_analysis_workflow'
+    )
+    runner_source = ast.get_source_segment(workflow_source, runner) or ''
 
-    assert "'enable_mixed_source_analyze': False" in settings_source
-    assert "'enable_mixed_source_analyze_all': False" in settings_source
-    assert 'def is_mixed_source_analyze_enabled(settings):' in settings_source
-    assert 'def is_mixed_source_analyze_all_enabled(settings):' in settings_source
-    assert workflow_source.count("mixed_source_enabled = bool(settings.get('enable_mixed_source_analyze', False))") == 2
-    assert 'def _raise_legacy_mixed_source_analyze_limitation(' in workflow_source
-    assert 'Mixed narrative and tabular Analyze is temporarily unavailable while mixed-source Analyze is disabled.' in workflow_source
-    assert "or analysis_result.get('generated_tabular_outputs')" in workflow_source
-    assert "or analysis_result.get('agent_citations')" in workflow_source
+    assert 'enable_mixed_source_analyze' not in settings_source
+    assert 'enable_mixed_source_analyze' not in workflow_source
+    assert 'def _raise_legacy_mixed_source_analyze_limitation(' not in workflow_source
+    assert runner_source.count('analysis_result = _execute_mixed_source_analyze_workflow(') == 2
+    assert '_is_per_document_analysis_mode(analysis_config)' in runner_source
+    assert 'return _combine_per_document_analysis_results(per_document_results)' in runner_source
+    assert "analysis_result.get('generated_tabular_outputs')" in runner_source
+    assert "analysis_result.get('agent_citations')" in runner_source
 
 
 def test_phase_3_reduction_prompt_requires_evidence_separation_and_failures():

--- a/functional_tests/test_mixed_source_conversation_continuity.py
+++ b/functional_tests/test_mixed_source_conversation_continuity.py
@@ -2,8 +2,8 @@
 # test_mixed_source_conversation_continuity.py
 """
 Functional test for Phase 5 mixed-source conversation continuity.
-Version: 0.250.070
-Implemented in: 0.250.068
+Version: 0.250.071
+Implemented in: 0.250.068; updated in 0.250.071
 
 This test ensures #1060 preserves compact source continuity only as a
 reauthorization hint for #1055 and prerequisite phases #1056, #1057, #1058,
@@ -118,7 +118,7 @@ def test_flag_and_standard_streaming_wiring_are_present():
     assert route_source.count("'history',") >= 2
     assert 'source_continuity_refs=None' in metadata_source
     assert 'source_continuity_refs=source_continuity_refs' in metadata_source
-    assert 'VERSION = "0.250.070"' in config_source
+    assert 'VERSION = "0.250.071"' in config_source
     print('PASS: flag and Chat parity wiring')
 
 

--- a/functional_tests/test_tabular_row_orchestration_scale.py
+++ b/functional_tests/test_tabular_row_orchestration_scale.py
@@ -1,8 +1,8 @@
 # test_tabular_row_orchestration_scale.py
 """
 Functional test for scalable per-row tabular orchestration.
-Version: 0.250.065
-Implemented in: 0.250.060; generated CSV formula safety in 0.250.065
+Version: 0.250.071
+Implemented in: 0.250.060; generated CSV formula safety in 0.250.065; shared CSV queue authorization in 0.250.071
 
 This test ensures generated exports preserve source identity and row order while
 enforcing one stable output schema across independently generated batches.
@@ -35,6 +35,7 @@ sys.path.append(str(APP_ROOT))
 
 from functions_assistant_table_exports import (  # noqa: E402
     build_safe_csv_headers,
+    has_generated_tabular_csv_output,
     neutralize_csv_spreadsheet_formula,
 )
 CONTRACT_FUNCTIONS = {
@@ -485,6 +486,7 @@ def _load_failed_export_helpers():
         '_build_tabular_generated_output_file_name': (
             lambda filename, output_format: f"{Path(filename).stem}_generated.{output_format}"
         ),
+        'has_generated_tabular_csv_output': has_generated_tabular_csv_output,
     }
     extracted_module = ast.Module(body=selected_nodes, type_ignores=[])
     exec(compile(extracted_module, str(CHAT_ROUTE), 'exec'), namespace)
@@ -964,6 +966,16 @@ def test_worker_revalidates_conversation_and_workspace_authorization():
     }
     assert authorize_personal(personal_run)['user_id'] == 'user-1'
 
+    staged_chat_run = {
+        'id': 'run-staged-chat',
+        'user_id': 'user-1',
+        'conversation_id': 'conversation-1',
+        'source_authorization': {
+            'source': 'chat',
+        },
+    }
+    assert authorize_personal(staged_chat_run)['user_id'] == 'user-1'
+
     authorize_wrong_owner = _load_authorization_helper('different-user')
     try:
         authorize_wrong_owner(personal_run)
@@ -1203,6 +1215,17 @@ def test_route_queues_replayable_pages_and_suppresses_summary_fallback():
     assert 'source_descriptor=source_descriptor' in route_source
     assert "output_metadata.get('background_export')" in route_source
     assert '_has_generated_tabular_csv_output(existing_outputs)' in route_source
+
+    route_module = ast.parse(route_source, filename=str(CHAT_ROUTE))
+    assistant_table_export = next(
+        node
+        for node in route_module.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == 'maybe_create_assistant_table_generated_output'
+    )
+    assistant_table_export_source = ast.get_source_segment(route_source, assistant_table_export)
+    assert "'source': 'chat'," in assistant_table_export_source
+    assert "'container': storage_account_personal_chat_container_name" not in assistant_table_export_source
 
     helpers = _load_failed_export_helpers()
     failed_output = helpers['_build_failed_tabular_generated_output_metadata'](


### PR DESCRIPTION
## Summary
- Unifies CSV intent detection and artifact finalization across standard and streaming Chat, Chat Search, selected agents, Analyze, Compare, workflows, and source-free structured responses.
- Adds one conversation-persisted row/schema clarification for ambiguous CSV requests; explicit row and column instructions proceed directly.
- Reuses the authorized immediate and durable background artifact contracts, including staged-row authorization, cancellation, reauthorization, and idempotent publication.
- Removes the default-off mixed-source Analyze gate so selected narrative and tabular sources consistently use the native combined workflow for model and agent runners.
- Updates versioned functional coverage, documentation, and release notes for `v0.250.071`.

## Validation
- `python functional_tests/test_assistant_table_csv_artifact.py` - 27/27 passed
- `python functional_tests/test_mixed_source_analyze_workflow.py` - passed
- `python functional_tests/test_document_action_token_usage_aggregation.py` - 5/5 passed
- `python functional_tests/test_document_action_conversation_scope_metadata.py` - 4/4 passed
- `python functional_tests/test_mixed_source_conversation_continuity.py` - 3/3 passed
- `python functional_tests/test_tabular_row_orchestration_scale.py` - passed
- `python functional_tests/test_tabular_background_generated_exports.py` - 7/7 passed
- `python functional_tests/test_document_analysis_generated_artifacts.py` - 2/2 passed
- `python functional_tests/test_document_comparison_generated_artifacts.py` - 2/2 passed
- `python -m py_compile` on modified production modules - passed
- Editor diagnostics and whitespace checks - passed

## Notes
- The branch is rebased on the current target, which already includes PR #1074's CSV timeout and throughput hardening.

Refs #1071
Refs #1058