### PR TITLE
Generalize workflows for document-free automation

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -97,7 +97,7 @@ load_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.250.063"
+VERSION = "0.250.064"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -97,7 +97,7 @@ load_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.250.062"
+VERSION = "0.250.063"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/functions_group_workflows.py
+++ b/application/single_app/functions_group_workflows.py
@@ -39,6 +39,8 @@ from functions_personal_workflows import (
     _normalize_document_action_config,
     _normalize_schedule,
     _normalize_text,
+    _normalize_workflow_error_handling,
+    _normalize_workflow_tasks,
     _strip_cosmos_metadata,
     _utc_now_iso,
     compute_next_run_at,
@@ -381,7 +383,12 @@ def save_group_workflow(group_id, workflow_data, actor_user_id, user_info=None):
 
     workflow_name = _normalize_text(workflow_data.get('name'), 'Workflow name', required=True)
     description = _normalize_text(workflow_data.get('description'), 'Description')
-    task_prompt = _normalize_text(workflow_data.get('task_prompt'), 'Task prompt', required=True)
+    tasks = _normalize_workflow_tasks(workflow_data, existing_workflow=existing_workflow)
+    task_prompt = _normalize_text(
+        workflow_data.get('task_prompt') or (tasks[0].get('instructions') if tasks else ''),
+        'Task prompt',
+        required=True,
+    )
     runner_type = _normalize_text(workflow_data.get('runner_type'), 'Runner type', required=True).lower()
     if runner_type not in WORKFLOW_RUNNER_TYPES:
         raise ValueError('Runner type must be agent or model.')
@@ -408,6 +415,7 @@ def save_group_workflow(group_id, workflow_data, actor_user_id, user_info=None):
     alert_priority = _normalize_alert_priority(
         workflow_data.get('alert_priority', (existing_workflow or {}).get('alert_priority', 'none'))
     )
+    error_handling = _normalize_workflow_error_handling(workflow_data, existing_workflow=existing_workflow)
     default_chat_capabilities_enabled = (
         (existing_workflow or {}).get('chat_capabilities_enabled', False)
         if existing_workflow
@@ -474,6 +482,8 @@ def save_group_workflow(group_id, workflow_data, actor_user_id, user_info=None):
         'name': workflow_name,
         'description': description,
         'task_prompt': task_prompt,
+        'tasks': tasks,
+        'error_handling': error_handling,
         'runner_type': runner_type,
         'chat_capabilities_enabled': chat_capabilities_enabled,
         'trigger_type': trigger_type,

--- a/application/single_app/functions_group_workflows.py
+++ b/application/single_app/functions_group_workflows.py
@@ -408,6 +408,15 @@ def save_group_workflow(group_id, workflow_data, actor_user_id, user_info=None):
     alert_priority = _normalize_alert_priority(
         workflow_data.get('alert_priority', (existing_workflow or {}).get('alert_priority', 'none'))
     )
+    default_chat_capabilities_enabled = (
+        (existing_workflow or {}).get('chat_capabilities_enabled', False)
+        if existing_workflow
+        else True
+    )
+    chat_capabilities_enabled = _normalize_bool(
+        workflow_data.get('chat_capabilities_enabled', default_chat_capabilities_enabled),
+        default=default_chat_capabilities_enabled,
+    )
     file_sync = _normalize_file_sync_config(
         actor_user_id,
         group_id,
@@ -466,6 +475,7 @@ def save_group_workflow(group_id, workflow_data, actor_user_id, user_info=None):
         'description': description,
         'task_prompt': task_prompt,
         'runner_type': runner_type,
+        'chat_capabilities_enabled': chat_capabilities_enabled,
         'trigger_type': trigger_type,
         'is_enabled': is_enabled,
         'url_access_enabled': url_access_enabled,

--- a/application/single_app/functions_personal_workflows.py
+++ b/application/single_app/functions_personal_workflows.py
@@ -545,6 +545,15 @@ def save_personal_workflow(user_id, workflow_data, actor_user_id=None):
     alert_priority = _normalize_alert_priority(
         workflow_data.get('alert_priority', (existing_workflow or {}).get('alert_priority', 'none'))
     )
+    default_chat_capabilities_enabled = (
+        (existing_workflow or {}).get('chat_capabilities_enabled', False)
+        if existing_workflow
+        else True
+    )
+    chat_capabilities_enabled = _normalize_bool(
+        workflow_data.get('chat_capabilities_enabled', default_chat_capabilities_enabled),
+        default=default_chat_capabilities_enabled,
+    )
     file_sync = _normalize_file_sync_config(user_id, workflow_data, existing_workflow=existing_workflow)
     allow_empty_file_sync_targets = bool(file_sync.get('enabled') and file_sync.get('use_changed_documents'))
     document_action = _normalize_document_action_config(
@@ -594,6 +603,7 @@ def save_personal_workflow(user_id, workflow_data, actor_user_id=None):
         'description': description,
         'task_prompt': task_prompt,
         'runner_type': runner_type,
+        'chat_capabilities_enabled': chat_capabilities_enabled,
         'trigger_type': trigger_type,
         'is_enabled': is_enabled,
         'url_access_enabled': url_access_enabled,

--- a/application/single_app/functions_personal_workflows.py
+++ b/application/single_app/functions_personal_workflows.py
@@ -45,6 +45,10 @@ WORKFLOW_ALERT_PRIORITIES = {'none', 'low', 'medium', 'high'}
 WORKFLOW_FILE_SYNC_WAIT_MODES = {'complete', 'queued'}
 WORKFLOW_FILE_SYNC_CONTINUE_MODES = {'always', 'changed'}
 WORKFLOW_FILE_SYNC_MAX_SOURCES = 10
+WORKFLOW_ERROR_STRATEGIES = {'halt', 'continue'}
+WORKFLOW_MAX_TASKS = 20
+WORKFLOW_TASK_INSTRUCTIONS_MAX_LENGTH = 12000
+WORKFLOW_TASK_NAME_MAX_LENGTH = 120
 WORKFLOW_CONVERSATION_ACCESS_ERROR = 'Workflow conversation not found or access denied.'
 
 
@@ -132,6 +136,79 @@ def _normalize_alert_priority(value):
     if normalized not in WORKFLOW_ALERT_PRIORITIES:
         raise ValueError('Alert priority must be none, low, medium, or high.')
     return normalized
+
+
+def _normalize_workflow_tasks(workflow_data, existing_workflow=None):
+    workflow_data = workflow_data if isinstance(workflow_data, dict) else {}
+    existing_workflow = existing_workflow if isinstance(existing_workflow, dict) else {}
+    if 'tasks' not in workflow_data:
+        return list(existing_workflow.get('tasks') or []) if existing_workflow else []
+
+    raw_tasks = workflow_data.get('tasks')
+    if not isinstance(raw_tasks, list):
+        raise ValueError('Workflow tasks must be a list.')
+    if not raw_tasks:
+        raise ValueError('Add at least one workflow task.')
+    if len(raw_tasks) > WORKFLOW_MAX_TASKS:
+        raise ValueError(f'Workflows support up to {WORKFLOW_MAX_TASKS} tasks.')
+
+    normalized_tasks = []
+    seen_task_ids = set()
+    for index, raw_task in enumerate(raw_tasks):
+        if not isinstance(raw_task, dict):
+            raise ValueError(f'Workflow task {index + 1} is invalid.')
+
+        task_type = _normalize_text(raw_task.get('type') or 'instructions', 'Task type').lower()
+        if task_type != 'instructions':
+            raise ValueError(f'Workflow task {index + 1} has an unsupported type.')
+
+        task_id = _normalize_text(raw_task.get('id'), 'Task id') or str(uuid.uuid4())
+        if task_id in seen_task_ids:
+            raise ValueError('Workflow task ids must be unique.')
+        seen_task_ids.add(task_id)
+
+        name = _normalize_text(raw_task.get('name'), 'Task name') or f'Task {index + 1}'
+        if len(name) > WORKFLOW_TASK_NAME_MAX_LENGTH:
+            raise ValueError(f'Task name must be {WORKFLOW_TASK_NAME_MAX_LENGTH} characters or fewer.')
+
+        instructions = _normalize_text(raw_task.get('instructions'), 'Task instructions', required=True)
+        if len(instructions) > WORKFLOW_TASK_INSTRUCTIONS_MAX_LENGTH:
+            raise ValueError(
+                f'Task instructions must be {WORKFLOW_TASK_INSTRUCTIONS_MAX_LENGTH} characters or fewer.'
+            )
+
+        normalized_tasks.append({
+            'id': task_id,
+            'type': task_type,
+            'name': name,
+            'instructions': instructions,
+            'order': index + 1,
+        })
+
+    return normalized_tasks
+
+
+def _normalize_workflow_error_handling(workflow_data, existing_workflow=None):
+    workflow_data = workflow_data if isinstance(workflow_data, dict) else {}
+    existing_workflow = existing_workflow if isinstance(existing_workflow, dict) else {}
+    existing_config = existing_workflow.get('error_handling') if isinstance(existing_workflow.get('error_handling'), dict) else {}
+    raw_config = workflow_data.get('error_handling') if isinstance(workflow_data.get('error_handling'), dict) else existing_config
+
+    strategy = _normalize_text(raw_config.get('strategy') or 'halt', 'Error strategy').lower()
+    if strategy not in WORKFLOW_ERROR_STRATEGIES:
+        raise ValueError('Error strategy must be halt or continue.')
+
+    try:
+        retry_count = int(raw_config.get('retry_count', 0))
+    except (TypeError, ValueError) as exc:
+        raise ValueError('Task retry count must be an integer.') from exc
+    if retry_count < 0 or retry_count > 5:
+        raise ValueError('Task retry count must be between 0 and 5.')
+
+    return {
+        'strategy': strategy,
+        'retry_count': retry_count,
+    }
 
 
 def _normalize_document_action_config(workflow_data, existing_workflow=None, allow_empty_file_sync_targets=False):
@@ -518,7 +595,12 @@ def save_personal_workflow(user_id, workflow_data, actor_user_id=None):
 
     workflow_name = _normalize_text(workflow_data.get('name'), 'Workflow name', required=True)
     description = _normalize_text(workflow_data.get('description'), 'Description')
-    task_prompt = _normalize_text(workflow_data.get('task_prompt'), 'Task prompt', required=True)
+    tasks = _normalize_workflow_tasks(workflow_data, existing_workflow=existing_workflow)
+    task_prompt = _normalize_text(
+        workflow_data.get('task_prompt') or (tasks[0].get('instructions') if tasks else ''),
+        'Task prompt',
+        required=True,
+    )
     runner_type = _normalize_text(workflow_data.get('runner_type'), 'Runner type', required=True).lower()
     if runner_type not in WORKFLOW_RUNNER_TYPES:
         raise ValueError('Runner type must be agent or model.')
@@ -545,6 +627,7 @@ def save_personal_workflow(user_id, workflow_data, actor_user_id=None):
     alert_priority = _normalize_alert_priority(
         workflow_data.get('alert_priority', (existing_workflow or {}).get('alert_priority', 'none'))
     )
+    error_handling = _normalize_workflow_error_handling(workflow_data, existing_workflow=existing_workflow)
     default_chat_capabilities_enabled = (
         (existing_workflow or {}).get('chat_capabilities_enabled', False)
         if existing_workflow
@@ -602,6 +685,8 @@ def save_personal_workflow(user_id, workflow_data, actor_user_id=None):
         'name': workflow_name,
         'description': description,
         'task_prompt': task_prompt,
+        'tasks': tasks,
+        'error_handling': error_handling,
         'runner_type': runner_type,
         'chat_capabilities_enabled': chat_capabilities_enabled,
         'trigger_type': trigger_type,

--- a/application/single_app/functions_workflow_runner.py
+++ b/application/single_app/functions_workflow_runner.py
@@ -132,6 +132,7 @@ DOCUMENT_ANALYSIS_ARTIFACT_PREVIEW_LINE_LENGTH = 220
 TABULAR_DOCUMENT_EXTENSIONS = {'.csv', '.xls', '.xlsx', '.xlsm'}
 WORKFLOW_CONVERSATION_ACCESS_ERROR = 'Workflow conversation not found or access denied.'
 WORKFLOW_RUN_CANCELLED_MESSAGE = 'Workflow cancellation was requested.'
+WORKFLOW_TASK_CONTEXT_MAX_CHARS = 12000
 
 
 class WorkflowRunCancelledError(BaseException):
@@ -4349,6 +4350,7 @@ def _apply_file_sync_context_to_workflow(workflow, file_sync_result):
     file_sync_context = _format_workflow_file_sync_context(file_sync_result)
     if file_sync_context:
         prepared_workflow['task_prompt'] = f"{workflow.get('task_prompt', '')}\n\n{file_sync_context}".strip()
+        prepared_workflow['file_sync_prompt_context'] = file_sync_context
 
     config = _get_workflow_file_sync_config(workflow)
     changed_document_ids = list(file_sync_result.get('changed_document_ids') or [])
@@ -5953,6 +5955,405 @@ def _execute_agent_workflow(workflow, settings, conversation_id='', run_id=None,
                 g.authorized_chat_context = previous_authorized_chat_context
 
 
+def _truncate_workflow_task_context(value, max_chars=WORKFLOW_TASK_CONTEXT_MAX_CHARS):
+    normalized = str(value or '').strip()
+    if len(normalized) <= max_chars:
+        return normalized
+
+    head_length = max_chars // 2
+    tail_length = max_chars - head_length
+    return (
+        f'{normalized[:head_length].rstrip()}\n\n'
+        '[Previous task output truncated]\n\n'
+        f'{normalized[-tail_length:].lstrip()}'
+    )
+
+
+def _build_workflow_task_execution_workflow(workflow, task, previous_reply='', include_document_action=False):
+    task = task if isinstance(task, dict) else {}
+    prepared_workflow = dict(workflow or {})
+    task_instructions = str(task.get('instructions') or '').strip()
+    file_sync_context = str(workflow.get('file_sync_prompt_context') or '').strip()
+    if include_document_action and file_sync_context:
+        task_instructions = (
+            f'{task_instructions}\n\n'
+            '[Workflow input context]\n'
+            f'{file_sync_context}'
+        ).strip()
+    previous_context = _truncate_workflow_task_context(previous_reply)
+    if previous_context:
+        task_instructions = (
+            f'{task_instructions}\n\n'
+            '[Previous workflow task output]\n'
+            f'{previous_context}\n\n'
+            'Use the previous task output as context. Complete only the current task instructions.'
+        ).strip()
+
+    prepared_workflow['task_prompt'] = task_instructions
+    prepared_workflow['active_task'] = {
+        'id': str(task.get('id') or '').strip(),
+        'name': str(task.get('name') or '').strip(),
+        'order': int(task.get('order') or 0),
+    }
+    if not include_document_action:
+        prepared_workflow['document_action'] = {'type': DOCUMENT_ACTION_TYPE_NONE}
+        prepared_workflow['analyze'] = build_analyze_config(prepared_workflow['document_action'])
+    return prepared_workflow
+
+
+def _workflow_task_run_item_id(run_id, task_id):
+    return str(uuid.uuid5(uuid.NAMESPACE_URL, f'workflow-task:{run_id}:{task_id}'))
+
+
+def _save_workflow_task_run_item(
+    workflow,
+    run_id,
+    task,
+    status,
+    attempt_count=0,
+    error='',
+    output_summary='',
+    created_at=None,
+):
+    task = task if isinstance(task, dict) else {}
+    task_id = str(task.get('id') or '').strip()
+    now_iso = _utc_now_iso()
+    item = {
+        'id': _workflow_task_run_item_id(run_id, task_id),
+        'type': 'workflow_run_item',
+        'item_type': 'task',
+        'run_id': run_id,
+        'user_id': str(workflow.get('user_id') or '').strip(),
+        'workflow_id': workflow.get('id'),
+        'group_id': _get_workflow_group_id(workflow) or None,
+        'workflow_name': workflow.get('name'),
+        'task_id': task_id,
+        'task_type': str(task.get('type') or 'instructions').strip(),
+        'task_order': int(task.get('order') or 0),
+        'label': str(task.get('name') or f"Task {task.get('order') or ''}").strip(),
+        'status': status,
+        'attempt_count': int(attempt_count or 0),
+        'error': str(error or '')[:2000],
+        'output_summary': str(output_summary or '')[:4000],
+        'created_at': created_at or now_iso,
+        'updated_at': now_iso,
+    }
+    if status == 'running':
+        item['started_at'] = now_iso
+    if status in {'succeeded', 'failed', 'skipped', 'cancelled'}:
+        item['completed_at'] = now_iso
+    return _save_workflow_run_item_record(workflow, item)
+
+
+def _execute_workflow_dispatch(
+    execution_workflow,
+    settings,
+    conversation_id,
+    run_id,
+    thought_tracker,
+    url_access_context,
+    file_sync_result=None,
+):
+    document_action = _get_document_action_config(execution_workflow)
+    workflow_search_context = None
+    if document_action.get('type') == DOCUMENT_ACTION_TYPE_SEARCH:
+        workflow_search_context = _execute_cancelable_workflow_step(
+            execution_workflow,
+            run_id,
+            lambda: _prepare_workflow_search_context(
+                execution_workflow,
+                document_action,
+                settings,
+                thought_tracker=thought_tracker,
+                run_id=run_id,
+            ),
+        )
+        execution_workflow = workflow_search_context.get('workflow') or execution_workflow
+        document_action = _get_document_action_config(execution_workflow)
+
+    if document_action.get('type') in {DOCUMENT_ACTION_TYPE_ANALYZE, DOCUMENT_ACTION_TYPE_COMPARISON}:
+        _raise_if_workflow_run_cancelled(execution_workflow, run_id)
+        document_action = _resolve_recent_document_action_targets(execution_workflow, document_action, settings)
+        execution_workflow = _apply_runtime_document_action_config(execution_workflow, document_action)
+        run_item_callback = _build_run_item_activity_callback(
+            execution_workflow,
+            run_id,
+            file_sync_result=file_sync_result or {},
+        )
+        _initialize_document_run_items(
+            execution_workflow,
+            run_id,
+            document_action,
+            file_sync_result=file_sync_result or {},
+        )
+        execution_result = _execute_cancelable_workflow_step(
+            execution_workflow,
+            run_id,
+            lambda: _execute_document_action_workflow(
+                execution_workflow,
+                settings,
+                conversation_id=conversation_id,
+                run_id=run_id,
+                thought_tracker=thought_tracker,
+                external_activity_callback=run_item_callback,
+                url_access_context=url_access_context,
+            ),
+        )
+    elif execution_workflow.get('runner_type') == 'agent':
+        execution_result = _execute_cancelable_workflow_step(
+            execution_workflow,
+            run_id,
+            lambda: _execute_agent_workflow(
+                execution_workflow,
+                settings,
+                conversation_id=conversation_id,
+                run_id=run_id,
+                thought_tracker=thought_tracker,
+                url_access_context=url_access_context,
+            ),
+        )
+    else:
+        execution_result = _execute_cancelable_workflow_step(
+            execution_workflow,
+            run_id,
+            lambda: _execute_model_workflow(
+                execution_workflow,
+                settings,
+                conversation_id=conversation_id,
+                run_id=run_id,
+                thought_tracker=thought_tracker,
+                url_access_context=url_access_context,
+            ),
+        )
+
+    if workflow_search_context:
+        execution_result.update({
+            'hybrid_citations': workflow_search_context.get('citations') or [],
+            'augmented': bool(workflow_search_context.get('citations')),
+            'document_search': {
+                'query': workflow_search_context.get('query'),
+                'result_count': workflow_search_context.get('result_count', 0),
+                'document_count': workflow_search_context.get('document_count', 0),
+            },
+        })
+    return execution_result
+
+
+def _merge_workflow_task_execution_results(task_results):
+    task_results = list(task_results or [])
+    successful_results = [item for item in task_results if item.get('status') == 'succeeded']
+    reply_sections = []
+    for item in task_results:
+        task = item.get('task') if isinstance(item.get('task'), dict) else {}
+        task_name = str(task.get('name') or f"Task {task.get('order') or ''}").strip()
+        if item.get('status') == 'succeeded':
+            reply_text = str((item.get('result') or {}).get('reply') or '').strip()
+            reply_sections.extend([f'## {task_name}', '', reply_text or 'No response was generated.', ''])
+        else:
+            reply_sections.extend([
+                f'## {task_name}',
+                '',
+                f"Task failed: {item.get('error') or 'Unknown error'}",
+                '',
+            ])
+
+    final_source = (successful_results[-1].get('result') or {}) if successful_results else {}
+    merged_result = dict(final_source)
+    merged_result['reply'] = '\n'.join(reply_sections).strip()
+    merged_result['task_results'] = [
+        {
+            'task_id': str((item.get('task') or {}).get('id') or '').strip(),
+            'task_name': str((item.get('task') or {}).get('name') or '').strip(),
+            'task_order': int((item.get('task') or {}).get('order') or 0),
+            'status': item.get('status'),
+            'attempt_count': int(item.get('attempt_count') or 0),
+            'error': str(item.get('error') or ''),
+            'response_preview': _build_response_preview((item.get('result') or {}).get('reply')),
+        }
+        for item in task_results
+    ]
+    merged_result['task_error_count'] = sum(1 for item in task_results if item.get('status') == 'failed')
+    merged_result['token_usage'] = _merge_token_usage_summaries([
+        item.get('result') or {}
+        for item in successful_results
+    ])
+
+    for field in (
+        'agent_citations',
+        'hybrid_citations',
+        'web_search_citations',
+        'generated_analysis_artifacts',
+        'generated_tabular_outputs',
+        'alert_targets',
+    ):
+        merged_result[field] = [
+            value
+            for item in successful_results
+            for value in list((item.get('result') or {}).get(field) or [])
+        ]
+    merged_result['augmented'] = any(
+        bool((item.get('result') or {}).get('augmented'))
+        for item in successful_results
+    )
+    return merged_result
+
+
+def _execute_workflow_task_sequence(
+    workflow,
+    settings,
+    conversation_id,
+    run_id,
+    thought_tracker,
+    url_access_context,
+    file_sync_result=None,
+):
+    tasks = list(workflow.get('tasks') or [])
+    error_handling = workflow.get('error_handling') if isinstance(workflow.get('error_handling'), dict) else {}
+    error_strategy = str(error_handling.get('strategy') or 'halt').strip().lower()
+    retry_count = max(0, min(5, int(error_handling.get('retry_count') or 0)))
+    previous_reply = ''
+    task_results = []
+
+    for task_index, raw_task in enumerate(tasks):
+        task = dict(raw_task or {})
+        task['order'] = task_index + 1
+        task_id = str(task.get('id') or f'task-{task_index + 1}').strip()
+        task['id'] = task_id
+        created_at = _utc_now_iso()
+        _save_workflow_task_run_item(workflow, run_id, task, 'queued', created_at=created_at)
+        if thought_tracker and run_id:
+            _add_workflow_activity_thought(
+                thought_tracker,
+                workflow,
+                run_id,
+                step_type='task',
+                content=f"Starting task {task_index + 1}: {task.get('name') or task_id}",
+                detail=None,
+                activity_key=f'task:{run_id}:{task_id}',
+                kind='workflow_task',
+                title=str(task.get('name') or f'Task {task_index + 1}'),
+                status='running',
+            )
+        prepared_workflow = _build_workflow_task_execution_workflow(
+            workflow,
+            task,
+            previous_reply=previous_reply,
+            include_document_action=task_index == 0,
+        )
+
+        task_result = None
+        task_error = ''
+        attempt_count = 0
+        for attempt_index in range(retry_count + 1):
+            attempt_count = attempt_index + 1
+            _save_workflow_task_run_item(
+                workflow,
+                run_id,
+                task,
+                'running',
+                attempt_count=attempt_count,
+                created_at=created_at,
+            )
+            try:
+                task_result = _execute_workflow_dispatch(
+                    prepared_workflow,
+                    settings,
+                    conversation_id,
+                    run_id,
+                    thought_tracker,
+                    url_access_context,
+                    file_sync_result=file_sync_result,
+                )
+                task_error = ''
+                break
+            except Exception as exc:
+                task_error = str(exc)
+                if attempt_index >= retry_count:
+                    break
+                if thought_tracker and run_id:
+                    _add_workflow_activity_thought(
+                        thought_tracker,
+                        workflow,
+                        run_id,
+                        step_type='task',
+                        content=f"Retrying task {task_index + 1}: {task.get('name') or task_id}",
+                        detail=f'attempt={attempt_count + 1}',
+                        activity_key=f'task:{run_id}:{task_id}',
+                        kind='workflow_task',
+                        title=str(task.get('name') or f'Task {task_index + 1}'),
+                        status='running',
+                    )
+
+        if task_result is not None:
+            _save_workflow_task_run_item(
+                workflow,
+                run_id,
+                task,
+                'succeeded',
+                attempt_count=attempt_count,
+                output_summary=_build_response_preview(task_result.get('reply'), max_length=4000),
+                created_at=created_at,
+            )
+            task_results.append({
+                'task': task,
+                'status': 'succeeded',
+                'attempt_count': attempt_count,
+                'result': task_result,
+                'error': '',
+            })
+            if thought_tracker and run_id:
+                _add_workflow_activity_thought(
+                    thought_tracker,
+                    workflow,
+                    run_id,
+                    step_type='task',
+                    content=f"Completed task {task_index + 1}: {task.get('name') or task_id}",
+                    detail=f'attempts={attempt_count}',
+                    activity_key=f'task:{run_id}:{task_id}',
+                    kind='workflow_task',
+                    title=str(task.get('name') or f'Task {task_index + 1}'),
+                    status='completed',
+                )
+            previous_reply = str(task_result.get('reply') or '').strip()
+            continue
+
+        _save_workflow_task_run_item(
+            workflow,
+            run_id,
+            task,
+            'failed',
+            attempt_count=attempt_count,
+            error=task_error,
+            created_at=created_at,
+        )
+        task_results.append({
+            'task': task,
+            'status': 'failed',
+            'attempt_count': attempt_count,
+            'result': {},
+            'error': task_error,
+        })
+        if thought_tracker and run_id:
+            _add_workflow_activity_thought(
+                thought_tracker,
+                workflow,
+                run_id,
+                step_type='task',
+                content=f"Failed task {task_index + 1}: {task.get('name') or task_id}",
+                detail=task_error,
+                activity_key=f'task:{run_id}:{task_id}',
+                kind='workflow_task',
+                title=str(task.get('name') or f'Task {task_index + 1}'),
+                status='failed',
+            )
+        if error_strategy != 'continue':
+            raise RuntimeError(
+                f"Workflow task '{task.get('name') or task_id}' failed after {attempt_count} attempt(s): {task_error}"
+            )
+
+    return _merge_workflow_task_execution_results(task_results)
+
+
 def _finalize_cancelled_workflow_run(
     workflow,
     run_record,
@@ -6161,11 +6562,19 @@ def run_personal_workflow(workflow, trigger_source='manual', user_roles=None, ac
             status='running',
         )
 
+        url_access_workflow = execution_workflow
+        if execution_workflow.get('tasks'):
+            url_access_workflow = dict(execution_workflow)
+            url_access_workflow['task_prompt'] = '\n\n'.join(
+                str(task.get('instructions') or '').strip()
+                for task in execution_workflow.get('tasks') or []
+                if str(task.get('instructions') or '').strip()
+            )
         url_access_context = _execute_cancelable_workflow_step(
             execution_workflow,
             run_id,
             lambda: _prepare_workflow_url_access_context(
-                execution_workflow,
+                url_access_workflow,
                 settings,
                 conversation.get('id'),
                 run_id,
@@ -6173,97 +6582,27 @@ def run_personal_workflow(workflow, trigger_source='manual', user_roles=None, ac
                 user_roles=user_roles,
             ),
         )
-        document_action = _get_document_action_config(execution_workflow)
-        workflow_search_context = None
-        if document_action.get('type') == DOCUMENT_ACTION_TYPE_SEARCH:
-            workflow_search_context = _execute_cancelable_workflow_step(
+        conversation_id = str(conversation.get('id') or '')
+        if execution_workflow.get('tasks'):
+            execution_result = _execute_workflow_task_sequence(
                 execution_workflow,
+                settings,
+                conversation_id,
                 run_id,
-                lambda: _prepare_workflow_search_context(
-                    execution_workflow,
-                    document_action,
-                    settings,
-                    thought_tracker=thought_tracker,
-                    run_id=run_id,
-                ),
+                thought_tracker,
+                url_access_context,
+                file_sync_result=file_sync_result,
             )
-            execution_workflow = workflow_search_context.get('workflow') or execution_workflow
-            document_action = _get_document_action_config(execution_workflow)
-
-        if document_action.get('type') in {DOCUMENT_ACTION_TYPE_ANALYZE, DOCUMENT_ACTION_TYPE_COMPARISON}:
-            _raise_if_workflow_run_cancelled(execution_workflow, run_id)
-            document_action = _resolve_recent_document_action_targets(execution_workflow, document_action, settings)
-            execution_workflow = _apply_runtime_document_action_config(execution_workflow, document_action)
-            run_item_callback = _build_run_item_activity_callback(
-                execution_workflow,
-                run_id,
-                file_sync_result=file_sync_result or {},
-            )
-            _initialize_document_run_items(
-                execution_workflow,
-                run_id,
-                document_action,
-                file_sync_result=file_sync_result or {},
-            )
-            execution_result = _execute_cancelable_workflow_step(
-                execution_workflow,
-                run_id,
-                lambda: _execute_document_action_workflow(
-                    execution_workflow,
-                    settings,
-                    conversation_id=conversation.get('id'),
-                    run_id=run_id,
-                    thought_tracker=thought_tracker,
-                    external_activity_callback=run_item_callback,
-                    url_access_context=url_access_context,
-                ),
-            )
-        elif execution_workflow.get('runner_type') == 'agent':
-            execution_result = _execute_cancelable_workflow_step(
-                execution_workflow,
-                run_id,
-                lambda: _execute_agent_workflow(
-                    execution_workflow,
-                    settings,
-                    conversation_id=conversation.get('id'),
-                    run_id=run_id,
-                    thought_tracker=thought_tracker,
-                    url_access_context=url_access_context,
-                ),
-            )
-            if workflow_search_context:
-                execution_result.update({
-                    'hybrid_citations': workflow_search_context.get('citations') or [],
-                    'augmented': bool(workflow_search_context.get('citations')),
-                    'document_search': {
-                        'query': workflow_search_context.get('query'),
-                        'result_count': workflow_search_context.get('result_count', 0),
-                        'document_count': workflow_search_context.get('document_count', 0),
-                    },
-                })
         else:
-            execution_result = _execute_cancelable_workflow_step(
+            execution_result = _execute_workflow_dispatch(
                 execution_workflow,
+                settings,
+                conversation_id,
                 run_id,
-                lambda: _execute_model_workflow(
-                    execution_workflow,
-                    settings,
-                    conversation_id=str(conversation.get('id') or ''),
-                    run_id=run_id,
-                    thought_tracker=thought_tracker,
-                    url_access_context=url_access_context,
-                ),
+                thought_tracker,
+                url_access_context,
+                file_sync_result=file_sync_result,
             )
-            if workflow_search_context:
-                execution_result.update({
-                    'hybrid_citations': workflow_search_context.get('citations') or [],
-                    'augmented': bool(workflow_search_context.get('citations')),
-                    'document_search': {
-                        'query': workflow_search_context.get('query'),
-                        'result_count': workflow_search_context.get('result_count', 0),
-                        'document_count': workflow_search_context.get('document_count', 0),
-                    },
-                })
         _raise_if_workflow_run_cancelled(execution_workflow, run_id)
         execution_result = _attach_workflow_url_access_result(execution_result, url_access_context)
 
@@ -6311,6 +6650,8 @@ def run_personal_workflow(workflow, trigger_source='manual', user_roles=None, ac
             'agent_name': execution_result.get('agent_name'),
             'agent_display_name': execution_result.get('agent_display_name'),
             'analysis_coverage': execution_result.get('analysis_coverage') or {},
+            'task_results': execution_result.get('task_results') or [],
+            'task_error_count': int(execution_result.get('task_error_count') or 0),
             'url_access': execution_result.get('url_access') or {},
             'source_review': execution_result.get('source_review') or {},
             'file_sync': file_sync_result or {},

--- a/application/single_app/functions_workflow_runner.py
+++ b/application/single_app/functions_workflow_runner.py
@@ -24,6 +24,9 @@ from azure.identity import (
 from flask import Flask, g, has_request_context, session
 from openai import AzureOpenAI
 from semantic_kernel import Kernel
+from semantic_kernel.connectors.ai.function_choice_behavior import FunctionChoiceBehavior
+from semantic_kernel.connectors.ai.prompt_execution_settings import PromptExecutionSettings
+from semantic_kernel.contents.chat_history import ChatHistory
 from semantic_kernel.contents.chat_message_content import ChatMessageContent
 
 from collaboration_models import (
@@ -87,7 +90,10 @@ from functions_message_artifacts import (
 from model_endpoint_clients import (
     MODEL_ENDPOINT_PROTOCOL_AZURE_OPENAI,
 )
-from functions_model_endpoint_runtime import build_model_endpoint_sync_chat_client
+from functions_model_endpoint_runtime import (
+    build_model_endpoint_sync_chat_client,
+    build_semantic_kernel_chat_service_for_model,
+)
 from functions_notifications import create_workflow_priority_notification
 from functions_personal_workflows import (
     get_personal_workflow,
@@ -108,7 +114,11 @@ from functions_source_review import (
     validate_url_access_request,
 )
 from functions_thoughts import ThoughtTracker
-from semantic_kernel_loader import load_user_semantic_kernel
+from semantic_kernel_loader import (
+    get_max_auto_invoke_attempts,
+    load_core_plugins_only,
+    load_user_semantic_kernel,
+)
 from semantic_kernel_plugins.plugin_invocation_logger import get_plugin_logger, sanitize_plugin_invocation_value
 from semantic_kernel_plugins.plugin_invocation_thoughts import register_plugin_invocation_thought_callback
 
@@ -4819,7 +4829,7 @@ def _combine_per_document_analysis_results(document_results):
     }
 
 
-def _execute_model_workflow(workflow, settings, run_id=None, thought_tracker=None, url_access_context=None):
+def _execute_raw_model_workflow(workflow, settings, run_id=None, thought_tracker=None, url_access_context=None):
     _raise_if_workflow_run_cancelled(workflow, run_id)
     if thought_tracker and run_id:
         _add_workflow_activity_thought(
@@ -4872,6 +4882,218 @@ def _execute_model_workflow(workflow, settings, run_id=None, thought_tracker=Non
         'model_deployment_name': deployment_name,
         'provider': provider,
     }
+
+
+def _workflow_model_chat_capabilities_enabled(workflow):
+    value = (workflow or {}).get('chat_capabilities_enabled', False)
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {'1', 'true', 'yes', 'on'}
+    return bool(value)
+
+
+def _build_workflow_model_context(workflow, deployment_name, provider):
+    workflow = workflow if isinstance(workflow, dict) else {}
+    binding_summary = workflow.get('model_binding_summary') if isinstance(workflow.get('model_binding_summary'), dict) else {}
+    endpoint_id = str(workflow.get('model_endpoint_id') or binding_summary.get('endpoint_id') or '').strip()
+    model_id = str(workflow.get('model_id') or binding_summary.get('model_id') or '').strip()
+    model_context = {
+        'user_id': str(workflow.get('user_id') or '').strip(),
+        'model_deployment': str(deployment_name or '').strip(),
+        'provider': str(provider or workflow.get('model_provider') or binding_summary.get('provider') or '').strip().lower(),
+    }
+    if endpoint_id:
+        model_context['endpoint_id'] = endpoint_id
+    if model_id:
+        model_context['model_id'] = model_id
+
+    group_id = _get_workflow_group_id(workflow)
+    if group_id:
+        model_context['active_group_ids'] = [group_id]
+
+    return model_context
+
+
+@contextmanager
+def _workflow_model_core_execution_context(workflow, conversation_id, run_id):
+    workflow = workflow if isinstance(workflow, dict) else {}
+    user_id = str(workflow.get('user_id') or '').strip()
+    group_id = _get_workflow_group_id(workflow)
+    context_values = {
+        'conversation_id': str(conversation_id or '').strip(),
+        'workflow_id': str(workflow.get('id') or '').strip(),
+        'workflow_run_id': str(run_id or '').strip(),
+        'conversation_group_id': group_id,
+        'authorized_chat_context': None,
+    }
+    if group_id:
+        context_values['authorized_chat_context'] = {
+            'user_id': user_id,
+            'conversation_id': str(conversation_id or '').strip(),
+            'active_group_ids': [group_id],
+            'active_group_id': group_id,
+            'active_public_workspace_ids': [],
+            'active_public_workspace_id': None,
+            'fact_memory_scope_id': group_id,
+            'fact_memory_scope_type': 'group',
+        }
+
+    with _ensure_execution_context(user_id):
+        previous_values = {
+            name: (hasattr(g, name), getattr(g, name, None))
+            for name in context_values
+        }
+        for name, value in context_values.items():
+            setattr(g, name, value)
+
+        try:
+            yield
+        finally:
+            for name, (was_defined, value) in previous_values.items():
+                if was_defined:
+                    setattr(g, name, value)
+                elif hasattr(g, name):
+                    delattr(g, name)
+
+
+def _execute_model_workflow_with_core_capabilities(
+    workflow,
+    settings,
+    conversation_id='',
+    run_id=None,
+    thought_tracker=None,
+    url_access_context=None,
+):
+    _raise_if_workflow_run_cancelled(workflow, run_id)
+    user_id = str(workflow.get('user_id') or '').strip()
+    if not user_id:
+        raise ValueError('Direct model workflows require an owning user.')
+
+    if thought_tracker and run_id:
+        _add_workflow_activity_thought(
+            thought_tracker,
+            workflow,
+            run_id,
+            step_type='generation',
+            content='Starting direct model execution with core capabilities',
+            detail=None,
+            activity_key=f'generation:{run_id}',
+            kind='model_execution',
+            title='Model execution',
+            status='running',
+        )
+
+    _, deployment_name, provider = _resolve_model_workflow_client(workflow, settings)
+    model_context = _build_workflow_model_context(workflow, deployment_name, provider)
+    workflow_kernel_settings = get_workflow_kernel_settings(settings)
+
+    with _workflow_model_core_execution_context(workflow, conversation_id, run_id):
+        plugin_logger = get_plugin_logger()
+        callback_key = None
+        if conversation_id:
+            plugin_logger.clear_invocations_for_conversation(user_id, conversation_id)
+        if thought_tracker and run_id and conversation_id:
+            callback_key = register_plugin_invocation_thought_callback(
+                plugin_logger,
+                thought_tracker,
+                user_id,
+                conversation_id,
+                actor_label='Workflow model',
+            )
+
+        try:
+            kernel = Kernel()
+            load_core_plugins_only(kernel, workflow_kernel_settings)
+            chat_service, _ = build_semantic_kernel_chat_service_for_model(
+                deployment_name,
+                settings,
+                service_id=f"workflow-model-{workflow.get('id') or 'default'}",
+                model_context=model_context,
+            )
+            kernel.add_service(chat_service)
+
+            chat_history = ChatHistory()
+            for message in _build_workflow_chat_messages(
+                workflow.get('task_prompt', ''),
+                url_access_context=url_access_context,
+                apply_generation_guidance=True,
+            ):
+                chat_history.add_message(message)
+
+            execution_settings = PromptExecutionSettings()
+            execution_settings.function_choice_behavior = FunctionChoiceBehavior.Auto(
+                maximum_auto_invoke_attempts=get_max_auto_invoke_attempts(workflow_kernel_settings)
+            )
+            completion_messages = _execute_cancelable_workflow_step(
+                workflow,
+                run_id,
+                lambda: asyncio.run(
+                    chat_service.get_chat_message_contents(
+                        chat_history,
+                        execution_settings,
+                        kernel=kernel,
+                    )
+                ),
+            )
+            reply = _extract_message_text(
+                completion_messages[0].content if completion_messages else ''
+            )
+            agent_citations = _build_agent_citations_from_invocations(user_id, conversation_id)
+            alert_targets = _collect_agent_alert_targets(user_id, conversation_id)
+        finally:
+            if callback_key:
+                plugin_logger.deregister_callbacks(callback_key)
+
+    if thought_tracker and run_id:
+        _add_workflow_activity_thought(
+            thought_tracker,
+            workflow,
+            run_id,
+            step_type='generation',
+            content=f'Direct model execution completed with {deployment_name}',
+            detail=f'provider={provider}; core_capabilities=true',
+            activity_key=f'generation:{run_id}',
+            kind='model_execution',
+            title='Model execution',
+            status='completed',
+        )
+
+    return {
+        'reply': reply,
+        'model_deployment_name': deployment_name,
+        'provider': provider,
+        'agent_citations': agent_citations,
+        'alert_targets': alert_targets,
+        'core_capabilities_enabled': True,
+    }
+
+
+def _execute_model_workflow(
+    workflow,
+    settings,
+    conversation_id='',
+    run_id=None,
+    thought_tracker=None,
+    url_access_context=None,
+):
+    if _workflow_model_chat_capabilities_enabled(workflow):
+        return _execute_model_workflow_with_core_capabilities(
+            workflow,
+            settings,
+            conversation_id=conversation_id,
+            run_id=run_id,
+            thought_tracker=thought_tracker,
+            url_access_context=url_access_context,
+        )
+
+    return _execute_raw_model_workflow(
+        workflow,
+        settings,
+        run_id=run_id,
+        thought_tracker=thought_tracker,
+        url_access_context=url_access_context,
+    )
 
 
 def _execute_document_analysis_workflow(
@@ -6026,6 +6248,7 @@ def run_personal_workflow(workflow, trigger_source='manual', user_roles=None, ac
                 lambda: _execute_model_workflow(
                     execution_workflow,
                     settings,
+                    conversation_id=str(conversation.get('id') or ''),
                     run_id=run_id,
                     thought_tracker=thought_tracker,
                     url_access_context=url_access_context,

--- a/application/single_app/static/css/workspace-responsive.css
+++ b/application/single_app/static/css/workspace-responsive.css
@@ -253,6 +253,212 @@
     text-align: center;
 }
 
+.workflow-builder-body {
+    background: var(--bs-tertiary-bg, #f8f9fa);
+    display: flex;
+    flex-direction: column;
+    min-height: 32rem;
+}
+
+.workflow-step-nav {
+    align-items: stretch;
+    background: var(--bs-body-bg, #fff);
+    border: 1px solid var(--bs-border-color, #dee2e6);
+    border-radius: 0.5rem;
+    display: grid;
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+    margin-bottom: 1.25rem;
+    overflow: hidden;
+    order: 0;
+}
+
+.workflow-step-nav__item {
+    align-items: center;
+    background: transparent;
+    border: 0;
+    border-right: 1px solid var(--bs-border-color, #dee2e6);
+    color: var(--bs-secondary-color, #6c757d);
+    display: flex;
+    font-size: 0.82rem;
+    font-weight: 600;
+    gap: 0.45rem;
+    justify-content: center;
+    min-height: 3rem;
+    padding: 0.65rem 0.5rem;
+}
+
+.workflow-step-nav__item:last-child {
+    border-right: 0;
+}
+
+.workflow-step-nav__item span {
+    align-items: center;
+    border: 1px solid currentColor;
+    border-radius: 50%;
+    display: inline-flex;
+    font-size: 0.72rem;
+    height: 1.45rem;
+    justify-content: center;
+    width: 1.45rem;
+}
+
+.workflow-step-nav__item:hover,
+.workflow-step-nav__item:focus-visible,
+.workflow-step-nav__item.is-complete {
+    background: rgba(13, 110, 253, 0.06);
+    color: var(--bs-primary, #0d6efd);
+}
+
+.workflow-step-nav__item.is-active {
+    background: rgba(13, 110, 253, 0.11);
+    box-shadow: inset 0 -2px 0 var(--bs-primary, #0d6efd);
+    color: var(--bs-primary, #0d6efd);
+}
+
+.workflow-step-nav__item.is-active span,
+.workflow-step-nav__item.is-complete span {
+    background: var(--bs-primary, #0d6efd);
+    border-color: var(--bs-primary, #0d6efd);
+    color: #fff;
+}
+
+.workflow-step-block {
+    order: 10;
+}
+
+.workflow-step-hidden {
+    display: none !important;
+}
+
+#workflow-trigger-settings-card {
+    order: 1;
+}
+
+#workflow-url-access-group {
+    order: 2;
+}
+
+#workflow-file-sync-card {
+    order: 3;
+}
+
+#workflow-review-summary-block {
+    order: 1;
+}
+
+.workflow-task-list {
+    display: grid;
+    gap: 0.65rem;
+}
+
+.workflow-task-item {
+    align-items: center;
+    background: var(--bs-body-bg, #fff);
+    border: 1px solid var(--bs-border-color, #dee2e6);
+    border-radius: 0.4rem;
+    display: grid;
+    gap: 0.75rem;
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    padding: 0.75rem;
+}
+
+.workflow-task-item.is-selected {
+    border-color: var(--bs-primary, #0d6efd);
+    box-shadow: 0 0 0 0.15rem rgba(13, 110, 253, 0.1);
+}
+
+.workflow-task-item__number {
+    align-items: center;
+    background: var(--bs-tertiary-bg, #f8f9fa);
+    border: 1px solid var(--bs-border-color, #dee2e6);
+    border-radius: 0.3rem;
+    display: inline-flex;
+    font-size: 0.8rem;
+    font-weight: 700;
+    height: 2rem;
+    justify-content: center;
+    width: 2rem;
+}
+
+.workflow-task-item.is-selected .workflow-task-item__number {
+    background: var(--bs-primary, #0d6efd);
+    border-color: var(--bs-primary, #0d6efd);
+    color: #fff;
+}
+
+.workflow-task-item__content {
+    min-width: 0;
+}
+
+.workflow-task-item__name {
+    font-size: 0.9rem;
+    font-weight: 600;
+    margin-bottom: 0.15rem;
+}
+
+.workflow-task-item__preview {
+    color: var(--bs-secondary-color, #6c757d);
+    font-size: 0.78rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.workflow-task-item__actions {
+    display: flex;
+    gap: 0.25rem;
+}
+
+.workflow-task-item__actions .btn {
+    align-items: center;
+    display: inline-flex;
+    height: 2rem;
+    justify-content: center;
+    padding: 0;
+    width: 2rem;
+}
+
+.workflow-task-editor {
+    background: var(--bs-body-bg, #fff);
+}
+
+.workflow-retry-input {
+    max-width: 8rem;
+}
+
+.workflow-review-summary {
+    display: grid;
+    gap: 0.75rem;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.workflow-review-summary__item {
+    background: var(--bs-body-bg, #fff);
+    border: 1px solid var(--bs-border-color, #dee2e6);
+    border-radius: 0.4rem;
+    min-width: 0;
+    padding: 0.8rem;
+}
+
+.workflow-review-summary__label {
+    color: var(--bs-secondary-color, #6c757d);
+    display: block;
+    font-size: 0.72rem;
+    font-weight: 700;
+    margin-bottom: 0.25rem;
+    text-transform: uppercase;
+}
+
+.workflow-review-summary__value {
+    font-size: 0.9rem;
+    overflow-wrap: anywhere;
+}
+
+[data-bs-theme="dark"] .workflow-step-nav__item.is-active,
+[data-bs-theme="dark"] .workflow-step-nav__item.is-complete {
+    background: rgba(110, 168, 254, 0.16);
+}
+
 @media (max-width: 991.98px) {
     .workspace-page-header {
         flex-direction: column;
@@ -284,6 +490,29 @@
 
     .workspace-page .filter-buttons-col .btn {
         flex: 1 1 100%;
+    }
+
+    .workflow-step-nav {
+        display: flex;
+        overflow-x: auto;
+    }
+
+    .workflow-step-nav__item {
+        flex: 0 0 auto;
+        min-width: 7.25rem;
+    }
+
+    .workflow-review-summary {
+        grid-template-columns: 1fr;
+    }
+
+    .workflow-task-item {
+        grid-template-columns: auto minmax(0, 1fr);
+    }
+
+    .workflow-task-item__actions {
+        grid-column: 1 / -1;
+        justify-content: flex-end;
     }
 
     #documents-table,

--- a/application/single_app/static/js/workspace/workspace_workflows.js
+++ b/application/single_app/static/js/workspace/workspace_workflows.js
@@ -169,6 +169,7 @@ const workflowAnalysisPublicWorkspaceIdsInput = document.getElementById("workflo
 const workflowAnalysisWindowUnitSelect = document.getElementById("workflow-analysis-window-unit");
 const workflowAnalysisWindowSizeInput = document.getElementById("workflow-analysis-window-size");
 const workflowAnalysisWindowPercentInput = document.getElementById("workflow-analysis-window-percent");
+const workflowAnalysisRetriesGroup = document.getElementById("workflow-analysis-retries-group");
 const workflowAnalysisRetriesInput = document.getElementById("workflow-analysis-retries");
 const workflowUseSelectedDocumentsBtn = document.getElementById("workflow-use-selected-documents-btn");
 const workflowSelectedDocumentsSummary = document.getElementById("workflow-selected-documents-summary");
@@ -212,7 +213,10 @@ function getWorkflowDocumentActionMaxDocuments(actionType) {
 }
 
 function getDocumentActionDisplayLabel(actionType) {
-    if (actionType === DOCUMENT_ACTION_SEARCH || actionType === DOCUMENT_ACTION_NONE) {
+    if (actionType === DOCUMENT_ACTION_NONE) {
+        return "No document action";
+    }
+    if (actionType === DOCUMENT_ACTION_SEARCH) {
         return "Search";
     }
     if (actionType === DOCUMENT_ACTION_COMPARISON) {
@@ -265,7 +269,7 @@ function syncWorkflowDocumentActionTooltip() {
     const description = normalizeText(
         selectedOption?.dataset.actionDescription
         || selectedOption?.getAttribute("title")
-        || getDocumentActionDescription(normalizeText(workflowDocumentActionTypeSelect.value) || DOCUMENT_ACTION_SEARCH)
+        || getDocumentActionDescription(normalizeText(workflowDocumentActionTypeSelect.value) || DOCUMENT_ACTION_NONE)
     );
 
     workflowDocumentActionTypeSelect.title = description;
@@ -712,7 +716,7 @@ function syncWorkflowPickerActionType() {
         return;
     }
 
-    const actionType = normalizeText(workflowDocumentActionTypeSelect.value) || DOCUMENT_ACTION_SEARCH;
+    const actionType = normalizeText(workflowDocumentActionTypeSelect.value) || DOCUMENT_ACTION_NONE;
     chatDocumentActionSelect.value = actionType;
     chatDocumentActionSelect.dispatchEvent(new Event("change", { bubbles: true }));
 }
@@ -734,6 +738,13 @@ function setWorkflowPickerError(message = "") {
 
 async function initializeWorkflowDocumentPicker(documentAction = {}) {
     if (!workflowDocumentPickerCard) {
+        return;
+    }
+
+    const actionType = normalizeText(documentAction.type || workflowDocumentActionTypeSelect?.value) || DOCUMENT_ACTION_NONE;
+    if (actionType === DOCUMENT_ACTION_NONE) {
+        setWorkflowPickerError("");
+        setWorkflowPickerLoadingState(false);
         return;
     }
 
@@ -1465,6 +1476,10 @@ function getDocumentActionConfig(workflow) {
 
 function getWorkflowDocumentActionSummary(workflow) {
     const config = getDocumentActionConfig(workflow);
+    if (config.type === DOCUMENT_ACTION_NONE) {
+        return "No document action";
+    }
+
     if (config.type === DOCUMENT_ACTION_SEARCH) {
         const documentCount = config.document_ids.length;
         if (config.target_mode === DOCUMENT_ANALYSIS_TARGET_RECENT) {
@@ -1503,7 +1518,7 @@ function getWorkflowDocumentActionSummary(workflow) {
         return `Compare one source to ${rightCount || 0} ${rightCount === 1 ? "target" : "targets"}`;
     }
 
-    return "Search";
+    return "No document action";
 }
 
 function updateSelectedDocumentsSummary() {
@@ -1529,14 +1544,16 @@ function updateWorkflowAnalysisTargetModeFields() {
 }
 
 function updateDocumentActionFields() {
-    const actionType = normalizeText(workflowDocumentActionTypeSelect?.value) || DOCUMENT_ACTION_SEARCH;
+    const actionType = normalizeText(workflowDocumentActionTypeSelect?.value) || DOCUMENT_ACTION_NONE;
     const hasDocumentAction = actionType !== DOCUMENT_ACTION_NONE;
+    const hasWindowedDocumentAction = [DOCUMENT_ACTION_ANALYZE, DOCUMENT_ACTION_COMPARISON].includes(actionType);
     const targetMode = normalizeText(workflowAnalysisTargetModeSelect?.value) || DOCUMENT_ANALYSIS_TARGET_SELECTED;
     const isRecentMode = targetMode === DOCUMENT_ANALYSIS_TARGET_RECENT;
     setElementVisibility(workflowDocumentTargetsFields, hasDocumentAction);
     setElementVisibility(workflowAnalysisTargetFields, hasDocumentAction);
     setElementVisibility(workflowAnalysisPerDocumentGroup, actionType === DOCUMENT_ACTION_ANALYZE);
     setElementVisibility(workflowComparisonTargetFields, actionType === DOCUMENT_ACTION_COMPARISON && !isRecentMode);
+    setElementVisibility(workflowAnalysisRetriesGroup, hasWindowedDocumentAction);
     syncWorkflowPickerActionType();
     syncWorkflowDocumentActionTooltip();
     updateWorkflowAnalysisTargetModeFields();
@@ -1567,7 +1584,10 @@ async function applySelectedWorkspaceDocumentsToWorkflow() {
         return;
     }
 
-    const actionType = normalizeText(workflowDocumentActionTypeSelect?.value) || DOCUMENT_ACTION_SEARCH;
+    const actionType = normalizeText(workflowDocumentActionTypeSelect?.value) || DOCUMENT_ACTION_NONE;
+    if (actionType === DOCUMENT_ACTION_NONE) {
+        return;
+    }
     const workflowMaxDocuments = getWorkflowDocumentActionMaxDocuments(actionType);
 
     const limitedSelectedIds = selectedIds.slice(0, workflowMaxDocuments);
@@ -2315,7 +2335,7 @@ function resetWorkflowForm() {
         workflowAlertPrioritySelect.value = "none";
     }
     if (workflowDocumentActionTypeSelect) {
-        workflowDocumentActionTypeSelect.value = DOCUMENT_ACTION_SEARCH;
+        workflowDocumentActionTypeSelect.value = DOCUMENT_ACTION_NONE;
     }
     if (workflowAnalysisTargetModeSelect) {
         workflowAnalysisTargetModeSelect.value = DOCUMENT_ANALYSIS_TARGET_SELECTED;
@@ -2520,7 +2540,7 @@ async function openWorkflowModal(workflow = null) {
 function buildWorkflowPayload() {
     const runnerType = normalizeText(workflowRunnerTypeSelect?.value) || "model";
     const triggerType = normalizeText(workflowTriggerTypeSelect?.value) || "manual";
-    const documentActionType = normalizeText(workflowDocumentActionTypeSelect?.value) || DOCUMENT_ACTION_SEARCH;
+    const documentActionType = normalizeText(workflowDocumentActionTypeSelect?.value) || DOCUMENT_ACTION_NONE;
     const analysisTargetMode = normalizeText(workflowAnalysisTargetModeSelect?.value) === DOCUMENT_ANALYSIS_TARGET_RECENT
         ? DOCUMENT_ANALYSIS_TARGET_RECENT
         : DOCUMENT_ANALYSIS_TARGET_SELECTED;
@@ -2554,6 +2574,9 @@ function buildWorkflowPayload() {
         task_prompt: normalizeText(workflowTaskPromptInput?.value),
         url_access_enabled: isWorkflowUrlAccessAvailable() ? Boolean(workflowUrlAccessEnabledToggle?.checked) : false,
         runner_type: runnerType,
+        chat_capabilities_enabled: currentEditingWorkflow
+            ? Boolean(currentEditingWorkflow.chat_capabilities_enabled)
+            : true,
         trigger_type: triggerType,
         alert_priority: normalizeText(workflowAlertPrioritySelect?.value).toLowerCase() || "none",
         is_enabled: ["interval", "file_sync"].includes(triggerType) ? Boolean(workflowEnabledToggle?.checked) : true,

--- a/application/single_app/static/js/workspace/workspace_workflows.js
+++ b/application/single_app/static/js/workspace/workspace_workflows.js
@@ -75,10 +75,18 @@ const workflowModal = workflowModalEl && window.bootstrap ? bootstrap.Modal.getO
 const workflowForm = document.getElementById("workflow-form");
 const workflowModalLabel = document.getElementById("workflowModalLabel");
 const workflowSaveBtn = document.getElementById("workflow-save-btn");
+const workflowStepDescription = document.getElementById("workflow-step-description");
+const workflowStepNavButtons = Array.from(document.querySelectorAll("[data-workflow-step-target]"));
+const workflowStepBlocks = Array.from(document.querySelectorAll("[data-workflow-step]"));
+const workflowStepBackBtn = document.getElementById("workflow-step-back-btn");
+const workflowStepNextBtn = document.getElementById("workflow-step-next-btn");
 
 const workflowIdInput = document.getElementById("workflow-id");
 const workflowNameInput = document.getElementById("workflow-name");
 const workflowDescriptionInput = document.getElementById("workflow-description");
+const workflowTaskList = document.getElementById("workflow-task-list");
+const workflowAddTaskBtn = document.getElementById("workflow-add-task-btn");
+const workflowTaskNameInput = document.getElementById("workflow-task-name");
 const workflowTaskBriefInput = document.getElementById("workflow-task-brief");
 const workflowDraftInstructionsBtn = document.getElementById("workflow-draft-instructions-btn");
 const workflowDraftInstructionsStatus = document.getElementById("workflow-draft-instructions-status");
@@ -111,6 +119,18 @@ const workflowFileSyncContinueModeSelect = document.getElementById("workflow-fil
 const workflowFileSyncUseChangedDocumentsToggle = document.getElementById("workflow-file-sync-use-changed-documents");
 const workflowFileSyncHelp = document.getElementById("workflow-file-sync-help");
 const workflowAlertPrioritySelect = document.getElementById("workflow-alert-priority");
+const workflowErrorStrategyInputs = Array.from(document.querySelectorAll('input[name="workflow-error-strategy"]'));
+const workflowTaskRetryCountInput = document.getElementById("workflow-task-retry-count");
+const workflowReviewSummary = document.getElementById("workflow-review-summary");
+const WORKFLOW_STEPS = ["general", "trigger", "tasks", "reliability", "review"];
+const WORKFLOW_STEP_DESCRIPTIONS = {
+    general: "Name the workflow and choose its runner.",
+    trigger: "Choose when the workflow runs and configure optional inputs.",
+    tasks: "Build the ordered instruction sequence.",
+    reliability: "Choose retry and failure behavior.",
+    review: "Review the workflow and completion alert before saving.",
+};
+const WORKFLOW_MAX_TASKS = 20;
 const DOCUMENT_ACTION_NONE = "none";
 const DOCUMENT_ACTION_SEARCH = "search";
 const DOCUMENT_ACTION_ANALYZE = "analyze";
@@ -238,7 +258,10 @@ function getWorkflowUrlAccessMaxUrls() {
 }
 
 function getWorkflowPromptUrls() {
-    const promptText = normalizeText(workflowTaskPromptInput?.value);
+    syncActiveWorkflowTaskFromEditor();
+    const promptText = workflowTasks.length
+        ? workflowTasks.map((task) => normalizeText(task.instructions)).filter(Boolean).join("\n")
+        : normalizeText(workflowTaskPromptInput?.value);
     if (!promptText) {
         return [];
     }
@@ -294,6 +317,9 @@ let workflowComparisonVersionLoadToken = 0;
 let workflowPickerDocumentIds = [];
 let workflowSavedComparisonTargetIds = [];
 let workflowSavedComparisonPreferredLeftId = "";
+let workflowTasks = [];
+let activeWorkflowTaskId = "";
+let currentWorkflowStepIndex = 0;
 
 function normalizeText(value) {
     return String(value || "").trim();
@@ -314,6 +340,320 @@ function clearElementChildren(element) {
     while (element.firstChild) {
         element.firstChild.remove();
     }
+}
+
+function createWorkflowTaskId() {
+    if (window.crypto?.randomUUID) {
+        return window.crypto.randomUUID();
+    }
+    return `task-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+function getActiveWorkflowTask() {
+    return workflowTasks.find((task) => task.id === activeWorkflowTaskId) || null;
+}
+
+function syncActiveWorkflowTaskFromEditor() {
+    const activeTask = getActiveWorkflowTask();
+    if (!activeTask) {
+        return;
+    }
+    activeTask.name = normalizeText(workflowTaskNameInput?.value);
+    activeTask.instructions = normalizeText(workflowTaskPromptInput?.value);
+}
+
+function populateWorkflowTaskEditor() {
+    const activeTask = getActiveWorkflowTask();
+    if (workflowTaskNameInput) {
+        workflowTaskNameInput.value = activeTask?.name || "";
+    }
+    if (workflowTaskPromptInput) {
+        workflowTaskPromptInput.value = activeTask?.instructions || "";
+    }
+    if (workflowTaskBriefInput) {
+        workflowTaskBriefInput.value = "";
+    }
+    if (workflowDraftInstructionsStatus) {
+        workflowDraftInstructionsStatus.textContent = "";
+    }
+}
+
+function createWorkflowTaskActionButton(iconClass, label, handler, disabled = false) {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "btn btn-sm btn-outline-secondary";
+    button.title = label;
+    button.setAttribute("aria-label", label);
+    button.disabled = disabled;
+    const icon = document.createElement("i");
+    icon.className = iconClass;
+    icon.setAttribute("aria-hidden", "true");
+    button.appendChild(icon);
+    button.addEventListener("click", handler);
+    return button;
+}
+
+function renderWorkflowTasks() {
+    if (!workflowTaskList) {
+        return;
+    }
+    clearElementChildren(workflowTaskList);
+
+    workflowTasks.forEach((task, index) => {
+        task.order = index + 1;
+        const item = document.createElement("div");
+        item.className = "workflow-task-item";
+        item.classList.toggle("is-selected", task.id === activeWorkflowTaskId);
+
+        const number = document.createElement("span");
+        number.className = "workflow-task-item__number";
+        number.textContent = String(index + 1);
+
+        const content = document.createElement("div");
+        content.className = "workflow-task-item__content";
+        const name = document.createElement("div");
+        name.className = "workflow-task-item__name";
+        name.textContent = task.name || `Task ${index + 1}`;
+        const preview = document.createElement("div");
+        preview.className = "workflow-task-item__preview";
+        preview.textContent = task.instructions || "Add task instructions";
+        content.append(name, preview);
+
+        const actions = document.createElement("div");
+        actions.className = "workflow-task-item__actions";
+        actions.append(
+            createWorkflowTaskActionButton("bi bi-arrow-up", `Move ${name.textContent} up`, () => moveWorkflowTask(task.id, -1), index === 0),
+            createWorkflowTaskActionButton("bi bi-arrow-down", `Move ${name.textContent} down`, () => moveWorkflowTask(task.id, 1), index === workflowTasks.length - 1),
+            createWorkflowTaskActionButton("bi bi-pencil", `Edit ${name.textContent}`, () => selectWorkflowTask(task.id)),
+            createWorkflowTaskActionButton("bi bi-trash", `Delete ${name.textContent}`, () => removeWorkflowTask(task.id), workflowTasks.length === 1),
+        );
+        item.append(number, content, actions);
+        workflowTaskList.appendChild(item);
+    });
+}
+
+function selectWorkflowTask(taskId) {
+    syncActiveWorkflowTaskFromEditor();
+    if (!workflowTasks.some((task) => task.id === taskId)) {
+        return;
+    }
+    activeWorkflowTaskId = taskId;
+    populateWorkflowTaskEditor();
+    renderWorkflowTasks();
+    workflowTaskNameInput?.focus();
+}
+
+function addWorkflowTask() {
+    syncActiveWorkflowTaskFromEditor();
+    if (workflowTasks.length >= WORKFLOW_MAX_TASKS) {
+        showToast(`Workflows support up to ${WORKFLOW_MAX_TASKS} tasks.`, "warning");
+        return;
+    }
+    const task = {
+        id: createWorkflowTaskId(),
+        type: "instructions",
+        name: `Task ${workflowTasks.length + 1}`,
+        instructions: "",
+        order: workflowTasks.length + 1,
+    };
+    workflowTasks.push(task);
+    activeWorkflowTaskId = task.id;
+    populateWorkflowTaskEditor();
+    renderWorkflowTasks();
+    workflowTaskNameInput?.focus();
+}
+
+function moveWorkflowTask(taskId, offset) {
+    syncActiveWorkflowTaskFromEditor();
+    const currentIndex = workflowTasks.findIndex((task) => task.id === taskId);
+    const nextIndex = currentIndex + offset;
+    if (currentIndex < 0 || nextIndex < 0 || nextIndex >= workflowTasks.length) {
+        return;
+    }
+    const [task] = workflowTasks.splice(currentIndex, 1);
+    workflowTasks.splice(nextIndex, 0, task);
+    renderWorkflowTasks();
+}
+
+function removeWorkflowTask(taskId) {
+    if (workflowTasks.length === 1) {
+        showToast("A workflow requires at least one task.", "warning");
+        return;
+    }
+    const taskIndex = workflowTasks.findIndex((task) => task.id === taskId);
+    if (taskIndex < 0) {
+        return;
+    }
+    workflowTasks.splice(taskIndex, 1);
+    const replacementTask = workflowTasks[Math.min(taskIndex, workflowTasks.length - 1)];
+    activeWorkflowTaskId = replacementTask.id;
+    populateWorkflowTaskEditor();
+    renderWorkflowTasks();
+}
+
+function initializeWorkflowTasks(workflow = null) {
+    const storedTasks = Array.isArray(workflow?.tasks) ? workflow.tasks : [];
+    workflowTasks = storedTasks.length
+        ? storedTasks.map((task, index) => ({
+            id: normalizeText(task.id) || createWorkflowTaskId(),
+            type: "instructions",
+            name: normalizeText(task.name) || `Task ${index + 1}`,
+            instructions: normalizeText(task.instructions),
+            order: index + 1,
+        }))
+        : [{
+            id: createWorkflowTaskId(),
+            type: "instructions",
+            name: "Task 1",
+            instructions: normalizeText(workflow?.task_prompt),
+            order: 1,
+        }];
+    activeWorkflowTaskId = workflowTasks[0].id;
+    populateWorkflowTaskEditor();
+    renderWorkflowTasks();
+}
+
+function getWorkflowErrorStrategy() {
+    return normalizeText(workflowErrorStrategyInputs.find((input) => input.checked)?.value) || "halt";
+}
+
+function addWorkflowReviewItem(labelText, valueText) {
+    if (!workflowReviewSummary) {
+        return;
+    }
+    const item = document.createElement("div");
+    item.className = "workflow-review-summary__item";
+    const label = document.createElement("span");
+    label.className = "workflow-review-summary__label";
+    label.textContent = labelText;
+    const value = document.createElement("div");
+    value.className = "workflow-review-summary__value";
+    value.textContent = valueText;
+    item.append(label, value);
+    workflowReviewSummary.appendChild(item);
+}
+
+function renderWorkflowReview() {
+    if (!workflowReviewSummary) {
+        return;
+    }
+    syncActiveWorkflowTaskFromEditor();
+    clearElementChildren(workflowReviewSummary);
+    const runnerLabel = workflowRunnerTypeSelect?.selectedOptions?.[0]?.textContent || "Direct Model";
+    const triggerLabel = workflowTriggerTypeSelect?.selectedOptions?.[0]?.textContent || "Manual";
+    const documentActionLabel = workflowDocumentActionTypeSelect?.selectedOptions?.[0]?.textContent || "No document action";
+    const alertLabel = workflowAlertPrioritySelect?.selectedOptions?.[0]?.textContent || "No notification";
+    const retryCount = Number(workflowTaskRetryCountInput?.value || 0);
+    const strategyLabel = getWorkflowErrorStrategy() === "continue" ? "Continue after failure" : "Stop after failure";
+
+    addWorkflowReviewItem("Workflow", normalizeText(workflowNameInput?.value) || "Untitled workflow");
+    addWorkflowReviewItem("Runner", normalizeText(runnerLabel));
+    addWorkflowReviewItem("Trigger", normalizeText(triggerLabel));
+    addWorkflowReviewItem("Tasks", `${workflowTasks.length} ordered ${workflowTasks.length === 1 ? "task" : "tasks"}`);
+    addWorkflowReviewItem("Workspace documents", normalizeText(documentActionLabel));
+    addWorkflowReviewItem("File Sync", workflowFileSyncEnabledToggle?.checked ? "Before each run" : "Not used");
+    addWorkflowReviewItem("Failure handling", `${strategyLabel}; ${retryCount} ${retryCount === 1 ? "retry" : "retries"}`);
+    addWorkflowReviewItem("Completion alert", normalizeText(alertLabel));
+}
+
+function validateWorkflowTasks() {
+    syncActiveWorkflowTaskFromEditor();
+    for (let index = 0; index < workflowTasks.length; index += 1) {
+        const task = workflowTasks[index];
+        if (!normalizeText(task.name) || !normalizeText(task.instructions)) {
+            activeWorkflowTaskId = task.id;
+            populateWorkflowTaskEditor();
+            renderWorkflowTasks();
+            showToast(`Add a name and instructions for task ${index + 1}.`, "warning");
+            (normalizeText(task.name) ? workflowTaskPromptInput : workflowTaskNameInput)?.focus();
+            return false;
+        }
+    }
+    return true;
+}
+
+function validateWorkflowStep(stepName) {
+    if (stepName === "general") {
+        if (!normalizeText(workflowNameInput?.value)) {
+            showToast("Workflow name is required.", "warning");
+            workflowNameInput?.focus();
+            return false;
+        }
+        if (normalizeText(workflowRunnerTypeSelect?.value) === "agent" && !getSelectedAgentOption()) {
+            showToast("Select an agent for this workflow.", "warning");
+            workflowAgentSelect?.focus();
+            return false;
+        }
+    }
+    if (stepName === "trigger") {
+        const triggerType = normalizeText(workflowTriggerTypeSelect?.value) || "manual";
+        const fileSyncEnabled = Boolean(workflowFileSyncEnabledToggle?.checked) || triggerType === "file_sync";
+        if (fileSyncEnabled && !getSelectedFileSyncSources().length) {
+            showToast("Select at least one File Sync source for this workflow.", "warning");
+            workflowFileSyncSourcesSelect?.focus();
+            return false;
+        }
+    }
+    if (stepName === "tasks") {
+        if (!validateWorkflowTasks()) {
+            return false;
+        }
+        try {
+            buildWorkflowPayload();
+        } catch (error) {
+            showToast(escapeHtml(error.message || "Complete the task configuration before continuing."), "warning");
+            return false;
+        }
+    }
+    if (stepName === "reliability") {
+        const retryCount = Number(workflowTaskRetryCountInput?.value || 0);
+        if (!Number.isInteger(retryCount) || retryCount < 0 || retryCount > 5) {
+            showToast("Task retry count must be between 0 and 5.", "warning");
+            workflowTaskRetryCountInput?.focus();
+            return false;
+        }
+    }
+    return true;
+}
+
+function showWorkflowStep(stepIndex) {
+    currentWorkflowStepIndex = Math.max(0, Math.min(WORKFLOW_STEPS.length - 1, stepIndex));
+    const stepName = WORKFLOW_STEPS[currentWorkflowStepIndex];
+    workflowStepBlocks.forEach((block) => {
+        block.classList.toggle("workflow-step-hidden", block.dataset.workflowStep !== stepName);
+    });
+    workflowStepNavButtons.forEach((button, index) => {
+        const isActive = index === currentWorkflowStepIndex;
+        button.classList.toggle("is-active", isActive);
+        button.classList.toggle("is-complete", index < currentWorkflowStepIndex);
+        if (isActive) {
+            button.setAttribute("aria-current", "step");
+        } else {
+            button.removeAttribute("aria-current");
+        }
+    });
+    if (workflowStepDescription) {
+        workflowStepDescription.textContent = WORKFLOW_STEP_DESCRIPTIONS[stepName] || "";
+    }
+    setElementVisibility(workflowStepBackBtn, currentWorkflowStepIndex > 0);
+    setElementVisibility(workflowStepNextBtn, currentWorkflowStepIndex < WORKFLOW_STEPS.length - 1);
+    setElementVisibility(workflowSaveBtn, currentWorkflowStepIndex === WORKFLOW_STEPS.length - 1);
+    if (stepName === "review") {
+        renderWorkflowReview();
+    }
+    workflowModalEl?.querySelector(".modal-body")?.scrollTo({ top: 0, behavior: "smooth" });
+}
+
+function navigateWorkflowStep(targetIndex) {
+    if (targetIndex > currentWorkflowStepIndex) {
+        for (let index = currentWorkflowStepIndex; index < targetIndex; index += 1) {
+            if (!validateWorkflowStep(WORKFLOW_STEPS[index])) {
+                showWorkflowStep(index);
+                return;
+            }
+        }
+    }
+    showWorkflowStep(targetIndex);
 }
 
 function formatDateTime(value) {
@@ -2297,6 +2637,7 @@ function resetWorkflowForm() {
     if (workflowTaskPromptInput) {
         workflowTaskPromptInput.value = "";
     }
+    initializeWorkflowTasks();
     if (workflowUrlAccessEnabledToggle) {
         workflowUrlAccessEnabledToggle.checked = false;
     }
@@ -2333,6 +2674,12 @@ function resetWorkflowForm() {
     }
     if (workflowAlertPrioritySelect) {
         workflowAlertPrioritySelect.value = "none";
+    }
+    workflowErrorStrategyInputs.forEach((input) => {
+        input.checked = input.value === "halt";
+    });
+    if (workflowTaskRetryCountInput) {
+        workflowTaskRetryCountInput.value = "0";
     }
     if (workflowDocumentActionTypeSelect) {
         workflowDocumentActionTypeSelect.value = DOCUMENT_ACTION_NONE;
@@ -2397,6 +2744,7 @@ function resetWorkflowForm() {
     updateTriggerFields();
     updateFileSyncFields();
     updateDocumentActionFields();
+    showWorkflowStep(0);
 }
 
 async function openWorkflowModal(workflow = null) {
@@ -2440,6 +2788,15 @@ async function openWorkflowModal(workflow = null) {
         }
         if (workflowAlertPrioritySelect) {
             workflowAlertPrioritySelect.value = normalizeText(workflow.alert_priority).toLowerCase() || "none";
+        }
+        const errorHandling = workflow.error_handling && typeof workflow.error_handling === "object"
+            ? workflow.error_handling
+            : {};
+        workflowErrorStrategyInputs.forEach((input) => {
+            input.checked = input.value === (normalizeText(errorHandling.strategy) || "halt");
+        });
+        if (workflowTaskRetryCountInput) {
+            workflowTaskRetryCountInput.value = String(errorHandling.retry_count ?? 0);
         }
         const fileSyncConfig = workflow.file_sync && typeof workflow.file_sync === "object" ? workflow.file_sync : {};
         if (workflowFileSyncEnabledToggle) {
@@ -2517,6 +2874,7 @@ async function openWorkflowModal(workflow = null) {
         }
     }
 
+    initializeWorkflowTasks(workflow);
     const documentAction = workflow ? getDocumentActionConfig(workflow) : null;
     if (documentAction?.type === DOCUMENT_ACTION_COMPARISON) {
         const savedTargetIds = [documentAction.left_document_id, ...documentAction.right_document_ids].filter(Boolean);
@@ -2533,11 +2891,20 @@ async function openWorkflowModal(workflow = null) {
     updateTriggerFields();
     updateFileSyncFields();
     updateDocumentActionFields();
+    showWorkflowStep(0);
     workflowModal.show();
     await initializeWorkflowDocumentPicker(documentAction || {});
 }
 
 function buildWorkflowPayload() {
+    syncActiveWorkflowTaskFromEditor();
+    const tasks = workflowTasks.map((task, index) => ({
+        id: normalizeText(task.id) || createWorkflowTaskId(),
+        type: "instructions",
+        name: normalizeText(task.name),
+        instructions: normalizeText(task.instructions),
+        order: index + 1,
+    }));
     const runnerType = normalizeText(workflowRunnerTypeSelect?.value) || "model";
     const triggerType = normalizeText(workflowTriggerTypeSelect?.value) || "manual";
     const documentActionType = normalizeText(workflowDocumentActionTypeSelect?.value) || DOCUMENT_ACTION_NONE;
@@ -2571,7 +2938,12 @@ function buildWorkflowPayload() {
         id: normalizeText(workflowIdInput?.value),
         name: normalizeText(workflowNameInput?.value),
         description: normalizeText(workflowDescriptionInput?.value),
-        task_prompt: normalizeText(workflowTaskPromptInput?.value),
+        task_prompt: normalizeText(tasks[0]?.instructions),
+        tasks,
+        error_handling: {
+            strategy: getWorkflowErrorStrategy(),
+            retry_count: Number(workflowTaskRetryCountInput?.value || 0),
+        },
         url_access_enabled: isWorkflowUrlAccessAvailable() ? Boolean(workflowUrlAccessEnabledToggle?.checked) : false,
         runner_type: runnerType,
         chat_capabilities_enabled: currentEditingWorkflow
@@ -2634,8 +3006,15 @@ function buildWorkflowPayload() {
     if (!payload.name) {
         throw new Error("Workflow name is required.");
     }
-    if (!payload.task_prompt) {
-        throw new Error("Task prompt is required.");
+    if (!payload.tasks.length) {
+        throw new Error("Add at least one workflow task.");
+    }
+    const incompleteTaskIndex = payload.tasks.findIndex((task) => !task.name || !task.instructions);
+    if (incompleteTaskIndex >= 0) {
+        throw new Error(`Add a name and instructions for task ${incompleteTaskIndex + 1}.`);
+    }
+    if (!Number.isInteger(payload.error_handling.retry_count) || payload.error_handling.retry_count < 0 || payload.error_handling.retry_count > 5) {
+        throw new Error("Task retry count must be between 0 and 5.");
     }
     if (payload.url_access_enabled) {
         const promptUrls = getWorkflowPromptUrls();
@@ -3280,6 +3659,20 @@ function initializeWorkflowEvents() {
     workflowsGridView?.addEventListener("click", handleWorkflowGridClick);
     workflowsGridView?.addEventListener("keydown", handleWorkflowGridKeydown);
     workflowForm?.addEventListener("submit", saveWorkflow);
+    workflowAddTaskBtn?.addEventListener("click", addWorkflowTask);
+    workflowTaskNameInput?.addEventListener("input", () => {
+        syncActiveWorkflowTaskFromEditor();
+        renderWorkflowTasks();
+    });
+    workflowTaskPromptInput?.addEventListener("input", () => {
+        syncActiveWorkflowTaskFromEditor();
+        renderWorkflowTasks();
+    });
+    workflowStepBackBtn?.addEventListener("click", () => navigateWorkflowStep(currentWorkflowStepIndex - 1));
+    workflowStepNextBtn?.addEventListener("click", () => navigateWorkflowStep(currentWorkflowStepIndex + 1));
+    workflowStepNavButtons.forEach((button, index) => {
+        button.addEventListener("click", () => navigateWorkflowStep(index));
+    });
     workflowDraftInstructionsBtn?.addEventListener("click", draftWorkflowInstructions);
     workflowDeleteConfirmBtn?.addEventListener("click", deleteWorkflow);
     workflowHistoryBody?.addEventListener("click", (event) => {
@@ -3312,6 +3705,7 @@ function initializeWorkflowEvents() {
         updateModelHelpText();
     });
     workflowModelSelect?.addEventListener("change", updateModelHelpText);
+    workflowAlertPrioritySelect?.addEventListener("change", renderWorkflowReview);
     workflowTriggerTypeSelect?.addEventListener("change", updateTriggerFields);
     workflowScheduleUnitSelect?.addEventListener("change", updateScheduleConstraints);
     workflowFileSyncEnabledToggle?.addEventListener("change", updateFileSyncFields);

--- a/application/single_app/templates/group_workspaces.html
+++ b/application/single_app/templates/group_workspaces.html
@@ -2086,10 +2086,13 @@ app_settings.app_title }} {% endblock %} {% block head %}
         {% endif %}
 
         <div class="card p-3 mb-3">
+          <h6 class="mb-1">Workspace documents</h6>
+          <div class="form-text mb-3">Optional. Use a document action only when this workflow needs workspace document context.</div>
           <div class="row g-3 mb-2">
             <div class="col-md-6">
-              <label for="workflow-document-action-type" class="form-label">Action Type</label>
-              <select class="form-select" id="workflow-document-action-type" title="Search selected or recent documents and use matching excerpts as workflow context.">
+              <label for="workflow-document-action-type" class="form-label">Document action</label>
+              <select class="form-select" id="workflow-document-action-type" title="Run the workflow instructions without workspace document context.">
+                <option value="none" data-action-description="Run the workflow instructions without workspace document context." title="Run the workflow instructions without workspace document context.">No document action</option>
                 <option value="search" data-action-description="Search selected or recent documents and use matching excerpts as workflow context." title="Search selected or recent documents and use matching excerpts as workflow context.">Search</option>
                 {% if settings.document_action_capabilities.analyze.enabled %}
                 <option value="analyze" data-action-description="Perform an in-depth analysis across all selected documents based on your request." title="Perform an in-depth analysis across all selected documents based on your request.">Analyze</option>
@@ -2099,12 +2102,12 @@ app_settings.app_title }} {% endblock %} {% block head %}
                 {% endif %}
               </select>
             </div>
-            <div class="col-md-6">
+            <div class="col-md-6 d-none" id="workflow-analysis-retries-group">
               <label for="workflow-analysis-retries" class="form-label">Retries Per Window</label>
               <input type="number" class="form-control" id="workflow-analysis-retries" min="0" max="5" value="1" />
             </div>
           </div>
-          <div class="form-text mt-2" id="workflow-document-action-help">Search selected or recent documents and use matching excerpts as workflow context.</div>
+          <div class="form-text mt-2" id="workflow-document-action-help">Run the workflow instructions without workspace document context.</div>
 
           <div id="workflow-document-targets-fields" class="mt-3 d-none">
             <input type="hidden" id="workflow-analysis-doc-scope" value="group" />
@@ -2145,6 +2148,7 @@ app_settings.app_title }} {% endblock %} {% block head %}
               </div>
               <div id="workflow-document-picker-error" class="alert alert-warning py-2 d-none" role="alert"></div>
               <select class="d-none" id="document-action-select" aria-label="Workflow document action">
+                <option value="none">No document action</option>
                 <option value="search">Search</option>
                 {% if settings.document_action_capabilities.analyze.enabled %}
                 <option value="analyze">Analyze</option>

--- a/application/single_app/templates/group_workspaces.html
+++ b/application/single_app/templates/group_workspaces.html
@@ -2037,15 +2037,25 @@ app_settings.app_title }} {% endblock %} {% block head %}
 
 {% if settings.allow_group_workflows %}
 <div class="modal fade" id="workflowModal" tabindex="-1" aria-labelledby="workflowModalLabel" aria-hidden="true">
-  <div class="modal-dialog modal-lg modal-dialog-scrollable">
+  <div class="modal-dialog modal-xl modal-dialog-scrollable">
     <form class="modal-content" id="workflow-form" autocomplete="off" data-lpignore="true" data-1p-ignore="true" data-bwignore="true">
       <div class="modal-header">
-        <h5 class="modal-title" id="workflowModalLabel">Create Group Workflow</h5>
+        <div>
+          <h5 class="modal-title" id="workflowModalLabel">Create Group Workflow</h5>
+          <div class="text-muted small mt-1" id="workflow-step-description">Name the workflow and choose its runner.</div>
+        </div>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
-      <div class="modal-body">
+      <div class="modal-body workflow-builder-body">
         <input type="hidden" id="workflow-id" />
-        <div class="row g-3 mb-3">
+        <nav class="workflow-step-nav" aria-label="Workflow setup steps">
+          <button type="button" class="workflow-step-nav__item is-active" data-workflow-step-target="general" aria-current="step"><span>1</span>General</button>
+          <button type="button" class="workflow-step-nav__item" data-workflow-step-target="trigger"><span>2</span>Trigger</button>
+          <button type="button" class="workflow-step-nav__item" data-workflow-step-target="tasks"><span>3</span>Tasks</button>
+          <button type="button" class="workflow-step-nav__item" data-workflow-step-target="reliability"><span>4</span>Reliability</button>
+          <button type="button" class="workflow-step-nav__item" data-workflow-step-target="review"><span>5</span>Review</button>
+        </nav>
+        <div class="row g-3 mb-3 workflow-step-block" data-workflow-step="general">
           <div class="col-md-7">
             <label for="workflow-name" class="form-label">Workflow Name</label>
             <input type="text" class="form-control" id="workflow-name" maxlength="120" required />
@@ -2058,11 +2068,27 @@ app_settings.app_title }} {% endblock %} {% block head %}
             </select>
           </div>
         </div>
-        <div class="mb-3">
+        <div class="mb-3 workflow-step-block" data-workflow-step="general">
           <label for="workflow-description" class="form-label">Description</label>
           <input type="text" class="form-control" id="workflow-description" maxlength="240" placeholder="Optional summary for the workflow list." />
         </div>
-        <div class="mb-3">
+        <div class="workflow-step-block" data-workflow-step="tasks">
+          <div class="d-flex flex-wrap align-items-center justify-content-between gap-2 mb-3">
+            <div>
+              <h6 class="mb-1">Task sequence</h6>
+              <div class="form-text mt-0">Tasks run from top to bottom with the selected runner.</div>
+            </div>
+            <button type="button" class="btn btn-outline-primary btn-sm" id="workflow-add-task-btn">
+              <i class="bi bi-plus-circle me-1" aria-hidden="true"></i>Add Task
+            </button>
+          </div>
+          <div id="workflow-task-list" class="workflow-task-list mb-3" aria-live="polite"></div>
+          <div class="workflow-task-editor border rounded-2 p-3 mb-3" id="workflow-task-editor">
+            <label for="workflow-task-name" class="form-label">Task Name</label>
+            <input type="text" class="form-control" id="workflow-task-name" maxlength="120" placeholder="e.g., Summarize findings" />
+          </div>
+        </div>
+        <div class="mb-3 workflow-step-block" data-workflow-step="tasks">
           <label for="workflow-task-brief" class="form-label">Task Brief</label>
           <textarea class="form-control" id="workflow-task-brief" rows="3" placeholder="Briefly describe what this workflow should accomplish."></textarea>
           <div class="d-flex align-items-center gap-2 mt-2">
@@ -2072,20 +2098,20 @@ app_settings.app_title }} {% endblock %} {% block head %}
             <span class="text-muted small" id="workflow-draft-instructions-status" aria-live="polite"></span>
           </div>
         </div>
-        <div class="mb-3">
-          <label for="workflow-task-prompt" class="form-label">Workflow Instructions</label>
-          <textarea class="form-control" id="workflow-task-prompt" rows="7" placeholder="Describe exactly what this workflow should do each time it runs." required></textarea>
-          <div class="form-text">This instruction will be used to guide the workflow's behavior in each run.</div>
+        <div class="mb-3 workflow-step-block" data-workflow-step="tasks">
+          <label for="workflow-task-prompt" class="form-label">Task Instructions</label>
+          <textarea class="form-control" id="workflow-task-prompt" rows="7" placeholder="Describe exactly what this task should do each time it runs."></textarea>
+          <div class="form-text">The next task receives this task's response as bounded context.</div>
         </div>
         {% if settings.enable_url_access %}
-        <div class="form-check form-switch mb-3" id="workflow-url-access-group">
+        <div class="form-check form-switch mb-3 workflow-step-block" id="workflow-url-access-group" data-workflow-step="trigger">
           <input class="form-check-input" type="checkbox" id="workflow-url-access-enabled" />
           <label class="form-check-label ms-2" for="workflow-url-access-enabled">Allow URL Access for this workflow</label>
           <div class="form-text">Workflow runs can review up to {{ settings.url_access_max_workflow_urls_per_run|default(50, true) }} HTTP(S) URLs from the task prompt using the shared admin domain policy.</div>
         </div>
         {% endif %}
 
-        <div class="card p-3 mb-3">
+        <div class="card p-3 mb-3 workflow-step-block" data-workflow-step="tasks">
           <h6 class="mb-1">Workspace documents</h6>
           <div class="form-text mb-3">Optional. Use a document action only when this workflow needs workspace document context.</div>
           <div class="row g-3 mb-2">
@@ -2251,7 +2277,7 @@ app_settings.app_title }} {% endblock %} {% block head %}
           </div>
         </div>
 
-        <div class="card p-3 mb-3" id="workflow-file-sync-card">
+        <div class="card p-3 mb-3 workflow-step-block" id="workflow-file-sync-card" data-workflow-step="trigger">
           <div class="d-flex flex-wrap gap-2 justify-content-between align-items-start mb-3">
             <div>
               <label class="form-label mb-0" for="workflow-file-sync-enabled">File Sync Before Run</label>
@@ -2290,7 +2316,7 @@ app_settings.app_title }} {% endblock %} {% block head %}
           </div>
         </div>
 
-        <div id="workflow-agent-fields" class="card p-3 mb-3 d-none">
+        <div id="workflow-agent-fields" class="card p-3 mb-3 d-none workflow-step-block" data-workflow-step="general">
           <div class="mb-0">
             <label for="workflow-agent-select" class="form-label">Selected Agent</label>
             <select class="form-select" id="workflow-agent-select"></select>
@@ -2298,7 +2324,7 @@ app_settings.app_title }} {% endblock %} {% block head %}
           </div>
         </div>
 
-        <div id="workflow-model-fields" class="card p-3 mb-3">
+        <div id="workflow-model-fields" class="card p-3 mb-3 workflow-step-block" data-workflow-step="general">
           <div class="row g-3">
             <div class="col-md-4">
               <label for="workflow-model-source" class="form-label">Model Source</label>
@@ -2319,7 +2345,7 @@ app_settings.app_title }} {% endblock %} {% block head %}
           <div class="form-text mt-2" id="workflow-model-help">The default app model follows your admin-configured default selection or legacy GPT settings.</div>
         </div>
 
-        <div class="card p-3 mb-3">
+        <div class="card p-3 mb-3 workflow-step-block" data-workflow-step="review">
           <div class="row g-3 align-items-end">
             <div class="col-md-5">
               <label for="workflow-alert-priority" class="form-label">Pop-up Alert Priority</label>
@@ -2336,7 +2362,7 @@ app_settings.app_title }} {% endblock %} {% block head %}
           </div>
         </div>
 
-        <div class="card p-3">
+        <div class="card p-3 workflow-step-block" id="workflow-trigger-settings-card" data-workflow-step="trigger">
           <div class="row g-3 align-items-end">
             <div class="col-md-4">
               <label for="workflow-trigger-type" class="form-label">Trigger</label>
@@ -2365,10 +2391,33 @@ app_settings.app_title }} {% endblock %} {% block head %}
           </div>
           <div class="form-text mt-2" id="workflow-trigger-help">Manual workflows run only when you trigger them from the group workspace.</div>
         </div>
+        <div class="workflow-step-block" data-workflow-step="reliability">
+          <div class="card p-3">
+            <h6 class="mb-3">Error strategy</h6>
+            <div class="form-check mb-2">
+              <input class="form-check-input" type="radio" name="workflow-error-strategy" id="workflow-error-strategy-halt" value="halt" checked />
+              <label class="form-check-label" for="workflow-error-strategy-halt">Stop when a task still fails after retries</label>
+            </div>
+            <div class="form-check mb-3">
+              <input class="form-check-input" type="radio" name="workflow-error-strategy" id="workflow-error-strategy-continue" value="continue" />
+              <label class="form-check-label" for="workflow-error-strategy-continue">Record the failure and continue to the next task</label>
+            </div>
+            <div class="border-top pt-3">
+              <label for="workflow-task-retry-count" class="form-label">Task Retry Count</label>
+              <input type="number" class="form-control workflow-retry-input" id="workflow-task-retry-count" min="0" max="5" value="0" />
+              <div class="form-text">Retries apply to each task before the selected error strategy.</div>
+            </div>
+          </div>
+        </div>
+        <div class="workflow-step-block" id="workflow-review-summary-block" data-workflow-step="review">
+          <div class="workflow-review-summary" id="workflow-review-summary" aria-live="polite"></div>
+        </div>
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
-        <button type="submit" class="btn btn-primary" id="workflow-save-btn">Save Workflow</button>
+        <button type="button" class="btn btn-outline-secondary d-none" id="workflow-step-back-btn"><i class="bi bi-arrow-left me-1" aria-hidden="true"></i>Back</button>
+        <button type="button" class="btn btn-primary" id="workflow-step-next-btn">Next<i class="bi bi-arrow-right ms-1" aria-hidden="true"></i></button>
+        <button type="submit" class="btn btn-primary d-none" id="workflow-save-btn">Save Workflow</button>
       </div>
     </form>
   </div>

--- a/application/single_app/templates/workspace.html
+++ b/application/single_app/templates/workspace.html
@@ -1433,15 +1433,25 @@
 
   {% if settings.allow_user_workflows %}
   <div class="modal fade" id="workflowModal" tabindex="-1" aria-labelledby="workflowModalLabel" aria-hidden="true">
-    <div class="modal-dialog modal-lg modal-dialog-scrollable">
+    <div class="modal-dialog modal-xl modal-dialog-scrollable">
       <form class="modal-content" id="workflow-form" autocomplete="off" data-lpignore="true" data-1p-ignore="true" data-bwignore="true">
         <div class="modal-header">
-          <h5 class="modal-title" id="workflowModalLabel">Create Personal Workflow</h5>
+          <div>
+            <h5 class="modal-title" id="workflowModalLabel">Create Personal Workflow</h5>
+            <div class="text-muted small mt-1" id="workflow-step-description">Name the workflow and choose its runner.</div>
+          </div>
           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
         </div>
-        <div class="modal-body">
+        <div class="modal-body workflow-builder-body">
           <input type="hidden" id="workflow-id" />
-          <div class="row g-3 mb-3">
+          <nav class="workflow-step-nav" aria-label="Workflow setup steps">
+            <button type="button" class="workflow-step-nav__item is-active" data-workflow-step-target="general" aria-current="step"><span>1</span>General</button>
+            <button type="button" class="workflow-step-nav__item" data-workflow-step-target="trigger"><span>2</span>Trigger</button>
+            <button type="button" class="workflow-step-nav__item" data-workflow-step-target="tasks"><span>3</span>Tasks</button>
+            <button type="button" class="workflow-step-nav__item" data-workflow-step-target="reliability"><span>4</span>Reliability</button>
+            <button type="button" class="workflow-step-nav__item" data-workflow-step-target="review"><span>5</span>Review</button>
+          </nav>
+          <div class="row g-3 mb-3 workflow-step-block" data-workflow-step="general">
             <div class="col-md-7">
               <label for="workflow-name" class="form-label">Workflow Name</label>
               <input type="text" class="form-control" id="workflow-name" maxlength="120" required />
@@ -1454,11 +1464,27 @@
               </select>
             </div>
           </div>
-          <div class="mb-3">
+          <div class="mb-3 workflow-step-block" data-workflow-step="general">
             <label for="workflow-description" class="form-label">Description</label>
             <input type="text" class="form-control" id="workflow-description" maxlength="240" placeholder="Optional summary for the workflow list." />
           </div>
-          <div class="mb-3">
+          <div class="workflow-step-block" data-workflow-step="tasks">
+            <div class="d-flex flex-wrap align-items-center justify-content-between gap-2 mb-3">
+              <div>
+                <h6 class="mb-1">Task sequence</h6>
+                <div class="form-text mt-0">Tasks run from top to bottom with the selected runner.</div>
+              </div>
+              <button type="button" class="btn btn-outline-primary btn-sm" id="workflow-add-task-btn">
+                <i class="bi bi-plus-circle me-1" aria-hidden="true"></i>Add Task
+              </button>
+            </div>
+            <div id="workflow-task-list" class="workflow-task-list mb-3" aria-live="polite"></div>
+            <div class="workflow-task-editor border rounded-2 p-3 mb-3" id="workflow-task-editor">
+              <label for="workflow-task-name" class="form-label">Task Name</label>
+              <input type="text" class="form-control" id="workflow-task-name" maxlength="120" placeholder="e.g., Summarize findings" />
+            </div>
+          </div>
+          <div class="mb-3 workflow-step-block" data-workflow-step="tasks">
             <label for="workflow-task-brief" class="form-label">Task Brief</label>
             <textarea class="form-control" id="workflow-task-brief" rows="3" placeholder="Briefly describe what this workflow should accomplish."></textarea>
             <div class="d-flex align-items-center gap-2 mt-2">
@@ -1468,20 +1494,20 @@
               <span class="text-muted small" id="workflow-draft-instructions-status" aria-live="polite"></span>
             </div>
           </div>
-          <div class="mb-3">
-            <label for="workflow-task-prompt" class="form-label">Workflow Instructions</label>
-            <textarea class="form-control" id="workflow-task-prompt" rows="7" placeholder="Describe exactly what this workflow should do each time it runs." required></textarea>
-            <div class="form-text">Each run appends this prompt to the workflow conversation as a new user message.</div>
+          <div class="mb-3 workflow-step-block" data-workflow-step="tasks">
+            <label for="workflow-task-prompt" class="form-label">Task Instructions</label>
+            <textarea class="form-control" id="workflow-task-prompt" rows="7" placeholder="Describe exactly what this task should do each time it runs."></textarea>
+            <div class="form-text">The next task receives this task's response as bounded context.</div>
           </div>
           {% if settings.enable_url_access %}
-          <div class="form-check form-switch mb-3" id="workflow-url-access-group">
+          <div class="form-check form-switch mb-3 workflow-step-block" id="workflow-url-access-group" data-workflow-step="trigger">
             <input class="form-check-input" type="checkbox" id="workflow-url-access-enabled" />
             <label class="form-check-label ms-2" for="workflow-url-access-enabled">Allow URL Access for this workflow</label>
             <div class="form-text">Workflow runs can review up to {{ settings.url_access_max_workflow_urls_per_run|default(50, true) }} HTTP(S) URLs from the task prompt using the shared admin domain policy.</div>
           </div>
           {% endif %}
 
-          <div class="card p-3 mb-3">
+          <div class="card p-3 mb-3 workflow-step-block" data-workflow-step="tasks">
             <h6 class="mb-1">Workspace documents</h6>
             <div class="form-text mb-3">Optional. Use a document action only when this workflow needs workspace document context.</div>
             <div class="row g-3 mb-2">
@@ -1647,7 +1673,7 @@
             </div>
           </div>
 
-          <div class="card p-3 mb-3" id="workflow-file-sync-card">
+          <div class="card p-3 mb-3 workflow-step-block" id="workflow-file-sync-card" data-workflow-step="trigger">
             <div class="d-flex flex-wrap gap-2 justify-content-between align-items-start mb-3">
               <div>
                 <label class="form-label mb-0" for="workflow-file-sync-enabled">File Sync Before Run</label>
@@ -1686,7 +1712,7 @@
             </div>
           </div>
 
-          <div id="workflow-agent-fields" class="card p-3 mb-3 d-none">
+          <div id="workflow-agent-fields" class="card p-3 mb-3 d-none workflow-step-block" data-workflow-step="general">
             <div class="mb-0">
               <label for="workflow-agent-select" class="form-label">Selected Agent</label>
               <select class="form-select" id="workflow-agent-select"></select>
@@ -1694,7 +1720,7 @@
             </div>
           </div>
 
-          <div id="workflow-model-fields" class="card p-3 mb-3">
+          <div id="workflow-model-fields" class="card p-3 mb-3 workflow-step-block" data-workflow-step="general">
             <div class="row g-3">
               <div class="col-md-4">
                 <label for="workflow-model-source" class="form-label">Model Source</label>
@@ -1715,7 +1741,7 @@
             <div class="form-text mt-2" id="workflow-model-help">The default app model follows your admin-configured default selection or legacy GPT settings.</div>
           </div>
 
-          <div class="card p-3 mb-3">
+          <div class="card p-3 mb-3 workflow-step-block" data-workflow-step="review">
             <div class="row g-3 align-items-end">
               <div class="col-md-5">
                 <label for="workflow-alert-priority" class="form-label">Pop-up Alert Priority</label>
@@ -1732,7 +1758,7 @@
             </div>
           </div>
 
-          <div class="card p-3">
+          <div class="card p-3 workflow-step-block" id="workflow-trigger-settings-card" data-workflow-step="trigger">
             <div class="row g-3 align-items-end">
               <div class="col-md-4">
                 <label for="workflow-trigger-type" class="form-label">Trigger</label>
@@ -1761,10 +1787,33 @@
             </div>
             <div class="form-text mt-2" id="workflow-trigger-help">Manual workflows run only when you trigger them from the workspace.</div>
           </div>
+          <div class="workflow-step-block" data-workflow-step="reliability">
+            <div class="card p-3">
+              <h6 class="mb-3">Error strategy</h6>
+              <div class="form-check mb-2">
+                <input class="form-check-input" type="radio" name="workflow-error-strategy" id="workflow-error-strategy-halt" value="halt" checked />
+                <label class="form-check-label" for="workflow-error-strategy-halt">Stop when a task still fails after retries</label>
+              </div>
+              <div class="form-check mb-3">
+                <input class="form-check-input" type="radio" name="workflow-error-strategy" id="workflow-error-strategy-continue" value="continue" />
+                <label class="form-check-label" for="workflow-error-strategy-continue">Record the failure and continue to the next task</label>
+              </div>
+              <div class="border-top pt-3">
+                <label for="workflow-task-retry-count" class="form-label">Task Retry Count</label>
+                <input type="number" class="form-control workflow-retry-input" id="workflow-task-retry-count" min="0" max="5" value="0" />
+                <div class="form-text">Retries apply to each task before the selected error strategy.</div>
+              </div>
+            </div>
+          </div>
+          <div class="workflow-step-block" id="workflow-review-summary-block" data-workflow-step="review">
+            <div class="workflow-review-summary" id="workflow-review-summary" aria-live="polite"></div>
+          </div>
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
-          <button type="submit" class="btn btn-primary" id="workflow-save-btn">Save Personal Workflow</button>
+          <button type="button" class="btn btn-outline-secondary d-none" id="workflow-step-back-btn"><i class="bi bi-arrow-left me-1" aria-hidden="true"></i>Back</button>
+          <button type="button" class="btn btn-primary" id="workflow-step-next-btn">Next<i class="bi bi-arrow-right ms-1" aria-hidden="true"></i></button>
+          <button type="submit" class="btn btn-primary d-none" id="workflow-save-btn">Save Personal Workflow</button>
         </div>
       </form>
     </div>

--- a/application/single_app/templates/workspace.html
+++ b/application/single_app/templates/workspace.html
@@ -1482,10 +1482,13 @@
           {% endif %}
 
           <div class="card p-3 mb-3">
+            <h6 class="mb-1">Workspace documents</h6>
+            <div class="form-text mb-3">Optional. Use a document action only when this workflow needs workspace document context.</div>
             <div class="row g-3 mb-2">
               <div class="col-md-6">
-                <label for="workflow-document-action-type" class="form-label">Action Type</label>
-                <select class="form-select" id="workflow-document-action-type" title="Search selected or recent documents and use matching excerpts as workflow context.">
+                <label for="workflow-document-action-type" class="form-label">Document action</label>
+                <select class="form-select" id="workflow-document-action-type" title="Run the workflow instructions without workspace document context.">
+                  <option value="none" data-action-description="Run the workflow instructions without workspace document context." title="Run the workflow instructions without workspace document context.">No document action</option>
                   <option value="search" data-action-description="Search selected or recent documents and use matching excerpts as workflow context." title="Search selected or recent documents and use matching excerpts as workflow context.">Search</option>
                   {% if settings.document_action_capabilities.analyze.enabled %}
                   <option value="analyze" data-action-description="Perform an in-depth analysis across all selected documents based on your request." title="Perform an in-depth analysis across all selected documents based on your request.">Analyze</option>
@@ -1495,12 +1498,12 @@
                   {% endif %}
                 </select>
               </div>
-              <div class="col-md-6">
+              <div class="col-md-6 d-none" id="workflow-analysis-retries-group">
                 <label for="workflow-analysis-retries" class="form-label">Retries Per Window</label>
                 <input type="number" class="form-control" id="workflow-analysis-retries" min="0" max="5" value="1" />
               </div>
             </div>
-            <div class="form-text mt-2" id="workflow-document-action-help">Search selected or recent documents and use matching excerpts as workflow context.</div>
+            <div class="form-text mt-2" id="workflow-document-action-help">Run the workflow instructions without workspace document context.</div>
 
             <div id="workflow-document-targets-fields" class="mt-3 d-none">
               <input type="hidden" id="workflow-analysis-doc-scope" value="personal" />
@@ -1541,6 +1544,7 @@
                 </div>
                 <div id="workflow-document-picker-error" class="alert alert-warning py-2 d-none" role="alert"></div>
                 <select class="d-none" id="document-action-select" aria-label="Workflow document action">
+                  <option value="none">No document action</option>
                   <option value="search">Search</option>
                   {% if settings.document_action_capabilities.analyze.enabled %}
                   <option value="analyze">Analyze</option>

--- a/docs/explanation/features/GENERIC_WORKFLOW_AUTOMATION.md
+++ b/docs/explanation/features/GENERIC_WORKFLOW_AUTOMATION.md
@@ -1,6 +1,7 @@
 # Generic Workflow Automation
 
 Implemented in version: **0.250.063**
+Enhanced in version: **0.250.064**
 
 Related issue: #1082
 
@@ -15,7 +16,7 @@ to the task.
 Fixed/Implemented in version: **0.250.063**
 
 Related version update:
-- `application/single_app/config.py` reports version `0.250.063`.
+- `application/single_app/config.py` reports version `0.250.064`.
 
 Dependencies:
 - `application/single_app/functions_personal_workflows.py`
@@ -40,6 +41,11 @@ Dependencies:
   without requiring document analysis.
 - Each run records its messages and result in the workflow conversation and
   retains the normal workflow run history.
+- A workflow can contain up to 20 ordered instruction tasks. Every task uses the
+   selected workflow runner and receives a bounded copy of the previous task's
+   response as context.
+- Global task error handling supports 0-5 retries and either stops the workflow
+   after the final failed attempt or records the failure and continues.
 
 New workflow definitions set `chat_capabilities_enabled` to `true`. Existing
 saved Direct Model workflows remain on their prior raw-completion behavior when
@@ -72,6 +78,10 @@ workflows. Document picker and analysis controls are initialized only after a
 document action is selected. Search, Analyze, and Compare continue to use the
 existing document-specialized execution paths and validation.
 
+For ordered workflows, the configured document action applies to the first
+task. Later tasks consume the prior task response without repeating document
+retrieval or analysis. File Sync remains a single optional pre-run input stage.
+
 File Sync remains independent of document selection. A workflow can run after
 syncing sources and then execute its model or agent instruction without a
 document action. A File Sync trigger still requires the existing completion and
@@ -89,16 +99,17 @@ enabled plugins.
 ## Usage Instructions
 
 1. Open the Personal Workspace or a Group Workspace and select Workflows.
-2. Create a workflow, provide a name and instructions, and choose Direct Model
-   or Agent.
-3. Leave `Workspace documents` set to `No document action` for prompt-only or
-   agent-only automation.
-4. Optionally choose Search, Analyze, or Compare when the workflow needs
-   workspace document context.
-5. Choose Manual, Interval, or File Sync trigger behavior. Configure File Sync
-   only when the workflow needs to synchronize sources before it runs.
-6. Save the workflow and review results, citations, and supported artifacts in
-   its workflow conversation and run history.
+2. In `General`, provide a name and choose Direct Model or Agent.
+3. In `Trigger`, choose Manual, Interval, or File Sync behavior and configure
+   optional URL or File Sync inputs.
+4. In `Tasks`, add, edit, remove, or reorder instruction tasks. Leave
+   `Workspace documents` set to `No document action` for prompt-only or
+   agent-only automation, or choose Search, Analyze, or Compare for task one.
+5. In `Reliability`, choose the task retry count and whether execution stops or
+   continues after a failed task.
+6. In `Review`, confirm the workflow and choose its completion alert priority.
+7. Save the workflow and review task outcomes, citations, and supported
+   artifacts in its workflow conversation and run history.
 
 ## Testing And Validation
 
@@ -108,11 +119,17 @@ Functional coverage:
 - `functional_tests/test_workflow_model_core_capabilities.py` verifies saved
   model binding, kernel-based core capability invocation, default-model binding,
   and legacy Direct Model compatibility.
+- `functional_tests/test_workflow_task_sequence.py` verifies ordered execution,
+   bounded result chaining, retries, continue-on-error behavior, and legacy
+   dispatch compatibility.
+- `functional_tests/test_workflow_stepped_builder.py` verifies the shared
+   five-step modal, browser payload, safe task rendering, and existing route
+   reuse.
 
 UI coverage:
 - `ui_tests/test_workflow_document_action_modal.py` verifies that a new
-  workflow defaults to `No document action`, hides document-only fields, and
-  submits a document-free Direct Model payload.
+   workflow navigates all five steps, builds an ordered task sequence, configures
+   error handling and alert priority, and preserves document action workflows.
 
 Validation should include the focused functional tests, JavaScript syntax
 validation, and the UI test against an authenticated `SIMPLECHAT_UI_BASE_URL`

--- a/docs/explanation/features/GENERIC_WORKFLOW_AUTOMATION.md
+++ b/docs/explanation/features/GENERIC_WORKFLOW_AUTOMATION.md
@@ -1,0 +1,119 @@
+# Generic Workflow Automation
+
+Implemented in version: **0.250.063**
+
+Related issue: #1082
+
+## Overview
+
+Workflows are repeatable AI automations. Their required configuration is a
+workflow instruction and one runner: either a Direct Model or an Agent.
+Workspace documents, document actions, File Sync, URL access, alerts, and
+scheduling are optional capabilities that can be added when they are relevant
+to the task.
+
+Fixed/Implemented in version: **0.250.063**
+
+Related version update:
+- `application/single_app/config.py` reports version `0.250.063`.
+
+Dependencies:
+- `application/single_app/functions_personal_workflows.py`
+- `application/single_app/functions_group_workflows.py`
+- `application/single_app/functions_workflow_runner.py`
+- `application/single_app/functions_model_endpoint_runtime.py`
+- `application/single_app/semantic_kernel_loader.py`
+- `application/single_app/templates/workspace.html`
+- `application/single_app/templates/group_workspaces.html`
+- `application/single_app/static/js/workspace/workspace_workflows.js`
+
+## Technical Specifications
+
+### Workflow contract
+
+- Required: `task_prompt` and `runner_type` (`model` or `agent`).
+- Optional document context: `document_action` can be `none`, `search`,
+  `analyze`, or `comparison`.
+- Optional trigger: manual execution, interval schedule, or File Sync change
+  monitoring.
+- Optional pre-run step: File Sync can run before manual or interval workflows
+  without requiring document analysis.
+- Each run records its messages and result in the workflow conversation and
+  retains the normal workflow run history.
+
+New workflow definitions set `chat_capabilities_enabled` to `true`. Existing
+saved Direct Model workflows remain on their prior raw-completion behavior when
+the field is absent, preserving established results until they are explicitly
+migrated or recreated.
+
+### Direct Model execution
+
+When `chat_capabilities_enabled` is enabled, a Direct Model workflow:
+
+1. Resolves the workflow's saved model endpoint and model selection.
+2. Creates a Semantic Kernel chat service for that selected model, including a
+   configured default-model selection when one is in use.
+3. Loads the same headless core plugins used by model-only chat: document
+   search, time, math, text, tabular processing, and conversation charts when
+   enabled by settings.
+4. Invokes the chat service with `FunctionChoiceBehavior.Auto` and the kernel
+   instance so supported model tool calls can execute.
+5. Saves the response, plugin citations, alerts, and workflow conversation
+   metadata through the standard workflow run path.
+
+The workflow runner establishes a scoped user, conversation, workflow, and
+group authorization context before loading tools. Group workflows retain their
+active group scope while core tools execute.
+
+### Document actions and File Sync
+
+The `No document action` option is the default for new personal and group
+workflows. Document picker and analysis controls are initialized only after a
+document action is selected. Search, Analyze, and Compare continue to use the
+existing document-specialized execution paths and validation.
+
+File Sync remains independent of document selection. A workflow can run after
+syncing sources and then execute its model or agent instruction without a
+document action. A File Sync trigger still requires the existing completion and
+changed-files safeguards.
+
+### Headless capability boundary
+
+Workflows support server-side core capabilities that can run safely without an
+interactive browser session. Streaming, browser-only upload interactions, and
+workflows that require a user approval gesture are not executed headlessly.
+Model endpoint protocols that do not support function calling still return a
+normal model response; capability use depends on the selected endpoint and
+enabled plugins.
+
+## Usage Instructions
+
+1. Open the Personal Workspace or a Group Workspace and select Workflows.
+2. Create a workflow, provide a name and instructions, and choose Direct Model
+   or Agent.
+3. Leave `Workspace documents` set to `No document action` for prompt-only or
+   agent-only automation.
+4. Optionally choose Search, Analyze, or Compare when the workflow needs
+   workspace document context.
+5. Choose Manual, Interval, or File Sync trigger behavior. Configure File Sync
+   only when the workflow needs to synchronize sources before it runs.
+6. Save the workflow and review results, citations, and supported artifacts in
+   its workflow conversation and run history.
+
+## Testing And Validation
+
+Functional coverage:
+- `functional_tests/test_generic_workflow_automation.py` verifies the
+  document-optional modal contract and Direct Model/Agent runner paths.
+- `functional_tests/test_workflow_model_core_capabilities.py` verifies saved
+  model binding, kernel-based core capability invocation, default-model binding,
+  and legacy Direct Model compatibility.
+
+UI coverage:
+- `ui_tests/test_workflow_document_action_modal.py` verifies that a new
+  workflow defaults to `No document action`, hides document-only fields, and
+  submits a document-free Direct Model payload.
+
+Validation should include the focused functional tests, JavaScript syntax
+validation, and the UI test against an authenticated `SIMPLECHAT_UI_BASE_URL`
+environment.

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,24 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](/explanation/features/) and [Fixes by Version](/explanation/fixes/).
 
+### **(v0.250.064)**
+
+#### New Features
+
+*   **Repeatable AI Workflow Task Sequences**
+    *   Personal and group workflows can now run with only instructions and a selected model or agent; workspace documents, File Sync, URL access, schedules, and completion alerts remain optional.
+    *   Workflows support ordered instruction tasks that share the selected runner and receive bounded prior-task output as context.
+    *   Added per-task retries and stop-or-continue error handling, with task outcomes recorded in run history and workflow activity.
+    *   Existing document Search, Analyze, and Compare behavior remains available as optional input for the first task, while existing workflows without task sequences retain their prior execution path.
+    *   (Ref: microsoft/simplechat#1082, `functions_personal_workflows.py`, `functions_group_workflows.py`, `functions_workflow_runner.py`)
+
+#### User Interface Enhancements
+
+*   **Stepped Workflow Builder**
+    *   Replaced the single-pane personal and group workflow form with a five-step General, Trigger, Tasks, Reliability, and Review builder.
+    *   Users can add, edit, remove, and reorder tasks, configure retry and failure behavior, and review runner, trigger, document input, File Sync, and pop-up alert settings before saving.
+    *   (Ref: microsoft/simplechat#1082, `workspace.html`, `group_workspaces.html`, `workspace_workflows.js`, `workspace-responsive.css`)
+
 ### **(v0.250.062)**
 
 #### New Features

--- a/functional_tests/test_generic_workflow_automation.py
+++ b/functional_tests/test_generic_workflow_automation.py
@@ -1,8 +1,9 @@
 # test_generic_workflow_automation.py
 """
 Functional test for generic workflow automation.
-Version: 0.250.063
+Version: 0.250.064
 Implemented in: 0.250.063
+Enhanced in: 0.250.064
 
 This test ensures a workflow requires instructions and a selected model or
 agent, while workspace document actions remain explicitly optional.
@@ -12,7 +13,7 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
-EXPECTED_VERSION = "0.250.063"
+EXPECTED_VERSION = "0.250.064"
 
 
 def read_text(relative_path: str) -> str:
@@ -35,7 +36,7 @@ def test_generic_workflow_ui_defaults_to_no_document_action() -> None:
 
     assert f'VERSION = "{EXPECTED_VERSION}"' in config_content
     assert "# Generic Workflow Automation" in feature_doc_content
-    assert f"Implemented in version: **{EXPECTED_VERSION}**" in feature_doc_content
+    assert f"Enhanced in version: **{EXPECTED_VERSION}**" in feature_doc_content
     assert "No document action" in feature_doc_content
     assert "workflowDocumentActionTypeSelect.value = DOCUMENT_ACTION_NONE;" in workflow_js_content
     assert "const documentActionType = normalizeText(workflowDocumentActionTypeSelect?.value) || DOCUMENT_ACTION_NONE;" in workflow_js_content
@@ -64,7 +65,7 @@ def test_generic_workflow_runner_retains_direct_execution_paths() -> None:
     workflow_runner_content = read_text("application/single_app/functions_workflow_runner.py")
     workflow_js_content = read_text("application/single_app/static/js/workspace/workspace_workflows.js")
 
-    assert "task_prompt = _normalize_text(workflow_data.get('task_prompt'), 'Task prompt', required=True)" in workflow_store_content
+    assert "workflow_data.get('task_prompt') or (tasks[0].get('instructions') if tasks else '')" in workflow_store_content
     assert "runner_type = _normalize_text(workflow_data.get('runner_type'), 'Runner type', required=True).lower()" in workflow_store_content
     assert "'chat_capabilities_enabled': chat_capabilities_enabled," in workflow_store_content
     assert "'chat_capabilities_enabled': chat_capabilities_enabled," in group_workflow_store_content
@@ -72,6 +73,8 @@ def test_generic_workflow_runner_retains_direct_execution_paths() -> None:
     assert "elif execution_workflow.get('runner_type') == 'agent':" in workflow_runner_content
     assert "lambda: _execute_agent_workflow(" in workflow_runner_content
     assert "lambda: _execute_model_workflow(" in workflow_runner_content
+    assert "if execution_workflow.get('tasks'):" in workflow_runner_content
+    assert "execution_result = _execute_workflow_dispatch(" in workflow_runner_content
 
     print("PASS: generic workflow execution retains direct model and agent paths")
 

--- a/functional_tests/test_generic_workflow_automation.py
+++ b/functional_tests/test_generic_workflow_automation.py
@@ -1,0 +1,100 @@
+# test_generic_workflow_automation.py
+"""
+Functional test for generic workflow automation.
+Version: 0.250.063
+Implemented in: 0.250.063
+
+This test ensures a workflow requires instructions and a selected model or
+agent, while workspace document actions remain explicitly optional.
+"""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+EXPECTED_VERSION = "0.250.063"
+
+
+def read_text(relative_path: str) -> str:
+    return (ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def get_document_action_selector(template_content: str) -> str:
+    selector_start = template_content.index('id="workflow-document-action-type"')
+    selector_end = template_content.index("</select>", selector_start)
+    return template_content[selector_start:selector_end]
+
+
+def test_generic_workflow_ui_defaults_to_no_document_action() -> None:
+    """New personal and group workflows must expose and default to no document action."""
+    print("Testing generic workflow document-optional UI contract...")
+
+    config_content = read_text("application/single_app/config.py")
+    feature_doc_content = read_text("docs/explanation/features/GENERIC_WORKFLOW_AUTOMATION.md")
+    workflow_js_content = read_text("application/single_app/static/js/workspace/workspace_workflows.js")
+
+    assert f'VERSION = "{EXPECTED_VERSION}"' in config_content
+    assert "# Generic Workflow Automation" in feature_doc_content
+    assert f"Implemented in version: **{EXPECTED_VERSION}**" in feature_doc_content
+    assert "No document action" in feature_doc_content
+    assert "workflowDocumentActionTypeSelect.value = DOCUMENT_ACTION_NONE;" in workflow_js_content
+    assert "const documentActionType = normalizeText(workflowDocumentActionTypeSelect?.value) || DOCUMENT_ACTION_NONE;" in workflow_js_content
+    assert "if (actionType === DOCUMENT_ACTION_NONE) {" in workflow_js_content
+    assert "setWorkflowPickerLoadingState(false);" in workflow_js_content
+    assert "setElementVisibility(workflowAnalysisRetriesGroup, hasWindowedDocumentAction);" in workflow_js_content
+
+    for template_path in (
+        "application/single_app/templates/workspace.html",
+        "application/single_app/templates/group_workspaces.html",
+    ):
+        selector_content = get_document_action_selector(read_text(template_path))
+        assert '<option value="none"' in selector_content
+        assert ">No document action</option>" in selector_content
+        assert selector_content.index('value="none"') < selector_content.index('value="search"')
+
+    print("PASS: generic workflow UI defaults to no document action")
+
+
+def test_generic_workflow_runner_retains_direct_execution_paths() -> None:
+    """No-document workflows must retain both direct model and agent execution branches."""
+    print("Testing generic workflow execution contract...")
+
+    workflow_store_content = read_text("application/single_app/functions_personal_workflows.py")
+    group_workflow_store_content = read_text("application/single_app/functions_group_workflows.py")
+    workflow_runner_content = read_text("application/single_app/functions_workflow_runner.py")
+    workflow_js_content = read_text("application/single_app/static/js/workspace/workspace_workflows.js")
+
+    assert "task_prompt = _normalize_text(workflow_data.get('task_prompt'), 'Task prompt', required=True)" in workflow_store_content
+    assert "runner_type = _normalize_text(workflow_data.get('runner_type'), 'Runner type', required=True).lower()" in workflow_store_content
+    assert "'chat_capabilities_enabled': chat_capabilities_enabled," in workflow_store_content
+    assert "'chat_capabilities_enabled': chat_capabilities_enabled," in group_workflow_store_content
+    assert "chat_capabilities_enabled: currentEditingWorkflow" in workflow_js_content
+    assert "elif execution_workflow.get('runner_type') == 'agent':" in workflow_runner_content
+    assert "lambda: _execute_agent_workflow(" in workflow_runner_content
+    assert "lambda: _execute_model_workflow(" in workflow_runner_content
+
+    print("PASS: generic workflow execution retains direct model and agent paths")
+
+
+def run_tests() -> bool:
+    tests = [
+        test_generic_workflow_ui_defaults_to_no_document_action,
+        test_generic_workflow_runner_retains_direct_execution_paths,
+    ]
+    results = []
+
+    for test in tests:
+        print(f"Running {test.__name__}...")
+        try:
+            test()
+            results.append(True)
+        except Exception as exc:
+            print(f"FAIL: {exc}")
+            results.append(False)
+
+    print(f"Results: {sum(results)}/{len(results)} tests passed")
+    return all(results)
+
+
+if __name__ == "__main__":
+    raise SystemExit(0 if run_tests() else 1)

--- a/functional_tests/test_workflow_model_core_capabilities.py
+++ b/functional_tests/test_workflow_model_core_capabilities.py
@@ -1,0 +1,257 @@
+# test_workflow_model_core_capabilities.py
+"""
+Functional test for Direct Model workflow core capabilities.
+Version: 0.250.063
+Implemented in: 0.250.063
+
+This test ensures new Direct Model workflows bind their saved model selection
+to a Semantic Kernel service and pass the kernel to auto-invoked core tools.
+"""
+
+import ast
+import asyncio
+from contextlib import contextmanager
+from pathlib import Path
+from types import SimpleNamespace
+
+from semantic_kernel.connectors.ai.function_choice_behavior import FunctionChoiceBehavior
+from semantic_kernel.connectors.ai.prompt_execution_settings import PromptExecutionSettings
+from semantic_kernel.contents.chat_history import ChatHistory
+
+
+ROOT = Path(__file__).resolve().parents[1]
+RUNNER_FILE = ROOT / "application" / "single_app" / "functions_workflow_runner.py"
+
+
+class FakeKernel:
+    """Minimal kernel double that captures the selected chat service."""
+
+    def __init__(self):
+        self.services = []
+
+    def add_service(self, service):
+        self.services.append(service)
+
+
+class FakeChatService:
+    """Minimal asynchronous chat service double for the workflow adapter."""
+
+    def __init__(self):
+        self.call = None
+
+    async def get_chat_message_contents(self, chat_history, settings, **kwargs):
+        self.call = {
+            "chat_history": chat_history,
+            "settings": settings,
+            "kwargs": kwargs,
+        }
+        return [SimpleNamespace(content="Core capability result")]
+
+
+class FakePluginLogger:
+    """Captures conversation-scoped plugin logging interactions."""
+
+    def __init__(self):
+        self.cleared_conversations = []
+        self.deregistered_keys = []
+
+    def clear_invocations_for_conversation(self, user_id, conversation_id):
+        self.cleared_conversations.append((user_id, conversation_id))
+
+    def deregister_callbacks(self, callback_key):
+        self.deregistered_keys.append(callback_key)
+
+
+def load_model_core_helpers():
+    """Load the isolated model-core helpers with deterministic dependencies."""
+    parsed = ast.parse(RUNNER_FILE.read_text(encoding="utf-8"), filename=str(RUNNER_FILE))
+    helper_names = {
+        "_workflow_model_chat_capabilities_enabled",
+        "_build_workflow_model_context",
+        "_workflow_model_core_execution_context",
+        "_execute_model_workflow_with_core_capabilities",
+        "_execute_model_workflow",
+    }
+    helper_nodes = [
+        node
+        for node in parsed.body
+        if isinstance(node, ast.FunctionDef) and node.name in helper_names
+    ]
+    assert len(helper_nodes) == len(helper_names), "Expected all Direct Model core capability helpers."
+
+    kernel = FakeKernel()
+    chat_service = FakeChatService()
+    plugin_logger = FakePluginLogger()
+    loaded_core_plugin_settings = []
+    semantic_service_requests = []
+    fake_g = SimpleNamespace(conversation_id="previous-conversation")
+
+    @contextmanager
+    def ensure_execution_context(_user_id):
+        yield
+
+    namespace = {
+        "asyncio": asyncio,
+        "ChatHistory": ChatHistory,
+        "FunctionChoiceBehavior": FunctionChoiceBehavior,
+        "Kernel": lambda: kernel,
+        "PromptExecutionSettings": PromptExecutionSettings,
+        "_add_workflow_activity_thought": lambda *args, **kwargs: None,
+        "_build_agent_citations_from_invocations": lambda user_id, conversation_id: [
+            {"user_id": user_id, "conversation_id": conversation_id}
+        ],
+        "_build_workflow_chat_messages": lambda prompt, **kwargs: [
+            {"role": "user", "content": prompt}
+        ],
+        "_collect_agent_alert_targets": lambda user_id, conversation_id: [
+            {"user_id": user_id, "conversation_id": conversation_id}
+        ],
+        "_ensure_execution_context": ensure_execution_context,
+        "_execute_cancelable_workflow_step": lambda workflow, run_id, operation: operation(),
+        "_execute_raw_model_workflow": lambda *args, **kwargs: {"reply": "legacy"},
+        "_extract_message_text": lambda message_content: str(message_content or ""),
+        "_get_workflow_group_id": lambda workflow: str(workflow.get("group_id") or ""),
+        "_raise_if_workflow_run_cancelled": lambda workflow, run_id: None,
+        "_resolve_model_workflow_client": lambda workflow, settings: (
+            object(),
+            "workflow-deployment",
+            "aoai",
+        ),
+        "build_semantic_kernel_chat_service_for_model": lambda deployment_name, settings, **kwargs: (
+            semantic_service_requests.append({
+                "deployment_name": deployment_name,
+                "settings": settings,
+                **kwargs,
+            }) or chat_service,
+            "azure_openai",
+        ),
+        "contextmanager": contextmanager,
+        "g": fake_g,
+        "get_max_auto_invoke_attempts": lambda settings: int(settings["max_auto_invoke_attempts"]),
+        "get_plugin_logger": lambda: plugin_logger,
+        "get_workflow_kernel_settings": lambda settings: {"max_auto_invoke_attempts": 7},
+        "load_core_plugins_only": lambda selected_kernel, settings: loaded_core_plugin_settings.append(
+            (selected_kernel, settings)
+        ),
+        "register_plugin_invocation_thought_callback": lambda *args, **kwargs: "callback-key",
+    }
+    module = ast.Module(body=helper_nodes, type_ignores=[])
+    exec(compile(module, str(RUNNER_FILE), "exec"), namespace)
+    return namespace, kernel, chat_service, plugin_logger, loaded_core_plugin_settings, semantic_service_requests, fake_g
+
+
+def test_direct_model_workflow_binds_core_capabilities_to_saved_model() -> None:
+    """Validate direct model core capability execution uses the selected model and kernel."""
+    print("Testing Direct Model workflow core capability adapter...")
+    (
+        helpers,
+        kernel,
+        chat_service,
+        plugin_logger,
+        loaded_core_plugin_settings,
+        semantic_service_requests,
+        fake_g,
+    ) = load_model_core_helpers()
+
+    workflow = {
+        "id": "workflow-1",
+        "user_id": "user-1",
+        "group_id": "group-1",
+        "task_prompt": "Create a chart from the available tabular data.",
+        "model_endpoint_id": "endpoint-1",
+        "model_id": "model-1",
+        "model_provider": "aoai",
+        "chat_capabilities_enabled": True,
+    }
+    result = helpers["_execute_model_workflow"](
+        workflow,
+        {"enable_semantic_kernel": True},
+        conversation_id="workflow-conversation-1",
+        run_id="run-1",
+    )
+
+    assert result["reply"] == "Core capability result"
+    assert result["core_capabilities_enabled"] is True
+    assert result["agent_citations"] == [{"user_id": "user-1", "conversation_id": "workflow-conversation-1"}]
+    assert kernel.services == [chat_service]
+    assert loaded_core_plugin_settings == [(kernel, {"max_auto_invoke_attempts": 7})]
+    assert semantic_service_requests[0]["deployment_name"] == "workflow-deployment"
+    assert semantic_service_requests[0]["model_context"] == {
+        "user_id": "user-1",
+        "model_deployment": "workflow-deployment",
+        "provider": "aoai",
+        "endpoint_id": "endpoint-1",
+        "model_id": "model-1",
+        "active_group_ids": ["group-1"],
+    }
+    assert chat_service.call["kwargs"]["kernel"] is kernel
+    assert chat_service.call["settings"].function_choice_behavior is not None
+    assert plugin_logger.cleared_conversations == [("user-1", "workflow-conversation-1")]
+    assert fake_g.conversation_id == "previous-conversation"
+    assert not hasattr(fake_g, "workflow_id")
+
+    print("PASS: Direct Model workflow uses core capabilities with its saved model")
+
+
+def test_legacy_direct_model_workflow_retains_raw_completion() -> None:
+    """Legacy workflows without the new flag must keep their existing direct path."""
+    print("Testing Direct Model workflow legacy compatibility...")
+    helpers, *_ = load_model_core_helpers()
+
+    result = helpers["_execute_model_workflow"](
+        {"user_id": "user-1", "chat_capabilities_enabled": False},
+        {},
+    )
+
+    assert result == {"reply": "legacy"}
+    print("PASS: legacy Direct Model workflow keeps raw completion")
+
+
+def test_default_model_selection_context_retains_saved_endpoint() -> None:
+    """Default app model selections must retain their saved endpoint identity."""
+    print("Testing default model selection context...")
+    helpers, *_ = load_model_core_helpers()
+
+    model_context = helpers["_build_workflow_model_context"](
+        {
+            "user_id": "user-1",
+            "model_binding_summary": {
+                "mode": "default_selection",
+                "endpoint_id": "default-endpoint-1",
+                "model_id": "default-model-1",
+                "provider": "aoai",
+            },
+        },
+        "default-deployment",
+        "aoai",
+    )
+
+    assert model_context["endpoint_id"] == "default-endpoint-1"
+    assert model_context["model_id"] == "default-model-1"
+    assert model_context["model_deployment"] == "default-deployment"
+    print("PASS: default model selection context retains saved endpoint")
+
+
+def run_tests() -> bool:
+    tests = [
+        test_direct_model_workflow_binds_core_capabilities_to_saved_model,
+        test_legacy_direct_model_workflow_retains_raw_completion,
+        test_default_model_selection_context_retains_saved_endpoint,
+    ]
+    results = []
+
+    for test in tests:
+        print(f"Running {test.__name__}...")
+        try:
+            test()
+            results.append(True)
+        except Exception as exc:
+            print(f"FAIL: {exc}")
+            results.append(False)
+
+    print(f"Results: {sum(results)}/{len(results)} tests passed")
+    return all(results)
+
+
+if __name__ == "__main__":
+    raise SystemExit(0 if run_tests() else 1)

--- a/functional_tests/test_workflow_model_core_capabilities.py
+++ b/functional_tests/test_workflow_model_core_capabilities.py
@@ -1,8 +1,9 @@
 # test_workflow_model_core_capabilities.py
 """
 Functional test for Direct Model workflow core capabilities.
-Version: 0.250.063
+Version: 0.250.064
 Implemented in: 0.250.063
+Enhanced in: 0.250.064
 
 This test ensures new Direct Model workflows bind their saved model selection
 to a Semantic Kernel service and pass the kernel to auto-invoked core tools.

--- a/functional_tests/test_workflow_stepped_builder.py
+++ b/functional_tests/test_workflow_stepped_builder.py
@@ -1,0 +1,119 @@
+# test_workflow_stepped_builder.py
+"""
+Functional test for the stepped workflow builder.
+Version: 0.250.064
+Implemented in: 0.250.064
+
+This test ensures personal and group workflow modals use the same five-step
+builder and submit ordered tasks and error handling through existing routes.
+"""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+EXPECTED_VERSION = "0.250.064"
+
+
+def read_text(relative_path: str) -> str:
+    return (ROOT / relative_path).read_text(encoding="utf-8")
+
+
+def test_personal_and_group_templates_share_five_step_builder() -> None:
+    """Both workflow scopes must expose the same step and task controls."""
+    print("Testing stepped workflow template contract...")
+    for template_path in (
+        "application/single_app/templates/workspace.html",
+        "application/single_app/templates/group_workspaces.html",
+    ):
+        content = read_text(template_path)
+        for step in ("general", "trigger", "tasks", "reliability", "review"):
+            assert f'data-workflow-step-target="{step}"' in content
+            assert f'data-workflow-step="{step}"' in content
+        for element_id in (
+            "workflow-task-list",
+            "workflow-add-task-btn",
+            "workflow-task-name",
+            "workflow-error-strategy-halt",
+            "workflow-error-strategy-continue",
+            "workflow-task-retry-count",
+            "workflow-review-summary",
+            "workflow-step-back-btn",
+            "workflow-step-next-btn",
+        ):
+            assert f'id="{element_id}"' in content
+        assert "modal-dialog modal-xl modal-dialog-scrollable" in content
+        assert "cdn.tailwindcss.com" not in content
+        assert "fonts.googleapis.com" not in content
+
+    print("PASS: stepped workflow template contract")
+
+
+def test_shared_browser_behavior_builds_safe_ordered_task_payload() -> None:
+    """The shared module must safely render and submit task sequence state."""
+    print("Testing stepped workflow browser behavior contract...")
+    content = read_text("application/single_app/static/js/workspace/workspace_workflows.js")
+
+    for function_name in (
+        "renderWorkflowTasks",
+        "addWorkflowTask",
+        "moveWorkflowTask",
+        "removeWorkflowTask",
+        "initializeWorkflowTasks",
+        "renderWorkflowReview",
+        "validateWorkflowStep",
+        "showWorkflowStep",
+        "navigateWorkflowStep",
+    ):
+        assert f"function {function_name}(" in content
+    assert "workflowTasks.map((task, index) => ({" in content
+    assert "error_handling:" in content
+    assert "workflow-review-summary__item" in content
+    assert 'name.textContent = task.name || `Task ${index + 1}`;' in content
+    assert "item.innerHTML" not in content
+
+    print("PASS: stepped workflow browser behavior contract")
+
+
+def test_existing_routes_persist_tasks_without_new_endpoints() -> None:
+    """Task sequencing must reuse current create/update and run routes."""
+    print("Testing stepped workflow route and persistence contract...")
+    personal_store = read_text("application/single_app/functions_personal_workflows.py")
+    group_store = read_text("application/single_app/functions_group_workflows.py")
+    routes = read_text("application/single_app/route_backend_workflows.py")
+    config = read_text("application/single_app/config.py")
+
+    assert f'VERSION = "{EXPECTED_VERSION}"' in config
+    assert "'tasks': tasks," in personal_store
+    assert "'error_handling': error_handling," in personal_store
+    assert "'tasks': tasks," in group_store
+    assert "'error_handling': error_handling," in group_store
+    assert "save_personal_workflow(" in routes
+    assert "save_group_workflow(" in routes
+    assert "/api/user/workflows/<workflow_id>/run" in routes
+    assert "/api/group/workflows/<workflow_id>/run" in routes
+
+    print("PASS: stepped workflow route and persistence contract")
+
+
+def run_tests() -> bool:
+    tests = [
+        test_personal_and_group_templates_share_five_step_builder,
+        test_shared_browser_behavior_builds_safe_ordered_task_payload,
+        test_existing_routes_persist_tasks_without_new_endpoints,
+    ]
+    results = []
+    for test in tests:
+        print(f"Running {test.__name__}...")
+        try:
+            test()
+            results.append(True)
+        except Exception as exc:
+            print(f"FAIL: {exc}")
+            results.append(False)
+    print(f"Results: {sum(results)}/{len(results)} tests passed")
+    return all(results)
+
+
+if __name__ == "__main__":
+    raise SystemExit(0 if run_tests() else 1)

--- a/functional_tests/test_workflow_task_sequence.py
+++ b/functional_tests/test_workflow_task_sequence.py
@@ -1,0 +1,238 @@
+# test_workflow_task_sequence.py
+"""
+Functional test for ordered workflow task sequences.
+Version: 0.250.064
+Implemented in: 0.250.064
+
+This test ensures workflow tasks are normalized in order, execute with bounded
+prior-task context, retry safely, and honor halt or continue error strategies.
+"""
+
+import ast
+import uuid
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+APP_ROOT = ROOT / "application" / "single_app"
+STORE_FILE = APP_ROOT / "functions_personal_workflows.py"
+RUNNER_FILE = APP_ROOT / "functions_workflow_runner.py"
+EXPECTED_VERSION = "0.250.064"
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def load_functions(path: Path, function_names: set[str], namespace: dict) -> dict:
+    parsed = ast.parse(read_text(path), filename=str(path))
+    selected_nodes = [
+        node
+        for node in parsed.body
+        if isinstance(node, ast.FunctionDef) and node.name in function_names
+    ]
+    assert len(selected_nodes) == len(function_names), f"Expected functions {sorted(function_names)}"
+    exec(compile(ast.Module(body=selected_nodes, type_ignores=[]), str(path), "exec"), namespace)
+    return namespace
+
+
+def load_store_helpers() -> dict:
+    return load_functions(
+        STORE_FILE,
+        {
+            "_normalize_text",
+            "_normalize_workflow_tasks",
+            "_normalize_workflow_error_handling",
+        },
+        {
+            "uuid": uuid,
+            "WORKFLOW_ERROR_STRATEGIES": {"halt", "continue"},
+            "WORKFLOW_MAX_TASKS": 20,
+            "WORKFLOW_TASK_INSTRUCTIONS_MAX_LENGTH": 12000,
+            "WORKFLOW_TASK_NAME_MAX_LENGTH": 120,
+        },
+    )
+
+
+def load_runner_helpers(dispatch):
+    saved_items = []
+    timestamps = iter(f"2026-07-27T00:00:{index:02d}+00:00" for index in range(60))
+    namespace = {
+        "DOCUMENT_ACTION_TYPE_NONE": "none",
+        "WORKFLOW_TASK_CONTEXT_MAX_CHARS": 12000,
+        "_add_workflow_activity_thought": lambda *args, **kwargs: None,
+        "_build_response_preview": lambda value, max_length=220: str(value or "")[:max_length],
+        "_execute_workflow_dispatch": dispatch,
+        "_get_workflow_group_id": lambda workflow: str(workflow.get("group_id") or ""),
+        "_merge_token_usage_summaries": lambda results: {
+            "total_tokens": sum(int((result.get("token_usage") or {}).get("total_tokens") or 0) for result in results)
+        },
+        "_save_workflow_run_item_record": lambda workflow, item: saved_items.append(dict(item)) or item,
+        "_utc_now_iso": lambda: next(timestamps),
+        "build_analyze_config": lambda action: {"enabled": action.get("type") == "analyze"},
+        "uuid": uuid,
+    }
+    helpers = load_functions(
+        RUNNER_FILE,
+        {
+            "_truncate_workflow_task_context",
+            "_build_workflow_task_execution_workflow",
+            "_workflow_task_run_item_id",
+            "_save_workflow_task_run_item",
+            "_merge_workflow_task_execution_results",
+            "_execute_workflow_task_sequence",
+        },
+        namespace,
+    )
+    return helpers, saved_items
+
+
+def test_task_and_error_policy_normalization() -> None:
+    """Normalize ordered instruction tasks and bounded error handling."""
+    print("Testing workflow task normalization...")
+    helpers = load_store_helpers()
+
+    tasks = helpers["_normalize_workflow_tasks"]({
+        "tasks": [
+            {"id": "collect", "name": "Collect", "instructions": "Collect the source facts."},
+            {"id": "summarize", "name": "Summarize", "instructions": "Summarize the facts."},
+        ]
+    })
+    policy = helpers["_normalize_workflow_error_handling"]({
+        "error_handling": {"strategy": "continue", "retry_count": 2}
+    })
+
+    assert [task["order"] for task in tasks] == [1, 2]
+    assert [task["type"] for task in tasks] == ["instructions", "instructions"]
+    assert policy == {"strategy": "continue", "retry_count": 2}
+
+    try:
+        helpers["_normalize_workflow_tasks"]({"tasks": []})
+        raise AssertionError("Expected an empty task list to be rejected.")
+    except ValueError as exc:
+        assert "at least one" in str(exc)
+
+    print("PASS: workflow task normalization")
+
+
+def test_ordered_tasks_chain_context_and_apply_documents_once() -> None:
+    """Execute tasks in order and apply configured document input only to task one."""
+    print("Testing ordered task context chaining...")
+    dispatched_workflows = []
+
+    def dispatch(workflow, *_args, **_kwargs):
+        dispatched_workflows.append(dict(workflow))
+        return {
+            "reply": f"Result {len(dispatched_workflows)}",
+            "token_usage": {"total_tokens": 5},
+            "agent_citations": [{"task": len(dispatched_workflows)}],
+        }
+
+    helpers, saved_items = load_runner_helpers(dispatch)
+    result = helpers["_execute_workflow_task_sequence"](
+        {
+            "id": "workflow-1",
+            "name": "Sequence",
+            "user_id": "user-1",
+            "runner_type": "model",
+            "document_action": {"type": "search", "document_ids": ["doc-1"]},
+            "file_sync_prompt_context": "File Sync context for this workflow run.",
+            "tasks": [
+                {"id": "collect", "name": "Collect", "instructions": "Collect facts."},
+                {"id": "summarize", "name": "Summarize", "instructions": "Write a summary."},
+            ],
+            "error_handling": {"strategy": "halt", "retry_count": 0},
+        },
+        {},
+        "conversation-1",
+        "run-1",
+        None,
+        {},
+    )
+
+    assert [workflow["active_task"]["id"] for workflow in dispatched_workflows] == ["collect", "summarize"]
+    assert dispatched_workflows[0]["document_action"]["type"] == "search"
+    assert "[Workflow input context]" in dispatched_workflows[0]["task_prompt"]
+    assert "File Sync context for this workflow run." in dispatched_workflows[0]["task_prompt"]
+    assert dispatched_workflows[1]["document_action"]["type"] == "none"
+    assert "[Previous workflow task output]" in dispatched_workflows[1]["task_prompt"]
+    assert "Result 1" in dispatched_workflows[1]["task_prompt"]
+    assert result["task_error_count"] == 0
+    assert result["token_usage"]["total_tokens"] == 10
+    assert [item["status"] for item in saved_items if item["item_type"] == "task"][-2:] == ["running", "succeeded"]
+
+    print("PASS: ordered task context chaining")
+
+
+def test_continue_strategy_retries_and_runs_later_tasks() -> None:
+    """Retry failed tasks, record the failure, and continue when configured."""
+    print("Testing workflow task retry and continue strategy...")
+    attempts = {"first": 0, "second": 0}
+
+    def dispatch(workflow, *_args, **_kwargs):
+        task_id = workflow["active_task"]["id"]
+        attempts[task_id] += 1
+        if task_id == "first":
+            raise ValueError("first task failed")
+        return {"reply": "second task succeeded"}
+
+    helpers, saved_items = load_runner_helpers(dispatch)
+    result = helpers["_execute_workflow_task_sequence"](
+        {
+            "id": "workflow-2",
+            "name": "Continue",
+            "user_id": "user-1",
+            "runner_type": "model",
+            "document_action": {"type": "none"},
+            "tasks": [
+                {"id": "first", "name": "First", "instructions": "Fail."},
+                {"id": "second", "name": "Second", "instructions": "Continue."},
+            ],
+            "error_handling": {"strategy": "continue", "retry_count": 1},
+        },
+        {},
+        "conversation-2",
+        "run-2",
+        None,
+        {},
+    )
+
+    assert attempts == {"first": 2, "second": 1}
+    assert result["task_error_count"] == 1
+    assert [task["status"] for task in result["task_results"]] == ["failed", "succeeded"]
+    assert any(item["task_id"] == "first" and item["status"] == "failed" for item in saved_items)
+
+    print("PASS: workflow task retry and continue strategy")
+
+
+def test_version_and_legacy_dispatch_contract() -> None:
+    """Keep the version and legacy no-task dispatch branch explicit."""
+    config_content = read_text(APP_ROOT / "config.py")
+    runner_content = read_text(RUNNER_FILE)
+    assert f'VERSION = "{EXPECTED_VERSION}"' in config_content
+    assert "if execution_workflow.get('tasks'):" in runner_content
+    assert "execution_result = _execute_workflow_dispatch(" in runner_content
+
+
+def run_tests() -> bool:
+    tests = [
+        test_task_and_error_policy_normalization,
+        test_ordered_tasks_chain_context_and_apply_documents_once,
+        test_continue_strategy_retries_and_runs_later_tasks,
+        test_version_and_legacy_dispatch_contract,
+    ]
+    results = []
+    for test in tests:
+        print(f"Running {test.__name__}...")
+        try:
+            test()
+            results.append(True)
+        except Exception as exc:
+            print(f"FAIL: {exc}")
+            results.append(False)
+    print(f"Results: {sum(results)}/{len(results)} tests passed")
+    return all(results)
+
+
+if __name__ == "__main__":
+    raise SystemExit(0 if run_tests() else 1)

--- a/ui_tests/test_workflow_document_action_modal.py
+++ b/ui_tests/test_workflow_document_action_modal.py
@@ -1,8 +1,9 @@
 # test_workflow_document_action_modal.py
 """
 UI test for workflow document action modal.
-Version: 0.250.063
+Version: 0.250.064
 Implemented in: 0.250.063
+Enhanced in: 0.250.064
 
 This test ensures the workflow modal supports generic no-document automation,
 uses Source/Target wording for comparison, and submits version-aware comparison
@@ -144,6 +145,28 @@ def _open_workflows_tab(page):
     expect(page.locator("#workflows-tab")).to_be_visible()
 
 
+def _advance_workflow_builder_to_tasks(page, workflow_name, instructions):
+    """Complete General and Trigger, then initialize the first task."""
+    expect(page.locator("[data-workflow-step-target='general']")).to_have_class("workflow-step-nav__item is-active")
+    expect(page.locator("#workflow-trigger-settings-card")).to_be_hidden()
+    page.fill("#workflow-name", workflow_name)
+    page.click("#workflow-step-next-btn")
+    expect(page.locator("#workflow-trigger-settings-card")).to_be_visible()
+    page.click("#workflow-step-next-btn")
+    expect(page.locator("#workflow-task-list .workflow-task-item")).to_have_count(1)
+    page.fill("#workflow-task-name", "Primary task")
+    page.fill("#workflow-task-prompt", instructions)
+
+
+def _advance_workflow_builder_to_review(page):
+    """Advance from Tasks through Reliability to Review."""
+    page.click("#workflow-step-next-btn")
+    expect(page.locator("#workflow-task-retry-count")).to_be_visible()
+    page.click("#workflow-step-next-btn")
+    expect(page.locator("#workflow-review-summary")).to_be_visible()
+    expect(page.locator("#workflow-save-btn")).to_be_visible()
+
+
 @pytest.mark.ui
 def test_workflow_modal_saves_generic_automation_without_documents():
     """Validate a workflow can be saved with instructions and a runner only."""
@@ -174,17 +197,31 @@ def test_workflow_modal_saves_generic_automation_without_documents():
             action_options = page.locator("#workflow-document-action-type option").all_text_contents()
             assert action_options[:2] == ["No document action", "Search"]
             expect(page.locator("#workflow-document-action-type")).to_have_value("none")
+            _advance_workflow_builder_to_tasks(
+                page,
+                "Scheduled Status Summary",
+                "Summarize the current status and propose next steps.",
+            )
             expect(page.locator("#workflow-document-targets-fields")).to_be_hidden()
-            expect(page.locator("#workflow-analysis-retries-group")).to_be_hidden()
-
-            page.fill("#workflow-name", "Scheduled Status Summary")
-            page.fill("#workflow-task-prompt", "Summarize the current status and propose next steps.")
+            page.click("#workflow-add-task-btn")
+            page.fill("#workflow-task-name", "Recommend actions")
+            page.fill("#workflow-task-prompt", "Turn the summary into ordered next actions.")
+            expect(page.locator("#workflow-task-list .workflow-task-item")).to_have_count(2)
+            page.click("#workflow-step-next-btn")
+            page.check("#workflow-error-strategy-continue")
+            page.fill("#workflow-task-retry-count", "2")
+            page.click("#workflow-step-next-btn")
+            page.select_option("#workflow-alert-priority", "high")
             page.click("#workflow-save-btn")
 
             assert workflow_state["saved_payloads"], "Expected the workflow save handler to capture the modal payload."
             saved_payload = workflow_state["saved_payloads"][0]
             assert saved_payload["runner_type"] == "model"
             assert saved_payload["chat_capabilities_enabled"] is True
+            assert [task["name"] for task in saved_payload["tasks"]] == ["Primary task", "Recommend actions"]
+            assert saved_payload["task_prompt"] == "Summarize the current status and propose next steps."
+            assert saved_payload["error_handling"] == {"strategy": "continue", "retry_count": 2}
+            assert saved_payload["alert_priority"] == "high"
             assert saved_payload["document_action"]["type"] == "none"
             assert saved_payload["document_action"]["document_ids"] == []
             assert saved_payload["analyze"]["enabled"] is False
@@ -228,8 +265,11 @@ def test_workflow_document_action_modal_comparison():
                 "Run the workflow instructions without workspace document context.",
             )
 
-            page.fill("#workflow-name", "Compare Contract Baseline")
-            page.fill("#workflow-task-prompt", "Compare the baseline contract against the latest amendments.")
+            _advance_workflow_builder_to_tasks(
+                page,
+                "Compare Contract Baseline",
+                "Compare the baseline contract against the latest amendments.",
+            )
             page.select_option("#workflow-document-action-type", "comparison")
 
             expect(page.locator("#workflow-document-action-type")).to_have_attribute(
@@ -258,6 +298,7 @@ def test_workflow_document_action_modal_comparison():
             page.select_option("#workflow-comparison-target-document-ids", ["doc-v2", "doc-v1"])
             expect(page.locator("#workflow-comparison-left-document-id option")).to_have_count(2)
             page.select_option("#workflow-comparison-left-document-id", "doc-v1")
+            _advance_workflow_builder_to_review(page)
             page.click("#workflow-save-btn")
 
             assert workflow_state["saved_payloads"], "Expected the workflow save handler to capture the modal payload."
@@ -300,8 +341,11 @@ def test_workflow_document_action_modal_per_document_analysis():
             page.get_by_role("button", name="New Workflow").click()
             expect(page.locator("#workflowModal")).to_be_visible()
 
-            page.fill("#workflow-name", "Analyze Each Policy")
-            page.fill("#workflow-task-prompt", "Summarize each selected policy.")
+            _advance_workflow_builder_to_tasks(
+                page,
+                "Analyze Each Policy",
+                "Summarize each selected policy.",
+            )
             page.select_option("#workflow-document-action-type", "analyze")
 
             expect(page.locator("#workflow-analysis-target-fields")).to_be_visible()
@@ -310,6 +354,7 @@ def test_workflow_document_action_modal_per_document_analysis():
 
             page.fill("#workflow-analysis-document-ids", "doc-alpha, doc-beta")
             page.check("#workflow-analysis-per-document")
+            _advance_workflow_builder_to_review(page)
             page.click("#workflow-save-btn")
 
             assert workflow_state["saved_payloads"], "Expected the workflow save handler to capture the modal payload."

--- a/ui_tests/test_workflow_document_action_modal.py
+++ b/ui_tests/test_workflow_document_action_modal.py
@@ -1,12 +1,12 @@
 # test_workflow_document_action_modal.py
 """
 UI test for workflow document action modal.
-Version: 0.241.182
-Implemented in: 0.241.103
+Version: 0.250.063
+Implemented in: 0.250.063
 
-This test ensures the workflow modal exposes the renamed Search/Analyze/Compare
-selector states, uses Source/Target wording, and submits version-aware
-comparison payloads. It also validates the per-document Analyze mode payload.
+This test ensures the workflow modal supports generic no-document automation,
+uses Source/Target wording for comparison, and submits version-aware comparison
+and per-document Analyze payloads.
 """
 
 import json
@@ -145,6 +145,55 @@ def _open_workflows_tab(page):
 
 
 @pytest.mark.ui
+def test_workflow_modal_saves_generic_automation_without_documents():
+    """Validate a workflow can be saved with instructions and a runner only."""
+    _require_ui_env()
+    playwright_sync = _require_playwright()
+
+    with playwright_sync.sync_playwright() as playwright:
+        browser = playwright.chromium.launch()
+        context = browser.new_context(
+            storage_state=STORAGE_STATE,
+            viewport={"width": 1440, "height": 900},
+        )
+        page = context.new_page()
+        workflow_state = {"items": [], "saved_payloads": []}
+
+        _route_workflow_api(page, workflow_state)
+        _route_agent_api(page)
+        _route_document_apis(page)
+
+        try:
+            response = page.goto(f"{BASE_URL}/workspace", wait_until="networkidle")
+            assert response is not None and response.ok, "Expected /workspace to load successfully."
+
+            _open_workflows_tab(page)
+            page.get_by_role("button", name="New Workflow").click()
+            expect(page.locator("#workflowModal")).to_be_visible()
+
+            action_options = page.locator("#workflow-document-action-type option").all_text_contents()
+            assert action_options[:2] == ["No document action", "Search"]
+            expect(page.locator("#workflow-document-action-type")).to_have_value("none")
+            expect(page.locator("#workflow-document-targets-fields")).to_be_hidden()
+            expect(page.locator("#workflow-analysis-retries-group")).to_be_hidden()
+
+            page.fill("#workflow-name", "Scheduled Status Summary")
+            page.fill("#workflow-task-prompt", "Summarize the current status and propose next steps.")
+            page.click("#workflow-save-btn")
+
+            assert workflow_state["saved_payloads"], "Expected the workflow save handler to capture the modal payload."
+            saved_payload = workflow_state["saved_payloads"][0]
+            assert saved_payload["runner_type"] == "model"
+            assert saved_payload["chat_capabilities_enabled"] is True
+            assert saved_payload["document_action"]["type"] == "none"
+            assert saved_payload["document_action"]["document_ids"] == []
+            assert saved_payload["analyze"]["enabled"] is False
+        finally:
+            context.close()
+            browser.close()
+
+
+@pytest.mark.ui
 def test_workflow_document_action_modal_comparison():
     """Validate the workflow modal shows the updated action labels and saves compare payloads."""
     _require_ui_env()
@@ -173,10 +222,10 @@ def test_workflow_document_action_modal_comparison():
             expect(page.locator("#workflowModal")).to_be_visible()
 
             action_options = page.locator("#workflow-document-action-type option").all_text_contents()
-            assert action_options[:3] == ["Search", "Analyze", "Compare"]
+            assert action_options[:4] == ["No document action", "Search", "Analyze", "Compare"]
             expect(page.locator("#workflow-document-action-type")).to_have_attribute(
                 "title",
-                "Find relevant information with the normal prompt flow instead of binding the workflow to fixed document targets.",
+                "Run the workflow instructions without workspace document context.",
             )
 
             page.fill("#workflow-name", "Compare Contract Baseline")


### PR DESCRIPTION
## Summary
- Replace the single-pane workflow form with a five-step General, Trigger, Tasks, Reliability, and Review builder for personal and group workflows.
- Add ordered instruction tasks that share the selected model or agent and receive bounded prior-task output context.
- Add per-task retries and halt-or-continue error handling, task run items, and task lifecycle events in workflow activity.
- Keep File Sync and document Search, Analyze, or Compare as optional inputs; document input applies to task one and later tasks consume its result.
- Preserve workflows without a tasks array on the legacy single-dispatch path.

## Validation
- 12/12 focused functional checks passed across stepped UI, task runtime, generic workflow compatibility, and Direct Model capabilities.
- JavaScript and Python syntax checks, editor diagnostics, and git diff --check passed.
- Revision-scoped XSS and broken access control guardrails passed.
- Azure Playwright module is updated and discoverable, but skipped locally because authenticated SIMPLECHAT_UI_BASE_URL/storage state was unavailable; the fresh local server redirects to Microsoft sign-in.

Fixes #1082