### PR TITLE
Fix GPT 5.6+ Multi-Modal Vision model selection

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -97,7 +97,7 @@ load_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.250.065"
+VERSION = "0.250.066"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/functions_model_capabilities.py
+++ b/application/single_app/functions_model_capabilities.py
@@ -1,0 +1,53 @@
+# functions_model_capabilities.py
+
+import re
+from collections.abc import Mapping
+
+
+MODEL_IDENTIFIER_SEPARATOR_PATTERN = re.compile(r"[\s_.]+")
+GPT_VISION_MODEL_PATTERN = re.compile(r"(?:^|-)gpt-(?:[5-9]|\d{2,})(?:-|$)")
+O_SERIES_MODEL_PATTERN = re.compile(r"(?:^|-)o\d+(?:-|$)")
+MODEL_IDENTIFIER_FIELDS = (
+    "modelName",
+    "displayName",
+    "deploymentName",
+    "deployment",
+    "name",
+)
+
+
+def _normalize_model_identifier(value):
+    return MODEL_IDENTIFIER_SEPARATOR_PATTERN.sub(
+        "-",
+        str(value or "").strip().lower(),
+    )
+
+
+def is_vision_capable_model_name(*model_names):
+    """Return whether any supplied identifier names a supported vision model."""
+    for model_name in model_names:
+        normalized_name = _normalize_model_identifier(model_name)
+        if (
+            "vision" in normalized_name
+            or "gpt-4o" in normalized_name
+            or "gpt-4-1" in normalized_name
+            or "gpt-4-5" in normalized_name
+            or GPT_VISION_MODEL_PATTERN.search(normalized_name)
+            or O_SERIES_MODEL_PATTERN.search(normalized_name)
+        ):
+            return True
+
+    return False
+
+
+def is_vision_capable_model(model):
+    """Return whether a model record or identifier names a supported vision model."""
+    if isinstance(model, str):
+        return is_vision_capable_model_name(model)
+
+    if isinstance(model, Mapping):
+        model_names = [model.get(field_name) for field_name in MODEL_IDENTIFIER_FIELDS]
+    else:
+        model_names = [getattr(model, field_name, None) for field_name in MODEL_IDENTIFIER_FIELDS]
+
+    return is_vision_capable_model_name(*model_names)

--- a/application/single_app/route_frontend_admin_settings.py
+++ b/application/single_app/route_frontend_admin_settings.py
@@ -27,6 +27,7 @@ from functions_activity_logging import log_web_search_consent_acceptance, log_ge
 from functions_notifications import broadcast_system_notification
 from functions_logging import *
 from functions_document_actions import normalize_document_action_capabilities
+from functions_model_capabilities import is_vision_capable_model
 from functions_terms_of_use import (
     TERMS_OF_USE_DEFAULT_REDIRECT,
     TERMS_OF_USE_MAX_BUTTON_TEXT_LENGTH,
@@ -596,7 +597,8 @@ def register_route_frontend_admin_settings(bp):
                 chunk_size_cap=get_chunk_size_cap(settings),
                 chunk_size_effective=get_chunk_size_config(settings),
                 audio_runtime_capabilities=audio_runtime_capabilities,
-                source_review_runtime_capabilities=source_review_runtime_capabilities
+                source_review_runtime_capabilities=source_review_runtime_capabilities,
+                is_vision_capable_model=is_vision_capable_model,
                 # You don't need to pass deployments separately if they are added to settings['..._model']['all']
                 # gpt_deployments=gpt_deployments,
                 # embedding_deployments=embedding_deployments,

--- a/application/single_app/static/js/admin/admin_settings.js
+++ b/application/single_app/static/js/admin/admin_settings.js
@@ -8364,18 +8364,22 @@ const visionToggle = document.getElementById('enable_multimodal_vision');
 const visionModelDiv = document.getElementById('multimodal_vision_model_settings');
 const visionSelect = document.getElementById('multimodal_vision_model');
 
-function isVisionCapableModelName(modelName) {
-    const modelNameLower = (modelName || '').toLowerCase();
-    return (
-        modelNameLower.includes('vision') ||
-        modelNameLower.includes('gpt-4o') ||
-        modelNameLower.includes('gpt-4.1') ||
-        modelNameLower.includes('gpt-4.5') ||
-        modelNameLower.includes('gpt-5') ||
-        /^o\d+/.test(modelNameLower) ||
-        modelNameLower.includes('o1-') ||
-        modelNameLower.includes('o3-')
-    );
+function isVisionCapableModelName(...modelNames) {
+    return modelNames.some(modelName => {
+        const normalizedName = String(modelName || '')
+            .trim()
+            .toLowerCase()
+            .replace(/[\s_.]+/g, '-');
+
+        return (
+            normalizedName.includes('vision') ||
+            normalizedName.includes('gpt-4o') ||
+            normalizedName.includes('gpt-4-1') ||
+            normalizedName.includes('gpt-4-5') ||
+            /(?:^|-)gpt-(?:[5-9]|\d{2,})(?:-|$)/.test(normalizedName) ||
+            /(?:^|-)o\d+(?:-|$)/.test(normalizedName)
+        );
+    });
 }
 
 function getSelectedVisionModelOption() {
@@ -8401,10 +8405,18 @@ function populateVisionModels() {
             .filter(ep => ep && ep.enabled)
             .forEach(ep => {
                 (ep.models || [])
-                    .filter(m => m && m.enabled && isVisionCapableModelName(m.modelName || m.displayName))
+                    .filter(m => m && m.enabled && isVisionCapableModelName(
+                        m.modelName,
+                        m.displayName,
+                        m.deploymentName,
+                        m.deployment,
+                        m.name
+                    ))
                     .forEach(m => {
                         const value = m.deploymentName;
-                        const label = `${m.displayName || m.deploymentName} (${m.modelName})`;
+                        const label = m.modelName
+                            ? `${m.displayName || m.deploymentName} (${m.modelName})`
+                            : (m.displayName || m.deploymentName);
                         const opt = new Option(label, value);
                         opt.dataset.endpointId = ep.id || '';
                         opt.dataset.modelId = m.id || '';

--- a/application/single_app/templates/admin_settings.html
+++ b/application/single_app/templates/admin_settings.html
@@ -8213,19 +8213,7 @@
                                 {# Iterate all enabled endpoints and models, filter to vision-capable #}
                                 {% for endpoint in settings.model_endpoints if endpoint.enabled %}
                                     {% for m in endpoint.models if m.enabled %}
-                                        {% set model_lower = (m.modelName or m.displayName or '').lower() %}
-                                        {% set is_vision =
-                                            'vision' in model_lower or
-                                            'gpt-4o' in model_lower or
-                                            'gpt-4.1' in model_lower or
-                                            'gpt-4.5' in model_lower or
-                                            '-5' in model_lower or
-                                            model_lower.startswith('o1') or
-                                            model_lower.startswith('o3') or
-                                            'o1-' in model_lower or
-                                            'o3-' in model_lower
-                                        %}
-                                        {% if is_vision %}
+                                        {% if is_vision_capable_model(m) %}
                                             {% set option_value = m.deploymentName %}
                                             <option value="{{ option_value }}"
                                                 data-endpoint-id="{{ endpoint.id or '' }}"
@@ -8233,7 +8221,7 @@
                                                 data-provider="{{ endpoint.provider or '' }}"
                                                 data-model-name="{{ m.modelName or '' }}"
                                                 {% if settings.multimodal_vision_model == option_value %}selected{% endif %}>
-                                                {{ m.displayName or m.deploymentName }} ({{ m.modelName }})
+                                                {{ m.displayName or m.deploymentName }}{% if m.modelName %} ({{ m.modelName }}){% endif %}
                                             </option>
                                         {% endif %}
                                     {% endfor %}
@@ -8242,19 +8230,7 @@
                                 {# Legacy APIM-based GPT configuration #}
                                 {% for d in (settings.azure_apim_gpt_deployment or '').split(',') if d %}
                                     {% set d_trim = d.strip() %}
-                                    {% set model_lower = d_trim.lower() %}
-                                    {% set is_vision =
-                                        'vision' in model_lower or
-                                        'gpt-4o' in model_lower or
-                                        'gpt-4.1' in model_lower or
-                                        'gpt-4.5' in model_lower or
-                                        '-5' in model_lower or
-                                        model_lower.startswith('o1') or
-                                        model_lower.startswith('o3') or
-                                        'o1-' in model_lower or
-                                        'o3-' in model_lower
-                                    %}
-                                    {% if is_vision %}
+                                    {% if is_vision_capable_model(d_trim) %}
                                         <option value="{{ d_trim }}"
                                             {% if settings.multimodal_vision_model == d_trim %}selected{% endif %}>
                                             {{ d_trim }}
@@ -8264,28 +8240,16 @@
                             {% else %}
                                 {# Legacy single-endpoint GPT configuration #}
                                 {% for m in settings.gpt_model.selected %}
-                                    {% set model_lower = (m.modelName or '').lower() %}
-                                    {% set is_vision =
-                                        'vision' in model_lower or
-                                        'gpt-4o' in model_lower or
-                                        'gpt-4.1' in model_lower or
-                                        'gpt-4.5' in model_lower or
-                                        'gpt-5' in model_lower or
-                                        model_lower.startswith('o1') or
-                                        model_lower.startswith('o3') or
-                                        'o1-' in model_lower or
-                                        'o3-' in model_lower
-                                    %}
-                                    {% if is_vision %}
+                                    {% if is_vision_capable_model(m) %}
                                         <option value="{{ m.deploymentName }}"
                                             {% if settings.multimodal_vision_model == m.deploymentName %}selected{% endif %}>
-                                            {{ m.deploymentName }} ({{ m.modelName }})
+                                            {{ m.deploymentName }}{% if m.modelName %} ({{ m.modelName }}){% endif %}
                                         </option>
                                     {% endif %}
                                 {% endfor %}
                             {% endif %}
                         </select>
-                        <div class="form-text">Select a GPT model with vision capabilities (e.g., gpt-4o, gpt-4-vision, gpt-5, gpt-5-nano, etc.). Only vision-capable models are shown.</div>
+                        <div class="form-text">Select a GPT model with vision capabilities (for example, gpt-4o or supported GPT 5 and later models). Only vision-capable models are shown.</div>
 
                         <button type="button" class="btn btn-secondary mt-3" id="test_multimodal_vision_button">
                             <i class="bi bi-clipboard-check me-1"></i>Test Vision Analysis

--- a/application/single_app/templates/admin_settings.html
+++ b/application/single_app/templates/admin_settings.html
@@ -8213,7 +8213,7 @@
                                 {# Iterate all enabled endpoints and models, filter to vision-capable #}
                                 {% for endpoint in settings.model_endpoints if endpoint.enabled %}
                                     {% for m in endpoint.models if m.enabled %}
-                                        {% if is_vision_capable_model(m) %}
+                                        {% if is_vision_capable_model is defined and is_vision_capable_model(m) %}
                                             {% set option_value = m.deploymentName %}
                                             <option value="{{ option_value }}"
                                                 data-endpoint-id="{{ endpoint.id or '' }}"
@@ -8230,7 +8230,7 @@
                                 {# Legacy APIM-based GPT configuration #}
                                 {% for d in (settings.azure_apim_gpt_deployment or '').split(',') if d %}
                                     {% set d_trim = d.strip() %}
-                                    {% if is_vision_capable_model(d_trim) %}
+                                    {% if is_vision_capable_model is defined and is_vision_capable_model(d_trim) %}
                                         <option value="{{ d_trim }}"
                                             {% if settings.multimodal_vision_model == d_trim %}selected{% endif %}>
                                             {{ d_trim }}
@@ -8240,7 +8240,7 @@
                             {% else %}
                                 {# Legacy single-endpoint GPT configuration #}
                                 {% for m in settings.gpt_model.selected %}
-                                    {% if is_vision_capable_model(m) %}
+                                    {% if is_vision_capable_model is defined and is_vision_capable_model(m) %}
                                         <option value="{{ m.deploymentName }}"
                                             {% if settings.multimodal_vision_model == m.deploymentName %}selected{% endif %}>
                                             {{ m.deploymentName }}{% if m.modelName %} ({{ m.modelName }}){% endif %}

--- a/docs/explanation/features/v0.229.088/MULTIMODAL_VISION_ANALYSIS.md
+++ b/docs/explanation/features/v0.229.088/MULTIMODAL_VISION_ANALYSIS.md
@@ -1,6 +1,6 @@
 # Multi-Modal Vision Analysis Feature
 
-**Version**: 0.229.088 (Initial), 0.229.089 (Expanded model support)  
+**Version**: 0.229.088 (Initial), 0.229.089 (Expanded model support), 0.250.066 (GPT 5.6+ endpoint aliases)
 **Implemented**: November 21, 2025
 
 ## Overview
@@ -337,8 +337,8 @@ group-documents/
 - `o3` - Next-generation reasoning model (if available)
 - `o3-mini` - Compact version (if available)
 
-**GPT-5 Series**:
-- All GPT-5 models support vision (when available in your region)
+**GPT-5 and Later Series**:
+- GPT 5.6 and later GPT model variants are available when they support vision in your region
 
 **GPT-4.5 & GPT-4.1 Series**:
 - `gpt-4.5` - Mid-generation update with vision
@@ -350,7 +350,7 @@ group-documents/
 - `gpt-4-vision` - Standard vision variant
 
 **Model Detection**:
-The admin UI automatically filters and displays only vision-capable models based on naming patterns. If your deployed model includes "vision", "gpt-4o", "gpt-4.1", "gpt-4.5", "gpt-5", or matches o-series patterns (o1, o3, etc.), it will appear in the dropdown.
+The admin UI filters vision-capable models using the model name, display name, and deployment name supplied by each enabled endpoint. Matching is case-insensitive and treats spaces, periods, and underscores as separators. Models identified as "vision", "gpt-4o", "gpt-4.1", "gpt-4.5", GPT major version 5 or later, or supported o-series patterns (o1, o3, etc.) appear in the dropdown.
 
 **API Requirements**:
 - Azure OpenAI API version 2024-02-15-preview or later
@@ -494,7 +494,7 @@ print(doc.get('vision_analysis'))
    - Contains "gpt-4o" (gpt-4o, gpt-4o-mini)
    - Contains "gpt-4.1" (any GPT-4.1 variant)
    - Contains "gpt-4.5" (any GPT-4.5 variant)
-   - Contains "gpt-5" (any GPT-5 variant)
+    - Identifies GPT major version 5 or later in its model, display, or deployment name
    - Matches o-series pattern (o1, o1-preview, o1-mini, o3, o3-mini)
 2. Was model fetched and selected in Chat Model?
 3. For APIM: Is deployment name listed in comma-separated list?
@@ -502,7 +502,7 @@ print(doc.get('vision_analysis'))
 **Supported Model Families**:
 - **GPT-4o series**: gpt-4o, gpt-4o-mini
 - **O-series**: o1, o1-preview, o1-mini, o3, o3-mini
-- **GPT-5 series**: All variants (when available)
+- **GPT-5 and later series**: GPT 5.6 and later variants (when available)
 - **GPT-4.5 & GPT-4.1**: All variants
 - **Legacy vision**: gpt-4-vision, gpt-4-turbo-vision
 
@@ -516,7 +516,7 @@ print(doc.get('vision_analysis'))
 6. Model should now appear in dropdown
 ```
 
-**Note**: If your model supports vision but doesn't appear, check that the deployment name follows Azure OpenAI naming conventions. Custom deployment names may not be detected automatically if they don't include the model family identifiers.
+**Note**: If a custom deployment alias does not identify the model family, ensure its model name or display name contains the supported family identifier.
 
 ## Related Features
 

--- a/docs/explanation/fixes/GPT_5_6_MULTIMODAL_VISION_SELECTOR_FIX.md
+++ b/docs/explanation/fixes/GPT_5_6_MULTIMODAL_VISION_SELECTOR_FIX.md
@@ -37,6 +37,8 @@ name as `GPT 5.6` did not match.
 - Evaluated model, display, deployment, and fallback name fields.
 - Applied the same capability contract during initial server rendering and
   client-side endpoint updates.
+- Allowed templates loaded ahead of a restarted application worker to fall
+  back to client-side option population instead of returning a Jinja error.
 - Preserved filtering for disabled endpoints, disabled models, and unsupported
   model families.
 - Incremented `config.py` from `0.250.065` to `0.250.066`.
@@ -49,9 +51,11 @@ requiring one exact metadata field or separator format.
 
 ## Validation
 
-The focused Playwright regression test executes the production matcher and
-dropdown population functions with GPT 5.6 Luna, Sol, Terra, GPT 5.7, GPT-4o,
-disabled model, disabled endpoint, and non-GPT cases.
+The focused Playwright regression test executes the production matcher, actual
+Jinja selector, and dropdown population functions with GPT 5.6 Luna, Sol,
+Terra, GPT 5.7, GPT-4o, disabled model, disabled endpoint, and non-GPT cases.
+It also renders the selector without the route helper to verify that a stale
+worker cannot return an `UndefinedError`.
 
 Before the fix, only the placeholder and GPT-4o option were rendered. After the
 fix, all enabled supported options render while excluded models remain absent.

--- a/docs/explanation/fixes/GPT_5_6_MULTIMODAL_VISION_SELECTOR_FIX.md
+++ b/docs/explanation/fixes/GPT_5_6_MULTIMODAL_VISION_SELECTOR_FIX.md
@@ -1,0 +1,57 @@
+# GPT 5.6+ Multi-Modal Vision Selector Fix (v0.250.066)
+
+Fixed in version: **0.250.066**
+
+Related issue: [#1086](https://github.com/microsoft/simplechat/issues/1086)
+
+## Issue
+
+Enabled GPT 5.6 deployments appeared in the Global Endpoints table but were
+missing from the Multi-Modal Vision Analysis model selector. The selector could
+therefore leave admins on GPT 5.4 even when Luna, Sol, Terra, or later GPT
+deployments were configured.
+
+## Root Cause
+
+The browser-side vision filter inspected only `modelName` or `displayName` and
+required narrow punctuation patterns. Endpoint records that exposed the model
+family through `deploymentName`, used a provider prefix, or formatted a display
+name as `GPT 5.6` did not match.
+
+## Technical Details
+
+### Files Modified
+
+- `application/single_app/static/js/admin/admin_settings.js`
+- `application/single_app/functions_model_capabilities.py`
+- `application/single_app/route_frontend_admin_settings.py`
+- `application/single_app/templates/admin_settings.html`
+- `application/single_app/config.py`
+- `ui_tests/test_admin_multimodal_vision_model_options.py`
+- `docs/explanation/features/v0.229.088/MULTIMODAL_VISION_ANALYSIS.md`
+
+### Code Changes
+
+- Normalized spaces, periods, and underscores before capability matching.
+- Recognized GPT major version 5 and later, including provider-prefixed names.
+- Evaluated model, display, deployment, and fallback name fields.
+- Applied the same capability contract during initial server rendering and
+  client-side endpoint updates.
+- Preserved filtering for disabled endpoints, disabled models, and unsupported
+  model families.
+- Incremented `config.py` from `0.250.065` to `0.250.066`.
+
+## Impact
+
+Azure OpenAI, New Foundry, and classic Foundry endpoints can expose supported
+GPT 5.6 and later deployments in the same Vision Model selector without
+requiring one exact metadata field or separator format.
+
+## Validation
+
+The focused Playwright regression test executes the production matcher and
+dropdown population functions with GPT 5.6 Luna, Sol, Terra, GPT 5.7, GPT-4o,
+disabled model, disabled endpoint, and non-GPT cases.
+
+Before the fix, only the placeholder and GPT-4o option were rendered. After the
+fix, all enabled supported options render while excluded models remain absent.

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,15 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](/explanation/features/) and [Fixes by Version](/explanation/fixes/).
 
+### **(v0.250.066)**
+
+#### Bug Fixes
+
+*   **GPT 5.6+ Multi-Modal Vision Model Selection**
+    *   Enabled GPT 5.6 Luna, Sol, Terra, and later supported GPT deployments to appear in the Multi-Modal Vision Analysis selector across Azure OpenAI and Foundry endpoints.
+    *   Model detection now evaluates model, display, and deployment names with normalized separators while preserving disabled-model and unsupported-family filtering.
+    *   (Ref: microsoft/simplechat#1086, `admin_settings.js`, `test_admin_multimodal_vision_model_options.py`)
+
 ### **(v0.250.065)**
 
 #### New Features

--- a/ui_tests/test_admin_multimodal_vision_model_options.py
+++ b/ui_tests/test_admin_multimodal_vision_model_options.py
@@ -1,0 +1,155 @@
+# test_admin_multimodal_vision_model_options.py
+"""
+UI test for Admin Settings multi-modal Vision Model options.
+
+Version: 0.250.066
+Implemented in: 0.250.066
+
+This test ensures enabled GPT 5.6 and later models are recognized across
+model, display, and deployment names from multi-model endpoints.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+from jinja2 import Environment
+
+from application.single_app.functions_model_capabilities import is_vision_capable_model
+
+try:
+    from playwright.sync_api import expect, sync_playwright
+except ModuleNotFoundError:
+    expect = None
+    sync_playwright = None
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ADMIN_JS = REPO_ROOT / "application" / "single_app" / "static" / "js" / "admin" / "admin_settings.js"
+ADMIN_TEMPLATE = REPO_ROOT / "application" / "single_app" / "templates" / "admin_settings.html"
+EXPECTED_OPTION_VALUES = [
+    "",
+    "luna-deployment",
+    "gpt-5.6-sol",
+    "gpt-4o",
+    "N-gpt-5.6-terra",
+    "gpt_5.7_preview",
+]
+
+
+def _build_model_endpoints():
+    return [
+        {
+            "id": "aoai-global",
+            "provider": "aoai",
+            "enabled": True,
+            "models": [
+                {"id": "luna", "enabled": True, "displayName": "GPT 5.6 Luna", "deploymentName": "luna-deployment", "modelName": ""},
+                {"id": "sol", "enabled": True, "displayName": "Sol", "deploymentName": "gpt-5.6-sol", "modelName": ""},
+                {"id": "legacy", "enabled": True, "displayName": "GPT-4o", "deploymentName": "gpt-4o", "modelName": "gpt-4o"},
+                {"id": "disabled", "enabled": False, "displayName": "GPT 5.6 Disabled", "deploymentName": "gpt-5.6-disabled", "modelName": ""},
+            ],
+        },
+        {
+            "id": "new-foundry",
+            "provider": "new_foundry",
+            "enabled": True,
+            "models": [
+                {"id": "terra", "enabled": True, "displayName": "Terra", "deploymentName": "N-gpt-5.6-terra", "modelName": ""},
+                {"id": "future", "enabled": True, "displayName": "Future model", "deploymentName": "gpt_5.7_preview", "modelName": ""},
+                {"id": "text-only", "enabled": True, "displayName": "Claude", "deploymentName": "claude-opus", "modelName": "claude-opus"},
+            ],
+        },
+        {
+            "id": "disabled-endpoint",
+            "provider": "aifoundry",
+            "enabled": False,
+            "models": [
+                {"id": "hidden", "enabled": True, "displayName": "GPT 6", "deploymentName": "gpt-6", "modelName": "gpt-6"},
+            ],
+        },
+    ]
+
+
+def _extract_javascript_function(source, function_name):
+    """Extract a named function declaration and its balanced body."""
+    start = source.index(f"function {function_name}(")
+    body_start = source.index("{", start)
+    depth = 0
+
+    for index in range(body_start, len(source)):
+        if source[index] == "{":
+            depth += 1
+        elif source[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start:index + 1]
+
+    raise AssertionError(f"Could not extract JavaScript function: {function_name}")
+
+
+def _extract_vision_select_template(source):
+    start = source.index('<select class="form-select" id="multimodal_vision_model"')
+    end = source.index("</select>", start) + len("</select>")
+    return source[start:end]
+
+
+def _assert_expected_options(page):
+    options = page.locator("#multimodal_vision_model option")
+    expect(options).to_have_count(len(EXPECTED_OPTION_VALUES))
+    assert options.evaluate_all("options => options.map(option => option.value)") == EXPECTED_OPTION_VALUES
+    assert all("()" not in label for label in options.all_text_contents())
+
+
+@pytest.mark.ui
+def test_multimodal_vision_options_include_gpt_5_6_and_later_aliases():
+    """Populate the Vision Model selector from all supported model name fields."""
+    if sync_playwright is None or expect is None:
+        pytest.skip("Install playwright to run this UI test.")
+
+    source = ADMIN_JS.read_text(encoding="utf-8")
+    template_source = ADMIN_TEMPLATE.read_text(encoding="utf-8")
+    vision_matcher = _extract_javascript_function(source, "isVisionCapableModelName")
+    vision_populator = _extract_javascript_function(source, "populateVisionModels")
+    model_endpoints = _build_model_endpoints()
+
+    with sync_playwright() as playwright:
+        browser = playwright.chromium.launch()
+        page = browser.new_page(viewport={"width": 1280, "height": 800})
+
+        try:
+            vision_select_template = Environment(autoescape=True).from_string(
+                _extract_vision_select_template(template_source)
+            )
+            page.set_content(vision_select_template.render(
+                settings={
+                    "enable_multi_model_endpoints": True,
+                    "model_endpoints": model_endpoints,
+                    "multimodal_vision_model": "N-gpt-5.6-terra",
+                    "enable_gpt_apim": False,
+                    "azure_apim_gpt_deployment": "",
+                    "gpt_model": {"selected": []},
+                },
+                is_vision_capable_model=is_vision_capable_model,
+            ))
+            _assert_expected_options(page)
+            expect(page.locator("#multimodal_vision_model")).to_have_value("N-gpt-5.6-terra")
+
+            page.set_content(
+                '<label for="multimodal_vision_model">Vision Model</label>'
+                '<select id="multimodal_vision_model"></select>'
+            )
+            page.add_script_tag(content=f"""
+                const visionSelect = document.getElementById('multimodal_vision_model');
+                {vision_matcher}
+                {vision_populator}
+
+                window.enableMultiModelEndpoints = true;
+                window.modelEndpoints = {json.dumps(model_endpoints)};
+
+                populateVisionModels();
+            """)
+
+            _assert_expected_options(page)
+        finally:
+            browser.close()

--- a/ui_tests/test_admin_multimodal_vision_model_options.py
+++ b/ui_tests/test_admin_multimodal_vision_model_options.py
@@ -121,15 +121,21 @@ def test_multimodal_vision_options_include_gpt_5_6_and_later_aliases():
             vision_select_template = Environment(autoescape=True).from_string(
                 _extract_vision_select_template(template_source)
             )
+            settings = {
+                "enable_multi_model_endpoints": True,
+                "model_endpoints": model_endpoints,
+                "multimodal_vision_model": "N-gpt-5.6-terra",
+                "enable_gpt_apim": False,
+                "azure_apim_gpt_deployment": "",
+                "gpt_model": {"selected": []},
+            }
+
+            fallback_html = vision_select_template.render(settings=settings)
+            page.set_content(fallback_html)
+            expect(page.locator("#multimodal_vision_model option")).to_have_count(1)
+
             page.set_content(vision_select_template.render(
-                settings={
-                    "enable_multi_model_endpoints": True,
-                    "model_endpoints": model_endpoints,
-                    "multimodal_vision_model": "N-gpt-5.6-terra",
-                    "enable_gpt_apim": False,
-                    "azure_apim_gpt_deployment": "",
-                    "gpt_model": {"selected": []},
-                },
+                settings=settings,
                 is_vision_capable_model=is_vision_capable_model,
             ))
             _assert_expected_options(page)


### PR DESCRIPTION
## Summary
- recognize GPT 5.6 and later vision-capable aliases across model, display, and deployment names
- keep initial Jinja rendering and client-side endpoint updates on the same capability contract
- preserve endpoint/model enablement filtering and improve labels when providers omit model names
- bump the application to v0.250.066 and update fix, feature, and release documentation

## Validation
- `python -m pytest ui_tests/test_admin_multimodal_vision_model_options.py functional_tests/test_multimodal_vision_multi_endpoint_connection.py functional_tests/test_vision_model_parameter_fix.py functional_tests/route_tests/test_route_blueprint_policy_inventory.py functional_tests/route_tests/test_route_unauthenticated_policy_contract.py functional_tests/route_tests/test_route_policy_test_coverage.py -q` (17 passed)
- `node --check application/single_app/static/js/admin/admin_settings.js`
- `python -m py_compile application/single_app/functions_model_capabilities.py application/single_app/route_frontend_admin_settings.py ui_tests/test_admin_multimodal_vision_model_options.py`
- `git diff --check`

Fixes #1086