### PR TITLE
Add Fork conversation action to assistant messages

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -97,7 +97,7 @@ load_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.250.073"
+VERSION = "0.250.074"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/functions_simplechat_operations.py
+++ b/application/single_app/functions_simplechat_operations.py
@@ -1,6 +1,7 @@
 # functions_simplechat_operations.py
 """Shared SimpleChat-native operations for routes and Semantic Kernel plugins."""
 
+import copy
 import logging
 import mimetypes
 import os
@@ -66,6 +67,21 @@ from utils_cache import invalidate_group_search_cache, invalidate_personal_searc
 
 SIMPLECHAT_PLUGIN_TYPE = "simplechat"
 SIMPLECHAT_DEFAULT_ENDPOINT = "simplechat://internal"
+PERSONAL_FORK_CHAT_TYPES = {"", "new", "personal", "personal_single_user"}
+PERSONAL_FORK_CONVERSATION_FIELDS = (
+    "context",
+    "tags",
+    "strict",
+    "classification",
+    "scope_locked",
+    "locked_contexts",
+    "selected_agent_id",
+    "selected_agent_name",
+    "selected_agent_is_global",
+    "model_endpoint_id",
+    "model_id",
+)
+COSMOS_SYSTEM_FIELDS = {"_rid", "_self", "_etag", "_attachments", "_ts"}
 SIMPLECHAT_CAPABILITY_TO_FUNCTION = {
     "create_group": "create_group",
     "add_group_member": "add_user_to_group",
@@ -222,6 +238,521 @@ def derive_conversation_title_from_message(content: str) -> str:
     if not normalized_content:
         return "New Conversation"
     return f"{normalized_content[:30]}..." if len(normalized_content) > 30 else normalized_content
+
+
+class ConversationForkConflictError(RuntimeError):
+    """Raised when the source changes or cannot be forked safely."""
+
+
+def is_forkable_personal_conversation(conversation_item: Dict[str, Any]) -> bool:
+    """Return whether a legacy personal conversation is eligible for forking."""
+    chat_type = str((conversation_item or {}).get("chat_type") or "").strip().lower()
+    if chat_type not in PERSONAL_FORK_CHAT_TYPES:
+        return False
+
+    for context_item in (conversation_item or {}).get("context") or []:
+        if not isinstance(context_item, dict):
+            continue
+        scope = str(context_item.get("scope") or "").strip().lower()
+        if scope and scope != "personal":
+            return False
+
+    return True
+
+
+def _message_fork_sort_key(message_doc: Dict[str, Any]) -> Tuple[str, int, str]:
+    fork_sequence = message_doc.get("fork_sequence")
+    try:
+        normalized_sequence = int(fork_sequence)
+    except (TypeError, ValueError):
+        normalized_sequence = 0
+    return (
+        str(message_doc.get("timestamp") or ""),
+        normalized_sequence,
+        str(message_doc.get("id") or ""),
+    )
+
+
+def _is_active_fork_timeline_message(message_doc: Dict[str, Any]) -> bool:
+    metadata = message_doc.get("metadata") or {}
+    thread_info = metadata.get("thread_info") or {}
+    active_thread = thread_info.get("active_thread")
+    return active_thread is not False
+
+
+def _is_assistant_artifact_document(message_doc: Dict[str, Any]) -> bool:
+    metadata = message_doc.get("metadata") or {}
+    role = str(message_doc.get("role") or "").strip().lower()
+    return bool(metadata.get("is_generated_chat_artifact")) or role.startswith("assistant_artifact")
+
+
+def _collect_artifact_message_reference_ids(value: Any, key: str = "") -> set:
+    referenced_ids = set()
+    if isinstance(value, dict):
+        for child_key, child_value in value.items():
+            referenced_ids.update(_collect_artifact_message_reference_ids(child_value, child_key))
+    elif isinstance(value, list):
+        for child_value in value:
+            referenced_ids.update(_collect_artifact_message_reference_ids(child_value, key))
+    elif isinstance(value, str) and (key == "artifact_message_id" or key.endswith("_artifact_message_id")):
+        normalized_value = value.strip()
+        if normalized_value:
+            referenced_ids.add(normalized_value)
+    return referenced_ids
+
+
+def _collect_fork_documents(
+    all_documents: List[Dict[str, Any]],
+    selected_message_id: str,
+) -> List[Dict[str, Any]]:
+    ordered_documents = sorted(all_documents, key=_message_fork_sort_key)
+    timeline_documents = [
+        document
+        for document in ordered_documents
+        if not _is_assistant_artifact_document(document)
+        and _is_active_fork_timeline_message(document)
+    ]
+
+    selected_index = next(
+        (
+            index
+            for index, document in enumerate(timeline_documents)
+            if str(document.get("id") or "") == selected_message_id
+        ),
+        None,
+    )
+    if selected_index is None:
+        raise LookupError("Selected assistant message was not found on the active conversation timeline")
+
+    selected_document = timeline_documents[selected_index]
+    if str(selected_document.get("role") or "").strip().lower() != "assistant":
+        raise ValueError("Selected message must be a persisted assistant message")
+
+    included_documents = timeline_documents[:selected_index + 1]
+    included_ids = {
+        str(document.get("id") or "")
+        for document in included_documents
+        if document.get("id")
+    }
+    documents_by_id = {
+        str(document.get("id") or ""): document
+        for document in ordered_documents
+        if document.get("id")
+    }
+    referenced_artifact_ids = _collect_artifact_message_reference_ids(included_documents)
+    missing_artifact_ids = referenced_artifact_ids.difference(documents_by_id)
+    if missing_artifact_ids:
+        raise ConversationForkConflictError(
+            "A generated assistant artifact is no longer available to fork"
+        )
+
+    pending_artifacts = [
+        document
+        for document in ordered_documents
+        if _is_assistant_artifact_document(document)
+    ]
+    while pending_artifacts:
+        added_document = False
+        remaining_artifacts = []
+        for artifact_document in pending_artifacts:
+            artifact_id = str(artifact_document.get("id") or "")
+            parent_message_id = str(artifact_document.get("parent_message_id") or "")
+            if artifact_id in referenced_artifact_ids or (
+                parent_message_id and parent_message_id in included_ids
+            ):
+                included_documents.append(artifact_document)
+                if artifact_id:
+                    included_ids.add(artifact_id)
+                referenced_artifact_ids.update(
+                    _collect_artifact_message_reference_ids(artifact_document)
+                )
+                added_document = True
+            else:
+                remaining_artifacts.append(artifact_document)
+        if not added_document:
+            break
+        pending_artifacts = remaining_artifacts
+
+    return sorted(included_documents, key=_message_fork_sort_key)
+
+
+def _remap_fork_references(
+    value: Any,
+    key: str,
+    source_conversation_id: str,
+    fork_conversation_id: str,
+    message_id_map: Dict[str, str],
+    thread_id_map: Dict[str, str],
+) -> Any:
+    if isinstance(value, dict):
+        return {
+            child_key: _remap_fork_references(
+                child_value,
+                child_key,
+                source_conversation_id,
+                fork_conversation_id,
+                message_id_map,
+                thread_id_map,
+            )
+            for child_key, child_value in value.items()
+        }
+    if isinstance(value, list):
+        return [
+            _remap_fork_references(
+                child_value,
+                key,
+                source_conversation_id,
+                fork_conversation_id,
+                message_id_map,
+                thread_id_map,
+            )
+            for child_value in value
+        ]
+    if isinstance(value, str):
+        if (key == "conversation_id" or key.endswith("_conversation_id")) and value == source_conversation_id:
+            return fork_conversation_id
+        if key == "thread_id" or key.endswith("_thread_id"):
+            if value not in thread_id_map:
+                thread_id_map[value] = str(uuid.uuid4())
+            return thread_id_map[value]
+        if key == "message_id" or key.endswith("_message_id"):
+            return message_id_map.get(value, value)
+        if key == "artifact_id" or key.endswith("_artifact_id"):
+            return message_id_map.get(value, value)
+    return value
+
+
+def _build_fork_message_documents(
+    source_documents: List[Dict[str, Any]],
+    source_conversation_id: str,
+    fork_conversation_id: str,
+) -> List[Dict[str, Any]]:
+    message_id_map = {
+        str(document["id"]): f"{fork_conversation_id}_{index:06d}_{uuid.uuid4().hex}"
+        for index, document in enumerate(source_documents, start=1)
+    }
+    thread_id_map: Dict[str, str] = {}
+    fork_documents = []
+
+    for sequence, source_document in enumerate(source_documents, start=1):
+        source_message_id = str(source_document["id"])
+        fork_document = {
+            key: copy.deepcopy(value)
+            for key, value in source_document.items()
+            if key not in COSMOS_SYSTEM_FIELDS
+        }
+        fork_document["id"] = message_id_map[source_message_id]
+        fork_document["conversation_id"] = fork_conversation_id
+        fork_document["fork_sequence"] = sequence
+        fork_document = _remap_fork_references(
+            fork_document,
+            "",
+            source_conversation_id,
+            fork_conversation_id,
+            message_id_map,
+            thread_id_map,
+        )
+        fork_documents.append(fork_document)
+
+    return fork_documents
+
+
+def _build_fork_conversation_document(
+    source_conversation: Dict[str, Any],
+    selected_message_id: str,
+    fork_conversation_id: str,
+    user_id: str,
+) -> Dict[str, Any]:
+    source_title = str(source_conversation.get("title") or "New Conversation").strip() or "New Conversation"
+    fork_title = f"Fork of {source_title}"
+    timestamp = datetime.now(timezone.utc).isoformat()
+    fork_conversation = {
+        "id": fork_conversation_id,
+        "user_id": user_id,
+        "last_updated": timestamp,
+        "title": fork_title,
+        "context": [],
+        "tags": [],
+        "strict": False,
+        "is_pinned": False,
+        "is_hidden": False,
+        "chat_type": "personal_single_user",
+        "has_unread_assistant_response": False,
+        "last_unread_assistant_message_id": None,
+        "last_unread_assistant_at": None,
+        "added_to_activity_log": True,
+        "forked_from": {
+            "conversation_id": str(source_conversation.get("id") or ""),
+            "message_id": selected_message_id,
+        },
+    }
+    for field_name in PERSONAL_FORK_CONVERSATION_FIELDS:
+        if field_name in source_conversation:
+            fork_conversation[field_name] = copy.deepcopy(source_conversation[field_name])
+    return fork_conversation
+
+
+def _source_record_changed(original_record: Dict[str, Any], current_record: Dict[str, Any]) -> bool:
+    original_etag = original_record.get("_etag")
+    current_etag = current_record.get("_etag")
+    if original_etag or current_etag:
+        return original_etag != current_etag
+    return original_record != current_record
+
+
+def _source_document_set_changed(
+    original_documents: List[Dict[str, Any]],
+    current_documents: List[Dict[str, Any]],
+) -> bool:
+    original_by_id = {
+        str(document.get("id") or ""): document
+        for document in original_documents
+    }
+    current_by_id = {
+        str(document.get("id") or ""): document
+        for document in current_documents
+    }
+    if original_by_id.keys() != current_by_id.keys():
+        return True
+    return any(
+        _source_record_changed(original_document, current_by_id[message_id])
+        for message_id, original_document in original_by_id.items()
+    )
+
+
+def _build_fork_blob_path(
+    source_blob_path: str,
+    source_conversation_id: str,
+    fork_conversation_id: str,
+    source_message_id: str,
+    fork_message_id: str,
+) -> str:
+    normalized_path = str(source_blob_path or "").strip().replace("\\", "/")
+    fork_blob_path = normalized_path.replace(source_message_id, fork_message_id, 1)
+    fork_blob_path = fork_blob_path.replace(source_conversation_id, fork_conversation_id, 1)
+    if fork_blob_path != normalized_path:
+        return fork_blob_path
+
+    parent_path, _, file_name = normalized_path.rpartition("/")
+    normalized_file_name = file_name or "artifact"
+    prefix = f"{parent_path}/" if parent_path else ""
+    return f"{prefix}forks/{fork_conversation_id}/{fork_message_id}/{normalized_file_name}"
+
+
+def _copy_fork_blob_files(
+    source_documents: List[Dict[str, Any]],
+    fork_documents: List[Dict[str, Any]],
+    source_conversation_id: str,
+    fork_conversation_id: str,
+    created_blob_targets: List[Tuple[str, str]],
+) -> None:
+    blob_service_client = CLIENTS.get("storage_account_office_docs_client")
+    for source_document, fork_document in zip(source_documents, fork_documents):
+        blob_container = str(source_document.get("blob_container") or "").strip()
+        source_blob_path = str(source_document.get("blob_path") or "").strip()
+        if not blob_container or not source_blob_path:
+            continue
+        if not blob_service_client:
+            raise RuntimeError("Blob storage client is required to fork attached files")
+
+        fork_blob_path = _build_fork_blob_path(
+            source_blob_path,
+            source_conversation_id,
+            fork_conversation_id,
+            str(source_document.get("id") or ""),
+            str(fork_document.get("id") or ""),
+        )
+        source_blob_client = blob_service_client.get_blob_client(
+            container=blob_container,
+            blob=source_blob_path,
+        )
+        source_blob_properties = source_blob_client.get_blob_properties()
+        source_blob_content = source_blob_client.download_blob().readall()
+        fork_blob_client = blob_service_client.get_blob_client(
+            container=blob_container,
+            blob=fork_blob_path,
+        )
+        source_metadata = dict(getattr(source_blob_properties, "metadata", None) or {})
+        if source_metadata.get("conversation_id") == source_conversation_id:
+            source_metadata["conversation_id"] = fork_conversation_id
+        upload_options = {
+            "overwrite": True,
+            "metadata": source_metadata,
+        }
+        content_settings = getattr(source_blob_properties, "content_settings", None)
+        if content_settings is not None:
+            upload_options["content_settings"] = content_settings
+        fork_blob_client.upload_blob(source_blob_content, **upload_options)
+        created_blob_targets.append((blob_container, fork_blob_path))
+        fork_document["blob_path"] = fork_blob_path
+
+
+def _cleanup_failed_fork(
+    fork_conversation_id: str,
+    written_message_ids: List[str],
+    created_blob_targets: List[Tuple[str, str]],
+) -> None:
+    for message_id in reversed(written_message_ids):
+        try:
+            cosmos_messages_container.delete_item(
+                item=message_id,
+                partition_key=fork_conversation_id,
+            )
+        except Exception as cleanup_error:
+            log_event(
+                f"[ConversationFork] Failed to clean up fork message: {cleanup_error}",
+                level=logging.ERROR,
+                properties={
+                    "fork_conversation_id": fork_conversation_id,
+                    "message_id": message_id,
+                },
+            )
+    blob_service_client = CLIENTS.get("storage_account_office_docs_client")
+    for blob_container, blob_path in reversed(created_blob_targets):
+        try:
+            if not blob_service_client:
+                raise RuntimeError("Blob storage client is unavailable")
+            blob_service_client.get_blob_client(
+                container=blob_container,
+                blob=blob_path,
+            ).delete_blob()
+        except Exception as cleanup_error:
+            log_event(
+                f"[ConversationFork] Failed to clean up fork blob: {cleanup_error}",
+                level=logging.ERROR,
+                properties={
+                    "fork_conversation_id": fork_conversation_id,
+                    "blob_container": blob_container,
+                    "blob_path": blob_path,
+                },
+            )
+    try:
+        cosmos_conversations_container.delete_item(
+            item=fork_conversation_id,
+            partition_key=fork_conversation_id,
+        )
+    except CosmosResourceNotFoundError:
+        pass
+    except Exception as cleanup_error:
+        log_event(
+            f"[ConversationFork] Failed to clean up fork conversation: {cleanup_error}",
+            level=logging.ERROR,
+            properties={"fork_conversation_id": fork_conversation_id},
+        )
+
+
+def fork_personal_conversation_for_user(
+    source_conversation: Dict[str, Any],
+    selected_message_id: str,
+    user_id: str,
+) -> Dict[str, Any]:
+    """Create an independent personal conversation through one assistant message."""
+    source_conversation_id = str(source_conversation.get("id") or "").strip()
+    normalized_message_id = str(selected_message_id or "").strip()
+    normalized_user_id = str(user_id or "").strip()
+    if not source_conversation_id or not normalized_message_id or not normalized_user_id:
+        raise ValueError("Source conversation, assistant message, and user are required")
+    if source_conversation.get("user_id") != normalized_user_id:
+        raise PermissionError("Forbidden")
+    if not is_forkable_personal_conversation(source_conversation):
+        raise ConversationForkConflictError("Only personal conversations can be forked")
+
+    query = (
+        "SELECT * FROM c "
+        "WHERE c.conversation_id = @conversation_id"
+    )
+    all_documents = list(cosmos_messages_container.query_items(
+        query=query,
+        parameters=[{"name": "@conversation_id", "value": source_conversation_id}],
+        partition_key=source_conversation_id,
+    ))
+    source_documents = _collect_fork_documents(all_documents, normalized_message_id)
+    selected_document = next(
+        document
+        for document in source_documents
+        if str(document.get("id") or "") == normalized_message_id
+    )
+
+    try:
+        current_conversation = cosmos_conversations_container.read_item(
+            item=source_conversation_id,
+            partition_key=source_conversation_id,
+        )
+        current_selected_message = cosmos_messages_container.read_item(
+            item=normalized_message_id,
+            partition_key=source_conversation_id,
+        )
+        current_documents = list(cosmos_messages_container.query_items(
+            query=query,
+            parameters=[{"name": "@conversation_id", "value": source_conversation_id}],
+            partition_key=source_conversation_id,
+        ))
+    except CosmosResourceNotFoundError as exc:
+        raise ConversationForkConflictError("The source conversation changed before it could be forked") from exc
+
+    if _source_record_changed(source_conversation, current_conversation) or _source_record_changed(
+        selected_document,
+        current_selected_message,
+    ) or _source_document_set_changed(all_documents, current_documents):
+        raise ConversationForkConflictError("The source conversation changed before it could be forked")
+
+    fork_conversation_id = str(uuid.uuid4())
+    fork_documents = _build_fork_message_documents(
+        source_documents,
+        source_conversation_id,
+        fork_conversation_id,
+    )
+    fork_conversation = _build_fork_conversation_document(
+        source_conversation,
+        normalized_message_id,
+        fork_conversation_id,
+        normalized_user_id,
+    )
+    written_message_ids = []
+    created_blob_targets: List[Tuple[str, str]] = []
+
+    try:
+        _copy_fork_blob_files(
+            source_documents,
+            fork_documents,
+            source_conversation_id,
+            fork_conversation_id,
+            created_blob_targets,
+        )
+        for fork_document in fork_documents:
+            cosmos_messages_container.upsert_item(fork_document)
+            written_message_ids.append(fork_document["id"])
+        cosmos_conversations_container.upsert_item(fork_conversation)
+    except Exception:
+        _cleanup_failed_fork(
+            fork_conversation_id,
+            written_message_ids,
+            created_blob_targets,
+        )
+        raise
+
+    try:
+        log_conversation_creation(
+            user_id=normalized_user_id,
+            conversation_id=fork_conversation_id,
+            title=fork_conversation["title"],
+            workspace_type="personal",
+        )
+    except Exception as log_error:
+        log_event(
+            f"[ConversationFork] Fork created but activity logging failed: {log_error}",
+            level=logging.WARNING,
+            properties={"fork_conversation_id": fork_conversation_id},
+        )
+
+    return {
+        "conversation": fork_conversation,
+        "message_count": len([
+            document
+            for document in fork_documents
+            if not _is_assistant_artifact_document(document)
+        ]),
+    }
 
 
 def create_personal_conversation_for_current_user(

--- a/application/single_app/functions_simplechat_operations.py
+++ b/application/single_app/functions_simplechat_operations.py
@@ -632,7 +632,11 @@ def _cleanup_failed_fork(
             partition_key=fork_conversation_id,
         )
     except CosmosResourceNotFoundError:
-        pass
+        log_event(
+            "[ConversationFork] Fork conversation already absent during cleanup",
+            level=logging.INFO,
+            properties={"fork_conversation_id": fork_conversation_id},
+        )
     except Exception as cleanup_error:
         log_event(
             f"[ConversationFork] Failed to clean up fork conversation: {cleanup_error}",

--- a/application/single_app/route_backend_conversations.py
+++ b/application/single_app/route_backend_conversations.py
@@ -1204,7 +1204,7 @@ def register_route_backend_conversations(bp):
             log_event(
                 f'[ConversationFork] Conflict while creating conversation fork: {conflict_error}',
                 level=logging.WARNING,
-                properties={
+                custom_dimensions={
                     'source_conversation_id': conversation_id,
                     'selected_message_id': selected_message_id,
                     'user_id': user_id,

--- a/application/single_app/route_backend_conversations.py
+++ b/application/single_app/route_backend_conversations.py
@@ -1176,7 +1176,7 @@ def register_route_backend_conversations(bp):
                 log_event(
                     f'[ConversationFork] Fork created but cache invalidation failed: {cache_error}',
                     level=logging.WARNING,
-                    properties={
+                    custom_dimensions={
                         'fork_conversation_id': fork_conversation['id'],
                         'user_id': user_id,
                     },
@@ -1197,7 +1197,7 @@ def register_route_backend_conversations(bp):
                 f'[ConversationFork] Failed to create conversation fork: {error}',
                 level=logging.ERROR,
                 exceptionTraceback=True,
-                properties={
+                custom_dimensions={
                     'source_conversation_id': conversation_id,
                     'selected_message_id': selected_message_id,
                     'user_id': user_id,

--- a/application/single_app/route_backend_conversations.py
+++ b/application/single_app/route_backend_conversations.py
@@ -55,9 +55,11 @@ from functions_message_artifacts import (
     hydrate_agent_citations_from_artifacts,
 )
 from functions_simplechat_operations import (
+    ConversationForkConflictError,
     create_personal_conversation_for_current_user,
     delete_blob_backed_chat_message_files,
     derive_conversation_title_from_message,
+    fork_personal_conversation_for_user,
 )
 from swagger_wrapper import swagger_route, get_auth_security
 from functions_activity_logging import log_conversation_creation, log_conversation_deletion, log_conversation_archival
@@ -902,6 +904,11 @@ def register_route_backend_conversations(bp):
                 query=message_query,
                 partition_key=conversation_id
             ))
+            all_items.sort(key=lambda item: (
+                str(item.get('timestamp') or ''),
+                int(item.get('fork_sequence')) if str(item.get('fork_sequence') or '').isdigit() else 0,
+                str(item.get('id') or ''),
+            ))
             artifact_payload_map = build_message_artifact_payload_map(all_items)
             all_items = filter_assistant_artifact_items(all_items)
             
@@ -1133,7 +1140,72 @@ def register_route_backend_conversations(bp):
             'conversation_id': conversation_item.get('id'),
             'title': conversation_item.get('title', 'New Conversation')
         }), 200
-    
+
+
+    @bp.route('/api/conversations/<conversation_id>/fork', methods=['POST'])
+    @swagger_route(security=get_auth_security())
+    @login_required
+    @user_required
+    def fork_conversation(conversation_id):
+        user_id = get_current_user_id()
+        if not user_id:
+            return jsonify({'error': 'User not authenticated'}), 401
+
+        request_payload = request.get_json(silent=True) or {}
+        selected_message_id = str(request_payload.get('message_id') or '').strip()
+        if not selected_message_id:
+            return jsonify({'error': 'A persisted assistant message is required'}), 400
+
+        try:
+            source_conversation = _authorize_personal_conversation_read(user_id, conversation_id)
+        except PermissionError:
+            return jsonify({'error': 'Forbidden'}), 403
+        except LookupError:
+            return jsonify({'error': 'The source conversation was not found'}), 404
+
+        try:
+            fork_result = fork_personal_conversation_for_user(
+                source_conversation=source_conversation,
+                selected_message_id=selected_message_id,
+                user_id=user_id,
+            )
+            fork_conversation = fork_result['conversation']
+            try:
+                bump_conversation_cache_version(user_id, reason="conversation_forked")
+            except Exception as cache_error:
+                log_event(
+                    f'[ConversationFork] Fork created but cache invalidation failed: {cache_error}',
+                    level=logging.WARNING,
+                    properties={
+                        'fork_conversation_id': fork_conversation['id'],
+                        'user_id': user_id,
+                    },
+                )
+            return jsonify({
+                'conversation_id': fork_conversation['id'],
+                'title': fork_conversation['title'],
+                'message_count': fork_result['message_count'],
+            }), 201
+        except LookupError:
+            return jsonify({'error': 'The selected assistant message was not found'}), 404
+        except ValueError as validation_error:
+            return jsonify({'error': str(validation_error)}), 400
+        except ConversationForkConflictError as conflict_error:
+            return jsonify({'error': str(conflict_error)}), 409
+        except Exception as error:
+            log_event(
+                f'[ConversationFork] Failed to create conversation fork: {error}',
+                level=logging.ERROR,
+                exceptionTraceback=True,
+                properties={
+                    'source_conversation_id': conversation_id,
+                    'selected_message_id': selected_message_id,
+                    'user_id': user_id,
+                },
+            )
+            return jsonify({'error': 'Failed to fork conversation'}), 500
+
+
     @bp.route('/api/conversations/<conversation_id>', methods=['PUT'])
     @swagger_route(security=get_auth_security())
     @login_required

--- a/application/single_app/route_backend_conversations.py
+++ b/application/single_app/route_backend_conversations.py
@@ -1201,7 +1201,16 @@ def register_route_backend_conversations(bp):
             )
             return jsonify({'error': 'Invalid request'}), 400
         except ConversationForkConflictError as conflict_error:
-            return jsonify({'error': str(conflict_error)}), 409
+            log_event(
+                f'[ConversationFork] Conflict while creating conversation fork: {conflict_error}',
+                level=logging.WARNING,
+                properties={
+                    'source_conversation_id': conversation_id,
+                    'selected_message_id': selected_message_id,
+                    'user_id': user_id,
+                },
+            )
+            return jsonify({'error': 'Conversation fork conflict'}), 409
         except Exception as error:
             log_event(
                 f'[ConversationFork] Failed to create conversation fork: {error}',

--- a/application/single_app/route_backend_conversations.py
+++ b/application/single_app/route_backend_conversations.py
@@ -1189,7 +1189,17 @@ def register_route_backend_conversations(bp):
         except LookupError:
             return jsonify({'error': 'The selected assistant message was not found'}), 404
         except ValueError as validation_error:
-            return jsonify({'error': str(validation_error)}), 400
+            log_event(
+                f'[ConversationFork] Validation failed while creating conversation fork: {validation_error}',
+                level=logging.WARNING,
+                exceptionTraceback=True,
+                properties={
+                    'source_conversation_id': conversation_id,
+                    'selected_message_id': selected_message_id,
+                    'user_id': user_id,
+                },
+            )
+            return jsonify({'error': 'Invalid request'}), 400
         except ConversationForkConflictError as conflict_error:
             return jsonify({'error': str(conflict_error)}), 409
         except Exception as error:

--- a/application/single_app/route_backend_conversations.py
+++ b/application/single_app/route_backend_conversations.py
@@ -1193,7 +1193,7 @@ def register_route_backend_conversations(bp):
                 f'[ConversationFork] Validation failed while creating conversation fork: {validation_error}',
                 level=logging.WARNING,
                 exceptionTraceback=True,
-                properties={
+                custom_dimensions={
                     'source_conversation_id': conversation_id,
                     'selected_message_id': selected_message_id,
                     'user_id': user_id,

--- a/application/single_app/static/js/chat/chat-messages.js
+++ b/application/single_app/static/js/chat/chat-messages.js
@@ -10,7 +10,8 @@ import { promptSelect } from "./chat-prompts.js";
 import {
   createNewConversation,
   selectConversation,
-  addConversationToList
+  addConversationToList,
+  loadConversations
 } from "./chat-conversations.js";
 import { updateSidebarConversationTitle } from "./chat-sidebar-conversations.js";
 import { getActiveConversationContext, getActiveConversationScope } from "./chat-conversation-scope.js";
@@ -58,6 +59,12 @@ const documentComparisonSelectionList = document.getElementById('document-compar
 const documentComparisonPickerPanel = document.getElementById('document-comparison-picker-panel');
 const documentComparisonPickerControls = document.getElementById('document-comparison-picker-controls');
 const documentComparisonPickerStatus = document.getElementById('document-comparison-picker-status');
+const conversationForkModalEl = document.getElementById('fork-conversation-modal');
+const confirmConversationForkBtn = document.getElementById('confirm-fork-conversation-btn');
+const conversationForkButtonLabel = document.getElementById('fork-conversation-button-label');
+const conversationForkButtonSpinner = document.getElementById('fork-conversation-button-spinner');
+let pendingConversationFork = null;
+let conversationForkRequestPending = false;
 let comparisonVersionLoadToken = 0;
 let comparisonVersionCatalog = [];
 let comparisonChatUploadCatalog = [];
@@ -3146,6 +3153,121 @@ function renderReplyQuoteHtml(fullMessageObject = null) {
     return !isStreamingAssistantPlaceholder(messageId, fullMessageObject);
   }
 
+  function getForkablePersonalConversationId(fullMessageObject = null) {
+    const conversationId = resolveMessageConversationId(fullMessageObject);
+    const activeConversationId = String(
+      window.chatConversations?.getCurrentConversationId?.()
+      || window.currentConversationId
+      || ''
+    ).trim();
+    if (!conversationId || conversationId !== activeConversationId) {
+      return '';
+    }
+
+    const conversationItem = document.querySelector(
+      `.conversation-item[data-conversation-id="${CSS.escape(conversationId)}"], `
+      + `.sidebar-conversation-item[data-conversation-id="${CSS.escape(conversationId)}"]`
+    );
+    if (!conversationItem || conversationItem.dataset.conversationKind === 'collaborative') {
+      return '';
+    }
+
+    const chatType = String(conversationItem.dataset.chatType || '').trim().toLowerCase();
+    return ['', 'new', 'personal', 'personal_single_user'].includes(chatType)
+      ? conversationId
+      : '';
+  }
+
+  function shouldRenderConversationForkAction(messageId, fullMessageObject = null) {
+    const normalizedMessageId = String(messageId || '').trim();
+    const persistedMessageId = String(fullMessageObject?.id || '').trim();
+    return Boolean(
+      normalizedMessageId
+      && persistedMessageId === normalizedMessageId
+      && shouldRenderCompletedAssistantActions(messageId, fullMessageObject)
+      && getForkablePersonalConversationId(fullMessageObject)
+    );
+  }
+
+  function setConversationForkPendingState(isPending) {
+    conversationForkRequestPending = isPending;
+    if (confirmConversationForkBtn) {
+      confirmConversationForkBtn.disabled = isPending;
+    }
+    conversationForkButtonLabel?.classList.toggle('d-none', isPending);
+    conversationForkButtonSpinner?.classList.toggle('d-none', !isPending);
+  }
+
+  function openConversationForkModal(messageDiv, fullMessageObject = null) {
+    if (!conversationForkModalEl || !window.bootstrap || conversationForkRequestPending) {
+      return;
+    }
+
+    const messageId = String(messageDiv?.dataset?.messageId || '').trim();
+    const conversationId = getForkablePersonalConversationId(fullMessageObject);
+    if (!messageId || !conversationId) {
+      showToast('This message is not available to fork.', 'warning');
+      return;
+    }
+
+    pendingConversationFork = { conversationId, messageId };
+    setConversationForkPendingState(false);
+    bootstrap.Modal.getOrCreateInstance(conversationForkModalEl).show();
+  }
+
+  async function executeConversationFork() {
+    if (!pendingConversationFork || conversationForkRequestPending) {
+      return;
+    }
+
+    const { conversationId, messageId } = pendingConversationFork;
+    setConversationForkPendingState(true);
+
+    try {
+      const response = await fetch(
+        `/api/conversations/${encodeURIComponent(conversationId)}/fork`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ message_id: messageId }),
+        }
+      );
+      const responsePayload = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        throw new Error(responsePayload.error || 'Failed to fork conversation');
+      }
+
+      const forkConversationId = String(responsePayload.conversation_id || '').trim();
+      if (!forkConversationId) {
+        throw new Error('The fork response did not include a conversation ID');
+      }
+
+      bootstrap.Modal.getOrCreateInstance(conversationForkModalEl).hide();
+      pendingConversationFork = null;
+      addConversationToList(
+        forkConversationId,
+        String(responsePayload.title || 'Forked Conversation')
+      );
+      await selectConversation(forkConversationId);
+      void loadConversations();
+      showToast('Conversation fork created.', 'success');
+    } catch (error) {
+      console.error('Failed to fork conversation:', error);
+      showToast(error.message || 'Failed to fork conversation', 'danger');
+    } finally {
+      setConversationForkPendingState(false);
+    }
+  }
+
+  confirmConversationForkBtn?.addEventListener('click', () => {
+    void executeConversationFork();
+  });
+  conversationForkModalEl?.addEventListener('hidden.bs.modal', () => {
+    if (!conversationForkRequestPending) {
+      pendingConversationFork = null;
+    }
+  });
+
   function buildInlineAssistantExportActionsHtml(messageId) {
     const previousMessage = getMostRecentRenderedMessage();
     if (!(previousMessage instanceof HTMLElement) || !previousMessage.classList.contains('user-message')) {
@@ -4785,6 +4907,9 @@ export function appendMessage(
             <li><a class="dropdown-item dropdown-export-ppt-btn" href="#" data-message-id="${messageId}"><i class="bi bi-file-earmark-slides me-2"></i>Export to PowerPoint</a></li>
             <li><a class="dropdown-item dropdown-copy-prompt-btn" href="#" data-message-id="${messageId}"><i class="bi bi-clipboard-plus me-2"></i>Use as Prompt</a></li>
             <li><a class="dropdown-item dropdown-open-email-btn" href="#" data-message-id="${messageId}"><i class="bi bi-envelope me-2"></i>Open in Email</a></li>` : '';
+    const forkConversationMenuItemHtml = shouldRenderConversationForkAction(messageId, fullMessageObject)
+      ? '<li><button class="dropdown-item dropdown-fork-conversation-btn" type="button"><i class="bi bi-signpost-split me-2"></i>Fork conversation</button></li>'
+      : '';
     const actionsDropdownHtml = `
             <div class="dropdown">
                 <button class="btn btn-sm btn-link text-muted" type="button" data-bs-toggle="dropdown" data-bs-boundary="viewport" data-bs-reference="parent" aria-expanded="false" title="More actions">
@@ -4793,6 +4918,7 @@ export function appendMessage(
                 <ul class="dropdown-menu dropdown-menu-start">
                     <li><a class="dropdown-item dropdown-delete-btn" href="#" data-message-id="${messageId}"><i class="bi bi-trash me-2"></i>Delete</a></li>
                     <li><a class="dropdown-item dropdown-retry-btn" href="#" data-message-id="${messageId}"><i class="bi bi-arrow-clockwise me-2"></i>Retry</a></li>
+                    ${forkConversationMenuItemHtml}
                     ${feedbackHtml}
             ${exportMenuItemsHtml}
                 </ul>
@@ -5018,6 +5144,11 @@ export function appendMessage(
         handleRetryButtonClick(messageDiv, currentMessageId, 'assistant');
       });
     }
+
+    const dropdownForkConversationBtn = messageDiv.querySelector('.dropdown-fork-conversation-btn');
+    dropdownForkConversationBtn?.addEventListener('click', () => {
+      openConversationForkModal(messageDiv, fullMessageObject);
+    });
 
     // Handle dropdown positioning manually - move to chatbox container
     const dropdownToggle = messageDiv.querySelector(".message-actions .dropdown button[data-bs-toggle='dropdown']");

--- a/application/single_app/templates/chats.html
+++ b/application/single_app/templates/chats.html
@@ -893,6 +893,34 @@
     </div>
 </div>
 
+<!-- Modal for forking a personal conversation -->
+<div class="modal fade" id="fork-conversation-modal" tabindex="-1" aria-labelledby="forkConversationModalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="forkConversationModalLabel">
+                    <i class="bi bi-signpost-split me-2"></i>Fork Conversation
+                </h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <p>Create a new personal conversation containing the history through this assistant response?</p>
+                <p class="text-muted small mb-0">The original conversation will not be changed.</p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                <button type="button" class="btn btn-primary" id="confirm-fork-conversation-btn">
+                    <span id="fork-conversation-button-label">Fork conversation</span>
+                    <span id="fork-conversation-button-spinner" class="d-none">
+                        <span class="spinner-border spinner-border-sm me-1" aria-hidden="true"></span>
+                        Forking...
+                    </span>
+                </button>
+            </div>
+        </div>
+    </div>
+</div>
+
 <!-- Modal for deleting user messages (with thread option) -->
 <div class="modal fade" id="delete-message-modal" tabindex="-1" aria-labelledby="deleteMessageModalLabel" aria-hidden="true">
     <div class="modal-dialog">

--- a/docs/explanation/features/FORK_CONVERSATION.md
+++ b/docs/explanation/features/FORK_CONVERSATION.md
@@ -1,0 +1,149 @@
+# Fork Conversation
+
+## Overview
+
+**Implemented in version: 0.250.074**
+
+Fork Conversation lets a user branch a personal conversation from a persisted
+assistant response without changing the source conversation. The fork contains
+the active message history from the beginning through the selected assistant
+message, inclusive, and opens immediately as an independent conversation.
+
+### Purpose
+
+- Preserve the original conversation while exploring an alternate direction.
+- Avoid manually recreating useful earlier context.
+- Keep copied messages and dependent assistant artifacts independent from the
+  source records.
+
+### Dependencies
+
+- Personal conversations stored in Azure Cosmos DB.
+- The existing chat message action menu, Bootstrap modal and toast components,
+  and conversation-list selection APIs.
+- Existing authenticated personal-conversation ownership checks.
+
+## Technical Specifications
+
+### Architecture
+
+1. The assistant message action is rendered only for a persisted, completed
+   assistant message in an active personal conversation.
+2. A Bootstrap confirmation modal submits the source conversation ID and
+   selected message ID.
+3. The backend authorizes ownership and resolves the authoritative persisted
+   timeline. The client does not send message history or a timestamp boundary.
+4. Active messages through the selected assistant response and supported
+   dependent assistant artifact records are copied with new identifiers.
+5. Conversation, message, artifact, reply, and thread references are remapped
+   to the destination identities.
+6. Blob-backed attachments and generated files are copied to destination blob
+   paths so deleting either conversation cannot affect the other.
+7. Destination messages are written before the conversation record is
+   published. Failed writes trigger destination cleanup, preventing a partial
+   fork from appearing in the conversation list.
+8. The client adds and selects the returned conversation, then refreshes the
+   conversation feed.
+
+### API
+
+`POST /api/conversations/<conversation_id>/fork`
+
+Request:
+
+```json
+{
+  "message_id": "persisted-assistant-message-id"
+}
+```
+
+Successful response (`201`):
+
+```json
+{
+  "conversation_id": "new-conversation-id",
+  "title": "Fork of Source title",
+  "message_count": 4
+}
+```
+
+The endpoint can return:
+
+- `400` for a missing message ID or a non-assistant fork point.
+- `403` when the current user does not own the source conversation.
+- `404` when the selected message is not on the active persisted timeline.
+- `409` when the source is not an eligible personal conversation or changes
+  during the operation.
+- `500` when destination persistence fails.
+
+### Security and authorization
+
+- Source ownership is revalidated at the API boundary.
+- Group, public, and collaborative conversation types are rejected.
+- Stored context is eligible only when it remains personal to the same owner.
+- The selected message must belong to the authorized source conversation and
+  must be an active assistant message.
+- Source conversation and message snapshots are checked again before writes to
+  detect concurrent changes.
+- The server queries the authoritative history and ignores client-supplied
+  timelines or timestamps.
+
+### Preserved and reset state
+
+The fork preserves personal context, tags, strict mode, classification, scope
+lock state, supported model/agent selections, message content, attachments,
+citations, and assistant artifact metadata. It assigns new conversation,
+message, artifact, and thread identifiers, and copies blob-backed message files
+to independent destination paths.
+
+Pin, hidden, unread, Cosmos system, streaming, and other destination lifecycle
+state is reset. The source conversation and all later messages remain
+unchanged.
+
+### Files
+
+- `application/single_app/functions_simplechat_operations.py`
+- `application/single_app/route_backend_conversations.py`
+- `application/single_app/static/js/chat/chat-messages.js`
+- `application/single_app/templates/chats.html`
+- `functional_tests/test_conversation_fork.py`
+- `ui_tests/test_chat_conversation_fork.py`
+
+## Usage
+
+1. Open a personal conversation containing a completed assistant response.
+2. Open the response's **More actions** menu.
+3. Select **Fork conversation**.
+4. Confirm the operation.
+5. Continue in the newly opened `Fork of <source title>` conversation.
+
+The action is unavailable for streaming or transient assistant messages and for
+group, public, or collaborative conversations.
+
+## Testing and Validation
+
+### Coverage
+
+- Inclusive assistant boundary and exclusion of later or inactive messages.
+- Stable ordering when timestamps match.
+- Independent and remapped message, artifact, reply, conversation, and thread
+  identifiers.
+- Source immutability.
+- Missing, non-assistant, inactive, foreign, and non-personal fork requests.
+- Concurrent source changes and failed-write cleanup.
+- Browser action visibility, confirmation and cancellation, failure feedback,
+  duplicate-click prevention, list insertion, and fork activation.
+
+### Performance
+
+Forking reads the source partition twice to verify a stable snapshot, then
+writes only records included through the selected boundary. The destination
+conversation is not listed until all destination message writes complete.
+
+### Limitations
+
+- Only personal, single-user conversations are supported.
+- Group, public, and collaborative conversations require separate resource and
+  participant authorization designs.
+- Cross-container atomic transactions are not available. The implementation
+  uses publish-last behavior plus cleanup to provide an atomic user experience.

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,16 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](/explanation/features/) and [Fixes by Version](/explanation/fixes/).
 
+### **(v0.250.074)**
+
+#### New Features
+
+*   **Fork Personal Conversations from Assistant Responses**
+    *   Added a Fork conversation action for persisted assistant messages, creating an independent personal conversation containing the active history through the selected response while leaving the source unchanged.
+    *   Forks remap conversation, message, thread, reply, and artifact identifiers; copy blob-backed attachments to independent paths; reject unauthorized or changed sources; and clean up failed copies before they become visible.
+    *   Added confirmation, duplicate-click prevention, failure feedback, immediate fork navigation, backend regression coverage, and browser workflow coverage.
+    *   (Ref: microsoft/simplechat#1025, `functions_simplechat_operations.py`, `route_backend_conversations.py`, `chat-messages.js`, `FORK_CONVERSATION.md`)
+
 ### **(v0.250.073)**
 
 #### New Features

--- a/functional_tests/test_conversation_fork.py
+++ b/functional_tests/test_conversation_fork.py
@@ -1,0 +1,681 @@
+#!/usr/bin/env python3
+# test_conversation_fork.py
+"""
+Functional test for personal conversation forking.
+Version: 0.250.074
+Implemented in: 0.250.074
+
+This test ensures persisted personal conversation history is copied through an
+assistant boundary with independent identifiers, deterministic ordering,
+authorization, concurrency protection, and failed-write cleanup.
+"""
+
+import copy
+import importlib
+import os
+import sys
+import types
+
+import pytest
+from azure.cosmos.exceptions import CosmosResourceNotFoundError
+
+
+sys.path.insert(
+    0,
+    os.path.join(
+        os.path.dirname(os.path.abspath(__file__)),
+        '..',
+        'application',
+        'single_app',
+    ),
+)
+
+TEST_OPERATIONS_MODULE = None
+
+
+def _stub_module(module_name, attributes):
+    """Build a lightweight dependency module for isolated import."""
+    module = types.ModuleType(module_name)
+    for attribute_name, attribute_value in attributes.items():
+        setattr(module, attribute_name, attribute_value)
+    return module
+
+
+def load_operations_module_for_test():
+    """Import the operation module without loading the full application config."""
+    global TEST_OPERATIONS_MODULE
+    if TEST_OPERATIONS_MODULE is not None:
+        return TEST_OPERATIONS_MODULE
+
+    no_op = lambda *args, **kwargs: None
+    dependency_stubs = {
+        'collaboration_models': _stub_module(
+            'collaboration_models',
+            {'normalize_collaboration_user': lambda value: value},
+        ),
+        'config': _stub_module(
+            'config',
+            {
+                'CLIENTS': {},
+                'TABULAR_EXTENSIONS': set(),
+                'cosmos_activity_logs_container': None,
+                'cosmos_conversations_container': None,
+                'cosmos_groups_container': None,
+                'cosmos_messages_container': None,
+                'storage_account_personal_chat_container_name': '',
+            },
+        ),
+        'functions_activity_logging': _stub_module(
+            'functions_activity_logging',
+            {
+                'log_chat_activity': no_op,
+                'log_conversation_creation': no_op,
+                'log_document_upload': no_op,
+                'log_group_status_change': no_op,
+                'log_workflow_creation': no_op,
+            },
+        ),
+        'functions_appinsights': _stub_module(
+            'functions_appinsights',
+            {'log_event': no_op},
+        ),
+        'functions_authentication': _stub_module(
+            'functions_authentication',
+            {
+                'get_current_user_info': lambda: None,
+                'get_graph_endpoint': lambda: '',
+                'get_valid_access_token': lambda: '',
+            },
+        ),
+        'functions_collaboration': _stub_module(
+            'functions_collaboration',
+            {
+                'assert_user_can_participate_in_collaboration_conversation': no_op,
+                'create_collaboration_message_notifications': no_op,
+                'create_group_collaboration_conversation_record': no_op,
+                'create_personal_collaboration_conversation_record': no_op,
+                'get_collaboration_conversation': no_op,
+                'invite_personal_collaboration_participants': no_op,
+                'is_group_collaboration_conversation': lambda value: False,
+                'persist_collaboration_message': no_op,
+            },
+        ),
+        'functions_documents': _stub_module(
+            'functions_documents',
+            {
+                'allowed_file': no_op,
+                'create_document': no_op,
+                'process_document_upload_background': no_op,
+                'update_document': no_op,
+            },
+        ),
+        'functions_chat_bootstrap_cache': _stub_module(
+            'functions_chat_bootstrap_cache',
+            {'bump_chat_bootstrap_global_cache_version': no_op},
+        ),
+        'functions_group': _stub_module(
+            'functions_group',
+            {
+                'assert_group_role': no_op,
+                'check_group_status_allows_operation': no_op,
+                'create_group': no_op,
+                'find_group_by_id': no_op,
+                'get_user_role_in_group': no_op,
+                'require_active_group': no_op,
+            },
+        ),
+        'functions_notifications': _stub_module(
+            'functions_notifications',
+            {'create_notification': no_op},
+        ),
+        'functions_personal_workflows': _stub_module(
+            'functions_personal_workflows',
+            {'save_personal_workflow': no_op},
+        ),
+        'functions_settings': _stub_module(
+            'functions_settings',
+            {
+                'get_settings': lambda: {},
+                'is_user_workflows_enabled_for_user': lambda user_id: False,
+            },
+        ),
+        'utils_cache': _stub_module(
+            'utils_cache',
+            {
+                'invalidate_group_search_cache': no_op,
+                'invalidate_personal_search_cache': no_op,
+            },
+        ),
+    }
+    original_modules = {
+        module_name: sys.modules.get(module_name)
+        for module_name in dependency_stubs
+    }
+    original_operations_module = sys.modules.pop('functions_simplechat_operations', None)
+    try:
+        sys.modules.update(dependency_stubs)
+        TEST_OPERATIONS_MODULE = importlib.import_module('functions_simplechat_operations')
+    finally:
+        for module_name, original_module in original_modules.items():
+            if original_module is None:
+                sys.modules.pop(module_name, None)
+            else:
+                sys.modules[module_name] = original_module
+        sys.modules.pop('functions_simplechat_operations', None)
+        if original_operations_module is not None:
+            sys.modules['functions_simplechat_operations'] = original_operations_module
+
+    return TEST_OPERATIONS_MODULE
+
+
+class FakeConversationContainer:
+    """In-memory personal conversation storage."""
+
+    def __init__(self, source_conversation):
+        self.items = {source_conversation['id']: copy.deepcopy(source_conversation)}
+        self.upserts = []
+        self.deleted_ids = []
+
+    def read_item(self, item, partition_key):
+        if item not in self.items:
+            raise CosmosResourceNotFoundError(message='Conversation not found')
+        return copy.deepcopy(self.items[item])
+
+    def upsert_item(self, item):
+        stored_item = copy.deepcopy(item)
+        self.items[stored_item['id']] = stored_item
+        self.upserts.append(stored_item)
+        return copy.deepcopy(stored_item)
+
+    def delete_item(self, item, partition_key):
+        if item not in self.items:
+            raise CosmosResourceNotFoundError(message='Conversation not found')
+        self.deleted_ids.append(item)
+        del self.items[item]
+
+
+class FakeMessageContainer:
+    """In-memory partitioned message storage with failure and race controls."""
+
+    def __init__(self, messages, fail_on_fork_upsert=None, mutate_on_second_query=False):
+        self.items = [copy.deepcopy(message) for message in messages]
+        self.fail_on_fork_upsert = fail_on_fork_upsert
+        self.mutate_on_second_query = mutate_on_second_query
+        self.query_count = 0
+        self.fork_upsert_count = 0
+        self.deleted_ids = []
+
+    def query_items(self, query, parameters=None, partition_key=None):
+        self.query_count += 1
+        if self.mutate_on_second_query and self.query_count == 2:
+            self.items.append({
+                'id': 'source-conversation_late_user',
+                'conversation_id': 'source-conversation',
+                'role': 'user',
+                'content': 'Concurrent update',
+                'timestamp': '2026-07-30T12:00:05Z',
+                'metadata': {},
+            })
+        return [
+            copy.deepcopy(message)
+            for message in self.items
+            if message.get('conversation_id') == partition_key
+        ]
+
+    def read_item(self, item, partition_key):
+        for message in self.items:
+            if message.get('id') == item and message.get('conversation_id') == partition_key:
+                return copy.deepcopy(message)
+        raise CosmosResourceNotFoundError(message='Message not found')
+
+    def upsert_item(self, item):
+        if item.get('conversation_id') != 'source-conversation':
+            self.fork_upsert_count += 1
+            if self.fail_on_fork_upsert == self.fork_upsert_count:
+                raise RuntimeError('Simulated message write failure')
+        stored_item = copy.deepcopy(item)
+        self.items.append(stored_item)
+        return copy.deepcopy(stored_item)
+
+    def delete_item(self, item, partition_key):
+        self.deleted_ids.append(item)
+        self.items = [
+            message
+            for message in self.items
+            if not (
+                message.get('id') == item
+                and message.get('conversation_id') == partition_key
+            )
+        ]
+
+
+class FakeBlobProperties:
+    """Minimal blob property payload."""
+
+    def __init__(self, metadata=None, content_settings=None):
+        self.metadata = copy.deepcopy(metadata or {})
+        self.content_settings = content_settings
+
+
+class FakeBlobDownload:
+    """Minimal blob download payload."""
+
+    def __init__(self, content):
+        self.content = content
+
+    def readall(self):
+        return self.content
+
+
+class FakeBlobClient:
+    """In-memory blob client."""
+
+    def __init__(self, service, container, blob_path):
+        self.service = service
+        self.target = (container, blob_path)
+
+    def get_blob_properties(self):
+        if self.target not in self.service.blobs:
+            raise CosmosResourceNotFoundError(message='Blob not found')
+        blob_record = self.service.blobs[self.target]
+        return FakeBlobProperties(
+            metadata=blob_record.get('metadata'),
+            content_settings=blob_record.get('content_settings'),
+        )
+
+    def download_blob(self):
+        if self.target not in self.service.blobs:
+            raise CosmosResourceNotFoundError(message='Blob not found')
+        return FakeBlobDownload(self.service.blobs[self.target]['content'])
+
+    def upload_blob(self, content, overwrite=False, metadata=None, content_settings=None):
+        if self.target in self.service.blobs and not overwrite:
+            raise RuntimeError('Blob already exists')
+        self.service.blobs[self.target] = {
+            'content': content,
+            'metadata': copy.deepcopy(metadata or {}),
+            'content_settings': content_settings,
+        }
+
+    def delete_blob(self):
+        self.service.deleted_targets.append(self.target)
+        self.service.blobs.pop(self.target, None)
+
+
+class FakeBlobService:
+    """In-memory blob service for fork copy and cleanup checks."""
+
+    def __init__(self):
+        self.blobs = {
+            (
+                'personal-chat',
+                'owner/source-conversation/generated/message-003-generated-file/report.docx',
+            ): {
+                'content': b'generated report bytes',
+                'metadata': {
+                    'conversation_id': 'source-conversation',
+                    'generated_artifact': 'true',
+                },
+                'content_settings': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+            },
+        }
+        self.deleted_targets = []
+
+    def get_blob_client(self, container, blob):
+        return FakeBlobClient(self, container, blob)
+
+
+class PatchSet:
+    """Temporarily replace module attributes."""
+
+    def __init__(self, module, replacements):
+        self.module = module
+        self.replacements = replacements
+        self.originals = {}
+
+    def __enter__(self):
+        for attribute_name, replacement in self.replacements.items():
+            self.originals[attribute_name] = getattr(self.module, attribute_name)
+            setattr(self.module, attribute_name, replacement)
+        return self
+
+    def __exit__(self, exc_type, exc, traceback):
+        for attribute_name, original in self.originals.items():
+            setattr(self.module, attribute_name, original)
+        return False
+
+
+def build_source_conversation(user_id='owner-user', chat_type='personal_single_user'):
+    """Build a stable source conversation fixture."""
+    return {
+        'id': 'source-conversation',
+        'user_id': user_id,
+        'title': 'Quarterly planning',
+        'chat_type': chat_type,
+        'context': [{'type': 'primary', 'scope': 'personal', 'id': 'doc-1'}],
+        'tags': ['planning'],
+        'strict': True,
+        'last_updated': '2026-07-30T12:00:04Z',
+        '_etag': 'conversation-etag-1',
+    }
+
+
+def build_source_messages():
+    """Build active, inactive, artifact, and post-boundary records."""
+    return [
+        {
+            'id': 'message-001-user',
+            'conversation_id': 'source-conversation',
+            'role': 'user',
+            'content': 'Start',
+            'timestamp': '2026-07-30T12:00:00Z',
+            'metadata': {
+                'chat_context': {'conversation_id': 'source-conversation'},
+                'thread_info': {'thread_id': 'thread-1', 'active_thread': True},
+            },
+            '_etag': 'message-etag-1',
+        },
+        {
+            'id': 'message-002-inactive',
+            'conversation_id': 'source-conversation',
+            'role': 'assistant',
+            'content': 'Old attempt',
+            'timestamp': '2026-07-30T12:00:01Z',
+            'metadata': {
+                'thread_info': {'thread_id': 'thread-old', 'active_thread': False},
+            },
+            '_etag': 'message-etag-2',
+        },
+        {
+            'id': 'message-003-target',
+            'conversation_id': 'source-conversation',
+            'role': 'assistant',
+            'content': 'Fork here',
+            'timestamp': '2026-07-30T12:00:02Z',
+            'reply_to_message_id': 'message-001-user',
+            'metadata': {
+                'chat_context': {'conversation_id': 'source-conversation'},
+                'thread_info': {
+                    'thread_id': 'thread-1',
+                    'previous_thread_id': 'thread-0',
+                    'active_thread': True,
+                },
+                'agent_citations': [{'artifact_id': 'message-003-target_artifact_1'}],
+                'generated_analysis_artifacts': [{
+                    'artifact_message_id': 'message-003-generated-file',
+                    'conversation_id': 'source-conversation',
+                    'file_name': 'report.docx',
+                }],
+            },
+            '_etag': 'message-etag-3',
+        },
+        {
+            'id': 'message-003-target_artifact_1',
+            'conversation_id': 'source-conversation',
+            'role': 'assistant_artifact',
+            'content': 'Citation payload',
+            'parent_message_id': 'message-003-target',
+            'timestamp': '2026-07-30T12:00:02Z',
+            'metadata': {
+                'is_generated_chat_artifact': True,
+                'root_message_id': 'message-003-target',
+            },
+            '_etag': 'message-etag-4',
+        },
+        {
+            'id': 'message-003-target_artifact_1_chunk_1',
+            'conversation_id': 'source-conversation',
+            'role': 'assistant_artifact_chunk',
+            'content': 'Citation payload continuation',
+            'parent_message_id': 'message-003-target_artifact_1',
+            'timestamp': '2026-07-30T12:00:02Z',
+            'metadata': {
+                'is_generated_chat_artifact': True,
+                'root_message_id': 'message-003-target',
+                'parent_message_id': 'message-003-target_artifact_1',
+            },
+            '_etag': 'message-etag-5',
+        },
+        {
+            'id': 'message-003-generated-file',
+            'conversation_id': 'source-conversation',
+            'role': 'file',
+            'filename': 'report.docx',
+            'file_content_source': 'blob',
+            'blob_container': 'personal-chat',
+            'blob_path': 'owner/source-conversation/generated/message-003-generated-file/report.docx',
+            'timestamp': '2026-07-30T12:00:02Z',
+            'metadata': {
+                'is_generated_chat_artifact': True,
+                'generated_artifact_capability': 'analysis',
+                'thread_info': {'thread_id': 'thread-file', 'active_thread': False},
+            },
+            '_etag': 'message-etag-5-file',
+        },
+        {
+            'id': 'message-004-later-user',
+            'conversation_id': 'source-conversation',
+            'role': 'user',
+            'content': 'Later question',
+            'timestamp': '2026-07-30T12:00:03Z',
+            'metadata': {'thread_info': {'thread_id': 'thread-2', 'active_thread': True}},
+            '_etag': 'message-etag-6',
+        },
+        {
+            'id': 'message-005-later-assistant',
+            'conversation_id': 'source-conversation',
+            'role': 'assistant',
+            'content': 'Later response',
+            'timestamp': '2026-07-30T12:00:04Z',
+            'metadata': {'thread_info': {'thread_id': 'thread-2', 'active_thread': True}},
+            '_etag': 'message-etag-7',
+        },
+    ]
+
+
+def run_fork(
+    source_conversation=None,
+    source_messages=None,
+    user_id='owner-user',
+    selected_message_id='message-003-target',
+    **message_container_options,
+):
+    """Execute the fork helper with isolated fake storage."""
+    operations_module = load_operations_module_for_test()
+    conversation = copy.deepcopy(source_conversation or build_source_conversation())
+    source_snapshot = copy.deepcopy(conversation)
+    messages = copy.deepcopy(source_messages or build_source_messages())
+    message_snapshot = copy.deepcopy(messages)
+    conversation_container = FakeConversationContainer(conversation)
+    message_container = FakeMessageContainer(messages, **message_container_options)
+    blob_service = FakeBlobService()
+
+    with PatchSet(
+        operations_module,
+        {
+            'cosmos_conversations_container': conversation_container,
+            'cosmos_messages_container': message_container,
+            'CLIENTS': {'storage_account_office_docs_client': blob_service},
+            'log_conversation_creation': lambda **kwargs: None,
+            'log_event': lambda *args, **kwargs: None,
+        },
+    ):
+        result = operations_module.fork_personal_conversation_for_user(
+            source_conversation=conversation,
+            selected_message_id=selected_message_id,
+            user_id=user_id,
+        )
+
+    return {
+        'module': operations_module,
+        'result': result,
+        'conversation_container': conversation_container,
+        'message_container': message_container,
+        'blob_service': blob_service,
+        'source_snapshot': source_snapshot,
+        'message_snapshot': message_snapshot,
+    }
+
+
+def test_fork_copies_inclusive_active_history_with_independent_ids():
+    """Copy through the target once while excluding inactive and later messages."""
+    test_state = run_fork()
+    fork_conversation = test_state['result']['conversation']
+    fork_id = fork_conversation['id']
+    fork_documents = [
+        message
+        for message in test_state['message_container'].items
+        if message.get('conversation_id') == fork_id
+    ]
+    visible_documents = [
+        message
+        for message in fork_documents
+        if not str(message.get('role') or '').startswith('assistant_artifact')
+        and not (message.get('metadata') or {}).get('is_generated_chat_artifact')
+    ]
+
+    assert fork_conversation['title'] == 'Fork of Quarterly planning'
+    assert fork_conversation['id'] != 'source-conversation'
+    assert fork_conversation['context'] == [{'type': 'primary', 'scope': 'personal', 'id': 'doc-1'}]
+    assert fork_conversation['forked_from']['message_id'] == 'message-003-target'
+    assert test_state['result']['message_count'] == 2
+    assert [message['content'] for message in visible_documents] == ['Start', 'Fork here']
+    assert len(fork_documents) == 5
+    assert len({message['id'] for message in fork_documents}) == 5
+    assert not {message['id'] for message in fork_documents}.intersection(
+        {message['id'] for message in test_state['message_snapshot']}
+    )
+    assert [message['fork_sequence'] for message in fork_documents] == [1, 2, 3, 4, 5]
+
+    fork_user = next(message for message in fork_documents if message.get('content') == 'Start')
+    fork_target = next(message for message in fork_documents if message.get('content') == 'Fork here')
+    fork_artifact = next(message for message in fork_documents if message.get('content') == 'Citation payload')
+    fork_artifact_chunk = next(
+        message
+        for message in fork_documents
+        if message.get('content') == 'Citation payload continuation'
+    )
+    fork_generated_file = next(
+        message
+        for message in fork_documents
+        if message.get('filename') == 'report.docx'
+    )
+    assert fork_target['reply_to_message_id'] == fork_user['id']
+    assert fork_target['metadata']['chat_context']['conversation_id'] == fork_id
+    assert fork_target['metadata']['thread_info']['thread_id'] != 'thread-1'
+    assert fork_artifact['parent_message_id'] == fork_target['id']
+    assert fork_artifact['metadata']['root_message_id'] == fork_target['id']
+    assert fork_artifact_chunk['parent_message_id'] == fork_artifact['id']
+    assert fork_target['metadata']['agent_citations'][0]['artifact_id'] == fork_artifact['id']
+    assert (
+        fork_target['metadata']['generated_analysis_artifacts'][0]['artifact_message_id']
+        == fork_generated_file['id']
+    )
+    assert fork_generated_file['blob_path'] != (
+        'owner/source-conversation/generated/message-003-generated-file/report.docx'
+    )
+    fork_blob_target = ('personal-chat', fork_generated_file['blob_path'])
+    assert test_state['blob_service'].blobs[fork_blob_target]['content'] == b'generated report bytes'
+    assert (
+        test_state['blob_service'].blobs[fork_blob_target]['metadata']['conversation_id']
+        == fork_id
+    )
+
+    assert test_state['conversation_container'].items['source-conversation'] == test_state['source_snapshot']
+    current_source_messages = [
+        message
+        for message in test_state['message_container'].items
+        if message.get('conversation_id') == 'source-conversation'
+    ]
+    assert current_source_messages == test_state['message_snapshot']
+    fork_target['content'] = 'Changed fork only'
+    assert next(
+        message
+        for message in current_source_messages
+        if message['id'] == 'message-003-target'
+    )['content'] == 'Fork here'
+
+
+@pytest.mark.parametrize(
+    ('selected_message_id', 'expected_exception'),
+    [
+        ('missing-message', LookupError),
+        ('message-001-user', ValueError),
+        ('message-002-inactive', LookupError),
+    ],
+)
+def test_fork_rejects_invalid_message_boundaries(selected_message_id, expected_exception):
+    """Reject missing, non-assistant, and inactive fork points."""
+    with pytest.raises(expected_exception):
+        run_fork(selected_message_id=selected_message_id)
+
+
+def test_fork_rejects_foreign_and_non_personal_conversations():
+    """Require source ownership and personal-only context."""
+    with pytest.raises(PermissionError):
+        run_fork(user_id='different-user')
+
+    group_conversation = build_source_conversation(chat_type='group-single-user')
+    group_conversation['context'] = [{'type': 'primary', 'scope': 'group', 'id': 'group-1'}]
+    operations_module = load_operations_module_for_test()
+    with pytest.raises(operations_module.ConversationForkConflictError):
+        run_fork(source_conversation=group_conversation)
+
+
+def test_fork_rejects_concurrent_source_changes():
+    """Abort when the authoritative source changes during the copy."""
+    operations_module = load_operations_module_for_test()
+    with pytest.raises(operations_module.ConversationForkConflictError):
+        run_fork(mutate_on_second_query=True)
+
+
+def test_fork_rejects_missing_generated_artifact_records():
+    """Reject a fork that would preserve a dangling generated-file reference."""
+    operations_module = load_operations_module_for_test()
+    messages = [
+        message
+        for message in build_source_messages()
+        if message.get('id') != 'message-003-generated-file'
+    ]
+    with pytest.raises(
+        operations_module.ConversationForkConflictError,
+        match='generated assistant artifact',
+    ):
+        run_fork(source_messages=messages)
+
+
+def test_fork_cleans_up_partial_message_writes():
+    """Delete destination records when a copy write fails."""
+    operations_module = load_operations_module_for_test()
+    conversation = build_source_conversation()
+    messages = build_source_messages()
+    conversation_container = FakeConversationContainer(conversation)
+    message_container = FakeMessageContainer(messages, fail_on_fork_upsert=2)
+    blob_service = FakeBlobService()
+
+    with PatchSet(
+        operations_module,
+        {
+            'cosmos_conversations_container': conversation_container,
+            'cosmos_messages_container': message_container,
+            'CLIENTS': {'storage_account_office_docs_client': blob_service},
+            'log_conversation_creation': lambda **kwargs: None,
+            'log_event': lambda *args, **kwargs: None,
+        },
+    ):
+        with pytest.raises(RuntimeError, match='Simulated message write failure'):
+            operations_module.fork_personal_conversation_for_user(
+                source_conversation=conversation,
+                selected_message_id='message-003-target',
+                user_id='owner-user',
+            )
+
+    assert message_container.deleted_ids
+    assert not [
+        message
+        for message in message_container.items
+        if message.get('conversation_id') != 'source-conversation'
+    ]
+    assert list(conversation_container.items) == ['source-conversation']
+    assert len(blob_service.blobs) == 1
+    assert blob_service.deleted_targets

--- a/functional_tests/test_conversations_read_ownership_authorization.py
+++ b/functional_tests/test_conversations_read_ownership_authorization.py
@@ -2,8 +2,8 @@
 # test_conversations_read_ownership_authorization.py
 """
 Functional test for personal conversation read authorization hardening.
-Version: 0.250.036
-Implemented in: 0.241.011; 0.241.022; 0.241.032; 0.250.033; 0.250.035
+Version: 0.250.074
+Implemented in: 0.241.011; 0.241.022; 0.241.032; 0.250.033; 0.250.035; 0.250.074
 
 This test ensures authenticated users can only read messages and images from
 their own personal conversations, and that foreign conversation reads fail with
@@ -237,9 +237,11 @@ def _install_route_import_stubs():
     stub_modules['functions_message_artifacts'] = artifacts_module
 
     simplechat_operations_module = types.ModuleType('functions_simplechat_operations')
+    simplechat_operations_module.ConversationForkConflictError = RuntimeError
     simplechat_operations_module.create_personal_conversation_for_current_user = lambda *args, **kwargs: {}
     simplechat_operations_module.delete_blob_backed_chat_message_files = lambda *args, **kwargs: None
     simplechat_operations_module.derive_conversation_title_from_message = lambda *args, **kwargs: ''
+    simplechat_operations_module.fork_personal_conversation_for_user = lambda *args, **kwargs: {}
     stub_modules['functions_simplechat_operations'] = simplechat_operations_module
 
     swagger_module = types.ModuleType('swagger_wrapper')

--- a/ui_tests/test_chat_conversation_fork.py
+++ b/ui_tests/test_chat_conversation_fork.py
@@ -1,0 +1,241 @@
+# test_chat_conversation_fork.py
+"""
+UI test for personal conversation forking.
+Version: 0.250.074
+Implemented in: 0.250.074
+
+This test ensures only persisted completed assistant messages in personal
+conversations expose the fork action and validates confirmation, failure
+feedback, duplicate-click prevention, and successful fork activation.
+"""
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+
+BASE_URL = os.getenv('SIMPLECHAT_UI_BASE_URL', '').rstrip('/')
+STORAGE_STATE = os.getenv('SIMPLECHAT_UI_STORAGE_STATE', '')
+
+
+@pytest.mark.ui
+def test_personal_assistant_message_fork_workflow():
+    """Validate the complete browser-side fork workflow."""
+    if not BASE_URL:
+        pytest.skip('Set SIMPLECHAT_UI_BASE_URL to run this UI test.')
+    if not STORAGE_STATE or not Path(STORAGE_STATE).exists():
+        pytest.skip('Set SIMPLECHAT_UI_STORAGE_STATE to a valid authenticated Playwright storage state file.')
+
+    playwright_sync_api = pytest.importorskip('playwright.sync_api')
+    expect = playwright_sync_api.expect
+    playwright = playwright_sync_api.sync_playwright().start()
+    browser = playwright.chromium.launch()
+    context = browser.new_context(
+        storage_state=STORAGE_STATE,
+        viewport={'width': 1440, 'height': 1000},
+    )
+    page = context.new_page()
+    fork_requests = []
+
+    def fulfill_synthetic_api(route):
+        request_url = route.request.url
+        if request_url.endswith('/api/conversations/fork-source/fork'):
+            fork_requests.append(route.request.post_data_json)
+            if len(fork_requests) == 1:
+                route.fulfill(
+                    status=500,
+                    content_type='application/json',
+                    body=json.dumps({'error': 'Simulated fork failure'}),
+                )
+                return
+            route.fulfill(
+                status=201,
+                content_type='application/json',
+                body=json.dumps({
+                    'conversation_id': 'fork-created',
+                    'title': 'Fork of UI source',
+                    'message_count': 2,
+                }),
+            )
+            return
+        if '/api/get_messages' in request_url:
+            route.fulfill(
+                status=200,
+                content_type='application/json',
+                body=json.dumps({'messages': []}),
+            )
+            return
+        if request_url.endswith('/metadata'):
+            conversation_id = request_url.split('/api/conversations/', 1)[1].split('/', 1)[0]
+            route.fulfill(
+                status=200,
+                content_type='application/json',
+                body=json.dumps({
+                    'id': conversation_id,
+                    'title': 'Fork of UI source' if conversation_id == 'fork-created' else 'UI source',
+                    'chat_type': 'personal_single_user',
+                    'context': [],
+                    'is_pinned': False,
+                    'is_hidden': False,
+                }),
+            )
+            return
+        if '/api/conversations/feed' in request_url:
+            route.fulfill(
+                status=200,
+                content_type='application/json',
+                body=json.dumps({
+                    'conversations': [{
+                        'id': 'fork-created',
+                        'title': 'Fork of UI source',
+                        'chat_type': 'personal_single_user',
+                        'last_updated': '2026-07-30T12:00:00Z',
+                    }],
+                    'next_cursor': None,
+                    'has_more': False,
+                    'hidden_count': 0,
+                }),
+            )
+            return
+        route.fulfill(
+            status=200,
+            content_type='application/json',
+            body=json.dumps({'success': True}),
+        )
+
+    try:
+        response = page.goto(f'{BASE_URL}/chats', wait_until='networkidle')
+        assert response is not None and response.ok
+        page.route('**/api/**', fulfill_synthetic_api)
+        page.wait_for_function(
+            "() => window.chatConversations && typeof window.chatConversations.selectConversation === 'function'"
+        )
+
+        visibility = page.evaluate(
+            """async () => {
+                const conversationsList = document.getElementById('conversations-list');
+                conversationsList.replaceChildren();
+
+                const sourceItem = document.createElement('div');
+                sourceItem.className = 'conversation-item';
+                sourceItem.dataset.conversationId = 'fork-source';
+                sourceItem.dataset.conversationTitle = 'UI source';
+                sourceItem.dataset.chatType = 'personal_single_user';
+                const title = document.createElement('span');
+                title.className = 'conversation-title';
+                title.textContent = 'UI source';
+                sourceItem.appendChild(title);
+                conversationsList.appendChild(sourceItem);
+
+                await window.chatConversations.selectConversation('fork-source');
+                const chatMessages = await import('/static/js/chat/chat-messages.js');
+                chatMessages.appendMessage(
+                    'AI',
+                    'Persisted response',
+                    null,
+                    'persisted-assistant',
+                    false,
+                    [],
+                    [],
+                    [],
+                    null,
+                    null,
+                    {
+                        id: 'persisted-assistant',
+                        conversation_id: 'fork-source',
+                        role: 'assistant',
+                        content: 'Persisted response',
+                        metadata: {},
+                    }
+                );
+                chatMessages.appendMessage(
+                    'AI',
+                    'Streaming response',
+                    null,
+                    'temp_ai_streaming',
+                    false,
+                    [],
+                    [],
+                    [],
+                    null,
+                    null,
+                    {
+                        id: 'temp_ai_streaming',
+                        conversation_id: 'fork-source',
+                        role: 'assistant',
+                        content: 'Streaming response',
+                        metadata: { stream_status: 'streaming' },
+                    }
+                );
+
+                sourceItem.dataset.chatType = 'group-single-user';
+                chatMessages.appendMessage(
+                    'AI',
+                    'Group response',
+                    null,
+                    'group-assistant',
+                    false,
+                    [],
+                    [],
+                    [],
+                    null,
+                    null,
+                    {
+                        id: 'group-assistant',
+                        conversation_id: 'fork-source',
+                        role: 'assistant',
+                        content: 'Group response',
+                        metadata: {},
+                    }
+                );
+                sourceItem.dataset.chatType = 'personal_single_user';
+
+                return {
+                    persisted: Boolean(document.querySelector('[data-message-id="persisted-assistant"] .dropdown-fork-conversation-btn')),
+                    streaming: Boolean(document.querySelector('[data-message-id="temp_ai_streaming"] .dropdown-fork-conversation-btn')),
+                    group: Boolean(document.querySelector('[data-message-id="group-assistant"] .dropdown-fork-conversation-btn')),
+                };
+            }"""
+        )
+
+        assert visibility == {'persisted': True, 'streaming': False, 'group': False}
+
+        fork_action = page.locator(
+            '[data-message-id="persisted-assistant"] .dropdown-fork-conversation-btn'
+        )
+        fork_action.click()
+        fork_modal = page.locator('#fork-conversation-modal')
+        expect(fork_modal).to_be_visible()
+        fork_modal.get_by_role('button', name='Cancel').click()
+        expect(fork_modal).to_be_hidden()
+
+        fork_action.click()
+        confirm_button = fork_modal.get_by_role('button', name='Fork conversation')
+        confirm_button.click()
+        expect(page.locator('.toast')).to_contain_text('Simulated fork failure')
+        expect(confirm_button).to_be_enabled()
+        expect(fork_modal).to_be_visible()
+
+        page.evaluate(
+            """() => {
+                const button = document.getElementById('confirm-fork-conversation-btn');
+                button.click();
+                button.click();
+            }"""
+        )
+        expect(fork_modal).to_be_hidden()
+        expect(page.locator('.conversation-item.active')).to_have_attribute(
+            'data-conversation-id',
+            'fork-created',
+        )
+        expect(page.locator('#current-conversation-title')).to_contain_text('Fork of UI source')
+        assert fork_requests == [
+            {'message_id': 'persisted-assistant'},
+            {'message_id': 'persisted-assistant'},
+        ]
+    finally:
+        context.close()
+        browser.close()
+        playwright.stop()


### PR DESCRIPTION
## Summary
- add a personal-only Fork conversation action to persisted assistant messages
- copy authoritative history through the selected response with independent message, artifact, thread, and blob identities
- enforce ownership and stable-source checks with publish-last cleanup on failure
- add confirmation, duplicate-click prevention, immediate navigation, tests, documentation, release notes, and version 0.250.074

## Validation
- 16 targeted tests passed; authenticated UI test collected and environment-skipped
- Python and JavaScript syntax checks passed
- XSS and broken-access-control committed-diff guardrails passed

Closes #1025