### PR TITLE
Add file processing log cleanup

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -97,7 +97,7 @@ load_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.250.074"
+VERSION = "0.250.075"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/functions_logging.py
+++ b/application/single_app/functions_logging.py
@@ -1,9 +1,127 @@
 # functions_logging.py
 
-# functions_logging.py
+from datetime import datetime, timedelta, timezone
+import logging
+import uuid
 
-from config import *
+from config import cosmos_file_processing_container
+from functions_appinsights import log_event
 import functions_settings
+
+
+FILE_PROCESSING_LOG_AGE_UNITS = {
+    'days': 1,
+    'weeks': 7,
+    'months': 30,
+}
+
+
+class FileProcessingLogDeletionError(RuntimeError):
+    """Report a cleanup failure without losing the number of completed deletes."""
+
+    def __init__(self, deleted_count):
+        super().__init__('File processing log cleanup did not complete.')
+        self.deleted_count = deleted_count
+
+
+def calculate_file_processing_log_cutoff(age, unit, now=None):
+    """Return the UTC cutoff for a validated age and unit."""
+    if isinstance(age, bool) or not isinstance(age, int) or age < 1:
+        raise ValueError('Age must be a positive integer.')
+
+    normalized_unit = str(unit or '').strip().lower()
+    if normalized_unit not in FILE_PROCESSING_LOG_AGE_UNITS:
+        raise ValueError('Unit must be days, weeks, or months.')
+
+    reference_time = now or datetime.now(timezone.utc)
+    if reference_time.tzinfo is None:
+        reference_time = reference_time.replace(tzinfo=timezone.utc)
+    else:
+        reference_time = reference_time.astimezone(timezone.utc)
+
+    days = age * FILE_PROCESSING_LOG_AGE_UNITS[normalized_unit]
+    try:
+        return reference_time - timedelta(days=days)
+    except OverflowError as exc:
+        raise ValueError('Age is too large.') from exc
+
+
+def delete_file_processing_logs(
+    *,
+    delete_all=False,
+    age=None,
+    unit=None,
+    now=None,
+    container=None,
+):
+    """Delete all file processing logs or only logs older than a cutoff."""
+    if not isinstance(delete_all, bool):
+        raise ValueError('delete_all must be a boolean.')
+    if delete_all and (age is not None or unit is not None):
+        raise ValueError('Delete-all requests cannot include an age or unit.')
+
+    target_container = (
+        container
+        if container is not None
+        else cosmos_file_processing_container
+    )
+    cutoff = None
+    query = (
+        'SELECT c.id, c.document_id FROM c '
+        'WHERE IS_DEFINED(c.id) AND IS_DEFINED(c.document_id)'
+    )
+    parameters = None
+
+    if not delete_all:
+        cutoff = calculate_file_processing_log_cutoff(age, unit, now=now)
+        cutoff_value = cutoff.replace(tzinfo=None).isoformat()
+        query += ' AND IS_DEFINED(c.timestamp) AND c.timestamp < @cutoff'
+        parameters = [{'name': '@cutoff', 'value': cutoff_value}]
+
+    deleted_count = 0
+    try:
+        items = list(
+            target_container.query_items(
+                query=query,
+                parameters=parameters,
+                enable_cross_partition_query=True,
+            )
+        )
+        for item in items:
+            item_id = item.get('id')
+            document_id = item.get('document_id')
+            if item_id is None or document_id is None:
+                raise ValueError('A selected log item is missing its id or document_id.')
+            target_container.delete_item(item=item_id, partition_key=document_id)
+            deleted_count += 1
+    except Exception as exc:
+        log_event(
+            '[FileProcessingLogs] Cleanup failed.',
+            extra={
+                'delete_all': delete_all,
+                'deleted_count': deleted_count,
+                'cutoff': cutoff.isoformat() if cutoff else None,
+                'error_type': type(exc).__name__,
+            },
+            level=logging.ERROR,
+        )
+        raise FileProcessingLogDeletionError(deleted_count) from exc
+
+    log_event(
+        '[FileProcessingLogs] Cleanup completed.',
+        extra={
+            'delete_all': delete_all,
+            'deleted_count': deleted_count,
+            'cutoff': cutoff.isoformat() if cutoff else None,
+        },
+        level=logging.INFO,
+    )
+    return {
+        'deleted_count': deleted_count,
+        'delete_all': delete_all,
+        'cutoff': cutoff.isoformat() if cutoff else None,
+    }
+
 
 def add_file_task_to_file_processing_log(document_id, user_id, content):
     settings = functions_settings.get_settings()

--- a/application/single_app/route_frontend_admin_settings.py
+++ b/application/single_app/route_frontend_admin_settings.py
@@ -158,9 +158,13 @@ def register_route_frontend_admin_settings(bp):
                 unit=unit,
             )
         except ValueError as exc:
+            current_app.logger.warning(
+                'Invalid file processing log cleanup request.',
+                exc_info=True,
+            )
             return jsonify({
                 'success': False,
-                'error': str(exc),
+                'error': 'Invalid file processing log cleanup request.',
             }), 400
         except FileProcessingLogDeletionError as exc:
             return jsonify({

--- a/application/single_app/route_frontend_admin_settings.py
+++ b/application/single_app/route_frontend_admin_settings.py
@@ -130,6 +130,69 @@ def normalize_agents_page_text(value, fallback, max_length):
 
 
 def register_route_frontend_admin_settings(bp):
+    @bp.route('/api/admin/settings/file-processing-logs/cleanup', methods=['POST'])
+    @swagger_route(security=get_auth_security())
+    @login_required
+    @admin_required
+    def cleanup_file_processing_logs():
+        payload = request.get_json(silent=True)
+        if not isinstance(payload, dict):
+            return jsonify({
+                'success': False,
+                'error': 'A JSON request body is required.',
+            }), 400
+        if payload.get('confirmed') is not True:
+            return jsonify({
+                'success': False,
+                'error': 'Explicit confirmation is required.',
+            }), 400
+
+        delete_all = payload.get('delete_all', False)
+        age = payload.get('age')
+        unit = payload.get('unit')
+
+        try:
+            result = delete_file_processing_logs(
+                delete_all=delete_all,
+                age=age,
+                unit=unit,
+            )
+        except ValueError as exc:
+            return jsonify({
+                'success': False,
+                'error': str(exc),
+            }), 400
+        except FileProcessingLogDeletionError as exc:
+            return jsonify({
+                'success': False,
+                'error': 'File processing log cleanup did not complete.',
+                'deleted_count': exc.deleted_count,
+            }), 500
+
+        admin_user = session.get('user', {})
+        admin_email = admin_user.get(
+            'preferred_username',
+            admin_user.get('email', 'unknown'),
+        )
+        log_general_admin_action(
+            admin_user_id=get_current_user_id(),
+            admin_email=admin_email,
+            action='file_processing_logs_deleted',
+            description='Deleted file processing logs.',
+            additional_context={
+                'delete_all': result['delete_all'],
+                'deleted_count': result['deleted_count'],
+                'cutoff': result['cutoff'],
+                'age': age,
+                'unit': unit,
+            },
+        )
+
+        return jsonify({
+            'success': True,
+            **result,
+        })
+
     @bp.route('/admin/settings', methods=['GET', 'POST'])
     @swagger_route(security=get_auth_security())
     @login_required

--- a/application/single_app/static/js/admin/admin_settings.js
+++ b/application/single_app/static/js/admin/admin_settings.js
@@ -37,6 +37,7 @@ let currentCosmosContainers = [];
 let currentCosmosMetricsWindowMinutes = 0;
 let currentCosmosStatusLoaded = false;
 let currentCosmosContainerSort = { field: 'container_name', direction: 'asc' };
+let pendingFileProcessingLogCleanup = null;
 let documentAccessIndexStatusPollId = null;
 let redisExplorerState = {
     cursor: '0',
@@ -493,6 +494,117 @@ function setElementText(elementId, value) {
     if (element) {
         element.textContent = value || 'Not loaded';
     }
+}
+
+function getFileProcessingLogCleanupElements() {
+    return {
+        ageInput: document.getElementById('file-processing-log-cleanup-age'),
+        unitSelect: document.getElementById('file-processing-log-cleanup-unit'),
+        deleteOlderButton: document.getElementById('delete-old-file-processing-logs-btn'),
+        deleteAllButton: document.getElementById('delete-all-file-processing-logs-btn'),
+        modalElement: document.getElementById('fileProcessingLogCleanupModal'),
+        confirmationText: document.getElementById('file-processing-log-cleanup-confirmation'),
+        confirmButton: document.getElementById('confirm-file-processing-log-cleanup-btn')
+    };
+}
+
+function setFileProcessingLogCleanupBusy(elements, isBusy) {
+    elements.ageInput.disabled = isBusy;
+    elements.unitSelect.disabled = isBusy;
+    elements.deleteOlderButton.disabled = isBusy;
+    elements.deleteAllButton.disabled = isBusy;
+    setButtonBusy(elements.confirmButton, isBusy, 'Deleting...');
+}
+
+function showFileProcessingLogCleanupConfirmation(elements, requestPayload, message) {
+    pendingFileProcessingLogCleanup = requestPayload;
+    elements.confirmationText.textContent = message;
+    bootstrap.Modal.getOrCreateInstance(elements.modalElement).show();
+}
+
+async function executeFileProcessingLogCleanup(elements) {
+    if (!pendingFileProcessingLogCleanup) {
+        return;
+    }
+
+    setFileProcessingLogCleanupBusy(elements, true);
+    try {
+        const response = await fetch('/api/admin/settings/file-processing-logs/cleanup', {
+            method: 'POST',
+            headers: {
+                'Accept': 'application/json',
+                'Content-Type': 'application/json'
+            },
+            credentials: 'same-origin',
+            body: JSON.stringify({
+                ...pendingFileProcessingLogCleanup,
+                confirmed: true
+            })
+        });
+        const payload = await response.json().catch(() => ({}));
+        if (!response.ok || !payload.success) {
+            const partialCount = Number.isInteger(payload.deleted_count) && payload.deleted_count > 0
+                ? ` ${payload.deleted_count} log${payload.deleted_count === 1 ? '' : 's'} were deleted before the operation stopped.`
+                : '';
+            throw new Error(`${payload.error || 'Unable to delete file processing logs.'}${partialCount}`);
+        }
+
+        const deletedCount = Number(payload.deleted_count) || 0;
+        bootstrap.Modal.getInstance(elements.modalElement)?.hide();
+        showToast(
+            `${deletedCount} file processing log${deletedCount === 1 ? '' : 's'} deleted.`,
+            'success'
+        );
+        pendingFileProcessingLogCleanup = null;
+    } catch (error) {
+        showToast(error.message || 'Unable to delete file processing logs.', 'danger');
+    } finally {
+        setFileProcessingLogCleanupBusy(elements, false);
+    }
+}
+
+function setupFileProcessingLogCleanup() {
+    const elements = getFileProcessingLogCleanupElements();
+    if (Object.values(elements).some(element => !element)) {
+        return;
+    }
+
+    elements.ageInput.addEventListener('input', () => {
+        elements.ageInput.classList.remove('is-invalid');
+    });
+    elements.deleteOlderButton.addEventListener('click', () => {
+        const age = Number(elements.ageInput.value);
+        if (!Number.isInteger(age) || age < 1) {
+            elements.ageInput.classList.add('is-invalid');
+            elements.ageInput.focus();
+            showToast('Enter a whole-number log age greater than zero.', 'warning');
+            return;
+        }
+
+        const unit = elements.unitSelect.value;
+        const singularUnit = unit.endsWith('s') ? unit.slice(0, -1) : unit;
+        const ageLabel = `${age} ${age === 1 ? singularUnit : unit}`;
+        showFileProcessingLogCleanupConfirmation(
+            elements,
+            { delete_all: false, age, unit },
+            `Delete every file processing log older than ${ageLabel}?`
+        );
+    });
+    elements.deleteAllButton.addEventListener('click', () => {
+        showFileProcessingLogCleanupConfirmation(
+            elements,
+            { delete_all: true },
+            'Delete every stored file processing log?'
+        );
+    });
+    elements.confirmButton.addEventListener('click', () => {
+        executeFileProcessingLogCleanup(elements);
+    });
+    elements.modalElement.addEventListener('hidden.bs.modal', () => {
+        if (!elements.confirmButton.disabled) {
+            pendingFileProcessingLogCleanup = null;
+        }
+    });
 }
 
 function formatNumber(value) {
@@ -4345,6 +4457,7 @@ document.addEventListener('DOMContentLoaded', () => {
     setupCosmosMaintenanceControls();
     setupDocumentAccessIndexControls();
     setupCosmosThroughputControls();
+    setupFileProcessingLogCleanup();
     
     // --- Setup form change tracking ---
     setupFormChangeTracking();

--- a/application/single_app/templates/admin_settings.html
+++ b/application/single_app/templates/admin_settings.html
@@ -1898,6 +1898,47 @@
                             </div>
                         </div>
                     </div>
+
+                    <hr class="my-4" />
+                    <section aria-labelledby="file-processing-log-cleanup-heading" data-ignore-settings-change="true">
+                        <h6 id="file-processing-log-cleanup-heading">Delete stored logs</h6>
+                        <p class="text-muted small">
+                            Permanently remove file processing logs from Cosmos DB. One month is treated as 30 days.
+                        </p>
+                        <div class="row g-3 align-items-end">
+                            <div class="col-sm-4">
+                                <label for="file-processing-log-cleanup-age" class="form-label">Delete logs older than</label>
+                                <input
+                                    type="number"
+                                    class="form-control"
+                                    id="file-processing-log-cleanup-age"
+                                    min="1"
+                                    step="1"
+                                    value="30"
+                                    aria-describedby="file-processing-log-cleanup-age-feedback"
+                                />
+                                <div id="file-processing-log-cleanup-age-feedback" class="invalid-feedback">
+                                    Enter a whole number greater than zero.
+                                </div>
+                            </div>
+                            <div class="col-sm-3">
+                                <label for="file-processing-log-cleanup-unit" class="form-label">Age unit</label>
+                                <select class="form-select" id="file-processing-log-cleanup-unit">
+                                    <option value="days" selected>Days</option>
+                                    <option value="weeks">Weeks</option>
+                                    <option value="months">Months (30 days)</option>
+                                </select>
+                            </div>
+                            <div class="col-sm-5 d-flex flex-wrap gap-2">
+                                <button type="button" class="btn btn-outline-danger" id="delete-old-file-processing-logs-btn">
+                                    <i class="bi bi-trash me-1" aria-hidden="true"></i>Delete older logs
+                                </button>
+                                <button type="button" class="btn btn-danger" id="delete-all-file-processing-logs-btn">
+                                    <i class="bi bi-trash3 me-1" aria-hidden="true"></i>Delete all logs
+                                </button>
+                            </div>
+                        </div>
+                    </section>
                 </div>
             </div>
 
@@ -10721,6 +10762,36 @@
         </div>
         <!-- End of Admin tab content -->
     </form>
+
+    <div
+        class="modal fade"
+        id="fileProcessingLogCleanupModal"
+        tabindex="-1"
+        aria-labelledby="fileProcessingLogCleanupModalLabel"
+        aria-describedby="file-processing-log-cleanup-confirmation"
+        aria-hidden="true"
+    >
+        <div class="modal-dialog modal-dialog-centered">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="fileProcessingLogCleanupModalLabel">Confirm permanent log deletion</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <p id="file-processing-log-cleanup-confirmation"></p>
+                    <div class="alert alert-danger mb-0" role="alert">
+                        This action cannot be undone.
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="button" class="btn btn-danger" id="confirm-file-processing-log-cleanup-btn">
+                        Delete logs
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
 
     <!-- Floating Save Button -->
     <button type="submit" form="admin-settings-form" class="btn btn-secondary floating-save-btn" id="floating-save-btn" disabled>

--- a/docs/admin_configuration.md
+++ b/docs/admin_configuration.md
@@ -229,6 +229,8 @@ For practical operator steps, see [Configure Branding, Home Page, and Support Se
   - Enable logging of file processing events
   - Logs stored in Cosmos DB file_processing container
   - Optional time-based auto-disable feature
+  - Permanently delete logs older than a positive number of days, weeks, or fixed 30-day months
+  - Delete all stored logs through a separate confirmation action
 
 ## Admin Settings Execution Guide
 
@@ -265,6 +267,7 @@ Use this section when you need to configure an area, validate it, and know what 
 1. Open **Logging** and enable Application Insights logging when agent, orchestration, or operational events should flow into Azure monitoring.
 2. Use **Debug Logging** for short diagnosis windows only, set an auto-disable time, and avoid leaving token or key capture enabled longer than necessary.
 3. Enable **File Processing Logs** when admins need upload, extraction, indexing, or sync troubleshooting history, then save and confirm the expected log container or telemetry stream receives events.
+4. Under **Delete stored logs**, choose an age and unit to remove older entries, or use **Delete all logs** for a complete cleanup. Review the permanent-deletion confirmation carefully; months are fixed 30-day periods.
 
 ### Scale
 

--- a/docs/explanation/features/FILE_PROCESSING_LOG_CLEANUP.md
+++ b/docs/explanation/features/FILE_PROCESSING_LOG_CLEANUP.md
@@ -1,0 +1,98 @@
+# File Processing Log Cleanup
+
+**Implemented in version:** **0.250.075**
+
+## Overview
+
+File Processing Log Cleanup lets administrators permanently remove accumulated file-processing logs from the Cosmos DB `file_processing` container. Admins can delete logs older than a chosen age or explicitly delete every stored log.
+
+**Dependencies:**
+
+- Cosmos DB `file_processing` container
+- SimpleChat administrator authentication and authorization
+- Bootstrap modal and toast components already included with SimpleChat
+
+## Technical specifications
+
+### Architecture
+
+The feature uses an admin-only API and the existing Admin Settings Logging tab:
+
+1. The browser validates an age and asks for confirmation in a Bootstrap modal.
+2. The API validates the request again and computes a UTC cutoff when needed.
+3. Cosmos DB is queried across partitions for matching `id` and `document_id` values.
+4. Each selected item is deleted with a point delete using its `document_id` partition key.
+5. The API returns the exact completed deletion count, and a general admin activity records the operation.
+
+The delete-all mode is explicit. Omitting an age or entering zero never implies delete-all.
+
+### API
+
+`POST /api/admin/settings/file-processing-logs/cleanup`
+
+The route requires an authenticated administrator and includes Swagger authentication metadata.
+
+Delete logs older than an age:
+
+```json
+{
+    "delete_all": false,
+    "age": 30,
+    "unit": "days",
+    "confirmed": true
+}
+```
+
+Delete all logs:
+
+```json
+{
+    "delete_all": true,
+    "confirmed": true
+}
+```
+
+The API rejects requests unless `confirmed` is exactly `true`. Supported units are `days`, `weeks`, and `months`. A month is a fixed 30-day period. Age-based deletion is strict: only timestamps earlier than the calculated cutoff are selected.
+
+A successful response includes `deleted_count`, `delete_all`, and the UTC `cutoff` when applicable. If Cosmos DB fails after some point deletes, the API returns an error and the number already deleted rather than reporting full success.
+
+### Configuration
+
+No new persistent settings are required. Cleanup controls do not alter the enabled state or auto-turnoff configuration for file-processing logging.
+
+### File structure
+
+- `application/single_app/functions_logging.py`: cutoff validation and Cosmos cleanup
+- `application/single_app/route_frontend_admin_settings.py`: secured cleanup API and admin activity
+- `application/single_app/templates/admin_settings.html`: cleanup controls and confirmation modal
+- `application/single_app/static/js/admin/admin_settings.js`: validation, confirmation, API request, and feedback
+- `functional_tests/test_file_processing_log_cleanup.py`: backend and authorization regression tests
+- `ui_tests/test_admin_file_processing_log_cleanup.py`: static UI contract and authenticated browser workflow
+
+## Usage
+
+1. Open **Admin Settings** and select **Logging**.
+2. Find **File Process Logging**, then scroll to **Delete stored logs**.
+3. To remove old logs, enter a positive whole number, choose days, weeks, or months, and select **Delete older logs**.
+4. To remove every log, select **Delete all logs**.
+5. Review the deletion scope in the confirmation modal and confirm. A toast reports the exact number deleted.
+
+Deletion is permanent and cannot be undone.
+
+## Testing and validation
+
+Coverage verifies:
+
+- Days, weeks, and fixed 30-day month cutoff calculations
+- Invalid and mixed-scope request rejection
+- Cross-partition selection and partition-aware point deletes
+- Delete-all behavior and exact counts
+- Partial Cosmos failure reporting
+- Required admin and Swagger route decorators
+- Accessible confirmation, cancellation, payloads, success feedback, and visible errors
+
+## Performance and limitations
+
+- Cleanup runs synchronously and performs one point delete per selected item. Very large containers may take time and consume Cosmos DB request units.
+- Age-based cleanup selects only items with a defined ISO timestamp. Delete-all also removes entries without timestamps when they have the required `id` and `document_id`.
+- A failure can occur after some items have already been deleted. The response reports that partial count; deleted items are not restored.

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,15 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](/explanation/features/) and [Fixes by Version](/explanation/fixes/).
 
+### **(v0.250.075)**
+
+#### New Features
+
+*   **File Processing Log Cleanup**
+    *   Added admin controls to permanently delete file-processing logs older than a chosen number of days, weeks, or fixed 30-day months, or delete every stored log through a separate action.
+    *   Added explicit confirmation, exact and partial deletion counts, admin activity logging, validation, and secured cross-partition Cosmos DB cleanup.
+    *   (Ref: microsoft/simplechat#398, `functions_logging.py`, `route_frontend_admin_settings.py`, `admin_settings.js`, `FILE_PROCESSING_LOG_CLEANUP.md`)
+
 ### **(v0.250.074)**
 
 #### New Features

--- a/functional_tests/test_file_processing_log_cleanup.py
+++ b/functional_tests/test_file_processing_log_cleanup.py
@@ -1,0 +1,210 @@
+# test_file_processing_log_cleanup.py
+"""
+Functional test for file processing log cleanup.
+Version: 0.250.075
+Implemented in: 0.250.075
+
+This test validates cutoff calculation, cross-partition Cosmos deletion,
+partial failure reporting, request validation, and route authorization.
+"""
+
+from datetime import datetime, timezone
+import importlib.util
+from pathlib import Path
+import sys
+import types
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FUNCTIONS_LOGGING_PATH = REPO_ROOT / 'application' / 'single_app' / 'functions_logging.py'
+ADMIN_ROUTE_PATH = REPO_ROOT / 'application' / 'single_app' / 'route_frontend_admin_settings.py'
+CONFIG_PATH = REPO_ROOT / 'application' / 'single_app' / 'config.py'
+
+
+class FakeContainer:
+    """Capture Cosmos queries and deletes without external dependencies."""
+
+    def __init__(self, items, fail_delete_number=None):
+        self.items = items
+        self.fail_delete_number = fail_delete_number
+        self.query_calls = []
+        self.delete_calls = []
+
+    def query_items(self, **kwargs):
+        self.query_calls.append(kwargs)
+        return list(self.items)
+
+    def delete_item(self, *, item, partition_key):
+        delete_number = len(self.delete_calls) + 1
+        if self.fail_delete_number == delete_number:
+            raise RuntimeError('simulated Cosmos delete failure')
+        self.delete_calls.append((item, partition_key))
+
+
+def load_functions_logging():
+    """Load the helper with lightweight stubs for application dependencies."""
+    fake_config = types.ModuleType('config')
+    fake_config.cosmos_file_processing_container = FakeContainer([])
+    fake_appinsights = types.ModuleType('functions_appinsights')
+    fake_appinsights.log_event = lambda *args, **kwargs: None
+    fake_settings = types.ModuleType('functions_settings')
+    fake_settings.get_settings = lambda: {'enable_file_processing_logs': True}
+
+    dependencies = {
+        'config': fake_config,
+        'functions_appinsights': fake_appinsights,
+        'functions_settings': fake_settings,
+    }
+    previous_modules = {name: sys.modules.get(name) for name in dependencies}
+    sys.modules.update(dependencies)
+    try:
+        module_name = 'testable_functions_logging'
+        spec = importlib.util.spec_from_file_location(module_name, FUNCTIONS_LOGGING_PATH)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        for name, previous_module in previous_modules.items():
+            if previous_module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = previous_module
+
+
+def test_cutoff_uses_days_weeks_and_fixed_30_day_months():
+    """Verify supported age units produce strict UTC cutoffs."""
+    module = load_functions_logging()
+    now = datetime(2026, 7, 30, 12, 0, tzinfo=timezone.utc)
+
+    assert module.calculate_file_processing_log_cutoff(2, 'days', now=now).isoformat() == (
+        '2026-07-28T12:00:00+00:00'
+    )
+    assert module.calculate_file_processing_log_cutoff(2, 'weeks', now=now).isoformat() == (
+        '2026-07-16T12:00:00+00:00'
+    )
+    assert module.calculate_file_processing_log_cutoff(2, 'months', now=now).isoformat() == (
+        '2026-05-31T12:00:00+00:00'
+    )
+
+
+@pytest.mark.parametrize(
+    ('age', 'unit'),
+    [
+        (0, 'days'),
+        (-1, 'days'),
+        (True, 'days'),
+        (1.5, 'days'),
+        (1_000_000_000, 'days'),
+        (1, 'hours'),
+        (1, ''),
+    ],
+)
+def test_cutoff_rejects_invalid_age_or_unit(age, unit):
+    """Reject unsupported or ambiguous cleanup input."""
+    module = load_functions_logging()
+
+    with pytest.raises(ValueError):
+        module.calculate_file_processing_log_cutoff(age, unit)
+
+
+def test_age_cleanup_queries_across_partitions_and_point_deletes():
+    """Delete selected items with their document partition keys."""
+    module = load_functions_logging()
+    container = FakeContainer([
+        {'id': 'log-1', 'document_id': 'document-a'},
+        {'id': 'log-2', 'document_id': 'document-b'},
+    ])
+    now = datetime(2026, 7, 30, 12, 0, tzinfo=timezone.utc)
+
+    result = module.delete_file_processing_logs(
+        age=30,
+        unit='days',
+        now=now,
+        container=container,
+    )
+
+    assert result == {
+        'deleted_count': 2,
+        'delete_all': False,
+        'cutoff': '2026-06-30T12:00:00+00:00',
+    }
+    assert container.delete_calls == [
+        ('log-1', 'document-a'),
+        ('log-2', 'document-b'),
+    ]
+    query_call = container.query_calls[0]
+    assert query_call['enable_cross_partition_query'] is True
+    assert 'c.timestamp < @cutoff' in query_call['query']
+    assert query_call['parameters'] == [
+        {'name': '@cutoff', 'value': '2026-06-30T12:00:00'},
+    ]
+
+
+def test_delete_all_has_no_cutoff_and_rejects_mixed_scope():
+    """Keep full deletion explicit and mutually exclusive with age input."""
+    module = load_functions_logging()
+    container = FakeContainer([
+        {'id': 'log-1', 'document_id': 'document-a'},
+        {'id': 'log-2', 'document_id': ''},
+    ])
+
+    result = module.delete_file_processing_logs(delete_all=True, container=container)
+
+    assert result == {
+        'deleted_count': 2,
+        'delete_all': True,
+        'cutoff': None,
+    }
+    assert container.delete_calls == [
+        ('log-1', 'document-a'),
+        ('log-2', ''),
+    ]
+    assert 'c.timestamp' not in container.query_calls[0]['query']
+    assert container.query_calls[0]['parameters'] is None
+
+    with pytest.raises(ValueError):
+        module.delete_file_processing_logs(
+            delete_all=True,
+            age=30,
+            unit='days',
+            container=container,
+        )
+
+
+def test_partial_failure_reports_completed_delete_count():
+    """Surface a failed cleanup and preserve its exact partial count."""
+    module = load_functions_logging()
+    container = FakeContainer(
+        [
+            {'id': 'log-1', 'document_id': 'document-a'},
+            {'id': 'log-2', 'document_id': 'document-b'},
+        ],
+        fail_delete_number=2,
+    )
+
+    with pytest.raises(module.FileProcessingLogDeletionError) as exc_info:
+        module.delete_file_processing_logs(delete_all=True, container=container)
+
+    assert exc_info.value.deleted_count == 1
+    assert container.delete_calls == [('log-1', 'document-a')]
+
+
+def test_cleanup_route_is_admin_only_and_versioned():
+    """Verify the cleanup endpoint keeps the required authorization boundary."""
+    route_source = ADMIN_ROUTE_PATH.read_text(encoding='utf-8')
+    config_source = CONFIG_PATH.read_text(encoding='utf-8')
+    decorator_block = """    @bp.route('/api/admin/settings/file-processing-logs/cleanup', methods=['POST'])
+    @swagger_route(security=get_auth_security())
+    @login_required
+    @admin_required
+    def cleanup_file_processing_logs():"""
+
+    assert decorator_block in route_source
+    assert "request.get_json(silent=True)" in route_source
+    assert "if payload.get('confirmed') is not True:" in route_source
+    assert "'error': 'Explicit confirmation is required.'" in route_source
+    assert "log_general_admin_action(" in route_source
+    assert "action='file_processing_logs_deleted'" in route_source
+    assert 'VERSION = "0.250.075"' in config_source

--- a/ui_tests/test_admin_file_processing_log_cleanup.py
+++ b/ui_tests/test_admin_file_processing_log_cleanup.py
@@ -1,0 +1,160 @@
+# test_admin_file_processing_log_cleanup.py
+"""
+UI test for Admin Settings file processing log cleanup.
+Version: 0.250.075
+Implemented in: 0.250.075
+
+This test validates safe cleanup controls, confirmation behavior, request
+payloads, exact deletion feedback, cancellation, and visible API failures.
+"""
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+try:
+    from playwright.sync_api import expect, sync_playwright
+except ModuleNotFoundError:
+    expect = None
+    sync_playwright = None
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ADMIN_TEMPLATE = REPO_ROOT / 'application' / 'single_app' / 'templates' / 'admin_settings.html'
+ADMIN_JS = REPO_ROOT / 'application' / 'single_app' / 'static' / 'js' / 'admin' / 'admin_settings.js'
+BASE_URL = os.getenv('SIMPLECHAT_UI_BASE_URL', '').rstrip('/')
+STORAGE_STATE = os.getenv('SIMPLECHAT_UI_ADMIN_STORAGE_STATE') or os.getenv(
+    'SIMPLECHAT_UI_STORAGE_STATE',
+    '',
+)
+
+
+def test_file_processing_log_cleanup_controls_are_safe_and_accessible():
+    """Validate the static UI and client contract."""
+    template = ADMIN_TEMPLATE.read_text(encoding='utf-8')
+    js_source = ADMIN_JS.read_text(encoding='utf-8')
+
+    required_ids = [
+        'file-processing-log-cleanup-heading',
+        'file-processing-log-cleanup-age',
+        'file-processing-log-cleanup-unit',
+        'delete-old-file-processing-logs-btn',
+        'delete-all-file-processing-logs-btn',
+        'fileProcessingLogCleanupModal',
+        'file-processing-log-cleanup-confirmation',
+        'confirm-file-processing-log-cleanup-btn',
+    ]
+    for element_id in required_ids:
+        assert f'id="{element_id}"' in template
+
+    assert 'data-ignore-settings-change="true"' in template
+    assert 'This action cannot be undone.' in template
+    assert 'One month is treated as 30 days.' in template
+    assert 'aria-describedby="file-processing-log-cleanup-confirmation"' in template
+    assert (
+        '                    </div>\n\n'
+        '                    <hr class="my-4" />\n'
+        '                    <section aria-labelledby="file-processing-log-cleanup-heading"'
+    ) in template
+    assert 'onclick=' not in template[
+        template.index('id="file-processing-logs-section"'):
+        template.index('id="general"')
+    ]
+    assert "elements.confirmationText.textContent = message" in js_source
+    assert "'/api/admin/settings/file-processing-logs/cleanup'" in js_source
+    assert '{ delete_all: false, age, unit }' in js_source
+    assert '{ delete_all: true }' in js_source
+    assert 'confirmed: true' in js_source
+    assert "credentials: 'same-origin'" in js_source
+    assert 'setupFileProcessingLogCleanup();' in js_source
+
+
+@pytest.mark.ui
+def test_file_processing_log_cleanup_browser_workflow():
+    """Exercise cancellation, scoped deletion, and visible delete-all failure."""
+    if not BASE_URL:
+        pytest.skip('Set SIMPLECHAT_UI_BASE_URL to run this UI test.')
+    if not STORAGE_STATE or not Path(STORAGE_STATE).exists():
+        pytest.skip('Set SIMPLECHAT_UI_ADMIN_STORAGE_STATE to a valid admin storage state file.')
+    if expect is None or sync_playwright is None:
+        pytest.skip('Install playwright to run this UI test.')
+
+    requests = []
+
+    def handle_cleanup(route):
+        payload = route.request.post_data_json
+        requests.append(payload)
+        if payload.get('delete_all'):
+            route.fulfill(
+                status=500,
+                content_type='application/json',
+                body=json.dumps({
+                    'success': False,
+                    'error': 'File processing log cleanup did not complete.',
+                    'deleted_count': 1,
+                }),
+            )
+            return
+        route.fulfill(
+            status=200,
+            content_type='application/json',
+            body=json.dumps({
+                'success': True,
+                'deleted_count': 2,
+                'delete_all': False,
+                'cutoff': '2026-07-16T12:00:00+00:00',
+            }),
+        )
+
+    playwright_context = sync_playwright().start()
+    browser = playwright_context.chromium.launch()
+    context = browser.new_context(storage_state=STORAGE_STATE, viewport={'width': 1440, 'height': 900})
+    page = context.new_page()
+    page.route('**/api/admin/settings/file-processing-logs/cleanup', handle_cleanup)
+
+    try:
+        response = page.goto(f'{BASE_URL}/admin/settings#logging', wait_until='networkidle')
+        if response and response.status >= 400:
+            pytest.skip('Admin settings are not accessible with the configured storage state.')
+        if page.locator('#logging-tab').count() == 0:
+            pytest.skip('Admin settings are not accessible with the configured storage state.')
+
+        page.locator('#logging-tab').click()
+        page.locator('#file-processing-log-cleanup-age').fill('2')
+        page.locator('#file-processing-log-cleanup-unit').select_option('weeks')
+        page.locator('#delete-old-file-processing-logs-btn').click()
+        expect(page.locator('#file-processing-log-cleanup-confirmation')).to_have_text(
+            'Delete every file processing log older than 2 weeks?'
+        )
+        page.get_by_role('button', name='Cancel').click()
+        expect(page.locator('#fileProcessingLogCleanupModal')).to_be_hidden()
+        assert requests == []
+
+        page.locator('#delete-old-file-processing-logs-btn').click()
+        page.locator('#confirm-file-processing-log-cleanup-btn').click()
+        expect(page.get_by_text('2 file processing logs deleted.')).to_be_visible()
+        assert requests[0] == {
+            'delete_all': False,
+            'age': 2,
+            'unit': 'weeks',
+            'confirmed': True,
+        }
+
+        page.locator('#delete-all-file-processing-logs-btn').click()
+        expect(page.locator('#file-processing-log-cleanup-confirmation')).to_have_text(
+            'Delete every stored file processing log?'
+        )
+        page.locator('#confirm-file-processing-log-cleanup-btn').click()
+        expect(
+            page.get_by_text(
+                'File processing log cleanup did not complete. '
+                '1 log was deleted before the operation stopped.'
+            )
+        ).to_be_visible()
+        assert requests[1] == {'delete_all': True, 'confirmed': True}
+    finally:
+        context.close()
+        browser.close()
+        playwright_context.stop()


### PR DESCRIPTION
## Summary
- add admin controls to delete file-processing logs by age or delete all
- require explicit confirmation and admin authorization, with exact and partial deletion reporting
- add regression coverage, documentation, release notes, and version 0.250.075

## Validation
- 13 focused tests passed; 1 environment-gated browser test skipped
- broken access control guardrail passed
- JavaScript and Python syntax checks passed

Resolves #398