### PR TITLE
Add admin feedback and safety record lifecycle

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -97,7 +97,7 @@ load_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.250.074"
+VERSION = "0.250.075"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/functions_activity_logging.py
+++ b/application/single_app/functions_activity_logging.py
@@ -1989,7 +1989,7 @@ def log_general_admin_action(
     action: str,
     description: Optional[str] = None,
     additional_context: Optional[dict] = None
-) -> None:
+) -> bool:
     """
     Log a general admin action to the activity_logs container.
 
@@ -2001,6 +2001,7 @@ def log_general_admin_action(
         additional_context (dict, optional): Additional context to store
     """
 
+    normalized_admin_user_id = str(admin_user_id or 'unknown')
     try:
         normalized_admin_user_id = coerce_activity_log_user_id(admin_user_id)
         activity_record = {
@@ -2032,6 +2033,7 @@ def log_general_admin_action(
             level=logging.INFO
         )
         debug_print(f"✅ Admin action logged: {action} by {admin_email}")
+        return True
 
     except Exception as e:
         log_event(
@@ -2045,6 +2047,7 @@ def log_general_admin_action(
             level=logging.ERROR
         )
         debug_print(f"⚠️  Warning: Failed to log admin action: {str(e)}")
+        return False
 
 
 def log_file_sync_activity(

--- a/application/single_app/functions_review_lifecycle.py
+++ b/application/single_app/functions_review_lifecycle.py
@@ -1,0 +1,105 @@
+# functions_review_lifecycle.py
+
+from datetime import datetime, timezone
+
+from functions_activity_logging import log_general_admin_action
+
+
+ARCHIVE_STATE_ACTIVE = 'active'
+ARCHIVE_STATE_ARCHIVED = 'archived'
+ALLOWED_ARCHIVE_STATES = {
+    ARCHIVE_STATE_ACTIVE,
+    ARCHIVE_STATE_ARCHIVED,
+}
+
+
+def normalize_archive_state(value):
+    """Normalize an archive-state query value, defaulting to active records."""
+    normalized_value = str(value or ARCHIVE_STATE_ACTIVE).strip().lower()
+    if normalized_value not in ALLOWED_ARCHIVE_STATES:
+        raise ValueError("Archive state must be 'active' or 'archived'.")
+    return normalized_value
+
+
+def append_archive_query_filter(where_clauses, archive_state):
+    """Add a backward-compatible archive predicate to a Cosmos SQL query."""
+    normalized_state = normalize_archive_state(archive_state)
+    if normalized_state == ARCHIVE_STATE_ARCHIVED:
+        where_clauses.append("IS_DEFINED(c.is_archived) AND c.is_archived = true")
+    else:
+        where_clauses.append("(NOT IS_DEFINED(c.is_archived) OR c.is_archived = false)")
+
+
+def apply_archive_state(item, archived, actor_id):
+    """Apply archive or unarchive metadata to a review record."""
+    changed_at = datetime.now(timezone.utc).isoformat()
+    item['is_archived'] = archived
+    if archived:
+        item['archived_at'] = changed_at
+        item['archived_by'] = actor_id
+    else:
+        item['unarchived_at'] = changed_at
+        item['unarchived_by'] = actor_id
+    return changed_at
+
+
+def serialize_archive_metadata(item):
+    """Return browser-safe lifecycle metadata for a review record."""
+    return {
+        'isArchived': bool(item.get('is_archived')),
+        'archivedAt': item.get('archived_at'),
+        'archivedBy': item.get('archived_by'),
+        'unarchivedAt': item.get('unarchived_at'),
+        'unarchivedBy': item.get('unarchived_by'),
+    }
+
+
+def log_review_lifecycle_action(
+    record_type,
+    lifecycle_action,
+    item,
+    actor,
+    was_archived=None,
+):
+    """Write a non-sensitive admin activity event for a review record mutation."""
+    action_names = {
+        'archive': f'{record_type}_archived',
+        'unarchive': f'{record_type}_unarchived',
+        'delete': f'{record_type}_deleted',
+    }
+    descriptions = {
+        'archive': f"Archived {record_type.replace('_', ' ')} record.",
+        'unarchive': f"Unarchived {record_type.replace('_', ' ')} record.",
+        'delete': f"Deleted {record_type.replace('_', ' ')} record.",
+    }
+    additional_context = {
+        'record_type': record_type,
+        'record_id': item.get('id'),
+        'target_user_id': item.get('userId') or item.get('user_id'),
+        'lifecycle_action': lifecycle_action,
+        'was_archived': (
+            bool(item.get('is_archived'))
+            if was_archived is None
+            else bool(was_archived)
+        ),
+    }
+
+    if record_type == 'feedback':
+        additional_context.update({
+            'conversation_id': item.get('conversationId'),
+            'message_id': item.get('messageId'),
+        })
+    elif record_type == 'safety_violation':
+        additional_context.update({
+            'action': item.get('action'),
+            'action_request_id': item.get('action_request_id'),
+            'action_request_status': item.get('action_request_status'),
+        })
+
+    return log_general_admin_action(
+        admin_user_id=actor.get('id'),
+        admin_email=actor.get('email') or '',
+        action=action_names[lifecycle_action],
+        description=descriptions[lifecycle_action],
+        additional_context=additional_context,
+    )

--- a/application/single_app/route_backend_feedback.py
+++ b/application/single_app/route_backend_feedback.py
@@ -463,10 +463,12 @@ def register_route_backend_feedback(bp):
                 archive_state=archive_state,
             )
             return jsonify(_build_feedback_stats(items))
-        except ValueError as e:
-            return jsonify({"error": str(e)}), 400
-        except Exception as e:
-            return jsonify({"error": f"Failed to retrieve feedback stats: {str(e)}"}), 500
+        except ValueError:
+            logging.exception("Invalid request parameters for feedback review stats")
+            return jsonify({"error": "Invalid request parameters."}), 400
+        except Exception:
+            logging.exception("Failed to retrieve feedback stats")
+            return jsonify({"error": "Failed to retrieve feedback stats."}), 500
 
     @bp.route("/feedback/review/export", methods=["GET"])
     @swagger_route(security=get_auth_security())

--- a/application/single_app/route_backend_feedback.py
+++ b/application/single_app/route_backend_feedback.py
@@ -73,11 +73,11 @@ def _parse_feedback_filters(include_archive_state=False):
     elif filter_ack_str == 'false':
         filter_ack_bool = False
 
+    archive_state = None
     if include_archive_state:
         archive_state = normalize_archive_state(request.args.get('archive', None, type=str))
-        return filter_type, filter_ack_bool, archive_state
 
-    return filter_type, filter_ack_bool
+    return filter_type, filter_ack_bool, archive_state
 
 
 def _serialize_feedback_item(item):

--- a/application/single_app/route_backend_feedback.py
+++ b/application/single_app/route_backend_feedback.py
@@ -2,11 +2,20 @@
 
 import csv
 import io
+import logging
 
 from flask import make_response
 
 from config import *
+from functions_appinsights import log_event
 from functions_authentication import *
+from functions_review_lifecycle import (
+    apply_archive_state,
+    append_archive_query_filter,
+    log_review_lifecycle_action,
+    normalize_archive_state,
+    serialize_archive_metadata,
+)
 from functions_settings import *
 from swagger_wrapper import swagger_route, get_auth_security   
 
@@ -54,7 +63,7 @@ def _normalize_feedback_type(feedback_type):
     return FEEDBACK_TYPE_NORMALIZATION.get(feedback_type.strip().lower())
 
 
-def _parse_feedback_filters():
+def _parse_feedback_filters(include_archive_state=False):
     filter_type = _normalize_feedback_type(request.args.get('type', None, type=str))
 
     filter_ack_str = request.args.get('ack', None, type=str)
@@ -64,13 +73,17 @@ def _parse_feedback_filters():
     elif filter_ack_str == 'false':
         filter_ack_bool = False
 
+    if include_archive_state:
+        archive_state = normalize_archive_state(request.args.get('archive', None, type=str))
+        return filter_type, filter_ack_bool, archive_state
+
     return filter_type, filter_ack_bool
 
 
 def _serialize_feedback_item(item):
     normalized_feedback_type = _normalize_feedback_type(item.get("feedbackType"))
 
-    return {
+    serialized_item = {
         "id": item.get("id"),
         "userId": item.get("userId"),
         "prompt": item.get("prompt"),
@@ -80,9 +93,16 @@ def _serialize_feedback_item(item):
         "timestamp": item.get("timestamp"),
         "adminReview": item.get("adminReview", {}),
     }
+    serialized_item.update(serialize_archive_metadata(item))
+    return serialized_item
 
 
-def _query_feedback_items(user_id=None, filter_type=None, filter_ack_bool=None):
+def _query_feedback_items(
+    user_id=None,
+    filter_type=None,
+    filter_ack_bool=None,
+    archive_state='active',
+):
     query = "SELECT * FROM c"
     where_clauses = []
     parameters = []
@@ -94,6 +114,8 @@ def _query_feedback_items(user_id=None, filter_type=None, filter_ack_bool=None):
     if filter_ack_bool is not None:
         where_clauses.append("c.adminReview.acknowledged = @ack")
         parameters.append({"name": "@ack", "value": filter_ack_bool})
+
+    append_archive_query_filter(where_clauses, archive_state)
 
     if where_clauses:
         query += " WHERE " + " AND ".join(where_clauses)
@@ -181,6 +203,9 @@ def _build_feedback_export_response(items, filename_prefix, include_user_id=Fals
         'Admin Notes',
         'Admin Response',
         'Admin Action',
+        'Archived',
+        'Archived At',
+        'Archived By',
     ]
     if include_user_id:
         headers.insert(1, 'User ID')
@@ -199,6 +224,9 @@ def _build_feedback_export_response(items, filename_prefix, include_user_id=Fals
             admin_review.get('analysisNotes') or '',
             admin_review.get('responseToUser') or '',
             admin_review.get('actionTaken') or '',
+            'Yes' if item.get('isArchived') else 'No',
+            item.get('archivedAt') or '',
+            item.get('archivedBy') or '',
         ]
         if include_user_id:
             row.insert(1, item.get('userId') or '')
@@ -210,6 +238,39 @@ def _build_feedback_export_response(items, filename_prefix, include_user_id=Fals
         f'attachment; filename={filename_prefix}_{datetime.utcnow().strftime("%Y%m%d_%H%M%S")}.csv'
     )
     return response
+
+
+def _get_feedback_admin_actor():
+    user = session.get('user', {}) or {}
+    actor_id = _get_feedback_session_user_id()
+    return {
+        'id': actor_id,
+        'email': user.get('preferred_username') or user.get('email') or '',
+    }
+
+
+def _feedback_lifecycle_response(message, audit_logged):
+    response = {
+        'success': True,
+        'message': message,
+        'audit_logged': audit_logged,
+    }
+    if not audit_logged:
+        response['audit_warning'] = (
+            'The record was updated, but the audit activity could not be recorded.'
+        )
+    return jsonify(response)
+
+
+def _log_feedback_audit_failure(feedback_id, lifecycle_action):
+    log_event(
+        '[FeedbackLifecycle] Failed to persist lifecycle audit event',
+        {
+            'feedback_id': feedback_id,
+            'lifecycle_action': lifecycle_action,
+        },
+        level=logging.ERROR,
+    )
 
 def register_route_backend_feedback(bp):
 
@@ -357,10 +418,13 @@ def register_route_backend_feedback(bp):
         try:
             page = request.args.get('page', 1, type=int)
             page_size = request.args.get('page_size', 10, type=int)
-            filter_type, filter_ack_bool = _parse_feedback_filters()
+            filter_type, filter_ack_bool, archive_state = _parse_feedback_filters(
+                include_archive_state=True,
+            )
             items = _query_feedback_items(
                 filter_type=filter_type,
                 filter_ack_bool=filter_ack_bool,
+                archive_state=archive_state,
             )
             paginated_items, page, page_size = _paginate_feedback_items(items, page, page_size)
             total_count = len(items)
@@ -373,6 +437,8 @@ def register_route_backend_feedback(bp):
                 "total_pages": math.ceil(total_count / page_size)
             })
 
+        except ValueError as e:
+            return jsonify({"error": str(e)}), 400
         except Exception as e:
              print(f"Error fetching feedback for review: {e}")
              # Log the full exception traceback if possible
@@ -388,12 +454,17 @@ def register_route_backend_feedback(bp):
     def feedback_review_stats():
         """Return aggregate feedback review statistics for the admin page."""
         try:
-            filter_type, filter_ack_bool = _parse_feedback_filters()
+            filter_type, filter_ack_bool, archive_state = _parse_feedback_filters(
+                include_archive_state=True,
+            )
             items = _query_feedback_items(
                 filter_type=filter_type,
                 filter_ack_bool=filter_ack_bool,
+                archive_state=archive_state,
             )
             return jsonify(_build_feedback_stats(items))
+        except ValueError as e:
+            return jsonify({"error": str(e)}), 400
         except Exception as e:
             return jsonify({"error": f"Failed to retrieve feedback stats: {str(e)}"}), 500
 
@@ -405,12 +476,17 @@ def register_route_backend_feedback(bp):
     def feedback_review_export():
         """Export feedback review rows as CSV for the active filter set."""
         try:
-            filter_type, filter_ack_bool = _parse_feedback_filters()
+            filter_type, filter_ack_bool, archive_state = _parse_feedback_filters(
+                include_archive_state=True,
+            )
             items = _query_feedback_items(
                 filter_type=filter_type,
                 filter_ack_bool=filter_ack_bool,
+                archive_state=archive_state,
             )
             return _build_feedback_export_response(items, 'feedback_review_export', include_user_id=True)
+        except ValueError as e:
+            return jsonify({"error": str(e)}), 400
         except Exception as e:
             return jsonify({"error": f"Failed to export feedback: {str(e)}"}), 500
 
@@ -440,6 +516,7 @@ def register_route_backend_feedback(bp):
                 "timestamp": feedback_doc.get("timestamp"),
                 "adminReview": feedback_doc.get("adminReview", {})
             }
+            result.update(serialize_archive_metadata(feedback_doc))
             return jsonify(result)
 
         except CosmosResourceNotFoundError: # Import this if not already done
@@ -493,6 +570,98 @@ def register_route_backend_feedback(bp):
         except Exception as e:
              print(f"Error updating feedback item {feedbackId}: {e}")
              return jsonify({"error": "Failed to save changes"}), 500
+
+    @bp.route("/feedback/review/<feedbackId>/archive", methods=["PATCH"])
+    @swagger_route(security=get_auth_security())
+    @login_required
+    @feedback_admin_required
+    @enabled_required("enable_user_feedback")
+    def feedback_review_archive(feedbackId):
+        """Archive or unarchive a feedback review record."""
+        data = request.get_json() or {}
+        archived = data.get('archived')
+        if not isinstance(archived, bool):
+            return jsonify({'error': 'The archived field must be a boolean.'}), 400
+
+        actor = _get_feedback_admin_actor()
+        if not actor.get('id'):
+            return jsonify({'error': 'No user ID found in session'}), 403
+
+        try:
+            feedback_doc = cosmos_feedback_container.read_item(
+                item=feedbackId,
+                partition_key=feedbackId,
+            )
+            was_archived = bool(feedback_doc.get('is_archived'))
+            apply_archive_state(feedback_doc, archived, actor['id'])
+            cosmos_feedback_container.upsert_item(feedback_doc)
+        except CosmosResourceNotFoundError:
+            return jsonify({'error': 'Feedback not found'}), 404
+        except Exception as e:
+            log_event(
+                '[FeedbackLifecycle] Failed to update feedback archive state',
+                {'feedback_id': feedbackId, 'error': str(e)},
+                level=logging.ERROR,
+            )
+            return jsonify({'error': 'Failed to update feedback archive state'}), 500
+
+        lifecycle_action = 'archive' if archived else 'unarchive'
+        audit_logged = log_review_lifecycle_action(
+            'feedback',
+            lifecycle_action,
+            feedback_doc,
+            actor,
+            was_archived=was_archived,
+        )
+        if not audit_logged:
+            _log_feedback_audit_failure(feedbackId, lifecycle_action)
+
+        message = 'Feedback archived successfully.' if archived else 'Feedback unarchived successfully.'
+        return _feedback_lifecycle_response(message, audit_logged), 200
+
+    @bp.route("/feedback/review/<feedbackId>", methods=["DELETE"])
+    @swagger_route(security=get_auth_security())
+    @login_required
+    @feedback_admin_required
+    @enabled_required("enable_user_feedback")
+    def feedback_review_delete(feedbackId):
+        """Permanently delete a feedback review record."""
+        actor = _get_feedback_admin_actor()
+        if not actor.get('id'):
+            return jsonify({'error': 'No user ID found in session'}), 403
+
+        try:
+            feedback_doc = cosmos_feedback_container.read_item(
+                item=feedbackId,
+                partition_key=feedbackId,
+            )
+            cosmos_feedback_container.delete_item(
+                item=feedbackId,
+                partition_key=feedbackId,
+            )
+        except CosmosResourceNotFoundError:
+            return jsonify({'error': 'Feedback not found'}), 404
+        except Exception as e:
+            log_event(
+                '[FeedbackLifecycle] Failed to delete feedback',
+                {'feedback_id': feedbackId, 'error': str(e)},
+                level=logging.ERROR,
+            )
+            return jsonify({'error': 'Failed to delete feedback'}), 500
+
+        audit_logged = log_review_lifecycle_action(
+            'feedback',
+            'delete',
+            feedback_doc,
+            actor,
+        )
+        if not audit_logged:
+            _log_feedback_audit_failure(feedbackId, 'delete')
+
+        return _feedback_lifecycle_response(
+            'Feedback permanently deleted.',
+            audit_logged,
+        ), 200
 
 
     @bp.route("/feedback/retest/<feedbackId>", methods=["POST"])

--- a/application/single_app/route_backend_safety.py
+++ b/application/single_app/route_backend_safety.py
@@ -2,6 +2,7 @@
 
 import csv
 import io
+import logging
 
 from flask import make_response
 
@@ -17,6 +18,13 @@ from functions_approvals import (
     mark_approval_executed,
 )
 from functions_authentication import *
+from functions_review_lifecycle import (
+    apply_archive_state,
+    append_archive_query_filter,
+    log_review_lifecycle_action,
+    normalize_archive_state,
+    serialize_archive_metadata,
+)
 from functions_safety_remediation import (
     SAFETY_REMEDIATION_BLOCK,
     SAFETY_REMEDIATION_SUSPEND,
@@ -54,11 +62,16 @@ def _normalize_safety_page_size(page_size):
     return page_size if page_size in ALLOWED_SAFETY_PAGE_SIZES else 10
 
 
-def _parse_safety_filters():
-    return (
+def _parse_safety_filters(include_archive_state=False):
+    filters = (
         request.args.get('status', None, type=str),
         request.args.get('action', None, type=str),
     )
+    if include_archive_state:
+        return filters + (
+            normalize_archive_state(request.args.get('archive', None, type=str)),
+        )
+    return filters
 
 
 def _format_triggered_categories(log_item):
@@ -134,7 +147,12 @@ def _build_safety_approval_metadata(
     }
 
 
-def _query_safety_logs(user_id=None, filter_status=None, filter_action=None):
+def _query_safety_logs(
+    user_id=None,
+    filter_status=None,
+    filter_action=None,
+    archive_state='active',
+):
     query = "SELECT * FROM c"
     where_clauses = []
     parameters = []
@@ -151,16 +169,21 @@ def _query_safety_logs(user_id=None, filter_status=None, filter_action=None):
         where_clauses.append("c.action = @action")
         parameters.append({"name": "@action", "value": filter_action})
 
+    append_archive_query_filter(where_clauses, archive_state)
+
     if where_clauses:
         query += " WHERE " + " AND ".join(where_clauses)
 
     query += " ORDER BY c.created_at DESC"
 
-    return list(cosmos_safety_container.query_items(
+    logs = list(cosmos_safety_container.query_items(
         query=query,
         parameters=parameters,
         enable_cross_partition_query=True,
     ))
+    for log_item in logs:
+        log_item.update(serialize_archive_metadata(log_item))
+    return logs
 
 
 def _paginate_safety_logs(logs, page, page_size):
@@ -242,6 +265,9 @@ def _build_safety_export_response(logs, filename_prefix, include_user_id=False):
         'Admin Notes',
         'Created At',
         'Last Updated',
+        'Archived',
+        'Archived At',
+        'Archived By',
     ]
     if include_user_id:
         headers.insert(1, 'User ID')
@@ -259,6 +285,9 @@ def _build_safety_export_response(logs, filename_prefix, include_user_id=False):
             log_item.get('notes') or '',
             log_item.get('created_at') or '',
             log_item.get('last_updated') or '',
+            'Yes' if log_item.get('isArchived') else 'No',
+            log_item.get('archivedAt') or '',
+            log_item.get('archivedBy') or '',
         ]
         if include_user_id:
             row.insert(1, log_item.get('user_id') or '')
@@ -270,6 +299,30 @@ def _build_safety_export_response(logs, filename_prefix, include_user_id=False):
         f'attachment; filename={filename_prefix}_{datetime.utcnow().strftime("%Y%m%d_%H%M%S")}.csv'
     )
     return response
+
+
+def _safety_lifecycle_response(message, audit_logged):
+    response = {
+        'success': True,
+        'message': message,
+        'audit_logged': audit_logged,
+    }
+    if not audit_logged:
+        response['audit_warning'] = (
+            'The record was updated, but the audit activity could not be recorded.'
+        )
+    return jsonify(response)
+
+
+def _log_safety_audit_failure(log_id, lifecycle_action):
+    log_event(
+        '[SafetyLifecycle] Failed to persist lifecycle audit event',
+        {
+            'safety_log_id': log_id,
+            'lifecycle_action': lifecycle_action,
+        },
+        level=logging.ERROR,
+    )
 
 def register_route_backend_safety(bp):
     @bp.route('/api/safety/logs', methods=['GET'])
@@ -289,10 +342,13 @@ def register_route_backend_safety(bp):
         try:
             page = int(request.args.get('page', 1))
             page_size = int(request.args.get('page_size', 10))
-            filter_status, filter_action = _parse_safety_filters()
+            filter_status, filter_action, archive_state = _parse_safety_filters(
+                include_archive_state=True,
+            )
             logs = _query_safety_logs(
                 filter_status=filter_status,
                 filter_action=filter_action,
+                archive_state=archive_state,
             )
             paginated_items, page, page_size = _paginate_safety_logs(logs, page, page_size)
 
@@ -303,6 +359,8 @@ def register_route_backend_safety(bp):
                 "total_count": len(logs)
             }), 200
 
+        except ValueError as e:
+            return jsonify({"error": str(e)}), 400
         except Exception as e:
             print(f"Error in get_safety_logs: {str(e)}") # Log the error server-side
             # Consider using Flask's logging mechanism
@@ -316,12 +374,17 @@ def register_route_backend_safety(bp):
     def get_safety_log_stats():
         """Return aggregate safety violation statistics for the admin page."""
         try:
-            filter_status, filter_action = _parse_safety_filters()
+            filter_status, filter_action, archive_state = _parse_safety_filters(
+                include_archive_state=True,
+            )
             logs = _query_safety_logs(
                 filter_status=filter_status,
                 filter_action=filter_action,
+                archive_state=archive_state,
             )
             return jsonify(_build_safety_stats(logs)), 200
+        except ValueError as e:
+            return jsonify({"error": str(e)}), 400
         except Exception as e:
             return jsonify({"error": f"Failed to retrieve safety stats: {str(e)}"}), 500
 
@@ -333,12 +396,17 @@ def register_route_backend_safety(bp):
     def export_safety_logs():
         """Export safety violation rows as CSV for the active filter set."""
         try:
-            filter_status, filter_action = _parse_safety_filters()
+            filter_status, filter_action, archive_state = _parse_safety_filters(
+                include_archive_state=True,
+            )
             logs = _query_safety_logs(
                 filter_status=filter_status,
                 filter_action=filter_action,
+                archive_state=archive_state,
             )
             return _build_safety_export_response(logs, 'admin_safety_violations_export', include_user_id=True)
+        except ValueError as e:
+            return jsonify({"error": str(e)}), 400
         except Exception as e:
             return jsonify({"error": f"Failed to export safety logs: {str(e)}"}), 500
 
@@ -489,6 +557,101 @@ def register_route_backend_safety(bp):
                 'error': str(e),
             }, level=logging.ERROR)
             return jsonify({'error': f'Failed to update safety log: {str(e)}'}), 500
+
+    @bp.route('/api/safety/logs/<string:log_id>/archive', methods=['PATCH'])
+    @swagger_route(security=get_auth_security())
+    @login_required
+    @safety_violation_admin_required
+    @enabled_required("enable_content_safety")
+    def archive_safety_log(log_id):
+        """Archive or unarchive a safety violation record."""
+        data = request.get_json() or {}
+        archived = data.get('archived')
+        if not isinstance(archived, bool):
+            return jsonify({'error': 'The archived field must be a boolean.'}), 400
+
+        actor = _get_safety_actor_context()
+        if not actor.get('id'):
+            return jsonify({'error': 'No user ID found in session'}), 403
+
+        try:
+            item = cosmos_safety_container.read_item(item=log_id, partition_key=log_id)
+            was_archived = bool(item.get('is_archived'))
+            apply_archive_state(item, archived, actor['id'])
+            item['last_updated'] = datetime.utcnow().isoformat()
+            cosmos_safety_container.upsert_item(item)
+        except exceptions.CosmosResourceNotFoundError:
+            return jsonify({'error': 'Safety violation not found'}), 404
+        except Exception as e:
+            log_event(
+                '[SafetyLifecycle] Failed to update safety violation archive state',
+                {'safety_log_id': log_id, 'error': str(e)},
+                level=logging.ERROR,
+            )
+            return jsonify({'error': 'Failed to update safety violation archive state'}), 500
+
+        lifecycle_action = 'archive' if archived else 'unarchive'
+        audit_logged = log_review_lifecycle_action(
+            'safety_violation',
+            lifecycle_action,
+            item,
+            actor,
+            was_archived=was_archived,
+        )
+        if not audit_logged:
+            _log_safety_audit_failure(log_id, lifecycle_action)
+
+        message = (
+            'Safety violation archived successfully.'
+            if archived
+            else 'Safety violation unarchived successfully.'
+        )
+        return _safety_lifecycle_response(message, audit_logged), 200
+
+    @bp.route('/api/safety/logs/<string:log_id>', methods=['DELETE'])
+    @swagger_route(security=get_auth_security())
+    @login_required
+    @safety_violation_admin_required
+    @enabled_required("enable_content_safety")
+    def delete_safety_log(log_id):
+        """Permanently delete a safety violation without deleting its audit history."""
+        actor = _get_safety_actor_context()
+        if not actor.get('id'):
+            return jsonify({'error': 'No user ID found in session'}), 403
+
+        try:
+            item = cosmos_safety_container.read_item(item=log_id, partition_key=log_id)
+            if str(item.get('action_request_status') or '').strip().lower() == 'pending':
+                return jsonify({
+                    'error': (
+                        'This safety violation cannot be deleted while a remediation '
+                        'approval request is pending.'
+                    )
+                }), 409
+            cosmos_safety_container.delete_item(item=log_id, partition_key=log_id)
+        except exceptions.CosmosResourceNotFoundError:
+            return jsonify({'error': 'Safety violation not found'}), 404
+        except Exception as e:
+            log_event(
+                '[SafetyLifecycle] Failed to delete safety violation',
+                {'safety_log_id': log_id, 'error': str(e)},
+                level=logging.ERROR,
+            )
+            return jsonify({'error': 'Failed to delete safety violation'}), 500
+
+        audit_logged = log_review_lifecycle_action(
+            'safety_violation',
+            'delete',
+            item,
+            actor,
+        )
+        if not audit_logged:
+            _log_safety_audit_failure(log_id, 'delete')
+
+        return _safety_lifecycle_response(
+            'Safety violation permanently deleted.',
+            audit_logged,
+        ), 200
         
     @bp.route('/api/safety/logs/my', methods=['GET'])
     @swagger_route(security=get_auth_security())

--- a/application/single_app/route_backend_safety.py
+++ b/application/single_app/route_backend_safety.py
@@ -359,12 +359,12 @@ def register_route_backend_safety(bp):
                 "total_count": len(logs)
             }), 200
 
-        except ValueError as e:
-            return jsonify({"error": str(e)}), 400
-        except Exception as e:
-            print(f"Error in get_safety_logs: {str(e)}") # Log the error server-side
-            # Consider using Flask's logging mechanism
-            return jsonify({"error": f"An error occurred while fetching safety logs: {str(e)}"}), 500
+        except ValueError:
+            logging.exception("Invalid request parameters in get_safety_logs")
+            return jsonify({"error": "Invalid request parameters."}), 400
+        except Exception:
+            logging.exception("Error in get_safety_logs")
+            return jsonify({"error": "An internal error occurred while fetching safety logs."}), 500
 
     @bp.route('/api/safety/logs/stats', methods=['GET'])
     @swagger_route(security=get_auth_security())
@@ -383,10 +383,12 @@ def register_route_backend_safety(bp):
                 archive_state=archive_state,
             )
             return jsonify(_build_safety_stats(logs)), 200
-        except ValueError as e:
-            return jsonify({"error": str(e)}), 400
-        except Exception as e:
-            return jsonify({"error": f"Failed to retrieve safety stats: {str(e)}"}), 500
+        except ValueError:
+            logging.exception("Invalid request parameters in get_safety_log_stats")
+            return jsonify({"error": "Invalid request parameters."}), 400
+        except Exception:
+            logging.exception("Error in get_safety_log_stats")
+            return jsonify({"error": "Failed to retrieve safety stats."}), 500
 
     @bp.route('/api/safety/logs/export', methods=['GET'])
     @swagger_route(security=get_auth_security())

--- a/application/single_app/route_backend_safety.py
+++ b/application/single_app/route_backend_safety.py
@@ -408,7 +408,8 @@ def register_route_backend_safety(bp):
             )
             return _build_safety_export_response(logs, 'admin_safety_violations_export', include_user_id=True)
         except ValueError as e:
-            return jsonify({"error": str(e)}), 400
+            logging.exception("Invalid parameters when exporting safety logs")
+            return jsonify({"error": "Invalid request parameters."}), 400
         except Exception as e:
             return jsonify({"error": f"Failed to export safety logs: {str(e)}"}), 500
 

--- a/application/single_app/static/js/admin/admin-feedback-review.js
+++ b/application/single_app/static/js/admin/admin-feedback-review.js
@@ -7,12 +7,14 @@
         viewMode: 'list',
         items: [],
         userCache: {},
+        activeItem: null,
     };
 
     const FEEDBACK_VIEW_STORAGE_KEY = 'simplechat.admin.feedback.viewMode';
 
     let editModalInstance = null;
     let retestModalInstance = null;
+    let deleteModalInstance = null;
 
     function clearElement(element) {
         if (!element) {
@@ -31,6 +33,16 @@
         }
 
         element.textContent = value == null || value === '' ? '-' : String(value);
+    }
+
+    function showPageStatus(message, variant) {
+        const alertElement = document.getElementById('feedbackPageStatusAlert');
+        if (!alertElement) {
+            return;
+        }
+
+        alertElement.textContent = message;
+        alertElement.className = `alert alert-${variant || 'info'} mb-3`;
     }
 
     function formatDateTime(value) {
@@ -104,6 +116,7 @@
         const params = new URLSearchParams();
         const type = document.getElementById('filterFeedbackType')?.value || '';
         const acknowledged = document.getElementById('filterAcknowledged')?.value || '';
+        const archiveState = document.getElementById('filterFeedbackArchive')?.value || 'active';
 
         if (includePagination) {
             params.set('page', String(state.currentPage));
@@ -116,6 +129,7 @@
         if (acknowledged) {
             params.set('ack', acknowledged);
         }
+        params.set('archive', archiveState);
 
         return params;
     }
@@ -210,15 +224,43 @@
         return cell;
     }
 
-    function createViewButton(feedbackId) {
+    function createActionButton(feedbackId, action, label, iconClass, variant) {
         const button = document.createElement('button');
         button.type = 'button';
-        button.className = 'btn btn-sm btn-primary';
+        button.className = `btn btn-sm btn-${variant}`;
         button.dataset.feedbackId = feedbackId || '';
-        button.dataset.action = 'view';
-        button.appendChild(createIcon('bi bi-eye me-1'));
-        button.appendChild(document.createTextNode('View'));
+        button.dataset.action = action;
+        button.title = label;
+        button.setAttribute('aria-label', label);
+        button.appendChild(createIcon(iconClass));
+        if (action === 'view') {
+            button.firstChild.classList.add('me-1');
+            button.appendChild(document.createTextNode(label));
+        }
         return button;
+    }
+
+    function createFeedbackActions(item) {
+        const actions = document.createElement('div');
+        actions.className = 'btn-group btn-group-sm';
+        actions.setAttribute('role', 'group');
+        actions.setAttribute('aria-label', 'Feedback actions');
+        actions.appendChild(createActionButton(item.id, 'view', 'View', 'bi bi-eye', 'primary'));
+        actions.appendChild(createActionButton(
+            item.id,
+            item.isArchived ? 'unarchive' : 'archive',
+            item.isArchived ? 'Unarchive' : 'Archive',
+            item.isArchived ? 'bi bi-arrow-counterclockwise' : 'bi bi-archive',
+            'outline-secondary',
+        ));
+        actions.appendChild(createActionButton(
+            item.id,
+            'delete',
+            'Delete',
+            'bi bi-trash',
+            'outline-danger',
+        ));
+        return actions;
     }
 
     function appendCardDetail(parent, label, value) {
@@ -379,7 +421,7 @@
 
             const viewCell = document.createElement('td');
             viewCell.className = 'table-details-cell';
-            viewCell.appendChild(createViewButton(item.id));
+            viewCell.appendChild(createFeedbackActions(item));
             row.appendChild(viewCell);
 
             tbody.appendChild(row);
@@ -433,7 +475,7 @@
             footerMeta.className = 'review-card-meta';
             footerMeta.textContent = adminReview.reviewTimestamp ? `Reviewed ${formatDateTime(adminReview.reviewTimestamp)}` : 'Waiting for review';
             footer.appendChild(footerMeta);
-            footer.appendChild(createViewButton(item.id));
+            footer.appendChild(createFeedbackActions(item));
 
             card.appendChild(header);
             card.appendChild(prompt);
@@ -492,6 +534,17 @@
         return retestModalInstance;
     }
 
+    function getDeleteModalInstance() {
+        if (!deleteModalInstance && typeof bootstrap !== 'undefined') {
+            const modalElement = document.getElementById('deleteFeedbackModal');
+            if (modalElement) {
+                deleteModalInstance = new bootstrap.Modal(modalElement);
+            }
+        }
+
+        return deleteModalInstance;
+    }
+
     async function openEditModal(feedbackId) {
         const item = state.items.find(function (entry) {
             return entry.id === feedbackId;
@@ -500,6 +553,7 @@
             return;
         }
 
+        state.activeItem = item;
         const userInfo = await lookupUserInfo(item.userId);
         const adminReview = item.adminReview || {};
 
@@ -515,6 +569,14 @@
         document.getElementById('editActionTaken').value = adminReview.actionTaken || '';
         document.getElementById('editFeedbackId').value = item.id || '';
         setTextContent('feedbackEditStatus', '');
+        const archiveButton = document.getElementById('archiveFeedbackBtn');
+        if (archiveButton) {
+            archiveButton.dataset.archived = item.isArchived ? 'true' : 'false';
+            const label = archiveButton.querySelector('span');
+            if (label) {
+                label.textContent = item.isArchived ? 'Unarchive' : 'Archive';
+            }
+        }
 
         const modalInstance = getEditModalInstance();
         if (modalInstance) {
@@ -599,6 +661,77 @@
         await refreshFeedbackView();
     }
 
+    function getLifecycleResultMessage(result) {
+        return result.audit_warning || result.message || 'Feedback updated successfully.';
+    }
+
+    async function updateFeedbackArchiveState(feedbackId, archived) {
+        const result = await fetchJson(`/feedback/review/${encodeURIComponent(feedbackId)}/archive`, {
+            method: 'PATCH',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ archived: archived }),
+        });
+
+        const modalInstance = getEditModalInstance();
+        if (modalInstance && state.activeItem?.id === feedbackId) {
+            modalInstance.hide();
+        }
+        showPageStatus(getLifecycleResultMessage(result), result.audit_warning ? 'warning' : 'success');
+        await refreshFeedbackView();
+    }
+
+    function openDeleteModal(feedbackId) {
+        const item = state.items.find(function (entry) {
+            return entry.id === feedbackId;
+        });
+        if (!item) {
+            return;
+        }
+
+        state.activeItem = item;
+        const modalInstance = getDeleteModalInstance();
+        if (modalInstance) {
+            modalInstance.show();
+        }
+    }
+
+    async function deleteFeedback() {
+        const feedbackId = state.activeItem?.id || '';
+        if (!feedbackId) {
+            return;
+        }
+
+        const confirmButton = document.getElementById('confirmDeleteFeedbackBtn');
+        if (confirmButton) {
+            confirmButton.disabled = true;
+        }
+
+        try {
+            const result = await fetchJson(`/feedback/review/${encodeURIComponent(feedbackId)}`, {
+                method: 'DELETE',
+            });
+            const deleteModal = getDeleteModalInstance();
+            if (deleteModal) {
+                deleteModal.hide();
+            }
+            const editModal = getEditModalInstance();
+            if (editModal) {
+                editModal.hide();
+            }
+            if (state.items.length === 1 && state.currentPage > 1) {
+                state.currentPage -= 1;
+            }
+            showPageStatus(getLifecycleResultMessage(result), result.audit_warning ? 'warning' : 'success');
+            await refreshFeedbackView();
+        } finally {
+            if (confirmButton) {
+                confirmButton.disabled = false;
+            }
+        }
+    }
+
     function handleFeedbackActionClick(event) {
         const actionButton = event.target.closest('button[data-feedback-id]');
         if (!actionButton) {
@@ -609,6 +742,12 @@
         const action = actionButton.dataset.action || 'view';
         if (action === 'retest') {
             openRetestModal(feedbackId);
+        } else if (action === 'archive' || action === 'unarchive') {
+            updateFeedbackArchiveState(feedbackId, action === 'archive').catch(function (error) {
+                showPageStatus(error.message, 'danger');
+            });
+        } else if (action === 'delete') {
+            openDeleteModal(feedbackId);
         } else {
             openEditModal(feedbackId);
         }
@@ -625,6 +764,9 @@
         const retestButton = document.getElementById('retestFeedbackBtn');
         const listViewRadio = document.getElementById('feedback-view-list');
         const cardsViewRadio = document.getElementById('feedback-view-cards');
+        const archiveButton = document.getElementById('archiveFeedbackBtn');
+        const deleteButton = document.getElementById('deleteFeedbackBtn');
+        const confirmDeleteButton = document.getElementById('confirmDeleteFeedbackBtn');
 
         if (tableBody) {
             tableBody.addEventListener('click', handleFeedbackActionClick);
@@ -653,11 +795,15 @@
             clearFiltersButton.addEventListener('click', function () {
                 const typeSelect = document.getElementById('filterFeedbackType');
                 const acknowledgedSelect = document.getElementById('filterAcknowledged');
+                const archiveSelect = document.getElementById('filterFeedbackArchive');
                 if (typeSelect) {
                     typeSelect.value = '';
                 }
                 if (acknowledgedSelect) {
                     acknowledgedSelect.value = '';
+                }
+                if (archiveSelect) {
+                    archiveSelect.value = 'active';
                 }
                 state.currentPage = 1;
                 refreshFeedbackView();
@@ -687,6 +833,34 @@
             retestButton.addEventListener('click', function () {
                 const feedbackId = document.getElementById('editFeedbackId')?.value || '';
                 openRetestModal(feedbackId);
+            });
+        }
+
+        if (archiveButton) {
+            archiveButton.addEventListener('click', function () {
+                const feedbackId = document.getElementById('editFeedbackId')?.value || '';
+                const archived = archiveButton.dataset.archived !== 'true';
+                updateFeedbackArchiveState(feedbackId, archived).catch(function (error) {
+                    const statusElement = document.getElementById('feedbackEditStatus');
+                    if (statusElement) {
+                        statusElement.textContent = error.message;
+                    }
+                });
+            });
+        }
+
+        if (deleteButton) {
+            deleteButton.addEventListener('click', function () {
+                const feedbackId = document.getElementById('editFeedbackId')?.value || '';
+                openDeleteModal(feedbackId);
+            });
+        }
+
+        if (confirmDeleteButton) {
+            confirmDeleteButton.addEventListener('click', function () {
+                deleteFeedback().catch(function (error) {
+                    showPageStatus(error.message, 'danger');
+                });
             });
         }
 

--- a/application/single_app/static/js/admin/admin-safety-violations.js
+++ b/application/single_app/static/js/admin/admin-safety-violations.js
@@ -22,6 +22,7 @@
     };
 
     let editModalInstance = null;
+    let deleteModalInstance = null;
 
     function clearElement(element) {
         if (!element) {
@@ -128,6 +129,7 @@
         const params = new URLSearchParams();
         const status = document.getElementById('filterStatus')?.value || '';
         const action = document.getElementById('filterAction')?.value || '';
+        const archiveState = document.getElementById('filterSafetyArchive')?.value || 'active';
 
         if (includePagination) {
             params.set('page', String(state.currentPage));
@@ -140,6 +142,7 @@
         if (action) {
             params.set('action', action);
         }
+        params.set('archive', archiveState);
 
         return params;
     }
@@ -317,14 +320,43 @@
         return cell;
     }
 
-    function createViewButton(logId) {
+    function createActionButton(logId, action, label, iconClass, variant) {
         const button = document.createElement('button');
         button.type = 'button';
-        button.className = 'btn btn-sm btn-primary';
+        button.className = `btn btn-sm btn-${variant}`;
         button.dataset.logId = logId || '';
-        button.appendChild(createIcon('bi bi-eye me-1'));
-        button.appendChild(document.createTextNode('View'));
+        button.dataset.action = action;
+        button.title = label;
+        button.setAttribute('aria-label', label);
+        button.appendChild(createIcon(iconClass));
+        if (action === 'view') {
+            button.firstChild.classList.add('me-1');
+            button.appendChild(document.createTextNode(label));
+        }
         return button;
+    }
+
+    function createSafetyActions(item) {
+        const actions = document.createElement('div');
+        actions.className = 'btn-group btn-group-sm';
+        actions.setAttribute('role', 'group');
+        actions.setAttribute('aria-label', 'Safety violation actions');
+        actions.appendChild(createActionButton(item.id, 'view', 'View', 'bi bi-eye', 'primary'));
+        actions.appendChild(createActionButton(
+            item.id,
+            item.isArchived ? 'unarchive' : 'archive',
+            item.isArchived ? 'Unarchive' : 'Archive',
+            item.isArchived ? 'bi bi-arrow-counterclockwise' : 'bi bi-archive',
+            'outline-secondary',
+        ));
+        actions.appendChild(createActionButton(
+            item.id,
+            'delete',
+            'Delete',
+            'bi bi-trash',
+            'outline-danger',
+        ));
+        return actions;
     }
 
     function getInitialViewMode() {
@@ -596,7 +628,7 @@
 
             const viewCell = document.createElement('td');
             viewCell.className = 'table-details-cell';
-            viewCell.appendChild(createViewButton(item.id));
+            viewCell.appendChild(createSafetyActions(item));
             row.appendChild(viewCell);
 
             tbody.appendChild(row);
@@ -648,7 +680,7 @@
             footerMeta.className = 'review-card-meta';
             footerMeta.textContent = item.notes ? 'Notes added' : 'No notes yet';
             footer.appendChild(footerMeta);
-            footer.appendChild(createViewButton(item.id));
+            footer.appendChild(createSafetyActions(item));
 
             card.appendChild(header);
             card.appendChild(message);
@@ -694,6 +726,17 @@
         return editModalInstance;
     }
 
+    function getDeleteModalInstance() {
+        if (!deleteModalInstance && typeof bootstrap !== 'undefined') {
+            const modalElement = document.getElementById('deleteSafetyModal');
+            if (modalElement) {
+                deleteModalInstance = new bootstrap.Modal(modalElement);
+            }
+        }
+
+        return deleteModalInstance;
+    }
+
     async function openEditModal(logId) {
         const item = state.items.find(function (entry) {
             return entry.id === logId;
@@ -713,6 +756,14 @@
         document.getElementById('editNotes').value = item.notes || '';
         document.getElementById('editLogId').value = item.id || '';
         setTextContent('safetyEditStatus', '');
+        const archiveButton = document.getElementById('archiveSafetyBtn');
+        if (archiveButton) {
+            archiveButton.dataset.archived = item.isArchived ? 'true' : 'false';
+            const label = archiveButton.querySelector('span');
+            if (label) {
+                label.textContent = item.isArchived ? 'Unarchive' : 'Archive';
+            }
+        }
         updateRemediationFields(item, true);
 
         const modalInstance = getEditModalInstance();
@@ -774,13 +825,94 @@
         await refreshSafetyView();
     }
 
+    function getLifecycleResultMessage(result) {
+        return result.audit_warning || result.message || 'Safety violation updated successfully.';
+    }
+
+    async function updateSafetyArchiveState(logId, archived) {
+        const result = await fetchJson(`/api/safety/logs/${encodeURIComponent(logId)}/archive`, {
+            method: 'PATCH',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({ archived: archived }),
+        });
+
+        const modalInstance = getEditModalInstance();
+        if (modalInstance && state.activeItem?.id === logId) {
+            modalInstance.hide();
+        }
+        showPageStatus(getLifecycleResultMessage(result), result.audit_warning ? 'warning' : 'success');
+        await refreshSafetyView();
+    }
+
+    function openDeleteModal(logId) {
+        const item = state.items.find(function (entry) {
+            return entry.id === logId;
+        });
+        if (!item) {
+            return;
+        }
+
+        state.activeItem = item;
+        const modalInstance = getDeleteModalInstance();
+        if (modalInstance) {
+            modalInstance.show();
+        }
+    }
+
+    async function deleteSafetyViolation() {
+        const logId = state.activeItem?.id || '';
+        if (!logId) {
+            return;
+        }
+
+        const confirmButton = document.getElementById('confirmDeleteSafetyBtn');
+        if (confirmButton) {
+            confirmButton.disabled = true;
+        }
+
+        try {
+            const result = await fetchJson(`/api/safety/logs/${encodeURIComponent(logId)}`, {
+                method: 'DELETE',
+            });
+            const deleteModal = getDeleteModalInstance();
+            if (deleteModal) {
+                deleteModal.hide();
+            }
+            const editModal = getEditModalInstance();
+            if (editModal) {
+                editModal.hide();
+            }
+            if (state.items.length === 1 && state.currentPage > 1) {
+                state.currentPage -= 1;
+            }
+            showPageStatus(getLifecycleResultMessage(result), result.audit_warning ? 'warning' : 'success');
+            await refreshSafetyView();
+        } finally {
+            if (confirmButton) {
+                confirmButton.disabled = false;
+            }
+        }
+    }
+
     function handleSafetyActionClick(event) {
         const actionButton = event.target.closest('button[data-log-id]');
         if (!actionButton) {
             return;
         }
 
-        openEditModal(actionButton.dataset.logId || '');
+        const logId = actionButton.dataset.logId || '';
+        const action = actionButton.dataset.action || 'view';
+        if (action === 'archive' || action === 'unarchive') {
+            updateSafetyArchiveState(logId, action === 'archive').catch(function (error) {
+                showPageStatus(error.message, 'danger');
+            });
+        } else if (action === 'delete') {
+            openDeleteModal(logId);
+        } else {
+            openEditModal(logId);
+        }
     }
 
     function attachEventListeners() {
@@ -794,6 +926,9 @@
         const actionSelect = document.getElementById('editAction');
         const listViewRadio = document.getElementById('safety-view-list');
         const cardsViewRadio = document.getElementById('safety-view-cards');
+        const archiveButton = document.getElementById('archiveSafetyBtn');
+        const deleteButton = document.getElementById('deleteSafetyBtn');
+        const confirmDeleteButton = document.getElementById('confirmDeleteSafetyBtn');
 
         if (tableBody) {
             tableBody.addEventListener('click', handleSafetyActionClick);
@@ -823,11 +958,15 @@
             clearFiltersButton.addEventListener('click', function () {
                 const statusSelect = document.getElementById('filterStatus');
                 const actionFilterSelect = document.getElementById('filterAction');
+                const archiveSelect = document.getElementById('filterSafetyArchive');
                 if (statusSelect) {
                     statusSelect.value = '';
                 }
                 if (actionFilterSelect) {
                     actionFilterSelect.value = '';
+                }
+                if (archiveSelect) {
+                    archiveSelect.value = 'active';
                 }
                 state.currentPage = 1;
                 clearPageStatus();
@@ -861,6 +1000,34 @@
                 }
 
                 updateRemediationFields(state.activeItem, false);
+            });
+        }
+
+        if (archiveButton) {
+            archiveButton.addEventListener('click', function () {
+                const logId = document.getElementById('editLogId')?.value || '';
+                const archived = archiveButton.dataset.archived !== 'true';
+                updateSafetyArchiveState(logId, archived).catch(function (error) {
+                    const statusElement = document.getElementById('safetyEditStatus');
+                    if (statusElement) {
+                        statusElement.textContent = error.message;
+                    }
+                });
+            });
+        }
+
+        if (deleteButton) {
+            deleteButton.addEventListener('click', function () {
+                const logId = document.getElementById('editLogId')?.value || '';
+                openDeleteModal(logId);
+            });
+        }
+
+        if (confirmDeleteButton) {
+            confirmDeleteButton.addEventListener('click', function () {
+                deleteSafetyViolation().catch(function (error) {
+                    showPageStatus(error.message, 'danger');
+                });
             });
         }
 

--- a/application/single_app/templates/admin_feedback_review.html
+++ b/application/single_app/templates/admin_feedback_review.html
@@ -81,7 +81,8 @@
 
   .table-details-cell {
     text-align: center;
-    width: 92px;
+    white-space: nowrap;
+    width: 128px;
   }
 
   .table-loading-row td {
@@ -188,6 +189,8 @@
       </button>
     </div>
   </div>
+
+  <div id="feedbackPageStatusAlert" class="alert d-none mb-3" role="status" aria-live="polite"></div>
 
   <ul class="nav nav-tabs feedback-nav-tabs mb-3" id="feedbackReviewTabs" role="tablist">
     <li class="nav-item" role="presentation">
@@ -302,7 +305,14 @@
                 <option value="false">Not Acknowledged</option>
               </select>
             </div>
-            <div class="col-md-6">
+            <div class="col-md-3">
+              <label for="filterFeedbackArchive" class="form-label mb-1">Records</label>
+              <select id="filterFeedbackArchive" class="form-select form-select-sm">
+                <option value="active">Active</option>
+                <option value="archived">Archived</option>
+              </select>
+            </div>
+            <div class="col-md-3">
               <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-md-end gap-2">
                 <div class="btn-group btn-group-sm review-view-toggle" role="group" aria-label="Feedback view mode">
                   <input type="radio" class="btn-check" name="feedback-view-mode" id="feedback-view-list" autocomplete="off" checked />
@@ -331,7 +341,7 @@
                 <th>Prompt</th>
                 <th>Feedback</th>
                 <th>Acknowledged</th>
-                <th class="table-details-cell">View</th>
+                <th class="table-details-cell">Actions</th>
               </tr>
             </thead>
             <tbody>
@@ -417,11 +427,35 @@
       </div>
       <div class="modal-footer">
         <div id="feedbackEditStatus" class="small text-danger me-auto"></div>
+        <button type="button" id="archiveFeedbackBtn" class="btn btn-outline-secondary">
+          <i class="bi bi-archive me-1"></i><span>Archive</span>
+        </button>
+        <button type="button" id="deleteFeedbackBtn" class="btn btn-outline-danger">
+          <i class="bi bi-trash me-1"></i>Delete
+        </button>
         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
         <button type="button" id="retestFeedbackBtn" class="btn btn-outline-secondary">
           <i class="bi bi-arrow-clockwise me-1"></i>Retest Prompt
         </button>
         <button type="button" id="saveFeedbackChangesBtn" class="btn btn-primary">Save Review</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="modal fade" id="deleteFeedbackModal" tabindex="-1" aria-labelledby="deleteFeedbackModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="deleteFeedbackModalLabel">Permanently delete feedback?</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        This permanently removes the feedback record and cannot be undone. The deletion action remains in the activity log.
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+        <button type="button" id="confirmDeleteFeedbackBtn" class="btn btn-danger">Permanently Delete</button>
       </div>
     </div>
   </div>

--- a/application/single_app/templates/admin_safety_violations.html
+++ b/application/single_app/templates/admin_safety_violations.html
@@ -81,7 +81,8 @@
 
   .table-details-cell {
     text-align: center;
-    width: 92px;
+    white-space: nowrap;
+    width: 128px;
   }
 
   .table-loading-row td {
@@ -316,7 +317,14 @@
                 <option value="BlockUser">Block user</option>
               </select>
             </div>
-            <div class="col-md-6">
+            <div class="col-md-3">
+              <label for="filterSafetyArchive" class="form-label mb-1">Records</label>
+              <select id="filterSafetyArchive" class="form-select form-select-sm">
+                <option value="active">Active</option>
+                <option value="archived">Archived</option>
+              </select>
+            </div>
+            <div class="col-md-3">
               <div class="d-flex flex-column flex-md-row align-items-md-center justify-content-md-end gap-2">
                 <div class="btn-group btn-group-sm review-view-toggle" role="group" aria-label="Safety violations view mode">
                   <input type="radio" class="btn-check" name="safety-view-mode" id="safety-view-list" autocomplete="off" checked />
@@ -345,7 +353,7 @@
                 <th>Triggered Categories</th>
                 <th>Status</th>
                 <th>Action</th>
-                <th class="table-details-cell">View</th>
+                <th class="table-details-cell">Actions</th>
               </tr>
             </thead>
             <tbody>
@@ -439,8 +447,32 @@
       </div>
       <div class="modal-footer">
         <div id="safetyEditStatus" class="small text-danger me-auto"></div>
+        <button type="button" id="archiveSafetyBtn" class="btn btn-outline-secondary">
+          <i class="bi bi-archive me-1"></i><span>Archive</span>
+        </button>
+        <button type="button" id="deleteSafetyBtn" class="btn btn-outline-danger">
+          <i class="bi bi-trash me-1"></i>Delete
+        </button>
         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
         <button type="button" id="saveChangesBtn" class="btn btn-primary">Save Review</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="modal fade" id="deleteSafetyModal" tabindex="-1" aria-labelledby="deleteSafetyModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="deleteSafetyModalLabel">Permanently delete safety violation?</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        This permanently removes the safety violation and cannot be undone. Approval and activity audit records are preserved. Violations with pending remediation approval cannot be deleted.
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+        <button type="button" id="confirmDeleteSafetyBtn" class="btn btn-danger">Permanently Delete</button>
       </div>
     </div>
   </div>

--- a/docs/explanation/features/ADMIN_REVIEW_RECORD_LIFECYCLE.md
+++ b/docs/explanation/features/ADMIN_REVIEW_RECORD_LIFECYCLE.md
@@ -1,0 +1,75 @@
+# Admin Review Record Lifecycle
+
+## Overview
+
+Administrators can archive, restore, and permanently delete records from the Feedback Review and Safety Violations pages. Archiving removes a record from active admin queues and the affected user's profile history while preserving it for later review.
+
+Implemented in version: **0.250.075**
+
+### Dependencies
+
+- Azure Cosmos DB feedback, safety, and activity log containers
+- Existing FeedbackAdmin and SafetyViolationAdmin role gates
+- Bootstrap 5 modals and alerts
+
+## Technical specifications
+
+### Record lifecycle
+
+Feedback and safety documents use these backward-compatible fields:
+
+- `is_archived`: Current archive state. Missing values are treated as active.
+- `archived_at` and `archived_by`: Most recent archive timestamp and administrator.
+- `unarchived_at` and `unarchived_by`: Most recent restore timestamp and administrator.
+
+Admin list, statistics, pagination, and CSV export requests accept `archive=active` or `archive=archived`. The default is `active`. User profile list, statistics, and export APIs always return active records only.
+
+### APIs
+
+| Record | Archive or restore | Permanent delete |
+|---|---|---|
+| Feedback | `PATCH /feedback/review/{id}/archive` with `{"archived": true\|false}` | `DELETE /feedback/review/{id}` |
+| Safety violation | `PATCH /api/safety/logs/{id}/archive` with `{"archived": true\|false}` | `DELETE /api/safety/logs/{id}` |
+
+All lifecycle routes require login, Swagger authentication metadata, the record-specific admin role, and the corresponding feature setting.
+
+Safety violations with a pending remediation approval return HTTP 409 when deletion is requested. Completed approval and activity records are stored separately and remain available after the violation is deleted.
+
+### Audit behavior
+
+Every successful archive, unarchive, and delete attempts to write an `admin_action` activity record. The audit stores the administrator, lifecycle action, record ID, target user ID, prior archive state, and relevant conversation/message or safety approval identifiers. User-generated prompt, response, and violation message content is not copied into the audit record.
+
+Cosmos cannot atomically mutate the source and activity containers. If activity logging fails, the lifecycle mutation remains successful, Application Insights records the failure, and the API returns an `audit_warning` for the admin UI.
+
+### Files
+
+- `application/single_app/functions_review_lifecycle.py`
+- `application/single_app/route_backend_feedback.py`
+- `application/single_app/route_backend_safety.py`
+- `application/single_app/templates/admin_feedback_review.html`
+- `application/single_app/templates/admin_safety_violations.html`
+- `application/single_app/static/js/admin/admin-feedback-review.js`
+- `application/single_app/static/js/admin/admin-safety-violations.js`
+
+## Usage
+
+1. Open Feedback Review or Safety Violations and select **All Data**.
+2. Use the **Records** filter to switch between active and archived records.
+3. Select **Archive** to remove an active record from both admin and user history.
+4. Select **Unarchive** in the archived view to restore the record.
+5. Select **Delete**, review the destructive confirmation, and choose **Permanently Delete**.
+
+Archive, restore, and delete actions refresh the current list/card view, statistics, pagination, and export scope. Audit persistence warnings appear as Bootstrap warning alerts without reporting the completed record mutation as failed.
+
+## Testing and validation
+
+- `functional_tests/test_admin_review_record_lifecycle.py` covers lifecycle metadata, query filters, audit payload minimization, route authorization markers, and pending remediation safeguards.
+- `functional_tests/test_backend_feedback_swagger_integration.py` covers all feedback route decorators and role gates.
+- `ui_tests/test_admin_review_list_card_views.py` covers archive actions, delete confirmation and cancellation, audit warnings, and pending safety deletion errors.
+
+The UI tests require an authenticated admin Playwright storage state and a configured `SIMPLECHAT_UI_BASE_URL`.
+
+### Known limitations
+
+- Lifecycle changes and activity log writes are separate Cosmos operations. Audit failures are surfaced but do not roll back the requested lifecycle action.
+- Permanent deletion cannot be undone. Only archive and unarchive are reversible.

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,16 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](/explanation/features/) and [Fixes by Version](/explanation/fixes/).
 
+### **(v0.250.075)**
+
+#### New Features
+
+*   **Admin Feedback and Safety Record Lifecycle**
+    *   Added archive, unarchive, and permanently delete actions to the Feedback Review and Safety Violations admin pages, with active/archived filtering across lists, cards, statistics, pagination, and CSV exports.
+    *   Archived records are hidden from user profile history, destructive deletion requires confirmation, and safety violations with pending remediation approvals cannot be deleted.
+    *   Archive, unarchive, and delete actions create non-sensitive admin activity audit records, while audit persistence failures are surfaced without undoing successful lifecycle changes.
+    *   (Ref: microsoft/simplechat#991, `functions_review_lifecycle.py`, `route_backend_feedback.py`, `route_backend_safety.py`, `ADMIN_REVIEW_RECORD_LIFECYCLE.md`)
+
 ### **(v0.250.074)**
 
 #### New Features

--- a/functional_tests/test_admin_review_record_lifecycle.py
+++ b/functional_tests/test_admin_review_record_lifecycle.py
@@ -1,0 +1,129 @@
+# test_admin_review_record_lifecycle.py
+#!/usr/bin/env python3
+"""
+Functional test for admin review record lifecycle management.
+Version: 0.250.075
+Implemented in: 0.250.075
+
+This test ensures feedback and safety records support active/archived filtering,
+non-sensitive activity audits, protected lifecycle routes, and pending safety
+remediation deletion safeguards.
+"""
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+ROOT_DIR = Path(__file__).resolve().parent.parent
+APP_DIR = ROOT_DIR / 'application' / 'single_app'
+LIFECYCLE_PATH = APP_DIR / 'functions_review_lifecycle.py'
+FEEDBACK_ROUTE_PATH = APP_DIR / 'route_backend_feedback.py'
+SAFETY_ROUTE_PATH = APP_DIR / 'route_backend_safety.py'
+
+
+def _load_lifecycle_module(activity_logger):
+    fake_activity_module = types.ModuleType('functions_activity_logging')
+    fake_activity_module.log_general_admin_action = activity_logger
+    previous_module = sys.modules.get('functions_activity_logging')
+    sys.modules['functions_activity_logging'] = fake_activity_module
+    try:
+        spec = importlib.util.spec_from_file_location(
+            'test_functions_review_lifecycle',
+            LIFECYCLE_PATH,
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        if previous_module is None:
+            sys.modules.pop('functions_activity_logging', None)
+        else:
+            sys.modules['functions_activity_logging'] = previous_module
+
+
+def test_archive_metadata_query_filters_and_audit_payload():
+    """Lifecycle helpers should preserve legacy active records and audit IDs only."""
+    captured_audits = []
+
+    def capture_audit(**kwargs):
+        captured_audits.append(kwargs)
+        return True
+
+    lifecycle = _load_lifecycle_module(capture_audit)
+    active_clauses = []
+    archived_clauses = []
+    lifecycle.append_archive_query_filter(active_clauses, 'active')
+    lifecycle.append_archive_query_filter(archived_clauses, 'archived')
+
+    assert 'NOT IS_DEFINED(c.is_archived)' in active_clauses[0]
+    assert 'c.is_archived = true' in archived_clauses[0]
+
+    item = {
+        'id': 'feedback-1',
+        'userId': 'user-1',
+        'conversationId': 'conversation-1',
+        'messageId': 'message-1',
+        'prompt': 'Sensitive prompt content must not enter the audit.',
+    }
+    lifecycle.apply_archive_state(item, True, 'admin-1')
+    metadata = lifecycle.serialize_archive_metadata(item)
+    assert metadata['isArchived'] is True
+    assert metadata['archivedBy'] == 'admin-1'
+    assert metadata['archivedAt']
+
+    assert lifecycle.log_review_lifecycle_action(
+        'feedback',
+        'archive',
+        item,
+        {'id': 'admin-1', 'email': 'admin@example.com'},
+        was_archived=False,
+    )
+    audit = captured_audits[0]
+    assert audit['action'] == 'feedback_archived'
+    assert audit['additional_context']['record_id'] == 'feedback-1'
+    assert audit['additional_context']['was_archived'] is False
+    assert 'prompt' not in audit['additional_context']
+
+
+def test_feedback_and_safety_route_contracts():
+    """Admin lifecycle routes should keep auth gates and active-only user history."""
+    feedback_source = FEEDBACK_ROUTE_PATH.read_text(encoding='utf-8')
+    safety_source = SAFETY_ROUTE_PATH.read_text(encoding='utf-8')
+
+    feedback_markers = [
+        '@bp.route("/feedback/review/<feedbackId>/archive", methods=["PATCH"])',
+        '@bp.route("/feedback/review/<feedbackId>", methods=["DELETE"])',
+        'def feedback_review_archive(feedbackId):',
+        'def feedback_review_delete(feedbackId):',
+        '@feedback_admin_required',
+        "archive_state='active'",
+        'log_review_lifecycle_action(',
+        "'audit_warning'",
+    ]
+    safety_markers = [
+        "@bp.route('/api/safety/logs/<string:log_id>/archive', methods=['PATCH'])",
+        "@bp.route('/api/safety/logs/<string:log_id>', methods=['DELETE'])",
+        'def archive_safety_log(log_id):',
+        'def delete_safety_log(log_id):',
+        '@safety_violation_admin_required',
+        "archive_state='active'",
+        "action_request_status') or '').strip().lower() == 'pending'",
+        'log_review_lifecycle_action(',
+        "'audit_warning'",
+    ]
+
+    for marker in feedback_markers:
+        assert marker in feedback_source, f'Missing feedback lifecycle marker: {marker}'
+    for marker in safety_markers:
+        assert marker in safety_source, f'Missing safety lifecycle marker: {marker}'
+
+    assert feedback_source.count('@swagger_route(security=get_auth_security())') == feedback_source.count('@bp.route(')
+    assert safety_source.count('@swagger_route(security=get_auth_security())') == safety_source.count('@bp.route(')
+
+
+if __name__ == '__main__':
+    test_archive_metadata_query_filters_and_audit_payload()
+    test_feedback_and_safety_route_contracts()
+    raise SystemExit(0)

--- a/functional_tests/test_backend_feedback_swagger_integration.py
+++ b/functional_tests/test_backend_feedback_swagger_integration.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
 Functional test for backend feedback swagger integration.
-Version: 0.229.069
+Version: 0.250.075
 Implemented in: 0.229.069
 
 This test ensures that all feedback endpoints in route_backend_feedback.py 
@@ -61,9 +61,14 @@ def test_feedback_swagger_decorators():
         expected_endpoints = [
             '/feedback/submit',
             '/feedback/review',
+            '/feedback/review/stats',
+            '/feedback/review/export',
             '/feedback/review/<feedbackId>',  # GET and PATCH versions
+            '/feedback/review/<feedbackId>/archive',
             '/feedback/retest/<feedbackId>',
-            '/feedback/my'
+            '/feedback/my',
+            '/feedback/my/stats',
+            '/feedback/my/export',
         ]
         
         # Track found decorators
@@ -73,7 +78,7 @@ def test_feedback_swagger_decorators():
         lines = content.split('\n')
         
         for i, line in enumerate(lines):
-            if '@app.route(' in line:
+            if '@bp.route(' in line:
                 # Found a route, check if next line has swagger decorator
                 if i + 1 < len(lines) and '@swagger_route(security=get_auth_security())' in lines[i + 1]:
                     decorated_endpoints += 1
@@ -82,9 +87,9 @@ def test_feedback_swagger_decorators():
                     print(f"❌ Missing swagger decorator for: {line.strip()}")
                     return False
         
-        # Verify we found all expected endpoints (6 total)
-        if decorated_endpoints != 6:
-            print(f"❌ Expected 6 decorated endpoints, found {decorated_endpoints}")
+        expected_route_count = 12
+        if decorated_endpoints != expected_route_count:
+            print(f"❌ Expected {expected_route_count} decorated endpoints, found {decorated_endpoints}")
             return False
             
         print(f"✅ All {decorated_endpoints} feedback endpoints properly decorated")
@@ -115,7 +120,7 @@ def test_feedback_decorator_order():
         route_count = 0
         
         for i, line in enumerate(lines):
-            if '@app.route(' in line:
+            if '@bp.route(' in line:
                 route_count += 1
                 
                 # Check if decorators are in correct order
@@ -161,8 +166,12 @@ def test_feedback_endpoint_coverage():
             'feedback_review_get',
             'feedback_review_get_single',
             'feedback_review_update',
+            'feedback_review_archive',
+            'feedback_review_delete',
             'feedback_retest',
-            'feedback_my'
+            'feedback_my',
+            'feedback_my_stats',
+            'feedback_my_export',
         ]
         
         found_functions = []
@@ -205,7 +214,7 @@ def test_feedback_auth_security_integration():
         
         # Count occurrences of security integration
         security_decorators = content.count('@swagger_route(security=get_auth_security())')
-        app_routes = content.count('@app.route(')
+        app_routes = content.count('@bp.route(')
         
         if security_decorators != app_routes:
             print(f"❌ Mismatch: {app_routes} routes but {security_decorators} security decorators")
@@ -241,12 +250,11 @@ def test_feedback_role_based_access():
             content = f.read()
         
         # Count admin and user required decorators
-        admin_required_count = content.count('@admin_required')
+        admin_required_count = content.count('@feedback_admin_required')
         user_required_count = content.count('@user_required')
         
-        # Expected: 4 admin endpoints (review, get_single, update, retest) + 2 user endpoints (submit, my)
-        expected_admin = 4
-        expected_user = 2
+        expected_admin = 8
+        expected_user = 4
         
         if admin_required_count != expected_admin:
             print(f"❌ Expected {expected_admin} @admin_required decorators, found {admin_required_count}")
@@ -283,8 +291,7 @@ def test_feedback_enabled_required_preservation():
         # All feedback endpoints should have @enabled_required("enable_user_feedback")
         enabled_required_count = content.count('@enabled_required("enable_user_feedback")')
         
-        # All 6 endpoints should have enabled_required
-        expected_enabled_required = 6
+        expected_enabled_required = 12
         
         if enabled_required_count != expected_enabled_required:
             print(f"❌ Expected {expected_enabled_required} @enabled_required decorators, found {enabled_required_count}")

--- a/ui_tests/test_admin_review_list_card_views.py
+++ b/ui_tests/test_admin_review_list_card_views.py
@@ -1,8 +1,8 @@
 # test_admin_review_list_card_views.py
 """
 UI tests for admin feedback and safety violation list/card views.
-Version: 0.241.032
-Implemented in: 0.241.032
+Version: 0.250.075
+Implemented in: 0.241.032; lifecycle controls extended in 0.250.075
 
 These tests ensure the admin review tables stay compact, card views render
 from the same data, safety category tags hide severity 0 entries, and the
@@ -78,6 +78,7 @@ def _mock_user_lookup(page):
 def test_admin_feedback_compact_list_and_card_view(playwright):
     """Validate feedback list columns, card toggle, and view modal behavior."""
     browser, context, page = _new_admin_page(playwright)
+    lifecycle_requests = []
 
     try:
         _mock_user_lookup(page)
@@ -97,9 +98,9 @@ def test_admin_feedback_compact_list_and_card_view(playwright):
                 },
             ),
         )
-        page.route(
-            "**/feedback/review?*",
-            lambda route: _fulfill_json(
+        def handle_feedback_list(route, request):
+            is_archived = "archive=archived" in request.url
+            _fulfill_json(
                 route,
                 {
                     "feedback": [
@@ -111,6 +112,7 @@ def test_admin_feedback_compact_list_and_card_view(playwright):
                             "aiResponse": "The response was too brief.",
                             "feedbackType": "Negative",
                             "reason": "The answer missed key customer segments.",
+                            "isArchived": is_archived,
                             "adminReview": {
                                 "acknowledged": False,
                                 "analysisNotes": "",
@@ -123,8 +125,38 @@ def test_admin_feedback_compact_list_and_card_view(playwright):
                     "page_size": 10,
                     "total_count": 1,
                 },
-            ),
-        )
+            )
+
+        page.route("**/feedback/review?*", handle_feedback_list)
+
+        def handle_feedback_archive(route, request):
+            lifecycle_requests.append({
+                "method": request.method,
+                "json": request.post_data_json,
+            })
+            _fulfill_json(
+                route,
+                {
+                    "success": True,
+                    "message": "Feedback archived successfully.",
+                    "audit_logged": False,
+                    "audit_warning": "The record was updated, but the audit activity could not be recorded.",
+                },
+            )
+
+        def handle_feedback_delete(route, request):
+            lifecycle_requests.append({"method": request.method})
+            _fulfill_json(
+                route,
+                {
+                    "success": True,
+                    "message": "Feedback permanently deleted.",
+                    "audit_logged": True,
+                },
+            )
+
+        page.route("**/feedback/review/feedback-*/archive", handle_feedback_archive)
+        page.route("**/feedback/review/feedback-*", handle_feedback_delete)
 
         response = page.goto(f"{BASE_URL}/admin/feedback_review", wait_until="domcontentloaded")
         _skip_unavailable(response, "/admin/feedback_review")
@@ -151,6 +183,30 @@ def test_admin_feedback_compact_list_and_card_view(playwright):
         expect(page.locator("#feedback-card-view")).to_contain_text("Summarize the quarterly launch feedback.")
         page.locator("#feedback-card-view").get_by_role("button", name="View").click()
         expect(page.get_by_role("heading", name="View Feedback Entry")).to_be_visible()
+        page.locator("#archiveFeedbackBtn").click()
+        expect(page.locator("#feedbackPageStatusAlert")).to_contain_text("audit activity could not be recorded")
+        assert lifecycle_requests[-1] == {
+            "method": "PATCH",
+            "json": {"archived": True},
+        }
+
+        page.locator("#filterFeedbackArchive").select_option("archived")
+        page.locator("#applyFiltersBtn").click()
+        expect(page.locator("#feedback-table").get_by_role("button", name="Unarchive")).to_be_visible()
+        page.locator("#feedback-table").get_by_role("button", name="Unarchive").click()
+        assert lifecycle_requests[-1] == {
+            "method": "PATCH",
+            "json": {"archived": False},
+        }
+
+        page.locator("#feedback-table").get_by_role("button", name="Delete").click()
+        expect(page.get_by_role("heading", name="Permanently delete feedback?")).to_be_visible()
+        page.get_by_role("button", name="Cancel").click()
+        expect(page.get_by_role("heading", name="Permanently delete feedback?")).not_to_be_visible()
+        page.locator("#feedback-table").get_by_role("button", name="Delete").click()
+        page.get_by_role("button", name="Permanently Delete").click()
+        expect(page.locator("#feedbackPageStatusAlert")).to_contain_text("Feedback permanently deleted")
+        assert lifecycle_requests[-1]["method"] == "DELETE"
     finally:
         context.close()
         browser.close()
@@ -161,6 +217,8 @@ def test_admin_safety_violations_tags_cards_and_view_save(playwright):
     """Validate safety category badges, compact columns, cards, and notes save."""
     browser, context, page = _new_admin_page(playwright)
     captured_payload = {}
+    lifecycle_requests = []
+    delete_attempts = {"count": 0}
 
     try:
         _mock_user_lookup(page)
@@ -205,6 +263,44 @@ def test_admin_safety_violations_tags_cards_and_view_save(playwright):
             if "/stats" in request.url:
                 _fulfill_json(route, safety_stats_payload)
                 return
+            if request.method == "DELETE":
+                delete_attempts["count"] += 1
+                lifecycle_requests.append({"method": request.method})
+                if delete_attempts["count"] == 1:
+                    _fulfill_json(
+                        route,
+                        {
+                            "error": (
+                                "This safety violation cannot be deleted while a "
+                                "remediation approval request is pending."
+                            )
+                        },
+                        status=409,
+                    )
+                    return
+                _fulfill_json(
+                    route,
+                    {
+                        "success": True,
+                        "message": "Safety violation permanently deleted.",
+                        "audit_logged": True,
+                    },
+                )
+                return
+            if "/archive" in request.url:
+                lifecycle_requests.append({
+                    "method": request.method,
+                    "json": request.post_data_json,
+                })
+                _fulfill_json(
+                    route,
+                    {
+                        "success": True,
+                        "message": "Safety violation archived successfully.",
+                        "audit_logged": True,
+                    },
+                )
+                return
             if request.method == "PATCH":
                 captured_payload["json"] = request.post_data_json
                 _fulfill_json(route, {"message": "Safety log updated successfully."})
@@ -241,6 +337,24 @@ def test_admin_safety_violations_tags_cards_and_view_save(playwright):
         page.get_by_role("button", name="Save Review").click()
         expect(page.locator("#safetyPageStatusAlert")).to_contain_text("Safety log updated successfully")
         assert captured_payload["json"]["notes"] == "Reviewed from the card view."
+
+        page.locator("#safety-card-view").get_by_role("button", name="View").click()
+        page.locator("#archiveSafetyBtn").click()
+        expect(page.locator("#safetyPageStatusAlert")).to_contain_text("Safety violation archived successfully")
+        assert lifecycle_requests[-1] == {
+            "method": "PATCH",
+            "json": {"archived": True},
+        }
+
+        page.locator("#safety-card-view").get_by_role("button", name="View").click()
+        page.locator("#deleteSafetyBtn").click()
+        expect(page.get_by_role("heading", name="Permanently delete safety violation?")).to_be_visible()
+        page.get_by_role("button", name="Permanently Delete").click()
+        expect(page.locator("#safetyPageStatusAlert")).to_contain_text("cannot be deleted while")
+        expect(page.get_by_role("heading", name="Permanently delete safety violation?")).to_be_visible()
+        page.get_by_role("button", name="Permanently Delete").click()
+        expect(page.locator("#safetyPageStatusAlert")).to_contain_text("Safety violation permanently deleted")
+        assert delete_attempts["count"] == 2
     finally:
         context.close()
         browser.close()


### PR DESCRIPTION
## Summary
- add archive, unarchive, and permanent delete workflows for admin feedback and safety reviews
- hide archived records from active admin queues and user profile history
- preserve safety approval history, block deletion while remediation is pending, and audit lifecycle actions
- add functional/UI coverage, feature documentation, and release notes for v0.250.075

## Validation
- 11 targeted tests passed; 2 environment-dependent UI tests skipped
- Python and JavaScript syntax checks passed
- XSS and broken access control guardrails passed

Closes #991