### PR TITLE
Add external link ordering controls

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -95,7 +95,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.250.101"
+VERSION = "0.250.102"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/static/js/admin/admin_settings.js
+++ b/application/single_app/static/js/admin/admin_settings.js
@@ -1,5 +1,6 @@
 // admin_settings.js
 import { showToast } from "../chat/chat-toast.js";
+import { sanitizeHttpUrl } from "../chat/chat-utils.js";
 
 let gptSelected = window.gptSelected || [];
 let gptAll      = window.gptAll || [];
@@ -5921,41 +5922,93 @@ function renderExternalLinks() {
  */
 function createExternalLinkRow(link, index, isNew = false) {
     const row = document.createElement('tr');
-    row.setAttribute('data-index', index);
+    row.dataset.index = String(index);
 
     if (isNew) {
-        // Create an editable row for new links
-        row.innerHTML = `
-            <td>
-                <input type="text" class="form-control form-control-sm external-link-label-input" 
-                       value="${escapeHtml(link.label)}" placeholder="Link Label">
-            </td>
-            <td>
-                <input type="url" class="form-control form-control-sm external-link-url-input" 
-                       value="${escapeHtml(link.url)}" placeholder="https://example.com">
-            </td>
-            <td>
-                <button type="button" class="btn btn-sm btn-success external-link-save-btn" data-index="${index}">Save</button>
-                <button type="button" class="btn btn-sm btn-secondary ms-1 external-link-cancel-btn" data-index="${index}">Cancel</button>
-            </td>
-        `;
+        populateExternalLinkEditorRow(row, link, index);
     } else {
-        // Create a read-only row for existing links
-        row.innerHTML = `
-            <td class="external-link-label">${escapeHtml(link.label)}</td>
-            <td class="external-link-url">
-                <a href="${escapeHtml(link.url)}" target="_blank" rel="noopener noreferrer">
-                    ${escapeHtml(link.url)}
-                </a>
-            </td>
-            <td>
-                <button type="button" class="btn btn-sm btn-outline-primary external-link-edit-btn" data-index="${index}">Edit</button>
-                <button type="button" class="btn btn-sm btn-outline-danger ms-1 external-link-delete-btn" data-index="${index}">Delete</button>
-            </td>
-        `;
+        const labelCell = document.createElement('td');
+        labelCell.className = 'external-link-label';
+        labelCell.textContent = link.label;
+
+        const urlCell = document.createElement('td');
+        urlCell.className = 'external-link-url';
+        const safeUrl = sanitizeHttpUrl(link.url);
+        if (safeUrl) {
+            const anchor = document.createElement('a');
+            anchor.href = safeUrl;
+            anchor.target = '_blank';
+            anchor.rel = 'noopener noreferrer';
+            anchor.textContent = link.url;
+            urlCell.appendChild(anchor);
+        } else {
+            urlCell.textContent = link.url;
+        }
+
+        const actionsCell = document.createElement('td');
+        actionsCell.className = 'text-nowrap';
+
+        const moveUpButton = createIconButton('bi bi-arrow-up', `Move ${link.label} up`);
+        moveUpButton.classList.add('external-link-move-up-btn');
+        moveUpButton.dataset.index = String(index);
+        moveUpButton.disabled = index === 0;
+
+        const moveDownButton = createIconButton('bi bi-arrow-down', `Move ${link.label} down`);
+        moveDownButton.classList.add('external-link-move-down-btn', 'ms-1');
+        moveDownButton.dataset.index = String(index);
+        moveDownButton.disabled = index === externalLinks.length - 1;
+
+        const editButton = document.createElement('button');
+        editButton.type = 'button';
+        editButton.className = 'btn btn-sm btn-outline-primary ms-1 external-link-edit-btn';
+        editButton.dataset.index = String(index);
+        editButton.textContent = 'Edit';
+
+        const deleteButton = document.createElement('button');
+        deleteButton.type = 'button';
+        deleteButton.className = 'btn btn-sm btn-outline-danger ms-1 external-link-delete-btn';
+        deleteButton.dataset.index = String(index);
+        deleteButton.textContent = 'Delete';
+
+        actionsCell.append(moveUpButton, moveDownButton, editButton, deleteButton);
+        row.append(labelCell, urlCell, actionsCell);
     }
 
     return row;
+}
+
+function populateExternalLinkEditorRow(row, link, index) {
+    const labelCell = document.createElement('td');
+    const labelInput = document.createElement('input');
+    labelInput.type = 'text';
+    labelInput.className = 'form-control form-control-sm external-link-label-input';
+    labelInput.value = link.label;
+    labelInput.placeholder = 'Link Label';
+    labelCell.appendChild(labelInput);
+
+    const urlCell = document.createElement('td');
+    const urlInput = document.createElement('input');
+    urlInput.type = 'url';
+    urlInput.className = 'form-control form-control-sm external-link-url-input';
+    urlInput.value = link.url;
+    urlInput.placeholder = 'https://example.com';
+    urlCell.appendChild(urlInput);
+
+    const actionsCell = document.createElement('td');
+    const saveButton = document.createElement('button');
+    saveButton.type = 'button';
+    saveButton.className = 'btn btn-sm btn-success external-link-save-btn';
+    saveButton.dataset.index = String(index);
+    saveButton.textContent = 'Save';
+
+    const cancelButton = document.createElement('button');
+    cancelButton.type = 'button';
+    cancelButton.className = 'btn btn-sm btn-secondary ms-1 external-link-cancel-btn';
+    cancelButton.dataset.index = String(index);
+    cancelButton.textContent = 'Cancel';
+
+    actionsCell.append(saveButton, cancelButton);
+    row.replaceChildren(labelCell, urlCell, actionsCell);
 }
 
 /**
@@ -5989,8 +6042,8 @@ function handleAddExternalLink() {
  * @param {Event} event - The click event.
  */
 function handleExternalLinksAction(event) {
-    const target = event.target;
-    if (!target.matches('button')) return;
+    const target = event.target.closest('button');
+    if (!target) return;
 
     const row = target.closest('tr');
     if (!row) return;
@@ -6006,7 +6059,32 @@ function handleExternalLinksAction(event) {
         handleCancelExternalLink(row, indexAttr, isNew);
     } else if (target.classList.contains('external-link-delete-btn')) {
         handleDeleteExternalLink(row, indexAttr, isNew);
+    } else if (target.classList.contains('external-link-move-up-btn')) {
+        handleMoveExternalLink(indexAttr, -1);
+    } else if (target.classList.contains('external-link-move-down-btn')) {
+        handleMoveExternalLink(indexAttr, 1);
     }
+}
+
+function handleMoveExternalLink(indexAttr, direction) {
+    const index = Number.parseInt(indexAttr, 10);
+    const destinationIndex = index + direction;
+
+    if (
+        !Number.isInteger(index)
+        || ![-1, 1].includes(direction)
+        || destinationIndex < 0
+        || destinationIndex >= externalLinks.length
+    ) {
+        return;
+    }
+
+    [externalLinks[index], externalLinks[destinationIndex]] = [
+        externalLinks[destinationIndex],
+        externalLinks[index],
+    ];
+    renderExternalLinks();
+    markFormAsModified();
 }
 
 /**
@@ -6014,25 +6092,11 @@ function handleExternalLinksAction(event) {
  * @param {HTMLTableRowElement} row - The table row to make editable.
  */
 function handleEditExternalLink(row) {
-    const index = parseInt(row.getAttribute('data-index'));
+    const index = Number.parseInt(row.dataset.index, 10);
     const link = externalLinks[index];
     if (!link) return;
 
-    // Replace the row content with editable inputs
-    row.innerHTML = `
-        <td>
-            <input type="text" class="form-control form-control-sm external-link-label-input" 
-                   value="${escapeHtml(link.label)}" placeholder="Link Label">
-        </td>
-        <td>
-            <input type="url" class="form-control form-control-sm external-link-url-input" 
-                   value="${escapeHtml(link.url)}" placeholder="https://example.com">
-        </td>
-        <td>
-            <button type="button" class="btn btn-sm btn-success external-link-save-btn" data-index="${index}">Save</button>
-            <button type="button" class="btn btn-sm btn-secondary ms-1 external-link-cancel-btn" data-index="${index}">Cancel</button>
-        </td>
-    `;
+    populateExternalLinkEditorRow(row, link, index);
 
     // Focus on the label input
     const labelInput = row.querySelector('.external-link-label-input');
@@ -6083,26 +6147,16 @@ function handleSaveExternalLink(row, indexAttr, isNew) {
     const linkData = { label, url };
 
     if (isNew) {
-        // Add new link to the array
         externalLinks.push(linkData);
-        const newIndex = externalLinks.length - 1;
-        
-        // Replace the row with a read-only version
-        const newRow = createExternalLinkRow(linkData, newIndex, false);
-        row.parentNode.replaceChild(newRow, row);
     } else {
-        // Update existing link
-        const index = parseInt(indexAttr);
-        if (index >= 0 && index < externalLinks.length) {
-            externalLinks[index] = linkData;
-            
-            // Replace the row with a read-only version
-            const updatedRow = createExternalLinkRow(linkData, index, false);
-            row.parentNode.replaceChild(updatedRow, row);
+        const index = Number.parseInt(indexAttr, 10);
+        if (index < 0 || index >= externalLinks.length) {
+            return;
         }
+        externalLinks[index] = linkData;
     }
 
-    updateExternalLinksJsonInput();
+    renderExternalLinks();
     markFormAsModified();
 }
 

--- a/docs/explanation/fixes/EXTERNAL_LINK_ORDERING_FIX.md
+++ b/docs/explanation/fixes/EXTERNAL_LINK_ORDERING_FIX.md
@@ -1,0 +1,46 @@
+# External Link Ordering Fix
+
+## Header information
+
+- **Issue:** Administrators could add, edit, delete, and save external links, but could not rearrange saved links.
+- **Root cause:** The admin table did not expose controls that changed the order of the existing `external_links` array.
+- **Fixed in version:** **0.250.102**
+- **Tracking:** GitHub issue #793
+
+## Technical details
+
+### Files modified
+
+- `application/single_app/static/js/admin/admin_settings.js`
+- `application/single_app/config.py`
+- `functional_tests/test_external_link_ordering.py`
+- `ui_tests/test_admin_external_link_ordering.py`
+
+### Code changes
+
+Saved external-link rows now include keyboard-accessible Move Up and Move Down buttons. The first row cannot move up, and the last row cannot move down. Activating a control swaps adjacent entries in the existing client-side array, rerenders the rows, updates the hidden `external_links_json` field, and marks the admin form as modified.
+
+The affected row rendering now uses DOM element creation and text assignment. Dynamic link destinations are normalized to HTTP or HTTPS URLs before being assigned to an anchor.
+
+### Testing approach
+
+- Functional checks verify that both ordering controls are wired to the shared move handler and existing JSON synchronization flow.
+- Azure Playwright coverage verifies boundary states, icon-button interaction, visible row order, and submitted JSON order.
+
+### Impact analysis
+
+No database migration or settings-schema change is required. The admin settings route already stores `external_links` in submitted list order, and navigation templates already render that list in order.
+
+## Validation
+
+### Before
+
+Saved external links displayed in their original order with only Edit and Delete actions.
+
+### After
+
+Admins can move saved links one position up or down and save the resulting order through the existing Admin Settings workflow.
+
+### User experience improvement
+
+Administrators can control navigation ordering without deleting and recreating links.

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,15 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](/explanation/features/) and [Fixes by Version](/explanation/fixes/).
 
+### **(v0.250.102)**
+
+#### User Interface Enhancements
+
+*   **External Link Ordering Controls**
+    *   Admins can now move saved external links up or down and save the resulting navigation order without deleting and recreating links.
+    *   The first and last links expose disabled boundary controls, and the visible order stays synchronized with the Admin Settings save payload.
+    *   (Ref: Closes #793, `admin_settings.js`, `test_admin_external_link_ordering.py`, `EXTERNAL_LINK_ORDERING_FIX.md`)
+
 ### **(v0.250.101)**
 
 #### New Features

--- a/functional_tests/test_external_link_ordering.py
+++ b/functional_tests/test_external_link_ordering.py
@@ -1,0 +1,91 @@
+# test_external_link_ordering.py
+#!/usr/bin/env python3
+"""
+Functional test for admin external-link ordering.
+Version: 0.250.102
+Implemented in: 0.250.102
+
+This test ensures the external-link table exposes both ordering actions and
+wires them to the array reordering and persistence flow.
+"""
+
+import os
+import sys
+
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+ADMIN_SETTINGS_JS = os.path.join(
+    REPO_ROOT,
+    "application",
+    "single_app",
+    "static",
+    "js",
+    "admin",
+    "admin_settings.js",
+)
+
+
+def read_admin_settings_javascript():
+    """Read the admin settings JavaScript for focused regression checks."""
+    with open(ADMIN_SETTINGS_JS, "r", encoding="utf-8") as javascript_file:
+        return javascript_file.read()
+
+
+def test_external_link_ordering_controls_are_wired():
+    """Verify both ordering controls dispatch to the shared move handler."""
+    javascript = read_admin_settings_javascript()
+
+    assert "external-link-move-up-btn" in javascript
+    assert "external-link-move-down-btn" in javascript
+    assert "handleMoveExternalLink(indexAttr, -1)" in javascript
+    assert "handleMoveExternalLink(indexAttr, 1)" in javascript
+
+
+def test_external_link_move_updates_saved_order():
+    """Verify moving links rerenders and updates the existing JSON field."""
+    javascript = read_admin_settings_javascript()
+    move_handler_start = javascript.index("function handleMoveExternalLink")
+    next_function_start = javascript.index(
+        "/**",
+        move_handler_start,
+    )
+    move_handler = javascript[move_handler_start:next_function_start]
+
+    assert "[externalLinks[index], externalLinks[destinationIndex]]" in move_handler
+    assert "renderExternalLinks();" in move_handler
+    assert "markFormAsModified();" in move_handler
+
+    render_start = javascript.index("function renderExternalLinks")
+    render_end = javascript.index("/**", render_start)
+    render_function = javascript[render_start:render_end]
+    assert "updateExternalLinksJsonInput();" in render_function
+
+
+def main():
+    """Run all external-link ordering regression checks."""
+    tests = [
+        test_external_link_ordering_controls_are_wired,
+        test_external_link_move_updates_saved_order,
+    ]
+    results = []
+
+    for test in tests:
+        print(f"\nRunning {test.__name__}...")
+        try:
+            test()
+            print("Test passed.")
+            results.append(True)
+        except Exception as exc:
+            print(f"Test failed: {exc}")
+            import traceback
+
+            traceback.print_exc()
+            results.append(False)
+
+    success = all(results)
+    print(f"\nResults: {sum(results)}/{len(results)} tests passed")
+    return 0 if success else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ui_tests/test_admin_external_link_ordering.py
+++ b/ui_tests/test_admin_external_link_ordering.py
@@ -1,0 +1,152 @@
+# test_admin_external_link_ordering.py
+"""
+UI test for admin external-link ordering.
+Version: 0.250.102
+Implemented in: 0.250.102
+
+This test ensures admins can move saved external links up and down while the
+visible row order and submitted JSON remain synchronized.
+"""
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+from playwright.sync_api import expect
+
+
+BASE_URL = os.getenv("SIMPLECHAT_UI_BASE_URL", "").rstrip("/")
+ADMIN_STORAGE_STATE = os.getenv("SIMPLECHAT_UI_ADMIN_STORAGE_STATE", "") or os.getenv(
+    "SIMPLECHAT_UI_STORAGE_STATE",
+    "",
+)
+
+
+def _require_base_url():
+    if not BASE_URL:
+        pytest.skip("Set SIMPLECHAT_UI_BASE_URL to run this UI test.")
+
+
+def _require_storage_state():
+    if not ADMIN_STORAGE_STATE or not Path(ADMIN_STORAGE_STATE).exists():
+        pytest.skip(
+            "Set SIMPLECHAT_UI_ADMIN_STORAGE_STATE or SIMPLECHAT_UI_STORAGE_STATE "
+            "to a valid authenticated Playwright storage state file."
+        )
+
+
+def _external_link_labels(page):
+    return [
+        label.strip()
+        for label in page.locator("#external-links-tbody .external-link-label").all_text_contents()
+    ]
+
+
+@pytest.mark.ui
+def test_admin_can_reorder_saved_external_links(playwright):
+    """Validate external-link ordering controls and save-payload synchronization."""
+    _require_base_url()
+    _require_storage_state()
+
+    browser = playwright.chromium.launch()
+    context = browser.new_context(
+        storage_state=ADMIN_STORAGE_STATE,
+        viewport={"width": 1440, "height": 900},
+    )
+
+    try:
+        page = context.new_page()
+        response = page.goto(
+            f"{BASE_URL}/admin/settings#general",
+            wait_until="domcontentloaded",
+        )
+        assert response is not None, (
+            "Expected a navigation response when loading /admin/settings."
+        )
+        if response.status in {401, 403, 404}:
+            pytest.skip(
+                "Admin settings page was not available for the configured admin session."
+            )
+
+        assert response.ok, (
+            f"Expected /admin/settings to load successfully, got HTTP {response.status}."
+        )
+
+        general_nav = page.locator(
+            '[data-bs-target="#general"], [data-tab="general"]'
+        ).first
+        if general_nav.count() > 0:
+            general_nav.click()
+
+        enable_toggle = page.locator("#enable_external_links")
+        expect(enable_toggle).to_have_count(1)
+        if not enable_toggle.is_checked():
+            enable_toggle.check(force=True)
+
+        rows = page.locator("#external-links-tbody tr")
+        expect(rows.first).to_be_visible()
+        if rows.count() < 2:
+            pytest.skip(
+                "Configure at least two saved external links to exercise ordering."
+            )
+
+        original_labels = _external_link_labels(page)
+        original_payload = json.loads(
+            page.locator("#external_links_json").input_value()
+        )
+        assert [link["label"] for link in original_payload] == original_labels
+
+        first_row = rows.nth(0)
+        last_row = rows.nth(rows.count() - 1)
+        expect(first_row.locator(".external-link-move-up-btn")).to_be_disabled()
+        expect(first_row.locator(".external-link-move-down-btn")).to_be_enabled()
+        expect(last_row.locator(".external-link-move-down-btn")).to_be_disabled()
+
+        first_row.locator(".external-link-move-down-btn i").click()
+
+        expected_labels = original_labels.copy()
+        expected_labels[0], expected_labels[1] = (
+            expected_labels[1],
+            expected_labels[0],
+        )
+        assert _external_link_labels(page) == expected_labels
+
+        reordered_payload = json.loads(
+            page.locator("#external_links_json").input_value()
+        )
+        assert [link["label"] for link in reordered_payload] == expected_labels
+
+        rows.nth(1).locator(".external-link-move-up-btn i").click()
+        assert _external_link_labels(page) == original_labels
+
+        restored_payload = json.loads(
+            page.locator("#external_links_json").input_value()
+        )
+        assert [link["label"] for link in restored_payload] == original_labels
+
+        original_row_count = rows.count()
+        page.locator("#add-external-link-btn").click()
+        new_row = rows.nth(original_row_count)
+        new_row.locator(".external-link-label-input").fill(
+            "External Link Ordering Test"
+        )
+        new_row.locator(".external-link-url-input").fill(
+            "https://example.com/external-link-ordering-test"
+        )
+        new_row.locator(".external-link-save-btn").click()
+
+        expect(rows).to_have_count(original_row_count + 1)
+        expect(
+            rows.nth(original_row_count - 1).locator(
+                ".external-link-move-down-btn"
+            )
+        ).to_be_enabled()
+        expect(
+            rows.nth(original_row_count).locator(
+                ".external-link-move-down-btn"
+            )
+        ).to_be_disabled()
+    finally:
+        context.close()
+        browser.close()


### PR DESCRIPTION
## Summary

- add accessible Move Up and Move Down controls for saved external links
- keep visible row order and the existing `external_links_json` save payload synchronized
- rerender boundary states after add, edit, delete, and move operations
- replace the touched dynamic row markup with safe DOM construction and HTTP/HTTPS URL normalization
- add functional and Azure Playwright regression coverage, fix documentation, release notes, and version `0.250.102`

## Validation

- `python -m pytest functional_tests\test_external_link_ordering.py ui_tests\test_admin_external_link_ordering.py -q` (`2 passed, 1 skipped` because authenticated UI environment variables are not configured locally)
- `node --check application\single_app\static\js\admin\admin_settings.js`
- `python scripts\check_xss_sinks.py application\single_app\static\js\admin\admin_settings.js --base-sha HEAD^ --head-sha HEAD`
- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check`

Closes #793