### PR TITLE
Add configurable Public Workspace display name

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -95,7 +95,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.250.109"
+VERSION = "0.250.110"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/functions_settings.py
+++ b/application/single_app/functions_settings.py
@@ -86,6 +86,9 @@ ADMIN_SETTINGS_FORM_SECRET_FIELDS = (
 ADMIN_SETTINGS_NESTED_SECRET_FIELDS = (
     "web_search_agent.other_settings.azure_ai_foundry.client_secret",
 )
+PUBLIC_WORKSPACE_DISPLAY_NAME_DEFAULT = "Public Workspace"
+PUBLIC_WORKSPACE_DISPLAY_NAME_PLURAL_DEFAULT = "Public Workspaces"
+PUBLIC_WORKSPACE_DISPLAY_NAME_MAX_LENGTH = 32
 
 
 def is_admin_settings_redacted_secret(value):
@@ -116,6 +119,59 @@ def resolve_admin_settings_secret_value(field_name, submitted_value, existing_se
     if not is_admin_settings_redacted_secret(submitted_text):
         return submitted_text
     return str(_get_nested_setting_value(existing_settings, field_name) or '').strip()
+
+
+def normalize_public_workspace_display_name(value):
+    """Return the end-user Public Workspace display name setting."""
+    display_name = " ".join(str(value or "").replace("\r", " ").replace("\n", " ").split())
+    return display_name[:PUBLIC_WORKSPACE_DISPLAY_NAME_MAX_LENGTH]
+
+
+def get_public_workspace_label_context(settings=None):
+    """Return safe labels for end-user Public Workspace UI copy."""
+    source_settings = settings if isinstance(settings, dict) else {}
+    custom_display_name = normalize_public_workspace_display_name(
+        source_settings.get("public_workspace_display_name")
+    )
+    is_custom = bool(custom_display_name)
+    singular = custom_display_name or PUBLIC_WORKSPACE_DISPLAY_NAME_DEFAULT
+    plural = custom_display_name or PUBLIC_WORKSPACE_DISPLAY_NAME_PLURAL_DEFAULT
+    lower_singular = singular if is_custom else "public workspace"
+    lower_plural = plural if is_custom else "public workspaces"
+    return {
+        "singular": singular,
+        "plural": plural,
+        "lower_singular": lower_singular,
+        "lower_plural": lower_plural,
+        "short": singular if is_custom else "Public",
+        "is_custom": is_custom,
+        "max_length": PUBLIC_WORKSPACE_DISPLAY_NAME_MAX_LENGTH,
+    }
+
+
+def normalize_public_workspace_display_settings(settings):
+    """Normalize stored Public Workspace display-name settings in-place."""
+    if not isinstance(settings, dict):
+        return False
+
+    changed = False
+    if "public_workspace_labels" in settings:
+        settings.pop("public_workspace_labels", None)
+        changed = True
+
+    normalized_display_name = normalize_public_workspace_display_name(
+        settings.get("public_workspace_display_name")
+    )
+    changed = changed or settings.get("public_workspace_display_name", "") != normalized_display_name
+    settings["public_workspace_display_name"] = normalized_display_name
+    return changed
+
+
+def attach_public_workspace_label_context(settings):
+    """Attach derived end-user Public Workspace label values to a settings dict."""
+    if isinstance(settings, dict):
+        settings["public_workspace_labels"] = get_public_workspace_label_context(settings)
+    return settings
 
 
 def normalize_document_access_index_required_settings(settings):
@@ -1024,6 +1080,7 @@ def get_settings(use_cosmos=False, include_source=False):
         'require_member_of_create_group': False,
         'require_owner_for_group_agent_management': False,
         'enable_public_workspaces': False,
+        'public_workspace_display_name': '',
         'require_member_of_create_public_workspace': False,
         'enable_file_sharing': False,
         'allow_personal_workspace_file_downloads': False,
@@ -1457,6 +1514,7 @@ def get_settings(use_cosmos=False, include_source=False):
         promoted_popular_settings_updated = normalize_agents_page_promoted_popular_settings(merged)
         document_access_index_settings_updated = normalize_document_access_index_required_settings(merged)
         inbound_mcp_settings_updated = normalize_inbound_mcp_settings(merged)
+        public_workspace_display_settings_updated = normalize_public_workspace_display_settings(merged)
 
         merged['enable_tabular_processing_plugin'] = is_tabular_processing_enabled(merged)
 
@@ -1469,6 +1527,7 @@ def get_settings(use_cosmos=False, include_source=False):
             or promoted_popular_settings_updated
             or document_access_index_settings_updated
             or inbound_mcp_settings_updated
+            or public_workspace_display_settings_updated
         ):
             cosmos_settings_container.upsert_item(merged)
             _refresh_app_settings_cache_after_write(merged, context="merge_upsert")
@@ -1480,10 +1539,10 @@ def get_settings(use_cosmos=False, include_source=False):
                 },
                 level=logging.INFO
             )
-            return _format_result(merged, settings_source)
+            return _format_result(attach_public_workspace_label_context(merged), settings_source)
         else:
             # If merged is unchanged, no new keys needed
-            return _format_result(merged, settings_source)
+            return _format_result(attach_public_workspace_label_context(merged), settings_source)
 
     except CosmosResourceNotFoundError:
         cosmos_settings_container.create_item(body=default_settings)
@@ -1496,7 +1555,7 @@ def get_settings(use_cosmos=False, include_source=False):
             },
             level=logging.WARNING
         )
-        return _format_result(default_settings, "cosmos_default_created")
+        return _format_result(attach_public_workspace_label_context(default_settings), "cosmos_default_created")
 
     except Exception as e:
         log_event(
@@ -1520,6 +1579,7 @@ def update_settings(new_settings):
         normalize_agents_page_promoted_popular_settings(settings_item)
         normalize_document_access_index_required_settings(settings_item)
         normalize_inbound_mcp_settings(settings_item)
+        normalize_public_workspace_display_settings(settings_item)
         settings_item['enable_multi_model_endpoints'] = coerce_multi_model_endpoint_enablement(
             existing_multi_endpoint_enabled,
             settings_item.get('enable_multi_model_endpoints', False),
@@ -2605,6 +2665,8 @@ def sanitize_settings_for_user(full_settings: dict) -> dict:
             **sanitized['multi_endpoint_migration_notice'],
             'enabled': False,
         }
+
+    sanitized['public_workspace_labels'] = get_public_workspace_label_context(full_settings)
 
     return sanitized
 

--- a/application/single_app/route_frontend_admin_settings.py
+++ b/application/single_app/route_frontend_admin_settings.py
@@ -1120,6 +1120,9 @@ def register_route_frontend_admin_settings(bp):
 
             require_member_of_create_group = form_data.get('require_member_of_create_group') == 'on'
             require_owner_for_group_agent_management = form_data.get('require_owner_for_group_agent_management') == 'on'
+            public_workspace_display_name = normalize_public_workspace_display_name(
+                form_data.get('public_workspace_display_name')
+            )
             require_member_of_create_public_workspace = form_data.get('require_member_of_create_public_workspace') == 'on'
             require_member_of_chat_file_upload_user = form_data.get('require_member_of_chat_file_upload_user') == 'on'
             require_member_of_workflow_user = form_data.get('require_member_of_workflow_user') == 'on'
@@ -2434,6 +2437,7 @@ def register_route_frontend_admin_settings(bp):
                 # disable_group_creation is inverted: when checked (on), enable_group_creation = False
                 'enable_group_creation': form_data.get('disable_group_creation') != 'on',
                 'enable_public_workspaces': form_data.get('enable_public_workspaces') == 'on',
+                'public_workspace_display_name': public_workspace_display_name,
                 'enable_file_sharing': form_data.get('enable_file_sharing') == 'on',
                 'enable_chat_file_uploads': form_data.get('enable_chat_file_uploads') == 'on',
                 'enable_conversation_contents_drawer': form_data.get('enable_conversation_contents_drawer') == 'on',

--- a/application/single_app/static/js/agent_modal_stepper.js
+++ b/application/single_app/static/js/agent_modal_stepper.js
@@ -6,6 +6,8 @@ import { getModelSupportedLevels } from "./chat/chat-reasoning.js";
 
 const ACTION_CAPABILITIES_KEY = 'action_capabilities';
 const ASSIGNED_KNOWLEDGE_KEY = 'assigned_knowledge';
+const publicWorkspaceLowerSingular = window.getPublicWorkspaceLabel ? window.getPublicWorkspaceLabel('lower_singular') : 'public workspace';
+const publicWorkspaceLowerPlural = window.getPublicWorkspaceLabel ? window.getPublicWorkspaceLabel('lower_plural') : 'public workspaces';
 const ASSIGNED_KNOWLEDGE_USER_ACTIONS = Object.freeze(['search', 'analyze', 'compare']);
 const ASSIGNED_KNOWLEDGE_WEB_SOURCE_MODES = Object.freeze(['url_review', 'deep_research']);
 const EMPTY_ASSIGNED_KNOWLEDGE = Object.freeze({
@@ -3094,7 +3096,9 @@ export class AgentModalStepper {
       summaryItems.push(`${scopes.group_ids.length} group source${scopes.group_ids.length === 1 ? '' : 's'}`);
     }
     if (scopes.public_workspace_ids?.length) {
-      summaryItems.push(`${scopes.public_workspace_ids.length} public workspace${scopes.public_workspace_ids.length === 1 ? '' : 's'}`);
+      const publicWorkspaceCount = scopes.public_workspace_ids.length;
+      const publicWorkspaceLabel = publicWorkspaceCount === 1 ? publicWorkspaceLowerSingular : publicWorkspaceLowerPlural;
+      summaryItems.push(`${publicWorkspaceCount} ${publicWorkspaceLabel}`);
     }
     if (assignedKnowledge.document_ids?.length) {
       summaryItems.push(`${assignedKnowledge.document_ids.length} specific document${assignedKnowledge.document_ids.length === 1 ? '' : 's'}`);

--- a/application/single_app/static/js/chat/chat-documents.js
+++ b/application/single_app/static/js/chat/chat-documents.js
@@ -8,6 +8,7 @@ const searchDocumentsBtn = document.getElementById("search-documents-btn");
 const docSelectEl = document.getElementById("document-select"); // Hidden select element
 const searchDocumentsContainer = document.getElementById("search-documents-container"); // Container for scope/doc/class
 const searchDocumentsMobileClose = document.getElementById("search-documents-mobile-close");
+const publicWorkspacePlural = window.getPublicWorkspaceLabel ? window.getPublicWorkspaceLabel("plural") : "Public Workspaces";
 
 // Custom dropdown elements
 const docDropdown = document.getElementById("document-dropdown");
@@ -1114,7 +1115,7 @@ function buildScopeDropdown() {
   if (publicWorkspaces.length > 0) {
     const pubHeader = document.createElement("div");
     pubHeader.classList.add("dropdown-header", "small", "text-muted", "px-2", "pt-2", "pb-1");
-    pubHeader.textContent = "Public Workspaces";
+    pubHeader.textContent = publicWorkspacePlural;
     scopeDropdownItems.appendChild(pubHeader);
 
     publicWorkspaces.forEach(ws => {

--- a/application/single_app/static/js/chat/chat-onload.js
+++ b/application/single_app/static/js/chat/chat-onload.js
@@ -24,6 +24,8 @@ import { initializeReasoningToggle } from "./chat-reasoning.js";
 import { initializeSpeechInput } from "./chat-speech-input.js";
 import { initChatTutorial } from "./chat-tutorial.js";
 
+const publicWorkspaceLowerSingular = window.getPublicWorkspaceLabel ? window.getPublicWorkspaceLabel("lower_singular") : "public workspace";
+
 
 function clearFeatureActionParam() {
     const url = new URL(window.location.href);
@@ -228,17 +230,17 @@ window.addEventListener('DOMContentLoaded', async () => {
                   // Trigger change to update UI
                   handleDocumentSelectChange();
                   
-                  showToast('Public workspace activated for chat', 'success');
+                  showToast(`${publicWorkspaceLowerSingular} activated for chat`, 'success');
               } else {
                   console.error('Failed to set active public workspace:', data.error || data.message);
-                  showToast('Failed to activate public workspace', 'error');
+                  showToast(`Failed to activate ${publicWorkspaceLowerSingular}`, 'error');
                   // Fall back to normal document handling
                   populateDocumentSelectScope();
               }
           })
           .catch(error => {
               console.error('Error setting active public workspace:', error);
-              showToast('Error activating public workspace', 'error');
+              showToast(`Error activating ${publicWorkspaceLowerSingular}`, 'error');
               // Fall back to normal document handling
               populateDocumentSelectScope();
           });

--- a/application/single_app/static/js/chat/chat-tutorial.js
+++ b/application/single_app/static/js/chat/chat-tutorial.js
@@ -3,6 +3,7 @@
 const STORAGE_KEY = "chatTutorialDismissed";
 const EDGE_PADDING = 12;
 const HIGHLIGHT_PADDING = 10;
+const publicWorkspaceLowerPlural = window.getPublicWorkspaceLabel ? window.getPublicWorkspaceLabel("lower_plural") : "public workspaces";
 let tutorialSteps = [];
 let layerEl = null;
 let highlightEl = null;
@@ -197,7 +198,7 @@ function buildSteps() {
             id: "workspace-search",
             selector: "#search-documents-btn",
             title: "Workspace search",
-            body: "Search personal, group, or public workspaces to ground answers with approved documents.",
+            body: `Search personal, group, or ${publicWorkspaceLowerPlural} to ground answers with approved documents.`,
             phase: "chat"
         },
         {

--- a/application/single_app/static/js/form-voice-input.js
+++ b/application/single_app/static/js/form-voice-input.js
@@ -4,6 +4,7 @@
 (function () {
     const MAX_RECORDING_DURATION_MS = 90000;
     const DEFAULT_TRANSCRIPTION_ENDPOINT = '/api/speech/transcribe-chat';
+    const publicWorkspaceLowerSingular = window.getPublicWorkspaceLabel ? window.getPublicWorkspaceLabel('lower_singular') : 'public workspace';
     const fieldControls = new WeakMap();
     const controls = [];
     let activeControl = null;
@@ -509,10 +510,10 @@
             ['groupDescription', { label: 'Dictate group description' }],
             ['editGroupName', { label: 'Dictate group name', insertMode: 'replace' }],
             ['editGroupDescription', { label: 'Dictate group description' }],
-            ['publicWorkspaceName', { label: 'Dictate public workspace name', insertMode: 'replace' }],
-            ['publicWorkspaceDescription', { label: 'Dictate public workspace description' }],
-            ['editWorkspaceName', { label: 'Dictate public workspace name', insertMode: 'replace' }],
-            ['editWorkspaceDescription', { label: 'Dictate public workspace description' }],
+            ['publicWorkspaceName', { label: `Dictate ${publicWorkspaceLowerSingular} name`, insertMode: 'replace' }],
+            ['publicWorkspaceDescription', { label: `Dictate ${publicWorkspaceLowerSingular} description` }],
+            ['editWorkspaceName', { label: `Dictate ${publicWorkspaceLowerSingular} name`, insertMode: 'replace' }],
+            ['editWorkspaceDescription', { label: `Dictate ${publicWorkspaceLowerSingular} description` }],
             ['doc-title', { label: 'Dictate title', insertMode: 'replace' }],
             ['doc-abstract', { label: 'Dictate abstract' }],
             ['doc-keywords', { label: 'Dictate keywords', mode: 'comma-list' }],

--- a/application/single_app/static/js/plugin_modal_stepper.js
+++ b/application/single_app/static/js/plugin_modal_stepper.js
@@ -23,6 +23,7 @@ const SNOWFLAKE_AUTH_METHOD_OAUTH = 'oauth';
 const TABLEAU_PLUGIN_TYPE = 'tableau';
 const TABLEAU_AUTH_METHOD_PAT = 'personal_access_token';
 const TABLEAU_AUTH_METHOD_USERNAME_PASSWORD = 'username_password';
+const publicWorkspacePlural = window.getPublicWorkspaceLabel ? window.getPublicWorkspaceLabel('plural') : 'Public Workspaces';
 const MCP_PLUGIN_TYPE = 'mcp';
 const MCP_HEADER_NAME_PATTERN = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
 const MCP_MAX_CUSTOM_HEADER_COUNT = 20;
@@ -2284,7 +2285,7 @@ export class PluginModalStepper {
       all: 'All Accessible Content',
       personal: 'Personal Workspace',
       group: 'Group Workspaces',
-      public: 'Public Workspaces'
+      public: publicWorkspacePlural
     };
 
     return scopeMap[scope] || scope || '-';

--- a/application/single_app/static/js/profile/profile-tabs.js
+++ b/application/single_app/static/js/profile/profile-tabs.js
@@ -2,6 +2,8 @@
 
 (function () {
     const pageConfig = window.profilePageConfig || {};
+    const publicWorkspaceLowerSingular = window.getPublicWorkspaceLabel ? window.getPublicWorkspaceLabel('lower_singular') : 'public workspace';
+    const publicWorkspaceLowerPlural = window.getPublicWorkspaceLabel ? window.getPublicWorkspaceLabel('lower_plural') : 'public workspaces';
     const feedbackState = {
         currentPage: 1,
         pageSize: 10,
@@ -371,8 +373,8 @@
         },
         publicWorkspaces: {
             type: 'publicWorkspaces',
-            label: 'public workspaces',
-            itemLabel: 'public workspace',
+            label: publicWorkspaceLowerPlural,
+            itemLabel: publicWorkspaceLowerSingular,
             state: publicWorkspaceState,
             apiEndpoint: '/api/public_workspaces',
             responseKey: 'workspaces',
@@ -409,9 +411,9 @@
             discoverStatusId: 'profile-find-public-workspaces-status',
             discoverTbodyId: 'profile-find-public-workspaces-tbody',
             storageKey: 'simplechat.profile.publicWorkspaces.viewMode',
-            emptyMessage: 'No public workspaces found for the current search.',
-            loadingMessage: 'Loading public workspaces...',
-            discoverEmptyMessage: 'No public workspaces found for the current search.',
+            emptyMessage: `No ${publicWorkspaceLowerPlural} found for the current search.`,
+            loadingMessage: `Loading ${publicWorkspaceLowerPlural}...`,
+            discoverEmptyMessage: `No ${publicWorkspaceLowerPlural} found for the current search.`,
             requestLabel: 'Request Access',
         },
     };

--- a/application/single_app/static/js/public/manage_public_workspace.js
+++ b/application/single_app/static/js/public/manage_public_workspace.js
@@ -9,6 +9,8 @@ let currentStatsWindow = { days: 30, startDate: '', endDate: '' };
 let currentStatsData = null;
 const defaultWorkspaceHeroColor = '#0078d4';
 const workspaceHeroColorPattern = /^#[0-9a-fA-F]{6}$/;
+const publicWorkspaceSingular = window.getPublicWorkspaceLabel ? window.getPublicWorkspaceLabel('singular') : 'Public Workspace';
+const publicWorkspaceLowerSingular = window.getPublicWorkspaceLabel ? window.getPublicWorkspaceLabel('lower_singular') : 'public workspace';
 
 function normalizeWorkspaceHeroColor(color) {
   const candidate = String(color || '').trim();
@@ -283,7 +285,7 @@ $(document).ready(function () {
           `);
           $("#deleteWorkspaceWarningModal").modal("show");
         } else {
-          if (!confirm("Permanently delete this public workspace?")) return;
+          if (!confirm(`Permanently delete this ${publicWorkspaceLowerSingular}?`)) return;
           $.ajax({
             url: `/api/public_workspaces/${workspaceId}`,
             method: "DELETE",
@@ -1025,7 +1027,7 @@ async function exportWorkspaceStats() {
     const windowLabel = stats.window?.label || getStatsWindowLabel(exportWindow);
     const rows = [];
 
-    rows.push('Public Workspace Stats Export');
+    rows.push(`${publicWorkspaceSingular} Stats Export`);
     appendCsvRow(rows, ['Export Date', new Date().toLocaleString()]);
     appendCsvRow(rows, ['Data Period', windowLabel]);
     appendCsvSectionBreak(rows);
@@ -1077,10 +1079,10 @@ async function exportWorkspaceStats() {
     if (modal) {
       modal.hide();
     }
-    showStatsToast('Public workspace stats exported successfully.', 'success');
+    showStatsToast(`${publicWorkspaceSingular} stats exported successfully.`, 'success');
   } catch (error) {
     console.error('Failed to export public workspace stats:', error);
-    showStatsToast('Failed to export public workspace stats.', 'danger');
+    showStatsToast(`Failed to export ${publicWorkspaceLowerSingular} stats.`, 'danger');
   } finally {
     if (exportButton) {
       exportButton.disabled = false;

--- a/application/single_app/static/js/public/my_public_workspaces.js
+++ b/application/single_app/static/js/public/my_public_workspaces.js
@@ -21,6 +21,30 @@ $(document).ready(function () {
   let pageSize           = parseInt(pageSizeSelect.val(), 10);
   let currentSearchQuery = "";
 
+  function setTableTextMessage(message, columnSpan = 5, className = "text-center p-4 text-muted") {
+    const row = document.createElement("tr");
+    const cell = document.createElement("td");
+    cell.colSpan = columnSpan;
+    cell.className = className;
+    cell.textContent = message;
+    row.appendChild(cell);
+    tableBody.empty().append(row);
+  }
+
+  function setEmptyPublicWorkspaceMessage() {
+    const row = document.createElement("tr");
+    const cell = document.createElement("td");
+    cell.colSpan = 5;
+    cell.className = "text-center p-4 text-muted";
+    cell.append(
+      document.createTextNode(`You don't have any ${publicWorkspaceLowerPlural} yet.`),
+      document.createElement("br"),
+      document.createTextNode(`Use "Create New ${publicWorkspaceSingular}" or "Find ${publicWorkspaceSingular}" above.`)
+    );
+    row.appendChild(cell);
+    tableBody.empty().append(row);
+  }
+
   // Fetch and render the list of public workspaces
   function fetchWorkspaces() {
     // Show loading placeholder
@@ -51,28 +75,15 @@ $(document).ready(function () {
         if (workspaces.length) {
           workspaces.forEach(renderWorkspaceRow);
         } else if (currentSearchQuery) {
-          tableBody.html(`
-            <tr><td colspan="5" class="text-center p-4 text-muted">
-              No workspaces found matching "${escapeHtml(currentSearchQuery)}".
-            </td></tr>
-          `);
+          setTableTextMessage(`No workspaces found matching "${currentSearchQuery}".`);
         } else {
-          tableBody.html(`
-            <tr><td colspan="5" class="text-center p-4 text-muted">
-              You don't have any ${escapeHtml(publicWorkspaceLowerPlural)} yet.<br>
-              Use "Create New ${escapeHtml(publicWorkspaceSingular)}" or "Find ${escapeHtml(publicWorkspaceSingular)}" above.
-            </td></tr>
-          `);
+          setEmptyPublicWorkspaceMessage();
         }
         renderPaginationControls(data.page, data.page_size, data.total_count);
       })
       .fail(function (jqXHR) {
         const err = jqXHR.responseJSON?.error || jqXHR.statusText;
-        tableBody.html(`
-          <tr><td colspan="5" class="text-center text-danger p-4">
-            Error loading workspaces: ${escapeHtml(err)}
-          </td></tr>
-        `);
+        setTableTextMessage(`Error loading workspaces: ${err}`, 5, "text-center text-danger p-4");
         renderPaginationControls(1, pageSize, 0);
       });
   }

--- a/application/single_app/static/js/public/my_public_workspaces.js
+++ b/application/single_app/static/js/public/my_public_workspaces.js
@@ -13,6 +13,8 @@ $(document).ready(function () {
   const clearSearchBtn       = $("#clearSearchBtn");
   const createModal          = window.canCreatePublicWorkspaces ? new bootstrap.Modal(document.getElementById('createPublicWorkspaceModal')) : null;
   const findModal            = new bootstrap.Modal(document.getElementById('findPublicWorkspaceModal'));
+  const publicWorkspaceSingular = window.getPublicWorkspaceLabel ? window.getPublicWorkspaceLabel('singular') : 'Public Workspace';
+  const publicWorkspaceLowerPlural = window.getPublicWorkspaceLabel ? window.getPublicWorkspaceLabel('lower_plural') : 'public workspaces';
 
   // State
   let currentPage        = 1;
@@ -57,8 +59,8 @@ $(document).ready(function () {
         } else {
           tableBody.html(`
             <tr><td colspan="5" class="text-center p-4 text-muted">
-              You don't have any public workspaces yet.<br>
-              Use "Create New Public Workspace" or "Find Public Workspace" above.
+              You don't have any ${escapeHtml(publicWorkspaceLowerPlural)} yet.<br>
+              Use "Create New ${escapeHtml(publicWorkspaceSingular)}" or "Find ${escapeHtml(publicWorkspaceSingular)}" above.
             </td></tr>
           `);
         }

--- a/application/single_app/static/js/public/public_directory.js
+++ b/application/single_app/static/js/public/public_directory.js
@@ -11,6 +11,8 @@ $(document).ready(function () {
   const allVisibleBtn = $("#allVisibleBtn");
   const allHiddenBtn = $("#allHiddenBtn");
   const viewModal = new bootstrap.Modal(document.getElementById('viewWorkspaceModal'));
+  const publicWorkspaceSingular = window.getPublicWorkspaceLabel ? window.getPublicWorkspaceLabel('singular') : 'Public Workspace';
+  const publicWorkspaceLowerPlural = window.getPublicWorkspaceLabel ? window.getPublicWorkspaceLabel('lower_plural') : 'public workspaces';
 
   // State
   let currentPage = 1;
@@ -175,7 +177,7 @@ function updateCuratedListStatus() {
       <tr class="table-loading-row">
         <td colspan="4" class="text-center p-4 text-muted">
           <div class="spinner-border spinner-border-sm me-2" role="status"></div>
-          Loading public workspaces...
+          Loading ${escapeHtml(publicWorkspaceLowerPlural)}...
         </td>
       </tr>
     `);
@@ -217,7 +219,7 @@ function updateCuratedListStatus() {
       } else {
         tableBody.html(`
           <tr><td colspan="4" class="text-center p-4 text-muted">
-            No public workspaces available.
+            No ${escapeHtml(publicWorkspaceLowerPlural)} available.
           </td></tr>
         `);
       }
@@ -312,7 +314,7 @@ function updateCuratedListStatus() {
             </div>
             <div class="mt-2">
               <button class="btn btn-primary btn-sm view-workspace-btn" data-id="${ws.id}">
-                Goto Public Workspace
+                Go to ${escapeHtml(publicWorkspaceSingular)}
               </button>
             </div>
           </div>

--- a/application/single_app/static/js/public/public_directory.js
+++ b/application/single_app/static/js/public/public_directory.js
@@ -21,6 +21,32 @@ $(document).ready(function () {
   let allWorkspaces = [];
   let userSettings = {};
 
+  function setDirectoryTableTextMessage(message, className = "text-center p-4 text-muted") {
+    const row = document.createElement("tr");
+    const cell = document.createElement("td");
+    cell.colSpan = 4;
+    cell.className = className;
+    cell.textContent = message;
+    row.appendChild(cell);
+    tableBody.empty().append(row);
+  }
+
+  function setDirectoryLoadingMessage(message) {
+    const row = document.createElement("tr");
+    row.className = "table-loading-row";
+    const cell = document.createElement("td");
+    cell.colSpan = 4;
+    cell.className = "text-center p-4 text-muted";
+
+    const spinner = document.createElement("div");
+    spinner.className = "spinner-border spinner-border-sm me-2";
+    spinner.setAttribute("role", "status");
+
+    cell.append(spinner, document.createTextNode(message));
+    row.appendChild(cell);
+    tableBody.empty().append(row);
+  }
+
 // --- Curated List Helpers ---
 let currentLoadedList = null;
 let curatedListDirty = false;
@@ -173,14 +199,7 @@ function updateCuratedListStatus() {
   // Fetch all public workspaces
   function fetchWorkspaces() {
     // Show loading placeholder
-    tableBody.html(`
-      <tr class="table-loading-row">
-        <td colspan="4" class="text-center p-4 text-muted">
-          <div class="spinner-border spinner-border-sm me-2" role="status"></div>
-          Loading ${escapeHtml(publicWorkspaceLowerPlural)}...
-        </td>
-      </tr>
-    `);
+    setDirectoryLoadingMessage(`Loading ${publicWorkspaceLowerPlural}...`);
     paginationContainer.empty();
 
     currentSearchQuery = searchInput.val().trim();
@@ -196,11 +215,7 @@ function updateCuratedListStatus() {
       })
       .fail(function (jqXHR) {
         const err = jqXHR.responseJSON?.error || jqXHR.statusText;
-        tableBody.html(`
-          <tr><td colspan="4" class="text-center text-danger p-4">
-            Error loading workspaces: ${escapeHtml(err)}
-          </td></tr>
-        `);
+        setDirectoryTableTextMessage(`Error loading workspaces: ${err}`, "text-center text-danger p-4");
         renderPaginationControls(1, pageSize, 0);
       });
   }
@@ -211,17 +226,9 @@ function updateCuratedListStatus() {
     
     if (!allWorkspaces.length) {
       if (currentSearchQuery) {
-        tableBody.html(`
-          <tr><td colspan="4" class="text-center p-4 text-muted">
-            No workspaces found matching "${escapeHtml(currentSearchQuery)}".
-          </td></tr>
-        `);
+        setDirectoryTableTextMessage(`No workspaces found matching "${currentSearchQuery}".`);
       } else {
-        tableBody.html(`
-          <tr><td colspan="4" class="text-center p-4 text-muted">
-            No ${escapeHtml(publicWorkspaceLowerPlural)} available.
-          </td></tr>
-        `);
+        setDirectoryTableTextMessage(`No ${publicWorkspaceLowerPlural} available.`);
       }
       renderPaginationControls(1, pageSize, 0);
       return;

--- a/application/single_app/static/js/public/public_workspace.js
+++ b/application/single_app/static/js/public/public_workspace.js
@@ -6,6 +6,8 @@ let userRoleInActivePublic = null;
 let userPublics = [];
 let activePublicId = null;
 let activePublicName = '';
+const publicWorkspaceLowerSingular = window.getPublicWorkspaceLabel ? window.getPublicWorkspaceLabel('lower_singular') : 'public workspace';
+const publicWorkspaceLowerPlural = window.getPublicWorkspaceLabel ? window.getPublicWorkspaceLabel('lower_plural') : 'public workspaces';
 
 // Documents state
 let publicDocsCurrentPage = 1;
@@ -251,7 +253,7 @@ async function downloadPublicDocumentFile(documentId, event) {
     event.stopPropagation();
   }
   if (!publicFileDownloadsEnabled) {
-    showPublicDocumentDeleteFeedback('File downloads are disabled for this public workspace.', 'warning');
+    showPublicDocumentDeleteFeedback(`File downloads are disabled for this ${publicWorkspaceLowerSingular}.`, 'warning');
     return;
   }
 
@@ -525,8 +527,8 @@ document.addEventListener('DOMContentLoaded', ()=>{
     if(activePublicId) loadActivePublicData();
     else {
       const noActivePublicMessage = userPublics.length === 0
-        ? 'No public workspaces are available. Select My Workspaces to create one.'
-        : 'Please select an active public workspace.';
+        ? `No ${publicWorkspaceLowerPlural} available. Select My Workspaces to create one.`
+        : `Please select an active ${publicWorkspaceLowerSingular}.`;
       setPublicTableMessage(publicDocsTableBody, 4, noActivePublicMessage);
       setPublicTableMessage(publicPromptsTableBody, 2, noActivePublicMessage);
       renderPublicPromptsEmptyState(noActivePublicMessage);
@@ -704,7 +706,7 @@ async function fetchUserPublics(){
 
       const emptyItem = document.createElement('div');
       emptyItem.className = 'dropdown-item-text text-muted small text-wrap';
-      emptyItem.textContent = 'No public workspaces are available. Select My Workspaces to create one.';
+      emptyItem.textContent = `No ${publicWorkspaceLowerPlural} available. Select My Workspaces to create one.`;
       publicDropdownItems.appendChild(emptyItem);
 
       const emptyOption = document.createElement('option');
@@ -2532,7 +2534,7 @@ async function downloadPublicSelectedDocuments() {
     return;
   }
   if (!publicFileDownloadsEnabled) {
-    showPublicDocumentDeleteFeedback('File downloads are disabled for this public workspace.', 'warning');
+    showPublicDocumentDeleteFeedback(`File downloads are disabled for this ${publicWorkspaceLowerSingular}.`, 'warning');
     return;
   }
 

--- a/application/single_app/templates/_sidebar_nav.html
+++ b/application/single_app/templates/_sidebar_nav.html
@@ -6,6 +6,7 @@
 {% set sidebar_menu_state = sidebar_menu_state_raw if sidebar_menu_state_raw is mapping else {} %}
 {% set sidebar_settings = settings if settings is defined else app_settings %}
 {% set latest_features_nav_is_hidden = latest_features_nav_hidden | default(false) %}
+{% set public_workspace_labels = app_settings.public_workspace_labels %}
 <div id="sidebar-nav" class="d-flex flex-column vh-100 bg-light border-end sidebar-expanded" style="width: var(--sidebar-width, 260px); min-width: var(--sidebar-min-width, 220px); position: fixed; left: 0; top: 0; z-index: 1040; transition: transform 0.3s ease;">
 
   <div id="sidebar-resize-handle" class="sidebar-resize-handle" aria-label="Resize sidebar" role="separator" tabindex="0">
@@ -246,8 +247,8 @@
           {% endif %}
           {% if app_settings.enable_public_workspaces %}
           <li class="nav-item">
-            <a class="nav-link d-flex align-items-center" href="{{ url_for('frontend_public_workspaces.public_directory') }}" title="Open public workspaces for shared document collections and prompts available to authorized users.">
-              <i class="bi bi-folder me-2"></i><span class="nav-text"> Public</span>
+            <a class="nav-link d-flex align-items-center" href="{{ url_for('frontend_public_workspaces.public_directory') }}" title="Open {{ public_workspace_labels.lower_plural }} for shared document collections and prompts available to authorized users.">
+              <i class="bi bi-folder me-2"></i><span class="nav-text"> {{ public_workspace_labels.short }}</span>
             </a>
           </li>
           {% endif %}
@@ -1101,7 +1102,7 @@
           {% endif %}
           {% if app_settings.enable_public_workspaces %}
           <li>
-            <a class="dropdown-item" href="{{ url_for('frontend_public_workspaces.my_public_workspaces') }}">My Public Workspaces</a>
+            <a class="dropdown-item" href="{{ url_for('frontend_public_workspaces.my_public_workspaces') }}">My {{ public_workspace_labels.plural }}</a>
           </li>
           {% endif %}
           {% if app_settings.enable_user_feedback %}

--- a/application/single_app/templates/_sidebar_short_nav.html
+++ b/application/single_app/templates/_sidebar_short_nav.html
@@ -5,6 +5,7 @@
 {% set sidebar_menu_state = sidebar_menu_state_raw if sidebar_menu_state_raw is mapping else {} %}
 {% set sidebar_settings = settings if settings is defined else app_settings %}
 {% set latest_features_nav_is_hidden = latest_features_nav_hidden | default(false) %}
+{% set public_workspace_labels = app_settings.public_workspace_labels %}
 <div id="sidebar-nav" class="d-flex flex-column bg-light border-end sidebar-expanded chat-sidebar-nav offcanvas-lg offcanvas-start" tabindex="-1" aria-labelledby="chatSidebarDrawerLabel" data-navigation-drawer="chat-rail">
 
   <div class="offcanvas-header chat-sidebar-mobile-header">
@@ -60,7 +61,7 @@
           {% endif %}
           {% if app_settings.enable_public_workspaces %}
           <a class="list-group-item list-group-item-action" href="{{ url_for('frontend_public_workspaces.public_directory') }}">
-            <i class="bi bi-globe-americas me-2"></i>Public
+            <i class="bi bi-globe-americas me-2"></i>{{ public_workspace_labels.short }}
           </a>
           {% endif %}
           <a class="list-group-item list-group-item-action" href="{{ url_for('frontend_chats.chats') }}">
@@ -286,7 +287,7 @@
           {% endif %}
           {% if app_settings.enable_public_workspaces %}
           <li>
-            <a class="dropdown-item" href="{{ url_for('frontend_public_workspaces.my_public_workspaces') }}">My Public Workspaces</a>
+            <a class="dropdown-item" href="{{ url_for('frontend_public_workspaces.my_public_workspaces') }}">My {{ public_workspace_labels.plural }}</a>
           </li>
           {% endif %}
           {% if app_settings.enable_user_feedback %}

--- a/application/single_app/templates/_top_nav.html
+++ b/application/single_app/templates/_top_nav.html
@@ -227,7 +227,7 @@
                                 <a class="dropdown-item" href="{{ url_for('frontend_profile.profile', tab='groups') }}">My Groups</a>
                             {% endif %}
                             {% if app_settings.enable_public_workspaces %}
-                                <a class="dropdown-item" href="{{ url_for('frontend_profile.profile', tab='public-workspaces') }}">My Public Workspaces</a>
+                                <a class="dropdown-item" href="{{ url_for('frontend_profile.profile', tab='public-workspaces') }}">My {{ public_workspace_labels.plural }}</a>
                             {% endif %}
                             {% if app_settings.enable_user_feedback %}
                                 <a class="dropdown-item" href="{{ url_for('frontend_profile.profile', tab='feedback') }}">My Feedback</a>
@@ -396,3 +396,4 @@
     </div>
 </div>
 {% endif %}
+{% set public_workspace_labels = app_settings.public_workspace_labels %}

--- a/application/single_app/templates/admin_settings.html
+++ b/application/single_app/templates/admin_settings.html
@@ -9621,6 +9621,23 @@
                         <i class="bi bi-info-circle ms-2" data-bs-toggle="tooltip" title="Allow creation of public workspaces that are visible and accessible to all users in the organization for broad knowledge sharing."></i>
                     </div>
 
+                    <div class="mb-3">
+                        <label class="form-label" for="public_workspace_display_name">End-user display name</label>
+                        <input
+                            type="text"
+                            class="form-control"
+                            id="public_workspace_display_name"
+                            name="public_workspace_display_name"
+                            maxlength="{{ settings.public_workspace_labels.max_length }}"
+                            value="{{ settings.public_workspace_display_name }}"
+                            placeholder="Public Workspace"
+                            aria-describedby="public-workspace-display-name-help"
+                        >
+                        <div class="form-text" id="public-workspace-display-name-help">
+                            Optional. End users will see this label instead of Public Workspace. Admin settings and internal references continue to use Public Workspace.
+                        </div>
+                    </div>
+
                     <div id="create_public_workspace_permission_setting" {% if not settings.enable_public_workspaces %}style="display: none;"{% endif %}>
                         <hr>
                         <div class="form-group form-check form-switch mb-2">

--- a/application/single_app/templates/base.html
+++ b/application/single_app/templates/base.html
@@ -203,6 +203,23 @@
   <!-- Dark mode early initialization to prevent flash -->
   <script>
     (function() {
+      window.publicWorkspaceLabels = {{ app_settings.public_workspace_labels | default({}) | tojson }};
+      window.getPublicWorkspaceLabel = function(key) {
+        var defaults = {
+          singular: 'Public Workspace',
+          plural: 'Public Workspaces',
+          lower_singular: 'public workspace',
+          lower_plural: 'public workspaces',
+          short: 'Public'
+        };
+        return (window.publicWorkspaceLabels && window.publicWorkspaceLabels[key]) || defaults[key] || '';
+      };
+      window.getPublicWorkspaceLabelHtml = function(key) {
+        var element = document.createElement('div');
+        element.textContent = window.getPublicWorkspaceLabel(key);
+        return element.innerHTML;
+      };
+
       // Check localStorage first for fast theme loading to prevent flash
       var savedTheme = localStorage.getItem('simplechat-theme');
       if (savedTheme) {

--- a/application/single_app/templates/base.html
+++ b/application/single_app/templates/base.html
@@ -214,11 +214,6 @@
         };
         return (window.publicWorkspaceLabels && window.publicWorkspaceLabels[key]) || defaults[key] || '';
       };
-      window.getPublicWorkspaceLabelHtml = function(key) {
-        var element = document.createElement('div');
-        element.textContent = window.getPublicWorkspaceLabel(key);
-        return element.innerHTML;
-      };
 
       // Check localStorage first for fast theme loading to prevent flash
       var savedTheme = localStorage.getItem('simplechat-theme');

--- a/application/single_app/templates/manage_public_workspace.html
+++ b/application/single_app/templates/manage_public_workspace.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
-{% block title %}Manage Public Workspace – {{ app_settings.app_title }}{% endblock %}
+{% set public_workspace_labels = app_settings.public_workspace_labels %}
+{% block title %}Manage {{ public_workspace_labels.singular }} – {{ app_settings.app_title }}{% endblock %}
 
 {% block head %}
 <style>
@@ -265,14 +266,14 @@
     {% if file_sync_enabled %}
     <li class="nav-item" role="presentation">
       <button class="nav-link" id="identities-tab" data-bs-toggle="tab" data-bs-target="#identities"
-        title="Manage reusable File Sync authentication profiles scoped to this public workspace."
+        title="Manage reusable File Sync authentication profiles scoped to this {{ public_workspace_labels.lower_singular }}."
         type="button" role="tab" aria-controls="identities" aria-selected="false">
         <i class="bi bi-person-badge me-2"></i>Identities
       </button>
     </li>
     <li class="nav-item" role="presentation">
       <button class="nav-link" id="sync-tab" data-bs-toggle="tab" data-bs-target="#sync"
-        title="Configure public workspace file sources that bring approved files into this workspace and run them through the document processing pipeline."
+        title="Configure {{ public_workspace_labels.lower_singular }} file sources that bring approved files into this workspace and run them through the document processing pipeline."
         type="button" role="tab" aria-controls="sync" aria-selected="false">
         <i class="bi bi-arrow-repeat me-2"></i>Sync
       </button>
@@ -280,7 +281,7 @@
     {% endif %}
     <li class="nav-item d-none" role="presentation" id="settings-tab-item">
       <button class="nav-link" id="settings-tab" data-bs-toggle="tab" data-bs-target="#settings"
-        title="Configure public workspace retention and file-download overrides when these controls are enabled."
+        title="Configure {{ public_workspace_labels.lower_singular }} retention and file-download overrides when these controls are enabled."
         type="button" role="tab" aria-controls="settings" aria-selected="false">
         <i class="bi bi-sliders me-2"></i>Settings
       </button>
@@ -298,7 +299,7 @@
             <form method="POST" action="/set_active_public_workspace" class="mb-3">
               <input type="hidden" name="workspace_id" value="{{ workspace_id }}">
               <button type="submit" class="btn btn-outline-primary btn-sm">
-                <i class="bi bi-box-arrow-in-right me-1"></i>Go to Public Workspace
+                <i class="bi bi-box-arrow-in-right me-1"></i>Go to {{ public_workspace_labels.singular }}
               </button>
             </form>
 
@@ -446,7 +447,7 @@
     <div class="tab-pane fade" id="stats" role="tabpanel">
       <div class="d-flex flex-column flex-lg-row justify-content-between align-items-lg-center gap-3 mb-3">
         <div>
-          <h5 class="mb-1"><i class="bi bi-graph-up me-2"></i>Public Workspace Stats</h5>
+          <h5 class="mb-1"><i class="bi bi-graph-up me-2"></i>{{ public_workspace_labels.singular }} Stats</h5>
           <div class="small text-muted">Showing <span class="stats-window-label">Last 30 Days</span></div>
         </div>
         <div class="d-flex align-items-center gap-2 flex-wrap">
@@ -580,11 +581,11 @@
     <div class="tab-pane fade d-none" id="settings" role="tabpanel">
       <div class="section-card d-none" id="public-file-download-settings-section">
         <h5 class="mb-3"><i class="bi bi-download me-2"></i>File Download Settings</h5>
-        <p class="text-muted">Disable original file downloads for this public workspace even when admins enable downloads globally or assign this workspace.</p>
+        <p class="text-muted">Disable original file downloads for this {{ public_workspace_labels.lower_singular }} even when admins enable downloads globally or assign this workspace.</p>
 
         <div class="form-check form-switch mb-3">
           <input class="form-check-input" type="checkbox" role="switch" id="public-disable-file-downloads">
-          <label class="form-check-label" for="public-disable-file-downloads">Disable file downloads for this public workspace</label>
+          <label class="form-check-label" for="public-disable-file-downloads">Disable file downloads for this {{ public_workspace_labels.lower_singular }}</label>
         </div>
 
         <div>
@@ -598,7 +599,7 @@
       {% if app_settings.enable_retention_policy_public %}
       <div class="section-card">
         <h5 class="mb-3"><i class="bi bi-hourglass-split me-2"></i>Retention Policy Settings</h5>
-        <p class="text-muted">Configure how long to keep conversations and documents in this public workspace. Items older than the specified period will be automatically deleted.</p>
+        <p class="text-muted">Configure how long to keep conversations and documents in this {{ public_workspace_labels.lower_singular }}. Items older than the specified period will be automatically deleted.</p>
 
         <div class="alert alert-info">
           <i class="bi bi-info-circle me-2"></i>
@@ -1101,7 +1102,7 @@
     <div class="modal-content">
       <div class="modal-header">
         <h5 class="modal-title" id="publicStatsExportModalLabel">
-          <i class="bi bi-download me-2"></i>Export Public Workspace Stats
+          <i class="bi bi-download me-2"></i>Export {{ public_workspace_labels.singular }} Stats
         </h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>

--- a/application/single_app/templates/my_public_workspaces.html
+++ b/application/single_app/templates/my_public_workspaces.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
-{% block title %}My Public Workspaces – {{ app_settings.app_title }}{% endblock %}
+{% set public_workspace_labels = app_settings.public_workspace_labels %}
+{% block title %}My {{ public_workspace_labels.plural }} – {{ app_settings.app_title }}{% endblock %}
 {% block head %}
 <style>
     /* Consistent table styling */
@@ -33,9 +34,9 @@
 {% endblock %}
 {% block content %}
 <div class="container">
-  <h2>My Public Workspaces</h2>
+  <h2>My {{ public_workspace_labels.plural }}</h2>
   <p class="text-muted">
-    View and manage the public workspaces you’re authorized to create.
+    View and manage the {{ public_workspace_labels.lower_plural }} you’re authorized to create.
   </p>
   <hr/>
 
@@ -46,7 +47,7 @@
               data-bs-toggle="modal"
               data-bs-target="#createPublicWorkspaceModal">
         <i class="bi bi-plus-circle-fill me-1"></i>
-        Create New Public Workspace
+        Create New {{ public_workspace_labels.singular }}
       </button>
     </div>
     {% endif %}
@@ -119,7 +120,7 @@
     <form id="createPublicWorkspaceForm">
       <div class="modal-content">
         <div class="modal-header">
-          <h5 class="modal-title" id="createPublicWorkspaceModalLabel">Create a New Public Workspace</h5>
+          <h5 class="modal-title" id="createPublicWorkspaceModalLabel">Create a New {{ public_workspace_labels.singular }}</h5>
           <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
         </div>
         <div class="modal-body">
@@ -147,12 +148,12 @@
   <div class="modal-dialog modal-lg">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title" id="findPublicWorkspaceModalLabel">Find a Public Workspace</h5>
+        <h5 class="modal-title" id="findPublicWorkspaceModalLabel">Find a {{ public_workspace_labels.singular }}</h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <div class="modal-body">
         <div class="input-group mb-2">
-          <input type="text" class="form-control" id="globalWorkspaceSearchInput" placeholder="Search all public workspaces..."/>
+          <input type="text" class="form-control" id="globalWorkspaceSearchInput" placeholder="Search all {{ public_workspace_labels.lower_plural }}..."/>
           <button class="btn btn-outline-secondary" type="button" id="globalWorkspaceSearchBtn">Search</button>
         </div>
         <div class="table-responsive">

--- a/application/single_app/templates/profile.html
+++ b/application/single_app/templates/profile.html
@@ -1,6 +1,7 @@
 <!-- templates/profile.html -->
 
 {% extends "base.html" %}
+{% set public_workspace_labels = app_settings.public_workspace_labels %}
 {% block title %}
     Profile - {{ app_settings.app_title }}
 {% endblock %}
@@ -1517,8 +1518,8 @@
             <div class="section-card">
                 <div class="d-flex flex-column flex-lg-row align-items-lg-start justify-content-between gap-3">
                     <div>
-                        <h5 class="mb-2"><i class="bi bi-globe-americas me-2"></i>My Public Workspaces</h5>
-                        <p class="text-muted mb-0">Browse public workspaces, set your active public workspace, and request access where needed.</p>
+                        <h5 class="mb-2"><i class="bi bi-globe-americas me-2"></i>My {{ public_workspace_labels.plural }}</h5>
+                        <p class="text-muted mb-0">Browse {{ public_workspace_labels.lower_plural }}, set your active {{ public_workspace_labels.lower_singular }}, and request access where needed.</p>
                     </div>
                     <div class="d-flex flex-wrap gap-2">
                         {% if profile_can_create_public_workspaces %}
@@ -1536,7 +1537,7 @@
             <div class="table-section-card">
                 <div class="profile-workspace-toolbar">
                     <div class="profile-workspace-search">
-                        <label for="profile-public-workspaces-search-input" class="form-label mb-1">Search public workspaces</label>
+                        <label for="profile-public-workspaces-search-input" class="form-label mb-1">Search {{ public_workspace_labels.lower_plural }}</label>
                         <div class="input-group input-group-sm">
                             <input class="form-control" type="search" placeholder="Search by name or description" id="profile-public-workspaces-search-input" />
                             <button class="btn btn-primary" type="button" id="profile-public-workspaces-search-btn">Search</button>
@@ -1573,7 +1574,7 @@
                             <tr class="table-loading-row">
                                 <td colspan="5">
                                     <div class="spinner-border spinner-border-sm me-2" role="status"><span class="visually-hidden">Loading...</span></div>
-                                    Loading public workspaces...
+                                    Loading {{ public_workspace_labels.lower_plural }}...
                                 </td>
                             </tr>
                         </tbody>
@@ -1919,7 +1920,7 @@
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">
-                <h5 class="modal-title" id="profileCreatePublicWorkspaceModalLabel">Create Public Workspace</h5>
+                <h5 class="modal-title" id="profileCreatePublicWorkspaceModalLabel">Create {{ public_workspace_labels.singular }}</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
             <form id="profile-create-public-workspace-form">
@@ -1936,7 +1937,7 @@
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-                    <button type="submit" class="btn btn-success">Create Public Workspace</button>
+                    <button type="submit" class="btn btn-success">Create {{ public_workspace_labels.singular }}</button>
                 </div>
             </form>
         </div>
@@ -1948,13 +1949,13 @@
     <div class="modal-dialog modal-lg modal-dialog-scrollable">
         <div class="modal-content">
             <div class="modal-header">
-                <h5 class="modal-title" id="profileFindPublicWorkspaceModalLabel">Find Public Workspace</h5>
+                <h5 class="modal-title" id="profileFindPublicWorkspaceModalLabel">Find {{ public_workspace_labels.singular }}</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
             <div class="modal-body">
                 <div id="profile-find-public-workspaces-status" class="alert d-none" role="status"></div>
                 <div class="input-group mb-3">
-                    <input type="search" class="form-control" id="profile-find-public-workspaces-search" placeholder="Search public workspaces" />
+                    <input type="search" class="form-control" id="profile-find-public-workspaces-search" placeholder="Search {{ public_workspace_labels.lower_plural }}" />
                     <button class="btn btn-primary" type="button" id="profile-find-public-workspaces-search-btn">Search</button>
                 </div>
                 <div class="table-responsive">
@@ -1968,7 +1969,7 @@
                         </thead>
                         <tbody id="profile-find-public-workspaces-tbody">
                             <tr>
-                                <td colspan="3" class="text-muted text-center py-3">Search for public workspaces to request access.</td>
+                                <td colspan="3" class="text-muted text-center py-3">Search for {{ public_workspace_labels.lower_plural }} to request access.</td>
                             </tr>
                         </tbody>
                     </table>

--- a/application/single_app/templates/public_directory.html
+++ b/application/single_app/templates/public_directory.html
@@ -1,5 +1,6 @@
 {% extends "base.html" %}
-{% block title %} Public Directory - {{ app_settings.app_title }} {% endblock %}
+{% set public_workspace_labels = app_settings.public_workspace_labels %}
+{% block title %} {{ public_workspace_labels.singular }} Directory - {{ app_settings.app_title }} {% endblock %}
 {% block head %}
 <style>
   /* Public Directory specific styles */
@@ -197,9 +198,9 @@
 {% block content %}
 <div class="container">
   <div class="d-flex justify-content-between align-items-center mb-2">
-    <h2>Public Directory</h2>
+    <h2>{{ public_workspace_labels.singular }} Directory</h2>
   </div>
-  <p class="text-muted mb-4">Browse and discover public workspaces accessible to all users. Use visibility settings to control which workspaces are shown on the chat page.</p>
+  <p class="text-muted mb-4">Browse and discover {{ public_workspace_labels.lower_plural }} accessible to all users. Use visibility settings to control which workspaces are shown on the chat page.</p>
 
   <!-- Chat Action Buttons -->
   <div class="mb-3 d-flex gap-2">
@@ -234,7 +235,7 @@
   <div class="mb-2">
     <p class="mb-2 small text-muted">
       <strong>Curated Lists & Visibility:</strong><br>
-      Save your current set of visible public workspaces as a named list, so you can quickly switch between different workspace sets for chat and search.
+      Save your current set of visible {{ public_workspace_labels.lower_plural }} as a named list, so you can quickly switch between different workspace sets for chat and search.
       Use <b>Save List</b> to store your current selection, <b>Load List</b> to apply a saved set.
       Use <b>All Visible</b> or <b>All Hidden</b> to quickly show or hide all workspaces at once.
     </p>
@@ -296,7 +297,7 @@
               <div class="spinner-border spinner-border-sm me-2" role="status">
                 <span class="visually-hidden">Loading...</span>
               </div>
-              Loading public workspaces...
+              Loading {{ public_workspace_labels.lower_plural }}...
             </td>
           </tr>
         </tbody>
@@ -323,7 +324,7 @@
   <div class="modal-dialog modal-lg">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title" id="viewWorkspaceModalLabel">Public Workspace Details</h5>
+        <h5 class="modal-title" id="viewWorkspaceModalLabel">{{ public_workspace_labels.singular }} Details</h5>
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <div class="modal-body">

--- a/application/single_app/templates/public_workspaces.html
+++ b/application/single_app/templates/public_workspaces.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 {% from "_supported_file_types_modal.html" import supported_file_types_modal %}
-{% block title %} Public Workspaces - {{ app_settings.app_title }} {% endblock %}
+{% set public_workspace_labels = app_settings.public_workspace_labels %}
+{% block title %} {{ public_workspace_labels.plural }} - {{ app_settings.app_title }} {% endblock %}
 {% block head %}
 <link rel="stylesheet" href="/static/css/simplemde.min.css" />
 <link rel="stylesheet" href="/static/css/workspace-responsive.css" />
@@ -197,14 +198,14 @@
   <div class="workspace-hero-card d-none" id="active-public-hero">
     <div class="row align-items-center g-3">
       <div class="col-auto">
-        <img class="workspace-hero-logo d-none" id="active-public-hero-logo" alt="Active public workspace logo">
+        <img class="workspace-hero-logo d-none" id="active-public-hero-logo" alt="Active {{ public_workspace_labels.lower_singular }} logo">
         <div class="workspace-hero-placeholder" id="active-public-hero-initial">P</div>
       </div>
       <div class="col">
-        <div class="small text-uppercase opacity-75">Active Public Workspace</div>
+        <div class="small text-uppercase opacity-75">Active {{ public_workspace_labels.singular }}</div>
         <h3 class="mb-1" id="active-public-hero-name">No active workspace selected</h3>
         <p class="mb-1 opacity-90"><i class="bi bi-person-circle me-2"></i><strong>Owner:</strong> <span id="active-public-hero-owner">-</span></p>
-        <p class="mb-0 opacity-75" id="active-public-hero-description">Choose an active public workspace to see its profile.</p>
+        <p class="mb-0 opacity-75" id="active-public-hero-description">Choose an active {{ public_workspace_labels.lower_singular }} to see its profile.</p>
       </div>
     </div>
   </div>
@@ -236,9 +237,9 @@
     <div class="col-auto" id="public-selector-actions">
       <div class="d-flex flex-wrap gap-2 justify-content-lg-end align-items-center h-100">
         <a class="btn btn-sm btn-outline-primary d-none" id="manage-active-public-btn" href="#">
-          <i class="bi bi-gear me-1"></i>Manage Public Workspace
+          <i class="bi bi-gear me-1"></i>Manage {{ public_workspace_labels.singular }}
         </a>
-        <button class="btn btn-sm btn-outline-secondary" id="btn-my-publics" title="My Public Workspaces" aria-label="My Public Workspaces">My Workspaces</button>
+        <button class="btn btn-sm btn-outline-secondary" id="btn-my-publics" title="My {{ public_workspace_labels.plural }}" aria-label="My {{ public_workspace_labels.plural }}">My Workspaces</button>
       </div>
     </div>
   </div>
@@ -250,10 +251,10 @@
 
   <ul class="nav nav-tabs" id="publicWorkspaceTab" role="tablist">
     <li class="nav-item" role="presentation">
-      <button class="nav-link active" id="public-docs-tab-btn" data-bs-toggle="tab" data-bs-target="#public-docs-tab" title="Browse and manage public workspace files with metadata filters, tags, folder views, extraction changes, and chat grounding when permitted." type="button" role="tab">Documents</button>
+      <button class="nav-link active" id="public-docs-tab-btn" data-bs-toggle="tab" data-bs-target="#public-docs-tab" title="Browse and manage {{ public_workspace_labels.lower_singular }} files with metadata filters, tags, folder views, extraction changes, and chat grounding when permitted." type="button" role="tab">Documents</button>
     </li>
     <li class="nav-item" role="presentation">
-      <button class="nav-link" id="public-prompts-tab-btn" data-bs-toggle="tab" data-bs-target="#public-prompts-tab" title="Manage reusable prompts associated with this public workspace, with list and card views for quick review." type="button" role="tab">Prompts</button>
+      <button class="nav-link" id="public-prompts-tab-btn" data-bs-toggle="tab" data-bs-target="#public-prompts-tab" title="Manage reusable prompts associated with this {{ public_workspace_labels.lower_singular }}, with list and card views for quick review." type="button" role="tab">Prompts</button>
     </li>
   </ul>
 

--- a/docs/explanation/features/PUBLIC_WORKSPACE_DISPLAY_NAME.md
+++ b/docs/explanation/features/PUBLIC_WORKSPACE_DISPLAY_NAME.md
@@ -1,0 +1,58 @@
+# Public Workspace Display Name
+
+Current version: **0.250.110**
+
+Implemented in version: **0.250.110**
+
+## Overview
+
+Admins can configure an end-user display name for Public Workspace so organizations can present terminology that matches their internal knowledge-management vocabulary, such as "Domain Knowledge". Admin settings and internal implementation details continue to use Public Workspace/public_workspace so app admins can clearly map the custom label back to the platform capability.
+
+## Dependencies
+
+- Admin settings defaults and sanitization in `application/single_app/functions_settings.py`
+- Admin Settings save route in `application/single_app/route_frontend_admin_settings.py`
+- Admin Settings UI in `application/single_app/templates/admin_settings.html`
+- Shared frontend label context in `application/single_app/templates/base.html`
+- End-user templates and JavaScript for public workspace navigation, profile, public directory, public workspace management, and chat document scope selection
+
+## Technical Specifications
+
+The feature stores a single setting named `public_workspace_display_name`. The value is normalized by trimming whitespace, collapsing line breaks and repeated spaces, and capping the stored value at 32 characters. Empty or missing values preserve the default user-facing labels:
+
+- Singular: `Public Workspace`
+- Plural: `Public Workspaces`
+- Lowercase singular: `public workspace`
+- Lowercase plural: `public workspaces`
+- Short navigation label: `Public`
+
+When a custom display name is configured, the exact custom value is reused for singular and plural contexts. This avoids awkward automatic pluralization for labels such as "Domain Knowledge".
+
+`get_public_workspace_label_context()` derives the frontend-safe label context from settings. `sanitize_settings_for_user()` always adds the derived `public_workspace_labels` object for templates and JavaScript without exposing sensitive settings. The derived labels are removed before settings are persisted so Cosmos DB stores only the raw `public_workspace_display_name` value.
+
+## Configuration Options
+
+- `public_workspace_display_name`: Optional end-user label for Public Workspace. Maximum length is 32 characters.
+
+Admins configure this in Admin Settings > Workspaces > Public Workspaces using the "End-user display name" field. The field helper text clarifies that admin settings and internal references continue to use Public Workspace.
+
+## Usage Instructions
+
+1. Open Admin Settings.
+2. Select the Workspaces tab.
+3. Find the Public Workspaces section.
+4. Enter an end-user display name, for example `Domain Knowledge`.
+5. Save Admin Settings.
+
+End users then see the configured label in navigation, profile Public Workspace areas, the public directory, public workspace management pages, chat scope selection, and related browser messages. Admin-only screens such as Admin Settings and Control Center continue to use Public Workspace terminology.
+
+## Testing and Validation
+
+Functional coverage is in `functional_tests/test_public_workspace_display_name_settings.py`. It validates normalization, default/custom label derivation, sanitized frontend label exposure, and removal of derived labels before persistence.
+
+UI coverage is in `ui_tests/test_public_workspace_display_name_ui.py`. It validates that the Admin Settings field is visible with a 32-character limit and that the public directory consumes the same label context exposed to browser code.
+
+Known limitations:
+
+- The feature intentionally does not rename routes, APIs, Cosmos containers, permissions, app roles, log field names, or backend identifiers.
+- Custom labels are reused exactly rather than automatically pluralized.

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,16 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](/explanation/features/) and [Fixes by Version](/explanation/fixes/).
 
+### **(v0.250.110)**
+
+#### New Features
+
+*   **Configurable Public Workspace Display Name**
+    *   Admins can now set an optional end-user display name for Public Workspace, capped at 32 characters, so organizations can present tenant-specific terms such as "Domain Knowledge".
+    *   End users see the configured label across navigation, Profile, Public Directory, Public Workspace pages, chat scope selection, and related browser messages while admin settings and internal identifiers continue to use Public Workspace/public_workspace.
+    *   Empty or unset values preserve the existing Public Workspace/Public Workspaces defaults.
+    *   (Ref: #1146, `functions_settings.py`, `admin_settings.html`, public workspace templates and JavaScript, `PUBLIC_WORKSPACE_DISPLAY_NAME.md`)
+
 ### **(v0.250.109)**
 
 #### New Features

--- a/functional_tests/test_public_workspace_display_name_settings.py
+++ b/functional_tests/test_public_workspace_display_name_settings.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""
+Functional test for configurable Public Workspace end-user display names.
+Version: 0.250.110
+Implemented in: 0.250.110
+
+This test ensures that Public Workspace display-name settings are normalized,
+derived labels are safe for frontend use, and only the raw setting is persisted.
+"""
+
+import ast
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+SETTINGS_HELPER = os.path.join(REPO_ROOT, "application", "single_app", "functions_settings.py")
+ADMIN_ROUTE = os.path.join(REPO_ROOT, "application", "single_app", "route_frontend_admin_settings.py")
+ADMIN_TEMPLATE = os.path.join(REPO_ROOT, "application", "single_app", "templates", "admin_settings.html")
+BASE_TEMPLATE = os.path.join(REPO_ROOT, "application", "single_app", "templates", "base.html")
+
+
+def read_source(path):
+    with open(path, "r", encoding="utf-8") as source_file:
+        return source_file.read()
+
+
+def assert_contains(source, needle, description):
+    if needle not in source:
+        raise AssertionError(f"Missing {description}: {needle}")
+
+
+def load_display_name_helpers():
+    """Load only the display-name helper definitions from functions_settings.py."""
+    source = read_source(SETTINGS_HELPER)
+    tree = ast.parse(source, filename=SETTINGS_HELPER)
+    names_to_load = {
+        "PUBLIC_WORKSPACE_DISPLAY_NAME_DEFAULT",
+        "PUBLIC_WORKSPACE_DISPLAY_NAME_PLURAL_DEFAULT",
+        "PUBLIC_WORKSPACE_DISPLAY_NAME_MAX_LENGTH",
+        "normalize_public_workspace_display_name",
+        "get_public_workspace_label_context",
+        "normalize_public_workspace_display_settings",
+        "attach_public_workspace_label_context",
+    }
+    selected_nodes = [
+        node
+        for node in tree.body
+        if (
+            isinstance(node, ast.Assign)
+            and any(isinstance(target, ast.Name) and target.id in names_to_load for target in node.targets)
+        )
+        or (
+            isinstance(node, ast.FunctionDef)
+            and node.name in names_to_load
+        )
+    ]
+    module = ast.Module(body=selected_nodes, type_ignores=[])
+    ast.fix_missing_locations(module)
+    namespace = {}
+    exec(compile(module, SETTINGS_HELPER, "exec"), namespace)
+    return namespace
+
+
+def test_display_name_normalization():
+    """Validate display-name normalization and default/custom label derivation."""
+    print("Testing Public Workspace display-name normalization...")
+    helpers = load_display_name_helpers()
+    normalize = helpers["normalize_public_workspace_display_name"]
+    get_context = helpers["get_public_workspace_label_context"]
+
+    assert normalize("  Domain\n Knowledge   ") == "Domain Knowledge"
+    long_value = "A" * 40
+    assert normalize(long_value) == "A" * 32
+
+    default_context = get_context({})
+    assert default_context["singular"] == "Public Workspace"
+    assert default_context["plural"] == "Public Workspaces"
+    assert default_context["lower_singular"] == "public workspace"
+    assert default_context["lower_plural"] == "public workspaces"
+    assert default_context["short"] == "Public"
+    assert default_context["is_custom"] is False
+    assert default_context["max_length"] == 32
+
+    custom_context = get_context({"public_workspace_display_name": "Domain Knowledge"})
+    assert custom_context["singular"] == "Domain Knowledge"
+    assert custom_context["plural"] == "Domain Knowledge"
+    assert custom_context["lower_singular"] == "Domain Knowledge"
+    assert custom_context["lower_plural"] == "Domain Knowledge"
+    assert custom_context["short"] == "Domain Knowledge"
+    assert custom_context["is_custom"] is True
+    print("Display-name normalization passed.")
+    return True
+
+
+def test_display_name_persistence_shape():
+    """Validate derived labels are attached for reads but removed before persistence."""
+    print("Testing Public Workspace display-name persistence shape...")
+    helpers = load_display_name_helpers()
+    normalize_settings = helpers["normalize_public_workspace_display_settings"]
+    attach_labels = helpers["attach_public_workspace_label_context"]
+
+    settings = {
+        "public_workspace_display_name": "  Domain\n Knowledge  ",
+        "public_workspace_labels": {"singular": "stale"},
+    }
+    changed = normalize_settings(settings)
+    assert changed is True
+    assert settings["public_workspace_display_name"] == "Domain Knowledge"
+    assert "public_workspace_labels" not in settings
+
+    attach_labels(settings)
+    assert settings["public_workspace_labels"]["singular"] == "Domain Knowledge"
+    assert settings["public_workspace_labels"]["max_length"] == 32
+
+    changed_again = normalize_settings(settings)
+    assert changed_again is True
+    assert "public_workspace_labels" not in settings
+    assert normalize_settings(settings) is False
+    print("Display-name persistence shape passed.")
+    return True
+
+
+def test_admin_and_frontend_wiring():
+    """Validate Admin Settings and frontend sanitized-label wiring."""
+    print("Testing Public Workspace display-name wiring...")
+    settings_source = read_source(SETTINGS_HELPER)
+    admin_route_source = read_source(ADMIN_ROUTE)
+    admin_template_source = read_source(ADMIN_TEMPLATE)
+    base_template_source = read_source(BASE_TEMPLATE)
+
+    assert_contains(
+        settings_source,
+        "'public_workspace_display_name': ''",
+        "default display-name setting",
+    )
+    assert_contains(
+        settings_source,
+        "sanitized['public_workspace_labels'] = get_public_workspace_label_context(full_settings)",
+        "sanitized frontend labels",
+    )
+    assert_contains(
+        admin_route_source,
+        "public_workspace_display_name = normalize_public_workspace_display_name(",
+        "admin route normalization",
+    )
+    assert_contains(
+        admin_route_source,
+        "'public_workspace_display_name': public_workspace_display_name",
+        "admin route persistence",
+    )
+    assert_contains(
+        admin_template_source,
+        'id="public_workspace_display_name"',
+        "admin display-name field",
+    )
+    assert_contains(
+        admin_template_source,
+        'maxlength="{{ settings.public_workspace_labels.max_length }}"',
+        "admin 32-character maxlength binding",
+    )
+    assert_contains(
+        base_template_source,
+        "window.publicWorkspaceLabels = {{ app_settings.public_workspace_labels | default({}) | tojson }};",
+        "global label JSON",
+    )
+    assert_contains(
+        base_template_source,
+        "window.getPublicWorkspaceLabel = function(key)",
+        "global label accessor",
+    )
+    print("Display-name wiring passed.")
+    return True
+
+
+def main():
+    """Run all Public Workspace display-name settings checks."""
+    tests = [
+        test_display_name_normalization,
+        test_display_name_persistence_shape,
+        test_admin_and_frontend_wiring,
+    ]
+    results = []
+    for test in tests:
+        print(f"\nRunning {test.__name__}...")
+        try:
+            results.append(test())
+        except Exception as exc:
+            print(f"Test failed: {exc}")
+            import traceback
+            traceback.print_exc()
+            results.append(False)
+
+    success = all(results)
+    print(f"\nResults: {sum(results)}/{len(results)} tests passed")
+    return success
+
+
+if __name__ == "__main__":
+    test_success = main()
+    sys.exit(0 if test_success else 1)

--- a/ui_tests/test_public_workspace_display_name_ui.py
+++ b/ui_tests/test_public_workspace_display_name_ui.py
@@ -1,0 +1,63 @@
+# test_public_workspace_display_name_ui.py
+"""
+UI test for configurable Public Workspace end-user display names.
+Version: 0.250.110
+Implemented in: 0.250.110
+
+This test ensures admins can see the Public Workspace display-name setting and
+end-user pages consume the same label context.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+from playwright.sync_api import expect
+
+
+BASE_URL = os.getenv("SIMPLECHAT_UI_BASE_URL", "").rstrip("/")
+ADMIN_STORAGE_STATE = os.getenv("SIMPLECHAT_UI_ADMIN_STORAGE_STATE", "")
+
+
+@pytest.mark.ui
+def test_public_workspace_display_name_admin_and_directory(playwright):
+    """Validate the admin field and public directory label wiring."""
+    if not BASE_URL:
+        pytest.skip("Set SIMPLECHAT_UI_BASE_URL to run this UI test.")
+    if not ADMIN_STORAGE_STATE or not Path(ADMIN_STORAGE_STATE).exists():
+        pytest.skip("Set SIMPLECHAT_UI_ADMIN_STORAGE_STATE to a valid authenticated admin storage state file.")
+
+    browser = playwright.chromium.launch()
+    context = browser.new_context(
+        storage_state=ADMIN_STORAGE_STATE,
+        viewport={"width": 1440, "height": 900},
+    )
+    page = context.new_page()
+
+    try:
+        response = page.goto(f"{BASE_URL}/admin/settings", wait_until="domcontentloaded")
+        assert response is not None, "Expected a navigation response for admin settings."
+        if response.status in {401, 403}:
+            pytest.skip("Configured admin storage state cannot access admin settings.")
+        assert response.ok, f"Expected admin settings to load, got HTTP {response.status}."
+
+        page.get_by_role("tab", name="Workspaces").click()
+        display_name_input = page.locator("#public_workspace_display_name")
+        expect(display_name_input).to_be_visible()
+        expect(display_name_input).to_have_attribute("maxlength", "32")
+        expect(page.get_by_text("Admin settings and internal references continue to use Public Workspace.")).to_be_visible()
+
+        label_context = page.evaluate("window.publicWorkspaceLabels")
+        assert label_context["singular"], "Expected singular Public Workspace label context."
+        assert label_context["max_length"] == 32
+
+        response = page.goto(f"{BASE_URL}/public_directory", wait_until="domcontentloaded")
+        if response is None or response.status in {401, 403, 404}:
+            pytest.skip("Configured storage state cannot access the public directory.")
+        if not response.ok:
+            pytest.skip(f"Public directory unavailable in this environment: HTTP {response.status}.")
+
+        expect(page.get_by_role("heading", name=f"{label_context['singular']} Directory")).to_be_visible()
+    finally:
+        context.close()
+        browser.close()


### PR DESCRIPTION
## Summary
- Add a 32-character Admin Settings field for the end-user Public Workspace display name.
- Use sanitized label context across end-user navigation, Profile, Public Directory, Public Workspace pages, chat scope labels, and related browser messages.
- Keep admin/internal terminology, APIs, routes, roles, storage fields, and identifiers as Public Workspace/public_workspace.
- Add feature documentation, release notes, and regression coverage.

Fixes #1146

## Validation
- `python functional_tests\test_public_workspace_display_name_settings.py`
- `python -m py_compile application\single_app\functions_settings.py application\single_app\route_frontend_admin_settings.py functional_tests\test_public_workspace_display_name_settings.py ui_tests\test_public_workspace_display_name_ui.py`
- `node --check` for changed JavaScript files
- `python -m pytest ui_tests\test_public_workspace_display_name_ui.py -q` (skips without UI env/storage state)
- `git diff --check`