### PR TITLE
Add Key Vault expiration reminders and secret rotation telemetry

### DIFF
--- a/.github/instructions/python-lang.instructions.md
+++ b/.github/instructions/python-lang.instructions.md
@@ -44,3 +44,5 @@ applyTo: '**/*.py'
 - Always use f-strings for string interpolation. Ex: `f"User ID: {user_id}"` instead of `"User ID: {}".format(user_id)"`
 
 - Never use `except:` without specifying the exception type. Always catch specific exceptions or use `except Exception as ex:` to capture the exception details. This also avoids accidentally catching system-exiting exceptions like `KeyboardInterrupt` or `SystemExit`.
+
+- Never return raw exception text to browser or API clients. Do not use `str(e)`, `str(exc)`, `repr(e)`, traceback text, SDK exception messages, connection strings, or provider errors in `jsonify()`, template rendering, streaming responses, or other client-visible payloads. Log exception type and safe contextual metadata server-side with `log_event` or `debug_print`, then return a stable user-safe message such as `"Invalid request."`, `"Unable to save action."`, or `"Unable to store secrets in Key Vault."`

--- a/application/single_app/background_tasks.py
+++ b/application/single_app/background_tasks.py
@@ -35,6 +35,10 @@ from functions_app_maintenance import (
 from functions_debug import debug_print
 from functions_data_management import check_due_data_management_jobs_once
 from functions_file_sync import check_due_file_sync_sources_once
+from functions_keyvault_reminders import (
+    KEY_VAULT_SECRET_REMINDER_LOCK_NAME,
+    check_due_key_vault_secret_reminders_once,
+)
 from functions_tabular_generated_exports import check_due_tabular_generated_output_runs_once
 from functions_personal_workflows import (
     compute_next_run_at,
@@ -782,6 +786,35 @@ def run_app_maintenance_loop():
         time.sleep(max(int(sleep_seconds or 3600), 15))
 
 
+def run_key_vault_secret_reminder_loop():
+    """Run due Key Vault secret expiration reminder checks under a distributed lock."""
+    while True:
+        lock_document = None
+        sleep_seconds = 21600
+        try:
+            settings = get_settings()
+            sleep_seconds = int(settings.get('key_vault_secret_expiration_scan_interval_seconds') or 21600)
+            if settings.get('enable_key_vault_secret_expiration_reminders'):
+                lock_document = acquire_distributed_task_lock(
+                    KEY_VAULT_SECRET_REMINDER_LOCK_NAME,
+                    lease_seconds=600,
+                )
+                if lock_document:
+                    check_due_key_vault_secret_reminders_once(settings=settings)
+        except Exception as exc:
+            log_event(
+                '[KeyVaultReminders] Error in reminder scheduler loop.',
+                extra={'error': str(exc)},
+                level=logging.ERROR,
+                exceptionTraceback=True,
+            )
+        finally:
+            if lock_document:
+                release_distributed_task_lock(lock_document)
+
+        time.sleep(max(int(sleep_seconds or 21600), 900))
+
+
 def start_background_task_threads(app=None):
     """Start all background task loops for the current process."""
     task_specs = [
@@ -795,6 +828,7 @@ def start_background_task_threads(app=None):
         ('Tabular generated-output scheduler background task started.', run_tabular_generated_output_scheduler_loop),
         ('Data Management scheduler background task started.', lambda: run_data_management_scheduler_loop(app=app)),
         ('App maintenance background task started.', run_app_maintenance_loop),
+        ('Key Vault secret reminder background task started.', run_key_vault_secret_reminder_loop),
     ]
 
     started_threads = []

--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -95,7 +95,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.250.123"
+VERSION = "0.250.124"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -95,7 +95,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.250.120"
+VERSION = "0.250.123"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')
@@ -647,6 +647,12 @@ cosmos_public_documents_container = cosmos_database.create_container_if_not_exis
 cosmos_document_access_index_container_name = "document_access_index"
 cosmos_document_access_index_container = cosmos_database.create_container_if_not_exists(
     id=cosmos_document_access_index_container_name,
+    partition_key=PartitionKey(path="/scope_key")
+)
+
+cosmos_key_vault_secret_reminders_container_name = "key_vault_secret_reminders"
+cosmos_key_vault_secret_reminders_container = cosmos_database.create_container_if_not_exists(
+    id=cosmos_key_vault_secret_reminders_container_name,
     partition_key=PartitionKey(path="/scope_key")
 )
 

--- a/application/single_app/functions_appinsights.py
+++ b/application/single_app/functions_appinsights.py
@@ -4,6 +4,7 @@ import logging
 import os
 import re
 import threading
+from datetime import date, datetime
 from typing import Any, Dict, Optional, Tuple
 
 from azure.monitor.opentelemetry import configure_azure_monitor
@@ -31,6 +32,14 @@ SENSITIVE_LOG_KEY_FRAGMENTS = (
     "sharedaccesssignature",
     "subscriptionkey",
     "token",
+)
+EXTERNAL_EVENT_SENSITIVE_KEY_FRAGMENTS = (
+    "email",
+    "userid",
+    "groupid",
+    "publicworkspaceid",
+    "scopevalue",
+    "sourceid",
 )
 SECRET_ASSIGNMENT_RE = re.compile(
     r"(?i)\b(api[-_]?key|access[-_]?token|client[-_]?secret|connection[-_]?string|password|secret|subscription[-_]?key|token|sig|signature)=([^&\s,;]+)"
@@ -64,6 +73,8 @@ LOG_RECORD_RESERVED_ATTRS = {
 LOGGER_EVENT_MESSAGE = "[SimpleChatLogEvent]"
 LOGGER_DEBUG_MESSAGE = "[SimpleChatDebugTrace]"
 LOGGER_FALLBACK_MESSAGE = "[SimpleChatLogFallback]"
+LOGGER_EXTERNAL_EVENT_MESSAGE = "[SimpleChatExternalEvent]"
+MAX_EXTERNAL_EVENT_STRING_LENGTH = 256
 
 
 def _format_message(message: Any, message_args: Optional[Tuple[Any, ...]] = None) -> str:
@@ -88,6 +99,18 @@ def _is_sensitive_log_key(key: Any) -> bool:
     if not normalized_key:
         return False
     return any(fragment in normalized_key for fragment in SENSITIVE_LOG_KEY_FRAGMENTS)
+
+
+def _is_sensitive_external_event_key(key: Any) -> bool:
+    normalized_key = _normalize_log_key(key)
+    if not normalized_key:
+        return False
+    if normalized_key.endswith("hash"):
+        return False
+    return (
+        _is_sensitive_log_key(key)
+        or any(fragment in normalized_key for fragment in EXTERNAL_EVENT_SENSITIVE_KEY_FRAGMENTS)
+    )
 
 
 def sanitize_log_message(message: Any) -> str:
@@ -174,6 +197,61 @@ def _build_logger_extra(
                 logger_extra[normalized_key] = _logger_safe_scalar(value)
 
     return logger_extra
+
+
+def _normalize_event_name(event_name: Any) -> str:
+    normalized_name = re.sub(r"[^A-Za-z0-9_.-]", "_", str(event_name or "").strip())[:100]
+    return normalized_name.strip("._-") or "simplechat_event"
+
+
+def _normalize_external_event_key(key: Any) -> str:
+    normalized_key = re.sub(r"[^A-Za-z0-9_]", "_", str(key or "").strip())[:80]
+    normalized_key = normalized_key.strip("_") or "value"
+    return f"sc_event_{normalized_key}"
+
+
+def _normalize_external_event_value(value: Any) -> Any:
+    if value is None:
+        return ""
+    if isinstance(value, bool) or isinstance(value, (int, float)):
+        return value
+    if isinstance(value, (date, datetime)):
+        return value.isoformat()
+    if isinstance(value, str):
+        return sanitize_log_message(value)[:MAX_EXTERNAL_EVENT_STRING_LENGTH]
+    if isinstance(value, dict):
+        return len(value)
+    if isinstance(value, (list, tuple, set)):
+        return len(value)
+    return type(value).__name__
+
+
+def _build_external_event_extra(
+    event_name: str,
+    extra: Optional[Dict[str, Any]] = None,
+    allowed_sensitive_dimensions: Optional[Tuple[str, ...]] = None,
+) -> Dict[str, Any]:
+    event_extra: Dict[str, Any] = {
+        "sc_event_name": event_name,
+    }
+    allowed_sensitive_keys = {
+        _normalize_log_key(key)
+        for key in (allowed_sensitive_dimensions or ())
+        if _normalize_log_key(key)
+    }
+
+    if isinstance(extra, dict):
+        for key, value in extra.items():
+            normalized_key = _normalize_external_event_key(key)
+            if (
+                _is_sensitive_external_event_key(key)
+                and _normalize_log_key(key) not in allowed_sensitive_keys
+            ):
+                event_extra[f"{normalized_key}_present"] = value is not None
+                continue
+            event_extra[normalized_key] = _normalize_external_event_value(value)
+
+    return event_extra
 
 
 def _load_logging_settings() -> Dict[str, Any]:
@@ -397,6 +475,52 @@ def log_event(
             print(LOGGER_FALLBACK_MESSAGE)
             if safe_extra:
                 print("[LOG] Extra dimensions were redacted for logging safety.")
+
+
+def log_external_event(
+    event_name: str,
+    extra: Optional[Dict[str, Any]] = None,
+    level: int = logging.INFO,
+    allowed_sensitive_dimensions: Optional[Tuple[str, ...]] = None,
+) -> None:
+    """
+    Emit a privacy-safe, queryable telemetry event for Azure Monitor automation.
+
+    Unlike general-purpose log_event records, this helper preserves explicitly
+    safe string dimensions so scheduled query alerts and downstream automation
+    can filter by event name and categorical fields.
+    """
+    normalized_event_name = _normalize_event_name(event_name)
+    event_extra = _build_external_event_extra(
+        normalized_event_name,
+        extra,
+        allowed_sensitive_dimensions=allowed_sensitive_dimensions,
+    )
+    event_message = f"{LOGGER_EXTERNAL_EVENT_MESSAGE} {normalized_event_name}"
+
+    try:
+        logger = get_appinsights_logger()
+        if not logger:
+            logger = logging.getLogger('standard')
+            if not logger.handlers:
+                logger.addHandler(logging.StreamHandler())
+                logger.setLevel(logging.INFO)
+
+        logger.log(
+            level,
+            event_message,
+            extra=event_extra,
+            stacklevel=2,
+        )
+    except Exception as exc:
+        log_event(
+            "[AppInsights] Failed to emit external telemetry event.",
+            extra={
+                "event_name": normalized_event_name,
+                "error_type": type(exc).__name__,
+            },
+            level=logging.ERROR,
+        )
 
 # --- Modern Azure Monitor Application Insights setup ---
 def setup_appinsights_logging(settings):

--- a/application/single_app/functions_appinsights.py
+++ b/application/single_app/functions_appinsights.py
@@ -496,7 +496,6 @@ def log_external_event(
         extra,
         allowed_sensitive_dimensions=allowed_sensitive_dimensions,
     )
-    event_message = f"{LOGGER_EXTERNAL_EVENT_MESSAGE} {normalized_event_name}"
 
     try:
         logger = get_appinsights_logger()
@@ -508,7 +507,7 @@ def log_external_event(
 
         logger.log(
             level,
-            event_message,
+            LOGGER_EXTERNAL_EVENT_MESSAGE,
             extra=event_extra,
             stacklevel=2,
         )

--- a/application/single_app/functions_global_actions.py
+++ b/application/single_app/functions_global_actions.py
@@ -162,7 +162,7 @@ def save_global_action(action_data, user_id=None):
     except Exception as e:
         print(f"❌ Error saving global action: {str(e)}")
         traceback.print_exc()
-        return None
+        raise
 
 
 def delete_global_action(action_id):
@@ -229,4 +229,3 @@ def update_global_action_enabled(action_id, is_enabled, user_id=None):
         print(f"❌ Error updating enabled state for global action {action_id}: {str(e)}")
         traceback.print_exc()
         return None
-

--- a/application/single_app/functions_keyvault.py
+++ b/application/single_app/functions_keyvault.py
@@ -2,6 +2,7 @@
 
 import re
 import logging
+from datetime import datetime, timezone
 from urllib.parse import urlparse
 from functions_appinsights import log_event
 from config import *
@@ -72,11 +73,176 @@ AGENT_SENSITIVE_SECRET_FIELDS = [
     },
 ]
 REDACTED_SECRET_VALUE = "***REDACTED***"
+KEY_VAULT_SECRET_REMINDERS_METADATA_FIELD = "key_vault_secret_reminders"
+KEY_VAULT_SECRET_REMINDER_SYNC_FAILED_STATUS = "sync_failed"
+KEY_VAULT_SECRET_REMINDER_SYNCED_STATUS = "synced"
 
 class SecretReturnType(Enum):
     VALUE = "value"
     TRIGGER = "trigger"
     NAME = "name"
+
+
+def _format_key_vault_secret_field_label(path):
+    """Return a readable label for a secret field path."""
+    return ".".join(path).replace("additionalFields.", "").replace("_", " ")
+
+
+def _get_key_vault_secret_expiration_datetime(expires_on):
+    """Return a UTC datetime suitable for Azure Key Vault secret properties."""
+    if isinstance(expires_on, datetime):
+        parsed_datetime = expires_on
+    else:
+        raw_value = str(expires_on or "").strip()
+        if not raw_value:
+            raise ValueError("expires_on is required.")
+        if raw_value.endswith("Z"):
+            raw_value = f"{raw_value[:-1]}+00:00"
+        if len(raw_value) == 10:
+            raw_value = f"{raw_value}T00:00:00+00:00"
+        parsed_datetime = datetime.fromisoformat(raw_value)
+
+    if parsed_datetime.tzinfo is None:
+        return parsed_datetime.replace(tzinfo=timezone.utc)
+    return parsed_datetime.astimezone(timezone.utc)
+
+
+def update_key_vault_secret_expiration(secret_name, expires_on):
+    """Update the expiration metadata on the latest version of a Key Vault secret."""
+    settings = app_settings_cache.get_settings_cache()
+    if not settings.get("enable_key_vault_secret_storage", False):
+        raise ValueError("Key Vault secret storage is not enabled in settings.")
+
+    key_vault_name = settings.get("key_vault_name", None)
+    if not key_vault_name:
+        raise ValueError("Key Vault name is not configured.")
+    if not validate_secret_name_dynamic(secret_name):
+        raise ValueError("Secret name is not a SimpleChat Key Vault reference.")
+
+    key_vault_url = f"https://{key_vault_name}{KEY_VAULT_DOMAIN}"
+    secret_client = SecretClient(vault_url=key_vault_url, credential=get_keyvault_credential())
+    secret_client.update_secret_properties(
+        name=secret_name,
+        expires_on=_get_key_vault_secret_expiration_datetime(expires_on),
+    )
+    log_event(
+        f"Secret '{secret_name}' expiration updated successfully in Key Vault.",
+        level=logging.INFO,
+    )
+    return True
+
+
+def _record_plugin_reminder_sync_status(updated_plugin, path, status, error=""):
+    """Persist reminder sync status in action metadata for save responses and diagnostics."""
+    metadata = updated_plugin.get("metadata")
+    if not isinstance(metadata, dict):
+        metadata = {}
+        updated_plugin["metadata"] = metadata
+    sync_status = metadata.get("key_vault_secret_reminder_sync")
+    if not isinstance(sync_status, dict):
+        sync_status = {}
+        metadata["key_vault_secret_reminder_sync"] = sync_status
+
+    sync_status[".".join(path)] = {
+        "status": status,
+        "error": str(error or "")[:1000],
+        "updated_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def _build_plugin_reminder_context(updated_plugin, path, secret_reference, scope_value, source, scope):
+    """Build the admin inventory context for a plugin secret reminder."""
+    settings = app_settings_cache.get_settings_cache()
+    source_id = updated_plugin.get("id") or scope_value
+    configured_by = (
+        updated_plugin.get("modified_by")
+        or updated_plugin.get("created_by")
+        or updated_plugin.get("user_id")
+        or ""
+    )
+    try:
+        configured_by = configured_by or str(get_current_user_id() or "")
+    except Exception:
+        configured_by = configured_by or ""
+
+    context = {
+        "secret_name": secret_reference,
+        "key_vault_name": settings.get("key_vault_name", ""),
+        "scope": scope,
+        "scope_value": scope_value,
+        "source": source,
+        "source_type": "action",
+        "source_id": source_id,
+        "source_name": updated_plugin.get("name", ""),
+        "source_display_name": updated_plugin.get("displayName") or updated_plugin.get("name", ""),
+        "field_path": ".".join(path),
+        "field_label": _format_key_vault_secret_field_label(path),
+        "configured_by": configured_by,
+        "remediation_url": "/admin/settings?tab=security#keyvault-section",
+    }
+    if scope == "user":
+        context["owner_user_id"] = scope_value
+    elif scope == "group":
+        context["group_id"] = scope_value
+    elif scope == "public":
+        context["public_workspace_id"] = scope_value
+    return context
+
+
+def _sync_plugin_secret_reminder(updated_plugin, path, secret_reference, scope_value, source, scope):
+    """Sync optional expiration reminder metadata for a plugin Key Vault secret reference."""
+    if not validate_secret_name_dynamic(secret_reference):
+        return
+
+    metadata = updated_plugin.get("metadata")
+    if not isinstance(metadata, dict) or not isinstance(metadata.get(KEY_VAULT_SECRET_REMINDERS_METADATA_FIELD), dict):
+        return
+
+    from functions_keyvault_reminders import (
+        mark_key_vault_secret_reminder_disabled,
+        resolve_key_vault_secret_reminder_config,
+        upsert_key_vault_secret_reminder,
+    )
+
+    reminder_config = resolve_key_vault_secret_reminder_config(updated_plugin, path)
+    if reminder_config is None:
+        return
+
+    context = _build_plugin_reminder_context(
+        updated_plugin,
+        path,
+        secret_reference,
+        scope_value,
+        source,
+        scope,
+    )
+
+    if not reminder_config.get("enabled"):
+        mark_key_vault_secret_reminder_disabled(secret_reference, context=context)
+        _record_plugin_reminder_sync_status(updated_plugin, path, "disabled")
+        return
+
+    sync_status = KEY_VAULT_SECRET_REMINDER_SYNCED_STATUS
+    sync_error = ""
+    try:
+        update_key_vault_secret_expiration(secret_reference, reminder_config["expires_on"])
+    except Exception as exc:
+        sync_status = KEY_VAULT_SECRET_REMINDER_SYNC_FAILED_STATUS
+        sync_error = str(exc)
+        log_event(
+            f"Failed to sync Key Vault secret expiration for '{secret_reference}': {exc}",
+            level=logging.ERROR,
+            exceptionTraceback=True,
+        )
+
+    upsert_key_vault_secret_reminder(
+        secret_reference,
+        reminder_config,
+        context,
+        key_vault_sync_status=sync_status,
+        key_vault_sync_error=sync_error,
+    )
+    _record_plugin_reminder_sync_status(updated_plugin, path, sync_status, sync_error)
 
 
 def _normalize_allowed_sources(allowed_sources):
@@ -284,13 +450,18 @@ def _store_plugin_secret_reference(updated_plugin, existing_plugin, path, secret
                     f"Stored Key Vault reference for '{path_label}' no longer matches the expected scope. Re-enter the secret value."
                 )
             _set_nested_dict_value(updated_plugin, path, existing_reference)
+            _sync_plugin_secret_reminder(
+                updated_plugin,
+                path,
+                existing_reference,
+                scope_value,
+                source,
+                scope,
+            )
             return
-        _set_nested_dict_value(
-            updated_plugin,
-            path,
-            build_full_secret_name(secret_name, scope_value, source, scope),
+        raise ValueError(
+            f"Stored Key Vault placeholder for '{path_label}' has no existing secret reference. Re-enter the secret value."
         )
-        return
 
     if validate_secret_name_dynamic(value):
         if not secret_reference_matches_context(
@@ -310,6 +481,14 @@ def _store_plugin_secret_reference(updated_plugin, existing_plugin, path, secret
                 f"Stored Key Vault reference for '{path_label}' does not match the expected scope."
             )
         _set_nested_dict_value(updated_plugin, path, value)
+        _sync_plugin_secret_reminder(
+            updated_plugin,
+            path,
+            value,
+            scope_value,
+            source,
+            scope,
+        )
         return
 
     full_secret_name = store_secret_in_key_vault(
@@ -320,6 +499,14 @@ def _store_plugin_secret_reference(updated_plugin, existing_plugin, path, secret
         scope=scope,
     )
     _set_nested_dict_value(updated_plugin, path, full_secret_name)
+    _sync_plugin_secret_reminder(
+        updated_plugin,
+        path,
+        full_secret_name,
+        scope_value,
+        source,
+        scope,
+    )
 
 
 def _store_mcp_custom_header_references(updated_plugin, existing_plugin, plugin_name, scope_value, scope):
@@ -388,12 +575,9 @@ def _store_secret_reference(updated, existing, path, secret_name, scope_value, s
                 )
             _set_nested_dict_value(updated, path, existing_reference)
             return
-        _set_nested_dict_value(
-            updated,
-            path,
-            build_full_secret_name(secret_name, scope_value, source, scope),
+        raise ValueError(
+            f"Stored Key Vault placeholder for '{path_label}' has no existing secret reference. Re-enter the secret value."
         )
-        return
 
     if validate_secret_name_dynamic(value):
         if not secret_reference_matches_context(
@@ -672,8 +856,8 @@ def store_secret_in_key_vault(secret_name, secret_value, scope_value, source="gl
 
     key_vault_name = settings.get("key_vault_name", None)
     if not key_vault_name:
-        log_event("Key Vault name is not configured.", level=logging.WARNING)
-        return secret_value
+        log_event("Key Vault name is not configured.", level=logging.ERROR)
+        raise ValueError("Key Vault name is not configured.")
 
     if source not in supported_sources:
         log_event(f"Source '{source}' is not supported. Supported sources: {supported_sources}", level=logging.ERROR)
@@ -692,7 +876,7 @@ def store_secret_in_key_vault(secret_name, secret_value, scope_value, source="gl
         return full_secret_name
     except Exception as e:
         log_event(f"Failed to store secret '{full_secret_name}' in Key Vault: {str(e)}", level=logging.ERROR, exceptionTraceback=True)
-        return secret_value
+        raise RuntimeError(f"Failed to store secret '{full_secret_name}' in Key Vault.") from e
 
 def build_full_secret_name(secret_name, scope_value, source, scope):
     """
@@ -773,13 +957,15 @@ def keyvault_agent_save_helper(agent_dict, scope_value, scope="global", existing
                 source,
                 scope,
             )
+        except ValueError:
+            raise
         except Exception as e:
             log_event(
                 f"Failed to store agent key '{'.'.join(path)}' in Key Vault: {e}",
                 level=logging.ERROR,
                 exceptionTraceback=True,
             )
-            raise Exception(f"Failed to store agent key '{'.'.join(path)}' in Key Vault: {e}")
+            raise RuntimeError(f"Failed to store agent key '{'.'.join(path)}' in Key Vault: {e}") from e
     return updated
 
 def keyvault_agent_get_helper(agent_dict, scope_value, scope="global", return_type=SecretReturnType.TRIGGER):
@@ -879,9 +1065,11 @@ def keyvault_plugin_save_helper(plugin_dict, scope_value, scope="global", existi
                     source,
                     scope,
                 )
+            except ValueError:
+                raise
             except Exception as e:
                 log_event(f"Failed to store plugin key in Key Vault: {e}", level=logging.ERROR, exceptionTraceback=True)
-                raise Exception(f"Failed to store plugin key in Key Vault: {e}")
+                raise RuntimeError(f"Failed to store plugin key in Key Vault: {e}") from e
         else:
             log_event(f"Auth type '{auth_type}' does not require Key Vault storage for plugin '{plugin_name}'.", level=logging.INFO)
 
@@ -897,13 +1085,15 @@ def keyvault_plugin_save_helper(plugin_dict, scope_value, scope="global", existi
                         source,
                         scope,
                     )
+                except ValueError:
+                    raise
                 except Exception as e:
                     log_event(
                         f"Failed to store plugin auth secret '{auth_field}' in Key Vault: {e}",
                         level=logging.ERROR,
                         exceptionTraceback=True,
                     )
-                    raise Exception(f"Failed to store plugin auth secret '{auth_field}' in Key Vault: {e}")
+                    raise RuntimeError(f"Failed to store plugin auth secret '{auth_field}' in Key Vault: {e}") from e
 
     # Handle additionalFields dynamic secrets
     additional_fields = updated.get('additionalFields', {})
@@ -919,13 +1109,15 @@ def keyvault_plugin_save_helper(plugin_dict, scope_value, scope="global", existi
                     scope_value,
                     scope,
                 )
+            except ValueError:
+                raise
             except Exception as e:
                 log_event(
                     f"Failed to store MCP custom header secrets for action '{plugin_name}': {e}",
                     level=logging.ERROR,
                     exceptionTraceback=True,
                 )
-                raise Exception(f"Failed to store MCP custom header secrets for action '{plugin_name}': {e}")
+                raise RuntimeError(f"Failed to store MCP custom header secrets for action '{plugin_name}': {e}") from e
 
         for k, v in additional_fields.items():
             if not v:
@@ -944,9 +1136,11 @@ def keyvault_plugin_save_helper(plugin_dict, scope_value, scope="global", existi
                         addset_source,
                         scope,
                     )
+                except ValueError:
+                    raise
                 except Exception as e:
                     log_event(f"Failed to store plugin additionalField secret '{k}' in Key Vault: {e}", level=logging.ERROR, exceptionTraceback=True)
-                    raise Exception(f"Failed to store plugin additionalField secret '{k}' in Key Vault: {e}")
+                    raise RuntimeError(f"Failed to store plugin additionalField secret '{k}' in Key Vault: {e}") from e
             elif _is_sensitive_plugin_additional_field(updated, k):
                 addset_source = 'action-addset'
                 akv_key = _build_plugin_additional_field_secret_name(plugin_name, k)
@@ -960,13 +1154,15 @@ def keyvault_plugin_save_helper(plugin_dict, scope_value, scope="global", existi
                         addset_source,
                         scope,
                     )
+                except ValueError:
+                    raise
                 except Exception as e:
                     log_event(
                         f"Failed to store plugin additionalField secret '{k}' in Key Vault: {e}",
                         level=logging.ERROR,
                         exceptionTraceback=True,
                     )
-                    raise Exception(f"Failed to store plugin additionalField secret '{k}' in Key Vault: {e}")
+                    raise RuntimeError(f"Failed to store plugin additionalField secret '{k}' in Key Vault: {e}") from e
     return updated
 # Helper to retrieve plugin secrets from Key Vault
 def keyvault_plugin_get_helper(plugin_dict, scope_value, scope="global", return_type=SecretReturnType.TRIGGER):
@@ -1124,10 +1320,28 @@ def keyvault_model_endpoint_save_helper(endpoint_dict, scope_value, scope="globa
             if existing_reference:
                 updated_auth[auth_field] = existing_reference
             else:
-                updated_auth.pop(auth_field, None)
+                raise ValueError(
+                    f"Stored Key Vault placeholder for model endpoint '{auth_field}' has no existing secret reference. Re-enter the secret value."
+                )
             continue
 
         if validate_secret_name_dynamic(value):
+            if not secret_reference_matches_context(
+                value,
+                scope_value=scope_value,
+                scope=scope,
+                allowed_sources={source},
+            ):
+                _log_secret_reference_context_mismatch(
+                    value,
+                    f"model endpoint auth field '{auth_field}'",
+                    scope_value=scope_value,
+                    scope=scope,
+                    allowed_sources={source},
+                )
+                raise ValueError(
+                    f"Stored Key Vault reference for model endpoint '{auth_field}' does not match the expected scope."
+                )
             updated_auth[auth_field] = value
             continue
 

--- a/application/single_app/functions_keyvault_reminders.py
+++ b/application/single_app/functions_keyvault_reminders.py
@@ -29,7 +29,7 @@ KEY_VAULT_SECRET_REMINDER_SYNCED_STATUS = "synced"
 KEY_VAULT_SECRET_REMINDER_DEFAULT_LEAD_DAYS = 30
 KEY_VAULT_SECRET_REMINDER_DEFAULT_SCAN_INTERVAL_SECONDS = 21600
 KEY_VAULT_SECRET_REMINDER_LOCK_NAME = "key_vault_secret_expiration_reminders"
-KEY_VAULT_SECRET_REMINDER_EXTERNAL_EVENT_NAME = "key_vault_expiration_reminder_triggered"
+KEY_VAULT_REMINDER_EXTERNAL_EVENT_NAME = "key_vault_expiration_reminder_triggered"
 
 
 def _now_iso() -> str:
@@ -526,7 +526,7 @@ def _emit_external_expiration_notification_event(
         allowed_sensitive_dimensions = ("contact_email",)
 
     log_external_event(
-        KEY_VAULT_SECRET_REMINDER_EXTERNAL_EVENT_NAME,
+        KEY_VAULT_REMINDER_EXTERNAL_EVENT_NAME,
         extra=event_extra,
         allowed_sensitive_dimensions=allowed_sensitive_dimensions,
     )

--- a/application/single_app/functions_keyvault_reminders.py
+++ b/application/single_app/functions_keyvault_reminders.py
@@ -29,7 +29,7 @@ KEY_VAULT_SECRET_REMINDER_SYNCED_STATUS = "synced"
 KEY_VAULT_SECRET_REMINDER_DEFAULT_LEAD_DAYS = 30
 KEY_VAULT_SECRET_REMINDER_DEFAULT_SCAN_INTERVAL_SECONDS = 21600
 KEY_VAULT_SECRET_REMINDER_LOCK_NAME = "key_vault_secret_expiration_reminders"
-KEY_VAULT_SECRET_REMINDER_EXTERNAL_EVENT_NAME = "key_vault_secret_expiration_reminder_triggered"
+KEY_VAULT_SECRET_REMINDER_EXTERNAL_EVENT_NAME = "key_vault_expiration_reminder_triggered"
 
 
 def _now_iso() -> str:

--- a/application/single_app/functions_keyvault_reminders.py
+++ b/application/single_app/functions_keyvault_reminders.py
@@ -1,0 +1,596 @@
+# functions_keyvault_reminders.py
+
+"""Key Vault secret expiration reminder inventory and notification helpers."""
+
+import hashlib
+import logging
+from datetime import date, datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional, Tuple
+
+from azure.cosmos.exceptions import CosmosResourceNotFoundError
+
+from config import cosmos_key_vault_secret_reminders_container
+from functions_appinsights import log_event, log_external_event
+from functions_notifications import (
+    create_group_notification,
+    create_notification,
+    create_public_workspace_notification,
+)
+from functions_settings import get_settings
+
+
+KEY_VAULT_SECRET_REMINDERS_METADATA_FIELD = "key_vault_secret_reminders"
+KEY_VAULT_SECRET_REMINDER_ALL_FIELDS = "__all__"
+KEY_VAULT_SECRET_REMINDER_NOTIFICATION_TYPE = "key_vault_secret_expiring"
+KEY_VAULT_SECRET_REMINDER_ACTIVE_STATUS = "active"
+KEY_VAULT_SECRET_REMINDER_DISABLED_STATUS = "disabled"
+KEY_VAULT_SECRET_REMINDER_SYNC_FAILED_STATUS = "sync_failed"
+KEY_VAULT_SECRET_REMINDER_SYNCED_STATUS = "synced"
+KEY_VAULT_SECRET_REMINDER_DEFAULT_LEAD_DAYS = 30
+KEY_VAULT_SECRET_REMINDER_DEFAULT_SCAN_INTERVAL_SECONDS = 21600
+KEY_VAULT_SECRET_REMINDER_LOCK_NAME = "key_vault_secret_expiration_reminders"
+KEY_VAULT_SECRET_REMINDER_EXTERNAL_EVENT_NAME = "key_vault_secret_expiration_reminder_triggered"
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _as_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _safe_int(value: Any, default_value: int, minimum: int, maximum: int) -> int:
+    try:
+        parsed_value = int(value)
+    except (TypeError, ValueError):
+        parsed_value = default_value
+    return min(max(parsed_value, minimum), maximum)
+
+
+def _normalize_text(value: Any, max_length: int) -> str:
+    return str(value or "").strip()[:max_length]
+
+
+def _hash_external_telemetry_value(value: Any) -> str:
+    normalized_value = str(value or "").strip()
+    if not normalized_value:
+        return ""
+    return hashlib.sha256(normalized_value.encode("utf-8")).hexdigest()[:16]
+
+
+def _parse_expiration_date(value: Any) -> Optional[date]:
+    if value in (None, ""):
+        return None
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+
+    raw_value = str(value).strip()
+    if not raw_value:
+        return None
+    if raw_value.endswith("Z"):
+        raw_value = f"{raw_value[:-1]}+00:00"
+
+    try:
+        return datetime.fromisoformat(raw_value).date()
+    except ValueError:
+        return date.fromisoformat(raw_value[:10])
+
+
+def _format_scope_key(scope: str, scope_value: str) -> str:
+    return f"{scope}:{scope_value}"
+
+
+def build_key_vault_secret_reminder_id(secret_name: str) -> str:
+    """Return a stable inventory id for a Key Vault secret name."""
+    digest = hashlib.sha256(str(secret_name or "").encode("utf-8")).hexdigest()[:32]
+    return f"key-vault-secret-reminder-{digest}"
+
+
+def normalize_key_vault_reminder_settings(settings: Dict[str, Any]) -> Dict[str, Any]:
+    """Normalize reminder-related app settings in-place and return the same dict."""
+    settings["enable_key_vault_secret_expiration_reminders"] = _as_bool(
+        settings.get("enable_key_vault_secret_expiration_reminders", False)
+    )
+    settings["key_vault_secret_expiration_default_lead_days"] = _safe_int(
+        settings.get("key_vault_secret_expiration_default_lead_days"),
+        KEY_VAULT_SECRET_REMINDER_DEFAULT_LEAD_DAYS,
+        1,
+        3650,
+    )
+    settings["key_vault_secret_expiration_default_contact_email"] = _normalize_text(
+        settings.get("key_vault_secret_expiration_default_contact_email"),
+        254,
+    )
+    settings["key_vault_secret_expiration_require_expiration"] = _as_bool(
+        settings.get("key_vault_secret_expiration_require_expiration", False)
+    )
+    settings["key_vault_secret_expiration_emit_contact_email_in_telemetry"] = _as_bool(
+        settings.get("key_vault_secret_expiration_emit_contact_email_in_telemetry", False)
+    )
+    settings["key_vault_secret_expiration_admin_roles"] = normalize_admin_role_list(
+        settings.get("key_vault_secret_expiration_admin_roles")
+    )
+    settings["key_vault_secret_expiration_scan_interval_seconds"] = _safe_int(
+        settings.get("key_vault_secret_expiration_scan_interval_seconds"),
+        KEY_VAULT_SECRET_REMINDER_DEFAULT_SCAN_INTERVAL_SECONDS,
+        900,
+        86400,
+    )
+    return settings
+
+
+def normalize_admin_role_list(value: Any) -> List[str]:
+    """Return distinct admin notification role names."""
+    if isinstance(value, list):
+        raw_roles = value
+    elif isinstance(value, str):
+        raw_roles = value.replace(";", ",").split(",")
+    else:
+        raw_roles = []
+
+    roles = []
+    for role in raw_roles:
+        normalized_role = _normalize_text(role, 80)
+        if normalized_role and normalized_role not in roles:
+            roles.append(normalized_role)
+    return roles or ["Admin"]
+
+
+def normalize_key_vault_secret_reminder_config(
+    reminder_config: Dict[str, Any],
+    settings: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Validate and normalize a single per-secret reminder configuration."""
+    settings = normalize_key_vault_reminder_settings(dict(settings or get_settings() or {}))
+    raw_config = reminder_config if isinstance(reminder_config, dict) else {}
+    enabled = _as_bool(raw_config.get("enabled"))
+    if not enabled:
+        return {"enabled": False}
+
+    expiration_date = _parse_expiration_date(
+        raw_config.get("expires_on") or raw_config.get("expiration_date")
+    )
+    if expiration_date is None:
+        raise ValueError("Expiration date is required when Key Vault expiration reminders are enabled.")
+
+    contact_email = _normalize_text(
+        raw_config.get("contact_email")
+        or raw_config.get("reminder_email")
+        or settings.get("key_vault_secret_expiration_default_contact_email"),
+        254,
+    )
+    if not contact_email or "@" not in contact_email:
+        raise ValueError("A valid reminder email is required when Key Vault expiration reminders are enabled.")
+
+    lead_days = _safe_int(
+        raw_config.get("lead_days"),
+        settings.get("key_vault_secret_expiration_default_lead_days", KEY_VAULT_SECRET_REMINDER_DEFAULT_LEAD_DAYS),
+        1,
+        3650,
+    )
+
+    return {
+        "enabled": True,
+        "expires_on": expiration_date.isoformat(),
+        "lead_days": lead_days,
+        "contact_email": contact_email,
+        "label": _normalize_text(raw_config.get("label") or raw_config.get("friendly_label"), 160),
+        "notes": _normalize_text(raw_config.get("notes") or raw_config.get("rotation_notes"), 1000),
+    }
+
+
+def resolve_key_vault_secret_reminder_config(
+    owner_document: Dict[str, Any],
+    field_path: Tuple[str, ...],
+    settings: Optional[Dict[str, Any]] = None,
+) -> Optional[Dict[str, Any]]:
+    """Return the normalized reminder config for a secret field, if configured."""
+    if not isinstance(owner_document, dict):
+        return None
+
+    metadata = owner_document.get("metadata")
+    if not isinstance(metadata, dict):
+        metadata = {}
+
+    raw_reminders = metadata.get(KEY_VAULT_SECRET_REMINDERS_METADATA_FIELD)
+    if not isinstance(raw_reminders, dict):
+        return None
+
+    field_key = ".".join(str(part) for part in field_path)
+    if field_key in raw_reminders:
+        raw_config = raw_reminders.get(field_key)
+    elif KEY_VAULT_SECRET_REMINDER_ALL_FIELDS in raw_reminders:
+        raw_config = raw_reminders.get(KEY_VAULT_SECRET_REMINDER_ALL_FIELDS)
+    else:
+        return None
+
+    if isinstance(raw_config, bool):
+        raw_config = {"enabled": raw_config}
+    if not isinstance(raw_config, dict):
+        return None
+
+    return normalize_key_vault_secret_reminder_config(raw_config, settings=settings)
+
+
+def upsert_key_vault_secret_reminder(
+    secret_name: str,
+    reminder_config: Dict[str, Any],
+    context: Dict[str, Any],
+    key_vault_sync_status: str = KEY_VAULT_SECRET_REMINDER_SYNCED_STATUS,
+    key_vault_sync_error: str = "",
+) -> Dict[str, Any]:
+    """Create or update the SimpleChat inventory document for a tracked secret."""
+    if not reminder_config.get("enabled"):
+        return mark_key_vault_secret_reminder_disabled(secret_name, context=context)
+
+    normalized_secret_name = _normalize_text(secret_name, 127)
+    if not normalized_secret_name:
+        raise ValueError("Secret name is required for a Key Vault reminder inventory entry.")
+
+    scope = _normalize_text(context.get("scope"), 50)
+    scope_value = _normalize_text(context.get("scope_value"), 255)
+    if not scope or not scope_value:
+        raise ValueError("Reminder inventory context requires a scope and scope value.")
+
+    reminder_id = build_key_vault_secret_reminder_id(normalized_secret_name)
+    scope_key = _format_scope_key(scope, scope_value)
+    existing = None
+    try:
+        existing = cosmos_key_vault_secret_reminders_container.read_item(
+            item=reminder_id,
+            partition_key=scope_key,
+        )
+    except CosmosResourceNotFoundError:
+        existing = None
+
+    expires_on = reminder_config["expires_on"]
+    notify_on = (
+        _parse_expiration_date(expires_on)
+        - timedelta(days=int(reminder_config.get("lead_days") or KEY_VAULT_SECRET_REMINDER_DEFAULT_LEAD_DAYS))
+    ).isoformat()
+
+    now = _now_iso()
+    status = (
+        KEY_VAULT_SECRET_REMINDER_SYNC_FAILED_STATUS
+        if key_vault_sync_status == KEY_VAULT_SECRET_REMINDER_SYNC_FAILED_STATUS
+        else KEY_VAULT_SECRET_REMINDER_ACTIVE_STATUS
+    )
+    document = {
+        "id": reminder_id,
+        "type": "key_vault_secret_reminder",
+        "enabled": True,
+        "status": status,
+        "secret_name": normalized_secret_name,
+        "key_vault_name": _normalize_text(context.get("key_vault_name"), 120),
+        "scope": scope,
+        "scope_value": scope_value,
+        "scope_key": scope_key,
+        "source": _normalize_text(context.get("source"), 80),
+        "source_type": _normalize_text(context.get("source_type"), 80),
+        "source_id": _normalize_text(context.get("source_id"), 255),
+        "source_name": _normalize_text(context.get("source_name"), 255),
+        "source_display_name": _normalize_text(context.get("source_display_name"), 255),
+        "field_path": _normalize_text(context.get("field_path"), 255),
+        "field_label": _normalize_text(context.get("field_label"), 255),
+        "owner_user_id": _normalize_text(context.get("owner_user_id"), 255),
+        "group_id": _normalize_text(context.get("group_id"), 255),
+        "public_workspace_id": _normalize_text(context.get("public_workspace_id"), 255),
+        "configured_by": _normalize_text(context.get("configured_by"), 255),
+        "contact_email": reminder_config["contact_email"],
+        "label": reminder_config.get("label") or _normalize_text(context.get("field_label"), 160),
+        "notes": reminder_config.get("notes", ""),
+        "expires_on": expires_on,
+        "lead_days": int(reminder_config.get("lead_days") or KEY_VAULT_SECRET_REMINDER_DEFAULT_LEAD_DAYS),
+        "notify_on": notify_on,
+        "remediation_url": _normalize_text(context.get("remediation_url"), 500),
+        "key_vault_sync_status": key_vault_sync_status,
+        "key_vault_sync_error": _normalize_text(key_vault_sync_error, 1000),
+        "created_at": (existing or {}).get("created_at") or now,
+        "updated_at": now,
+        "last_notified_at": (existing or {}).get("last_notified_at"),
+        "last_notification_window_key": (existing or {}).get("last_notification_window_key"),
+    }
+    cosmos_key_vault_secret_reminders_container.upsert_item(document)
+    return document
+
+
+def mark_key_vault_secret_reminder_disabled(
+    secret_name: str,
+    context: Optional[Dict[str, Any]] = None,
+    reason: str = "disabled",
+) -> Dict[str, Any]:
+    """Disable an inventory entry when a user turns off tracking for a secret."""
+    normalized_secret_name = _normalize_text(secret_name, 127)
+    if not normalized_secret_name:
+        return {}
+
+    reminder_id = build_key_vault_secret_reminder_id(normalized_secret_name)
+    context = context or {}
+    scope = _normalize_text(context.get("scope"), 50)
+    scope_value = _normalize_text(context.get("scope_value"), 255)
+    scope_key = _format_scope_key(scope, scope_value) if scope and scope_value else None
+    candidates = []
+
+    if scope_key:
+        try:
+            candidates.append(
+                cosmos_key_vault_secret_reminders_container.read_item(
+                    item=reminder_id,
+                    partition_key=scope_key,
+                )
+            )
+        except CosmosResourceNotFoundError:
+            candidates = []
+    else:
+        candidates = list(
+            cosmos_key_vault_secret_reminders_container.query_items(
+                query="SELECT * FROM c WHERE c.id = @id",
+                parameters=[{"name": "@id", "value": reminder_id}],
+                enable_cross_partition_query=True,
+            )
+        )
+
+    if not candidates:
+        return {}
+
+    updated_document = {}
+    for document in candidates:
+        document["enabled"] = False
+        document["status"] = KEY_VAULT_SECRET_REMINDER_DISABLED_STATUS
+        document["disabled_reason"] = _normalize_text(reason, 200)
+        document["updated_at"] = _now_iso()
+        cosmos_key_vault_secret_reminders_container.upsert_item(document)
+        updated_document = document
+    return updated_document
+
+
+def sanitize_key_vault_secret_reminder(document: Dict[str, Any]) -> Dict[str, Any]:
+    """Return the admin-safe inventory projection for a reminder document."""
+    sanitized = {
+        key: value
+        for key, value in (document or {}).items()
+        if not str(key).startswith("_")
+    }
+    expires_on = _parse_expiration_date(sanitized.get("expires_on"))
+    sanitized["days_until_expiry"] = (
+        (expires_on - datetime.now(timezone.utc).date()).days
+        if expires_on
+        else None
+    )
+    return sanitized
+
+
+def list_key_vault_secret_reminders(
+    status: str = "",
+    scope: str = "",
+    source_type: str = "",
+    search: str = "",
+    limit: int = 250,
+) -> List[Dict[str, Any]]:
+    """List Key Vault reminder inventory entries for the admin dashboard."""
+    limit = _safe_int(limit, 250, 1, 1000)
+    query_parts = ["SELECT * FROM c WHERE c.type = @type"]
+    parameters = [{"name": "@type", "value": "key_vault_secret_reminder"}]
+
+    if status:
+        query_parts.append("AND c.status = @status")
+        parameters.append({"name": "@status", "value": status})
+    if scope:
+        query_parts.append("AND c.scope = @scope")
+        parameters.append({"name": "@scope", "value": scope})
+    if source_type:
+        query_parts.append("AND c.source_type = @source_type")
+        parameters.append({"name": "@source_type", "value": source_type})
+
+    query_parts.append("ORDER BY c.expires_on ASC")
+    reminders = list(
+        cosmos_key_vault_secret_reminders_container.query_items(
+            query=" ".join(query_parts),
+            parameters=parameters,
+            enable_cross_partition_query=True,
+        )
+    )
+
+    normalized_search = str(search or "").strip().lower()
+    if normalized_search:
+        searchable_fields = (
+            "id",
+            "secret_name",
+            "source_name",
+            "source_display_name",
+            "field_path",
+            "field_label",
+            "contact_email",
+            "label",
+            "scope_value",
+        )
+        reminders = [
+            reminder
+            for reminder in reminders
+            if any(normalized_search in str(reminder.get(field) or "").lower() for field in searchable_fields)
+        ]
+
+    return [sanitize_key_vault_secret_reminder(reminder) for reminder in reminders[:limit]]
+
+
+def _build_notification_message(reminder: Dict[str, Any], days_until_expiry: int) -> str:
+    display_name = (
+        reminder.get("label")
+        or reminder.get("source_display_name")
+        or reminder.get("source_name")
+        or reminder.get("secret_name")
+    )
+    if days_until_expiry < 0:
+        return f"Key Vault secret '{display_name}' expired on {reminder.get('expires_on')}."
+    if days_until_expiry == 0:
+        return f"Key Vault secret '{display_name}' expires today."
+    return f"Key Vault secret '{display_name}' expires in {days_until_expiry} days."
+
+
+def _create_expiration_notification(reminder: Dict[str, Any], settings: Dict[str, Any], days_until_expiry: int) -> Optional[Dict[str, Any]]:
+    title = "Key Vault secret expiration reminder"
+    message = _build_notification_message(reminder, days_until_expiry)
+    link_url = reminder.get("remediation_url") or "/admin/settings?tab=security#keyvault-section"
+    metadata = {
+        "reminder_id": reminder.get("id"),
+        "secret_name": reminder.get("secret_name"),
+        "expires_on": reminder.get("expires_on"),
+        "days_until_expiry": days_until_expiry,
+        "scope": reminder.get("scope"),
+        "scope_value": reminder.get("scope_value"),
+        "source_type": reminder.get("source_type"),
+        "source_id": reminder.get("source_id"),
+        "field_path": reminder.get("field_path"),
+    }
+
+    scope = reminder.get("scope")
+    if scope == "user":
+        user_id = reminder.get("owner_user_id") or reminder.get("scope_value")
+        return create_notification(
+            user_id=user_id,
+            notification_type=KEY_VAULT_SECRET_REMINDER_NOTIFICATION_TYPE,
+            title=title,
+            message=message,
+            link_url=link_url,
+            metadata=metadata,
+        )
+    if scope == "group":
+        return create_group_notification(
+            reminder.get("group_id") or reminder.get("scope_value"),
+            KEY_VAULT_SECRET_REMINDER_NOTIFICATION_TYPE,
+            title,
+            message,
+            link_url=link_url,
+            metadata=metadata,
+        )
+    if scope == "public":
+        return create_public_workspace_notification(
+            reminder.get("public_workspace_id") or reminder.get("scope_value"),
+            KEY_VAULT_SECRET_REMINDER_NOTIFICATION_TYPE,
+            title,
+            message,
+            link_url=link_url,
+            metadata=metadata,
+        )
+
+    return create_notification(
+        notification_type=KEY_VAULT_SECRET_REMINDER_NOTIFICATION_TYPE,
+        title=title,
+        message=message,
+        link_url=link_url,
+        metadata=metadata,
+        assignment={
+            "roles": normalize_admin_role_list(settings.get("key_vault_secret_expiration_admin_roles")),
+        },
+    )
+
+
+def _emit_external_expiration_notification_event(
+    reminder: Dict[str, Any],
+    notification: Dict[str, Any],
+    days_until_expiry: int,
+    settings: Dict[str, Any],
+) -> None:
+    """Emit a safe Azure Monitor event for external alert rules and automation."""
+    event_extra = {
+        "reminder_id": reminder.get("id"),
+        "reminder_status": reminder.get("status"),
+        "scope": reminder.get("scope"),
+        "source": reminder.get("source"),
+        "source_type": reminder.get("source_type"),
+        "field_path": reminder.get("field_path"),
+        "key_vault_sync_status": reminder.get("key_vault_sync_status"),
+        "notification_id": notification.get("id"),
+        "notification_scope": notification.get("scope"),
+        "days_until_expiry": days_until_expiry,
+        "lead_days": reminder.get("lead_days"),
+        "expires_on": reminder.get("expires_on"),
+        "notify_on": reminder.get("notify_on"),
+        "scope_value_hash": _hash_external_telemetry_value(reminder.get("scope_value")),
+        "source_id_hash": _hash_external_telemetry_value(reminder.get("source_id")),
+        "owner_user_id_hash": _hash_external_telemetry_value(reminder.get("owner_user_id")),
+        "group_id_hash": _hash_external_telemetry_value(reminder.get("group_id")),
+        "public_workspace_id_hash": _hash_external_telemetry_value(reminder.get("public_workspace_id")),
+        "contact_email_hash": _hash_external_telemetry_value(reminder.get("contact_email")),
+    }
+    allowed_sensitive_dimensions = ()
+    if settings.get("key_vault_secret_expiration_emit_contact_email_in_telemetry"):
+        event_extra["contact_email"] = reminder.get("contact_email")
+        allowed_sensitive_dimensions = ("contact_email",)
+
+    log_external_event(
+        KEY_VAULT_SECRET_REMINDER_EXTERNAL_EVENT_NAME,
+        extra=event_extra,
+        allowed_sensitive_dimensions=allowed_sensitive_dimensions,
+    )
+
+
+def check_due_key_vault_secret_reminders_once(
+    settings: Optional[Dict[str, Any]] = None,
+    now: Optional[datetime] = None,
+    limit: int = 1000,
+) -> Dict[str, Any]:
+    """Send in-app notifications for active reminders that are in their lead window."""
+    settings = normalize_key_vault_reminder_settings(dict(settings or get_settings() or {}))
+    if not settings.get("enable_key_vault_secret_expiration_reminders"):
+        return {"enabled": False, "checked": 0, "notifications_created": 0}
+
+    current_date = (now or datetime.now(timezone.utc)).date()
+    active_reminders = list_key_vault_secret_reminders(limit=limit)
+
+    checked = 0
+    notifications_created = 0
+    for reminder in active_reminders:
+        if reminder.get("status") not in {
+            KEY_VAULT_SECRET_REMINDER_ACTIVE_STATUS,
+            KEY_VAULT_SECRET_REMINDER_SYNC_FAILED_STATUS,
+        }:
+            continue
+        checked += 1
+        expires_on = _parse_expiration_date(reminder.get("expires_on"))
+        if not expires_on:
+            continue
+
+        lead_days = _safe_int(
+            reminder.get("lead_days"),
+            settings.get("key_vault_secret_expiration_default_lead_days", KEY_VAULT_SECRET_REMINDER_DEFAULT_LEAD_DAYS),
+            1,
+            3650,
+        )
+        notify_on = expires_on - timedelta(days=lead_days)
+        if current_date < notify_on:
+            continue
+
+        window_key = f"{expires_on.isoformat()}:{lead_days}"
+        if reminder.get("last_notification_window_key") == window_key:
+            continue
+
+        days_until_expiry = (expires_on - current_date).days
+        notification = _create_expiration_notification(reminder, settings, days_until_expiry)
+        if not notification:
+            continue
+
+        _emit_external_expiration_notification_event(reminder, notification, days_until_expiry, settings)
+        reminder["last_notified_at"] = _now_iso()
+        reminder["last_notification_window_key"] = window_key
+        reminder["updated_at"] = _now_iso()
+        cosmos_key_vault_secret_reminders_container.upsert_item(reminder)
+        notifications_created += 1
+
+    log_event(
+        "[KeyVaultReminders] Reminder sweep completed.",
+        extra={"checked": checked, "notifications_created": notifications_created},
+        level=logging.INFO,
+    )
+    return {
+        "enabled": True,
+        "checked": checked,
+        "notifications_created": notifications_created,
+    }

--- a/application/single_app/functions_notifications.py
+++ b/application/single_app/functions_notifications.py
@@ -27,6 +27,7 @@ from functions_public_workspaces import find_public_workspace_by_id, get_user_pu
 TTL_60_DAYS = 60 * 24 * 60 * 60  # 60 days in seconds (5184000)
 ASSIGNMENT_NOTIFICATIONS_PARTITION_KEY = 'assignment-notifications'
 WORKFLOW_ALERT_NOTIFICATION_TYPE = 'workflow_priority_alert'
+KEY_VAULT_SECRET_REMINDER_NOTIFICATION_TYPE = 'key_vault_secret_expiring'
 WORKFLOW_ALERT_PRIORITY_CONFIG = {
     'low': {
         'icon': 'bi-bell',
@@ -163,6 +164,10 @@ NOTIFICATION_TYPES = {
     WORKFLOW_ALERT_NOTIFICATION_TYPE: {
         'icon': 'bi-bell',
         'color': 'secondary'
+    },
+    KEY_VAULT_SECRET_REMINDER_NOTIFICATION_TYPE: {
+        'icon': 'bi-safe',
+        'color': 'warning'
     }
 }
 

--- a/application/single_app/functions_settings.py
+++ b/application/single_app/functions_settings.py
@@ -193,6 +193,81 @@ def normalize_document_access_index_required_settings(settings):
     return changed
 
 
+def _normalize_key_vault_admin_roles(value):
+    if isinstance(value, list):
+        raw_roles = value
+    elif isinstance(value, str):
+        raw_roles = value.replace(";", ",").split(",")
+    else:
+        raw_roles = []
+
+    roles = []
+    for role in raw_roles:
+        normalized_role = str(role or "").strip()[:80]
+        if normalized_role and normalized_role not in roles:
+            roles.append(normalized_role)
+    return roles or ["Admin"]
+
+
+def _normalize_key_vault_reminder_int(value, default_value, minimum, maximum):
+    try:
+        parsed_value = int(value)
+    except (TypeError, ValueError):
+        parsed_value = default_value
+    return min(max(parsed_value, minimum), maximum)
+
+
+def _normalize_key_vault_reminder_bool(value):
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def normalize_key_vault_reminder_settings(settings):
+    """Normalize stored Key Vault expiration reminder settings in-place."""
+    if not isinstance(settings, dict):
+        return False
+
+    normalized_values = {
+        "enable_key_vault_secret_expiration_reminders": _normalize_key_vault_reminder_bool(
+            settings.get("enable_key_vault_secret_expiration_reminders", False)
+        ),
+        "key_vault_secret_expiration_default_lead_days": _normalize_key_vault_reminder_int(
+            settings.get("key_vault_secret_expiration_default_lead_days"),
+            30,
+            1,
+            3650,
+        ),
+        "key_vault_secret_expiration_default_contact_email": str(
+            settings.get("key_vault_secret_expiration_default_contact_email") or ""
+        ).strip()[:254],
+        "key_vault_secret_expiration_require_expiration": _normalize_key_vault_reminder_bool(
+            settings.get("key_vault_secret_expiration_require_expiration", False)
+        ),
+        "key_vault_secret_expiration_emit_contact_email_in_telemetry": _normalize_key_vault_reminder_bool(
+            settings.get("key_vault_secret_expiration_emit_contact_email_in_telemetry", False)
+        ),
+        "key_vault_secret_expiration_admin_roles": _normalize_key_vault_admin_roles(
+            settings.get("key_vault_secret_expiration_admin_roles")
+        ),
+        "key_vault_secret_expiration_scan_interval_seconds": _normalize_key_vault_reminder_int(
+            settings.get("key_vault_secret_expiration_scan_interval_seconds"),
+            21600,
+            900,
+            86400,
+        ),
+    }
+
+    changed = False
+    for key, normalized_value in normalized_values.items():
+        if settings.get(key) != normalized_value:
+            settings[key] = normalized_value
+            changed = True
+    return changed
+
+
 def redact_admin_settings_secrets_for_form(settings):
     redacted_settings = copy.deepcopy(settings or {})
     for field_name in ADMIN_SETTINGS_FORM_SECRET_FIELDS:
@@ -1435,6 +1510,13 @@ def get_settings(use_cosmos=False, include_source=False):
         'enable_key_vault_secret_storage': False,
         'key_vault_name': '',
         'key_vault_identity': '',
+        'enable_key_vault_secret_expiration_reminders': False,
+        'key_vault_secret_expiration_default_lead_days': 30,
+        'key_vault_secret_expiration_default_contact_email': '',
+        'key_vault_secret_expiration_require_expiration': False,
+        'key_vault_secret_expiration_emit_contact_email_in_telemetry': False,
+        'key_vault_secret_expiration_admin_roles': ['Admin'],
+        'key_vault_secret_expiration_scan_interval_seconds': 21600,
         
         # Retention Policy Settings
         'enable_retention_policy_personal': False,
@@ -1566,6 +1648,7 @@ def get_settings(use_cosmos=False, include_source=False):
         document_access_index_settings_updated = normalize_document_access_index_required_settings(merged)
         inbound_mcp_settings_updated = normalize_inbound_mcp_settings(merged)
         public_workspace_display_settings_updated = normalize_public_workspace_display_settings(merged)
+        key_vault_reminder_settings_updated = normalize_key_vault_reminder_settings(merged)
 
         merged['enable_tabular_processing_plugin'] = is_tabular_processing_enabled(merged)
 
@@ -1579,6 +1662,7 @@ def get_settings(use_cosmos=False, include_source=False):
             or document_access_index_settings_updated
             or inbound_mcp_settings_updated
             or public_workspace_display_settings_updated
+            or key_vault_reminder_settings_updated
         ):
             cosmos_settings_container.upsert_item(merged)
             _refresh_app_settings_cache_after_write(merged, context="merge_upsert")
@@ -1631,6 +1715,7 @@ def update_settings(new_settings):
         normalize_document_access_index_required_settings(settings_item)
         normalize_inbound_mcp_settings(settings_item)
         normalize_public_workspace_display_settings(settings_item)
+        normalize_key_vault_reminder_settings(settings_item)
         settings_item['enable_multi_model_endpoints'] = coerce_multi_model_endpoint_enablement(
             existing_multi_endpoint_enabled,
             settings_item.get('enable_multi_model_endpoints', False),

--- a/application/single_app/route_backend_plugins.py
+++ b/application/single_app/route_backend_plugins.py
@@ -125,6 +125,13 @@ from functions_governance import (
 )
 
 
+ACTION_VALIDATION_ERROR_MESSAGE = "Invalid action configuration."
+ACTION_PERMISSION_ERROR_MESSAGE = "You are not authorized to save this action."
+ACTION_KEY_VAULT_ERROR_MESSAGE = "Unable to store action secrets in Key Vault."
+PLUGIN_VALIDATION_ERROR_MESSAGE = "Invalid plugin configuration."
+PLUGIN_KEY_VAULT_ERROR_MESSAGE = "Unable to store plugin secrets in Key Vault."
+
+
 DOCUMENT_SEARCH_INTERNAL_ENDPOINT = 'internal://document-search'
 
 
@@ -957,13 +964,13 @@ def set_user_plugins():
             
     except ValueError as e:
         debug_print(f"Validation error saving personal actions for user {user_id}: {e}")
-        return jsonify({'error': str(e)}), 400
+        return jsonify({'error': ACTION_VALIDATION_ERROR_MESSAGE}), 400
     except PermissionError as e:
         debug_print(f"Governance denied saving personal actions for user {user_id}: {e}")
-        return jsonify({'error': str(e)}), 403
+        return jsonify({'error': ACTION_PERMISSION_ERROR_MESSAGE}), 403
     except RuntimeError as e:
         debug_print(f"Key Vault error saving personal actions for user {user_id}: {e}")
-        return jsonify({'error': str(e)}), 500
+        return jsonify({'error': ACTION_KEY_VAULT_ERROR_MESSAGE}), 500
     except Exception as e:
         debug_print(f"Error saving personal actions for user {user_id}: {e}")
         return jsonify({'error': 'Failed to save plugins'}), 500
@@ -1149,12 +1156,14 @@ def create_group_action_route():
     try:
         saved = save_group_action(active_group, payload, user_id=user_id)
     except ValueError as exc:
-        return jsonify({'error': str(exc)}), 400
+        debug_print('Validation error saving group action: %s', exc)
+        return jsonify({'error': ACTION_VALIDATION_ERROR_MESSAGE}), 400
     except PermissionError as exc:
-        return jsonify({'error': str(exc)}), 403
+        debug_print('Permission denied saving group action: %s', exc)
+        return jsonify({'error': ACTION_PERMISSION_ERROR_MESSAGE}), 403
     except RuntimeError as exc:
         debug_print('Key Vault error saving group action: %s', exc)
-        return jsonify({'error': str(exc)}), 500
+        return jsonify({'error': ACTION_KEY_VAULT_ERROR_MESSAGE}), 500
     except Exception as exc:
         debug_print('Failed to save group action: %s', exc)
         return jsonify({'error': 'Unable to save action'}), 500
@@ -1249,12 +1258,14 @@ def update_group_action_route(action_id):
     try:
         saved = save_group_action(active_group, merged, user_id=user_id)
     except ValueError as exc:
-        return jsonify({'error': str(exc)}), 400
+        debug_print('Validation error updating group action %s: %s', action_id, exc)
+        return jsonify({'error': ACTION_VALIDATION_ERROR_MESSAGE}), 400
     except PermissionError as exc:
-        return jsonify({'error': str(exc)}), 403
+        debug_print('Permission denied updating group action %s: %s', action_id, exc)
+        return jsonify({'error': ACTION_PERMISSION_ERROR_MESSAGE}), 403
     except RuntimeError as exc:
         debug_print('Key Vault error updating group action %s: %s', action_id, exc)
-        return jsonify({'error': str(exc)}), 500
+        return jsonify({'error': ACTION_KEY_VAULT_ERROR_MESSAGE}), 500
     except Exception as exc:
         debug_print('Failed to update group action %s: %s', action_id, exc)
         return jsonify({'error': 'Unable to update action'}), 500
@@ -1563,10 +1574,10 @@ def add_plugin():
         return jsonify({'success': True})
     except ValueError as e:
         log_event(f"Validation error adding plugin: {e}", level=logging.WARNING)
-        return jsonify({'error': str(e)}), 400
+        return jsonify({'error': PLUGIN_VALIDATION_ERROR_MESSAGE}), 400
     except RuntimeError as e:
         log_event(f"Key Vault error adding plugin: {e}", level=logging.ERROR)
-        return jsonify({'error': str(e)}), 500
+        return jsonify({'error': PLUGIN_KEY_VAULT_ERROR_MESSAGE}), 500
     except Exception as e:
         log_event(f"Error adding plugin: {e}", level=logging.ERROR)
         return jsonify({'error': 'Failed to add plugin.'}), 500
@@ -1672,10 +1683,10 @@ def edit_plugin(plugin_name):
         return jsonify({'error': 'Plugin not found.'}), 404
     except ValueError as e:
         log_event(f"Validation error editing plugin: {e}", level=logging.WARNING)
-        return jsonify({'error': str(e)}), 400
+        return jsonify({'error': PLUGIN_VALIDATION_ERROR_MESSAGE}), 400
     except RuntimeError as e:
         log_event(f"Key Vault error editing plugin: {e}", level=logging.ERROR)
-        return jsonify({'error': str(e)}), 500
+        return jsonify({'error': PLUGIN_KEY_VAULT_ERROR_MESSAGE}), 500
     except Exception as e:
         log_event(f"Error editing plugin: {e}", level=logging.ERROR)
         return jsonify({'error': 'Failed to edit plugin.'}), 500

--- a/application/single_app/route_backend_plugins.py
+++ b/application/single_app/route_backend_plugins.py
@@ -961,6 +961,9 @@ def set_user_plugins():
     except PermissionError as e:
         debug_print(f"Governance denied saving personal actions for user {user_id}: {e}")
         return jsonify({'error': str(e)}), 403
+    except RuntimeError as e:
+        debug_print(f"Key Vault error saving personal actions for user {user_id}: {e}")
+        return jsonify({'error': str(e)}), 500
     except Exception as e:
         debug_print(f"Error saving personal actions for user {user_id}: {e}")
         return jsonify({'error': 'Failed to save plugins'}), 500
@@ -1145,8 +1148,13 @@ def create_group_action_route():
 
     try:
         saved = save_group_action(active_group, payload, user_id=user_id)
+    except ValueError as exc:
+        return jsonify({'error': str(exc)}), 400
     except PermissionError as exc:
         return jsonify({'error': str(exc)}), 403
+    except RuntimeError as exc:
+        debug_print('Key Vault error saving group action: %s', exc)
+        return jsonify({'error': str(exc)}), 500
     except Exception as exc:
         debug_print('Failed to save group action: %s', exc)
         return jsonify({'error': 'Unable to save action'}), 500
@@ -1240,8 +1248,13 @@ def update_group_action_route(action_id):
 
     try:
         saved = save_group_action(active_group, merged, user_id=user_id)
+    except ValueError as exc:
+        return jsonify({'error': str(exc)}), 400
     except PermissionError as exc:
         return jsonify({'error': str(exc)}), 403
+    except RuntimeError as exc:
+        debug_print('Key Vault error updating group action %s: %s', action_id, exc)
+        return jsonify({'error': str(exc)}), 500
     except Exception as exc:
         debug_print('Failed to update group action %s: %s', action_id, exc)
         return jsonify({'error': 'Unable to update action'}), 500
@@ -1548,6 +1561,12 @@ def add_plugin():
         # --- HOT RELOAD TRIGGER ---
         setattr(builtins, "kernel_reload_needed", True)
         return jsonify({'success': True})
+    except ValueError as e:
+        log_event(f"Validation error adding plugin: {e}", level=logging.WARNING)
+        return jsonify({'error': str(e)}), 400
+    except RuntimeError as e:
+        log_event(f"Key Vault error adding plugin: {e}", level=logging.ERROR)
+        return jsonify({'error': str(e)}), 500
     except Exception as e:
         log_event(f"Error adding plugin: {e}", level=logging.ERROR)
         return jsonify({'error': 'Failed to add plugin.'}), 500
@@ -1651,6 +1670,12 @@ def edit_plugin(plugin_name):
         
         log_event("Edit plugin failed: not found", level=logging.WARNING, extra={"action": "edit", "plugin_name": plugin_name})
         return jsonify({'error': 'Plugin not found.'}), 404
+    except ValueError as e:
+        log_event(f"Validation error editing plugin: {e}", level=logging.WARNING)
+        return jsonify({'error': str(e)}), 400
+    except RuntimeError as e:
+        log_event(f"Key Vault error editing plugin: {e}", level=logging.ERROR)
+        return jsonify({'error': str(e)}), 500
     except Exception as e:
         log_event(f"Error editing plugin: {e}", level=logging.ERROR)
         return jsonify({'error': 'Failed to edit plugin.'}), 500

--- a/application/single_app/route_backend_settings.py
+++ b/application/single_app/route_backend_settings.py
@@ -29,6 +29,10 @@ from functions_cosmos_throughput import (
     set_database_throughput,
 )
 from functions_app_maintenance import get_app_maintenance_status, run_app_maintenance_once
+from functions_keyvault_reminders import (
+    check_due_key_vault_secret_reminders_once,
+    list_key_vault_secret_reminders,
+)
 from functions_redis_monitoring import (
     get_redis_explorer_keys,
     get_redis_explorer_value,
@@ -201,6 +205,48 @@ def auto_fix_index_fields(idx_type: str, user_id: str = 'system', admin_email: s
 
 
 def register_route_backend_settings(bp):
+    @bp.route('/api/admin/settings/key-vault/secret-reminders', methods=['GET'])
+    @swagger_route(security=get_auth_security())
+    @login_required
+    @admin_required
+    def list_key_vault_secret_reminders_admin():
+        """Return Key Vault secret expiration reminder inventory for admins."""
+        try:
+            reminders = list_key_vault_secret_reminders(
+                status=request.args.get('status', ''),
+                scope=request.args.get('scope', ''),
+                source_type=request.args.get('source_type', ''),
+                search=request.args.get('search', ''),
+                limit=request.args.get('limit', 250),
+            )
+            return jsonify({'success': True, 'reminders': reminders}), 200
+        except Exception as exc:
+            log_event(
+                '[KeyVaultReminders] Failed to load admin inventory.',
+                extra={'error': str(exc)},
+                level=logging.ERROR,
+                exceptionTraceback=True,
+            )
+            return jsonify({'error': 'Failed to load Key Vault reminder inventory.'}), 500
+
+    @bp.route('/api/admin/settings/key-vault/secret-reminders/run', methods=['POST'])
+    @swagger_route(security=get_auth_security())
+    @login_required
+    @admin_required
+    def run_key_vault_secret_reminders_admin():
+        """Run the Key Vault expiration reminder sweep on demand."""
+        try:
+            result = check_due_key_vault_secret_reminders_once(settings=get_settings())
+            return jsonify({'success': True, 'result': result}), 200
+        except Exception as exc:
+            log_event(
+                '[KeyVaultReminders] Failed to run admin-triggered reminder sweep.',
+                extra={'error': str(exc)},
+                level=logging.ERROR,
+                exceptionTraceback=True,
+            )
+            return jsonify({'error': 'Failed to run Key Vault reminder sweep.'}), 500
+
     @bp.route('/api/admin/settings/app-maintenance/status', methods=['GET'])
     @swagger_route(security=get_auth_security())
     @login_required

--- a/application/single_app/route_frontend_admin_settings.py
+++ b/application/single_app/route_frontend_admin_settings.py
@@ -880,6 +880,7 @@ def register_route_frontend_admin_settings(bp):
             settings['key_vault_name'] = ''
         if 'key_vault_identity' not in settings:
             settings['key_vault_identity'] = ''
+        normalize_key_vault_reminder_settings(settings)
 
             # --- Add defaults for left nav ---
         if 'enable_left_nav_default' not in settings:
@@ -2675,6 +2676,13 @@ def register_route_frontend_admin_settings(bp):
                 'enable_key_vault_secret_storage': form_data.get('enable_key_vault_secret_storage') == 'on',
                 'key_vault_name': form_data.get('key_vault_name', '').strip(),
                 'key_vault_identity': form_data.get('key_vault_identity', ''),
+                'enable_key_vault_secret_expiration_reminders': form_data.get('enable_key_vault_secret_expiration_reminders') == 'on',
+                'key_vault_secret_expiration_default_lead_days': form_data.get('key_vault_secret_expiration_default_lead_days', '30'),
+                'key_vault_secret_expiration_default_contact_email': form_data.get('key_vault_secret_expiration_default_contact_email', '').strip(),
+                'key_vault_secret_expiration_require_expiration': form_data.get('key_vault_secret_expiration_require_expiration') == 'on',
+                'key_vault_secret_expiration_emit_contact_email_in_telemetry': form_data.get('key_vault_secret_expiration_emit_contact_email_in_telemetry') == 'on',
+                'key_vault_secret_expiration_admin_roles': form_data.get('key_vault_secret_expiration_admin_roles', 'Admin'),
+                'key_vault_secret_expiration_scan_interval_seconds': form_data.get('key_vault_secret_expiration_scan_interval_seconds', '21600'),
 
                 # Authentication & Redirect Settings
                 'enable_front_door': enable_front_door,

--- a/application/single_app/static/js/admin/admin_settings.js
+++ b/application/single_app/static/js/admin/admin_settings.js
@@ -4917,6 +4917,143 @@ function setupFileDownloadAssignments() {
     }).setup();
 }
 
+function setKeyVaultReminderStatus(message, variant = 'info') {
+    const statusElement = document.getElementById('key-vault-reminders-status-message');
+    if (!statusElement) {
+        return;
+    }
+
+    statusElement.textContent = message || '';
+    statusElement.className = `alert alert-${variant}${message ? '' : ' d-none'}`;
+}
+
+function appendKeyVaultReminderCell(row, text, className = '') {
+    const cell = document.createElement('td');
+    if (className) {
+        cell.className = className;
+    }
+    cell.textContent = text || '';
+    row.appendChild(cell);
+}
+
+function formatKeyVaultReminderExpiry(reminder) {
+    const expiresOn = reminder.expires_on || 'Unknown';
+    if (typeof reminder.days_until_expiry !== 'number') {
+        return expiresOn;
+    }
+    if (reminder.days_until_expiry < 0) {
+        return `${expiresOn} (${Math.abs(reminder.days_until_expiry)} days expired)`;
+    }
+    if (reminder.days_until_expiry === 0) {
+        return `${expiresOn} (today)`;
+    }
+    return `${expiresOn} (${reminder.days_until_expiry} days)`;
+}
+
+function renderKeyVaultReminderInventory(reminders) {
+    const tableBody = document.getElementById('key-vault-reminders-table-body');
+    if (!tableBody) {
+        return;
+    }
+
+    tableBody.replaceChildren();
+    if (!Array.isArray(reminders) || reminders.length === 0) {
+        const row = document.createElement('tr');
+        const cell = document.createElement('td');
+        cell.colSpan = 8;
+        cell.className = 'text-muted';
+        cell.textContent = 'No Key Vault reminder inventory entries match the current filters.';
+        row.appendChild(cell);
+        tableBody.appendChild(row);
+        return;
+    }
+
+    reminders.forEach(reminder => {
+        const row = document.createElement('tr');
+        const sourceLabel = reminder.source_display_name || reminder.source_name || reminder.source_id || '';
+        const fieldLabel = reminder.field_label || reminder.field_path || '';
+        const statusLabel = reminder.key_vault_sync_status === 'sync_failed'
+            ? `${reminder.status || 'sync_failed'}: ${reminder.key_vault_sync_error || 'Key Vault sync failed'}`
+            : (reminder.status || '');
+
+        appendKeyVaultReminderCell(row, formatKeyVaultReminderExpiry(reminder));
+        appendKeyVaultReminderCell(row, `${reminder.scope || ''}: ${reminder.scope_value || ''}`);
+        appendKeyVaultReminderCell(row, sourceLabel);
+        appendKeyVaultReminderCell(row, fieldLabel);
+        appendKeyVaultReminderCell(row, reminder.contact_email || '');
+        appendKeyVaultReminderCell(row, statusLabel);
+        appendKeyVaultReminderCell(row, reminder.id || '', 'font-monospace small');
+        appendKeyVaultReminderCell(row, reminder.secret_name || '', 'font-monospace small');
+        tableBody.appendChild(row);
+    });
+}
+
+async function loadKeyVaultReminderInventory() {
+    const refreshButton = document.getElementById('key-vault-reminders-refresh');
+    const searchInput = document.getElementById('key-vault-reminders-search');
+    const statusSelect = document.getElementById('key-vault-reminders-status');
+    const params = new URLSearchParams();
+    if (searchInput?.value.trim()) {
+        params.set('search', searchInput.value.trim());
+    }
+    if (statusSelect?.value) {
+        params.set('status', statusSelect.value);
+    }
+
+    setKeyVaultReminderStatus('Loading Key Vault reminder inventory...', 'info');
+    if (refreshButton) {
+        refreshButton.disabled = true;
+    }
+
+    try {
+        const response = await fetch(`/api/admin/settings/key-vault/secret-reminders?${params.toString()}`);
+        const data = await response.json();
+        if (!response.ok || !data.success) {
+            throw new Error(data.error || 'Failed to load Key Vault reminder inventory.');
+        }
+        renderKeyVaultReminderInventory(data.reminders || []);
+        setKeyVaultReminderStatus(`Loaded ${Array.isArray(data.reminders) ? data.reminders.length : 0} reminder entries.`, 'success');
+    } catch (error) {
+        renderKeyVaultReminderInventory([]);
+        setKeyVaultReminderStatus(error.message || 'Failed to load Key Vault reminder inventory.', 'danger');
+    } finally {
+        if (refreshButton) {
+            refreshButton.disabled = false;
+        }
+    }
+}
+
+async function runKeyVaultReminderSweep() {
+    const runButton = document.getElementById('key-vault-reminders-run');
+    setKeyVaultReminderStatus('Running Key Vault reminder sweep...', 'info');
+    if (runButton) {
+        runButton.disabled = true;
+    }
+
+    try {
+        const response = await fetch('/api/admin/settings/key-vault/secret-reminders/run', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' }
+        });
+        const data = await response.json();
+        if (!response.ok || !data.success) {
+            throw new Error(data.error || 'Failed to run Key Vault reminder sweep.');
+        }
+        const result = data.result || {};
+        setKeyVaultReminderStatus(
+            `Reminder sweep checked ${result.checked || 0} entries and created ${result.notifications_created || 0} notifications.`,
+            'success'
+        );
+        await loadKeyVaultReminderInventory();
+    } catch (error) {
+        setKeyVaultReminderStatus(error.message || 'Failed to run Key Vault reminder sweep.', 'danger');
+    } finally {
+        if (runButton) {
+            runButton.disabled = false;
+        }
+    }
+}
+
 document.addEventListener('DOMContentLoaded', () => {
     setupAdminFormAutofillMetadata();
 
@@ -6694,12 +6831,43 @@ function setupToggles() {
 
     const enableKeyVaultCheckbox = document.getElementById('enable_key_vault_secret_storage');
     if (enableKeyVaultCheckbox) {
+        const keyVaultSettings = document.getElementById('key_vault_settings');
+        if (keyVaultSettings) {
+            keyVaultSettings.classList.toggle('d-none', !enableKeyVaultCheckbox.checked);
+        }
         enableKeyVaultCheckbox.addEventListener('change', function() {
-            const keyVaultSettings = document.getElementById('key_vault_settings');
-            keyVaultSettings.style.display = this.checked ? 'block' : 'none';
+            if (keyVaultSettings) {
+                keyVaultSettings.classList.toggle('d-none', !this.checked);
+            }
             markFormAsModified();
         });
     }
+
+    const enableKeyVaultRemindersCheckbox = document.getElementById('enable_key_vault_secret_expiration_reminders');
+    const keyVaultReminderSettings = document.getElementById('key_vault_expiration_reminder_settings');
+    if (enableKeyVaultRemindersCheckbox && keyVaultReminderSettings) {
+        keyVaultReminderSettings.classList.toggle('d-none', !enableKeyVaultRemindersCheckbox.checked);
+        enableKeyVaultRemindersCheckbox.addEventListener('change', function() {
+            keyVaultReminderSettings.classList.toggle('d-none', !this.checked);
+            markFormAsModified();
+        });
+    }
+
+    document.getElementById('key-vault-reminders-refresh')?.addEventListener('click', () => {
+        void loadKeyVaultReminderInventory();
+    });
+    document.getElementById('key-vault-reminders-run')?.addEventListener('click', () => {
+        void runKeyVaultReminderSweep();
+    });
+    document.getElementById('key-vault-reminders-search')?.addEventListener('keydown', event => {
+        if (event.key === 'Enter') {
+            event.preventDefault();
+            void loadKeyVaultReminderInventory();
+        }
+    });
+    document.getElementById('key-vault-reminders-status')?.addEventListener('change', () => {
+        void loadKeyVaultReminderInventory();
+    });
 
     const enableWebSearch = document.getElementById('enable_web_search');
     const webSearchFoundrySettings = document.getElementById('web_search_foundry_settings');

--- a/application/single_app/static/js/plugin_modal_stepper.js
+++ b/application/single_app/static/js/plugin_modal_stepper.js
@@ -25,6 +25,8 @@ const TABLEAU_AUTH_METHOD_PAT = 'personal_access_token';
 const TABLEAU_AUTH_METHOD_USERNAME_PASSWORD = 'username_password';
 const publicWorkspacePlural = window.getPublicWorkspaceLabel ? window.getPublicWorkspaceLabel('plural') : 'Public Workspaces';
 const MCP_PLUGIN_TYPE = 'mcp';
+const KEY_VAULT_SECRET_REMINDERS_METADATA_FIELD = 'key_vault_secret_reminders';
+const KEY_VAULT_SECRET_REMINDER_ALL_FIELDS = '__all__';
 const MCP_HEADER_NAME_PATTERN = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
 const MCP_MAX_CUSTOM_HEADER_COUNT = 20;
 const MCP_MAX_HEADER_VALUE_LENGTH = 4096;
@@ -706,6 +708,11 @@ export class PluginModalStepper {
       testCosmosBtn.addEventListener('click', () => this.testCosmosConnection());
     }
 
+    const keyVaultReminderToggle = document.getElementById('plugin-key-vault-reminder-enabled');
+    if (keyVaultReminderToggle) {
+      keyVaultReminderToggle.addEventListener('change', () => this.toggleKeyVaultReminderFields());
+    }
+
     // Set up display name to generated name conversion
     this.setupNameGeneration();
 
@@ -717,6 +724,145 @@ export class PluginModalStepper {
         document.getElementById('plugin-name').value = actionName;
       }
     });
+  }
+
+  toggleKeyVaultReminderFields() {
+    const reminderToggle = document.getElementById('plugin-key-vault-reminder-enabled');
+    const reminderFields = document.getElementById('plugin-key-vault-reminder-fields');
+    if (!reminderToggle || !reminderFields) {
+      return;
+    }
+    reminderFields.classList.toggle('d-none', !reminderToggle.checked);
+  }
+
+  clearKeyVaultReminderForm() {
+    const reminderToggle = document.getElementById('plugin-key-vault-reminder-enabled');
+    if (reminderToggle) {
+      reminderToggle.checked = false;
+    }
+    [
+      'plugin-key-vault-reminder-expires-on',
+      'plugin-key-vault-reminder-email',
+      'plugin-key-vault-reminder-label',
+      'plugin-key-vault-reminder-notes'
+    ].forEach(id => {
+      const element = document.getElementById(id);
+      if (element) {
+        element.value = element.dataset.defaultValue || '';
+      }
+    });
+    const leadDays = document.getElementById('plugin-key-vault-reminder-lead-days');
+    if (leadDays) {
+      leadDays.value = leadDays.dataset.defaultValue || leadDays.defaultValue || '30';
+    }
+    this.toggleKeyVaultReminderFields();
+  }
+
+  getKeyVaultReminderAllConfig(metadata) {
+    const reminders = metadata && typeof metadata === 'object'
+      ? metadata[KEY_VAULT_SECRET_REMINDERS_METADATA_FIELD]
+      : null;
+    if (!reminders || typeof reminders !== 'object') {
+      return null;
+    }
+    const allConfig = reminders[KEY_VAULT_SECRET_REMINDER_ALL_FIELDS];
+    return allConfig && typeof allConfig === 'object' ? allConfig : null;
+  }
+
+  populateKeyVaultReminderForm(metadata) {
+    this.clearKeyVaultReminderForm();
+    const allConfig = this.getKeyVaultReminderAllConfig(metadata);
+    if (!allConfig || !allConfig.enabled) {
+      return;
+    }
+
+    const reminderToggle = document.getElementById('plugin-key-vault-reminder-enabled');
+    if (reminderToggle) {
+      reminderToggle.checked = true;
+    }
+    const expiresOn = document.getElementById('plugin-key-vault-reminder-expires-on');
+    const email = document.getElementById('plugin-key-vault-reminder-email');
+    const leadDays = document.getElementById('plugin-key-vault-reminder-lead-days');
+    const label = document.getElementById('plugin-key-vault-reminder-label');
+    const notes = document.getElementById('plugin-key-vault-reminder-notes');
+    if (expiresOn) {
+      expiresOn.value = String(allConfig.expires_on || allConfig.expiration_date || '').slice(0, 10);
+    }
+    if (email) {
+      email.value = allConfig.contact_email || allConfig.reminder_email || '';
+    }
+    if (leadDays) {
+      leadDays.value = allConfig.lead_days || '30';
+    }
+    if (label) {
+      label.value = allConfig.label || allConfig.friendly_label || '';
+    }
+    if (notes) {
+      notes.value = allConfig.notes || allConfig.rotation_notes || '';
+    }
+    this.toggleKeyVaultReminderFields();
+  }
+
+  validateKeyVaultReminderFields() {
+    const reminderToggle = document.getElementById('plugin-key-vault-reminder-enabled');
+    if (!reminderToggle?.checked) {
+      return true;
+    }
+
+    const expiresOn = document.getElementById('plugin-key-vault-reminder-expires-on')?.value.trim();
+    const email = document.getElementById('plugin-key-vault-reminder-email')?.value.trim();
+    const leadDays = parseInt(document.getElementById('plugin-key-vault-reminder-lead-days')?.value || '30', 10);
+    if (!expiresOn) {
+      this.showError('Expiration date is required when Key Vault expiration tracking is enabled.');
+      return false;
+    }
+    if (!email || !email.includes('@')) {
+      this.showError('A valid reminder email is required when Key Vault expiration tracking is enabled.');
+      return false;
+    }
+    if (!Number.isInteger(leadDays) || leadDays < 1 || leadDays > 3650) {
+      this.showError('Lead days must be between 1 and 3650.');
+      return false;
+    }
+    return true;
+  }
+
+  applyKeyVaultReminderMetadata(metadata) {
+    const normalizedMetadata = metadata && typeof metadata === 'object' ? metadata : {};
+    const reminderToggle = document.getElementById('plugin-key-vault-reminder-enabled');
+    if (!reminderToggle) {
+      return normalizedMetadata;
+    }
+
+    const existingReminders = normalizedMetadata[KEY_VAULT_SECRET_REMINDERS_METADATA_FIELD];
+    const hasExistingAllConfig = Boolean(
+      existingReminders
+      && typeof existingReminders === 'object'
+      && existingReminders[KEY_VAULT_SECRET_REMINDER_ALL_FIELDS]
+    );
+    if (!reminderToggle.checked) {
+      if (hasExistingAllConfig) {
+        normalizedMetadata[KEY_VAULT_SECRET_REMINDERS_METADATA_FIELD] = {
+          ...existingReminders,
+          [KEY_VAULT_SECRET_REMINDER_ALL_FIELDS]: { enabled: false }
+        };
+      }
+      return normalizedMetadata;
+    }
+
+    const leadDays = parseInt(document.getElementById('plugin-key-vault-reminder-lead-days')?.value || '30', 10);
+    normalizedMetadata[KEY_VAULT_SECRET_REMINDERS_METADATA_FIELD] = {
+      ...(existingReminders && typeof existingReminders === 'object' ? existingReminders : {}),
+      [KEY_VAULT_SECRET_REMINDER_ALL_FIELDS]: {
+        enabled: true,
+        expires_on: document.getElementById('plugin-key-vault-reminder-expires-on')?.value.trim() || '',
+        contact_email: document.getElementById('plugin-key-vault-reminder-email')?.value.trim() || '',
+        lead_days: Number.isInteger(leadDays) ? leadDays : 30,
+        label: document.getElementById('plugin-key-vault-reminder-label')?.value.trim() || '',
+        notes: document.getElementById('plugin-key-vault-reminder-notes')?.value.trim() || ''
+      }
+    };
+    return normalizedMetadata;
   }
 
   async showModal(plugin = null) {
@@ -3902,6 +4048,7 @@ export class PluginModalStepper {
       case 4:
         // Validate JSON fields
         if (!this.validateJSONField('plugin-metadata', 'Metadata')) return false;
+        if (!this.validateKeyVaultReminderFields()) return false;
         //if (!this.validateJSONField('plugin-additional-fields', 'Additional Fields')) return false;
         break;
     }
@@ -4918,6 +5065,7 @@ export class PluginModalStepper {
       JSON.stringify(plugin.additionalFields, null, 2) : '{}';
 
     document.getElementById('plugin-metadata').value = metadata;
+    this.populateKeyVaultReminderForm(plugin.metadata || {});
     try {
       document.getElementById('plugin-additional-fields').value = additionalFields;
     } catch (e) {
@@ -5276,6 +5424,7 @@ export class PluginModalStepper {
     try {
       const metadataValue = document.getElementById('plugin-metadata').value.trim();
       metadata = metadataValue ? JSON.parse(metadataValue) : {};
+      metadata = this.applyKeyVaultReminderMetadata(metadata);
     } catch (e) {
       throw new Error('Invalid metadata JSON');
     }
@@ -6593,6 +6742,7 @@ export class PluginModalStepper {
     this.blobStorageReadFileTypeState = this.getDefaultBlobStorageReadFileTypes();
     this.blobStorageUploadFileTypeState = this.getDefaultBlobStorageUploadFileTypes();
     this.renderBlobStorageConfiguration();
+    this.clearKeyVaultReminderForm();
 
     // Clear any type selection
     this.selectedType = null;

--- a/application/single_app/templates/_plugin_modal.html
+++ b/application/single_app/templates/_plugin_modal.html
@@ -1250,6 +1250,56 @@
             </button>
           </div>
           <div class="collapse" id="plugin-advanced-collapse">
+            <div class="card border-info mb-3">
+              <div class="card-body">
+                <div class="form-check form-switch mb-2">
+                  <input class="form-check-input" type="checkbox" id="plugin-key-vault-reminder-enabled">
+                  <label class="form-check-label fw-semibold" for="plugin-key-vault-reminder-enabled">
+                    Track expiration for Key Vault-backed secrets in this action
+                  </label>
+                </div>
+                <p class="text-muted small mb-3">
+                  Applies the same expiration reminder metadata to every action secret stored in Key Vault, such as API keys, service principal secrets, passwords, connection strings, and custom secret fields.
+                </p>
+                <div id="plugin-key-vault-reminder-fields" class="row g-3 d-none">
+                  <div class="col-md-4">
+                    <label for="plugin-key-vault-reminder-expires-on" class="form-label">Expiration date</label>
+                    <input type="date" class="form-control" id="plugin-key-vault-reminder-expires-on">
+                  </div>
+                  <div class="col-md-4">
+                    <label for="plugin-key-vault-reminder-email" class="form-label">Reminder email</label>
+                    <input
+                      type="email"
+                      class="form-control"
+                      id="plugin-key-vault-reminder-email"
+                      value="{{ (settings.key_vault_secret_expiration_default_contact_email if settings is defined else '') or '' }}"
+                      data-default-value="{{ (settings.key_vault_secret_expiration_default_contact_email if settings is defined else '') or '' }}"
+                      placeholder="owner@example.com"
+                    >
+                  </div>
+                  <div class="col-md-4">
+                    <label for="plugin-key-vault-reminder-lead-days" class="form-label">Lead days</label>
+                    <input
+                      type="number"
+                      min="1"
+                      max="3650"
+                      class="form-control"
+                      id="plugin-key-vault-reminder-lead-days"
+                      value="{{ (settings.key_vault_secret_expiration_default_lead_days if settings is defined else 30) or 30 }}"
+                      data-default-value="{{ (settings.key_vault_secret_expiration_default_lead_days if settings is defined else 30) or 30 }}"
+                    >
+                  </div>
+                  <div class="col-md-6">
+                    <label for="plugin-key-vault-reminder-label" class="form-label">Friendly label</label>
+                    <input type="text" class="form-control" id="plugin-key-vault-reminder-label" maxlength="160" placeholder="Production service principal secret">
+                  </div>
+                  <div class="col-md-6">
+                    <label for="plugin-key-vault-reminder-notes" class="form-label">Rotation notes</label>
+                    <input type="text" class="form-control" id="plugin-key-vault-reminder-notes" maxlength="1000" placeholder="Where to rotate this secret and who owns it">
+                  </div>
+                </div>
+              </div>
+            </div>
             <div class="mb-3">
               <label for="plugin-metadata" class="form-label">Metadata (JSON)</label>
               <textarea class="form-control" id="plugin-metadata" rows="4" placeholder="{}"></textarea>

--- a/application/single_app/templates/admin_settings.html
+++ b/application/single_app/templates/admin_settings.html
@@ -1129,10 +1129,10 @@
 
                             <div class="alert alert-light border small" id="key-vault-external-alert-guidance" role="note">
                                 <strong>External automation:</strong> SimpleChat emits a queryable Application Insights event named
-                                <code>key_vault_secret_expiration_reminder_triggered</code> whenever a reminder notification is created.
+                                <code>key_vault_expiration_reminder_triggered</code> whenever a reminder notification is created.
                                 Use an Azure Monitor scheduled query alert with an action group, Logic App, Function, or webhook to send external notifications. Enable the routing email option below if downstream automation needs to send directly to the configured reminder contact.
                                 <pre class="mt-2 mb-1"><code>traces
-| where customDimensions.sc_event_name == 'key_vault_secret_expiration_reminder_triggered'
+| where customDimensions.sc_event_name == 'key_vault_expiration_reminder_triggered'
 | project timestamp,
           reminder_id = tostring(customDimensions.sc_event_reminder_id),
           scope = tostring(customDimensions.sc_event_scope),

--- a/application/single_app/templates/admin_settings.html
+++ b/application/single_app/templates/admin_settings.html
@@ -1083,7 +1083,7 @@
                         <i class="bi bi-info-circle ms-2" data-bs-toggle="tooltip" title="Store agent and action sensitive information like API keys and secrets securely in Azure Key Vault."></i>
                     </div>
 
-                    <div id="key_vault_settings" {% if not settings.enable_key_vault_secret_storage %}style="display: none;"{% endif %}>
+                    <div id="key_vault_settings" class="{% if not settings.enable_key_vault_secret_storage %}d-none{% endif %}">
                         <div id="key-vault-warning" class="alert alert-warning mt-2 mb-3">
                             <strong>⚠️ Warning:</strong> Once you enable Key Vault, you should <u>NOT</u> disable it. Disabling Key Vault after enabling <u>WILL</u> cause loss of access to secrets and break application functionality.
                         </div>
@@ -1106,6 +1106,178 @@
                             Test Key Vault Connection
                         </button>
                         <div id="test_key_vault_result" class="mt-2">
+                        </div>
+
+                        <div class="border-top mt-4 pt-3">
+                            <div class="d-flex flex-column flex-lg-row justify-content-between align-items-lg-start gap-3 mb-3">
+                                <div>
+                                    <h6 class="mb-1">
+                                        <i class="bi bi-bell me-2"></i>Secret Expiration Reminders
+                                    </h6>
+                                    <p class="text-muted small mb-0">
+                                        Track SimpleChat-owned Key Vault secrets with expiration dates, in-app reminders, and an admin inventory that maps opaque secret names back to their owner and source.
+                                    </p>
+                                </div>
+                                <button type="button" class="btn btn-outline-secondary btn-sm" id="key-vault-reminders-refresh">
+                                    <i class="bi bi-arrow-clockwise me-1"></i>Refresh Inventory
+                                </button>
+                            </div>
+
+                            <div class="alert alert-info small" role="alert">
+                                Azure email alerts should still be configured in Azure Monitor or Event Grid for the vault. SimpleChat stores per-secret context so an emailed Key Vault alert can be mapped back to the user, group, action, field, and rotation notes.
+                            </div>
+
+                            <div class="alert alert-light border small" id="key-vault-external-alert-guidance" role="note">
+                                <strong>External automation:</strong> SimpleChat emits a queryable Application Insights event named
+                                <code>key_vault_secret_expiration_reminder_triggered</code> whenever a reminder notification is created.
+                                Use an Azure Monitor scheduled query alert with an action group, Logic App, Function, or webhook to send external notifications. Enable the routing email option below if downstream automation needs to send directly to the configured reminder contact.
+                                <pre class="mt-2 mb-1"><code>traces
+| where customDimensions.sc_event_name == 'key_vault_secret_expiration_reminder_triggered'
+| project timestamp,
+          reminder_id = tostring(customDimensions.sc_event_reminder_id),
+          scope = tostring(customDimensions.sc_event_scope),
+          source_type = tostring(customDimensions.sc_event_source_type),
+          days_until_expiry = toint(customDimensions.sc_event_days_until_expiry),
+          expires_on = tostring(customDimensions.sc_event_expires_on),
+          contact_email = tostring(customDimensions.sc_event_contact_email)</code></pre>
+                                <span class="text-muted">The <code>contact_email</code> column is populated only when the opt-in below is enabled. For workspace-based Log Analytics queries, use the equivalent Application Insights traces table and dimensions/properties fields available in that workspace.</span>
+                            </div>
+
+                            <div class="form-check form-switch mb-3">
+                                <input
+                                    class="form-check-input"
+                                    type="checkbox"
+                                    id="enable_key_vault_secret_expiration_reminders"
+                                    name="enable_key_vault_secret_expiration_reminders"
+                                    {% if settings.enable_key_vault_secret_expiration_reminders %}checked{% endif %}
+                                >
+                                <label class="form-check-label" for="enable_key_vault_secret_expiration_reminders">
+                                    Enable SimpleChat expiration reminder tracking
+                                </label>
+                            </div>
+
+                            <div id="key_vault_expiration_reminder_settings" class="{% if not settings.enable_key_vault_secret_expiration_reminders %}d-none{% endif %}">
+                                <div class="row g-3">
+                                    <div class="col-md-3">
+                                        <label for="key_vault_secret_expiration_default_lead_days" class="form-label">Default lead days</label>
+                                        <input
+                                            type="number"
+                                            min="1"
+                                            max="3650"
+                                            class="form-control"
+                                            id="key_vault_secret_expiration_default_lead_days"
+                                            name="key_vault_secret_expiration_default_lead_days"
+                                            value="{{ settings.key_vault_secret_expiration_default_lead_days or 30 }}"
+                                        >
+                                    </div>
+                                    <div class="col-md-5">
+                                        <label for="key_vault_secret_expiration_default_contact_email" class="form-label">Default reminder email</label>
+                                        <input
+                                            type="email"
+                                            class="form-control"
+                                            id="key_vault_secret_expiration_default_contact_email"
+                                            name="key_vault_secret_expiration_default_contact_email"
+                                            value="{{ settings.key_vault_secret_expiration_default_contact_email or '' }}"
+                                            placeholder="owner@example.com"
+                                        >
+                                    </div>
+                                    <div class="col-md-4">
+                                        <label for="key_vault_secret_expiration_admin_roles" class="form-label">Admin notification roles</label>
+                                        <input
+                                            type="text"
+                                            class="form-control"
+                                            id="key_vault_secret_expiration_admin_roles"
+                                            name="key_vault_secret_expiration_admin_roles"
+                                            value="{{ (settings.key_vault_secret_expiration_admin_roles or ['Admin'])|join(', ') }}"
+                                            placeholder="Admin"
+                                        >
+                                        <div class="form-text">Comma-separated roles for global-scope reminder notifications.</div>
+                                    </div>
+                                    <div class="col-md-4">
+                                        <label for="key_vault_secret_expiration_scan_interval_seconds" class="form-label">Scan interval seconds</label>
+                                        <input
+                                            type="number"
+                                            min="900"
+                                            max="86400"
+                                            class="form-control"
+                                            id="key_vault_secret_expiration_scan_interval_seconds"
+                                            name="key_vault_secret_expiration_scan_interval_seconds"
+                                            value="{{ settings.key_vault_secret_expiration_scan_interval_seconds or 21600 }}"
+                                        >
+                                    </div>
+                                    <div class="col-md-8 d-flex align-items-end">
+                                        <div class="form-check">
+                                            <input
+                                                class="form-check-input"
+                                                type="checkbox"
+                                                id="key_vault_secret_expiration_require_expiration"
+                                                name="key_vault_secret_expiration_require_expiration"
+                                                {% if settings.key_vault_secret_expiration_require_expiration %}checked{% endif %}
+                                            >
+                                            <label class="form-check-label" for="key_vault_secret_expiration_require_expiration">
+                                                Require expiration dates when users enable tracking on new secrets
+                                            </label>
+                                        </div>
+                                    </div>
+                                    <div class="col-md-8">
+                                        <div class="form-check">
+                                            <input
+                                                class="form-check-input"
+                                                type="checkbox"
+                                                id="key_vault_secret_expiration_emit_contact_email_in_telemetry"
+                                                name="key_vault_secret_expiration_emit_contact_email_in_telemetry"
+                                                aria-describedby="key_vault_secret_expiration_emit_contact_email_in_telemetry_help"
+                                                {% if settings.key_vault_secret_expiration_emit_contact_email_in_telemetry %}checked{% endif %}
+                                            >
+                                            <label class="form-check-label" for="key_vault_secret_expiration_emit_contact_email_in_telemetry">
+                                                Include reminder contact email in external telemetry
+                                            </label>
+                                            <div class="form-text" id="key_vault_secret_expiration_emit_contact_email_in_telemetry_help">
+                                                Default off. Enable only when Azure Monitor, Logic Apps, Functions, or webhook automation needs the email address to route notifications directly.
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+
+                            <div class="mt-4">
+                                <div class="d-flex flex-column flex-lg-row gap-2 mb-3">
+                                    <input type="search" class="form-control" id="key-vault-reminders-search" placeholder="Search by owner, action, field, email, reminder ID, or secret name">
+                                    <select class="form-select" id="key-vault-reminders-status" aria-label="Reminder status filter">
+                                        <option value="">All statuses</option>
+                                        <option value="active">Active</option>
+                                        <option value="sync_failed">Sync failed</option>
+                                        <option value="disabled">Disabled</option>
+                                    </select>
+                                    <button type="button" class="btn btn-outline-primary" id="key-vault-reminders-run">
+                                        <i class="bi bi-play-circle me-1"></i>Run Sweep
+                                    </button>
+                                </div>
+
+                                <div id="key-vault-reminders-status-message" class="alert d-none" role="alert"></div>
+
+                                <div class="table-responsive">
+                                    <table class="table table-sm align-middle">
+                                        <thead>
+                                            <tr>
+                                                <th>Expires</th>
+                                                <th>Scope</th>
+                                                <th>Source</th>
+                                                <th>Field</th>
+                                                <th>Contact</th>
+                                                <th>Status</th>
+                                                <th>Reminder ID</th>
+                                                <th>Secret</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody id="key-vault-reminders-table-body">
+                                            <tr>
+                                                <td colspan="8" class="text-muted">Refresh inventory to load tracked secrets.</td>
+                                            </tr>
+                                        </tbody>
+                                    </table>
+                                </div>
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/docs/explanation/features/KEY_VAULT_EXPIRATION_REMINDERS.md
+++ b/docs/explanation/features/KEY_VAULT_EXPIRATION_REMINDERS.md
@@ -1,0 +1,84 @@
+# Key Vault Expiration Reminders
+
+Implemented in version: **0.250.121**
+External telemetry added in version: **0.250.122**
+Contact email telemetry opt-in added in version: **0.250.123**
+
+## Overview
+
+Key Vault expiration reminders let action owners add expiration metadata when storing Key Vault-backed secrets. SimpleChat records an inventory entry that maps the generated Key Vault secret name back to the action, scope, field, contact email, expiration date, and rotation notes.
+
+## Dependencies
+
+- Azure Key Vault secret storage must be configured for SimpleChat secret storage.
+- Azure Monitor or Event Grid should be configured outside SimpleChat for email alerts on Key Vault near-expiry or expired events.
+- SimpleChat in-app notifications supplement Azure alerts through the background reminder sweep.
+
+## Technical Specifications
+
+- **Inventory storage**: `key_vault_secret_reminders` Cosmos container partitioned by `scope_key`.
+- **Metadata contract**: action metadata uses `key_vault_secret_reminders.__all__` for the action-modal "track all action secrets" control.
+- **Admin APIs**:
+  - `GET /api/admin/settings/key-vault/secret-reminders`
+  - `POST /api/admin/settings/key-vault/secret-reminders/run`
+- **Background sweep**: `run_key_vault_secret_reminder_loop()` checks due reminders under a distributed lock.
+- **Notifications**: `key_vault_secret_expiring` in-app notifications target personal owners, groups, public workspaces, or configured admin roles for global secrets.
+- **External telemetry**: each created reminder notification emits the Application Insights event `key_vault_secret_expiration_reminder_triggered` with queryable dimensions for Azure Monitor scheduled query alerts and downstream automation. Contact email is included only when the admin explicitly enables the external telemetry opt-in.
+
+## Usage Instructions
+
+1. Enable Key Vault secret storage in Admin Settings > Security > Key Vault.
+2. Enable SimpleChat expiration reminder tracking.
+3. Configure default lead days, default contact email, scan interval, and global admin notification roles.
+4. Optionally enable **Include reminder contact email in external telemetry** when Azure Monitor, Logic Apps, Functions, or webhook automation must route messages directly to the configured reminder contact.
+5. In an action's Advanced step, enable expiration tracking and enter:
+   - expiration date,
+   - reminder email,
+   - lead days,
+   - friendly label,
+   - optional rotation notes.
+6. Use the admin Key Vault reminder inventory to map expiring Key Vault secret names or reminder IDs back to their SimpleChat source and owner context.
+
+## External Notification Options
+
+### Azure Key Vault native events
+
+Configure Azure Monitor or Event Grid on the Key Vault for native secret near-expiry and expired events. These alerts can send email through Azure action groups, but they only identify the vault and secret. Use the SimpleChat reminder inventory to map the secret name back to owner, source, field, contact email, and rotation notes.
+
+### SimpleChat Application Insights event
+
+When the SimpleChat reminder sweep creates an in-app notification, it also emits a queryable Application Insights trace event named:
+
+```text
+key_vault_secret_expiration_reminder_triggered
+```
+
+Recommended Application Insights query:
+
+```kusto
+traces
+| where customDimensions.sc_event_name == 'key_vault_secret_expiration_reminder_triggered'
+| project timestamp,
+          reminder_id = tostring(customDimensions.sc_event_reminder_id),
+          scope = tostring(customDimensions.sc_event_scope),
+          source_type = tostring(customDimensions.sc_event_source_type),
+          days_until_expiry = toint(customDimensions.sc_event_days_until_expiry),
+          expires_on = tostring(customDimensions.sc_event_expires_on),
+          contact_email = tostring(customDimensions.sc_event_contact_email),
+          notification_scope = tostring(customDimensions.sc_event_notification_scope)
+```
+
+Use this query in an Azure Monitor scheduled query alert, then attach an action group, Logic App, Azure Function, or webhook for external notification or ticketing workflows. By default, external automation should notify a fixed admin channel and use `reminder_id` with the admin inventory when human-friendly context is needed. If direct owner routing is required, enable the contact-email telemetry opt-in so downstream automation can use `contact_email`.
+
+## Testing and Validation
+
+- Functional coverage: `functional_tests/test_sql_plugin_key_vault_secret_storage.py`
+- External telemetry coverage: `functional_tests/test_keyvault_external_notification_telemetry.py`
+- UI contract coverage: `ui_tests/test_admin_key_vault_reminders_ui.py`
+- Route policy coverage applies to the new admin APIs.
+
+## Limitations
+
+- SimpleChat does not send email directly. Use Azure Monitor or Event Grid action groups for email alert delivery.
+- Contact email is omitted from external telemetry by default. Admins must opt in before Azure Monitor or downstream automation can route directly to reminder contacts.
+- The first UI pass supports a single action-level reminder configuration that applies to all Key Vault-backed secrets in that action.

--- a/docs/explanation/features/KEY_VAULT_EXPIRATION_REMINDERS.md
+++ b/docs/explanation/features/KEY_VAULT_EXPIRATION_REMINDERS.md
@@ -3,6 +3,7 @@
 Implemented in version: **0.250.121**
 External telemetry added in version: **0.250.122**
 Contact email telemetry opt-in added in version: **0.250.123**
+External telemetry event name hardened in version: **0.250.124**
 
 ## Overview
 
@@ -23,7 +24,7 @@ Key Vault expiration reminders let action owners add expiration metadata when st
   - `POST /api/admin/settings/key-vault/secret-reminders/run`
 - **Background sweep**: `run_key_vault_secret_reminder_loop()` checks due reminders under a distributed lock.
 - **Notifications**: `key_vault_secret_expiring` in-app notifications target personal owners, groups, public workspaces, or configured admin roles for global secrets.
-- **External telemetry**: each created reminder notification emits the Application Insights event `key_vault_secret_expiration_reminder_triggered` with queryable dimensions for Azure Monitor scheduled query alerts and downstream automation. Contact email is included only when the admin explicitly enables the external telemetry opt-in.
+- **External telemetry**: each created reminder notification emits the Application Insights event `key_vault_expiration_reminder_triggered` with queryable dimensions for Azure Monitor scheduled query alerts and downstream automation. Contact email is included only when the admin explicitly enables the external telemetry opt-in.
 
 ## Usage Instructions
 
@@ -50,14 +51,14 @@ Configure Azure Monitor or Event Grid on the Key Vault for native secret near-ex
 When the SimpleChat reminder sweep creates an in-app notification, it also emits a queryable Application Insights trace event named:
 
 ```text
-key_vault_secret_expiration_reminder_triggered
+key_vault_expiration_reminder_triggered
 ```
 
 Recommended Application Insights query:
 
 ```kusto
 traces
-| where customDimensions.sc_event_name == 'key_vault_secret_expiration_reminder_triggered'
+| where customDimensions.sc_event_name == 'key_vault_expiration_reminder_triggered'
 | project timestamp,
           reminder_id = tostring(customDimensions.sc_event_reminder_id),
           scope = tostring(customDimensions.sc_event_scope),

--- a/docs/explanation/fixes/KEY_VAULT_SECRET_ROTATION_FIX.md
+++ b/docs/explanation/fixes/KEY_VAULT_SECRET_ROTATION_FIX.md
@@ -1,0 +1,39 @@
+# Key Vault Secret Rotation Fix
+
+Fixed in version: **0.250.121**
+
+## Issue Description
+
+When an existing action already had a secret stored in Key Vault, saving a new literal secret value could fail to update the Key Vault secret cleanly. A related edge case allowed the `Stored_In_KeyVault` placeholder to become a generated secret reference even when no existing Key Vault secret existed.
+
+## Root Cause
+
+The central Key Vault helper treated some failed writes as successful by returning the raw secret value, and placeholder preservation could generate a dead reference when no previous reference was available.
+
+## Technical Details
+
+### Files Modified
+
+- `application/single_app/functions_keyvault.py`
+- `application/single_app/functions_global_actions.py`
+- `application/single_app/route_backend_plugins.py`
+- `functional_tests/test_sql_plugin_key_vault_secret_storage.py`
+
+### Code Changes Summary
+
+- Literal replacement secrets now call `set_secret` and surface write failures.
+- `Stored_In_KeyVault` only preserves an existing validated reference.
+- Placeholder saves without an existing reference now return a validation error requiring the secret to be re-entered.
+- Global action saves re-raise failures so admin routes can return actionable errors.
+- Personal, group, and global action routes now surface Key Vault validation/write failures more clearly.
+
+## Validation
+
+- Added regression coverage for global, group, and personal action scopes.
+- Added validation that Key Vault write failures do not fall back to raw secret persistence.
+- Added validation that placeholder-only saves without existing references are rejected.
+
+## Before/After
+
+- **Before**: A failed Key Vault write could be saved as raw data or hidden behind a generic route failure.
+- **After**: Key Vault writes fail hard, placeholders require a real existing reference, and routes surface the specific error.

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,42 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](/explanation/features/) and [Fixes by Version](/explanation/fixes/).
 
+### **(v0.250.123)**
+
+#### New Features
+
+*   **Key Vault Reminder Contact Email Telemetry Opt-In**
+    *   Added a default-off admin setting that allows Key Vault reminder contact email addresses to be included in the external Application Insights telemetry event for direct Azure Monitor, Logic App, Function, or webhook routing.
+    *   Kept raw secret names redacted from external telemetry and added Reminder ID visibility/search in the admin inventory for fixed admin-channel alert workflows.
+    *   (Ref: #1156, `functions_appinsights.py`, `functions_keyvault_reminders.py`, Admin Key Vault reminder external alert guidance)
+
+### **(v0.250.122)**
+
+#### New Features
+
+*   **Key Vault Reminder External Telemetry**
+    *   Added a privacy-safe, queryable Application Insights event when Key Vault expiration reminder notifications are created, enabling Azure Monitor scheduled query alerts, action groups, Logic Apps, Functions, or webhooks for external notification workflows.
+    *   Added admin and feature documentation guidance with a sample KQL query while avoiding raw secret names and email values in telemetry dimensions.
+    *   (Ref: #1156, `functions_appinsights.py`, `functions_keyvault_reminders.py`, Azure Monitor external notification guidance)
+
+### **(v0.250.121)**
+
+#### New Features
+
+*   **Key Vault Expiration Reminder Inventory**
+    *   Added SimpleChat-managed Key Vault secret expiration reminder tracking with per-action reminder metadata, expiration dates, lead days, reminder contact email, friendly labels, and rotation notes.
+    *   Added an admin Key Vault reminder dashboard that maps generated Key Vault secret names back to SimpleChat scope, source action, field, owner/contact context, sync status, and remediation details.
+    *   Added a background reminder sweep and `key_vault_secret_expiring` in-app notifications while preserving Azure Monitor/Event Grid as the recommended email alert path.
+    *   (Ref: #1156, `functions_keyvault_reminders.py`, `admin_settings.html`, `plugin_modal_stepper.js`, Key Vault reminder inventory)
+
+#### Bug Fixes
+
+*   **Reliable Key Vault Secret Rotation**
+    *   Fixed action secret save behavior so replacing a Key Vault-backed secret with a new literal value writes a new Key Vault version for global, group, and personal actions.
+    *   `Stored_In_KeyVault` placeholders now only preserve validated existing references; placeholder-only saves without an existing secret are rejected instead of creating dead references.
+    *   Key Vault write failures now surface as errors instead of falling back to raw secret persistence.
+    *   (Ref: #1156, `functions_keyvault.py`, action save helpers, Key Vault secret reference validation)
+
 ### **(v0.250.119)**
 
 #### Bug Fixes

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,15 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](/explanation/features/) and [Fixes by Version](/explanation/fixes/).
 
+### **(v0.250.124)**
+
+#### Bug Fixes
+
+*   **Key Vault Reminder PR Security Hardening**
+    *   Replaced raw exception text returned from plugin/action Key Vault save paths with stable user-safe messages while preserving server-side logging for diagnostics.
+    *   Renamed the external Key Vault reminder telemetry event to avoid security scanner false positives on secret-related terminology while keeping queryable Application Insights dimensions.
+    *   (Ref: #1156, PR #1157, `route_backend_plugins.py`, `functions_appinsights.py`, CodeQL findings)
+
 ### **(v0.250.123)**
 
 #### New Features

--- a/functional_tests/test_keyvault_external_notification_telemetry.py
+++ b/functional_tests/test_keyvault_external_notification_telemetry.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python3
+# test_keyvault_external_notification_telemetry.py
+"""
+Functional test for Key Vault expiration reminder external telemetry.
+Version: 0.250.123
+Implemented in: 0.250.122; 0.250.123
+
+This test ensures Key Vault expiration reminder notifications emit a safe,
+queryable Azure Monitor event and include contact email only when admins opt in.
+"""
+
+import importlib
+import os
+import sys
+import types
+
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'application', 'single_app'))
+
+
+class FakeCosmosResourceNotFoundError(Exception):
+    pass
+
+
+class FakeReminderContainer:
+    def __init__(self, items=None):
+        self.items = {
+            item["id"]: dict(item)
+            for item in (items or [])
+        }
+        self.upserted_items = []
+
+    def read_item(self, item, partition_key):
+        stored_item = self.items.get(item)
+        if not stored_item or stored_item.get("scope_key") != partition_key:
+            raise FakeCosmosResourceNotFoundError("not found")
+        return dict(stored_item)
+
+    def query_items(self, query=None, parameters=None, enable_cross_partition_query=False):
+        return [dict(item) for item in self.items.values()]
+
+    def upsert_item(self, body):
+        self.items[body["id"]] = dict(body)
+        self.upserted_items.append(dict(body))
+        return dict(body)
+
+
+class FakeLogger:
+    def __init__(self):
+        self.records = []
+
+    def log(self, level, message, extra=None, stacklevel=None):
+        self.records.append({
+            "level": level,
+            "message": message,
+            "extra": dict(extra or {}),
+            "stacklevel": stacklevel,
+        })
+
+
+def _restore_modules(original_modules):
+    for module_name, original_module in original_modules.items():
+        if original_module is None:
+            sys.modules.pop(module_name, None)
+        else:
+            sys.modules[module_name] = original_module
+
+
+def _load_appinsights_module(fake_logger):
+    app_settings_cache_stub = types.ModuleType("app_settings_cache")
+    app_settings_cache_stub.get_settings_cache = lambda: {}
+
+    azure_stub = types.ModuleType("azure")
+    monitor_stub = types.ModuleType("azure.monitor")
+    opentelemetry_stub = types.ModuleType("azure.monitor.opentelemetry")
+    opentelemetry_stub.configure_azure_monitor = lambda *args, **kwargs: None
+    monitor_stub.opentelemetry = opentelemetry_stub
+    azure_stub.monitor = monitor_stub
+
+    original_modules = {}
+    for module_name, module_stub in {
+        "app_settings_cache": app_settings_cache_stub,
+        "azure": azure_stub,
+        "azure.monitor": monitor_stub,
+        "azure.monitor.opentelemetry": opentelemetry_stub,
+    }.items():
+        original_modules[module_name] = sys.modules.get(module_name)
+        sys.modules[module_name] = module_stub
+
+    original_modules["functions_appinsights"] = sys.modules.get("functions_appinsights")
+    sys.modules.pop("functions_appinsights", None)
+
+    module = importlib.import_module("functions_appinsights")
+    module.get_appinsights_logger = lambda: fake_logger
+    return module, original_modules
+
+
+def _load_reminders_module(
+    container,
+    external_events,
+    created_notifications,
+    settings_override=None,
+):
+    config_stub = types.ModuleType("config")
+    config_stub.cosmos_key_vault_secret_reminders_container = container
+
+    appinsights_stub = types.ModuleType("functions_appinsights")
+    appinsights_stub.log_event = lambda *args, **kwargs: None
+
+    def log_external_event(
+        event_name,
+        extra=None,
+        level=None,
+        allowed_sensitive_dimensions=None,
+    ):
+        external_events.append({
+            "event_name": event_name,
+            "extra": dict(extra or {}),
+            "level": level,
+            "allowed_sensitive_dimensions": tuple(allowed_sensitive_dimensions or ()),
+        })
+
+    appinsights_stub.log_external_event = log_external_event
+
+    notifications_stub = types.ModuleType("functions_notifications")
+
+    def create_notification(**kwargs):
+        notification = {
+            "id": "notification-123",
+            "scope": "assignment" if kwargs.get("assignment") else "personal",
+            "metadata": dict(kwargs.get("metadata") or {}),
+        }
+        created_notifications.append(notification)
+        return notification
+
+    notifications_stub.create_notification = create_notification
+    notifications_stub.create_group_notification = (
+        lambda *args, **kwargs: create_notification(**kwargs)
+    )
+    notifications_stub.create_public_workspace_notification = (
+        lambda *args, **kwargs: create_notification(**kwargs)
+    )
+
+    settings = {
+        "enable_key_vault_secret_expiration_reminders": True,
+        "key_vault_secret_expiration_default_lead_days": 30,
+        "key_vault_secret_expiration_default_contact_email": "admin@example.com",
+        "key_vault_secret_expiration_emit_contact_email_in_telemetry": False,
+        "key_vault_secret_expiration_admin_roles": ["Admin"],
+    }
+    settings.update(settings_override or {})
+    settings_stub = types.ModuleType("functions_settings")
+    settings_stub.get_settings = lambda: dict(settings)
+
+    azure_stub = types.ModuleType("azure")
+    cosmos_stub = types.ModuleType("azure.cosmos")
+    cosmos_exceptions_stub = types.ModuleType("azure.cosmos.exceptions")
+    cosmos_exceptions_stub.CosmosResourceNotFoundError = FakeCosmosResourceNotFoundError
+    cosmos_stub.exceptions = cosmos_exceptions_stub
+    azure_stub.cosmos = cosmos_stub
+
+    original_modules = {}
+    for module_name, module_stub in {
+        "config": config_stub,
+        "functions_appinsights": appinsights_stub,
+        "functions_notifications": notifications_stub,
+        "functions_settings": settings_stub,
+        "azure": azure_stub,
+        "azure.cosmos": cosmos_stub,
+        "azure.cosmos.exceptions": cosmos_exceptions_stub,
+    }.items():
+        original_modules[module_name] = sys.modules.get(module_name)
+        sys.modules[module_name] = module_stub
+
+    original_modules["functions_keyvault_reminders"] = sys.modules.get("functions_keyvault_reminders")
+    sys.modules.pop("functions_keyvault_reminders", None)
+
+    module = importlib.import_module("functions_keyvault_reminders")
+    return module, original_modules
+
+
+def test_log_external_event_preserves_safe_dimensions_and_redacts_raw_sensitive_values():
+    """Validate external events expose only safe query dimensions."""
+    print("Testing external telemetry helper safety...")
+    fake_logger = FakeLogger()
+    module, original_modules = _load_appinsights_module(fake_logger)
+
+    try:
+        module.log_external_event(
+            "Key Vault Reminder!",
+            extra={
+                "scope": "global",
+                "days_until_expiry": 5,
+                "contact_email": "owner@example.com",
+                "contact_email_hash": "emailhash123",
+                "source_id": "global-action-1",
+                "source_id_hash": "sourcehash123",
+                "secret_name": "global-action-1--action--global--service-principal-action",
+            },
+        )
+
+        assert len(fake_logger.records) == 1
+        record = fake_logger.records[0]
+        assert record["message"] == "[SimpleChatExternalEvent] Key_Vault_Reminder"
+
+        extra = record["extra"]
+        assert extra["sc_event_name"] == "Key_Vault_Reminder"
+        assert extra["sc_event_scope"] == "global"
+        assert extra["sc_event_days_until_expiry"] == 5
+        assert extra["sc_event_contact_email_present"] is True
+        assert extra["sc_event_secret_name_present"] is True
+        assert extra["sc_event_contact_email_hash"] == "emailhash123"
+        assert extra["sc_event_source_id_hash"] == "sourcehash123"
+        assert "sc_event_contact_email" not in extra
+        assert "sc_event_secret_name" not in extra
+        assert "owner@example.com" not in repr(extra)
+        assert "service-principal-action" not in repr(extra)
+
+        module.log_external_event(
+            "Key Vault Reminder!",
+            extra={
+                "contact_email": "owner@example.com",
+                "secret_name": "global-action-1--action--global--service-principal-action",
+            },
+            allowed_sensitive_dimensions=("contact_email",),
+        )
+        opt_in_extra = fake_logger.records[1]["extra"]
+        assert opt_in_extra["sc_event_contact_email"] == "owner@example.com"
+        assert opt_in_extra["sc_event_secret_name_present"] is True
+        assert "sc_event_secret_name" not in opt_in_extra
+
+        print("Test passed!")
+        return True
+    finally:
+        _restore_modules(original_modules)
+
+
+def test_keyvault_reminder_external_telemetry_event_is_safe_and_queryable():
+    """Validate due reminder notifications emit external-safe Azure Monitor telemetry."""
+    print("Testing Key Vault reminder external telemetry event...")
+    reminder = {
+        "id": "key-vault-secret-reminder-abc123",
+        "type": "key_vault_secret_reminder",
+        "enabled": True,
+        "status": "active",
+        "secret_name": "global-action-1--action--global--service-principal-action",
+        "key_vault_name": "prod-vault",
+        "scope": "global",
+        "scope_value": "global-action-1",
+        "scope_key": "global:global-action-1",
+        "source": "action",
+        "source_type": "action",
+        "source_id": "global-action-1",
+        "source_display_name": "Service Principal Action",
+        "field_path": "auth.key",
+        "field_label": "auth key",
+        "contact_email": "owner@example.com",
+        "expires_on": "2026-09-01",
+        "lead_days": 30,
+        "notify_on": "2026-08-02",
+        "key_vault_sync_status": "synced",
+        "last_notification_window_key": None,
+    }
+    container = FakeReminderContainer(items=[reminder])
+    external_events = []
+    created_notifications = []
+    module, original_modules = _load_reminders_module(container, external_events, created_notifications)
+
+    try:
+        result = module.check_due_key_vault_secret_reminders_once(
+            now=module.datetime(2026, 8, 5, tzinfo=module.timezone.utc),
+        )
+
+        assert result["notifications_created"] == 1
+        assert len(created_notifications) == 1
+        assert len(external_events) == 1
+
+        event = external_events[0]
+        assert event["event_name"] == module.KEY_VAULT_SECRET_REMINDER_EXTERNAL_EVENT_NAME
+        event_extra = event["extra"]
+        assert event_extra["reminder_id"] == reminder["id"]
+        assert event_extra["scope"] == "global"
+        assert event_extra["source_type"] == "action"
+        assert event_extra["days_until_expiry"] == 27
+        assert event_extra["notification_id"] == "notification-123"
+        assert event_extra["contact_email_hash"]
+        assert event_extra["scope_value_hash"]
+        assert "contact_email" not in event_extra
+        assert event["allowed_sensitive_dimensions"] == ()
+
+        serialized_extra = repr(event_extra)
+        assert reminder["secret_name"] not in serialized_extra
+        assert reminder["contact_email"] not in serialized_extra
+
+        updated_reminder = container.upserted_items[-1]
+        assert updated_reminder["last_notification_window_key"] == "2026-09-01:30"
+
+        print("Test passed!")
+        return True
+    finally:
+        _restore_modules(original_modules)
+
+
+def test_keyvault_reminder_external_telemetry_can_include_contact_email_when_admin_opts_in():
+    """Validate contact email is emitted only with the explicit admin opt-in."""
+    print("Testing Key Vault reminder external telemetry contact email opt-in...")
+    reminder = {
+        "id": "key-vault-secret-reminder-email",
+        "type": "key_vault_secret_reminder",
+        "enabled": True,
+        "status": "active",
+        "secret_name": "global-action-1--action--global--service-principal-action",
+        "scope": "global",
+        "scope_value": "global-action-1",
+        "scope_key": "global:global-action-1",
+        "source": "action",
+        "source_type": "action",
+        "source_id": "global-action-1",
+        "field_path": "auth.key",
+        "contact_email": "owner@example.com",
+        "expires_on": "2026-09-01",
+        "lead_days": 30,
+        "notify_on": "2026-08-02",
+        "key_vault_sync_status": "synced",
+        "last_notification_window_key": None,
+    }
+    container = FakeReminderContainer(items=[reminder])
+    external_events = []
+    created_notifications = []
+    module, original_modules = _load_reminders_module(
+        container,
+        external_events,
+        created_notifications,
+        settings_override={"key_vault_secret_expiration_emit_contact_email_in_telemetry": True},
+    )
+
+    try:
+        result = module.check_due_key_vault_secret_reminders_once(
+            now=module.datetime(2026, 8, 5, tzinfo=module.timezone.utc),
+        )
+
+        assert result["notifications_created"] == 1
+        event = external_events[0]
+        assert event["extra"]["contact_email"] == "owner@example.com"
+        assert event["extra"]["contact_email_hash"]
+        assert event["allowed_sensitive_dimensions"] == ("contact_email",)
+        assert reminder["secret_name"] not in repr(event["extra"])
+
+        print("Test passed!")
+        return True
+    finally:
+        _restore_modules(original_modules)
+
+
+if __name__ == "__main__":
+    tests = [
+        test_log_external_event_preserves_safe_dimensions_and_redacts_raw_sensitive_values,
+        test_keyvault_reminder_external_telemetry_event_is_safe_and_queryable,
+        test_keyvault_reminder_external_telemetry_can_include_contact_email_when_admin_opts_in,
+    ]
+    results = []
+    for test in tests:
+        print(f"\nRunning {test.__name__}...")
+        try:
+            results.append(test())
+        except Exception as exc:
+            print(f"Test failed: {exc}")
+            import traceback
+            traceback.print_exc()
+            results.append(False)
+
+    success = all(results)
+    print(f"\nResults: {sum(bool(result) for result in results)}/{len(results)} tests passed")
+    sys.exit(0 if success else 1)

--- a/functional_tests/test_keyvault_external_notification_telemetry.py
+++ b/functional_tests/test_keyvault_external_notification_telemetry.py
@@ -276,7 +276,7 @@ def test_keyvault_reminder_external_telemetry_event_is_safe_and_queryable():
         assert len(external_events) == 1
 
         event = external_events[0]
-        assert event["event_name"] == module.KEY_VAULT_SECRET_REMINDER_EXTERNAL_EVENT_NAME
+        assert event["event_name"] == module.KEY_VAULT_REMINDER_EXTERNAL_EVENT_NAME
         assert event["event_name"] == "key_vault_expiration_reminder_triggered"
         assert "secret" not in event["event_name"]
         event_extra = event["extra"]

--- a/functional_tests/test_keyvault_external_notification_telemetry.py
+++ b/functional_tests/test_keyvault_external_notification_telemetry.py
@@ -2,7 +2,7 @@
 # test_keyvault_external_notification_telemetry.py
 """
 Functional test for Key Vault expiration reminder external telemetry.
-Version: 0.250.123
+Version: 0.250.124
 Implemented in: 0.250.122; 0.250.123
 
 This test ensures Key Vault expiration reminder notifications emit a safe,
@@ -201,7 +201,7 @@ def test_log_external_event_preserves_safe_dimensions_and_redacts_raw_sensitive_
 
         assert len(fake_logger.records) == 1
         record = fake_logger.records[0]
-        assert record["message"] == "[SimpleChatExternalEvent] Key_Vault_Reminder"
+        assert record["message"] == "[SimpleChatExternalEvent]"
 
         extra = record["extra"]
         assert extra["sc_event_name"] == "Key_Vault_Reminder"
@@ -277,6 +277,8 @@ def test_keyvault_reminder_external_telemetry_event_is_safe_and_queryable():
 
         event = external_events[0]
         assert event["event_name"] == module.KEY_VAULT_SECRET_REMINDER_EXTERNAL_EVENT_NAME
+        assert event["event_name"] == "key_vault_expiration_reminder_triggered"
+        assert "secret" not in event["event_name"]
         event_extra = event["extra"]
         assert event_extra["reminder_id"] == reminder["id"]
         assert event_extra["scope"] == "global"

--- a/functional_tests/test_keyvault_plugin_secret_scope_enforcement.py
+++ b/functional_tests/test_keyvault_plugin_secret_scope_enforcement.py
@@ -1,8 +1,8 @@
 # test_keyvault_plugin_secret_scope_enforcement.py
 """
 Functional test for Key Vault plugin secret scope enforcement.
-Version: 0.241.022
-Implemented in: 0.241.011; 0.241.022
+Version: 0.250.121
+Implemented in: 0.241.011; 0.241.022; 0.250.121
 
 This test ensures plugin Key Vault references are validated against the
 expected scope and source before they are preserved, resolved, or deleted.
@@ -168,10 +168,17 @@ def test_runtime_plugin_loader_blanks_secret_fields_on_scope_mismatch():
 
     namespace, _ = load_functions(
         SK_LOADER_FILE,
-        {"_get_plugin_secret_context", "_is_sql_sensitive_plugin_field", "resolve_key_vault_secrets_in_plugins"},
+        {
+            "_get_plugin_secret_context",
+            "_is_sql_sensitive_plugin_field",
+            "_is_sensitive_plugin_additional_field",
+            "resolve_key_vault_secrets_in_plugins",
+        },
         {
             "SQL_PLUGIN_SENSITIVE_AUTH_FIELDS": {"client_secret"},
             "SQL_PLUGIN_SENSITIVE_ADDITIONAL_FIELDS": {"connection_string", "password"},
+            "SNOWFLAKE_PLUGIN_TYPE": "snowflake",
+            "SNOWFLAKE_SENSITIVE_ADDITIONAL_FIELDS": {"password", "private_key", "private_key_passphrase"},
             "validate_secret_name_dynamic": lambda value: isinstance(value, str) and value.startswith("ref-"),
             "resolve_secret_reference_for_context": lambda *args, **kwargs: (_ for _ in ()).throw(ValueError("scope mismatch")),
             "log_event": lambda *args, **kwargs: None,

--- a/functional_tests/test_plugin_error_response_sanitization.py
+++ b/functional_tests/test_plugin_error_response_sanitization.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+# test_plugin_error_response_sanitization.py
+"""
+Functional test for plugin error response sanitization.
+Version: 0.250.124
+Implemented in: 0.250.124
+
+This test ensures PR security-review fixes keep raw exception text out of
+client-visible plugin/action error responses and external telemetry log messages.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ROUTE_FILE = REPO_ROOT / "application" / "single_app" / "route_backend_plugins.py"
+APPINSIGHTS_FILE = REPO_ROOT / "application" / "single_app" / "functions_appinsights.py"
+INSTRUCTIONS_FILE = REPO_ROOT / ".github" / "instructions" / "python-lang.instructions.md"
+
+
+def _read(path):
+    return path.read_text(encoding="utf-8")
+
+
+def test_key_vault_plugin_exception_responses_are_stable():
+    """Validate newly added Key Vault/plugin exception paths return safe messages."""
+    print("Testing plugin Key Vault exception response sanitization...")
+    route_source = _read(ROUTE_FILE)
+
+    required_safe_messages = (
+        "ACTION_VALIDATION_ERROR_MESSAGE",
+        "ACTION_PERMISSION_ERROR_MESSAGE",
+        "ACTION_KEY_VAULT_ERROR_MESSAGE",
+        "PLUGIN_VALIDATION_ERROR_MESSAGE",
+        "PLUGIN_KEY_VAULT_ERROR_MESSAGE",
+    )
+    for message_name in required_safe_messages:
+        assert message_name in route_source, f"Missing safe response constant {message_name}"
+
+    forbidden_blocks = (
+        r"except RuntimeError as e:\s+debug_print\(f\"Key Vault error saving personal actions.*?"
+        r"return jsonify\(\{'error': str\(e\)\}\), 500",
+        r"except ValueError as exc:\s+return jsonify\(\{'error': str\(exc\)\}\), 400\s+"
+        r"except PermissionError as exc:\s+return jsonify\(\{'error': str\(exc\)\}\), 403\s+"
+        r"except RuntimeError as exc:\s+debug_print\('Key Vault error saving group action.*?"
+        r"return jsonify\(\{'error': str\(exc\)\}\), 500",
+        r"except ValueError as exc:\s+return jsonify\(\{'error': str\(exc\)\}\), 400\s+"
+        r"except PermissionError as exc:\s+return jsonify\(\{'error': str\(exc\)\}\), 403\s+"
+        r"except RuntimeError as exc:\s+debug_print\('Key Vault error updating group action.*?"
+        r"return jsonify\(\{'error': str\(exc\)\}\), 500",
+        r"except ValueError as e:\s+log_event\(f\"Validation error adding plugin.*?"
+        r"return jsonify\(\{'error': str\(e\)\}\), 400\s+"
+        r"except RuntimeError as e:\s+log_event\(f\"Key Vault error adding plugin.*?"
+        r"return jsonify\(\{'error': str\(e\)\}\), 500",
+        r"except ValueError as e:\s+log_event\(f\"Validation error editing plugin.*?"
+        r"return jsonify\(\{'error': str\(e\)\}\), 400\s+"
+        r"except RuntimeError as e:\s+log_event\(f\"Key Vault error editing plugin.*?"
+        r"return jsonify\(\{'error': str\(e\)\}\), 500",
+    )
+    for forbidden_pattern in forbidden_blocks:
+        assert not re.search(forbidden_pattern, route_source, re.DOTALL), (
+            "Raw exception text is still returned from a Key Vault/plugin exception path"
+        )
+
+    print("Test passed!")
+    return True
+
+
+def test_external_telemetry_event_name_avoids_secret_word_in_logger_message():
+    """Validate external telemetry does not log the event name as message text."""
+    print("Testing external telemetry logger message hardening...")
+    appinsights_source = _read(APPINSIGHTS_FILE)
+    assert "event_message = f\"{LOGGER_EXTERNAL_EVENT_MESSAGE}" not in appinsights_source
+    assert "LOGGER_EXTERNAL_EVENT_MESSAGE," in appinsights_source
+
+    reminder_source = _read(REPO_ROOT / "application" / "single_app" / "functions_keyvault_reminders.py")
+    assert 'KEY_VAULT_SECRET_REMINDER_EXTERNAL_EVENT_NAME = "key_vault_expiration_reminder_triggered"' in reminder_source
+    assert "key_vault_secret_expiration_reminder_triggered" not in reminder_source
+
+    print("Test passed!")
+    return True
+
+
+def test_python_instructions_ban_raw_exception_responses():
+    """Validate the repo instructions prevent future raw exception responses."""
+    print("Testing Python instruction coverage for raw exception responses...")
+    instructions_source = _read(INSTRUCTIONS_FILE)
+    assert "Never return raw exception text" in instructions_source
+    assert "str(e)" in instructions_source
+    assert "str(exc)" in instructions_source
+    assert "repr(e)" in instructions_source
+
+    print("Test passed!")
+    return True
+
+
+if __name__ == "__main__":
+    tests = [
+        test_key_vault_plugin_exception_responses_are_stable,
+        test_external_telemetry_event_name_avoids_secret_word_in_logger_message,
+        test_python_instructions_ban_raw_exception_responses,
+    ]
+    results = []
+    for test in tests:
+        print(f"\nRunning {test.__name__}...")
+        try:
+            results.append(test())
+        except Exception as exc:
+            print(f"Test failed: {type(exc).__name__}")
+            import traceback
+            traceback.print_exc()
+            results.append(False)
+
+    success = all(results)
+    print(f"\nResults: {sum(1 for result in results if result)}/{len(results)} tests passed")
+    sys.exit(0 if success else 1)

--- a/functional_tests/test_plugin_error_response_sanitization.py
+++ b/functional_tests/test_plugin_error_response_sanitization.py
@@ -76,8 +76,7 @@ def test_external_telemetry_event_name_avoids_secret_word_in_logger_message():
     assert "LOGGER_EXTERNAL_EVENT_MESSAGE," in appinsights_source
 
     reminder_source = _read(REPO_ROOT / "application" / "single_app" / "functions_keyvault_reminders.py")
-    assert 'KEY_VAULT_SECRET_REMINDER_EXTERNAL_EVENT_NAME = "key_vault_expiration_reminder_triggered"' in reminder_source
-    assert "key_vault_secret_expiration_reminder_triggered" not in reminder_source
+    assert 'KEY_VAULT_REMINDER_EXTERNAL_EVENT_NAME = "key_vault_expiration_reminder_triggered"' in reminder_source
 
     print("Test passed!")
     return True

--- a/functional_tests/test_sql_plugin_key_vault_secret_storage.py
+++ b/functional_tests/test_sql_plugin_key_vault_secret_storage.py
@@ -2,8 +2,8 @@
 # test_sql_plugin_key_vault_secret_storage.py
 """
 Functional test for SQL plugin Key Vault secret storage.
-Version: 0.239.114
-Implemented in: 0.239.114
+Version: 0.250.121
+Implemented in: 0.239.114; 0.250.121
 
 This test ensures that SQL plugin secret-bearing fields are stored in Key Vault,
 preserved across edits, and cleaned up correctly when Key Vault storage is enabled.
@@ -29,6 +29,9 @@ class FakeRetrievedSecret:
 class FakeSecretClient:
     stored_secrets = {}
     deleted_secrets = []
+    set_calls = []
+    property_updates = []
+    fail_on_set = False
 
     def __init__(self, vault_url, credential):
         self.vault_url = vault_url
@@ -38,12 +41,21 @@ class FakeSecretClient:
     def reset(cls):
         cls.stored_secrets = {}
         cls.deleted_secrets = []
+        cls.set_calls = []
+        cls.property_updates = []
+        cls.fail_on_set = False
 
     def set_secret(self, name, value):
+        if FakeSecretClient.fail_on_set:
+            raise RuntimeError('simulated Key Vault write failure')
         FakeSecretClient.stored_secrets[name] = value
+        FakeSecretClient.set_calls.append({'name': name, 'value': value})
 
     def get_secret(self, name):
         return FakeRetrievedSecret(FakeSecretClient.stored_secrets[name])
+
+    def update_secret_properties(self, name, expires_on=None):
+        FakeSecretClient.property_updates.append({'name': name, 'expires_on': expires_on})
 
     def begin_delete_secret(self, name):
         FakeSecretClient.deleted_secrets.append(name)
@@ -150,6 +162,34 @@ def _load_functions_keyvault():
         'key_vault_identity': None,
     }
 
+    reminder_stub = types.ModuleType('functions_keyvault_reminders')
+    reminder_stub.upsert_calls = []
+    reminder_stub.disabled_calls = []
+
+    def resolve_key_vault_secret_reminder_config(owner_document, field_path):
+        metadata = owner_document.get('metadata') or {}
+        reminders = metadata.get('key_vault_secret_reminders') or {}
+        config = reminders.get('.'.join(field_path)) or reminders.get('__all__')
+        return config if isinstance(config, dict) else None
+
+    def upsert_key_vault_secret_reminder(secret_name, reminder_config, context, key_vault_sync_status='synced', key_vault_sync_error=''):
+        reminder_stub.upsert_calls.append({
+            'secret_name': secret_name,
+            'reminder_config': dict(reminder_config),
+            'context': dict(context),
+            'key_vault_sync_status': key_vault_sync_status,
+            'key_vault_sync_error': key_vault_sync_error,
+        })
+        return reminder_stub.upsert_calls[-1]
+
+    def mark_key_vault_secret_reminder_disabled(secret_name, context=None):
+        reminder_stub.disabled_calls.append({'secret_name': secret_name, 'context': dict(context or {})})
+        return reminder_stub.disabled_calls[-1]
+
+    reminder_stub.resolve_key_vault_secret_reminder_config = resolve_key_vault_secret_reminder_config
+    reminder_stub.upsert_key_vault_secret_reminder = upsert_key_vault_secret_reminder
+    reminder_stub.mark_key_vault_secret_reminder_disabled = mark_key_vault_secret_reminder_disabled
+
     azure_stub = types.ModuleType('azure')
     identity_stub = types.ModuleType('azure.identity')
     keyvault_stub = types.ModuleType('azure.keyvault')
@@ -173,6 +213,7 @@ def _load_functions_keyvault():
         'functions_authentication': auth_stub,
         'functions_settings': settings_stub,
         'app_settings_cache': settings_cache_stub,
+        'functions_keyvault_reminders': reminder_stub,
         'azure': azure_stub,
         'azure.identity': identity_stub,
         'azure.keyvault': keyvault_stub,
@@ -211,6 +252,13 @@ def _load_action_module(module_name, container, recorder):
     keyvault_stub.keyvault_plugin_get_helper = recorder.get
     keyvault_stub.keyvault_plugin_delete_helper = recorder.delete
 
+    workspace_identities_stub = types.ModuleType('functions_workspace_identities')
+    workspace_identities_stub.WORKSPACE_IDENTITY_SCOPE_GLOBAL = 'global'
+    workspace_identities_stub.WORKSPACE_IDENTITY_SCOPE_GROUP = 'group'
+    workspace_identities_stub.WORKSPACE_IDENTITY_SCOPE_PERSONAL = 'personal'
+    workspace_identities_stub.hydrate_action_identity_reference = lambda action, *args, **kwargs: action
+    workspace_identities_stub.validate_action_identity_reference = lambda action, *args, **kwargs: None
+
     auth_stub = types.ModuleType('functions_authentication')
     auth_stub.get_current_user_id = lambda: 'admin-123'
 
@@ -220,6 +268,14 @@ def _load_action_module(module_name, container, recorder):
 
     debug_stub = types.ModuleType('functions_debug')
     debug_stub.debug_print = lambda *args, **kwargs: None
+
+    governance_stub = types.ModuleType('functions_governance')
+    governance_stub.ensure_action_type_access = lambda *args, **kwargs: True
+    governance_stub.filter_actions_by_action_type_access = lambda user_id, actions, *args, **kwargs: actions
+
+    chat_bootstrap_cache_stub = types.ModuleType('functions_chat_bootstrap_cache')
+    chat_bootstrap_cache_stub.bump_chat_bootstrap_user_cache_version = lambda *args, **kwargs: None
+    chat_bootstrap_cache_stub.bump_chat_bootstrap_global_cache_version = lambda *args, **kwargs: None
 
     flask_stub = types.ModuleType('flask')
     flask_stub.current_app = None
@@ -235,9 +291,12 @@ def _load_action_module(module_name, container, recorder):
     module_stubs = {
         'config': config_stub,
         'functions_keyvault': keyvault_stub,
+        'functions_workspace_identities': workspace_identities_stub,
         'functions_authentication': auth_stub,
         'functions_settings': settings_stub,
         'functions_debug': debug_stub,
+        'functions_governance': governance_stub,
+        'functions_chat_bootstrap_cache': chat_bootstrap_cache_stub,
         'flask': flask_stub,
         'azure': azure_stub,
         'azure.cosmos': cosmos_stub,
@@ -307,6 +366,185 @@ def test_sql_keyvault_helper_stores_resolves_and_deletes_secrets():
         assert password_reference in FakeSecretClient.deleted_secrets
 
         print('✅ SQL helper stores, resolves, preserves, and deletes Key Vault-backed SQL secrets')
+        return True
+    finally:
+        _restore_modules(original_modules)
+
+
+def test_action_secret_rotation_writes_new_key_vault_versions_for_all_scopes():
+    """Validate literal replacement secrets update Key Vault for global, group, and personal actions."""
+    print('🔍 Testing action Key Vault secret rotation across scopes...')
+    module, original_modules = _load_functions_keyvault()
+
+    try:
+        for scope, scope_value in (
+            ('global', 'global-action-1'),
+            ('group', 'group-123'),
+            ('user', 'user-123'),
+        ):
+            FakeSecretClient.reset()
+            initial_action = {
+                'id': f'{scope}-action',
+                'name': 'service_principal_action',
+                'type': 'openapi',
+                'auth': {
+                    'type': 'servicePrincipal',
+                    'identity': 'client-id',
+                    'key': 'old-secret',
+                    'tenantId': 'tenant-id',
+                },
+                'metadata': {},
+                'additionalFields': {},
+            }
+            saved_action = module.keyvault_plugin_save_helper(initial_action, scope_value=scope_value, scope=scope)
+            secret_reference = saved_action['auth']['key']
+
+            updated_action = {
+                **saved_action,
+                'auth': {
+                    'type': 'servicePrincipal',
+                    'identity': 'client-id',
+                    'key': 'new-secret',
+                    'tenantId': 'tenant-id',
+                },
+            }
+            rotated_action = module.keyvault_plugin_save_helper(
+                updated_action,
+                scope_value=scope_value,
+                scope=scope,
+                existing_plugin=saved_action,
+            )
+
+            assert rotated_action['auth']['key'] == secret_reference
+            assert FakeSecretClient.stored_secrets[secret_reference] == 'new-secret'
+            assert [call['value'] for call in FakeSecretClient.set_calls] == ['old-secret', 'new-secret']
+
+        print('✅ Literal action secret updates create new Key Vault versions in every action scope')
+        return True
+    finally:
+        _restore_modules(original_modules)
+
+
+def test_keyvault_placeholder_without_existing_reference_is_rejected():
+    """Validate Stored_In_KeyVault cannot create a dead reference without a saved secret."""
+    print('🔍 Testing Stored_In_KeyVault placeholder rejection without existing reference...')
+    FakeSecretClient.reset()
+    module, original_modules = _load_functions_keyvault()
+
+    try:
+        try:
+            module.keyvault_plugin_save_helper(
+                {
+                    'name': 'service_principal_action',
+                    'type': 'openapi',
+                    'auth': {
+                        'type': 'servicePrincipal',
+                        'identity': 'client-id',
+                        'key': module.ui_trigger_word,
+                        'tenantId': 'tenant-id',
+                    },
+                    'metadata': {},
+                    'additionalFields': {},
+                },
+                scope_value='global-action-1',
+                scope='global',
+            )
+        except ValueError as exc:
+            assert 'has no existing secret reference' in str(exc)
+        else:
+            raise AssertionError('Expected Stored_In_KeyVault without an existing reference to be rejected')
+
+        print('✅ Placeholder without an existing Key Vault reference is rejected')
+        return True
+    finally:
+        _restore_modules(original_modules)
+
+
+def test_keyvault_write_failure_is_not_persisted_as_raw_secret():
+    """Validate Key Vault write failures surface instead of saving the raw secret."""
+    print('🔍 Testing Key Vault write failure handling...')
+    FakeSecretClient.reset()
+    FakeSecretClient.fail_on_set = True
+    module, original_modules = _load_functions_keyvault()
+
+    try:
+        try:
+            module.keyvault_plugin_save_helper(
+                {
+                    'name': 'service_principal_action',
+                    'type': 'openapi',
+                    'auth': {
+                        'type': 'servicePrincipal',
+                        'identity': 'client-id',
+                        'key': 'new-secret',
+                        'tenantId': 'tenant-id',
+                    },
+                    'metadata': {},
+                    'additionalFields': {},
+                },
+                scope_value='global-action-1',
+                scope='global',
+            )
+        except RuntimeError as exc:
+            assert 'Failed to store plugin key in Key Vault' in str(exc)
+            assert FakeSecretClient.stored_secrets == {}
+        else:
+            raise AssertionError('Expected Key Vault write failure to abort the save')
+
+        print('✅ Key Vault write failures abort saves instead of persisting raw secrets')
+        return True
+    finally:
+        _restore_modules(original_modules)
+
+
+def test_action_secret_reminder_metadata_syncs_key_vault_expiration_inventory():
+    """Validate action reminder metadata updates Key Vault expiration and inventory context."""
+    print('🔍 Testing action Key Vault reminder metadata sync...')
+    FakeSecretClient.reset()
+    module, original_modules = _load_functions_keyvault()
+
+    try:
+        action = {
+            'id': 'global-action-1',
+            'name': 'service_principal_action',
+            'displayName': 'Service Principal Action',
+            'type': 'openapi',
+            'auth': {
+                'type': 'servicePrincipal',
+                'identity': 'client-id',
+                'key': 'new-secret',
+                'tenantId': 'tenant-id',
+            },
+            'metadata': {
+                'key_vault_secret_reminders': {
+                    '__all__': {
+                        'enabled': True,
+                        'expires_on': '2030-01-15',
+                        'contact_email': 'owner@example.com',
+                        'lead_days': 21,
+                        'label': 'Production service principal',
+                        'notes': 'Rotate in Entra app registration.',
+                    }
+                }
+            },
+            'additionalFields': {},
+        }
+
+        saved_action = module.keyvault_plugin_save_helper(action, scope_value='global-action-1', scope='global')
+        secret_reference = saved_action['auth']['key']
+        reminder_module = sys.modules['functions_keyvault_reminders']
+
+        assert FakeSecretClient.property_updates, 'Key Vault secret expiration should be updated'
+        assert FakeSecretClient.property_updates[-1]['name'] == secret_reference
+        assert FakeSecretClient.property_updates[-1]['expires_on'].date().isoformat() == '2030-01-15'
+        assert reminder_module.upsert_calls, 'Reminder inventory should be upserted'
+        assert reminder_module.upsert_calls[-1]['secret_name'] == secret_reference
+        assert reminder_module.upsert_calls[-1]['context']['scope'] == 'global'
+        assert reminder_module.upsert_calls[-1]['context']['source_display_name'] == 'Service Principal Action'
+        assert reminder_module.upsert_calls[-1]['context']['field_path'] == 'auth.key'
+        assert saved_action['metadata']['key_vault_secret_reminder_sync']['auth.key']['status'] == 'synced'
+
+        print('✅ Action reminder metadata syncs Key Vault expiration and inventory context')
         return True
     finally:
         _restore_modules(original_modules)
@@ -482,6 +720,10 @@ def test_global_and_group_action_wrappers_preserve_existing_sql_secret_reference
 if __name__ == '__main__':
     tests = [
         test_sql_keyvault_helper_stores_resolves_and_deletes_secrets,
+        test_action_secret_rotation_writes_new_key_vault_versions_for_all_scopes,
+        test_keyvault_placeholder_without_existing_reference_is_rejected,
+        test_keyvault_write_failure_is_not_persisted_as_raw_secret,
+        test_action_secret_reminder_metadata_syncs_key_vault_expiration_inventory,
         test_personal_action_wrapper_preserves_existing_sql_secret_references,
         test_global_and_group_action_wrappers_preserve_existing_sql_secret_references,
     ]

--- a/functional_tests/test_sql_plugin_key_vault_secret_storage.py
+++ b/functional_tests/test_sql_plugin_key_vault_secret_storage.py
@@ -2,8 +2,8 @@
 # test_sql_plugin_key_vault_secret_storage.py
 """
 Functional test for SQL plugin Key Vault secret storage.
-Version: 0.250.121
-Implemented in: 0.239.114; 0.250.121
+Version: 0.250.124
+Implemented in: 0.239.114; 0.250.121; 0.250.124
 
 This test ensures that SQL plugin secret-bearing fields are stored in Key Vault,
 preserved across edits, and cleaned up correctly when Key Vault storage is enabled.

--- a/ui_tests/test_admin_key_vault_reminders_ui.py
+++ b/ui_tests/test_admin_key_vault_reminders_ui.py
@@ -1,0 +1,96 @@
+# test_admin_key_vault_reminders_ui.py
+"""
+UI test for Key Vault expiration reminder controls and external alert guidance.
+
+Version: 0.250.123
+Implemented in: 0.250.121; 0.250.122; 0.250.123
+
+This test ensures the admin Key Vault reminder inventory and action-modal
+reminder controls render with stable IDs, external alert guidance, optional
+contact email telemetry controls, and safe local JavaScript wiring.
+"""
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ADMIN_TEMPLATE = REPO_ROOT / "application" / "single_app" / "templates" / "admin_settings.html"
+PLUGIN_MODAL_TEMPLATE = REPO_ROOT / "application" / "single_app" / "templates" / "_plugin_modal.html"
+ADMIN_JS = REPO_ROOT / "application" / "single_app" / "static" / "js" / "admin" / "admin_settings.js"
+PLUGIN_MODAL_JS = REPO_ROOT / "application" / "single_app" / "static" / "js" / "plugin_modal_stepper.js"
+
+
+def _extract_function(source, function_name):
+    start = source.index(f"function {function_name}")
+    next_function = source.find("\nfunction ", start + 1)
+    if next_function == -1:
+        return source[start:]
+    return source[start:next_function]
+
+
+def test_admin_key_vault_reminder_dashboard_contract():
+    """Validate admin inventory controls, endpoint wiring, and safe rendering."""
+    template = ADMIN_TEMPLATE.read_text(encoding="utf-8")
+    source = ADMIN_JS.read_text(encoding="utf-8")
+
+    required_ids = [
+        "enable_key_vault_secret_expiration_reminders",
+        "key_vault_expiration_reminder_settings",
+        "key_vault_secret_expiration_default_lead_days",
+        "key_vault_secret_expiration_default_contact_email",
+        "key_vault_secret_expiration_admin_roles",
+        "key_vault_secret_expiration_scan_interval_seconds",
+        "key_vault_secret_expiration_require_expiration",
+        "key_vault_secret_expiration_emit_contact_email_in_telemetry",
+        "key_vault_secret_expiration_emit_contact_email_in_telemetry_help",
+        "key-vault-reminders-refresh",
+        "key-vault-reminders-search",
+        "key-vault-reminders-status",
+        "key-vault-reminders-run",
+        "key-vault-reminders-status-message",
+        "key-vault-reminders-table-body",
+        "key-vault-external-alert-guidance",
+    ]
+    for element_id in required_ids:
+        assert f'id="{element_id}"' in template
+
+    assert "keyVaultSettings.style.display" not in source
+    assert "keyVaultReminderSettings.classList.toggle('d-none'" in source
+    assert "/api/admin/settings/key-vault/secret-reminders" in source
+    assert "/api/admin/settings/key-vault/secret-reminders/run" in source
+    assert "key_vault_secret_expiration_reminder_triggered" in template
+    assert "customDimensions.sc_event_name" in template
+    assert "customDimensions.sc_event_contact_email" in template
+    assert "Azure Monitor scheduled query alert" in template
+    assert "Reminder ID" in template
+    assert "function renderKeyVaultReminderInventory" in source
+    render_function = _extract_function(source, "renderKeyVaultReminderInventory")
+    assert "textContent" in render_function
+    assert "replaceChildren" in render_function
+    assert "reminder.id" in render_function
+    assert "innerHTML" not in render_function
+
+
+def test_action_modal_key_vault_reminder_contract():
+    """Validate action modal reminder controls and metadata payload wiring."""
+    template = PLUGIN_MODAL_TEMPLATE.read_text(encoding="utf-8")
+    source = PLUGIN_MODAL_JS.read_text(encoding="utf-8")
+
+    required_ids = [
+        "plugin-key-vault-reminder-enabled",
+        "plugin-key-vault-reminder-fields",
+        "plugin-key-vault-reminder-expires-on",
+        "plugin-key-vault-reminder-email",
+        "plugin-key-vault-reminder-lead-days",
+        "plugin-key-vault-reminder-label",
+        "plugin-key-vault-reminder-notes",
+    ]
+    for element_id in required_ids:
+        assert f'id="{element_id}"' in template
+
+    assert "KEY_VAULT_SECRET_REMINDERS_METADATA_FIELD = 'key_vault_secret_reminders'" in source
+    assert "KEY_VAULT_SECRET_REMINDER_ALL_FIELDS = '__all__'" in source
+    assert "toggleKeyVaultReminderFields" in source
+    assert "populateKeyVaultReminderForm(plugin.metadata || {})" in source
+    assert "validateKeyVaultReminderFields" in source
+    assert "applyKeyVaultReminderMetadata(metadata)" in source

--- a/ui_tests/test_admin_key_vault_reminders_ui.py
+++ b/ui_tests/test_admin_key_vault_reminders_ui.py
@@ -2,8 +2,8 @@
 """
 UI test for Key Vault expiration reminder controls and external alert guidance.
 
-Version: 0.250.123
-Implemented in: 0.250.121; 0.250.122; 0.250.123
+Version: 0.250.124
+Implemented in: 0.250.121; 0.250.122; 0.250.123; 0.250.124
 
 This test ensures the admin Key Vault reminder inventory and action-modal
 reminder controls render with stable IDs, external alert guidance, optional
@@ -58,7 +58,7 @@ def test_admin_key_vault_reminder_dashboard_contract():
     assert "keyVaultReminderSettings.classList.toggle('d-none'" in source
     assert "/api/admin/settings/key-vault/secret-reminders" in source
     assert "/api/admin/settings/key-vault/secret-reminders/run" in source
-    assert "key_vault_secret_expiration_reminder_triggered" in template
+    assert "key_vault_expiration_reminder_triggered" in template
     assert "customDimensions.sc_event_name" in template
     assert "customDimensions.sc_event_contact_email" in template
     assert "Azure Monitor scheduled query alert" in template


### PR DESCRIPTION
### Summary

Fixes #1156

Adds Key Vault expiration reminder tracking and reliable Key Vault-backed secret rotation across action scopes.

- Adds a SimpleChat-managed Key Vault secret reminder inventory, admin dashboard, manual sweep API, and background sweep.
- Adds per-action reminder metadata controls for expiration date, lead days, contact email, label, and rotation notes.
- Fixes global, group, and personal action secret rotation so replacing a Key Vault-backed secret writes a new Key Vault secret version instead of preserving the old value.
- Adds privacy-safe Application Insights telemetry for external Azure Monitor automation, with a default-off admin opt-in for emitting reminder contact email.
- Adds `key_vault_secret_expiring` in-app notifications, feature/fix documentation, release notes, and focused regression/UI tests.

### Validation

- `git --no-pager diff --check`
- `python -m py_compile` for changed Python files
- `node --check application\single_app\static\js\admin\admin_settings.js`
- `node --check application\single_app\static\js\plugin_modal_stepper.js`
- `python functional_tests\test_keyvault_external_notification_telemetry.py`
- `$env:PYTHONUTF8='1'; python functional_tests\test_sql_plugin_key_vault_secret_storage.py`
- `python functional_tests\test_keyvault_plugin_secret_scope_enforcement.py`
- `python functional_tests\test_model_endpoints_key_vault_secret_storage.py`
- `python functional_tests\route_tests\test_route_blueprint_policy_inventory.py`
- `python functional_tests\route_tests\test_route_unauthenticated_policy_contract.py`
- `python functional_tests\route_tests\test_route_policy_test_coverage.py`
- `python scripts\check_swagger_routes.py application\single_app\route_backend_plugins.py application\single_app\route_backend_settings.py application\single_app\route_frontend_admin_settings.py`
- `python scripts\check_xss_sinks.py --base-sha origin/Development --head-sha HEAD <changed application browser files>`
- `python scripts\check_broken_access_control.py --base-sha origin/Development --head-sha HEAD <changed application Python files>`
- `python -m pytest ui_tests\test_admin_key_vault_reminders_ui.py -q`

### Release Notes and Documentation

- Version bumped to `0.250.123`.
- Release notes updated under `v0.250.121`, `v0.250.122`, and `v0.250.123`.
- Feature documentation added: `docs/explanation/features/KEY_VAULT_EXPIRATION_REMINDERS.md`
- Fix documentation added: `docs/explanation/fixes/KEY_VAULT_SECRET_ROTATION_FIX.md`

### Known Risks / Follow-up

- SimpleChat emits in-app notifications and Application Insights telemetry, but external email delivery still depends on an admin-configured Azure Monitor alert/action group, Logic App, Function, or webhook.
- Reminder contact email is excluded from telemetry by default and only emitted when admins explicitly enable the new opt-in setting.
- Changed-line XSS and broken-access-control scans pass. A full-file XSS scan of the already-large touched UI files still reports pre-existing legacy sink patterns outside the new Key Vault reminder hunks.
