### PR TITLE
Add Phase 11A deliverable planning contracts

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -95,7 +95,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.250.125"
+VERSION = "0.250.126"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/functions_central_synthesis.py
+++ b/application/single_app/functions_central_synthesis.py
@@ -5,6 +5,7 @@ import json
 import re
 from collections.abc import Mapping
 
+from functions_deliverable_planner import materialize_deliverable_plan
 from functions_evidence_ledger import compact_evidence_ledger_for_model
 
 
@@ -89,6 +90,16 @@ def create_central_synthesis_request(
     requested_output = compact_ledger.get('requested_output')
     if not isinstance(requested_output, Mapping):
         requested_output = {}
+    deliverable_intent = compact_ledger.get('deliverable_intent')
+    if not isinstance(deliverable_intent, Mapping):
+        deliverable_intent = {}
+    materialized_deliverable_plan = compact_ledger.get('materialized_deliverable_plan')
+    if not isinstance(materialized_deliverable_plan, Mapping) or not materialized_deliverable_plan:
+        materialized_deliverable_plan = (
+            materialize_deliverable_plan(deliverable_intent, compact_ledger)
+            if deliverable_intent.get('version')
+            else {}
+        )
 
     return {
         'version': CENTRAL_SYNTHESIS_CONTRACT_VERSION,
@@ -98,6 +109,8 @@ def create_central_synthesis_request(
         'task_profile': compact_ledger.get('task_profile'),
         'original_request': normalized_request,
         'requested_output': dict(requested_output),
+        'deliverable_intent': dict(deliverable_intent),
+        'materialized_deliverable_plan': dict(materialized_deliverable_plan),
         'finalizer': str(plan.get('finalizer') or requested_output.get('type') or 'response'),
         'evidence_status': compact_ledger.get('status'),
         'evidence_ledger': compact_ledger,
@@ -157,6 +170,7 @@ def build_central_synthesis_messages(synthesis_request):
         'Never use unsupported_facts as factual content or fill missing evidence with assumptions.',
         'Disclose material missing evidence, failed required attempts, authorization denials, and unresolved conflicts.',
         'Produce one coherent final output that follows output_profile and requested_output.',
+        'Use materialized_deliverable_plan to distinguish complete inline answers, summaries, and artifacts.',
         'Do not claim that a proposed artifact was generated when approval is still required.',
     ])
     user_message = (

--- a/application/single_app/functions_deliverable_planner.py
+++ b/application/single_app/functions_deliverable_planner.py
@@ -1,0 +1,495 @@
+# functions_deliverable_planner.py
+"""Deterministic deliverable planning contracts for chat orchestration."""
+
+import re
+from collections.abc import Mapping
+from datetime import datetime, timezone
+
+
+DELIVERABLE_PLAN_CONTRACT_VERSION = 1
+DELIVERABLE_ADAPTER_REGISTRY_REVISION = 1
+DEFAULT_DELIVERABLE_INTENT_REVISION = 1
+DEFAULT_MATERIALIZED_DELIVERABLE_PLAN_REVISION = 1
+DEFAULT_INLINE_RESPONSE_MAX_CHARS = 12000
+
+DELIVERABLE_RESPONSE_MODES = frozenset({
+    'inline_response_only',
+    'full_inline_with_supporting_artifacts',
+    'summary_with_primary_artifact',
+    'summary_with_supporting_artifacts',
+    'clarification_required',
+})
+DELIVERABLE_KINDS = frozenset({'inline_response', 'generated_file', 'workspace_artifact'})
+DELIVERABLE_DIRECTIVE_EFFECTS = (
+    'prefer',
+    'avoid',
+    'require',
+    'explicit_only',
+    'ask_first',
+    'forbid',
+    'automatic_when_useful',
+)
+GENERATED_FILE_FORMAT_ALIASES = {
+    'csv': 'csv',
+    'comma-separated values': 'csv',
+    'md': 'md',
+    'markdown': 'md',
+    'json': 'json',
+    'xml': 'xml',
+    'pdf': 'pdf',
+    'docx': 'docx',
+    'word': 'docx',
+    'powerpoint': 'pptx',
+    'pptx': 'pptx',
+}
+FORMAT_TOKEN_PATTERN = re.compile(
+    r'\b(csv|markdown|md|json|xml|pdf|docx|word|powerpoint|pptx)\b',
+    re.IGNORECASE,
+)
+
+
+def _utc_now():
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _normalize_text(value, *, max_chars=4000):
+    normalized = re.sub(r'\s+', ' ', str(value or '').strip())
+    return normalized[:max_chars].rstrip()
+
+
+def _normalize_identifier(value, field_name, *, max_chars=160):
+    normalized = _normalize_text(value, max_chars=max_chars).lower()
+    normalized = re.sub(r'[^a-z0-9_.:-]+', '_', normalized).strip('_')
+    if not normalized:
+        raise ValueError(f'{field_name} is required')
+    return normalized
+
+
+def _normalize_ids(values):
+    if values is None:
+        return []
+    if isinstance(values, str):
+        values = [values]
+
+    normalized = []
+    for value in values:
+        identifier = str(value or '').strip()
+        if identifier and identifier not in normalized:
+            normalized.append(identifier)
+    return normalized
+
+
+def _normalize_bool(value, default=False):
+    if value is None:
+        return default
+    if isinstance(value, str):
+        return value.strip().lower() in {'1', 'true', 'yes', 'on'}
+    return bool(value)
+
+
+def _normalize_mapping(value, field_name):
+    if value is None:
+        return {}
+    if not isinstance(value, Mapping):
+        raise ValueError(f'{field_name} must be a mapping')
+    return dict(value)
+
+
+def _normalize_format(value):
+    normalized = _normalize_text(value, max_chars=80).lower()
+    return GENERATED_FILE_FORMAT_ALIASES.get(normalized, normalized)
+
+
+def _detect_format_from_text(value):
+    match = FORMAT_TOKEN_PATTERN.search(str(value or ''))
+    if not match:
+        return ''
+    return _normalize_format(match.group(1))
+
+
+def _build_adapter(adapter_id, *, kind, output_format, role, approval_required=False):
+    return {
+        'id': adapter_id,
+        'kind': kind,
+        'format': output_format,
+        'role': role,
+        'schema_revision': 1,
+        'registry_revision': DELIVERABLE_ADAPTER_REGISTRY_REVISION,
+        'approval_required': bool(approval_required),
+        'automatic_generation_supported': True,
+    }
+
+
+def get_available_deliverable_adapters(policy=None):
+    """Return deterministic, server-owned deliverable adapter descriptors."""
+    normalized_policy = _normalize_mapping(policy, 'policy')
+    disabled_adapter_ids = set(_normalize_ids(normalized_policy.get('disabled_adapter_ids')))
+    adapters = [
+        _build_adapter(
+            'inline_response',
+            kind='inline_response',
+            output_format='markdown',
+            role='primary_inline_answer',
+        ),
+        _build_adapter(
+            'markdown_analysis_artifact',
+            kind='generated_file',
+            output_format='md',
+            role='supporting_audit_artifact',
+        ),
+        _build_adapter(
+            'csv_structured_artifact',
+            kind='generated_file',
+            output_format='csv',
+            role='structured_supporting_output',
+        ),
+    ]
+    return [adapter for adapter in adapters if adapter['id'] not in disabled_adapter_ids]
+
+
+def _adapter_by_format(adapters, requested_format):
+    normalized_format = _normalize_format(requested_format)
+    for adapter in adapters:
+        if adapter.get('kind') == 'generated_file' and adapter.get('format') == normalized_format:
+            return adapter
+    return None
+
+
+def normalize_directive_snapshot(directive_snapshot=None):
+    """Normalize a resolved directive snapshot without reading raw instruction text."""
+    if directive_snapshot is None:
+        return {
+            'available': False,
+            'revision': None,
+            'effects': {effect: [] for effect in DELIVERABLE_DIRECTIVE_EFFECTS},
+        }
+    if not isinstance(directive_snapshot, Mapping):
+        raise ValueError('directive_snapshot must be a mapping')
+
+    raw_effects = directive_snapshot.get('effects')
+    if not isinstance(raw_effects, Mapping):
+        raw_effects = directive_snapshot
+
+    effects = {}
+    for effect in DELIVERABLE_DIRECTIVE_EFFECTS:
+        entries = []
+        for index, entry in enumerate(raw_effects.get(effect) or []):
+            if not isinstance(entry, Mapping):
+                continue
+            directive_ref = _normalize_text(
+                entry.get('directive_ref') or entry.get('ref') or f'{effect}_{index + 1}',
+                max_chars=160,
+            )
+            target = _normalize_text(
+                entry.get('target') or entry.get('deliverable_kind') or entry.get('format'),
+                max_chars=160,
+            )
+            if directive_ref:
+                entries.append({
+                    'directive_ref': directive_ref,
+                    'target': target or '*',
+                    'reason_code': _normalize_text(
+                        entry.get('reason_code') or effect,
+                        max_chars=120,
+                    ),
+                })
+        effects[effect] = entries
+
+    return {
+        'available': True,
+        'revision': _normalize_text(
+            directive_snapshot.get('revision') or directive_snapshot.get('snapshot_revision'),
+            max_chars=120,
+        ) or None,
+        'effects': effects,
+    }
+
+
+def _normalize_requested_output(requested_output=None):
+    normalized = _normalize_mapping(requested_output, 'requested_output')
+    output_type = _normalize_text(normalized.get('type') or 'response', max_chars=120) or 'response'
+    output_format = _normalize_format(normalized.get('format') or normalized.get('file_format'))
+    if not output_format:
+        output_format = _detect_format_from_text(output_type)
+    if not output_format:
+        output_format = _detect_format_from_text(normalized.get('instructions'))
+
+    normalized_output = {
+        'type': output_type,
+    }
+    if output_format:
+        normalized_output['format'] = output_format
+    if isinstance(normalized.get('schema'), Mapping):
+        normalized_output['schema'] = dict(normalized['schema'])
+    instructions = []
+    for instruction in normalized.get('instructions') or []:
+        normalized_instruction = _normalize_text(instruction, max_chars=1000)
+        if normalized_instruction and normalized_instruction not in instructions:
+            instructions.append(normalized_instruction)
+    if instructions:
+        normalized_output['instructions'] = instructions[:24]
+    return normalized_output
+
+
+def _build_provisional_deliverables(requested_output, adapters):
+    requested_format = requested_output.get('format')
+    requested_type = str(requested_output.get('type') or '').strip().lower()
+    if not requested_format and requested_type in GENERATED_FILE_FORMAT_ALIASES:
+        requested_format = _normalize_format(requested_type)
+    if not requested_format and requested_type in {'generated_file', 'file', 'artifact'}:
+        requested_format = 'md'
+
+    if not requested_format:
+        return []
+
+    adapter = _adapter_by_format(adapters, requested_format)
+    if not adapter:
+        return [{
+            'id': f'unsupported_{requested_format}_deliverable',
+            'kind': 'generated_file',
+            'format': requested_format,
+            'role': 'requested_output',
+            'required': True,
+            'adapter_id': None,
+            'status': 'unsupported',
+            'reason_codes': ['requested_format_not_supported'],
+        }]
+
+    return [{
+        'id': f'{adapter["format"]}_requested_deliverable',
+        'kind': adapter['kind'],
+        'format': adapter['format'],
+        'role': 'primary_requested_artifact',
+        'required': True,
+        'adapter_id': adapter['id'],
+        'status': 'provisional',
+        'reason_codes': ['explicit_requested_output'],
+    }]
+
+
+def _select_response_mode(provisional_deliverables, requested_output):
+    if not provisional_deliverables:
+        return 'inline_response_only'
+    if str(requested_output.get('type') or '').strip().lower() in {'summary_with_artifact', 'summary'}:
+        return 'summary_with_supporting_artifacts'
+    if any(deliverable.get('required') for deliverable in provisional_deliverables):
+        return 'summary_with_primary_artifact'
+    return 'summary_with_supporting_artifacts'
+
+
+def build_deliverable_intent(
+    original_request,
+    plan,
+    *,
+    requested_output=None,
+    output_profile=None,
+    directive_snapshot=None,
+    adapters=None,
+    policy=None,
+    capability_plan_revision=None,
+    intent_revision=DEFAULT_DELIVERABLE_INTENT_REVISION,
+    created_at=None,
+):
+    """Build the pre-execution, server-authoritative deliverable intent."""
+    if not isinstance(plan, Mapping):
+        raise ValueError('plan must be a mapping')
+    normalized_requested_output = _normalize_requested_output(requested_output)
+    normalized_output_profile = _normalize_mapping(output_profile, 'output_profile')
+    normalized_policy = _normalize_mapping(policy, 'policy')
+    available_adapters = list(adapters or get_available_deliverable_adapters(normalized_policy))
+    provisional_deliverables = _build_provisional_deliverables(
+        normalized_requested_output,
+        available_adapters,
+    )
+    directive_constraints = normalize_directive_snapshot(directive_snapshot)
+    response_mode = _select_response_mode(provisional_deliverables, normalized_requested_output)
+
+    return {
+        'version': DELIVERABLE_PLAN_CONTRACT_VERSION,
+        'deliverable_intent_revision': int(intent_revision),
+        'run_id': _normalize_text(plan.get('run_id'), max_chars=160) or None,
+        'source_plan_id': _normalize_text(plan.get('run_id'), max_chars=160) or None,
+        'capability_plan_revision': capability_plan_revision or plan.get('version'),
+        'requested_outcome': _normalize_text(original_request, max_chars=8000),
+        'requested_output': normalized_requested_output,
+        'output_profile': normalized_output_profile,
+        'response_mode': response_mode,
+        'primary_response': {
+            'type': 'inline_summary' if provisional_deliverables else 'inline_answer',
+            'target_length': 'concise' if provisional_deliverables else 'complete',
+            'must_include': ['what_was_done', 'key_findings', 'next_actions']
+            if provisional_deliverables
+            else [],
+        },
+        'provisional_deliverables': provisional_deliverables,
+        'available_adapters': available_adapters,
+        'directive_constraints': directive_constraints,
+        'constraints': {
+            'supported_evidence_only': True,
+            'do_not_claim_unpublished_artifacts': True,
+            'preserve_missing_and_partial_coverage': True,
+            'max_inline_chars': int(
+                normalized_policy.get('max_inline_chars') or DEFAULT_INLINE_RESPONSE_MAX_CHARS
+            ),
+            'automatic_optional_artifacts_allowed': _normalize_bool(
+                normalized_policy.get('automatic_optional_artifacts_allowed'),
+                default=True,
+            ),
+        },
+        'policy': {
+            'publication_target': _normalize_text(
+                normalized_policy.get('publication_target') or 'chat_message',
+                max_chars=120,
+            ),
+            'audience_scope': _normalize_text(
+                normalized_policy.get('audience_scope') or 'conversation',
+                max_chars=120,
+            ),
+            'approval_required_for_storage': _normalize_bool(
+                normalized_policy.get('approval_required_for_storage'),
+                default=False,
+            ),
+        },
+        'created_at': _normalize_text(created_at, max_chars=120) or _utc_now(),
+    }
+
+
+def _ledger_ids(ledger, section):
+    if not isinstance(ledger, Mapping):
+        return []
+    values = ledger.get(section) or []
+    return [entry.get('id') for entry in values if isinstance(entry, Mapping) and entry.get('id')]
+
+
+def _build_evidence_snapshot(ledger):
+    return {
+        'ledger_status': _normalize_text((ledger or {}).get('status'), max_chars=80),
+        'requirement_ids': _ledger_ids(ledger, 'requirements'),
+        'source_ids': _ledger_ids(ledger, 'sources'),
+        'fact_ids': _ledger_ids(ledger, 'facts'),
+        'result_ids': _ledger_ids(ledger, 'results'),
+        'artifact_ids': _ledger_ids(ledger, 'artifacts'),
+        'conflict_ids': _ledger_ids(ledger, 'conflicts'),
+        'missing_or_failed_ids': _ledger_ids(ledger, 'missing_or_failed'),
+    }
+
+
+def _materialize_deliverable(deliverable, evidence_snapshot, intent):
+    required = _normalize_bool(deliverable.get('required'), default=False)
+    ledger_status = evidence_snapshot.get('ledger_status')
+    missing_count = len(evidence_snapshot.get('missing_or_failed_ids') or [])
+    status = 'planned'
+    if deliverable.get('status') == 'unsupported':
+        status = 'failed'
+    elif ledger_status == 'failed' and required:
+        status = 'failed'
+    elif missing_count:
+        status = 'partial'
+
+    approval_required = bool(
+        deliverable.get('approval_required')
+        or intent.get('policy', {}).get('approval_required_for_storage')
+        or intent.get('directive_constraints', {}).get('effects', {}).get('ask_first')
+    )
+    return {
+        'id': _normalize_identifier(deliverable.get('id'), 'deliverable id'),
+        'kind': _normalize_identifier(deliverable.get('kind'), 'deliverable kind'),
+        'format': _normalize_text(deliverable.get('format'), max_chars=80) or None,
+        'role': _normalize_text(deliverable.get('role'), max_chars=160) or 'supporting_output',
+        'required': required,
+        'status': status,
+        'adapter_id': _normalize_text(deliverable.get('adapter_id'), max_chars=160) or None,
+        'adapter_schema_revision': 1,
+        'source_evidence': (
+            ['ledger_supported_facts']
+            if evidence_snapshot.get('fact_ids')
+            else ['ledger_results']
+            if evidence_snapshot.get('result_ids')
+            else []
+        ),
+        'approval_required': approval_required,
+        'approval': {
+            'state': 'required' if approval_required else 'not_required',
+            'bound_to_materialized_plan_revision': None,
+        },
+        'publication': {
+            'target': intent.get('policy', {}).get('publication_target') or 'chat_message',
+            'audience_scope': intent.get('policy', {}).get('audience_scope') or 'conversation',
+            'state': 'not_published',
+        },
+        'failure_behavior': 'disclose_failure_and_continue',
+        'reason_codes': list(deliverable.get('reason_codes') or []),
+    }
+
+
+def materialize_deliverable_plan(
+    deliverable_intent,
+    ledger,
+    *,
+    materialized_plan_revision=DEFAULT_MATERIALIZED_DELIVERABLE_PLAN_REVISION,
+    partial_evidence_override=None,
+    approval_decision=None,
+    created_at=None,
+):
+    """Bind deliverable intent to a terminal evidence snapshot."""
+    intent = _normalize_mapping(deliverable_intent, 'deliverable_intent')
+    if intent.get('version') != DELIVERABLE_PLAN_CONTRACT_VERSION:
+        raise ValueError('deliverable_intent must use a supported version')
+    if not isinstance(ledger, Mapping):
+        raise ValueError('ledger must be a mapping')
+
+    evidence_snapshot = _build_evidence_snapshot(ledger)
+    deliverables = [
+        _materialize_deliverable(deliverable, evidence_snapshot, intent)
+        for deliverable in intent.get('provisional_deliverables') or []
+        if isinstance(deliverable, Mapping)
+    ]
+    approval = _normalize_mapping(approval_decision, 'approval_decision')
+    normalized_revision = int(materialized_plan_revision)
+    for deliverable in deliverables:
+        deliverable['approval']['bound_to_materialized_plan_revision'] = normalized_revision
+        if approval.get('state'):
+            deliverable['approval']['state'] = _normalize_text(approval.get('state'), max_chars=80)
+
+    materialized = {
+        'version': DELIVERABLE_PLAN_CONTRACT_VERSION,
+        'deliverable_intent_revision': intent.get('deliverable_intent_revision'),
+        'materialized_plan_revision': normalized_revision,
+        'run_id': intent.get('run_id') or ledger.get('run_id'),
+        'source_plan_id': intent.get('source_plan_id'),
+        'requested_outcome': intent.get('requested_outcome') or '',
+        'response_mode': intent.get('response_mode') or 'inline_response_only',
+        'primary_response': dict(intent.get('primary_response') or {}),
+        'deliverables': deliverables,
+        'evidence_snapshot': evidence_snapshot,
+        'constraints': dict(intent.get('constraints') or {}),
+        'directive_outcomes': {
+            'applied': [],
+            'overridden': [],
+            'conflicting': [],
+            'ignored': [],
+            'source_revision': (
+                intent.get('directive_constraints') or {}
+            ).get('revision'),
+        },
+        'approval_decision': approval or {'state': 'not_required'},
+        'publication_lineage': [],
+        'created_at': _normalize_text(created_at, max_chars=120) or _utc_now(),
+    }
+    if partial_evidence_override:
+        if not isinstance(partial_evidence_override, Mapping):
+            raise ValueError('partial_evidence_override must be a mapping')
+        materialized['partial_evidence_override'] = {
+            'state': 'accepted',
+            'missing_or_failed_ids': evidence_snapshot['missing_or_failed_ids'],
+            'decision_ref': _normalize_text(
+                partial_evidence_override.get('decision_ref'),
+                max_chars=160,
+            ) or None,
+            'approved_at': _normalize_text(
+                partial_evidence_override.get('approved_at'),
+                max_chars=120,
+            ) or _utc_now(),
+            'disclosure_required': True,
+        }
+    return materialized

--- a/application/single_app/functions_evidence_ledger.py
+++ b/application/single_app/functions_evidence_ledger.py
@@ -7,6 +7,8 @@ from collections.abc import Mapping
 from datetime import datetime, timezone
 from urllib.parse import urlsplit, urlunsplit
 
+from functions_deliverable_planner import build_deliverable_intent, materialize_deliverable_plan
+
 
 EVIDENCE_LEDGER_VERSION = 1
 EVIDENCE_LEDGER_GUIDANCE_MARKER = '[Turn Evidence Ledger]'
@@ -287,6 +289,8 @@ def create_evidence_ledger(
     created_at=None,
     orchestration_mode='coordinated',
     plan_version=None,
+    deliverable_intent=None,
+    materialized_deliverable_plan=None,
 ):
     """Create an empty JSON-serializable result and evidence ledger."""
     if not isinstance(requested_output, Mapping):
@@ -310,6 +314,8 @@ def create_evidence_ledger(
         'created_at': _normalize_text(created_at, 'created_at')
         or datetime.now(timezone.utc).isoformat(),
         'requested_output': _sanitize_metadata(requested_output),
+        'deliverable_intent': _sanitize_metadata(deliverable_intent),
+        'materialized_deliverable_plan': _sanitize_metadata(materialized_deliverable_plan),
         'status': ledger_status,
         'requirements': [],
         'sources': [],
@@ -329,6 +335,8 @@ def create_evidence_ledger_from_plan(
     user_message_id,
     conversation_id=None,
     requested_output=None,
+    deliverable_intent=None,
+    original_request=None,
     created_at=None,
 ):
     """Initialize a ledger from an immutable orchestration plan."""
@@ -343,6 +351,11 @@ def create_evidence_ledger_from_plan(
         'type': plan.get('finalizer') or 'response',
         'task_type': plan.get('task_type') or 'answer',
     }
+    effective_deliverable_intent = deliverable_intent or build_deliverable_intent(
+        original_request or '',
+        plan,
+        requested_output=effective_requested_output,
+    )
     ledger = create_evidence_ledger(
         plan.get('task_type') or 'answer',
         effective_conversation_id,
@@ -353,6 +366,7 @@ def create_evidence_ledger_from_plan(
         created_at=created_at,
         orchestration_mode=plan.get('mode') or 'direct',
         plan_version=plan.get('version'),
+        deliverable_intent=effective_deliverable_intent,
     )
 
     for requirement_id in _normalize_ids(plan.get('evidence_requirements')):
@@ -386,6 +400,39 @@ def create_evidence_ledger_from_plan(
         )
 
     return ledger
+
+
+def set_deliverable_intent(ledger, deliverable_intent):
+    """Persist a sanitized deliverable intent on an evidence ledger."""
+    _require_ledger(ledger)
+    if not isinstance(deliverable_intent, Mapping):
+        raise ValueError('deliverable_intent must be a mapping')
+    ledger['deliverable_intent'] = _sanitize_metadata(deliverable_intent)
+    ledger['materialized_deliverable_plan'] = {}
+    return ledger['deliverable_intent']
+
+
+def set_materialized_deliverable_plan(ledger, materialized_plan):
+    """Persist a sanitized materialized deliverable plan on an evidence ledger."""
+    _require_ledger(ledger)
+    if not isinstance(materialized_plan, Mapping):
+        raise ValueError('materialized_plan must be a mapping')
+    ledger['materialized_deliverable_plan'] = _sanitize_metadata(materialized_plan)
+    return ledger['materialized_deliverable_plan']
+
+
+def materialize_deliverable_plan_for_ledger(ledger, **kwargs):
+    """Materialize the ledger's deliverable intent against its current evidence state."""
+    _require_ledger(ledger)
+    deliverable_intent = ledger.get('deliverable_intent')
+    if not isinstance(deliverable_intent, Mapping) or not deliverable_intent:
+        raise ValueError('ledger does not contain deliverable_intent')
+    materialized_plan = materialize_deliverable_plan(
+        deliverable_intent,
+        ledger,
+        **kwargs,
+    )
+    return set_materialized_deliverable_plan(ledger, materialized_plan)
 
 
 def add_evidence_requirement(
@@ -914,6 +961,10 @@ def _model_safe_ledger(ledger):
         'task_profile': ledger.get('task_profile'),
         'orchestration_mode': ledger.get('orchestration_mode'),
         'requested_output': _sanitize_metadata(ledger.get('requested_output')),
+        'deliverable_intent': _sanitize_metadata(ledger.get('deliverable_intent')),
+        'materialized_deliverable_plan': _sanitize_metadata(
+            ledger.get('materialized_deliverable_plan')
+        ),
         'status': ledger.get('status'),
         **model_sections,
     }

--- a/application/single_app/route_backend_chats.py
+++ b/application/single_app/route_backend_chats.py
@@ -17281,6 +17281,7 @@ def register_route_backend_chats(bp):
             turn_orchestration_plan,
             conversation_id=conversation_id,
             user_message_id=user_message_id,
+            original_request=document_action_user_message,
         )
         turn_orchestration_run = OrchestrationRun.from_plan(
             turn_orchestration_plan,
@@ -26272,6 +26273,7 @@ def register_route_backend_chats(bp):
                     turn_orchestration_plan,
                     conversation_id=conversation_id,
                     user_message_id=user_message_id,
+                    original_request=user_message,
                 )
                 turn_orchestration_run = OrchestrationRun.from_plan(
                     turn_orchestration_plan,

--- a/docs/explanation/features/DELIVERABLE_PLANNING.md
+++ b/docs/explanation/features/DELIVERABLE_PLANNING.md
@@ -1,0 +1,50 @@
+# Deliverable Planning
+
+## Overview
+
+Deliverable planning introduces a first-class output planning layer for orchestration. It separates capability and evidence planning from the decision about what SimpleChat should produce for the user, such as a complete inline answer, a concise summary, or a generated supporting artifact.
+
+Implemented in version: **0.250.126**
+
+## Purpose
+
+The Phase 11A foundation records a server-authoritative `deliverable_intent` before execution and a `materialized_deliverable_plan` after evidence reaches a terminal state. This lets central synthesis distinguish the answer shape from evidence collection, preserve required explicit outputs, and avoid claiming generated artifacts before publication succeeds.
+
+## Dependencies
+
+*   `application/single_app/functions_deliverable_planner.py` for intent, adapter, directive, and materialized-plan contracts.
+*   `application/single_app/functions_evidence_ledger.py` for persisted deliverable plan fields and evidence binding.
+*   `application/single_app/functions_central_synthesis.py` for finalizer access to deliverable metadata.
+*   `application/single_app/config.py` version `0.250.126` for this implementation slice.
+
+## Technical Specifications
+
+The initial implementation adds deterministic contracts for:
+
+*   Inline response only.
+*   Summary plus Markdown analysis artifact adapter metadata.
+*   Summary plus CSV structured artifact adapter metadata.
+*   Explicit generated-file requests that must fail visibly when unsupported instead of being silently removed.
+*   Partial evidence override revisions that bind to missing or failed evidence ids.
+
+The current adapter registry is intentionally small and server-owned. Existing Analyze and export heuristics can be migrated into this contract as hints and fallbacks in later Phase 11A work without making route-local marker checks the authoritative output decision.
+
+## Usage
+
+Backend orchestration creates or supplies a `deliverable_intent` when initializing an evidence ledger. After evidence collection reaches `ready`, `partial`, or `failed`, the ledger can materialize a plan with exact evidence snapshot ids, output roles, approval state, publication state, and partial-output disclosure metadata.
+
+Central synthesis receives both plan stages in the finalizer request and must use them to separate complete inline answers, summaries, planned artifacts, and failed or unpublished artifacts.
+
+## Testing And Validation
+
+Functional coverage is in `functional_tests/test_deliverable_planner_contract.py`.
+
+The test validates:
+
+*   Inline-only requests do not create artifact deliverables.
+*   Explicit CSV requests create required artifact plans and remain visible to central synthesis.
+*   `ask_first` directives require approval on generated artifacts.
+*   Partial evidence acceptance creates a distinct materialized-plan revision.
+*   Unsupported explicit file requests fail visibly instead of being removed.
+
+Known limitation: this first slice adds the persisted contract and synthesis handoff. Analyze/generated-export route migration and non-Analyze output adapter consumption remain follow-up implementation work in Phase 11A.

--- a/functional_tests/test_deliverable_planner_contract.py
+++ b/functional_tests/test_deliverable_planner_contract.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+# test_deliverable_planner_contract.py
+"""
+Functional test for the Phase 11A deliverable planner contract.
+Version: 0.250.126
+Implemented in: 0.250.126
+
+This test ensures deliverable intent and materialized deliverable plans remain
+separate from capability planning and are available to central synthesis.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SINGLE_APP_ROOT = REPO_ROOT / 'application' / 'single_app'
+sys.path.insert(0, str(SINGLE_APP_ROOT))
+
+from functions_central_synthesis import create_central_synthesis_request  # noqa: E402
+from functions_chat_orchestration import build_turn_orchestration_plan  # noqa: E402
+from functions_deliverable_planner import (  # noqa: E402
+    build_deliverable_intent,
+    materialize_deliverable_plan,
+)
+from functions_evidence_ledger import (  # noqa: E402
+    add_evidence_source,
+    add_fact,
+    add_missing_evidence,
+    create_evidence_ledger_from_plan,
+    materialize_deliverable_plan_for_ledger,
+    set_evidence_ledger_status,
+)
+
+
+def _source_requirement_ids(ledger, source_id):
+    return list(next(
+        source.get('requirement_ids') or []
+        for source in ledger.get('sources') or []
+        if source.get('id') == source_id
+    ))
+
+
+def _build_agent_plan(original_request, run_id):
+    return build_turn_orchestration_plan(
+        original_request,
+        run_id=run_id,
+        selected_agent={'id': 'analysis-agent'},
+    )
+
+
+def test_inline_answer_intent_persists_without_artifact():
+    original_request = 'Summarize the current account status in two sentences.'
+    plan = build_turn_orchestration_plan(
+        original_request,
+        run_id='phase-11a-inline-only',
+    )
+    ledger = create_evidence_ledger_from_plan(
+        plan,
+        user_message_id='phase-11a-inline-message',
+        original_request=original_request,
+    )
+
+    assert ledger['requested_output']['type'] == 'response'
+    assert ledger['deliverable_intent']['response_mode'] == 'inline_response_only'
+    assert ledger['deliverable_intent']['primary_response']['type'] == 'inline_answer'
+    assert ledger['deliverable_intent']['provisional_deliverables'] == []
+    assert ledger['materialized_deliverable_plan'] == {}
+
+
+def test_explicit_csv_request_materializes_required_artifact_for_synthesis():
+    original_request = 'Use the selected agent and create a CSV with one row per project.'
+    requested_output = {
+        'type': 'generated_file',
+        'format': 'csv',
+        'instructions': ['Include one row per project.'],
+    }
+    directive_snapshot = {
+        'revision': 'memory-revision-7',
+        'effects': {
+            'ask_first': [
+                {
+                    'ref': 'directive-review-files',
+                    'target': 'generated_file',
+                    'reason_code': 'ask_before_files',
+                }
+            ],
+        },
+    }
+    plan = _build_agent_plan(original_request, 'phase-11a-csv-artifact')
+    intent = build_deliverable_intent(
+        original_request,
+        plan,
+        requested_output=requested_output,
+        directive_snapshot=directive_snapshot,
+    )
+    ledger = create_evidence_ledger_from_plan(
+        plan,
+        user_message_id='phase-11a-csv-message',
+        requested_output=requested_output,
+        deliverable_intent=intent,
+        original_request=original_request,
+    )
+    requirement_ids = _source_requirement_ids(ledger, 'selected_agent')
+    add_evidence_source(
+        ledger,
+        'selected_agent',
+        'succeeded',
+        source_id='selected_agent',
+        summary='The selected agent returned authorized project rows.',
+        requirement_ids=requirement_ids,
+        authorization_status='authorized',
+    )
+    add_fact(
+        ledger,
+        'Project Apollo is green and Project Borealis is at risk.',
+        ['selected_agent'],
+        requirement_ids=requirement_ids,
+        confidence='source_supported',
+    )
+    set_evidence_ledger_status(ledger, 'ready')
+    materialized = materialize_deliverable_plan_for_ledger(ledger)
+    synthesis_request = create_central_synthesis_request(original_request, plan, ledger)
+
+    assert intent['response_mode'] == 'summary_with_primary_artifact'
+    assert intent['provisional_deliverables'][0]['adapter_id'] == 'csv_structured_artifact'
+    assert materialized['deliverables'][0]['required'] is True
+    assert materialized['deliverables'][0]['format'] == 'csv'
+    assert materialized['deliverables'][0]['approval_required'] is True
+    assert materialized['deliverables'][0]['approval']['state'] == 'required'
+    assert synthesis_request['deliverable_intent']['directive_constraints']['revision'] == 'memory-revision-7'
+    assert synthesis_request['materialized_deliverable_plan']['deliverables'][0]['format'] == 'csv'
+    assert synthesis_request['materialized_deliverable_plan']['evidence_snapshot']['ledger_status'] == 'ready'
+    assert 'one row per project' in json.dumps(synthesis_request)
+
+
+def test_partial_evidence_override_creates_distinct_plan_revision():
+    original_request = 'Create a CSV from selected agent evidence even if one source is missing.'
+    requested_output = {'type': 'generated_file', 'format': 'csv'}
+    plan = _build_agent_plan(original_request, 'phase-11a-partial-evidence')
+    intent = build_deliverable_intent(
+        original_request,
+        plan,
+        requested_output=requested_output,
+    )
+    ledger = create_evidence_ledger_from_plan(
+        plan,
+        user_message_id='phase-11a-partial-message',
+        requested_output=requested_output,
+        deliverable_intent=intent,
+        original_request=original_request,
+    )
+    requirement_ids = _source_requirement_ids(ledger, 'selected_agent')
+    add_evidence_source(
+        ledger,
+        'selected_agent',
+        'not_found',
+        source_id='selected_agent',
+        summary='The selected agent did not return usable rows.',
+        requirement_ids=requirement_ids,
+        authorization_status='authorized',
+    )
+    missing = add_missing_evidence(
+        ledger,
+        requirement_ids[0] if requirement_ids else None,
+        'selected_agent',
+        'not_found',
+        'The selected agent did not return usable rows.',
+        source_id='selected_agent',
+    )
+    set_evidence_ledger_status(ledger, 'partial')
+    materialized = materialize_deliverable_plan(
+        intent,
+        ledger,
+        materialized_plan_revision=2,
+        partial_evidence_override={'decision_ref': 'accepted-limited-output'},
+    )
+
+    assert materialized['materialized_plan_revision'] == 2
+    assert materialized['deliverables'][0]['status'] == 'partial'
+    assert materialized['partial_evidence_override']['decision_ref'] == 'accepted-limited-output'
+    assert materialized['partial_evidence_override']['missing_or_failed_ids'] == [missing['id']]
+    assert materialized['partial_evidence_override']['disclosure_required'] is True
+
+
+def test_unsupported_explicit_file_is_failed_not_silently_removed():
+    original_request = 'Create a PowerPoint deck from this answer.'
+    requested_output = {'type': 'generated_file', 'format': 'pptx'}
+    plan = build_turn_orchestration_plan(
+        original_request,
+        run_id='phase-11a-unsupported-pptx',
+    )
+    intent = build_deliverable_intent(
+        original_request,
+        plan,
+        requested_output=requested_output,
+    )
+    ledger = create_evidence_ledger_from_plan(
+        plan,
+        user_message_id='phase-11a-unsupported-message',
+        requested_output=requested_output,
+        deliverable_intent=intent,
+        original_request=original_request,
+    )
+    materialized = materialize_deliverable_plan_for_ledger(ledger)
+
+    assert len(intent['provisional_deliverables']) == 1
+    assert intent['provisional_deliverables'][0]['required'] is True
+    assert intent['provisional_deliverables'][0]['status'] == 'unsupported'
+    assert materialized['deliverables'][0]['required'] is True
+    assert materialized['deliverables'][0]['status'] == 'failed'
+    assert materialized['deliverables'][0]['reason_codes'] == ['requested_format_not_supported']
+
+
+if __name__ == '__main__':
+    tests = [
+        test_inline_answer_intent_persists_without_artifact,
+        test_explicit_csv_request_materializes_required_artifact_for_synthesis,
+        test_partial_evidence_override_creates_distinct_plan_revision,
+        test_unsupported_explicit_file_is_failed_not_silently_removed,
+    ]
+    results = []
+
+    for test in tests:
+        print(f'\nRunning {test.__name__}...')
+        try:
+            test()
+            print('Passed')
+            results.append(True)
+        except Exception as exc:
+            print(f'Failed: {exc}')
+            results.append(False)
+
+    passed = sum(results)
+    total = len(results)
+    print(f'\nResults: {passed}/{total} tests passed')
+    sys.exit(0 if all(results) else 1)


### PR DESCRIPTION
## Summary

Adds the first Phase 11A deliverable-planning implementation slice on top of `feature/orchestration`.

- Introduces deterministic `deliverable_intent` and `materialized_deliverable_plan` contracts.
- Persists deliverable metadata in the evidence ledger and exposes it to central synthesis.
- Adds a small server-owned adapter registry for inline responses, Markdown analysis artifacts, and CSV structured artifacts.
- Preserves explicit unsupported deliverable requests as failed/visible states instead of silently removing them.
- Adds partial evidence override revision support and focused functional coverage.
- Bumps app version to `0.250.126` and adds feature documentation.

This PR is the contract foundation only; Analyze/generated-export route migration and broader non-Analyze adapter consumption remain follow-up Phase 11A work.

## Validation

- `python -m py_compile e:\repos\simplechat\application\single_app\route_backend_chats.py e:\repos\simplechat\application\single_app\functions_deliverable_planner.py e:\repos\simplechat\application\single_app\functions_evidence_ledger.py e:\repos\simplechat\application\single_app\functions_central_synthesis.py e:\repos\simplechat\functional_tests\test_deliverable_planner_contract.py`
- `python e:\repos\simplechat\functional_tests\test_deliverable_planner_contract.py` — 4/4 passed
- `python e:\repos\simplechat\functional_tests\test_central_synthesis_contract.py` — 9/9 passed
- CRLF-aware `git diff --check` plus whitespace check for new files

Refs #1021
Related #1071