### PR TITLE
Implement Phase 12 orchestration interaction modes

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -95,7 +95,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.250.126"
+VERSION = "0.250.127"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/functions_orchestration_interaction.py
+++ b/application/single_app/functions_orchestration_interaction.py
@@ -1,0 +1,639 @@
+# functions_orchestration_interaction.py
+"""Phase 12 orchestration interaction policy and per-turn snapshot helpers."""
+
+import copy
+import hashlib
+import json
+from collections.abc import Mapping
+
+
+ORCHESTRATION_INTERACTION_VERSION = 2
+DIRECTIVE_RESOLUTION_VERSION = 1
+
+EXECUTION_MODE_MANUAL = 'manual'
+EXECUTION_MODE_BALANCED = 'balanced'
+EXECUTION_MODE_AUTO = 'auto'
+EXECUTION_MODES = (
+    EXECUTION_MODE_MANUAL,
+    EXECUTION_MODE_BALANCED,
+    EXECUTION_MODE_AUTO,
+)
+
+REVIEW_VISIBILITY_COLLAPSED = 'collapsed'
+REVIEW_VISIBILITY_EXPANDED = 'expanded'
+REVIEW_VISIBILITY_LEVELS = (
+    REVIEW_VISIBILITY_COLLAPSED,
+    REVIEW_VISIBILITY_EXPANDED,
+)
+
+ORCHESTRATION_CONTEXT_PERSONAL = 'personal'
+ORCHESTRATION_CONTEXT_GROUP = 'group'
+ORCHESTRATION_CONTEXT_PUBLIC = 'public'
+ORCHESTRATION_CONTEXT_EXTERNAL = 'external'
+ORCHESTRATION_CONTEXTS = (
+    ORCHESTRATION_CONTEXT_PERSONAL,
+    ORCHESTRATION_CONTEXT_GROUP,
+    ORCHESTRATION_CONTEXT_PUBLIC,
+    ORCHESTRATION_CONTEXT_EXTERNAL,
+)
+
+LEGACY_REVIEW_ONLY_MODE = 'review_only'
+DEFAULT_HARD_APPROVAL_BOUNDARIES = (
+    'external_data',
+    'sensitive_data',
+    'write_action',
+    'consequential_action',
+    'budget_overflow',
+    'unsupported_output_adapter',
+)
+
+DEFAULT_ORCHESTRATION_INTERACTION_POLICY = {
+    'enabled_execution_modes': list(EXECUTION_MODES),
+    'default_execution_mode': EXECUTION_MODE_BALANCED,
+    'enabled_review_visibility': list(REVIEW_VISIBILITY_LEVELS),
+    'default_review_visibility': REVIEW_VISIBILITY_COLLAPSED,
+    'allow_conversation_execution_mode': True,
+    'allow_per_message_execution_mode': True,
+    'allow_conversation_review_visibility': True,
+    'allow_per_message_review_visibility': True,
+    'require_expanded_review_visibility': False,
+    'context_execution_modes': {
+        ORCHESTRATION_CONTEXT_PERSONAL: list(EXECUTION_MODES),
+        ORCHESTRATION_CONTEXT_GROUP: list(EXECUTION_MODES),
+        ORCHESTRATION_CONTEXT_PUBLIC: list(EXECUTION_MODES),
+        ORCHESTRATION_CONTEXT_EXTERNAL: list(EXECUTION_MODES),
+    },
+    'capability_automation': {
+        'workspace_search': 'recommend',
+        'analyze': 'recommend',
+        'compare': 'recommend',
+        'image': 'recommend',
+        'web_search': 'recommend',
+        'url_access': 'recommend',
+        'deep_research': 'recommend',
+    },
+    'deliverable_automation': 'recommend',
+    'budgets': {
+        EXECUTION_MODE_MANUAL: {
+            'max_latency_seconds': 60,
+            'max_cost_usd': 1.0,
+            'max_tokens': 32000,
+            'max_sources': 20,
+            'max_artifact_bytes': 5000000,
+        },
+        EXECUTION_MODE_BALANCED: {
+            'max_latency_seconds': 120,
+            'max_cost_usd': 3.0,
+            'max_tokens': 64000,
+            'max_sources': 40,
+            'max_artifact_bytes': 15000000,
+        },
+        EXECUTION_MODE_AUTO: {
+            'max_latency_seconds': 240,
+            'max_cost_usd': 5.0,
+            'max_tokens': 128000,
+            'max_sources': 80,
+            'max_artifact_bytes': 30000000,
+        },
+    },
+    'plan_details_drawer_enabled': True,
+    'advanced_plan_editing': 'view_only',
+    'retention_days': 90,
+    'audit_enabled': True,
+    'hard_approval_boundaries': list(DEFAULT_HARD_APPROVAL_BOUNDARIES),
+}
+
+
+def _compact_string(value, *, max_length=128):
+    return ' '.join(str(value or '').split())[:max_length]
+
+
+def _stable_digest(value):
+    serialized = json.dumps(value, sort_keys=True, separators=(',', ':'))
+    return hashlib.sha256(serialized.encode('utf-8')).hexdigest()[:24]
+
+
+def _as_dict(value):
+    return value if isinstance(value, Mapping) else {}
+
+
+def _normalize_identifier_list(values, allowed_values, *, fallback_values):
+    if isinstance(values, str):
+        values = [values]
+    if not isinstance(values, list):
+        values = list(fallback_values)
+
+    allowed = set(allowed_values)
+    normalized = []
+    for value in values:
+        item = str(value or '').strip().lower()
+        if item in allowed and item not in normalized:
+            normalized.append(item)
+    if not normalized:
+        normalized = list(fallback_values)
+    return normalized
+
+
+def _normalize_execution_mode(value, fallback=EXECUTION_MODE_BALANCED):
+    mode = str(value or '').strip().lower()
+    if mode == LEGACY_REVIEW_ONLY_MODE:
+        return LEGACY_REVIEW_ONLY_MODE
+    return mode if mode in EXECUTION_MODES else fallback
+
+
+def _normalize_review_visibility(value, fallback=REVIEW_VISIBILITY_COLLAPSED):
+    visibility = str(value or '').strip().lower()
+    return visibility if visibility in REVIEW_VISIBILITY_LEVELS else fallback
+
+
+def _normalize_bool(value, fallback=False):
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {'true', '1', 'yes', 'on'}:
+            return True
+        if normalized in {'false', '0', 'no', 'off'}:
+            return False
+    return fallback
+
+
+def _normalize_automation_value(value, fallback='recommend'):
+    normalized = str(value or '').strip().lower()
+    if normalized in {'manual_only', 'recommend', 'auto_read_only', 'blocked'}:
+        return normalized
+    if normalized in {'automatic', 'auto'}:
+        return 'auto_read_only'
+    return fallback
+
+
+def _normalize_deliverable_automation(value):
+    normalized = str(value or '').strip().lower()
+    if normalized in {'automatic', 'recommend', 'manual_only'}:
+        return normalized
+    if normalized == 'auto':
+        return 'automatic'
+    return 'recommend'
+
+
+def _bounded_int(value, fallback, *, minimum, maximum):
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        parsed = fallback
+    return min(maximum, max(minimum, parsed))
+
+
+def _bounded_float(value, fallback, *, minimum, maximum):
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        parsed = fallback
+    return min(maximum, max(minimum, parsed))
+
+
+def _normalize_mode_budget(raw_budget, fallback_budget):
+    raw_budget = _as_dict(raw_budget)
+    return {
+        'max_latency_seconds': _bounded_int(
+            raw_budget.get('max_latency_seconds'),
+            fallback_budget['max_latency_seconds'],
+            minimum=1,
+            maximum=3600,
+        ),
+        'max_cost_usd': _bounded_float(
+            raw_budget.get('max_cost_usd'),
+            fallback_budget['max_cost_usd'],
+            minimum=0,
+            maximum=1000,
+        ),
+        'max_tokens': _bounded_int(
+            raw_budget.get('max_tokens'),
+            fallback_budget['max_tokens'],
+            minimum=1000,
+            maximum=2000000,
+        ),
+        'max_sources': _bounded_int(
+            raw_budget.get('max_sources'),
+            fallback_budget['max_sources'],
+            minimum=0,
+            maximum=1000,
+        ),
+        'max_artifact_bytes': _bounded_int(
+            raw_budget.get('max_artifact_bytes'),
+            fallback_budget['max_artifact_bytes'],
+            minimum=0,
+            maximum=500000000,
+        ),
+    }
+
+
+def _select_allowed_value(
+    candidates,
+    allowed_values,
+    default_value,
+    default_source,
+    *,
+    fallback_source='admin_policy_fallback',
+):
+    allowed = list(allowed_values or [])
+    normalized_default = str(default_value or '').strip().lower()
+    if normalized_default not in allowed:
+        normalized_default = allowed[0]
+
+    for candidate in candidates:
+        value = str(candidate.get('value') or '').strip().lower()
+        if not value:
+            continue
+        if value in allowed:
+            return value, candidate.get('source') or default_source, None
+        return normalized_default, fallback_source, {
+            'requested': value,
+            'source': candidate.get('source') or 'unknown',
+            'reason': 'not_allowed_by_admin_policy',
+            'fallback': normalized_default,
+        }
+    return normalized_default, default_source, None
+
+
+def normalize_orchestration_interaction_policy(settings=None):
+    """Return a bounded admin policy for Phase 12 interaction controls."""
+    source_settings = _as_dict(settings)
+    source_policy = _as_dict(source_settings.get('orchestration_interaction_policy'))
+    defaults = DEFAULT_ORCHESTRATION_INTERACTION_POLICY
+
+    enabled_execution_modes = _normalize_identifier_list(
+        source_policy.get(
+            'enabled_execution_modes',
+            source_settings.get('orchestration_execution_modes_enabled'),
+        ),
+        EXECUTION_MODES,
+        fallback_values=defaults['enabled_execution_modes'],
+    )
+    default_execution_mode = _normalize_execution_mode(
+        source_policy.get(
+            'default_execution_mode',
+            source_settings.get('orchestration_default_execution_mode'),
+        ),
+        defaults['default_execution_mode'],
+    )
+    if default_execution_mode == LEGACY_REVIEW_ONLY_MODE:
+        default_execution_mode = EXECUTION_MODE_BALANCED
+    if default_execution_mode not in enabled_execution_modes:
+        default_execution_mode = enabled_execution_modes[0]
+
+    enabled_review_visibility = _normalize_identifier_list(
+        source_policy.get(
+            'enabled_review_visibility',
+            source_settings.get('orchestration_review_visibility_levels_enabled'),
+        ),
+        REVIEW_VISIBILITY_LEVELS,
+        fallback_values=defaults['enabled_review_visibility'],
+    )
+    default_review_visibility = _normalize_review_visibility(
+        source_policy.get(
+            'default_review_visibility',
+            source_settings.get('orchestration_default_review_visibility'),
+        ),
+        defaults['default_review_visibility'],
+    )
+    require_expanded = _normalize_bool(
+        source_policy.get(
+            'require_expanded_review_visibility',
+            source_settings.get('orchestration_require_expanded_review_visibility'),
+        ),
+        defaults['require_expanded_review_visibility'],
+    )
+    if require_expanded and REVIEW_VISIBILITY_EXPANDED not in enabled_review_visibility:
+        enabled_review_visibility.append(REVIEW_VISIBILITY_EXPANDED)
+    if default_review_visibility not in enabled_review_visibility:
+        default_review_visibility = enabled_review_visibility[0]
+    if require_expanded:
+        default_review_visibility = REVIEW_VISIBILITY_EXPANDED
+
+    raw_context_modes = _as_dict(
+        source_policy.get(
+            'context_execution_modes',
+            source_settings.get('orchestration_context_execution_modes'),
+        )
+    )
+    context_execution_modes = {}
+    for context_name in ORCHESTRATION_CONTEXTS:
+        context_execution_modes[context_name] = [
+            mode
+            for mode in _normalize_identifier_list(
+                raw_context_modes.get(context_name),
+                EXECUTION_MODES,
+                fallback_values=enabled_execution_modes,
+            )
+            if mode in enabled_execution_modes
+        ]
+        if not context_execution_modes[context_name]:
+            context_execution_modes[context_name] = [default_execution_mode]
+
+    raw_capability_automation = _as_dict(
+        source_policy.get(
+            'capability_automation',
+            source_settings.get('orchestration_capability_automation'),
+        )
+    )
+    capability_automation = {}
+    for capability_id, fallback_mode in defaults['capability_automation'].items():
+        capability_automation[capability_id] = _normalize_automation_value(
+            raw_capability_automation.get(capability_id),
+            fallback_mode,
+        )
+
+    raw_budgets = _as_dict(source_policy.get('budgets', source_settings.get('orchestration_mode_budgets')))
+    budgets = {
+        mode: _normalize_mode_budget(raw_budgets.get(mode), defaults['budgets'][mode])
+        for mode in EXECUTION_MODES
+    }
+
+    hard_approval_boundaries = _normalize_identifier_list(
+        source_policy.get(
+            'hard_approval_boundaries',
+            source_settings.get('orchestration_hard_approval_boundaries'),
+        ),
+        DEFAULT_HARD_APPROVAL_BOUNDARIES,
+        fallback_values=DEFAULT_HARD_APPROVAL_BOUNDARIES,
+    )
+
+    policy = {
+        'version': ORCHESTRATION_INTERACTION_VERSION,
+        'enabled_execution_modes': enabled_execution_modes,
+        'default_execution_mode': default_execution_mode,
+        'enabled_review_visibility': enabled_review_visibility,
+        'default_review_visibility': default_review_visibility,
+        'allow_conversation_execution_mode': _normalize_bool(
+            source_policy.get(
+                'allow_conversation_execution_mode',
+                source_settings.get('orchestration_allow_conversation_execution_mode'),
+            ),
+            defaults['allow_conversation_execution_mode'],
+        ),
+        'allow_per_message_execution_mode': _normalize_bool(
+            source_policy.get(
+                'allow_per_message_execution_mode',
+                source_settings.get('orchestration_allow_per_message_execution_mode'),
+            ),
+            defaults['allow_per_message_execution_mode'],
+        ),
+        'allow_conversation_review_visibility': _normalize_bool(
+            source_policy.get(
+                'allow_conversation_review_visibility',
+                source_settings.get('orchestration_allow_conversation_review_visibility'),
+            ),
+            defaults['allow_conversation_review_visibility'],
+        ),
+        'allow_per_message_review_visibility': _normalize_bool(
+            source_policy.get(
+                'allow_per_message_review_visibility',
+                source_settings.get('orchestration_allow_per_message_review_visibility'),
+            ),
+            defaults['allow_per_message_review_visibility'],
+        ),
+        'require_expanded_review_visibility': require_expanded,
+        'context_execution_modes': context_execution_modes,
+        'capability_automation': capability_automation,
+        'deliverable_automation': _normalize_deliverable_automation(
+            source_policy.get(
+                'deliverable_automation',
+                source_settings.get('orchestration_deliverable_automation'),
+            )
+        ),
+        'budgets': budgets,
+        'plan_details_drawer_enabled': _normalize_bool(
+            source_policy.get(
+                'plan_details_drawer_enabled',
+                source_settings.get('orchestration_plan_details_drawer_enabled'),
+            ),
+            defaults['plan_details_drawer_enabled'],
+        ),
+        'advanced_plan_editing': (
+            _compact_string(
+                source_policy.get(
+                    'advanced_plan_editing',
+                    source_settings.get('orchestration_advanced_plan_editing'),
+                ),
+                max_length=32,
+            )
+            or defaults['advanced_plan_editing']
+        ),
+        'retention_days': _bounded_int(
+            source_policy.get(
+                'retention_days',
+                source_settings.get('orchestration_interaction_retention_days'),
+            ),
+            defaults['retention_days'],
+            minimum=1,
+            maximum=3650,
+        ),
+        'audit_enabled': _normalize_bool(
+            source_policy.get(
+                'audit_enabled',
+                source_settings.get('orchestration_interaction_audit_enabled'),
+            ),
+            defaults['audit_enabled'],
+        ),
+        'hard_approval_boundaries': hard_approval_boundaries,
+    }
+    policy['policy_version'] = _stable_digest(policy)
+    return policy
+
+
+def _extract_preference_container(value):
+    if not isinstance(value, Mapping):
+        return {}
+    settings = value.get('settings') if isinstance(value.get('settings'), Mapping) else value
+    preference = settings.get('orchestration_interaction')
+    if isinstance(preference, Mapping):
+        return preference
+    camel_preference = settings.get('orchestrationInteraction')
+    return camel_preference if isinstance(camel_preference, Mapping) else {}
+
+
+def _extract_request_interaction(request_payload):
+    payload = _as_dict(request_payload)
+    interaction = payload.get('orchestration_interaction')
+    if isinstance(interaction, Mapping):
+        return interaction
+
+    legacy_mode = payload.get('mode')
+    return {
+        'execution_mode': payload.get('execution_mode') or legacy_mode,
+        'review_visibility': payload.get('review_visibility'),
+    }
+
+
+def _normalize_context_type(value):
+    normalized = str(value or '').strip().lower()
+    return normalized if normalized in ORCHESTRATION_CONTEXTS else ORCHESTRATION_CONTEXT_PERSONAL
+
+
+def resolve_orchestration_interaction(
+    *,
+    settings=None,
+    user_settings=None,
+    conversation=None,
+    request_payload=None,
+    context_type=ORCHESTRATION_CONTEXT_PERSONAL,
+):
+    """Resolve one submitted turn's execution mode and review visibility snapshot."""
+    policy = normalize_orchestration_interaction_policy(settings)
+    context_name = _normalize_context_type(context_type)
+    context_allowed_modes = list(
+        policy['context_execution_modes'].get(context_name)
+        or policy['enabled_execution_modes']
+    )
+    if policy['default_execution_mode'] not in context_allowed_modes:
+        context_default_mode = context_allowed_modes[0]
+    else:
+        context_default_mode = policy['default_execution_mode']
+
+    user_preference = _extract_preference_container(user_settings)
+    conversation_preference = _extract_preference_container(conversation)
+    request_interaction = _extract_request_interaction(request_payload)
+
+    requested_mode = _normalize_execution_mode(
+        request_interaction.get('execution_mode'),
+        fallback='',
+    )
+    requested_visibility = _normalize_review_visibility(
+        request_interaction.get('review_visibility'),
+        fallback='',
+    )
+    legacy_review_only = requested_mode == LEGACY_REVIEW_ONLY_MODE
+    if legacy_review_only:
+        requested_mode = EXECUTION_MODE_BALANCED
+        requested_visibility = REVIEW_VISIBILITY_EXPANDED
+
+    execution_candidates = []
+    if requested_mode and policy['allow_per_message_execution_mode']:
+        execution_candidates.append({
+            'value': requested_mode,
+            'source': 'per_message_override',
+        })
+    if policy['allow_conversation_execution_mode']:
+        execution_candidates.append({
+            'value': conversation_preference.get('execution_mode'),
+            'source': 'conversation_preference',
+        })
+    execution_candidates.append({
+        'value': user_preference.get('default_execution_mode'),
+        'source': 'user_preference',
+    })
+    execution_mode, execution_source, execution_fallback = _select_allowed_value(
+        execution_candidates,
+        context_allowed_modes,
+        context_default_mode,
+        'admin_default',
+    )
+
+    visibility_candidates = []
+    if requested_visibility and policy['allow_per_message_review_visibility']:
+        visibility_candidates.append({
+            'value': requested_visibility,
+            'source': 'per_message_override',
+        })
+    if policy['allow_conversation_review_visibility']:
+        visibility_candidates.append({
+            'value': conversation_preference.get('review_visibility'),
+            'source': 'conversation_preference',
+        })
+    visibility_candidates.append({
+        'value': user_preference.get('default_review_visibility'),
+        'source': 'user_preference',
+    })
+    review_visibility, review_source, review_fallback = _select_allowed_value(
+        visibility_candidates,
+        policy['enabled_review_visibility'],
+        policy['default_review_visibility'],
+        'admin_default',
+    )
+    if policy['require_expanded_review_visibility']:
+        review_visibility = REVIEW_VISIBILITY_EXPANDED
+        review_source = 'admin_policy_required'
+        review_fallback = None
+
+    user_preference_version = _stable_digest(user_preference)
+    snapshot = {
+        'version': ORCHESTRATION_INTERACTION_VERSION,
+        'execution_mode': execution_mode,
+        'execution_mode_source': execution_source,
+        'review_visibility': review_visibility,
+        'review_visibility_source': review_source,
+        'admin_policy_version': policy['policy_version'],
+        'user_preference_version': user_preference_version,
+        'directive_resolution_version': DIRECTIVE_RESOLUTION_VERSION,
+        'memory_revision_digest': '',
+        'applied_directive_refs': [],
+        'overridden_directive_refs': [],
+        'conflicting_directive_refs': [],
+        'hard_approval_boundaries': list(policy['hard_approval_boundaries']),
+        'context_type': context_name,
+        'policy_summary': {
+            'enabled_execution_modes': list(context_allowed_modes),
+            'enabled_review_visibility': list(policy['enabled_review_visibility']),
+            'allow_per_message_execution_mode': policy['allow_per_message_execution_mode'],
+            'allow_conversation_execution_mode': policy['allow_conversation_execution_mode'],
+            'allow_per_message_review_visibility': policy['allow_per_message_review_visibility'],
+            'allow_conversation_review_visibility': policy['allow_conversation_review_visibility'],
+            'plan_details_drawer_enabled': policy['plan_details_drawer_enabled'],
+            'advanced_plan_editing': policy['advanced_plan_editing'],
+        },
+        'mode_budget': copy.deepcopy(policy['budgets'][execution_mode]),
+    }
+    fallbacks = [fallback for fallback in (execution_fallback, review_fallback) if fallback]
+    if legacy_review_only:
+        snapshot.setdefault('legacy_migration', {})['mode'] = LEGACY_REVIEW_ONLY_MODE
+    if fallbacks:
+        snapshot['fallbacks'] = fallbacks
+    return snapshot
+
+
+def execution_mode_allows_automatic_read(interaction_snapshot, capability_entry):
+    """Return whether the selected mode permits silent low-risk read-only work."""
+    snapshot = _as_dict(interaction_snapshot)
+    capability = _as_dict(capability_entry)
+    mode = _normalize_execution_mode(snapshot.get('execution_mode'))
+    if mode == EXECUTION_MODE_MANUAL:
+        return False
+    if capability.get('read_only') is not True:
+        return False
+    if capability.get('external_data') is True:
+        return False
+    if capability.get('auto_use_allowed') is not True:
+        return False
+    return mode in {EXECUTION_MODE_BALANCED, EXECUTION_MODE_AUTO}
+
+
+def execution_mode_allows_recommendation(interaction_snapshot, capability_entry):
+    """Return whether unselected optional capability recommendations may pause the turn."""
+    snapshot = _as_dict(interaction_snapshot)
+    capability = _as_dict(capability_entry)
+    mode = _normalize_execution_mode(snapshot.get('execution_mode'))
+    if capability.get('requires_user_choice') is not True:
+        return False
+    if mode == EXECUTION_MODE_AUTO and capability.get('external_data') is not True:
+        return False
+    return True
+
+
+def apply_execution_mode_to_capability_inventory(inventory, interaction_snapshot):
+    """Return an inventory with mode-specific automation/recommendation flags applied."""
+    if not isinstance(inventory, Mapping):
+        return inventory
+    updated = copy.deepcopy(dict(inventory))
+    capabilities = []
+    for entry in updated.get('capabilities') or []:
+        if not isinstance(entry, Mapping):
+            continue
+        capability = dict(entry)
+        if not execution_mode_allows_automatic_read(interaction_snapshot, capability):
+            capability['auto_use_allowed'] = False
+        if not execution_mode_allows_recommendation(interaction_snapshot, capability):
+            capability['requires_user_choice'] = False
+        capabilities.append(capability)
+    updated['capabilities'] = capabilities
+    return updated

--- a/application/single_app/functions_settings.py
+++ b/application/single_app/functions_settings.py
@@ -14,6 +14,10 @@ from functions_document_actions import get_default_document_action_capabilities
 from functions_icon_utils import normalize_icon_payload
 from functions_latest_features_nav import LATEST_FEATURES_HIDDEN_VERSION_SETTING
 from functions_mcp_server_config import INBOUND_MCP_SETTINGS_DEFAULTS, normalize_inbound_mcp_settings
+from functions_orchestration_interaction import (
+    DEFAULT_ORCHESTRATION_INTERACTION_POLICY,
+    normalize_orchestration_interaction_policy,
+)
 from functions_service_health import get_default_service_health
 import app_settings_cache
 import inspect
@@ -270,6 +274,17 @@ def normalize_chat_capability_planner_settings(settings):
         'chat_capability_planner_model_endpoint_id': model_endpoint_id,
         'chat_capability_planner_model_id': model_id,
     }
+
+
+def normalize_orchestration_interaction_settings(settings):
+    """Normalize Phase 12 interaction policy on an app settings document."""
+    if not isinstance(settings, dict):
+        return False
+    normalized_policy = normalize_orchestration_interaction_policy(settings)
+    if settings.get('orchestration_interaction_policy') == normalized_policy:
+        return False
+    settings['orchestration_interaction_policy'] = normalized_policy
+    return True
 
 
 def _normalize_key_vault_admin_roles(value):
@@ -1507,6 +1522,9 @@ def get_settings(use_cosmos=False, include_source=False):
         },
         'chat_capability_choice_ttl_seconds': 86400,
         **CHAT_CAPABILITY_PLANNER_DEFAULTS,
+        'orchestration_interaction_policy': copy.deepcopy(
+            DEFAULT_ORCHESTRATION_INTERACTION_POLICY
+        ),
 
         # URL Access and Deep Research (bounded source-page inspection for web evidence)
         'enable_url_access': False,
@@ -1741,6 +1759,7 @@ def get_settings(use_cosmos=False, include_source=False):
         inbound_mcp_settings_updated = normalize_inbound_mcp_settings(merged)
         public_workspace_display_settings_updated = normalize_public_workspace_display_settings(merged)
         key_vault_reminder_settings_updated = normalize_key_vault_reminder_settings(merged)
+        orchestration_interaction_settings_updated = normalize_orchestration_interaction_settings(merged)
 
         merged['enable_tabular_processing_plugin'] = is_tabular_processing_enabled(merged)
 
@@ -1755,6 +1774,7 @@ def get_settings(use_cosmos=False, include_source=False):
             or inbound_mcp_settings_updated
             or public_workspace_display_settings_updated
             or key_vault_reminder_settings_updated
+            or orchestration_interaction_settings_updated
         ):
             cosmos_settings_container.upsert_item(merged)
             _refresh_app_settings_cache_after_write(merged, context="merge_upsert")
@@ -1808,6 +1828,7 @@ def update_settings(new_settings):
         normalize_inbound_mcp_settings(settings_item)
         normalize_public_workspace_display_settings(settings_item)
         normalize_key_vault_reminder_settings(settings_item)
+        normalize_orchestration_interaction_settings(settings_item)
         settings_item['enable_multi_model_endpoints'] = coerce_multi_model_endpoint_enablement(
             existing_multi_endpoint_enabled,
             settings_item.get('enable_multi_model_endpoints', False),

--- a/application/single_app/route_backend_chats.py
+++ b/application/single_app/route_backend_chats.py
@@ -292,6 +292,11 @@ from functions_orchestration_runtime import (
     resolve_orchestration_evidence_discovery,
     start_orchestration_node,
 )
+from functions_orchestration_interaction import (
+    apply_execution_mode_to_capability_inventory,
+    normalize_orchestration_interaction_policy,
+    resolve_orchestration_interaction,
+)
 from functions_image_messages import build_image_message_documents, decode_image_content
 from functions_icon_utils import normalize_icon_payload
 from functions_image_generation import (
@@ -3822,6 +3827,97 @@ def _get_policy_blocked_selected_capability_ids(settings, data):
     ]
 
 
+def _get_orchestration_interaction_context_type(conversation_item, data=None):
+    """Return the Phase 12 context bucket for the current chat turn."""
+    request_data = data if isinstance(data, Mapping) else {}
+    chat_type = str(
+        (conversation_item or {}).get('chat_type')
+        or request_data.get('chat_type')
+        or ''
+    ).strip().lower()
+    if chat_type.startswith('group'):
+        return 'group'
+    if chat_type.startswith('public'):
+        return 'public'
+
+    primary_context = next(
+        (
+            context
+            for context in (conversation_item or {}).get('context', []) or []
+            if isinstance(context, Mapping) and context.get('type') == 'primary'
+        ),
+        None,
+    )
+    primary_scope = str((primary_context or {}).get('scope') or '').strip().lower()
+    if primary_scope in {'group', 'public'}:
+        return primary_scope
+    if request_data.get('active_public_workspace_ids'):
+        return 'public'
+    if request_data.get('active_group_ids'):
+        return 'group'
+    return 'personal'
+
+
+def _get_message_orchestration_interaction(conversation_id, message_id):
+    normalized_message_id = str(message_id or '').strip()
+    if not normalized_message_id:
+        return None
+    message_doc = cosmos_messages_container.read_item(
+        item=normalized_message_id,
+        partition_key=conversation_id,
+    )
+    metadata = message_doc.get('metadata') if isinstance(message_doc.get('metadata'), Mapping) else {}
+    interaction = metadata.get('orchestration_interaction')
+    return copy.deepcopy(dict(interaction)) if isinstance(interaction, Mapping) else None
+
+
+def _resolve_chat_turn_orchestration_interaction(
+    *,
+    settings,
+    user_id,
+    conversation_item,
+    data,
+    capability_resume_context=None,
+    retry_user_message_id=None,
+):
+    """Resolve or restore the per-turn Phase 12 interaction snapshot."""
+    if isinstance(capability_resume_context, Mapping):
+        interaction = capability_resume_context.get('orchestration_interaction')
+        if isinstance(interaction, Mapping):
+            return copy.deepcopy(dict(interaction))
+
+    conversation_id = str((conversation_item or {}).get('id') or '').strip()
+    if retry_user_message_id and conversation_id:
+        try:
+            retry_interaction = _get_message_orchestration_interaction(
+                conversation_id,
+                retry_user_message_id,
+            )
+            if retry_interaction:
+                return retry_interaction
+        except Exception as exc:
+            log_event(
+                '[ORCHESTRATION_INTERACTION] Retry snapshot restore failed',
+                extra={
+                    'conversation_id': conversation_id,
+                    'error_type': type(exc).__name__,
+                },
+                level=logging.WARNING,
+            )
+
+    user_settings_doc = get_user_settings(user_id)
+    return resolve_orchestration_interaction(
+        settings=settings,
+        user_settings=user_settings_doc,
+        conversation=conversation_item,
+        request_payload=data,
+        context_type=_get_orchestration_interaction_context_type(
+            conversation_item,
+            data,
+        ),
+    )
+
+
 def _get_rejected_selected_capability_entries(inventory, selected_capability_ids):
     try:
         selected_ids = set(
@@ -4141,6 +4237,7 @@ def _build_server_capability_discovery(
     authorized_document_count=0,
     selected_agent_present=False,
     enable_deterministic_matching=True,
+    orchestration_interaction=None,
 ):
     inventory = _resolve_server_chat_capability_inventory(
         settings=settings,
@@ -4160,6 +4257,10 @@ def _build_server_capability_discovery(
         settings=settings,
         user_id=user_id,
         selected_agent_present=selected_agent_present,
+    )
+    inventory = apply_execution_mode_to_capability_inventory(
+        inventory,
+        orchestration_interaction,
     )
     if not enable_deterministic_matching:
         return {
@@ -4513,6 +4614,24 @@ def _load_authorized_capability_proposal_context(
         if isinstance(user_message_doc.get('metadata'), Mapping)
         else {}
     )
+    source_orchestration_interaction = (
+        copy.deepcopy(dict(user_metadata.get('orchestration_interaction')))
+        if isinstance(user_metadata.get('orchestration_interaction'), Mapping)
+        else None
+    )
+    if source_orchestration_interaction:
+        current_policy = normalize_orchestration_interaction_policy(settings)
+        source_policy_version = str(
+            source_orchestration_interaction.get('admin_policy_version') or ''
+        ).strip()
+        if (
+            source_policy_version
+            and source_policy_version != current_policy.get('policy_version')
+        ):
+            raise CapabilityChoiceError(
+                'orchestration interaction policy changed after this decision was created',
+                code='orchestration_policy_changed',
+            )
     user_thread_info = (
         user_metadata.get('thread_info')
         if isinstance(user_metadata.get('thread_info'), Mapping)
@@ -4725,6 +4844,10 @@ def _load_authorized_capability_proposal_context(
     )
     refreshed_inventory = copy.deepcopy(refreshed_inventory)
     refreshed_inventory['agents'] = copy.deepcopy(agent_inventory.get('agents') or [])
+    refreshed_inventory = apply_execution_mode_to_capability_inventory(
+        refreshed_inventory,
+        source_orchestration_interaction,
+    )
     provenance = (
         proposal_metadata.get('capability_provenance')
         if isinstance(proposal_metadata.get('capability_provenance'), Mapping)
@@ -4752,6 +4875,7 @@ def _load_authorized_capability_proposal_context(
         'selected_capability_ids': selected_capability_ids,
         'automatic_capability_root_ids': automatic_capability_root_ids,
         'automatic_capability_effective_ids': automatic_capability_effective_ids,
+        'orchestration_interaction': source_orchestration_interaction,
         'selected_agent_present': bool(
             selected_agent_snapshot_id or stored_selected_agent_binding
         ),
@@ -6097,6 +6221,9 @@ def _claim_authorized_capability_resume_impl(
         ),
         'automatic_capability_effective_ids': copy.deepcopy(
             context.get('automatic_capability_effective_ids')
+        ),
+        'orchestration_interaction': copy.deepcopy(
+            context.get('orchestration_interaction')
         ),
         'agent_ref': agent_ref or None,
         'agent_origin': 'discovery_approved' if agent_ref else None,
@@ -17060,6 +17187,18 @@ def register_route_backend_chats(bp):
         conversation_id = conversation_item.get('id')
         g.conversation_id = conversation_id
         _set_authorized_chat_request_context(user_id, conversation_id, action_scope_context)
+        turn_orchestration_interaction = _resolve_chat_turn_orchestration_interaction(
+            settings=settings,
+            user_id=user_id,
+            conversation_item=conversation_item,
+            data=data,
+            capability_resume_context=capability_resume_context,
+            retry_user_message_id=(
+                data.get('retry_user_message_id')
+                or data.get('edited_user_message_id')
+            ),
+        )
+        data['orchestration_interaction'] = turn_orchestration_interaction
 
         if isinstance(
             (capability_resume_context or {}).get('_contextual_proposal'),
@@ -17136,6 +17275,10 @@ def register_route_backend_chats(bp):
                 user_id=user_id,
                 selected_agent_present=_has_chat_agent_selection(request_agent_info),
             )
+        action_capability_inventory = apply_execution_mode_to_capability_inventory(
+            action_capability_inventory,
+            turn_orchestration_interaction,
+        )
         rejected_selected_capabilities = _get_rejected_selected_capability_entries(
             action_capability_inventory,
             selected_builtin_capability_ids,
@@ -17333,6 +17476,7 @@ def register_route_backend_chats(bp):
         else:
             user_metadata = generated_user_metadata
         user_metadata['orchestration'] = turn_orchestration_plan
+        user_metadata['orchestration_interaction'] = turn_orchestration_interaction
         user_metadata['evidence_ledger'] = turn_evidence_ledger
         user_metadata['orchestration_runtime'] = turn_orchestration_run.to_metadata()
         user_metadata['capability_provenance'] = turn_capability_provenance
@@ -17445,6 +17589,7 @@ def register_route_backend_chats(bp):
                 'user_message_id': user_message_id,
                 'metadata': {
                     'orchestration': turn_orchestration_plan,
+                    'orchestration_interaction': turn_orchestration_interaction,
                     'orchestration_runtime': turn_orchestration_run.to_metadata(),
                     'evidence_ledger': turn_evidence_ledger,
                 },
@@ -17931,6 +18076,7 @@ def register_route_backend_chats(bp):
                         'incomplete': True,
                         'error': 'runtime_reconciliation_failed',
                         'orchestration': turn_orchestration_plan,
+                        'orchestration_interaction': turn_orchestration_interaction,
                         'orchestration_runtime': turn_orchestration_run.to_metadata(),
                         'evidence_ledger': turn_evidence_ledger,
                         'capability_provenance': turn_capability_provenance,
@@ -17965,6 +18111,7 @@ def register_route_backend_chats(bp):
                 'user_message_id': user_message_id,
                 'metadata': {
                     'orchestration': turn_orchestration_plan,
+                    'orchestration_interaction': turn_orchestration_interaction,
                     'orchestration_runtime': turn_orchestration_run.to_metadata(),
                     'evidence_ledger': turn_evidence_ledger,
                 },
@@ -18099,6 +18246,7 @@ def register_route_backend_chats(bp):
                 'token_usage': execution_result.get('token_usage'),
                 'user_info': response_message_context.get('user_info'),
                 'orchestration': turn_orchestration_plan,
+                'orchestration_interaction': turn_orchestration_interaction,
                 'orchestration_runtime': turn_orchestration_run.to_metadata(),
                 'evidence_ledger': turn_evidence_ledger,
                 'capability_provenance': turn_capability_provenance,
@@ -19635,6 +19783,15 @@ def register_route_backend_chats(bp):
                 return build_json_error_response('Failed to read conversation')
 
             _set_authorized_chat_request_context(user_id, conversation_id, scope_context)
+            turn_orchestration_interaction = _resolve_chat_turn_orchestration_interaction(
+                settings=settings,
+                user_id=user_id,
+                conversation_item=conversation_item,
+                data=data,
+                capability_resume_context=trusted_capability_resume_context,
+                retry_user_message_id=retry_user_message_id,
+            )
+            data['orchestration_interaction'] = turn_orchestration_interaction
 
             auto_linked_chat_upload_document_ids = []
             auto_merge_chat_upload_workspace_context = (
@@ -19737,6 +19894,10 @@ def register_route_backend_chats(bp):
                 settings=settings,
                 user_id=user_id,
                 selected_agent_present=_has_chat_agent_selection(request_agent_info),
+            )
+            compatibility_capability_inventory = apply_execution_mode_to_capability_inventory(
+                compatibility_capability_inventory,
+                turn_orchestration_interaction,
             )
             compatibility_rejected_capabilities = _get_rejected_selected_capability_entries(
                 compatibility_capability_inventory,
@@ -20262,6 +20423,7 @@ def register_route_backend_chats(bp):
                 invalidate_conversation_cache_for_item(conversation_item, reason="conversation_title_initialized")
 
             user_metadata['capability_provenance'] = compatibility_capability_provenance
+            user_metadata['orchestration_interaction'] = turn_orchestration_interaction
             user_message_doc['metadata'] = user_metadata
             cosmos_messages_container.upsert_item(user_message_doc)
 
@@ -21282,6 +21444,7 @@ def register_route_backend_chats(bp):
                         'model_deployment_name': image_gen_model,
                         'metadata': {
                             'user_info': user_info_for_image,
+                            'orchestration_interaction': turn_orchestration_interaction,
                             'capability_provenance': compatibility_capability_provenance,
                             'capability_resume': (
                                 {
@@ -21345,6 +21508,7 @@ def register_route_backend_chats(bp):
                         'message_id': image_message_id,
                         'user_message_id': user_message_id,
                         'metadata': {
+                            'orchestration_interaction': turn_orchestration_interaction,
                             'capability_provenance': compatibility_capability_provenance,
                         },
                     }), 200
@@ -24555,6 +24719,16 @@ def register_route_backend_chats(bp):
                         yield f"data: {json.dumps({'error': 'Forbidden'})}\n\n"
                         return
 
+                turn_orchestration_interaction = _resolve_chat_turn_orchestration_interaction(
+                    settings=settings,
+                    user_id=user_id,
+                    conversation_item=conversation_item,
+                    data=data,
+                    capability_resume_context=capability_resume_context,
+                    retry_user_message_id=retry_user_message_id,
+                )
+                data['orchestration_interaction'] = turn_orchestration_interaction
+
                 capability_dialogue_context_state = {
                     'prior_user_messages': [],
                     'predecessor_thread_id': None,
@@ -25473,6 +25647,7 @@ def register_route_backend_chats(bp):
                         enable_deterministic_matching=(
                             capability_planner_mode != 'assist'
                         ),
+                        orchestration_interaction=turn_orchestration_interaction,
                     )
                 inventory_entries = capability_discovery.get('inventory', {}).get('capabilities', [])
                 log_event(
@@ -26416,6 +26591,7 @@ def register_route_backend_chats(bp):
                         copy.deepcopy(dict(user_metadata['orchestration'])),
                     )
                 user_metadata['orchestration'] = turn_orchestration_plan
+                user_metadata['orchestration_interaction'] = turn_orchestration_interaction
                 user_metadata['evidence_ledger'] = turn_evidence_ledger
                 user_metadata['orchestration_runtime'] = turn_orchestration_run.to_metadata()
                 user_metadata['capability_provenance'] = turn_capability_provenance
@@ -26780,6 +26956,9 @@ def register_route_backend_chats(bp):
                             safety_doc.setdefault('metadata', {})[
                                 'orchestration'
                             ] = turn_orchestration_plan
+                            safety_doc.setdefault('metadata', {})[
+                                'orchestration_interaction'
+                            ] = turn_orchestration_interaction
                             cosmos_messages_container.upsert_item(safety_doc)
                             complete_stream_capability_resume(assistant_message_id)
 
@@ -26863,6 +27042,7 @@ def register_route_backend_chats(bp):
                         'metadata': {
                             'awaiting_user_clarification': True,
                             'orchestration': turn_orchestration_plan,
+                            'orchestration_interaction': turn_orchestration_interaction,
                             'orchestration_runtime': (
                                 turn_orchestration_run.to_metadata()
                             ),
@@ -26953,6 +27133,7 @@ def register_route_backend_chats(bp):
                         'metadata': {
                             'awaiting_user_choice': True,
                             'orchestration': turn_orchestration_plan,
+                            'orchestration_interaction': turn_orchestration_interaction,
                             'orchestration_runtime': turn_orchestration_run.to_metadata(),
                             'evidence_ledger': turn_evidence_ledger,
                             'capability_proposal': proposal,
@@ -28827,6 +29008,7 @@ def register_route_backend_chats(bp):
                                 },
                                 'history_context': history_debug_info,
                                 'orchestration': turn_orchestration_plan,
+                                'orchestration_interaction': turn_orchestration_interaction,
                                 'orchestration_runtime': turn_orchestration_run.to_metadata(),
                                 'evidence_ledger': turn_evidence_ledger,
                                 'capability_provenance': turn_capability_provenance,
@@ -28892,6 +29074,7 @@ def register_route_backend_chats(bp):
                             'metadata': {
                                 **cancel_metadata,
                                 'orchestration': turn_orchestration_plan,
+                                'orchestration_interaction': turn_orchestration_interaction,
                                 'orchestration_runtime': turn_orchestration_run.to_metadata(),
                                 'evidence_ledger': turn_evidence_ledger,
                                 'central_synthesis': central_synthesis_metadata,
@@ -29839,6 +30022,7 @@ def register_route_backend_chats(bp):
                             },
                             'history_context': history_debug_info,
                             'orchestration': turn_orchestration_plan,
+                            'orchestration_interaction': turn_orchestration_interaction,
                             'orchestration_runtime': turn_orchestration_run.to_metadata(),
                             'evidence_ledger': turn_evidence_ledger,
                             'capability_provenance': turn_capability_provenance,
@@ -30206,6 +30390,7 @@ def register_route_backend_chats(bp):
                                 'reasoning_effort': reasoning_effort,
                                 'history_context': history_debug_info,
                                 'orchestration': turn_orchestration_plan,
+                                'orchestration_interaction': turn_orchestration_interaction,
                                 'orchestration_runtime': turn_orchestration_run.to_metadata(),
                                 'evidence_ledger': turn_evidence_ledger,
                                 'capability_provenance': turn_capability_provenance,

--- a/application/single_app/route_backend_conversations.py
+++ b/application/single_app/route_backend_conversations.py
@@ -60,6 +60,9 @@ from functions_message_artifacts import (
     filter_assistant_artifact_items,
     hydrate_agent_citations_from_artifacts,
 )
+from functions_orchestration_interaction import (
+    normalize_orchestration_interaction_policy,
+)
 from functions_simplechat_operations import (
     ConversationForkConflictError,
     create_personal_conversation_for_current_user,
@@ -900,6 +903,59 @@ def _authorize_personal_conversation_read(user_id, conversation_id):
         raise PermissionError('Forbidden')
 
     return conversation_item
+
+
+def _get_orchestration_interaction_context_type(conversation_item):
+    chat_type = str((conversation_item or {}).get('chat_type') or '').strip().lower()
+    if chat_type.startswith('group'):
+        return 'group'
+    if chat_type.startswith('public'):
+        return 'public'
+    primary_context = next(
+        (
+            context
+            for context in (conversation_item or {}).get('context', []) or []
+            if isinstance(context, dict) and context.get('type') == 'primary'
+        ),
+        None,
+    )
+    primary_scope = str((primary_context or {}).get('scope') or '').strip().lower()
+    if primary_scope in {'group', 'public'}:
+        return primary_scope
+    return 'personal'
+
+
+def _normalize_conversation_orchestration_interaction_preference(payload, policy, context_type):
+    """Validate a conversation-level Phase 12 interaction preference."""
+    request_payload = payload if isinstance(payload, dict) else {}
+    existing = request_payload.get('orchestration_interaction')
+    if isinstance(existing, dict):
+        request_payload = existing
+
+    normalized = {}
+    execution_mode = str(request_payload.get('execution_mode') or '').strip().lower()
+    if execution_mode:
+        enabled_modes = set(
+            (policy.get('context_execution_modes') or {}).get(context_type)
+            or policy.get('enabled_execution_modes')
+            or []
+        )
+        if execution_mode not in enabled_modes:
+            raise ValueError('execution_mode is not allowed by admin policy')
+        normalized['execution_mode'] = execution_mode
+
+    review_visibility = str(request_payload.get('review_visibility') or '').strip().lower()
+    if review_visibility:
+        enabled_visibility = set(policy.get('enabled_review_visibility') or [])
+        if review_visibility not in enabled_visibility:
+            raise ValueError('review_visibility is not allowed by admin policy')
+        normalized['review_visibility'] = review_visibility
+
+    if not normalized:
+        raise ValueError('execution_mode or review_visibility is required')
+
+    normalized['version'] = 2
+    return normalized
 
 
 def _invalidate_conversation_cache_after_message_mutation(conversation_id, user_id, reason):
@@ -1917,6 +1973,7 @@ def register_route_backend_conversations(bp):
                 "last_unread_assistant_at": conversation_item.get('last_unread_assistant_at'),
                 "scope_locked": conversation_item.get('scope_locked'),
                 "locked_contexts": conversation_item.get('locked_contexts', []),
+                "orchestration_interaction": conversation_item.get('orchestration_interaction') or {},
                 "chat_type": conversation_item.get('chat_type'),
                 "workflow_id": conversation_item.get('workflow_id'),
                 "summary": conversation_item.get('summary'),
@@ -1928,6 +1985,77 @@ def register_route_backend_conversations(bp):
         except Exception as e:
             print(f"Error retrieving conversation metadata: {e}")
             return jsonify({'error': 'Failed to retrieve conversation metadata'}), 500
+
+    @bp.route('/api/conversations/<conversation_id>/orchestration-interaction', methods=['PATCH'])
+    @swagger_route(security=get_auth_security())
+    @login_required
+    @user_required
+    def patch_conversation_orchestration_interaction(conversation_id):
+        """Persist a validated per-conversation Phase 12 interaction default."""
+        user_id = get_current_user_id()
+        if not user_id:
+            return jsonify({'error': 'User not authenticated'}), 401
+
+        data = request.get_json(silent=True) or {}
+        try:
+            settings = get_settings()
+            policy = normalize_orchestration_interaction_policy(settings)
+            requested_preference = (
+                data.get('orchestration_interaction')
+                if isinstance(data.get('orchestration_interaction'), dict)
+                else data
+            )
+            if not policy.get('allow_conversation_execution_mode') and 'execution_mode' in requested_preference:
+                return jsonify({'error': 'Conversation execution mode defaults are disabled by administrator'}), 403
+            if not policy.get('allow_conversation_review_visibility') and 'review_visibility' in requested_preference:
+                return jsonify({'error': 'Conversation review visibility defaults are disabled by administrator'}), 403
+
+            conversation_item = _authorize_personal_conversation_read(
+                user_id,
+                conversation_id,
+            )
+            context_type = _get_orchestration_interaction_context_type(conversation_item)
+            preference = _normalize_conversation_orchestration_interaction_preference(
+                data,
+                policy,
+                context_type,
+            )
+            current_preference = (
+                conversation_item.get('orchestration_interaction')
+                if isinstance(conversation_item.get('orchestration_interaction'), dict)
+                else {}
+            )
+            updated_preference = dict(current_preference)
+            updated_preference.update(preference)
+            updated_preference['updated_at'] = datetime.utcnow().isoformat()
+            conversation_item['orchestration_interaction'] = updated_preference
+            conversation_item['last_updated'] = datetime.utcnow().isoformat()
+            cosmos_conversations_container.upsert_item(conversation_item)
+            invalidate_conversation_cache_for_item(
+                conversation_item,
+                reason='conversation_orchestration_interaction_updated',
+            )
+            return jsonify({
+                'success': True,
+                'orchestration_interaction': updated_preference,
+            }), 200
+        except ValueError as exc:
+            return jsonify({'error': str(exc)}), 400
+        except PermissionError:
+            return jsonify({'error': 'Forbidden'}), 403
+        except (CosmosResourceNotFoundError, LookupError):
+            return jsonify({'error': 'Conversation not found'}), 404
+        except Exception as exc:
+            log_event(
+                '[ORCHESTRATION_INTERACTION] Conversation preference update failed',
+                extra={
+                    'conversation_id': conversation_id,
+                    'error_type': type(exc).__name__,
+                },
+                level=logging.ERROR,
+                exceptionTraceback=True,
+            )
+            return jsonify({'error': 'Failed to update conversation preference'}), 500
 
     @bp.route('/api/conversations/<conversation_id>/mark-read', methods=['POST'])
     @swagger_route(security=get_auth_security())

--- a/application/single_app/route_backend_users.py
+++ b/application/single_app/route_backend_users.py
@@ -513,6 +513,7 @@ def register_route_backend_users(bp):
                     'aiNoticeDismissal',
                     'sidebarToggleStyle', 'sidebarMenuState', 'fontSizePreference',
                     'conversationContentsDrawerEnabled',
+                    'orchestration_interaction',
                     LATEST_FEATURES_HIDDEN_VERSION_SETTING,
                     # Microphone permission settings
                     'microphonePermissionPreference', 'microphonePermissionState',

--- a/application/single_app/route_frontend_admin_settings.py
+++ b/application/single_app/route_frontend_admin_settings.py
@@ -982,6 +982,7 @@ def register_route_frontend_admin_settings(bp):
             settings_for_template.update(
                 normalize_chat_capability_planner_settings(settings_for_template)
             )
+            normalize_orchestration_interaction_settings(settings_for_template)
             normalize_inbound_mcp_settings(settings_for_template)
             settings_for_template['model_endpoints'] = frontend_model_endpoints
             audio_runtime_capabilities = get_audio_runtime_capabilities()
@@ -1126,6 +1127,62 @@ def register_route_frontend_admin_settings(bp):
                     submitted_planner_settings
                 )
             )
+            submitted_orchestration_interaction_policy = {
+                'enabled_execution_modes': form_data.getlist(
+                    'orchestration_execution_modes_enabled'
+                ),
+                'default_execution_mode': form_data.get(
+                    'orchestration_default_execution_mode',
+                    'balanced',
+                ),
+                'enabled_review_visibility': form_data.getlist(
+                    'orchestration_review_visibility_levels_enabled'
+                ),
+                'default_review_visibility': form_data.get(
+                    'orchestration_default_review_visibility',
+                    'collapsed',
+                ),
+                'allow_conversation_execution_mode': (
+                    form_data.get('orchestration_allow_conversation_execution_mode') == 'on'
+                ),
+                'allow_per_message_execution_mode': (
+                    form_data.get('orchestration_allow_per_message_execution_mode') == 'on'
+                ),
+                'allow_conversation_review_visibility': (
+                    form_data.get('orchestration_allow_conversation_review_visibility') == 'on'
+                ),
+                'allow_per_message_review_visibility': (
+                    form_data.get('orchestration_allow_per_message_review_visibility') == 'on'
+                ),
+                'require_expanded_review_visibility': (
+                    form_data.get('orchestration_require_expanded_review_visibility') == 'on'
+                ),
+                'context_execution_modes': {
+                    'personal': form_data.getlist('orchestration_context_modes_personal'),
+                    'group': form_data.getlist('orchestration_context_modes_group'),
+                    'public': form_data.getlist('orchestration_context_modes_public'),
+                    'external': form_data.getlist('orchestration_context_modes_external'),
+                },
+                'plan_details_drawer_enabled': (
+                    form_data.get('orchestration_plan_details_drawer_enabled') == 'on'
+                ),
+                'advanced_plan_editing': form_data.get(
+                    'orchestration_advanced_plan_editing',
+                    'view_only',
+                ),
+                'audit_enabled': (
+                    form_data.get('orchestration_interaction_audit_enabled') == 'on'
+                ),
+                'retention_days': parse_admin_int(
+                    form_data.get('orchestration_interaction_retention_days'),
+                    (settings.get('orchestration_interaction_policy') or {}).get('retention_days', 90),
+                    'orchestration_interaction_retention_days',
+                    90,
+                ),
+            }
+            orchestration_interaction_policy = normalize_orchestration_interaction_policy({
+                'orchestration_interaction_policy': submitted_orchestration_interaction_policy,
+            })
 
             # --- Fetch all other form data as before ---
             app_title = form_data.get('app_title', 'AI Chat Application')
@@ -2427,6 +2484,7 @@ def register_route_frontend_admin_settings(bp):
                 'multi_endpoint_migrated_at': migrated_at,
                 'multi_endpoint_migration_notice': migration_notice,
                 **chat_capability_planner_settings,
+                'orchestration_interaction_policy': orchestration_interaction_policy,
                 'azure_apim_gpt_endpoint': form_data.get('azure_apim_gpt_endpoint', '').strip(),
                 'azure_apim_gpt_subscription_key': admin_secret('azure_apim_gpt_subscription_key'),
                 'azure_apim_gpt_deployment': form_data.get('azure_apim_gpt_deployment', '').strip(),

--- a/application/single_app/route_frontend_chats.py
+++ b/application/single_app/route_frontend_chats.py
@@ -33,6 +33,7 @@ from functions_group import (
 )
 from functions_governance import ensure_governance_access
 from functions_image_messages import build_image_message_documents
+from functions_orchestration_interaction import normalize_orchestration_interaction_policy
 from functions_prompts import list_all_prompts_for_scope
 from functions_public_workspaces import find_public_workspace_by_id, get_user_visible_public_workspace_ids_from_settings
 from functions_simplechat_operations import upload_chat_image_bytes_for_user
@@ -707,6 +708,7 @@ def register_route_frontend_chats(bp):
         public_settings['enable_url_access'] = url_access_enabled_for_user
         public_settings['enable_chat_file_uploads'] = chat_file_upload_enabled_for_user
         public_settings['allow_user_workflows'] = user_workflows_enabled_for_user
+        public_settings['orchestration_interaction_policy'] = normalize_orchestration_interaction_policy(settings)
         conversation_contents_drawer_enabled = is_conversation_contents_drawer_enabled(
             public_settings,
             user_settings_dict,

--- a/application/single_app/static/js/chat/chat-messages.js
+++ b/application/single_app/static/js/chat/chat-messages.js
@@ -22,6 +22,7 @@ import { saveUserSetting } from "./chat-layout.js";
 import { sendMessageWithStreaming } from "./chat-streaming.js";
 import { getCurrentReasoningEffort, isReasoningEffortEnabled } from './chat-reasoning.js';
 import { areAgentsEnabled } from './chat-agents.js';
+import { getOrchestrationInteractionRequest, markOrchestrationInteractionSubmitted } from './chat-orchestration-interaction.js';
 import { createThoughtsToggleHtml, attachThoughtsToggleListener } from './chat-thoughts.js';
 import { destroyInlineCharts, extractInlineChartBlocks, hydrateInlineCharts, injectInlineChartHtml, restoreInlineChartTokens } from './chat-inline-charts.js';
 import { attachGeneratedImageProposalResults, extractInlineImageProposalBlocks, hydrateInlineImageProposals, injectInlineImageProposalHtml, restoreInlineImageProposalTokens } from './chat-inline-image-proposals.js';
@@ -5127,7 +5128,12 @@ export function appendMessage(
     const metadataContainerId = `metadata-${messageId || Date.now()}`;
     const metadataContainerHtml = `<div class="metadata-container mt-2 pt-2 border-top" id="${metadataContainerId}" style="display: none;"><div class="text-muted">Loading metadata...</div></div>`;
 
-    const thoughtsHtml = createThoughtsToggleHtml(messageId);
+    const reviewVisibility = String(
+      fullMessageObject?.metadata?.orchestration_interaction?.review_visibility || ''
+    ).trim().toLowerCase();
+    const thoughtsHtml = createThoughtsToggleHtml(messageId, {
+      expanded: reviewVisibility === 'expanded',
+    });
 
     const footerContentHtml = `<div class="message-footer d-flex justify-content-between align-items-center mt-2">
       <div class="d-flex align-items-center">${copyAndFeedbackHtml}</div>
@@ -6456,6 +6462,11 @@ export function buildChatRequestPayload(finalMessageToSend, conversationId = cur
     requestPayload.document_action = documentAction;
   }
 
+  const orchestrationInteraction = getOrchestrationInteractionRequest();
+  if (Object.keys(orchestrationInteraction).length > 0) {
+    requestPayload.orchestration_interaction = orchestrationInteraction;
+  }
+
   if (documentActionType === DOCUMENT_ACTION_ANALYZE) {
     requestPayload.analyze = {
       enabled: true,
@@ -6654,6 +6665,7 @@ export function actuallySendMessage(finalMessageToSend) {
       fallbackAgentInfo: messageData.agent_info || null,
     }
   );
+  markOrchestrationInteractionSubmitted();
 
   return;
 }

--- a/application/single_app/static/js/chat/chat-orchestration-interaction.js
+++ b/application/single_app/static/js/chat/chat-orchestration-interaction.js
@@ -1,0 +1,405 @@
+// chat-orchestration-interaction.js
+
+import { loadUserSettings, saveUserSetting } from './chat-layout.js';
+import { showToast } from './chat-toast.js';
+
+const EXECUTION_MODE_LABELS = {
+    manual: 'Manual',
+    balanced: 'Balanced',
+    auto: 'Auto',
+};
+
+const EXECUTION_MODE_DESCRIPTIONS = {
+    manual: 'Ask before optional tools or artifacts.',
+    balanced: 'Use safe automation, ask when needed.',
+    auto: 'Run governed plans until approval is required.',
+};
+
+const REVIEW_VISIBILITY_LABELS = {
+    collapsed: 'Collapsed',
+    expanded: 'Expanded',
+};
+
+const DEFAULT_POLICY = {
+    enabled_execution_modes: ['manual', 'balanced', 'auto'],
+    default_execution_mode: 'balanced',
+    enabled_review_visibility: ['collapsed', 'expanded'],
+    default_review_visibility: 'collapsed',
+    allow_conversation_execution_mode: true,
+    allow_per_message_execution_mode: true,
+    allow_conversation_review_visibility: true,
+    allow_per_message_review_visibility: true,
+    context_execution_modes: {
+        personal: ['manual', 'balanced', 'auto'],
+        group: ['manual', 'balanced', 'auto'],
+        public: ['manual', 'balanced', 'auto'],
+        external: ['manual', 'balanced', 'auto'],
+    },
+};
+
+const container = document.getElementById('orchestration-mode-container');
+const dropdownButton = document.getElementById('orchestration-mode-dropdown-button');
+const dropdownText = document.getElementById('orchestration-mode-dropdown-text');
+const optionsContainer = document.getElementById('orchestration-mode-options');
+const reviewToggle = document.getElementById('orchestration-review-visibility-toggle');
+const saveConversationDefaultBtn = document.getElementById('orchestration-save-conversation-default-btn');
+const saveUserDefaultBtn = document.getElementById('orchestration-save-user-default-btn');
+const statusEl = document.getElementById('orchestration-mode-status');
+
+let userPreference = {};
+let conversationPreference = {};
+let currentContextType = 'personal';
+let selectedExecutionMode = null;
+let selectedReviewVisibility = null;
+let perMessageExecutionModeOverride = false;
+let perMessageReviewVisibilityOverride = false;
+
+function normalizeArray(value, fallback) {
+    if (!Array.isArray(value)) {
+        return fallback.slice();
+    }
+    const normalized = [];
+    value.forEach(item => {
+        const text = String(item || '').trim().toLowerCase();
+        if (text && !normalized.includes(text)) {
+            normalized.push(text);
+        }
+    });
+    return normalized.length ? normalized : fallback.slice();
+}
+
+function getPolicy() {
+    const rawPolicy = window.appSettings?.orchestrationInteractionPolicy;
+    const policy = rawPolicy && typeof rawPolicy === 'object' ? rawPolicy : {};
+    const enabledExecutionModes = normalizeArray(
+        policy.enabled_execution_modes,
+        DEFAULT_POLICY.enabled_execution_modes,
+    ).filter(mode => EXECUTION_MODE_LABELS[mode]);
+    const enabledReviewVisibility = normalizeArray(
+        policy.enabled_review_visibility,
+        DEFAULT_POLICY.enabled_review_visibility,
+    ).filter(visibility => REVIEW_VISIBILITY_LABELS[visibility]);
+    const contextModes = policy.context_execution_modes && typeof policy.context_execution_modes === 'object'
+        ? policy.context_execution_modes
+        : DEFAULT_POLICY.context_execution_modes;
+
+    return {
+        ...DEFAULT_POLICY,
+        ...policy,
+        enabled_execution_modes: enabledExecutionModes.length ? enabledExecutionModes : DEFAULT_POLICY.enabled_execution_modes.slice(),
+        enabled_review_visibility: enabledReviewVisibility.length ? enabledReviewVisibility : DEFAULT_POLICY.enabled_review_visibility.slice(),
+        context_execution_modes: contextModes,
+    };
+}
+
+function getAllowedExecutionModes(contextType = currentContextType) {
+    const policy = getPolicy();
+    const enabledModes = policy.enabled_execution_modes;
+    const contextModes = normalizeArray(
+        policy.context_execution_modes?.[contextType],
+        enabledModes,
+    ).filter(mode => enabledModes.includes(mode));
+    return contextModes.length ? contextModes : enabledModes.slice(0, 1);
+}
+
+function getAllowedReviewVisibility() {
+    return getPolicy().enabled_review_visibility;
+}
+
+function pickAllowed(value, allowedValues, fallback) {
+    const normalized = String(value || '').trim().toLowerCase();
+    if (normalized && allowedValues.includes(normalized)) {
+        return normalized;
+    }
+    if (allowedValues.includes(fallback)) {
+        return fallback;
+    }
+    return allowedValues[0] || fallback;
+}
+
+function normalizePreference(preference) {
+    if (!preference || typeof preference !== 'object') {
+        return {};
+    }
+    const nested = preference.orchestration_interaction;
+    return nested && typeof nested === 'object' ? nested : preference;
+}
+
+function deriveContextType(metadata = {}) {
+    const chatType = String(metadata.chat_type || '').trim().toLowerCase();
+    if (chatType.startsWith('group')) {
+        return 'group';
+    }
+    if (chatType.startsWith('public')) {
+        return 'public';
+    }
+    const context = Array.isArray(metadata.context) ? metadata.context : [];
+    const primary = context.find(item => item && item.type === 'primary');
+    const scope = String(primary?.scope || '').trim().toLowerCase();
+    if (scope === 'group' || scope === 'public') {
+        return scope;
+    }
+    return 'personal';
+}
+
+function getDefaultExecutionMode() {
+    const policy = getPolicy();
+    const allowedModes = getAllowedExecutionModes();
+    return pickAllowed(
+        conversationPreference.execution_mode
+            || userPreference.default_execution_mode
+            || policy.default_execution_mode,
+        allowedModes,
+        policy.default_execution_mode || 'balanced',
+    );
+}
+
+function getDefaultReviewVisibility() {
+    const policy = getPolicy();
+    const allowedVisibility = getAllowedReviewVisibility();
+    return pickAllowed(
+        conversationPreference.review_visibility
+            || userPreference.default_review_visibility
+            || policy.default_review_visibility,
+        allowedVisibility,
+        policy.default_review_visibility || 'collapsed',
+    );
+}
+
+function setStatus(message) {
+    if (!statusEl) {
+        return;
+    }
+    statusEl.textContent = message || '';
+}
+
+function setSelectedExecutionMode(mode, options = {}) {
+    const allowedModes = getAllowedExecutionModes();
+    selectedExecutionMode = pickAllowed(mode, allowedModes, getDefaultExecutionMode());
+    perMessageExecutionModeOverride = Boolean(options.perMessageOverride);
+    render();
+}
+
+function setSelectedReviewVisibility(visibility, options = {}) {
+    const allowedVisibility = getAllowedReviewVisibility();
+    selectedReviewVisibility = pickAllowed(visibility, allowedVisibility, getDefaultReviewVisibility());
+    perMessageReviewVisibilityOverride = Boolean(options.perMessageOverride);
+    render();
+}
+
+function getSelectedExecutionMode() {
+    return selectedExecutionMode || getDefaultExecutionMode();
+}
+
+function getSelectedReviewVisibility() {
+    return selectedReviewVisibility || getDefaultReviewVisibility();
+}
+
+function createModeOption(mode) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'btn btn-sm text-start border d-flex flex-column align-items-start';
+    button.dataset.executionMode = mode;
+
+    const label = document.createElement('span');
+    label.className = 'fw-semibold';
+    label.textContent = EXECUTION_MODE_LABELS[mode] || mode;
+
+    const description = document.createElement('span');
+    description.className = 'small text-muted';
+    description.textContent = EXECUTION_MODE_DESCRIPTIONS[mode] || '';
+
+    button.append(label, description);
+    button.addEventListener('click', () => {
+        setSelectedExecutionMode(mode, { perMessageOverride: true });
+        setStatus(`${EXECUTION_MODE_LABELS[mode]} applies to the next message.`);
+    });
+    return button;
+}
+
+function renderModeOptions() {
+    if (!optionsContainer) {
+        return;
+    }
+    const allowedModes = getAllowedExecutionModes();
+    optionsContainer.replaceChildren();
+    allowedModes.forEach(mode => {
+        const option = createModeOption(mode);
+        option.classList.toggle('btn-primary', getSelectedExecutionMode() === mode);
+        option.classList.toggle('btn-outline-secondary', getSelectedExecutionMode() !== mode);
+        option.setAttribute('aria-pressed', getSelectedExecutionMode() === mode ? 'true' : 'false');
+        optionsContainer.appendChild(option);
+    });
+}
+
+function render() {
+    if (!container) {
+        return;
+    }
+    const policy = getPolicy();
+    const allowedModes = getAllowedExecutionModes();
+    const allowedVisibility = getAllowedReviewVisibility();
+    if (!allowedModes.length) {
+        container.classList.add('d-none');
+        return;
+    }
+    container.classList.remove('d-none');
+
+    selectedExecutionMode = pickAllowed(getSelectedExecutionMode(), allowedModes, policy.default_execution_mode || 'balanced');
+    selectedReviewVisibility = pickAllowed(getSelectedReviewVisibility(), allowedVisibility, policy.default_review_visibility || 'collapsed');
+
+    if (dropdownText) {
+        dropdownText.textContent = EXECUTION_MODE_LABELS[selectedExecutionMode] || 'Balanced';
+    }
+    if (dropdownButton) {
+        const label = EXECUTION_MODE_LABELS[selectedExecutionMode] || selectedExecutionMode;
+        const visibilityLabel = REVIEW_VISIBILITY_LABELS[selectedReviewVisibility] || selectedReviewVisibility;
+        dropdownButton.title = `${label} mode, ${visibilityLabel} review visibility`;
+        dropdownButton.setAttribute('aria-label', dropdownButton.title);
+    }
+    if (reviewToggle) {
+        reviewToggle.checked = selectedReviewVisibility === 'expanded';
+        reviewToggle.disabled = !allowedVisibility.includes('expanded');
+    }
+    if (saveConversationDefaultBtn) {
+        saveConversationDefaultBtn.disabled = !window.currentConversationId || !policy.allow_conversation_execution_mode;
+    }
+    if (saveUserDefaultBtn) {
+        saveUserDefaultBtn.disabled = false;
+    }
+    renderModeOptions();
+}
+
+function resetPerMessageOverrides() {
+    perMessageExecutionModeOverride = false;
+    perMessageReviewVisibilityOverride = false;
+    selectedExecutionMode = getDefaultExecutionMode();
+    selectedReviewVisibility = getDefaultReviewVisibility();
+    setStatus('');
+    render();
+}
+
+async function refreshConversationPreference(conversationId) {
+    conversationPreference = {};
+    currentContextType = 'personal';
+    if (!conversationId) {
+        resetPerMessageOverrides();
+        return;
+    }
+    try {
+        const response = await fetch(`/api/conversations/${encodeURIComponent(conversationId)}/metadata`, {
+            credentials: 'same-origin',
+        });
+        if (!response.ok) {
+            throw new Error(`HTTP ${response.status}`);
+        }
+        const metadata = await response.json();
+        currentContextType = deriveContextType(metadata);
+        conversationPreference = normalizePreference(metadata.orchestration_interaction || {});
+    } catch (error) {
+        console.warn('Unable to load conversation orchestration interaction preference:', error);
+    }
+    resetPerMessageOverrides();
+}
+
+async function initializeUserPreference() {
+    try {
+        const settings = await loadUserSettings();
+        userPreference = normalizePreference(settings?.orchestration_interaction || {});
+    } catch (error) {
+        console.warn('Unable to load orchestration interaction user preference:', error);
+    }
+    resetPerMessageOverrides();
+}
+
+async function saveConversationDefault() {
+    const conversationId = String(window.currentConversationId || '').trim();
+    if (!conversationId) {
+        showToast('Open a conversation before saving a conversation default.', 'warning');
+        return;
+    }
+    const payload = {
+        execution_mode: getSelectedExecutionMode(),
+        review_visibility: getSelectedReviewVisibility(),
+    };
+    try {
+        const response = await fetch(`/api/conversations/${encodeURIComponent(conversationId)}/orchestration-interaction`, {
+            method: 'PATCH',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            credentials: 'same-origin',
+            body: JSON.stringify(payload),
+        });
+        const result = await response.json().catch(() => ({}));
+        if (!response.ok || result.success !== true) {
+            throw new Error(result.error || 'Unable to save conversation default.');
+        }
+        conversationPreference = normalizePreference(result.orchestration_interaction || payload);
+        resetPerMessageOverrides();
+        showToast('Conversation orchestration default saved.', 'success');
+    } catch (error) {
+        showToast(error.message || 'Unable to save conversation default.', 'danger');
+    }
+}
+
+async function saveUserDefault() {
+    const preference = {
+        default_execution_mode: getSelectedExecutionMode(),
+        default_review_visibility: getSelectedReviewVisibility(),
+    };
+    const saved = await saveUserSetting({ orchestration_interaction: preference });
+    if (saved) {
+        userPreference = preference;
+        resetPerMessageOverrides();
+        showToast('Default orchestration mode saved.', 'success');
+    } else {
+        showToast('Unable to save orchestration default.', 'danger');
+    }
+}
+
+export function getOrchestrationInteractionRequest() {
+    const payload = {};
+    if (perMessageExecutionModeOverride) {
+        payload.execution_mode = getSelectedExecutionMode();
+    }
+    if (perMessageReviewVisibilityOverride) {
+        payload.review_visibility = getSelectedReviewVisibility();
+    }
+    return payload;
+}
+
+export function markOrchestrationInteractionSubmitted() {
+    resetPerMessageOverrides();
+}
+
+export function initializeOrchestrationInteractionControls() {
+    if (!container) {
+        return;
+    }
+    reviewToggle?.addEventListener('change', () => {
+        setSelectedReviewVisibility(reviewToggle.checked ? 'expanded' : 'collapsed', {
+            perMessageOverride: true,
+        });
+        setStatus(`${reviewToggle.checked ? 'Expanded' : 'Collapsed'} review applies to the next message.`);
+    });
+    saveConversationDefaultBtn?.addEventListener('click', () => {
+        void saveConversationDefault();
+    });
+    saveUserDefaultBtn?.addEventListener('click', () => {
+        void saveUserDefault();
+    });
+    window.addEventListener('chat:conversation-context-changed', event => {
+        void refreshConversationPreference(event.detail?.conversationId || window.currentConversationId || '');
+    });
+    void initializeUserPreference();
+    render();
+}
+
+initializeOrchestrationInteractionControls();
+
+window.chatOrchestrationInteraction = {
+    getOrchestrationInteractionRequest,
+    markOrchestrationInteractionSubmitted,
+    initializeOrchestrationInteractionControls,
+};

--- a/application/single_app/static/js/chat/chat-thoughts.js
+++ b/application/single_app/static/js/chat/chat-thoughts.js
@@ -1381,15 +1381,21 @@ export function handleStreamingThought(thoughtData, targetMessageId = null) {
  * Create HTML for the thoughts toggle button and hidden container.
  * Returns an object with { toggleHtml, containerHtml }.
  * @param {string} messageId
+ * @param {Object} options
  */
-export function createThoughtsToggleHtml(messageId) {
+export function createThoughtsToggleHtml(messageId, options = {}) {
     if (!window.appSettings?.enable_thoughts) {
         return { toggleHtml: '', containerHtml: '' };
     }
 
     const containerId = `thoughts-${messageId || Date.now()}`;
-    const toggleHtml = `<button class="btn btn-sm btn-link text-muted thoughts-toggle-btn" title="Show processing thoughts" aria-expanded="false" aria-controls="${containerId}"><i class="bi bi-stars"></i></button>`;
-    const containerHtml = `<div id="${containerId}" class="thoughts-container d-none mt-2 pt-2 border-top"><div class="text-muted small">Loading thoughts...</div></div>`;
+    const isExpanded = options.expanded === true;
+    const safeContainerId = escapeHtml(containerId);
+    const expandedClass = isExpanded ? '' : ' d-none';
+    const toggleHtml = isExpanded
+        ? `<button class="btn btn-sm btn-link text-muted thoughts-toggle-btn" title="Hide processing thoughts" aria-expanded="true" aria-controls="${safeContainerId}"><i class="bi bi-chevron-up"></i></button>`
+        : `<button class="btn btn-sm btn-link text-muted thoughts-toggle-btn" title="Show processing thoughts" aria-expanded="false" aria-controls="${safeContainerId}"><i class="bi bi-stars"></i></button>`;
+    const containerHtml = `<div id="${safeContainerId}" class="thoughts-container${expandedClass} mt-2 pt-2 border-top"><div class="text-muted small">Loading thoughts...</div></div>`;
 
     return { toggleHtml, containerHtml };
 }
@@ -1403,6 +1409,12 @@ export function createThoughtsToggleHtml(messageId) {
 export function attachThoughtsToggleListener(messageDiv, messageId, conversationId) {
     const toggleBtn = messageDiv.querySelector('.thoughts-toggle-btn');
     if (!toggleBtn) return;
+
+    const loadIfNeeded = container => {
+        if (container && container.innerHTML.includes('Loading thoughts')) {
+            loadThoughtsForMessage(conversationId, messageId, container);
+        }
+    };
 
     toggleBtn.addEventListener('click', () => {
         const targetId = toggleBtn.getAttribute('aria-controls');
@@ -1426,9 +1438,7 @@ export function attachThoughtsToggleListener(messageDiv, messageId, conversation
             toggleBtn.innerHTML = '<i class="bi bi-chevron-up"></i>';
 
             // Lazy-load thoughts on first expand
-            if (container.innerHTML.includes('Loading thoughts')) {
-                loadThoughtsForMessage(conversationId, messageId, container);
-            }
+            loadIfNeeded(container);
         }
 
         // Restore scroll position
@@ -1440,6 +1450,12 @@ export function attachThoughtsToggleListener(messageDiv, messageId, conversation
             }
         }, 10);
     });
+
+    const initialTargetId = toggleBtn.getAttribute('aria-controls');
+    const initialContainer = initialTargetId ? messageDiv.querySelector(`#${initialTargetId}`) : null;
+    if (toggleBtn.getAttribute('aria-expanded') === 'true') {
+        loadIfNeeded(initialContainer);
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/application/single_app/templates/admin_settings.html
+++ b/application/single_app/templates/admin_settings.html
@@ -4972,6 +4972,150 @@
                     </div>
                 </div>
 
+                <!-- Orchestration Interaction Controls Section -->
+                {% set orchestration_policy = settings.orchestration_interaction_policy %}
+                <div class="card p-3 mb-4" id="orchestration-interaction-section" data-testid="orchestration-interaction-settings">
+                    <h5 class="card-title d-flex align-items-center">
+                        <i class="bi bi-toggles2 me-2"></i>Orchestration Interaction
+                        <button type="button" class="btn btn-link p-0 ms-2 text-secondary lh-1" data-bs-toggle="tooltip" data-bs-trigger="hover focus" title="Controls which execution modes and plan visibility levels users can choose. Authorization and hard approval policy still apply." aria-label="About orchestration interaction">
+                            <i class="bi bi-info-circle" aria-hidden="true"></i>
+                        </button>
+                    </h5>
+                    <p class="text-muted small">
+                        Govern the mode selector shown in chat. Manual asks more often, Balanced automates low-risk internal reads, and Auto uses the best governed plan until a hard approval boundary is reached.
+                    </p>
+
+                    <div class="row g-3">
+                        <div class="col-lg-6">
+                            <fieldset class="border rounded p-3 h-100">
+                                <legend class="float-none w-auto px-2 fs-6">Execution modes</legend>
+                                {% for mode, label, help_text in [
+                                    ('manual', 'Manual', 'Ask before adding tools or optional artifacts.'),
+                                    ('balanced', 'Balanced', 'Use safe automation and ask when policy requires review.'),
+                                    ('auto', 'Auto', 'Run the best governed plan automatically until a hard boundary is reached.')
+                                ] %}
+                                <div class="form-check mb-2">
+                                    <input class="form-check-input" type="checkbox" id="orchestration_execution_mode_{{ mode }}" name="orchestration_execution_modes_enabled" value="{{ mode }}" {% if mode in orchestration_policy.enabled_execution_modes %}checked{% endif %}>
+                                    <label class="form-check-label" for="orchestration_execution_mode_{{ mode }}">
+                                        <strong>{{ label }}</strong>
+                                        <span class="text-muted small d-block">{{ help_text }}</span>
+                                    </label>
+                                </div>
+                                {% endfor %}
+                                <label class="form-label mt-2" for="orchestration_default_execution_mode">Default mode</label>
+                                <select class="form-select" id="orchestration_default_execution_mode" name="orchestration_default_execution_mode">
+                                    {% for mode, label in [('manual', 'Manual'), ('balanced', 'Balanced'), ('auto', 'Auto')] %}
+                                    <option value="{{ mode }}" {% if orchestration_policy.default_execution_mode == mode %}selected{% endif %}>{{ label }}</option>
+                                    {% endfor %}
+                                </select>
+                            </fieldset>
+                        </div>
+
+                        <div class="col-lg-6">
+                            <fieldset class="border rounded p-3 h-100">
+                                <legend class="float-none w-auto px-2 fs-6">Review visibility</legend>
+                                {% for visibility, label, help_text in [
+                                    ('collapsed', 'Collapsed', 'Show concise progress and collapse details after completion.'),
+                                    ('expanded', 'Expanded', 'Expand plan, approvals, sources, and deliverables by default.')
+                                ] %}
+                                <div class="form-check mb-2">
+                                    <input class="form-check-input" type="checkbox" id="orchestration_review_visibility_{{ visibility }}" name="orchestration_review_visibility_levels_enabled" value="{{ visibility }}" {% if visibility in orchestration_policy.enabled_review_visibility %}checked{% endif %}>
+                                    <label class="form-check-label" for="orchestration_review_visibility_{{ visibility }}">
+                                        <strong>{{ label }}</strong>
+                                        <span class="text-muted small d-block">{{ help_text }}</span>
+                                    </label>
+                                </div>
+                                {% endfor %}
+                                <label class="form-label mt-2" for="orchestration_default_review_visibility">Default visibility</label>
+                                <select class="form-select" id="orchestration_default_review_visibility" name="orchestration_default_review_visibility">
+                                    {% for visibility, label in [('collapsed', 'Collapsed'), ('expanded', 'Expanded')] %}
+                                    <option value="{{ visibility }}" {% if orchestration_policy.default_review_visibility == visibility %}selected{% endif %}>{{ label }}</option>
+                                    {% endfor %}
+                                </select>
+                                <div class="form-check form-switch mt-3">
+                                    <input class="form-check-input" type="checkbox" role="switch" id="orchestration_require_expanded_review_visibility" name="orchestration_require_expanded_review_visibility" {% if orchestration_policy.require_expanded_review_visibility %}checked{% endif %}>
+                                    <label class="form-check-label" for="orchestration_require_expanded_review_visibility">Require expanded visibility</label>
+                                </div>
+                            </fieldset>
+                        </div>
+
+                        <div class="col-12">
+                            <fieldset class="border rounded p-3">
+                                <legend class="float-none w-auto px-2 fs-6">User controls</legend>
+                                <div class="row g-3">
+                                    <div class="col-md-3">
+                                        <div class="form-check form-switch">
+                                            <input class="form-check-input" type="checkbox" role="switch" id="orchestration_allow_conversation_execution_mode" name="orchestration_allow_conversation_execution_mode" {% if orchestration_policy.allow_conversation_execution_mode %}checked{% endif %}>
+                                            <label class="form-check-label" for="orchestration_allow_conversation_execution_mode">Conversation mode defaults</label>
+                                        </div>
+                                    </div>
+                                    <div class="col-md-3">
+                                        <div class="form-check form-switch">
+                                            <input class="form-check-input" type="checkbox" role="switch" id="orchestration_allow_per_message_execution_mode" name="orchestration_allow_per_message_execution_mode" {% if orchestration_policy.allow_per_message_execution_mode %}checked{% endif %}>
+                                            <label class="form-check-label" for="orchestration_allow_per_message_execution_mode">Per-message mode override</label>
+                                        </div>
+                                    </div>
+                                    <div class="col-md-3">
+                                        <div class="form-check form-switch">
+                                            <input class="form-check-input" type="checkbox" role="switch" id="orchestration_allow_conversation_review_visibility" name="orchestration_allow_conversation_review_visibility" {% if orchestration_policy.allow_conversation_review_visibility %}checked{% endif %}>
+                                            <label class="form-check-label" for="orchestration_allow_conversation_review_visibility">Conversation visibility defaults</label>
+                                        </div>
+                                    </div>
+                                    <div class="col-md-3">
+                                        <div class="form-check form-switch">
+                                            <input class="form-check-input" type="checkbox" role="switch" id="orchestration_allow_per_message_review_visibility" name="orchestration_allow_per_message_review_visibility" {% if orchestration_policy.allow_per_message_review_visibility %}checked{% endif %}>
+                                            <label class="form-check-label" for="orchestration_allow_per_message_review_visibility">Per-message visibility override</label>
+                                        </div>
+                                    </div>
+                                </div>
+                            </fieldset>
+                        </div>
+
+                        <div class="col-12">
+                            <fieldset class="border rounded p-3">
+                                <legend class="float-none w-auto px-2 fs-6">Context restrictions</legend>
+                                <div class="row g-3">
+                                    {% for context_name, context_label in [('personal', 'Personal'), ('group', 'Group'), ('public', 'Public'), ('external', 'External')] %}
+                                    <div class="col-md-3">
+                                        <label class="form-label" for="orchestration_context_modes_{{ context_name }}">{{ context_label }}</label>
+                                        <select class="form-select" id="orchestration_context_modes_{{ context_name }}" name="orchestration_context_modes_{{ context_name }}" multiple size="3">
+                                            {% for mode, label in [('manual', 'Manual'), ('balanced', 'Balanced'), ('auto', 'Auto')] %}
+                                            <option value="{{ mode }}" {% if mode in orchestration_policy.context_execution_modes[context_name] %}selected{% endif %}>{{ label }}</option>
+                                            {% endfor %}
+                                        </select>
+                                    </div>
+                                    {% endfor %}
+                                </div>
+                            </fieldset>
+                        </div>
+
+                        <div class="col-md-4">
+                            <div class="form-check form-switch">
+                                <input class="form-check-input" type="checkbox" role="switch" id="orchestration_plan_details_drawer_enabled" name="orchestration_plan_details_drawer_enabled" {% if orchestration_policy.plan_details_drawer_enabled %}checked{% endif %}>
+                                <label class="form-check-label" for="orchestration_plan_details_drawer_enabled">Plan details drawer</label>
+                            </div>
+                        </div>
+                        <div class="col-md-4">
+                            <label class="form-label" for="orchestration_advanced_plan_editing">Advanced plan editing</label>
+                            <select class="form-select" id="orchestration_advanced_plan_editing" name="orchestration_advanced_plan_editing">
+                                {% for value, label in [('disabled', 'Disabled'), ('view_only', 'View only'), ('server_alternatives', 'Server-authored alternatives')] %}
+                                <option value="{{ value }}" {% if orchestration_policy.advanced_plan_editing == value %}selected{% endif %}>{{ label }}</option>
+                                {% endfor %}
+                            </select>
+                        </div>
+                        <div class="col-md-2">
+                            <label class="form-label" for="orchestration_interaction_retention_days">Audit retention days</label>
+                            <input type="number" class="form-control" id="orchestration_interaction_retention_days" name="orchestration_interaction_retention_days" min="1" max="3650" value="{{ orchestration_policy.retention_days }}">
+                        </div>
+                        <div class="col-md-2 d-flex align-items-end">
+                            <div class="form-check form-switch mb-2">
+                                <input class="form-check-input" type="checkbox" role="switch" id="orchestration_interaction_audit_enabled" name="orchestration_interaction_audit_enabled" {% if orchestration_policy.audit_enabled %}checked{% endif %}>
+                                <label class="form-check-label" for="orchestration_interaction_audit_enabled">Audit mode decisions</label>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
                 <!-- Capability Planner Section -->
                 <div class="card p-3 mb-4" id="chat-capability-planner-section" data-testid="chat-capability-planner-settings">
                     <h5 class="card-title d-flex align-items-center">

--- a/application/single_app/templates/chats.html
+++ b/application/single_app/templates/chats.html
@@ -520,6 +520,33 @@
                                             </select>
                                         </div>
 
+                                        <div id="orchestration-mode-container" class="chat-toolbar-selector">
+                                            <label for="orchestration-mode-dropdown-button" class="visually-hidden">Execution mode</label>
+                                            <div class="dropdown" id="orchestration-mode-dropdown">
+                                                <button class="form-select chat-searchable-select-button"
+                                                        type="button"
+                                                        id="orchestration-mode-dropdown-button"
+                                                        data-bs-toggle="dropdown"
+                                                        data-bs-auto-close="outside"
+                                                        aria-expanded="false">
+                                                    <span class="chat-searchable-select-text text-truncate" id="orchestration-mode-dropdown-text">Balanced</span>
+                                                </button>
+                                                <div class="dropdown-menu p-2 chat-searchable-select-menu" id="orchestration-mode-dropdown-menu">
+                                                    <div id="orchestration-mode-options" class="d-grid gap-1"></div>
+                                                    <hr class="my-2">
+                                                    <div class="form-check form-switch px-2 mb-2">
+                                                        <input class="form-check-input ms-0 me-2" type="checkbox" role="switch" id="orchestration-review-visibility-toggle">
+                                                        <label class="form-check-label small" for="orchestration-review-visibility-toggle">Expanded plan details</label>
+                                                    </div>
+                                                    <div class="d-grid gap-1">
+                                                        <button type="button" class="btn btn-sm btn-outline-secondary" id="orchestration-save-conversation-default-btn">Save for this conversation</button>
+                                                        <button type="button" class="btn btn-sm btn-outline-secondary" id="orchestration-save-user-default-btn">Save as my default</button>
+                                                    </div>
+                                                    <div class="small text-muted mt-2" id="orchestration-mode-status" aria-live="polite"></div>
+                                                </div>
+                                            </div>
+                                        </div>
+
                                         <div id="agent-select-container" class="chat-toolbar-selector" style="display: none;">
                                             <label for="agent-select" class="visually-hidden">Agent</label>
                                             <div class="dropdown chat-searchable-select" id="agent-dropdown">
@@ -1584,6 +1611,7 @@
         enable_desktop_notifications: {{ settings.enable_desktop_notifications|default(false, true)|tojson }},
         desktop_notifications_enabled: {{ desktop_notifications_enabled|default(false, true)|tojson }},
         app_title: {{ settings.app_title|default('Simple Chat', true)|tojson }},
+        orchestrationInteractionPolicy: {{ settings.orchestration_interaction_policy|default({}, true)|tojson|safe }},
         documentActionCapabilities: {{ settings.document_action_capabilities|default({}, true)|tojson|safe }}
     };
 
@@ -1610,6 +1638,7 @@
 <script type="module" src="{{ url_for('static', filename='js/chat/chat-sidebar-conversations.js') }}"></script>
 <script type="module" src="{{ url_for('static', filename='js/chat/chat-documents.js') }}"></script>
 <script type="module" src="{{ url_for('static', filename='js/chat/chat-prompts.js') }}"></script>
+<script type="module" src="{{ url_for('static', filename='js/chat/chat-orchestration-interaction.js') }}"></script>
 <script type="module" src="{{ url_for('static', filename='js/chat/chat-input-actions.js') }}"></script>
 <script type="module" src="{{ url_for('static', filename='js/chat/chat-toast.js') }}"></script>
 <script type="module" src="{{ url_for('static', filename='js/chat/chat-ai-notice.js') }}"></script>

--- a/docs/explanation/features/ORCHESTRATION_INTERACTION_MODES.md
+++ b/docs/explanation/features/ORCHESTRATION_INTERACTION_MODES.md
@@ -1,0 +1,57 @@
+# Orchestration Interaction Modes
+
+Implemented in version: **0.250.127**
+
+## Overview
+
+Phase 12 adds governed orchestration interaction controls for chat turns. Administrators define which execution modes and review visibility levels are available, while users can choose a per-message override, save a personal default, or save a conversation default when allowed by policy.
+
+Execution mode changes how optional orchestration work is handled. Review visibility changes how much plan/progress detail is expanded in the UI. Review visibility does not authorize tools, data access, writes, or deliverables.
+
+## Dependencies
+
+- Admin Settings application configuration in `application/single_app/functions_settings.py`
+- Chat turn orchestration and capability discovery in `application/single_app/route_backend_chats.py`
+- Conversation metadata and preference persistence in `application/single_app/route_backend_conversations.py`
+- Chat composer controls in `application/single_app/templates/chats.html` and `application/single_app/static/js/chat/chat-orchestration-interaction.js`
+
+## Technical Specifications
+
+The normalized admin policy is stored as `orchestration_interaction_policy` and includes:
+
+- enabled execution modes: `manual`, `balanced`, `auto`
+- default execution mode
+- enabled/default review visibility: `collapsed`, `expanded`
+- per-conversation and per-message override toggles
+- context-specific mode restrictions for personal, group, public, and external contexts
+- plan drawer, advanced editing, audit, retention, and hard approval boundary metadata
+
+Each submitted turn persists an `orchestration_interaction` snapshot beside existing orchestration metadata. The snapshot includes the resolved execution mode, review visibility, policy/preference version digests, context type, hard approval boundaries, and mode budget summary.
+
+Pending capability decisions are revalidated against the current admin policy version before resume. If policy changed after a proposal was created, the stale pending decision fails closed.
+
+## Usage Instructions
+
+Administrators configure the policy in Admin Settings under **Orchestration Interaction**. Users choose the active mode from the chat composer dropdown beside the model selector.
+
+Users may:
+
+- choose a mode for only the next submitted message;
+- toggle expanded plan details for only the next submitted message;
+- save the current selection as their personal default;
+- save the current selection as the conversation default when admin policy allows it.
+
+## Testing and Validation
+
+Coverage added in version **0.250.127**:
+
+- `functional_tests/test_orchestration_interaction_policy.py`
+- `ui_tests/test_chat_orchestration_interaction_modes.py`
+
+The focused functional test validates policy normalization, per-message overrides, legacy `review_only` migration, context-specific fallback recording, and mode-specific capability inventory behavior.
+
+The UI source-contract test validates chat composer controls, Admin Settings controls, safe DOM rendering patterns, request payload wiring, and expanded review visibility integration with processing thoughts.
+
+## Known Limitations
+
+Directive conflict persistence and memory revision enforcement remain bounded to the snapshot contract in this phase. Future governed memory phases can populate applied, overridden, and conflicting directive references without changing the per-turn interaction snapshot shape.

--- a/functional_tests/test_orchestration_interaction_policy.py
+++ b/functional_tests/test_orchestration_interaction_policy.py
@@ -1,0 +1,171 @@
+# test_orchestration_interaction_policy.py
+#!/usr/bin/env python3
+"""
+Functional test for Phase 12 orchestration interaction policy.
+Version: 0.250.127
+Implemented in: 0.250.127
+
+This test ensures that execution mode and review visibility policy resolves
+deterministically before chat turns persist their per-turn snapshot.
+"""
+
+import os
+import sys
+
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+APP_ROOT = os.path.join(REPO_ROOT, "application", "single_app")
+if APP_ROOT not in sys.path:
+    sys.path.insert(0, APP_ROOT)
+
+from functions_orchestration_interaction import (  # noqa: E402
+    apply_execution_mode_to_capability_inventory,
+    normalize_orchestration_interaction_policy,
+    resolve_orchestration_interaction,
+)
+
+
+def assert_equal(actual, expected, label):
+    if actual != expected:
+        raise AssertionError(f"{label}: expected {expected!r}, got {actual!r}")
+
+
+def test_admin_policy_normalization():
+    """Disabled modes and invalid defaults fall back to an enabled admin mode."""
+    policy = normalize_orchestration_interaction_policy({
+        "orchestration_interaction_policy": {
+            "enabled_execution_modes": ["manual", "balanced"],
+            "default_execution_mode": "auto",
+            "enabled_review_visibility": ["collapsed"],
+            "default_review_visibility": "expanded",
+            "context_execution_modes": {
+                "public": ["auto"],
+            },
+        }
+    })
+
+    assert_equal(policy["enabled_execution_modes"], ["manual", "balanced"], "enabled modes")
+    assert_equal(policy["default_execution_mode"], "manual", "default mode fallback")
+    assert_equal(policy["default_review_visibility"], "collapsed", "review visibility fallback")
+    assert_equal(policy["context_execution_modes"]["public"], ["manual"], "context fallback")
+    assert policy["policy_version"]
+
+
+def test_per_message_override_and_legacy_review_only():
+    """Per-message overrides win when allowed; legacy review_only migrates safely."""
+    settings = {
+        "orchestration_interaction_policy": {
+            "enabled_execution_modes": ["manual", "balanced", "auto"],
+            "default_execution_mode": "manual",
+            "enabled_review_visibility": ["collapsed", "expanded"],
+        }
+    }
+    user_settings = {
+        "settings": {
+            "orchestration_interaction": {
+                "default_execution_mode": "balanced",
+                "default_review_visibility": "collapsed",
+            }
+        }
+    }
+
+    snapshot = resolve_orchestration_interaction(
+        settings=settings,
+        user_settings=user_settings,
+        request_payload={
+            "orchestration_interaction": {
+                "execution_mode": "auto",
+                "review_visibility": "expanded",
+            }
+        },
+    )
+    assert_equal(snapshot["execution_mode"], "auto", "per-message execution mode")
+    assert_equal(snapshot["execution_mode_source"], "per_message_override", "execution source")
+    assert_equal(snapshot["review_visibility"], "expanded", "per-message review visibility")
+
+    legacy_snapshot = resolve_orchestration_interaction(
+        settings=settings,
+        request_payload={"mode": "review_only"},
+    )
+    assert_equal(legacy_snapshot["execution_mode"], "balanced", "legacy execution mode")
+    assert_equal(legacy_snapshot["review_visibility"], "expanded", "legacy review visibility")
+    assert_equal(legacy_snapshot["legacy_migration"]["mode"], "review_only", "legacy marker")
+
+
+def test_context_restriction_and_fallback_record():
+    """Context-specific restrictions create an explicit fallback state."""
+    snapshot = resolve_orchestration_interaction(
+        settings={
+            "orchestration_interaction_policy": {
+                "enabled_execution_modes": ["manual", "balanced", "auto"],
+                "default_execution_mode": "balanced",
+                "context_execution_modes": {
+                    "public": ["manual"],
+                },
+            }
+        },
+        request_payload={"orchestration_interaction": {"execution_mode": "auto"}},
+        context_type="public",
+    )
+
+    assert_equal(snapshot["execution_mode"], "manual", "restricted context fallback")
+    assert_equal(snapshot["execution_mode_source"], "admin_policy_fallback", "fallback source")
+    assert_equal(snapshot["fallbacks"][0]["requested"], "auto", "fallback requested mode")
+    assert_equal(snapshot["context_type"], "public", "context type")
+
+
+def test_mode_applies_to_inventory_flags():
+    """Manual mode disables silent automation while balanced keeps safe read-only auto-use."""
+    inventory = {
+        "version": 1,
+        "capabilities": [
+            {
+                "id": "workspace_search",
+                "read_only": True,
+                "external_data": False,
+                "auto_use_allowed": True,
+                "requires_user_choice": True,
+            },
+            {
+                "id": "web_search",
+                "read_only": True,
+                "external_data": True,
+                "auto_use_allowed": False,
+                "requires_user_choice": True,
+            },
+        ],
+    }
+    manual_inventory = apply_execution_mode_to_capability_inventory(
+        inventory,
+        {"execution_mode": "manual"},
+    )
+    assert_equal(manual_inventory["capabilities"][0]["auto_use_allowed"], False, "manual auto-use")
+    assert_equal(manual_inventory["capabilities"][0]["requires_user_choice"], True, "manual recommendation")
+
+    auto_inventory = apply_execution_mode_to_capability_inventory(
+        inventory,
+        {"execution_mode": "auto"},
+    )
+    assert_equal(auto_inventory["capabilities"][0]["auto_use_allowed"], True, "auto internal read")
+    assert_equal(auto_inventory["capabilities"][0]["requires_user_choice"], False, "auto internal recommendation")
+    assert_equal(auto_inventory["capabilities"][1]["requires_user_choice"], True, "auto external approval")
+
+
+def main():
+    tests = [
+        test_admin_policy_normalization,
+        test_per_message_override_and_legacy_review_only,
+        test_context_restriction_and_fallback_record,
+        test_mode_applies_to_inventory_flags,
+    ]
+    passed = 0
+    for test in tests:
+        print(f"Running {test.__name__}...")
+        test()
+        passed += 1
+    print(f"Passed {passed}/{len(tests)} orchestration interaction tests")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ui_tests/test_chat_orchestration_interaction_modes.py
+++ b/ui_tests/test_chat_orchestration_interaction_modes.py
@@ -1,0 +1,116 @@
+# test_chat_orchestration_interaction_modes.py
+"""
+UI tests for Phase 12 orchestration interaction mode controls.
+Version: 0.250.127
+Implemented in: 0.250.127
+
+This test ensures that the chat composer and Admin Settings expose governed
+execution mode and review visibility controls without unsafe rendering paths.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CHAT_TEMPLATE = REPO_ROOT / "application" / "single_app" / "templates" / "chats.html"
+ADMIN_TEMPLATE = REPO_ROOT / "application" / "single_app" / "templates" / "admin_settings.html"
+CHAT_MESSAGES_JS = REPO_ROOT / "application" / "single_app" / "static" / "js" / "chat" / "chat-messages.js"
+CHAT_THOUGHTS_JS = REPO_ROOT / "application" / "single_app" / "static" / "js" / "chat" / "chat-thoughts.js"
+INTERACTION_JS = REPO_ROOT / "application" / "single_app" / "static" / "js" / "chat" / "chat-orchestration-interaction.js"
+
+
+def read_text(path):
+    """Read a UTF-8 source file."""
+    return path.read_text(encoding="utf-8")
+
+
+def test_orchestration_interaction_source_contract():
+    """Validate static UI wiring for Phase 12 controls."""
+    chat_template = read_text(CHAT_TEMPLATE)
+    admin_template = read_text(ADMIN_TEMPLATE)
+    messages_source = read_text(CHAT_MESSAGES_JS)
+    thoughts_source = read_text(CHAT_THOUGHTS_JS)
+    interaction_source = read_text(INTERACTION_JS)
+
+    assert 'id="orchestration-mode-container"' in chat_template
+    assert 'id="orchestration-mode-dropdown-button"' in chat_template
+    assert 'id="orchestration-review-visibility-toggle"' in chat_template
+    assert 'id="orchestration-save-conversation-default-btn"' in chat_template
+    assert 'id="orchestration-save-user-default-btn"' in chat_template
+    assert 'orchestrationInteractionPolicy' in chat_template
+    assert "js/chat/chat-orchestration-interaction.js" in chat_template
+
+    assert 'id="orchestration-interaction-section"' in admin_template
+    assert 'name="orchestration_execution_modes_enabled"' in admin_template
+    assert 'name="orchestration_review_visibility_levels_enabled"' in admin_template
+    assert "('personal', 'Personal')" in admin_template
+    assert "('group', 'Group')" in admin_template
+    assert "('public', 'Public')" in admin_template
+    assert "('external', 'External')" in admin_template
+    assert 'name="orchestration_context_modes_{{ context_name }}"' in admin_template
+
+    assert 'getOrchestrationInteractionRequest' in messages_source
+    assert 'requestPayload.orchestration_interaction = orchestrationInteraction;' in messages_source
+    assert 'markOrchestrationInteractionSubmitted();' in messages_source
+    assert 'review_visibility ||' in messages_source
+    assert 'expanded: reviewVisibility === \'expanded\'' in messages_source
+
+    assert 'createThoughtsToggleHtml(messageId, options = {})' in thoughts_source
+    assert "options.expanded === true" in thoughts_source
+    assert "loadIfNeeded(initialContainer);" in thoughts_source
+
+    assert "optionsContainer.replaceChildren();" in interaction_source
+    assert "label.textContent = EXECUTION_MODE_LABELS[mode] || mode;" in interaction_source
+    assert "description.textContent = EXECUTION_MODE_DESCRIPTIONS[mode] || '';" in interaction_source
+    assert "saveUserSetting({ orchestration_interaction: preference });" in interaction_source
+    assert "/orchestration-interaction" in interaction_source
+    assert "payload.execution_mode = getSelectedExecutionMode();" in interaction_source
+    assert "payload.review_visibility = getSelectedReviewVisibility();" in interaction_source
+
+
+def _chat_url():
+    base_url = os.getenv("SIMPLECHAT_UI_BASE_URL", "").rstrip("/")
+    if not base_url:
+        pytest.skip("Set SIMPLECHAT_UI_BASE_URL to run orchestration interaction UI tests.")
+    return f"{base_url}/chats"
+
+
+@pytest.mark.ui
+@pytest.mark.parametrize(
+    "viewport",
+    [
+        {"width": 1280, "height": 900},
+        {"width": 390, "height": 844},
+    ],
+)
+def test_orchestration_mode_dropdown_renders_in_chat(viewport):
+    """Validate the composer mode dropdown in a live authenticated browser."""
+    chat_url = _chat_url()
+    from playwright.sync_api import expect, sync_playwright
+
+    with sync_playwright() as playwright:
+        browser = playwright.chromium.launch(headless=True)
+        context_kwargs = {"viewport": viewport, "ignore_https_errors": True}
+        storage_state = os.getenv("SIMPLECHAT_UI_STORAGE_STATE", "").strip()
+        if storage_state:
+            context_kwargs["storage_state"] = storage_state
+        context = browser.new_context(**context_kwargs)
+        page = context.new_page()
+        page.goto(chat_url)
+
+        dropdown = page.locator("#orchestration-mode-dropdown-button")
+        expect(dropdown).to_be_visible()
+        dropdown.click()
+        expect(page.locator("#orchestration-mode-options")).to_be_visible()
+        expect(page.get_by_role("button", name="Manual Ask before optional tools or artifacts.")).to_be_visible()
+        expect(page.get_by_role("button", name="Balanced Use safe automation, ask when needed.")).to_be_visible()
+        expect(page.get_by_role("button", name="Auto Run governed plans until approval is required.")).to_be_visible()
+        page.get_by_role("button", name="Auto Run governed plans until approval is required.").click()
+        expect(dropdown).to_have_text("Auto")
+        expect(page.locator("#orchestration-review-visibility-toggle")).to_be_visible()
+
+        context.close()
+        browser.close()


### PR DESCRIPTION
## Summary

Implements Phase 12 orchestration interaction controls for issue #1021.

- Adds a server-side orchestration interaction policy resolver and per-turn snapshot contract.
- Adds admin-governed execution modes (`manual`, `balanced`, `auto`) and review visibility (`collapsed`, `expanded`).
- Adds chat composer mode controls, per-message overrides, user defaults, and conversation defaults.
- Persists `metadata.orchestration_interaction` on chat/user/assistant terminal records and restores it for retry/resume.
- Applies execution mode to capability discovery so optional automation/recommendations follow the selected mode.
- Revalidates pending capability decisions against current policy version and fails closed on drift.
- Documents the feature and bumps app version to `0.250.127`.

Refs #1021.

## Validation

- `python -m py_compile application/single_app/functions_orchestration_interaction.py application/single_app/functions_settings.py application/single_app/route_backend_chats.py application/single_app/route_backend_conversations.py application/single_app/route_backend_users.py application/single_app/route_frontend_admin_settings.py application/single_app/route_frontend_chats.py application/single_app/config.py functional_tests/test_orchestration_interaction_policy.py ui_tests/test_chat_orchestration_interaction_modes.py`
- `node --check application/single_app/static/js/chat/chat-orchestration-interaction.js`
- `node --check application/single_app/static/js/chat/chat-messages.js`
- `node --check application/single_app/static/js/chat/chat-thoughts.js`
- `pytest functional_tests/test_orchestration_interaction_policy.py ui_tests/test_chat_orchestration_interaction_modes.py -q` (`5 passed, 2 skipped`)
- `python functional_tests/route_tests/test_route_blueprint_policy_inventory.py` (`6/6`)
- `python functional_tests/route_tests/test_route_unauthenticated_policy_contract.py` (`4/4`)
- `python functional_tests/route_tests/test_route_policy_test_coverage.py` (`2/2`)
- VS Code diagnostics clean for touched files.
- Staged whitespace check clean.
- Broken-access-control guardrail passed for touched Python/test files.
- Phase 12 added-line XSS sink grep clean. Full-file XSS scan still reports existing legacy sinks in `chat-messages.js` and `admin_settings.html` outside this change.