### PR TITLE
Phase 1: Generalize tabular source descriptors

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -96,7 +96,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.250.126"
+VERSION = "0.250.127"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/functions_tabular_csv_query.py
+++ b/application/single_app/functions_tabular_csv_query.py
@@ -44,7 +44,111 @@ TABULAR_ROW_LOCAL_QUERY_AST_NODES = (
     ast.USub,
     ast.UAdd,
     ast.Invert,
+    ast.Call,
+    ast.Attribute,
+    ast.keyword,
 )
+
+TABULAR_ROW_LOCAL_STRING_ATTRIBUTES = {
+    'astype',
+    'contains',
+    'endswith',
+    'lower',
+    'startswith',
+    'str',
+}
+
+
+def _is_row_local_string_cast(call_node):
+    """Return True for a column-level astype('str') call."""
+    return bool(
+        isinstance(call_node, ast.Call)
+        and isinstance(call_node.func, ast.Attribute)
+        and call_node.func.attr == 'astype'
+        and isinstance(call_node.func.value, ast.Name)
+        and len(call_node.args) == 1
+        and isinstance(call_node.args[0], ast.Constant)
+        and call_node.args[0].value == 'str'
+        and not call_node.keywords
+    )
+
+
+def _is_row_local_lower_call(call_node):
+    """Return True for an allowlisted column string lower() call."""
+    if not (
+        isinstance(call_node, ast.Call)
+        and isinstance(call_node.func, ast.Attribute)
+        and call_node.func.attr == 'lower'
+        and not call_node.args
+        and not call_node.keywords
+    ):
+        return False
+
+    string_accessor = call_node.func.value
+    return bool(
+        isinstance(string_accessor, ast.Attribute)
+        and string_accessor.attr == 'str'
+        and _is_row_local_string_cast(string_accessor.value)
+    )
+
+
+def _is_row_local_string_accessor(attribute_node, allow_lower=False):
+    """Return True for .str on an allowlisted cast or lower() result."""
+    if not isinstance(attribute_node, ast.Attribute) or attribute_node.attr != 'str':
+        return False
+    if _is_row_local_string_cast(attribute_node.value):
+        return True
+    return bool(allow_lower and _is_row_local_lower_call(attribute_node.value))
+
+
+def _has_exact_false_keywords(call_node, expected_names):
+    """Return True when a call has exactly the required False keyword arguments."""
+    keyword_values = {
+        keyword.arg: keyword.value
+        for keyword in call_node.keywords
+        if keyword.arg
+    }
+    return bool(
+        set(keyword_values) == set(expected_names)
+        and all(
+            isinstance(keyword_values[name], ast.Constant)
+            and keyword_values[name].value is False
+            for name in expected_names
+        )
+    )
+
+
+def _is_row_local_string_match_call(call_node):
+    """Return True for a generated literal string match on one column."""
+    if not (
+        isinstance(call_node, ast.Call)
+        and isinstance(call_node.func, ast.Attribute)
+        and call_node.func.attr in {'contains', 'startswith', 'endswith'}
+        and len(call_node.args) == 1
+        and isinstance(call_node.args[0], ast.Constant)
+        and isinstance(call_node.args[0].value, str)
+    ):
+        return False
+
+    method_name = call_node.func.attr
+    if method_name == 'contains':
+        return bool(
+            _is_row_local_string_accessor(call_node.func.value)
+            and _has_exact_false_keywords(call_node, {'case', 'regex', 'na'})
+        )
+    return bool(
+        _is_row_local_string_accessor(call_node.func.value, allow_lower=True)
+        and _has_exact_false_keywords(call_node, {'na'})
+    )
+
+
+def _is_supported_row_local_call(call_node):
+    """Return True only for generated, side-effect-free per-column string calls."""
+    return bool(
+        _is_row_local_string_cast(call_node)
+        or _is_row_local_lower_call(call_node)
+        or _is_row_local_string_match_call(call_node)
+    )
 
 
 def _replace_backtick_column_references(expression):
@@ -121,6 +225,15 @@ def validate_tabular_csv_query_expression(query_expression):
     for node in ast.walk(parsed_expression):
         if isinstance(node, ast.Name) and node.id.startswith('__') and not node.id.startswith('__simplechat_column_'):
             raise ValueError('Source query contains an unsupported private identifier')
+        if isinstance(node, ast.Attribute) and node.attr not in TABULAR_ROW_LOCAL_STRING_ATTRIBUTES:
+            raise ValueError(
+                'Source query uses an operation that cannot be replayed equivalently in bounded chunks: '
+                f'{node.attr}'
+            )
+        if isinstance(node, ast.Call) and not _is_supported_row_local_call(node):
+            raise ValueError(
+                'Source query uses a method call that cannot be replayed equivalently in bounded chunks'
+            )
     return normalized_expression
 
 

--- a/application/single_app/route_backend_chats.py
+++ b/application/single_app/route_backend_chats.py
@@ -4232,6 +4232,8 @@ def get_tabular_execution_mode(user_question):
         return 'schema_summary'
     if is_tabular_entity_lookup_question(user_question):
         return 'entity_lookup'
+    if question_requests_tabular_exhaustive_results(user_question):
+        return 'exhaustive'
     return 'analysis'
 
 
@@ -5031,6 +5033,8 @@ def question_requests_tabular_generated_output(user_question):
     exhaustive_markers = (
         'all rows',
         'every row',
+        'for each row',
+        'for every row',
         'full json',
         'full csv',
         'full xml',
@@ -5045,6 +5049,7 @@ def question_requests_tabular_generated_output(user_question):
         'populate',
         'one object per',
         'one row per',
+        'one output row per',
         'each object',
         'each row',
     )
@@ -5068,6 +5073,10 @@ def question_requests_tabular_structured_object_output(user_question):
         'one object per submission',
         'one object for each row',
         'for each row',
+        'for every row',
+        'every row',
+        'each row',
+        'one row per',
         'each object must contain',
         'exactly these fields',
     )
@@ -5505,7 +5514,7 @@ def _build_tabular_generated_output_candidate_diagnostic(invocation):
         'has_more': bool(result_payload.get('has_more')) if isinstance(result_payload, dict) else False,
         'next_start_row': result_payload.get('next_start_row') if isinstance(result_payload, dict) else None,
         'filter_applied': result_payload.get('filter_applied') if isinstance(result_payload, dict) else None,
-        'normalized_match': result_payload.get('normalized_match') if isinstance(result_payload, dict) else None,
+        'normalized_match': result_payload.get('normalize_match') if isinstance(result_payload, dict) else None,
         'skip_reason': skip_reason,
         'error_message': error_message,
     }
@@ -5654,6 +5663,9 @@ def _build_tabular_generated_output_source_candidate(invocations):
             'selected_sheet': result_payload.get('selected_sheet'),
             'source_parameters': dict(getattr(invocation, 'parameters', {}) or {}),
             'source_descriptor': invocation_internal_metadata.get('tabular_generated_export_source'),
+            'source_descriptor_error': invocation_internal_metadata.get(
+                'tabular_generated_export_source_error'
+            ),
             'source_authorization': invocation_internal_metadata.get('tabular_source_authorization'),
             'function_rank': diagnostic.get('function_rank') or 0,
             'total_matches': diagnostic.get('total_matches') or 0,
@@ -5700,6 +5712,7 @@ def _build_tabular_generated_output_source_candidate(invocations):
             'selected_sheet': candidate_group.get('selected_sheet'),
             'source_parameters': candidate_group.get('source_parameters'),
             'source_descriptor': candidate_group.get('source_descriptor'),
+            'source_descriptor_error': candidate_group.get('source_descriptor_error'),
             'source_authorization': candidate_group.get('source_authorization'),
             'rows': coalesced_result.get('rows'),
             'row_count': coalesced_result.get('row_count'),
@@ -5722,18 +5735,37 @@ def _build_tabular_generated_output_query_descriptor(
 ):
     if not isinstance(source_candidate, dict):
         return None
-    if source_candidate.get('function_name') != 'query_tabular_data':
+    function_name = str(source_candidate.get('function_name') or '').strip()
+    if function_name not in {'query_tabular_data', 'filter_rows', 'search_rows'}:
         return None
 
     source_parameters = source_candidate.get('source_parameters') or {}
-    query_expression = str(source_parameters.get('query_expression') or '').strip()
     source_descriptor = source_candidate.get('source_descriptor') or {}
+    source_descriptor_error = str(
+        source_candidate.get('source_descriptor_error') or ''
+    ).strip()
+    if source_descriptor_error:
+        raise ValueError(source_descriptor_error)
+
+    query_expression = str(source_descriptor.get('query_expression') or '').strip()
+    descriptor_source_function = str(
+        source_descriptor.get('source_function') or 'query_tabular_data'
+    ).strip()
     if (
         not query_expression
         or source_descriptor.get('kind') != 'query_tabular_data'
+        or descriptor_source_function != function_name
         or str(source_descriptor.get('filename') or '') != str(source_candidate.get('filename') or '')
-        or str(source_descriptor.get('query_expression') or '') != query_expression
     ):
+        return None
+    if (
+        function_name == 'query_tabular_data'
+        and query_expression != str(source_parameters.get('query_expression') or '').strip()
+    ):
+        return None
+    if str(source_descriptor.get('return_columns') or '').strip() != str(
+        source_parameters.get('return_columns') or ''
+    ).strip():
         return None
     validate_tabular_csv_query_expression(query_expression)
 
@@ -8542,9 +8574,13 @@ def question_requests_tabular_exhaustive_results(user_question):
         'all values',
         'all of them',
         'complete list',
+        'each row',
         'each one',
+        'every row',
         'every one',
         'exhaustive',
+        'for each row',
+        'for every row',
         'full list',
         'list all',
         'list each',
@@ -8565,6 +8601,8 @@ def question_requests_tabular_exhaustive_results(user_question):
         r'\bone row per (?:comment|submission|input )?row\b',
         r'\bone row per (?:comment|submission)\b',
         r'\bone object for each row\b',
+        r'\bone row per\b',
+        r'\bfor (?:each|every) row\b',
     )
     structured_output_markers = (
         'json array',
@@ -10697,9 +10735,15 @@ async def run_tabular_sk_analysis(user_question, tabular_filenames, user_id,
 
     try:
         plugin_logger = get_plugin_logger()
-        execution_mode = execution_mode if execution_mode in {'analysis', 'schema_summary', 'entity_lookup'} else 'analysis'
+        execution_mode = execution_mode if execution_mode in {
+            'analysis',
+            'schema_summary',
+            'entity_lookup',
+            'exhaustive',
+        } else 'analysis'
         schema_summary_mode = execution_mode == 'schema_summary'
         entity_lookup_mode = execution_mode == 'entity_lookup'
+        exhaustive_mode = execution_mode == 'exhaustive'
         fact_memory_enabled = bool(settings.get('enable_fact_memory_plugin', False))
         fact_memory_scope_id = group_id or user_id
         fact_memory_scope_type = 'group' if group_id else 'user'
@@ -11087,6 +11131,13 @@ async def run_tabular_sk_analysis(user_question, tabular_filenames, user_id,
                     "If the right worksheet or columns are unclear, call describe_tabular_file without sheet_name as an exploration step, then continue with one or more analytical tool calls. You may need multiple tool rounds.\n\n"
                 )
 
+            exhaustive_request_feedback = ""
+            if exhaustive_mode:
+                exhaustive_request_feedback = (
+                    "EXHAUSTIVE ROW REQUEST:\n"
+                    "The user requires one result per source row or a complete structured export. Prefer one query_tabular_data call with a simple row-local query expression that identifies the complete cohort, even when filter_rows or search_rows could return a preview. For the entire CSV, use a full-cohort expression such as index == index. Include the source columns needed for the requested per-row work in return_columns. A bounded returned page is sufficient because the server will replay the authorized source query durably; do not page the full cohort into model context. Do not use normalized or cross-row matching for a durable export.\n\n"
+                )
+
             related_sheet_feedback = ""
             if workbook_related_sheet_hints:
                 rendered_related_sheet_hints = "\n".join(
@@ -11189,6 +11240,7 @@ async def run_tabular_sk_analysis(user_question, tabular_filenames, user_id,
                 f"{related_sheet_feedback}"
                 f"{cross_sheet_bridge_feedback}"
                 f"{discovery_step_feedback}"
+                f"{exhaustive_request_feedback}"
                 f"{missing_sheet_feedback}"
                 f"FILE SCHEMAS:\n"
                 f"{schema_context}\n\n"

--- a/application/single_app/semantic_kernel_plugins/tabular_processing_plugin.py
+++ b/application/single_app/semantic_kernel_plugins/tabular_processing_plugin.py
@@ -12,6 +12,7 @@ from datetime import date, datetime
 import io
 import json
 import logging
+import math
 import re
 import tempfile
 import warnings
@@ -24,7 +25,10 @@ from semantic_kernel.functions import kernel_function
 from semantic_kernel_plugins.plugin_invocation_logger import PluginInvocationResult, plugin_function_logger
 from functions_appinsights import log_event
 from functions_authentication import get_current_user_id
-from functions_tabular_csv_query import iter_tabular_csv_query_rows
+from functions_tabular_csv_query import (
+    iter_tabular_csv_query_rows,
+    validate_tabular_csv_query_expression,
+)
 from functions_group import find_group_by_id, get_user_role_in_group
 from functions_public_workspaces import get_user_visible_public_workspace_ids_from_settings
 from config import (
@@ -3478,11 +3482,13 @@ class TabularProcessingPlugin:
         return_columns: Optional[str] = None,
         expected_row_count: int = 0,
         blob_version: Optional[dict] = None,
+        source_function: str = 'query_tabular_data',
     ) -> dict:
         """Pin a durable query descriptor to an already-authorized blob location."""
         if not str(blob_path or '').lower().endswith('.csv'):
             raise ValueError('Durable source-backed generated exports currently require a CSV source')
 
+        normalized_query_expression = validate_tabular_csv_query_expression(query_expression)
         blob_version = dict(blob_version or self._get_tabular_blob_version(container_name, blob_path))
         blob_etag = blob_version.get('blob_etag')
         blob_size = blob_version.get('blob_size')
@@ -3493,6 +3499,7 @@ class TabularProcessingPlugin:
         return {
             'version': 1,
             'kind': 'query_tabular_data',
+            'source_function': str(source_function or 'query_tabular_data').strip(),
             'source': resolved_source,
             'scope_id': scope_id,
             'container': container_name,
@@ -3500,10 +3507,202 @@ class TabularProcessingPlugin:
             'blob_etag': str(blob_etag),
             'blob_size': int(blob_size or 0),
             'filename': str(filename or '').strip(),
-            'query_expression': str(query_expression or '').strip(),
+            'query_expression': normalized_query_expression,
             'return_columns': return_columns,
             'expected_row_count': max(0, int(expected_row_count or 0)),
         }
+
+    def _build_generated_export_column_reference(self, column_name: str) -> str:
+        """Return a safe pandas query reference for one resolved source column."""
+        normalized_column_name = str(column_name or '').strip()
+        if not normalized_column_name:
+            raise ValueError('A source column is required for durable replay')
+        if '`' in normalized_column_name:
+            raise ValueError(
+                f"Column '{normalized_column_name}' cannot be represented in a durable row-local query"
+            )
+        return f'`{normalized_column_name}`'
+
+    def _build_generated_export_filter_clause(
+        self,
+        dataframe: pandas.DataFrame,
+        column_name: str,
+        operator: str,
+        value,
+    ) -> str:
+        """Translate one successful filter into an equivalent row-local query clause."""
+        if column_name not in dataframe.columns:
+            raise ValueError(f"Column '{column_name}' is unavailable for durable replay")
+
+        normalized_operator = str(operator or 'equals').strip().lower()
+        column_reference = self._build_generated_export_column_reference(column_name)
+        numeric_value = None
+        try:
+            numeric_value = float(value)
+        except (TypeError, ValueError):
+            pass
+
+        if (
+            normalized_operator in {'==', 'equals', '!=', '>', '<', '>=', '<='}
+            and numeric_value is not None
+            and math.isfinite(numeric_value)
+            and pandas.api.types.is_numeric_dtype(dataframe[column_name])
+        ):
+            resolved_operator = '==' if normalized_operator == 'equals' else normalized_operator
+            return f'{column_reference} {resolved_operator} {numeric_value!r}'
+
+        if normalized_operator in {'>', '<', '>=', '<='}:
+            raise ValueError(
+                f"Filter '{column_name} {normalized_operator} {value}' is not a replayable numeric comparison"
+            )
+
+        string_series = f'{column_reference}.astype("str")'
+        rendered_value = json.dumps(str(value), ensure_ascii=False)
+        rendered_lower_value = json.dumps(str(value).lower(), ensure_ascii=False)
+        if normalized_operator in {'==', 'equals'}:
+            return f'{string_series}.str.lower() == {rendered_lower_value}'
+        if normalized_operator == '!=':
+            return f'{string_series}.str.lower() != {rendered_lower_value}'
+        if normalized_operator == 'contains':
+            return (
+                f'{string_series}.str.contains('
+                f'{rendered_value}, case=False, regex=False, na=False)'
+            )
+        if normalized_operator == 'startswith':
+            return (
+                f'{string_series}.str.lower().str.startswith('
+                f'{rendered_lower_value}, na=False)'
+            )
+        if normalized_operator == 'endswith':
+            return (
+                f'{string_series}.str.lower().str.endswith('
+                f'{rendered_lower_value}, na=False)'
+            )
+        raise ValueError(f"Filter operator '{operator}' cannot be replayed durably")
+
+    def _build_filter_rows_generated_export_query_expression(
+        self,
+        dataframe: pandas.DataFrame,
+        column: str,
+        operator: str,
+        value,
+        additional_filter_column: Optional[str] = None,
+        additional_filter_operator: str = 'equals',
+        additional_filter_value=None,
+        normalize_match: bool = False,
+    ) -> str:
+        """Build the full row-local query represented by a filter_rows call."""
+        if normalize_match:
+            raise ValueError(
+                'filter_rows with normalize_match=true cannot be replayed equivalently by the row-local CSV engine'
+            )
+
+        clauses = [
+            self._build_generated_export_filter_clause(dataframe, column, operator, value),
+        ]
+        if additional_filter_column:
+            clauses.append(self._build_generated_export_filter_clause(
+                dataframe,
+                additional_filter_column,
+                additional_filter_operator,
+                additional_filter_value,
+            ))
+        return validate_tabular_csv_query_expression(
+            ' and '.join(f'({clause})' for clause in clauses)
+        )
+
+    def _build_search_rows_generated_export_query_expression(
+        self,
+        dataframe: pandas.DataFrame,
+        search_value,
+        searched_columns: List[str],
+        search_operator: str = 'contains',
+        query_expression: Optional[str] = None,
+        filter_column: Optional[str] = None,
+        filter_operator: str = 'equals',
+        filter_value=None,
+        additional_filter_column: Optional[str] = None,
+        additional_filter_operator: str = 'equals',
+        additional_filter_value=None,
+        normalize_match: bool = False,
+    ) -> str:
+        """Build the full row-local query represented by a search_rows call."""
+        if normalize_match:
+            raise ValueError(
+                'search_rows with normalize_match=true cannot be replayed equivalently by the row-local CSV engine'
+            )
+
+        clauses = []
+        if query_expression:
+            clauses.append(validate_tabular_csv_query_expression(query_expression))
+        if filter_column:
+            clauses.append(self._build_generated_export_filter_clause(
+                dataframe,
+                filter_column,
+                filter_operator,
+                filter_value,
+            ))
+        if additional_filter_column:
+            clauses.append(self._build_generated_export_filter_clause(
+                dataframe,
+                additional_filter_column,
+                additional_filter_operator,
+                additional_filter_value,
+            ))
+
+        search_clauses = [
+            self._build_generated_export_filter_clause(
+                dataframe,
+                search_column,
+                search_operator,
+                search_value,
+            )
+            for search_column in searched_columns
+        ]
+        if not search_clauses:
+            raise ValueError('search_rows did not resolve a replayable search column')
+        clauses.append(' or '.join(f'({clause})' for clause in search_clauses))
+        return validate_tabular_csv_query_expression(
+            ' and '.join(f'({clause})' for clause in clauses)
+        )
+
+    def _build_tabular_generated_export_internal_metadata(
+        self,
+        container_name: str,
+        blob_path: str,
+        filename: str,
+        source_function: str,
+        query_expression: Optional[str],
+        return_columns: Optional[str],
+        expected_row_count: int,
+        replay_error: Optional[str] = None,
+    ) -> dict:
+        """Build source authorization plus either a replay descriptor or a safe error."""
+        blob_version = self._get_tabular_blob_version(container_name, blob_path)
+        internal_metadata = {
+            'tabular_source_authorization': self._build_source_authorization_from_location(
+                container_name,
+                blob_path,
+                blob_version=blob_version,
+            ),
+        }
+        if replay_error:
+            internal_metadata['tabular_generated_export_source_error'] = str(replay_error)
+            return internal_metadata
+
+        internal_metadata['tabular_generated_export_source'] = (
+            self._build_generated_export_query_descriptor_from_location(
+                container_name=container_name,
+                blob_path=blob_path,
+                filename=filename,
+                query_expression=query_expression,
+                return_columns=return_columns,
+                expected_row_count=expected_row_count,
+                blob_version=blob_version,
+                source_function=source_function,
+            )
+        )
+        return internal_metadata
 
     def _build_source_authorization_from_location(
         self,
@@ -4451,7 +4650,38 @@ class TabularProcessingPlugin:
                     max_rows=limit,
                     return_columns=parsed_return_columns,
                 ))
-                return json.dumps(response_payload, indent=2, default=str)
+                response_json = json.dumps(response_payload, indent=2, default=str)
+                if not str(blob_path or '').lower().endswith('.csv'):
+                    return response_json
+
+                replay_expression = None
+                replay_error = None
+                try:
+                    replay_expression = self._build_filter_rows_generated_export_query_expression(
+                        df,
+                        column,
+                        operator,
+                        value,
+                        additional_filter_column=additional_filter_column,
+                        additional_filter_operator=additional_filter_operator,
+                        additional_filter_value=additional_filter_value,
+                        normalize_match=normalize_match_flag,
+                    )
+                except ValueError as exc:
+                    replay_error = str(exc)
+                return PluginInvocationResult(
+                    response_json,
+                    internal_metadata=self._build_tabular_generated_export_internal_metadata(
+                        container_name=container,
+                        blob_path=blob_path,
+                        filename=filename,
+                        source_function='filter_rows',
+                        query_expression=replay_expression,
+                        return_columns=return_columns,
+                        expected_row_count=len(filtered_df),
+                        replay_error=replay_error,
+                    ),
+                )
             except Exception as e:
                 log_event(f"[TABULAR_PROCESSING_PLUGIN] Error filtering rows: {e}", level=logging.WARNING)
                 return json.dumps({"error": str(e)})
@@ -4624,7 +4854,7 @@ class TabularProcessingPlugin:
                         'selected_sheet': selected_sheet if workbook_metadata.get('is_workbook') else None,
                     })
 
-                return json.dumps({
+                response_json = json.dumps({
                     'filename': filename,
                     'selected_sheet': selected_sheet if workbook_metadata.get('is_workbook') else None,
                     'search_value': search_value,
@@ -4642,6 +4872,41 @@ class TabularProcessingPlugin:
                     'next_start_row': search_result['next_start_row'],
                     'data': search_result['data'],
                 }, indent=2, default=str)
+                if not str(blob_path or '').lower().endswith('.csv'):
+                    return response_json
+
+                replay_expression = None
+                replay_error = None
+                try:
+                    replay_expression = self._build_search_rows_generated_export_query_expression(
+                        df,
+                        search_value,
+                        search_result['searched_columns'],
+                        search_operator=search_operator,
+                        query_expression=query_expression,
+                        filter_column=filter_column,
+                        filter_operator=filter_operator,
+                        filter_value=filter_value,
+                        additional_filter_column=additional_filter_column,
+                        additional_filter_operator=additional_filter_operator,
+                        additional_filter_value=additional_filter_value,
+                        normalize_match=normalize_match_flag,
+                    )
+                except ValueError as exc:
+                    replay_error = str(exc)
+                return PluginInvocationResult(
+                    response_json,
+                    internal_metadata=self._build_tabular_generated_export_internal_metadata(
+                        container_name=container,
+                        blob_path=blob_path,
+                        filename=filename,
+                        source_function='search_rows',
+                        query_expression=replay_expression,
+                        return_columns=return_columns,
+                        expected_row_count=search_result['total_matches'],
+                        replay_error=replay_error,
+                    ),
+                )
             except Exception as e:
                 log_event(f"[TABULAR_PROCESSING_PLUGIN] Error searching rows: {e}", level=logging.WARNING)
                 return json.dumps({"error": str(e)})

--- a/docs/explanation/fixes/TABULAR_SOURCE_DESCRIPTOR_GENERALIZATION_FIX.md
+++ b/docs/explanation/fixes/TABULAR_SOURCE_DESCRIPTOR_GENERALIZATION_FIX.md
@@ -1,0 +1,54 @@
+# Tabular Source Descriptor Generalization Fix
+
+Fixed/Implemented in version: **0.250.127**
+
+Related work: Refs #1031
+
+## Issue
+
+Exhaustive per-row CSV requests could fail when the tabular mini-agent selected `filter_rows` or `search_rows`. Those tools returned bounded preview pages but did not attach the replayable, version-pinned source descriptor used by the durable generated-export runner. The export selector therefore rejected otherwise valid partial pages instead of replaying the full source cohort.
+
+## Root Cause
+
+Only `query_tabular_data` produced a durable `query_tabular_data` source descriptor. The generated-output route also accepted descriptors only from that function, even when `filter_rows` or `search_rows` represented an equivalent row-local CSV query.
+
+## Technical Details
+
+### Files Modified
+
+- `application/single_app/functions_tabular_csv_query.py`
+- `application/single_app/semantic_kernel_plugins/tabular_processing_plugin.py`
+- `application/single_app/route_backend_chats.py`
+- `application/single_app/config.py`
+- `functional_tests/test_tabular_large_result_pagination.py`
+- `functional_tests/test_tabular_row_orchestration_scale.py`
+- `functional_tests/test_tabular_entity_lookup_mode.py`
+
+### Code Changes
+
+- Added a strict row-local AST allowlist for generated case-insensitive string equality, containment, prefix, and suffix expressions.
+- Attached authorized, blob-version-pinned replay descriptors to replayable CSV `filter_rows` and `search_rows` results without changing their bounded preview output.
+- Propagated explicit replay errors for semantics such as `normalize_match=true` that cannot be represented equivalently.
+- Generalized durable generated-output routing to accept server-issued descriptors from all three row-returning tabular functions.
+- Added an exhaustive execution mode for natural phrases such as "for each row," "every row," and "one row per," steering the mini-agent toward a full-cohort `query_tabular_data` call.
+- Updated `application/single_app/config.py` from version `0.250.126` to `0.250.127`.
+
+## Impact Analysis
+
+- Exhaustive CSV exports can continue from a bounded `filter_rows` or `search_rows` preview by replaying the complete authorized cohort in the existing durable runner.
+- Ordinary previews retain their current pagination and output-trimming behavior.
+- Deterministic aggregation remains on the existing direct execution path.
+- Group, public, personal workspace, and chat-upload source authorization remains bound to the exact container, blob path, scope, and ETag.
+- Non-replayable semantics fail closed and do not publish a partial CSV.
+
+## Validation
+
+- A simulated 3,000-row `filter_rows` request returns a trimmed preview while bounded replay yields all 3,000 rows.
+- Two 60-row pages from a 3,000-row cohort queue one source-backed durable run with `expected_row_count=3000`.
+- A filtered multi-column `search_rows` request replays the same complete cohort.
+- `normalize_match=true` produces an explicit failed-export status and queues no run.
+- Existing pagination, source-version, durable retry, cancellation, fencing, and authorization contract tests continue to pass.
+
+## Before and After
+
+Before, an incomplete `filter_rows` candidate ended with a page-gap validation failure because no source replay was available. After this fix, replayable filters and searches queue the full source cohort; unsupported semantics report why replay is unavailable and no partial export is created.

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,16 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](/explanation/features/) and [Fixes by Version](/explanation/fixes/).
 
+### **(v0.250.127)**
+
+#### Bug Fixes
+
+*   **Replayable Exhaustive Tabular Exports**
+    *   Generalized version-pinned CSV source descriptors so exhaustive `filter_rows` and `search_rows` requests can replay the complete authorized cohort through the existing durable export runner instead of failing on bounded preview gaps.
+    *   Added exhaustive per-row request routing for natural phrases such as "for each row," "every row," and "one row per," while preserving direct deterministic aggregation behavior.
+    *   Non-replayable semantics such as normalized entity matching now fail closed with an explicit reason and never publish a partial CSV.
+    *   (Ref: #1031, tabular source descriptors, durable generated exports, `functions_tabular_csv_query.py`, `tabular_processing_plugin.py`, `route_backend_chats.py`)
+
 ### **(v0.250.126)**
 
 #### Bug Fixes

--- a/functional_tests/test_tabular_entity_lookup_mode.py
+++ b/functional_tests/test_tabular_entity_lookup_mode.py
@@ -2,8 +2,8 @@
 # test_tabular_entity_lookup_mode.py
 """
 Functional test for cross-sheet entity lookup routing fix.
-Version: 0.240.009
-Implemented in: 0.240.009
+Version: 0.250.127
+Implemented in: 0.240.009; exhaustive row routing in 0.250.127
 
 This test ensures related-record workbook questions route to entity-lookup
 mode, rank relevant worksheets beyond the first successful sheet, keep the
@@ -27,6 +27,9 @@ ROUTE_FILE = os.path.join(ROOT_DIR, 'application', 'single_app', 'route_backend_
 TARGET_FUNCTIONS = {
     'is_tabular_schema_summary_question',
     'is_tabular_entity_lookup_question',
+    'question_requests_tabular_exhaustive_results',
+    'question_requests_tabular_generated_output',
+    'question_requests_tabular_structured_object_output',
     'get_tabular_execution_mode',
     'get_tabular_invocation_result_payload',
     'get_tabular_invocation_selected_sheet',
@@ -56,6 +59,10 @@ def load_tabular_route_helpers():
 
     module = ast.Module(body=selected_nodes, type_ignores=[])
     namespace = {
+        'assistant_table_export_requested': lambda question: 'csv' in str(question).lower(),
+        'get_tabular_generated_output_format': lambda question: (
+            'csv' if 'csv' in str(question).lower() else None
+        ),
         'json': json,
         're': __import__('re'),
     }
@@ -98,6 +105,44 @@ def test_cross_sheet_questions_route_to_entity_lookup_mode():
         print('✅ Cross-sheet entity-lookup intent detection passed')
         return True
 
+    except Exception as exc:
+        print(f'❌ Test failed: {exc}')
+        import traceback
+        traceback.print_exc()
+        return False
+
+
+def test_per_row_exports_route_to_exhaustive_mode():
+    """Verify natural per-row export prompts select replay-oriented orchestration."""
+    print('🔍 Testing exhaustive per-row export routing...')
+
+    try:
+        helpers, route_content = load_tabular_route_helpers()
+        requests_exhaustive_results = helpers['question_requests_tabular_exhaustive_results']
+        requests_generated_output = helpers['question_requests_tabular_generated_output']
+        requests_structured_output = helpers[
+            'question_requests_tabular_structured_object_output'
+        ]
+        get_execution_mode = helpers['get_tabular_execution_mode']
+        prompts = (
+            'For each row, answer each question and generate a CSV.',
+            'Answer this for every row and save the complete CSV.',
+            'Produce one row per source row in a CSV file.',
+        )
+
+        for prompt in prompts:
+            assert requests_exhaustive_results(prompt), prompt
+            assert requests_generated_output(prompt), prompt
+            assert requests_structured_output(prompt), prompt
+            assert get_execution_mode(prompt) == 'exhaustive', prompt
+
+        assert get_execution_mode('What is the average risk score?') == 'analysis'
+        assert 'EXHAUSTIVE ROW REQUEST:' in route_content
+        assert 'Prefer one query_tabular_data call with a simple row-local query expression' in route_content
+        assert 'do not page the full cohort into model context' in route_content
+
+        print('✅ Exhaustive per-row export routing passed')
+        return True
     except Exception as exc:
         print(f'❌ Test failed: {exc}')
         import traceback
@@ -343,6 +388,7 @@ def test_entity_lookup_missing_sheet_feedback_generates_concrete_examples():
 if __name__ == '__main__':
     tests = [
         test_cross_sheet_questions_route_to_entity_lookup_mode,
+        test_per_row_exports_route_to_exhaustive_mode,
         test_entity_lookup_sheet_selection_prioritizes_related_worksheets,
         test_entity_lookup_primary_sheet_hint_prefers_anchor_entity_sheet,
         test_entity_lookup_retry_guardrails_detect_incomplete_successes,

--- a/functional_tests/test_tabular_large_result_pagination.py
+++ b/functional_tests/test_tabular_large_result_pagination.py
@@ -2,8 +2,8 @@
 # test_tabular_large_result_pagination.py
 """
 Functional test for tabular SK large-result pagination and output trimming.
-Version: 0.250.061
-Implemented in: 0.242.067; bounded CSV query path in 0.250.060
+Version: 0.250.127
+Implemented in: 0.242.067; bounded CSV query path in 0.250.060; source descriptor generalization in 0.250.127
 
 This test ensures row-returning tabular processing tools support start_row/max_rows
 pagination, avoid skipped rows after auto-trimming oversized output, honor
@@ -13,9 +13,11 @@ row-linked document evidence enrichment.
 
 import asyncio
 import importlib.util
+import io
 import json
 import os
 import sys
+import types
 
 import pandas as pd
 
@@ -23,6 +25,7 @@ import pandas as pd
 ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.append(ROOT_DIR)
 sys.path.append(os.path.join(ROOT_DIR, 'application', 'single_app'))
+sys.modules.setdefault('olefile', types.SimpleNamespace())
 
 PLUGIN_FILE = os.path.join(
     ROOT_DIR,
@@ -395,6 +398,173 @@ def test_query_tabular_csv_uses_bounded_shared_engine_and_exact_descriptor():
         return False
 
 
+def test_filter_rows_csv_attaches_replayable_descriptor_for_full_cohort():
+    """Verify a trimmed filter_rows page can replay all matching CSV rows durably."""
+    print('🔍 Testing filter_rows durable replay descriptor...')
+
+    try:
+        source_rows = [
+            {
+                'transaction_id': f'BT-{row_index + 1:04d}',
+                'status': 'Open' if row_index % 2 == 0 else 'Closed',
+            }
+            for row_index in range(3000)
+        ]
+        source_frame = pd.DataFrame(source_rows)
+        csv_content = source_frame.to_csv(index=False).encode('utf-8')
+        plugin = TabularProcessingPlugin()
+        plugin._resolve_blob_location_with_fallback = lambda *args, **kwargs: (
+            'mock-container',
+            'nested/version-7/large-results.csv',
+        )
+        plugin._get_blob_service_client = lambda: MockCsvBlobServiceClient(csv_content)
+        plugin._read_tabular_blob_to_dataframe = lambda *args, **kwargs: source_frame.copy()
+
+        result = asyncio.run(plugin.filter_rows(
+            user_id='test-user',
+            conversation_id='test-conversation',
+            filename='large-results.csv',
+            column='transaction_id',
+            operator='contains',
+            value='BT-',
+            source='chat',
+            return_columns='transaction_id,status',
+            max_rows='3000',
+        ))
+        payload = json.loads(result)
+        descriptor = result.internal_metadata['tabular_generated_export_source']
+        replayed_rows = list(PLUGIN_MODULE.iter_tabular_csv_query_rows(
+            csv_stream=io.BytesIO(csv_content),
+            query_expression=descriptor['query_expression'],
+            return_columns=descriptor['return_columns'],
+            source_chunk_rows=137,
+            tabular_plugin=plugin,
+        ))
+
+        assert payload['total_matches'] == 3000, payload
+        assert payload['returned_rows'] < payload['total_matches'], payload
+        assert descriptor['source_function'] == 'filter_rows', descriptor
+        assert descriptor['expected_row_count'] == 3000, descriptor
+        assert len(replayed_rows) == 3000, len(replayed_rows)
+        assert replayed_rows[0][1]['transaction_id'] == 'BT-0001', replayed_rows[0]
+        assert replayed_rows[-1][1]['transaction_id'] == 'BT-3000', replayed_rows[-1]
+
+        print('✅ filter_rows durable replay descriptor passed')
+        return True
+    except Exception as exc:
+        print(f'❌ Test failed: {exc}')
+        import traceback
+        traceback.print_exc()
+        return False
+
+
+def test_filter_rows_csv_rejects_non_replayable_normalized_matching():
+    """Verify normalized matching fails closed instead of advertising partial replay."""
+    print('🔍 Testing normalized filter_rows replay rejection...')
+
+    try:
+        source_frame = pd.DataFrame([
+            {'Owner': 'Contoso, Inc.'},
+            {'Owner': 'CONTOSO INC'},
+        ])
+        csv_content = source_frame.to_csv(index=False).encode('utf-8')
+        plugin = TabularProcessingPlugin()
+        plugin._resolve_blob_location_with_fallback = lambda *args, **kwargs: (
+            'mock-container',
+            'nested/version-7/large-results.csv',
+        )
+        plugin._get_blob_service_client = lambda: MockCsvBlobServiceClient(csv_content)
+        plugin._read_tabular_blob_to_dataframe = lambda *args, **kwargs: source_frame.copy()
+
+        result = asyncio.run(plugin.filter_rows(
+            user_id='test-user',
+            conversation_id='test-conversation',
+            filename='large-results.csv',
+            column='Owner',
+            operator='equals',
+            value='Contoso Inc',
+            normalize_match='true',
+            source='chat',
+        ))
+        payload = json.loads(result)
+        metadata = result.internal_metadata
+
+        assert payload['total_matches'] == 2, payload
+        assert 'tabular_generated_export_source' not in metadata, metadata
+        assert 'normalize_match=true' in metadata['tabular_generated_export_source_error'], metadata
+
+        print('✅ Normalized filter_rows replay rejection passed')
+        return True
+    except Exception as exc:
+        print(f'❌ Test failed: {exc}')
+        import traceback
+        traceback.print_exc()
+        return False
+
+
+def test_search_rows_csv_attaches_replayable_multi_column_descriptor():
+    """Verify filtered multi-column searches replay the same complete CSV cohort."""
+    print('🔍 Testing search_rows durable replay descriptor...')
+
+    try:
+        source_rows = [
+            {
+                'transaction_id': f'BT-{row_index + 1:04d}',
+                'status': 'Open' if row_index % 2 == 0 else 'Closed',
+                'notes': 'Risk review' if row_index % 3 == 0 else 'Routine',
+            }
+            for row_index in range(300)
+        ]
+        source_frame = pd.DataFrame(source_rows)
+        csv_content = source_frame.to_csv(index=False).encode('utf-8')
+        plugin = TabularProcessingPlugin()
+        plugin._resolve_blob_location_with_fallback = lambda *args, **kwargs: (
+            'mock-container',
+            'nested/version-7/large-results.csv',
+        )
+        plugin._get_blob_service_client = lambda: MockCsvBlobServiceClient(csv_content)
+        plugin._read_tabular_blob_to_dataframe = lambda *args, **kwargs: source_frame.copy()
+
+        result = asyncio.run(plugin.search_rows(
+            user_id='test-user',
+            conversation_id='test-conversation',
+            filename='large-results.csv',
+            search_value='risk',
+            search_columns='transaction_id,notes',
+            filter_column='status',
+            filter_operator='equals',
+            filter_value='Open',
+            return_columns='transaction_id,status,notes',
+            source='chat',
+            max_rows='10',
+        ))
+        payload = json.loads(result)
+        descriptor = result.internal_metadata['tabular_generated_export_source']
+        replayed_rows = list(PLUGIN_MODULE.iter_tabular_csv_query_rows(
+            csv_stream=io.BytesIO(csv_content),
+            query_expression=descriptor['query_expression'],
+            return_columns=descriptor['return_columns'],
+            source_chunk_rows=41,
+            tabular_plugin=plugin,
+        ))
+
+        assert payload['total_matches'] == 50, payload
+        assert payload['returned_rows'] == 10, payload
+        assert descriptor['source_function'] == 'search_rows', descriptor
+        assert descriptor['expected_row_count'] == 50, descriptor
+        assert len(replayed_rows) == payload['total_matches'], replayed_rows
+        assert all(row['status'] == 'Open' for _, row in replayed_rows), replayed_rows[:3]
+        assert all('risk' in row['notes'].lower() for _, row in replayed_rows), replayed_rows[:3]
+
+        print('✅ search_rows durable replay descriptor passed')
+        return True
+    except Exception as exc:
+        print(f'❌ Test failed: {exc}')
+        import traceback
+        traceback.print_exc()
+        return False
+
+
 if __name__ == '__main__':
     tests = [
         test_filter_rows_paginates_without_skipping_after_row_trim,
@@ -403,6 +573,9 @@ if __name__ == '__main__':
         test_search_rows_preserves_attachment_references_with_return_columns,
         test_query_tabular_data_supports_return_columns_and_pagination,
         test_query_tabular_csv_uses_bounded_shared_engine_and_exact_descriptor,
+        test_filter_rows_csv_attaches_replayable_descriptor_for_full_cohort,
+        test_filter_rows_csv_rejects_non_replayable_normalized_matching,
+        test_search_rows_csv_attaches_replayable_multi_column_descriptor,
     ]
 
     results = []

--- a/functional_tests/test_tabular_row_orchestration_scale.py
+++ b/functional_tests/test_tabular_row_orchestration_scale.py
@@ -1,14 +1,15 @@
 # test_tabular_row_orchestration_scale.py
 """
 Functional test for scalable per-row tabular orchestration.
-Version: 0.250.073
-Implemented in: 0.250.060; generated CSV formula safety in 0.250.065; generated file export routing in 0.250.072; updated in 0.250.073
+Version: 0.250.127
+Implemented in: 0.250.060; generated CSV formula safety in 0.250.065; generated file export routing in 0.250.072; source descriptor generalization in 0.250.127
 
 This test ensures generated exports preserve source identity and row order while
 enforcing one stable output schema across independently generated batches.
 """
 
 import ast
+import asyncio
 import csv
 import io
 import importlib.util
@@ -174,6 +175,46 @@ def _load_candidate_helpers():
     return namespace
 
 
+def _load_query_descriptor_helper():
+    """Load the generalized durable query descriptor adapter in isolation."""
+    module_tree = ast.parse(CHAT_ROUTE.read_text(encoding='utf-8'), filename=str(CHAT_ROUTE))
+    function_node = next(
+        node
+        for node in module_tree.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == '_build_tabular_generated_output_query_descriptor'
+    )
+    source_reader_helpers = _load_source_reader_helpers()
+    namespace = {
+        '_get_tabular_generated_output_batch_budget': lambda settings: {
+            'max_rows': 60,
+            'max_chars': 60000,
+        },
+        '_safe_int': lambda value: int(value or 0),
+        'validate_tabular_csv_query_expression': source_reader_helpers[
+            'validate_tabular_csv_query_expression'
+        ],
+    }
+    extracted_module = ast.Module(body=[function_node], type_ignores=[])
+    exec(compile(extracted_module, str(CHAT_ROUTE), 'exec'), namespace)
+    return namespace['_build_tabular_generated_output_query_descriptor']
+
+
+def _load_generated_output_router(route_dependencies):
+    """Load maybe_create_tabular_generated_output with focused dependency stubs."""
+    module_tree = ast.parse(CHAT_ROUTE.read_text(encoding='utf-8'), filename=str(CHAT_ROUTE))
+    function_node = next(
+        node
+        for node in module_tree.body
+        if isinstance(node, ast.AsyncFunctionDef)
+        and node.name == 'maybe_create_tabular_generated_output'
+    )
+    namespace = dict(route_dependencies)
+    extracted_module = ast.Module(body=[function_node], type_ignores=[])
+    exec(compile(extracted_module, str(CHAT_ROUTE), 'exec'), namespace)
+    return namespace['maybe_create_tabular_generated_output']
+
+
 def _build_query_invocation(start_row, row_count, total_matches=300, source_etag='etag-source-7'):
     class InvocationPayload(dict):
         pass
@@ -221,6 +262,76 @@ def _build_query_invocation(start_row, row_count, total_matches=300, source_etag
             'source': 'chat',
             'start_row': str(start_row),
             'max_rows': '100',
+        },
+        result=result_payload,
+        error_message=None,
+    )
+
+
+def _build_filter_invocation(
+    start_row,
+    row_count,
+    total_matches=3000,
+    source_etag='etag-source-filter-7',
+    replay_error=None,
+):
+    """Build one logged filter_rows page with server-only replay metadata."""
+    class InvocationPayload(dict):
+        pass
+
+    rows = [
+        {'transaction_id': f'BT-{row_index + 1:04d}'}
+        for row_index in range(start_row, start_row + row_count)
+    ]
+    result_payload = InvocationPayload({
+        'filename': 'bank_treasury_operations_dataset-3000.csv',
+        'filter_applied': ['transaction_id contains BT-'],
+        'normalize_match': bool(replay_error),
+        'start_row': start_row,
+        'returned_rows': row_count,
+        'total_matches': total_matches,
+        'has_more': start_row + row_count < total_matches,
+        'next_start_row': start_row + row_count if start_row + row_count < total_matches else None,
+        'data': rows,
+    })
+    result_payload.internal_metadata = {
+        'tabular_source_authorization': {
+            'source': 'workspace',
+            'scope_id': None,
+            'container': 'user-documents',
+            'blob_path': 'user-1/nested/version-7/source.csv',
+            'blob_etag': source_etag,
+        },
+    }
+    if replay_error:
+        result_payload.internal_metadata['tabular_generated_export_source_error'] = replay_error
+    else:
+        result_payload.internal_metadata['tabular_generated_export_source'] = {
+            'version': 1,
+            'kind': 'query_tabular_data',
+            'source_function': 'filter_rows',
+            'source': 'workspace',
+            'scope_id': None,
+            'container': 'user-documents',
+            'blob_path': 'user-1/nested/version-7/source.csv',
+            'blob_etag': source_etag,
+            'filename': 'bank_treasury_operations_dataset-3000.csv',
+            'query_expression': '(`transaction_id`.astype("str").str.contains("BT-", case=False, regex=False, na=False))',
+            'return_columns': 'transaction_id',
+            'expected_row_count': total_matches,
+        }
+    return SimpleNamespace(
+        plugin_name='TabularProcessingPlugin',
+        function_name='filter_rows',
+        parameters={
+            'filename': 'bank_treasury_operations_dataset-3000.csv',
+            'column': 'transaction_id',
+            'operator': 'contains',
+            'value': 'BT-',
+            'source': 'workspace',
+            'return_columns': 'transaction_id',
+            'start_row': str(start_row),
+            'max_rows': '3000',
         },
         result=result_payload,
         error_message=None,
@@ -781,6 +892,154 @@ def test_paginated_candidate_rejects_mixed_source_versions():
     assert 'different source blobs or versions' in candidate['validation_error'].lower()
 
 
+def test_filter_rows_pages_queue_full_3000_row_source_replay():
+    """Incomplete filter pages queue one durable run from the full source descriptor."""
+    candidate_helpers = _load_candidate_helpers()
+    descriptor_builder = _load_query_descriptor_helper()
+    invocations = [
+        _build_filter_invocation(0, 60),
+        _build_filter_invocation(60, 60),
+    ]
+    candidate = candidate_helpers['_build_tabular_generated_output_source_candidate'](
+        invocations
+    )
+    queued_calls = []
+
+    def queue_run(**kwargs):
+        queued_calls.append(kwargs)
+        return {
+            'id': 'filter-run-3000',
+            'row_count': kwargs['source_descriptor']['expected_row_count'],
+            'batch_count': 50,
+        }
+
+    async def emit_thought(*args, **kwargs):
+        return None
+
+    class MixedSourceCancellationError(Exception):
+        pass
+
+    router = _load_generated_output_router({
+        'MixedSourceCancellationError': MixedSourceCancellationError,
+        '_build_failed_tabular_generated_output_metadata': lambda source, output_format, reason: {
+            'status': 'failed',
+            'status_detail': reason,
+        },
+        '_build_tabular_generated_output_candidate_diagnostics': lambda values: [],
+        '_build_tabular_generated_output_input_row': lambda row, source_file_name=None: row,
+        '_build_tabular_generated_output_query_descriptor': descriptor_builder,
+        '_build_tabular_generated_output_row_batches': lambda rows, settings=None: [rows],
+        '_build_tabular_generated_output_source_authorization': lambda source: source.get(
+            'source_authorization'
+        ),
+        '_build_tabular_generated_output_source_candidate': lambda values: candidate,
+        '_safe_int': lambda value: int(value or 0),
+        'build_background_tabular_generated_output_metadata': lambda run: {
+            'background_export': True,
+            'export_run_id': run['id'],
+            'row_count': run['row_count'],
+        },
+        'build_tabular_post_processing_activity_payload': lambda *args, **kwargs: {},
+        'cancel_tabular_generated_output_run': lambda *args, **kwargs: None,
+        'emit_tabular_post_processing_thought': emit_thought,
+        'get_tabular_generated_output_format': lambda question: 'csv',
+        'logging': logging,
+        'log_event': lambda *args, **kwargs: None,
+        'question_requests_tabular_generated_output': lambda question: True,
+        'question_requests_tabular_structured_object_output': lambda question: True,
+        'queue_tabular_generated_output_run': queue_run,
+        'raise_if_mixed_source_cancelled': lambda *args, **kwargs: None,
+        'should_queue_tabular_generated_output_background': lambda *args, **kwargs: True,
+    })
+
+    output_metadata = asyncio.run(router(
+        user_question='For each row, answer each question and generate a CSV.',
+        invocations=invocations,
+        gpt_model='test-model',
+        settings={},
+        conversation_id='conversation-1',
+        user_id='user-1',
+    ))
+
+    assert candidate['full_result_available'] is False
+    assert candidate['row_count'] == 120
+    assert candidate['total_matches'] == 3000
+    assert len(queued_calls) == 1
+    assert queued_calls[0]['row_batches'] is None
+    queued_descriptor = queued_calls[0]['source_descriptor']
+    assert queued_descriptor['source_function'] == 'filter_rows'
+    assert queued_descriptor['expected_row_count'] == 3000
+    assert queued_descriptor['batch_max_rows'] == 60
+    assert output_metadata['background_export'] is True
+    assert output_metadata['export_run_id'] == 'filter-run-3000'
+
+
+def test_non_replayable_filter_rows_reports_explicit_failure():
+    """Normalized filter semantics fail closed with a user-visible reason."""
+    candidate_helpers = _load_candidate_helpers()
+    descriptor_builder = _load_query_descriptor_helper()
+    replay_error = (
+        'filter_rows with normalize_match=true cannot be replayed equivalently '
+        'by the row-local CSV engine'
+    )
+    invocations = [
+        _build_filter_invocation(0, 60, replay_error=replay_error),
+    ]
+    candidate = candidate_helpers['_build_tabular_generated_output_source_candidate'](
+        invocations
+    )
+    queued_calls = []
+
+    async def emit_thought(*args, **kwargs):
+        return None
+
+    class MixedSourceCancellationError(Exception):
+        pass
+
+    router = _load_generated_output_router({
+        'MixedSourceCancellationError': MixedSourceCancellationError,
+        '_build_failed_tabular_generated_output_metadata': lambda source, output_format, reason: {
+            'status': 'failed',
+            'status_detail': reason,
+        },
+        '_build_tabular_generated_output_candidate_diagnostics': lambda values: [],
+        '_build_tabular_generated_output_input_row': lambda row, source_file_name=None: row,
+        '_build_tabular_generated_output_query_descriptor': descriptor_builder,
+        '_build_tabular_generated_output_row_batches': lambda rows, settings=None: [rows],
+        '_build_tabular_generated_output_source_authorization': lambda source: source.get(
+            'source_authorization'
+        ),
+        '_build_tabular_generated_output_source_candidate': lambda values: candidate,
+        '_safe_int': lambda value: int(value or 0),
+        'build_background_tabular_generated_output_metadata': lambda run: run,
+        'build_tabular_post_processing_activity_payload': lambda *args, **kwargs: {},
+        'cancel_tabular_generated_output_run': lambda *args, **kwargs: None,
+        'emit_tabular_post_processing_thought': emit_thought,
+        'get_tabular_generated_output_format': lambda question: 'csv',
+        'logging': logging,
+        'log_event': lambda *args, **kwargs: None,
+        'question_requests_tabular_generated_output': lambda question: True,
+        'question_requests_tabular_structured_object_output': lambda question: True,
+        'queue_tabular_generated_output_run': lambda **kwargs: queued_calls.append(kwargs),
+        'raise_if_mixed_source_cancelled': lambda *args, **kwargs: None,
+        'should_queue_tabular_generated_output_background': lambda *args, **kwargs: True,
+    })
+
+    output_metadata = asyncio.run(router(
+        user_question='For every row, answer the question and generate a CSV.',
+        invocations=invocations,
+        gpt_model='test-model',
+        settings={},
+        conversation_id='conversation-1',
+        user_id='user-1',
+    ))
+
+    assert not queued_calls
+    assert output_metadata['status'] == 'failed'
+    assert 'normalize_match=true' in output_metadata['status_detail']
+    assert 'No partial CSV was created' in output_metadata['status_detail']
+
+
 def test_streaming_finalizer_writes_30000_rows_in_bounded_chunks():
     """Final assembly reads one checkpoint at a time and never builds a full row list."""
     requested_batches = []
@@ -1266,6 +1525,8 @@ def main():
         test_paginated_candidate_coalesces_all_300_rows,
         test_paginated_candidate_rejects_gaps,
         test_paginated_candidate_rejects_mixed_source_versions,
+        test_filter_rows_pages_queue_full_3000_row_source_replay,
+        test_non_replayable_filter_rows_reports_explicit_failure,
         test_streaming_finalizer_writes_30000_rows_in_bounded_chunks,
         test_streaming_finalizer_neutralizes_csv_formulas,
         test_streaming_finalizer_rejects_source_order_gaps,


### PR DESCRIPTION
## Summary

- Generalizes authorized, version-pinned CSV replay descriptors from `query_tabular_data` to replayable `filter_rows` and `search_rows` calls.
- Routes natural exhaustive prompts such as "for each row," "every row," and "one row per" through an exhaustive mini-agent mode that prefers a full-cohort query descriptor.
- Preserves bounded preview pagination while allowing the existing durable runner to replay the complete source cohort.
- Fails closed with an explicit user-visible reason when semantics such as `normalize_match=true` cannot be replayed equivalently.
- Bumps the application version to `0.250.127` and adds fix/release documentation.

## Validation

- `python functional_tests/test_tabular_large_result_pagination.py`
- `python functional_tests/test_tabular_row_orchestration_scale.py`
- `python functional_tests/test_tabular_entity_lookup_mode.py`
- `python -m py_compile` for all modified Python files
- `python scripts/check_broken_access_control.py` for the modified production modules
- `python functional_tests/test_app_version_assertion_guardrails.py`
- Git whitespace validation with CRLF-aware settings
- Pylance diagnostics review for all modified Python files

## Scope

This PR implements Phase 1 only: source descriptor generalization and exhaustive request routing. It does not introduce the Phase 2 unified durable run contract or Phase 3 analysis-only reduction pipeline.

Refs #1031.