### PR TITLE
Phase 2: unify tabular durable run contract

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -96,7 +96,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.250.127"
+VERSION = "0.250.128"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/functions_tabular_generated_exports.py
+++ b/application/single_app/functions_tabular_generated_exports.py
@@ -52,7 +52,17 @@ from functions_simplechat_operations import upload_generated_analysis_artifact_s
 
 
 TABULAR_EXPORT_RUN_TYPE = 'tabular_generated_output_run'
-TABULAR_EXPORT_CONTRACT_VERSION = 2
+TABULAR_EXPORT_CONTRACT_VERSION = 3
+TABULAR_RUN_TASK_STRUCTURED_EXPORT = 'structured_export'
+TABULAR_RUN_TASK_HIERARCHICAL_ANALYSIS = 'hierarchical_analysis'
+TABULAR_RUN_TASK_COMBINED = 'combined'
+TABULAR_RUN_TASK_TYPES = {
+    TABULAR_RUN_TASK_STRUCTURED_EXPORT,
+    TABULAR_RUN_TASK_HIERARCHICAL_ANALYSIS,
+    TABULAR_RUN_TASK_COMBINED,
+}
+TABULAR_RUN_CHUNK_MANIFEST_VERSION = 1
+TABULAR_RUN_DEFAULT_CHUNK_MANIFEST_PAGE_SIZE = 250
 TABULAR_EXPORT_STATUS_QUEUED = 'queued'
 TABULAR_EXPORT_STATUS_RUNNING = 'running'
 TABULAR_EXPORT_STATUS_COMPLETED = 'completed'
@@ -169,6 +179,13 @@ def _settings_bool(settings, key, default=False):
 
 def _settings_int(settings, key, default, minimum=None, maximum=None):
     return _safe_int((settings or {}).get(key, default), default=default, minimum=minimum, maximum=maximum)
+
+
+def _normalize_tabular_run_task_type(task_type):
+    normalized_task_type = str(task_type or '').strip().lower()
+    if normalized_task_type in TABULAR_RUN_TASK_TYPES:
+        return normalized_task_type
+    return TABULAR_RUN_TASK_STRUCTURED_EXPORT
 
 
 def _iter_exception_chain(exc):
@@ -548,12 +565,154 @@ def _input_batches_blob_path(user_id, conversation_id, run_id):
     return f"{user_id}/{conversation_id}/generated/tabular_runs/{run_id}/input/input_batches.json"
 
 
+def _chunk_manifest_blob_prefix(user_id, conversation_id, run_id):
+    return f"{user_id}/{conversation_id}/generated/tabular_runs/{run_id}/manifest/chunks/"
+
+
+def _chunk_manifest_page_blob_path(user_id, conversation_id, run_id, page_number):
+    return f"{_chunk_manifest_blob_prefix(user_id, conversation_id, run_id)}page_{page_number:06d}.json"
+
+
 def _output_blob_path(user_id, conversation_id, run_id, batch_number):
     return f"{user_id}/{conversation_id}/generated/tabular_runs/{run_id}/output/batch_{batch_number:06d}.json"
 
 
 def _output_summary_blob_path(user_id, conversation_id, run_id, batch_number):
     return f"{user_id}/{conversation_id}/generated/tabular_runs/{run_id}/summary/batch_{batch_number:06d}.json"
+
+
+def _build_chunk_manifest_contract(user_id, conversation_id, run_id, total_chunk_count, row_count=0, page_size=None):
+    normalized_total_chunk_count = _safe_int(total_chunk_count, default=0, minimum=0)
+    normalized_page_size = _safe_int(
+        page_size,
+        default=TABULAR_RUN_DEFAULT_CHUNK_MANIFEST_PAGE_SIZE,
+        minimum=1,
+        maximum=1000,
+    )
+    page_count = math.ceil(normalized_total_chunk_count / normalized_page_size) if normalized_total_chunk_count else 0
+    return {
+        'version': TABULAR_RUN_CHUNK_MANIFEST_VERSION,
+        'storage': 'blob',
+        'container': storage_account_personal_chat_container_name,
+        'blob_prefix': _chunk_manifest_blob_prefix(user_id, conversation_id, run_id),
+        'page_blob_name_pattern': 'page_{page_number:06d}.json',
+        'page_size': normalized_page_size,
+        'page_count': page_count,
+        'chunk_index_base': 1,
+        'total_chunk_count': normalized_total_chunk_count,
+        'row_count': _safe_int(row_count, default=0, minimum=0),
+    }
+
+
+def _build_chunk_manifest_entries(
+    user_id,
+    conversation_id,
+    run_id,
+    total_chunk_count,
+    row_count=0,
+    chunk_row_counts=None,
+    estimated_rows_per_chunk=None,
+    chunk_status='staged',
+):
+    normalized_total_chunk_count = _safe_int(total_chunk_count, default=0, minimum=0)
+    normalized_row_count = _safe_int(row_count, default=0, minimum=0)
+    normalized_estimated_rows_per_chunk = _safe_int(estimated_rows_per_chunk, default=0, minimum=0)
+    exact_chunk_row_counts = [
+        _safe_int(chunk_row_count, default=0, minimum=0)
+        for chunk_row_count in (chunk_row_counts or [])
+    ]
+    entries = []
+    next_source_row_number = 1
+    for chunk_index in range(1, normalized_total_chunk_count + 1):
+        chunk_row_count = 0
+        if chunk_index <= len(exact_chunk_row_counts):
+            chunk_row_count = exact_chunk_row_counts[chunk_index - 1]
+        elif normalized_estimated_rows_per_chunk and normalized_row_count:
+            remaining_rows = max(normalized_row_count - next_source_row_number + 1, 0)
+            chunk_row_count = min(normalized_estimated_rows_per_chunk, remaining_rows)
+
+        entry = {
+            'chunk_index': chunk_index,
+            'status': str(chunk_status or 'staged').strip() or 'staged',
+            'input_blob_path': _input_blob_path(user_id, conversation_id, run_id, chunk_index),
+            'output_blob_path': _output_blob_path(user_id, conversation_id, run_id, chunk_index),
+            'summary_blob_path': _output_summary_blob_path(user_id, conversation_id, run_id, chunk_index),
+        }
+        if chunk_row_count > 0:
+            entry.update({
+                'source_row_start': next_source_row_number,
+                'source_row_end': next_source_row_number + chunk_row_count - 1,
+                'row_count': chunk_row_count,
+            })
+            next_source_row_number += chunk_row_count
+        entries.append(entry)
+    return entries
+
+
+def _write_chunk_manifest_pages(user_id, conversation_id, run_id, manifest, chunk_entries):
+    page_size = _safe_int(
+        (manifest or {}).get('page_size'),
+        default=TABULAR_RUN_DEFAULT_CHUNK_MANIFEST_PAGE_SIZE,
+        minimum=1,
+        maximum=1000,
+    )
+    total_chunk_count = _safe_int((manifest or {}).get('total_chunk_count'), default=len(chunk_entries), minimum=0)
+    page_count = math.ceil(total_chunk_count / page_size) if total_chunk_count else 0
+    for page_number in range(1, page_count + 1):
+        page_start = (page_number - 1) * page_size
+        page_entries = list(chunk_entries[page_start:page_start + page_size])
+        page_payload = {
+            'version': TABULAR_RUN_CHUNK_MANIFEST_VERSION,
+            'run_id': run_id,
+            'page_number': page_number,
+            'page_count': page_count,
+            'page_size': page_size,
+            'chunk_index_start': page_start + 1,
+            'chunk_index_end': page_start + len(page_entries),
+            'chunks': page_entries,
+        }
+        _upload_json_blob(
+            _chunk_manifest_page_blob_path(user_id, conversation_id, run_id, page_number),
+            page_payload,
+            metadata={
+                'run_id': run_id,
+                'conversation_id': conversation_id,
+                'chunk_manifest': 'true',
+                'page_number': page_number,
+                'contract_version': TABULAR_EXPORT_CONTRACT_VERSION,
+            },
+        )
+
+
+def _write_chunk_manifest_for_run(
+    user_id,
+    conversation_id,
+    run_id,
+    total_chunk_count,
+    row_count=0,
+    chunk_row_counts=None,
+    estimated_rows_per_chunk=None,
+    chunk_status='staged',
+):
+    manifest = _build_chunk_manifest_contract(
+        user_id,
+        conversation_id,
+        run_id,
+        total_chunk_count,
+        row_count=row_count,
+    )
+    chunk_entries = _build_chunk_manifest_entries(
+        user_id,
+        conversation_id,
+        run_id,
+        total_chunk_count,
+        row_count=row_count,
+        chunk_row_counts=chunk_row_counts,
+        estimated_rows_per_chunk=estimated_rows_per_chunk,
+        chunk_status=chunk_status,
+    )
+    _write_chunk_manifest_pages(user_id, conversation_id, run_id, manifest, chunk_entries)
+    return manifest
 
 
 def _upload_json_blob(blob_path, payload, metadata=None, overwrite=True):
@@ -881,11 +1040,35 @@ def _stage_tabular_generated_output_source(run, settings):
     if staged_batch_count <= 0:
         raise ValueError('Source query produced no input checkpoints')
 
+    staged_chunk_row_counts = []
+    for batch_number in range(1, staged_batch_count + 1):
+        batch_rows = _download_json_blob(_input_blob_path(
+            run.get('user_id'),
+            run.get('conversation_id'),
+            run.get('id'),
+            batch_number,
+        ))
+        if not isinstance(batch_rows, list):
+            raise ValueError(f'Source input checkpoint {batch_number}/{staged_batch_count} was not a JSON array')
+        staged_chunk_row_counts.append(len(batch_rows))
+
+    chunk_manifest = _write_chunk_manifest_for_run(
+        run.get('user_id'),
+        run.get('conversation_id'),
+        run.get('id'),
+        staged_batch_count,
+        row_count=staged_row_count,
+        chunk_row_counts=staged_chunk_row_counts,
+        chunk_status='staged',
+    )
+
     now = _now_iso()
     run.update({
         'source_staging_complete': True,
         'row_count': staged_row_count,
         'batch_count': staged_batch_count,
+        'total_chunk_count': staged_batch_count,
+        'chunk_manifest': chunk_manifest,
         'updated_at': now,
         'last_heartbeat_at': now,
         'last_message': (
@@ -913,6 +1096,7 @@ def _migrate_legacy_tabular_export_run(run):
             raise ValueError('Legacy input batches blob was not a JSON array')
 
     migrated_row_count = 0
+    migrated_chunk_row_counts = []
     for batch_number in range(1, batch_count + 1):
         _raise_if_tabular_export_canceled(run)
         if aggregate_input_batches is not None:
@@ -963,16 +1147,33 @@ def _migrate_legacy_tabular_export_run(run):
             run.get('id'),
             batch_number,
         ))
-        migrated_row_count += len(prepared_rows)
+        prepared_row_count = len(prepared_rows)
+        migrated_chunk_row_counts.append(prepared_row_count)
+        migrated_row_count += prepared_row_count
 
     if migrated_row_count != expected_row_count:
         raise ValueError(
             f'Legacy input migration found {migrated_row_count} row(s); expected {expected_row_count}'
         )
 
+    chunk_manifest = _write_chunk_manifest_for_run(
+        run.get('user_id'),
+        run.get('conversation_id'),
+        run.get('id'),
+        batch_count,
+        row_count=migrated_row_count,
+        chunk_row_counts=migrated_chunk_row_counts,
+        chunk_status='staged',
+    )
     now = _now_iso()
     run.update({
         'contract_version': TABULAR_EXPORT_CONTRACT_VERSION,
+        'task_type': _normalize_tabular_run_task_type(run.get('task_type')),
+        'analysis_objective': str(run.get('analysis_objective') or '').strip(),
+        'total_chunk_count': batch_count,
+        'processed_chunk_count': 0,
+        'failed_chunk_count': 0,
+        'chunk_manifest': chunk_manifest,
         'input_blob_path': None,
         'completed_batches': 0,
         'processed_rows': 0,
@@ -1592,6 +1793,9 @@ def _build_run_public_status(run, settings=None):
     completed_batches = _safe_int(run.get('completed_batches'))
     row_count = _safe_int(run.get('row_count'))
     processed_rows = _safe_int(run.get('processed_rows'))
+    total_chunk_count = _safe_int(run.get('total_chunk_count'), default=batch_count, minimum=0)
+    processed_chunk_count = _safe_int(run.get('processed_chunk_count'), default=completed_batches, minimum=0)
+    failed_chunk_count = _safe_int(run.get('failed_chunk_count'), default=0, minimum=0)
     progress_percent = 0.0
     if batch_count:
         progress_percent = round((completed_batches / batch_count) * 100, 2)
@@ -1620,6 +1824,7 @@ def _build_run_public_status(run, settings=None):
     return {
         'run_id': run.get('id'),
         'conversation_id': run.get('conversation_id'),
+        'task_type': _normalize_tabular_run_task_type(run.get('task_type')),
         'status': run.get('status'),
         'source_file_name': run.get('source_file_name'),
         'selected_sheet': run.get('selected_sheet'),
@@ -1628,6 +1833,9 @@ def _build_run_public_status(run, settings=None):
         'processed_rows': processed_rows,
         'batch_count': batch_count,
         'completed_batches': completed_batches,
+        'total_chunk_count': total_chunk_count,
+        'processed_chunk_count': processed_chunk_count,
+        'failed_chunk_count': failed_chunk_count,
         'progress_percent': progress_percent,
         'created_at': run.get('created_at'),
         'started_at': run.get('started_at'),
@@ -2156,6 +2364,7 @@ def _update_run_progress(run, completed_batches, processed_rows, batch_rows, bat
     run.update({
         'completed_batches': completed_batches,
         'processed_rows': processed_rows,
+        'processed_chunk_count': completed_batches,
         'updated_at': now.isoformat(),
         'last_heartbeat_at': now.isoformat(),
         'active_processing_seconds': round(active_processing_seconds, 3),
@@ -2325,6 +2534,8 @@ def _complete_run(run):
         'last_heartbeat_at': now,
         'processed_rows': output_entry_count,
         'completed_batches': _safe_int(run.get('batch_count')),
+        'processed_chunk_count': _safe_int(run.get('batch_count')),
+        'failed_chunk_count': 0,
         'last_message': 'Background structured export completed',
         'post_run_summary': post_run_summary,
         'generated_file_name': uploaded_message.get('file_name') or generated_file_name,
@@ -2776,6 +2987,8 @@ def queue_tabular_generated_output_run(
     model_context=None,
     source_descriptor=None,
     passthrough_input_rows=False,
+    task_type=TABULAR_RUN_TASK_STRUCTURED_EXPORT,
+    analysis_objective=None,
 ):
     """Stage batch input blobs, create a run record, and submit background processing."""
     normalized_user_id = str(user_id or '').strip()
@@ -2788,6 +3001,13 @@ def queue_tabular_generated_output_run(
     source_file_name = str(source_candidate.get('filename') or 'tabular_output').strip() or 'tabular_output'
     selected_sheet = str(source_candidate.get('selected_sheet') or '').strip()
     normalized_output_format = str(output_format or 'json').strip().lower() or 'json'
+    normalized_task_type = _normalize_tabular_run_task_type(task_type)
+    normalized_analysis_objective = str(analysis_objective or '').strip()
+    if not normalized_analysis_objective and normalized_task_type in {
+        TABULAR_RUN_TASK_HIERARCHICAL_ANALYSIS,
+        TABULAR_RUN_TASK_COMBINED,
+    }:
+        normalized_analysis_objective = str(user_question or '').strip()
     generated_file_name = _build_generated_file_name(source_file_name, normalized_output_format)
     settings = settings or {}
     source_descriptor = dict(source_descriptor or {})
@@ -2795,6 +3015,7 @@ def queue_tabular_generated_output_run(
     staged_row_count = 0
     staged_char_count = 0
     staged_batch_count = 0
+    staged_chunk_row_counts = []
 
     if source_descriptor:
         staged_row_count = _safe_int(source_descriptor.get('expected_row_count'))
@@ -2852,17 +3073,31 @@ def queue_tabular_generated_output_run(
                 },
             )
             staged_row_count += len(prepared_batch_rows)
+            staged_chunk_row_counts.append(len(prepared_batch_rows))
             staged_char_count += len(json.dumps(prepared_batch_rows, default=str, ensure_ascii=False))
             staged_batch_count = index
 
         if not staged_batch_count or not staged_row_count:
             raise ValueError('At least one source row is required for a background tabular export')
 
+    chunk_manifest = _write_chunk_manifest_for_run(
+        normalized_user_id,
+        normalized_conversation_id,
+        run_id,
+        staged_batch_count,
+        row_count=staged_row_count,
+        chunk_row_counts=staged_chunk_row_counts if staged_chunk_row_counts else None,
+        estimated_rows_per_chunk=source_descriptor.get('batch_max_rows') if source_descriptor else None,
+        chunk_status='pending_source_staging' if source_descriptor else 'staged',
+    )
+
     now = _now_iso()
     run = {
         'id': run_id,
         'type': TABULAR_EXPORT_RUN_TYPE,
         'contract_version': TABULAR_EXPORT_CONTRACT_VERSION,
+        'task_type': normalized_task_type,
+        'analysis_objective': normalized_analysis_objective,
         'user_id': normalized_user_id,
         'conversation_id': normalized_conversation_id,
         'status': TABULAR_EXPORT_STATUS_QUEUED,
@@ -2881,6 +3116,10 @@ def queue_tabular_generated_output_run(
         'generated_file_name': generated_file_name,
         'row_count': staged_row_count,
         'batch_count': staged_batch_count,
+        'total_chunk_count': staged_batch_count,
+        'processed_chunk_count': 0,
+        'failed_chunk_count': 0,
+        'chunk_manifest': chunk_manifest,
         'completed_batches': 0,
         'processed_rows': 0,
         'output_schema': None,
@@ -2917,8 +3156,10 @@ def queue_tabular_generated_output_run(
             'source_file_name': source_file_name,
             'selected_sheet': selected_sheet,
             'output_format': normalized_output_format,
+            'task_type': normalized_task_type,
             'row_count': staged_row_count,
             'batch_count': staged_batch_count,
+            'total_chunk_count': staged_batch_count,
             'staged_input_char_count': staged_char_count,
             'source_backed': bool(source_descriptor),
             'submitted_to_executor': submitted,

--- a/functional_tests/test_tabular_background_generated_exports.py
+++ b/functional_tests/test_tabular_background_generated_exports.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """
 Functional test for durable tabular generated-output background exports.
-Version: 0.250.070
-Implemented in: 0.241.060; throughput and timeout hardening in: 0.250.070
+Version: 0.250.128
+Implemented in: 0.241.060; throughput and timeout hardening in: 0.250.070; unified durable run contract in: 0.250.128
 
 This test ensures that large tabular structured exports are wired through the
 durable background queue, status API, queued retry recovery, and chat progress
@@ -83,7 +83,11 @@ def test_export_runner_module():
     assert_contains(source_text, '_stage_tabular_generated_output_source', 'bounded source-query staging')
     assert_contains(source_text, '_authorize_tabular_export_run_execution', 'worker-boundary authorization')
     assert_contains(source_text, '_migrate_legacy_tabular_export_run', 'legacy run contract migration')
-    assert_contains(source_text, 'TABULAR_EXPORT_CONTRACT_VERSION = 2', 'versioned row orchestration contract')
+    assert_contains(source_text, 'TABULAR_EXPORT_CONTRACT_VERSION = 3', 'versioned row orchestration contract')
+    assert_contains(source_text, "TABULAR_RUN_TASK_STRUCTURED_EXPORT = 'structured_export'", 'structured export task type')
+    assert_contains(source_text, "'total_chunk_count': staged_batch_count", 'compact chunk counter')
+    assert_contains(source_text, "'chunk_manifest': chunk_manifest", 'blob-backed chunk manifest pointer')
+    assert_contains(source_text, '_write_chunk_manifest_for_run', 'paged chunk manifest writer')
     assert_contains(source_text, 'lease_generation', 'worker fencing generation')
     assert_contains(source_text, '_replace_claimed_run', 'ETag-fenced worker persistence')
     assert_contains(source_text, 'TABULAR_EXPORT_INPUT_ROW_TOKEN_FIELD', 'opaque row binding token')

--- a/functional_tests/test_tabular_row_orchestration_scale.py
+++ b/functional_tests/test_tabular_row_orchestration_scale.py
@@ -1,8 +1,8 @@
 # test_tabular_row_orchestration_scale.py
 """
 Functional test for scalable per-row tabular orchestration.
-Version: 0.250.127
-Implemented in: 0.250.060; generated CSV formula safety in 0.250.065; generated file export routing in 0.250.072; source descriptor generalization in 0.250.127
+Version: 0.250.128
+Implemented in: 0.250.060; generated CSV formula safety in 0.250.065; generated file export routing in 0.250.072; source descriptor generalization in 0.250.127; unified durable run contract in 0.250.128
 
 This test ensures generated exports preserve source identity and row order while
 enforcing one stable output schema across independently generated batches.
@@ -15,6 +15,7 @@ import io
 import importlib.util
 import json
 import logging
+import math
 import os
 import re
 import sys
@@ -94,6 +95,18 @@ FAILURE_FUNCTIONS = {
 }
 ARTIFACT_FUNCTIONS = {'_upload_generated_chat_artifact_for_current_user'}
 SCHEDULER_FUNCTIONS = {'_query_scheduler_candidates_by_status'}
+MANIFEST_FUNCTIONS = {
+    '_normalize_tabular_run_task_type',
+    '_input_blob_path',
+    '_chunk_manifest_blob_prefix',
+    '_chunk_manifest_page_blob_path',
+    '_output_blob_path',
+    '_output_summary_blob_path',
+    '_build_chunk_manifest_contract',
+    '_build_chunk_manifest_entries',
+    '_write_chunk_manifest_pages',
+    '_write_chunk_manifest_for_run',
+}
 
 
 def _load_contract_helpers():
@@ -552,26 +565,44 @@ def _load_legacy_migration_helper(aggregate_batches):
     selected_nodes = [
         node
         for node in module_tree.body
-        if isinstance(node, ast.FunctionDef) and node.name in LEGACY_MIGRATION_FUNCTIONS
+        if isinstance(node, ast.FunctionDef) and node.name in LEGACY_MIGRATION_FUNCTIONS | MANIFEST_FUNCTIONS
     ]
-    if len(selected_nodes) != len(LEGACY_MIGRATION_FUNCTIONS):
+    found_functions = {node.name for node in selected_nodes}
+    missing_functions = (LEGACY_MIGRATION_FUNCTIONS | MANIFEST_FUNCTIONS) - found_functions
+    if missing_functions:
         raise AssertionError('Missing legacy export migration helpers')
+
+    def safe_int(value, default=0, minimum=None, maximum=None):
+        try:
+            parsed_value = int(value)
+        except (TypeError, ValueError):
+            parsed_value = default
+        if minimum is not None:
+            parsed_value = max(minimum, parsed_value)
+        if maximum is not None:
+            parsed_value = min(maximum, parsed_value)
+        return parsed_value
 
     uploaded_batches = {}
     deleted_blobs = []
     namespace = {
         're': re,
         'uuid': uuid,
-        'TABULAR_EXPORT_CONTRACT_VERSION': 2,
+        'math': math,
+        'TABULAR_EXPORT_CONTRACT_VERSION': 3,
+        'TABULAR_RUN_TASK_STRUCTURED_EXPORT': 'structured_export',
+        'TABULAR_RUN_TASK_HIERARCHICAL_ANALYSIS': 'hierarchical_analysis',
+        'TABULAR_RUN_TASK_COMBINED': 'combined',
+        'TABULAR_RUN_TASK_TYPES': {'structured_export', 'hierarchical_analysis', 'combined'},
+        'TABULAR_RUN_CHUNK_MANIFEST_VERSION': 1,
+        'TABULAR_RUN_DEFAULT_CHUNK_MANIFEST_PAGE_SIZE': 250,
         'TABULAR_EXPORT_INPUT_ROW_NUMBER_FIELD': '__simplechat_source_row_number',
         'TABULAR_EXPORT_INPUT_ROW_IDENTITY_FIELD': '__simplechat_source_row_identity',
         'TABULAR_EXPORT_INPUT_ROW_TOKEN_FIELD': '__simplechat_source_row_token',
-        '_safe_int': lambda value: int(value or 0),
+        'storage_account_personal_chat_container_name': 'personal-chat',
+        '_safe_int': safe_int,
         '_download_json_blob': lambda path: aggregate_batches if path == 'legacy-input.json' else uploaded_batches[path],
         '_upload_json_blob': lambda path, payload, metadata=None: uploaded_batches.__setitem__(path, payload),
-        '_input_blob_path': lambda user_id, conversation_id, run_id, batch_number: f'batch-{batch_number}',
-        '_output_blob_path': lambda user_id, conversation_id, run_id, batch_number: f'output-{batch_number}',
-        '_output_summary_blob_path': lambda user_id, conversation_id, run_id, batch_number: f'summary-{batch_number}',
         '_delete_blob_if_exists': deleted_blobs.append,
         '_now_iso': lambda: '2026-07-21T18:00:00+00:00',
         '_raise_if_tabular_export_canceled': lambda run: run,
@@ -580,6 +611,49 @@ def _load_legacy_migration_helper(aggregate_batches):
     extracted_module = ast.Module(body=selected_nodes, type_ignores=[])
     exec(compile(extracted_module, str(EXPORT_MODULE), 'exec'), namespace)
     return namespace['_migrate_legacy_tabular_export_run'], uploaded_batches, deleted_blobs
+
+
+def _load_manifest_helpers():
+    module_tree = ast.parse(EXPORT_MODULE.read_text(encoding='utf-8'), filename=str(EXPORT_MODULE))
+    selected_nodes = [
+        node
+        for node in module_tree.body
+        if isinstance(node, ast.FunctionDef) and node.name in MANIFEST_FUNCTIONS
+    ]
+    found_functions = {node.name for node in selected_nodes}
+    missing_functions = MANIFEST_FUNCTIONS - found_functions
+    if missing_functions:
+        raise AssertionError(f'Missing manifest helpers: {sorted(missing_functions)}')
+
+    uploaded_pages = {}
+
+    def safe_int(value, default=0, minimum=None, maximum=None):
+        try:
+            parsed_value = int(value)
+        except (TypeError, ValueError):
+            parsed_value = default
+        if minimum is not None:
+            parsed_value = max(minimum, parsed_value)
+        if maximum is not None:
+            parsed_value = min(maximum, parsed_value)
+        return parsed_value
+
+    namespace = {
+        'math': math,
+        'TABULAR_EXPORT_CONTRACT_VERSION': 3,
+        'TABULAR_RUN_TASK_STRUCTURED_EXPORT': 'structured_export',
+        'TABULAR_RUN_TASK_HIERARCHICAL_ANALYSIS': 'hierarchical_analysis',
+        'TABULAR_RUN_TASK_COMBINED': 'combined',
+        'TABULAR_RUN_TASK_TYPES': {'structured_export', 'hierarchical_analysis', 'combined'},
+        'TABULAR_RUN_CHUNK_MANIFEST_VERSION': 1,
+        'TABULAR_RUN_DEFAULT_CHUNK_MANIFEST_PAGE_SIZE': 250,
+        'storage_account_personal_chat_container_name': 'personal-chat',
+        '_safe_int': safe_int,
+        '_upload_json_blob': lambda path, payload, metadata=None: uploaded_pages.__setitem__(path, payload),
+    }
+    extracted_module = ast.Module(body=selected_nodes, type_ignores=[])
+    exec(compile(extracted_module, str(EXPORT_MODULE), 'exec'), namespace)
+    return namespace, uploaded_pages
 
 
 def _load_failed_export_helpers():
@@ -1349,6 +1423,64 @@ def test_worker_lease_fencing_rejects_stale_claims():
         raise AssertionError('An ETag conflict must fence the stale worker')
 
 
+def test_chunk_manifest_contract_stays_compact_at_100000_rows():
+    """Large run manifests keep chunk entries outside the Cosmos run document."""
+    helpers, uploaded_pages = _load_manifest_helpers()
+
+    manifest = helpers['_write_chunk_manifest_for_run'](
+        'user-1',
+        'conversation-1',
+        'run-100000',
+        2000,
+        row_count=100000,
+        estimated_rows_per_chunk=50,
+        chunk_status='pending_source_staging',
+    )
+    run_document = {
+        'id': 'run-100000',
+        'type': 'tabular_generated_output_run',
+        'contract_version': 3,
+        'task_type': 'structured_export',
+        'analysis_objective': '',
+        'row_count': 100000,
+        'batch_count': 2000,
+        'total_chunk_count': manifest['total_chunk_count'],
+        'processed_chunk_count': 0,
+        'failed_chunk_count': 0,
+        'chunk_manifest': manifest,
+    }
+    safe_cosmos_document_threshold = 16 * 1024
+    serialized_run_document = json.dumps(
+        run_document,
+        separators=(',', ':'),
+        ensure_ascii=False,
+    ).encode('utf-8')
+
+    assert len(serialized_run_document) < safe_cosmos_document_threshold
+    assert 'chunks' not in run_document['chunk_manifest']
+    assert manifest['page_count'] == 8
+    assert len(uploaded_pages) == 8
+
+    first_page = uploaded_pages[
+        'user-1/conversation-1/generated/tabular_runs/run-100000/manifest/chunks/page_000001.json'
+    ]
+    last_page = uploaded_pages[
+        'user-1/conversation-1/generated/tabular_runs/run-100000/manifest/chunks/page_000008.json'
+    ]
+    assert first_page['chunk_index_start'] == 1
+    assert len(first_page['chunks']) == 250
+    assert first_page['chunks'][0]['source_row_start'] == 1
+    assert first_page['chunks'][0]['source_row_end'] == 50
+    assert last_page['chunk_index_end'] == 2000
+    assert last_page['chunks'][-1]['source_row_end'] == 100000
+
+    max_manifest_page_size = max(
+        len(json.dumps(page, separators=(',', ':'), ensure_ascii=False).encode('utf-8'))
+        for page in uploaded_pages.values()
+    )
+    assert max_manifest_page_size < 128 * 1024
+
+
 def test_legacy_run_migration_tokenizes_inputs_and_resets_outputs():
     """Pre-contract runs migrate deterministic inputs and regenerate old outputs."""
     aggregate_batches = [
@@ -1367,15 +1499,35 @@ def test_legacy_run_migration_tokenizes_inputs_and_resets_outputs():
         'input_blob_path': 'legacy-input.json',
     })
 
-    assert migrated_run['contract_version'] == 2
+    input_batch_1_path = 'user-1/conversation-1/generated/tabular_runs/legacy-run/input/batch_000001.json'
+    input_batch_2_path = 'user-1/conversation-1/generated/tabular_runs/legacy-run/input/batch_000002.json'
+    output_batch_1_path = 'user-1/conversation-1/generated/tabular_runs/legacy-run/output/batch_000001.json'
+    output_batch_2_path = 'user-1/conversation-1/generated/tabular_runs/legacy-run/output/batch_000002.json'
+    summary_batch_1_path = 'user-1/conversation-1/generated/tabular_runs/legacy-run/summary/batch_000001.json'
+    summary_batch_2_path = 'user-1/conversation-1/generated/tabular_runs/legacy-run/summary/batch_000002.json'
+    manifest_page_path = 'user-1/conversation-1/generated/tabular_runs/legacy-run/manifest/chunks/page_000001.json'
+
+    assert migrated_run['contract_version'] == 3
+    assert migrated_run['task_type'] == 'structured_export'
+    assert migrated_run['analysis_objective'] == ''
+    assert migrated_run['total_chunk_count'] == 2
+    assert migrated_run['processed_chunk_count'] == 0
+    assert migrated_run['failed_chunk_count'] == 0
+    assert migrated_run['chunk_manifest']['page_count'] == 1
     assert migrated_run['completed_batches'] == 0
     assert migrated_run['processed_rows'] == 0
     assert migrated_run['output_schema'] is None
     assert migrated_run['regenerate_legacy_output_checkpoints'] is False
     assert migrated_run['input_blob_path'] is None
-    assert [row['__simplechat_source_row_number'] for row in uploaded_batches['batch-1']] == [1, 2]
-    assert uploaded_batches['batch-2'][0]['__simplechat_source_row_number'] == 3
-    assert deleted_blobs == ['output-1', 'summary-1', 'output-2', 'summary-2']
+    assert [row['__simplechat_source_row_number'] for row in uploaded_batches[input_batch_1_path]] == [1, 2]
+    assert uploaded_batches[input_batch_2_path][0]['__simplechat_source_row_number'] == 3
+    assert uploaded_batches[manifest_page_path]['chunks'][0]['row_count'] == 2
+    assert deleted_blobs == [
+        output_batch_1_path,
+        summary_batch_1_path,
+        output_batch_2_path,
+        summary_batch_2_path,
+    ]
     migrate_again, second_uploaded_batches, _ = _load_legacy_migration_helper(aggregate_batches)
     migrate_again({
         'id': 'legacy-run',
@@ -1387,8 +1539,8 @@ def test_legacy_run_migration_tokenizes_inputs_and_resets_outputs():
         'processed_rows': 2,
         'input_blob_path': 'legacy-input.json',
     })
-    assert uploaded_batches['batch-1'][0]['__simplechat_source_row_token'] == (
-        second_uploaded_batches['batch-1'][0]['__simplechat_source_row_token']
+    assert uploaded_batches[input_batch_1_path][0]['__simplechat_source_row_token'] == (
+        second_uploaded_batches[input_batch_1_path][0]['__simplechat_source_row_token']
     )
 
 
@@ -1534,6 +1686,7 @@ def main():
         test_worker_revalidates_conversation_and_workspace_authorization,
         test_durable_cancellation_is_idempotent_and_terminal,
         test_worker_lease_fencing_rejects_stale_claims,
+        test_chunk_manifest_contract_stays_compact_at_100000_rows,
         test_legacy_run_migration_tokenizes_inputs_and_resets_outputs,
         test_post_run_summary_uses_only_bounded_batch_summaries,
         test_final_artifact_publication_is_retry_idempotent,


### PR DESCRIPTION
## Summary

- Generalizes tabular generated-output durable runs to contract version 3 with `task_type` and `analysis_objective` fields.
- Adds compact chunk counters plus blob-backed paged chunk manifests so large runs do not embed full chunk lists in Cosmos run documents.
- Migrates existing export runs deterministically to `structured_export` and refreshes manifests for source-backed staging.
- Updates app version to `0.250.128` and expands functional coverage for the Phase 2 contract.

## Validation

- `python -m py_compile application/single_app/functions_tabular_generated_exports.py functional_tests/test_tabular_row_orchestration_scale.py functional_tests/test_tabular_background_generated_exports.py application/single_app/config.py`
- `python functional_tests/test_tabular_row_orchestration_scale.py`
- `python functional_tests/test_tabular_background_generated_exports.py`
- Editor diagnostics: no errors
- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check`

Refs #1031, #1071.