### PR TITLE
Implement Phase 2 tabular background handoff

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -96,7 +96,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.250.137"
+VERSION = "0.250.138"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/functions_tabular_generated_exports.py
+++ b/application/single_app/functions_tabular_generated_exports.py
@@ -3366,6 +3366,17 @@ def build_background_tabular_generated_output_metadata(run):
         'background_export': True,
         'capability': 'tabular',
         'suppress_assistant_table_export': True,
+        'handoff_mode': (
+            'background_combined'
+            if is_combined
+            else 'background_analysis'
+            if is_hierarchical_analysis
+            else 'background_export'
+        ),
+        'requested_row_count': row_count,
+        'preview_available': False,
+        'preview_row_count': 0,
+        'foreground_response_policy_version': 'phase2.v1',
         'summary': (
             f"Queued combined tabular analysis and {output_label} export for {public_status.get('row_count', 0)} row(s) "
             f"across {public_status.get('batch_count', 0)} chunk(s)."

--- a/application/single_app/route_backend_chats.py
+++ b/application/single_app/route_backend_chats.py
@@ -6124,6 +6124,91 @@ def _build_failed_tabular_generated_output_metadata(source_candidate, output_for
     }
 
 
+def _is_active_tabular_background_handoff(output_metadata):
+    """Return True when metadata represents a queued or running background tabular handoff."""
+    if not isinstance(output_metadata, dict) or not output_metadata.get('background_export'):
+        return False
+
+    output_status = str(output_metadata.get('status') or '').strip().lower()
+    return output_status not in {'failed', 'canceled', 'cancelled', 'completed'}
+
+
+def _tabular_background_handoff_has_preview(output_metadata):
+    if not isinstance(output_metadata, dict):
+        return False
+
+    preview_fields = (
+        output_metadata.get('preview_rows'),
+        output_metadata.get('preview_items'),
+        output_metadata.get('preview_lines'),
+    )
+    if any(isinstance(value, list) and value for value in preview_fields):
+        return True
+    if str(output_metadata.get('preview_text') or output_metadata.get('analysis_text') or '').strip():
+        return True
+    if output_metadata.get('preview_available'):
+        return True
+    return _safe_int(output_metadata.get('preview_row_count')) > 0
+
+
+def _format_tabular_background_handoff_row_phrase(row_count):
+    normalized_row_count = _safe_int(row_count)
+    if normalized_row_count > 0:
+        return f"all {normalized_row_count:,} rows"
+    return 'all requested rows'
+
+
+def _build_tabular_background_handoff_content(output_metadata):
+    """Build the concise user-facing acknowledgment for an accepted background tabular run."""
+    if not _is_active_tabular_background_handoff(output_metadata):
+        return ''
+
+    output_format = str(output_metadata.get('output_format') or 'csv').strip().upper() or 'CSV'
+    task_type = str(output_metadata.get('task_type') or '').strip().lower()
+    row_phrase = _format_tabular_background_handoff_row_phrase(output_metadata.get('row_count'))
+    has_preview = _tabular_background_handoff_has_preview(output_metadata)
+
+    if task_type == TABULAR_RUN_TASK_COMBINED:
+        if has_preview:
+            return (
+                f'Understood. I am generating the complete {output_format} and analysis for {row_phrase}. '
+                'The rows shown here are a sample; both completed results will appear in this chat when ready.'
+            )
+        return (
+            f'Understood. I am generating the complete {output_format} and analysis for {row_phrase}. '
+            'Both completed results will appear in this chat when ready.'
+        )
+
+    if task_type == TABULAR_RUN_TASK_HIERARCHICAL_ANALYSIS:
+        if has_preview:
+            return (
+                f'Understood. I am analyzing {row_phrase}. '
+                'Any content shown here is a sample; the complete analysis is continuing in the background and will appear in this chat when ready.'
+            )
+        return (
+            f'Understood. I am analyzing {row_phrase}. '
+            'The complete analysis is continuing in the background and will appear in this chat when ready.'
+        )
+
+    if has_preview:
+        return (
+            f'Understood. I am generating the complete {output_format} for {row_phrase}. '
+            'The rows shown here are a sample; the rest is being generated in the background, and the complete file will appear in this chat when ready.'
+        )
+    return (
+        f'Understood. I am generating the complete {output_format} for {row_phrase}. '
+        'Processing continues in the background, and the complete file will appear in this chat when ready.'
+    )
+
+
+def _build_active_tabular_background_handoff_content(generated_tabular_outputs):
+    for output_metadata in generated_tabular_outputs or []:
+        handoff_content = _build_tabular_background_handoff_content(output_metadata)
+        if handoff_content:
+            return handoff_content
+    return ''
+
+
 def _build_tabular_generated_output_batch_prompt(
     user_question,
     batch_rows,
@@ -6174,9 +6259,6 @@ def _build_tabular_generated_output_system_message(output_metadata):
     file_name = str(output_metadata.get('file_name') or 'generated output').strip() or 'generated output'
     row_count = _safe_int(output_metadata.get('row_count'))
     output_status = str(output_metadata.get('status') or '').strip().lower()
-    task_type = str(output_metadata.get('task_type') or '').strip().lower()
-    is_hierarchical_analysis = task_type == TABULAR_RUN_TASK_HIERARCHICAL_ANALYSIS
-    is_combined = task_type == TABULAR_RUN_TASK_COMBINED
 
     if output_status == 'failed':
         failure_detail = str(
@@ -6196,31 +6278,13 @@ def _build_tabular_generated_output_system_message(output_metadata):
             'Do not claim that the full export is attached, and do not recreate a partial assistant-table CSV.'
         )
 
-    if output_metadata.get('background_export'):
-        run_id = str(output_metadata.get('export_run_id') or output_metadata.get('run_id') or '').strip()
-        batch_count = _safe_int(output_metadata.get('batch_count'))
-        if is_combined:
-            return (
-                f'A durable background tabular analysis and {output_format} export has been queued for {row_count} row(s) '
-                f'across {batch_count} chunk(s). '
-                'Do not claim either full deliverable is complete yet. Tell the user the combined run is continuing in the background, '
-                'that progress is checkpointed, and that the downloadable file and final answer artifact will appear in the chat when ready. '
-                f'Run id: {run_id}.'
-            )
-        if is_hierarchical_analysis:
-            return (
-                f'A durable background tabular analysis has been queued for {row_count} row(s) '
-                f'across {batch_count} chunk(s). '
-                'Do not claim the full analysis is complete yet. Tell the user the analysis is continuing in the background, '
-                'that progress is checkpointed, and that the final answer artifact will appear in the chat when the run completes. '
-                f'Run id: {run_id}.'
-            )
+    background_handoff = _build_tabular_background_handoff_content(output_metadata)
+    if background_handoff:
         return (
-            f'A durable background {output_format} export has been queued for {row_count} row(s) '
-            f'across {batch_count} batch(es). '
-            'Do not claim the full export is attached yet. Tell the user the export is continuing in the background, '
-            'that progress is checkpointed, and that the downloadable file will appear in the chat when the run completes. '
-            f'Run id: {run_id}.'
+            'Use this exact concise response for the accepted background tabular work. '
+            'Do not add limitation language, internal identifiers, storage locations, internal progress details, tool names, '
+            'duplicate CSV blocks, or follow-up offers.\n\n'
+            f'{background_handoff}'
         )
 
     return (
@@ -19121,6 +19185,11 @@ def register_route_backend_chats(bp):
             if assistant_file_generated_output:
                 generated_analysis_artifacts_list.append(assistant_file_generated_output)
                 ai_message = _build_assistant_file_output_handoff(assistant_file_generated_output)
+            tabular_background_handoff_content = _build_active_tabular_background_handoff_content(
+                generated_tabular_outputs_list
+            )
+            if tabular_background_handoff_content:
+                ai_message = tabular_background_handoff_content
             generated_analysis_metadata = _build_generated_analysis_metadata(
                 generated_analysis_artifacts=generated_analysis_artifacts_list,
                 generated_tabular_outputs=generated_tabular_outputs_list,
@@ -22871,6 +22940,11 @@ def register_route_backend_chats(bp):
                     if assistant_file_generated_output:
                         generated_analysis_artifacts_list.append(assistant_file_generated_output)
                         accumulated_content = _build_assistant_file_output_handoff(assistant_file_generated_output)
+                    tabular_background_handoff_content = _build_active_tabular_background_handoff_content(
+                        generated_tabular_outputs_list
+                    )
+                    if tabular_background_handoff_content:
+                        accumulated_content = tabular_background_handoff_content
                     if mixed_source_manifest:
                         fresh_finalization_manifest = resolve_authorized_source_manifest(
                             [source.get('document_id') for source in mixed_source_manifest],

--- a/docs/explanation/features/TABULAR_BACKGROUND_GENERATED_EXPORTS.md
+++ b/docs/explanation/features/TABULAR_BACKGROUND_GENERATED_EXPORTS.md
@@ -2,7 +2,7 @@
 
 Implemented in version: **0.241.046**
 
-Updated through version: **0.250.137**
+Updated through version: **0.250.138**
 
 ## Overview
 
@@ -33,6 +33,7 @@ The feature supports large spreadsheet-driven analysis, including workbooks that
 - Queued retry runs whose retry time has already passed are surfaced as resumable so deployments without active scheduler loops still give users a recovery action.
 - Run status includes safe user-facing status detail, checkpoint summaries, retry timing, heartbeat state, and continuation availability.
 - Phase 1 acceleration groundwork adds additive generation contract fields, legacy-off rollout gates, safe batch latency/token telemetry, and deterministic fake model/storage harnesses without changing fixed-window execution behavior.
+- Phase 2 foreground handoff uses server-composed acknowledgment text for accepted background export, analysis, and combined runs, so the assistant response describes the complete queued work instead of narrating preview limitations.
 
 ### API Endpoints
 
@@ -77,6 +78,8 @@ The Phase 1 rollout settings default to legacy behavior and are copied into new 
 
 Users continue requesting tabular structured output in chat or workflows. For smaller exports, the file is attached during the response. For larger exports, the assistant message shows a background progress card and the final download appears when processing completes. If a resumable run stops after a transient infrastructure failure, the card shows a Continue action that queues the same run to resume from completed checkpoints.
 
+When a background run is accepted, the immediate assistant response acknowledges the complete requested row count and deliverable. Any visible rows are identified as a sample or preview, while mutable progress remains in the status card and the completed file or analysis appears in the chat when ready.
+
 When a workflow/document analysis request also creates a full generated tabular export, the generated export is presented as the primary deliverable. The analysis layer may still attach a supporting CSV preview, but redundant analysis JSON and Markdown artifacts are suppressed so they do not compete with the full generated export card.
 
 The progress card displays current status, completed checkpoint counts, processed row counts, wall-clock rows per minute, model concurrency, estimated remaining time, scheduled retry time, retry-due state, transient retry count, manual continuation count, last update time, and heartbeat time when available.
@@ -85,6 +88,7 @@ The progress card displays current status, completed checkpoint counts, processe
 
 - Functional regression: `functional_tests/test_tabular_background_generated_exports.py`
 - Scale and performance regression: `functional_tests/test_tabular_row_orchestration_scale.py`
+- Phase 2 handoff regression: `functional_tests/test_tabular_row_orchestration_scale.py`
 - Phase 1 baseline and fake harness coverage: `functional_tests/test_tabular_row_orchestration_scale.py`
 - Functional regression for workflow/document-action presentation: `functional_tests/test_document_analysis_lossless_artifacts.py`
 - UI regression: `ui_tests/test_chat_background_generated_export_status.py`
@@ -119,3 +123,4 @@ The progress card displays current status, completed checkpoint counts, processe
 - `application/single_app/config.py` was updated to version **0.241.064** for generated export artifact presentation cleanup.
 - `application/single_app/config.py` was updated to version **0.250.136** for model-aware batch sizing, adaptive LLM concurrency, and parallel wall-clock ETA.
 - `application/single_app/config.py` was updated to version **0.250.137** for Phase 1 acceleration baseline contracts, rollout controls, privacy-safe telemetry, and fake model/storage harnesses.
+- `application/single_app/config.py` was updated to version **0.250.138** for Phase 2 truthful foreground handoff wording and metadata.

--- a/docs/explanation/features/TABULAR_LLM_GENERATION_ACCELERATION_PHASE_2_HANDOFF.md
+++ b/docs/explanation/features/TABULAR_LLM_GENERATION_ACCELERATION_PHASE_2_HANDOFF.md
@@ -1,0 +1,57 @@
+# Tabular LLM Generation Acceleration Phase 2 Handoff
+
+Implemented in version: **0.250.138**
+
+## Overview
+
+Phase 2 makes accepted background tabular runs produce one concise, truthful foreground acknowledgment. When SimpleChat queues an exhaustive export, analysis, or combined run, the assistant response now describes the complete accepted work and labels visible rows as a sample or preview instead of saying only retrieved preview rows can be generated.
+
+## Purpose
+
+The goal is to keep the static assistant prose aligned with the durable run that the server accepted. Progress, retry, and completion details remain in the background status card, while the assistant text acknowledges the requested row count and deliverable.
+
+## Dependencies
+
+- Background tabular generated-output runner in `application/single_app/functions_tabular_generated_exports.py`
+- Chat handoff and message finalization in `application/single_app/route_backend_chats.py`
+- Background status card rendering in `application/single_app/static/js/chat/chat-messages.js`
+- Functional and UI coverage in `functional_tests/test_tabular_row_orchestration_scale.py` and `ui_tests/test_chat_background_generated_export_status.py`
+
+## Technical Specifications
+
+### Server-Composed Handoff
+
+`route_backend_chats.py` now builds the user-facing handoff from public run metadata for active background tabular runs. The shared helper handles structured export, hierarchical analysis, and combined export plus analysis modes.
+
+The final assistant content is replaced with the server-composed handoff before non-streaming messages are persisted and before streaming final completion metadata is emitted. The model-facing system message is constrained to the same text and no longer includes run identifiers, storage locations, batch counts, or checkpoint details.
+
+### Public Metadata
+
+`build_background_tabular_generated_output_metadata(...)` now includes safe handoff metadata:
+
+- `handoff_mode`
+- `requested_row_count`
+- `preview_available`
+- `preview_row_count`
+- `foreground_response_policy_version`
+
+These fields do not expose settings, source storage paths, raw rows, or protected backend details.
+
+## Usage Instructions
+
+Users continue asking for exhaustive row-level CSV, JSON, XML, or analysis output. If the work is queued, the immediate response acknowledges the complete row count and tells the user that processing continues in the background. Any visible preview rows are described as a sample, and the status card remains the source of mutable progress details.
+
+## Testing and Validation
+
+- Functional contract: `python functional_tests/test_tabular_row_orchestration_scale.py`
+- UI contract: `ui_tests/test_chat_background_generated_export_status.py`
+- Python syntax: `python -m py_compile application/single_app/route_backend_chats.py application/single_app/functions_tabular_generated_exports.py functional_tests/test_tabular_row_orchestration_scale.py ui_tests/test_chat_background_generated_export_status.py`
+
+## Known Limitations
+
+- Streaming clients may briefly receive model tokens before the final server-authored message replaces the temporary streaming content at completion.
+- This phase changes foreground communication only. It does not alter run scheduling, checkpointing, retry behavior, or artifact finalization.
+
+## Related Version Updates
+
+- `application/single_app/config.py` was updated to version **0.250.138** for Phase 2 truthful background handoff behavior.

--- a/functional_tests/test_tabular_row_orchestration_scale.py
+++ b/functional_tests/test_tabular_row_orchestration_scale.py
@@ -1,8 +1,8 @@
 # test_tabular_row_orchestration_scale.py
 """
 Functional test for scalable per-row tabular orchestration.
-Version: 0.250.137
-Implemented in: 0.250.060; generated CSV formula safety in 0.250.065; generated file export routing in 0.250.072; source descriptor generalization in 0.250.127; unified durable run contract in 0.250.128; hierarchical analysis in 0.250.129; combined analysis and export in 0.250.130; scale validation in 0.250.132; direct source-backed exhaustive queueing in 0.250.133; direct queue call-site hardening in 0.250.134; model-validation auto retry in 0.250.135; model-aware parallel throughput in 0.250.136; Phase 1 acceleration contracts and observability in 0.250.137
+Version: 0.250.138
+Implemented in: 0.250.060; generated CSV formula safety in 0.250.065; generated file export routing in 0.250.072; source descriptor generalization in 0.250.127; unified durable run contract in 0.250.128; hierarchical analysis in 0.250.129; combined analysis and export in 0.250.130; scale validation in 0.250.132; direct source-backed exhaustive queueing in 0.250.133; direct queue call-site hardening in 0.250.134; model-validation auto retry in 0.250.135; model-aware parallel throughput in 0.250.136; Phase 1 acceleration contracts and observability in 0.250.137; Phase 2 truthful background handoff in 0.250.138
 
 This test ensures generated exports preserve source identity and row order while
 enforcing one stable output schema across independently generated batches.
@@ -117,9 +117,14 @@ LEGACY_MIGRATION_FUNCTIONS = {
 }
 FAILURE_FUNCTIONS = {
     '_build_failed_tabular_generated_output_metadata',
+    '_build_active_tabular_background_handoff_content',
+    '_build_tabular_background_handoff_content',
     '_build_tabular_generated_output_system_message',
     '_has_generated_tabular_csv_output',
+    '_format_tabular_background_handoff_row_phrase',
+    '_is_active_tabular_background_handoff',
     '_normalize_generated_analysis_artifact_metadata',
+    '_tabular_background_handoff_has_preview',
 }
 ARTIFACT_FUNCTIONS = {'_upload_generated_chat_artifact_for_current_user'}
 SCHEDULER_FUNCTIONS = {'_query_scheduler_candidates_by_status'}
@@ -881,6 +886,28 @@ def _load_failed_export_helpers():
     extracted_module = ast.Module(body=selected_nodes, type_ignores=[])
     exec(compile(extracted_module, str(CHAT_ROUTE), 'exec'), namespace)
     return namespace
+
+
+def _assert_concise_background_handoff_contract(text, expected_row_count, expected_output_label):
+    normalized_text = str(text or '')
+    normalized_lower = normalized_text.lower()
+    assert f"{expected_row_count:,}" in normalized_text
+    assert expected_output_label.lower() in normalized_lower
+    assert 'background' in normalized_lower or 'appear in this chat when ready' in normalized_lower
+    prohibited_markers = (
+        'can only',
+        'could not be completed',
+        'available tool results',
+        'schema preview',
+        'if you want, i can',
+        'run id',
+        'run_id',
+        'blob',
+        'batch',
+        'checkpoint',
+    )
+    for marker in prohibited_markers:
+        assert marker not in normalized_lower
 
 
 def _load_idempotent_artifact_helper():
@@ -3033,6 +3060,72 @@ def test_route_queues_replayable_pages_and_suppresses_summary_fallback():
     assert 'output.suppress_assistant_table_export' in chat_messages_source
 
 
+def test_phase_two_background_handoff_contracts_are_server_composed():
+    """Queued export, analysis, and combined runs use concise truthful handoff text."""
+    helpers = _load_failed_export_helpers()
+
+    export_output = {
+        'background_export': True,
+        'status': 'queued',
+        'export_run_id': 'run-export-30000',
+        'output_format': 'csv',
+        'row_count': 30000,
+        'batch_count': 909,
+        'preview_rows': [{'question': 'Sample?', 'answer': 'Yes'}],
+    }
+    export_handoff = helpers['_build_tabular_background_handoff_content'](export_output)
+    _assert_concise_background_handoff_contract(export_handoff, 30000, 'CSV')
+    assert 'rows shown here are a sample' in export_handoff.lower()
+    assert 'complete file will appear in this chat when ready' in export_handoff.lower()
+
+    analysis_output = {
+        'background_export': True,
+        'status': 'running',
+        'export_run_id': 'run-analysis-30000',
+        'task_type': 'hierarchical_analysis',
+        'output_format': 'md',
+        'row_count': 30000,
+        'preview_text': 'sample finding',
+    }
+    analysis_handoff = helpers['_build_tabular_background_handoff_content'](analysis_output)
+    _assert_concise_background_handoff_contract(analysis_handoff, 30000, 'analysis')
+    assert 'any content shown here is a sample' in analysis_handoff.lower()
+    assert 'complete analysis is continuing' in analysis_handoff.lower()
+
+    combined_output = {
+        'background_export': True,
+        'status': 'queued',
+        'export_run_id': 'run-combined-30000',
+        'task_type': 'combined',
+        'output_format': 'csv',
+        'row_count': 30000,
+        'preview_available': True,
+        'preview_row_count': 3,
+    }
+    combined_handoff = helpers['_build_tabular_background_handoff_content'](combined_output)
+    _assert_concise_background_handoff_contract(combined_handoff, 30000, 'CSV')
+    assert 'complete csv and analysis' in combined_handoff.lower()
+    assert 'both completed results will appear in this chat when ready' in combined_handoff.lower()
+
+    system_message = helpers['_build_tabular_generated_output_system_message'](export_output)
+    assert export_handoff in system_message
+    _assert_concise_background_handoff_contract(system_message, 30000, 'CSV')
+
+    final_handoff = helpers['_build_active_tabular_background_handoff_content']([
+        {'background_export': True, 'status': 'completed', 'output_format': 'csv', 'row_count': 30000},
+        combined_output,
+    ])
+    assert final_handoff == combined_handoff
+
+    canceled_handoff = helpers['_build_tabular_background_handoff_content']({
+        'background_export': True,
+        'status': 'canceled',
+        'output_format': 'csv',
+        'row_count': 30000,
+    })
+    assert canceled_handoff == ''
+
+
 def main():
     """Run focused row-orchestration contract checks."""
     tests = [
@@ -3053,6 +3146,7 @@ def main():
         test_filter_rows_pages_queue_combined_analysis_and_export_run,
         test_direct_source_backed_csv_queue_bypasses_tool_paging,
         test_direct_source_backed_queue_failure_falls_back_without_stream_abort,
+        test_phase_two_background_handoff_contracts_are_server_composed,
         test_direct_source_backed_queue_call_sites_use_required_keywords,
         test_model_validation_failures_auto_retry_then_manual_continue,
         test_hierarchical_analysis_routing_requires_feature_flag,

--- a/ui_tests/test_chat_background_generated_export_status.py
+++ b/ui_tests/test_chat_background_generated_export_status.py
@@ -1,8 +1,8 @@
 # test_chat_background_generated_export_status.py
 """
 UI test for chat background generated export status cards.
-Version: 0.250.136
-Implemented in: 0.241.046; cancellation in 0.250.060; automatic-only refresh in 0.250.061; combined progress and large-run confirmation in 0.250.131; throughput and concurrency status in 0.250.136
+Version: 0.250.138
+Implemented in: 0.241.046; cancellation in 0.250.060; automatic-only refresh in 0.250.061; combined progress and large-run confirmation in 0.250.131; throughput and concurrency status in 0.250.136; truthful background handoff in 0.250.138
 
 This test ensures queued tabular generated exports render progress in chat and
 turn into a downloadable artifact when complete or a visible canceled state.
@@ -81,7 +81,7 @@ def test_chat_background_generated_export_status_card_auto_refreshes_to_download
                 window.currentConversationId = 'conversation-ui-test';
                 module.appendMessage(
                     'AI',
-                    'The large export is continuing in the background.',
+                    'Understood. I am generating the complete JSON for all 3,539 rows. The rows shown here are a sample; the rest is being generated in the background, and the complete file will appear in this chat when ready.',
                     null,
                     'message-ui-test',
                     false,
@@ -105,7 +105,11 @@ def test_chat_background_generated_export_status_card_auto_refreshes_to_download
                                     processed_rows: 652,
                                     batch_count: 1592,
                                     completed_batches: 298,
-                                    source_file_name: 'query_data.xlsx'
+                                    source_file_name: 'query_data.xlsx',
+                                    preview_rows: [
+                                        { account_id: 'sample-001', risk: 'review' },
+                                        { account_id: 'sample-002', risk: 'clear' }
+                                    ]
                                 }
                             ]
                         }
@@ -117,9 +121,16 @@ def test_chat_background_generated_export_status_card_auto_refreshes_to_download
         )
 
         message = page.locator('[data-message-id="message-ui-test"]')
+        expect(message.get_by_text("Understood. I am generating the complete JSON for all 3,539 rows.")).to_be_visible()
+        expect(message.get_by_text("The rows shown here are a sample")).to_be_visible()
+        expect(message.get_by_text("Preview", exact=True)).to_be_visible()
         expect(message.get_by_text("Background export")).to_be_visible()
         expect(message.get_by_text("Running")).to_be_visible()
         expect(message.get_by_text("298 of 1,592 batches")).to_be_visible()
+        rendered_text = message.inner_text().lower()
+        assert "can only" not in rendered_text
+        assert "schema preview" not in rendered_text
+        assert "if you want, i can" not in rendered_text
         expect(message.get_by_role("button", name="Refresh Status")).to_have_count(0)
         assert message.get_by_role("button", name="Download JSON").count() == 0
 


### PR DESCRIPTION
## Summary
- Adds server-composed Phase 2 foreground handoffs for accepted background tabular export, analysis, and combined runs.
- Replaces final persisted assistant text with the concise handoff for active background runs so it cannot contradict queued durable work.
- Adds public handoff metadata, focused functional/UI coverage, feature documentation, and bumps the app version to 0.250.138.

## Validation
- `python functional_tests/test_tabular_row_orchestration_scale.py`
- `python -m py_compile application/single_app/config.py application/single_app/route_backend_chats.py application/single_app/functions_tabular_generated_exports.py functional_tests/test_tabular_row_orchestration_scale.py ui_tests/test_chat_background_generated_export_status.py`
- `python -m pytest ui_tests/test_chat_background_generated_export_status.py -q` (5 skipped locally: authenticated UI target not configured)
- VS Code diagnostics clean for touched Python files
- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check`

Refs #1031