### PR TITLE
Phase 4 compact row response protocol

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -96,7 +96,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.250.139"
+VERSION = "0.250.140"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/functions_tabular_generated_exports.py
+++ b/application/single_app/functions_tabular_generated_exports.py
@@ -56,6 +56,12 @@ TABULAR_EXPORT_RUN_TYPE = 'tabular_generated_output_run'
 TABULAR_EXPORT_CONTRACT_VERSION = 3
 TABULAR_GENERATION_CONTRACT_VERSION = 1
 TABULAR_RESPONSE_PROTOCOL_OBJECT_V1 = 'object-v1'
+TABULAR_RESPONSE_PROTOCOL_COMPACT_ROW_ARRAY_V1 = 'compact-row-array-v1'
+TABULAR_RESPONSE_PROTOCOLS = {
+    TABULAR_RESPONSE_PROTOCOL_OBJECT_V1,
+    TABULAR_RESPONSE_PROTOCOL_COMPACT_ROW_ARRAY_V1,
+}
+TABULAR_COMPACT_PLAN_HASH_PREFIX_LENGTH = 12
 TABULAR_EXECUTOR_MODE_FIXED_WINDOW = 'fixed-window-v1'
 TABULAR_GENERATION_PLAN_VERSION = 1
 TABULAR_GENERATION_PLAN_PROMPT_VERSION = 'tabular-generation-plan-v1'
@@ -227,12 +233,14 @@ TABULAR_EXPORT_MODEL_VALIDATION_RETRYABLE_MESSAGE_MARKERS = (
 TABULAR_EXPORT_INPUT_ROW_NUMBER_FIELD = '__simplechat_source_row_number'
 TABULAR_EXPORT_INPUT_ROW_IDENTITY_FIELD = '__simplechat_source_row_identity'
 TABULAR_EXPORT_INPUT_ROW_TOKEN_FIELD = '__simplechat_source_row_token'
+TABULAR_EXPORT_INPUT_ROW_KEY_FIELD = '__simplechat_batch_row_key'
 TABULAR_EXPORT_OUTPUT_ROW_NUMBER_FIELD = 'source_row_number'
 TABULAR_EXPORT_OUTPUT_ROW_IDENTITY_FIELD = 'source_row_identity'
 TABULAR_GENERATION_PLAN_RESERVED_FIELDS = {
     TABULAR_EXPORT_INPUT_ROW_NUMBER_FIELD,
     TABULAR_EXPORT_INPUT_ROW_IDENTITY_FIELD,
     TABULAR_EXPORT_INPUT_ROW_TOKEN_FIELD,
+    TABULAR_EXPORT_INPUT_ROW_KEY_FIELD,
     TABULAR_EXPORT_OUTPUT_ROW_NUMBER_FIELD,
     TABULAR_EXPORT_OUTPUT_ROW_IDENTITY_FIELD,
 }
@@ -307,6 +315,21 @@ def _settings_mode(settings, key, default, allowed_modes):
     if normalized_mode in allowed_modes:
         return normalized_mode
     return default
+
+
+def _is_compact_row_array_protocol(response_protocol):
+    return str(response_protocol or '').strip() == TABULAR_RESPONSE_PROTOCOL_COMPACT_ROW_ARRAY_V1
+
+
+def _select_tabular_response_protocol(rollout_settings, requested_plan_mode, task_type, passthrough_input_rows=False):
+    if (
+        _settings_bool(rollout_settings, 'enable_tabular_compact_response_protocol', False)
+        and str(requested_plan_mode or '').strip().lower() == 'active'
+        and _normalize_tabular_run_task_type(task_type) == TABULAR_RUN_TASK_STRUCTURED_EXPORT
+        and not passthrough_input_rows
+    ):
+        return TABULAR_RESPONSE_PROTOCOL_COMPACT_ROW_ARRAY_V1
+    return TABULAR_RESPONSE_PROTOCOL_OBJECT_V1
 
 
 def _canonical_json_bytes(payload):
@@ -500,7 +523,7 @@ def _build_tabular_generation_plan(run, planner_payload, input_contract, planner
     response_protocol = str(
         (run or {}).get('response_protocol_version') or TABULAR_RESPONSE_PROTOCOL_OBJECT_V1
     ).strip()
-    if response_protocol != TABULAR_RESPONSE_PROTOCOL_OBJECT_V1:
+    if response_protocol not in TABULAR_RESPONSE_PROTOCOLS:
         raise ValueError('Planner response protocol is not supported')
 
     batch_budget = (run or {}).get('batch_budget') or {}
@@ -699,6 +722,129 @@ def _get_tabular_generation_plan_output_schema(plan):
         for output_field in (plan or {}).get('output_fields') or []
         if isinstance(output_field, dict)
     ]
+
+
+def _get_tabular_generation_plan_llm_fields(plan):
+    return [
+        output_field
+        for output_field in (plan or {}).get('output_fields') or []
+        if isinstance(output_field, dict)
+        and str(output_field.get('source') or '').strip().lower() == 'llm'
+    ]
+
+
+def _get_compact_plan_hash_prefix(plan):
+    plan_hash = str((plan or {}).get('plan_hash') or '').strip()
+    if not plan_hash:
+        raise ValueError('Compact response plan hash is missing')
+    return plan_hash[:TABULAR_COMPACT_PLAN_HASH_PREFIX_LENGTH]
+
+
+def _build_compact_batch_row_key(row_index):
+    return f'r{_safe_int(row_index, minimum=1)}'
+
+
+def _build_compact_batch_key_map(source_rows):
+    key_map = {}
+    ordered_keys = []
+    for row_index, source_row in enumerate(source_rows or [], start=1):
+        if not isinstance(source_row, dict):
+            raise ValueError(f'Source row {row_index} is not an object')
+        row_key = _build_compact_batch_row_key(row_index)
+        ordered_keys.append(row_key)
+        key_map[row_key] = source_row
+    return ordered_keys, key_map
+
+
+def _build_compact_prompt_rows(source_rows):
+    prompt_rows = []
+    ordered_keys, _ = _build_compact_batch_key_map(source_rows)
+    for row_key, source_row in zip(ordered_keys, source_rows or []):
+        prompt_row = {
+            TABULAR_EXPORT_INPUT_ROW_KEY_FIELD: row_key,
+        }
+        prompt_row.update({
+            str(field_name): field_value
+            for field_name, field_value in source_row.items()
+            if str(field_name) not in TABULAR_GENERATION_PLAN_RESERVED_FIELDS
+        })
+        prompt_rows.append(prompt_row)
+    return prompt_rows
+
+
+def _validate_compact_row_field_value(field_contract, field_value, row_key):
+    field_name = str((field_contract or {}).get('name') or '').strip()
+    field_type = str((field_contract or {}).get('type') or '').strip().lower()
+    if field_value is None:
+        if field_contract.get('nullable') is True:
+            return
+        raise ValueError(f'Compact row {row_key} returned null for non-nullable field {field_name}')
+
+    type_matches = (
+        (field_type == 'string' and isinstance(field_value, str))
+        or (field_type == 'boolean' and isinstance(field_value, bool))
+        or (field_type == 'integer' and isinstance(field_value, int) and not isinstance(field_value, bool))
+        or (field_type == 'number' and isinstance(field_value, (int, float)) and not isinstance(field_value, bool))
+        or (field_type == 'array' and isinstance(field_value, list))
+        or (field_type == 'object' and isinstance(field_value, dict))
+    )
+    if not type_matches:
+        raise ValueError(
+            f'Compact row {row_key} field {field_name} did not match expected {field_type} value type'
+        )
+
+
+def _parse_compact_row_array_entries(response_content, source_rows, generation_plan):
+    if not isinstance(generation_plan, dict):
+        raise ValueError('Compact response validation requires an active generation plan')
+    payload = _parse_generated_json_object(response_content)
+    if not isinstance(payload, dict):
+        raise ValueError('Compact response was not a JSON object')
+    if set(payload) != {'p', 'rows'}:
+        raise ValueError('Compact response contained unsupported top-level properties')
+
+    expected_prefix = _get_compact_plan_hash_prefix(generation_plan)
+    if str(payload.get('p') or '').strip() != expected_prefix:
+        raise ValueError('Compact response plan hash prefix mismatch')
+    compact_rows = payload.get('rows')
+    if not isinstance(compact_rows, list):
+        raise ValueError('Compact response rows must be an array')
+
+    llm_fields = _get_tabular_generation_plan_llm_fields(generation_plan)
+    if not llm_fields:
+        raise ValueError('Compact response plan has no LLM output fields')
+    expected_width = 1 + len(llm_fields)
+    ordered_keys, key_map = _build_compact_batch_key_map(source_rows)
+    entries_by_key = {}
+    for response_row_index, compact_row in enumerate(compact_rows, start=1):
+        if not isinstance(compact_row, list):
+            raise ValueError(f'Compact response row {response_row_index} was not an array')
+        if len(compact_row) != expected_width:
+            raise ValueError(
+                f'Compact response row {response_row_index} had {len(compact_row)} value(s); '
+                f'expected {expected_width}'
+            )
+        row_key = str(compact_row[0] or '').strip()
+        if row_key not in key_map:
+            raise ValueError(f'Compact response included unknown row key {row_key}')
+        if row_key in entries_by_key:
+            raise ValueError(f'Compact response duplicated row key {row_key}')
+
+        source_row = key_map[row_key]
+        generated_entry = {
+            TABULAR_EXPORT_INPUT_ROW_TOKEN_FIELD: str(
+                source_row.get(TABULAR_EXPORT_INPUT_ROW_TOKEN_FIELD) or ''
+            ).strip(),
+        }
+        for field_contract, field_value in zip(llm_fields, compact_row[1:]):
+            _validate_compact_row_field_value(field_contract, field_value, row_key)
+            generated_entry[str(field_contract.get('name') or '').strip()] = field_value
+        entries_by_key[row_key] = generated_entry
+
+    missing_keys = [row_key for row_key in ordered_keys if row_key not in entries_by_key]
+    if missing_keys:
+        raise ValueError(f'Compact response missed row key(s): {missing_keys}')
+    return [entries_by_key[row_key] for row_key in ordered_keys]
 
 
 def _normalize_tabular_generation_rollout_settings(settings):
@@ -2313,7 +2459,20 @@ def _build_batch_prompt(
     source_file_name,
     selected_sheet='',
     output_schema=None,
+    response_protocol=TABULAR_RESPONSE_PROTOCOL_OBJECT_V1,
+    generation_plan=None,
 ):
+    if _is_compact_row_array_protocol(response_protocol):
+        return _build_compact_batch_prompt(
+            user_question,
+            batch_rows,
+            batch_index,
+            total_batches,
+            source_file_name,
+            selected_sheet=selected_sheet,
+            generation_plan=generation_plan,
+        )
+
     source_file_name = str(source_file_name or 'unknown file').strip() or 'unknown file'
     selected_sheet = str(selected_sheet or '').strip()
     batch_rows_json = _dump_generated_output_json(batch_rows)
@@ -2352,6 +2511,55 @@ def _build_batch_prompt(
         f'{selected_sheet_line}'
         f'Batch: {batch_index + 1}/{total_batches}\n\n'
         f'Input rows:\n{batch_rows_json}'
+    )
+
+
+def _build_compact_batch_prompt(
+    user_question,
+    batch_rows,
+    batch_index,
+    total_batches,
+    source_file_name,
+    selected_sheet='',
+    generation_plan=None,
+):
+    source_file_name = str(source_file_name or 'unknown file').strip() or 'unknown file'
+    selected_sheet = str(selected_sheet or '').strip()
+    selected_sheet_line = f"Worksheet: {selected_sheet}\n" if selected_sheet else ''
+    llm_fields = _get_tabular_generation_plan_llm_fields(generation_plan)
+    if not llm_fields:
+        raise ValueError('Compact batch prompt requires an active generation plan')
+    row_keys, _ = _build_compact_batch_key_map(batch_rows)
+    field_contract = [
+        {
+            'position': field_index,
+            'name': field.get('name'),
+            'type': field.get('type'),
+            'nullable': field.get('nullable'),
+            'description': field.get('description'),
+        }
+        for field_index, field in enumerate(llm_fields, start=1)
+    ]
+    protocol_contract = {
+        'p': _get_compact_plan_hash_prefix(generation_plan),
+        'row_key_position': 0,
+        'fields': field_contract,
+        'expected_row_keys': row_keys,
+    }
+    prompt_rows = _build_compact_prompt_rows(batch_rows)
+    return (
+        'Transform the tabular input rows below into compact positional JSON for the user.\n\n'
+        f'User instructions:\n{user_question}\n\n'
+        'Return ONLY one valid JSON object with exactly these top-level fields: p, rows.\n'
+        'Do not include markdown fences, explanations, field names inside rows, source metadata, or extra properties.\n'
+        'Each item in rows must be an array. Position 0 is the batch-local row key. Positions 1..N are the field values in the exact plan order below.\n'
+        'Return every expected row key exactly once. Do not use source row tokens. Do not drop, merge, summarize, cap, or reorder by source content.\n'
+        'If a nullable field cannot be derived, return null. Non-nullable fields must contain a value of the requested type.\n\n'
+        f'Compact protocol contract:\n{_dump_generated_output_json(protocol_contract)}\n\n'
+        f'Source file: {source_file_name}\n'
+        f'{selected_sheet_line}'
+        f'Batch: {batch_index + 1}/{total_batches}\n\n'
+        f'Input rows:\n{_dump_generated_output_json(prompt_rows)}'
     )
 
 
@@ -3063,8 +3271,12 @@ async def _generate_batch_entries(
     run_id,
     expected_output_schema=None,
     batch_timeout_seconds=TABULAR_EXPORT_DEFAULT_BATCH_TIMEOUT_SECONDS,
+    response_protocol=TABULAR_RESPONSE_PROTOCOL_OBJECT_V1,
+    generation_plan=None,
 ):
     batch_number = batch_index + 1
+    normalized_response_protocol = str(response_protocol or TABULAR_RESPONSE_PROTOCOL_OBJECT_V1).strip()
+    compact_protocol = _is_compact_row_array_protocol(normalized_response_protocol)
     batch_prompt = _build_batch_prompt(
         user_question,
         batch_rows,
@@ -3073,6 +3285,8 @@ async def _generate_batch_entries(
         source_file_name,
         selected_sheet=selected_sheet,
         output_schema=expected_output_schema,
+        response_protocol=normalized_response_protocol,
+        generation_plan=generation_plan,
     )
 
     parsed_entries = None
@@ -3097,16 +3311,29 @@ async def _generate_batch_entries(
     )
     for attempt_number in range(1, retry_attempts + 1):
         chat_history = SKChatHistory()
-        chat_history.add_system_message(
-            'You transform tabular input rows into deterministic structured output. '
-            'Return only a valid JSON array with one object per input row. '
-            'Never add markdown, explanation text, or omit rows.'
-        )
-        if attempt_number > 1:
+        if compact_protocol:
             chat_history.add_system_message(
-                f'The previous attempt did not return the required {len(batch_rows)} JSON object(s). '
-                'Retry now and preserve the input row count exactly.'
+                'You transform tabular input rows into compact positional output. '
+                'Return only one valid JSON object with p and rows. '
+                'Never repeat field names, source tokens, markdown, explanation text, or omit rows.'
             )
+        else:
+            chat_history.add_system_message(
+                'You transform tabular input rows into deterministic structured output. '
+                'Return only a valid JSON array with one object per input row. '
+                'Never add markdown, explanation text, or omit rows.'
+            )
+        if attempt_number > 1:
+            if compact_protocol:
+                chat_history.add_system_message(
+                    f'The previous attempt did not return the required {len(batch_rows)} compact row array(s). '
+                    'Retry now with the same p value and every expected row key exactly once.'
+                )
+            else:
+                chat_history.add_system_message(
+                    f'The previous attempt did not return the required {len(batch_rows)} JSON object(s). '
+                    'Retry now and preserve the input row count exactly.'
+                )
         chat_history.add_user_message(batch_prompt)
 
         execution_settings = AzureChatPromptExecutionSettings(service_id='tabular-generated-output-background')
@@ -3125,7 +3352,18 @@ async def _generate_batch_entries(
         raw_response_content = result[0].content if result and result[0].content else ''
         usage = _extract_tabular_response_usage(result)
         validation_started_at = time.monotonic()
-        parsed_entries = _parse_generated_json_entries(raw_response_content) if raw_response_content else None
+        try:
+            if compact_protocol and raw_response_content:
+                parsed_entries = _parse_compact_row_array_entries(
+                    raw_response_content,
+                    batch_rows,
+                    generation_plan,
+                )
+            else:
+                parsed_entries = _parse_generated_json_entries(raw_response_content) if raw_response_content else None
+        except ValueError as exc:
+            parsed_entries = None
+            last_validation_error = str(exc)
         parsed_entry_count = len(parsed_entries) if parsed_entries is not None else 0
         last_attempt_metrics = {
             'input_char_count': len(batch_prompt),
@@ -3170,6 +3408,7 @@ async def _generate_batch_entries(
                 'input_token_count': last_attempt_metrics.get('input_token_count'),
                 'output_token_count': last_attempt_metrics.get('output_token_count'),
                 'total_token_count': last_attempt_metrics.get('total_token_count'),
+                'response_protocol_version': normalized_response_protocol,
             },
             debug_only=True,
         )
@@ -3195,6 +3434,8 @@ async def _generate_batch_entries_for_window(
     run_id,
     expected_output_schema,
     batch_timeout_seconds,
+    response_protocol,
+    generation_plan,
 ):
     queued_at = time.monotonic()
     async with semaphore:
@@ -3212,6 +3453,8 @@ async def _generate_batch_entries_for_window(
             run_id,
             expected_output_schema=expected_output_schema,
             batch_timeout_seconds=batch_timeout_seconds,
+            response_protocol=response_protocol,
+            generation_plan=generation_plan,
         )
         elapsed_seconds = time.monotonic() - batch_started_at
         log_event(
@@ -3266,6 +3509,8 @@ async def _generate_batch_window_entries(
     batch_concurrency,
     expected_output_schema=None,
     batch_timeout_seconds=TABULAR_EXPORT_DEFAULT_BATCH_TIMEOUT_SECONDS,
+    response_protocol=TABULAR_RESPONSE_PROTOCOL_OBJECT_V1,
+    generation_plan=None,
 ):
     semaphore = asyncio.Semaphore(max(1, batch_concurrency))
     tasks = [
@@ -3281,6 +3526,8 @@ async def _generate_batch_window_entries(
             run_id,
             expected_output_schema,
             batch_timeout_seconds,
+            response_protocol,
+            generation_plan,
         )
         for batch_request in batch_requests
     ]
@@ -5545,6 +5792,21 @@ def _record_shadow_tabular_generation_plan_comparison(run, actual_output_schema)
     return True
 
 
+def _load_active_compact_generation_plan(run):
+    if not _is_compact_row_array_protocol((run or {}).get('response_protocol_version')):
+        return None
+    if _get_tabular_generation_plan_mode(run) != 'active' or (run or {}).get('plan_status') != 'ready':
+        raise ValueError('Compact row protocol requires a ready active generation plan')
+    plan_blob_path = str((run or {}).get('plan_blob_path') or '').strip()
+    if not plan_blob_path:
+        raise ValueError('Compact row protocol plan path is missing')
+    plan = _download_json_blob(plan_blob_path)
+    _validate_tabular_generation_plan(plan, run)
+    if plan.get('plan_hash') != (run or {}).get('plan_hash'):
+        raise ValueError('Compact row protocol plan hash does not match the run record')
+    return plan
+
+
 def _checkpoint_generated_batch_results(run, generated_results):
     _raise_if_tabular_export_canceled(run)
     batch_results = {}
@@ -6261,6 +6523,7 @@ def process_tabular_generated_output_run(run_id, user_id):
             settings,
             batch_timeout_seconds,
         )
+        generation_plan = _load_active_compact_generation_plan(run)
 
         log_event(
             '[TABULAR_GENERATED_OUTPUT] Background export run started',
@@ -6352,6 +6615,8 @@ def process_tabular_generated_output_run(run_id, user_id):
                             batch_concurrency,
                             expected_output_schema=run.get('output_schema'),
                             batch_timeout_seconds=batch_timeout_seconds,
+                            response_protocol=run.get('response_protocol_version'),
+                            generation_plan=generation_plan,
                         )
                     )
                 _raise_if_tabular_export_canceled(run)
@@ -6477,6 +6742,12 @@ def queue_tabular_generated_output_run(
     )
     if normalized_task_type == TABULAR_RUN_TASK_HIERARCHICAL_ANALYSIS or passthrough_input_rows:
         requested_plan_mode = 'off'
+    response_protocol_version = _select_tabular_response_protocol(
+        rollout_settings,
+        requested_plan_mode,
+        normalized_task_type,
+        passthrough_input_rows=passthrough_input_rows,
+    )
 
     if source_descriptor:
         staged_row_count = _safe_int(source_descriptor.get('expected_row_count'))
@@ -6536,7 +6807,7 @@ def queue_tabular_generated_output_run(
         'type': TABULAR_EXPORT_RUN_TYPE,
         'contract_version': TABULAR_EXPORT_CONTRACT_VERSION,
         'generation_contract_version': TABULAR_GENERATION_CONTRACT_VERSION,
-        'response_protocol_version': TABULAR_RESPONSE_PROTOCOL_OBJECT_V1,
+        'response_protocol_version': response_protocol_version,
         'executor_mode': TABULAR_EXECUTOR_MODE_FIXED_WINDOW,
         'generation_rollout_settings': rollout_settings,
         'task_type': normalized_task_type,
@@ -6643,7 +6914,7 @@ def queue_tabular_generated_output_run(
             'batch_output_token_budget': model_batch_budget.get('output_token_budget'),
             'model_limit_source': model_batch_budget.get('limit_source'),
             'generation_contract_version': TABULAR_GENERATION_CONTRACT_VERSION,
-            'response_protocol_version': TABULAR_RESPONSE_PROTOCOL_OBJECT_V1,
+            'response_protocol_version': response_protocol_version,
             'executor_mode': TABULAR_EXECUTOR_MODE_FIXED_WINDOW,
             'planner_mode': rollout_settings.get('tabular_generation_plan_mode'),
             'compact_protocol_enabled': rollout_settings.get('enable_tabular_compact_response_protocol'),

--- a/docs/explanation/features/TABULAR_BACKGROUND_GENERATED_EXPORTS.md
+++ b/docs/explanation/features/TABULAR_BACKGROUND_GENERATED_EXPORTS.md
@@ -2,7 +2,7 @@
 
 Implemented in version: **0.241.046**
 
-Updated through version: **0.250.139**
+Updated through version: **0.250.140**
 
 ## Overview
 
@@ -35,6 +35,7 @@ The feature supports large spreadsheet-driven analysis, including workbooks that
 - Phase 1 acceleration groundwork adds additive generation contract fields, legacy-off rollout gates, safe batch latency/token telemetry, and deterministic fake model/storage harnesses without changing fixed-window execution behavior.
 - Phase 2 foreground handoff uses server-composed acknowledgment text for accepted background export, analysis, and combined runs, so the assistant response describes the complete queued work instead of narrating preview limitations.
 - Phase 3 creates one bounded LLM schema plan after source staging, stores it as an immutable hashed blob, and binds planned output checkpoints to that plan and source ETag.
+- Phase 4 adds an active-plan compact row response protocol for structured exports. The model emits one short batch-local row key plus positional LLM values, while the server reattaches source metadata and checkpoints the same object-shaped rows as before.
 
 ### API Endpoints
 
@@ -90,6 +91,7 @@ The progress card displays current status, completed checkpoint counts, processe
 - Functional regression: `functional_tests/test_tabular_background_generated_exports.py`
 - Scale and performance regression: `functional_tests/test_tabular_row_orchestration_scale.py`
 - Phase 3 immutable plan, recovery, shadow comparison, active schema, and checkpoint-integrity regression: `functional_tests/test_tabular_row_orchestration_scale.py`
+- Phase 4 compact protocol selection, prompt, validation, row-key, plan-hash, and normalized-output equivalence regression: `functional_tests/test_tabular_row_orchestration_scale.py`
 - Phase 2 handoff regression: `functional_tests/test_tabular_row_orchestration_scale.py`
 - Phase 1 baseline and fake harness coverage: `functional_tests/test_tabular_row_orchestration_scale.py`
 - Functional regression for workflow/document-action presentation: `functional_tests/test_document_analysis_lossless_artifacts.py`
@@ -106,6 +108,7 @@ The progress card displays current status, completed checkpoint counts, processe
 - Progress is persisted once per completed parallel window. ETA uses recent wall-clock rows per minute rather than summing concurrent model-call durations as serial work.
 - Phase 1 telemetry separates safe model-call, validation, and checkpoint timing metrics where the current executor can observe them. Validation mismatch logs record counts and timings only, not generated response previews.
 - Phase 3 planning reads at most five staged rows from at most two input checkpoints and sends only column metadata plus redacted value shapes, so planner input remains bounded independently of source row count.
+- Phase 4 compact responses reduce repeated generated field names and avoid model-emitted long source tokens for active planned structured exports. Compact responses are normalized before checkpointing, so final CSV, JSON, and XML serialization remains unchanged.
 - Background processing writes each completed batch before moving on, allowing the run to resume after worker restarts.
 - The run status API returns compact metadata only, not source rows or generated batch content.
 - User-facing status details are derived from run metadata instead of displaying raw backend errors in the progress card.
@@ -118,6 +121,7 @@ The progress card displays current status, completed checkpoint counts, processe
 - Completion appears through status polling or on the next chat reload; no push notification is added in this version.
 - Manual continuation applies to retryable failures, stale running leases, queued retries whose retry time has passed, and stale queued runs; hard validation failures remain terminal.
 - Shadow mode does not remove the first-batch schema barrier. Administrators should move new runs to `active` only after representative shadow comparisons preserve every requested field.
+- Compact row responses apply only to new active planned structured exports. Existing runs, shadow runs, fallback runs, passthrough rows, analysis-only runs, and combined analysis/export runs remain on `object-v1`.
 
 ## Related Version Updates
 
@@ -129,3 +133,4 @@ The progress card displays current status, completed checkpoint counts, processe
 - `application/single_app/config.py` was updated to version **0.250.137** for Phase 1 acceleration baseline contracts, rollout controls, privacy-safe telemetry, and fake model/storage harnesses.
 - `application/single_app/config.py` was updated to version **0.250.138** for Phase 2 truthful foreground handoff wording and metadata.
 - `application/single_app/config.py` was updated to version **0.250.139** for Phase 3 immutable LLM schema planning, shadow comparison, active scheduling, and checkpoint integrity.
+- `application/single_app/config.py` was updated to version **0.250.140** for Phase 4 compact row response protocol validation and normalized checkpoint compatibility.

--- a/docs/explanation/features/TABULAR_LLM_GENERATION_ACCELERATION_PHASE_3_DURABLE_PLAN.md
+++ b/docs/explanation/features/TABULAR_LLM_GENERATION_ACCELERATION_PHASE_3_DURABLE_PLAN.md
@@ -106,7 +106,7 @@ Planning input and output are bounded independently of dataset row count. Shadow
 ## Known Limitations
 
 - Active mode requires administrator rollout after shadow agreement is acceptable.
-- Phase 3 keeps the `object-v1` row response protocol; compact positional output is deferred to Phase 4.
+- Phase 3 keeps the `object-v1` row response protocol. Phase 4 adds compact positional output for new active planned structured exports.
 - Completion-driven checkpointing, rolling scheduling, and independent batch retries remain deferred to later phases.
 
 ## Related Version Updates

--- a/docs/explanation/features/TABULAR_LLM_GENERATION_ACCELERATION_PHASE_4_COMPACT_PROTOCOL.md
+++ b/docs/explanation/features/TABULAR_LLM_GENERATION_ACCELERATION_PHASE_4_COMPACT_PROTOCOL.md
@@ -1,0 +1,95 @@
+# Tabular LLM Generation Acceleration Phase 4 Compact Protocol
+
+Implemented in version: **0.250.140**
+
+Associated issue: **microsoft/simplechat#1031**
+
+## Overview
+
+Phase 4 adds `compact-row-array-v1`, a persisted response protocol for new active planned structured tabular exports. Instead of asking the model to repeat JSON object field names and copy long source-row tokens for every row, each batch prompt assigns short keys such as `r1` and the model returns positional arrays keyed by those values.
+
+## Purpose
+
+The compact protocol reduces generated structural text and removes source-token copying from the model output while preserving the existing public artifact contract. The server validates compact rows, maps each key back to the authoritative staged source row, reattaches source metadata, and stores the same normalized object-shaped output checkpoints used by `object-v1`.
+
+## Dependencies
+
+- Durable Phase 3 generation plans in `application/single_app/functions_tabular_generated_exports.py`
+- Backend rollout setting `enable_tabular_compact_response_protocol`
+- Active planner mode `tabular_generation_plan_mode=active`
+- Existing checkpoint metadata validation for plan hash and source ETag
+- Existing CSV, JSON, and XML finalizers
+
+## Technical Specifications
+
+### Protocol Selection
+
+New run records snapshot `response_protocol_version` at creation. The compact protocol is selected only when all of these are true:
+
+- `enable_tabular_compact_response_protocol` is enabled.
+- `tabular_generation_plan_mode` resolves to `active`.
+- The task type is structured export.
+- The run is not using passthrough input rows.
+
+All existing runs, shadow runs, fallback runs, analysis-only runs, combined analysis/export runs, and passthrough runs remain on `object-v1`.
+
+### Compact Prompt Shape
+
+For compact batches, prompts include the stable user instructions, plan field order, plan hash prefix, protocol rules, expected row keys, and source rows with `__simplechat_batch_row_key`. Internal source-row tokens, source row numbers, and source identities are not included in compact prompt rows.
+
+The model must return one JSON object:
+
+```json
+{"p":"planhashpref","rows":[["r1","answer","low"],["r2","answer",null]]}
+```
+
+Position 0 is the batch-local row key. Positions 1 through N correspond to the LLM-owned fields from the active plan in exact order. Field names, source tokens, source row numbers, source identities, markdown, and explanations are invalid in the response.
+
+### Validation and Normalization
+
+Server validation requires:
+
+- The top-level object contains only `p` and `rows`.
+- The plan hash prefix matches the immutable active plan.
+- Every expected key appears exactly once.
+- Unknown, duplicate, or missing keys fail validation.
+- Every row array has exactly `1 + len(plan LLM fields)` positions.
+- Non-null values match the plan field type where practical.
+- Nullable fields may return `null`; non-nullable fields may not.
+
+After validation, rows are normalized by key back to source order. The server adds the staged source token only long enough to reuse the existing source-token normalizer, then checkpoints object-shaped rows with `source_row_number`, `source_row_identity`, and the LLM-owned fields.
+
+## Usage Instructions
+
+No end-user workflow changes are required. Administrators can enable `enable_tabular_compact_response_protocol` after Phase 3 active planning is ready for the target environment. Because the selected protocol is copied into each run, later administrator setting changes affect only new runs.
+
+## Testing and Validation
+
+Coverage is in `functional_tests/test_tabular_row_orchestration_scale.py`:
+
+- Compact protocol is selected only for active planned structured exports.
+- Compact plans persist and validate the recorded response protocol.
+- Compact prompts omit long source-row tokens.
+- Reordered compact responses normalize back to source order.
+- Normalized compact entries match the existing object-shaped checkpoint schema.
+- Duplicate, missing, unknown, malformed-width, plan-hash-mismatched, null non-nullable, and wrong-type values fail validation.
+
+Validation command:
+
+```bash
+python functional_tests/test_tabular_row_orchestration_scale.py
+```
+
+## Performance Considerations
+
+Compact responses are intended to lower output tokens and response characters for multi-field row generation by removing repeated field names and long source-token values from model output. Phase 4 preserves the existing fixed-window executor and checkpoint timing so compact output can be measured independently before completion-driven checkpointing or rolling scheduling changes.
+
+## Known Limitations
+
+- The protocol is implemented for structured export batches only. Combined analysis/export keeps `object-v1` until its nested analysis payload can be measured separately.
+- Provider-side structured output schemas are not required for this phase; server-side validation remains authoritative.
+- Live token and latency measurement gates still need to be captured with representative deployments before broad activation.
+
+## Related Version Updates
+
+- `application/single_app/config.py` was updated from **0.250.139** to **0.250.140** for Phase 4 compact row response protocol validation and normalized checkpoint compatibility.

--- a/functional_tests/test_tabular_row_orchestration_scale.py
+++ b/functional_tests/test_tabular_row_orchestration_scale.py
@@ -1,8 +1,8 @@
 # test_tabular_row_orchestration_scale.py
 """
 Functional test for scalable per-row tabular orchestration.
-Version: 0.250.139
-Implemented in: 0.250.060; generated CSV formula safety in 0.250.065; generated file export routing in 0.250.072; source descriptor generalization in 0.250.127; unified durable run contract in 0.250.128; hierarchical analysis in 0.250.129; combined analysis and export in 0.250.130; scale validation in 0.250.132; direct source-backed exhaustive queueing in 0.250.133; direct queue call-site hardening in 0.250.134; model-validation auto retry in 0.250.135; model-aware parallel throughput in 0.250.136; Phase 1 acceleration contracts and observability in 0.250.137; Phase 2 truthful background handoff in 0.250.138; Phase 3 durable LLM generation planning in 0.250.139
+Version: 0.250.140
+Implemented in: 0.250.060; generated CSV formula safety in 0.250.065; generated file export routing in 0.250.072; source descriptor generalization in 0.250.127; unified durable run contract in 0.250.128; hierarchical analysis in 0.250.129; combined analysis and export in 0.250.130; scale validation in 0.250.132; direct source-backed exhaustive queueing in 0.250.133; direct queue call-site hardening in 0.250.134; model-validation auto retry in 0.250.135; model-aware parallel throughput in 0.250.136; Phase 1 acceleration contracts and observability in 0.250.137; Phase 2 truthful background handoff in 0.250.138; Phase 3 durable LLM generation planning in 0.250.139; Phase 4 compact row response protocol in 0.250.140
 
 This test ensures generated exports preserve source identity and row order while
 enforcing one stable output schema across independently generated batches.
@@ -225,6 +225,9 @@ GENERATION_PLAN_FUNCTIONS = {
 }
 GENERATION_PLAN_CONSTANTS = {
     'TABULAR_RESPONSE_PROTOCOL_OBJECT_V1',
+    'TABULAR_RESPONSE_PROTOCOL_COMPACT_ROW_ARRAY_V1',
+    'TABULAR_RESPONSE_PROTOCOLS',
+    'TABULAR_COMPACT_PLAN_HASH_PREFIX_LENGTH',
     'TABULAR_ROLLOUT_PLANNER_MODES',
     'TABULAR_RUN_TASK_STRUCTURED_EXPORT',
     'TABULAR_RUN_TASK_HIERARCHICAL_ANALYSIS',
@@ -233,8 +236,42 @@ GENERATION_PLAN_CONSTANTS = {
     'TABULAR_EXPORT_INPUT_ROW_NUMBER_FIELD',
     'TABULAR_EXPORT_INPUT_ROW_IDENTITY_FIELD',
     'TABULAR_EXPORT_INPUT_ROW_TOKEN_FIELD',
+    'TABULAR_EXPORT_INPUT_ROW_KEY_FIELD',
     'TABULAR_EXPORT_OUTPUT_ROW_NUMBER_FIELD',
     'TABULAR_EXPORT_OUTPUT_ROW_IDENTITY_FIELD',
+}
+COMPACT_PROTOCOL_FUNCTIONS = {
+    '_safe_int',
+    '_settings_bool',
+    '_settings_mode',
+    '_canonical_json_bytes',
+    '_sha256_json',
+    '_hash_tabular_generation_plan',
+    '_normalize_tabular_run_task_type',
+    '_is_compact_row_array_protocol',
+    '_select_tabular_response_protocol',
+    '_clean_generated_json_code_fence',
+    '_parse_generated_json_entries',
+    '_parse_generated_json_object',
+    '_dump_generated_output_json',
+    '_describe_tabular_generation_plan_value',
+    '_infer_tabular_generation_plan_value_type',
+    '_build_tabular_generation_plan_input_contract',
+    '_validate_tabular_generation_plan_output_fields',
+    '_get_tabular_generation_plan_source',
+    '_build_tabular_generation_plan',
+    '_validate_tabular_generation_plan',
+    '_get_tabular_generation_plan_output_schema',
+    '_get_tabular_generation_plan_llm_fields',
+    '_get_compact_plan_hash_prefix',
+    '_build_compact_batch_row_key',
+    '_build_compact_batch_key_map',
+    '_build_compact_prompt_rows',
+    '_validate_compact_row_field_value',
+    '_parse_compact_row_array_entries',
+    '_build_batch_prompt',
+    '_build_compact_batch_prompt',
+    '_normalize_generated_batch_entries',
 }
 
 
@@ -1235,6 +1272,45 @@ def _load_generation_plan_helpers():
     return namespace, PlannerError, state
 
 
+def _load_compact_protocol_helpers():
+    module_tree = ast.parse(EXPORT_MODULE.read_text(encoding='utf-8'), filename=str(EXPORT_MODULE))
+    selected_nodes = []
+    found_functions = set()
+    for node in module_tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name in COMPACT_PROTOCOL_FUNCTIONS:
+            selected_nodes.append(node)
+            found_functions.add(node.name)
+        elif isinstance(node, ast.Assign):
+            assigned_names = {
+                target.id
+                for target in node.targets
+                if isinstance(target, ast.Name)
+            }
+            if any(
+                name.startswith('TABULAR_EXPORT_')
+                or name.startswith('TABULAR_GENERATION_')
+                or name.startswith('TABULAR_RESPONSE_')
+                or name.startswith('TABULAR_RUN_TASK_')
+                or name.startswith('TABULAR_ROLLOUT_')
+                or name.startswith('TABULAR_COMPACT_')
+                for name in assigned_names
+            ):
+                selected_nodes.append(node)
+
+    missing_functions = COMPACT_PROTOCOL_FUNCTIONS - found_functions
+    if missing_functions:
+        raise AssertionError(f'Missing compact protocol helpers: {sorted(missing_functions)}')
+
+    namespace = {
+        'hashlib': hashlib,
+        'json': json,
+        're': re,
+    }
+    extracted_module = ast.Module(body=selected_nodes, type_ignores=[])
+    exec(compile(extracted_module, str(EXPORT_MODULE), 'exec'), namespace)
+    return namespace
+
+
 def _build_phase_three_test_run(plan_mode='shadow', plan_status='pending'):
     return {
         'id': 'run-phase-3',
@@ -1307,6 +1383,70 @@ def _build_phase_three_plan(helpers, run):
                     'description': 'Risk level requested for the source row.',
                     'type': 'string',
                     'nullable': True,
+                    'source': 'llm',
+                },
+            ],
+            'output_verbosity': 'concise',
+        },
+        input_contract,
+        {
+            'endpoint_id': 'endpoint-1',
+            'model_id': 'gpt-plan',
+            'deployment': 'gpt-plan',
+        },
+        created_at='2026-08-10T12:00:00+00:00',
+    )
+    return plan, input_contract
+
+
+def _build_phase_four_plan(helpers, run):
+    input_contract = helpers['_build_tabular_generation_plan_input_contract'](
+        run['_test_batches'][0] + run['_test_batches'][1]
+    )
+    plan = helpers['_build_tabular_generation_plan'](
+        run,
+        {
+            'output_fields': [
+                {
+                    'name': 'answer',
+                    'description': 'Answer requested for the source row.',
+                    'type': 'string',
+                    'nullable': False,
+                    'source': 'llm',
+                },
+                {
+                    'name': 'risk',
+                    'description': 'Risk level requested for the source row.',
+                    'type': 'string',
+                    'nullable': True,
+                    'source': 'llm',
+                },
+                {
+                    'name': 'score',
+                    'description': 'Numeric score requested for the source row.',
+                    'type': 'number',
+                    'nullable': False,
+                    'source': 'llm',
+                },
+                {
+                    'name': 'flagged',
+                    'description': 'Boolean flag requested for the source row.',
+                    'type': 'boolean',
+                    'nullable': False,
+                    'source': 'llm',
+                },
+                {
+                    'name': 'evidence',
+                    'description': 'Compact evidence object for the source row.',
+                    'type': 'object',
+                    'nullable': False,
+                    'source': 'llm',
+                },
+                {
+                    'name': 'tags',
+                    'description': 'Array of tags requested for the source row.',
+                    'type': 'array',
+                    'nullable': False,
                     'source': 'llm',
                 },
             ],
@@ -1996,6 +2136,180 @@ def test_phase_three_plan_persistence_boundaries_never_replan():
     assert legacy_run['plan_blob_path'] is None
     assert legacy_run['plan_hash'] is None
     assert legacy_run['output_schema'] is None
+
+
+def test_phase_four_compact_protocol_requires_active_plan_rollout():
+    """Compact row arrays are selected only for new active planned structured exports."""
+    helpers = _load_compact_protocol_helpers()
+    select_protocol = helpers['_select_tabular_response_protocol']
+    object_protocol = helpers['TABULAR_RESPONSE_PROTOCOL_OBJECT_V1']
+    compact_protocol = helpers['TABULAR_RESPONSE_PROTOCOL_COMPACT_ROW_ARRAY_V1']
+
+    assert select_protocol({}, 'active', 'structured_export') == object_protocol
+    assert select_protocol(
+        {'enable_tabular_compact_response_protocol': True},
+        'shadow',
+        'structured_export',
+    ) == object_protocol
+    assert select_protocol(
+        {'enable_tabular_compact_response_protocol': True},
+        'active',
+        'combined',
+    ) == object_protocol
+    assert select_protocol(
+        {'enable_tabular_compact_response_protocol': True},
+        'active',
+        'structured_export',
+        passthrough_input_rows=True,
+    ) == object_protocol
+    assert select_protocol(
+        {'enable_tabular_compact_response_protocol': True},
+        'active',
+        'structured_export',
+    ) == compact_protocol
+
+    run = _build_phase_three_test_run(plan_mode='active')
+    run['response_protocol_version'] = compact_protocol
+    plan, input_contract = _build_phase_three_plan(helpers, run)
+    assert plan['response_protocol'] == compact_protocol
+    helpers['_validate_tabular_generation_plan'](
+        plan,
+        run,
+        input_schema_hash=input_contract['input_schema_hash'],
+    )
+
+    invalid_run = dict(run)
+    invalid_run['response_protocol_version'] = 'unknown-protocol'
+    try:
+        helpers['_build_tabular_generation_plan'](
+            invalid_run,
+            {'output_fields': plan['output_fields'][2:]},
+            input_contract,
+            {'model_id': 'gpt-plan', 'deployment': 'gpt-plan'},
+        )
+    except ValueError as exc:
+        assert 'protocol' in str(exc).lower()
+    else:
+        raise AssertionError('Unknown response protocols must fail plan creation')
+
+
+def test_phase_four_compact_response_reconstructs_object_contract():
+    """Compact rows normalize to the same object-shaped checkpoint entries as object-v1."""
+    helpers = _load_compact_protocol_helpers()
+    compact_protocol = helpers['TABULAR_RESPONSE_PROTOCOL_COMPACT_ROW_ARRAY_V1']
+    run = _build_phase_three_test_run(plan_mode='active')
+    run['response_protocol_version'] = compact_protocol
+    plan, _ = _build_phase_four_plan(helpers, run)
+    source_rows = run['_test_batches'][0] + run['_test_batches'][1]
+
+    prompt = helpers['_build_batch_prompt'](
+        run['user_question'],
+        source_rows,
+        0,
+        1,
+        'source.csv',
+        output_schema=helpers['_get_tabular_generation_plan_output_schema'](plan),
+        response_protocol=compact_protocol,
+        generation_plan=plan,
+    )
+    assert '__simplechat_batch_row_key' in prompt
+    assert '__simplechat_source_row_token' not in prompt
+    assert 'token-1' not in prompt
+    assert 'token-2' not in prompt
+
+    response_payload = {
+        'p': helpers['_get_compact_plan_hash_prefix'](plan),
+        'rows': [
+            ['r2', 'second answer', None, 9.5, False, {'quote': 'line, quote "two"'}, ['beta']],
+            ['r1', 'first answer', 'low', 7, True, {'note': 'line one\nline two'}, ['alpha']],
+        ],
+    }
+    generated_entries = helpers['_parse_compact_row_array_entries'](
+        json.dumps(response_payload),
+        source_rows,
+        plan,
+    )
+    normalized_entries, output_schema = helpers['_normalize_generated_batch_entries'](
+        source_rows,
+        generated_entries,
+        expected_output_schema=helpers['_get_tabular_generation_plan_output_schema'](plan),
+    )
+
+    assert output_schema == [
+        'source_row_number',
+        'source_row_identity',
+        'answer',
+        'risk',
+        'score',
+        'flagged',
+        'evidence',
+        'tags',
+    ]
+    assert normalized_entries[0]['source_row_number'] == 1
+    assert normalized_entries[0]['source_row_identity'] == 'SC-1'
+    assert normalized_entries[0]['answer'] == 'first answer'
+    assert normalized_entries[0]['risk'] == 'low'
+    assert normalized_entries[0]['score'] == 7
+    assert normalized_entries[0]['flagged'] is True
+    assert normalized_entries[0]['evidence']['note'] == 'line one\nline two'
+    assert normalized_entries[1]['source_row_number'] == 2
+    assert normalized_entries[1]['answer'] == 'second answer'
+    assert normalized_entries[1]['risk'] is None
+    assert '__simplechat_source_row_token' not in normalized_entries[0]
+
+
+def test_phase_four_compact_response_rejects_key_and_value_failures():
+    """Malformed compact rows fail validation instead of receiving deterministic answers."""
+    helpers = _load_compact_protocol_helpers()
+    compact_protocol = helpers['TABULAR_RESPONSE_PROTOCOL_COMPACT_ROW_ARRAY_V1']
+    run = _build_phase_three_test_run(plan_mode='active')
+    run['response_protocol_version'] = compact_protocol
+    plan, _ = _build_phase_four_plan(helpers, run)
+    source_rows = run['_test_batches'][0] + run['_test_batches'][1]
+    prefix = helpers['_get_compact_plan_hash_prefix'](plan)
+    valid_r1 = ['r1', 'first answer', 'low', 7, True, {'note': 'one'}, ['alpha']]
+    valid_r2 = ['r2', 'second answer', None, 9.5, False, {'note': 'two'}, ['beta']]
+    failure_cases = [
+        (
+            {'p': prefix, 'rows': [valid_r1, valid_r1]},
+            'duplicated',
+        ),
+        (
+            {'p': prefix, 'rows': [valid_r1]},
+            'missed',
+        ),
+        (
+            {'p': prefix, 'rows': [valid_r1, ['r3', 'third', 'high', 1, False, {}, []]]},
+            'unknown',
+        ),
+        (
+            {'p': prefix, 'rows': [valid_r1, ['r2', 'second answer']]},
+            'expected',
+        ),
+        (
+            {'p': 'bad-prefix', 'rows': [valid_r1, valid_r2]},
+            'hash',
+        ),
+        (
+            {'p': prefix, 'rows': [[*valid_r1[:1], None, *valid_r1[2:]], valid_r2]},
+            'non-nullable',
+        ),
+        (
+            {'p': prefix, 'rows': [[*valid_r1[:3], 'not-a-number', *valid_r1[4:]], valid_r2]},
+            'expected number',
+        ),
+    ]
+    for payload, expected_message in failure_cases:
+        try:
+            helpers['_parse_compact_row_array_entries'](
+                json.dumps(payload),
+                source_rows,
+                plan,
+            )
+        except ValueError as exc:
+            assert expected_message in str(exc).lower()
+        else:
+            raise AssertionError(f'Compact validation accepted invalid payload: {payload}')
 
 
 def test_source_identity_and_order_contract():
@@ -3713,6 +4027,9 @@ def main():
         test_phase_three_shadow_active_and_checkpoint_contracts,
         test_phase_three_planner_timeout_retries_before_fallback,
         test_phase_three_plan_persistence_boundaries_never_replan,
+        test_phase_four_compact_protocol_requires_active_plan_rollout,
+        test_phase_four_compact_response_reconstructs_object_contract,
+        test_phase_four_compact_response_rejects_key_and_value_failures,
         test_source_identity_and_order_contract,
         test_generated_batch_schema_contract,
         test_durable_runner_enforces_row_contract,


### PR DESCRIPTION
## Summary

- Implements `compact-row-array-v1` for new active planned structured tabular exports.
- Adds compact prompt construction, row-key mapping, plan-hash-prefix validation, type/nullability checks, and normalization back to the existing object-shaped checkpoint contract.
- Keeps existing, shadow, fallback, passthrough, analysis-only, and combined runs on `object-v1` for backward-compatible resume and finalization.
- Updates app version to `0.250.140` and adds Phase 4 feature documentation.

Refs #1031

## Validation

- `python -m py_compile application/single_app/functions_tabular_generated_exports.py application/single_app/config.py functional_tests/test_tabular_row_orchestration_scale.py`
- `python functional_tests/test_tabular_row_orchestration_scale.py`
- Phase-doc relative Markdown link check
- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --cached --check`