### PR TITLE
Implement Phase 5 completion-driven checkpointing

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -96,7 +96,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.250.140"
+VERSION = "0.250.141"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/functions_tabular_generated_exports.py
+++ b/application/single_app/functions_tabular_generated_exports.py
@@ -1475,6 +1475,10 @@ def _output_blob_path(user_id, conversation_id, run_id, batch_number):
     return f"{user_id}/{conversation_id}/generated/tabular_runs/{run_id}/output/batch_{batch_number:06d}.json"
 
 
+def _output_blob_prefix(user_id, conversation_id, run_id):
+    return f"{user_id}/{conversation_id}/generated/tabular_runs/{run_id}/output/"
+
+
 def _output_summary_blob_path(user_id, conversation_id, run_id, batch_number):
     return f"{user_id}/{conversation_id}/generated/tabular_runs/{run_id}/summary/batch_{batch_number:06d}.json"
 
@@ -1689,6 +1693,36 @@ def _build_tabular_output_checkpoint_metadata(run, metadata=None):
             'source_etag': _get_tabular_generation_plan_source_etag(run),
         })
     return checkpoint_metadata
+
+
+def _scan_output_checkpoint_batches_for_run(run):
+    user_id = str((run or {}).get('user_id') or '').strip()
+    conversation_id = str((run or {}).get('conversation_id') or '').strip()
+    run_id = str((run or {}).get('id') or '').strip()
+    batch_count = _safe_int((run or {}).get('batch_count'), default=0, minimum=0)
+    if not user_id or not conversation_id or not run_id or batch_count <= 0:
+        return set()
+
+    output_prefix = _output_blob_prefix(user_id, conversation_id, run_id)
+    container_client = _get_blob_service_client().get_container_client(
+        storage_account_personal_chat_container_name,
+    )
+    output_batch_numbers = set()
+    for blob_properties in container_client.list_blobs(name_starts_with=output_prefix):
+        if isinstance(blob_properties, dict):
+            blob_name = str(blob_properties.get('name') or '').strip()
+        else:
+            blob_name = str(getattr(blob_properties, 'name', '') or '').strip()
+        if not blob_name.startswith(output_prefix):
+            continue
+        suffix = blob_name[len(output_prefix):]
+        match = re.fullmatch(r'batch_(\d{6})\.json', suffix)
+        if not match:
+            continue
+        batch_number = _safe_int(match.group(1), default=0, minimum=0)
+        if 1 <= batch_number <= batch_count:
+            output_batch_numbers.add(batch_number)
+    return output_batch_numbers
 
 
 def _validate_tabular_output_checkpoint_metadata(run, blob_path, batch_number):
@@ -3541,6 +3575,110 @@ async def _generate_batch_window_entries(
             continue
         successful_results.append(gathered_result)
     return successful_results, first_error
+
+
+def _is_completion_driven_checkpointing_enabled(settings):
+    rollout_settings = _normalize_tabular_generation_rollout_settings(settings or {})
+    return bool(rollout_settings.get('enable_tabular_completion_driven_checkpointing'))
+
+
+def _get_checkpoint_writer_concurrency(settings):
+    rollout_settings = _normalize_tabular_generation_rollout_settings(settings or {})
+    return _safe_int(
+        rollout_settings.get('tabular_generation_checkpoint_writer_concurrency'),
+        default=TABULAR_GENERATION_DEFAULT_CHECKPOINT_WRITER_CONCURRENCY,
+        minimum=1,
+        maximum=16,
+    )
+
+
+async def _checkpoint_generated_result_async(run, generated_result, writer_semaphore):
+    async with writer_semaphore:
+        checkpoint_results = await asyncio.to_thread(
+            _checkpoint_generated_batch_results,
+            run,
+            [generated_result],
+        )
+    return checkpoint_results
+
+
+async def _generate_and_checkpoint_batch_window_entries(
+    run,
+    chat_service,
+    user_question,
+    batch_requests,
+    total_batches,
+    source_file_name,
+    selected_sheet,
+    retry_attempts,
+    run_id,
+    batch_concurrency,
+    checkpoint_writer_concurrency,
+    expected_output_schema=None,
+    batch_timeout_seconds=TABULAR_EXPORT_DEFAULT_BATCH_TIMEOUT_SECONDS,
+    response_protocol=TABULAR_RESPONSE_PROTOCOL_OBJECT_V1,
+    generation_plan=None,
+):
+    semaphore = asyncio.Semaphore(max(1, batch_concurrency))
+    writer_semaphore = asyncio.Semaphore(max(1, checkpoint_writer_concurrency))
+    tasks = [
+        asyncio.create_task(
+            _generate_batch_entries_for_window(
+                semaphore,
+                chat_service,
+                user_question,
+                batch_request,
+                total_batches,
+                source_file_name,
+                selected_sheet,
+                retry_attempts,
+                run_id,
+                expected_output_schema,
+                batch_timeout_seconds,
+                response_protocol,
+                generation_plan,
+            )
+        )
+        for batch_request in batch_requests
+    ]
+    batch_results = {}
+    first_error = None
+    checkpoint_tasks = set()
+    checkpoint_high_water_mark = max(1, checkpoint_writer_concurrency) * 2
+
+    def collect_checkpoint_results(completed_checkpoint_tasks):
+        nonlocal first_error
+        for checkpointed_task in completed_checkpoint_tasks:
+            try:
+                checkpointed_result = checkpointed_task.result()
+            except Exception as exc:
+                if first_error is None:
+                    first_error = exc
+                continue
+            batch_results.update(checkpointed_result)
+
+    for completed_task in asyncio.as_completed(tasks):
+        try:
+            generated_result = await completed_task
+        except Exception as exc:
+            if first_error is None:
+                first_error = exc
+            continue
+        checkpoint_task = asyncio.create_task(
+            _checkpoint_generated_result_async(run, generated_result, writer_semaphore)
+        )
+        checkpoint_tasks.add(checkpoint_task)
+        if len(checkpoint_tasks) >= checkpoint_high_water_mark:
+            completed_checkpoint_tasks, checkpoint_tasks = await asyncio.wait(
+                checkpoint_tasks,
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            collect_checkpoint_results(completed_checkpoint_tasks)
+
+    if checkpoint_tasks:
+        completed_checkpoint_tasks, _ = await asyncio.wait(checkpoint_tasks)
+        collect_checkpoint_results(completed_checkpoint_tasks)
+    return batch_results, first_error
 
 
 async def _generate_analysis_chunk_summary(
@@ -5554,9 +5692,19 @@ def _load_input_batch_rows(run, input_batches, user_id, run_id, batch_number, ba
     return batch_rows
 
 
-def _build_batch_window(run, input_batches, user_id, run_id, window_start, window_end, batch_count):
+def _build_batch_window(
+    run,
+    input_batches,
+    user_id,
+    run_id,
+    window_start,
+    window_end,
+    batch_count,
+    durable_output_batches=None,
+):
     batch_results = {}
     batch_requests = []
+    listed_output_batches = durable_output_batches if durable_output_batches is not None else None
     for batch_number in range(window_start, window_end + 1):
         batch_started_at = time.monotonic()
         output_blob_path = _output_blob_path(
@@ -5565,8 +5713,13 @@ def _build_batch_window(run, input_batches, user_id, run_id, window_start, windo
             run_id,
             batch_number,
         )
+        output_checkpoint_exists = (
+            batch_number in listed_output_batches
+            if listed_output_batches is not None
+            else _blob_exists(output_blob_path)
+        )
 
-        if _blob_exists(output_blob_path) and not run.get('regenerate_legacy_output_checkpoints'):
+        if output_checkpoint_exists and not run.get('regenerate_legacy_output_checkpoints'):
             _validate_tabular_output_checkpoint_metadata(run, output_blob_path, batch_number)
             batch_entries = _download_json_blob(output_blob_path)
             expected_output_schema = set(run.get('output_schema') or [])
@@ -6566,6 +6719,7 @@ def process_tabular_generated_output_run(run_id, user_id):
                 settings,
             )
 
+        durable_output_batches = _scan_output_checkpoint_batches_for_run(run)
         while completed_batches < batch_count:
             _raise_if_tabular_export_canceled(run)
             window_start = completed_batches + 1
@@ -6580,6 +6734,7 @@ def process_tabular_generated_output_run(run_id, user_id):
                 window_start,
                 window_end,
                 batch_count,
+                durable_output_batches=durable_output_batches,
             )
 
             generation_error = None
@@ -6601,6 +6756,29 @@ def process_tabular_generated_output_run(run_id, user_id):
                 )
                 if run.get('passthrough_input_rows'):
                     generated_results = _build_passthrough_batch_results(run, batch_requests)
+                elif _is_completion_driven_checkpointing_enabled(settings):
+                    generated_batch_results, generation_error = asyncio.run(
+                        _generate_and_checkpoint_batch_window_entries(
+                            run,
+                            chat_service,
+                            run.get('user_question'),
+                            batch_requests,
+                            batch_count,
+                            run.get('source_file_name'),
+                            run.get('selected_sheet'),
+                            retry_attempts,
+                            normalized_run_id,
+                            batch_concurrency,
+                            _get_checkpoint_writer_concurrency(settings),
+                            expected_output_schema=run.get('output_schema'),
+                            batch_timeout_seconds=batch_timeout_seconds,
+                            response_protocol=run.get('response_protocol_version'),
+                            generation_plan=generation_plan,
+                        )
+                    )
+                    batch_results.update(generated_batch_results)
+                    durable_output_batches.update(generated_batch_results)
+                    generated_results = []
                 else:
                     generated_results, generation_error = asyncio.run(
                         _generate_batch_window_entries(
@@ -6620,7 +6798,10 @@ def process_tabular_generated_output_run(run_id, user_id):
                         )
                     )
                 _raise_if_tabular_export_canceled(run)
-                batch_results.update(_checkpoint_generated_batch_results(run, generated_results))
+                if generated_results:
+                    checkpointed_batch_results = _checkpoint_generated_batch_results(run, generated_results)
+                    batch_results.update(checkpointed_batch_results)
+                    durable_output_batches.update(checkpointed_batch_results)
 
             previous_completed_batches = completed_batches
             run, completed_batches, processed_rows = _advance_run_progress_for_window(

--- a/docs/explanation/features/TABULAR_BACKGROUND_GENERATED_EXPORTS.md
+++ b/docs/explanation/features/TABULAR_BACKGROUND_GENERATED_EXPORTS.md
@@ -2,7 +2,7 @@
 
 Implemented in version: **0.241.046**
 
-Updated through version: **0.250.140**
+Updated through version: **0.250.141**
 
 ## Overview
 
@@ -36,6 +36,7 @@ The feature supports large spreadsheet-driven analysis, including workbooks that
 - Phase 2 foreground handoff uses server-composed acknowledgment text for accepted background export, analysis, and combined runs, so the assistant response describes the complete queued work instead of narrating preview limitations.
 - Phase 3 creates one bounded LLM schema plan after source staging, stores it as an immutable hashed blob, and binds planned output checkpoints to that plan and source ETag.
 - Phase 4 adds an active-plan compact row response protocol for structured exports. The model emits one short batch-local row key plus positional LLM values, while the server reattaches source metadata and checkpoints the same object-shaped rows as before.
+- Phase 5 adds opt-in completion-driven checkpointing for structured exports. Validated model results are submitted to a bounded checkpoint writer as soon as each task completes while the executor still preserves fixed window boundaries.
 
 ### API Endpoints
 
@@ -92,6 +93,7 @@ The progress card displays current status, completed checkpoint counts, processe
 - Scale and performance regression: `functional_tests/test_tabular_row_orchestration_scale.py`
 - Phase 3 immutable plan, recovery, shadow comparison, active schema, and checkpoint-integrity regression: `functional_tests/test_tabular_row_orchestration_scale.py`
 - Phase 4 compact protocol selection, prompt, validation, row-key, plan-hash, and normalized-output equivalence regression: `functional_tests/test_tabular_row_orchestration_scale.py`
+- Phase 5 completion-driven checkpoint timing and output-prefix resume scan regression: `functional_tests/test_tabular_row_orchestration_scale.py`
 - Phase 2 handoff regression: `functional_tests/test_tabular_row_orchestration_scale.py`
 - Phase 1 baseline and fake harness coverage: `functional_tests/test_tabular_row_orchestration_scale.py`
 - Functional regression for workflow/document-action presentation: `functional_tests/test_document_analysis_lossless_artifacts.py`
@@ -109,6 +111,7 @@ The progress card displays current status, completed checkpoint counts, processe
 - Phase 1 telemetry separates safe model-call, validation, and checkpoint timing metrics where the current executor can observe them. Validation mismatch logs record counts and timings only, not generated response previews.
 - Phase 3 planning reads at most five staged rows from at most two input checkpoints and sends only column metadata plus redacted value shapes, so planner input remains bounded independently of source row count.
 - Phase 4 compact responses reduce repeated generated field names and avoid model-emitted long source tokens for active planned structured exports. Compact responses are normalized before checkpointing, so final CSV, JSON, and XML serialization remains unchanged.
+- Phase 5 completion-driven checkpointing offloads synchronous Blob/Cosmos checkpoint work from the event loop through a bounded writer backlog. A fast validated batch can commit its output blob before a slower batch in the same fixed window finishes.
 - Background processing writes each completed batch before moving on, allowing the run to resume after worker restarts.
 - The run status API returns compact metadata only, not source rows or generated batch content.
 - User-facing status details are derived from run metadata instead of displaying raw backend errors in the progress card.
@@ -122,6 +125,7 @@ The progress card displays current status, completed checkpoint counts, processe
 - Manual continuation applies to retryable failures, stale running leases, queued retries whose retry time has passed, and stale queued runs; hard validation failures remain terminal.
 - Shadow mode does not remove the first-batch schema barrier. Administrators should move new runs to `active` only after representative shadow comparisons preserve every requested field.
 - Compact row responses apply only to new active planned structured exports. Existing runs, shadow runs, fallback runs, passthrough rows, analysis-only runs, and combined analysis/export runs remain on `object-v1`.
+- Completion-driven checkpointing in Phase 5 preserves fixed window boundaries. Rolling scheduling and independent non-blocking batch retry remain later rollout phases.
 
 ## Related Version Updates
 
@@ -134,3 +138,4 @@ The progress card displays current status, completed checkpoint counts, processe
 - `application/single_app/config.py` was updated to version **0.250.138** for Phase 2 truthful foreground handoff wording and metadata.
 - `application/single_app/config.py` was updated to version **0.250.139** for Phase 3 immutable LLM schema planning, shadow comparison, active scheduling, and checkpoint integrity.
 - `application/single_app/config.py` was updated to version **0.250.140** for Phase 4 compact row response protocol validation and normalized checkpoint compatibility.
+- `application/single_app/config.py` was updated to version **0.250.141** for Phase 5 completion-driven checkpointing and output-prefix resume scanning.

--- a/docs/explanation/features/TABULAR_LLM_GENERATION_ACCELERATION_PHASE_5_CHECKPOINTING.md
+++ b/docs/explanation/features/TABULAR_LLM_GENERATION_ACCELERATION_PHASE_5_CHECKPOINTING.md
@@ -1,0 +1,76 @@
+# Tabular LLM Generation Acceleration Phase 5 Checkpointing
+
+Implemented in version: **0.250.141**
+
+Associated issue: **microsoft/simplechat#1031**
+
+## Overview
+
+Phase 5 adds opt-in completion-driven checkpointing for structured tabular generated exports. Within each existing fixed execution window, model calls are consumed with `asyncio.as_completed()`, and every validated result is submitted to checkpoint storage as soon as that model call finishes.
+
+## Purpose
+
+The change narrows crash-loss exposure. A fast batch no longer waits for the slowest model call in the same window before its output blob can become durable. Fixed window boundaries are intentionally retained so checkpoint durability can be validated independently before rolling scheduling is introduced.
+
+## Dependencies
+
+- Backend rollout setting `enable_tabular_completion_driven_checkpointing`
+- Backend writer limit `tabular_generation_checkpoint_writer_concurrency`
+- Existing structured-export checkpoint helper and metadata validation
+- Existing fixed-window structured-export executor
+- Existing final CSV, JSON, and XML publication paths
+
+## Technical Specifications
+
+### Completion Stream
+
+When completion-driven checkpointing is enabled, the structured-export window creates the same batch tasks as before, but consumes them through `asyncio.as_completed()`. Successful validated model results are passed immediately to the checkpoint writer path. Model failures are recorded as the first window error while other already-active tasks continue to settle and checkpoint any successful results.
+
+### Bounded Checkpoint Writer
+
+Checkpoint storage remains synchronous, so the Phase 5 path uses `asyncio.to_thread()` behind an `asyncio.Semaphore`. The writer concurrency is resolved from `tabular_generation_checkpoint_writer_concurrency` and clamped to a bounded range. Pending checkpoint tasks are capped at twice the writer concurrency; when that high-water mark is reached, the executor waits for at least one checkpoint to finish before accepting more completed results for publication.
+
+### Durable Completion Semantics
+
+The existing `_checkpoint_generated_batch_results(...)` helper remains the authoritative commit path. It verifies lease ownership before writing, uploads the output blob with overwrite disabled for normal runs, validates a concurrent existing output when necessary, then writes the derived summary blob. A batch only appears in returned window results after its output checkpoint succeeds or a compatible existing checkpoint is validated.
+
+### Resume Scan
+
+Structured runs now build a durable completed set by listing the run output prefix once before the fixed-window loop. The existing batch-window loader uses that set to find candidate output checkpoints, then lazily validates checkpoint metadata and payload shape before treating the batch as complete. Missing summaries are repaired from valid output payloads without another model call.
+
+### Progress and Ordering
+
+Output blobs may commit out of order. Public status already exposes bounded aggregate contract fields such as `completed_batch_count`, `highest_contiguous_batch`, and `checkpointed_row_count`; final publication still depends on contiguous `completed_batches` reaching the planned batch count. Ordered artifact assembly remains unchanged and continues to read output rows by batch number.
+
+## Usage Instructions
+
+No end-user workflow changes are required. Administrators can enable `enable_tabular_completion_driven_checkpointing` after representative validation confirms checkpoint latency and storage throughput are acceptable. The feature applies to new structured-export work in the fixed-window executor and can be disabled for new runs without changing the normalized output blob shape.
+
+## Testing and Validation
+
+Coverage is in `functional_tests/test_tabular_row_orchestration_scale.py`:
+
+- A fast model completion checkpoints before a slower batch in the same fixed window finishes.
+- The checkpoint writer path honors the configured bounded writer concurrency.
+- Resume builds the completed checkpoint set from one output-prefix listing and ignores malformed, foreign, and out-of-range blobs.
+
+Validation commands:
+
+```bash
+python -m py_compile application/single_app/functions_tabular_generated_exports.py functional_tests/test_tabular_row_orchestration_scale.py
+python -m pytest functional_tests/test_tabular_row_orchestration_scale.py::test_phase_five_completion_driven_checkpointing_commits_fast_batch_before_straggler functional_tests/test_tabular_row_orchestration_scale.py::test_phase_five_resume_scan_lists_output_prefix_once -q
+```
+
+## Performance Considerations
+
+Checkpoint I/O is bounded separately from model concurrency, so active model calls do not block directly on Blob or Cosmos operations running on the event loop. The writer backlog remains bounded by the configured writer concurrency. Fixed-window model dispatch is preserved, so this phase should not materially reduce existing throughput while proving durability semantics.
+
+## Known Limitations
+
+- Rolling worker scheduling remains deferred to Phase 6; no work launches beyond the current fixed window.
+- Independent non-blocking batch retry remains deferred to Phase 7.
+- The Phase 5 completion stream is implemented for structured export batches. Combined analysis/export keeps the existing window-level checkpoint barrier until its nested analysis checkpoint contract is separated.
+
+## Related Version Updates
+
+- `application/single_app/config.py` was updated from **0.250.140** to **0.250.141** for Phase 5 completion-driven checkpointing and output-prefix resume scanning.

--- a/functional_tests/test_tabular_row_orchestration_scale.py
+++ b/functional_tests/test_tabular_row_orchestration_scale.py
@@ -1,8 +1,8 @@
 # test_tabular_row_orchestration_scale.py
 """
 Functional test for scalable per-row tabular orchestration.
-Version: 0.250.140
-Implemented in: 0.250.060; generated CSV formula safety in 0.250.065; generated file export routing in 0.250.072; source descriptor generalization in 0.250.127; unified durable run contract in 0.250.128; hierarchical analysis in 0.250.129; combined analysis and export in 0.250.130; scale validation in 0.250.132; direct source-backed exhaustive queueing in 0.250.133; direct queue call-site hardening in 0.250.134; model-validation auto retry in 0.250.135; model-aware parallel throughput in 0.250.136; Phase 1 acceleration contracts and observability in 0.250.137; Phase 2 truthful background handoff in 0.250.138; Phase 3 durable LLM generation planning in 0.250.139; Phase 4 compact row response protocol in 0.250.140
+Version: 0.250.141
+Implemented in: 0.250.060; generated CSV formula safety in 0.250.065; generated file export routing in 0.250.072; source descriptor generalization in 0.250.127; unified durable run contract in 0.250.128; hierarchical analysis in 0.250.129; combined analysis and export in 0.250.130; scale validation in 0.250.132; direct source-backed exhaustive queueing in 0.250.133; direct queue call-site hardening in 0.250.134; model-validation auto retry in 0.250.135; model-aware parallel throughput in 0.250.136; Phase 1 acceleration contracts and observability in 0.250.137; Phase 2 truthful background handoff in 0.250.138; Phase 3 durable LLM generation planning in 0.250.139; Phase 4 compact row response protocol in 0.250.140; Phase 5 completion-driven checkpointing in 0.250.141
 
 This test ensures generated exports preserve source identity and row order while
 enforcing one stable output schema across independently generated batches.
@@ -272,6 +272,21 @@ COMPACT_PROTOCOL_FUNCTIONS = {
     '_build_batch_prompt',
     '_build_compact_batch_prompt',
     '_normalize_generated_batch_entries',
+}
+COMPLETION_CHECKPOINT_FUNCTIONS = {
+    '_safe_int',
+    '_safe_float',
+    '_settings_bool',
+    '_settings_int',
+    '_settings_float',
+    '_settings_mode',
+    '_normalize_tabular_generation_rollout_settings',
+    '_output_blob_prefix',
+    '_scan_output_checkpoint_batches_for_run',
+    '_is_completion_driven_checkpointing_enabled',
+    '_get_checkpoint_writer_concurrency',
+    '_checkpoint_generated_result_async',
+    '_generate_and_checkpoint_batch_window_entries',
 }
 
 
@@ -1311,6 +1326,37 @@ def _load_compact_protocol_helpers():
     return namespace
 
 
+def _load_completion_checkpoint_helpers():
+    module_tree = ast.parse(EXPORT_MODULE.read_text(encoding='utf-8'), filename=str(EXPORT_MODULE))
+    selected_nodes = []
+    found_functions = set()
+    for node in module_tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name in COMPLETION_CHECKPOINT_FUNCTIONS:
+            selected_nodes.append(node)
+            found_functions.add(node.name)
+        elif isinstance(node, ast.Assign):
+            assigned_names = {
+                target.id
+                for target in node.targets
+                if isinstance(target, ast.Name)
+            }
+            if any(name.startswith('TABULAR_') for name in assigned_names):
+                selected_nodes.append(node)
+
+    missing_functions = COMPLETION_CHECKPOINT_FUNCTIONS - found_functions
+    if missing_functions:
+        raise AssertionError(f'Missing completion checkpoint helpers: {sorted(missing_functions)}')
+
+    namespace = {
+        'asyncio': asyncio,
+        're': re,
+        'storage_account_personal_chat_container_name': 'personal-chat',
+    }
+    extracted_module = ast.Module(body=selected_nodes, type_ignores=[])
+    exec(compile(extracted_module, str(EXPORT_MODULE), 'exec'), namespace)
+    return namespace
+
+
 def _build_phase_three_test_run(plan_mode='shadow', plan_status='pending'):
     return {
         'id': 'run-phase-3',
@@ -2310,6 +2356,142 @@ def test_phase_four_compact_response_rejects_key_and_value_failures():
             assert expected_message in str(exc).lower()
         else:
             raise AssertionError(f'Compact validation accepted invalid payload: {payload}')
+
+
+def test_phase_five_completion_driven_checkpointing_commits_fast_batch_before_straggler():
+    """A completed model response is checkpointed before a slower batch in the same fixed window settles."""
+    helpers = _load_completion_checkpoint_helpers()
+    events = []
+    straggler_finished_at = {'value': None}
+
+    async def generate_batch_entries_for_window(
+        semaphore,
+        chat_service,
+        user_question,
+        batch_request,
+        total_batches,
+        source_file_name,
+        selected_sheet,
+        retry_attempts,
+        run_id,
+        expected_output_schema,
+        batch_timeout_seconds,
+        response_protocol,
+        generation_plan,
+    ):
+        del chat_service, user_question, total_batches, source_file_name, selected_sheet
+        del retry_attempts, run_id, expected_output_schema, batch_timeout_seconds
+        del response_protocol, generation_plan
+        batch_number = batch_request['batch_number']
+        async with semaphore:
+            if batch_number == 2:
+                await asyncio.sleep(0.2)
+                straggler_finished_at['value'] = time.monotonic()
+            else:
+                await asyncio.sleep(0.01)
+            return {
+                'batch_number': batch_number,
+                'batch_entries': [{'source_row_number': batch_number, 'answer': f'a{batch_number}'}],
+                'batch_summary': {'row_count': 1},
+                'batch_row_count': 1,
+                'elapsed_seconds': 0.01 if batch_number == 1 else 0.2,
+                'mismatch_count': 0,
+                'output_schema': ['source_row_number', 'answer'],
+            }
+
+    def checkpoint_generated_batch_results(run, generated_results):
+        del run
+        generated_result = generated_results[0]
+        batch_number = generated_result['batch_number']
+        events.append({
+            'batch_number': batch_number,
+            'checkpointed_at': time.monotonic(),
+        })
+        return {
+            batch_number: {
+                'batch_number': batch_number,
+                'batch_row_count': generated_result['batch_row_count'],
+                'elapsed_seconds': generated_result['elapsed_seconds'],
+                'mismatch_count': 0,
+                'from_checkpoint': False,
+            }
+        }
+
+    helpers['_generate_batch_entries_for_window'] = generate_batch_entries_for_window
+    helpers['_checkpoint_generated_batch_results'] = checkpoint_generated_batch_results
+
+    settings = {
+        'enable_tabular_completion_driven_checkpointing': True,
+        'tabular_generation_checkpoint_writer_concurrency': '1',
+    }
+    assert helpers['_is_completion_driven_checkpointing_enabled'](settings) is True
+    assert helpers['_get_checkpoint_writer_concurrency'](settings) == 1
+
+    batch_results, generation_error = asyncio.run(
+        helpers['_generate_and_checkpoint_batch_window_entries'](
+            {'id': 'run-phase-5', 'output_schema': ['source_row_number', 'answer']},
+            None,
+            'answer every row',
+            [
+                {'batch_number': 1, 'rows': [{'row': 1}]},
+                {'batch_number': 2, 'rows': [{'row': 2}]},
+            ],
+            2,
+            'source.csv',
+            None,
+            1,
+            'run-phase-5',
+            2,
+            1,
+            expected_output_schema=['source_row_number', 'answer'],
+        )
+    )
+
+    assert generation_error is None
+    assert set(batch_results) == {1, 2}
+    fast_checkpoint = next(event for event in events if event['batch_number'] == 1)
+    assert straggler_finished_at['value'] is not None
+    assert fast_checkpoint['checkpointed_at'] < straggler_finished_at['value']
+
+
+def test_phase_five_resume_scan_lists_output_prefix_once():
+    """Resume builds the durable completed set from one output-prefix listing."""
+    helpers = _load_completion_checkpoint_helpers()
+    list_calls = []
+    run = {
+        'id': 'run-phase-5',
+        'user_id': 'user-1',
+        'conversation_id': 'conversation-1',
+        'batch_count': 3,
+    }
+    prefix = helpers['_output_blob_prefix']('user-1', 'conversation-1', 'run-phase-5')
+
+    class BlobProperties:
+        def __init__(self, name):
+            self.name = name
+
+    class ContainerClient:
+        def list_blobs(self, name_starts_with=None):
+            list_calls.append(name_starts_with)
+            return [
+                BlobProperties(f'{prefix}batch_000001.json'),
+                BlobProperties(f'{prefix}batch_000003.json'),
+                BlobProperties(f'{prefix}batch_000004.json'),
+                BlobProperties(f'{prefix}batch_bad.json'),
+                BlobProperties('other/run/output/batch_000002.json'),
+            ]
+
+    class BlobServiceClient:
+        def get_container_client(self, container_name):
+            assert container_name == 'personal-chat'
+            return ContainerClient()
+
+    helpers['_get_blob_service_client'] = lambda: BlobServiceClient()
+
+    completed_batches = helpers['_scan_output_checkpoint_batches_for_run'](run)
+
+    assert completed_batches == {1, 3}
+    assert list_calls == [prefix]
 
 
 def test_source_identity_and_order_contract():


### PR DESCRIPTION
## Summary

- Add opt-in Phase 5 completion-driven checkpointing for structured tabular generated exports behind `enable_tabular_completion_driven_checkpointing`.
- Consume fixed-window model tasks with `asyncio.as_completed()` and checkpoint each successful validated result through a bounded `asyncio.to_thread()` writer backlog.
- Add one output-prefix resume scan for structured runs, preserving lazy metadata/payload validation and summary repair through the existing checkpoint path.
- Bump the app version to `0.250.141` and document Phase 5 checkpointing.

## Validation

- `python -m py_compile application/single_app/functions_tabular_generated_exports.py functional_tests/test_tabular_row_orchestration_scale.py application/single_app/config.py`
- `python -m pytest functional_tests/test_tabular_row_orchestration_scale.py::test_phase_five_completion_driven_checkpointing_commits_fast_batch_before_straggler functional_tests/test_tabular_row_orchestration_scale.py::test_phase_five_resume_scan_lists_output_prefix_once -q`
- `python -m pytest functional_tests/test_tabular_row_orchestration_scale.py -q`
- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check`

Refs #1031