### PR TITLE
Tabular LLM generation acceleration phase 8

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -96,7 +96,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.250.143"
+VERSION = "0.250.144"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/functions_settings.py
+++ b/application/single_app/functions_settings.py
@@ -87,6 +87,7 @@ ADMIN_SETTINGS_NESTED_SECRET_FIELDS = (
     "web_search_agent.other_settings.azure_ai_foundry.client_secret",
 )
 TABULAR_GENERATION_BACKEND_SETTING_KEYS = {
+    'tabular_generation_rollout_percentage',
     'tabular_background_handoff_mode',
     'enable_tabular_generation_plan',
     'tabular_generation_plan_mode',
@@ -96,6 +97,7 @@ TABULAR_GENERATION_BACKEND_SETTING_KEYS = {
     'enable_tabular_independent_batch_retries',
     'tabular_generation_checkpoint_writer_concurrency',
     'tabular_generation_heartbeat_seconds',
+    'tabular_generation_stale_seconds',
     'tabular_generation_systemic_failure_threshold',
 }
 PUBLIC_WORKSPACE_DISPLAY_NAME_DEFAULT = "Public Workspace"
@@ -1016,6 +1018,7 @@ def get_settings(use_cosmos=False, include_source=False):
         'tabular_generated_output_chunk_model_mode': 'current',
         'tabular_generated_output_chunk_model_deployment': '',
         'tabular_generated_output_model_validation_auto_retries': 3,
+        'tabular_generation_rollout_percentage': 100,
         'tabular_background_handoff_mode': 'legacy',
         'enable_tabular_generation_plan': True,
         'tabular_generation_plan_mode': 'shadow',
@@ -1025,6 +1028,7 @@ def get_settings(use_cosmos=False, include_source=False):
         'enable_tabular_independent_batch_retries': False,
         'tabular_generation_checkpoint_writer_concurrency': 1,
         'tabular_generation_heartbeat_seconds': 30,
+        'tabular_generation_stale_seconds': 120,
         'tabular_generation_systemic_failure_threshold': 0.5,
         'enable_multi_agent_orchestration': False,
         'enable_mixed_source_development_telemetry': False,

--- a/application/single_app/functions_tabular_generated_exports.py
+++ b/application/single_app/functions_tabular_generated_exports.py
@@ -85,6 +85,13 @@ TABULAR_GENERATION_PLAN_VALUE_TYPES = {
 }
 TABULAR_ROLLOUT_PLANNER_MODES = {'off', 'shadow', 'active'}
 TABULAR_ROLLOUT_HANDOFF_MODES = {'legacy', 'server', 'constrained_model'}
+TABULAR_GENERATION_ROLLOUT_DEFAULT_PERCENTAGE = 100
+TABULAR_GENERATION_ROLLOUT_BUCKET_COUNT = 100
+TABULAR_GENERATION_ROLLOUT_HASH_VERSION = 1
+TABULAR_GENERATION_ROLLOUT_COHORT_CANARY = 'canary'
+TABULAR_GENERATION_ROLLOUT_COHORT_CONTROL = 'control'
+TABULAR_RETRY_MODE_RUN_LEVEL = 'run-level-v1'
+TABULAR_RETRY_MODE_INDEPENDENT_BATCH = 'independent-batch-v1'
 TABULAR_RUN_TASK_STRUCTURED_EXPORT = 'structured_export'
 TABULAR_RUN_TASK_HIERARCHICAL_ANALYSIS = 'hierarchical_analysis'
 TABULAR_RUN_TASK_COMBINED = 'combined'
@@ -182,6 +189,7 @@ TABULAR_EXPORT_SUMMARY_MAX_VALUES_PER_FIELD = 5
 TABULAR_EXPORT_SUMMARY_AGGREGATE_MAX_VALUES = 25
 TABULAR_EXPORT_PROGRESS_LOG_INTERVAL_SECONDS = 30
 TABULAR_GENERATION_DEFAULT_HEARTBEAT_SECONDS = 30
+TABULAR_GENERATION_DEFAULT_STALE_SECONDS = 120
 TABULAR_GENERATION_DEFAULT_CHECKPOINT_WRITER_CONCURRENCY = 1
 TABULAR_GENERATION_CHECKPOINT_HIGH_WATER_MULTIPLIER = 2
 TABULAR_GENERATION_DEFAULT_SYSTEMIC_FAILURE_THRESHOLD = 0.5
@@ -857,6 +865,13 @@ def _parse_compact_row_array_entries(response_content, source_rows, generation_p
 def _normalize_tabular_generation_rollout_settings(settings):
     settings = settings or {}
     return {
+        'tabular_generation_rollout_percentage': _settings_int(
+            settings,
+            'tabular_generation_rollout_percentage',
+            TABULAR_GENERATION_ROLLOUT_DEFAULT_PERCENTAGE,
+            minimum=0,
+            maximum=100,
+        ),
         'tabular_background_handoff_mode': _settings_mode(
             settings,
             'tabular_background_handoff_mode',
@@ -908,6 +923,13 @@ def _normalize_tabular_generation_rollout_settings(settings):
             minimum=5,
             maximum=300,
         ),
+        'tabular_generation_stale_seconds': _settings_int(
+            settings,
+            'tabular_generation_stale_seconds',
+            TABULAR_GENERATION_DEFAULT_STALE_SECONDS,
+            minimum=60,
+            maximum=900,
+        ),
         'tabular_generation_systemic_failure_threshold': _settings_float(
             settings,
             'tabular_generation_systemic_failure_threshold',
@@ -918,10 +940,63 @@ def _normalize_tabular_generation_rollout_settings(settings):
     }
 
 
+def _get_tabular_generation_rollout_bucket(user_id, conversation_id, run_id):
+    assignment_key = ':'.join((
+        f'v{TABULAR_GENERATION_ROLLOUT_HASH_VERSION}',
+        str(user_id or '').strip(),
+        str(conversation_id or '').strip(),
+        str(run_id or '').strip(),
+    ))
+    assignment_digest = hashlib.sha256(assignment_key.encode('utf-8')).digest()
+    return int.from_bytes(assignment_digest[:8], byteorder='big') % TABULAR_GENERATION_ROLLOUT_BUCKET_COUNT + 1
+
+
+def _build_tabular_generation_rollout_assignment(settings, user_id, conversation_id, run_id):
+    rollout_settings = _normalize_tabular_generation_rollout_settings(settings)
+    rollout_percentage = rollout_settings['tabular_generation_rollout_percentage']
+    rollout_bucket = _get_tabular_generation_rollout_bucket(user_id, conversation_id, run_id)
+    rollout_cohort = (
+        TABULAR_GENERATION_ROLLOUT_COHORT_CANARY
+        if rollout_bucket <= rollout_percentage
+        else TABULAR_GENERATION_ROLLOUT_COHORT_CONTROL
+    )
+    if rollout_cohort == TABULAR_GENERATION_ROLLOUT_COHORT_CONTROL:
+        rollout_settings.update({
+            'tabular_background_handoff_mode': 'legacy',
+            'tabular_generation_plan_mode': 'off',
+            'enable_tabular_generation_plan': False,
+            'enable_tabular_compact_response_protocol': False,
+            'enable_tabular_completion_driven_checkpointing': False,
+            'enable_tabular_rolling_worker_pool': False,
+            'enable_tabular_independent_batch_retries': False,
+        })
+    rollout_settings.update({
+        'tabular_generation_rollout_bucket': rollout_bucket,
+        'tabular_generation_rollout_cohort': rollout_cohort,
+        'tabular_generation_rollout_hash_version': TABULAR_GENERATION_ROLLOUT_HASH_VERSION,
+    })
+    return rollout_settings
+
+
 def _get_tabular_generation_rollout_settings_for_run(run=None, settings=None):
     rollout_settings = (run or {}).get('generation_rollout_settings') if isinstance(run, dict) else None
     if isinstance(rollout_settings, dict) and rollout_settings:
-        return _normalize_tabular_generation_rollout_settings(rollout_settings)
+        normalized_rollout_settings = _normalize_tabular_generation_rollout_settings(rollout_settings)
+        if 'tabular_generation_stale_seconds' not in rollout_settings:
+            normalized_rollout_settings['tabular_generation_stale_seconds'] = TABULAR_EXPORT_DEFAULT_STALE_SECONDS
+        return normalized_rollout_settings
+    if isinstance(run, dict):
+        return _normalize_tabular_generation_rollout_settings({
+            'tabular_generation_rollout_percentage': 0,
+            'tabular_background_handoff_mode': 'legacy',
+            'tabular_generation_plan_mode': 'off',
+            'enable_tabular_generation_plan': False,
+            'enable_tabular_compact_response_protocol': False,
+            'enable_tabular_completion_driven_checkpointing': False,
+            'enable_tabular_rolling_worker_pool': False,
+            'enable_tabular_independent_batch_retries': False,
+            'tabular_generation_stale_seconds': TABULAR_EXPORT_DEFAULT_STALE_SECONDS,
+        })
     return _normalize_tabular_generation_rollout_settings(settings or {})
 
 
@@ -944,6 +1019,15 @@ def _select_tabular_executor_mode(
     return TABULAR_EXECUTOR_MODE_FIXED_WINDOW
 
 
+def _select_tabular_retry_mode(rollout_settings, executor_mode):
+    if (
+        str(executor_mode or '').strip() == TABULAR_EXECUTOR_MODE_ROLLING_POOL
+        and _settings_bool(rollout_settings, 'enable_tabular_independent_batch_retries', False)
+    ):
+        return TABULAR_RETRY_MODE_INDEPENDENT_BATCH
+    return TABULAR_RETRY_MODE_RUN_LEVEL
+
+
 def _is_rolling_executor_ready(run):
     if str((run or {}).get('executor_mode') or '').strip() != TABULAR_EXECUTOR_MODE_ROLLING_POOL:
         return False
@@ -964,6 +1048,7 @@ def _downgrade_rolling_executor_to_fixed_window(run, reason):
     now = _now_iso()
     run.update({
         'executor_mode': TABULAR_EXECUTOR_MODE_FIXED_WINDOW,
+        'retry_mode': TABULAR_RETRY_MODE_RUN_LEVEL,
         'updated_at': now,
         'last_heartbeat_at': now,
         'last_message': f'Rolling worker pool unavailable; continuing with fixed windows ({reason})',
@@ -997,6 +1082,7 @@ def _sync_tabular_generation_contract_fields(run):
     run.setdefault('generation_contract_version', TABULAR_GENERATION_CONTRACT_VERSION)
     run.setdefault('response_protocol_version', TABULAR_RESPONSE_PROTOCOL_OBJECT_V1)
     run.setdefault('executor_mode', TABULAR_EXECUTOR_MODE_FIXED_WINDOW)
+    run.setdefault('retry_mode', TABULAR_RETRY_MODE_RUN_LEVEL)
     run.setdefault('plan_blob_path', None)
     run.setdefault('plan_hash', None)
     run['planned_batch_count'] = planned_batch_count
@@ -2135,6 +2221,16 @@ def _get_versioned_source_blob_client(source_descriptor):
     if current_etag != expected_etag:
         raise ValueError('Source CSV changed after the export was queued')
     return blob_client
+
+
+def _revalidate_tabular_source_version_for_publication(run):
+    source_descriptor = (
+        (run or {}).get('source_descriptor')
+        or (run or {}).get('source_authorization')
+    )
+    if not isinstance(source_descriptor, dict) or not source_descriptor.get('blob_etag'):
+        return None
+    return _get_versioned_source_blob_client(source_descriptor)
 
 
 def _clean_generated_json_code_fence(response_content):
@@ -5326,6 +5422,9 @@ def _build_run_public_status(run, settings=None):
         'completed_batches': completed_batches,
         'generation_contract_version': _safe_int(run.get('generation_contract_version')),
         'response_protocol_version': run.get('response_protocol_version'),
+        'executor_mode': run.get('executor_mode'),
+        'retry_mode': run.get('retry_mode'),
+        'plan_mode': run.get('plan_mode'),
         'planned_batch_count': _safe_int(run.get('planned_batch_count')),
         'completed_batch_count': _safe_int(run.get('completed_batch_count')),
         'highest_contiguous_batch': _safe_int(run.get('highest_contiguous_batch')),
@@ -5355,7 +5454,6 @@ def _build_run_public_status(run, settings=None):
         'completed_at': run.get('completed_at'),
         'last_heartbeat_at': run.get('last_heartbeat_at'),
         'last_message': run.get('last_message'),
-        'last_error': run.get('last_error'),
         'status_label': status_detail.get('status_label'),
         'status_tone': status_detail.get('status_tone'),
         'status_detail': status_detail.get('status_detail'),
@@ -5717,11 +5815,12 @@ def _lease_holder_id():
 
 
 def _is_stale_running_run(run, settings):
-    stale_seconds = _settings_int(
-        settings,
-        'tabular_generated_output_stale_seconds',
-        TABULAR_EXPORT_DEFAULT_STALE_SECONDS,
+    rollout_settings = _get_tabular_generation_rollout_settings_for_run(run, settings)
+    stale_seconds = _safe_int(
+        rollout_settings.get('tabular_generation_stale_seconds'),
+        default=TABULAR_EXPORT_DEFAULT_STALE_SECONDS,
         minimum=60,
+        maximum=900,
     )
     last_heartbeat = str(run.get('last_heartbeat_at') or run.get('updated_at') or '').strip()
     if not last_heartbeat:
@@ -5796,6 +5895,7 @@ def _mark_run_failed(run, error_message):
         'last_error': str(error_message or 'Unknown error')[:1000],
         'last_message': 'Background structured export failed',
     })
+    run['performance_summary'] = _build_tabular_generation_performance_summary(run, completed_at=now)
     try:
         run = _replace_claimed_run(run)
     except TabularExportLeaseLostError:
@@ -5811,6 +5911,7 @@ def _mark_run_failed(run, error_message):
             'processed_rows': run.get('processed_rows'),
             'row_count': run.get('row_count'),
             'error': str(error_message or '')[:1000],
+            **run.get('performance_summary', {}),
         },
         level=logging.ERROR,
         exceptionTraceback=True,
@@ -5950,6 +6051,57 @@ def _calculate_window_throughput(
         'rows_per_minute': rows_per_minute,
         'estimated_total_seconds': estimated_total_seconds,
         'estimated_remaining_seconds': estimated_remaining_seconds,
+    }
+
+
+def _build_tabular_generation_performance_summary(run, completed_at=None):
+    completed_time = _parse_iso_datetime(completed_at or (run or {}).get('completed_at')) or _now_utc()
+
+    def elapsed_seconds(started_at):
+        started_time = _parse_iso_datetime(started_at)
+        if not started_time:
+            return None
+        return round(max((completed_time - started_time).total_seconds(), 0.0), 3)
+
+    planner_started_at = (run or {}).get('planner_started_at')
+    planner_completed_at = _parse_iso_datetime((run or {}).get('planner_completed_at'))
+    planner_started_time = _parse_iso_datetime(planner_started_at)
+    created_time = _parse_iso_datetime((run or {}).get('created_at'))
+    started_time = _parse_iso_datetime((run or {}).get('started_at'))
+    planning_latency_seconds = None
+    if planner_started_time and planner_completed_at:
+        planning_latency_seconds = round(
+            max((planner_completed_at - planner_started_time).total_seconds(), 0.0),
+            3,
+        )
+    queue_latency_seconds = None
+    if created_time and started_time:
+        queue_latency_seconds = round(
+            max((started_time - created_time).total_seconds(), 0.0),
+            3,
+        )
+
+    return {
+        'planning_latency_seconds': planning_latency_seconds,
+        'queue_latency_seconds': queue_latency_seconds,
+        'generation_elapsed_seconds': elapsed_seconds((run or {}).get('generation_started_at')),
+        'end_to_end_elapsed_seconds': elapsed_seconds((run or {}).get('created_at')),
+        'durable_rows_per_minute': (run or {}).get('rows_per_minute'),
+        'configured_concurrency': _safe_int((run or {}).get('batch_concurrency')),
+        'effective_concurrency': _safe_int((run or {}).get('effective_batch_concurrency')),
+        'retry_count': _safe_int((run or {}).get('retry_count')),
+        'transient_failure_count': _safe_int((run or {}).get('transient_failure_count')),
+        'row_count': _safe_int((run or {}).get('row_count')),
+        'completed_row_count': _safe_int((run or {}).get('processed_rows')),
+        'batch_count': _safe_int((run or {}).get('batch_count')),
+        'completed_batch_count': _safe_int((run or {}).get('completed_batch_count')),
+        'rollout_cohort': ((run or {}).get('generation_rollout_settings') or {}).get(
+            'tabular_generation_rollout_cohort'
+        ),
+        'plan_mode': (run or {}).get('plan_mode'),
+        'executor_mode': (run or {}).get('executor_mode'),
+        'response_protocol_version': (run or {}).get('response_protocol_version'),
+        'retry_mode': (run or {}).get('retry_mode'),
     }
 
 
@@ -6151,6 +6303,7 @@ def _publish_structured_export_artifact(run):
                 })
                 run = _replace_claimed_run(run)
             _authorize_tabular_export_run_execution(run)
+            _revalidate_tabular_source_version_for_publication(run)
             text_output_stream.flush()
             output_size = binary_output_stream.tell()
             binary_output_stream.seek(0)
@@ -6199,6 +6352,7 @@ def _complete_run(run):
         run.get('batch_count'),
         output_entry_count,
     ))
+    run['performance_summary'] = _build_tabular_generation_performance_summary(run, completed_at=now)
     run = _replace_claimed_run(run)
     log_event(
         '[TABULAR_GENERATED_OUTPUT] Background export completed',
@@ -6216,6 +6370,7 @@ def _complete_run(run):
             'response_protocol_version': run.get('response_protocol_version'),
             'artifact_message_id': uploaded_message.get('id'),
             'generated_file_name': uploaded_message.get('file_name') or generated_file_name,
+            **run.get('performance_summary', {}),
         },
         level=logging.INFO,
     )
@@ -6303,6 +6458,7 @@ def _publish_analysis_artifact(run, final_summary):
         })
         run = _replace_claimed_run(run)
     _authorize_tabular_export_run_execution(run)
+    _revalidate_tabular_source_version_for_publication(run)
 
     with tempfile.SpooledTemporaryFile(
         max_size=TABULAR_EXPORT_FINAL_SPOOL_MAX_MEMORY_BYTES,
@@ -6353,6 +6509,7 @@ def _complete_analysis_run(run, final_summary):
         run.get('batch_count'),
         run.get('processed_rows'),
     ))
+    run['performance_summary'] = _build_tabular_generation_performance_summary(run, completed_at=now)
     run = _replace_claimed_run(run)
     log_event(
         '[TABULAR_GENERATED_OUTPUT] Background tabular analysis completed',
@@ -6365,6 +6522,7 @@ def _complete_analysis_run(run, final_summary):
             'batch_count': run.get('batch_count'),
             'artifact_message_id': uploaded_message.get('id'),
             'generated_file_name': uploaded_message.get('file_name') or generated_file_name,
+            **run.get('performance_summary', {}),
         },
         level=logging.INFO,
     )
@@ -6456,6 +6614,7 @@ def _complete_combined_analysis_run(run, final_summary):
         run.get('batch_count'),
         run.get('processed_rows'),
     ))
+    run['performance_summary'] = _build_tabular_generation_performance_summary(run, completed_at=now)
     run = _replace_claimed_run(run)
     log_event(
         '[TABULAR_GENERATED_OUTPUT] Background combined tabular run completed',
@@ -6468,6 +6627,7 @@ def _complete_combined_analysis_run(run, final_summary):
             'batch_count': run.get('batch_count'),
             'structured_artifact_message_id': structured_artifact.get('artifact_message_id'),
             'analysis_artifact_message_id': analysis_artifact.get('artifact_message_id'),
+            **run.get('performance_summary', {}),
         },
         level=logging.INFO,
     )
@@ -7796,7 +7956,12 @@ def queue_tabular_generated_output_run(
         settings,
         model_context=model_context,
     )
-    rollout_settings = _normalize_tabular_generation_rollout_settings(settings)
+    rollout_settings = _build_tabular_generation_rollout_assignment(
+        settings,
+        normalized_user_id,
+        normalized_conversation_id,
+        run_id,
+    )
     requested_plan_mode = (
         rollout_settings.get('tabular_generation_plan_mode')
         if rollout_settings.get('enable_tabular_generation_plan')
@@ -7816,6 +7981,7 @@ def queue_tabular_generated_output_run(
         normalized_task_type,
         passthrough_input_rows=passthrough_input_rows,
     )
+    retry_mode = _select_tabular_retry_mode(rollout_settings, executor_mode)
 
     if source_descriptor:
         staged_row_count = _safe_int(source_descriptor.get('expected_row_count'))
@@ -7877,6 +8043,7 @@ def queue_tabular_generated_output_run(
         'generation_contract_version': TABULAR_GENERATION_CONTRACT_VERSION,
         'response_protocol_version': response_protocol_version,
         'executor_mode': executor_mode,
+        'retry_mode': retry_mode,
         'generation_rollout_settings': rollout_settings,
         'task_type': normalized_task_type,
         'analysis_objective': normalized_analysis_objective,
@@ -7992,6 +8159,11 @@ def queue_tabular_generated_output_run(
             'generation_contract_version': TABULAR_GENERATION_CONTRACT_VERSION,
             'response_protocol_version': response_protocol_version,
             'executor_mode': executor_mode,
+            'retry_mode': retry_mode,
+            'rollout_percentage': rollout_settings.get('tabular_generation_rollout_percentage'),
+            'rollout_bucket': rollout_settings.get('tabular_generation_rollout_bucket'),
+            'rollout_cohort': rollout_settings.get('tabular_generation_rollout_cohort'),
+            'rollout_hash_version': rollout_settings.get('tabular_generation_rollout_hash_version'),
             'planner_mode': rollout_settings.get('tabular_generation_plan_mode'),
             'compact_protocol_enabled': rollout_settings.get('enable_tabular_compact_response_protocol'),
             'completion_checkpointing_enabled': rollout_settings.get(

--- a/docs/explanation/features/TABULAR_BACKGROUND_GENERATED_EXPORTS.md
+++ b/docs/explanation/features/TABULAR_BACKGROUND_GENERATED_EXPORTS.md
@@ -2,7 +2,7 @@
 
 Implemented in version: **0.241.046**
 
-Updated through version: **0.250.141**
+Updated through version: **0.250.144**
 
 ## Overview
 
@@ -37,6 +37,9 @@ The feature supports large spreadsheet-driven analysis, including workbooks that
 - Phase 3 creates one bounded LLM schema plan after source staging, stores it as an immutable hashed blob, and binds planned output checkpoints to that plan and source ETag.
 - Phase 4 adds an active-plan compact row response protocol for structured exports. The model emits one short batch-local row key plus positional LLM values, while the server reattaches source metadata and checkpoints the same object-shaped rows as before.
 - Phase 5 adds opt-in completion-driven checkpointing for structured exports. Validated model results are submitted to a bounded checkpoint writer as soon as each task completes while the executor still preserves fixed window boundaries.
+- Phase 6 adds an opt-in rolling worker pool that replaces completed model slots without waiting for a fixed window barrier.
+- Phase 7 adds durable per-batch retry records and a delayed retry heap so one retrying batch does not pause healthy pending work.
+- Phase 8 assigns new runs to deterministic rollout cohorts, records explicit planner/executor/protocol/retry modes, reclaims new-run workers after a snapshotted two-minute stale interval, and revalidates source ETags before final publication.
 
 ### API Endpoints
 
@@ -55,6 +58,7 @@ The feature supports large spreadsheet-driven analysis, including workbooks that
 - `tabular_generated_output_input_token_soft_cap`
 - `tabular_generated_output_output_token_ratio`
 - `tabular_generated_output_output_expansion_ratio`
+- `tabular_generation_rollout_percentage`
 - `tabular_background_handoff_mode`
 - `enable_tabular_generation_plan`
 - `tabular_generation_plan_mode`
@@ -64,10 +68,12 @@ The feature supports large spreadsheet-driven analysis, including workbooks that
 - `enable_tabular_independent_batch_retries`
 - `tabular_generation_checkpoint_writer_concurrency`
 - `tabular_generation_heartbeat_seconds`
+- `tabular_generation_stale_seconds`
 - `tabular_generation_systemic_failure_threshold`
 
 If a fixed concurrency is not configured, runs use up to 4, 16, 64, or 128 concurrent model calls according to the actual staged batch count. Model-aware source batching uses selected-model metadata, local `model_capabilities.json` token-limit fields when present, and bounded fallback limits otherwise.
 Phase 3 enables generation planning in output-neutral `shadow` mode for new runs. Shadow mode preserves first-batch schema discovery and records agreement metrics only. `active` mode is available as an explicit administrator rollout choice and removes the first-batch schema barrier. Rollout settings are copied into new run records, and backend-only settings are filtered from sanitized non-admin frontend settings payloads.
+Phase 8 applies the configured acceleration settings only to new runs whose deterministic bucket is within `tabular_generation_rollout_percentage`. The percentage defaults to 100 to preserve existing behavior. A control run stores legacy effective modes, while a canary run stores the configured effective modes; later setting changes cannot switch either run during resume.
 
 ### File Structure
 
@@ -94,6 +100,9 @@ The progress card displays current status, completed checkpoint counts, processe
 - Phase 3 immutable plan, recovery, shadow comparison, active schema, and checkpoint-integrity regression: `functional_tests/test_tabular_row_orchestration_scale.py`
 - Phase 4 compact protocol selection, prompt, validation, row-key, plan-hash, and normalized-output equivalence regression: `functional_tests/test_tabular_row_orchestration_scale.py`
 - Phase 5 completion-driven checkpoint timing and output-prefix resume scan regression: `functional_tests/test_tabular_row_orchestration_scale.py`
+- Phase 6 rolling scheduling, heartbeat, backpressure, and straggler regression: `functional_tests/test_tabular_row_orchestration_scale.py`
+- Phase 7 independent retry, durable retry-ledger, and circuit-breaker regression: `functional_tests/test_tabular_row_orchestration_scale.py`
+- Phase 8 stable cohort, stale reclaim, source-version publication, crash recovery, and performance-summary regression: `functional_tests/test_tabular_row_orchestration_scale.py`
 - Phase 2 handoff regression: `functional_tests/test_tabular_row_orchestration_scale.py`
 - Phase 1 baseline and fake harness coverage: `functional_tests/test_tabular_row_orchestration_scale.py`
 - Functional regression for workflow/document-action presentation: `functional_tests/test_document_analysis_lossless_artifacts.py`
@@ -112,6 +121,9 @@ The progress card displays current status, completed checkpoint counts, processe
 - Phase 3 planning reads at most five staged rows from at most two input checkpoints and sends only column metadata plus redacted value shapes, so planner input remains bounded independently of source row count.
 - Phase 4 compact responses reduce repeated generated field names and avoid model-emitted long source tokens for active planned structured exports. Compact responses are normalized before checkpointing, so final CSV, JSON, and XML serialization remains unchanged.
 - Phase 5 completion-driven checkpointing offloads synchronous Blob/Cosmos checkpoint work from the event loop through a bounded writer backlog. A fast validated batch can commit its output blob before a slower batch in the same fixed window finishes.
+- Phase 6 rolling execution keeps eligible slots occupied as individual tasks complete, subject to checkpoint backpressure.
+- Phase 7 delayed per-batch retries leave unrelated pending batches eligible for dispatch.
+- Phase 8 stores a bounded terminal performance summary with queue, planning, generation, end-to-end, throughput, concurrency, retry, and rollout dimensions. Detailed latency percentiles remain available from the existing per-batch telemetry events.
 - Background processing writes each completed batch before moving on, allowing the run to resume after worker restarts.
 - The run status API returns compact metadata only, not source rows or generated batch content.
 - User-facing status details are derived from run metadata instead of displaying raw backend errors in the progress card.
@@ -125,7 +137,8 @@ The progress card displays current status, completed checkpoint counts, processe
 - Manual continuation applies to retryable failures, stale running leases, queued retries whose retry time has passed, and stale queued runs; hard validation failures remain terminal.
 - Shadow mode does not remove the first-batch schema barrier. Administrators should move new runs to `active` only after representative shadow comparisons preserve every requested field.
 - Compact row responses apply only to new active planned structured exports. Existing runs, shadow runs, fallback runs, passthrough rows, analysis-only runs, and combined analysis/export runs remain on `object-v1`.
-- Completion-driven checkpointing in Phase 5 preserves fixed window boundaries. Rolling scheduling and independent non-blocking batch retry remain later rollout phases.
+- Percentage rollback affects new runs only. Existing runs resume with their persisted cohort, effective settings, executor, response protocol, and retry mode.
+- The 30,000-row live LLM throughput target remains dependent on provisioned model throughput and must be measured in the target environment before 100% activation.
 
 ## Related Version Updates
 
@@ -139,3 +152,6 @@ The progress card displays current status, completed checkpoint counts, processe
 - `application/single_app/config.py` was updated to version **0.250.139** for Phase 3 immutable LLM schema planning, shadow comparison, active scheduling, and checkpoint integrity.
 - `application/single_app/config.py` was updated to version **0.250.140** for Phase 4 compact row response protocol validation and normalized checkpoint compatibility.
 - `application/single_app/config.py` was updated to version **0.250.141** for Phase 5 completion-driven checkpointing and output-prefix resume scanning.
+- `application/single_app/config.py` was updated to version **0.250.142** for Phase 6 rolling worker pool scheduling.
+- `application/single_app/config.py` was updated to version **0.250.143** for Phase 7 independent batch retries.
+- `application/single_app/config.py` was updated to version **0.250.144** for Phase 8 stable rollout cohorts, stale reclaim, source-version publication checks, chaos recovery coverage, and bounded performance summaries.

--- a/docs/explanation/features/TABULAR_LLM_GENERATION_ACCELERATION_PHASE_8_SCALE_CHAOS_AND_ROLLOUT.md
+++ b/docs/explanation/features/TABULAR_LLM_GENERATION_ACCELERATION_PHASE_8_SCALE_CHAOS_AND_ROLLOUT.md
@@ -1,0 +1,99 @@
+# Tabular LLM Generation Acceleration Phase 8: Scale, Chaos, and Rollout
+
+Implemented in version: **0.250.144**
+
+Related issue: **microsoft/simplechat#1031**
+
+## Overview
+
+Phase 8 adds the activation and validation layer for the completed tabular generation acceleration pipeline. New runs receive a deterministic canary or control assignment, keep that assignment across resume, expose explicit execution modes, reclaim stale workers promptly, revalidate source versions immediately before publication, and retain a bounded terminal performance summary.
+
+This phase also extends the deterministic scale harness across rollout, crash recovery, source authorization/version checks, and performance reporting. It does not claim that the live 30,000-row LLM throughput gate has passed; that result requires provisioned target-model capacity and an authenticated deployment observation window.
+
+## Dependencies
+
+- Phase 3 immutable generation plans and plan hashes.
+- Phase 4 compact row response protocol.
+- Phase 5 completion-driven checkpoints.
+- Phase 6 rolling worker pool.
+- Phase 7 independent per-batch retries.
+- Existing conversation ownership, group membership, public workspace visibility, source ETag, lease fencing, and cancellation checks.
+
+## Technical Specifications
+
+### Stable Rollout Assignment
+
+`tabular_generation_rollout_percentage` accepts values from 0 through 100 and defaults to 100 to preserve existing behavior. At queue time, the server hashes the rollout contract version, user ID, conversation ID, and generated run ID into a stable bucket from 1 through 100.
+
+- A bucket within the configured percentage receives the `canary` cohort and the configured effective acceleration settings.
+- A bucket outside the configured percentage receives the `control` cohort and legacy handoff, planner, protocol, checkpoint, executor, and retry behavior.
+- The percentage, bucket, cohort, hash version, and effective settings are persisted in `generation_rollout_settings`.
+- Resume reads the persisted snapshot instead of current administrator settings.
+
+Each run also records `plan_mode`, `executor_mode`, `response_protocol_version`, and `retry_mode`. Independent batch retry is recorded as `independent-batch-v1`; fixed-window or non-independent execution uses `run-level-v1`.
+
+### Recovery and Publication
+
+New runs snapshot `tabular_generation_stale_seconds`, which defaults to 120 seconds and is bounded from 60 through 900 seconds. Phase 7 and older snapshots that do not contain this setting retain the previous 900-second stale interval.
+
+Before a structured export or analysis artifact is uploaded, the worker repeats conversation and workspace authorization and verifies that a source-backed run still references the queued Blob ETag. A changed or deleted source stops publication.
+
+Committed output Blobs remain authoritative after an ambiguous failure. If a worker exits after the output commit but before summary or Cosmos progress updates, resume rebuilds the derived summary and schedules only missing batches without another LLM call for the committed batch.
+
+### Performance Summary
+
+Terminal run records contain a bounded `performance_summary` with:
+
+- Queue, planning, generation, and end-to-end elapsed seconds.
+- Durable rows per minute.
+- Configured and effective concurrency.
+- Retry and transient failure counts.
+- Expected and completed row and batch counts.
+- Rollout cohort, planner mode, executor mode, response protocol, and retry mode.
+
+The summary contains no prompts, source rows, file paths, provider errors, credentials, or lease holder IDs. Existing per-batch telemetry supplies model/checkpoint latency and token measurements for percentile analysis.
+
+## Rollout Instructions
+
+1. Configure the desired acceleration flags while keeping `tabular_generation_rollout_percentage` at 0 for control-only new runs.
+2. Advance new-run assignment through explicit observation windows such as 5, 25, 50, and 100 percent.
+3. Compare control and canary completion, retry, throughput, latency, and exact-coverage results by persisted cohort.
+4. Roll back by setting the percentage to 0 or disabling an affected capability. Existing runs continue with their saved modes; new runs receive control behavior.
+
+## Testing and Validation
+
+The deterministic functional suite covers:
+
+- Stable canary/control assignment and resume isolation from later setting changes.
+- Explicit retry modes and two-minute stale-worker detection for new runs.
+- Legacy stale-timeout compatibility.
+- Source ETag revalidation before structured and analysis publication.
+- Recovery when output commit succeeds but summary and Cosmos progress do not.
+- Bounded, content-free performance summaries.
+- Existing 300, 3,000, 30,000, and 100,000-row planning, finalization, source authorization, cancellation, checkpoint, and manifest contracts.
+
+Validated locally with:
+
+```bash
+python -m py_compile application/single_app/functions_tabular_generated_exports.py application/single_app/functions_settings.py application/single_app/config.py functional_tests/test_tabular_row_orchestration_scale.py
+python -m pytest functional_tests/test_tabular_row_orchestration_scale.py -k "phase_eight" -q
+python -m pytest functional_tests/test_tabular_row_orchestration_scale.py -q
+```
+
+## Security and Privacy
+
+- Rollout controls remain backend-only and are removed from sanitized non-admin settings payloads.
+- Conversation ownership, group membership, and public workspace visibility are revalidated before artifact publication.
+- Source-backed runs revalidate the exact queued ETag before upload.
+- Public run status exposes safe modes and aggregate progress only; it does not expose rollout hashes, prompts, row data, provider errors, credentials, or lease identities.
+
+## Known Limitations
+
+- One application worker still owns a run at a time; Phase 8 does not distribute one run across instances.
+- Live 30,000-row LLM throughput, connection-pool wait, provider queueing, and model slot utilization require deployment telemetry and are not established by the deterministic local suite.
+- The 1,500 durable rows-per-minute and approximately 20-minute stretch targets remain rollout gates, not correctness promises.
+- Percentage assignment is per run, so one user may create both control and canary runs during a partial rollout.
+
+## Related Version Update
+
+`application/single_app/config.py` was updated to version **0.250.144** for Phase 8 stable rollout cohorts, stale-worker reclaim, source-version publication checks, deterministic chaos recovery, and bounded performance reporting.

--- a/functional_tests/test_tabular_row_orchestration_scale.py
+++ b/functional_tests/test_tabular_row_orchestration_scale.py
@@ -1,8 +1,8 @@
 # test_tabular_row_orchestration_scale.py
 """
 Functional test for scalable per-row tabular orchestration.
-Version: 0.250.143
-Implemented in: 0.250.060; generated CSV formula safety in 0.250.065; generated file export routing in 0.250.072; source descriptor generalization in 0.250.127; unified durable run contract in 0.250.128; hierarchical analysis in 0.250.129; combined analysis and export in 0.250.130; scale validation in 0.250.132; direct source-backed exhaustive queueing in 0.250.133; direct queue call-site hardening in 0.250.134; model-validation auto retry in 0.250.135; model-aware parallel throughput in 0.250.136; Phase 1 acceleration contracts and observability in 0.250.137; Phase 2 truthful background handoff in 0.250.138; Phase 3 durable LLM generation planning in 0.250.139; Phase 4 compact row response protocol in 0.250.140; Phase 5 completion-driven checkpointing in 0.250.141; Phase 6 rolling worker pool in 0.250.142; Phase 7 independent batch retries in 0.250.143
+Version: 0.250.144
+Implemented in: 0.250.060; generated CSV formula safety in 0.250.065; generated file export routing in 0.250.072; source descriptor generalization in 0.250.127; unified durable run contract in 0.250.128; hierarchical analysis in 0.250.129; combined analysis and export in 0.250.130; scale validation in 0.250.132; direct source-backed exhaustive queueing in 0.250.133; direct queue call-site hardening in 0.250.134; model-validation auto retry in 0.250.135; model-aware parallel throughput in 0.250.136; Phase 1 acceleration contracts and observability in 0.250.137; Phase 2 truthful background handoff in 0.250.138; Phase 3 durable LLM generation planning in 0.250.139; Phase 4 compact row response protocol in 0.250.140; Phase 5 completion-driven checkpointing in 0.250.141; Phase 6 rolling worker pool in 0.250.142; Phase 7 independent batch retries in 0.250.143; Phase 8 scale, chaos, and rollout in 0.250.144
 
 This test ensures generated exports preserve source identity and row order while
 enforcing one stable output schema across independently generated batches.
@@ -74,6 +74,8 @@ STREAM_FUNCTIONS = {
     '_validate_tabular_output_checkpoint_metadata',
     '_write_ordered_output_stream',
 }
+SOURCE_VERSION_FUNCTIONS = {'_revalidate_tabular_source_version_for_publication'}
+CHECKPOINT_RESUME_FUNCTIONS = {'_build_batch_window'}
 SOURCE_READER_FUNCTIONS = {
     'detect_tabular_csv_numeric_columns',
     'iter_tabular_csv_query_rows',
@@ -95,6 +97,8 @@ FENCING_FUNCTIONS = {
 RETRY_FUNCTIONS = {
     '_safe_int',
     '_settings_int',
+    '_parse_iso_datetime',
+    '_build_tabular_generation_performance_summary',
     '_is_retryable_export_error_message',
     '_is_retryable_model_validation_error_message',
     '_is_retryable_failed_run',
@@ -181,6 +185,9 @@ PERFORMANCE_FUNCTIONS = {
     '_settings_float',
     '_settings_mode',
     '_normalize_tabular_generation_rollout_settings',
+    '_get_tabular_generation_rollout_bucket',
+    '_build_tabular_generation_rollout_assignment',
+    '_get_tabular_generation_rollout_settings_for_run',
     '_sync_tabular_generation_contract_fields',
     '_build_generation_progress_contract_fields',
     '_extract_tabular_response_usage',
@@ -196,6 +203,8 @@ PERFORMANCE_FUNCTIONS = {
     '_build_model_aware_source_batch_budget',
     '_is_schema_discovery_progress_window',
     '_calculate_window_throughput',
+    '_parse_iso_datetime',
+    '_build_tabular_generation_performance_summary',
     '_advance_run_progress_for_window',
 }
 GENERATION_PLAN_FUNCTIONS = {
@@ -290,6 +299,7 @@ COMPLETION_CHECKPOINT_FUNCTIONS = {
     '_normalize_tabular_generation_rollout_settings',
     '_get_tabular_generation_rollout_settings_for_run',
     '_select_tabular_executor_mode',
+    '_select_tabular_retry_mode',
     '_is_rolling_worker_pool_enabled',
     '_is_independent_batch_retries_enabled',
     '_get_tabular_generation_plan_mode',
@@ -312,6 +322,7 @@ COMPLETION_CHECKPOINT_FUNCTIONS = {
     '_is_completion_driven_checkpointing_enabled',
     '_get_checkpoint_writer_concurrency',
     '_get_tabular_generation_heartbeat_seconds',
+    '_is_stale_running_run',
     '_checkpoint_generated_result_async',
     '_generate_and_checkpoint_batch_window_entries',
     '_rolling_pool_heartbeat_loop',
@@ -686,6 +697,69 @@ def _load_source_reader_helpers():
     } | {'module': query_module}
 
 
+def _load_source_version_publication_helper(revalidated_descriptors):
+    module_tree = ast.parse(EXPORT_MODULE.read_text(encoding='utf-8'), filename=str(EXPORT_MODULE))
+    selected_nodes = [
+        node
+        for node in module_tree.body
+        if isinstance(node, ast.FunctionDef) and node.name in SOURCE_VERSION_FUNCTIONS
+    ]
+    if len(selected_nodes) != len(SOURCE_VERSION_FUNCTIONS):
+        raise AssertionError('Missing source-version publication helper')
+
+    namespace = {
+        '_get_versioned_source_blob_client': lambda descriptor: revalidated_descriptors.append(
+            dict(descriptor)
+        ),
+    }
+    extracted_module = ast.Module(body=selected_nodes, type_ignores=[])
+    exec(compile(extracted_module, str(EXPORT_MODULE), 'exec'), namespace)
+    return namespace['_revalidate_tabular_source_version_for_publication']
+
+
+def _load_checkpoint_resume_helper(blobs, uploads):
+    module_tree = ast.parse(EXPORT_MODULE.read_text(encoding='utf-8'), filename=str(EXPORT_MODULE))
+    selected_nodes = [
+        node
+        for node in module_tree.body
+        if isinstance(node, ast.FunctionDef) and node.name in CHECKPOINT_RESUME_FUNCTIONS
+    ]
+    if len(selected_nodes) != len(CHECKPOINT_RESUME_FUNCTIONS):
+        raise AssertionError('Missing checkpoint resume helper')
+
+    def output_blob_path(user_id, conversation_id, run_id, batch_number):
+        del user_id, conversation_id, run_id
+        return f'output/batch_{batch_number:06d}.json'
+
+    def summary_blob_path(user_id, conversation_id, run_id, batch_number):
+        del user_id, conversation_id, run_id
+        return f'summary/batch_{batch_number:06d}.json'
+
+    def upload_json_blob(path, payload, metadata=None):
+        blobs[path] = payload
+        uploads.append({'path': path, 'metadata': dict(metadata or {})})
+
+    namespace = {
+        'time': time,
+        '_output_blob_path': output_blob_path,
+        '_output_summary_blob_path': summary_blob_path,
+        '_blob_exists': lambda path: path in blobs,
+        '_download_json_blob': lambda path: blobs[path],
+        '_upload_json_blob': upload_json_blob,
+        '_validate_tabular_output_checkpoint_metadata': lambda *args, **kwargs: None,
+        '_build_generated_batch_summary': lambda rows: {'row_count': len(rows)},
+        '_build_tabular_output_checkpoint_metadata': lambda run, metadata: dict(metadata),
+        '_load_input_batch_rows': (
+            lambda run, input_batches, user_id, run_id, batch_number, batch_count:
+            input_batches[batch_number - 1]
+        ),
+        'log_event': lambda *args, **kwargs: None,
+    }
+    extracted_module = ast.Module(body=selected_nodes, type_ignores=[])
+    exec(compile(extracted_module, str(EXPORT_MODULE), 'exec'), namespace)
+    return namespace['_build_batch_window']
+
+
 def _load_authorization_helper(conversation_owner, visible_public_ids=None, group_authorizer=None):
     class CosmosResourceNotFoundError(Exception):
         pass
@@ -855,7 +929,9 @@ def _load_retry_helpers():
         return dict(stored_run)
 
     namespace = {
+        'datetime': datetime,
         'timedelta': timedelta,
+        'timezone': timezone,
         'logging': logging,
         'TabularExportLeaseLostError': RuntimeError,
         '_now_iso': lambda: '2026-08-09T16:00:00+00:00',
@@ -902,6 +978,7 @@ def _load_legacy_migration_helper(aggregate_batches):
         'TABULAR_GENERATION_CONTRACT_VERSION': 1,
         'TABULAR_RESPONSE_PROTOCOL_OBJECT_V1': 'object-v1',
         'TABULAR_EXECUTOR_MODE_FIXED_WINDOW': 'fixed-window-v1',
+        'TABULAR_RETRY_MODE_RUN_LEVEL': 'run-level-v1',
         'TABULAR_RUN_TASK_STRUCTURED_EXPORT': 'structured_export',
         'TABULAR_RUN_TASK_HIERARCHICAL_ANALYSIS': 'hierarchical_analysis',
         'TABULAR_RUN_TASK_COMBINED': 'combined',
@@ -1179,6 +1256,7 @@ def _load_performance_helpers(progress_updates=None):
                 or name.startswith('TABULAR_GENERATION_')
                 or name.startswith('TABULAR_RESPONSE_')
                 or name.startswith('TABULAR_EXECUTOR_')
+                or name.startswith('TABULAR_RETRY_')
                 or name.startswith('TABULAR_ROLLOUT_')
                 for name in assigned_names
             ):
@@ -1190,10 +1268,13 @@ def _load_performance_helpers(progress_updates=None):
 
     namespace = {
         '__file__': str(EXPORT_MODULE),
+        'datetime': datetime,
+        'hashlib': hashlib,
         'json': json,
         'math': math,
         'os': os,
         're': re,
+        'timezone': timezone,
     }
     extracted_module = ast.Module(body=selected_nodes, type_ignores=[])
     exec(compile(extracted_module, str(EXPORT_MODULE), 'exec'), namespace)
@@ -1789,6 +1870,7 @@ def test_phase_three_rollout_activates_shadow_only_and_stays_backend_only():
 
     defaults = normalize_rollout({})
     assert defaults == {
+        'tabular_generation_rollout_percentage': 100,
         'tabular_background_handoff_mode': 'legacy',
         'tabular_generation_plan_mode': 'shadow',
         'enable_tabular_generation_plan': True,
@@ -1798,6 +1880,7 @@ def test_phase_three_rollout_activates_shadow_only_and_stays_backend_only():
         'enable_tabular_independent_batch_retries': False,
         'tabular_generation_checkpoint_writer_concurrency': 1,
         'tabular_generation_heartbeat_seconds': 30,
+        'tabular_generation_stale_seconds': 120,
         'tabular_generation_systemic_failure_threshold': 0.5,
     }
     overridden = normalize_rollout({
@@ -1828,6 +1911,256 @@ def test_phase_three_rollout_activates_shadow_only_and_stays_backend_only():
         assert f"'{setting_key}'" in settings_source
     assert 'TABULAR_GENERATION_BACKEND_SETTING_KEYS' in settings_source
     assert 'if k in TABULAR_GENERATION_BACKEND_SETTING_KEYS' in settings_source
+
+
+def test_phase_eight_rollout_assignment_is_stable_and_control_runs_stay_legacy():
+    """Percentage rollout is deterministic per run and frozen for every resume."""
+    helpers = _load_performance_helpers()
+    build_assignment = helpers['_build_tabular_generation_rollout_assignment']
+    get_rollout_for_run = helpers['_get_tabular_generation_rollout_settings_for_run']
+    enabled_settings = {
+        'tabular_generation_rollout_percentage': 25,
+        'tabular_background_handoff_mode': 'server',
+        'enable_tabular_generation_plan': True,
+        'tabular_generation_plan_mode': 'active',
+        'enable_tabular_compact_response_protocol': True,
+        'enable_tabular_completion_driven_checkpointing': True,
+        'enable_tabular_rolling_worker_pool': True,
+        'enable_tabular_independent_batch_retries': True,
+    }
+    assignment = build_assignment(
+        enabled_settings,
+        'user-1',
+        'conversation-1',
+        'run-phase-8',
+    )
+    repeated_assignment = build_assignment(
+        enabled_settings,
+        'user-1',
+        'conversation-1',
+        'run-phase-8',
+    )
+
+    assert repeated_assignment == assignment
+    assert 1 <= assignment['tabular_generation_rollout_bucket'] <= 100
+    expected_cohort = (
+        'canary'
+        if assignment['tabular_generation_rollout_bucket'] <= 25
+        else 'control'
+    )
+    assert assignment['tabular_generation_rollout_cohort'] == expected_cohort
+    assert assignment['tabular_generation_rollout_hash_version'] == 1
+
+    if expected_cohort == 'canary':
+        assert assignment['tabular_generation_plan_mode'] == 'active'
+        assert assignment['enable_tabular_rolling_worker_pool'] is True
+    else:
+        assert assignment['tabular_background_handoff_mode'] == 'legacy'
+        assert assignment['tabular_generation_plan_mode'] == 'off'
+        assert assignment['enable_tabular_generation_plan'] is False
+        assert assignment['enable_tabular_compact_response_protocol'] is False
+        assert assignment['enable_tabular_completion_driven_checkpointing'] is False
+        assert assignment['enable_tabular_rolling_worker_pool'] is False
+        assert assignment['enable_tabular_independent_batch_retries'] is False
+
+    resumed_settings = get_rollout_for_run(
+        {'generation_rollout_settings': assignment},
+        {
+            'tabular_generation_rollout_percentage': 100,
+            'tabular_generation_plan_mode': 'active',
+            'enable_tabular_rolling_worker_pool': not assignment['enable_tabular_rolling_worker_pool'],
+        },
+    )
+    assert resumed_settings['tabular_generation_plan_mode'] == assignment['tabular_generation_plan_mode']
+    assert resumed_settings['enable_tabular_rolling_worker_pool'] == assignment['enable_tabular_rolling_worker_pool']
+
+    legacy_settings = get_rollout_for_run(
+        {'id': 'pre-snapshot-run'},
+        enabled_settings,
+    )
+    assert legacy_settings['tabular_generation_rollout_percentage'] == 0
+    assert legacy_settings['tabular_generation_plan_mode'] == 'off'
+    assert legacy_settings['enable_tabular_generation_plan'] is False
+    assert legacy_settings['enable_tabular_rolling_worker_pool'] is False
+    assert legacy_settings['tabular_generation_stale_seconds'] == 900
+
+    control_assignment = build_assignment(
+        {**enabled_settings, 'tabular_generation_rollout_percentage': 0},
+        'user-1',
+        'conversation-1',
+        'run-phase-8-control',
+    )
+    canary_assignment = build_assignment(
+        {**enabled_settings, 'tabular_generation_rollout_percentage': 100},
+        'user-1',
+        'conversation-1',
+        'run-phase-8-canary',
+    )
+    assert control_assignment['tabular_generation_rollout_cohort'] == 'control'
+    assert control_assignment['enable_tabular_generation_plan'] is False
+    assert canary_assignment['tabular_generation_rollout_cohort'] == 'canary'
+    assert canary_assignment['enable_tabular_rolling_worker_pool'] is True
+
+
+def test_phase_eight_retry_and_stale_reclaim_modes_are_snapshotted():
+    """New runs reclaim stale workers promptly while legacy snapshots retain their timeout."""
+    helpers = _load_completion_checkpoint_helpers()
+    now = datetime(2026, 8, 10, 12, 0, 0, tzinfo=timezone.utc)
+    helpers['_now_utc'] = lambda: now
+    rolling_mode = helpers['TABULAR_EXECUTOR_MODE_ROLLING_POOL']
+    fixed_mode = helpers['TABULAR_EXECUTOR_MODE_FIXED_WINDOW']
+
+    assert helpers['_select_tabular_retry_mode'](
+        {'enable_tabular_independent_batch_retries': True},
+        rolling_mode,
+    ) == 'independent-batch-v1'
+    assert helpers['_select_tabular_retry_mode'](
+        {'enable_tabular_independent_batch_retries': True},
+        fixed_mode,
+    ) == 'run-level-v1'
+
+    new_run = {
+        'last_heartbeat_at': (now - timedelta(seconds=121)).isoformat(),
+        'generation_rollout_settings': {
+            'tabular_generation_stale_seconds': 120,
+        },
+    }
+    legacy_run = {
+        'last_heartbeat_at': (now - timedelta(seconds=121)).isoformat(),
+        'generation_rollout_settings': {
+            'enable_tabular_generation_plan': True,
+        },
+    }
+    assert helpers['_is_stale_running_run'](new_run, {}) is True
+    assert helpers['_is_stale_running_run'](legacy_run, {}) is False
+
+
+def test_phase_eight_publication_revalidates_source_version():
+    """Every source-backed artifact rechecks its queued ETag immediately before upload."""
+    revalidated_descriptors = []
+    revalidate_source = _load_source_version_publication_helper(revalidated_descriptors)
+    source_descriptor = {
+        'source': 'chat',
+        'container': 'personal-chat',
+        'blob_path': 'user-1/conversation-1/source.csv',
+        'blob_etag': 'etag-queued',
+    }
+
+    revalidate_source({'source_descriptor': source_descriptor})
+    revalidate_source({'source_authorization': source_descriptor})
+
+    assert revalidated_descriptors == [source_descriptor, source_descriptor]
+    structured_publish_source = ast.unparse(_get_function_node('_publish_structured_export_artifact'))
+    analysis_publish_source = ast.unparse(_get_function_node('_publish_analysis_artifact'))
+    for publish_source in (structured_publish_source, analysis_publish_source):
+        assert publish_source.index('_revalidate_tabular_source_version_for_publication') < publish_source.index(
+            'upload_generated_analysis_artifact_stream_for_user'
+        )
+
+
+def test_phase_eight_committed_output_survives_summary_and_progress_crash():
+    """Resume reuses an authoritative output Blob and regenerates only its derived summary."""
+    committed_output_path = 'output/batch_000001.json'
+    summary_path = 'summary/batch_000001.json'
+    blobs = {
+        committed_output_path: [
+            {'source_row_number': 1, 'answer': 'durable answer'},
+        ],
+    }
+    uploads = []
+    build_batch_window = _load_checkpoint_resume_helper(blobs, uploads)
+    run = {
+        'id': 'run-phase-8-crash',
+        'conversation_id': 'conversation-1',
+        'source_file_name': 'source.csv',
+        'output_format': 'csv',
+        'completed_batches': 0,
+        'processed_rows': 0,
+        'output_schema': ['source_row_number', 'answer'],
+    }
+    input_batches = [
+        [{'Case ID': 'SC-1'}],
+        [{'Case ID': 'SC-2'}],
+    ]
+
+    batch_results, batch_requests = build_batch_window(
+        run,
+        input_batches,
+        'user-1',
+        run['id'],
+        1,
+        2,
+        2,
+        durable_output_batches={1},
+    )
+
+    assert batch_results[1]['from_checkpoint'] is True
+    assert batch_results[1]['batch_row_count'] == 1
+    assert [request['batch_number'] for request in batch_requests] == [2]
+    assert blobs[committed_output_path][0]['answer'] == 'durable answer'
+    assert blobs[summary_path] == {'row_count': 1}
+    assert [upload['path'] for upload in uploads] == [summary_path]
+
+
+def test_phase_eight_performance_summary_is_bounded_and_cohort_comparable():
+    """Terminal metrics retain safe rollout dimensions without prompts or row payloads."""
+    helpers = _load_performance_helpers()
+    helpers['_now_utc'] = lambda: datetime(2026, 8, 10, 12, 20, 0, tzinfo=timezone.utc)
+    summary = helpers['_build_tabular_generation_performance_summary']({
+        'created_at': '2026-08-10T12:00:00+00:00',
+        'started_at': '2026-08-10T12:01:00+00:00',
+        'generation_started_at': '2026-08-10T12:02:00+00:00',
+        'planner_started_at': '2026-08-10T12:02:00+00:00',
+        'planner_completed_at': '2026-08-10T12:02:03.500000+00:00',
+        'row_count': 30000,
+        'processed_rows': 30000,
+        'batch_count': 909,
+        'completed_batch_count': 909,
+        'rows_per_minute': 1625.25,
+        'batch_concurrency': 64,
+        'effective_batch_concurrency': 61,
+        'retry_count': 4,
+        'transient_failure_count': 2,
+        'generation_rollout_settings': {
+            'tabular_generation_rollout_cohort': 'canary',
+        },
+        'plan_mode': 'active',
+        'executor_mode': 'rolling-pool-v1',
+        'response_protocol_version': 'compact-row-array-v1',
+        'retry_mode': 'independent-batch-v1',
+    }, completed_at='2026-08-10T12:20:00+00:00')
+
+    assert summary['planning_latency_seconds'] == 3.5
+    assert summary['queue_latency_seconds'] == 60.0
+    assert summary['generation_elapsed_seconds'] == 1080.0
+    assert summary['end_to_end_elapsed_seconds'] == 1200.0
+    assert summary['durable_rows_per_minute'] == 1625.25
+    assert summary['configured_concurrency'] == 64
+    assert summary['effective_concurrency'] == 61
+    assert summary['rollout_cohort'] == 'canary'
+    serialized_summary = json.dumps(summary, sort_keys=True)
+    assert len(serialized_summary.encode('utf-8')) < 2048
+    assert 'prompt' not in serialized_summary
+    assert 'source_file' not in serialized_summary
+
+
+def test_phase_eight_public_status_omits_private_execution_details():
+    """Browser status contains safe aggregate modes but no raw errors or assignment internals."""
+    public_status_source = ast.unparse(_get_function_node('_build_run_public_status'))
+
+    assert "'executor_mode': run.get('executor_mode')" in public_status_source
+    assert "'retry_mode': run.get('retry_mode')" in public_status_source
+    assert "'plan_mode': run.get('plan_mode')" in public_status_source
+    for private_field in (
+        "'last_error'",
+        'generation_rollout_settings',
+        'tabular_generation_rollout_bucket',
+        'tabular_generation_rollout_hash_version',
+        'lease_holder_id',
+        'user_question',
+        'performance_summary',
+    ):
+        assert private_field not in public_status_source
 
 
 def test_phase_one_observability_uses_safe_metrics_not_response_content():
@@ -4829,6 +5162,12 @@ def main():
         test_dynamic_concurrency_and_parallel_window_eta,
         test_phase_one_generation_contract_fields_are_additive_and_compact,
         test_phase_three_rollout_activates_shadow_only_and_stays_backend_only,
+        test_phase_eight_rollout_assignment_is_stable_and_control_runs_stay_legacy,
+        test_phase_eight_retry_and_stale_reclaim_modes_are_snapshotted,
+        test_phase_eight_publication_revalidates_source_version,
+        test_phase_eight_committed_output_survives_summary_and_progress_crash,
+        test_phase_eight_performance_summary_is_bounded_and_cohort_comparable,
+        test_phase_eight_public_status_omits_private_execution_details,
         test_phase_one_observability_uses_safe_metrics_not_response_content,
         test_phase_one_fake_harnesses_control_completion_order_and_storage_failures,
         test_phase_three_plan_contract_is_bounded_immutable_and_private,


### PR DESCRIPTION
## Summary

- add deterministic 0-100 canary/control assignment and persist each run's effective planner, protocol, executor, retry, heartbeat, and stale-worker settings
- keep pre-snapshot and in-flight runs on their recorded legacy-compatible behavior while allowing new-run rollout through explicit percentages
- revalidate conversation/workspace authorization and the queued source ETag immediately before artifact publication, and remove raw backend errors from public status
- persist bounded terminal performance summaries and extend deterministic scale/chaos coverage for crash recovery without repeated committed LLM work
- bump the application to 0.250.144 and document the Phase 8 rollout and remaining live gates

## Validation

- `python -m py_compile application/single_app/functions_tabular_generated_exports.py application/single_app/functions_settings.py application/single_app/config.py functional_tests/test_tabular_row_orchestration_scale.py`
- `python -m pytest functional_tests/test_tabular_row_orchestration_scale.py -q` (`63 passed`)
- `python -m pytest functional_tests/test_tabular_background_generated_exports.py functional_tests/test_settings_secrets_exposure_hardening.py -q` (`11 passed`, 4 existing return-value warnings)
- `python -m pytest ui_tests/test_chat_background_generated_export_status.py -q -rs` (`5 skipped`: `SIMPLECHAT_UI_BASE_URL` is not configured locally)
- Windows-safe `git diff --check`

## Rollout Notes

The deterministic local suite covers the 30,000-row finalizer and 100,000-row bounded planning/manifest contracts, but it does not claim the live 30,000-row LLM throughput gate. Authenticated Playwright validation and the provisioned-model 1,500 durable rows/minute observation remain deployment gates before broad activation.

Refs #1031