### PR TITLE
Fix tabular background streaming and token recovery

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -96,7 +96,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.250.144"
+VERSION = "0.250.145"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -96,7 +96,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.250.145"
+VERSION = "0.250.146"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/functions_tabular_generated_exports.py
+++ b/application/single_app/functions_tabular_generated_exports.py
@@ -1457,6 +1457,75 @@ def _normalize_generated_batch_entries(
     return ordered_entries, output_schema
 
 
+def _generated_entry_has_source_position_conflict(source_row, generated_entry):
+    source_row_number = _safe_int(source_row.get(TABULAR_EXPORT_INPUT_ROW_NUMBER_FIELD), default=0, minimum=0)
+    source_row_identity = str(source_row.get(TABULAR_EXPORT_INPUT_ROW_IDENTITY_FIELD) or '').strip()
+
+    for row_number_field in (
+        TABULAR_EXPORT_INPUT_ROW_NUMBER_FIELD,
+        TABULAR_EXPORT_OUTPUT_ROW_NUMBER_FIELD,
+    ):
+        if row_number_field not in generated_entry or generated_entry.get(row_number_field) in (None, ''):
+            continue
+        if _safe_int(generated_entry.get(row_number_field), default=-1) != source_row_number:
+            return True
+
+    for row_identity_field in (
+        TABULAR_EXPORT_INPUT_ROW_IDENTITY_FIELD,
+        TABULAR_EXPORT_OUTPUT_ROW_IDENTITY_FIELD,
+    ):
+        if row_identity_field not in generated_entry or generated_entry.get(row_identity_field) in (None, ''):
+            continue
+        if str(generated_entry.get(row_identity_field) or '').strip() != source_row_identity:
+            return True
+
+    return False
+
+
+def _normalize_model_generated_batch_entries(
+    source_rows,
+    generated_entries,
+    expected_output_schema=None,
+    allow_source_token_recovery=True,
+    run_id=None,
+    batch_number=None,
+):
+    try:
+        return _normalize_generated_batch_entries(
+            source_rows,
+            generated_entries,
+            expected_output_schema=expected_output_schema,
+        )
+    except ValueError as exc:
+        if (
+            not allow_source_token_recovery
+            or 'source row token mismatch' not in str(exc).lower()
+        ):
+            raise
+        for source_row, generated_entry in zip(source_rows or [], generated_entries or []):
+            if not isinstance(source_row, dict) or not isinstance(generated_entry, dict):
+                raise
+            if _generated_entry_has_source_position_conflict(source_row, generated_entry):
+                raise
+        normalized_entries, output_schema = _normalize_generated_batch_entries(
+            source_rows,
+            generated_entries,
+            expected_output_schema=expected_output_schema,
+            require_source_token=False,
+        )
+        log_event(
+            '[TABULAR_GENERATED_OUTPUT] Recovered generated batch from source-token echo mismatch',
+            {
+                'run_id': run_id,
+                'batch_number': batch_number,
+                'row_count': len(normalized_entries),
+                'recovery_reason': 'source_token_echo_mismatch',
+            },
+            level=logging.WARNING,
+        )
+        return normalized_entries, output_schema
+
+
 def _build_generated_batch_summary(entries):
     entries = [entry for entry in (entries or []) if isinstance(entry, dict)]
     summary = {
@@ -2544,10 +2613,12 @@ def _normalize_combined_chunk_payload(run, payload, batch_rows, batch_number, ex
     )
     if not isinstance(structured_rows, list):
         raise ValueError('Combined chunk response did not include structured_rows as an array')
-    normalized_entries, output_schema = _normalize_generated_batch_entries(
+    normalized_entries, output_schema = _normalize_model_generated_batch_entries(
         batch_rows,
         structured_rows,
         expected_output_schema=expected_output_schema,
+        run_id=run.get('id'),
+        batch_number=batch_number,
     )
 
     analysis_payload = payload.get('analysis_summary')
@@ -3803,10 +3874,13 @@ async def _generate_batch_entries(
         }
         if parsed_entries is not None and parsed_entry_count == len(batch_rows):
             try:
-                normalized_entries, output_schema = _normalize_generated_batch_entries(
+                normalized_entries, output_schema = _normalize_model_generated_batch_entries(
                     batch_rows,
                     parsed_entries,
                     expected_output_schema=expected_output_schema,
+                    allow_source_token_recovery=not compact_protocol,
+                    run_id=run_id,
+                    batch_number=batch_number,
                 )
                 last_attempt_metrics['validation_seconds'] = round(
                     time.monotonic() - validation_started_at,

--- a/application/single_app/functions_tabular_generated_exports.py
+++ b/application/single_app/functions_tabular_generated_exports.py
@@ -5499,6 +5499,7 @@ def build_background_tabular_generated_output_metadata(run):
     is_hierarchical_analysis = task_type == TABULAR_RUN_TASK_HIERARCHICAL_ANALYSIS
     is_combined = task_type == TABULAR_RUN_TASK_COMBINED
     output_label = str(public_status.get('output_format') or 'json').upper()
+    row_count = _safe_int(public_status.get('row_count'))
     public_status.update({
         'export_run_id': public_status.get('run_id'),
         'background_export': True,
@@ -5516,14 +5517,14 @@ def build_background_tabular_generated_output_metadata(run):
         'preview_row_count': 0,
         'foreground_response_policy_version': 'phase2.v1',
         'summary': (
-            f"Queued combined tabular analysis and {output_label} export for {public_status.get('row_count', 0)} row(s) "
+            f"Queued combined tabular analysis and {output_label} export for {row_count} row(s) "
             f"across {public_status.get('batch_count', 0)} chunk(s)."
             if is_combined
             else
-            f"Queued hierarchical tabular analysis for {public_status.get('row_count', 0)} row(s) "
+            f"Queued hierarchical tabular analysis for {row_count} row(s) "
             f"across {public_status.get('batch_count', 0)} chunk(s)."
             if is_hierarchical_analysis
-            else f"Queued structured {output_label} export for {public_status.get('row_count', 0)} row(s) "
+            else f"Queued structured {output_label} export for {row_count} row(s) "
             f"across {public_status.get('batch_count', 0)} batch(es)."
         ),
     })

--- a/docs/explanation/features/TABULAR_BACKGROUND_GENERATED_EXPORTS.md
+++ b/docs/explanation/features/TABULAR_BACKGROUND_GENERATED_EXPORTS.md
@@ -2,7 +2,7 @@
 
 Implemented in version: **0.241.046**
 
-Updated through version: **0.250.144**
+Updated through version: **0.250.145**
 
 ## Overview
 
@@ -40,6 +40,7 @@ The feature supports large spreadsheet-driven analysis, including workbooks that
 - Phase 6 adds an opt-in rolling worker pool that replaces completed model slots without waiting for a fixed window barrier.
 - Phase 7 adds durable per-batch retry records and a delayed retry heap so one retrying batch does not pause healthy pending work.
 - Phase 8 assigns new runs to deterministic rollout cohorts, records explicit planner/executor/protocol/retry modes, reclaims new-run workers after a snapshotted two-minute stale interval, and revalidates source ETags before final publication.
+- Background handoff metadata derives its requested row count from the safe public run status so accepted durable runs cannot terminate the foreground stream while constructing the status card payload.
 
 ### API Endpoints
 
@@ -103,6 +104,7 @@ The progress card displays current status, completed checkpoint counts, processe
 - Phase 6 rolling scheduling, heartbeat, backpressure, and straggler regression: `functional_tests/test_tabular_row_orchestration_scale.py`
 - Phase 7 independent retry, durable retry-ledger, and circuit-breaker regression: `functional_tests/test_tabular_row_orchestration_scale.py`
 - Phase 8 stable cohort, stale reclaim, source-version publication, crash recovery, and performance-summary regression: `functional_tests/test_tabular_row_orchestration_scale.py`
+- Background metadata streaming regression for export, analysis, and combined modes: `functional_tests/test_tabular_row_orchestration_scale.py`
 - Phase 2 handoff regression: `functional_tests/test_tabular_row_orchestration_scale.py`
 - Phase 1 baseline and fake harness coverage: `functional_tests/test_tabular_row_orchestration_scale.py`
 - Functional regression for workflow/document-action presentation: `functional_tests/test_document_analysis_lossless_artifacts.py`
@@ -155,3 +157,4 @@ The progress card displays current status, completed checkpoint counts, processe
 - `application/single_app/config.py` was updated to version **0.250.142** for Phase 6 rolling worker pool scheduling.
 - `application/single_app/config.py` was updated to version **0.250.143** for Phase 7 independent batch retries.
 - `application/single_app/config.py` was updated to version **0.250.144** for Phase 8 stable rollout cohorts, stale reclaim, source-version publication checks, chaos recovery coverage, and bounded performance summaries.
+- `application/single_app/config.py` was updated to version **0.250.145** to prevent accepted background-run metadata from terminating the foreground stream with an undefined row-count variable.

--- a/docs/explanation/features/TABULAR_BACKGROUND_GENERATED_EXPORTS.md
+++ b/docs/explanation/features/TABULAR_BACKGROUND_GENERATED_EXPORTS.md
@@ -2,7 +2,7 @@
 
 Implemented in version: **0.241.046**
 
-Updated through version: **0.250.145**
+Updated through version: **0.250.146**
 
 ## Overview
 
@@ -41,6 +41,7 @@ The feature supports large spreadsheet-driven analysis, including workbooks that
 - Phase 7 adds durable per-batch retry records and a delayed retry heap so one retrying batch does not pause healthy pending work.
 - Phase 8 assigns new runs to deterministic rollout cohorts, records explicit planner/executor/protocol/retry modes, reclaims new-run workers after a snapshotted two-minute stale interval, and revalidates source ETags before final publication.
 - Background handoff metadata derives its requested row count from the safe public run status so accepted durable runs cannot terminate the foreground stream while constructing the status card payload.
+- Object-protocol model responses can recover from hidden source-token echo mismatches when row count and any explicit source row number or identity markers preserve the requested source order.
 
 ### API Endpoints
 
@@ -105,6 +106,7 @@ The progress card displays current status, completed checkpoint counts, processe
 - Phase 7 independent retry, durable retry-ledger, and circuit-breaker regression: `functional_tests/test_tabular_row_orchestration_scale.py`
 - Phase 8 stable cohort, stale reclaim, source-version publication, crash recovery, and performance-summary regression: `functional_tests/test_tabular_row_orchestration_scale.py`
 - Background metadata streaming regression for export, analysis, and combined modes: `functional_tests/test_tabular_row_orchestration_scale.py`
+- Source-token echo recovery regression: `functional_tests/test_tabular_row_orchestration_scale.py`
 - Phase 2 handoff regression: `functional_tests/test_tabular_row_orchestration_scale.py`
 - Phase 1 baseline and fake harness coverage: `functional_tests/test_tabular_row_orchestration_scale.py`
 - Functional regression for workflow/document-action presentation: `functional_tests/test_document_analysis_lossless_artifacts.py`
@@ -158,3 +160,4 @@ The progress card displays current status, completed checkpoint counts, processe
 - `application/single_app/config.py` was updated to version **0.250.143** for Phase 7 independent batch retries.
 - `application/single_app/config.py` was updated to version **0.250.144** for Phase 8 stable rollout cohorts, stale reclaim, source-version publication checks, chaos recovery coverage, and bounded performance summaries.
 - `application/single_app/config.py` was updated to version **0.250.145** to prevent accepted background-run metadata from terminating the foreground stream with an undefined row-count variable.
+- `application/single_app/config.py` was updated to version **0.250.146** to recover object-protocol model responses that preserve row order but fail to echo hidden source-row tokens.

--- a/docs/explanation/fixes/TABULAR_BACKGROUND_METADATA_STREAMING_FIX.md
+++ b/docs/explanation/fixes/TABULAR_BACKGROUND_METADATA_STREAMING_FIX.md
@@ -1,0 +1,59 @@
+# Tabular Background Metadata Streaming Fix
+
+Fixed in version: **0.250.145**
+
+Related issue: **microsoft/simplechat#1031**
+
+## Issue Description
+
+After a durable tabular run was accepted, the foreground SSE response could end with `Something went wrong while streaming the response. Please try again.` instead of returning the background status card metadata. The failure affected structured export, hierarchical analysis, and combined modes.
+
+Production evidence showed the stream remained open without content and then failed while constructing accepted-run metadata:
+
+```text
+NameError: name 'row_count' is not defined
+build_background_tabular_generated_output_metadata
+```
+
+The same exception was caught earlier by direct source-backed queueing, which caused 300, 3,000, and 30,000-row requests to fall back to the slower foreground orchestration path.
+
+## Root Cause
+
+`build_background_tabular_generated_output_metadata(...)` added a `requested_row_count` field but referenced a local `row_count` variable that had never been initialized. The safe public status already contained the authoritative run row count, but the metadata builder did not normalize it into the local scope.
+
+## Technical Details
+
+### Files Modified
+
+- `application/single_app/functions_tabular_generated_exports.py`
+- `application/single_app/config.py`
+- `functional_tests/test_tabular_row_orchestration_scale.py`
+- `docs/explanation/features/TABULAR_BACKGROUND_GENERATED_EXPORTS.md`
+
+### Code Changes
+
+The metadata builder now derives one normalized row count from `_build_run_public_status(...)` and uses it for `requested_row_count` and all queued-run summary variants. The change does not alter SSE framing, durable queue semantics, source authorization, or background execution.
+
+### Impact Analysis
+
+- Accepted durable runs can complete their foreground handoff instead of emitting a stream error.
+- Direct source-backed queueing no longer falls back because metadata construction raised `NameError`.
+- Export, analysis-only, and combined handoff payloads retain the same public schema and wording.
+
+## Validation
+
+An executable regression calls the production metadata builder for structured export, hierarchical analysis, and combined modes and verifies that the requested row count comes from public run status.
+
+Validated with:
+
+```bash
+python -m py_compile application/single_app/functions_tabular_generated_exports.py application/single_app/config.py functional_tests/test_tabular_row_orchestration_scale.py
+python -m pytest functional_tests/test_tabular_row_orchestration_scale.py -k "background_metadata or phase_two" -q
+python -m pytest functional_tests/test_tabular_row_orchestration_scale.py -q
+```
+
+Before the fix, the focused regression reproduced the production `NameError`. After the fix, accepted-run metadata is returned with the expected row count and handoff mode.
+
+## Related Version Update
+
+`application/single_app/config.py` was incremented from **0.250.144** to **0.250.145** for this streaming handoff fix.

--- a/docs/explanation/fixes/TABULAR_SOURCE_TOKEN_ECHO_RECOVERY_FIX.md
+++ b/docs/explanation/fixes/TABULAR_SOURCE_TOKEN_ECHO_RECOVERY_FIX.md
@@ -1,0 +1,57 @@
+# Tabular Source Token Echo Recovery Fix
+
+Fixed in version: **0.250.146**
+
+Related issue: **microsoft/simplechat#1031**
+
+## Issue Description
+
+Large background tabular generated exports could appear to stall after the first schema-discovery batch. Production logs showed full durable runs were accepted, for example `row_count=300`, `batch_count=6` and `row_count=3000`, `batch_count=52`, but later object-protocol batches were repeatedly rejected with:
+
+```text
+Generated source row token mismatch at row 1
+```
+
+For the 300-row run, the first 50-row batch completed, then the worker repeatedly scheduled batches 2 through 5 because the fixed-window concurrency was 4. Those batches returned the expected 50 generated objects but failed validation because the model did not echo the hidden `__simplechat_source_row_token` value exactly.
+
+## Root Cause
+
+The object response protocol asked the model to copy a hidden source token into each output row. Some live responses preserved row count and visible row order but invented, omitted, or mutated that hidden token. The server treated that token mismatch as a hard validation error, retried the same batches, and did not advance completed row progress.
+
+## Technical Details
+
+### Files Modified
+
+- `application/single_app/functions_tabular_generated_exports.py`
+- `application/single_app/config.py`
+- `functional_tests/test_tabular_row_orchestration_scale.py`
+- `docs/explanation/features/TABULAR_BACKGROUND_GENERATED_EXPORTS.md`
+
+### Code Changes
+
+The low-level `_normalize_generated_batch_entries(...)` function remains strict and still rejects token mismatches. Model response normalization now uses a wrapper that:
+
+- first attempts strict token validation;
+- recovers only from source-token mismatch errors;
+- requires the parsed generated row count to already match the source row count;
+- rejects recovery when the model includes an explicit source row number or identity that conflicts with the source row at that position;
+- reattaches source row number and source identity server-side after recovery;
+- logs a safe recovery event without row data or prompt content.
+
+Compact row protocol behavior is unchanged because compact responses already use batch-local row keys and do not ask the model to echo source tokens.
+
+## Validation
+
+Functional coverage verifies that direct strict normalization still rejects swapped source tokens, while model-response normalization can recover token echo mismatches only when row order is preserved and explicit source markers do not conflict.
+
+Validated with:
+
+```bash
+python -m py_compile application/single_app/functions_tabular_generated_exports.py application/single_app/config.py functional_tests/test_tabular_row_orchestration_scale.py
+python -m pytest functional_tests/test_tabular_row_orchestration_scale.py -k "token_echo_recovery or background_metadata or phase_two" -q
+python -m pytest functional_tests/test_tabular_row_orchestration_scale.py -q
+```
+
+## Related Version Update
+
+`application/single_app/config.py` was incremented from **0.250.145** to **0.250.146** for this source-token echo recovery fix.

--- a/functional_tests/test_tabular_row_orchestration_scale.py
+++ b/functional_tests/test_tabular_row_orchestration_scale.py
@@ -1,8 +1,8 @@
 # test_tabular_row_orchestration_scale.py
 """
 Functional test for scalable per-row tabular orchestration.
-Version: 0.250.144
-Implemented in: 0.250.060; generated CSV formula safety in 0.250.065; generated file export routing in 0.250.072; source descriptor generalization in 0.250.127; unified durable run contract in 0.250.128; hierarchical analysis in 0.250.129; combined analysis and export in 0.250.130; scale validation in 0.250.132; direct source-backed exhaustive queueing in 0.250.133; direct queue call-site hardening in 0.250.134; model-validation auto retry in 0.250.135; model-aware parallel throughput in 0.250.136; Phase 1 acceleration contracts and observability in 0.250.137; Phase 2 truthful background handoff in 0.250.138; Phase 3 durable LLM generation planning in 0.250.139; Phase 4 compact row response protocol in 0.250.140; Phase 5 completion-driven checkpointing in 0.250.141; Phase 6 rolling worker pool in 0.250.142; Phase 7 independent batch retries in 0.250.143; Phase 8 scale, chaos, and rollout in 0.250.144
+Version: 0.250.145
+Implemented in: 0.250.060; generated CSV formula safety in 0.250.065; generated file export routing in 0.250.072; source descriptor generalization in 0.250.127; unified durable run contract in 0.250.128; hierarchical analysis in 0.250.129; combined analysis and export in 0.250.130; scale validation in 0.250.132; direct source-backed exhaustive queueing in 0.250.133; direct queue call-site hardening in 0.250.134; model-validation auto retry in 0.250.135; model-aware parallel throughput in 0.250.136; Phase 1 acceleration contracts and observability in 0.250.137; Phase 2 truthful background handoff in 0.250.138; Phase 3 durable LLM generation planning in 0.250.139; Phase 4 compact row response protocol in 0.250.140; Phase 5 completion-driven checkpointing in 0.250.141; Phase 6 rolling worker pool in 0.250.142; Phase 7 independent batch retries in 0.250.143; Phase 8 scale, chaos, and rollout in 0.250.144; background metadata streaming fix in 0.250.145
 
 This test ensures generated exports preserve source identity and row order while
 enforcing one stable output schema across independently generated batches.
@@ -139,6 +139,7 @@ FAILURE_FUNCTIONS = {
     '_normalize_generated_analysis_artifact_metadata',
     '_tabular_background_handoff_has_preview',
 }
+BACKGROUND_METADATA_FUNCTIONS = {'build_background_tabular_generated_output_metadata'}
 ARTIFACT_FUNCTIONS = {'_upload_generated_chat_artifact_for_current_user'}
 SCHEDULER_FUNCTIONS = {'_query_scheduler_candidates_by_status'}
 MANIFEST_FUNCTIONS = {
@@ -1101,6 +1102,28 @@ def _load_failed_export_helpers():
     extracted_module = ast.Module(body=selected_nodes, type_ignores=[])
     exec(compile(extracted_module, str(CHAT_ROUTE), 'exec'), namespace)
     return namespace
+
+
+def _load_background_generated_output_metadata_helper():
+    module_tree = ast.parse(EXPORT_MODULE.read_text(encoding='utf-8'), filename=str(EXPORT_MODULE))
+    selected_nodes = [
+        node
+        for node in module_tree.body
+        if isinstance(node, ast.FunctionDef) and node.name in BACKGROUND_METADATA_FUNCTIONS
+    ]
+    if len(selected_nodes) != len(BACKGROUND_METADATA_FUNCTIONS):
+        raise AssertionError('Missing background generated-output metadata helper')
+
+    namespace = {
+        '_build_run_public_status': lambda run: dict(run.get('_public_status') or {}),
+        '_normalize_tabular_run_task_type': lambda task_type: task_type or 'structured_export',
+        '_safe_int': lambda value: int(value or 0),
+        'TABULAR_RUN_TASK_HIERARCHICAL_ANALYSIS': 'hierarchical_analysis',
+        'TABULAR_RUN_TASK_COMBINED': 'combined',
+    }
+    extracted_module = ast.Module(body=selected_nodes, type_ignores=[])
+    exec(compile(extracted_module, str(EXPORT_MODULE), 'exec'), namespace)
+    return namespace['build_background_tabular_generated_output_metadata']
 
 
 def _assert_concise_background_handoff_contract(text, expected_row_count, expected_output_label):
@@ -5155,6 +5178,34 @@ def test_phase_two_background_handoff_contracts_are_server_composed():
     assert canceled_handoff == ''
 
 
+def test_background_metadata_uses_public_status_row_count():
+    """Accepted durable runs build stream metadata from their safe public row count."""
+    build_metadata = _load_background_generated_output_metadata_helper()
+    cases = (
+        ('structured_export', 'csv', 'background_export'),
+        ('hierarchical_analysis', 'md', 'background_analysis'),
+        ('combined', 'csv', 'background_combined'),
+    )
+
+    for task_type, output_format, handoff_mode in cases:
+        metadata = build_metadata({
+            'task_type': task_type,
+            '_public_status': {
+                'run_id': f'run-{task_type}',
+                'task_type': task_type,
+                'output_format': output_format,
+                'row_count': 3000,
+                'batch_count': 52,
+            },
+        })
+
+        assert metadata['requested_row_count'] == 3000
+        assert metadata['row_count'] == 3000
+        assert metadata['handoff_mode'] == handoff_mode
+        assert '3,000' not in metadata['summary']
+        assert '3000 row(s)' in metadata['summary']
+
+
 def main():
     """Run focused row-orchestration contract checks."""
     tests = [
@@ -5190,6 +5241,7 @@ def main():
         test_direct_source_backed_csv_queue_bypasses_tool_paging,
         test_direct_source_backed_queue_failure_falls_back_without_stream_abort,
         test_phase_two_background_handoff_contracts_are_server_composed,
+        test_background_metadata_uses_public_status_row_count,
         test_direct_source_backed_queue_call_sites_use_required_keywords,
         test_model_validation_failures_auto_retry_then_manual_continue,
         test_hierarchical_analysis_routing_requires_feature_flag,

--- a/functional_tests/test_tabular_row_orchestration_scale.py
+++ b/functional_tests/test_tabular_row_orchestration_scale.py
@@ -1,8 +1,8 @@
 # test_tabular_row_orchestration_scale.py
 """
 Functional test for scalable per-row tabular orchestration.
-Version: 0.250.145
-Implemented in: 0.250.060; generated CSV formula safety in 0.250.065; generated file export routing in 0.250.072; source descriptor generalization in 0.250.127; unified durable run contract in 0.250.128; hierarchical analysis in 0.250.129; combined analysis and export in 0.250.130; scale validation in 0.250.132; direct source-backed exhaustive queueing in 0.250.133; direct queue call-site hardening in 0.250.134; model-validation auto retry in 0.250.135; model-aware parallel throughput in 0.250.136; Phase 1 acceleration contracts and observability in 0.250.137; Phase 2 truthful background handoff in 0.250.138; Phase 3 durable LLM generation planning in 0.250.139; Phase 4 compact row response protocol in 0.250.140; Phase 5 completion-driven checkpointing in 0.250.141; Phase 6 rolling worker pool in 0.250.142; Phase 7 independent batch retries in 0.250.143; Phase 8 scale, chaos, and rollout in 0.250.144; background metadata streaming fix in 0.250.145
+Version: 0.250.146
+Implemented in: 0.250.060; generated CSV formula safety in 0.250.065; generated file export routing in 0.250.072; source descriptor generalization in 0.250.127; unified durable run contract in 0.250.128; hierarchical analysis in 0.250.129; combined analysis and export in 0.250.130; scale validation in 0.250.132; direct source-backed exhaustive queueing in 0.250.133; direct queue call-site hardening in 0.250.134; model-validation auto retry in 0.250.135; model-aware parallel throughput in 0.250.136; Phase 1 acceleration contracts and observability in 0.250.137; Phase 2 truthful background handoff in 0.250.138; Phase 3 durable LLM generation planning in 0.250.139; Phase 4 compact row response protocol in 0.250.140; Phase 5 completion-driven checkpointing in 0.250.141; Phase 6 rolling worker pool in 0.250.142; Phase 7 independent batch retries in 0.250.143; Phase 8 scale, chaos, and rollout in 0.250.144; background metadata streaming fix in 0.250.145; source-token echo recovery in 0.250.146
 
 This test ensures generated exports preserve source identity and row order while
 enforcing one stable output schema across independently generated batches.
@@ -51,10 +51,13 @@ from functions_assistant_table_exports import (  # noqa: E402
     neutralize_csv_spreadsheet_formula,
 )
 CONTRACT_FUNCTIONS = {
+    '_safe_int',
     '_normalize_source_identity_label',
     '_select_source_row_identity',
     '_prepare_tabular_source_rows',
     '_normalize_generated_batch_entries',
+    '_generated_entry_has_source_position_conflict',
+    '_normalize_model_generated_batch_entries',
 }
 CONTRACT_CONSTANTS = {
     'TABULAR_EXPORT_INPUT_ROW_NUMBER_FIELD',
@@ -372,6 +375,8 @@ def _load_contract_helpers():
         )
 
     namespace = {'re': re, 'uuid': uuid}
+    namespace['log_event'] = lambda *args, **kwargs: None
+    namespace['logging'] = logging
     extracted_module = ast.Module(body=selected_nodes, type_ignores=[])
     exec(compile(extracted_module, str(EXPORT_MODULE), 'exec'), namespace)
     return namespace
@@ -3566,6 +3571,68 @@ def test_generated_batch_schema_contract():
         raise AssertionError('Swapped model rows must fail source-token validation')
 
 
+def test_model_batch_token_echo_recovery_preserves_order_contract():
+    """Model responses may omit hidden token echoes but cannot contradict row order."""
+    helpers = _load_contract_helpers()
+    prepared_rows = helpers['_prepare_tabular_source_rows'](
+        [
+            {'Case ID': 'SC-2001', 'Comment': 'first'},
+            {'Case ID': 'SC-2002', 'Comment': 'second'},
+        ],
+        start_row=0,
+    )
+    token_echo_mismatch_entries = [
+        {
+            '__simplechat_source_row_token': 'model-made-up-token-1',
+            'source_row_number': 1,
+            'source_row_identity': 'SC-2001',
+            'answer': 'yes',
+        },
+        {
+            '__simplechat_source_row_token': 'model-made-up-token-2',
+            'source_row_number': 2,
+            'source_row_identity': 'SC-2002',
+            'answer': 'no',
+        },
+    ]
+
+    recovered_entries, output_schema = helpers['_normalize_model_generated_batch_entries'](
+        prepared_rows,
+        token_echo_mismatch_entries,
+        run_id='run-token-recovery',
+        batch_number=2,
+    )
+
+    assert output_schema == ['source_row_number', 'source_row_identity', 'answer']
+    assert recovered_entries == [
+        {'source_row_number': 1, 'source_row_identity': 'SC-2001', 'answer': 'yes'},
+        {'source_row_number': 2, 'source_row_identity': 'SC-2002', 'answer': 'no'},
+    ]
+
+    try:
+        helpers['_normalize_model_generated_batch_entries'](
+            prepared_rows,
+            [
+                {
+                    '__simplechat_source_row_token': 'model-made-up-token-1',
+                    'source_row_number': 2,
+                    'source_row_identity': 'SC-2002',
+                    'answer': 'no',
+                },
+                {
+                    '__simplechat_source_row_token': 'model-made-up-token-2',
+                    'source_row_number': 1,
+                    'source_row_identity': 'SC-2001',
+                    'answer': 'yes',
+                },
+            ],
+        )
+    except ValueError as exc:
+        assert 'token mismatch' in str(exc).lower()
+    else:
+        raise AssertionError('Explicit source row conflicts must not use positional recovery')
+
+
 def test_durable_runner_enforces_row_contract():
     """Queueing, generation, and checkpointing must all enforce the shared contract."""
     queue_calls = _called_function_names(_get_function_node('queue_tabular_generated_output_run'))
@@ -3574,7 +3641,7 @@ def test_durable_runner_enforces_row_contract():
     process_source = ast.unparse(_get_function_node('process_tabular_generated_output_run'))
 
     assert '_prepare_tabular_source_rows' in queue_calls
-    assert '_normalize_generated_batch_entries' in generation_calls
+    assert '_normalize_model_generated_batch_entries' in generation_calls
     assert "run['output_schema']" in checkpoint_source
     assert "run.get('output_schema')" in process_source
     assert 'window_end = window_start' in process_source
@@ -5231,6 +5298,7 @@ def main():
         test_phase_four_compact_response_rejects_key_and_value_failures,
         test_source_identity_and_order_contract,
         test_generated_batch_schema_contract,
+        test_model_batch_token_echo_recovery_preserves_order_contract,
         test_durable_runner_enforces_row_contract,
         test_paginated_candidate_coalesces_all_300_rows,
         test_paginated_candidate_rejects_gaps,


### PR DESCRIPTION
## Summary

- fix `build_background_tabular_generated_output_metadata` using an undefined `row_count` while constructing accepted durable-run stream metadata
- derive `requested_row_count` and queued summaries from the safe public run status for export, analysis-only, and combined modes
- recover object-protocol model responses that preserve row order but fail to echo hidden source-row tokens exactly
- keep strict low-level token validation intact and reject recovery when explicit row number or identity markers conflict
- add executable regressions for the stream metadata crash and source-token echo recovery
- bump the application to 0.250.146 and document both fixes

## Production Evidence

The attached App Service logs show direct durable queueing falling back for 300, 3,000, and 30,000-row requests with `NameError: name 'row_count' is not defined`. The accepted-run path later raised the same error in `build_background_tabular_generated_output_metadata`, terminating SSE after 45 non-content events with `Something went wrong while streaming the response.`

A later log extract showed a separate blocker after the stream metadata issue: full durable runs were accepted (`row_count=300`, `batch_count=6`; `row_count=3000`, `batch_count=52`; `row_count=30000`, `batch_count=514`), but object-protocol batches repeatedly failed with `Generated source row token mismatch at row 1`. The 300-row run completed the first 50-row schema batch, then retried batches 2-5 because fixed-window concurrency was 4. The 30,000-row run advanced past schema discovery and scheduled a 128-batch window, so this was not a five-row cap.

## Validation

- pre-fix: `python -m pytest functional_tests/test_tabular_row_orchestration_scale.py -k "background_metadata_uses_public_status_row_count" -q` reproduced the production `NameError`
- focused post-fix: `python -m pytest functional_tests/test_tabular_row_orchestration_scale.py -k "token_echo_recovery or background_metadata or phase_two" -q` (`3 passed`)
- full scale/recovery suite: `python -m pytest functional_tests/test_tabular_row_orchestration_scale.py -q` (`65 passed`)
- neighboring background-export suite: `python -m pytest functional_tests/test_tabular_background_generated_exports.py -q` (`7 passed`)
- Python compile checks passed
- Pylance `reportUndefinedVariable` for `row_count` is cleared
- Windows-safe `git diff --check` passed

Refs #1031