### PR TITLE
Fix tabular fixed-window stale status

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -96,7 +96,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.250.146"
+VERSION = "0.250.147"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/functions_tabular_generated_exports.py
+++ b/application/single_app/functions_tabular_generated_exports.py
@@ -5229,6 +5229,16 @@ def _build_run_status_detail(run, settings, retryable_failure, can_resume):
     retry_due = _is_due_queued_retry_run(run)
     stale_queued = _is_stale_queued_run(run, settings or {})
     retry_delay_seconds = _seconds_until((run or {}).get('next_attempt_at')) if waiting_for_retry else None
+    retry_category = str((run or {}).get('last_retry_category') or '').strip().lower()
+
+    def retry_reason_text():
+        if retry_category == 'model_validation':
+            return 'model output validation failed'
+        if retry_category in {'transient', 'connection', 'timeout', 'provider_transient', 'rate_limit'}:
+            return 'a transient provider or connection interruption occurred'
+        if retry_category == 'batch_exhausted':
+            return 'one or more batches exhausted independent retries'
+        return 'a retryable interruption occurred'
 
     if status == TABULAR_EXPORT_STATUS_COMPLETED:
         return {
@@ -5334,7 +5344,7 @@ def _build_run_status_detail(run, settings, retryable_failure, can_resume):
         return {
             'status_label': 'Retry Scheduled',
             'status_tone': 'warning',
-            'status_detail': 'Automatic retry is scheduled. Continue can resume now from the last checkpoint.',
+            'status_detail': f'Automatic retry is scheduled because {retry_reason_text()}. Continue can resume now from the last checkpoint.',
             'is_stale': False,
             'waiting_for_retry': True,
             'retry_due': False,
@@ -5344,7 +5354,7 @@ def _build_run_status_detail(run, settings, retryable_failure, can_resume):
         return {
             'status_label': 'Needs Attention',
             'status_tone': 'warning',
-            'status_detail': 'Automatic retry is due but no worker has picked it up. Continue will resume from the last checkpoint.',
+            'status_detail': f'Automatic retry is due because {retry_reason_text()}, but no worker has picked it up. Continue will resume from the last checkpoint.',
             'is_stale': False,
             'waiting_for_retry': False,
             'retry_due': True,
@@ -5365,9 +5375,9 @@ def _build_run_status_detail(run, settings, retryable_failure, can_resume):
             'status_label': 'Needs Attention',
             'status_tone': 'warning' if can_resume else 'danger',
             'status_detail': (
-                'Analysis stopped after a retryable interruption. Continue will resume from the last checkpoint.'
+                f'Analysis stopped because {retry_reason_text()}. Continue will resume from the last checkpoint.'
                 if is_analysis_like
-                else 'Export stopped after a retryable interruption. Continue will resume from the last checkpoint.'
+                else f'Export stopped because {retry_reason_text()}. Continue will resume from the last checkpoint.'
             ),
             'is_stale': False,
             'waiting_for_retry': False,
@@ -5897,6 +5907,15 @@ def _is_stale_running_run(run, settings):
         minimum=60,
         maximum=900,
     )
+    if str((run or {}).get('executor_mode') or '').strip() != TABULAR_EXECUTOR_MODE_ROLLING_POOL:
+        batch_timeout_seconds = _settings_int(
+            settings,
+            'tabular_generated_output_batch_timeout_seconds',
+            TABULAR_EXPORT_DEFAULT_BATCH_TIMEOUT_SECONDS,
+            minimum=30,
+            maximum=900,
+        )
+        stale_seconds = max(stale_seconds, batch_timeout_seconds + 60)
     last_heartbeat = str(run.get('last_heartbeat_at') or run.get('updated_at') or '').strip()
     if not last_heartbeat:
         return True

--- a/docs/explanation/features/TABULAR_BACKGROUND_GENERATED_EXPORTS.md
+++ b/docs/explanation/features/TABULAR_BACKGROUND_GENERATED_EXPORTS.md
@@ -2,7 +2,7 @@
 
 Implemented in version: **0.241.046**
 
-Updated through version: **0.250.146**
+Updated through version: **0.250.147**
 
 ## Overview
 
@@ -42,6 +42,7 @@ The feature supports large spreadsheet-driven analysis, including workbooks that
 - Phase 8 assigns new runs to deterministic rollout cohorts, records explicit planner/executor/protocol/retry modes, reclaims new-run workers after a snapshotted two-minute stale interval, and revalidates source ETags before final publication.
 - Background handoff metadata derives its requested row count from the safe public run status so accepted durable runs cannot terminate the foreground stream while constructing the status card payload.
 - Object-protocol model responses can recover from hidden source-token echo mismatches when row count and any explicit source row number or identity markers preserve the requested source order.
+- Fixed-window runs use a timeout-aware stale threshold so normal long model calls are not shown as stale while only rolling-pool runs use the short heartbeat interval. Retry status text includes safe reason categories such as model output validation or transient provider interruption.
 
 ### API Endpoints
 
@@ -107,6 +108,7 @@ The progress card displays current status, completed checkpoint counts, processe
 - Phase 8 stable cohort, stale reclaim, source-version publication, crash recovery, and performance-summary regression: `functional_tests/test_tabular_row_orchestration_scale.py`
 - Background metadata streaming regression for export, analysis, and combined modes: `functional_tests/test_tabular_row_orchestration_scale.py`
 - Source-token echo recovery regression: `functional_tests/test_tabular_row_orchestration_scale.py`
+- Fixed-window stale heartbeat regression: `functional_tests/test_tabular_row_orchestration_scale.py`
 - Phase 2 handoff regression: `functional_tests/test_tabular_row_orchestration_scale.py`
 - Phase 1 baseline and fake harness coverage: `functional_tests/test_tabular_row_orchestration_scale.py`
 - Functional regression for workflow/document-action presentation: `functional_tests/test_document_analysis_lossless_artifacts.py`
@@ -161,3 +163,4 @@ The progress card displays current status, completed checkpoint counts, processe
 - `application/single_app/config.py` was updated to version **0.250.144** for Phase 8 stable rollout cohorts, stale reclaim, source-version publication checks, chaos recovery coverage, and bounded performance summaries.
 - `application/single_app/config.py` was updated to version **0.250.145** to prevent accepted background-run metadata from terminating the foreground stream with an undefined row-count variable.
 - `application/single_app/config.py` was updated to version **0.250.146** to recover object-protocol model responses that preserve row order but fail to echo hidden source-row tokens.
+- `application/single_app/config.py` was updated to version **0.250.147** to prevent fixed-window runs from being falsely marked stale during normal long model calls and to show safe retry-reason details in the status card.

--- a/docs/explanation/fixes/TABULAR_FIXED_WINDOW_STALE_HEARTBEAT_FIX.md
+++ b/docs/explanation/fixes/TABULAR_FIXED_WINDOW_STALE_HEARTBEAT_FIX.md
@@ -1,0 +1,52 @@
+# Tabular Fixed-Window Stale Heartbeat Fix
+
+Fixed in version: **0.250.147**
+
+Related issue: **microsoft/simplechat#1031**
+
+## Issue Description
+
+Large background generated CSV runs could show `Needs Attention` with `Worker heartbeat is stale. Continue will resume from the last checkpoint.` while the worker was still inside a long fixed-window model call. This made the front end look like the run had errored and required manual Continue even when no persisted backend error existed. When a real retry was scheduled, the status text also lacked a safe category explaining why.
+
+The issue affected 300, 3,000, and 30,000-row runs that were still using `fixed-window-v1`. Logs showed accepted full runs such as `row_count=3000`, `batch_count=52`, but the status card exposed stale-heartbeat state after the worker spent more than the Phase 8 two-minute stale interval waiting for the model.
+
+## Root Cause
+
+Phase 8 introduced a short `tabular_generation_stale_seconds` default of 120 seconds for faster rolling-pool recovery. Rolling-pool execution has a heartbeat loop, so that threshold is appropriate there. Fixed-window execution does not heartbeat while awaiting long model calls, and live calls commonly take more than 120 seconds. The shared stale detector therefore marked healthy fixed-window work as stale.
+
+## Technical Details
+
+### Files Modified
+
+- `application/single_app/functions_tabular_generated_exports.py`
+- `application/single_app/config.py`
+- `functional_tests/test_tabular_row_orchestration_scale.py`
+- `docs/explanation/features/TABULAR_BACKGROUND_GENERATED_EXPORTS.md`
+
+### Code Changes
+
+`_is_stale_running_run(...)` now uses the short snapshotted stale interval for rolling-pool runs only. Fixed-window runs use a timeout-aware threshold of at least the configured batch timeout plus a 60-second grace period. This prevents the public status API from surfacing stale-heartbeat recovery while a fixed-window worker is legitimately waiting for the model.
+
+The public status detail now also includes safe retry reason categories, such as model output validation failure or transient provider/connection interruption, without exposing raw provider errors or generated row content.
+
+## Validation
+
+Functional coverage verifies that:
+
+- rolling-pool runs are stale after the short Phase 8 heartbeat window;
+- fixed-window runs are not stale during a normal 300-second model timeout window;
+- fixed-window runs become stale after the timeout-aware grace period;
+- legacy snapshots continue to avoid premature stale detection.
+- retry status text exposes safe reason categories without raw error text.
+
+Validated with:
+
+```bash
+python -m py_compile application/single_app/functions_tabular_generated_exports.py application/single_app/config.py functional_tests/test_tabular_row_orchestration_scale.py
+python -m pytest functional_tests/test_tabular_row_orchestration_scale.py -k "phase_eight_retry_and_stale or retry_status_detail or token_echo_recovery or background_metadata" -q
+python -m pytest functional_tests/test_tabular_row_orchestration_scale.py -q
+```
+
+## Related Version Update
+
+`application/single_app/config.py` was incremented from **0.250.146** to **0.250.147** for this false stale-heartbeat status fix and safe retry-reason status text.

--- a/functional_tests/test_tabular_background_generated_exports.py
+++ b/functional_tests/test_tabular_background_generated_exports.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """
 Functional test for durable tabular generated-output background exports.
-Version: 0.250.142
-Implemented in: 0.241.060; throughput and timeout hardening in: 0.250.070; unified durable run contract in: 0.250.128; Phase 6 rolling worker pool compatibility in: 0.250.142
+Version: 0.250.147
+Implemented in: 0.241.060; throughput and timeout hardening in: 0.250.070; unified durable run contract in: 0.250.128; Phase 6 rolling worker pool compatibility in: 0.250.142; safe retry reason status text in: 0.250.147
 
 This test ensures that large tabular structured exports are wired through the
 durable background queue, status API, queued retry recovery, and chat progress
@@ -113,7 +113,7 @@ def test_export_runner_module():
     assert_contains(source_text, 'active_processing_seconds', 'active-time ETA accounting')
     assert_contains(source_text, 'or _is_due_queued_retry_run(run)', 'queued retry-due manual resume eligibility')
     assert_contains(source_text, 'or _is_stale_queued_run(run, settings or {})', 'stale queued manual resume eligibility')
-    assert_contains(source_text, 'Automatic retry is due but no worker has picked it up', 'queued retry-due status detail')
+    assert_contains(source_text, 'Automatic retry is due because', 'queued retry-due status detail')
     assert_contains(source_text, "'retry_due': status_detail.get('retry_due')", 'retry-due public status payload')
     assert_contains(source_text, 'Manual resume queued', 'manual checkpoint resume message')
     assert_contains(source_text, 'manual_resume_count', 'manual resume counter')

--- a/functional_tests/test_tabular_row_orchestration_scale.py
+++ b/functional_tests/test_tabular_row_orchestration_scale.py
@@ -1,8 +1,8 @@
 # test_tabular_row_orchestration_scale.py
 """
 Functional test for scalable per-row tabular orchestration.
-Version: 0.250.146
-Implemented in: 0.250.060; generated CSV formula safety in 0.250.065; generated file export routing in 0.250.072; source descriptor generalization in 0.250.127; unified durable run contract in 0.250.128; hierarchical analysis in 0.250.129; combined analysis and export in 0.250.130; scale validation in 0.250.132; direct source-backed exhaustive queueing in 0.250.133; direct queue call-site hardening in 0.250.134; model-validation auto retry in 0.250.135; model-aware parallel throughput in 0.250.136; Phase 1 acceleration contracts and observability in 0.250.137; Phase 2 truthful background handoff in 0.250.138; Phase 3 durable LLM generation planning in 0.250.139; Phase 4 compact row response protocol in 0.250.140; Phase 5 completion-driven checkpointing in 0.250.141; Phase 6 rolling worker pool in 0.250.142; Phase 7 independent batch retries in 0.250.143; Phase 8 scale, chaos, and rollout in 0.250.144; background metadata streaming fix in 0.250.145; source-token echo recovery in 0.250.146
+Version: 0.250.147
+Implemented in: 0.250.060; generated CSV formula safety in 0.250.065; generated file export routing in 0.250.072; source descriptor generalization in 0.250.127; unified durable run contract in 0.250.128; hierarchical analysis in 0.250.129; combined analysis and export in 0.250.130; scale validation in 0.250.132; direct source-backed exhaustive queueing in 0.250.133; direct queue call-site hardening in 0.250.134; model-validation auto retry in 0.250.135; model-aware parallel throughput in 0.250.136; Phase 1 acceleration contracts and observability in 0.250.137; Phase 2 truthful background handoff in 0.250.138; Phase 3 durable LLM generation planning in 0.250.139; Phase 4 compact row response protocol in 0.250.140; Phase 5 completion-driven checkpointing in 0.250.141; Phase 6 rolling worker pool in 0.250.142; Phase 7 independent batch retries in 0.250.143; Phase 8 scale, chaos, and rollout in 0.250.144; background metadata streaming fix in 0.250.145; source-token echo recovery in 0.250.146; fixed-window stale heartbeat fix in 0.250.147
 
 This test ensures generated exports preserve source identity and row order while
 enforcing one stable output schema across independently generated batches.
@@ -143,6 +143,7 @@ FAILURE_FUNCTIONS = {
     '_tabular_background_handoff_has_preview',
 }
 BACKGROUND_METADATA_FUNCTIONS = {'build_background_tabular_generated_output_metadata'}
+STATUS_DETAIL_FUNCTIONS = {'_build_run_status_detail'}
 ARTIFACT_FUNCTIONS = {'_upload_generated_chat_artifact_for_current_user'}
 SCHEDULER_FUNCTIONS = {'_query_scheduler_candidates_by_status'}
 MANIFEST_FUNCTIONS = {
@@ -1131,6 +1132,37 @@ def _load_background_generated_output_metadata_helper():
     return namespace['build_background_tabular_generated_output_metadata']
 
 
+def _load_run_status_detail_helper():
+    module_tree = ast.parse(EXPORT_MODULE.read_text(encoding='utf-8'), filename=str(EXPORT_MODULE))
+    selected_nodes = [
+        node
+        for node in module_tree.body
+        if isinstance(node, ast.FunctionDef) and node.name in STATUS_DETAIL_FUNCTIONS
+    ]
+    if len(selected_nodes) != len(STATUS_DETAIL_FUNCTIONS):
+        raise AssertionError('Missing run status detail helper')
+
+    namespace = {
+        'TABULAR_EXPORT_STATUS_COMPLETED': 'completed',
+        'TABULAR_EXPORT_STATUS_CANCELED': 'canceled',
+        'TABULAR_EXPORT_STATUS_RUNNING': 'running',
+        'TABULAR_EXPORT_STATUS_FAILED': 'failed',
+        'TABULAR_RUN_TASK_HIERARCHICAL_ANALYSIS': 'hierarchical_analysis',
+        'TABULAR_RUN_TASK_COMBINED': 'combined',
+        '_normalize_tabular_run_task_type': lambda task_type: task_type or 'structured_export',
+        '_is_stale_running_run': lambda run, settings: bool(run.get('_test_is_stale')),
+        '_is_waiting_for_retry': lambda run: bool(run.get('_test_waiting_for_retry')),
+        '_is_due_queued_retry_run': lambda run: bool(run.get('_test_retry_due')),
+        '_is_stale_queued_run': lambda run, settings: bool(run.get('_test_stale_queued')),
+        '_seconds_until': lambda value: 15 if value else None,
+        '_safe_int': lambda value: int(value or 0),
+        '_has_exhausted_independent_batch_retries': lambda run: bool(run.get('_test_exhausted')),
+    }
+    extracted_module = ast.Module(body=selected_nodes, type_ignores=[])
+    exec(compile(extracted_module, str(EXPORT_MODULE), 'exec'), namespace)
+    return namespace['_build_run_status_detail']
+
+
 def _assert_concise_background_handoff_contract(text, expected_row_count, expected_output_label):
     normalized_text = str(text or '')
     normalized_lower = normalized_text.lower()
@@ -2047,20 +2079,66 @@ def test_phase_eight_retry_and_stale_reclaim_modes_are_snapshotted():
         fixed_mode,
     ) == 'run-level-v1'
 
-    new_run = {
+    rolling_run = {
+        'executor_mode': rolling_mode,
         'last_heartbeat_at': (now - timedelta(seconds=121)).isoformat(),
         'generation_rollout_settings': {
             'tabular_generation_stale_seconds': 120,
         },
     }
+    fixed_window_run = {
+        'executor_mode': fixed_mode,
+        'last_heartbeat_at': (now - timedelta(seconds=121)).isoformat(),
+        'generation_rollout_settings': {
+            'tabular_generation_stale_seconds': 120,
+        },
+    }
+    stale_fixed_window_run = {
+        **fixed_window_run,
+        'last_heartbeat_at': (now - timedelta(seconds=361)).isoformat(),
+    }
     legacy_run = {
+        'executor_mode': fixed_mode,
         'last_heartbeat_at': (now - timedelta(seconds=121)).isoformat(),
         'generation_rollout_settings': {
             'enable_tabular_generation_plan': True,
         },
     }
-    assert helpers['_is_stale_running_run'](new_run, {}) is True
+    assert helpers['_is_stale_running_run'](rolling_run, {}) is True
+    assert helpers['_is_stale_running_run'](fixed_window_run, {}) is False
+    assert helpers['_is_stale_running_run'](stale_fixed_window_run, {}) is True
     assert helpers['_is_stale_running_run'](legacy_run, {}) is False
+
+
+def test_retry_status_detail_exposes_safe_retry_reason():
+    """Public status explains retry categories without exposing raw provider errors."""
+    build_status_detail = _load_run_status_detail_helper()
+
+    scheduled_detail = build_status_detail(
+        {
+            'status': 'queued',
+            'last_retry_category': 'model_validation',
+            'next_attempt_at': '2026-08-10T12:01:00+00:00',
+            '_test_waiting_for_retry': True,
+        },
+        {},
+        retryable_failure=False,
+        can_resume=True,
+    )
+    assert scheduled_detail['status_label'] == 'Retry Scheduled'
+    assert 'model output validation failed' in scheduled_detail['status_detail']
+    assert 'raw' not in scheduled_detail['status_detail'].lower()
+
+    failed_detail = build_status_detail(
+        {
+            'status': 'failed',
+            'last_retry_category': 'transient',
+        },
+        {},
+        retryable_failure=True,
+        can_resume=True,
+    )
+    assert 'transient provider or connection interruption' in failed_detail['status_detail']
 
 
 def test_phase_eight_publication_revalidates_source_version():
@@ -5282,6 +5360,7 @@ def main():
         test_phase_three_rollout_activates_shadow_only_and_stays_backend_only,
         test_phase_eight_rollout_assignment_is_stable_and_control_runs_stay_legacy,
         test_phase_eight_retry_and_stale_reclaim_modes_are_snapshotted,
+        test_retry_status_detail_exposes_safe_retry_reason,
         test_phase_eight_publication_revalidates_source_version,
         test_phase_eight_committed_output_survives_summary_and_progress_crash,
         test_phase_eight_performance_summary_is_bounded_and_cohort_comparable,


### PR DESCRIPTION
## Summary

- prevent `fixed-window-v1` tabular runs from being marked stale during normal long model calls
- keep the short Phase 8 stale heartbeat window for `rolling-pool-v1`, which has an active heartbeat loop
- use a timeout-aware stale window for fixed-window runs: configured batch timeout plus a 60-second grace period
- improve public status text with safe retry reason categories such as model output validation failure or transient provider/connection interruption
- bump the app to 0.250.147 and document the false stale heartbeat/status fix

## Production Evidence

`query_data (15).csv` shows full runs were accepted, not capped: `row_count=300`, `batch_count=6`; `row_count=3000`, `batch_count=52`; and `row_count=30000`, `batch_count=514`. The UI screenshot showed `Worker heartbeat is stale` for a fixed-window run with `0 of 52 batches checkpointed`. Fixed-window execution does not heartbeat while waiting on model calls, and live calls can exceed the Phase 8 120-second stale threshold. That made healthy in-progress work look like an error requiring manual Continue.

The logs also show retry/recovery situations where a safe reason category is useful on the status card. This PR keeps raw errors hidden but surfaces safe categories in `status_detail`.

## Validation

- `python -m py_compile application/single_app/functions_tabular_generated_exports.py application/single_app/config.py functional_tests/test_tabular_row_orchestration_scale.py functional_tests/test_tabular_background_generated_exports.py`
- `python -m pytest functional_tests/test_tabular_row_orchestration_scale.py -k "phase_eight_retry_and_stale or retry_status_detail or token_echo_recovery or background_metadata" -q` (`4 passed`)
- `python -m pytest functional_tests/test_tabular_row_orchestration_scale.py -q` (`66 passed`)
- `python -m pytest functional_tests/test_tabular_background_generated_exports.py -q` (`7 passed`)
- Windows-safe `git diff --check`
- Editor diagnostics show no new errors in touched files

Refs #1031