### PR TITLE
Fix tabular nested CSV output schema

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -96,7 +96,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.250.147"
+VERSION = "0.250.148"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/functions_tabular_generated_exports.py
+++ b/application/single_app/functions_tabular_generated_exports.py
@@ -1482,6 +1482,60 @@ def _generated_entry_has_source_position_conflict(source_row, generated_entry):
     return False
 
 
+def _parse_single_nested_csv_generated_entry(generated_entry):
+    if not isinstance(generated_entry, dict):
+        return None
+    csv_payload = generated_entry.get('csv')
+    if not isinstance(csv_payload, str) or not csv_payload.strip():
+        return None
+    allowed_metadata_fields = {
+        'csv',
+        TABULAR_EXPORT_INPUT_ROW_NUMBER_FIELD,
+        TABULAR_EXPORT_INPUT_ROW_IDENTITY_FIELD,
+        TABULAR_EXPORT_INPUT_ROW_TOKEN_FIELD,
+        TABULAR_EXPORT_OUTPUT_ROW_NUMBER_FIELD,
+        TABULAR_EXPORT_OUTPUT_ROW_IDENTITY_FIELD,
+    }
+
+    try:
+        csv_rows = list(csv.DictReader(io.StringIO(csv_payload.strip())))
+    except (csv.Error, TypeError, ValueError):
+        return None
+    if len(csv_rows) != 1:
+        return None
+    parsed_row = {
+        str(field_name or '').strip(): field_value
+        for field_name, field_value in (csv_rows[0] or {}).items()
+        if str(field_name or '').strip()
+    }
+    if not parsed_row:
+        return None
+    for field_name, field_value in generated_entry.items():
+        if field_name in allowed_metadata_fields:
+            continue
+        if field_name not in parsed_row:
+            return None
+        if str(parsed_row.get(field_name) or '') != str(field_value or ''):
+            return None
+    for metadata_field in allowed_metadata_fields - {'csv'}:
+        if metadata_field in generated_entry and generated_entry.get(metadata_field) not in (None, ''):
+            parsed_row[metadata_field] = generated_entry.get(metadata_field)
+    return parsed_row
+
+
+def _expand_nested_csv_generated_entries(generated_entries):
+    expanded_entries = []
+    recovered_count = 0
+    for generated_entry in generated_entries or []:
+        parsed_entry = _parse_single_nested_csv_generated_entry(generated_entry)
+        if parsed_entry is None:
+            expanded_entries.append(generated_entry)
+            continue
+        expanded_entries.append(parsed_entry)
+        recovered_count += 1
+    return expanded_entries, recovered_count
+
+
 def _normalize_model_generated_batch_entries(
     source_rows,
     generated_entries,
@@ -1490,6 +1544,17 @@ def _normalize_model_generated_batch_entries(
     run_id=None,
     batch_number=None,
 ):
+    generated_entries, nested_csv_recovered_count = _expand_nested_csv_generated_entries(generated_entries)
+    if nested_csv_recovered_count:
+        log_event(
+            '[TABULAR_GENERATED_OUTPUT] Expanded nested CSV model output rows',
+            {
+                'run_id': run_id,
+                'batch_number': batch_number,
+                'recovered_row_count': nested_csv_recovered_count,
+            },
+            level=logging.WARNING,
+        )
     try:
         return _normalize_generated_batch_entries(
             source_rows,
@@ -2999,6 +3064,7 @@ def _build_batch_prompt(
         f'Copy {TABULAR_EXPORT_INPUT_ROW_TOKEN_FIELD} exactly from each input row into its matching output object. '
         f'The {TABULAR_EXPORT_INPUT_ROW_NUMBER_FIELD} and {TABULAR_EXPORT_INPUT_ROW_IDENTITY_FIELD} fields are internal; '
         'do not include those two fields in generated objects.\n'
+        'Do not return CSV text, embedded CSV headers, markdown tables, or a field named csv; every requested output column must be a separate JSON object field.\n'
         'Do not drop, merge, summarize, or cap rows.\n'
         'Input rows may include normalized helper fields such as comment_id, body_text, source_file, attachment_present, attachment_names, and attachment_text. Use those normalized fields when they are present.\n'
         'Input rows may include a referenced_documents array containing row-linked evidence from explicitly referenced non-tabular documents. Use that evidence as part of the source row context when it is relevant to the requested output.\n'

--- a/docs/explanation/features/TABULAR_BACKGROUND_GENERATED_EXPORTS.md
+++ b/docs/explanation/features/TABULAR_BACKGROUND_GENERATED_EXPORTS.md
@@ -2,7 +2,7 @@
 
 Implemented in version: **0.241.046**
 
-Updated through version: **0.250.147**
+Updated through version: **0.250.148**
 
 ## Overview
 
@@ -43,6 +43,7 @@ The feature supports large spreadsheet-driven analysis, including workbooks that
 - Background handoff metadata derives its requested row count from the safe public run status so accepted durable runs cannot terminate the foreground stream while constructing the status card payload.
 - Object-protocol model responses can recover from hidden source-token echo mismatches when row count and any explicit source row number or identity markers preserve the requested source order.
 - Fixed-window runs use a timeout-aware stale threshold so normal long model calls are not shown as stale while only rolling-pool runs use the short heartbeat interval. Retry status text includes safe reason categories such as model output validation or transient provider interruption.
+- Object-protocol responses that wrap one generated CSV row inside a `csv` property are expanded before schema inference so final artifacts use the requested generated columns instead of a nested CSV column.
 
 ### API Endpoints
 
@@ -109,6 +110,7 @@ The progress card displays current status, completed checkpoint counts, processe
 - Background metadata streaming regression for export, analysis, and combined modes: `functional_tests/test_tabular_row_orchestration_scale.py`
 - Source-token echo recovery regression: `functional_tests/test_tabular_row_orchestration_scale.py`
 - Fixed-window stale heartbeat regression: `functional_tests/test_tabular_row_orchestration_scale.py`
+- Nested CSV output recovery regression: `functional_tests/test_tabular_row_orchestration_scale.py`
 - Phase 2 handoff regression: `functional_tests/test_tabular_row_orchestration_scale.py`
 - Phase 1 baseline and fake harness coverage: `functional_tests/test_tabular_row_orchestration_scale.py`
 - Functional regression for workflow/document-action presentation: `functional_tests/test_document_analysis_lossless_artifacts.py`
@@ -164,3 +166,4 @@ The progress card displays current status, completed checkpoint counts, processe
 - `application/single_app/config.py` was updated to version **0.250.145** to prevent accepted background-run metadata from terminating the foreground stream with an undefined row-count variable.
 - `application/single_app/config.py` was updated to version **0.250.146** to recover object-protocol model responses that preserve row order but fail to echo hidden source-row tokens.
 - `application/single_app/config.py` was updated to version **0.250.147** to prevent fixed-window runs from being falsely marked stale during normal long model calls and to show safe retry-reason details in the status card.
+- `application/single_app/config.py` was updated to version **0.250.148** to flatten single-row nested CSV model outputs before generated-export schema inference.

--- a/docs/explanation/fixes/TABULAR_NESTED_CSV_OUTPUT_FIX.md
+++ b/docs/explanation/fixes/TABULAR_NESTED_CSV_OUTPUT_FIX.md
@@ -1,0 +1,55 @@
+# Tabular Nested CSV Output Fix
+
+Fixed in version: **0.250.148**
+
+Related issue: **microsoft/simplechat#1031**
+
+## Issue Description
+
+Some completed background generated CSV exports contained the expected number of source rows but had the wrong output shape. Instead of separate generated columns such as `transaction_summary`, `counterparty_classification`, and `risk_prioritization`, the final file contained columns like:
+
+```text
+source_row_number,source_row_identity,transaction_id,csv
+```
+
+Each `csv` cell then contained a complete mini CSV payload for that source row. This made the artifact technically complete by source row count but not usable as the requested flat CSV dataset.
+
+## Root Cause
+
+The object response protocol accepts a JSON object per source row. When the model returned one object containing a `csv` property with a single generated CSV row, the server inferred that object shape as the run schema. Finalization then faithfully serialized the nested `csv` field instead of expanding the generated columns.
+
+## Technical Details
+
+### Files Modified
+
+- `application/single_app/functions_tabular_generated_exports.py`
+- `application/single_app/config.py`
+- `functional_tests/test_tabular_row_orchestration_scale.py`
+- `docs/explanation/features/TABULAR_BACKGROUND_GENERATED_EXPORTS.md`
+
+### Code Changes
+
+Model response normalization now detects generated objects whose only meaningful model output is a `csv` field. When that field parses as exactly one CSV data row, the server expands it before schema inference and then applies the existing row count, source identity, source token recovery, and schema validation contracts.
+
+The recovery is deliberately narrow:
+
+- it applies only to single-row nested CSV payloads;
+- it does not accept multi-row nested CSV content inside one generated row;
+- it does not bypass source row order or schema validation;
+- compact row protocol behavior is unchanged.
+
+## Validation
+
+Functional coverage creates object-protocol model output with a nested `csv` property and verifies the normalized entries flatten into generated columns with no residual `csv` field.
+
+Validated with:
+
+```bash
+python -m py_compile application/single_app/functions_tabular_generated_exports.py application/single_app/config.py functional_tests/test_tabular_row_orchestration_scale.py
+python -m pytest functional_tests/test_tabular_row_orchestration_scale.py -k "nested_csv or token_echo_recovery or background_metadata" -q
+python -m pytest functional_tests/test_tabular_row_orchestration_scale.py -q
+```
+
+## Related Version Update
+
+`application/single_app/config.py` was incremented from **0.250.147** to **0.250.148** for this nested CSV output-shape fix.

--- a/functional_tests/test_tabular_row_orchestration_scale.py
+++ b/functional_tests/test_tabular_row_orchestration_scale.py
@@ -1,8 +1,8 @@
 # test_tabular_row_orchestration_scale.py
 """
 Functional test for scalable per-row tabular orchestration.
-Version: 0.250.147
-Implemented in: 0.250.060; generated CSV formula safety in 0.250.065; generated file export routing in 0.250.072; source descriptor generalization in 0.250.127; unified durable run contract in 0.250.128; hierarchical analysis in 0.250.129; combined analysis and export in 0.250.130; scale validation in 0.250.132; direct source-backed exhaustive queueing in 0.250.133; direct queue call-site hardening in 0.250.134; model-validation auto retry in 0.250.135; model-aware parallel throughput in 0.250.136; Phase 1 acceleration contracts and observability in 0.250.137; Phase 2 truthful background handoff in 0.250.138; Phase 3 durable LLM generation planning in 0.250.139; Phase 4 compact row response protocol in 0.250.140; Phase 5 completion-driven checkpointing in 0.250.141; Phase 6 rolling worker pool in 0.250.142; Phase 7 independent batch retries in 0.250.143; Phase 8 scale, chaos, and rollout in 0.250.144; background metadata streaming fix in 0.250.145; source-token echo recovery in 0.250.146; fixed-window stale heartbeat fix in 0.250.147
+Version: 0.250.148
+Implemented in: 0.250.060; generated CSV formula safety in 0.250.065; generated file export routing in 0.250.072; source descriptor generalization in 0.250.127; unified durable run contract in 0.250.128; hierarchical analysis in 0.250.129; combined analysis and export in 0.250.130; scale validation in 0.250.132; direct source-backed exhaustive queueing in 0.250.133; direct queue call-site hardening in 0.250.134; model-validation auto retry in 0.250.135; model-aware parallel throughput in 0.250.136; Phase 1 acceleration contracts and observability in 0.250.137; Phase 2 truthful background handoff in 0.250.138; Phase 3 durable LLM generation planning in 0.250.139; Phase 4 compact row response protocol in 0.250.140; Phase 5 completion-driven checkpointing in 0.250.141; Phase 6 rolling worker pool in 0.250.142; Phase 7 independent batch retries in 0.250.143; Phase 8 scale, chaos, and rollout in 0.250.144; background metadata streaming fix in 0.250.145; source-token echo recovery in 0.250.146; fixed-window stale heartbeat fix in 0.250.147; nested CSV output recovery in 0.250.148
 
 This test ensures generated exports preserve source identity and row order while
 enforcing one stable output schema across independently generated batches.
@@ -57,6 +57,8 @@ CONTRACT_FUNCTIONS = {
     '_prepare_tabular_source_rows',
     '_normalize_generated_batch_entries',
     '_generated_entry_has_source_position_conflict',
+    '_parse_single_nested_csv_generated_entry',
+    '_expand_nested_csv_generated_entries',
     '_normalize_model_generated_batch_entries',
 }
 CONTRACT_CONSTANTS = {
@@ -375,7 +377,7 @@ def _load_contract_helpers():
             f'constants={sorted(missing_constants)}'
         )
 
-    namespace = {'re': re, 'uuid': uuid}
+    namespace = {'csv': csv, 'io': io, 're': re, 'uuid': uuid}
     namespace['log_event'] = lambda *args, **kwargs: None
     namespace['logging'] = logging
     extracted_module = ast.Module(body=selected_nodes, type_ignores=[])
@@ -3711,6 +3713,117 @@ def test_model_batch_token_echo_recovery_preserves_order_contract():
         raise AssertionError('Explicit source row conflicts must not use positional recovery')
 
 
+def test_model_batch_nested_csv_output_is_flattened_before_schema_inference():
+    """Object responses that wrap one CSV row are expanded into final columns."""
+    helpers = _load_contract_helpers()
+    prepared_rows = helpers['_prepare_tabular_source_rows'](
+        [
+            {'transaction_id': 'BT-000001'},
+            {'transaction_id': 'BT-000002'},
+        ],
+        start_row=0,
+    )
+    generated_entries = [
+        {
+            'transaction_id': 'BT-000001',
+            'csv': (
+                'transaction_id,transaction_summary,counterparty_classification\n'
+                'BT-000001,"summary one","Treasury"'
+            ),
+        },
+        {
+            'transaction_id': 'BT-000002',
+            'csv': (
+                'transaction_id,transaction_summary,counterparty_classification\n'
+                'BT-000002,"summary two","Bank-to-bank"'
+            ),
+        },
+    ]
+
+    recovered_entries, output_schema = helpers['_normalize_model_generated_batch_entries'](
+        prepared_rows,
+        generated_entries,
+        run_id='run-nested-csv',
+        batch_number=1,
+    )
+
+    assert output_schema == [
+        'source_row_number',
+        'source_row_identity',
+        'transaction_id',
+        'transaction_summary',
+        'counterparty_classification',
+    ]
+    assert recovered_entries[0] == {
+        'source_row_number': 1,
+        'source_row_identity': 'BT-000001',
+        'transaction_id': 'BT-000001',
+        'transaction_summary': 'summary one',
+        'counterparty_classification': 'Treasury',
+    }
+    assert 'csv' not in recovered_entries[0]
+
+
+def test_model_batch_nested_csv_output_supports_arbitrary_csv_headers():
+    """Nested CSV recovery is not tied to one source dataset or field set."""
+    helpers = _load_contract_helpers()
+    prepared_rows = helpers['_prepare_tabular_source_rows'](
+        [
+            {'case_id': 'CASE-001', 'department': 'Operations'},
+            {'case_id': 'CASE-002', 'department': 'Support'},
+        ],
+        start_row=0,
+    )
+    expected_schema = [
+        'source_row_number',
+        'source_row_identity',
+        'case_id',
+        'quality_score',
+        'next_step',
+    ]
+    generated_entries = [
+        {
+            'csv': (
+                'case_id,quality_score,next_step\n'
+                'CASE-001,high,"Escalate with notes"'
+            ),
+        },
+        {
+            'csv': (
+                'case_id,quality_score,next_step\n'
+                'CASE-002,medium,"Monitor until resolved"'
+            ),
+        },
+    ]
+
+    recovered_entries, output_schema = helpers['_normalize_model_generated_batch_entries'](
+        prepared_rows,
+        generated_entries,
+        expected_output_schema=expected_schema,
+        run_id='run-nested-csv-generic',
+        batch_number=1,
+    )
+
+    assert output_schema == expected_schema
+    assert recovered_entries == [
+        {
+            'source_row_number': 1,
+            'source_row_identity': 'CASE-001',
+            'case_id': 'CASE-001',
+            'quality_score': 'high',
+            'next_step': 'Escalate with notes',
+        },
+        {
+            'source_row_number': 2,
+            'source_row_identity': 'CASE-002',
+            'case_id': 'CASE-002',
+            'quality_score': 'medium',
+            'next_step': 'Monitor until resolved',
+        },
+    ]
+    assert all('csv' not in recovered_entry for recovered_entry in recovered_entries)
+
+
 def test_durable_runner_enforces_row_contract():
     """Queueing, generation, and checkpointing must all enforce the shared contract."""
     queue_calls = _called_function_names(_get_function_node('queue_tabular_generated_output_run'))
@@ -5378,6 +5491,8 @@ def main():
         test_source_identity_and_order_contract,
         test_generated_batch_schema_contract,
         test_model_batch_token_echo_recovery_preserves_order_contract,
+        test_model_batch_nested_csv_output_is_flattened_before_schema_inference,
+        test_model_batch_nested_csv_output_supports_arbitrary_csv_headers,
         test_durable_runner_enforces_row_contract,
         test_paginated_candidate_coalesces_all_300_rows,
         test_paginated_candidate_rejects_gaps,


### PR DESCRIPTION
## Summary
- Flatten single-row nested CSV model responses before generated-export schema inference.
- Harden the object-protocol prompt so models return separate JSON fields instead of embedded CSV text or a `csv` wrapper.
- Add regression coverage and update versioned fix/feature documentation.

## Validation
- `python -m py_compile application/single_app/functions_tabular_generated_exports.py application/single_app/config.py functional_tests/test_tabular_row_orchestration_scale.py`
- `python -m pytest functional_tests/test_tabular_row_orchestration_scale.py -k "nested_csv or token_echo_recovery or background_metadata" -q`
- `python -m pytest functional_tests/test_tabular_row_orchestration_scale.py -q`
- `python -m pytest functional_tests/test_tabular_background_generated_exports.py -q`
- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check`

Refs #1031