### PR TITLE
Collapse tabular export status details

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -96,7 +96,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.250.149"
+VERSION = "0.250.150"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/static/js/chat/chat-messages.js
+++ b/application/single_app/static/js/chat/chat-messages.js
@@ -4549,7 +4549,7 @@ function renderReplyQuoteHtml(fullMessageObject = null) {
     }
   }
 
-  function createBackgroundGeneratedOutputStatusBlock(outputMetadata) {
+  function createBackgroundGeneratedOutputStatusBlock(outputMetadata, supportingDetailElements = []) {
     const wrapper = document.createElement('div');
     wrapper.className = 'generated-tabular-background-status mt-3';
 
@@ -4577,18 +4577,39 @@ function renderReplyQuoteHtml(fullMessageObject = null) {
     progress.appendChild(progressBar);
     wrapper.appendChild(progress);
 
+    const details = document.createElement('details');
+    details.className = 'generated-analysis-preview-details generated-tabular-background-details mt-2';
+    details.dataset.generatedExportDetails = 'true';
+
+    const detailsSummary = document.createElement('summary');
+    detailsSummary.className = 'small fw-semibold';
+    detailsSummary.textContent = 'View details';
+    details.appendChild(detailsSummary);
+
+    const detailsContent = document.createElement('div');
+    detailsContent.className = 'mt-2';
+    supportingDetailElements.forEach(detailElement => {
+      if (detailElement instanceof HTMLElement) {
+        detailsContent.appendChild(detailElement);
+      }
+    });
+
     const detailText = document.createElement('div');
-    detailText.className = 'small text-muted mt-2';
-    wrapper.appendChild(detailText);
+    detailText.className = 'small text-muted';
+    detailsContent.appendChild(detailText);
 
     const updatedText = document.createElement('div');
     updatedText.className = 'small text-muted';
-    wrapper.appendChild(updatedText);
+    detailsContent.appendChild(updatedText);
+    details.appendChild(detailsContent);
+    wrapper.appendChild(details);
 
     const statusElements = {
       statusLabel,
       statusBadge,
       progressBar,
+      details,
+      detailsContent,
       detailText,
       updatedText,
     };
@@ -4813,6 +4834,15 @@ function renderReplyQuoteHtml(fullMessageObject = null) {
     const previewText = String(
       outputMetadata?.preview_text || outputMetadata?.analysis_text || outputMetadata?.panalysis_text || ''
     ).trim();
+    const isBackgroundExport = Boolean(outputMetadata?.background_export);
+    const backgroundDetailElements = [];
+    const appendSupportingDetail = element => {
+      if (isBackgroundExport) {
+        backgroundDetailElements.push(element);
+      } else {
+        card.appendChild(element);
+      }
+    };
 
     const header = document.createElement('div');
     header.className = 'd-flex flex-wrap justify-content-between align-items-start gap-2';
@@ -4825,15 +4855,24 @@ function renderReplyQuoteHtml(fullMessageObject = null) {
 
     const fileNameText = document.createElement('div');
     fileNameText.className = 'small text-muted text-break';
-    fileNameText.textContent = fileName;
-    headerText.appendChild(fileNameText);
+    fileNameText.textContent = isBackgroundExport ? `File: ${fileName}` : fileName;
+    if (isBackgroundExport) {
+      backgroundDetailElements.push(fileNameText);
+    } else {
+      headerText.appendChild(fileNameText);
+    }
     header.appendChild(headerText);
 
-    if (rowCountLabel) {
+    if (rowCountLabel && !isBackgroundExport) {
       const rowCountBadge = document.createElement('span');
       rowCountBadge.className = 'badge text-bg-light';
       rowCountBadge.textContent = `${rowCountLabel} rows`;
       header.appendChild(rowCountBadge);
+    } else if (rowCountLabel) {
+      const rowCountDetail = document.createElement('div');
+      rowCountDetail.className = 'small text-muted';
+      rowCountDetail.textContent = `Rows: ${rowCountLabel}`;
+      backgroundDetailElements.push(rowCountDetail);
     }
 
     card.appendChild(header);
@@ -4841,7 +4880,7 @@ function renderReplyQuoteHtml(fullMessageObject = null) {
     const storageNote = document.createElement('div');
     storageNote.className = 'small text-muted mt-2';
     storageNote.textContent = getGeneratedTabularStorageNote(outputMetadata);
-    card.appendChild(storageNote);
+    appendSupportingDetail(storageNote);
 
     if (sourceFileName || selectedSheet) {
       const sourceNote = document.createElement('div');
@@ -4854,19 +4893,22 @@ function renderReplyQuoteHtml(fullMessageObject = null) {
         sourceSegments.push(`Sheet: ${selectedSheet}`);
       }
       sourceNote.textContent = sourceSegments.join(' | ');
-      card.appendChild(sourceNote);
+      appendSupportingDetail(sourceNote);
     }
 
     if (summary) {
       const summaryText = document.createElement('p');
       summaryText.className = 'small mb-0 mt-2';
       summaryText.textContent = summary;
-      card.appendChild(summaryText);
+      appendSupportingDetail(summaryText);
     }
 
     let backgroundStatusElements = null;
-    if (outputMetadata?.background_export) {
-      const backgroundStatusBlock = createBackgroundGeneratedOutputStatusBlock(outputMetadata);
+    if (isBackgroundExport) {
+      const backgroundStatusBlock = createBackgroundGeneratedOutputStatusBlock(
+        outputMetadata,
+        backgroundDetailElements,
+      );
       backgroundStatusElements = backgroundStatusBlock.statusElements;
       card.appendChild(backgroundStatusBlock.wrapper);
     }
@@ -4888,7 +4930,13 @@ function renderReplyQuoteHtml(fullMessageObject = null) {
       }
 
       if (previewContent) {
-        if (shouldCollapseGeneratedAnalysisPreview(outputMetadata)) {
+        if (isBackgroundExport && backgroundStatusElements?.detailsContent) {
+          const previewLabel = document.createElement('div');
+          previewLabel.className = 'small fw-semibold mt-3 mb-2';
+          previewLabel.textContent = 'Preview';
+          backgroundStatusElements.detailsContent.appendChild(previewLabel);
+          backgroundStatusElements.detailsContent.appendChild(previewContent);
+        } else if (shouldCollapseGeneratedAnalysisPreview(outputMetadata)) {
           const previewDetails = document.createElement('details');
           previewDetails.className = 'generated-analysis-preview-details mt-3';
 

--- a/docs/explanation/features/TABULAR_BACKGROUND_GENERATED_EXPORTS.md
+++ b/docs/explanation/features/TABULAR_BACKGROUND_GENERATED_EXPORTS.md
@@ -2,7 +2,7 @@
 
 Implemented in version: **0.241.046**
 
-Updated through version: **0.250.149**
+Updated through version: **0.250.150**
 
 ## Overview
 
@@ -47,6 +47,7 @@ The feature supports large spreadsheet-driven analysis, including workbooks that
 - Direct durable artifact routing accepts every configured tabular input format (`csv`, `xlsx`, `xls`, and `xlsm`) through one version-pinned replay contract. Multi-sheet workbooks replay worksheets in workbook order.
 - Recognized exhaustive artifact requests never fall back to dumping generated rows into the assistant response when source preparation fails. The chat receives a concise artifact handoff or safe failure status instead.
 - Shadow schema planning is deferred off the production critical path. Unplanned source-backed runs checkpoint a small first batch before opening normal batch concurrency, and the status card identifies source preparation, active planning, or initial checkpoint generation before row progress appears.
+- Running background cards keep the status badge, progress bar, and available actions visible by default. File/source metadata, checkpoint counts, remaining work, throughput, concurrency, timestamps, and previews are grouped under a collapsed `View details` disclosure.
 
 ### API Endpoints
 
@@ -116,6 +117,7 @@ The progress card displays current status, completed checkpoint counts, processe
 - Nested CSV output recovery regression: `functional_tests/test_tabular_row_orchestration_scale.py`
 - Generic CSV and workbook durable routing regressions: `functional_tests/test_tabular_row_orchestration_scale.py`
 - Artifact-only failure and fast-start regressions: `functional_tests/test_tabular_row_orchestration_scale.py`
+- Collapsed background status detail regressions: `functional_tests/test_tabular_background_generated_exports.py` and `ui_tests/test_chat_background_generated_export_status.py`
 - Phase 2 handoff regression: `functional_tests/test_tabular_row_orchestration_scale.py`
 - Phase 1 baseline and fake harness coverage: `functional_tests/test_tabular_row_orchestration_scale.py`
 - Functional regression for workflow/document-action presentation: `functional_tests/test_document_analysis_lossless_artifacts.py`
@@ -173,3 +175,4 @@ The progress card displays current status, completed checkpoint counts, processe
 - `application/single_app/config.py` was updated to version **0.250.147** to prevent fixed-window runs from being falsely marked stale during normal long model calls and to show safe retry-reason details in the status card.
 - `application/single_app/config.py` was updated to version **0.250.148** to flatten single-row nested CSV model outputs before generated-export schema inference.
 - `application/single_app/config.py` was updated to version **0.250.149** to route every supported tabular input through artifact-only durable generation and reduce time to the first visible checkpoint.
+- `application/single_app/config.py` was updated to version **0.250.150** to simplify background export cards while preserving expandable operational detail.

--- a/docs/explanation/fixes/TABULAR_BACKGROUND_STATUS_DETAILS_FIX.md
+++ b/docs/explanation/fixes/TABULAR_BACKGROUND_STATUS_DETAILS_FIX.md
@@ -1,0 +1,62 @@
+# Tabular Background Status Details Fix
+
+Fixed in version: **0.250.150**
+
+Related issue: **microsoft/simplechat#1031**
+
+## Issue Description
+
+Running tabular export cards displayed filename and source metadata, background-processing guidance, checkpoint counts, remaining batch and chunk counts, throughput, model concurrency, timestamps, and optional previews at the same time. The information was useful for troubleshooting but too dense for the normal progress-monitoring workflow.
+
+## Root Cause
+
+The card renderer appended every status and metadata element directly to the visible card. Although previews for some completed analysis artifacts already used a native disclosure, running background export metadata did not have an equivalent collapsed boundary.
+
+## Technical Details
+
+### Files Modified
+
+- `application/single_app/static/js/chat/chat-messages.js`
+- `application/single_app/config.py`
+- `functional_tests/test_tabular_background_generated_exports.py`
+- `ui_tests/test_chat_background_generated_export_status.py`
+- `docs/explanation/features/TABULAR_BACKGROUND_GENERATED_EXPORTS.md`
+
+### Code Changes
+
+Background export cards now show these elements without expansion:
+
+- generated export title;
+- current status badge;
+- progress bar;
+- available Continue or Cancel actions;
+- a `View details` disclosure.
+
+The closed disclosure contains:
+
+- generated filename and total row count;
+- storage and source information;
+- safe status details and checkpoint summaries;
+- remaining work, throughput, concurrency, retry, and ETA information;
+- last update and heartbeat timestamps;
+- optional generated previews.
+
+The renderer continues to create DOM nodes and populate dynamic values through `textContent`. No untrusted content is inserted through an HTML execution sink.
+
+## Validation
+
+The browser regression verifies that status and progress remain visible, operational details are hidden initially, and every detail becomes visible after activating `View details`. Cancellation and terminal failure states retain their existing controls and status badges.
+
+Validated with:
+
+```bash
+node --check application/single_app/static/js/chat/chat-messages.js
+python -m pytest functional_tests/test_tabular_background_generated_exports.py -q
+python -m pytest ui_tests/test_chat_background_generated_export_status.py -q
+```
+
+The authenticated Playwright scenarios require `SIMPLECHAT_UI_BASE_URL` and `SIMPLECHAT_UI_STORAGE_STATE`; they skip when those values are not configured.
+
+## Related Version Update
+
+`application/single_app/config.py` was incremented from **0.250.149** to **0.250.150** for this background status-card simplification.

--- a/functional_tests/test_tabular_background_generated_exports.py
+++ b/functional_tests/test_tabular_background_generated_exports.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """
 Functional test for durable tabular generated-output background exports.
-Version: 0.250.147
-Implemented in: 0.241.060; throughput and timeout hardening in: 0.250.070; unified durable run contract in: 0.250.128; Phase 6 rolling worker pool compatibility in: 0.250.142; safe retry reason status text in: 0.250.147
+Version: 0.250.150
+Implemented in: 0.241.060; throughput and timeout hardening in: 0.250.070; unified durable run contract in: 0.250.128; Phase 6 rolling worker pool compatibility in: 0.250.142; safe retry reason status text in: 0.250.147; collapsed operational details in: 0.250.150
 
 This test ensures that large tabular structured exports are wired through the
 durable background queue, status API, queued retry recovery, and chat progress
@@ -284,6 +284,12 @@ def test_chat_ui_renders_and_polls_background_exports():
     assert_contains(source_text, 'status_detail', 'safe status detail rendering')
     assert_contains(source_text, '/api/tabular/generated-output/runs/', 'status polling endpoint')
     assert_contains(source_text, 'textContent', 'safe text rendering boundary')
+    assert_contains(source_text, "details.dataset.generatedExportDetails = 'true'", 'collapsed details selector')
+    assert_contains(source_text, "detailsSummary.textContent = 'View details'", 'details disclosure label')
+    assert_contains(source_text, 'supportingDetailElements.forEach', 'supporting metadata disclosure routing')
+    assert_contains(source_text, 'backgroundStatusElements?.detailsContent', 'background preview disclosure routing')
+    if 'details.open = true' in source_text:
+        raise AssertionError('Background export operational details must remain collapsed until the user expands them')
     if 'generated-tabular-refresh-status-btn' in source_text or 'Refresh Status' in source_text:
         raise AssertionError('Background export cards must rely on automatic polling without a manual refresh button')
 

--- a/ui_tests/test_chat_background_generated_export_status.py
+++ b/ui_tests/test_chat_background_generated_export_status.py
@@ -1,8 +1,8 @@
 # test_chat_background_generated_export_status.py
 """
 UI test for chat background generated export status cards.
-Version: 0.250.138
-Implemented in: 0.241.046; cancellation in 0.250.060; automatic-only refresh in 0.250.061; combined progress and large-run confirmation in 0.250.131; throughput and concurrency status in 0.250.136; truthful background handoff in 0.250.138
+Version: 0.250.150
+Implemented in: 0.241.046; cancellation in 0.250.060; automatic-only refresh in 0.250.061; combined progress and large-run confirmation in 0.250.131; throughput and concurrency status in 0.250.136; truthful background handoff in 0.250.138; collapsed operational details in 0.250.150
 
 This test ensures queued tabular generated exports render progress in chat and
 turn into a downloadable artifact when complete or a visible canceled state.
@@ -123,10 +123,16 @@ def test_chat_background_generated_export_status_card_auto_refreshes_to_download
         message = page.locator('[data-message-id="message-ui-test"]')
         expect(message.get_by_text("Understood. I am generating the complete JSON for all 3,539 rows.")).to_be_visible()
         expect(message.get_by_text("The rows shown here are a sample")).to_be_visible()
-        expect(message.get_by_text("Preview", exact=True)).to_be_visible()
+        expect(message.get_by_text("Preview", exact=True)).to_be_hidden()
         expect(message.get_by_text("Background export")).to_be_visible()
         expect(message.get_by_text("Running")).to_be_visible()
+        details = message.locator('[data-generated-export-details="true"]')
+        expect(details).not_to_have_attribute("open", "")
+        expect(message.get_by_text("298 of 1,592 batches")).to_be_hidden()
+        expect(message.get_by_text("Continuing in the background.", exact=False)).to_be_hidden()
+        details.get_by_text("View details", exact=True).click()
         expect(message.get_by_text("298 of 1,592 batches")).to_be_visible()
+        expect(message.get_by_text("Preview", exact=True)).to_be_visible()
         rendered_text = message.inner_text().lower()
         assert "can only" not in rendered_text
         assert "schema preview" not in rendered_text
@@ -235,6 +241,9 @@ def test_chat_background_generated_export_can_be_canceled(playwright) -> None:
         )
 
         message = page.locator('[data-message-id="message-cancel-test"]')
+        details = message.locator('[data-generated-export-details="true"]')
+        expect(message.get_by_text("25 of 600 batches", exact=False)).to_be_hidden()
+        details.get_by_text("View details", exact=True).click()
         cancel_button = message.get_by_role("button", name="Cancel background export")
         expect(cancel_button).to_be_visible()
         cancel_button.click()
@@ -359,6 +368,18 @@ def test_chat_combined_background_status_shows_reduce_progress(playwright) -> No
         message = page.locator('[data-message-id="message-combined-progress"]')
         expect(message.get_by_text("Background analysis + export")).to_be_visible()
         expect(message.get_by_text("Running", exact=True)).to_be_visible()
+        expect(message.get_by_role("progressbar")).to_be_visible()
+        details = message.locator('[data-generated-export-details="true"]')
+        expect(message.get_by_text("File: combined-output.csv", exact=True)).to_be_hidden()
+        expect(message.get_by_text("Rows: 3,000", exact=True)).to_be_hidden()
+        expect(message.get_by_text("Source: large-source.csv", exact=True)).to_be_hidden()
+        expect(message.get_by_text("Reduce phase level 1 node 2 of 4")).to_be_hidden()
+        expect(message.get_by_text("Remaining batches: 12")).to_be_hidden()
+        expect(message.get_by_text("Model concurrency: 16")).to_be_hidden()
+        details.get_by_text("View details", exact=True).click()
+        expect(message.get_by_text("File: combined-output.csv", exact=True)).to_be_visible()
+        expect(message.get_by_text("Rows: 3,000", exact=True)).to_be_visible()
+        expect(message.get_by_text("Source: large-source.csv", exact=True)).to_be_visible()
         expect(message.get_by_text("Reduce phase level 1 node 2 of 4")).to_be_visible()
         expect(message.get_by_text("Remaining batches: 12")).to_be_visible()
         expect(message.get_by_text("Remaining chunks: 12")).to_be_visible()
@@ -496,6 +517,8 @@ def test_chat_failed_exhaustive_export_without_run_id_remains_visible(playwright
         message = page.locator('[data-message-id="message-failed-export"]')
         expect(message.get_by_text("Background export")).to_be_visible()
         expect(message.get_by_text("Failed", exact=True)).to_be_visible()
+        expect(message.get_by_text("No partial CSV was created.")).to_be_hidden()
+        message.get_by_text("View details", exact=True).click()
         expect(message.get_by_text("No partial CSV was created.")).to_be_visible()
         expect(message.get_by_role("button", name="Continue")).to_have_count(0)
         expect(message.get_by_role("button", name="Cancel background export")).to_have_count(0)


### PR DESCRIPTION
## Summary
- Keep only the generated-export title, status badge, progress bar, `View details`, and available actions visible on running background cards.
- Collapse filename, row count, source/storage notes, checkpoint metrics, remaining work, throughput, model concurrency, retry/ETA data, timestamps, and previews into one native details disclosure.
- Preserve safe DOM rendering through `createElement` and `textContent`.
- Bump the app version to `0.250.150` and add versioned documentation.

## Validation
- `82 passed` across `test_tabular_background_generated_exports.py` and `test_tabular_row_orchestration_scale.py`
- Updated Playwright coverage verifies hidden-first and visible-after-expansion behavior for polling, cancellation, combined progress, previews, and terminal failures
- Authenticated Playwright execution skipped locally because `SIMPLECHAT_UI_BASE_URL` and `SIMPLECHAT_UI_STORAGE_STATE` are not configured
- `node --check` passed
- VS Code diagnostics clean
- XSS added-line guardrail passed
- Windows-safe `git diff --check` passed

Refs #1031