### PR TITLE
Simplify completed tabular artifact cards

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -96,7 +96,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.250.150"
+VERSION = "0.250.151"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/functions_tabular_generated_exports.py
+++ b/application/single_app/functions_tabular_generated_exports.py
@@ -189,6 +189,9 @@ TABULAR_ANALYSIS_MAX_NOTABLE_ROWS = 25
 TABULAR_EXPORT_SUMMARY_MAX_FIELDS = 25
 TABULAR_EXPORT_SUMMARY_MAX_VALUES_PER_FIELD = 5
 TABULAR_EXPORT_SUMMARY_AGGREGATE_MAX_VALUES = 25
+TABULAR_EXPORT_ARTIFACT_PREVIEW_MAX_ROWS = 10
+TABULAR_EXPORT_ARTIFACT_PREVIEW_MAX_CHARS = 24000
+TABULAR_EXPORT_ARTIFACT_PREVIEW_CELL_MAX_CHARS = 240
 TABULAR_EXPORT_PROGRESS_LOG_INTERVAL_SECONDS = 30
 TABULAR_GENERATION_DEFAULT_HEARTBEAT_SECONDS = 30
 TABULAR_GENERATION_DEFAULT_STALE_SECONDS = 120
@@ -5715,6 +5718,16 @@ def _build_run_public_status(run, settings=None):
             'source_file_name': run.get('source_file_name'),
             'selected_sheet': run.get('selected_sheet'),
             'summary': summary,
+            'preview_rows': list(artifact.get('preview_rows') or [])[
+                :TABULAR_EXPORT_ARTIFACT_PREVIEW_MAX_ROWS
+            ],
+            'preview_columns': list(artifact.get('preview_columns') or [])[
+                :TABULAR_GENERATION_PLAN_MAX_FIELDS + 2
+            ],
+            'preview_text': str(artifact.get('preview_text') or '')[
+                :TABULAR_EXPORT_ARTIFACT_PREVIEW_MAX_CHARS
+            ],
+            'suppress_assistant_text': bool(artifact.get('suppress_assistant_text')),
             'suppress_assistant_table_export': True,
         })
 
@@ -6605,8 +6618,79 @@ def _write_ordered_output_stream(run, output_stream):
     return written_row_count
 
 
-def _build_artifact_metadata(uploaded_message, generated_file_name, output_format):
+def _build_structured_export_preview_rows(run):
+    output_schema = list((run or {}).get('output_schema') or [])
+    if not output_schema:
+        return []
+
+    output_format = str((run or {}).get('output_format') or 'json').strip().lower() or 'json'
+    preview_schema = (
+        build_safe_csv_headers(output_schema)
+        if output_format == 'csv'
+        else output_schema
+    )
+    preview_rows = []
+    preview_char_count = 0
+    expected_source_row_number = 1
+    batch_count = _safe_int((run or {}).get('batch_count'))
+    for batch_number in range(1, batch_count + 1):
+        batch_blob_path = _output_blob_path(
+            (run or {}).get('user_id'),
+            (run or {}).get('conversation_id'),
+            (run or {}).get('id'),
+            batch_number,
+        )
+        _validate_tabular_output_checkpoint_metadata(run, batch_blob_path, batch_number)
+        batch_entries = _download_json_blob(batch_blob_path)
+        if not isinstance(batch_entries, list):
+            raise ValueError(f'Output checkpoint {batch_number}/{batch_count} was not a JSON array')
+
+        for batch_row_index, entry in enumerate(batch_entries, start=1):
+            if not isinstance(entry, dict) or set(entry) != set(output_schema):
+                raise ValueError(
+                    f'Output checkpoint {batch_number}/{batch_count} row {batch_row_index} has schema drift'
+                )
+            source_row_number = _safe_int(entry.get(TABULAR_EXPORT_OUTPUT_ROW_NUMBER_FIELD))
+            if source_row_number != expected_source_row_number:
+                raise ValueError(
+                    f'Source row order gap or overlap: expected {expected_source_row_number}, '
+                    f'found {source_row_number}'
+                )
+
+            preview_row = {}
+            for field_name, preview_field_name in zip(output_schema, preview_schema):
+                rendered_value = _serialize_generated_output_value(entry.get(field_name))
+                if len(rendered_value) > TABULAR_EXPORT_ARTIFACT_PREVIEW_CELL_MAX_CHARS:
+                    rendered_value = (
+                        f'{rendered_value[:TABULAR_EXPORT_ARTIFACT_PREVIEW_CELL_MAX_CHARS - 3]}...'
+                    )
+                preview_row[preview_field_name] = rendered_value
+
+            preview_row_char_count = len(json.dumps(preview_row, ensure_ascii=False, separators=(',', ':')))
+            if (
+                preview_rows
+                and preview_char_count + preview_row_char_count > TABULAR_EXPORT_ARTIFACT_PREVIEW_MAX_CHARS
+            ):
+                return preview_rows
+            preview_rows.append(preview_row)
+            preview_char_count += preview_row_char_count
+            expected_source_row_number += 1
+            if len(preview_rows) >= TABULAR_EXPORT_ARTIFACT_PREVIEW_MAX_ROWS:
+                return preview_rows
+
+    return preview_rows
+
+
+def _build_artifact_metadata(
+    uploaded_message,
+    generated_file_name,
+    output_format,
+    preview_rows=None,
+    preview_text='',
+    suppress_assistant_text=False,
+):
     uploaded_message = uploaded_message or {}
+    normalized_preview_rows = list(preview_rows or [])[:TABULAR_EXPORT_ARTIFACT_PREVIEW_MAX_ROWS]
     return {
         'artifact_message_id': uploaded_message.get('id'),
         'file_name': uploaded_message.get('file_name') or generated_file_name,
@@ -6614,6 +6698,10 @@ def _build_artifact_metadata(uploaded_message, generated_file_name, output_forma
         'blob_path': uploaded_message.get('blob_path'),
         'capability': uploaded_message.get('capability') or 'tabular',
         'output_format': uploaded_message.get('output_format') or output_format,
+        'preview_rows': normalized_preview_rows,
+        'preview_columns': list(normalized_preview_rows[0]) if normalized_preview_rows else [],
+        'preview_text': str(preview_text or '')[:TABULAR_EXPORT_ARTIFACT_PREVIEW_MAX_CHARS],
+        'suppress_assistant_text': bool(suppress_assistant_text),
     }
 
 
@@ -6672,6 +6760,7 @@ def _complete_run(run):
     run, uploaded_message, post_run_summary, output_entry_count, output_format, generated_file_name = (
         _publish_structured_export_artifact(run)
     )
+    artifact_preview_rows = _build_structured_export_preview_rows(run)
     now = _now_iso()
     run.update({
         'status': TABULAR_EXPORT_STATUS_COMPLETED,
@@ -6686,7 +6775,13 @@ def _complete_run(run):
         'last_message': 'Background structured export completed',
         'post_run_summary': post_run_summary,
         'generated_file_name': uploaded_message.get('file_name') or generated_file_name,
-        'final_artifact': _build_artifact_metadata(uploaded_message, generated_file_name, output_format),
+        'final_artifact': _build_artifact_metadata(
+            uploaded_message,
+            generated_file_name,
+            output_format,
+            preview_rows=artifact_preview_rows,
+            suppress_assistant_text=True,
+        ),
         'estimated_remaining_seconds': 0,
     })
     run.update(_build_generation_progress_contract_fields(
@@ -6827,6 +6922,7 @@ def _publish_analysis_artifact(run, final_summary):
 
 def _complete_analysis_run(run, final_summary):
     run, uploaded_message, final_summary, generated_file_name = _publish_analysis_artifact(run, final_summary)
+    artifact_preview_text = _build_analysis_summary_markdown(run, final_summary)
     now = _now_iso()
     run.update({
         'status': TABULAR_EXPORT_STATUS_COMPLETED,
@@ -6843,7 +6939,13 @@ def _complete_analysis_run(run, final_summary):
         'post_run_summary': final_summary.get('summary'),
         'generated_file_name': uploaded_message.get('file_name') or generated_file_name,
         'output_format': 'md',
-        'final_artifact': _build_artifact_metadata(uploaded_message, generated_file_name, 'md'),
+        'final_artifact': _build_artifact_metadata(
+            uploaded_message,
+            generated_file_name,
+            'md',
+            preview_text=artifact_preview_text,
+            suppress_assistant_text=True,
+        ),
         'estimated_remaining_seconds': 0,
     })
     run.update(_build_generation_progress_contract_fields(
@@ -6878,7 +6980,13 @@ def _publish_combined_structured_export_phase(run):
     run, uploaded_message, post_run_summary, output_entry_count, output_format, generated_file_name = (
         _publish_structured_export_artifact(run)
     )
-    structured_artifact = _build_artifact_metadata(uploaded_message, generated_file_name, output_format)
+    structured_artifact = _build_artifact_metadata(
+        uploaded_message,
+        generated_file_name,
+        output_format,
+        preview_rows=_build_structured_export_preview_rows(run),
+        suppress_assistant_text=True,
+    )
     now = _now_iso()
     run.update({
         'updated_at': now,
@@ -6925,7 +7033,13 @@ def _complete_combined_analysis_run(run, final_summary):
         generated_file_name = existing_analysis_artifact.get('file_name') or run.get('analysis_generated_file_name')
     else:
         run, uploaded_message, final_summary, generated_file_name = _publish_analysis_artifact(run, final_summary)
-        analysis_artifact = _build_artifact_metadata(uploaded_message, generated_file_name, 'md')
+        analysis_artifact = _build_artifact_metadata(
+            uploaded_message,
+            generated_file_name,
+            'md',
+            preview_text=_build_analysis_summary_markdown(run, final_summary),
+            suppress_assistant_text=True,
+        )
 
     structured_artifact = run.get('structured_export_artifact') or run.get('final_artifact') or {}
     now = _now_iso()

--- a/application/single_app/static/js/chat/chat-messages.js
+++ b/application/single_app/static/js/chat/chat-messages.js
@@ -3773,12 +3773,14 @@ function renderReplyQuoteHtml(fullMessageObject = null) {
     return Boolean(row) && typeof row === 'object' && !Array.isArray(row);
   }
 
-  function buildGeneratedTabularPreviewTable(previewRows) {
+  function buildGeneratedTabularPreviewTable(previewRows, options = {}) {
     if (!Array.isArray(previewRows) || !previewRows.length || !previewRows.every(isGeneratedTabularPreviewObjectRow)) {
       return null;
     }
 
-    const previewColumns = [];
+    const previewColumns = Array.isArray(options.columns)
+      ? options.columns.map(columnName => String(columnName || '')).filter(Boolean)
+      : [];
     previewRows.forEach(row => {
       Object.keys(row).forEach(columnName => {
         if (!previewColumns.includes(columnName)) {
@@ -3791,7 +3793,15 @@ function renderReplyQuoteHtml(fullMessageObject = null) {
       return null;
     }
 
-    const displayedColumns = previewColumns.slice(0, 4);
+    const requestedMaxColumns = Number.parseInt(options.maxColumns, 10);
+    const maxColumns = Number.isFinite(requestedMaxColumns) && requestedMaxColumns > 0
+      ? requestedMaxColumns
+      : 4;
+    const requestedCellLength = Number.parseInt(options.maxCellLength, 10);
+    const maxCellLength = Number.isFinite(requestedCellLength) && requestedCellLength > 0
+      ? requestedCellLength
+      : 120;
+    const displayedColumns = previewColumns.slice(0, maxColumns);
     const tableWrapper = document.createElement('div');
     tableWrapper.className = 'table-responsive small border rounded';
 
@@ -3814,7 +3824,7 @@ function renderReplyQuoteHtml(fullMessageObject = null) {
       const tableRow = document.createElement('tr');
       displayedColumns.forEach(columnName => {
         const valueCell = document.createElement('td');
-        valueCell.textContent = formatGeneratedTabularPreviewValue(row[columnName]);
+        valueCell.textContent = formatGeneratedTabularPreviewValue(row[columnName], maxCellLength);
         tableRow.appendChild(valueCell);
       });
       tbody.appendChild(tableRow);
@@ -3887,6 +3897,149 @@ function renderReplyQuoteHtml(fullMessageObject = null) {
     const previewBlock = formatGeneratedAnalysisPreviewBlock(document.createElement('pre'));
     previewBlock.textContent = String(previewText || '').trim();
     return previewBlock;
+  }
+
+  function getGeneratedArtifactPreviewRows(outputMetadata) {
+    if (Array.isArray(outputMetadata?.preview_rows) && outputMetadata.preview_rows.length) {
+      return outputMetadata.preview_rows;
+    }
+    if (Array.isArray(outputMetadata?.preview_items) && outputMetadata.preview_items.length) {
+      return outputMetadata.preview_items;
+    }
+    return [];
+  }
+
+  function hasGeneratedArtifactPreview(outputMetadata, outputFormat) {
+    void outputFormat;
+    return Boolean(
+      getGeneratedArtifactPreviewRows(outputMetadata).length
+      || (Array.isArray(outputMetadata?.preview_lines) && outputMetadata.preview_lines.length)
+      || String(
+        outputMetadata?.preview_text
+        || outputMetadata?.analysis_text
+        || outputMetadata?.panalysis_text
+        || ''
+      ).trim()
+    );
+  }
+
+  function getOrCreateGeneratedArtifactPreviewModal() {
+    let modal = document.getElementById('generated-artifact-preview-modal');
+    if (modal) {
+      return modal;
+    }
+
+    modal = document.createElement('div');
+    modal.id = 'generated-artifact-preview-modal';
+    modal.className = 'modal fade';
+    modal.tabIndex = -1;
+    modal.setAttribute('aria-labelledby', 'generated-artifact-preview-modal-label');
+    modal.setAttribute('aria-hidden', 'true');
+
+    const dialog = document.createElement('div');
+    dialog.className = 'modal-dialog modal-xl modal-dialog-centered modal-dialog-scrollable';
+    modal.appendChild(dialog);
+
+    const content = document.createElement('div');
+    content.className = 'modal-content';
+    dialog.appendChild(content);
+
+    const header = document.createElement('div');
+    header.className = 'modal-header';
+    content.appendChild(header);
+
+    const title = document.createElement('h5');
+    title.id = 'generated-artifact-preview-modal-label';
+    title.className = 'modal-title';
+    header.appendChild(title);
+
+    const closeButton = document.createElement('button');
+    closeButton.type = 'button';
+    closeButton.className = 'btn-close';
+    closeButton.setAttribute('data-bs-dismiss', 'modal');
+    closeButton.setAttribute('aria-label', 'Close');
+    header.appendChild(closeButton);
+
+    const body = document.createElement('div');
+    body.className = 'modal-body';
+    body.dataset.generatedArtifactPreviewBody = 'true';
+    content.appendChild(body);
+
+    const footer = document.createElement('div');
+    footer.className = 'modal-footer justify-content-between';
+    content.appendChild(footer);
+
+    const rowInfo = document.createElement('span');
+    rowInfo.className = 'small text-muted';
+    rowInfo.dataset.generatedArtifactPreviewInfo = 'true';
+    footer.appendChild(rowInfo);
+
+    const footerCloseButton = document.createElement('button');
+    footerCloseButton.type = 'button';
+    footerCloseButton.className = 'btn btn-sm btn-secondary';
+    footerCloseButton.setAttribute('data-bs-dismiss', 'modal');
+    footerCloseButton.textContent = 'Close';
+    footer.appendChild(footerCloseButton);
+
+    document.body.appendChild(modal);
+    return modal;
+  }
+
+  function showGeneratedArtifactPreviewModal(outputMetadata, outputFormat) {
+    const previewRows = getGeneratedArtifactPreviewRows(outputMetadata);
+    const previewLines = Array.isArray(outputMetadata?.preview_lines) ? outputMetadata.preview_lines : [];
+    const previewText = String(
+      outputMetadata?.preview_text
+      || outputMetadata?.analysis_text
+      || outputMetadata?.panalysis_text
+      || ''
+    ).trim();
+    let previewContent = null;
+    if (previewRows.length) {
+      previewContent = buildGeneratedTabularPreviewTable(previewRows, {
+        columns: outputMetadata?.preview_columns,
+        maxColumns: 50,
+        maxCellLength: 240,
+      }) || buildGeneratedTabularPreviewFallback(previewRows);
+    } else if (previewLines.length) {
+      previewContent = buildGeneratedAnalysisPreviewText(
+        previewLines.join('\n'),
+        outputMetadata,
+        outputFormat,
+      );
+    } else if (previewText) {
+      previewContent = buildGeneratedAnalysisPreviewText(previewText, outputMetadata, outputFormat);
+    }
+
+    if (!previewContent) {
+      showToast('A preview is not available for this generated artifact.', 'warning');
+      return;
+    }
+
+    const modal = getOrCreateGeneratedArtifactPreviewModal();
+    const title = modal.querySelector('.modal-title');
+    const body = modal.querySelector('[data-generated-artifact-preview-body="true"]');
+    const rowInfo = modal.querySelector('[data-generated-artifact-preview-info="true"]');
+    const fileName = String(outputMetadata?.file_name || `generated-output.${outputFormat}`).trim();
+    if (title) {
+      title.textContent = `Preview: ${fileName}`;
+    }
+    if (body) {
+      body.replaceChildren(previewContent);
+    }
+    if (rowInfo) {
+      const totalRows = formatGeneratedTabularRowCount(outputMetadata?.row_count);
+      rowInfo.textContent = previewRows.length
+        ? `Showing ${previewRows.length.toLocaleString()}${totalRows ? ` of ${totalRows}` : ''} rows`
+        : 'Generated artifact preview';
+    }
+
+    const modalInstance = window.bootstrap?.Modal?.getOrCreateInstance(modal);
+    if (!modalInstance) {
+      showToast('Could not open the generated artifact preview.', 'warning');
+      return;
+    }
+    modalInstance.show();
   }
 
   function getGeneratedAnalysisArtifactTitle(outputMetadata, outputFormat) {
@@ -4621,6 +4774,17 @@ function renderReplyQuoteHtml(fullMessageObject = null) {
     };
   }
 
+  function hideCompletedGeneratedArtifactHandoff(container, outputMetadata) {
+    if (outputMetadata?.background_export || !outputMetadata?.suppress_assistant_text) {
+      return;
+    }
+    const message = container?.matches?.('.message')
+      ? container
+      : container?.closest?.('.message');
+    message?.querySelector('.message-text')?.classList.add('d-none');
+    message?.querySelector('.message-footer')?.classList.add('d-none');
+  }
+
   async function refreshBackgroundGeneratedOutputStatus(outputMetadata, card, statusElements = {}) {
     const runId = String(outputMetadata?.export_run_id || outputMetadata?.run_id || '').trim();
     if (!runId || !(card instanceof HTMLElement) || !document.body.contains(card)) {
@@ -4655,6 +4819,7 @@ function renderReplyQuoteHtml(fullMessageObject = null) {
           run_id: runStatus.run_id || runId,
         });
         const refreshedCard = createGeneratedAnalysisArtifactCard(outputMetadata);
+        hideCompletedGeneratedArtifactHandoff(card, outputMetadata);
         card.replaceWith(refreshedCard);
         return;
       }
@@ -4711,6 +4876,7 @@ function renderReplyQuoteHtml(fullMessageObject = null) {
           run_id: runStatus.run_id || runId,
         });
         const refreshedCard = createGeneratedAnalysisArtifactCard(outputMetadata);
+        hideCompletedGeneratedArtifactHandoff(card, outputMetadata);
         card.replaceWith(refreshedCard);
         showToast(responseData?.message || 'Background export is already complete.', 'success');
         return;
@@ -4835,6 +5001,8 @@ function renderReplyQuoteHtml(fullMessageObject = null) {
       outputMetadata?.preview_text || outputMetadata?.analysis_text || outputMetadata?.panalysis_text || ''
     ).trim();
     const isBackgroundExport = Boolean(outputMetadata?.background_export);
+    const capability = String(outputMetadata?.capability || '').trim().toLowerCase();
+    const isCompletedTabularArtifact = !isBackgroundExport && capability === 'tabular';
     const backgroundDetailElements = [];
     const appendSupportingDetail = element => {
       if (isBackgroundExport) {
@@ -4877,30 +5045,32 @@ function renderReplyQuoteHtml(fullMessageObject = null) {
 
     card.appendChild(header);
 
-    const storageNote = document.createElement('div');
-    storageNote.className = 'small text-muted mt-2';
-    storageNote.textContent = getGeneratedTabularStorageNote(outputMetadata);
-    appendSupportingDetail(storageNote);
+    if (!isCompletedTabularArtifact) {
+      const storageNote = document.createElement('div');
+      storageNote.className = 'small text-muted mt-2';
+      storageNote.textContent = getGeneratedTabularStorageNote(outputMetadata);
+      appendSupportingDetail(storageNote);
 
-    if (sourceFileName || selectedSheet) {
-      const sourceNote = document.createElement('div');
-      sourceNote.className = 'small text-muted';
-      const sourceSegments = [];
-      if (sourceFileName) {
-        sourceSegments.push(`Source: ${sourceFileName}`);
+      if (sourceFileName || selectedSheet) {
+        const sourceNote = document.createElement('div');
+        sourceNote.className = 'small text-muted';
+        const sourceSegments = [];
+        if (sourceFileName) {
+          sourceSegments.push(`Source: ${sourceFileName}`);
+        }
+        if (selectedSheet) {
+          sourceSegments.push(`Sheet: ${selectedSheet}`);
+        }
+        sourceNote.textContent = sourceSegments.join(' | ');
+        appendSupportingDetail(sourceNote);
       }
-      if (selectedSheet) {
-        sourceSegments.push(`Sheet: ${selectedSheet}`);
-      }
-      sourceNote.textContent = sourceSegments.join(' | ');
-      appendSupportingDetail(sourceNote);
-    }
 
-    if (summary) {
-      const summaryText = document.createElement('p');
-      summaryText.className = 'small mb-0 mt-2';
-      summaryText.textContent = summary;
-      appendSupportingDetail(summaryText);
+      if (summary) {
+        const summaryText = document.createElement('p');
+        summaryText.className = 'small mb-0 mt-2';
+        summaryText.textContent = summary;
+        appendSupportingDetail(summaryText);
+      }
     }
 
     let backgroundStatusElements = null;
@@ -4913,7 +5083,7 @@ function renderReplyQuoteHtml(fullMessageObject = null) {
       card.appendChild(backgroundStatusBlock.wrapper);
     }
 
-    if (previewRows.length || previewItems.length || previewLines.length || previewText) {
+    if (!isCompletedTabularArtifact && (previewRows.length || previewItems.length || previewLines.length || previewText)) {
       let previewContent = null;
       if (previewRows.length) {
         previewContent = buildGeneratedTabularPreviewTable(previewRows) || buildGeneratedTabularPreviewFallback(previewRows);
@@ -5006,7 +5176,19 @@ function renderReplyQuoteHtml(fullMessageObject = null) {
     });
     actions.appendChild(downloadButton);
 
-    if (isGeneratedMarkdownArtifact(outputMetadata, outputFormat)) {
+    if (isCompletedTabularArtifact && hasGeneratedArtifactPreview(outputMetadata, outputFormat)) {
+      const viewButton = document.createElement('button');
+      viewButton.type = 'button';
+      viewButton.className = 'btn btn-sm btn-outline-secondary generated-artifact-view-btn';
+      viewButton.textContent = 'View';
+      viewButton.setAttribute('aria-label', `View generated ${outputFormat.toUpperCase()} preview`);
+      viewButton.addEventListener('click', () => {
+        showGeneratedArtifactPreviewModal(outputMetadata, outputFormat);
+      });
+      actions.appendChild(viewButton);
+    }
+
+    if (isGeneratedMarkdownArtifact(outputMetadata, outputFormat) && !isCompletedTabularArtifact) {
       const normalizedArtifactMessageId = String(outputMetadata?.artifact_message_id || '').trim();
       const normalizedConversationId = String(outputMetadata?.conversation_id || window.currentConversationId || '').trim();
       if (normalizedArtifactMessageId && normalizedConversationId) {
@@ -5069,6 +5251,7 @@ function renderReplyQuoteHtml(fullMessageObject = null) {
 
     generatedOutputs.forEach(outputMetadata => {
       generatedOutputsContainer.appendChild(createGeneratedAnalysisArtifactCard(outputMetadata));
+      hideCompletedGeneratedArtifactHandoff(messageDiv, outputMetadata);
     });
     generatedOutputsContainer.classList.remove('d-none');
   }
@@ -5088,6 +5271,7 @@ function renderReplyQuoteHtml(fullMessageObject = null) {
 
     generatedOutputs.forEach(outputMetadata => {
       generatedOutputsContainer.appendChild(createGeneratedTabularOutputCard(outputMetadata));
+      hideCompletedGeneratedArtifactHandoff(messageDiv, outputMetadata);
     });
     generatedOutputsContainer.classList.remove('d-none');
   }

--- a/docs/explanation/features/TABULAR_BACKGROUND_GENERATED_EXPORTS.md
+++ b/docs/explanation/features/TABULAR_BACKGROUND_GENERATED_EXPORTS.md
@@ -2,7 +2,7 @@
 
 Implemented in version: **0.241.046**
 
-Updated through version: **0.250.150**
+Updated through version: **0.250.151**
 
 ## Overview
 
@@ -48,6 +48,7 @@ The feature supports large spreadsheet-driven analysis, including workbooks that
 - Recognized exhaustive artifact requests never fall back to dumping generated rows into the assistant response when source preparation fails. The chat receives a concise artifact handoff or safe failure status instead.
 - Shadow schema planning is deferred off the production critical path. Unplanned source-backed runs checkpoint a small first batch before opening normal batch concurrency, and the status card identifies source preparation, active planning, or initial checkpoint generation before row progress appears.
 - Running background cards keep the status badge, progress bar, and available actions visible by default. File/source metadata, checkpoint counts, remaining work, throughput, concurrency, timestamps, and previews are grouped under a collapsed `View details` disclosure.
+- Completed structured artifacts show only the generated filename, total row count, and `Download`, `View`, and `Add to Workspace` actions. `View` opens a bounded validated preview in a modal, and the stale background handoff prose is hidden after completion.
 
 ### API Endpoints
 
@@ -118,6 +119,7 @@ The progress card displays current status, completed checkpoint counts, processe
 - Generic CSV and workbook durable routing regressions: `functional_tests/test_tabular_row_orchestration_scale.py`
 - Artifact-only failure and fast-start regressions: `functional_tests/test_tabular_row_orchestration_scale.py`
 - Collapsed background status detail regressions: `functional_tests/test_tabular_background_generated_exports.py` and `ui_tests/test_chat_background_generated_export_status.py`
+- Completed artifact card and bounded modal regressions: `functional_tests/test_tabular_background_generated_exports.py` and `ui_tests/test_chat_generated_tabular_output_card.py`
 - Phase 2 handoff regression: `functional_tests/test_tabular_row_orchestration_scale.py`
 - Phase 1 baseline and fake harness coverage: `functional_tests/test_tabular_row_orchestration_scale.py`
 - Functional regression for workflow/document-action presentation: `functional_tests/test_document_analysis_lossless_artifacts.py`
@@ -176,3 +178,4 @@ The progress card displays current status, completed checkpoint counts, processe
 - `application/single_app/config.py` was updated to version **0.250.148** to flatten single-row nested CSV model outputs before generated-export schema inference.
 - `application/single_app/config.py` was updated to version **0.250.149** to route every supported tabular input through artifact-only durable generation and reduce time to the first visible checkpoint.
 - `application/single_app/config.py` was updated to version **0.250.150** to simplify background export cards while preserving expandable operational detail.
+- `application/single_app/config.py` was updated to version **0.250.151** to simplify completed artifact cards and add bounded on-demand previews.

--- a/docs/explanation/fixes/TABULAR_COMPLETED_ARTIFACT_CARD_FIX.md
+++ b/docs/explanation/fixes/TABULAR_COMPLETED_ARTIFACT_CARD_FIX.md
@@ -1,0 +1,75 @@
+# Tabular Completed Artifact Card Fix
+
+Fixed in version: **0.250.151**
+
+Related issue: **microsoft/simplechat#1031**
+
+## Issue Description
+
+Completed generated-file cards continued to show background handoff prose, storage and source notes, a long post-run completeness and common-values summary, and an inline preview. The resulting card looked like an execution report even though the user's primary task was simply to open, download, or retain the completed file.
+
+## Root Cause
+
+The same artifact renderer handled running and completed states. Supporting metadata and previews were appended directly for every completed tabular artifact, while the original assistant handoff remained visible after polling replaced the progress card.
+
+## Technical Details
+
+### Files Modified
+
+- `application/single_app/functions_tabular_generated_exports.py`
+- `application/single_app/static/js/chat/chat-messages.js`
+- `application/single_app/config.py`
+- `functional_tests/test_tabular_background_generated_exports.py`
+- `ui_tests/test_chat_generated_tabular_output_card.py`
+- `docs/explanation/features/TABULAR_BACKGROUND_GENERATED_EXPORTS.md`
+
+### Completed Card
+
+Completed structured tabular artifacts now display:
+
+- generated artifact title;
+- filename;
+- total row count;
+- `Download` action;
+- `View` action;
+- `Add to Workspace` action.
+
+The renderer omits storage/source notes, post-run diagnostics, and inline preview rows from the finished card. Durable completion metadata also suppresses the stale assistant sentence that says processing is still continuing.
+
+### Bounded View Modal
+
+The durable runner copies a validated preview from output checkpoints into completed artifact metadata. The preview is bounded to:
+
+- at most 10 rows;
+- at most 24,000 serialized characters;
+- at most 240 characters per displayed cell.
+
+The browser renders these rows in a responsive modal and reports how many preview rows are shown out of the complete artifact row count. It does not download the complete large artifact merely to display the preview.
+
+All modal elements are created with DOM APIs, and dynamic content is assigned through `textContent`.
+
+## Validation
+
+Coverage verifies:
+
+- preview rows preserve source order and remain within row and character bounds;
+- completed artifact metadata propagates the preview and handoff-suppression flag;
+- completed cards omit background notes, source details, summaries, and inline rows;
+- the `View` modal displays bounded rows and total row count;
+- `Download` and `Add to Workspace` continue to work;
+- untrusted filename and cell content remain inert text.
+
+Validated with:
+
+```bash
+node --check application/single_app/static/js/chat/chat-messages.js
+python -m pytest functional_tests/test_tabular_background_generated_exports.py -q
+python -m pytest functional_tests/test_tabular_row_orchestration_scale.py -q
+python -m pytest ui_tests/test_chat_generated_tabular_output_card.py -q
+```
+
+The completed-card and modal workflow was also verified through an authenticated browser session using the local unmerged JavaScript module.
+
+## Related Version Update
+
+`application/single_app/config.py` was incremented from **0.250.150** to **0.250.151** for this completed artifact-card simplification.

--- a/functional_tests/test_tabular_background_generated_exports.py
+++ b/functional_tests/test_tabular_background_generated_exports.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """
 Functional test for durable tabular generated-output background exports.
-Version: 0.250.150
-Implemented in: 0.241.060; throughput and timeout hardening in: 0.250.070; unified durable run contract in: 0.250.128; Phase 6 rolling worker pool compatibility in: 0.250.142; safe retry reason status text in: 0.250.147; collapsed operational details in: 0.250.150
+Version: 0.250.151
+Implemented in: 0.241.060; throughput and timeout hardening in: 0.250.070; unified durable run contract in: 0.250.128; Phase 6 rolling worker pool compatibility in: 0.250.142; safe retry reason status text in: 0.250.147; collapsed operational details in: 0.250.150; simplified completed artifact cards in: 0.250.151
 
 This test ensures that large tabular structured exports are wired through the
 durable background queue, status API, queued retry recovery, and chat progress
@@ -288,10 +288,87 @@ def test_chat_ui_renders_and_polls_background_exports():
     assert_contains(source_text, "detailsSummary.textContent = 'View details'", 'details disclosure label')
     assert_contains(source_text, 'supportingDetailElements.forEach', 'supporting metadata disclosure routing')
     assert_contains(source_text, 'backgroundStatusElements?.detailsContent', 'background preview disclosure routing')
+    assert_contains(source_text, 'isCompletedTabularArtifact', 'completed tabular card state')
+    assert_contains(source_text, 'generated-artifact-view-btn', 'completed artifact View action')
+    assert_contains(source_text, 'generated-artifact-preview-modal', 'bounded artifact preview modal')
+    assert_contains(source_text, 'hideCompletedGeneratedArtifactHandoff', 'stale completion handoff suppression')
     if 'details.open = true' in source_text:
         raise AssertionError('Background export operational details must remain collapsed until the user expands them')
     if 'generated-tabular-refresh-status-btn' in source_text or 'Refresh Status' in source_text:
         raise AssertionError('Background export cards must rely on automatic polling without a manual refresh button')
+
+
+def test_completed_artifact_preview_is_bounded_and_ordered():
+    """Completed artifact metadata carries only a bounded validated preview."""
+    module_tree = parse_python(EXPORT_MODULE)
+    helper_names = {
+        '_build_structured_export_preview_rows',
+        '_build_artifact_metadata',
+    }
+    helper_nodes = [
+        node
+        for node in module_tree.body
+        if isinstance(node, ast.FunctionDef) and node.name in helper_names
+    ]
+    if len(helper_nodes) != len(helper_names):
+        raise AssertionError('Completed artifact preview helpers were not found')
+
+    batches = {
+        'output-1': [
+            {'source_row_number': 1, 'source_row_identity': 'A-1', 'answer': 'first'},
+            {'source_row_number': 2, 'source_row_identity': 'A-2', 'answer': 'x' * 20},
+        ],
+        'output-2': [
+            {'source_row_number': 3, 'source_row_identity': 'A-3', 'answer': 'third'},
+            {'source_row_number': 4, 'source_row_identity': 'A-4', 'answer': 'fourth'},
+        ],
+    }
+    validated_batches = []
+    namespace = {
+        'TABULAR_EXPORT_ARTIFACT_PREVIEW_MAX_ROWS': 3,
+        'TABULAR_EXPORT_ARTIFACT_PREVIEW_MAX_CHARS': 24000,
+        'TABULAR_EXPORT_ARTIFACT_PREVIEW_CELL_MAX_CHARS': 12,
+        'TABULAR_EXPORT_OUTPUT_ROW_NUMBER_FIELD': 'source_row_number',
+        '_safe_int': lambda value: int(value or 0),
+        '_output_blob_path': lambda user_id, conversation_id, run_id, batch_number: f'output-{batch_number}',
+        '_validate_tabular_output_checkpoint_metadata': (
+            lambda run, path, batch_number: validated_batches.append((path, batch_number))
+        ),
+        '_download_json_blob': lambda path: batches[path],
+        '_serialize_generated_output_value': lambda value: '' if value is None else str(value),
+        'build_safe_csv_headers': lambda values: list(values),
+        'json': __import__('json'),
+    }
+    exec(
+        compile(ast.Module(body=helper_nodes, type_ignores=[]), str(EXPORT_MODULE), 'exec'),
+        namespace,
+    )
+
+    run = {
+        'id': 'run-preview',
+        'user_id': 'user-1',
+        'conversation_id': 'conversation-1',
+        'batch_count': 2,
+        'output_format': 'csv',
+        'output_schema': ['source_row_number', 'source_row_identity', 'answer'],
+    }
+    preview_rows = namespace['_build_structured_export_preview_rows'](run)
+    artifact = namespace['_build_artifact_metadata'](
+        {'id': 'artifact-1', 'file_name': 'generated.csv'},
+        'fallback.csv',
+        'csv',
+        preview_rows=preview_rows,
+        preview_text='m' * 25000,
+        suppress_assistant_text=True,
+    )
+
+    assert [row['source_row_number'] for row in preview_rows] == ['1', '2', '3']
+    assert preview_rows[1]['answer'] == 'xxxxxxxxx...'
+    assert validated_batches == [('output-1', 1), ('output-2', 2)]
+    assert artifact['preview_rows'] == preview_rows
+    assert artifact['preview_columns'] == ['source_row_number', 'source_row_identity', 'answer']
+    assert len(artifact['preview_text']) == 24000
+    assert artifact['suppress_assistant_text'] is True
 
 
 def main():
@@ -304,6 +381,7 @@ def main():
         test_generated_export_batch_packing_phase_three,
         test_background_scheduler_and_config_registered,
         test_chat_ui_renders_and_polls_background_exports,
+        test_completed_artifact_preview_is_bounded_and_ordered,
     ]
     results = []
 

--- a/ui_tests/test_chat_generated_tabular_output_card.py
+++ b/ui_tests/test_chat_generated_tabular_output_card.py
@@ -1,9 +1,9 @@
 # test_chat_generated_tabular_output_card.py
 """
 UI test for chat generated tabular output cards.
-Version: 0.241.096
+Version: 0.250.151
 Implemented in: 0.241.033
-Updated in: 0.241.096
+Updated in: 0.241.096; simplified completed artifact cards and bounded View modal in 0.250.151
 
 This test ensures assistant replies with generic generated analysis artifact
 metadata render a reusable export card, preserve untrusted values as text,
@@ -55,7 +55,7 @@ def _wait_for_chatbox_or_skip(page):
 
 @pytest.mark.ui
 def test_chat_generated_tabular_output_card(playwright):
-    """Validate generated tabular output cards render preview data and trigger downloads."""
+    """Validate completed tabular cards stay concise and open bounded previews on demand."""
     _require_ui_env()
 
     download_requests = []
@@ -158,6 +158,8 @@ def test_chat_generated_tabular_output_card(playwright):
                                     source_file_name: 'feedback_comments.xlsx',
                                     selected_sheet: 'Comments',
                                     summary: 'The full export is saved separately so the reply can stay concise. <analysis>',
+                                    suppress_assistant_text: true,
+                                    preview_columns: ['comment_id', 'author', 'comment'],
                                     preview_rows: [
                                         {
                                             comment_id: '001',
@@ -181,15 +183,31 @@ def test_chat_generated_tabular_output_card(playwright):
         )
 
         card = page.locator('.generated-tabular-output-card')
+        message = page.locator('[data-message-id="assistant-generated-output"]')
         expect(card).to_be_visible()
         expect(card).to_contain_text('Generated JSON export')
-        expect(card).to_contain_text('Saved to this chat for download in this conversation.')
         expect(card).to_contain_text('124 rows')
-        expect(card).to_contain_text('Source: feedback_comments.xlsx | Sheet: Comments')
         expect(card).to_contain_text('comments<script>alert(1)</script>.json')
-        expect(card).to_contain_text('The full export is saved separately so the reply can stay concise. <analysis>')
-        expect(card).to_contain_text('Alicia <Admin>')
-        expect(card).to_contain_text('First <tag> comment')
+        expect(card).not_to_contain_text('Saved to this chat for download in this conversation.')
+        expect(card).not_to_contain_text('Source: feedback_comments.xlsx | Sheet: Comments')
+        expect(card).not_to_contain_text('The full export is saved separately so the reply can stay concise. <analysis>')
+        expect(card).not_to_contain_text('Alicia <Admin>')
+        expect(message.locator('.message-text')).to_be_hidden()
+        expect(message.locator('.message-footer')).to_be_hidden()
+
+        view_button = card.get_by_role('button', name='View generated JSON preview', exact=True)
+        expect(view_button).to_be_visible()
+        view_button.click()
+        preview_modal = page.locator('#generated-artifact-preview-modal')
+        expect(preview_modal).to_be_visible()
+        expect(preview_modal.get_by_role('heading', name='Preview: comments<script>alert(1)</script>.json')).to_be_visible()
+        expect(preview_modal).to_contain_text('Alicia <Admin>')
+        expect(preview_modal).to_contain_text('First <tag> comment')
+        expect(preview_modal).to_contain_text('Showing 2 of 124 rows')
+        assert preview_modal.locator('thead th').all_text_contents() == ['comment_id', 'author', 'comment']
+        expect(preview_modal.locator('script')).to_have_count(0)
+        preview_modal.locator('.modal-footer button').click()
+        expect(preview_modal).to_be_hidden()
 
         assert page.locator('.generated-tabular-output-card script').count() == 0
 


### PR DESCRIPTION
## Summary
- Reduce completed tabular artifact cards to the generated filename, row count, and `Download`, `View`, and `Add to Workspace` actions.
- Hide stale background handoff prose and generic assistant message actions after completion.
- Add a responsive `View` modal backed by validated preview metadata instead of downloading the complete artifact.
- Bound structured previews to 10 rows, 24,000 serialized characters, and 240 characters per cell while preserving schema column order.
- Carry bounded Markdown preview text for completed analysis artifacts.
- Bump the app version to `0.250.151` and add versioned documentation.

## Validation
- `83 passed` across `test_tabular_background_generated_exports.py` and `test_tabular_row_orchestration_scale.py`
- Updated Playwright coverage for concise completed cards, hidden stale prose/footer, ordered modal previews, download, and workspace promotion
- Authenticated browser verification passed using the local unmerged `chat-messages.js`: exactly three artifact actions were visible and the modal reported bounded rows correctly
- `node --check` and Python compilation passed
- VS Code diagnostics clean
- Broken Access Control and XSS added-line guardrails passed
- Windows-safe `git diff --check` passed

Refs #1031