### PR TITLE
Normalize generated structured artifact intent

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -96,7 +96,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.250.153"
+VERSION = "0.250.154"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/functions_document_analysis.py
+++ b/application/single_app/functions_document_analysis.py
@@ -8,6 +8,7 @@ from typing import Any, Callable, Dict, List, Optional
 
 from functions_appinsights import log_event
 from functions_debug import debug_print
+from functions_generated_file_exports import get_requested_structured_artifact_format
 from functions_search import normalize_search_id_list, normalize_search_scope
 
 
@@ -374,85 +375,11 @@ def _build_window_label(document_name, window_range):
 
 
 def _prompt_requests_json_output(analysis_prompt):
-    prompt_text = str(analysis_prompt or '').strip().lower()
-    if not prompt_text:
-        return False
-
-    json_markers = (
-        'json artifact',
-        'json export',
-        'json output',
-        'json array',
-        'json object',
-        'json file',
-        'json format',
-        'valid json',
-        'convert into json',
-        'convert to json',
-        'return json',
-        'return only json',
-        'respond with json',
-        'format as json',
-        'output as json',
-        'save as json',
-        'export as json',
-        'download as json',
-        'create json',
-        'create a json',
-        'make json',
-        'make a json',
-        'generate json',
-        'generate a json',
-    )
-    if any(marker in prompt_text for marker in json_markers):
-        return True
-
-    return bool(re.search(
-        r'\b(convert|create|make|build|generate|produce|return|respond|format|output|save|export|download)\b[\w\s.,:;\-/]{0,80}\bjson\b',
-        prompt_text,
-    ))
+    return get_requested_structured_artifact_format(analysis_prompt) == 'json'
 
 
 def _prompt_requests_xml_output(analysis_prompt):
-    prompt_text = str(analysis_prompt or '').strip().lower()
-    if not prompt_text:
-        return False
-
-    xml_markers = (
-        'xml artifact',
-        'xml export',
-        'xml output',
-        'xml document',
-        'xml file',
-        'xml template',
-        'valid xml',
-        'well-formed xml',
-        'convert into xml',
-        'convert to xml',
-        'populate xml',
-        'populate the xml',
-        'return xml',
-        'return only xml',
-        'respond with xml',
-        'format as xml',
-        'output as xml',
-        'save as xml',
-        'export as xml',
-        'download as xml',
-        'create xml',
-        'create an xml',
-        'make xml',
-        'make an xml',
-        'generate xml',
-        'generate an xml',
-    )
-    if any(marker in prompt_text for marker in xml_markers):
-        return True
-
-    return bool(re.search(
-        r'\b(convert|populate|create|make|build|generate|produce|return|respond|format|output|save|export|download)\b[\w\s.,:;\-/]{0,80}\bxml\b',
-        prompt_text,
-    ))
+    return get_requested_structured_artifact_format(analysis_prompt) == 'xml'
 
 
 def _build_requested_output_guidance(analysis_prompt, stage):

--- a/application/single_app/functions_generated_file_exports.py
+++ b/application/single_app/functions_generated_file_exports.py
@@ -32,6 +32,68 @@ GENERATED_FILE_FORMATS = {
 }
 SUPPORTED_GENERATED_EXPORT_FORMATS = {'csv', 'json', 'xml'}
 GENERATED_FILE_PREVIEW_ROWS = 3
+STRUCTURED_ARTIFACT_FORMAT_MARKERS = {
+    'json': (
+        'json artifact',
+        'json export',
+        'json output',
+        'json array',
+        'json object',
+        'json file',
+        'json format',
+        'valid json',
+        'convert into json',
+        'convert to json',
+        'return json',
+        'return only json',
+        'respond with json',
+        'format as json',
+        'output as json',
+        'save as json',
+        'export as json',
+        'download as json',
+        'create json',
+        'create a json',
+        'make json',
+        'make a json',
+        'generate json',
+        'generate a json',
+    ),
+    'xml': (
+        'xml artifact',
+        'xml export',
+        'xml output',
+        'xml document',
+        'xml file',
+        'xml template',
+        'valid xml',
+        'well-formed xml',
+        'convert into xml',
+        'convert to xml',
+        'populate xml',
+        'populate the xml',
+        'return xml',
+        'return only xml',
+        'respond with xml',
+        'format as xml',
+        'output as xml',
+        'save as xml',
+        'export as xml',
+        'download as xml',
+        'create xml',
+        'create an xml',
+        'make xml',
+        'make an xml',
+        'generate xml',
+        'generate an xml',
+    ),
+}
+STRUCTURED_ARTIFACT_ACTION_PATTERN = (
+    r'convert|populate|create|make|build|generate|produce|return|respond|format|output|save|export|download'
+)
+STRUCTURED_ARTIFACT_DESTINATION_ACTION_PATTERN = (
+    r'convert|transform|translate|turn|put|place|write|map|load|insert|transfer|copy|move'
+)
 FUNCTION_RESULT_ROW_KEYS = (
     'rows',
     'data',
@@ -129,6 +191,64 @@ def get_requested_generated_file_format(user_question: str) -> Optional[str]:
     return None
 
 
+def get_requested_structured_artifact_format(user_question: str) -> Optional[str]:
+    """Return a requested CSV, JSON, or XML artifact target without resolving source orchestration."""
+    normalized_question = re.sub(r'\s+', ' ', str(user_question or '').strip().casefold())
+    if not normalized_question:
+        return None
+
+    clauses = [
+        clause.strip()
+        for clause in re.split(r'[.!?;\n]+', normalized_question)
+        if clause.strip()
+    ]
+    destination_matches = []
+    for clause_index, clause in enumerate(clauses):
+        for output_format in ('json', 'xml'):
+            if output_format not in clause or _structured_artifact_format_is_negated(clause, output_format):
+                continue
+            destination_match = re.search(
+                rf'\b(?:{STRUCTURED_ARTIFACT_DESTINATION_ACTION_PATTERN})\b'
+                rf'[\w\s,():;\-/]{{0,120}}\b(?:into|in|to|as)\s+'
+                rf'(?:(?:an?|the)\s+)?(?:new\s+)?{output_format}'
+                rf'(?:\s+(?:artifact|document|file|format|output|template))?\b',
+                clause,
+            )
+            if destination_match:
+                destination_matches.append((clause_index, destination_match.start(), output_format))
+    if destination_matches:
+        return min(destination_matches)[2]
+
+    for output_format in ('json', 'xml'):
+        for clause in clauses:
+            if output_format not in clause or _structured_artifact_format_is_negated(clause, output_format):
+                continue
+            if any(marker in clause for marker in STRUCTURED_ARTIFACT_FORMAT_MARKERS[output_format]):
+                return output_format
+            if re.search(
+                rf'\b(?:{STRUCTURED_ARTIFACT_ACTION_PATTERN})\b'
+                rf'[\w\s.,:;\-/]{{0,80}}\b(?:an?\s+)?{output_format}\b',
+                clause,
+            ):
+                return output_format
+    if assistant_table_export_requested(user_question):
+        return GENERATED_FILE_FORMAT_CSV
+    return None
+
+
+def _structured_artifact_format_is_negated(clause: str, output_format: str) -> bool:
+    """Return whether a clause directly negates creating the target structured format."""
+    return bool(
+        re.search(
+            rf"\b(?:do\s+not|don't|dont|never)\s+"
+            rf"(?:{STRUCTURED_ARTIFACT_ACTION_PATTERN}|{STRUCTURED_ARTIFACT_DESTINATION_ACTION_PATTERN})"
+            rf"\b[\w\s.,:;\-/]{{0,80}}\b{output_format}\b",
+            clause,
+        )
+        or re.search(rf'\bwithout\s+(?:(?:an?|the)\s+)?{output_format}\b', clause)
+    )
+
+
 def generated_file_export_requested(user_question: str) -> bool:
     """Return whether the user asked for a supported generated file artifact."""
     return get_requested_generated_file_format(user_question) is not None
@@ -139,7 +259,11 @@ def build_generated_file_output_guidance(
     requested_format: Optional[str] = None,
 ) -> str:
     """Return shared model guidance for a requested generated output format."""
-    output_format = str(requested_format or '').strip().lower() or get_requested_generated_file_format(user_question)
+    output_format = (
+        str(requested_format or '').strip().lower()
+        or get_requested_generated_file_format(user_question)
+        or get_requested_structured_artifact_format(user_question)
+    )
     if output_format == GENERATED_FILE_FORMAT_CSV:
         return build_csv_output_clarification_guidance(user_question)
     if output_format == 'json':

--- a/application/single_app/functions_workflow_runner.py
+++ b/application/single_app/functions_workflow_runner.py
@@ -66,6 +66,7 @@ from functions_generated_file_exports import (
     build_generated_file_output_guidance,
     get_generated_file_export_content,
     get_requested_generated_file_format,
+    get_requested_structured_artifact_format,
     has_generated_file_output,
 )
 from functions_chart_operations import append_proactive_chart_guidance
@@ -436,106 +437,11 @@ def _prompt_explicitly_requests_artifact(analysis_prompt):
 
 
 def _prompt_explicitly_requests_json_artifact(analysis_prompt):
-    prompt_text = str(analysis_prompt or '').strip().lower()
-    if not prompt_text:
-        return False
-
-    json_markers = (
-        'json artifact',
-        'json export',
-        'json output',
-        'json array',
-        'json object',
-        'json format',
-        'valid json',
-        'convert into json',
-        'convert to json',
-        'return json',
-        'return only json',
-        'return only valid json',
-        'respond with json',
-        'format as json',
-        'output as json',
-        'save as json',
-        'save it as json',
-        'export as json',
-        'download as json',
-        'create json',
-        'create a json',
-        'make json',
-        'make a json',
-        'generate json',
-        'generate a json',
-        'produce json',
-        'produce a json',
-        'save to .json',
-        'export to .json',
-        'download .json',
-        'create .json',
-        'make .json',
-        'generate .json',
-    )
-    if any(marker in prompt_text for marker in json_markers):
-        return True
-
-    return bool(re.search(
-        r'\b(convert|create|make|build|generate|produce|return|respond|format|output|save|export|download)\b[\w\s.,:;\-/]{0,60}\bjson\b',
-        prompt_text,
-    ))
+    return get_requested_structured_artifact_format(analysis_prompt) == 'json'
 
 
 def _prompt_explicitly_requests_xml_artifact(analysis_prompt):
-    prompt_text = str(analysis_prompt or '').strip().lower()
-    if not prompt_text:
-        return False
-
-    xml_markers = (
-        'xml artifact',
-        'xml export',
-        'xml output',
-        'xml document',
-        'xml file',
-        'xml template',
-        'valid xml',
-        'well-formed xml',
-        'convert into xml',
-        'convert to xml',
-        'populate xml',
-        'populate the xml',
-        'return xml',
-        'return only xml',
-        'return only valid xml',
-        'respond with xml',
-        'format as xml',
-        'output as xml',
-        'save as xml',
-        'save it as xml',
-        'export as xml',
-        'download as xml',
-        'create xml',
-        'create an xml',
-        'create a xml',
-        'make xml',
-        'make an xml',
-        'make a xml',
-        'generate xml',
-        'generate an xml',
-        'produce xml',
-        'produce an xml',
-        'save to .xml',
-        'export to .xml',
-        'download .xml',
-        'create .xml',
-        'make .xml',
-        'generate .xml',
-    )
-    if any(marker in prompt_text for marker in xml_markers):
-        return True
-
-    return bool(re.search(
-        r'\b(convert|populate|create|make|build|generate|produce|return|respond|format|output|save|export|download)\b[\w\s.,:;\-/]{0,80}\bxml\b',
-        prompt_text,
-    ))
+    return get_requested_structured_artifact_format(analysis_prompt) == 'xml'
 
 
 def _normalize_generated_artifact_file_stem(value, fallback_value='analysis-artifact'):

--- a/application/single_app/route_backend_chats.py
+++ b/application/single_app/route_backend_chats.py
@@ -133,6 +133,7 @@ from functions_generated_file_exports import (
     build_generated_file_output_guidance,
     get_generated_file_export_content,
     get_requested_generated_file_format,
+    get_requested_structured_artifact_format,
     has_generated_file_output,
     normalize_json_artifact_payload,
     normalize_generated_output_format,
@@ -4981,58 +4982,7 @@ def build_tabular_computed_results_system_message(source_label, tabular_analysis
 
 def get_tabular_generated_output_format(user_question):
     """Return the requested generated-output file format when the user asked for one."""
-    normalized_question = str(user_question or '').strip().lower()
-    if not normalized_question:
-        return None
-    shared_output_format = get_requested_generated_file_format(user_question)
-    if shared_output_format == 'csv':
-        return 'csv'
-
-    json_markers = (
-        'convert into json',
-        'convert to json',
-        'json array',
-        'json file',
-        'download json',
-        'save json',
-        'make a json',
-        'create a json',
-        'generate json',
-        'generate a json',
-        'return json',
-        'valid json',
-    )
-    xml_markers = (
-        'convert into xml',
-        'convert to xml',
-        'xml file',
-        'download xml',
-        'save xml',
-        'make an xml',
-        'make a xml',
-        'create an xml',
-        'create a xml',
-        'generate xml',
-        'generate an xml',
-        'populate xml',
-        'populate the xml',
-        'return xml',
-        'valid xml',
-        'well-formed xml',
-        'output as xml',
-        'format as xml',
-    )
-    if any(marker in normalized_question for marker in json_markers) or re.search(
-        r'\b(convert|create|make|build|generate|produce|return|respond|format|output|save|export|download)\b[\w\s.,:;\-/]{0,80}\ba?\s*json\b',
-        normalized_question,
-    ):
-        return 'json'
-    if any(marker in normalized_question for marker in xml_markers) or re.search(
-        r'\b(convert|populate|create|make|build|generate|produce|return|respond|format|output|save|export|download)\b[\w\s.,:;\-/]{0,80}\ba?\s*xml\b',
-        normalized_question,
-    ):
-        return 'xml'
-    return None
+    return get_requested_structured_artifact_format(user_question)
 
 
 def question_requests_tabular_generated_output(user_question):

--- a/docs/explanation/features/GENERATED_FILE_EXPORT_FRAMEWORK.md
+++ b/docs/explanation/features/GENERATED_FILE_EXPORT_FRAMEWORK.md
@@ -2,7 +2,7 @@
 
 Implemented in version: **0.250.072**
 
-Updated through version: **0.250.153**
+Updated through version: **0.250.154**
 
 GitHub issue: [#1071](https://github.com/microsoft/simplechat/issues/1071)
 
@@ -76,6 +76,8 @@ Completed CSV, JSON, and XML file-export cards omit inline payloads and supporti
 
 During streaming JSON/XML generation, the browser receives one server-authored status such as `Generating the XML file. It will appear here when ready.` The model payload is accumulated privately for validation and publication rather than rendered token by token. If artifact publication cannot complete, finalization falls back to the accumulated model response instead of leaving the temporary status in place.
 
+Structured artifact intent is normalized once for Chat, document Analyze, and workflow output selection. Destination phrasing such as `put the PDF content into the XML`, `place these fields in an XML document`, or `write these records as JSON` selects the existing artifact generation path without requiring words such as `create`, `download`, `file`, or `populate`. Source-only mentions such as `summarize the selected XML` and explicitly negated generation requests do not select an output artifact.
+
 ## Usage
 
 Examples:
@@ -93,6 +95,7 @@ When an action returns structured data and the assistant summarizes it instead o
 - `functional_tests/test_generated_json_xml_exports.py` covers JSON/XML parsing, hardened XML handling, completed file-export metadata, and format-specific View actions.
 - `ui_tests/test_chat_generated_tabular_output_card.py` covers concise completed cards and bounded CSV, JSON, and XML preview modals.
 - `functional_tests/test_generated_json_xml_exports.py` also covers payload-only model guidance, private stream gates for agent and direct-model paths, truthful generation status, and safe failure fallback.
+- The same test executes a cross-path terminology matrix for Chat, Analyze, and workflow wrappers, including destination disambiguation such as `Convert JSON to XML`.
 - `functional_tests/test_mixed_source_hardening.py` covers cancellation and artifact rollback through the generic finalizer.
 - `functional_tests/test_document_action_token_usage_aggregation.py` covers workflow assistant-message persistence with the shared finalizer.
 - Existing durable CSV, document action, workflow, and generated-artifact tests remain part of validation.

--- a/docs/explanation/fixes/GENERATED_STRUCTURED_ARTIFACT_INTENT_FIX.md
+++ b/docs/explanation/fixes/GENERATED_STRUCTURED_ARTIFACT_INTENT_FIX.md
@@ -1,0 +1,46 @@
+# Generated Structured Artifact Intent Fix
+
+Fixed in version: **0.250.154**
+
+Related issue: **microsoft/simplechat#1031**
+
+## Issue Description
+
+Prompts such as `Take the content for the PDF and put it into the XML` did not follow the generated XML artifact path unless the user also used recognized terms such as `create`, `download`, `populate`, or `XML file`. The model therefore rendered XML inline even though a semantically equivalent prompt using explicit file terminology produced the expected downloadable artifact.
+
+## Root Cause
+
+Chat, document analysis, and workflow artifact creation each maintained separate marker lists and regular expressions. Those predicates recognized conventional export verbs but did not treat destination language such as `put into`, `place in`, or `write as` as structured output intent.
+
+## Technical Details
+
+### Files Modified
+
+- `application/single_app/functions_generated_file_exports.py`
+- `application/single_app/route_backend_chats.py`
+- `application/single_app/functions_document_analysis.py`
+- `application/single_app/functions_workflow_runner.py`
+- `application/single_app/config.py`
+- `functional_tests/test_generated_json_xml_exports.py`
+- `docs/explanation/features/GENERATED_FILE_EXPORT_FRAMEWORK.md`
+
+### Code Changes
+
+- Added one shared CSV/JSON/XML artifact-format detector.
+- Preserved existing explicit export phrases and CSV table intent.
+- Added destination transformations including put, place, write, map, load, insert, transfer, copy, move, transform, and translate when directed into/in/to/as JSON or XML.
+- Destination syntax takes precedence, so `Convert JSON to XML` selects XML and `Put the XML into JSON` selects JSON.
+- Directly negated output requests and source-only XML/JSON mentions do not select artifact generation.
+- Chat, Analyze, and workflow JSON/XML predicates now delegate to the shared detector.
+
+## Scope
+
+This change only normalizes output-format intent. It does not change source selection, document extraction, model orchestration, comparison behavior, or artifact publication mechanics.
+
+## Validation
+
+The regression matrix verifies legacy phrases, the reported PDF-to-XML phrase, JSON and XML destination disambiguation, negation, and source-only mentions. It executes the shared detector and the Chat, Analyze, and workflow wrappers to ensure every supported execution path makes the same decision.
+
+## Related Version Update
+
+`application/single_app/config.py` was incremented from **0.250.153** to **0.250.154** for this terminology normalization fix.

--- a/functional_tests/test_document_analysis_lossless_artifacts.py
+++ b/functional_tests/test_document_analysis_lossless_artifacts.py
@@ -2,12 +2,13 @@
 # test_document_analysis_lossless_artifacts.py
 """
 Functional test for document analysis lossless artifacts.
-Version: 0.250.112
+Version: 0.250.154
 Implemented in: 0.241.040
 Updated in: 0.241.065
 Updated in: 0.241.197
 Updated in: 0.250.065
 Updated in: 0.250.112
+Updated in: 0.250.154
 
 This test ensures exhaustive/table-style document analysis preserves raw window
 outputs and can build both structured CSV rows and Markdown raw-note artifacts
@@ -50,6 +51,12 @@ from functions_assistant_table_exports import (  # noqa: E402
     build_safe_csv_headers,
     neutralize_csv_spreadsheet_formula,
 )
+from functions_generated_file_exports import (  # noqa: E402
+    get_requested_structured_artifact_format,
+    normalize_xml_artifact_payload,
+    serialize_generated_json,
+)
+from test_support.versioning import assert_app_version_at_least  # noqa: E402
 
 
 def assert_equal(actual, expected, label):
@@ -88,6 +95,9 @@ def load_module_functions(file_path, extra_globals=None):
         'json': json,
         'logging': logging,
         'neutralize_csv_spreadsheet_formula': neutralize_csv_spreadsheet_formula,
+        'get_requested_structured_artifact_format': get_requested_structured_artifact_format,
+        'normalize_xml_artifact_payload': normalize_xml_artifact_payload,
+        'serialize_generated_json': serialize_generated_json,
         'os': os,
         're': re,
         'WORKFLOW_TASK_CONTEXT_MAX_CHARS': 12000,
@@ -486,7 +496,7 @@ def test_workflow_markdown_fence_parser_is_linear_and_compatible():
 
 def test_version_alignment():
     print('Testing version alignment...')
-    assert_equal(read_config_version(), '0.250.112', 'config version')
+    assert_app_version_at_least('0.250.154')
     print('Version alignment verified.')
 
 

--- a/functional_tests/test_generated_json_xml_exports.py
+++ b/functional_tests/test_generated_json_xml_exports.py
@@ -2,8 +2,8 @@
 # test_generated_json_xml_exports.py
 """
 Functional test for generated JSON/XML export artifacts.
-Version: 0.250.153
-Implemented in: 0.250.114; completed file-export cards and View actions in 0.250.152; truthful private payload streaming in 0.250.153
+Version: 0.250.154
+Implemented in: 0.250.114; completed file-export cards and View actions in 0.250.152; truthful private payload streaming in 0.250.153; shared structured-format intent terminology in 0.250.154
 
 This test ensures JSON/XML generation requests are recognized as downloadable
 artifact workflows, reuse shared serialization helpers, avoid duplicate XML
@@ -87,9 +87,21 @@ def test_shared_json_xml_export_helpers():
 
     assert module.normalize_generated_output_format(".xml") == "xml"
     assert module.normalize_generated_output_format("json") == "json"
+    intent_cases = {
+        'Take the content for the PDF and put it into the XML.': 'xml',
+        'Place these extracted fields in an XML document.': 'xml',
+        'Put this table into XML.': 'xml',
+        'Write these records as JSON.': 'json',
+        'Convert JSON to XML.': 'xml',
+        'Put the XML into JSON.': 'json',
+        'Explain what XML namespaces are.': None,
+        'Use the selected XML source and summarize it.': None,
+        'Do not create XML; summarize the source instead.': None,
+    }
+    for prompt, expected_format in intent_cases.items():
+        assert module.get_requested_structured_artifact_format(prompt) == expected_format
     xml_guidance = module.build_generated_file_output_guidance(
-        'Create a downloadable XML file.',
-        requested_format='xml',
+        'Take the content for the PDF and put it into the XML.',
     )
     json_guidance = module.build_generated_file_output_guidance(
         'Create a downloadable JSON file.',
@@ -110,10 +122,8 @@ def test_chat_route_json_xml_artifact_hooks():
     assert_contains(chat_source, "normalize_json_artifact_payload", "JSON artifact extraction import")
     assert_contains(chat_source, "normalize_xml_artifact_payload", "XML artifact extraction import")
     assert_contains(chat_source, "def maybe_create_assistant_file_generated_output(", "assistant JSON/XML artifact helper")
-    assert_contains(chat_source, "convert into json", "natural JSON conversion marker")
-    assert_contains(chat_source, r"\ba?\s*json\b", "natural JSON conversion regex")
-    assert_contains(chat_source, "populate the xml", "XML template population marker")
-    assert_contains(chat_source, r"\ba?\s*xml\b", "natural XML conversion regex")
+    assert_contains(chat_source, "get_requested_structured_artifact_format", "shared structured format detector")
+    assert_contains(chat_source, "return get_requested_structured_artifact_format(user_question)", "Chat format delegation")
     assert_contains(chat_source, "_build_assistant_file_output_handoff", "no-inline assistant handoff builder")
     assert chat_source.count("maybe_create_assistant_file_generated_output(") >= 4, (
         "Expected helper definition plus document-action, non-streaming, and streaming save path calls."
@@ -145,6 +155,48 @@ def test_chat_route_json_xml_artifact_hooks():
     )
     assert namespace['_build_streaming_assistant_file_status']('docx') == ''
     print("Chat route checks passed")
+
+
+def test_structured_artifact_intent_is_shared_across_execution_paths():
+    """Chat, Analyze, and workflow wrappers must share the same terminology decision."""
+    module = load_generated_exports_module()
+
+    def load_predicates(source_file, function_names):
+        source_text = read_text(source_file)
+        module_tree = ast.parse(source_text, filename=str(source_file))
+        selected_nodes = [
+            node
+            for node in module_tree.body
+            if isinstance(node, ast.FunctionDef) and node.name in function_names
+        ]
+        assert len(selected_nodes) == len(function_names)
+        namespace = {
+            'get_requested_structured_artifact_format': module.get_requested_structured_artifact_format,
+        }
+        exec(compile(ast.Module(body=selected_nodes, type_ignores=[]), str(source_file), 'exec'), namespace)
+        return namespace
+
+    chat_helpers = load_predicates(CHAT_ROUTE_FILE, {'get_tabular_generated_output_format'})
+    analysis_helpers = load_predicates(
+        DOCUMENT_ANALYSIS_FILE,
+        {'_prompt_requests_json_output', '_prompt_requests_xml_output'},
+    )
+    workflow_helpers = load_predicates(
+        WORKFLOW_RUNNER_FILE,
+        {'_prompt_explicitly_requests_json_artifact', '_prompt_explicitly_requests_xml_artifact'},
+    )
+
+    xml_prompt = 'Take the content for the PDF and put it into the XML.'
+    assert chat_helpers['get_tabular_generated_output_format'](xml_prompt) == 'xml'
+    assert analysis_helpers['_prompt_requests_xml_output'](xml_prompt) is True
+    assert analysis_helpers['_prompt_requests_json_output'](xml_prompt) is False
+    assert workflow_helpers['_prompt_explicitly_requests_xml_artifact'](xml_prompt) is True
+    assert workflow_helpers['_prompt_explicitly_requests_json_artifact'](xml_prompt) is False
+
+    source_only_prompt = 'Read the selected XML source and summarize it.'
+    assert chat_helpers['get_tabular_generated_output_format'](source_only_prompt) is None
+    assert analysis_helpers['_prompt_requests_xml_output'](source_only_prompt) is False
+    assert workflow_helpers['_prompt_explicitly_requests_xml_artifact'](source_only_prompt) is False
 
 
 def test_json_xml_completed_artifact_metadata_and_view_actions():
@@ -208,11 +260,13 @@ def test_document_analysis_xml_json_intent_and_artifacts():
 
     assert_contains(analysis_source, "def _prompt_requests_json_output(", "document-analysis JSON output intent")
     assert_contains(analysis_source, "def _prompt_requests_xml_output(", "document-analysis XML output intent")
+    assert_contains(analysis_source, "get_requested_structured_artifact_format", "shared Analyze format detector")
     assert_contains(analysis_source, "Return only one complete well-formed XML document", "XML-only reduction guidance")
     assert_contains(analysis_source, "Return only valid JSON for the final answer", "JSON-only reduction guidance")
     assert_contains(analysis_source, "'xml_output_requested': xml_output_requested", "XML intent metadata")
 
     assert_contains(workflow_source, "def _prompt_explicitly_requests_xml_artifact(", "workflow XML artifact intent")
+    assert_contains(workflow_source, "get_requested_structured_artifact_format", "shared workflow format detector")
     assert_contains(workflow_source, "xml_payload = normalize_xml_artifact_payload(analysis_reply)", "XML payload extraction")
     assert_contains(workflow_source, "_build_document_analysis_artifact_file_name(analysis_result, 'xml')", "XML artifact filename")
     assert_contains(workflow_source, "output_format = 'xml' if xml_payload and xml_artifact_requested", "XML artifact output selection")
@@ -246,11 +300,12 @@ def test_security_review_fixes():
 
 
 def run_tests():
-    assert_app_version_at_least("0.250.153")
+    assert_app_version_at_least("0.250.154")
 
     tests = [
         test_shared_json_xml_export_helpers,
         test_chat_route_json_xml_artifact_hooks,
+        test_structured_artifact_intent_is_shared_across_execution_paths,
         test_json_xml_completed_artifact_metadata_and_view_actions,
         test_document_analysis_xml_json_intent_and_artifacts,
         test_xml_processing_consolidated,

--- a/functional_tests/test_tabular_row_orchestration_scale.py
+++ b/functional_tests/test_tabular_row_orchestration_scale.py
@@ -53,7 +53,10 @@ from functions_assistant_table_exports import (  # noqa: E402
     has_generated_tabular_csv_output,
     neutralize_csv_spreadsheet_formula,
 )
-from functions_generated_file_exports import get_requested_generated_file_format  # noqa: E402
+from functions_generated_file_exports import (  # noqa: E402
+    get_requested_generated_file_format,
+    get_requested_structured_artifact_format,
+)
 CONTRACT_FUNCTIONS = {
     '_safe_int',
     '_normalize_source_identity_label',
@@ -540,6 +543,7 @@ def _load_tabular_request_intent_helpers():
     namespace = {
         'assistant_table_export_requested': assistant_table_export_requested,
         'get_requested_generated_file_format': get_requested_generated_file_format,
+        'get_requested_structured_artifact_format': get_requested_structured_artifact_format,
         're': re,
     }
     exec(


### PR DESCRIPTION
## Summary
- Add one shared structured artifact format detector for CSV, JSON, and XML output intent.
- Recognize destination terminology such as `put the PDF content into the XML`, `place these fields in an XML document`, and `write these records as JSON` without requiring create/download/file/populate terminology.
- Prioritize the destination format for transformations such as `Convert JSON to XML` and `Put the XML into JSON`.
- Reject directly negated generation requests and source-only mentions such as `summarize the selected XML`.
- Delegate Chat, document Analyze, and workflow JSON/XML predicates to the shared detector.
- Make shared generated-file guidance derive JSON/XML payload-only instructions from the same detector.
- Bump the app version to `0.250.154` and add versioned documentation.

## Scope
This changes output-format intent normalization only. It does not change source selection, PDF extraction, document limits, comparison behavior, model orchestration, or artifact publication mechanics.

## Validation
- `94 passed` across full JSON/XML, document-analysis, workflow, and durable tabular suites
- `2 passed` shared CSV/workflow generated-file compatibility tests
- Cross-path executable matrix verifies Chat, Analyze, and workflow decisions for:
  - `Take the content for the PDF and put it into the XML` -> XML
  - `Place these extracted fields in an XML document` -> XML
  - `Write these records as JSON` -> JSON
  - `Convert JSON to XML` -> XML
  - `Put the XML into JSON` -> JSON
  - source-only and negated requests -> no artifact target
- Python compilation and VS Code diagnostics clean
- Broken Access Control guardrail passed
- Windows-safe `git diff --check` passed

Refs #1031