### PR TITLE
Add configurable workflow task limits

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -96,7 +96,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.250.128"
+VERSION = "0.250.129"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/functions_group_workflows.py
+++ b/application/single_app/functions_group_workflows.py
@@ -45,6 +45,7 @@ from functions_personal_workflows import (
     _strip_cosmos_metadata,
     _utc_now_iso,
     compute_next_run_at,
+    get_workflow_max_tasks,
 )
 from functions_settings import get_settings, normalize_model_endpoints
 
@@ -448,6 +449,7 @@ def save_group_workflow(group_id, workflow_data, actor_user_id, user_info=None):
             runner,
             settings=settings,
         ),
+        max_tasks=get_workflow_max_tasks(settings),
     )
     task_prompt = _normalize_text(
         workflow_data.get('task_prompt') or (tasks[0].get('instructions') if tasks else ''),

--- a/application/single_app/functions_personal_workflows.py
+++ b/application/single_app/functions_personal_workflows.py
@@ -46,7 +46,10 @@ WORKFLOW_FILE_SYNC_WAIT_MODES = {'complete', 'queued'}
 WORKFLOW_FILE_SYNC_CONTINUE_MODES = {'always', 'changed'}
 WORKFLOW_FILE_SYNC_MAX_SOURCES = 10
 WORKFLOW_ERROR_STRATEGIES = {'halt', 'continue'}
-WORKFLOW_MAX_TASKS = 20
+WORKFLOW_TASK_LIMIT_DEFAULT = 50
+WORKFLOW_TASK_LIMIT_MIN = 1
+WORKFLOW_TASK_LIMIT_MAX = 100
+WORKFLOW_MAX_TASKS = WORKFLOW_TASK_LIMIT_DEFAULT
 WORKFLOW_TASK_INSTRUCTIONS_MAX_LENGTH = 12000
 WORKFLOW_TASK_NAME_MAX_LENGTH = 120
 WORKFLOW_TASK_RUNNER_TYPES = {'inherit', 'agent', 'model'}
@@ -82,6 +85,21 @@ def _normalize_bool(value, default=False):
     if isinstance(value, str):
         return value.strip().lower() in {'1', 'true', 'yes', 'on'}
     return bool(value)
+
+
+def normalize_workflow_max_tasks(value=None):
+    """Normalize configured workflow task limits to the supported range."""
+    try:
+        parsed_value = int(value)
+    except (TypeError, ValueError):
+        parsed_value = WORKFLOW_TASK_LIMIT_DEFAULT
+    return min(WORKFLOW_TASK_LIMIT_MAX, max(WORKFLOW_TASK_LIMIT_MIN, parsed_value))
+
+
+def get_workflow_max_tasks(settings=None):
+    """Return the effective max task count for workflow authoring."""
+    source_settings = settings if isinstance(settings, dict) else get_settings()
+    return normalize_workflow_max_tasks(source_settings.get('workflow_max_tasks'))
 
 
 def _normalize_personal_workflow_conversation_id(user_id, workflow_data, existing_workflow=None):
@@ -139,9 +157,15 @@ def _normalize_alert_priority(value):
     return normalized
 
 
-def _normalize_workflow_tasks(workflow_data, existing_workflow=None, task_runner_normalizer=None):
+def _normalize_workflow_tasks(
+    workflow_data,
+    existing_workflow=None,
+    task_runner_normalizer=None,
+    max_tasks=WORKFLOW_MAX_TASKS,
+):
     workflow_data = workflow_data if isinstance(workflow_data, dict) else {}
     existing_workflow = existing_workflow if isinstance(existing_workflow, dict) else {}
+    configured_max_tasks = normalize_workflow_max_tasks(max_tasks)
     tasks_supplied = 'tasks' in workflow_data
     raw_tasks = workflow_data.get('tasks') if tasks_supplied else existing_workflow.get('tasks') or []
     if not isinstance(raw_tasks, list):
@@ -150,8 +174,8 @@ def _normalize_workflow_tasks(workflow_data, existing_workflow=None, task_runner
         if not tasks_supplied:
             return []
         raise ValueError('Add at least one workflow task.')
-    if len(raw_tasks) > WORKFLOW_MAX_TASKS:
-        raise ValueError(f'Workflows support up to {WORKFLOW_MAX_TASKS} tasks.')
+    if len(raw_tasks) > configured_max_tasks:
+        raise ValueError(f'Workflows support up to {configured_max_tasks} tasks.')
 
     normalized_tasks = []
     seen_task_ids = set()
@@ -666,6 +690,7 @@ def save_personal_workflow(user_id, workflow_data, actor_user_id=None):
             runner,
             settings=settings,
         ),
+        max_tasks=get_workflow_max_tasks(settings),
     )
     task_prompt = _normalize_text(
         workflow_data.get('task_prompt') or (tasks[0].get('instructions') if tasks else ''),

--- a/application/single_app/functions_settings.py
+++ b/application/single_app/functions_settings.py
@@ -1020,6 +1020,7 @@ def get_settings(use_cosmos=False, include_source=False):
         'allow_user_plugins': False,
         'allow_user_workflows': False,
         'require_member_of_workflow_user': False,
+        'workflow_max_tasks': 50,
         'allow_group_workflows': False,
         'require_group_assignment_for_group_workflows': False,
         'group_workflow_allowed_group_ids': [],

--- a/application/single_app/route_frontend_admin_settings.py
+++ b/application/single_app/route_frontend_admin_settings.py
@@ -57,6 +57,11 @@ from functions_terms_of_use import (
 from swagger_wrapper import swagger_route, get_auth_security
 from datetime import datetime, timedelta, timezone
 from admin_settings_int_utils import safe_int_with_source
+from functions_personal_workflows import (
+    WORKFLOW_TASK_LIMIT_DEFAULT,
+    WORKFLOW_TASK_LIMIT_MAX,
+    WORKFLOW_TASK_LIMIT_MIN,
+)
 from support_menu_config import (
     get_admin_latest_feature_release_groups_for_settings,
     get_support_latest_feature_catalog,
@@ -1140,6 +1145,18 @@ def register_route_frontend_admin_settings(bp):
                         settings.get('workflow_max_auto_invoke_attempts', 60),
                         'workflow_max_auto_invoke_attempts',
                         60
+                    )
+                )
+            )
+            workflow_max_tasks = min(
+                WORKFLOW_TASK_LIMIT_MAX,
+                max(
+                    WORKFLOW_TASK_LIMIT_MIN,
+                    parse_admin_int(
+                        form_data.get('workflow_max_tasks'),
+                        settings.get('workflow_max_tasks', WORKFLOW_TASK_LIMIT_DEFAULT),
+                        'workflow_max_tasks',
+                        WORKFLOW_TASK_LIMIT_DEFAULT
                     )
                 )
             )
@@ -2450,6 +2467,7 @@ def register_route_frontend_admin_settings(bp):
                 'require_group_assignment_for_group_workflows': form_data.get('require_group_assignment_for_group_workflows') == 'on',
                 'group_workflow_allowed_group_ids': group_workflow_allowed_group_ids,
                 'workflow_max_auto_invoke_attempts': workflow_max_auto_invoke_attempts,
+                'workflow_max_tasks': workflow_max_tasks,
                 'allow_personal_workspace_file_downloads': form_data.get('allow_personal_workspace_file_downloads') == 'on',
                 'allow_group_workspace_file_downloads': form_data.get('allow_group_workspace_file_downloads') == 'on',
                 'require_group_assignment_for_file_downloads': form_data.get('require_group_assignment_for_file_downloads') == 'on',

--- a/application/single_app/static/js/workspace/workspace_workflows.js
+++ b/application/single_app/static/js/workspace/workspace_workflows.js
@@ -138,7 +138,20 @@ const WORKFLOW_STEP_DESCRIPTIONS = {
     reliability: "Choose retry and failure behavior.",
     review: "Review the workflow and completion alert before saving.",
 };
-const WORKFLOW_MAX_TASKS = 20;
+const WORKFLOW_TASK_LIMIT_DEFAULT = 50;
+const WORKFLOW_TASK_LIMIT_MIN = 1;
+const WORKFLOW_TASK_LIMIT_MAX = 100;
+function getWorkflowMaxTasks() {
+    const configuredLimit = Number.parseInt(
+        window.workflowSettings?.workflow_max_tasks ?? WORKFLOW_TASK_LIMIT_DEFAULT,
+        10,
+    );
+    if (!Number.isFinite(configuredLimit)) {
+        return WORKFLOW_TASK_LIMIT_DEFAULT;
+    }
+    return Math.min(WORKFLOW_TASK_LIMIT_MAX, Math.max(WORKFLOW_TASK_LIMIT_MIN, configuredLimit));
+}
+const WORKFLOW_MAX_TASKS = getWorkflowMaxTasks();
 const DOCUMENT_ACTION_NONE = "none";
 const DOCUMENT_ACTION_SEARCH = "search";
 const DOCUMENT_ACTION_ANALYZE = "analyze";

--- a/application/single_app/templates/admin_settings.html
+++ b/application/single_app/templates/admin_settings.html
@@ -9438,6 +9438,23 @@
                         </div>
                     </div>
 
+                    <div class="form-group mt-3 mb-3">
+                        <label for="workflow_max_tasks" class="form-label">
+                            Workflow Task Limit
+                        </label>
+                        <input type="number"
+                            class="form-control"
+                            id="workflow_max_tasks"
+                            name="workflow_max_tasks"
+                            min="1"
+                            max="100"
+                            step="1"
+                            value="{{ settings.workflow_max_tasks|default(50, true) }}">
+                        <div class="form-text">
+                            Maximum ordered instruction tasks users can add to one workflow. Default is 50; supported range is 1-100.
+                        </div>
+                    </div>
+
                     <hr>
 
                     <div class="form-group form-check form-switch mb-3">

--- a/application/single_app/templates/group_workspaces.html
+++ b/application/single_app/templates/group_workspaces.html
@@ -8893,6 +8893,9 @@ app_settings.app_title }} {% endblock %} {% block head %}
     enable_url_access: {{ settings.enable_url_access|default(false, true)|tojson }},
     url_access_max_workflow_urls_per_run: {{ settings.url_access_max_workflow_urls_per_run|default(50, true)|tojson }}
   };
+  window.workflowSettings = {
+    workflow_max_tasks: {{ settings.workflow_max_tasks|default(50, true)|tojson }}
+  };
   window.workflowWorkspaceConfig = {
     scope: 'group',
     apiBase: '/api/group/workflows',

--- a/application/single_app/templates/workspace.html
+++ b/application/single_app/templates/workspace.html
@@ -2572,6 +2572,9 @@
       enable_url_access: {{ settings.enable_url_access|default(false, true)|tojson }},
       url_access_max_workflow_urls_per_run: {{ settings.url_access_max_workflow_urls_per_run|default(50, true)|tojson }}
     };
+    window.workflowSettings = {
+      workflow_max_tasks: {{ settings.workflow_max_tasks|default(50, true)|tojson }}
+    };
     window.max_file_size_mb = {{ settings.max_file_size_mb | default(16) }};
     
     // Pass current user ID for ownership checks

--- a/docs/explanation/features/GENERIC_WORKFLOW_AUTOMATION.md
+++ b/docs/explanation/features/GENERIC_WORKFLOW_AUTOMATION.md
@@ -3,6 +3,7 @@
 Implemented in version: **0.250.063**
 Enhanced in version: **0.250.065**
 Task-level runner selection implemented in version: **0.250.065**
+Configurable task limits implemented in version: **0.250.129**
 
 Related issues: #1082, #1084
 
@@ -17,9 +18,10 @@ scheduling are optional capabilities that can be added when they are relevant
 to the task.
 
 Fixed/Implemented in version: **0.250.063**
+Configurable task limits implemented in version: **0.250.129**
 
 Related version update:
-- `application/single_app/config.py` reports version `0.250.065`.
+- `application/single_app/config.py` reports version `0.250.129`.
 
 Dependencies:
 - `application/single_app/functions_personal_workflows.py`
@@ -44,7 +46,8 @@ Dependencies:
   without requiring document analysis.
 - Each run records its messages and result in the workflow conversation and
   retains the normal workflow run history.
-- A workflow can contain up to 20 ordered instruction tasks. A task runner can
+- A workflow can contain up to the admin-configured ordered instruction task
+   limit, which defaults to 50 and is hard-capped at 100. A task runner can
    inherit the workflow default, use an authorized Direct Model override, or use
    an authorized Agent override. Every task receives a bounded copy of the
    previous task's response as context.

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,15 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](/explanation/features/) and [Fixes by Version](/explanation/fixes/).
 
+### **(v0.250.129)**
+
+#### New Features
+
+*   **Configurable Workflow Task Limit**
+    *   Added an admin setting that controls how many ordered instruction tasks users can add to a workflow.
+    *   The default is 50 tasks, with backend and browser enforcement clamped to a supported range of 1-100 tasks.
+    *   (Ref: workflow task sequences, Admin Settings Workflow section, `functions_personal_workflows.py`, `workspace_workflows.js`)
+
 ### **(v0.250.128)**
 
 #### Bug Fixes

--- a/functional_tests/test_workflow_stepped_builder.py
+++ b/functional_tests/test_workflow_stepped_builder.py
@@ -1,9 +1,10 @@
 # test_workflow_stepped_builder.py
 """
 Functional test for the stepped workflow builder.
-Version: 0.250.065
+Version: 0.250.129
 Implemented in: 0.250.064
 Enhanced in: 0.250.065
+Enhanced in: 0.250.129
 
 This test ensures personal and group workflow modals use the same five-step
 builder and submit ordered tasks and error handling through existing routes.
@@ -13,7 +14,7 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
-EXPECTED_VERSION = "0.250.065"
+EXPECTED_VERSION = "0.250.129"
 
 
 def read_text(relative_path: str) -> str:
@@ -55,6 +56,7 @@ def test_personal_and_group_templates_share_five_step_builder() -> None:
         assert '<option value="inherit">Workflow default</option>' in content
         assert "cdn.tailwindcss.com" not in content
         assert "fonts.googleapis.com" not in content
+        assert "window.workflowSettings" in content
 
     print("PASS: stepped workflow template contract")
 
@@ -78,10 +80,13 @@ def test_shared_browser_behavior_builds_safe_ordered_task_payload() -> None:
         "validateWorkflowStep",
         "showWorkflowStep",
         "navigateWorkflowStep",
+        "getWorkflowMaxTasks",
     ):
         assert f"function {function_name}(" in content
     assert "workflowTasks.map((task, index) => ({" in content
     assert "runner: serializeWorkflowTaskRunner(task.runner)," in content
+    assert "const WORKFLOW_MAX_TASKS = getWorkflowMaxTasks();" in content
+    assert "const WORKFLOW_MAX_TASKS = 20;" not in content
     assert "error_handling:" in content
     assert "workflow-review-summary__item" in content
     assert 'name.textContent = task.name || `Task ${index + 1}`;' in content
@@ -104,8 +109,10 @@ def test_existing_routes_persist_tasks_without_new_endpoints() -> None:
     assert f'VERSION = "{EXPECTED_VERSION}"' in config
     assert "'tasks': tasks," in personal_store
     assert "'error_handling': error_handling," in personal_store
+    assert "max_tasks=get_workflow_max_tasks(settings)" in personal_store
     assert "'tasks': tasks," in group_store
     assert "'error_handling': error_handling," in group_store
+    assert "max_tasks=get_workflow_max_tasks(settings)" in group_store
     assert "save_personal_workflow(" in routes
     assert "save_group_workflow(" in routes
     assert "/api/user/workflows/<workflow_id>/run" in routes

--- a/functional_tests/test_workflow_task_sequence.py
+++ b/functional_tests/test_workflow_task_sequence.py
@@ -1,9 +1,10 @@
 # test_workflow_task_sequence.py
 """
 Functional test for ordered workflow task sequences.
-Version: 0.250.105
+Version: 0.250.129
 Implemented in: 0.250.064
 Enhanced in: 0.250.065
+Enhanced in: 0.250.129
 
 This test ensures workflow tasks are normalized in order, execute with bounded
 prior-task context, retry safely, and honor halt or continue error strategies.
@@ -19,7 +20,7 @@ APP_ROOT = ROOT / "application" / "single_app"
 STORE_FILE = APP_ROOT / "functions_personal_workflows.py"
 GROUP_STORE_FILE = APP_ROOT / "functions_group_workflows.py"
 RUNNER_FILE = APP_ROOT / "functions_workflow_runner.py"
-EXPECTED_VERSION = "0.250.105"
+EXPECTED_VERSION = "0.250.129"
 
 
 def read_text(path: Path) -> str:
@@ -43,13 +44,17 @@ def load_store_helpers() -> dict:
         STORE_FILE,
         {
             "_normalize_text",
+            "normalize_workflow_max_tasks",
             "_normalize_workflow_tasks",
             "_normalize_workflow_error_handling",
         },
         {
             "uuid": uuid,
             "WORKFLOW_ERROR_STRATEGIES": {"halt", "continue"},
-            "WORKFLOW_MAX_TASKS": 20,
+            "WORKFLOW_TASK_LIMIT_DEFAULT": 50,
+            "WORKFLOW_TASK_LIMIT_MIN": 1,
+            "WORKFLOW_TASK_LIMIT_MAX": 100,
+            "WORKFLOW_MAX_TASKS": 50,
             "WORKFLOW_TASK_INSTRUCTIONS_MAX_LENGTH": 12000,
             "WORKFLOW_TASK_NAME_MAX_LENGTH": 120,
             "WORKFLOW_TASK_RUNNER_TYPES": {"inherit", "agent", "model"},
@@ -197,6 +202,64 @@ def test_task_and_error_policy_normalization() -> None:
         assert "at least one" in str(exc)
 
     print("PASS: workflow task normalization")
+
+
+def test_configurable_task_limit_normalization() -> None:
+    """Clamp admin-configured task limits and enforce the effective limit."""
+    print("Testing configurable workflow task limit normalization...")
+    helpers = load_store_helpers()
+
+    assert helpers["normalize_workflow_max_tasks"](None) == 50
+    assert helpers["normalize_workflow_max_tasks"](0) == 1
+    assert helpers["normalize_workflow_max_tasks"](150) == 100
+
+    fifty_tasks = [
+        {
+            "id": f"task-{index}",
+            "name": f"Task {index}",
+            "instructions": f"Complete task {index}.",
+        }
+        for index in range(1, 51)
+    ]
+    assert len(helpers["_normalize_workflow_tasks"]({"tasks": fifty_tasks}, max_tasks=50)) == 50
+
+    try:
+        helpers["_normalize_workflow_tasks"](
+            {
+                "tasks": [
+                    {
+                        "id": f"task-{index}",
+                        "name": f"Task {index}",
+                        "instructions": f"Complete task {index}.",
+                    }
+                    for index in range(1, 52)
+                ]
+            },
+            max_tasks=50,
+        )
+        raise AssertionError("Expected the configured 50-task limit to be enforced.")
+    except ValueError as exc:
+        assert "up to 50 tasks" in str(exc)
+
+    try:
+        helpers["_normalize_workflow_tasks"](
+            {
+                "tasks": [
+                    {
+                        "id": f"task-{index}",
+                        "name": f"Task {index}",
+                        "instructions": f"Complete task {index}.",
+                    }
+                    for index in range(1, 102)
+                ]
+            },
+            max_tasks=150,
+        )
+        raise AssertionError("Expected the hard 100-task limit to be enforced.")
+    except ValueError as exc:
+        assert "up to 100 tasks" in str(exc)
+
+    print("PASS: configurable workflow task limit normalization")
 
 
 def test_personal_task_runner_normalization_and_authorization() -> None:
@@ -744,6 +807,7 @@ def test_version_and_legacy_dispatch_contract() -> None:
 def run_tests() -> bool:
     tests = [
         test_task_and_error_policy_normalization,
+        test_configurable_task_limit_normalization,
         test_personal_task_runner_normalization_and_authorization,
         test_group_task_agent_authorization,
         test_ordered_tasks_chain_context_and_apply_documents_once,

--- a/ui_tests/test_admin_workflow_settings_access.py
+++ b/ui_tests/test_admin_workflow_settings_access.py
@@ -1,17 +1,18 @@
 # test_admin_workflow_settings_access.py
 """
 UI test for admin workflow access settings.
-Version: 0.241.194
+Version: 0.250.129
 Implemented in: 0.241.106
 Updated in: 0.241.110
 Updated in: 0.241.179
 Updated in: 0.241.193
 Updated in: 0.241.194
+Updated in: 0.250.129
 
 This test ensures admins can see the dedicated Workspace settings sections with
 consistent app-role labels for workflow, group workflow assignment, group creation,
-public workspace creation, chat file uploads, and workflow action limits.
-It also verifies capacity guidance for higher workflow action limits.
+public workspace creation, chat file uploads, workflow action limits, and workflow
+task limits. It also verifies capacity guidance for higher workflow action limits.
 """
 
 import os
@@ -68,6 +69,8 @@ def test_admin_workflow_settings_section():
         expect(workflow_section).to_contain_text("Workflow Agent Action Limit")
         expect(workflow_section).to_contain_text("Values above 100 are capacity-sensitive")
         expect(workflow_section).to_contain_text("Enable Cosmos DB Throughput automation in SimpleChat")
+        expect(workflow_section).to_contain_text("Workflow Task Limit")
+        expect(workflow_section).to_contain_text("Default is 50; supported range is 1-100")
         expect(workflow_section).to_contain_text("Enable Group Workflows")
         expect(workflow_section).to_contain_text("Require Group Assignment to Use Workflow")
         expect(workflow_section).to_contain_text("Group Workflow Assignments")
@@ -79,6 +82,11 @@ def test_admin_workflow_settings_section():
         expect(workflow_action_limit).to_have_attribute("type", "number")
         expect(workflow_action_limit).to_have_attribute("min", "1")
         expect(workflow_action_limit).to_have_attribute("max", "500")
+        workflow_task_limit = page.locator("#workflow_max_tasks")
+        expect(workflow_task_limit).to_have_count(1)
+        expect(workflow_task_limit).to_have_attribute("type", "number")
+        expect(workflow_task_limit).to_have_attribute("min", "1")
+        expect(workflow_task_limit).to_have_attribute("max", "100")
         expect(page.locator("#allow_group_workflows")).to_have_count(1)
         expect(page.locator("#require_group_assignment_for_group_workflows")).to_have_count(1)
         expect(page.locator("#manage-group-workflow-groups-btn")).to_have_count(1)


### PR DESCRIPTION
## Summary
- Add `workflow_max_tasks` app setting with default 50 and supported range 1-100.
- Enforce the configured task limit in personal and group workflow backend validation.
- Wire the shared workflow builder to the sanitized configured limit and expose the control in Admin Settings.
- Update workflow feature docs, release notes, tests, and app version to `0.250.129`.

## Validation
- `python functional_tests\test_workflow_task_sequence.py`
- `python functional_tests\test_workflow_stepped_builder.py`
- `python functional_tests\test_workflow_auto_invoke_attempt_settings.py`
- `python -m py_compile application\single_app\functions_personal_workflows.py application\single_app\functions_group_workflows.py application\single_app\functions_settings.py application\single_app\route_frontend_admin_settings.py functional_tests\test_workflow_task_sequence.py functional_tests\test_workflow_stepped_builder.py ui_tests\test_admin_workflow_settings_access.py`
- `node --check application\single_app\static\js\workspace\workspace_workflows.js`
- `python -m pytest ui_tests\test_admin_workflow_settings_access.py -q` (skipped locally because UI env is not configured)
- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check`