### PR TITLE
Fix tabular contains replay semantics

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -96,7 +96,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.250.154"
+VERSION = "0.250.155"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/semantic_kernel_plugins/tabular_processing_plugin.py
+++ b/application/single_app/semantic_kernel_plugins/tabular_processing_plugin.py
@@ -2418,7 +2418,7 @@ class TabularProcessingPlugin:
             text_series = series.astype(str)
             value_text = str(value)
             if op == 'contains':
-                return text_series.str.contains(value_text, case=False, na=False)
+                return text_series.str.contains(value_text, case=False, regex=False, na=False)
             if op == 'startswith':
                 return text_series.str.lower().str.startswith(value_text.lower())
             if op == 'endswith':

--- a/docs/explanation/fixes/TABULAR_CONTAINS_REPLAY_SEMANTICS_FIX.md
+++ b/docs/explanation/fixes/TABULAR_CONTAINS_REPLAY_SEMANTICS_FIX.md
@@ -1,0 +1,42 @@
+# Tabular Contains Replay Semantics Fix
+
+Fixed/Implemented in version: **0.250.155**
+
+Related work: Fixes #1197
+
+## Issue
+
+Durable tabular CSV replay descriptors for `filter_rows` could select a different row cohort than the foreground `filter_rows` call when the `contains` value included regex-sensitive characters such as `A.*`.
+
+## Root Cause
+
+The foreground filter path used pandas `Series.str.contains(value, case=False, na=False)`, where `value` is interpreted as a regular expression by default. The durable replay descriptor emitted `.str.contains(value, case=False, regex=False, na=False)`, which treats the same value as a literal string. Because the bounded CSV replay engine intentionally allowlists literal string methods, the mismatch could make replayed exports disagree with the preview row set.
+
+## Technical Details
+
+### Files Modified
+
+- `application/single_app/semantic_kernel_plugins/tabular_processing_plugin.py`
+- `application/single_app/config.py`
+- `functional_tests/test_tabular_large_result_pagination.py`
+- `docs/explanation/release_notes.md`
+
+### Code Changes
+
+- Updated foreground `contains` filtering to use `regex=False`, matching the durable replay descriptor and the bounded CSV query validator.
+- Added a regression case where the filter value `A.*` must match literal `A.*` values case-insensitively without matching unrelated `A`-prefixed rows.
+- Updated the application version from `0.250.154` to `0.250.155`.
+
+## Impact Analysis
+
+- `filter_rows` preview results and durable generated export replay now use the same literal containment semantics.
+- Regex-shaped user input is no longer accidentally treated as a regular expression by `filter_rows` containment matching.
+- The bounded CSV replay evaluator remains restricted to side-effect-free literal string operations.
+
+## Validation
+
+- `python functional_tests\test_tabular_large_result_pagination.py`
+
+## Before and After
+
+Before, filtering for `A.*` could match a broader regex cohort in the foreground preview while durable replay matched only literal `A.*` rows. After this fix, both paths match the same literal rows and report the same expected row count.

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,15 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](/explanation/features/) and [Fixes by Version](/explanation/fixes/).
 
+### **(v0.250.155)**
+
+#### Bug Fixes
+
+*   **Tabular Contains Replay Semantics**
+    *   Aligned foreground `filter_rows contains` matching with durable CSV replay by using literal, case-insensitive containment in both paths.
+    *   Added regression coverage for regex-shaped values such as `A.*` so previews and generated export replays select the same row cohort.
+    *   (Ref: #1197, tabular durable replay descriptors, `tabular_processing_plugin.py`, `test_tabular_large_result_pagination.py`)
+
 ### **(v0.250.129)**
 
 #### New Features

--- a/functional_tests/test_tabular_large_result_pagination.py
+++ b/functional_tests/test_tabular_large_result_pagination.py
@@ -2,8 +2,8 @@
 # test_tabular_large_result_pagination.py
 """
 Functional test for tabular SK large-result pagination and output trimming.
-Version: 0.250.152
-Implemented in: 0.242.067; bounded CSV query path in 0.250.060; source descriptor generalization in 0.250.127; serialized row-size estimation in 0.250.152
+Version: 0.250.155
+Implemented in: 0.242.067; bounded CSV query path in 0.250.060; source descriptor generalization in 0.250.127; serialized row-size estimation in 0.250.152; contains replay semantics in 0.250.155
 
 This test ensures row-returning tabular processing tools support start_row/max_rows
 pagination, avoid skipped rows after auto-trimming oversized output, honor
@@ -459,6 +459,61 @@ def test_filter_rows_csv_attaches_replayable_descriptor_for_full_cohort():
         return False
 
 
+def test_filter_rows_csv_contains_replay_uses_literal_semantics():
+    """Verify contains filters use literal semantics in foreground and durable replay."""
+    print('🔍 Testing filter_rows contains replay literal semantics...')
+
+    try:
+        source_frame = pd.DataFrame([
+            {'transaction_id': 'A.*', 'status': 'Open'},
+            {'transaction_id': 'ABCD', 'status': 'Open'},
+            {'transaction_id': 'a.*', 'status': 'Closed'},
+            {'transaction_id': 'B-100', 'status': 'Closed'},
+        ])
+        csv_content = source_frame.to_csv(index=False).encode('utf-8')
+        plugin = TabularProcessingPlugin()
+        plugin._resolve_blob_location_with_fallback = lambda *args, **kwargs: (
+            'mock-container',
+            'nested/version-7/large-results.csv',
+        )
+        plugin._get_blob_service_client = lambda: MockCsvBlobServiceClient(csv_content)
+        plugin._read_tabular_blob_to_dataframe = lambda *args, **kwargs: source_frame.copy()
+
+        result = asyncio.run(plugin.filter_rows(
+            user_id='test-user',
+            conversation_id='test-conversation',
+            filename='large-results.csv',
+            column='transaction_id',
+            operator='contains',
+            value='A.*',
+            source='chat',
+            return_columns='transaction_id,status',
+            max_rows='100',
+        ))
+        payload = json.loads(result)
+        descriptor = result.internal_metadata['tabular_generated_export_source']
+        replayed_rows = list(PLUGIN_MODULE.iter_tabular_csv_query_rows(
+            csv_stream=io.BytesIO(csv_content),
+            query_expression=descriptor['query_expression'],
+            return_columns=descriptor['return_columns'],
+            source_chunk_rows=2,
+            tabular_plugin=plugin,
+        ))
+
+        assert payload['total_matches'] == 2, payload
+        assert descriptor['expected_row_count'] == 2, descriptor
+        assert 'regex=False' in descriptor['query_expression'], descriptor
+        assert [row['transaction_id'] for _, row in replayed_rows] == ['A.*', 'a.*'], replayed_rows
+
+        print('✅ filter_rows contains replay literal semantics passed')
+        return True
+    except Exception as exc:
+        print(f'❌ Test failed: {exc}')
+        import traceback
+        traceback.print_exc()
+        return False
+
+
 def test_filter_rows_csv_rejects_non_replayable_normalized_matching():
     """Verify normalized matching fails closed instead of advertising partial replay."""
     print('🔍 Testing normalized filter_rows replay rejection...')
@@ -575,6 +630,7 @@ if __name__ == '__main__':
         test_query_tabular_data_supports_return_columns_and_pagination,
         test_query_tabular_csv_uses_bounded_shared_engine_and_exact_descriptor,
         test_filter_rows_csv_attaches_replayable_descriptor_for_full_cohort,
+        test_filter_rows_csv_contains_replay_uses_literal_semantics,
         test_filter_rows_csv_rejects_non_replayable_normalized_matching,
         test_search_rows_csv_attaches_replayable_multi_column_descriptor,
     ]


### PR DESCRIPTION
## Summary
- Fixes #1197.
- Aligns foreground `filter_rows contains` behavior with durable CSV replay by using literal, case-insensitive containment in both paths.
- Adds regression coverage for regex-shaped values such as `A.*`, plus fix documentation and release notes for v0.250.155.

## Validation
- `python functional_tests\test_tabular_large_result_pagination.py`
- `python -m py_compile application\single_app\semantic_kernel_plugins\tabular_processing_plugin.py application\single_app\config.py functional_tests\test_tabular_large_result_pagination.py`
- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check`