### PR TITLE
Merge prior grounded sources into follow-up tasks

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -96,7 +96,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.250.156"
+VERSION = "0.250.157"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/route_backend_chats.py
+++ b/application/single_app/route_backend_chats.py
@@ -15728,6 +15728,7 @@ def register_route_backend_chats(bp):
             history_grounded_search_used = False
             history_only_answerability = None
             prior_grounded_document_refs = []
+            prior_grounded_source_merge = None
             continuity_decision = None
             effective_document_scope = document_scope
             effective_selected_document_ids = list(selected_document_ids or [])
@@ -16067,6 +16068,67 @@ def register_route_backend_chats(bp):
                 selected_document_id = effective_selected_document_id
                 document_scope = effective_document_scope
 
+            prior_grounded_document_refs = _normalize_prior_grounded_document_refs(conversation_item)
+            current_document_context_available = bool(
+                effective_selected_document_ids
+                or effective_selected_document_id
+                or hybrid_search_enabled
+                or document_context_requested
+            )
+            if (
+                current_document_context_available
+                and prior_grounded_document_refs
+                and _prior_grounded_source_reference_requested(user_message)
+            ):
+                prior_search_parameters = build_prior_grounded_document_search_parameters(
+                    prior_grounded_document_refs
+                )
+                prior_search_parameters = revalidate_prior_grounded_document_search_parameters(
+                    user_id,
+                    prior_search_parameters,
+                )
+                prior_grounded_source_merge = _merge_prior_grounded_sources_with_current_context(
+                    effective_selected_document_ids,
+                    effective_document_scope,
+                    effective_active_group_ids,
+                    effective_active_public_workspace_ids,
+                    prior_search_parameters,
+                )
+                if prior_grounded_source_merge.get('used'):
+                    effective_selected_document_ids = list(
+                        prior_grounded_source_merge.get('document_ids') or []
+                    )
+                    effective_selected_document_id = (
+                        effective_selected_document_ids[0]
+                        if len(effective_selected_document_ids) == 1
+                        else None
+                    )
+                    effective_document_scope = prior_grounded_source_merge.get('doc_scope') or 'all'
+                    effective_active_group_ids = list(
+                        prior_grounded_source_merge.get('active_group_ids') or []
+                    )
+                    effective_active_group_id = (
+                        effective_active_group_ids[0]
+                        if effective_active_group_ids
+                        else None
+                    )
+                    effective_active_public_workspace_ids = list(
+                        prior_grounded_source_merge.get('active_public_workspace_ids') or []
+                    )
+                    effective_active_public_workspace_id = (
+                        effective_active_public_workspace_ids[0]
+                        if effective_active_public_workspace_ids
+                        else None
+                    )
+                    selected_document_ids = list(effective_selected_document_ids)
+                    selected_document_id = effective_selected_document_id
+                    document_scope = effective_document_scope
+                    active_group_ids = list(effective_active_group_ids)
+                    active_group_id = effective_active_group_id
+                    active_public_workspace_ids = list(effective_active_public_workspace_ids)
+                    active_public_workspace_id = effective_active_public_workspace_id
+                    hybrid_search_enabled = True
+
             mixed_source_manifest = []
             mixed_source_partitions = {}
             mixed_source_narrative_document_ids = []
@@ -16274,6 +16336,13 @@ def register_route_backend_chats(bp):
                         'tags': tags_filter,
                         'classification': classifications_to_send
                     }
+                    if prior_grounded_source_merge:
+                        user_metadata['workspace_search']['prior_grounded_source_merge'] = {
+                            'used': bool(prior_grounded_source_merge.get('used')),
+                            'prior_document_count': len(prior_grounded_source_merge.get('prior_document_ids') or []),
+                            'added_document_count': len(prior_grounded_source_merge.get('prior_added_document_ids') or []),
+                            'selection_origin': 'selected+history',
+                        }
                     if assigned_knowledge_filters:
                         assigned_knowledge = assigned_knowledge_filters.get('assigned_knowledge') or {}
                         user_metadata['workspace_search']['assigned_knowledge'] = {
@@ -16599,8 +16668,8 @@ def register_route_backend_chats(bp):
                 not original_hybrid_search_enabled
                 and not explicit_external_retrieval_requested
                 and not mixed_source_explicit_selection
+                and not prior_grounded_source_merge
             ):
-                prior_grounded_document_refs = _normalize_prior_grounded_document_refs(conversation_item)
                 if prior_grounded_document_refs:
                     continuity_decision = _resolve_reauthorized_continuity_decision(
                         settings,
@@ -18283,6 +18352,7 @@ def register_route_backend_chats(bp):
                 current_document_context_requested=(
                     is_mixed_source_chat_search_enabled(settings)
                     and document_context_requested
+                    or bool(prior_grounded_source_merge)
                 ),
             ):
                 history_grounding_message = build_history_grounding_system_message()
@@ -19971,6 +20041,7 @@ def register_route_backend_chats(bp):
                 history_grounded_search_used = False
                 history_only_answerability = None
                 prior_grounded_document_refs = []
+                prior_grounded_source_merge = None
                 continuity_decision = None
                 effective_document_scope = document_scope
                 effective_selected_document_ids = list(selected_document_ids or [])
@@ -20330,6 +20401,67 @@ def register_route_backend_chats(bp):
                     selected_document_id = effective_selected_document_id
                     document_scope = effective_document_scope
 
+                prior_grounded_document_refs = _normalize_prior_grounded_document_refs(conversation_item)
+                current_document_context_available = bool(
+                    effective_selected_document_ids
+                    or effective_selected_document_id
+                    or hybrid_search_enabled
+                    or document_context_requested
+                )
+                if (
+                    current_document_context_available
+                    and prior_grounded_document_refs
+                    and _prior_grounded_source_reference_requested(user_message)
+                ):
+                    prior_search_parameters = build_prior_grounded_document_search_parameters(
+                        prior_grounded_document_refs
+                    )
+                    prior_search_parameters = revalidate_prior_grounded_document_search_parameters(
+                        user_id,
+                        prior_search_parameters,
+                    )
+                    prior_grounded_source_merge = _merge_prior_grounded_sources_with_current_context(
+                        effective_selected_document_ids,
+                        effective_document_scope,
+                        effective_active_group_ids,
+                        effective_active_public_workspace_ids,
+                        prior_search_parameters,
+                    )
+                    if prior_grounded_source_merge.get('used'):
+                        effective_selected_document_ids = list(
+                            prior_grounded_source_merge.get('document_ids') or []
+                        )
+                        effective_selected_document_id = (
+                            effective_selected_document_ids[0]
+                            if len(effective_selected_document_ids) == 1
+                            else None
+                        )
+                        effective_document_scope = prior_grounded_source_merge.get('doc_scope') or 'all'
+                        effective_active_group_ids = list(
+                            prior_grounded_source_merge.get('active_group_ids') or []
+                        )
+                        effective_active_group_id = (
+                            effective_active_group_ids[0]
+                            if effective_active_group_ids
+                            else None
+                        )
+                        effective_active_public_workspace_ids = list(
+                            prior_grounded_source_merge.get('active_public_workspace_ids') or []
+                        )
+                        effective_active_public_workspace_id = (
+                            effective_active_public_workspace_ids[0]
+                            if effective_active_public_workspace_ids
+                            else None
+                        )
+                        selected_document_ids = list(effective_selected_document_ids)
+                        selected_document_id = effective_selected_document_id
+                        document_scope = effective_document_scope
+                        active_group_ids = list(effective_active_group_ids)
+                        active_group_id = effective_active_group_id
+                        active_public_workspace_ids = list(effective_active_public_workspace_ids)
+                        active_public_workspace_id = effective_active_public_workspace_id
+                        hybrid_search_enabled = True
+
                 mixed_source_manifest = []
                 mixed_source_partitions = {}
                 mixed_source_narrative_document_ids = []
@@ -20527,6 +20659,13 @@ def register_route_backend_chats(bp):
                             'active_public_workspace_ids': effective_active_public_workspace_ids,
                             'classification': classifications_to_send
                         }
+                        if prior_grounded_source_merge:
+                            user_metadata['workspace_search']['prior_grounded_source_merge'] = {
+                                'used': bool(prior_grounded_source_merge.get('used')),
+                                'prior_document_count': len(prior_grounded_source_merge.get('prior_document_ids') or []),
+                                'added_document_count': len(prior_grounded_source_merge.get('prior_added_document_ids') or []),
+                                'selection_origin': 'selected+history',
+                            }
                         if assigned_knowledge_filters:
                             assigned_knowledge = assigned_knowledge_filters.get('assigned_knowledge') or {}
                             user_metadata['workspace_search']['assigned_knowledge'] = {
@@ -20872,8 +21011,8 @@ def register_route_backend_chats(bp):
                     not original_hybrid_search_enabled
                     and not explicit_external_retrieval_requested
                     and not mixed_source_explicit_selection
+                    and not prior_grounded_source_merge
                 ):
-                    prior_grounded_document_refs = _normalize_prior_grounded_document_refs(conversation_item)
                     if prior_grounded_document_refs:
                         continuity_decision = _resolve_reauthorized_continuity_decision(
                             settings,
@@ -22170,6 +22309,7 @@ def register_route_backend_chats(bp):
                     current_document_context_requested=(
                         is_mixed_source_chat_search_enabled(settings)
                         and document_context_requested
+                        or bool(prior_grounded_source_merge)
                     ),
                 ):
                     history_grounding_message = build_history_grounding_system_message()
@@ -24244,6 +24384,82 @@ def revalidate_prior_grounded_document_search_parameters(user_id, search_paramet
         else 'all'
     )
     return normalized_parameters
+
+
+def _prior_grounded_source_reference_requested(user_message):
+    """Return whether the user is asking to reuse a prior grounded source."""
+    normalized_message = re.sub(r'\s+', ' ', str(user_message or '').strip().casefold())
+    if not normalized_message:
+        return False
+
+    source_noun_pattern = (
+        r'(?:source|document|file|template|spreadsheet|workbook|table|xml|json|pdf|csv|xlsx|xls)'
+    )
+    reference_patterns = (
+        rf'\b(?:that|those|same|previous|prior|earlier|last)\s+{source_noun_pattern}\b',
+        rf'\b(?:that|the|same|previous|prior|earlier|last)\s+'
+        rf'(?:xml|json|pdf|csv|xlsx|xls)\s+(?:source|document|file|template|workbook)\b',
+        rf'\b(?:into|in|with|using|from|against|compare\s+to)\s+'
+        rf'(?:that|the|same|previous|prior|earlier|last)\s+{source_noun_pattern}\b',
+    )
+    return any(re.search(pattern, normalized_message) for pattern in reference_patterns)
+
+
+def _merge_unique_strings(*collections):
+    merged = []
+    seen_values = set()
+    for collection in collections:
+        for value in list(collection or []):
+            normalized_value = str(value or '').strip()
+            if not normalized_value or normalized_value in seen_values:
+                continue
+            seen_values.add(normalized_value)
+            merged.append(normalized_value)
+    return merged
+
+
+def _merge_prior_grounded_sources_with_current_context(
+    current_document_ids,
+    current_document_scope,
+    current_active_group_ids,
+    current_active_public_workspace_ids,
+    prior_search_parameters,
+):
+    """Merge reauthorized prior grounded source parameters into current source context."""
+    prior_document_ids = _normalize_conversation_task_document_ids(
+        (prior_search_parameters or {}).get('document_ids')
+    )
+    current_document_ids = _normalize_conversation_task_document_ids(current_document_ids)
+    current_document_id_set = set(current_document_ids)
+    prior_only_document_ids = [
+        document_id
+        for document_id in prior_document_ids
+        if document_id not in current_document_id_set
+    ]
+    merged_document_ids = _merge_unique_strings(current_document_ids, prior_document_ids)
+
+    current_scope = str(current_document_scope or '').strip().lower()
+    prior_scope = str((prior_search_parameters or {}).get('doc_scope') or '').strip().lower()
+    scope_candidates = [scope for scope in (current_scope, prior_scope) if scope]
+    merged_scope = scope_candidates[0] if len(set(scope_candidates)) == 1 else 'all'
+    if not scope_candidates:
+        merged_scope = None
+
+    return {
+        'used': bool(prior_only_document_ids),
+        'document_ids': merged_document_ids,
+        'prior_document_ids': prior_document_ids,
+        'prior_added_document_ids': prior_only_document_ids,
+        'doc_scope': merged_scope,
+        'active_group_ids': _merge_unique_strings(
+            current_active_group_ids,
+            (prior_search_parameters or {}).get('active_group_ids'),
+        ),
+        'active_public_workspace_ids': _merge_unique_strings(
+            current_active_public_workspace_ids,
+            (prior_search_parameters or {}).get('active_public_workspace_ids'),
+        ),
+    }
 
 
 def build_history_only_assessment_messages(history_segments, default_system_prompt=''):

--- a/docs/explanation/fixes/PRIOR_GROUNDED_SOURCE_CONTINUITY_FIX.md
+++ b/docs/explanation/fixes/PRIOR_GROUNDED_SOURCE_CONTINUITY_FIX.md
@@ -1,0 +1,53 @@
+# Prior Grounded Source Continuity Fix
+
+Fixed/Implemented in version: **0.250.157**
+
+Related work: Fixes #1204
+
+## Issue Description
+
+Follow-up mixed-source tasks did not automatically combine previously grounded sources with the current turn's selected or retrieved sources. For example, after summarizing an XML template, a user could ask to add a selected PDF's content into "that XML file," but the current turn would only use the PDF context and not rehydrate the prior XML template as an active source.
+
+## Root Cause Analysis
+
+SimpleChat already persisted compact prior grounded source references in `last_grounded_document_refs`, and it had a history-grounded fallback path for turns with workspace search disabled. However, that fallback only ran when the current turn was not already performing retrieval or explicit mixed-source selection. A turn with a current PDF/source selection therefore bypassed the fallback and never merged in prior cited sources.
+
+## Technical Details
+
+Files modified:
+
+- `application/single_app/route_backend_chats.py`
+- `application/single_app/config.py`
+- `functional_tests/test_chat_history_grounded_follow_up_fix.py`
+- `docs/explanation/release_notes.md`
+
+Code changes:
+
+- Added detection for explicit follow-up references to prior sources, including phrases such as "that XML file," "same template," and "previous spreadsheet."
+- Added a shared merge helper that combines current selected document IDs with revalidated prior grounded document IDs while preserving group and public workspace scope context.
+- Wired the merge helper into both standard and streaming chat paths before mixed-source manifest/search resolution.
+- Stored a compact `prior_grounded_source_merge` metadata marker on the current user message when prior sources are merged.
+- Prevented the no-search history grounding prompt from being inserted when prior sources have been merged into the current retrieval context.
+- Updated `config.py` from `0.250.156` to `0.250.157`.
+
+## Testing Approach
+
+Updated `functional_tests/test_chat_history_grounded_follow_up_fix.py` to verify:
+
+- Prior-source reference phrases are detected for XML templates, same-source prompts, and previous spreadsheets.
+- Generic current-source prompts do not trigger prior-source reuse.
+- Current document IDs and prior grounded document IDs merge without duplicates.
+- Mixed personal/group scopes collapse to `all` with authorized group context preserved.
+- Standard and streaming chat paths both include prior-source merge wiring.
+
+## Impact Analysis
+
+Users can chain document workflows more naturally when a follow-up explicitly references a prior grounded source and also supplies or selects a current source. The prior source is still treated only as a reauthorization hint; source content and storage locators are not trusted from conversation history.
+
+## Validation
+
+- `python functional_tests\test_chat_history_grounded_follow_up_fix.py`
+
+## Before and After
+
+Before, a follow-up such as "add this PDF content into that XML file" could ground only on the selected PDF. After this fix, the route detects the reference to the prior XML source, revalidates it, and includes it alongside the current PDF before mixed-source execution.

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,15 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](/explanation/features/) and [Fixes by Version](/explanation/fixes/).
 
+### **(v0.250.157)**
+
+#### Bug Fixes
+
+*   **Prior Grounded Source Continuity**
+    *   Follow-up mixed-source turns can now detect references such as "that XML file," "same template," or "previous spreadsheet" and merge reauthorized prior grounded sources with the current selected sources.
+    *   Preserved authorization boundaries by deriving prior sources from `last_grounded_document_refs` and revalidating scope before use.
+    *   (Ref: #1204, mixed-source source continuity, `route_backend_chats.py`, `test_chat_history_grounded_follow_up_fix.py`)
+
 ### **(v0.250.156)**
 
 #### Bug Fixes

--- a/functional_tests/test_chat_history_grounded_follow_up_fix.py
+++ b/functional_tests/test_chat_history_grounded_follow_up_fix.py
@@ -1,8 +1,8 @@
 # test_chat_history_grounded_follow_up_fix.py
 """
 Functional test for grounded follow-up chat fallback.
-Version: 0.250.002
-Implemented in: 0.240.054; Updated in: 0.250.002
+Version: 0.250.157
+Implemented in: 0.240.054; Updated in: 0.250.002; prior-source merge in 0.250.157
 
 This test ensures follow-up turns with workspace search disabled can reuse
 prior grounded document refs, derive bounded fallback search parameters, and
@@ -13,6 +13,7 @@ Deep Research turns bypass the history-grounded document fallback.
 
 import ast
 import os
+import re
 from test_support.versioning import assert_app_version_at_least
 
 
@@ -28,11 +29,16 @@ FIX_DOC = os.path.join(
     'WEB_RESEARCH_EXTERNAL_RETRIEVAL_PRIORITY_FIX.md',
 )
 ROUTE_TARGET_FUNCTIONS = {
+    '_safe_metadata_int',
     '_normalize_prior_grounded_document_refs',
     'build_prior_grounded_document_search_parameters',
     'build_history_only_assessment_messages',
     'build_history_grounding_system_message',
     '_is_explicit_external_retrieval_requested',
+    '_merge_prior_grounded_sources_with_current_context',
+    '_merge_unique_strings',
+    '_normalize_conversation_task_document_ids',
+    '_prior_grounded_source_reference_requested',
     '_should_auto_merge_chat_upload_workspace_context',
     'should_apply_history_grounding_message',
 }
@@ -67,7 +73,7 @@ def load_route_helpers():
     )
 
     module = ast.Module(body=selected_nodes, type_ignores=[])
-    namespace = {}
+    namespace = {'re': re}
     exec(compile(module, ROUTE_FILE, 'exec'), namespace)
     return namespace, source
 
@@ -189,6 +195,17 @@ def test_prior_grounded_refs_normalize_from_saved_refs_and_tags():
             'scope_id': 'group-1',
             'file_name': 'Plan A.docx',
             'classification': 'internal',
+            'source_role': None,
+            'requested_order': None,
+            'source_kind': None,
+            'engine': None,
+            'source_version': None,
+            'status': None,
+            'coverage': {},
+            'selection_origin': None,
+            'action_mode': None,
+            'citation_count': 0,
+            'artifact_count': 0,
             'group_id': 'group-1',
         },
         {
@@ -197,6 +214,17 @@ def test_prior_grounded_refs_normalize_from_saved_refs_and_tags():
             'scope_id': 'user-1',
             'file_name': 'Notes.txt',
             'classification': None,
+            'source_role': None,
+            'requested_order': None,
+            'source_kind': None,
+            'engine': None,
+            'source_version': None,
+            'status': None,
+            'coverage': {},
+            'selection_origin': None,
+            'action_mode': None,
+            'citation_count': 0,
+            'artifact_count': 0,
             'user_id': 'user-1',
         },
     ], normalized_refs
@@ -220,6 +248,17 @@ def test_prior_grounded_refs_normalize_from_saved_refs_and_tags():
             'scope_id': 'workspace-7',
             'file_name': 'Workspace FAQ.md',
             'classification': 'public',
+            'source_role': None,
+            'requested_order': None,
+            'source_kind': None,
+            'engine': None,
+            'source_version': None,
+            'status': None,
+            'coverage': {},
+            'selection_origin': None,
+            'action_mode': None,
+            'citation_count': 0,
+            'artifact_count': 0,
             'public_workspace_id': 'workspace-7',
         },
     ], tag_fallback_refs
@@ -249,6 +288,12 @@ def test_prior_grounded_search_parameters_stay_bounded():
         'active_group_id': 'group-1',
         'active_public_workspace_ids': ['workspace-1'],
         'active_public_workspace_id': 'workspace-1',
+        'chat_conversation_ids': [],
+        'document_scopes': {
+            'doc-1': {'scope': 'group', 'scope_id': ''},
+            'doc-2': {'scope': 'public', 'scope_id': ''},
+            'doc-3': {'scope': 'personal', 'scope_id': ''},
+        },
         'scope_types': ['group', 'personal', 'public'],
     }, mixed_scope_parameters
 
@@ -262,6 +307,60 @@ def test_prior_grounded_search_parameters_stay_bounded():
     assert group_only_parameters['document_ids'] == ['group-doc-1', 'group-doc-2']
 
     print('✅ Grounded fallback search parameter derivation passed')
+    return True
+
+
+def test_prior_grounded_source_references_merge_with_current_context():
+    """Verify explicit follow-up source references merge prior and current source ids."""
+    print('🔍 Testing prior grounded source merge...')
+
+    namespace, _ = load_route_helpers()
+    reference_requested = namespace['_prior_grounded_source_reference_requested']
+    merge_context = namespace['_merge_prior_grounded_sources_with_current_context']
+
+    assert reference_requested('Add this PDF content into that XML file.') is True
+    assert reference_requested('Use the same template with this source report.') is True
+    assert reference_requested('Compare this file against the previous spreadsheet.') is True
+    assert reference_requested('Summarize the uploaded PDF.') is False
+
+    merged = merge_context(
+        current_document_ids=['current-pdf'],
+        current_document_scope='personal',
+        current_active_group_ids=[],
+        current_active_public_workspace_ids=[],
+        prior_search_parameters={
+            'document_ids': ['prior-xml', 'prior-table'],
+            'doc_scope': 'group',
+            'active_group_ids': ['group-1'],
+            'active_public_workspace_ids': [],
+        },
+    )
+
+    assert merged == {
+        'used': True,
+        'document_ids': ['current-pdf', 'prior-xml', 'prior-table'],
+        'prior_document_ids': ['prior-xml', 'prior-table'],
+        'prior_added_document_ids': ['prior-xml', 'prior-table'],
+        'doc_scope': 'all',
+        'active_group_ids': ['group-1'],
+        'active_public_workspace_ids': [],
+    }, merged
+
+    duplicate_only = merge_context(
+        current_document_ids=['prior-xml'],
+        current_document_scope='group',
+        current_active_group_ids=['group-1'],
+        current_active_public_workspace_ids=[],
+        prior_search_parameters={
+            'document_ids': ['prior-xml'],
+            'doc_scope': 'group',
+            'active_group_ids': ['group-1'],
+        },
+    )
+    assert duplicate_only['used'] is False
+    assert duplicate_only['document_ids'] == ['prior-xml']
+
+    print('✅ Prior grounded source merge passed')
     return True
 
 
@@ -330,17 +429,23 @@ def test_route_and_metadata_wiring_cover_both_chat_paths():
     _, route_source = load_route_helpers()
     _, metadata_source = load_metadata_helpers()
 
-    assert "conversation_item['last_grounded_document_refs'] = _build_last_grounded_document_refs(document_map)" in metadata_source
+    assert "conversation_item['last_grounded_document_refs'] = _build_last_grounded_document_refs(" in metadata_source
+    assert 'source_continuity_refs=source_continuity_refs' in metadata_source
     assert route_source.count('history_grounded_search_used = True') == 2
+    assert route_source.count('prior_grounded_source_merge = None') == 2
+    assert route_source.count('_prior_grounded_source_reference_requested(user_message)') == 3
+    assert route_source.count('_merge_prior_grounded_sources_with_current_context(') >= 3
+    assert route_source.count("'prior_grounded_source_merge'") == 2
     assert route_source.count('Checking whether prior conversation context already answers the question') == 2
     assert route_source.count('Conversation context alone was insufficient; searching previously grounded documents') == 2
     assert route_source.count('No prior grounded documents were available; using conversation history only') == 2
     assert route_source.count("'history_grounded_fallback'") == 2
-    assert route_source.count('if not original_hybrid_search_enabled and not explicit_external_retrieval_requested:') == 2
+    assert route_source.count('not original_hybrid_search_enabled') == 2
+    assert route_source.count('and not prior_grounded_source_merge') == 2
     assert route_source.count('if should_apply_history_grounding_message(') == 2
     assert route_source.count('explicit_external_retrieval_requested,') >= 4
     assert route_source.count('_should_auto_merge_chat_upload_workspace_context(') >= 3
-    assert route_source.count('include_assistant_citation_context=not explicit_external_retrieval_requested') == 2
+    assert route_source.count('include_assistant_citation_context') >= 4
     assert route_source.count("if role == 'assistant' and include_assistant_citation_context:") == 2
     assert route_source.count('history_grounding_message = build_history_grounding_system_message()') == 2
 
@@ -372,6 +477,7 @@ if __name__ == '__main__':
         test_grounded_document_refs_capture_stable_document_ids,
         test_prior_grounded_refs_normalize_from_saved_refs_and_tags,
         test_prior_grounded_search_parameters_stay_bounded,
+        test_prior_grounded_source_references_merge_with_current_context,
         test_history_only_prompt_contract_is_explicit,
         test_route_and_metadata_wiring_cover_both_chat_paths,
         test_version_and_fix_documentation_alignment,


### PR DESCRIPTION
## Summary
- Fixes #1204.
- Detects explicit follow-up references to prior grounded sources such as `that XML file`, `same template`, and `previous spreadsheet`.
- Revalidates prior grounded source refs and merges them with current selected/retrieved source IDs before standard and streaming mixed-source resolution.
- Adds metadata, fix docs, release notes, and focused regression coverage for the prior-source merge behavior.

## Validation
- `python functional_tests\test_chat_history_grounded_follow_up_fix.py`
- `python functional_tests\test_mixed_source_conversation_continuity.py`
- `python -m py_compile application\single_app\route_backend_chats.py application\single_app\config.py functional_tests\test_chat_history_grounded_follow_up_fix.py`
- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check`