### PR TITLE
Add chat used documents pane

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -96,7 +96,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.250.158"
+VERSION = "0.250.159"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/static/css/chats.css
+++ b/application/single_app/static/css/chats.css
@@ -1697,6 +1697,12 @@ body.layout-split .gutter {
   gap: 0.25rem;
 }
 
+.conversation-contents-mode-switch .btn {
+  align-items: center;
+  display: inline-flex;
+  justify-content: center;
+}
+
 .conversation-contents-entry {
   border-radius: 0.375rem;
   color: var(--bs-body-color);
@@ -1718,6 +1724,37 @@ body.layout-split .gutter {
   background: rgba(var(--bs-primary-rgb), 0.12);
   color: var(--bs-primary);
   font-weight: 600;
+}
+
+.conversation-documents-list {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.conversation-documents-entry {
+  background: var(--bs-body-bg);
+  color: var(--bs-body-color);
+  padding: 0.75rem;
+}
+
+.conversation-documents-entry:focus-visible {
+  outline: 2px solid rgba(var(--bs-primary-rgb), 0.45);
+  outline-offset: 2px;
+}
+
+.conversation-documents-title {
+  min-width: 0;
+}
+
+.conversation-documents-classification {
+  flex: 0 0 auto;
+  max-width: 8rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.conversation-documents-meta-line {
+  overflow-wrap: anywhere;
 }
 
 .conversation-contents-destination {

--- a/application/single_app/static/js/chat/chat-conversation-contents.js
+++ b/application/single_app/static/js/chat/chat-conversation-contents.js
@@ -1,27 +1,53 @@
 // chat-conversation-contents.js
 
+import {
+    extractPageNumbers,
+    fetchConversationMetadata,
+    getConversationDocumentTags,
+} from "./chat-conversation-details.js";
+import { isColorLight } from "./chat-utils.js";
+
 const CONTENTS_LABEL_MAX_LENGTH = 72;
 const DESKTOP_MEDIA_QUERY = "(min-width: 1200px)";
 const TEMP_MESSAGE_PREFIX = "temp_user_";
+const DRAWER_MODE_CONTENTS = "contents";
+const DRAWER_MODE_DOCUMENTS = "documents";
 
 const chatContainer = document.querySelector(".chat-container");
 const chatbox = document.getElementById("chatbox");
 const scrollContainer = document.getElementById("chat-messages-container");
 const drawer = document.getElementById("conversation-contents-drawer");
+const drawerTitle = document.getElementById("conversation-contents-title");
+const drawerSubtitle = document.getElementById("conversation-contents-subtitle");
+const contentsPanel = document.getElementById("conversation-contents-panel");
 const list = document.getElementById("conversation-contents-list");
 const emptyState = document.getElementById("conversation-contents-empty");
-const toggleButton = document.getElementById("conversation-contents-toggle");
+const contentsToggleButton = document.getElementById("conversation-contents-toggle");
+const documentsToggleButton = document.getElementById("conversation-documents-toggle");
 const closeButton = document.getElementById("conversation-contents-close");
+const contentsModeButton = document.getElementById("conversation-contents-mode-contents");
+const documentsModeButton = document.getElementById("conversation-contents-mode-documents");
+const documentsPanel = document.getElementById("conversation-documents-panel");
+const documentsList = document.getElementById("conversation-documents-list");
+const documentsEmptyState = document.getElementById("conversation-documents-empty");
+const documentsStatus = document.getElementById("conversation-documents-status");
+const documentsCountBadge = document.getElementById("conversation-documents-count");
 const desktopMediaQuery = window.matchMedia(DESKTOP_MEDIA_QUERY);
 
 let contentsEntries = [];
+let documentEntries = [];
 let activeMessageId = "";
 let drawerOpen = false;
+let drawerMode = DRAWER_MODE_CONTENTS;
 let rebuildScheduled = false;
 let scrollUpdateScheduled = false;
 let offcanvasInstance = null;
 let highlightTimeout = null;
 let restoreFocusAfterClose = true;
+let metadataRequestToken = 0;
+let documentLoadState = "idle";
+let activeDocumentConversationId = "";
+const autoOpenedDocumentConversationIds = new Set();
 
 export function normalizeConversationContentsLabel(value, fallbackLabel = "User message") {
     const source = String(value || "").replace(/\r\n?/g, "\n");
@@ -66,6 +92,13 @@ function getMessageLabel(messageElement, index) {
         renderedText || sourceText,
         `User message ${index + 1}`
     );
+}
+
+function getCurrentConversationId() {
+    const conversationId = window.chatConversations?.getCurrentConversationId?.()
+        || window.currentConversationId
+        || "";
+    return String(conversationId || "").trim();
 }
 
 function setActiveEntry(messageId) {
@@ -119,6 +152,84 @@ function scheduleActiveEntryUpdate() {
     window.requestAnimationFrame(updateActiveEntry);
 }
 
+function getDrawerTriggerButton(mode = drawerMode) {
+    return mode === DRAWER_MODE_DOCUMENTS ? documentsToggleButton : contentsToggleButton;
+}
+
+function syncDrawerModeControls() {
+    const documentsAvailable = documentEntries.length > 0;
+    const contentsActive = drawerMode === DRAWER_MODE_CONTENTS;
+    const documentsActive = drawerMode === DRAWER_MODE_DOCUMENTS;
+
+    contentsModeButton?.classList.toggle("active", contentsActive);
+    contentsModeButton?.setAttribute("aria-pressed", String(contentsActive));
+    documentsModeButton?.classList.toggle("active", documentsActive);
+    documentsModeButton?.setAttribute("aria-pressed", String(documentsActive));
+    if (documentsModeButton) {
+        documentsModeButton.disabled = !documentsAvailable && documentLoadState !== "loading";
+    }
+
+    contentsToggleButton?.classList.toggle("active", drawerOpen && contentsActive);
+    documentsToggleButton?.classList.toggle("active", drawerOpen && documentsActive);
+    contentsToggleButton?.setAttribute("aria-expanded", String(drawerOpen && contentsActive));
+    documentsToggleButton?.setAttribute("aria-expanded", String(drawerOpen && documentsActive));
+
+    if (drawerTitle) {
+        drawerTitle.textContent = contentsActive ? "Conversation contents" : "Used documents";
+    }
+    if (drawerSubtitle) {
+        drawerSubtitle.textContent = contentsActive
+            ? "Jump to a user message"
+            : "Documents cited in this conversation";
+    }
+
+    contentsPanel?.classList.toggle("d-none", !contentsActive);
+    documentsPanel?.classList.toggle("d-none", !documentsActive);
+}
+
+function setDrawerMode(mode) {
+    const requestedMode = mode === DRAWER_MODE_DOCUMENTS ? DRAWER_MODE_DOCUMENTS : DRAWER_MODE_CONTENTS;
+    if (requestedMode === DRAWER_MODE_DOCUMENTS && documentEntries.length === 0 && documentLoadState !== "loading") {
+        drawerMode = contentsEntries.length > 0 ? DRAWER_MODE_CONTENTS : DRAWER_MODE_DOCUMENTS;
+    } else if (requestedMode === DRAWER_MODE_CONTENTS && contentsEntries.length === 0 && documentEntries.length > 0) {
+        drawerMode = DRAWER_MODE_DOCUMENTS;
+    } else {
+        drawerMode = requestedMode;
+    }
+    syncDrawerModeControls();
+}
+
+function updateDrawerTriggers() {
+    const hasContents = contentsEntries.length > 0;
+    const hasDocuments = documentEntries.length > 0;
+
+    if (contentsToggleButton) {
+        contentsToggleButton.classList.toggle("d-none", !hasContents);
+        contentsToggleButton.disabled = !hasContents;
+    }
+    if (documentsToggleButton) {
+        documentsToggleButton.classList.toggle("d-none", !hasDocuments);
+        documentsToggleButton.disabled = !hasDocuments;
+    }
+
+    if (documentsCountBadge) {
+        documentsCountBadge.textContent = String(documentEntries.length);
+        documentsCountBadge.classList.toggle("d-none", !hasDocuments);
+    }
+
+    if (drawerMode === DRAWER_MODE_CONTENTS && !hasContents && hasDocuments) {
+        setDrawerMode(DRAWER_MODE_DOCUMENTS);
+    } else if (drawerMode === DRAWER_MODE_DOCUMENTS && !hasDocuments && hasContents) {
+        setDrawerMode(DRAWER_MODE_CONTENTS);
+    } else {
+        syncDrawerModeControls();
+    }
+
+    if (!hasContents && !hasDocuments) {
+        closeDrawer({ restoreFocus: false });
+    }
+}
+
 function closeDrawer({ restoreFocus = true } = {}) {
     if (!drawerOpen) {
         return;
@@ -128,9 +239,9 @@ function closeDrawer({ restoreFocus = true } = {}) {
         drawerOpen = false;
         chatContainer?.classList.remove("conversation-contents-open");
         drawer?.setAttribute("aria-hidden", "true");
-        toggleButton?.setAttribute("aria-expanded", "false");
+        syncDrawerModeControls();
         if (restoreFocus) {
-            toggleButton?.focus();
+            getDrawerTriggerButton()?.focus();
         }
         return;
     }
@@ -139,29 +250,50 @@ function closeDrawer({ restoreFocus = true } = {}) {
     offcanvasInstance?.hide();
 }
 
-function openDrawer() {
-    if (!drawer || contentsEntries.length === 0) {
+function focusActiveDrawerContent() {
+    if (drawerMode === DRAWER_MODE_CONTENTS) {
+        list?.querySelector("button")?.focus();
         return;
     }
 
+    documentsList?.querySelector(".conversation-documents-entry")?.focus();
+}
+
+function openDrawer(mode = drawerMode) {
+    const requestedMode = mode === DRAWER_MODE_DOCUMENTS ? DRAWER_MODE_DOCUMENTS : DRAWER_MODE_CONTENTS;
+    const hasRequestedEntries = requestedMode === DRAWER_MODE_DOCUMENTS
+        ? documentEntries.length > 0
+        : contentsEntries.length > 0;
+    const hasFallbackEntries = requestedMode === DRAWER_MODE_DOCUMENTS
+        ? contentsEntries.length > 0
+        : documentEntries.length > 0;
+
+    if (!drawer || (!hasRequestedEntries && !hasFallbackEntries)) {
+        return;
+    }
+
+    setDrawerMode(hasRequestedEntries ? requestedMode : (
+        requestedMode === DRAWER_MODE_DOCUMENTS ? DRAWER_MODE_CONTENTS : DRAWER_MODE_DOCUMENTS
+    ));
     drawerOpen = true;
-    toggleButton?.setAttribute("aria-expanded", "true");
+    syncDrawerModeControls();
 
     if (desktopMediaQuery.matches) {
         chatContainer?.classList.add("conversation-contents-open");
         drawer.setAttribute("aria-hidden", "false");
-        list?.querySelector("button")?.focus();
+        focusActiveDrawerContent();
         return;
     }
 
     offcanvasInstance?.show();
 }
 
-function toggleDrawer() {
-    if (drawerOpen) {
+function toggleDrawer(mode = drawerMode) {
+    const requestedMode = mode === DRAWER_MODE_DOCUMENTS ? DRAWER_MODE_DOCUMENTS : DRAWER_MODE_CONTENTS;
+    if (drawerOpen && drawerMode === requestedMode) {
         closeDrawer();
     } else {
-        openDrawer();
+        openDrawer(requestedMode);
     }
 }
 
@@ -213,7 +345,7 @@ function createEntry(messageElement, index) {
 
 export function rebuildConversationContents() {
     rebuildScheduled = false;
-    if (!chatbox || !list || !emptyState || !toggleButton) {
+    if (!chatbox || !list || !emptyState || !contentsToggleButton) {
         return;
     }
 
@@ -239,17 +371,188 @@ export function rebuildConversationContents() {
     }
 
     const hasEntries = contentsEntries.length > 0;
-    toggleButton.classList.toggle("d-none", !hasEntries);
-    toggleButton.disabled = !hasEntries;
     emptyState.classList.toggle("d-none", hasEntries);
 
     if (!hasEntries) {
-        closeDrawer({ restoreFocus: false });
         setActiveEntry("");
+        updateDrawerTriggers();
         return;
     }
 
+    updateDrawerTriggers();
     scheduleActiveEntryUpdate();
+}
+
+function getScopeIcon(scope) {
+    switch (scope) {
+        case "personal": return "person";
+        case "group": return "people";
+        case "public": return "globe";
+        default: return "question-circle";
+    }
+}
+
+function createClassificationBadge(classification) {
+    const label = String(classification || "None");
+    const badge = document.createElement("span");
+    badge.className = "badge conversation-documents-classification";
+    badge.textContent = label;
+
+    const allCategories = window.classification_categories || [];
+    const category = allCategories.find(cat => cat.label === label);
+    if (category?.color) {
+        badge.style.backgroundColor = category.color;
+        badge.classList.add(isColorLight(category.color) ? "text-dark" : "text-white");
+    } else {
+        badge.classList.add("bg-warning", "text-dark");
+        badge.title = `Definition for "${label}" not found`;
+    }
+
+    return badge;
+}
+
+function createDocumentMetaLine(iconName, text) {
+    const line = document.createElement("div");
+    line.className = "small text-muted conversation-documents-meta-line";
+
+    const icon = document.createElement("i");
+    icon.className = `bi bi-${iconName} me-1`;
+    icon.setAttribute("aria-hidden", "true");
+
+    const textNode = document.createElement("span");
+    textNode.textContent = text;
+
+    line.append(icon, textNode);
+    return line;
+}
+
+function createDocumentEntry(doc) {
+    const chunkIds = Array.isArray(doc?.chunk_ids) ? doc.chunk_ids : [];
+    const chunkPages = extractPageNumbers(chunkIds);
+    const chunkCount = chunkIds.length;
+    const documentId = String(doc?.document_id || "Unknown Document");
+    const documentTitle = String(doc?.title || documentId);
+    const scopeType = String(doc?.scope?.type || "Unknown");
+    const scopeName = String(doc?.scope?.name || doc?.scope?.id || "Unknown");
+
+    const listItem = document.createElement("li");
+    const entry = document.createElement("article");
+    entry.className = "conversation-documents-entry border rounded";
+    entry.tabIndex = -1;
+
+    const header = document.createElement("div");
+    header.className = "d-flex justify-content-between align-items-start gap-2 mb-2";
+
+    const title = document.createElement("div");
+    title.className = "fw-semibold text-truncate conversation-documents-title";
+    title.title = documentTitle;
+    title.textContent = documentTitle;
+
+    header.append(title, createClassificationBadge(doc?.classification));
+    entry.appendChild(header);
+    entry.appendChild(createDocumentMetaLine(
+        "file-earmark",
+        `${chunkCount} chunk${chunkCount !== 1 ? "s" : ""}${chunkPages.length > 0 ? ` (Pages: ${chunkPages.join(", ")})` : ""}`
+    ));
+    entry.appendChild(createDocumentMetaLine(
+        getScopeIcon(scopeType),
+        `${scopeType} scope: ${scopeName}`
+    ));
+
+    if (doc?.title && doc.title !== doc.document_id) {
+        entry.appendChild(createDocumentMetaLine("hash", `ID: ${documentId}`));
+    }
+
+    listItem.appendChild(entry);
+    return {
+        listItem,
+        documentId,
+    };
+}
+
+function setDocumentsStatus(message, isError = false) {
+    if (!documentsStatus) {
+        return;
+    }
+
+    documentsStatus.textContent = message;
+    documentsStatus.classList.toggle("d-none", !message);
+    documentsStatus.classList.toggle("text-danger", Boolean(isError));
+    documentsStatus.classList.toggle("text-muted", !isError);
+}
+
+function renderConversationDocuments(documents) {
+    if (!documentsList || !documentsEmptyState) {
+        return;
+    }
+
+    documentsList.replaceChildren();
+    documentEntries = documents.map(createDocumentEntry);
+    documentEntries.forEach(entry => documentsList.appendChild(entry.listItem));
+
+    const hasDocuments = documentEntries.length > 0;
+    documentsEmptyState.classList.toggle("d-none", hasDocuments || documentLoadState === "loading");
+    setDocumentsStatus("");
+    updateDrawerTriggers();
+}
+
+async function refreshConversationDocuments(options = {}) {
+    const conversationId = String(options.conversationId || getCurrentConversationId()).trim();
+    const requestToken = ++metadataRequestToken;
+    const autoOpen = Boolean(options.autoOpen);
+    const conversationChanged = conversationId !== activeDocumentConversationId;
+
+    activeDocumentConversationId = conversationId;
+    if (!conversationId) {
+        documentLoadState = "idle";
+        renderConversationDocuments([]);
+        return;
+    }
+
+    documentLoadState = "loading";
+    if (conversationChanged) {
+        documentEntries = [];
+        documentsList?.replaceChildren();
+        setDocumentsStatus("");
+        updateDrawerTriggers();
+    }
+    documentsEmptyState?.classList.add("d-none");
+    if (drawerMode === DRAWER_MODE_DOCUMENTS) {
+        setDocumentsStatus("Loading used documents...");
+    }
+
+    try {
+        const metadata = await fetchConversationMetadata(conversationId);
+        if (requestToken !== metadataRequestToken || conversationId !== activeDocumentConversationId) {
+            return;
+        }
+
+        documentLoadState = "ready";
+        const documents = getConversationDocumentTags(metadata);
+        renderConversationDocuments(documents);
+
+        if (
+            autoOpen
+            && documents.length > 0
+            && conversationId === getCurrentConversationId()
+            && !autoOpenedDocumentConversationIds.has(conversationId)
+        ) {
+            autoOpenedDocumentConversationIds.add(conversationId);
+            openDrawer(DRAWER_MODE_DOCUMENTS);
+        }
+    } catch (error) {
+        if (requestToken !== metadataRequestToken || conversationId !== activeDocumentConversationId) {
+            return;
+        }
+
+        documentLoadState = "error";
+        documentEntries = [];
+        documentsList?.replaceChildren();
+        documentsEmptyState?.classList.add("d-none");
+        setDocumentsStatus("Unable to load used documents.", true);
+        console.warn("Failed to load conversation documents:", error);
+        updateDrawerTriggers();
+    }
 }
 
 function scheduleRebuild() {
@@ -268,7 +571,7 @@ function handleViewportChange() {
     chatContainer?.classList.remove("conversation-contents-open");
     drawerOpen = false;
     drawer?.setAttribute("aria-hidden", "true");
-    toggleButton?.setAttribute("aria-expanded", "false");
+    syncDrawerModeControls();
 }
 
 function mutationAffectsContents(mutations) {
@@ -301,7 +604,7 @@ function handleMessageMutations(mutations) {
 }
 
 function initializeConversationContents() {
-    if (!chatbox || !drawer || !list || !toggleButton || !closeButton) {
+    if (!chatbox || !drawer || !list || !contentsToggleButton || !closeButton) {
         return;
     }
 
@@ -314,20 +617,29 @@ function initializeConversationContents() {
         drawer.addEventListener("shown.bs.offcanvas", () => {
             drawerOpen = true;
             drawer.setAttribute("aria-hidden", "false");
-            toggleButton.setAttribute("aria-expanded", "true");
+            syncDrawerModeControls();
         });
         drawer.addEventListener("hidden.bs.offcanvas", () => {
             drawerOpen = false;
             drawer.setAttribute("aria-hidden", "true");
-            toggleButton.setAttribute("aria-expanded", "false");
+            syncDrawerModeControls();
             if (restoreFocusAfterClose) {
-                toggleButton.focus();
+                getDrawerTriggerButton()?.focus();
             }
             restoreFocusAfterClose = true;
         });
     }
 
-    toggleButton.addEventListener("click", toggleDrawer);
+    contentsToggleButton.addEventListener("click", () => toggleDrawer(DRAWER_MODE_CONTENTS));
+    documentsToggleButton?.addEventListener("click", () => toggleDrawer(DRAWER_MODE_DOCUMENTS));
+    contentsModeButton?.addEventListener("click", () => {
+        setDrawerMode(DRAWER_MODE_CONTENTS);
+    });
+    documentsModeButton?.addEventListener("click", () => {
+        if (documentEntries.length > 0 || documentLoadState === "loading") {
+            setDrawerMode(DRAWER_MODE_DOCUMENTS);
+        }
+    });
     closeButton.addEventListener("click", () => closeDrawer());
     scrollContainer?.addEventListener("scroll", scheduleActiveEntryUpdate, { passive: true });
     desktopMediaQuery.addEventListener("change", handleViewportChange);
@@ -336,6 +648,22 @@ function initializeConversationContents() {
             event.preventDefault();
             closeDrawer();
         }
+    });
+    window.addEventListener("chat:conversation-context-changed", event => {
+        void refreshConversationDocuments({
+            conversationId: event.detail?.conversationId || "",
+            autoOpen: false,
+        });
+    });
+    window.addEventListener("chat:conversation-documents-refresh", event => {
+        const conversationId = String(event.detail?.conversationId || getCurrentConversationId()).trim();
+        if (!conversationId || conversationId !== getCurrentConversationId()) {
+            return;
+        }
+        void refreshConversationDocuments({
+            conversationId,
+            autoOpen: Boolean(event.detail?.autoOpen),
+        });
     });
 
     const messageObserver = new MutationObserver(handleMessageMutations);
@@ -348,6 +676,7 @@ function initializeConversationContents() {
     });
 
     rebuildConversationContents();
+    void refreshConversationDocuments();
 }
 
 initializeConversationContents();

--- a/application/single_app/static/js/chat/chat-conversation-details.js
+++ b/application/single_app/static/js/chat/chat-conversation-details.js
@@ -33,6 +33,41 @@ function getConversationDetailsModalInstance() {
   return bootstrap.Modal.getOrCreateInstance(modal);
 }
 
+function getConversationMetadataDomItem(conversationId) {
+  const escapedConversationId = window.CSS?.escape
+    ? CSS.escape(conversationId)
+    : String(conversationId || '').replace(/["\\]/g, '\\$&');
+  return document.querySelector(`.conversation-item[data-conversation-id="${escapedConversationId}"]`)
+    || document.querySelector(`.sidebar-conversation-item[data-conversation-id="${escapedConversationId}"]`);
+}
+
+export async function fetchConversationMetadata(conversationId) {
+  const normalizedConversationId = String(conversationId || '').trim();
+  if (!normalizedConversationId) {
+    throw new Error('Conversation ID is required');
+  }
+
+  const conversationItem = getConversationMetadataDomItem(normalizedConversationId);
+  const isCollaborativeConversation = conversationItem?.dataset?.conversationKind === 'collaborative';
+
+  if (isCollaborativeConversation && window.chatCollaboration?.fetchConversationMetadata) {
+    return window.chatCollaboration.fetchConversationMetadata(normalizedConversationId);
+  }
+
+  const response = await fetch(`/api/conversations/${encodeURIComponent(normalizedConversationId)}/metadata`);
+
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+  }
+
+  return response.json();
+}
+
+export function getConversationDocumentTags(metadata = {}) {
+  const tags = Array.isArray(metadata.tags) ? metadata.tags : [];
+  return tags.filter(tag => tag?.category === 'document');
+}
+
 export function hideConversationDetails() {
   const { modal } = getConversationDetailsModalElements();
   const modalInstance = getConversationDetailsModalInstance();
@@ -121,22 +156,7 @@ export async function showConversationDetails(conversationId) {
   }
 
   try {
-    const conversationItem = document.querySelector(`.conversation-item[data-conversation-id="${conversationId}"]`)
-      || document.querySelector(`.sidebar-conversation-item[data-conversation-id="${conversationId}"]`);
-    const isCollaborativeConversation = conversationItem?.dataset?.conversationKind === 'collaborative';
-    let metadata = null;
-
-    if (isCollaborativeConversation && window.chatCollaboration?.fetchConversationMetadata) {
-      metadata = await window.chatCollaboration.fetchConversationMetadata(conversationId);
-    } else {
-      const response = await fetch(`/api/conversations/${conversationId}/metadata`);
-
-      if (!response.ok) {
-        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-      }
-
-      metadata = await response.json();
-    }
+    const metadata = await fetchConversationMetadata(conversationId);
 
     const safeConversationTitle = escapeHtml(metadata.title || 'Conversation Details');
     // Update modal title with conversation title, pin icon, and hidden icon
@@ -334,8 +354,10 @@ function renderConversationMetadata(metadata, conversationId) {
     `;
   }
 
+  const documentTags = getConversationDocumentTags(metadata);
+
   // Documents Section
-  if (tagsByCategory.document.length > 0) {
+  if (documentTags.length > 0) {
     html += `
       <div class="col-md-6">
         <div class="card h-100">
@@ -343,7 +365,7 @@ function renderConversationMetadata(metadata, conversationId) {
             <h6 class="mb-0"><i class="bi bi-file-earmark-text me-2"></i>Documents</h6>
           </div>
           <div class="card-body">
-            ${renderDocumentsSection(tagsByCategory.document)}
+            ${renderDocumentsSection(documentTags)}
           </div>
         </div>
       </div>
@@ -911,7 +933,7 @@ function getScopeIcon(scope) {
   }
 }
 
-function extractPageNumbers(chunkIds) {
+export function extractPageNumbers(chunkIds) {
   const pages = [];
   chunkIds.forEach(chunkId => {
     const parts = chunkId.split('_');

--- a/application/single_app/static/js/chat/chat-streaming.js
+++ b/application/single_app/static/js/chat/chat-streaming.js
@@ -351,6 +351,20 @@ function updateStreamContextConversation(streamContext, conversationId) {
     setStreamingStopButtonState(streamContext.tempAiMessageId, streamContext.cancelEndpoint ? 'ready' : 'waiting_for_conversation');
 }
 
+function notifyConversationDocumentsMayHaveChanged(conversationId, autoOpen = false) {
+    const normalizedConversationId = String(conversationId || '').trim();
+    if (!normalizedConversationId) {
+        return;
+    }
+
+    window.dispatchEvent(new CustomEvent('chat:conversation-documents-refresh', {
+        detail: {
+            conversationId: normalizedConversationId,
+            autoOpen,
+        },
+    }));
+}
+
 async function requestStreamCancellation(streamContext = currentStreamContext) {
     if (!streamContext || streamContext.cancellationRequested) {
         return false;
@@ -1281,6 +1295,7 @@ function finalizeStreamingMessage(messageId, userMessageId, finalData, fallbackA
 
     if (existingFinalMessage) {
         markStreamingConversationReadIfActive(finalData.conversation_id, 'live streaming completion');
+        notifyConversationDocumentsMayHaveChanged(finalData.conversation_id, Boolean(finalData.augmented));
         return;
     }
 
@@ -1309,6 +1324,7 @@ function finalizeStreamingMessage(messageId, userMessageId, finalData, fallbackA
         if (finalData.reload_messages && finalData.conversation_id && typeof window.chatMessages?.loadMessages === 'function') {
             window.chatMessages.loadMessages(finalData.conversation_id);
         }
+        notifyConversationDocumentsMayHaveChanged(finalData.conversation_id, Boolean(finalData.augmented));
         return;
     }
 
@@ -1372,6 +1388,7 @@ function finalizeStreamingMessage(messageId, userMessageId, finalData, fallbackA
         window.chatMessages.loadMessages(finalData.conversation_id);
     }
 
+    notifyConversationDocumentsMayHaveChanged(finalData.conversation_id, Boolean(finalData.augmented));
     markStreamingConversationReadIfActive(finalData.conversation_id, 'live streaming completion');
 }
 

--- a/application/single_app/templates/chats.html
+++ b/application/single_app/templates/chats.html
@@ -292,6 +292,17 @@
                             >
                                <i class="bi bi-list-nested" aria-hidden="true"></i>
                             </button>
+                            <button
+                               id="conversation-documents-toggle"
+                               type="button"
+                               class="btn btn-sm chat-shell-icon-button d-none"
+                               title="Open used documents"
+                               aria-label="Open used documents"
+                               aria-controls="conversation-contents-drawer"
+                               aria-expanded="false"
+                            >
+                               <i class="bi bi-file-earmark-text" aria-hidden="true"></i>
+                            </button>
                             {% endif %}
                         </div>
                     </div>
@@ -836,7 +847,7 @@
                     <div class="offcanvas-header border-bottom">
                         <div>
                             <h5 class="offcanvas-title mb-0" id="conversation-contents-title">Conversation contents</h5>
-                            <p class="small text-muted mb-0">Jump to a user message</p>
+                            <p class="small text-muted mb-0" id="conversation-contents-subtitle">Jump to a user message</p>
                         </div>
                         <button
                             id="conversation-contents-close"
@@ -845,12 +856,42 @@
                             aria-label="Close conversation contents"
                         ></button>
                     </div>
-                    <nav class="offcanvas-body p-2" aria-label="User messages in this conversation">
-                        <ol id="conversation-contents-list" class="conversation-contents-list list-unstyled mb-0"></ol>
-                        <p id="conversation-contents-empty" class="small text-muted text-center px-3 py-4 mb-0">
-                            No user messages are available yet.
-                        </p>
-                    </nav>
+                    <div class="px-2 pt-2">
+                        <div class="btn-group w-100 conversation-contents-mode-switch" role="group" aria-label="Conversation side pane mode">
+                            <button
+                                type="button"
+                                class="btn btn-outline-secondary btn-sm active"
+                                id="conversation-contents-mode-contents"
+                                aria-pressed="true"
+                            >
+                                <i class="bi bi-list-nested me-1" aria-hidden="true"></i>Contents
+                            </button>
+                            <button
+                                type="button"
+                                class="btn btn-outline-secondary btn-sm"
+                                id="conversation-contents-mode-documents"
+                                aria-pressed="false"
+                            >
+                                <i class="bi bi-file-earmark-text me-1" aria-hidden="true"></i>Documents
+                                <span id="conversation-documents-count" class="badge rounded-pill text-bg-secondary ms-1 d-none">0</span>
+                            </button>
+                        </div>
+                    </div>
+                    <div class="offcanvas-body p-2">
+                        <nav id="conversation-contents-panel" aria-label="User messages in this conversation">
+                            <ol id="conversation-contents-list" class="conversation-contents-list list-unstyled mb-0"></ol>
+                            <p id="conversation-contents-empty" class="small text-muted text-center px-3 py-4 mb-0">
+                                No user messages are available yet.
+                            </p>
+                        </nav>
+                        <section id="conversation-documents-panel" class="d-none" aria-label="Used documents in this conversation">
+                            <div id="conversation-documents-status" class="small text-muted text-center px-3 py-4 mb-0 d-none" role="status" aria-live="polite"></div>
+                            <ol id="conversation-documents-list" class="conversation-documents-list list-unstyled mb-0"></ol>
+                            <p id="conversation-documents-empty" class="small text-muted text-center px-3 py-4 mb-0">
+                                No cited documents have been used in this conversation yet.
+                            </p>
+                        </section>
+                    </div>
                 </aside>
                 {% endif %}
             </div>

--- a/docs/explanation/features/CONVERSATION_CONTENTS_DRAWER.md
+++ b/docs/explanation/features/CONVERSATION_CONTENTS_DRAWER.md
@@ -2,13 +2,15 @@
 
 ## Overview
 
-The conversation contents drawer provides a compact index of persisted user messages in the active chat. It helps users navigate long conversations without manually scrolling through the transcript.
+The conversation contents drawer provides a compact index of persisted user messages in the active chat. It also includes a used-documents mode so users can review the documents that have actually been cited in the conversation without opening the full details modal.
 
 Implemented in version: **0.250.074**
+Used documents mode added in version: **0.250.159**
 
 ### Dependencies
 
 - Existing authorized chat message loading
+- Existing conversation metadata API (`/api/conversations/<conversation_id>/metadata`)
 - Local Bootstrap 5 off-canvas runtime and Bootstrap Icons
 - Existing current-user settings API
 
@@ -16,7 +18,9 @@ Implemented in version: **0.250.074**
 
 ### Architecture
 
-The feature is derived entirely from messages already loaded into the chat DOM. It does not add a conversation-index API or a second datastore. `chat-conversation-contents.js` observes persisted user-message elements, renders labels with `textContent`, and tracks the message nearest the current scroll position.
+The contents mode is derived entirely from messages already loaded into the chat DOM. It does not add a conversation-index API or a second datastore. `chat-conversation-contents.js` observes persisted user-message elements, renders labels with `textContent`, and tracks the message nearest the current scroll position.
+
+The documents mode uses the same conversation metadata source as the details modal. `chat-conversation-details.js` exposes shared helpers for fetching conversation metadata and filtering `tags` where `category === "document"`. `chat-conversation-contents.js` renders those document tags into a vertical row list, so selected-but-unused documents are excluded and the side pane stays aligned with the details modal document card.
 
 The application setting `enable_conversation_contents_drawer` is the authoritative global gate and defaults to `true`. The user setting `conversationContentsDrawerEnabled` also defaults to `true`; it is only effective while the admin gate is enabled.
 
@@ -29,6 +33,10 @@ The application setting `enable_conversation_contents_drawer` is the authoritati
 - Messages without usable text receive an ordered fallback such as `User message 3`.
 - Selecting an entry scrolls and focuses the source message, applies a temporary highlight, and marks the entry as the current location.
 - Mutation and scroll observers refresh entries after loads, sends, edits, timeline replacement, and conversation switching.
+- The chat header exposes a separate used-documents icon once cited documents exist for the active conversation.
+- Contents and Documents share the same right-side drawer. Opening either mode swaps the drawer content instead of creating side-by-side panes.
+- After a streamed response completes, the drawer refreshes full conversation metadata and auto-opens Documents once per conversation when cited documents first appear.
+- Document rows show title, classification, cited chunk/page summary, workspace scope, and document ID when the title differs from the ID.
 
 ### Files
 
@@ -40,8 +48,10 @@ The application setting `enable_conversation_contents_drawer` is the authoritati
 - `application/single_app/templates/admin_settings.html`
 - `application/single_app/templates/profile.html`
 - `application/single_app/templates/chats.html`
+- `application/single_app/static/js/chat/chat-conversation-details.js`
 - `application/single_app/static/js/chat/chat-conversation-contents.js`
 - `application/single_app/static/js/chat/chat-messages.js`
+- `application/single_app/static/js/chat/chat-streaming.js`
 - `application/single_app/static/css/chats.css`
 
 ## Usage
@@ -49,15 +59,17 @@ The application setting `enable_conversation_contents_drawer` is the authoritati
 1. In **Admin Settings**, leave **Enable Conversation Contents Drawer** enabled or turn it off globally.
 2. When globally enabled, users can open **Profile > Settings > Conversation Navigation** and choose whether the drawer appears for their account.
 3. In Chat, select the list icon in the conversation header and choose a user-message label to jump to that point.
+4. After a response cites workspace documents, select the document icon in the conversation header to view the cited-document list. If this is the first cited-document response in the conversation, the Documents mode opens automatically.
 
 ## Testing and validation
 
 - `functional_tests/test_conversation_contents_drawer_settings.py` validates global and user defaults, persistence wiring, validation, and gate precedence.
-- `ui_tests/test_chat_conversation_contents_drawer.py` covers filtering, ordering, safe and truncated labels, fallback labels, navigation, focus, live updates, conversation replacement, keyboard closing, and desktop/mobile layouts.
-- The contents list is generated locally from authorized messages and inserts user-authored labels only through safe text APIs.
+- `ui_tests/test_chat_conversation_contents_drawer.py` covers filtering, ordering, safe and truncated labels, fallback labels, cited-document rendering, documents-mode swapping, auto-open behavior, navigation, focus, live updates, conversation replacement, keyboard closing, and desktop/mobile layouts.
+- The contents list is generated locally from authorized messages and inserts user-authored labels only through safe text APIs. The documents list also renders metadata through DOM APIs and `textContent`.
 
 ### Known limitations
 
-- The initial implementation indexes user messages only.
-- Search, grouping, generated summaries, and assistant-message entries are not included.
+- Contents mode indexes user messages only.
+- Documents mode includes cited/used conversation metadata documents only; documents merely selected in the picker but not used for citations are intentionally excluded.
+- Search, grouping, generated summaries, assistant-message entries, and document filtering are not included.
 - Only messages currently loaded into the active timeline can appear in the contents list.

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,15 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](/explanation/features/) and [Fixes by Version](/explanation/fixes/).
 
+### **(v0.250.159)**
+
+#### New Features
+
+*   **Chat Used Documents Pane**
+    *   Added a Used Documents mode to the existing chat conversation side pane so users can review documents that were actually cited in the conversation without opening the full details modal.
+    *   Reuses the same conversation metadata document tags as the details modal, excludes selected-but-unused documents, and auto-opens once when cited documents first appear.
+    *   (Ref: #1209, conversation contents drawer, cited document metadata, `chat-conversation-contents.js`, `chat-conversation-details.js`)
+
 ### **(v0.250.157)**
 
 #### Bug Fixes

--- a/ui_tests/test_chat_conversation_contents_drawer.py
+++ b/ui_tests/test_chat_conversation_contents_drawer.py
@@ -1,13 +1,16 @@
 # test_chat_conversation_contents_drawer.py
 """
 UI test for the conversation contents drawer.
-Version: 0.250.074
+Version: 0.250.159
 Implemented in: 0.250.074
+Documents mode added in: 0.250.159
 
-This test validates user-message filtering, safe labels, navigation, live
-updates, conversation replacement, keyboard closing, and responsive layouts.
+This test validates user-message filtering, cited-document mode, safe labels,
+navigation, live updates, conversation replacement, keyboard closing, and
+responsive layouts.
 """
 
+import json
 import os
 from pathlib import Path
 
@@ -17,6 +20,14 @@ from playwright.sync_api import expect
 
 BASE_URL = os.getenv("SIMPLECHAT_UI_BASE_URL", "").rstrip("/")
 STORAGE_STATE = os.getenv("SIMPLECHAT_UI_STORAGE_STATE", "")
+
+
+def _fulfill_json(route, payload, status=200):
+    route.fulfill(
+        status=status,
+        content_type="application/json",
+        body=json.dumps(payload),
+    )
 
 
 def _require_authenticated_chat_env():
@@ -197,6 +208,74 @@ def test_chat_conversation_contents_drawer(playwright, viewport):
         )
         expect(entries).to_have_count(1)
         expect(entries.nth(0)).to_have_text("Next conversation topic")
+
+        document_title = "Policy Handbook <img src=x onerror='window.__documentsPaneXss = true'>"
+        page.route(
+            "**/api/conversations/conversation-documents-pane/metadata",
+            lambda route: _fulfill_json(route, {
+                "title": "Documents pane conversation",
+                "tags": [
+                    {
+                        "category": "document",
+                        "document_id": "doc-1",
+                        "title": document_title,
+                        "classification": "Confidential",
+                        "chunk_ids": ["doc-1_1", "doc-1_2"],
+                        "scope": {
+                            "type": "group",
+                            "id": "group-1",
+                            "name": "Product Docs",
+                        },
+                    },
+                    {
+                        "category": "document",
+                        "document_id": "doc-2",
+                        "title": "Release Plan",
+                        "classification": "None",
+                        "chunk_ids": ["doc-2_4"],
+                        "scope": {
+                            "type": "personal",
+                            "id": "user-1",
+                            "name": "Personal",
+                        },
+                    },
+                ],
+            }),
+        )
+
+        page.evaluate(
+            """
+            () => {
+                window.__documentsPaneXss = false;
+                window.currentConversationId = 'conversation-documents-pane';
+                window.dispatchEvent(new CustomEvent('chat:conversation-documents-refresh', {
+                    detail: {
+                        conversationId: 'conversation-documents-pane',
+                        autoOpen: true
+                    }
+                }));
+            }
+            """
+        )
+
+        documents_toggle = page.locator("#conversation-documents-toggle")
+        documents_entries = page.locator(".conversation-documents-entry")
+        expect(documents_toggle).to_be_visible()
+        expect(page.locator("#conversation-contents-drawer")).to_be_visible()
+        expect(page.locator("#conversation-contents-title")).to_have_text("Used documents")
+        expect(documents_entries).to_have_count(2)
+        expect(documents_entries.nth(0)).to_contain_text(document_title)
+        expect(documents_entries.nth(0)).to_contain_text("2 chunks (Pages: 1, 2)")
+        expect(documents_entries.nth(0)).to_contain_text("group scope: Product Docs")
+        expect(documents_entries.nth(1)).to_contain_text("Release Plan")
+        expect(page.locator("#conversation-documents-count")).to_have_text("2")
+        expect(page.locator("#conversation-documents-panel img[src='x']")).to_have_count(0)
+        assert page.evaluate("() => window.__documentsPaneXss") is False
+
+        page.locator("#conversation-contents-mode-contents").click()
+        expect(page.locator("#conversation-contents-title")).to_have_text("Conversation contents")
+        expect(page.locator("#conversation-contents-panel")).to_be_visible()
+        expect(page.locator("#conversation-documents-panel")).to_be_hidden()
 
         toggle.click()
         page.keyboard.press("Escape")


### PR DESCRIPTION
## Summary
- Add a Used Documents mode to the existing chat conversation side pane, sharing the same drawer surface as Conversation Contents.
- Reuse conversation metadata document tags from the details modal so the pane shows cited/used documents and excludes selected-but-unused documents.
- Refresh the document list after streamed grounded responses and auto-open Documents once when cited documents first appear.
- Update feature documentation, release notes, version, and UI coverage.

## Validation
- `node --check application\single_app\static\js\chat\chat-conversation-details.js`
- `node --check application\single_app\static\js\chat\chat-conversation-contents.js`
- `node --check application\single_app\static\js\chat\chat-streaming.js`
- `python -m pytest ui_tests\test_chat_conversation_contents_drawer.py -q` *(2 skipped locally because authenticated UI test env vars are not configured)*
- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check`

Fixes #1209