### PR TITLE
Phase 3: Route Search through shared tabular preflight

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -96,7 +96,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.250.158"
+VERSION = "0.250.159"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/route_backend_chats.py
+++ b/application/single_app/route_backend_chats.py
@@ -56,6 +56,8 @@ from functions_mixed_source_orchestration import (
 )
 from functions_tabular_analysis import (
     get_new_plugin_invocations as _shared_get_new_plugin_invocations,
+    orchestrate_tabular_request as _shared_orchestrate_tabular_request,
+    queue_direct_tabular_generated_output_from_plan as _shared_queue_direct_tabular_generated_output_from_plan,
 )
 from functions_tabular_orchestration import (
     get_tabular_generated_output_format as _shared_get_tabular_generated_output_format,
@@ -6119,6 +6121,164 @@ def maybe_queue_direct_tabular_generated_output(
                     'The downloadable tabular artifact could not be queued. No inline row output was generated.',
                 )
         return None
+
+
+def _build_search_shared_preflight_metrics(file_contexts, result=None, generated_output=None):
+    metrics = {
+        'source_count': len(file_contexts or []),
+    }
+    if isinstance(result, dict):
+        metrics['planned_source_count'] = _safe_int(result.get('source_count'))
+    if isinstance(generated_output, dict):
+        metrics['generated_output_count'] = 1
+        metrics['row_count'] = _safe_int(generated_output.get('row_count'))
+    return metrics
+
+
+def _emit_search_shared_preflight_event(
+    event_name,
+    settings,
+    file_contexts,
+    result=None,
+    generated_output=None,
+    dimensions=None,
+    level=logging.INFO,
+):
+    safe_dimensions = {
+        'preflight_owner': 'shared',
+    }
+    if isinstance(result, dict):
+        safe_dimensions.update({
+            'planner_mode': str(result.get('planner_mode') or '').strip().lower()[:40],
+            'execution_contract': str(result.get('execution_contract') or '').strip().lower()[:80],
+            'execution_state': str(result.get('execution_state') or '').strip().lower()[:40],
+            'reason_code': str(result.get('reason_code') or '').strip().lower()[:80],
+            'planner_contract_version': str(result.get('planner_contract_version') or '').strip()[:80],
+        })
+    if isinstance(generated_output, dict):
+        safe_dimensions.update({
+            'output_status': str(generated_output.get('status') or '').strip().lower()[:40],
+            'task_type': str(generated_output.get('task_type') or '').strip().lower()[:80],
+            'output_format': str(generated_output.get('output_format') or '').strip().lower()[:20],
+        })
+    for key, value in (dimensions or {}).items():
+        safe_dimensions[str(key)[:60]] = str(value or '').strip().lower()[:80]
+
+    log_event(
+        f'[TABULAR_SHARED_PREFLIGHT] Search shared preflight {event_name}',
+        {
+            'event_name': event_name,
+            **safe_dimensions,
+            **_build_search_shared_preflight_metrics(
+                file_contexts,
+                result=result,
+                generated_output=generated_output,
+            ),
+        },
+        level=level,
+        debug_only=True,
+    )
+
+
+def maybe_queue_search_tabular_generated_output(
+    user_question,
+    file_contexts,
+    user_id,
+    conversation_id,
+    gpt_model,
+    settings,
+    thought_callback=None,
+    model_context=None,
+    cancel_requested=None,
+    request_correlation_id=None,
+):
+    """Queue Search durable tabular work through the shared preflight when enabled."""
+    legacy_direct_preflight = lambda: maybe_queue_direct_tabular_generated_output(
+        user_question=user_question,
+        file_contexts=file_contexts,
+        user_id=user_id,
+        conversation_id=conversation_id,
+        gpt_model=gpt_model,
+        settings=settings,
+        thought_callback=thought_callback,
+        model_context=model_context,
+        cancel_requested=cancel_requested,
+        request_correlation_id=request_correlation_id,
+    )
+
+    if not _settings_flag_enabled(settings, 'enable_tabular_search_shared_preflight', False):
+        return legacy_direct_preflight()
+
+    planner_mode = str((settings or {}).get('tabular_request_planner_mode') or '').strip().lower()
+    if planner_mode not in {'shadow', 'active'}:
+        return legacy_direct_preflight()
+
+    try:
+        _emit_search_shared_preflight_event(
+            'attempted',
+            settings,
+            file_contexts,
+            dimensions={'planner_mode': planner_mode},
+        )
+        result = _shared_orchestrate_tabular_request(
+            user_question,
+            file_contexts,
+            action_mode='search',
+            caller='search',
+            settings=settings,
+            planner_mode=planner_mode,
+            durable_execution_callback=_shared_queue_direct_tabular_generated_output_from_plan,
+            user_id=user_id,
+            conversation_id=conversation_id,
+            gpt_model=gpt_model,
+            thought_callback=thought_callback,
+            model_context=model_context,
+            cancel_requested=cancel_requested,
+            request_correlation_id=request_correlation_id,
+        )
+    except MixedSourceCancellationError:
+        raise
+    except Exception as exc:
+        _emit_search_shared_preflight_event(
+            'failed',
+            settings,
+            file_contexts,
+            dimensions={'error_type': exc.__class__.__name__},
+            level=logging.WARNING,
+        )
+        return legacy_direct_preflight()
+
+    planner_mode = str((result or {}).get('planner_mode') or '').strip().lower()
+    generated_output = (result or {}).get('generated_output_metadata') if isinstance(result, dict) else None
+    if planner_mode == 'shadow':
+        _emit_search_shared_preflight_event(
+            'shadow_compared',
+            settings,
+            file_contexts,
+            result=result,
+        )
+        return legacy_direct_preflight()
+
+    if planner_mode == 'active' and generated_output:
+        output_status = str(generated_output.get('status') or '').strip().lower()
+        event_name = 'failed' if output_status == 'failed' else 'accepted'
+        _emit_search_shared_preflight_event(
+            event_name,
+            settings,
+            file_contexts,
+            result=result,
+            generated_output=generated_output,
+            level=logging.WARNING if event_name == 'failed' else logging.INFO,
+        )
+        return generated_output
+
+    _emit_search_shared_preflight_event(
+        'declined',
+        settings,
+        file_contexts,
+        result=result,
+    )
+    return None
 
 
 def _build_tabular_generated_output_source_authorization(source_candidate):
@@ -12507,7 +12667,7 @@ def _execute_mixed_source_tabular_evidence(
         if not file_context:
             raise ValueError('Authorized tabular source context is unavailable')
 
-        direct_generated_output = maybe_queue_direct_tabular_generated_output(
+        direct_generated_output = maybe_queue_search_tabular_generated_output(
             user_question=user_question,
             file_contexts=[file_context],
             user_id=user_id,
@@ -17896,7 +18056,7 @@ def register_route_backend_chats(bp):
                 streamed_tabular_tool_thoughts = []
                 tabular_invocations = []
                 tabular_related_document_summary = ''
-                tabular_generated_output = maybe_queue_direct_tabular_generated_output(
+                tabular_generated_output = maybe_queue_search_tabular_generated_output(
                     user_question=user_message,
                     file_contexts=workspace_tabular_file_contexts,
                     user_id=user_id,
@@ -18263,7 +18423,7 @@ def register_route_backend_chats(bp):
                         build_tabular_file_context(file_name, source_hint='chat')
                         for file_name in chat_tabular_files
                     ]
-                    chat_tabular_generated_output = maybe_queue_direct_tabular_generated_output(
+                    chat_tabular_generated_output = maybe_queue_search_tabular_generated_output(
                         user_question=user_message,
                         file_contexts=chat_tabular_file_contexts,
                         user_id=user_id,
@@ -21832,7 +21992,7 @@ def register_route_backend_chats(bp):
                     streamed_tabular_tool_thoughts = []
                     tabular_invocations = []
                     tabular_related_document_summary = ''
-                    tabular_generated_output = maybe_queue_direct_tabular_generated_output(
+                    tabular_generated_output = maybe_queue_search_tabular_generated_output(
                         user_question=user_message,
                         file_contexts=workspace_tabular_file_contexts,
                         user_id=user_id,
@@ -22216,7 +22376,7 @@ def register_route_backend_chats(bp):
                             build_tabular_file_context(file_name, source_hint='chat')
                             for file_name in chat_tabular_files
                         ]
-                        chat_tabular_generated_output = maybe_queue_direct_tabular_generated_output(
+                        chat_tabular_generated_output = maybe_queue_search_tabular_generated_output(
                             user_question=user_message,
                             file_contexts=chat_tabular_file_contexts,
                             user_id=user_id,

--- a/docs/explanation/features/TABULAR_ANALYZE_SEARCH_PARITY_PHASE_3_SEARCH_ADAPTER.md
+++ b/docs/explanation/features/TABULAR_ANALYZE_SEARCH_PARITY_PHASE_3_SEARCH_ADAPTER.md
@@ -1,0 +1,66 @@
+# Tabular Analyze/Search Parity Phase 3 Search Adapter
+
+Implemented in version: **0.250.159**
+
+## Overview
+
+Phase 3 routes Search tabular durable preflight through the shared tabular request planner introduced in Phase 2. Search keeps its existing durable generated-output runner, source replay, authorization checks, artifact metadata, and bounded foreground fallback, but the decision point can now be owned by the shared planner when the Search-specific gate is enabled.
+
+The behavior remains default-off. With the gate disabled, or with planner mode set to `off`, Search calls the legacy direct preflight path exactly as before.
+
+## Dependencies
+
+- Shared planner facade in `application/single_app/functions_tabular_orchestration.py`
+- Lazy adapter surface in `application/single_app/functions_tabular_analysis.py`
+- Existing Search direct durable preflight in `application/single_app/route_backend_chats.py`
+- Existing durable generated-output runner in `application/single_app/functions_tabular_generated_exports.py`
+- Current application version from `application/single_app/config.py`: **0.250.159**
+
+## Technical Specifications
+
+Search now calls `maybe_queue_search_tabular_generated_output(...)` at the preflight points that previously called the route-owned direct helper. The wrapper applies these rules:
+
+- `enable_tabular_search_shared_preflight = False`: call the legacy direct preflight.
+- `enable_tabular_search_shared_preflight = True` and `tabular_request_planner_mode = off` or invalid: call the legacy direct preflight.
+- `tabular_request_planner_mode = shadow`: run shared planning without side effects, emit safe comparison telemetry, then call the legacy direct preflight.
+- `tabular_request_planner_mode = active`: run the shared facade with the existing direct durable queue callback and return accepted generated-output metadata without a duplicate legacy call.
+- Active foreground or ineligible results return `None`, so existing bounded Search tabular evidence continues normally.
+- Shared preflight exceptions emit safe failure telemetry and fall back to the legacy direct preflight.
+
+The route still retains `maybe_queue_direct_tabular_generated_output(...)` as the durable side-effect owner and compatibility safety net. Phase 3 does not remove the late post-tool generated-output fallback.
+
+## Rollout Controls
+
+Phase 3 uses the existing backend-only controls:
+
+- `enable_tabular_search_shared_preflight`: default `False`.
+- `tabular_request_planner_mode`: default `off`; supported active rollout values are `shadow` and `active`.
+
+Both controls remain in the backend settings denylist used by `sanitize_settings_for_user(...)`, so non-admin frontend routes do not receive them.
+
+## Usage Instructions
+
+Operators can observe Search parity decisions by enabling `enable_tabular_search_shared_preflight` and setting `tabular_request_planner_mode` to `shadow`. In shadow mode, the shared planner records its decision without creating durable work, and Search still uses the legacy direct preflight outcome.
+
+After shadow telemetry is acceptable, operators can set `tabular_request_planner_mode` to `active` for Search. Active mode still uses the existing direct durable runner callback and does not change Analyze behavior.
+
+Rollback is immediate for new requests: set `enable_tabular_search_shared_preflight` to `False` or set `tabular_request_planner_mode` to `off`. Runs already accepted by the durable runner continue under their recorded generated-output contract.
+
+## Testing and Validation
+
+Functional coverage is in `functional_tests/test_tabular_search_shared_preflight_adapter.py`.
+
+The test validates:
+
+- Gate-off and planner-off behavior preserve the legacy direct preflight.
+- Shadow mode invokes shared planning without durable side effects and then preserves legacy behavior.
+- Active mode returns shared accepted metadata without a duplicate legacy preflight.
+- Active foreground results decline to the existing bounded foreground Search path.
+- Shared planner failures fall back to the legacy direct safety net.
+- Search preflight call sites use the Phase 3 adapter with explicit required arguments.
+
+The existing shared planner test remains the route-neutral facade contract, and the direct generated-output queue tests continue to cover the legacy durable side-effect owner.
+
+## Known Limitations
+
+Phase 3 migrates Search only. Analyze still uses its existing foreground-first path until the next phase activates Analyze durable preflight behind its own gate.

--- a/functional_tests/test_tabular_row_orchestration_scale.py
+++ b/functional_tests/test_tabular_row_orchestration_scale.py
@@ -1,8 +1,8 @@
 # test_tabular_row_orchestration_scale.py
 """
 Functional test for scalable per-row tabular orchestration.
-Version: 0.250.152
-Implemented in: 0.250.060; generated CSV formula safety in 0.250.065; generated file export routing in 0.250.072; source descriptor generalization in 0.250.127; unified durable run contract in 0.250.128; hierarchical analysis in 0.250.129; combined analysis and export in 0.250.130; scale validation in 0.250.132; direct source-backed exhaustive queueing in 0.250.133; direct queue call-site hardening in 0.250.134; model-validation auto retry in 0.250.135; model-aware parallel throughput in 0.250.136; Phase 1 acceleration contracts and observability in 0.250.137; Phase 2 truthful background handoff in 0.250.138; Phase 3 durable LLM generation planning in 0.250.139; Phase 4 compact row response protocol in 0.250.140; Phase 5 completion-driven checkpointing in 0.250.141; Phase 6 rolling worker pool in 0.250.142; Phase 7 independent batch retries in 0.250.143; Phase 8 scale, chaos, and rollout in 0.250.144; background metadata streaming fix in 0.250.145; source-token echo recovery in 0.250.146; fixed-window stale heartbeat fix in 0.250.147; nested CSV output recovery in 0.250.148; generic tabular artifact routing and fast startup in 0.250.149; balanced concurrency waves and default completion checkpoints in 0.250.152
+Version: 0.250.159
+Implemented in: 0.250.060; generated CSV formula safety in 0.250.065; generated file export routing in 0.250.072; source descriptor generalization in 0.250.127; unified durable run contract in 0.250.128; hierarchical analysis in 0.250.129; combined analysis and export in 0.250.130; scale validation in 0.250.132; direct source-backed exhaustive queueing in 0.250.133; direct queue call-site hardening in 0.250.134; model-validation auto retry in 0.250.135; model-aware parallel throughput in 0.250.136; Phase 1 acceleration contracts and observability in 0.250.137; Phase 2 truthful background handoff in 0.250.138; Phase 3 durable LLM generation planning in 0.250.139; Phase 4 compact row response protocol in 0.250.140; Phase 5 completion-driven checkpointing in 0.250.141; Phase 6 rolling worker pool in 0.250.142; Phase 7 independent batch retries in 0.250.143; Phase 8 scale, chaos, and rollout in 0.250.144; background metadata streaming fix in 0.250.145; source-token echo recovery in 0.250.146; fixed-window stale heartbeat fix in 0.250.147; nested CSV output recovery in 0.250.148; generic tabular artifact routing and fast startup in 0.250.149; balanced concurrency waves and default completion checkpoints in 0.250.152; Search shared preflight adapter in 0.250.159
 
 This test ensures generated exports preserve source identity and row order while
 enforcing one stable output schema across independently generated batches.
@@ -4814,8 +4814,15 @@ def test_direct_source_backed_queue_failure_suppresses_inline_exhaustive_output(
 
 
 def test_direct_source_backed_queue_call_sites_use_required_keywords():
-    """Every direct queue call site passes required arguments explicitly."""
+    """Every Search queue call site passes required arguments explicitly."""
     module_tree = ast.parse(CHAT_ROUTE.read_text(encoding='utf-8'), filename=str(CHAT_ROUTE))
+    search_queue_calls = [
+        call
+        for call in ast.walk(module_tree)
+        if isinstance(call, ast.Call)
+        and isinstance(call.func, ast.Name)
+        and call.func.id == 'maybe_queue_search_tabular_generated_output'
+    ]
     direct_queue_calls = [
         call
         for call in ast.walk(module_tree)
@@ -4823,7 +4830,8 @@ def test_direct_source_backed_queue_call_sites_use_required_keywords():
         and isinstance(call.func, ast.Name)
         and call.func.id == 'maybe_queue_direct_tabular_generated_output'
     ]
-    assert len(direct_queue_calls) >= 4
+    assert len(search_queue_calls) >= 4
+    assert len(direct_queue_calls) >= 1
 
     required_keyword_names = {
         'user_question',
@@ -4833,7 +4841,7 @@ def test_direct_source_backed_queue_call_sites_use_required_keywords():
         'gpt_model',
         'settings',
     }
-    for call in direct_queue_calls:
+    for call in search_queue_calls + direct_queue_calls:
         keyword_names = {
             keyword.arg
             for keyword in call.keywords

--- a/functional_tests/test_tabular_search_shared_preflight_adapter.py
+++ b/functional_tests/test_tabular_search_shared_preflight_adapter.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+# test_tabular_search_shared_preflight_adapter.py
+"""
+Functional test for the Search shared tabular preflight adapter.
+Version: 0.250.159
+Implemented in: 0.250.159
+
+This test ensures Phase 3 routes Search durable tabular preflight through the
+shared planner gate while preserving legacy direct preflight behavior when the
+gate is disabled or shadow-only.
+"""
+
+import ast
+import logging
+import sys
+from pathlib import Path
+
+from test_support.versioning import assert_app_version_at_least
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CHAT_ROUTE = REPO_ROOT / "application" / "single_app" / "route_backend_chats.py"
+IMPLEMENTED_VERSION = "0.250.159"
+
+
+class FakeCancellationError(Exception):
+    pass
+
+
+def assert_equal(actual, expected, label):
+    if actual != expected:
+        raise AssertionError(f"{label}: expected {expected!r}, got {actual!r}")
+
+
+def assert_true(value, label):
+    if not value:
+        raise AssertionError(f"Expected truthy value for {label}")
+
+
+def load_search_adapter_namespace(flag_enabled=True, orchestration_result=None, orchestration_error=None):
+    source = CHAT_ROUTE.read_text(encoding="utf-8")
+    module_tree = ast.parse(source, filename=str(CHAT_ROUTE))
+    function_names = {
+        "_build_search_shared_preflight_metrics",
+        "_emit_search_shared_preflight_event",
+        "maybe_queue_search_tabular_generated_output",
+    }
+    selected_nodes = [
+        node
+        for node in module_tree.body
+        if isinstance(node, ast.FunctionDef) and node.name in function_names
+    ]
+    namespace = {
+        "MixedSourceCancellationError": FakeCancellationError,
+        "logging": logging,
+        "_safe_int": lambda value: int(value or 0),
+    }
+    legacy_calls = []
+    orchestrator_calls = []
+    log_events = []
+
+    def fake_settings_flag_enabled(settings, key, default=False):
+        assert_equal(key, "enable_tabular_search_shared_preflight", "settings flag key")
+        return flag_enabled
+
+    def fake_direct_preflight(**kwargs):
+        legacy_calls.append(kwargs)
+        return {"export_run_id": "legacy-run", "status": "queued"}
+
+    def fake_orchestrate_tabular_request(*args, **kwargs):
+        orchestrator_calls.append({"args": args, "kwargs": kwargs})
+        if orchestration_error:
+            raise orchestration_error
+        return dict(orchestration_result or {})
+
+    def fake_log_event(*args, **kwargs):
+        log_events.append({"args": args, "kwargs": kwargs})
+
+    namespace.update({
+        "_settings_flag_enabled": fake_settings_flag_enabled,
+        "maybe_queue_direct_tabular_generated_output": fake_direct_preflight,
+        "_shared_orchestrate_tabular_request": fake_orchestrate_tabular_request,
+        "_shared_queue_direct_tabular_generated_output_from_plan": object(),
+        "log_event": fake_log_event,
+    })
+    compiled = compile(ast.Module(body=selected_nodes, type_ignores=[]), str(CHAT_ROUTE), "exec")
+    exec(compiled, namespace)
+    namespace["legacy_calls"] = legacy_calls
+    namespace["orchestrator_calls"] = orchestrator_calls
+    namespace["log_events"] = log_events
+    return namespace
+
+
+def call_adapter(namespace, settings=None):
+    return namespace["maybe_queue_search_tabular_generated_output"](
+        user_question="Analyze every row and create a CSV file.",
+        file_contexts=[{"file_name": "survey.csv", "source_hint": "workspace"}],
+        user_id="user-1",
+        conversation_id="conversation-1",
+        gpt_model="gpt-4o",
+        settings=settings or {
+            "enable_tabular_search_shared_preflight": True,
+            "tabular_request_planner_mode": "active",
+        },
+    )
+
+
+def test_gate_off_uses_legacy_direct_preflight():
+    print("Testing Search shared preflight gate-off behavior...")
+    assert_app_version_at_least(IMPLEMENTED_VERSION)
+    namespace = load_search_adapter_namespace(flag_enabled=False)
+
+    result = call_adapter(namespace, settings={"enable_tabular_search_shared_preflight": False})
+
+    assert_equal(result["export_run_id"], "legacy-run", "legacy metadata")
+    assert_equal(len(namespace["legacy_calls"]), 1, "legacy call count")
+    assert_equal(len(namespace["orchestrator_calls"]), 0, "shared orchestrator call count")
+
+
+def test_gate_on_planner_off_preserves_legacy_direct_preflight():
+    print("Testing Search shared preflight planner-off behavior...")
+    namespace = load_search_adapter_namespace(flag_enabled=True)
+
+    result = call_adapter(namespace, settings={"tabular_request_planner_mode": "off"})
+
+    assert_equal(result["export_run_id"], "legacy-run", "planner-off legacy metadata")
+    assert_equal(len(namespace["legacy_calls"]), 1, "planner-off legacy call count")
+    assert_equal(len(namespace["orchestrator_calls"]), 0, "planner-off orchestrator call count")
+
+
+def test_shadow_mode_compares_then_preserves_legacy_preflight():
+    print("Testing Search shared preflight shadow behavior...")
+    namespace = load_search_adapter_namespace(
+        flag_enabled=True,
+        orchestration_result={
+            "planner_mode": "shadow",
+            "execution_contract": "combined",
+            "execution_state": "declined",
+            "reason_code": "durable_intent",
+            "planner_contract_version": "tabular-orchestration-v1",
+            "source_count": 1,
+        },
+    )
+
+    result = call_adapter(namespace, settings={"tabular_request_planner_mode": "shadow"})
+
+    assert_equal(result["export_run_id"], "legacy-run", "shadow legacy metadata")
+    assert_equal(len(namespace["legacy_calls"]), 1, "shadow legacy call count")
+    assert_equal(len(namespace["orchestrator_calls"]), 1, "shadow orchestrator count")
+    orchestrator_kwargs = namespace["orchestrator_calls"][0]["kwargs"]
+    assert_equal(orchestrator_kwargs["action_mode"], "search", "shared action mode")
+    assert_equal(orchestrator_kwargs["caller"], "search", "shared caller")
+    assert_equal(orchestrator_kwargs["planner_mode"], "shadow", "shared planner mode")
+    assert_true(
+        any(event["args"][0].endswith("shadow_compared") for event in namespace["log_events"]),
+        "shadow telemetry",
+    )
+
+
+def test_active_mode_returns_shared_metadata_without_legacy_duplicate():
+    print("Testing Search shared preflight active accepted behavior...")
+    namespace = load_search_adapter_namespace(
+        flag_enabled=True,
+        orchestration_result={
+            "planner_mode": "active",
+            "execution_contract": "combined",
+            "execution_state": "queued",
+            "reason_code": "active_execution_accepted",
+            "planner_contract_version": "tabular-orchestration-v1",
+            "source_count": 1,
+            "generated_output_metadata": {
+                "export_run_id": "shared-run",
+                "status": "queued",
+                "row_count": 42,
+                "task_type": "combined",
+                "output_format": "csv",
+            },
+        },
+    )
+
+    result = call_adapter(namespace)
+
+    assert_equal(result["export_run_id"], "shared-run", "shared metadata")
+    assert_equal(len(namespace["legacy_calls"]), 0, "legacy duplicate count")
+    assert_equal(len(namespace["orchestrator_calls"]), 1, "active orchestrator count")
+    assert_true(
+        any(event["args"][0].endswith("accepted") for event in namespace["log_events"]),
+        "accepted telemetry",
+    )
+
+
+def test_active_failed_metadata_emits_failed_preflight_event():
+    print("Testing Search shared preflight active failed metadata telemetry...")
+    namespace = load_search_adapter_namespace(
+        flag_enabled=True,
+        orchestration_result={
+            "planner_mode": "active",
+            "execution_contract": "structured_export",
+            "execution_state": "queued",
+            "reason_code": "active_execution_accepted",
+            "planner_contract_version": "tabular-orchestration-v1",
+            "source_count": 1,
+            "generated_output_metadata": {
+                "background_export": True,
+                "status": "failed",
+                "output_format": "csv",
+                "row_count": 0,
+            },
+        },
+    )
+
+    result = call_adapter(namespace)
+
+    assert_equal(result["status"], "failed", "failed metadata status")
+    assert_equal(len(namespace["legacy_calls"]), 0, "failed metadata legacy duplicate count")
+    assert_true(
+        any(event["args"][0].endswith("failed") for event in namespace["log_events"]),
+        "failed metadata telemetry",
+    )
+
+
+def test_active_foreground_contract_declines_to_existing_foreground_path():
+    print("Testing Search shared preflight active foreground decline behavior...")
+    namespace = load_search_adapter_namespace(
+        flag_enabled=True,
+        orchestration_result={
+            "planner_mode": "active",
+            "execution_contract": "foreground_aggregate",
+            "execution_state": "foreground",
+            "reason_code": "foreground_contract",
+            "planner_contract_version": "tabular-orchestration-v1",
+            "source_count": 1,
+            "generated_output_metadata": None,
+        },
+    )
+
+    result = call_adapter(namespace)
+
+    assert_equal(result, None, "foreground adapter result")
+    assert_equal(len(namespace["legacy_calls"]), 0, "foreground legacy call count")
+    assert_true(
+        any(event["args"][0].endswith("declined") for event in namespace["log_events"]),
+        "declined telemetry",
+    )
+
+
+def test_shared_failure_falls_back_to_legacy_safety_net():
+    print("Testing Search shared preflight failure fallback behavior...")
+    namespace = load_search_adapter_namespace(
+        flag_enabled=True,
+        orchestration_error=RuntimeError("simulated shared planner failure"),
+    )
+
+    result = call_adapter(namespace)
+
+    assert_equal(result["export_run_id"], "legacy-run", "failure fallback metadata")
+    assert_equal(len(namespace["legacy_calls"]), 1, "failure legacy call count")
+    assert_true(
+        any(event["args"][0].endswith("failed") for event in namespace["log_events"]),
+        "failed telemetry",
+    )
+
+
+def test_search_call_sites_use_phase_3_adapter():
+    print("Testing Search direct preflight call-site migration...")
+    module_tree = ast.parse(CHAT_ROUTE.read_text(encoding="utf-8"), filename=str(CHAT_ROUTE))
+    search_adapter_calls = [
+        call
+        for call in ast.walk(module_tree)
+        if isinstance(call, ast.Call)
+        and isinstance(call.func, ast.Name)
+        and call.func.id == "maybe_queue_search_tabular_generated_output"
+    ]
+    required_keyword_names = {
+        "user_question",
+        "file_contexts",
+        "user_id",
+        "conversation_id",
+        "gpt_model",
+        "settings",
+    }
+
+    assert_true(len(search_adapter_calls) >= 4, "Search adapter call count")
+    for call in search_adapter_calls:
+        keyword_names = {
+            keyword.arg
+            for keyword in call.keywords
+            if keyword.arg
+        }
+        assert_true(required_keyword_names <= keyword_names, "required adapter keywords")
+
+
+def run_tests():
+    tests = [
+        test_gate_off_uses_legacy_direct_preflight,
+        test_gate_on_planner_off_preserves_legacy_direct_preflight,
+        test_shadow_mode_compares_then_preserves_legacy_preflight,
+        test_active_mode_returns_shared_metadata_without_legacy_duplicate,
+        test_active_failed_metadata_emits_failed_preflight_event,
+        test_active_foreground_contract_declines_to_existing_foreground_path,
+        test_shared_failure_falls_back_to_legacy_safety_net,
+        test_search_call_sites_use_phase_3_adapter,
+    ]
+    results = []
+    for test in tests:
+        print(f"\nRunning {test.__name__}...")
+        try:
+            test()
+            results.append(True)
+        except Exception as exc:
+            print(f"Test failed: {exc}")
+            import traceback
+
+            traceback.print_exc()
+            results.append(False)
+    print(f"\nResults: {sum(results)}/{len(results)} tests passed")
+    return all(results)
+
+
+if __name__ == "__main__":
+    sys.exit(0 if run_tests() else 1)


### PR DESCRIPTION
## Summary

Phase 3 migrates Search durable tabular preflight to the shared tabular request planner facade while preserving the existing direct durable runner and default-off behavior.

- Adds `maybe_queue_search_tabular_generated_output(...)` as the Search adapter wrapper.
- Keeps legacy direct preflight when `enable_tabular_search_shared_preflight` is disabled or `tabular_request_planner_mode` is `off`/invalid.
- Runs shadow comparison without side effects, then preserves legacy direct preflight.
- Runs active shared preflight through the existing direct durable queue callback and avoids duplicate legacy queueing.
- Preserves bounded foreground Search behavior when the shared planner returns `foreground_aggregate`.
- Adds safe shared-preflight telemetry for attempted, shadow compared, accepted, declined, and failed outcomes.
- Adds Phase 3 feature documentation and bumps the app version to `0.250.159`.

Refs #1031, #1055, #1058.

## PR Topology

- Repository: `microsoft/simplechat`
- Base: `feature/tabular-analyze-search-parity`
- Head: `paullizer:feature/tabular-analyze-search-parity-phase-3-search-adapter`
- This PR intentionally does not target `Development`.

## Explicit Non-Goals

- Does not migrate Analyze durable preflight; that remains Phase 4.
- Does not remove the legacy direct preflight helper.
- Does not remove the post-tool generated-output fallback.
- Does not create a second durable runner, source resolver, authorization model, or artifact UI.

## Behavior Gates And Defaults

- `enable_tabular_search_shared_preflight`: default `False`.
- `tabular_request_planner_mode`: default `off`.
- Gate off or planner off/invalid: legacy direct preflight remains unchanged.
- `shadow`: shared planner compares without side effects, then legacy preflight runs.
- `active`: shared facade executes through the existing direct durable queue callback.

## Validation

Passed locally on Windows:

- `python functional_tests/test_tabular_search_shared_preflight_adapter.py` -> `8/8` passed.
- `python functional_tests/test_tabular_shared_request_planner.py` -> `6/6` passed.
- Route policy suite:
  - `python functional_tests/route_tests/test_route_blueprint_policy_inventory.py` -> `6/6` passed.
  - `python functional_tests/route_tests/test_route_unauthenticated_policy_contract.py` -> `4/4` passed.
  - `python functional_tests/route_tests/test_route_policy_test_coverage.py` -> `2/2` passed.
- `python -m py_compile application/single_app/route_backend_chats.py functional_tests/test_tabular_search_shared_preflight_adapter.py functional_tests/test_tabular_shared_request_planner.py application/single_app/config.py` -> passed.
- VS Code diagnostics for touched Python files -> no errors.
- Dependency-free AST check for Search/direct queue call-site keyword coverage -> passed.
- Windows-safe whitespace check with `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check` -> passed.
- Direct final-newline/trailing-whitespace/code-fence hygiene check for new files -> passed.

Note: importing the full `functional_tests/test_tabular_row_orchestration_scale.py` module was blocked in this local venv by missing optional dependencies (`pandas`, then `defusedxml`), so the edited call-site assertion was validated with an equivalent dependency-free AST check.

## Security And Source Scope

- Shared Search preflight receives only server-built tabular file contexts from existing authorized Search paths.
- The active side-effect boundary still calls the existing direct durable queue helper, preserving source replay, authorization, and generated-output lifecycle owners.
- New telemetry records only safe mode, state, reason, count, task, and format fields; it does not log prompts, file names, blob paths, source locators, credentials, or raw provider errors.
- Backend-only rollout settings remain denied from sanitized frontend settings payloads.

## Rollback

For new Search requests, set `enable_tabular_search_shared_preflight` to `False` or set `tabular_request_planner_mode` to `off`. Existing durable runs continue under their recorded generated-output contract.

## Version

- `application/single_app/config.py`: `0.250.158` -> `0.250.159`

## Next Phase Boundary

Phase 4 should start from the updated `feature/tabular-analyze-search-parity` branch after this PR merges. Analyze behavior is intentionally unchanged in this PR.