### PR TITLE
Phase 5: mixed-source deferred tabular composition

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -96,7 +96,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.250.160"
+VERSION = "0.250.161"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/functions_mixed_source_orchestration.py
+++ b/application/single_app/functions_mixed_source_orchestration.py
@@ -133,6 +133,7 @@ MIXED_SOURCE_TELEMETRY_METRICS = frozenset({
     "narrative_source_count",
     "partial_failure_count",
     "partial_source_count",
+    "pending_source_count",
     "prompt_tokens",
     "request_count",
     "skipped_source_count",
@@ -1478,6 +1479,8 @@ def _get_terminal_reason(status, source, envelope=None):
         return "unsupported_source"
     if status == EVIDENCE_STATUS_SKIPPED:
         return "bounded_policy_skip"
+    if status == EVIDENCE_STATUS_PENDING:
+        return "pending_durable_evidence"
     if status == EVIDENCE_STATUS_PARTIAL:
         return "incomplete_native_coverage"
     if status == EVIDENCE_STATUS_FAILED:
@@ -1490,7 +1493,7 @@ def build_terminal_coverage_ledger(
     evidence_envelopes,
     max_handoff_envelopes=MIXED_SOURCE_HANDOFF_MAX_ENVELOPES,
 ):
-    """Align exactly one terminal state and bounded evidence item to each manifest source."""
+    """Align one source state and bounded evidence item to each manifest source."""
     manifest_entries = [entry for entry in list(manifest or []) if isinstance(entry, dict)]
     raw_envelopes = [
         envelope
@@ -1586,6 +1589,7 @@ def build_terminal_coverage_ledger(
 
     partial_coverage = bool(
         status_counts[EVIDENCE_STATUS_PARTIAL]
+        or status_counts[EVIDENCE_STATUS_PENDING]
         or status_counts[EVIDENCE_STATUS_FAILED]
         or status_counts[EVIDENCE_STATUS_SKIPPED]
         or missing_coverage_violation_count
@@ -1598,6 +1602,7 @@ def build_terminal_coverage_ledger(
         "evidence_envelopes": aligned_envelopes,
         "requested_source_count": len(manifest_entries),
         "completed_source_count": status_counts[EVIDENCE_STATUS_COMPLETED],
+        "pending_source_count": status_counts[EVIDENCE_STATUS_PENDING],
         "partial_source_count": status_counts[EVIDENCE_STATUS_PARTIAL],
         "failed_source_count": status_counts[EVIDENCE_STATUS_FAILED],
         "skipped_source_count": status_counts[EVIDENCE_STATUS_SKIPPED],
@@ -1614,7 +1619,7 @@ def build_terminal_coverage_ledger(
 
 
 def evaluate_mixed_source_mode_outcome(mode, coverage_ledger):
-    """Apply the Phase 6 terminal failure policy to one aggregate-only ledger."""
+    """Apply the mixed-source reduction policy to one aggregate ledger."""
     normalized_mode = str(mode or "").strip().lower()
     if normalized_mode not in MIXED_SOURCE_MODES:
         raise ValueError(f"Unsupported mixed-source mode: {normalized_mode}")
@@ -1628,6 +1633,10 @@ def evaluate_mixed_source_mode_outcome(mode, coverage_ledger):
     successful_statuses = {EVIDENCE_STATUS_COMPLETED, EVIDENCE_STATUS_PARTIAL}
     successful_source_count = sum(
         str(entry.get("status") or "").strip().lower() in successful_statuses
+        for entry in entries
+    )
+    pending_source_count = sum(
+        str(entry.get("status") or "").strip().lower() == EVIDENCE_STATUS_PENDING
         for entry in entries
     )
     partial_coverage = bool(coverage_ledger.get("partial_coverage"))
@@ -1659,9 +1668,15 @@ def evaluate_mixed_source_mode_outcome(mode, coverage_ledger):
             reason = "no_target_prepared"
         partial_coverage = partial_coverage or successful_target_count < len(target_entries)
 
+    if pending_source_count:
+        should_reduce = False
+        reason = "pending_required_evidence"
+
     if not should_reduce:
         status = EVIDENCE_STATUS_FAILED
         reason = reason or "no_successful_source"
+        if pending_source_count:
+            status = EVIDENCE_STATUS_PENDING
     elif partial_coverage:
         status = EVIDENCE_STATUS_PARTIAL
     else:
@@ -1672,6 +1687,7 @@ def evaluate_mixed_source_mode_outcome(mode, coverage_ledger):
         "status": status,
         "should_reduce": should_reduce,
         "successful_source_count": successful_source_count,
+        "pending_source_count": pending_source_count,
         "partial_coverage": partial_coverage,
         "reason": reason,
     }
@@ -1813,11 +1829,16 @@ def build_mixed_source_evidence_handoff(
     if len(serialized_payload.encode("utf-8")) > MIXED_SOURCE_HANDOFF_MAX_BYTES:
         raise ValueError("Mixed-source evidence handoff exceeds its size bound")
 
-    partial_coverage_instruction = (
-        "State clearly that source coverage was partial and identify unavailable authorized source labels."
-        if coverage["partial_coverage"]
-        else "Do not claim that selected sources were omitted."
-    )
+    if coverage.get("pending_source_count"):
+        partial_coverage_instruction = (
+            "State clearly that required source evidence is still pending and do not treat pending sources as completed."
+        )
+    elif coverage["partial_coverage"]:
+        partial_coverage_instruction = (
+            "State clearly that source coverage was partial and identify unavailable authorized source labels."
+        )
+    else:
+        partial_coverage_instruction = "Do not claim that selected sources were omitted."
     if mode:
         emit_mixed_source_coverage_telemetry(
             telemetry_settings,

--- a/application/single_app/functions_settings.py
+++ b/application/single_app/functions_settings.py
@@ -94,6 +94,7 @@ TABULAR_GENERATION_BACKEND_SETTING_KEYS = {
     'tabular_request_planner_mode',
     'enable_tabular_search_shared_preflight',
     'enable_tabular_analyze_durable_preflight',
+    'enable_tabular_mixed_deferred_composition',
     'enable_tabular_generation_plan',
     'tabular_generation_plan_mode',
     'enable_tabular_compact_response_protocol',
@@ -1032,6 +1033,7 @@ def get_settings(use_cosmos=False, include_source=False):
         'tabular_request_planner_mode': 'off',
         'enable_tabular_search_shared_preflight': False,
         'enable_tabular_analyze_durable_preflight': False,
+        'enable_tabular_mixed_deferred_composition': False,
         'enable_tabular_generation_plan': True,
         'tabular_generation_plan_mode': 'shadow',
         'enable_tabular_compact_response_protocol': False,
@@ -1787,6 +1789,7 @@ def update_settings(new_settings):
             exceptionTraceback=True
         )
         return False
+
 
 
 def coerce_multi_model_endpoint_enablement(existing_enabled, requested_enabled):

--- a/application/single_app/functions_workflow_runner.py
+++ b/application/single_app/functions_workflow_runner.py
@@ -1341,6 +1341,9 @@ def _maybe_create_document_analysis_generated_artifacts(
         or xml_artifact_requested
         or primary_tabular_outputs
     )
+    deferred_composition = analysis_result.get('deferred_composition') if isinstance(analysis_result.get('deferred_composition'), dict) else {}
+    if deferred_composition.get('status') in {'pending', 'gate_disabled'}:
+        return {'artifacts': [], 'assistant_reply': None}
 
     if create_lossless_artifacts:
         artifacts = []
@@ -2301,6 +2304,19 @@ def _build_mixed_source_analysis_coverage(handoff):
         )
     coverage['engine_status_totals'] = engine_status_totals
     coverage['document_count'] = coverage.get('requested_source_count', 0)
+    try:
+        pending_source_count = max(0, int(coverage.get('pending_source_count') or 0))
+    except (TypeError, ValueError):
+        pending_source_count = 0
+    if pending_source_count:
+        coverage['progress_meta'] = {
+            'phase': 'waiting_for_tabular_outputs',
+            'phase_label': 'Pending tabular evidence',
+            'phase_detail': 'Mixed-source Analyze is waiting for full-source tabular work to finish',
+            'status': EVIDENCE_STATUS_PENDING,
+            'percent_override': 0,
+        }
+        return coverage
     coverage['progress_meta'] = {
         'phase': 'complete',
         'phase_label': 'Complete' if not coverage.get('partial_coverage') else 'Partial',
@@ -2316,6 +2332,190 @@ def _settings_bool(settings, key, default=False):
     if isinstance(value, str):
         return value.strip().lower() in {'1', 'true', 'yes', 'on'}
     return bool(value)
+
+
+def _get_tabular_generated_output_run_id(generated_output):
+    generated_output = generated_output if isinstance(generated_output, dict) else {}
+    for key in ('export_run_id', 'run_id', 'id'):
+        run_id = str(generated_output.get(key) or '').strip()
+        if run_id:
+            return run_id
+    return ''
+
+
+def _get_tabular_generated_output_status(generated_output):
+    generated_output = generated_output if isinstance(generated_output, dict) else {}
+    for key in ('status', 'execution_status', 'output_status'):
+        status = str(generated_output.get(key) or '').strip().lower()
+        if status:
+            return status
+    return 'queued' if _get_tabular_generated_output_run_id(generated_output) else ''
+
+
+def _is_nonterminal_tabular_generated_output(generated_output):
+    generated_output = generated_output if isinstance(generated_output, dict) else {}
+    if not generated_output:
+        return False
+
+    status = _get_tabular_generated_output_status(generated_output)
+    if status in {'completed', 'failed', 'canceled', 'cancelled'}:
+        return False
+    if status in {'queued', 'running', 'retrying', 'finalizing'}:
+        return True
+    return bool(
+        generated_output.get('background_export')
+        or str(generated_output.get('handoff_mode') or '').strip().lower().startswith('background_')
+        or _get_tabular_generated_output_run_id(generated_output)
+    )
+
+
+def _get_pending_tabular_generated_output(generated_outputs):
+    for generated_output in list(generated_outputs or []):
+        if _is_nonterminal_tabular_generated_output(generated_output):
+            return generated_output
+    return None
+
+
+def _build_pending_tabular_run_reference(source, generated_output):
+    source = source if isinstance(source, dict) else {}
+    generated_output = generated_output if isinstance(generated_output, dict) else {}
+    return {
+        'document_id': str(source.get('document_id') or '').strip(),
+        'run_id': _get_tabular_generated_output_run_id(generated_output),
+        'status': _get_tabular_generated_output_status(generated_output),
+        'task_type': str(generated_output.get('task_type') or '').strip().lower(),
+        'output_format': str(generated_output.get('output_format') or '').strip().lower(),
+        'source_version': source.get('source_version'),
+    }
+
+
+def _build_pending_tabular_evidence_envelope(source, generated_outputs, settings):
+    source = source if isinstance(source, dict) else {}
+    generated_outputs = [
+        output
+        for output in list(generated_outputs or [])
+        if isinstance(output, dict)
+    ]
+    primary_output = _get_pending_tabular_generated_output(generated_outputs) or (
+        generated_outputs[0] if generated_outputs else {}
+    )
+    execution_status = _get_tabular_generated_output_status(primary_output) or 'queued'
+    deferred_enabled = _settings_bool(
+        settings,
+        'enable_tabular_mixed_deferred_composition',
+        False,
+    )
+    if deferred_enabled:
+        summary = (
+            'Full-source tabular analysis is pending in a generated-output run. '
+            'Collective mixed-source synthesis will wait until that run reaches a terminal state.'
+        )
+    else:
+        summary = (
+            'Full-source tabular analysis is pending in a generated-output run. '
+            'Collective mixed-source synthesis was not started because deferred composition is disabled.'
+        )
+
+    return build_evidence_envelope(
+        document_id=source.get('document_id'),
+        source_kind='tabular',
+        engine=EVIDENCE_ENGINE_TABULAR_TOOLS,
+        status=EVIDENCE_STATUS_PENDING,
+        summary=summary,
+        citations=[],
+        generated_artifacts=generated_outputs,
+        coverage={
+            'terminal': False,
+            'execution_status': execution_status,
+            'execution_state': EVIDENCE_STATUS_PENDING,
+            'tool_call_count': 0,
+            'execution_mode': 'durable_background',
+            'generated_output_run_ids': [
+                run_id
+                for run_id in (
+                    _get_tabular_generated_output_run_id(output)
+                    for output in generated_outputs
+                )
+                if run_id
+            ],
+            'durable_task_type': str(primary_output.get('task_type') or '').strip().lower(),
+            'deferred_composition': {
+                'required': True,
+                'enabled': deferred_enabled,
+                'status': 'waiting_for_tabular_output' if deferred_enabled else 'gate_disabled',
+            },
+        },
+    )
+
+
+def _build_mixed_source_deferred_composition_descriptor(
+    workflow,
+    conversation_id,
+    manifest,
+    pending_tabular_runs,
+    settings,
+    request_correlation_id=None,
+):
+    manifest_identity = []
+    for source in list(manifest or []):
+        if not isinstance(source, dict):
+            continue
+        manifest_identity.append({
+            'document_id': str(source.get('document_id') or '').strip(),
+            'scope': source.get('scope'),
+            'scope_id': source.get('scope_id'),
+            'source_kind': source.get('source_kind'),
+            'source_version': source.get('source_version'),
+        })
+    manifest_fingerprint = str(uuid.uuid5(
+        uuid.NAMESPACE_URL,
+        json.dumps(manifest_identity, sort_keys=True, default=str, separators=(',', ':')),
+    ))
+    deferred_enabled = _settings_bool(
+        settings,
+        'enable_tabular_mixed_deferred_composition',
+        False,
+    )
+    return {
+        'composition_id': str(uuid.uuid4()),
+        'contract_version': 'phase5.v1',
+        'status': 'pending' if deferred_enabled else 'gate_disabled',
+        'enabled': deferred_enabled,
+        'created_at': _utc_now_iso(),
+        'user_id': str((workflow or {}).get('user_id') or '').strip(),
+        'conversation_id': str(conversation_id or '').strip(),
+        'workflow_id': str((workflow or {}).get('id') or '').strip(),
+        'request_correlation_id': normalize_mixed_source_correlation_id(
+            request_correlation_id,
+        ),
+        'manifest_fingerprint': manifest_fingerprint,
+        'required_tabular_runs': [
+            run_reference
+            for run_reference in list(pending_tabular_runs or [])
+            if isinstance(run_reference, dict)
+        ],
+        'required_source_count': len(manifest_identity),
+        'pending_source_count': len(list(pending_tabular_runs or [])),
+    }
+
+
+def _build_mixed_source_deferred_reply(deferred_descriptor):
+    descriptor = deferred_descriptor if isinstance(deferred_descriptor, dict) else {}
+    pending_source_count = _coerce_document_analysis_count(
+        descriptor.get('pending_source_count'),
+    )
+    source_label = 'source' if pending_source_count == 1 else 'sources'
+    if descriptor.get('enabled'):
+        return (
+            f'Completed narrative and bounded evidence has been preserved. '
+            f'Collective mixed-source conclusions are deferred while {pending_source_count} tabular {source_label} '
+            'finish full-source generated-output processing.'
+        )
+    return (
+        f'Completed narrative and bounded evidence has been preserved, but {pending_source_count} tabular {source_label} '
+        'still require full-source generated-output processing. Deferred mixed-source composition is currently disabled, '
+        'so no collective conclusion was generated from incomplete table evidence.'
+    )
 
 
 def _emit_analyze_shared_preflight_event(
@@ -2639,6 +2839,7 @@ def _execute_mixed_source_analyze_workflow(
     partitions = partition_source_manifest(manifest)
     evidence_envelopes = []
     generated_tabular_outputs = []
+    pending_tabular_runs = []
     tabular_agent_citations = []
 
     tabular_preflight_result = _maybe_execute_pure_tabular_analyze_preflight(
@@ -2746,15 +2947,32 @@ def _execute_mixed_source_analyze_workflow(
                 ))
                 continue
             tabular_result = tabular_payload.get('result') or {}
+            tabular_generated_outputs = list(tabular_payload.get('generated_tabular_outputs') or [])
+            pending_generated_output = _get_pending_tabular_generated_output(
+                tabular_generated_outputs,
+            )
+            if pending_generated_output:
+                evidence_envelopes.append(_build_pending_tabular_evidence_envelope(
+                    source,
+                    tabular_generated_outputs,
+                    settings,
+                ))
+                pending_tabular_runs.append(_build_pending_tabular_run_reference(
+                    source,
+                    pending_generated_output,
+                ))
+                generated_tabular_outputs.extend(tabular_generated_outputs)
+                tabular_agent_citations.extend(tabular_payload.get('agent_citations') or [])
+                continue
             evidence_envelopes.append(build_evidence_envelope(
                 document_id=source.get('document_id'), source_kind='tabular',
                 engine=EVIDENCE_ENGINE_TABULAR_TOOLS, status=EVIDENCE_STATUS_COMPLETED,
                 summary=str(tabular_result.get('analysis_reply') or tabular_result.get('reply') or ''),
                 citations=list(tabular_payload.get('agent_citations') or []),
-                generated_artifacts=list(tabular_payload.get('generated_tabular_outputs') or []),
+                generated_artifacts=tabular_generated_outputs,
                 coverage={'terminal': True, 'tool_call_count': 1},
             ))
-            generated_tabular_outputs.extend(tabular_payload.get('generated_tabular_outputs') or [])
+            generated_tabular_outputs.extend(tabular_generated_outputs)
             tabular_agent_citations.extend(tabular_payload.get('agent_citations') or [])
 
     handoff = build_mixed_source_evidence_handoff(
@@ -2773,6 +2991,36 @@ def _execute_mixed_source_analyze_workflow(
         },
     )
     if not mode_outcome['should_reduce']:
+        if mode_outcome.get('status') == EVIDENCE_STATUS_PENDING:
+            coverage = _build_mixed_source_analysis_coverage(handoff)
+            deferred_descriptor = _build_mixed_source_deferred_composition_descriptor(
+                workflow,
+                conversation_id,
+                manifest,
+                pending_tabular_runs,
+                settings,
+                request_correlation_id=request_correlation_id,
+            )
+            deferred_reply = _build_mixed_source_deferred_reply(deferred_descriptor)
+            if callable(activity_callback):
+                activity_callback({
+                    'type': 'mixed_source_progress',
+                    'phase': 'waiting_for_tabular_outputs',
+                    'label': coverage['progress_meta']['phase_label'],
+                    'status': coverage['progress_meta']['status'],
+                })
+            return {
+                'reply': deferred_reply,
+                'analysis_reply': deferred_reply,
+                'coverage': coverage,
+                'documents': list(coverage.get('sources') or []),
+                'document_ids': [source.get('document_id') for source in manifest],
+                'mixed_source_manifest': manifest,
+                'mixed_source_evidence': handoff.get('evidence_envelopes') or [],
+                'generated_tabular_outputs': generated_tabular_outputs,
+                'agent_citations': tabular_agent_citations,
+                'deferred_composition': deferred_descriptor,
+            }
         raise RuntimeError(
             'Mixed-source Analyze could not prepare evidence from any selected source.'
         )
@@ -5095,6 +5343,7 @@ def _create_assistant_message(conversation, workflow, result, trigger_source, ru
                 'mixed_source_coverage': result.get('mixed_source_coverage') or {},
                 'analyze': workflow.get('analyze') or {},
                 'analysis_coverage': result.get('analysis_coverage') or {},
+                'deferred_composition': result.get('deferred_composition') or {},
             },
             'thread_info': {
                 'thread_id': str(uuid.uuid4()),
@@ -7181,6 +7430,7 @@ def _execute_document_analysis_workflow(
                         analysis_result.get('generated_tabular_outputs')
                         or []
                     ),
+                    'deferred_composition': analysis_result.get('deferred_composition') or {},
                     'alert_targets': alert_targets,
                 }
             finally:
@@ -7334,6 +7584,7 @@ def _execute_document_analysis_workflow(
             analysis_result.get('generated_tabular_outputs')
             or []
         ),
+        'deferred_composition': analysis_result.get('deferred_composition') or {},
     }
 
 

--- a/docs/explanation/features/TABULAR_ANALYZE_SEARCH_PARITY_PHASE_5_DEFERRED_COMPOSITION.md
+++ b/docs/explanation/features/TABULAR_ANALYZE_SEARCH_PARITY_PHASE_5_DEFERRED_COMPOSITION.md
@@ -1,0 +1,64 @@
+# Tabular Analyze/Search Parity Phase 5 Deferred Composition
+
+Implemented in version: **0.250.161**
+
+## Overview
+
+Phase 5 starts the mixed-source deferred composition contract for Analyze. When a mixed narrative-plus-tabular Analyze request produces full-source generated-output metadata for a tabular source, the tabular source is represented as pending evidence instead of completed factual evidence. The workflow preserves completed narrative and bounded evidence, returns an interim handoff, and skips collective mixed-source reduction until required tabular work can be treated as terminal evidence.
+
+The behavior prevents queued or running generated-output cards from being interpreted as completed analysis. It also keeps the generic generated-output card behavior unchanged, so users can still see background tabular progress through the existing artifact UI.
+
+## Dependencies
+
+- Mixed-source manifest and evidence contracts in `application/single_app/functions_mixed_source_orchestration.py`
+- Mixed-source Analyze workflow coordination in `application/single_app/functions_workflow_runner.py`
+- Existing durable tabular generated-output runner in `application/single_app/functions_tabular_generated_exports.py`
+- Backend settings defaults and frontend sanitization in `application/single_app/functions_settings.py`
+- Current application version from `application/single_app/config.py`: **0.250.161**
+
+## Technical Specifications
+
+The shared mixed-source ledger now counts `pending` as a first-class nonterminal evidence state. Pending evidence:
+
+- increments `pending_source_count`
+- marks aggregate coverage as partial/incomplete
+- receives the safe reason `pending_durable_evidence`
+- blocks mixed-source reduction with `pending_required_evidence`
+- is not counted as successful completed factual evidence
+
+The mixed Analyze workflow inspects tabular generated-output metadata returned from the tabular document-action helper. Queued, running, retrying, or finalizing tabular generated-output metadata builds a pending tabular evidence envelope with `coverage.terminal = false`. The workflow then returns an interim response and a compact deferred-composition descriptor containing source/run identities and a manifest fingerprint. It does not include source rows, generated row payloads, credentials, raw prompts, or unsanitized errors.
+
+The document-analysis artifact finalizer leaves pending deferred-composition replies intact instead of replacing them with the generic generated-output summary text.
+
+## Rollout Controls
+
+Phase 5 adds the backend-only setting:
+
+- `enable_tabular_mixed_deferred_composition`: default `False`
+
+When the setting is disabled, mixed Analyze still refuses to run a collective answer from incomplete tabular evidence. The response states that deferred composition is disabled and that no collective conclusion was generated from pending table evidence.
+
+The setting is included in the backend settings denylist used by `sanitize_settings_for_user(...)`, so non-admin frontend routes do not receive it.
+
+## Usage Instructions
+
+Operators can keep the setting disabled to preserve honest gate-off behavior while validating pending-source telemetry and generated-output handoff behavior. Enabling the setting marks new pending descriptors as continuation-eligible for later lifecycle processing.
+
+Rollback for new requests is immediate: set `enable_tabular_mixed_deferred_composition` to `False`. Existing generated-output runs continue under their recorded durable runner contract.
+
+## Testing and Validation
+
+Functional coverage is in `functional_tests/test_mixed_source_deferred_composition_phase5.py`.
+
+The test validates:
+
+- pending tabular evidence blocks mixed-source Analyze reduction
+- pending sources are counted separately from completed, partial, failed, and skipped sources
+- pending ledger entries receive the safe nonterminal reason
+- the workflow runner branches on pending generated-output metadata before reduction
+- the artifact finalizer preserves pending deferred-composition replies
+- the Phase 5 rollout setting defaults off and remains backend-only
+
+## Known Limitations
+
+This phase creates the nonterminal evidence contract and interim handoff behavior. Terminal notification, persisted continuation execution after generated-output completion, restart recovery, and broader lifecycle hardening are reserved for subsequent Phase 5 hardening and Phase 7 coverage. Per-document and multi-table Analyze remain separate Phase 6 scope.

--- a/functional_tests/test_mixed_source_deferred_composition_phase5.py
+++ b/functional_tests/test_mixed_source_deferred_composition_phase5.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+# test_mixed_source_deferred_composition_phase5.py
+"""
+Functional test for Phase 5 mixed-source deferred composition.
+Version: 0.250.161
+Implemented in: 0.250.161
+
+This test ensures pending durable tabular work remains nonterminal evidence,
+blocks mixed-source Analyze reduction, and is guarded by a backend-only rollout
+setting instead of being treated as completed source coverage.
+"""
+
+import ast
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SINGLE_APP = ROOT / 'application' / 'single_app'
+WORKFLOW_RUNNER = SINGLE_APP / 'functions_workflow_runner.py'
+SETTINGS = SINGLE_APP / 'functions_settings.py'
+sys.path.insert(0, str(SINGLE_APP))
+
+from functions_mixed_source_orchestration import (  # noqa: E402
+    AUTHORIZATION_STATUS_AUTHORIZED,
+    EVIDENCE_ENGINE_DOCUMENT_ANALYSIS,
+    EVIDENCE_ENGINE_TABULAR_TOOLS,
+    EVIDENCE_STATUS_COMPLETED,
+    EVIDENCE_STATUS_PENDING,
+    SOURCE_KIND_NARRATIVE,
+    SOURCE_KIND_TABULAR,
+    build_evidence_envelope,
+    build_mixed_source_evidence_handoff,
+    evaluate_mixed_source_mode_outcome,
+)
+
+
+def test_pending_tabular_evidence_blocks_mixed_analyze_reduction():
+    """Pending generated-output metadata must not count as completed evidence."""
+    manifest = [
+        {
+            'document_id': 'narrative-1',
+            'display_name': 'Policy.pdf',
+            'source_kind': SOURCE_KIND_NARRATIVE,
+            'authorization_status': AUTHORIZATION_STATUS_AUTHORIZED,
+        },
+        {
+            'document_id': 'table-1',
+            'display_name': 'Rows.csv',
+            'source_kind': SOURCE_KIND_TABULAR,
+            'authorization_status': AUTHORIZATION_STATUS_AUTHORIZED,
+        },
+    ]
+    envelopes = [
+        build_evidence_envelope(
+            document_id='narrative-1',
+            source_kind=SOURCE_KIND_NARRATIVE,
+            engine=EVIDENCE_ENGINE_DOCUMENT_ANALYSIS,
+            status=EVIDENCE_STATUS_COMPLETED,
+            summary='Narrative analysis completed.',
+            coverage={'terminal': True, 'processed_windows': 1, 'total_windows': 1},
+        ),
+        build_evidence_envelope(
+            document_id='table-1',
+            source_kind=SOURCE_KIND_TABULAR,
+            engine=EVIDENCE_ENGINE_TABULAR_TOOLS,
+            status=EVIDENCE_STATUS_PENDING,
+            summary='Full-source tabular analysis is pending.',
+            generated_artifacts=[{
+                'run_id': 'run-1',
+                'status': 'queued',
+                'task_type': 'hierarchical_analysis',
+                'background_export': True,
+                'capability': 'tabular',
+            }],
+            coverage={
+                'terminal': False,
+                'execution_status': 'queued',
+                'deferred_composition': {'required': True, 'enabled': True},
+            },
+        ),
+    ]
+
+    handoff = build_mixed_source_evidence_handoff(
+        manifest,
+        envelopes,
+        'selected',
+        mode='analyze',
+        telemetry_settings={},
+    )
+    coverage = handoff['mixed_source_coverage']
+    assert coverage['completed_source_count'] == 1
+    assert coverage['pending_source_count'] == 1
+    assert coverage['partial_coverage'] is True
+    pending_entry = next(
+        entry for entry in coverage['terminal_ledger']
+        if entry['document_id'] == 'table-1'
+    )
+    assert pending_entry['status'] == EVIDENCE_STATUS_PENDING
+    assert pending_entry['reason'] == 'pending_durable_evidence'
+
+    outcome = evaluate_mixed_source_mode_outcome(
+        'analyze',
+        {
+            'entries': coverage['terminal_ledger'],
+            'partial_coverage': coverage['partial_coverage'],
+        },
+    )
+    assert outcome['status'] == EVIDENCE_STATUS_PENDING
+    assert outcome['should_reduce'] is False
+    assert outcome['pending_source_count'] == 1
+    assert outcome['reason'] == 'pending_required_evidence'
+
+
+def test_workflow_runner_defers_pending_tabular_outputs_before_reduction():
+    """Mixed Analyze must branch on pending tabular output before model reduction."""
+    source = WORKFLOW_RUNNER.read_text(encoding='utf-8')
+    tree = ast.parse(source)
+    helper = next(
+        node for node in tree.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == '_execute_mixed_source_analyze_workflow'
+    )
+    helper_source = ast.get_source_segment(source, helper) or ''
+
+    pending_branch = "if pending_generated_output:"
+    reduction_call = "stage='mixed_source_reduction'"
+    assert pending_branch in helper_source
+    assert "_build_pending_tabular_evidence_envelope(" in helper_source
+    assert "pending_tabular_runs.append(" in helper_source
+    assert "if mode_outcome.get('status') == EVIDENCE_STATUS_PENDING:" in helper_source
+    assert "'deferred_composition': deferred_descriptor" in helper_source
+    assert helper_source.index(pending_branch) < helper_source.index(reduction_call)
+    assert "continue" in helper_source[
+        helper_source.index(pending_branch):helper_source.index(reduction_call)
+    ]
+
+    artifact_helper = next(
+        node for node in tree.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == '_maybe_create_document_analysis_generated_artifacts'
+    )
+    artifact_source = ast.get_source_segment(source, artifact_helper) or ''
+    assert "deferred_composition.get('status') in {'pending', 'gate_disabled'}" in artifact_source
+    assert "return {'artifacts': [], 'assistant_reply': None}" in artifact_source
+    assert "'deferred_composition': result.get('deferred_composition') or {}" in source
+    assert source.count("'deferred_composition': analysis_result.get('deferred_composition') or {}") >= 2
+
+
+def test_deferred_composition_setting_defaults_backend_only():
+    """The Phase 5 gate must default off and remain sanitized from frontend settings."""
+    settings_source = SETTINGS.read_text(encoding='utf-8')
+    assert "'enable_tabular_mixed_deferred_composition': False" in settings_source
+    assert "'enable_tabular_mixed_deferred_composition'," in settings_source
+    backend_key_index = settings_source.index("'enable_tabular_mixed_deferred_composition',")
+    sanitizer_index = settings_source.index('def sanitize_settings_for_user')
+    assert backend_key_index < sanitizer_index
+
+
+if __name__ == '__main__':
+    tests = [
+        test_pending_tabular_evidence_blocks_mixed_analyze_reduction,
+        test_workflow_runner_defers_pending_tabular_outputs_before_reduction,
+        test_deferred_composition_setting_defaults_backend_only,
+    ]
+    failures = []
+    for test in tests:
+        try:
+            test()
+            print(f'PASS {test.__name__}')
+        except Exception as exc:
+            failures.append((test.__name__, exc))
+            print(f'FAIL {test.__name__}: {exc}')
+
+    if failures:
+        sys.exit(1)
+    sys.exit(0)

--- a/functional_tests/test_tabular_analyze_shared_preflight_adapter.py
+++ b/functional_tests/test_tabular_analyze_shared_preflight_adapter.py
@@ -2,8 +2,8 @@
 # test_tabular_analyze_shared_preflight_adapter.py
 """
 Functional test for the Analyze shared tabular preflight adapter.
-Version: 0.250.160
-Implemented in: 0.250.160
+Version: 0.250.161
+Implemented in: 0.250.160; updated in 0.250.161
 
 This test ensures Phase 4 routes pure single-source tabular Analyze durable
 work through the shared planner before foreground tabular tools or immediate
@@ -65,9 +65,19 @@ def load_workflow_namespace(orchestration_result=None, manifest=None):
     source = WORKFLOW_RUNNER.read_text(encoding="utf-8")
     module_tree = ast.parse(source, filename=str(WORKFLOW_RUNNER))
     function_names = {
+        "_coerce_document_analysis_count",
         "_settings_bool",
+        "_utc_now_iso",
         "_emit_analyze_shared_preflight_event",
         "_build_tabular_analyze_durable_handoff",
+        "_get_tabular_generated_output_run_id",
+        "_get_tabular_generated_output_status",
+        "_is_nonterminal_tabular_generated_output",
+        "_get_pending_tabular_generated_output",
+        "_build_pending_tabular_run_reference",
+        "_build_pending_tabular_evidence_envelope",
+        "_build_mixed_source_deferred_composition_descriptor",
+        "_build_mixed_source_deferred_reply",
         "_maybe_execute_pure_tabular_analyze_preflight",
         "_build_mixed_source_analysis_coverage",
         "_execute_mixed_source_analyze_workflow",


### PR DESCRIPTION
## Phase Objective

Implement the Phase 5 backend slice for mixed-source deferred composition so queued or running tabular generated-output work is represented as nonterminal pending evidence instead of completed factual evidence.

Refs #1031, #1055, #1058.

## Changes

- Adds first-class pending mixed-source evidence accounting and reduction blocking.
- Updates mixed-source Analyze to build pending tabular evidence envelopes for nonterminal generated-output metadata.
- Returns an interim deferred-composition handoff instead of running collective reduction from incomplete tabular evidence.
- Persists compact deferred-composition metadata into workflow message metadata.
- Adds backend-only setting `enable_tabular_mixed_deferred_composition`, default `False`.
- Documents Phase 5 behavior and bumps app version to `0.250.161`.

## Explicit Non-Goals

- Does not implement terminal generated-output notification or continuation execution.
- Does not implement per-document or multi-table Analyze parity.
- Does not add a new tabular runner, source resolver, authorization model, route, or artifact UI.
- Does not remove the legacy post-tool fallback path.

## Behavior Gates And Defaults

- `enable_tabular_mixed_deferred_composition`: default `False`.
- With the gate off, pending tabular evidence still blocks collective reduction and returns an honest limitation/handoff.
- With the gate on, new descriptors are marked continuation-eligible for later lifecycle processing.
- Existing generated-output runs continue under their recorded durable runner contract.

## Security And Source Scope

- Deferred descriptors store bounded source/run identities and a manifest fingerprint only.
- No source rows, generated row payloads, credentials, raw prompts, or unsanitized errors are persisted in the descriptor.
- The new setting is included in backend-only settings sanitization exclusions.
- No browser routes or frontend runtime assets changed.
- Existing mixed-source final reauthorization remains in the workflow publication path.

## Validation

Passed:

- `python functional_tests/test_mixed_source_deferred_composition_phase5.py`
- `python functional_tests/test_tabular_analyze_shared_preflight_adapter.py` (`6/6`)
- `python functional_tests/test_mixed_source_analyze_workflow.py`
- `python -m py_compile application/single_app/functions_mixed_source_orchestration.py application/single_app/functions_settings.py application/single_app/functions_workflow_runner.py application/single_app/config.py functional_tests/test_mixed_source_deferred_composition_phase5.py functional_tests/test_tabular_analyze_shared_preflight_adapter.py`
- Changed-file hygiene check for final newline and trailing whitespace
- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check`

Not run locally:

- `python functional_tests/test_mixed_source_manifest_contracts.py` could not start because the local venv is missing `azure`.

## Version

- `application/single_app/config.py`: `0.250.160` -> `0.250.161`

## Rollback

- Set `enable_tabular_mixed_deferred_composition` to `False` to stop creating continuation-eligible descriptors for new requests.
- Pending generated-output metadata will still avoid false completed reduction and report the gate-disabled handoff.
- Existing durable generated-output runs remain resumable under their recorded runner contract.

## Next Phase Confirmation

This PR does not include Phase 6 per-document or multi-table behavior. It only establishes pending evidence, interim handoff, and compact deferred-composition metadata for mixed-source Analyze.