### PR TITLE
Phase 7: Add tabular parity lifecycle coverage metadata

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -96,7 +96,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.250.162"
+VERSION = "0.250.163"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/functions_mixed_source_orchestration.py
+++ b/application/single_app/functions_mixed_source_orchestration.py
@@ -83,12 +83,14 @@ EVIDENCE_STATUS_PENDING = "pending"
 EVIDENCE_STATUS_PARTIAL = "partial"
 EVIDENCE_STATUS_FAILED = "failed"
 EVIDENCE_STATUS_SKIPPED = "skipped"
+EVIDENCE_STATUS_CANCELED = "canceled"
 EVIDENCE_STATUSES = frozenset({
     EVIDENCE_STATUS_COMPLETED,
     EVIDENCE_STATUS_PENDING,
     EVIDENCE_STATUS_PARTIAL,
     EVIDENCE_STATUS_FAILED,
     EVIDENCE_STATUS_SKIPPED,
+    EVIDENCE_STATUS_CANCELED,
 })
 
 EVIDENCE_ENVELOPE_MAX_BYTES = 65536
@@ -118,6 +120,7 @@ MIXED_SOURCE_TELEMETRY_METRICS = frozenset({
     "authorization_failure_count",
     "background_export_count",
     "cancellation_count",
+    "canceled_source_count",
     "citation_count",
     "completed_source_count",
     "duplicate_evidence_count",
@@ -279,16 +282,19 @@ def emit_mixed_source_coverage_telemetry(
         if source_kind in source_kind_counts:
             source_kind_counts[source_kind] += 1
 
-    outcome_status = (
-        EVIDENCE_STATUS_PARTIAL
-        if coverage.get("partial_coverage")
-        else EVIDENCE_STATUS_COMPLETED
-    )
-    if coverage.get("successful_source_count", 0) == 0 and coverage.get(
-        "requested_source_count",
-        0,
-    ):
+    requested_source_count = coverage.get("requested_source_count", 0)
+    successful_source_count = coverage.get("successful_source_count", 0)
+    pending_source_count = coverage.get("pending_source_count", 0)
+    canceled_source_count = coverage.get("canceled_source_count", 0)
+    outcome_status = EVIDENCE_STATUS_COMPLETED
+    if pending_source_count:
+        outcome_status = EVIDENCE_STATUS_PENDING
+    elif canceled_source_count and canceled_source_count == requested_source_count:
+        outcome_status = EVIDENCE_STATUS_CANCELED
+    elif successful_source_count == 0 and requested_source_count:
         outcome_status = EVIDENCE_STATUS_FAILED
+    elif coverage.get("partial_coverage"):
+        outcome_status = EVIDENCE_STATUS_PARTIAL
     return emit_mixed_source_telemetry(
         settings,
         "terminal_coverage",
@@ -297,9 +303,11 @@ def emit_mixed_source_coverage_telemetry(
         metrics={
             "total_source_count": coverage.get("requested_source_count", 0),
             "completed_source_count": coverage.get("completed_source_count", 0),
+            "pending_source_count": coverage.get("pending_source_count", 0),
             "partial_source_count": coverage.get("partial_source_count", 0),
             "failed_source_count": coverage.get("failed_source_count", 0),
             "skipped_source_count": coverage.get("skipped_source_count", 0),
+            "canceled_source_count": coverage.get("canceled_source_count", 0),
             "successful_source_count": coverage.get("successful_source_count", 0),
             "tabular_source_count": source_kind_counts[SOURCE_KIND_TABULAR],
             "narrative_source_count": source_kind_counts[SOURCE_KIND_NARRATIVE],
@@ -1484,6 +1492,8 @@ def _get_terminal_reason(status, source, envelope=None):
         return "bounded_policy_skip"
     if status == EVIDENCE_STATUS_PENDING:
         return "pending_durable_evidence"
+    if status == EVIDENCE_STATUS_CANCELED:
+        return "durable_work_canceled"
     if status == EVIDENCE_STATUS_PARTIAL:
         return "incomplete_native_coverage"
     if status == EVIDENCE_STATUS_FAILED:
@@ -1563,6 +1573,36 @@ def build_terminal_coverage_ledger(
 
         status_counts[status] += 1
         handoff_included = False
+        coverage = (
+            envelope.get("coverage")
+            if isinstance(envelope, dict) and isinstance(envelope.get("coverage"), dict)
+            else {}
+        )
+        generated_artifacts = (
+            list(envelope.get("generated_artifacts") or [])
+            if isinstance(envelope, dict)
+            else []
+        )
+        generated_reference_present = any(
+            isinstance(artifact, dict)
+            and str(
+                artifact.get("run_id")
+                or artifact.get("export_run_id")
+                or artifact.get("artifact_id")
+                or artifact.get("id")
+                or ""
+            ).strip()
+            for artifact in generated_artifacts
+        )
+        required_for_composition = coverage.get(
+            "required_for_composition",
+            source.get("required_for_composition"),
+        )
+        if required_for_composition is None:
+            required_for_composition = bool(
+                source.get("authorization_status") == AUTHORIZATION_STATUS_AUTHORIZED
+                and source_kind in {SOURCE_KIND_TABULAR, SOURCE_KIND_NARRATIVE}
+            )
         if envelope is not None:
             if len(aligned_envelopes) < max(0, int(max_handoff_envelopes)):
                 aligned_envelopes.append(envelope)
@@ -1586,6 +1626,11 @@ def build_terminal_coverage_ledger(
             "request_order": request_order,
             "status": status,
             "reason": reason,
+            "terminal": status != EVIDENCE_STATUS_PENDING,
+            "required_for_composition": bool(required_for_composition),
+            "native_engine": envelope.get("engine") if isinstance(envelope, dict) else None,
+            "execution_contract": coverage.get("execution_contract") or source.get("execution_contract"),
+            "generated_reference_present": generated_reference_present,
             "handoff_included": handoff_included,
         }
         ledger_entries.append(ledger_entry)
@@ -1593,6 +1638,7 @@ def build_terminal_coverage_ledger(
     partial_coverage = bool(
         status_counts[EVIDENCE_STATUS_PARTIAL]
         or status_counts[EVIDENCE_STATUS_PENDING]
+        or status_counts[EVIDENCE_STATUS_CANCELED]
         or status_counts[EVIDENCE_STATUS_FAILED]
         or status_counts[EVIDENCE_STATUS_SKIPPED]
         or missing_coverage_violation_count
@@ -1609,6 +1655,7 @@ def build_terminal_coverage_ledger(
         "partial_source_count": status_counts[EVIDENCE_STATUS_PARTIAL],
         "failed_source_count": status_counts[EVIDENCE_STATUS_FAILED],
         "skipped_source_count": status_counts[EVIDENCE_STATUS_SKIPPED],
+        "canceled_source_count": status_counts[EVIDENCE_STATUS_CANCELED],
         "successful_source_count": (
             status_counts[EVIDENCE_STATUS_COMPLETED]
             + status_counts[EVIDENCE_STATUS_PARTIAL]
@@ -1640,6 +1687,10 @@ def evaluate_mixed_source_mode_outcome(mode, coverage_ledger):
     )
     pending_source_count = sum(
         str(entry.get("status") or "").strip().lower() == EVIDENCE_STATUS_PENDING
+        for entry in entries
+    )
+    canceled_source_count = sum(
+        str(entry.get("status") or "").strip().lower() == EVIDENCE_STATUS_CANCELED
         for entry in entries
     )
     partial_coverage = bool(coverage_ledger.get("partial_coverage"))
@@ -1675,11 +1726,19 @@ def evaluate_mixed_source_mode_outcome(mode, coverage_ledger):
         should_reduce = False
         reason = "pending_required_evidence"
 
+    all_sources_canceled = bool(canceled_source_count and canceled_source_count == len(entries))
+
     if not should_reduce:
         status = EVIDENCE_STATUS_FAILED
-        reason = reason or "no_successful_source"
+        reason = reason or (
+            "required_evidence_canceled"
+            if all_sources_canceled
+            else "no_successful_source"
+        )
         if pending_source_count:
             status = EVIDENCE_STATUS_PENDING
+        elif all_sources_canceled:
+            status = EVIDENCE_STATUS_CANCELED
     elif partial_coverage:
         status = EVIDENCE_STATUS_PARTIAL
     else:
@@ -1691,6 +1750,7 @@ def evaluate_mixed_source_mode_outcome(mode, coverage_ledger):
         "should_reduce": should_reduce,
         "successful_source_count": successful_source_count,
         "pending_source_count": pending_source_count,
+        "canceled_source_count": canceled_source_count,
         "partial_coverage": partial_coverage,
         "reason": reason,
     }

--- a/application/single_app/functions_tabular_generated_exports.py
+++ b/application/single_app/functions_tabular_generated_exports.py
@@ -5501,6 +5501,50 @@ def _build_checkpoint_summary(completed_batches, batch_count, processed_rows, ro
     return '; '.join(checkpoint_parts)
 
 
+def _build_tabular_run_lifecycle_public_fields(run, status_detail=None, can_resume=False):
+    """Return normalized lifecycle fields for generated-output status metadata."""
+    run = run if isinstance(run, dict) else {}
+    status_detail = status_detail if isinstance(status_detail, dict) else {}
+    status = str(run.get('status') or TABULAR_EXPORT_STATUS_QUEUED).strip().lower()
+    lifecycle_state = status or TABULAR_EXPORT_STATUS_QUEUED
+    safe_reason_code = lifecycle_state
+
+    if status == TABULAR_EXPORT_STATUS_RUNNING and run.get('publishing_started_at'):
+        lifecycle_state = 'finalizing'
+        safe_reason_code = 'finalizing_publication'
+    elif status == TABULAR_EXPORT_STATUS_QUEUED and status_detail.get('waiting_for_retry'):
+        lifecycle_state = 'retrying'
+        safe_reason_code = 'retry_scheduled'
+    elif status == TABULAR_EXPORT_STATUS_FAILED and can_resume:
+        lifecycle_state = 'intervention_required'
+        safe_reason_code = 'continue_required'
+    elif status == TABULAR_EXPORT_STATUS_COMPLETED:
+        safe_reason_code = 'completed'
+    elif status == TABULAR_EXPORT_STATUS_CANCELED:
+        safe_reason_code = 'durable_work_canceled'
+    elif status == TABULAR_EXPORT_STATUS_FAILED:
+        safe_reason_code = 'failed'
+
+    terminal = status in TABULAR_EXPORT_TERMINAL_STATUSES
+    if status == TABULAR_EXPORT_STATUS_COMPLETED:
+        evidence_status = 'completed'
+    elif status == TABULAR_EXPORT_STATUS_CANCELED:
+        evidence_status = 'canceled'
+    elif status == TABULAR_EXPORT_STATUS_FAILED:
+        evidence_status = 'failed'
+    else:
+        evidence_status = 'pending'
+
+    return {
+        'lifecycle_state': lifecycle_state,
+        'execution_state': lifecycle_state,
+        'evidence_status': evidence_status,
+        'terminal': terminal,
+        'required_for_composition': True,
+        'safe_reason_code': safe_reason_code,
+    }
+
+
 def _build_run_status_detail(run, settings, retryable_failure, can_resume):
     status = str((run or {}).get('status') or '').strip().lower()
     task_type = _normalize_tabular_run_task_type((run or {}).get('task_type'))
@@ -5762,6 +5806,11 @@ def _build_run_public_status(run, settings=None):
     retryable_failure = _is_retryable_failed_run(run)
     can_resume = _can_resume_run(run, settings)
     status_detail = _build_run_status_detail(run, settings, retryable_failure, can_resume)
+    lifecycle_fields = _build_tabular_run_lifecycle_public_fields(
+        run,
+        status_detail=status_detail,
+        can_resume=can_resume,
+    )
     checkpoint_summary = _build_checkpoint_summary(completed_batches, batch_count, processed_rows, row_count)
     generated_artifacts = []
 
@@ -5820,6 +5869,7 @@ def _build_run_public_status(run, settings=None):
         'conversation_id': run.get('conversation_id'),
         'task_type': task_type,
         'status': run.get('status'),
+        **lifecycle_fields,
         'source_file_name': run.get('source_file_name'),
         'selected_sheet': run.get('selected_sheet'),
         'output_format': run.get('output_format'),

--- a/application/single_app/functions_tabular_orchestration.py
+++ b/application/single_app/functions_tabular_orchestration.py
@@ -23,6 +23,8 @@ TABULAR_EXECUTION_STATE_FOREGROUND = "foreground"
 TABULAR_EXECUTION_STATE_DECLINED = "declined"
 TABULAR_EXECUTION_STATE_QUEUED = "queued"
 TABULAR_EXECUTION_STATE_CANCELED = "canceled"
+TABULAR_LIFECYCLE_STATE_PLANNED = "planned"
+TABULAR_LIFECYCLE_EVIDENCE_PENDING = "pending"
 TABULAR_PLANNER_MODE_OFF = "off"
 TABULAR_PLANNER_MODE_SHADOW = "shadow"
 TABULAR_PLANNER_MODE_ACTIVE = "active"
@@ -201,7 +203,13 @@ def _build_source_coverage(file_contexts):
             "source_format": source_format,
             "source_hint": str(file_context.get("source_hint") or "workspace").strip().lower(),
             "document_id": str(file_context.get("document_id") or "").strip(),
-            "coverage_state": "planned",
+            "coverage_state": TABULAR_LIFECYCLE_STATE_PLANNED,
+            "execution_state": TABULAR_LIFECYCLE_STATE_PLANNED,
+            "evidence_status": TABULAR_LIFECYCLE_EVIDENCE_PENDING,
+            "terminal": False,
+            "required_for_composition": True,
+            "safe_reason_code": "planned",
+            "generated_reference_present": False,
         })
     return coverage_entries
 

--- a/docs/explanation/features/TABULAR_ANALYZE_SEARCH_PARITY_PHASE_7_LIFECYCLE.md
+++ b/docs/explanation/features/TABULAR_ANALYZE_SEARCH_PARITY_PHASE_7_LIFECYCLE.md
@@ -1,0 +1,78 @@
+# Tabular Analyze/Search Parity Phase 7 Lifecycle Coverage
+
+Implemented in version: **0.250.163**
+
+## Overview
+
+Phase 7 starts lifecycle hardening for the shared tabular Analyze/Search parity path. It makes durable generated-output lifecycle state explicit in planner coverage, mixed-source evidence ledgers, and generated-output public metadata so pending, canceled, completed, failed, and partial evidence cannot be confused during deferred composition.
+
+This phase reuses the existing durable tabular generated-output runner, source authorization checks, cancellation API, rollback helper, and artifact UI. It does not introduce a second runner, source resolver, or card renderer.
+
+## Dependencies
+
+- Shared tabular planner in `application/single_app/functions_tabular_orchestration.py`
+- Mixed-source evidence ledger in `application/single_app/functions_mixed_source_orchestration.py`
+- Durable tabular generated-output runner in `application/single_app/functions_tabular_generated_exports.py`
+- Deferred mixed-source workflow coordination in `application/single_app/functions_workflow_runner.py`
+- Current application version from `application/single_app/config.py`: **0.250.163**
+
+## Technical Specifications
+
+Planner source coverage now starts each replayable tabular source as planned, pending, nonterminal evidence. The coverage entry includes:
+
+- `coverage_state`
+- `execution_state`
+- `evidence_status`
+- `terminal`
+- `required_for_composition`
+- `safe_reason_code`
+- `generated_reference_present`
+
+The mixed-source coverage ledger now treats `canceled` as a first-class terminal evidence status. Canceled evidence:
+
+- increments `canceled_source_count`
+- marks aggregate coverage as partial/incomplete
+- receives the safe reason `durable_work_canceled`
+- remains terminal, unlike pending generated-output work
+- does not count as completed or successful factual evidence
+
+Generated-output public status metadata now includes normalized lifecycle fields for queued, retrying, running, finalizing, completed, failed, and canceled states. These fields let downstream coverage and deferred-composition code inspect `lifecycle_state`, `execution_state`, `evidence_status`, `terminal`, `required_for_composition`, and `safe_reason_code` without inferring lifecycle behavior from presentation labels.
+
+## Rollout Controls
+
+The lifecycle fields are additive and safe for existing generated-output records. Existing runs without newer planner or composition fields still load through the same public status builder and retain their recorded durable runner behavior.
+
+Rollback for new parity assignment remains controlled by the existing backend gates, including:
+
+- `tabular_request_planner_mode`
+- `enable_tabular_search_shared_preflight`
+- `enable_tabular_analyze_durable_preflight`
+- `enable_tabular_mixed_deferred_composition`
+- `enable_tabular_multifile_durable_preflight`
+
+The lifecycle readers must remain in place while any accepted generated-output run or deferred composition descriptor can still reference them.
+
+## Usage Instructions
+
+Operators can use the existing generated-output status API and artifact card metadata to distinguish pending work from canceled or completed work. Canceled durable tabular work should be treated as terminal but incomplete evidence. Pending durable tabular work should continue to block collective mixed-source conclusions that require it.
+
+## Testing and Validation
+
+Functional coverage is in `functional_tests/test_tabular_phase7_lifecycle_coverage.py`.
+
+The test validates:
+
+- planner source coverage begins as planned pending nonterminal evidence
+- canceled durable tabular evidence is terminal but incomplete
+- canceled sources are counted separately from pending and completed sources
+- all-canceled required evidence produces a canceled mode outcome instead of a generic failed outcome
+- generated-output public status exposes queued, retrying, finalizing, and canceled lifecycle metadata
+
+Adjacent regression coverage includes:
+
+- `functional_tests/test_mixed_source_deferred_composition_phase5.py`
+- `functional_tests/test_tabular_shared_request_planner.py`
+
+## Known Limitations
+
+This phase establishes explicit lifecycle status and coverage semantics. Broader restart recovery, terminal notification replay, and full deferred-composition continuation execution still rely on subsequent lifecycle work and existing durable worker recovery paths.

--- a/functional_tests/test_tabular_phase7_lifecycle_coverage.py
+++ b/functional_tests/test_tabular_phase7_lifecycle_coverage.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+# test_tabular_phase7_lifecycle_coverage.py
+"""
+Functional test for Phase 7 tabular lifecycle coverage hardening.
+Version: 0.250.163
+Implemented in: 0.250.163
+
+This test ensures shared tabular planner coverage starts as planned pending
+evidence, canceled durable tabular evidence remains terminal but incomplete,
+and pending or canceled required sources cannot be represented as full coverage.
+"""
+
+import sys
+import ast
+import types
+from pathlib import Path
+
+from test_support.versioning import assert_app_version_at_least
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+APP_ROOT = REPO_ROOT / "application" / "single_app"
+EXPORT_MODULE = APP_ROOT / "functions_tabular_generated_exports.py"
+sys.path.insert(0, str(APP_ROOT))
+
+
+def install_lightweight_planner_dependency_stubs():
+    assistant_exports_module = types.ModuleType("functions_assistant_table_exports")
+    assistant_exports_module.assistant_table_export_requested = (
+        lambda prompt: "csv" in str(prompt or "").lower()
+    )
+    generated_exports_module = types.ModuleType("functions_generated_file_exports")
+
+    def get_requested_structured_artifact_format(prompt):
+        normalized_prompt = str(prompt or "").lower()
+        for output_format in ("json", "xml", "csv"):
+            if output_format in normalized_prompt:
+                return output_format
+        return None
+
+    generated_exports_module.get_requested_structured_artifact_format = (
+        get_requested_structured_artifact_format
+    )
+    sys.modules.setdefault("functions_assistant_table_exports", assistant_exports_module)
+    sys.modules.setdefault("functions_generated_file_exports", generated_exports_module)
+
+
+install_lightweight_planner_dependency_stubs()
+
+from functions_mixed_source_orchestration import (  # noqa: E402
+    AUTHORIZATION_STATUS_AUTHORIZED,
+    EVIDENCE_ENGINE_TABULAR_TOOLS,
+    EVIDENCE_STATUS_CANCELED,
+    EVIDENCE_STATUS_PENDING,
+    SOURCE_KIND_TABULAR,
+    build_evidence_envelope,
+    build_mixed_source_evidence_handoff,
+    evaluate_mixed_source_mode_outcome,
+)
+from functions_tabular_orchestration import plan_tabular_request  # noqa: E402
+
+
+def load_lifecycle_public_fields_helper():
+    source = EXPORT_MODULE.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(EXPORT_MODULE))
+    helper = next(
+        node for node in tree.body
+        if isinstance(node, ast.FunctionDef)
+        and node.name == "_build_tabular_run_lifecycle_public_fields"
+    )
+    namespace = {
+        "TABULAR_EXPORT_STATUS_QUEUED": "queued",
+        "TABULAR_EXPORT_STATUS_RUNNING": "running",
+        "TABULAR_EXPORT_STATUS_COMPLETED": "completed",
+        "TABULAR_EXPORT_STATUS_FAILED": "failed",
+        "TABULAR_EXPORT_STATUS_CANCELED": "canceled",
+        "TABULAR_EXPORT_TERMINAL_STATUSES": {"completed", "failed", "canceled"},
+    }
+    module = ast.Module(body=[helper], type_ignores=[])
+    ast.fix_missing_locations(module)
+    exec(compile(module, str(EXPORT_MODULE), "exec"), namespace)
+    return namespace["_build_tabular_run_lifecycle_public_fields"]
+
+
+def build_context(document_id="table-1", file_name="rows.csv"):
+    return {
+        "document_id": document_id,
+        "file_name": file_name,
+        "source_hint": "workspace",
+        "source_version": f"etag-{document_id}",
+        "storage_locator": {
+            "container": "documents",
+            "blob_path": f"user/{file_name}",
+        },
+    }
+
+
+def test_planner_source_coverage_starts_as_nonterminal_pending_lifecycle():
+    """Preflight source coverage must be planned pending evidence, not complete."""
+    assert_app_version_at_least("0.250.163")
+    plan = plan_tabular_request(
+        "Analyze every row for risk patterns.",
+        [build_context()],
+        action_mode="analyze",
+        settings={"enable_tabular_hierarchical_analysis": True},
+        caller="analyze",
+    )
+
+    source_coverage = plan["source_coverage"]
+    assert len(source_coverage) == 1
+    assert source_coverage[0]["coverage_state"] == "planned"
+    assert source_coverage[0]["execution_state"] == "planned"
+    assert source_coverage[0]["evidence_status"] == EVIDENCE_STATUS_PENDING
+    assert source_coverage[0]["terminal"] is False
+    assert source_coverage[0]["required_for_composition"] is True
+    assert source_coverage[0]["generated_reference_present"] is False
+
+
+def test_canceled_durable_evidence_is_terminal_but_incomplete():
+    """Canceled durable work must not be pending or complete coverage."""
+    manifest = [{
+        "document_id": "table-1",
+        "display_name": "Rows.csv",
+        "source_kind": SOURCE_KIND_TABULAR,
+        "scope": "personal",
+        "scope_id": "user-1",
+        "source_version": "etag-table-1",
+        "authorization_status": AUTHORIZATION_STATUS_AUTHORIZED,
+    }]
+    canceled_envelope = build_evidence_envelope(
+        document_id="table-1",
+        source_kind=SOURCE_KIND_TABULAR,
+        engine=EVIDENCE_ENGINE_TABULAR_TOOLS,
+        status=EVIDENCE_STATUS_CANCELED,
+        summary="Full-source tabular analysis was canceled before completion.",
+        generated_artifacts=[{
+            "run_id": "run-1",
+            "status": "canceled",
+            "task_type": "hierarchical_analysis",
+        }],
+        coverage={
+            "terminal": True,
+            "execution_contract": "hierarchical_analysis",
+            "required_for_composition": True,
+        },
+    )
+
+    handoff = build_mixed_source_evidence_handoff(
+        manifest,
+        [canceled_envelope],
+        "selected",
+        mode="analyze",
+        telemetry_settings={},
+    )
+    coverage = handoff["mixed_source_coverage"]
+    assert coverage["completed_source_count"] == 0
+    assert coverage["pending_source_count"] == 0
+    assert coverage["canceled_source_count"] == 1
+    assert coverage["partial_coverage"] is True
+
+    ledger_entry = coverage["terminal_ledger"][0]
+    assert ledger_entry["status"] == EVIDENCE_STATUS_CANCELED
+    assert ledger_entry["reason"] == "durable_work_canceled"
+    assert ledger_entry["terminal"] is True
+    assert ledger_entry["required_for_composition"] is True
+    assert ledger_entry["execution_contract"] == "hierarchical_analysis"
+    assert ledger_entry["generated_reference_present"] is True
+
+    outcome = evaluate_mixed_source_mode_outcome(
+        "analyze",
+        {
+            "entries": coverage["terminal_ledger"],
+            "partial_coverage": coverage["partial_coverage"],
+        },
+    )
+    assert outcome["status"] == EVIDENCE_STATUS_CANCELED
+    assert outcome["should_reduce"] is False
+    assert outcome["canceled_source_count"] == 1
+    assert outcome["reason"] == "required_evidence_canceled"
+
+    mixed_terminal_outcome = evaluate_mixed_source_mode_outcome(
+        "analyze",
+        {
+            "entries": [
+                {"status": EVIDENCE_STATUS_CANCELED},
+                {"status": "failed"},
+            ],
+            "partial_coverage": True,
+        },
+    )
+    assert mixed_terminal_outcome["status"] == "failed"
+    assert mixed_terminal_outcome["reason"] == "no_successful_source"
+
+
+def test_generated_output_public_status_exposes_lifecycle_contract():
+    """Run metadata must expose lifecycle state without leaking internals."""
+    build_fields = load_lifecycle_public_fields_helper()
+
+    queued_fields = build_fields({"status": "queued"}, status_detail={}, can_resume=False)
+    assert queued_fields["lifecycle_state"] == "queued"
+    assert queued_fields["evidence_status"] == EVIDENCE_STATUS_PENDING
+    assert queued_fields["terminal"] is False
+    assert queued_fields["safe_reason_code"] == "queued"
+
+    retry_fields = build_fields(
+        {"status": "queued"},
+        status_detail={"waiting_for_retry": True},
+        can_resume=True,
+    )
+    assert retry_fields["lifecycle_state"] == "retrying"
+    assert retry_fields["evidence_status"] == EVIDENCE_STATUS_PENDING
+    assert retry_fields["terminal"] is False
+    assert retry_fields["safe_reason_code"] == "retry_scheduled"
+
+    finalizing_fields = build_fields(
+        {"status": "running", "publishing_started_at": "2026-08-11T00:00:00Z"},
+        status_detail={},
+        can_resume=False,
+    )
+    assert finalizing_fields["lifecycle_state"] == "finalizing"
+    assert finalizing_fields["evidence_status"] == EVIDENCE_STATUS_PENDING
+    assert finalizing_fields["terminal"] is False
+    assert finalizing_fields["safe_reason_code"] == "finalizing_publication"
+
+    canceled_fields = build_fields({"status": "canceled"}, status_detail={}, can_resume=False)
+    assert canceled_fields["lifecycle_state"] == "canceled"
+    assert canceled_fields["evidence_status"] == EVIDENCE_STATUS_CANCELED
+    assert canceled_fields["terminal"] is True
+    assert canceled_fields["required_for_composition"] is True
+    assert canceled_fields["safe_reason_code"] == "durable_work_canceled"
+
+
+if __name__ == "__main__":
+    tests = [
+        test_planner_source_coverage_starts_as_nonterminal_pending_lifecycle,
+        test_canceled_durable_evidence_is_terminal_but_incomplete,
+        test_generated_output_public_status_exposes_lifecycle_contract,
+    ]
+    failures = []
+    for test in tests:
+        try:
+            test()
+            print(f"PASS {test.__name__}")
+        except Exception as exc:
+            failures.append((test.__name__, exc))
+            print(f"FAIL {test.__name__}: {exc}")
+
+    if failures:
+        sys.exit(1)
+    sys.exit(0)


### PR DESCRIPTION
## Summary

Phase 7 starts lifecycle hardening for the tabular Analyze/Search parity roadmap.

- Add explicit planner source lifecycle coverage fields so replayable tabular sources begin as planned, pending, nonterminal evidence.
- Add `canceled` as a first-class mixed-source terminal evidence status with separate counts, safe reason codes, and aggregate reducer handling.
- Add normalized generated-output public lifecycle metadata (`lifecycle_state`, `execution_state`, `evidence_status`, `terminal`, `required_for_composition`, `safe_reason_code`) for queued, retrying, finalizing, completed, failed, and canceled states.
- Document the Phase 7 lifecycle coverage contract and bump the app version to `0.250.163`.

Refs #1031
Refs #1055
Refs #1058

## Explicit Non-Goals

- No new durable runner, source resolver, authorization model, or artifact UI.
- No Phase 8 UI rollout changes.
- No restart recovery or terminal notification replay implementation beyond the additive lifecycle status contract.

## Behavior Gates And Defaults

This change is additive to existing Phase 2-6 gates. New parity assignment remains controlled by the existing backend settings, including:

- `tabular_request_planner_mode`
- `enable_tabular_search_shared_preflight`
- `enable_tabular_analyze_durable_preflight`
- `enable_tabular_mixed_deferred_composition`
- `enable_tabular_multifile_durable_preflight`

Existing generated-output runs still load through the existing public status builder.

## Validation

Passed:

- `python -m py_compile application/single_app/functions_mixed_source_orchestration.py application/single_app/functions_tabular_orchestration.py application/single_app/functions_tabular_generated_exports.py application/single_app/config.py functional_tests/test_tabular_phase7_lifecycle_coverage.py`
- `python functional_tests/test_tabular_phase7_lifecycle_coverage.py`
- `python functional_tests/test_mixed_source_deferred_composition_phase5.py`
- `python functional_tests/test_tabular_shared_request_planner.py`
- `python functional_tests/test_tabular_background_generated_exports.py`
- VS Code diagnostics on changed Python files
- New-file hygiene check for final newline/trailing whitespace
- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check`

Attempted but not green in this workspace:

- `functional_tests/test_mixed_source_hardening.py` ran past dependency import after using the configured `.venv`, then failed an existing Foundry context opt-out assertion around preserving `Safe task.`. That path is outside the Phase 7 changed files.

## Security And Source Scope

- Canceled durable tabular evidence is terminal but incomplete and cannot count as completed factual coverage.
- Pending durable tabular work remains nonterminal and continues to block required mixed-source reduction.
- Generated-output public metadata exposes only normalized safe lifecycle/status reason codes.
- Existing user-scoped generated-output status, resume, cancel, rollback, and artifact deletion helpers are reused.

## Rollback

Disable new parity assignment with the existing backend gates. Keep the additive lifecycle readers in place while any accepted generated-output run or deferred composition descriptor can still reference them.

## Version

- `application/single_app/config.py`: `0.250.162` -> `0.250.163`

## Release Notes

Not updated in this commit.