### PR TITLE
Phase 9: Add tabular legacy fallback retirement controls

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -96,7 +96,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.250.164"
+VERSION = "0.250.165"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/functions_tabular_orchestration.py
+++ b/application/single_app/functions_tabular_orchestration.py
@@ -35,6 +35,7 @@ TABULAR_PLANNER_MODES = {
 }
 TABULAR_PARITY_ROLLOUT_CONTRACT_VERSION = "tabular-parity-rollout-v1"
 TABULAR_LEGACY_POST_TOOL_FALLBACK_MODES = {"enabled", "observe", "disabled"}
+TABULAR_LEGACY_POST_TOOL_FALLBACK_DECISION_VERSION = "tabular-legacy-fallback-retirement-v1"
 
 
 def settings_flag_enabled(settings, key, default=False):
@@ -73,6 +74,55 @@ def normalize_tabular_legacy_post_tool_fallback_mode(settings=None, mode=None):
     if normalized_mode in TABULAR_LEGACY_POST_TOOL_FALLBACK_MODES:
         return normalized_mode
     return "enabled"
+
+
+def build_tabular_legacy_post_tool_fallback_decision(
+    settings=None,
+    mode=None,
+    planner_result=None,
+    generated_output=None,
+    fallback_source="post_tool_generated_output",
+):
+    """Return the Phase 9 decision for the legacy post-tool fallback path."""
+    normalized_mode = normalize_tabular_legacy_post_tool_fallback_mode(settings, mode=mode)
+    normalized_source = str(fallback_source or "post_tool_generated_output").strip().lower()
+    if normalized_source not in {"post_tool_generated_output", "shared_preflight", "planner"}:
+        normalized_source = "post_tool_generated_output"
+
+    result = planner_result if isinstance(planner_result, Mapping) else {}
+    generated_metadata = generated_output if isinstance(generated_output, Mapping) else None
+    if generated_metadata is None and isinstance(result.get("generated_output_metadata"), Mapping):
+        generated_metadata = result.get("generated_output_metadata")
+
+    if generated_metadata:
+        action = "suppress"
+        should_invoke = False
+        reason_code = "shared_durable_metadata_present"
+    elif normalized_mode == "observe":
+        action = "observe"
+        should_invoke = False
+        reason_code = "observe_only"
+    elif normalized_mode == "disabled":
+        action = "suppress"
+        should_invoke = False
+        reason_code = "mode_disabled"
+    else:
+        action = "invoke"
+        should_invoke = True
+        reason_code = "mode_enabled"
+
+    return {
+        "contract_version": TABULAR_LEGACY_POST_TOOL_FALLBACK_DECISION_VERSION,
+        "fallback_source": normalized_source,
+        "mode": normalized_mode,
+        "action": action,
+        "should_invoke": should_invoke,
+        "reason_code": reason_code,
+        "planner_contract_version": str(result.get("planner_contract_version") or "").strip(),
+        "execution_contract": str(result.get("execution_contract") or "").strip().lower(),
+        "execution_state": str(result.get("execution_state") or "").strip().lower(),
+        "generated_metadata_present": bool(generated_metadata),
+    }
 
 
 def build_tabular_parity_rollout_assignment(settings=None, request_key=None, mode=None):
@@ -496,6 +546,12 @@ def plan_tabular_request(
         else:
             reason_code = "multi_context_durable_not_enabled"
 
+    rollout_assignment = build_tabular_parity_rollout_assignment(
+        settings,
+        request_key=request_fingerprint,
+        mode=action_mode,
+    )
+
     return {
         "planner_contract_version": TABULAR_ORCHESTRATION_PLANNER_CONTRACT_VERSION,
         "execution_contract": execution_contract,
@@ -511,10 +567,10 @@ def plan_tabular_request(
         "execution_group_id": execution_group_id,
         "execution_units": execution_units,
         "request_fingerprint": request_fingerprint,
-        "rollout_assignment": build_tabular_parity_rollout_assignment(
-            settings,
-            request_key=request_fingerprint,
-            mode=action_mode,
+        "rollout_assignment": rollout_assignment,
+        "legacy_post_tool_fallback_decision": build_tabular_legacy_post_tool_fallback_decision(
+            mode=rollout_assignment.get("legacy_post_tool_fallback_mode"),
+            fallback_source="planner",
         ),
         "reason_code": reason_code,
         "requested_output_hints": dict(requested_output_hints or {})
@@ -648,6 +704,10 @@ def orchestrate_tabular_request(
             "generated_output_metadata": None,
             "reason_code": "planner_off",
             "shadow_side_effects": False,
+            "legacy_post_tool_fallback_decision": build_tabular_legacy_post_tool_fallback_decision(
+                settings=settings,
+                fallback_source="planner",
+            ),
             "safe_failure_details": None,
         }
 
@@ -661,6 +721,11 @@ def orchestrate_tabular_request(
     )
     plan["planner_mode"] = normalized_mode
     plan["shadow_side_effects"] = False
+    plan["legacy_post_tool_fallback_decision"] = build_tabular_legacy_post_tool_fallback_decision(
+        settings=settings,
+        planner_result=plan,
+        fallback_source="planner",
+    )
     if normalized_mode == TABULAR_PLANNER_MODE_SHADOW:
         return plan
 
@@ -668,14 +733,20 @@ def orchestrate_tabular_request(
     active_execution_context.setdefault("user_question", user_question)
     active_execution_context.setdefault("file_contexts", file_contexts)
     active_execution_context.setdefault("settings", settings)
-    return {
-        **execute_tabular_plan(
-            plan,
-            durable_execution_callback=durable_execution_callback,
-            cancel_requested=cancel_requested,
-            idempotency_cache=idempotency_cache,
-            **active_execution_context,
-        ),
+    result = execute_tabular_plan(
+        plan,
+        durable_execution_callback=durable_execution_callback,
+        cancel_requested=cancel_requested,
+        idempotency_cache=idempotency_cache,
+        **active_execution_context,
+    )
+    result.update({
         "planner_mode": normalized_mode,
         "shadow_side_effects": False,
-    }
+    })
+    result["legacy_post_tool_fallback_decision"] = build_tabular_legacy_post_tool_fallback_decision(
+        settings=settings,
+        planner_result=result,
+        fallback_source="shared_preflight",
+    )
+    return result

--- a/application/single_app/functions_workflow_runner.py
+++ b/application/single_app/functions_workflow_runner.py
@@ -2551,6 +2551,26 @@ def _emit_analyze_shared_preflight_event(
                     rollout_assignment.get('legacy_post_tool_fallback_mode') or 'enabled'
                 ).strip().lower()[:40],
             })
+        fallback_decision = (
+            result.get('legacy_post_tool_fallback_decision')
+            if isinstance(result.get('legacy_post_tool_fallback_decision'), dict)
+            else {}
+        )
+        if fallback_decision:
+            safe_dimensions.update({
+                'legacy_post_tool_fallback_contract_version': str(
+                    fallback_decision.get('contract_version') or ''
+                ).strip()[:80],
+                'legacy_post_tool_fallback_action': str(
+                    fallback_decision.get('action') or ''
+                ).strip().lower()[:40],
+                'legacy_post_tool_fallback_reason': str(
+                    fallback_decision.get('reason_code') or ''
+                ).strip().lower()[:80],
+                'legacy_post_tool_fallback_should_invoke': str(
+                    bool(fallback_decision.get('should_invoke'))
+                ).lower(),
+            })
     if isinstance(generated_output, dict):
         safe_dimensions.update({
             'output_status': str(generated_output.get('status') or '').strip().lower()[:40],

--- a/application/single_app/route_backend_chats.py
+++ b/application/single_app/route_backend_chats.py
@@ -60,6 +60,7 @@ from functions_tabular_analysis import (
     queue_direct_tabular_generated_output_from_plan as _shared_queue_direct_tabular_generated_output_from_plan,
 )
 from functions_tabular_orchestration import (
+    build_tabular_legacy_post_tool_fallback_decision as _shared_build_tabular_legacy_post_tool_fallback_decision,
     get_tabular_generated_output_format as _shared_get_tabular_generated_output_format,
     get_tabular_generated_output_task_type as _shared_get_tabular_generated_output_task_type,
     question_requests_tabular_generated_output as _shared_question_requests_tabular_generated_output,
@@ -6169,6 +6170,26 @@ def _emit_search_shared_preflight_event(
                     rollout_assignment.get('legacy_post_tool_fallback_mode') or 'enabled'
                 ).strip().lower()[:40],
             })
+        fallback_decision = (
+            result.get('legacy_post_tool_fallback_decision')
+            if isinstance(result.get('legacy_post_tool_fallback_decision'), dict)
+            else {}
+        )
+        if fallback_decision:
+            safe_dimensions.update({
+                'legacy_post_tool_fallback_contract_version': str(
+                    fallback_decision.get('contract_version') or ''
+                ).strip()[:80],
+                'legacy_post_tool_fallback_action': str(
+                    fallback_decision.get('action') or ''
+                ).strip().lower()[:40],
+                'legacy_post_tool_fallback_reason': str(
+                    fallback_decision.get('reason_code') or ''
+                ).strip().lower()[:80],
+                'legacy_post_tool_fallback_should_invoke': str(
+                    bool(fallback_decision.get('should_invoke'))
+                ).lower(),
+            })
     if isinstance(generated_output, dict):
         safe_dimensions.update({
             'output_status': str(generated_output.get('status') or '').strip().lower()[:40],
@@ -6853,6 +6874,17 @@ async def maybe_create_tabular_generated_output(
     parity_emitter = globals().get('emit_tabular_parity_event')
     parity_result_builder = globals().get('build_tabular_parity_planner_result')
     parity_result = parity_classifier(user_question) if callable(parity_classifier) else None
+    fallback_decision = _shared_build_tabular_legacy_post_tool_fallback_decision(
+        settings=settings,
+        fallback_source='post_tool_generated_output',
+    )
+    fallback_dimensions = {
+        'legacy_post_tool_fallback_contract_version': fallback_decision.get('contract_version'),
+        'legacy_post_tool_fallback_mode': fallback_decision.get('mode'),
+        'legacy_post_tool_fallback_action': fallback_decision.get('action'),
+        'legacy_post_tool_fallback_reason': fallback_decision.get('reason_code'),
+        'legacy_post_tool_fallback_should_invoke': str(bool(fallback_decision.get('should_invoke'))).lower(),
+    }
 
     def emit_fallback_parity_event(event_name, planner_result=None, metrics=None, dimensions=None, level=None):
         if not callable(parity_emitter):
@@ -6874,9 +6906,28 @@ async def maybe_create_tabular_generated_output(
         'classification_completed',
         metrics={'invocation_count': len(invocations or [])},
     )
+    if not fallback_decision.get('should_invoke'):
+        emit_fallback_parity_event(
+            'post_tool_generated_output_fallback_suppressed',
+            metrics={'invocation_count': len(invocations or [])},
+            dimensions=fallback_dimensions,
+        )
+        log_event(
+            '[TABULAR_GENERATED_OUTPUT] Legacy post-tool generated output fallback suppressed',
+            {
+                'conversation_id': conversation_id,
+                'mode': mode,
+                'invocation_count': len(invocations or []),
+                **fallback_dimensions,
+            },
+            debug_only=True,
+        )
+        return None
+
     emit_fallback_parity_event(
         'post_tool_generated_output_fallback_attempted',
         metrics={'invocation_count': len(invocations or [])},
+        dimensions=fallback_dimensions,
     )
 
     output_format = get_tabular_generated_output_format(user_question) or 'md'

--- a/docs/explanation/features/TABULAR_ANALYZE_SEARCH_PARITY_PHASE_9_LEGACY_RETIREMENT.md
+++ b/docs/explanation/features/TABULAR_ANALYZE_SEARCH_PARITY_PHASE_9_LEGACY_RETIREMENT.md
@@ -1,0 +1,65 @@
+# Tabular Analyze Search Parity Phase 9 Legacy Retirement
+
+Implemented in version: **0.250.165**
+
+Related version update:
+- `application/single_app/config.py` reports version `0.250.165`.
+
+## Overview
+
+Phase 9 adds evidence-backed retirement controls for the legacy post-tool generated-output fallback used by tabular Search and Analyze. The default remains compatible: `tabular_legacy_post_tool_fallback_mode='enabled'` keeps the existing fallback available for genuinely tool-derived outputs that are not covered by direct source preflight.
+
+Dependencies:
+- `application/single_app/functions_tabular_orchestration.py`
+- `application/single_app/route_backend_chats.py`
+- `application/single_app/functions_workflow_runner.py`
+- `application/single_app/config.py`
+- `functional_tests/test_tabular_phase9_legacy_retirement.py`
+
+## Technical Specifications
+
+Architecture overview:
+- The shared tabular planner now records `legacy_post_tool_fallback_decision` using contract `tabular-legacy-fallback-retirement-v1`.
+- Shared durable acceptance records `action='suppress'` and `reason_code='shared_durable_metadata_present'`, proving the legacy fallback must not create a duplicate run after generated-output metadata already exists.
+- `observe` mode suppresses post-tool fallback side effects while emitting safe telemetry that the fallback would have been considered.
+- `disabled` mode suppresses the same legacy post-tool fallback path without changing direct shared-preflight execution, old-run readers, status routes, cancel/resume behavior, or artifact rendering.
+
+Telemetry fields:
+- `legacy_post_tool_fallback_contract_version`
+- `legacy_post_tool_fallback_mode`
+- `legacy_post_tool_fallback_action`
+- `legacy_post_tool_fallback_reason`
+- `legacy_post_tool_fallback_should_invoke`
+
+The decision intentionally excludes prompts, filenames, blob paths, raw source locators, row content, credentials, and raw provider errors.
+
+Configuration options:
+- `tabular_legacy_post_tool_fallback_mode='enabled'`: invoke the legacy post-tool fallback when no shared durable metadata already exists.
+- `tabular_legacy_post_tool_fallback_mode='observe'`: suppress post-tool fallback side effects and emit observation telemetry.
+- `tabular_legacy_post_tool_fallback_mode='disabled'`: suppress post-tool fallback side effects for eligible new requests.
+
+## Usage Instructions
+
+Operator workflow:
+1. Keep `tabular_legacy_post_tool_fallback_mode='enabled'` until shared Search and Analyze preflight traffic has no planner mismatches or duplicate run incidents.
+2. Switch to `observe` for a canary cohort after direct-source shared preflight has proven coverage for eligible generated-output requests.
+3. Query `[TABULAR_SHARED_PREFLIGHT]`, `[TABULAR_PARITY_CONTRACT]`, and `[TABULAR_GENERATED_OUTPUT]` events for fallback action, reason, and invocation counts.
+4. Move to `disabled` only when observe-mode telemetry shows no required tool-derived fallback cases for the supported classification matrix.
+5. Return to `enabled` if canary telemetry shows a required replayable tool-derived output is not covered by shared direct-source preflight.
+
+Rollback behavior:
+- Changing the setting affects new post-tool fallback decisions only.
+- Existing generated-output runs keep their persisted executor and planner metadata.
+- Direct shared-preflight runs, run status, cancel, resume, and artifact publication remain available while the compatibility reader stays present.
+
+## Testing And Validation
+
+Functional coverage:
+- `functional_tests/test_tabular_phase9_legacy_retirement.py` verifies decision modes, duplicate fallback suppression after shared durable acceptance, and observe-mode post-tool side-effect suppression.
+- `functional_tests/test_tabular_shared_request_planner.py` verifies the shared planner and facade remain compatible.
+- `functional_tests/test_tabular_search_shared_preflight_adapter.py` and `functional_tests/test_tabular_analyze_shared_preflight_adapter.py` verify Search and Analyze shared-preflight behavior still avoids duplicate legacy work after active acceptance.
+
+Performance and limitations:
+- Phase 9 does not delete compatibility wrappers or old-run readers.
+- Phase 9 does not remove post-tool recovery while the mode remains `enabled`.
+- Full scale, chaos, and final parent integration validation still require the broader Phase 9 matrix before the feature branch can merge to `Development`.

--- a/functional_tests/test_tabular_phase9_legacy_retirement.py
+++ b/functional_tests/test_tabular_phase9_legacy_retirement.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+# test_tabular_phase9_legacy_retirement.py
+"""
+Functional test for Phase 9 tabular legacy fallback retirement controls.
+Version: 0.250.165
+Implemented in: 0.250.165
+
+This test ensures the shared planner records safe legacy post-tool fallback
+retirement decisions, active shared durable acceptance suppresses duplicate
+legacy fallback evidence, and observe mode prevents post-tool fallback side
+effects while emitting safe telemetry.
+"""
+
+import ast
+import asyncio
+import sys
+import types
+from pathlib import Path
+
+from test_support.versioning import assert_app_version_at_least
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+APP_ROOT = REPO_ROOT / "application" / "single_app"
+CHAT_ROUTE = APP_ROOT / "route_backend_chats.py"
+IMPLEMENTED_VERSION = "0.250.165"
+sys.path.insert(0, str(APP_ROOT))
+
+
+def install_lightweight_planner_dependency_stubs():
+    assistant_exports_module = types.ModuleType("functions_assistant_table_exports")
+    assistant_exports_module.assistant_table_export_requested = (
+        lambda prompt: "csv" in str(prompt or "").lower()
+    )
+    generated_exports_module = types.ModuleType("functions_generated_file_exports")
+
+    def get_requested_structured_artifact_format(prompt):
+        normalized_prompt = str(prompt or "").lower()
+        for output_format in ("json", "xml", "csv"):
+            if output_format in normalized_prompt:
+                return output_format
+        return None
+
+    generated_exports_module.get_requested_structured_artifact_format = (
+        get_requested_structured_artifact_format
+    )
+    sys.modules.setdefault("functions_assistant_table_exports", assistant_exports_module)
+    sys.modules.setdefault("functions_generated_file_exports", generated_exports_module)
+
+
+install_lightweight_planner_dependency_stubs()
+
+from functions_tabular_orchestration import (  # noqa: E402
+    build_tabular_legacy_post_tool_fallback_decision,
+    orchestrate_tabular_request,
+)
+
+
+def assert_equal(actual, expected, label):
+    if actual != expected:
+        raise AssertionError(f"{label}: expected {expected!r}, got {actual!r}")
+
+
+def assert_true(value, label):
+    if not value:
+        raise AssertionError(f"Expected truthy value for {label}")
+
+
+def assert_false(value, label):
+    if value:
+        raise AssertionError(f"Expected falsy value for {label}")
+
+
+def build_context():
+    return {
+        "document_id": "table-1",
+        "file_name": "survey.csv",
+        "source_hint": "workspace",
+        "source_version": "etag-table-1",
+        "storage_locator": {
+            "container": "documents",
+            "blob_path": "user-1/survey.csv",
+        },
+    }
+
+
+def test_decision_modes_and_shared_acceptance_suppression():
+    """Legacy fallback decisions must be deterministic and telemetry-safe."""
+    print("Testing Phase 9 legacy fallback decision modes...")
+    assert_app_version_at_least(IMPLEMENTED_VERSION)
+
+    enabled_decision = build_tabular_legacy_post_tool_fallback_decision(
+        settings={"tabular_legacy_post_tool_fallback_mode": "enabled"},
+    )
+    observe_decision = build_tabular_legacy_post_tool_fallback_decision(
+        settings={"tabular_legacy_post_tool_fallback_mode": "observe"},
+    )
+    disabled_decision = build_tabular_legacy_post_tool_fallback_decision(
+        settings={"tabular_legacy_post_tool_fallback_mode": "disabled"},
+    )
+    accepted_decision = build_tabular_legacy_post_tool_fallback_decision(
+        settings={"tabular_legacy_post_tool_fallback_mode": "enabled"},
+        planner_result={
+            "planner_contract_version": "tabular-orchestration-v1",
+            "execution_contract": "combined",
+            "execution_state": "queued",
+            "generated_output_metadata": {"export_run_id": "run-123", "status": "queued"},
+        },
+    )
+
+    assert_true(enabled_decision["should_invoke"], "enabled fallback invocation")
+    assert_equal(enabled_decision["action"], "invoke", "enabled action")
+    assert_false(observe_decision["should_invoke"], "observe fallback invocation")
+    assert_equal(observe_decision["action"], "observe", "observe action")
+    assert_equal(observe_decision["reason_code"], "observe_only", "observe reason")
+    assert_false(disabled_decision["should_invoke"], "disabled fallback invocation")
+    assert_equal(disabled_decision["reason_code"], "mode_disabled", "disabled reason")
+    assert_false(accepted_decision["should_invoke"], "accepted durable fallback invocation")
+    assert_equal(accepted_decision["action"], "suppress", "accepted durable action")
+    assert_equal(
+        accepted_decision["reason_code"],
+        "shared_durable_metadata_present",
+        "accepted durable reason",
+    )
+
+    serialized_decision = str(accepted_decision)
+    assert_false("survey.csv" in serialized_decision, "no file names in decision")
+    assert_false("blob_path" in serialized_decision, "no blob paths in decision")
+
+
+def test_active_shared_orchestrator_records_suppressed_fallback_decision():
+    """Accepted shared durable work must record duplicate fallback suppression."""
+    print("Testing active shared durable acceptance fallback suppression...")
+    calls = []
+
+    def fake_durable_executor(plan, **execution_context):
+        calls.append({"plan": plan, "execution_context": execution_context})
+        return {
+            "export_run_id": "run-123",
+            "status": "queued",
+            "task_type": plan["durable_task_type"],
+        }
+
+    result = orchestrate_tabular_request(
+        "Analyze every row and create a CSV file with one output row per source row.",
+        [build_context()],
+        action_mode="analyze",
+        caller="analyze",
+        settings={
+            "enable_tabular_hierarchical_analysis": True,
+            "tabular_legacy_post_tool_fallback_mode": "enabled",
+        },
+        planner_mode="active",
+        durable_execution_callback=fake_durable_executor,
+    )
+
+    decision = result["legacy_post_tool_fallback_decision"]
+    assert_equal(len(calls), 1, "durable executor calls")
+    assert_equal(result["execution_state"], "queued", "execution state")
+    assert_equal(decision["contract_version"], "tabular-legacy-fallback-retirement-v1", "decision contract")
+    assert_equal(decision["fallback_source"], "shared_preflight", "decision source")
+    assert_false(decision["should_invoke"], "shared accepted fallback invocation")
+    assert_equal(decision["reason_code"], "shared_durable_metadata_present", "shared accepted reason")
+
+
+def load_post_tool_namespace():
+    """Load only the post-tool fallback helper with lightweight stubs."""
+    source = CHAT_ROUTE.read_text(encoding="utf-8")
+    module_tree = ast.parse(source, filename=str(CHAT_ROUTE))
+    selected_nodes = [
+        node
+        for node in module_tree.body
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == "maybe_create_tabular_generated_output"
+    ]
+    assert_equal(len(selected_nodes), 1, "loaded post-tool helper")
+
+    parity_events = []
+    log_events = []
+
+    def fake_emit_tabular_parity_event(settings, event_name, mode, **kwargs):
+        parity_events.append({
+            "settings": settings,
+            "event_name": event_name,
+            "mode": mode,
+            "kwargs": kwargs,
+        })
+
+    namespace = {
+        "TABULAR_RUN_TASK_COMBINED": "combined",
+        "TABULAR_RUN_TASK_HIERARCHICAL_ANALYSIS": "hierarchical_analysis",
+        "_get_tabular_generated_output_task_type": lambda generated, hierarchical, settings: "structured_export",
+        "_shared_build_tabular_legacy_post_tool_fallback_decision": build_tabular_legacy_post_tool_fallback_decision,
+        "classify_tabular_parity_request": lambda prompt: {"execution_contract": "structured_export"},
+        "emit_tabular_parity_event": fake_emit_tabular_parity_event,
+        "log_event": lambda *args, **kwargs: log_events.append({"args": args, "kwargs": kwargs}),
+        "question_requests_tabular_generated_output": lambda prompt: True,
+        "question_requests_tabular_hierarchical_analysis": lambda prompt: False,
+        "raise_if_mixed_source_cancelled": lambda *args, **kwargs: None,
+    }
+    exec(compile(ast.Module(body=selected_nodes, type_ignores=[]), str(CHAT_ROUTE), "exec"), namespace)
+    namespace.update({
+        "parity_events": parity_events,
+        "log_events": log_events,
+    })
+    return namespace
+
+
+def test_observe_mode_suppresses_post_tool_side_effects_before_source_selection():
+    """Observe mode must not create legacy fallback work from tool invocations."""
+    print("Testing observe-only post-tool fallback suppression...")
+    namespace = load_post_tool_namespace()
+
+    result = asyncio.run(namespace["maybe_create_tabular_generated_output"](
+        user_question="Export every row as CSV.",
+        invocations=[object()],
+        gpt_model="gpt-4o",
+        settings={"tabular_legacy_post_tool_fallback_mode": "observe"},
+        conversation_id="conversation-1",
+        user_id="user-1",
+    ))
+
+    event_names = [event["event_name"] for event in namespace["parity_events"]]
+    suppressed_events = [
+        event for event in namespace["parity_events"]
+        if event["event_name"] == "post_tool_generated_output_fallback_suppressed"
+    ]
+    assert_equal(result, None, "observe mode result")
+    assert_true("classification_started" in event_names, "classification started event")
+    assert_true("classification_completed" in event_names, "classification completed event")
+    assert_true(suppressed_events, "suppressed fallback event")
+    assert_false("post_tool_generated_output_fallback_attempted" in event_names, "attempted fallback event")
+
+    dimensions = suppressed_events[0]["kwargs"].get("dimensions") or {}
+    assert_equal(dimensions["legacy_post_tool_fallback_mode"], "observe", "fallback mode dimension")
+    assert_equal(dimensions["legacy_post_tool_fallback_action"], "observe", "fallback action dimension")
+    assert_equal(dimensions["legacy_post_tool_fallback_reason"], "observe_only", "fallback reason dimension")
+    assert_equal(dimensions["legacy_post_tool_fallback_should_invoke"], "false", "fallback invoke dimension")
+    assert_true(namespace["log_events"], "suppression log event")
+
+
+def run_tests():
+    tests = [
+        test_decision_modes_and_shared_acceptance_suppression,
+        test_active_shared_orchestrator_records_suppressed_fallback_decision,
+        test_observe_mode_suppresses_post_tool_side_effects_before_source_selection,
+    ]
+    results = []
+    for test in tests:
+        print(f"\nRunning {test.__name__}...")
+        try:
+            test()
+            results.append(True)
+        except Exception as exc:
+            print(f"Test failed: {exc}")
+            import traceback
+
+            traceback.print_exc()
+            results.append(False)
+    print(f"\nResults: {sum(results)}/{len(results)} tests passed")
+    return all(results)
+
+
+if __name__ == "__main__":
+    sys.exit(0 if run_tests() else 1)


### PR DESCRIPTION
## Summary

- Add the Phase 9 `tabular-legacy-fallback-retirement-v1` decision contract for legacy post-tool generated-output fallback handling.
- Record safe fallback-decision telemetry on Search and Analyze shared preflight events.
- Allow `tabular_legacy_post_tool_fallback_mode='observe'` and `'disabled'` to suppress post-tool fallback side effects while preserving the default `'enabled'` compatibility behavior.
- Add Phase 9 functional coverage and public feature documentation.

## Scope and Non-Goals

- This is the first Phase 9 retirement-control slice, not the full Phase 9 scale/chaos/live canary matrix.
- Does not delete compatibility wrappers, old-run readers, status/cancel/resume routes, artifact rendering, or direct shared-preflight execution.
- Does not update release notes yet; release-note update can be handled separately if approved.

## Validation

- `python -m py_compile application/single_app/functions_tabular_orchestration.py application/single_app/route_backend_chats.py application/single_app/functions_workflow_runner.py application/single_app/config.py functional_tests/test_tabular_phase9_legacy_retirement.py`
- `functional_tests/test_tabular_phase9_legacy_retirement.py` - 3/3 passed
- `functional_tests/test_tabular_shared_request_planner.py` - 7/7 passed
- `functional_tests/test_tabular_search_shared_preflight_adapter.py` - 8/8 passed
- `functional_tests/test_tabular_analyze_shared_preflight_adapter.py` - 6/6 passed
- VS Code diagnostics clean for touched Python files
- Windows-safe `git diff --check`
- New file final-newline/trailing-whitespace/markdown-fence hygiene

## Security and Rollback

- Fallback decisions and telemetry exclude prompts, file names, blob paths, source locators, row content, credentials, and raw provider errors.
- Rollback for new requests is to set `tabular_legacy_post_tool_fallback_mode='enabled'`.
- Existing generated-output runs keep their persisted executor and planner metadata.

Refs #1031
Refs #1055
Refs #1058