### PR TITLE
Sanitize admin-only tabular execution settings

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -96,7 +96,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.250.167"
+VERSION = "0.250.168"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/functions_settings.py
+++ b/application/single_app/functions_settings.py
@@ -87,8 +87,13 @@ ADMIN_SETTINGS_NESTED_SECRET_FIELDS = (
     "web_search_agent.other_settings.azure_ai_foundry.client_secret",
 )
 TABULAR_GENERATION_BACKEND_SETTING_KEYS = {
+    'enable_tabular_hierarchical_analysis',
     'enable_tabular_parity_contract_telemetry',
     'tabular_parity_contract_mode',
+    'tabular_hierarchical_analysis_reduce_fan_in',
+    'tabular_generated_output_chunk_model_mode',
+    'tabular_generated_output_chunk_model_deployment',
+    'tabular_generated_output_model_validation_auto_retries',
     'tabular_generation_rollout_percentage',
     'tabular_analyze_parity_rollout_percent',
     'tabular_background_handoff_mode',

--- a/docs/explanation/fixes/TABULAR_EXECUTION_SETTINGS_SANITIZATION_FIX.md
+++ b/docs/explanation/fixes/TABULAR_EXECUTION_SETTINGS_SANITIZATION_FIX.md
@@ -1,0 +1,43 @@
+# Tabular Execution Settings Sanitization Fix (0.250.168)
+
+Fixed in version: **0.250.168**
+
+Related version update: `application/single_app/config.py` reports `0.250.168`.
+
+## Issue Description
+
+Normal user-facing settings responses could include admin-only tabular execution controls. These values revealed internal execution behavior and could expose the configured deployment name used for chunk processing.
+
+Related issue: [#1199](https://github.com/microsoft/simplechat/issues/1199).
+
+## Root Cause
+
+`sanitize_settings_for_user()` removes tabular backend settings through `TABULAR_GENERATION_BACKEND_SETTING_KEYS`. Newly added hierarchical-analysis, chunk-model, and model-validation retry settings were not added to that denylist, so they passed through the sanitizer.
+
+## Technical Details
+
+The backend-only denylist now removes:
+
+- `enable_tabular_hierarchical_analysis`
+- `tabular_hierarchical_analysis_reduce_fan_in`
+- `tabular_generated_output_chunk_model_mode`
+- `tabular_generated_output_chunk_model_deployment`
+- `tabular_generated_output_model_validation_auto_retries`
+
+The durable-run confirmation toggle and row and batch thresholds remain available because the chat frontend uses them to confirm very large tabular runs.
+
+Files modified:
+
+- `application/single_app/functions_settings.py`
+- `application/single_app/config.py`
+- `functional_tests/test_tabular_execution_settings_sanitization.py`
+
+## Impact
+
+Non-admin frontend routes that use `sanitize_settings_for_user()` no longer receive the five internal execution controls. Admin settings behavior is unchanged because admin routes continue to use the full settings object.
+
+## Validation
+
+Focused functional coverage executes the shared sanitizer and verifies that all five backend settings are removed, all three chat-required confirmation settings remain available, and ordinary public settings are preserved.
+
+Before the fix, the five execution controls passed through normal frontend settings responses. After the fix, only the chat-required confirmation fields remain visible.

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,15 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](/explanation/features/) and [Fixes by Version](/explanation/fixes/).
 
+### **(v0.250.168)**
+
+#### Bug Fixes
+
+*   **Tabular Execution Settings Sanitization**
+    *   Prevented normal user-facing settings responses from exposing admin-only hierarchical-analysis, chunk-model deployment, and model-validation retry controls.
+    *   Preserved the durable-run confirmation settings required by chat so users continue to receive prompts before very large tabular runs.
+    *   (Ref: #1199, `sanitize_settings_for_user()`, `TABULAR_GENERATION_BACKEND_SETTING_KEYS`)
+
 ### **(v0.250.167)**
 
 #### Bug Fixes

--- a/functional_tests/test_tabular_execution_settings_sanitization.py
+++ b/functional_tests/test_tabular_execution_settings_sanitization.py
@@ -1,0 +1,85 @@
+# test_tabular_execution_settings_sanitization.py
+#!/usr/bin/env python3
+"""
+Functional test for admin-only tabular execution settings sanitization.
+Version: 0.250.168
+Implemented in: 0.250.168
+
+This test ensures normal frontend settings responses omit admin-only tabular
+execution controls while retaining the confirmation fields required by chat.
+"""
+
+import ast
+from pathlib import Path
+
+from test_support.versioning import assert_app_version_at_least
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+SETTINGS_FILE = ROOT_DIR / "application" / "single_app" / "functions_settings.py"
+IMPLEMENTED_VERSION = "0.250.168"
+
+ADMIN_ONLY_TABULAR_SETTINGS = {
+    "enable_tabular_hierarchical_analysis": True,
+    "tabular_hierarchical_analysis_reduce_fan_in": 10,
+    "tabular_generated_output_chunk_model_mode": "configured",
+    "tabular_generated_output_chunk_model_deployment": "internal-chunk-deployment",
+    "tabular_generated_output_model_validation_auto_retries": 7,
+}
+
+CHAT_CONFIRMATION_SETTINGS = {
+    "enable_tabular_durable_run_confirmation": True,
+    "tabular_durable_run_confirmation_threshold_rows": 750,
+    "tabular_durable_run_confirmation_threshold_batches": 100,
+}
+
+
+def load_sanitize_settings_for_user():
+    """Load the sanitizer without importing the full Flask application."""
+    source = SETTINGS_FILE.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(SETTINGS_FILE))
+    selected_nodes = []
+
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == "TABULAR_GENERATION_BACKEND_SETTING_KEYS":
+                    selected_nodes.append(node)
+        if isinstance(node, ast.FunctionDef) and node.name == "sanitize_settings_for_user":
+            selected_nodes.append(node)
+
+    namespace = {
+        "sanitize_model_endpoints_for_frontend": lambda endpoints: list(endpoints or []),
+        "normalize_support_latest_features_visibility": lambda visibility: {},
+        "has_visible_support_latest_features": lambda settings: False,
+        "get_public_workspace_label_context": lambda settings: {},
+    }
+    exec(
+        compile(ast.Module(body=selected_nodes, type_ignores=[]), str(SETTINGS_FILE), "exec"),
+        namespace,
+    )
+    return namespace["sanitize_settings_for_user"]
+
+
+def test_admin_only_tabular_execution_settings_are_sanitized():
+    """Backend execution controls must not reach normal frontend settings."""
+    assert_app_version_at_least(IMPLEMENTED_VERSION)
+    sanitize_settings_for_user = load_sanitize_settings_for_user()
+    raw_settings = {
+        "app_title": "SimpleChat",
+        **ADMIN_ONLY_TABULAR_SETTINGS,
+        **CHAT_CONFIRMATION_SETTINGS,
+    }
+
+    sanitized = sanitize_settings_for_user(raw_settings)
+
+    assert sanitized["app_title"] == "SimpleChat"
+    for setting_key in ADMIN_ONLY_TABULAR_SETTINGS:
+        assert setting_key not in sanitized, f"{setting_key} must remain backend-only"
+    for setting_key, expected_value in CHAT_CONFIRMATION_SETTINGS.items():
+        assert sanitized[setting_key] == expected_value, f"{setting_key} is required by chat"
+
+
+if __name__ == "__main__":
+    test_admin_only_tabular_execution_settings_are_sanitized()
+    print("Tabular execution settings sanitization test passed.")


### PR DESCRIPTION
## Summary
- remove five admin-only tabular execution controls from normal frontend settings responses
- preserve the durable-run confirmation fields consumed by chat
- add focused regression coverage, fix documentation, release notes, and version 0.250.168

## Testing
- `python functional_tests\test_tabular_execution_settings_sanitization.py`
- `python functional_tests\test_tabular_phase8_ui_telemetry_rollout.py`
- `python functional_tests\test_tabular_shared_request_planner.py`

Fixes #1199