### PR TITLE
Refine conversation contents sidebar layout

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -96,7 +96,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.250.168"
+VERSION = "0.250.169"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/functions_conversation_metadata.py
+++ b/application/single_app/functions_conversation_metadata.py
@@ -200,6 +200,7 @@ def _add_document_metadata_entry(document_map, document_id, scope_info, chunk_id
                                  classification='None', file_name=None):
     """Add or merge a document-level metadata entry used by conversation tagging."""
     normalized_document_id = str(document_id or '').strip()
+    normalized_file_name = str(file_name or '').strip()
     scope_info = scope_info if isinstance(scope_info, dict) else {}
     scope_type = str(scope_info.get('scope') or '').strip()
     scope_id = str(scope_info.get('id') or '').strip()
@@ -214,8 +215,16 @@ def _add_document_metadata_entry(document_map, document_id, scope_info, chunk_id
             },
             'chunk_ids': [],
             'classification': classification or 'None',
-            'file_name': file_name or 'Unknown Document'
+            'file_name': normalized_file_name or 'Unknown Document'
         }
+
+    existing_file_name = document_map[normalized_document_id].get('file_name')
+    if (
+        normalized_file_name
+        and normalized_file_name != 'Unknown Document'
+        and (not existing_file_name or existing_file_name == 'Unknown Document')
+    ):
+        document_map[normalized_document_id]['file_name'] = normalized_file_name
 
     normalized_chunk_id = str(chunk_id or '').strip()
     if normalized_chunk_id and normalized_chunk_id not in document_map[normalized_document_id]['chunk_ids']:
@@ -671,8 +680,17 @@ def collect_conversation_metadata(user_message, conversation_id, user_id, active
             # Update the existing document entry with chunk IDs
             existing_doc['chunk_ids'] = existing_chunks
             
-            # Ensure existing document has title and scope name if missing
-            if 'title' not in existing_doc or not existing_doc.get('title'):
+            # Ensure existing document has user-facing title and filename metadata.
+            needs_title = not existing_doc.get('title')
+            existing_file_name = str(existing_doc.get('file_name') or '').strip()
+            needs_file_name = not existing_file_name or existing_file_name == 'Unknown Document'
+            collected_file_name = str(doc_info.get('file_name') or '').strip()
+            has_collected_file_name = (
+                collected_file_name
+                and collected_file_name != 'Unknown Document'
+            )
+            doc_metadata = None
+            if needs_title or (needs_file_name and not has_collected_file_name):
                 doc_scope = doc_info['scope']
                 scope_type = doc_scope['scope']
                 scope_id = doc_scope['id']
@@ -684,9 +702,21 @@ def collect_conversation_metadata(user_message, conversation_id, user_id, active
                     doc_metadata = get_document_metadata(document_id, user_id, public_workspace_id=scope_id)
                 else:  # personal
                     doc_metadata = get_document_metadata(document_id, user_id)
-                
-                if doc_metadata:
-                    existing_doc['title'] = doc_metadata.get('title') or doc_metadata.get('file_name', 'Unknown Document')
+
+            if needs_title:
+                existing_doc['title'] = (
+                    (doc_metadata or {}).get('title')
+                    or (doc_metadata or {}).get('file_name')
+                    or collected_file_name
+                    or 'Unknown Document'
+                )
+            if needs_file_name:
+                existing_doc['file_name'] = (
+                    (doc_metadata or {}).get('file_name')
+                    or collected_file_name
+                    or existing_doc.get('title')
+                    or 'Unknown Document'
+                )
             
             # Ensure scope has name if missing
             if isinstance(existing_doc.get('scope'), dict) and 'name' not in existing_doc['scope']:
@@ -722,8 +752,11 @@ def collect_conversation_metadata(user_message, conversation_id, user_id, active
                 doc_metadata = get_document_metadata(document_id, user_id)
             
             doc_title = "Unknown Document"
+            doc_file_name = str(doc_info.get('file_name') or '').strip()
             if doc_metadata:
                 doc_title = doc_metadata.get('title') or doc_metadata.get('file_name', 'Unknown Document')
+                doc_file_name = doc_metadata.get('file_name') or doc_file_name
+            doc_file_name = doc_file_name or doc_title
             
             # Get scope name
             scope_name = "Unknown"
@@ -741,6 +774,7 @@ def collect_conversation_metadata(user_message, conversation_id, user_id, active
                 "category": "document",
                 "document_id": document_id,
                 "title": doc_title,
+                "file_name": doc_file_name,
                 "scope": {
                     "type": scope_type,
                     "id": scope_id,

--- a/application/single_app/static/css/chats.css
+++ b/application/single_app/static/css/chats.css
@@ -1692,9 +1692,31 @@ body.layout-split .gutter {
   --bs-offcanvas-width: min(22rem, 88vw);
 }
 
+.conversation-contents-drawer .offcanvas-body,
+.conversation-contents-drawer nav,
+.conversation-contents-drawer section {
+  max-width: 100%;
+  min-width: 0;
+}
+
+.conversation-contents-drawer .offcanvas-body {
+  overflow-x: hidden;
+}
+
 .conversation-contents-list {
   display: grid;
   gap: 0.25rem;
+  grid-template-columns: minmax(0, 1fr);
+  margin-left: 0;
+  min-width: 0;
+  padding-left: 0;
+  width: 100%;
+}
+
+.conversation-contents-list > li,
+.conversation-documents-list > li {
+  max-width: 100%;
+  min-width: 0;
 }
 
 .conversation-contents-mode-switch .btn {
@@ -1704,11 +1726,16 @@ body.layout-split .gutter {
 }
 
 .conversation-contents-entry {
+  box-sizing: border-box;
   border-radius: 0.375rem;
   color: var(--bs-body-color);
   display: block;
+  font-size: 0.875rem;
+  line-height: 1.25;
+  max-width: 100%;
+  min-width: 0;
   overflow: hidden;
-  padding: 0.625rem 0.75rem;
+  padding: 0.5rem 0.625rem;
   text-align: left;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -1728,13 +1755,24 @@ body.layout-split .gutter {
 
 .conversation-documents-list {
   display: grid;
-  gap: 0.5rem;
+  gap: 0.375rem;
+  grid-template-columns: minmax(0, 1fr);
+  margin-left: 0;
+  min-width: 0;
+  padding-left: 0;
+  width: 100%;
 }
 
 .conversation-documents-entry {
   background: var(--bs-body-bg);
+  box-sizing: border-box;
   color: var(--bs-body-color);
-  padding: 0.75rem;
+  font-size: 0.875rem;
+  max-width: 100%;
+  min-width: 0;
+  overflow: hidden;
+  padding: 0.625rem;
+  width: 100%;
 }
 
 .conversation-documents-entry:focus-visible {
@@ -1742,19 +1780,49 @@ body.layout-split .gutter {
   outline-offset: 2px;
 }
 
+.conversation-documents-header {
+  min-width: 0;
+  width: 100%;
+}
+
 .conversation-documents-title {
+  flex: 1 1 auto;
+  line-height: 1.25;
+  max-width: 100%;
   min-width: 0;
 }
 
 .conversation-documents-classification {
   flex: 0 0 auto;
-  max-width: 8rem;
+  font-size: 0.675rem;
+  max-width: 6.5rem;
   overflow: hidden;
   text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .conversation-documents-meta-line {
-  overflow-wrap: anywhere;
+  align-items: center;
+  display: flex;
+  font-size: 0.75rem;
+  gap: 0.25rem;
+  line-height: 1.3;
+  margin-top: 0.25rem;
+  max-width: 100%;
+  min-width: 0;
+}
+
+.conversation-documents-meta-line > i {
+  flex: 0 0 auto;
+  margin-right: 0 !important;
+}
+
+.conversation-documents-meta-text {
+  display: block;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .conversation-contents-destination {

--- a/application/single_app/static/js/chat/chat-conversation-contents.js
+++ b/application/single_app/static/js/chat/chat-conversation-contents.js
@@ -7,7 +7,7 @@ import {
 } from "./chat-conversation-details.js";
 import { isColorLight } from "./chat-utils.js";
 
-const CONTENTS_LABEL_MAX_LENGTH = 72;
+const CONTENTS_LABEL_MAX_LENGTH = 30;
 const DESKTOP_MEDIA_QUERY = "(min-width: 1200px)";
 const TEMP_MESSAGE_PREFIX = "temp_user_";
 const DRAWER_MODE_CONTENTS = "contents";
@@ -420,7 +420,9 @@ function createDocumentMetaLine(iconName, text) {
     icon.setAttribute("aria-hidden", "true");
 
     const textNode = document.createElement("span");
+    textNode.className = "conversation-documents-meta-text";
     textNode.textContent = text;
+    textNode.title = text;
 
     line.append(icon, textNode);
     return line;
@@ -429,9 +431,9 @@ function createDocumentMetaLine(iconName, text) {
 function createDocumentEntry(doc) {
     const chunkIds = Array.isArray(doc?.chunk_ids) ? doc.chunk_ids : [];
     const chunkPages = extractPageNumbers(chunkIds);
-    const chunkCount = chunkIds.length;
     const documentId = String(doc?.document_id || "Unknown Document");
-    const documentTitle = String(doc?.title || documentId);
+    const documentTitle = String(doc?.title || doc?.file_name || documentId);
+    const documentFileName = String(doc?.file_name || "");
     const scopeType = String(doc?.scope?.type || "Unknown");
     const scopeName = String(doc?.scope?.name || doc?.scope?.id || "Unknown");
 
@@ -441,7 +443,7 @@ function createDocumentEntry(doc) {
     entry.tabIndex = -1;
 
     const header = document.createElement("div");
-    header.className = "d-flex justify-content-between align-items-start gap-2 mb-2";
+    header.className = "d-flex justify-content-between align-items-start gap-2 mb-1 conversation-documents-header";
 
     const title = document.createElement("div");
     title.className = "fw-semibold text-truncate conversation-documents-title";
@@ -450,18 +452,21 @@ function createDocumentEntry(doc) {
 
     header.append(title, createClassificationBadge(doc?.classification));
     entry.appendChild(header);
-    entry.appendChild(createDocumentMetaLine(
-        "file-earmark",
-        `${chunkCount} chunk${chunkCount !== 1 ? "s" : ""}${chunkPages.length > 0 ? ` (Pages: ${chunkPages.join(", ")})` : ""}`
-    ));
+
+    if (
+        documentFileName
+        && documentFileName !== "Unknown Document"
+        && documentFileName !== documentTitle
+    ) {
+        entry.appendChild(createDocumentMetaLine("file-earmark", documentFileName));
+    }
+    if (chunkPages.length > 0) {
+        entry.appendChild(createDocumentMetaLine("file-earmark-text", `Pages: ${chunkPages.join(", ")}`));
+    }
     entry.appendChild(createDocumentMetaLine(
         getScopeIcon(scopeType),
         `${scopeType} scope: ${scopeName}`
     ));
-
-    if (doc?.title && doc.title !== doc.document_id) {
-        entry.appendChild(createDocumentMetaLine("hash", `ID: ${documentId}`));
-    }
 
     listItem.appendChild(entry);
     return {

--- a/docs/explanation/features/CONVERSATION_CONTENTS_DRAWER.md
+++ b/docs/explanation/features/CONVERSATION_CONTENTS_DRAWER.md
@@ -6,6 +6,7 @@ The conversation contents drawer provides a compact index of persisted user mess
 
 Implemented in version: **0.250.074**
 Used documents mode added in version: **0.250.159**
+Compact overflow-safe layout added in version: **0.250.169**
 
 ### Dependencies
 
@@ -20,7 +21,7 @@ Used documents mode added in version: **0.250.159**
 
 The contents mode is derived entirely from messages already loaded into the chat DOM. It does not add a conversation-index API or a second datastore. `chat-conversation-contents.js` observes persisted user-message elements, renders labels with `textContent`, and tracks the message nearest the current scroll position.
 
-The documents mode uses the same conversation metadata source as the details modal. `chat-conversation-details.js` exposes shared helpers for fetching conversation metadata and filtering `tags` where `category === "document"`. `chat-conversation-contents.js` renders those document tags into a vertical row list, so selected-but-unused documents are excluded and the side pane stays aligned with the details modal document card.
+The documents mode uses the same conversation metadata source as the details modal. `functions_conversation_metadata.py` retains each document's user-facing title and source filename in the conversation tag. `chat-conversation-details.js` exposes shared helpers for fetching conversation metadata and filtering `tags` where `category === "document"`. `chat-conversation-contents.js` renders those document tags into a vertical row list, so selected-but-unused documents are excluded and the side pane stays aligned with the details modal document card.
 
 The application setting `enable_conversation_contents_drawer` is the authoritative global gate and defaults to `true`. The user setting `conversationContentsDrawerEnabled` also defaults to `true`; it is only effective while the admin gate is enabled.
 
@@ -29,19 +30,22 @@ The application setting `enable_conversation_contents_drawer` is the authoritati
 - The chat header exposes an accessible contents button after at least one persisted user message is available.
 - Desktop viewports reserve space for a persistent right-side drawer.
 - Tablet and mobile viewports use a Bootstrap off-canvas drawer.
-- Labels use the first meaningful plain-text line, normalize whitespace, and truncate at 72 characters.
+- Labels use the first meaningful plain-text line, normalize whitespace, and truncate to a maximum of 30 displayed characters including the ellipsis.
 - Messages without usable text receive an ordered fallback such as `User message 3`.
 - Selecting an entry scrolls and focuses the source message, applies a temporary highlight, and marks the entry as the current location.
 - Mutation and scroll observers refresh entries after loads, sends, edits, timeline replacement, and conversation switching.
 - The chat header exposes a separate used-documents icon once cited documents exist for the active conversation.
 - Contents and Documents share the same right-side drawer. Opening either mode swaps the drawer content instead of creating side-by-side panes.
 - After a streamed response completes, the drawer refreshes full conversation metadata and auto-opens Documents once per conversation when cited documents first appear.
-- Document rows show title, classification, cited chunk/page summary, workspace scope, and document ID when the title differs from the ID.
+- Document rows show title, classification, source filename when it differs from the title, cited page references, and workspace scope.
+- Chunk counts and backend document IDs are intentionally omitted from the user-facing drawer.
+- Both lists use compact typography and constrained grid/flex tracks so long labels and metadata truncate instead of creating horizontal scrolling.
 
 ### Files
 
 - `application/single_app/functions_settings.py`
 - `application/single_app/functions_conversation_contents.py`
+- `application/single_app/functions_conversation_metadata.py`
 - `application/single_app/route_frontend_admin_settings.py`
 - `application/single_app/route_backend_users.py`
 - `application/single_app/route_frontend_chats.py`
@@ -64,7 +68,8 @@ The application setting `enable_conversation_contents_drawer` is the authoritati
 ## Testing and validation
 
 - `functional_tests/test_conversation_contents_drawer_settings.py` validates global and user defaults, persistence wiring, validation, and gate precedence.
-- `ui_tests/test_chat_conversation_contents_drawer.py` covers filtering, ordering, safe and truncated labels, fallback labels, cited-document rendering, documents-mode swapping, auto-open behavior, navigation, focus, live updates, conversation replacement, keyboard closing, and desktop/mobile layouts.
+- `functional_tests/test_document_action_conversation_scope_metadata.py` validates that source filenames survive conversation document-tag creation and refresh.
+- `ui_tests/test_chat_conversation_contents_drawer.py` covers filtering, ordering, safe 30-character labels, fallback labels, compact cited-document rendering, documents-mode swapping, auto-open behavior, navigation, focus, live updates, conversation replacement, keyboard closing, and desktop/mobile horizontal-overflow measurements.
 - The contents list is generated locally from authorized messages and inserts user-authored labels only through safe text APIs. The documents list also renders metadata through DOM APIs and `textContent`.
 
 ### Known limitations

--- a/docs/explanation/fixes/CONVERSATION_CONTENTS_SIDEBAR_OVERFLOW_FIX.md
+++ b/docs/explanation/fixes/CONVERSATION_CONTENTS_SIDEBAR_OVERFLOW_FIX.md
@@ -1,0 +1,65 @@
+# Conversation Contents Sidebar Overflow Fix
+
+Fixed/Implemented in version: **0.250.169**
+
+Related configuration update: `VERSION = "0.250.169"` in `application/single_app/config.py`.
+
+## Issue Description
+
+The shared Conversation contents / Used documents drawer could expose a horizontal scrollbar when a user message, document title, filename, classification, or workspace name exceeded the sidebar width. The document cards also displayed backend-oriented chunk counts and document IDs that added visual noise for normal users.
+
+## Root Cause Analysis
+
+- The list grids used automatic minimum tracks, so nowrap content could contribute its full intrinsic width before truncation was applied.
+- Several document-card flex and text children did not have a zero minimum width.
+- User-message labels allowed up to 72 displayed characters, which made the compact navigation entries unnecessarily wide.
+- Conversation document tags retained filenames while collecting metadata but dropped the field from the final tag consumed by the drawer.
+- Document cards repeated chunk counts and internal IDs even though cited pages and workspace scope were the useful user-facing details.
+
+## Technical Details
+
+### Files Modified
+
+- `application/single_app/functions_conversation_metadata.py`
+- `application/single_app/static/js/chat/chat-conversation-contents.js`
+- `application/single_app/static/css/chats.css`
+- `application/single_app/config.py`
+- `functional_tests/test_document_action_conversation_scope_metadata.py`
+- `ui_tests/test_chat_conversation_contents_drawer.py`
+- `docs/explanation/features/CONVERSATION_CONTENTS_DRAWER.md`
+
+### Code Changes Summary
+
+- Preserved `file_name` on new and refreshed conversation document tags.
+- Reduced contents labels to a maximum of 30 displayed characters including the ellipsis.
+- Limited document cards to title, filename, cited pages, scope, and classification.
+- Removed chunk-count and document-ID rows from the drawer.
+- Reduced card spacing and typography while retaining selection and focus behavior.
+- Added zero-minimum grid and flex sizing, maximum-width constraints, and visible-text ellipsis rules across both drawer tabs.
+- Continued rendering untrusted message and document values with DOM APIs and `textContent`.
+
+### Testing Approach
+
+- Extended the document-action metadata functional test to cover new tags and existing-tag filename backfill.
+- Extended the existing Playwright drawer test at desktop and mobile viewports to verify the compact field set, 30-character label behavior, XSS-safe rendering, and `scrollWidth <= clientWidth` for both tabs.
+- Included a JavaScript syntax check and repository whitespace validation.
+
+### Impact Analysis
+
+- The authorized metadata endpoint, feature gates, drawer width, navigation, keyboard behavior, and responsive off-canvas behavior are unchanged.
+- Existing conversation tags without a separate filename continue to show their title; refreshed and newly created tags can display a distinct source filename.
+- Long values remain available as safe hover text while their visible rows stay within the sidebar.
+
+## Validation
+
+### Before and After
+
+- **Before:** Long nowrap content could widen grid tracks, and document cards exposed chunk counts and backend IDs.
+- **After:** Contents and document rows remain within the allocated drawer width and show only user-relevant metadata.
+
+### Test Results
+
+- `functional_tests/test_document_action_conversation_scope_metadata.py`: 5 tests passed.
+- A local Playwright harness loaded the production module and stylesheet and confirmed the field set and no horizontal overflow at 1440px and 430px viewports.
+- `ui_tests/test_chat_conversation_contents_drawer.py`: both authenticated viewport cases were collected and skipped because the required UI environment variables were not available locally.
+- JavaScript syntax, Python compilation, and repository whitespace checks passed.

--- a/functional_tests/test_document_action_conversation_scope_metadata.py
+++ b/functional_tests/test_document_action_conversation_scope_metadata.py
@@ -1,26 +1,26 @@
-#!/usr/bin/env python3
 # test_document_action_conversation_scope_metadata.py
 """
 Functional test for document-action conversation scope metadata.
-Version: 0.250.073
-Implemented in: 0.241.124; Updated in: 0.250.073
+Version: 0.250.169
+Implemented in: 0.241.124; Updated in: 0.250.073 and 0.250.169
 
 This test ensures Analyze and tabular document-action results can assign
 conversation workspace metadata from selected document summaries when no
 hybrid search results are present, while preserving personal assigned-knowledge
-primary context behavior.
+primary context behavior and user-facing document filenames.
 """
 
 import ast
 import os
 import sys
 
+from test_support.versioning import assert_app_version_at_least
+
 
 ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 METADATA_FILE = os.path.join(ROOT_DIR, 'application', 'single_app', 'functions_conversation_metadata.py')
 ROUTE_FILE = os.path.join(ROOT_DIR, 'application', 'single_app', 'route_backend_chats.py')
-CONFIG_FILE = os.path.join(ROOT_DIR, 'application', 'single_app', 'config.py')
-FIX_VERSION = '0.250.073'
+FIX_VERSION = '0.250.169'
 TEST_USER_ID = 'scope-user-1'
 CRIMSON_GROUP_ID = 'crimson-group-1'
 PUBLIC_WORKSPACE_ID = 'public-workspace-1'
@@ -42,13 +42,6 @@ METADATA_TARGET_FUNCTIONS = {
 def read_text(file_path):
     with open(file_path, 'r', encoding='utf-8') as file_handle:
         return file_handle.read()
-
-
-def read_config_version():
-    for line in read_text(CONFIG_FILE).splitlines():
-        if line.startswith('VERSION = '):
-            return line.split('=', 1)[1].strip().strip('"')
-    raise AssertionError('VERSION assignment not found in config.py')
 
 
 def load_metadata_helpers():
@@ -136,6 +129,8 @@ def test_selected_group_document_sets_conversation_primary_context():
 
     document_tag = next(tag for tag in updated['tags'] if tag.get('category') == 'document')
     assert document_tag['document_id'] == 'crimson-workbook-doc'
+    assert document_tag['title'] == 'Crimson Workbook'
+    assert document_tag['file_name'] == 'Crimson.xlsx'
     assert document_tag['scope']['type'] == 'group'
     assert document_tag['scope']['id'] == CRIMSON_GROUP_ID
 
@@ -196,6 +191,51 @@ def test_assigned_knowledge_personal_agent_keeps_personal_primary_context():
     print('PASS: assigned-knowledge primary context preservation')
 
 
+def test_existing_document_tag_backfills_filename():
+    """Existing document tags should gain a filename without losing stored metadata."""
+    print('Testing existing document filename backfill...')
+    namespace = load_metadata_helpers()
+    collect_metadata = namespace['collect_conversation_metadata']
+
+    updated = collect_metadata(
+        user_message='Continue analyzing the Crimson workbook',
+        conversation_id='conversation-3',
+        user_id=TEST_USER_ID,
+        document_scope='all',
+        active_group_ids=[CRIMSON_GROUP_ID],
+        selected_documents=[{
+            'document_id': 'crimson-workbook-doc',
+            'file_name': 'Crimson.xlsx',
+            'scope': 'group',
+            'scope_id': CRIMSON_GROUP_ID,
+            'classification': 'Confidential',
+        }],
+        search_results=None,
+        conversation_item={
+            'context': [],
+            'tags': [{
+                'category': 'document',
+                'document_id': 'crimson-workbook-doc',
+                'title': 'Crimson Workbook',
+                'scope': {
+                    'type': 'group',
+                    'id': CRIMSON_GROUP_ID,
+                    'name': 'Crimson',
+                },
+                'chunk_ids': [],
+                'classification': 'Confidential',
+            }],
+            'strict': False,
+        },
+    )
+
+    document_tag = next(tag for tag in updated['tags'] if tag.get('category') == 'document')
+    assert document_tag['title'] == 'Crimson Workbook'
+    assert document_tag['file_name'] == 'Crimson.xlsx'
+    assert document_tag['classification'] == 'Confidential'
+    print('PASS: existing document filename backfill')
+
+
 def test_document_action_stream_payload_preserves_metadata_fields():
     """Streaming document-action responses should carry conversation metadata updates."""
     print('Testing document-action stream payload metadata fields...')
@@ -214,7 +254,7 @@ def test_document_action_stream_payload_preserves_metadata_fields():
 def test_version_bumped_for_fix():
     """Verify config.py version was bumped for this fix."""
     print('Testing version bump...')
-    assert read_config_version() == FIX_VERSION
+    assert_app_version_at_least(FIX_VERSION)
     print('PASS: version bump')
 
 
@@ -222,6 +262,7 @@ if __name__ == '__main__':
     tests = [
         test_selected_group_document_sets_conversation_primary_context,
         test_assigned_knowledge_personal_agent_keeps_personal_primary_context,
+        test_existing_document_tag_backfills_filename,
         test_document_action_stream_payload_preserves_metadata_fields,
         test_version_bumped_for_fix,
     ]

--- a/ui_tests/test_chat_conversation_contents_drawer.py
+++ b/ui_tests/test_chat_conversation_contents_drawer.py
@@ -1,13 +1,14 @@
 # test_chat_conversation_contents_drawer.py
 """
 UI test for the conversation contents drawer.
-Version: 0.250.159
+Version: 0.250.169
 Implemented in: 0.250.074
 Documents mode added in: 0.250.159
+Compact overflow-safe layout added in: 0.250.169
 
 This test validates user-message filtering, cited-document mode, safe labels,
 navigation, live updates, conversation replacement, keyboard closing, and
-responsive layouts.
+responsive layouts without horizontal overflow.
 """
 
 import json
@@ -35,6 +36,21 @@ def _require_authenticated_chat_env():
         pytest.skip("Set SIMPLECHAT_UI_BASE_URL to run this UI test.")
     if not STORAGE_STATE or not Path(STORAGE_STATE).exists():
         pytest.skip("Set SIMPLECHAT_UI_STORAGE_STATE to a valid authenticated Playwright storage state file.")
+
+
+def _assert_no_horizontal_overflow(locator, label):
+    metrics = locator.evaluate(
+        """
+        node => ({
+            scrollWidth: node.scrollWidth,
+            clientWidth: node.clientWidth,
+        })
+        """
+    )
+    assert metrics["scrollWidth"] <= metrics["clientWidth"] + 1, (
+        f"Expected no horizontal overflow in {label}, got "
+        f"scrollWidth={metrics['scrollWidth']} and clientWidth={metrics['clientWidth']}"
+    )
 
 
 def _set_drawer_preference(page, enabled):
@@ -146,12 +162,21 @@ def test_chat_conversation_contents_drawer(playwright, viewport):
         expect(toggle).to_be_visible()
         expect(entries).to_have_count(3)
         expect(entries.nth(0)).to_have_text("First topic")
-        expect(entries.nth(1)).to_have_text("A very long user prompt that should be truncated without overflowing th…")
+        expect(entries.nth(1)).to_have_text("A very long user prompt that…")
         expect(entries.nth(2)).to_have_text("User message 3")
         assert "<" not in entries.nth(0).inner_html()
 
         toggle.click()
         expect(page.locator("#conversation-contents-drawer")).to_be_visible()
+        _assert_no_horizontal_overflow(
+            page.locator("#conversation-contents-drawer .offcanvas-body"),
+            "drawer body",
+        )
+        _assert_no_horizontal_overflow(
+            page.locator("#conversation-contents-list"),
+            "contents list",
+        )
+        _assert_no_horizontal_overflow(entries.nth(1), "contents entry")
         entries.nth(1).click()
         expect(page.locator('.message[data-message-id="user-2"]')).to_be_focused()
         page.evaluate(
@@ -210,6 +235,10 @@ def test_chat_conversation_contents_drawer(playwright, viewport):
         expect(entries.nth(0)).to_have_text("Next conversation topic")
 
         document_title = "Policy Handbook <img src=x onerror='window.__documentsPaneXss = true'>"
+        document_file_name = (
+            "bank-treasury-operations-quarterly-reference-"
+            "with-an-intentionally-long-filename.xlsx"
+        )
         page.route(
             "**/api/conversations/conversation-documents-pane/metadata",
             lambda route: _fulfill_json(route, {
@@ -219,18 +248,20 @@ def test_chat_conversation_contents_drawer(playwright, viewport):
                         "category": "document",
                         "document_id": "doc-1",
                         "title": document_title,
+                        "file_name": document_file_name,
                         "classification": "Confidential",
                         "chunk_ids": ["doc-1_1", "doc-1_2"],
                         "scope": {
                             "type": "group",
                             "id": "group-1",
-                            "name": "Product Docs",
+                            "name": "Product Documentation Workspace With A Long Display Name",
                         },
                     },
                     {
                         "category": "document",
                         "document_id": "doc-2",
                         "title": "Release Plan",
+                        "file_name": "release-plan.pdf",
                         "classification": "None",
                         "chunk_ids": ["doc-2_4"],
                         "scope": {
@@ -265,12 +296,23 @@ def test_chat_conversation_contents_drawer(playwright, viewport):
         expect(page.locator("#conversation-contents-title")).to_have_text("Used documents")
         expect(documents_entries).to_have_count(2)
         expect(documents_entries.nth(0)).to_contain_text(document_title)
-        expect(documents_entries.nth(0)).to_contain_text("2 chunks (Pages: 1, 2)")
-        expect(documents_entries.nth(0)).to_contain_text("group scope: Product Docs")
+        expect(documents_entries.nth(0)).to_contain_text(document_file_name)
+        expect(documents_entries.nth(0)).to_contain_text("Confidential")
+        expect(documents_entries.nth(0)).to_contain_text("Pages: 1, 2")
+        expect(documents_entries.nth(0)).to_contain_text(
+            "group scope: Product Documentation Workspace With A Long Display Name"
+        )
+        expect(documents_entries.nth(0)).not_to_contain_text("chunks")
+        expect(documents_entries.nth(0)).not_to_contain_text("ID:")
         expect(documents_entries.nth(1)).to_contain_text("Release Plan")
         expect(page.locator("#conversation-documents-count")).to_have_text("2")
         expect(page.locator("#conversation-documents-panel img[src='x']")).to_have_count(0)
         assert page.evaluate("() => window.__documentsPaneXss") is False
+        _assert_no_horizontal_overflow(
+            page.locator("#conversation-documents-list"),
+            "documents list",
+        )
+        _assert_no_horizontal_overflow(documents_entries.nth(0), "document entry")
 
         page.locator("#conversation-contents-mode-contents").click()
         expect(page.locator("#conversation-contents-title")).to_have_text("Conversation contents")


### PR DESCRIPTION
## Summary
- compact Conversation contents labels to 30 characters and constrain both drawer lists to eliminate horizontal scrolling
- simplify Used documents cards to title, filename, cited pages, scope, and classification while removing chunk counts and document IDs
- preserve source filenames in conversation metadata and update documentation/version to `0.250.169`

## Validation
- `python -m pytest -q functional_tests\test_document_action_conversation_scope_metadata.py` (5 passed)
- local Playwright desktop/mobile layout harness (passed at 1440px and 430px)
- `node --check application\single_app\static\js\chat\chat-conversation-contents.js`
- Python compilation and `git diff --check`
- authenticated UI test collected successfully; 2 cases skipped because local UI environment variables were unavailable