### PR TITLE
Phase 2: unify Analyze deliverable intent

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -96,7 +96,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.250.171"
+VERSION = "0.250.172"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/functions_analysis_deliverables.py
+++ b/application/single_app/functions_analysis_deliverables.py
@@ -326,6 +326,7 @@ def _fingerprint_payload(payload):
 def build_analysis_deliverable_contract(
     action_mode=None,
     requested_output_format=None,
+    requested_output_formats=None,
     requested_artifacts=None,
     public_output_schema=None,
     row_cardinality=None,
@@ -350,6 +351,9 @@ def build_analysis_deliverable_contract(
     if requested_artifacts is None:
         artifact_descriptors = []
         request_order = 0
+        output_formats = list(requested_output_formats or [])
+        if requested_output_format and not output_formats:
+            output_formats = [requested_output_format]
         if normalized_analysis_required:
             artifact_descriptors.append(build_analysis_deliverable_artifact(
                 "analysis",
@@ -359,8 +363,14 @@ def build_analysis_deliverable_contract(
                 request_order=request_order,
             ))
             request_order += 1
-        if requested_output_format:
-            normalized_output_format = _normalize_artifact_format(requested_output_format)
+        seen_output_formats = set()
+        for output_format in output_formats:
+            normalized_output_format = _normalize_artifact_format(output_format)
+            if normalized_analysis_required and normalized_output_format == "md":
+                continue
+            if normalized_output_format in seen_output_formats:
+                continue
+            seen_output_formats.add(normalized_output_format)
             artifact_descriptors.append(build_analysis_deliverable_artifact(
                 f"requested-{normalized_output_format}",
                 ANALYSIS_ARTIFACT_ROLE_REQUESTED_OUTPUT,
@@ -368,6 +378,7 @@ def build_analysis_deliverable_contract(
                 required=True,
                 request_order=request_order,
             ))
+            request_order += 1
     else:
         artifact_descriptors = list(requested_artifacts or [])
 

--- a/application/single_app/functions_generated_file_exports.py
+++ b/application/single_app/functions_generated_file_exports.py
@@ -32,6 +32,7 @@ GENERATED_FILE_FORMATS = {
 }
 SUPPORTED_GENERATED_EXPORT_FORMATS = {'csv', 'json', 'xml'}
 GENERATED_FILE_PREVIEW_ROWS = 3
+REQUESTED_ARTIFACT_FORMATS = ('csv', 'json', 'xml', 'md', 'docx', 'pdf')
 STRUCTURED_ARTIFACT_FORMAT_MARKERS = {
     'json': (
         'json artifact',
@@ -165,37 +166,67 @@ th { background-color: #e8eef5; font-weight: bold; }
 th, td { border: 0.6pt solid #aab7c4; padding: 4pt; vertical-align: top; }
 """
 
+MARKDOWN_OUTPUT_REQUEST_PATTERNS = (
+    re.compile(
+        r'\b(?:build|create|download|export|generate|make|prepare|save|write)\b'
+        r'.{0,120}\b(?:markdown|md)(?:\s+(?:analysis|artifact|document|file|output|report))?\b'
+    ),
+    re.compile(r'\b(?:markdown|md)\s+(?:analysis|artifact|document|file|output|report|version)\b'),
+    re.compile(r'\b(?:in|as)\s+(?:a\s+)?(?:markdown|md)(?:\s+(?:document|file|report))?\b'),
+)
 
-def get_requested_generated_file_format(user_question: str) -> Optional[str]:
-    """Return the requested generated file format, if any."""
-    if assistant_table_export_requested(user_question):
-        return GENERATED_FILE_FORMAT_CSV
 
-    normalized_question = re.sub(r'\s+', ' ', str(user_question or '').strip().casefold())
-    if not normalized_question:
+def _normalize_question_for_artifact_detection(user_question: str) -> str:
+    return re.sub(r'\s+', ' ', str(user_question or '').strip().casefold())
+
+
+def _iter_request_clauses(normalized_question: str):
+    for match in re.finditer(r'[^.!?;\n]+', normalized_question):
+        clause = match.group(0).strip()
+        if clause:
+            leading_offset = len(match.group(0)) - len(match.group(0).lstrip())
+            yield clause, match.start() + leading_offset
+
+
+def _first_pattern_position(normalized_question: str, patterns) -> Optional[int]:
+    positions = [match.start() for pattern in patterns for match in [pattern.search(normalized_question)] if match]
+    return min(positions) if positions else None
+
+
+def _format_aliases(output_format: str) -> Tuple[str, ...]:
+    aliases = {
+        'docx': ('docx', 'word'),
+        'md': ('md', 'markdown'),
+    }
+    return aliases.get(output_format, (output_format,))
+
+
+def _clause_negates_output_format(clause: str, output_format: str) -> bool:
+    return any(
+        _structured_artifact_format_is_negated(clause, format_alias)
+        for format_alias in _format_aliases(output_format)
+    )
+
+
+def _first_csv_artifact_position(user_question: str, normalized_question: str) -> Optional[int]:
+    if not assistant_table_export_requested(user_question):
         return None
-    if any(pattern.search(normalized_question) for pattern in DOCX_OUTPUT_REQUEST_PATTERNS):
-        return GENERATED_FILE_FORMAT_DOCX
-    if any(pattern.search(normalized_question) for pattern in PDF_OUTPUT_REQUEST_PATTERNS):
-        return GENERATED_FILE_FORMAT_PDF
-    return None
+    for clause, clause_offset in _iter_request_clauses(normalized_question):
+        if _clause_negates_output_format(clause, 'csv'):
+            continue
+        for marker in ('csv', 'spreadsheet'):
+            marker_position = clause.find(marker)
+            if marker_position >= 0:
+                return clause_offset + marker_position
+    return 0
 
 
-def get_requested_structured_artifact_format(user_question: str) -> Optional[str]:
-    """Return a requested CSV, JSON, or XML artifact target without resolving source orchestration."""
-    normalized_question = re.sub(r'\s+', ' ', str(user_question or '').strip().casefold())
-    if not normalized_question:
-        return None
-
-    clauses = [
-        clause.strip()
-        for clause in re.split(r'[.!?;\n]+', normalized_question)
-        if clause.strip()
-    ]
-    destination_matches = []
-    for clause_index, clause in enumerate(clauses):
+def _collect_structured_artifact_format_matches(normalized_question: str) -> List[Tuple[int, str]]:
+    matches = []
+    destination_formats_by_clause_offset = {}
+    for clause, clause_offset in _iter_request_clauses(normalized_question):
         for output_format in ('json', 'xml'):
-            if output_format not in clause or _structured_artifact_format_is_negated(clause, output_format):
+            if output_format not in clause or _clause_negates_output_format(clause, output_format):
                 continue
             destination_match = re.search(
                 rf'\b(?:{STRUCTURED_ARTIFACT_DESTINATION_ACTION_PATTERN})\b'
@@ -205,25 +236,102 @@ def get_requested_structured_artifact_format(user_question: str) -> Optional[str
                 clause,
             )
             if destination_match:
-                destination_matches.append((clause_index, destination_match.start(), output_format))
-    if destination_matches:
-        return min(destination_matches)[2]
+                matches.append((clause_offset + destination_match.start(), output_format))
+                destination_formats_by_clause_offset.setdefault(clause_offset, set()).add(output_format)
 
-    for output_format in ('json', 'xml'):
-        for clause in clauses:
-            if output_format not in clause or _structured_artifact_format_is_negated(clause, output_format):
+    for clause, clause_offset in _iter_request_clauses(normalized_question):
+        destination_formats = destination_formats_by_clause_offset.get(clause_offset, set())
+        for output_format in ('json', 'xml'):
+            if output_format not in clause or _clause_negates_output_format(clause, output_format):
                 continue
-            if any(marker in clause for marker in STRUCTURED_ARTIFACT_FORMAT_MARKERS[output_format]):
-                return output_format
-            if re.search(
+            if destination_formats and output_format not in destination_formats:
+                continue
+            marker_positions = [
+                clause.find(marker)
+                for marker in STRUCTURED_ARTIFACT_FORMAT_MARKERS[output_format]
+                if marker in clause
+            ]
+            if marker_positions:
+                matches.append((clause_offset + min(marker_positions), output_format))
+                continue
+            generic_match = re.search(
                 rf'\b(?:{STRUCTURED_ARTIFACT_ACTION_PATTERN})\b'
                 rf'[\w\s.,:;\-/]{{0,80}}\b(?:an?\s+)?{output_format}\b',
                 clause,
-            ):
-                return output_format
-    if assistant_table_export_requested(user_question):
-        return GENERATED_FILE_FORMAT_CSV
-    return None
+            )
+            if generic_match:
+                matches.append((clause_offset + generic_match.start(), output_format))
+    return matches
+
+
+def get_requested_artifact_formats(user_question: str) -> List[str]:
+    """Return explicitly requested artifact formats in user-request order."""
+    normalized_question = _normalize_question_for_artifact_detection(user_question)
+    if not normalized_question:
+        return []
+
+    matches = []
+    csv_position = _first_csv_artifact_position(user_question, normalized_question)
+    if csv_position is not None:
+        matches.append((csv_position, 'csv'))
+    matches.extend(_collect_structured_artifact_format_matches(normalized_question))
+
+    format_pattern_sets = {
+        'md': MARKDOWN_OUTPUT_REQUEST_PATTERNS,
+        'docx': DOCX_OUTPUT_REQUEST_PATTERNS,
+        'pdf': PDF_OUTPUT_REQUEST_PATTERNS,
+    }
+    for output_format, patterns in format_pattern_sets.items():
+        position = _first_pattern_position(normalized_question, patterns)
+        if position is None:
+            continue
+        containing_clause = next(
+            (
+                clause
+                for clause, clause_offset in _iter_request_clauses(normalized_question)
+                if clause_offset <= position < clause_offset + len(clause)
+            ),
+            normalized_question,
+        )
+        if _clause_negates_output_format(containing_clause, output_format):
+            continue
+        matches.append((position, output_format))
+
+    ordered_formats = []
+    for _, output_format in sorted(matches, key=lambda item: (item[0], REQUESTED_ARTIFACT_FORMATS.index(item[1]))):
+        if output_format not in ordered_formats:
+            ordered_formats.append(output_format)
+    return ordered_formats
+
+
+def get_requested_structured_artifact_formats(user_question: str) -> List[str]:
+    """Return requested durable structured artifact formats in user-request order."""
+    return [
+        output_format
+        for output_format in get_requested_artifact_formats(user_question)
+        if output_format in SUPPORTED_GENERATED_EXPORT_FORMATS
+    ]
+
+
+def get_requested_generated_file_formats(user_question: str) -> List[str]:
+    """Return requested single-reply generated file formats in user-request order."""
+    return [
+        output_format
+        for output_format in get_requested_artifact_formats(user_question)
+        if output_format in GENERATED_FILE_FORMATS
+    ]
+
+
+def get_requested_generated_file_format(user_question: str) -> Optional[str]:
+    """Return the requested generated file format, if any."""
+    requested_formats = get_requested_generated_file_formats(user_question)
+    return requested_formats[0] if requested_formats else None
+
+
+def get_requested_structured_artifact_format(user_question: str) -> Optional[str]:
+    """Return a requested CSV, JSON, or XML artifact target without resolving source orchestration."""
+    requested_formats = get_requested_structured_artifact_formats(user_question)
+    return requested_formats[0] if requested_formats else None
 
 
 def _structured_artifact_format_is_negated(clause: str, output_format: str) -> bool:

--- a/application/single_app/functions_tabular_orchestration.py
+++ b/application/single_app/functions_tabular_orchestration.py
@@ -20,7 +20,9 @@ from functions_analysis_deliverables import (
     emit_analysis_deliverable_contract_event,
 )
 from functions_assistant_table_exports import assistant_table_export_requested
+from functions_generated_file_exports import get_requested_artifact_formats
 from functions_generated_file_exports import get_requested_structured_artifact_format
+from functions_generated_file_exports import get_requested_structured_artifact_formats
 
 
 TABULAR_ORCHESTRATION_PLANNER_CONTRACT_VERSION = "tabular-orchestration-v1"
@@ -194,7 +196,13 @@ def build_tabular_parity_rollout_assignment(settings=None, request_key=None, mod
 
 def get_tabular_generated_output_format(user_question):
     """Return the requested generated-output file format when the user asked for one."""
-    return get_requested_structured_artifact_format(user_question)
+    requested_formats = get_tabular_generated_output_formats(user_question)
+    return requested_formats[0] if requested_formats else None
+
+
+def get_tabular_generated_output_formats(user_question):
+    """Return requested durable tabular artifact formats in user-request order."""
+    return get_requested_structured_artifact_formats(user_question)
 
 
 def question_requests_tabular_generated_output(user_question):
@@ -279,6 +287,7 @@ def get_tabular_generated_output_task_type(
     generated_output_requested,
     hierarchical_analysis_requested,
     settings,
+    action_mode=None,
 ):
     """Map request intent to the existing durable generated-output task type."""
     hierarchical_analysis_enabled = settings_flag_enabled(
@@ -286,8 +295,11 @@ def get_tabular_generated_output_task_type(
         "enable_tabular_hierarchical_analysis",
         False,
     )
-    if generated_output_requested and hierarchical_analysis_requested and hierarchical_analysis_enabled:
+    analysis_required = str(action_mode or "").strip().lower() == "analyze"
+    if generated_output_requested and (hierarchical_analysis_requested or analysis_required) and hierarchical_analysis_enabled:
         return TABULAR_RUN_TASK_COMBINED
+    if generated_output_requested and analysis_required:
+        return None
     if generated_output_requested:
         return TABULAR_RUN_TASK_STRUCTURED_EXPORT
     if hierarchical_analysis_requested and hierarchical_analysis_enabled:
@@ -517,14 +529,27 @@ def plan_tabular_request(
         if _is_supported_tabular_context(file_context)
     ]
     output_hints = dict(requested_output_hints or {}) if isinstance(requested_output_hints, Mapping) else {}
+    normalized_action_mode = str(action_mode or "").strip().lower()
+    analysis_required = normalized_action_mode == "analyze"
+    requested_output_formats = get_requested_artifact_formats(user_question)
+    structured_output_formats = get_tabular_generated_output_formats(user_question)
     generated_output_requested = question_requests_tabular_generated_output(user_question)
     hierarchical_analysis_requested = question_requests_tabular_hierarchical_analysis(user_question)
     durable_task_type = get_tabular_generated_output_task_type(
         generated_output_requested,
         hierarchical_analysis_requested,
         settings,
+        action_mode=normalized_action_mode,
     )
-    output_format = get_tabular_generated_output_format(user_question)
+    output_format = structured_output_formats[0] if structured_output_formats else None
+    unsupported_multi_artifact_request = len(structured_output_formats) > 1
+    analysis_durable_capability_disabled = bool(
+        analysis_required
+        and generated_output_requested
+        and not settings_flag_enabled(settings, "enable_tabular_hierarchical_analysis", False)
+    )
+    if unsupported_multi_artifact_request or analysis_durable_capability_disabled:
+        durable_task_type = None
     execution_contract = durable_task_type or TABULAR_EXECUTION_CONTRACT_FOREGROUND_AGGREGATE
     source_coverage = _build_source_coverage(normalized_contexts)
     execution_group_id = _build_execution_group_id(
@@ -558,6 +583,14 @@ def plan_tabular_request(
     if durable_task_type:
         execution_state = TABULAR_EXECUTION_STATE_DECLINED
         reason_code = "durable_intent"
+    elif unsupported_multi_artifact_request:
+        execution_state = TABULAR_EXECUTION_STATE_DECLINED
+        reason_code = "unsupported_multi_artifact_request"
+        safe_failure_details = "Multiple durable tabular artifact formats are not yet supported for one request."
+    elif analysis_durable_capability_disabled:
+        execution_state = TABULAR_EXECUTION_STATE_DECLINED
+        reason_code = "analysis_required_durable_capability_disabled"
+        safe_failure_details = "Analyze with a requested tabular artifact requires the hierarchical analysis capability."
     elif hierarchical_analysis_requested and not durable_task_type:
         reason_code = "hierarchical_analysis_disabled"
 
@@ -581,7 +614,7 @@ def plan_tabular_request(
     )
     deliverable_contract = build_analysis_deliverable_contract(
         action_mode=action_mode,
-        requested_output_format=output_format if generated_output_requested else None,
+        requested_output_formats=requested_output_formats,
         public_output_schema=(
             output_hints.get("public_output_schema")
             or output_hints.get("output_schema")
@@ -615,8 +648,9 @@ def plan_tabular_request(
         "durable_task_type": durable_task_type,
         "generated_output_requested": generated_output_requested,
         "hierarchical_analysis_requested": hierarchical_analysis_requested,
+        "requested_output_formats": requested_output_formats,
         "output_format": output_format,
-        "action_mode": str(action_mode or "").strip().lower(),
+        "action_mode": normalized_action_mode,
         "caller": str(caller or "").strip().lower(),
         "source_count": len(normalized_contexts),
         "source_coverage": source_coverage,

--- a/application/single_app/functions_workflow_runner.py
+++ b/application/single_app/functions_workflow_runner.py
@@ -733,6 +733,14 @@ def _get_primary_tabular_generated_outputs(primary_generated_outputs):
     return normalized_outputs
 
 
+def _primary_tabular_generated_outputs_are_pending(primary_tabular_outputs):
+    for output in primary_tabular_outputs or []:
+        status = str(output.get('status') or output.get('run_status') or '').strip().lower()
+        if output.get('background_export') or status in {'pending', 'queued', 'running', 'in_progress'}:
+            return True
+    return False
+
+
 def _prompt_explicitly_requests_markdown_artifact(analysis_prompt):
     prompt_text = str(analysis_prompt or '').strip().lower()
     if not prompt_text:
@@ -1339,13 +1347,16 @@ def _maybe_create_document_analysis_generated_artifacts(
     create_lossless_artifacts = bool(
         artifact_intent.get('exhaustive')
         or artifact_intent.get('table_output_requested')
+        or json_artifact_requested
         or xml_artifact_requested
         or primary_tabular_outputs
+        or analysis_reply
     )
     deferred_composition = analysis_result.get('deferred_composition') if isinstance(analysis_result.get('deferred_composition'), dict) else {}
     if deferred_composition.get('status') in {'pending', 'gate_disabled', 'continuation_unavailable'}:
         return {'artifacts': [], 'assistant_reply': None}
 
+    primary_tabular_outputs_pending = _primary_tabular_generated_outputs_are_pending(primary_tabular_outputs)
     if create_lossless_artifacts:
         artifacts = []
         structured_rows = _build_document_analysis_structured_rows(analysis_result)
@@ -1372,15 +1383,8 @@ def _maybe_create_document_analysis_generated_artifacts(
 
             markdown_output = _build_document_analysis_markdown_artifact(analysis_result)
             should_create_markdown_artifact = bool(
-                (
-                    artifact_intent.get('markdown_analysis_artifact_recommended')
-                    or (json_payload is not None and not json_artifact_requested)
-                )
-                and markdown_output
-                and (
-                    not primary_tabular_outputs
-                    or _prompt_explicitly_requests_markdown_artifact(analysis_prompt)
-                )
+                markdown_output
+                and not primary_tabular_outputs_pending
             )
             if should_create_markdown_artifact:
                 markdown_file_name = _build_document_analysis_artifact_file_name(analysis_result, 'md')
@@ -1446,14 +1450,26 @@ def _maybe_create_document_analysis_generated_artifacts(
             raise
 
         if artifacts or primary_tabular_outputs:
-            assistant_reply = _build_document_analysis_multi_artifact_reply(
-                document_count,
-                artifacts,
-                len(structured_rows),
-                len(raw_analysis_items),
-                analysis_reply,
-                structured_rows=structured_rows,
+            markdown_only_artifacts = bool(
+                artifacts
+                and not primary_tabular_outputs
+                and all(str(artifact.get('output_format') or '').strip().lower() == 'md' for artifact in artifacts)
             )
+            if markdown_only_artifacts:
+                assistant_reply = _build_document_analysis_artifact_reply(
+                    document_count,
+                    'md',
+                    analysis_reply=analysis_reply,
+                )
+            else:
+                assistant_reply = _build_document_analysis_multi_artifact_reply(
+                    document_count,
+                    artifacts,
+                    len(structured_rows),
+                    len(raw_analysis_items),
+                    analysis_reply,
+                    structured_rows=structured_rows,
+                )
             if primary_tabular_outputs:
                 assistant_reply = _build_document_analysis_primary_output_reply(
                     document_count,

--- a/application/single_app/route_backend_chats.py
+++ b/application/single_app/route_backend_chats.py
@@ -5015,11 +5015,12 @@ def _settings_flag_enabled(settings, key, default=False):
     return _shared_settings_flag_enabled(settings, key, default=default)
 
 
-def _get_tabular_generated_output_task_type(generated_output_requested, hierarchical_analysis_requested, settings):
+def _get_tabular_generated_output_task_type(generated_output_requested, hierarchical_analysis_requested, settings, action_mode=None):
     return _shared_get_tabular_generated_output_task_type(
         generated_output_requested,
         hierarchical_analysis_requested,
         settings,
+        action_mode=action_mode,
     )
 
 
@@ -5741,7 +5742,7 @@ def _build_tabular_generated_output_query_descriptor(
     return descriptor
 
 
-def _build_direct_tabular_generated_output_source(user_question, file_contexts, user_id, conversation_id, settings):
+def _build_direct_tabular_generated_output_source(user_question, file_contexts, user_id, conversation_id, settings, action_mode=None):
     """Build a replayable full-tabular source descriptor without requiring a prior tool page."""
     generated_output_requested = question_requests_tabular_generated_output(user_question)
     hierarchical_analysis_requested = question_requests_tabular_hierarchical_analysis(user_question)
@@ -5749,9 +5750,12 @@ def _build_direct_tabular_generated_output_source(user_question, file_contexts, 
         generated_output_requested,
         hierarchical_analysis_requested,
         settings,
+        action_mode=action_mode,
     )
     analysis_only_requested = durable_task_type == TABULAR_RUN_TASK_HIERARCHICAL_ANALYSIS
     combined_requested = durable_task_type == TABULAR_RUN_TASK_COMBINED
+    if generated_output_requested and str(action_mode or '').strip().lower() == 'analyze' and not durable_task_type:
+        return None
     if not generated_output_requested and not analysis_only_requested:
         return None
     if hierarchical_analysis_requested and not generated_output_requested and not analysis_only_requested:
@@ -5991,6 +5995,7 @@ def maybe_queue_direct_tabular_generated_output(
             user_id,
             conversation_id,
             settings,
+            action_mode=planner_action_mode,
         )
         if not direct_source:
             emit_direct_parity_event(
@@ -6864,9 +6869,12 @@ async def maybe_create_tabular_generated_output(
         generated_output_requested,
         hierarchical_analysis_requested,
         settings,
+        action_mode=mode,
     )
     analysis_only_requested = durable_task_type == TABULAR_RUN_TASK_HIERARCHICAL_ANALYSIS
     combined_requested = durable_task_type == TABULAR_RUN_TASK_COMBINED
+    if generated_output_requested and str(mode or '').strip().lower() == 'analyze' and not durable_task_type:
+        return None
     if hierarchical_analysis_requested and not generated_output_requested and not analysis_only_requested:
         return None
     if not generated_output_requested and not hierarchical_analysis_requested:

--- a/docs/explanation/features/ANALYZE_DELIVERABLE_CONTRACT.md
+++ b/docs/explanation/features/ANALYZE_DELIVERABLE_CONTRACT.md
@@ -2,18 +2,23 @@
 
 Implemented in version: **0.250.171**
 
+Phase 2 updated in version: **0.250.172**
+
 ## Overview
 
 The Analyze deliverable contract defines a server-owned, versioned plan for analysis artifacts before production routing changes are made. It records whether an action requires a primary Markdown analysis artifact, which sibling artifacts were explicitly requested, the public structured schema, row cardinality, ordering, transformation mode, validation profile, and publication policy.
 
-The Phase 1 contract is additive and observation-focused. It does not switch Analyze execution behavior or repair generated values.
+Phase 2 keeps the contract additive, but begins enforcing intent admission for shared tabular planning and bounded document Analyze finalization. Successful bounded Analyze results now publish a primary Markdown artifact. Explicit JSON, XML, or CSV requests are represented as ordered sibling artifacts, and Analyze plus structured output can no longer silently downgrade to structured-only export work when analysis is required.
 
 ## Dependencies
 
 - `application/single_app/functions_analysis_deliverables.py` for contract construction, artifact-set validation, structured-row validation, and gated shadow telemetry.
-- `application/single_app/functions_tabular_orchestration.py` for attaching the contract to shared tabular planner results.
+- `application/single_app/functions_generated_file_exports.py` for ordered, negation-aware requested artifact format detection.
+- `application/single_app/functions_tabular_orchestration.py` for attaching the contract to shared tabular planner results and selecting Analyze-safe execution contracts.
+- `application/single_app/functions_workflow_runner.py` for bounded Analyze Markdown artifact finalization.
 - `functional_tests/test_analyze_deliverable_contract.py` for the executable regression oracle.
-- `application/single_app/config.py` version `0.250.171`.
+- `functional_tests/test_document_analysis_lossless_artifacts.py` for document-analysis artifact finalizer behavior.
+- `application/single_app/config.py` version `0.250.172`.
 
 ## Technical Specifications
 
@@ -56,6 +61,10 @@ Validation reports intentionally omit prompts, row values, storage paths, creden
 
 Shared tabular planning attaches a `deliverable_contract` field to planner results. When `enable_analysis_deliverable_contract_telemetry` is true and `analysis_deliverable_contract_mode` is `observe` or `shadow`, the planner emits debug-only `[ANALYSIS_DELIVERABLE_CONTRACT]` events with safe dimensions.
 
+The planner preserves explicit requested artifact order and direct negation. For example, Analyze with CSV plans Markdown first and CSV second. Analyze with JSON and XML preserves both requested siblings in order, but declines durable tabular execution until multi-artifact publication is available. Search can request Markdown as a normal requested output, but Search does not receive automatic primary Markdown.
+
+When Analyze requests a structured tabular artifact, the shared planner selects `combined` only when hierarchical analysis is enabled. If the required analysis capability is disabled, the request is declined before durable execution rather than being reinterpreted as `structured_export`.
+
 The default settings keep telemetry off:
 
 ```python
@@ -71,6 +80,10 @@ The committed 200-row fixture builder in `functional_tests/test_support/analyze_
 
 - Analyze requires Markdown while Search does not receive automatic Markdown.
 - The requested structured contract is shared across Search and Analyze.
+- Analyze plus CSV maps to Markdown plus CSV and selects `combined` when hierarchical analysis is enabled.
+- Analyze plus JSON and XML preserves both requested siblings in order and fails before unsupported multi-artifact durable execution.
+- Analyze plus structured output does not silently downgrade to `structured_export` when the hierarchical capability is disabled.
+- Bounded document Analyze publishes Markdown, and explicit JSON is a sibling rather than a replacement.
 - JSON serialization round trips and unknown additive fields are ignored for forward compatibility.
 - The source-shaped Analyze failure is rejected.
 - The Search-shaped output with `source_row_number`, `source_row_identity`, and five known rule mismatches is rejected.
@@ -78,4 +91,4 @@ The committed 200-row fixture builder in `functional_tests/test_support/analyze_
 
 ## Known Limitations
 
-Phase 1 defines and observes the contract only. Later phases make Analyze Markdown admission mandatory, separate public schema from lineage, add deterministic and semantic repair, publish atomic artifact sets, and update the plural artifact UI.
+Phase 2 decides and preserves the required artifact set, but it does not implement deterministic rule execution, semantic repair, atomic multi-artifact durable publication, public-schema lineage separation, or plural artifact UI rendering. Those remain in later phases.

--- a/functional_tests/test_analyze_deliverable_contract.py
+++ b/functional_tests/test_analyze_deliverable_contract.py
@@ -2,7 +2,7 @@
 # test_analyze_deliverable_contract.py
 """
 Functional test for Analyze deliverable contract baselines.
-Version: 0.250.171
+Version: 0.250.172
 Implemented in: 0.250.171
 
 This test ensures Phase 1 defines a versioned Analyze deliverable contract,
@@ -50,7 +50,7 @@ from functions_analysis_deliverables import (  # noqa: E402
     validate_analysis_artifact_set,
     validate_structured_deliverable_rows,
 )
-from functions_tabular_orchestration import plan_tabular_request  # noqa: E402
+from functions_tabular_orchestration import get_tabular_generated_output_task_type, plan_tabular_request  # noqa: E402
 
 
 IMPLEMENTED_VERSION = "0.250.171"
@@ -237,8 +237,74 @@ def test_planner_attaches_shadow_deliverable_contract():
     assert deliverable_contract["analysis_required"] is True
     assert deliverable_contract["public_output_schema"] == FINANCIAL_REVIEW_OUTPUT_COLUMNS
     assert [artifact["format"] for artifact in deliverable_contract["requested_artifacts"]] == ["md", "csv"]
-    assert plan["durable_task_type"] == "structured_export"
-    assert plan["execution_contract"] == "structured_export"
+    assert plan["durable_task_type"] == "combined"
+    assert plan["execution_contract"] == "combined"
+
+
+def test_phase2_planner_normalizes_ordered_artifact_intent():
+    print("Testing Phase 2 normalized Analyze artifact intent...")
+    assert_app_version_at_least("0.250.172")
+
+    csv_plan = plan_tabular_request(
+        "Analyze every row and create a CSV artifact.",
+        [{"file_name": "financial_review.csv", "document_id": "doc-1", "source_version": "v1"}],
+        action_mode="analyze",
+        settings={"enable_tabular_hierarchical_analysis": True},
+    )
+    assert csv_plan["requested_output_formats"] == ["csv"]
+    assert csv_plan["durable_task_type"] == "combined"
+    assert [artifact["format"] for artifact in csv_plan["deliverable_contract"]["requested_artifacts"]] == [
+        "md",
+        "csv",
+    ]
+
+    multi_plan = plan_tabular_request(
+        "Analyze every row and export as JSON, then create XML too. Do not create CSV.",
+        [{"file_name": "financial_review.csv", "document_id": "doc-1", "source_version": "v1"}],
+        action_mode="analyze",
+        settings={"enable_tabular_hierarchical_analysis": True},
+    )
+    assert multi_plan["requested_output_formats"] == ["json", "xml"]
+    assert [artifact["format"] for artifact in multi_plan["deliverable_contract"]["requested_artifacts"]] == [
+        "md",
+        "json",
+        "xml",
+    ]
+    assert multi_plan["execution_state"] == "declined"
+    assert multi_plan["reason_code"] == "unsupported_multi_artifact_request"
+
+    disabled_plan = plan_tabular_request(
+        "Analyze every row and create a CSV artifact.",
+        [{"file_name": "financial_review.csv", "document_id": "doc-1", "source_version": "v1"}],
+        action_mode="analyze",
+        settings={"enable_tabular_hierarchical_analysis": False},
+    )
+    assert disabled_plan["durable_task_type"] is None
+    assert disabled_plan["execution_state"] == "declined"
+    assert disabled_plan["reason_code"] == "analysis_required_durable_capability_disabled"
+    assert get_tabular_generated_output_task_type(
+        True,
+        False,
+        {"enable_tabular_hierarchical_analysis": False},
+        action_mode="analyze",
+    ) is None
+    assert get_tabular_generated_output_task_type(
+        True,
+        False,
+        {"enable_tabular_hierarchical_analysis": False},
+        action_mode="search",
+    ) == "structured_export"
+
+    search_markdown_plan = plan_tabular_request(
+        "Search every row and write a Markdown report.",
+        [{"file_name": "financial_review.csv", "document_id": "doc-1", "source_version": "v1"}],
+        action_mode="search",
+        settings={"enable_tabular_hierarchical_analysis": True},
+    )
+    assert search_markdown_plan["generated_output_requested"] is False
+    assert [artifact["format"] for artifact in search_markdown_plan["deliverable_contract"]["requested_artifacts"]] == [
+        "md",
+    ]
 
 
 def test_safe_deliverable_telemetry_excludes_prompt_and_row_values():
@@ -293,6 +359,7 @@ if __name__ == "__main__":
         test_artifact_set_requires_markdown_and_requested_sibling,
         test_financial_review_fixture_rejects_observed_failure_shapes,
         test_planner_attaches_shadow_deliverable_contract,
+        test_phase2_planner_normalizes_ordered_artifact_intent,
         test_safe_deliverable_telemetry_excludes_prompt_and_row_values,
     ]
     results = []

--- a/functional_tests/test_assistant_table_csv_artifact.py
+++ b/functional_tests/test_assistant_table_csv_artifact.py
@@ -2,8 +2,8 @@
 #!/usr/bin/env python3
 """
 Functional test for assistant-rendered table CSV artifacts.
-Version: 0.250.112
-Implemented in: 0.241.050; non-tabular document CSV parsing in 0.250.065; generated file export framework in 0.250.072; updated in 0.250.073; linear fence parsing coverage in 0.250.112
+Version: 0.250.172
+Implemented in: 0.241.050; non-tabular document CSV parsing in 0.250.065; generated file export framework in 0.250.072; updated in 0.250.073; linear fence parsing coverage in 0.250.112; version assertion compatibility updated in 0.250.172
 
 This test ensures that explicit table-format requests with assistant-rendered
 tables, including CSV rows extracted from non-tabular documents, are converted
@@ -18,14 +18,18 @@ import sys
 import traceback
 from pathlib import Path
 
+from test_support.versioning import assert_app_version_at_least
+
 
 ROOT = Path(__file__).resolve().parents[1]
 APP_DIR = ROOT / 'application' / 'single_app'
 CONFIG_FILE = APP_DIR / 'config.py'
 CHAT_ROUTE_FILE = APP_DIR / 'route_backend_chats.py'
 BACKGROUND_EXPORT_FILE = APP_DIR / 'functions_tabular_generated_exports.py'
+GENERATED_EXPORTS_FILE = APP_DIR / 'functions_generated_file_exports.py'
+TABULAR_ORCHESTRATION_FILE = APP_DIR / 'functions_tabular_orchestration.py'
 WORKFLOW_RUNNER_FILE = APP_DIR / 'functions_workflow_runner.py'
-EXPECTED_VERSION = '0.250.112'
+IMPLEMENTED_VERSION = '0.250.112'
 
 sys.path.append(str(APP_DIR))
 
@@ -1030,10 +1034,9 @@ Source: ParkingPrint.pdf, Page: 1
 def test_chat_route_wires_assistant_table_artifacts():
     print('Testing chat route assistant-table artifact plumbing...')
 
-    current_version = read_current_version()
     chat_route_content = read_text(CHAT_ROUTE_FILE)
 
-    assert_true(current_version == EXPECTED_VERSION, f'Expected config.py version {EXPECTED_VERSION}.')
+    assert_app_version_at_least(IMPLEMENTED_VERSION)
     assert_true(
         'assistant_table_export_requested' in chat_route_content,
         'Expected route_backend_chats.py to reuse the shared assistant table export intent predicate.',
@@ -1067,7 +1070,8 @@ def test_chat_route_wires_assistant_table_artifacts():
         'Expected normal and streaming assistant messages to include generated file artifacts.',
     )
     assert_true(
-        'assistant_content=get_generated_file_export_content(execution_result)' in chat_route_content,
+        'document_action_reply_content = get_generated_file_export_content(execution_result)' in chat_route_content
+        and 'assistant_content=document_action_reply_content' in chat_route_content,
         'Expected document-action file exports to use the structured analysis reply when available.',
     )
     assert_true(
@@ -1075,10 +1079,12 @@ def test_chat_route_wires_assistant_table_artifacts():
         'Expected workflow file exports to use the structured analysis reply when available.',
     )
     assert_true(
-        chat_route_content.count('build_generated_file_output_guidance(user_message)') == 2,
+        chat_route_content.count('build_generated_file_output_guidance(') == 2,
         'Expected normal and streaming Chat to apply the same file-output guidance.',
     )
     workflow_runner_content = read_text(WORKFLOW_RUNNER_FILE)
+    generated_exports_content = read_text(GENERATED_EXPORTS_FILE)
+    tabular_orchestration_content = read_text(TABULAR_ORCHESTRATION_FILE)
     assert_true(
         workflow_runner_content.count('build_generated_file_output_guidance(prompt_text)') == 2,
         'Expected workflow model and agent execution to apply the same file-output guidance.',
@@ -1096,11 +1102,11 @@ def test_chat_route_wires_assistant_table_artifacts():
         'Expected workflows to pass current-turn action results to generated-file exports.',
     )
     assert_true(
-        'if assistant_table_export_requested(user_question):' in chat_route_content,
+        'if not assistant_table_export_requested(user_question):' in generated_exports_content,
         'Expected tabular output format detection to use the shared CSV/table intent predicate.',
     )
     assert_true(
-        "requested_format == 'csv'" in chat_route_content,
+        'return get_requested_structured_artifact_formats(user_question)' in tabular_orchestration_content,
         'Expected CSV request markers to create tabular generated outputs when available.',
     )
 

--- a/functional_tests/test_document_analysis_lossless_artifacts.py
+++ b/functional_tests/test_document_analysis_lossless_artifacts.py
@@ -2,19 +2,21 @@
 # test_document_analysis_lossless_artifacts.py
 """
 Functional test for document analysis lossless artifacts.
-Version: 0.250.154
+Version: 0.250.172
 Implemented in: 0.241.040
 Updated in: 0.241.065
 Updated in: 0.241.197
 Updated in: 0.250.065
 Updated in: 0.250.112
 Updated in: 0.250.154
+Updated in: 0.250.172
 
 This test ensures exhaustive/table-style document analysis preserves raw window
 outputs and can build both structured CSV rows and Markdown raw-note artifacts
 instead of relying only on the reduced final answer. It also ensures primary
 tabular generated exports suppress redundant analysis JSON/Markdown cards, and
-that JSON artifacts are only created when the prompt explicitly requests JSON.
+that explicitly requested JSON artifacts are siblings of the required Markdown
+analysis artifact.
 """
 
 import ast
@@ -461,15 +463,22 @@ def test_json_artifact_requires_explicit_json_request():
         conversation_id='conversation-1',
     )
 
-    assert_equal(len(uploaded_artifacts), 1, 'explicit JSON upload count')
-    assert_equal(uploaded_artifacts[0]['output_format'], 'json', 'explicit JSON artifact format')
+    assert_equal(len(uploaded_artifacts), 2, 'explicit JSON upload count')
     assert_equal(
-        uploaded_artifacts[0]['file_name'],
-        '14-cfr-part-91-general-operating-and-flight-rules-analysis.json',
+        [artifact['output_format'] for artifact in uploaded_artifacts],
+        ['md', 'json'],
+        'explicit JSON artifact formats',
+    )
+    assert_equal(
+        [artifact['file_name'] for artifact in uploaded_artifacts],
+        [
+            '14-cfr-part-91-general-operating-and-flight-rules-analysis.md',
+            '14-cfr-part-91-general-operating-and-flight-rules-analysis.json',
+        ],
         'explicit JSON artifact filename',
     )
     explicit_assistant_reply = explicit_artifact_payload.get('assistant_reply') or ''
-    assert_contains(explicit_assistant_reply, 'downloadable JSON artifact', 'explicit JSON assistant reply')
+    assert_contains(explicit_assistant_reply, 'MD, JSON artifacts', 'explicit JSON assistant reply')
     print('JSON artifact opt-in behavior verified.')
 
 

--- a/functional_tests/test_generated_json_xml_exports.py
+++ b/functional_tests/test_generated_json_xml_exports.py
@@ -2,8 +2,8 @@
 # test_generated_json_xml_exports.py
 """
 Functional test for generated JSON/XML export artifacts.
-Version: 0.250.156
-Implemented in: 0.250.114; completed file-export cards and View actions in 0.250.152; truthful private payload streaming in 0.250.153; shared structured-format intent terminology in 0.250.154; source-only intent guardrails in 0.250.156
+Version: 0.250.172
+Implemented in: 0.250.114; completed file-export cards and View actions in 0.250.152; truthful private payload streaming in 0.250.153; shared structured-format intent terminology in 0.250.154; source-only intent guardrails in 0.250.156; ordered artifact intent in 0.250.172
 
 This test ensures JSON/XML generation requests are recognized as downloadable
 artifact workflows, reuse shared serialization helpers, avoid duplicate XML
@@ -133,7 +133,7 @@ def test_chat_route_json_xml_artifact_hooks():
     assert_contains(chat_source, "return _shared_get_tabular_generated_output_format(user_question)", "Chat format delegation")
     assert_contains(
         orchestration_source,
-        "return get_requested_structured_artifact_format(user_question)",
+        "return get_requested_structured_artifact_formats(user_question)",
         "Shared planner format delegation",
     )
     assert_contains(chat_source, "_build_assistant_file_output_handoff", "no-inline assistant handoff builder")
@@ -184,6 +184,7 @@ def test_structured_artifact_intent_is_shared_across_execution_paths():
         assert len(selected_nodes) == len(function_names)
         namespace = {
             'get_requested_structured_artifact_format': module.get_requested_structured_artifact_format,
+            '_shared_get_tabular_generated_output_format': module.get_requested_structured_artifact_format,
         }
         exec(compile(ast.Module(body=selected_nodes, type_ignores=[]), str(source_file), 'exec'), namespace)
         return namespace


### PR DESCRIPTION
## Phase Objective

Implement Phase 2 of the Analyze artifact output contract roadmap: normalize requested artifact intent before execution and make successful bounded Analyze results publish a primary Markdown artifact while preserving explicit requested outputs as siblings.

## Explicit Non-Goals

- Does not add deterministic row-rule execution or semantic repair.
- Does not split public schema from internal lineage fields beyond the Phase 1 validators.
- Does not implement atomic durable multi-artifact publication.
- Does not change the plural artifact UI.
- Does not retire legacy readers or old run formats.

## Behavior Flags And Effective Defaults

- Existing defaults remain unchanged: `analysis_deliverable_contract_mode=off` and `enable_analysis_deliverable_contract_telemetry=False`.
- Existing `enable_tabular_hierarchical_analysis` remains the capability gate for exhaustive Analyze plus structured output.
- Analyze plus structured tabular output now selects `combined` only when hierarchical analysis is enabled.
- If hierarchical analysis is disabled, Analyze plus a structured artifact is declined before durable execution instead of being reinterpreted as `structured_export`.
- Search does not receive automatic Markdown; an explicit Search Markdown request is represented as a requested output.

## Contract-Version Changes

- Keeps `analysis-deliverables-v1` unchanged.
- Extends the contract builder to preserve ordered requested sibling artifact formats.
- Adds ordered, negation-aware artifact-format detection while keeping single-format compatibility wrappers.

## Old-Run Compatibility Impact

- Existing persisted runs and old contract payloads remain readable.
- Changes are additive to planner metadata and finalization behavior for new requests.
- No old durable run task type or stored run schema is removed.

## Implementation Summary

- Added ordered requested artifact detection for CSV, JSON, XML, Markdown, DOCX, and PDF.
- Preserved direct negation such as `do not create CSV`.
- Made shared tabular planning carry all requested artifact formats while using only supported durable structured formats for tabular execution selection.
- Prevented Analyze structured requests from silently downgrading to structured-only durable export.
- Made bounded document Analyze finalization create Markdown as the primary artifact and explicit JSON/XML as sibling artifacts.
- Updated feature documentation and functional tests.

## Validation

Passed locally:

```powershell
python -m py_compile application/single_app/functions_generated_file_exports.py application/single_app/functions_analysis_deliverables.py application/single_app/functions_tabular_orchestration.py application/single_app/functions_workflow_runner.py application/single_app/route_backend_chats.py application/single_app/config.py functional_tests/test_analyze_deliverable_contract.py functional_tests/test_document_analysis_lossless_artifacts.py functional_tests/test_generated_json_xml_exports.py functional_tests/test_assistant_table_csv_artifact.py
python functional_tests/test_analyze_deliverable_contract.py
python functional_tests/test_document_analysis_lossless_artifacts.py
python functional_tests/test_generated_json_xml_exports.py
python functional_tests/test_assistant_table_csv_artifact.py
```

Additional checks passed:

```powershell
git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check
```

VS Code diagnostics reported no errors for touched Python files.

## Security And Source-Scope Coverage

- Action mode remains server-derived; browser metadata does not decide Analyze requirements.
- Artifact formats are normalized through allowlisted detection and bounded contract descriptors.
- No raw settings are sent to the frontend.
- No new Flask routes were added.
- Pending deferred composition does not fabricate a terminal Markdown artifact.
- Existing cancellation rollback and reauthorization paths remain in place for artifact publication.

## Application Version

- Bumped `application/single_app/config.py` from `0.250.171` to `0.250.172`.

## Rollout And Rollback

- Rollout follows existing planner/contract gates and `enable_tabular_hierarchical_analysis` capability control.
- Rollback for new requests can disable the shared planner or hierarchical analysis gate while old accepted runs retain their persisted plans.
- Since this phase is additive and does not remove old run readers, rollback does not require data migration.

## Later Phases Excluded

This PR intentionally excludes Phase 3 public-schema/lineage separation, Phase 4 correctness and repair, Phase 5 atomic artifact-set lifecycle, Phase 6 plural artifact UI, and Phase 7 rollout/legacy retirement.