### PR TITLE
Phase 3: separate public schema from tabular lineage

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -96,7 +96,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.250.172"
+VERSION = "0.250.173"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/functions_analysis_deliverables.py
+++ b/application/single_app/functions_analysis_deliverables.py
@@ -18,7 +18,10 @@ def log_event(*args, **kwargs):
     return _log_event_impl(*args, **kwargs)
 
 
-ANALYSIS_DELIVERABLE_CONTRACT_VERSION = "analysis-deliverables-v1"
+ANALYSIS_DELIVERABLE_CONTRACT_VERSION = "analysis-deliverables-v2"
+ANALYSIS_DELIVERABLE_LEGACY_CONTRACT_VERSIONS = frozenset({
+    "analysis-deliverables-v1",
+})
 
 ANALYSIS_DELIVERABLE_ACTION_ANALYZE = "analyze"
 ANALYSIS_DELIVERABLE_ACTION_SEARCH = "search"
@@ -112,6 +115,10 @@ ANALYSIS_INTERNAL_LINEAGE_FIELD_NAMES = frozenset({
     "source_row_number",
     "source_row_identity",
 })
+ANALYSIS_DEFAULT_LINEAGE_SCHEMA = (
+    "source_row_number",
+    "source_row_identity",
+)
 ANALYSIS_INTERNAL_LINEAGE_FIELD_PREFIX = "__simplechat"
 
 ANALYSIS_DELIVERABLE_MAX_ARTIFACTS = 12
@@ -145,6 +152,8 @@ class AnalysisDeliverableContract:
     primary_artifact_role: str = ""
     requested_artifacts: tuple = field(default_factory=tuple)
     public_output_schema: tuple = field(default_factory=tuple)
+    internal_checkpoint_schema: tuple = field(default_factory=tuple)
+    lineage_schema: tuple = field(default_factory=tuple)
     row_cardinality: str = ANALYSIS_ROW_CARDINALITY_NOT_APPLICABLE
     ordering: str = ANALYSIS_ORDERING_NOT_APPLICABLE
     transformation_mode: str = ANALYSIS_TRANSFORMATION_MODE_SEMANTIC
@@ -160,6 +169,8 @@ class AnalysisDeliverableContract:
             for artifact in self.requested_artifacts
         ]
         payload["public_output_schema"] = list(self.public_output_schema)
+        payload["internal_checkpoint_schema"] = list(self.internal_checkpoint_schema)
+        payload["lineage_schema"] = list(self.lineage_schema)
         return payload
 
 
@@ -261,12 +272,62 @@ def _normalize_public_output_schema(public_output_schema=None):
             raise ValueError("Analysis public output schema contains an empty field name")
         if len(normalized_field) > ANALYSIS_DELIVERABLE_MAX_FIELD_NAME_LENGTH:
             raise ValueError("Analysis public output schema field exceeds the bounded metadata limit")
+        if _is_internal_lineage_field(normalized_field):
+            raise ValueError("Analysis public output schema cannot include reserved internal fields")
         if normalized_field in seen_fields:
             raise ValueError("Analysis public output schema contains duplicate fields")
         seen_fields.add(normalized_field)
         normalized_schema.append(normalized_field)
     if len(normalized_schema) > ANALYSIS_DELIVERABLE_MAX_SCHEMA_FIELDS:
         raise ValueError("Analysis public output schema exceeds the bounded metadata limit")
+    return tuple(normalized_schema)
+
+
+def _normalize_lineage_schema(lineage_schema=None):
+    normalized_schema = []
+    seen_fields = set()
+    raw_schema = list(lineage_schema or ANALYSIS_DEFAULT_LINEAGE_SCHEMA)
+    for field_name in raw_schema:
+        normalized_field = str(field_name or "").strip()
+        if not normalized_field:
+            raise ValueError("Analysis lineage schema contains an empty field name")
+        if len(normalized_field) > ANALYSIS_DELIVERABLE_MAX_FIELD_NAME_LENGTH:
+            raise ValueError("Analysis lineage schema field exceeds the bounded metadata limit")
+        if not _is_internal_lineage_field(normalized_field):
+            raise ValueError("Analysis lineage schema can only include reserved internal fields")
+        if normalized_field in seen_fields:
+            raise ValueError("Analysis lineage schema contains duplicate fields")
+        seen_fields.add(normalized_field)
+        normalized_schema.append(normalized_field)
+    return tuple(normalized_schema)
+
+
+def _normalize_internal_checkpoint_schema(
+    public_output_schema=None,
+    internal_checkpoint_schema=None,
+    lineage_schema=None,
+):
+    normalized_public_schema = tuple(public_output_schema or [])
+    normalized_lineage_schema = _normalize_lineage_schema(lineage_schema)
+    if internal_checkpoint_schema is None:
+        return tuple(list(normalized_lineage_schema) + list(normalized_public_schema))
+
+    normalized_schema = []
+    seen_fields = set()
+    for field_name in list(internal_checkpoint_schema or []):
+        normalized_field = str(field_name or "").strip()
+        if not normalized_field:
+            raise ValueError("Analysis internal checkpoint schema contains an empty field name")
+        if len(normalized_field) > ANALYSIS_DELIVERABLE_MAX_FIELD_NAME_LENGTH:
+            raise ValueError("Analysis internal checkpoint schema field exceeds the bounded metadata limit")
+        if normalized_field in seen_fields:
+            raise ValueError("Analysis internal checkpoint schema contains duplicate fields")
+        seen_fields.add(normalized_field)
+        normalized_schema.append(normalized_field)
+
+    expected_schema = tuple(list(normalized_lineage_schema) + list(normalized_public_schema))
+    if tuple(normalized_schema) != expected_schema:
+        raise ValueError("Analysis internal checkpoint schema must be lineage fields followed by public fields")
     return tuple(normalized_schema)
 
 
@@ -329,6 +390,8 @@ def build_analysis_deliverable_contract(
     requested_output_formats=None,
     requested_artifacts=None,
     public_output_schema=None,
+    internal_checkpoint_schema=None,
+    lineage_schema=None,
     row_cardinality=None,
     ordering=None,
     transformation_mode=None,
@@ -347,6 +410,12 @@ def build_analysis_deliverable_contract(
         else analysis_required
     )
     normalized_schema = _normalize_public_output_schema(public_output_schema)
+    normalized_lineage_schema = _normalize_lineage_schema(lineage_schema)
+    normalized_internal_checkpoint_schema = _normalize_internal_checkpoint_schema(
+        public_output_schema=normalized_schema,
+        internal_checkpoint_schema=internal_checkpoint_schema,
+        lineage_schema=normalized_lineage_schema,
+    )
 
     if requested_artifacts is None:
         artifact_descriptors = []
@@ -432,6 +501,8 @@ def build_analysis_deliverable_contract(
         primary_artifact_role=normalized_primary_role,
         requested_artifacts=normalized_artifacts,
         public_output_schema=normalized_schema,
+        internal_checkpoint_schema=normalized_internal_checkpoint_schema,
+        lineage_schema=normalized_lineage_schema,
         row_cardinality=normalized_row_cardinality,
         ordering=normalized_ordering,
         transformation_mode=normalized_transformation_mode,
@@ -451,12 +522,19 @@ def coerce_analysis_deliverable_contract(contract):
     if isinstance(contract, AnalysisDeliverableContract):
         return contract
     payload = dict(contract or {}) if isinstance(contract, Mapping) else {}
-    if payload.get("contract_version") not in {None, "", ANALYSIS_DELIVERABLE_CONTRACT_VERSION}:
+    if payload.get("contract_version") not in {
+        None,
+        "",
+        ANALYSIS_DELIVERABLE_CONTRACT_VERSION,
+        *ANALYSIS_DELIVERABLE_LEGACY_CONTRACT_VERSIONS,
+    }:
         raise ValueError("Unsupported analysis deliverable contract version")
     return build_analysis_deliverable_contract(
         action_mode=payload.get("action_mode"),
         requested_artifacts=payload.get("requested_artifacts") or [],
         public_output_schema=payload.get("public_output_schema") or [],
+        internal_checkpoint_schema=payload.get("internal_checkpoint_schema"),
+        lineage_schema=payload.get("lineage_schema"),
         row_cardinality=payload.get("row_cardinality"),
         ordering=payload.get("ordering"),
         transformation_mode=payload.get("transformation_mode"),
@@ -572,6 +650,37 @@ def _is_internal_lineage_field(field_name):
         normalized_field in ANALYSIS_INTERNAL_LINEAGE_FIELD_NAMES
         or normalized_field.startswith(ANALYSIS_INTERNAL_LINEAGE_FIELD_PREFIX)
     )
+
+
+def is_analysis_internal_lineage_field(field_name):
+    """Return whether a field name is reserved for server lineage metadata."""
+    return _is_internal_lineage_field(field_name)
+
+
+def project_structured_deliverable_row(row, public_output_schema, require_all_fields=True):
+    """Project one internal generated row to the persisted public schema."""
+    if not isinstance(row, Mapping):
+        raise ValueError("Structured deliverable row must be an object")
+    normalized_schema = _normalize_public_output_schema(public_output_schema)
+    if not normalized_schema:
+        raise ValueError("Structured deliverable projection requires a public output schema")
+    if require_all_fields:
+        missing_fields = [field_name for field_name in normalized_schema if field_name not in row]
+        if missing_fields:
+            raise ValueError("Structured deliverable row is missing required public fields")
+    return {field_name: row.get(field_name) for field_name in normalized_schema}
+
+
+def project_structured_deliverable_rows(rows, public_output_schema, require_all_fields=True):
+    """Project internal generated rows to the exact user-facing schema and order."""
+    return [
+        project_structured_deliverable_row(
+            row,
+            public_output_schema,
+            require_all_fields=require_all_fields,
+        )
+        for row in list(rows or [])
+    ]
 
 
 def _row_identity(row, identity_field):

--- a/application/single_app/functions_generated_file_exports.py
+++ b/application/single_app/functions_generated_file_exports.py
@@ -175,6 +175,23 @@ MARKDOWN_OUTPUT_REQUEST_PATTERNS = (
     re.compile(r'\b(?:in|as)\s+(?:a\s+)?(?:markdown|md)(?:\s+(?:document|file|report))?\b'),
 )
 
+PASSTHROUGH_DERIVED_OUTPUT_PATTERNS = (
+    re.compile(r'\b(?:derive|derived|classify|classification|categorize|category|calculate|computed?|map|mapping)\b'),
+    re.compile(r'\b(?:score|rank|judge|evaluate|determine|flag|label|extract|populate|fill)\b'),
+    re.compile(r'\b(?:analy[sz]e|analysis|summari[sz]e|summary|sentiment|risk|attention|status)\b'),
+    re.compile(r'\b(?:exactly|only)\s+(?:these\s+)?(?:fields|columns)\b'),
+    re.compile(r'\b(?:output|requested|derived)\s+(?:fields|columns|schema)\b'),
+    re.compile(r'\bone\s+output\s+row\s+(?:for|per)\s+(?:each|every|source)\s+row\b'),
+)
+PASSTHROUGH_COPY_PATTERNS = (
+    re.compile(r'\b(?:unchanged|as-is|as\s+is|verbatim|raw|original|source)\s+(?:copy|rows?|data|table|result|results)\b'),
+    re.compile(r'\b(?:copy|export|download|save)\b[\w\s,.:;\-/]{0,100}\b(?:unchanged|as-is|as\s+is|verbatim|raw|original|source)\b'),
+)
+PASSTHROUGH_SERIALIZE_PATTERNS = (
+    re.compile(r'\b(?:build|create|download|export|format|generate|make|prepare|save|serialize|convert)\b[\w\s,.:;\-/]{0,100}\b(?:csv|json|xml|docx|pdf|spreadsheet)\b'),
+    re.compile(r'\b(?:csv|json|xml|docx|pdf|spreadsheet)\b[\w\s,.:;\-/]{0,100}\b(?:export|download|file|format|copy)\b'),
+)
+
 
 def _normalize_question_for_artifact_detection(user_question: str) -> str:
     return re.sub(r'\s+', ' ', str(user_question or '').strip().casefold())
@@ -352,6 +369,57 @@ def generated_file_export_requested(user_question: str) -> bool:
     return get_requested_generated_file_format(user_question) is not None
 
 
+def _question_requires_derived_output(normalized_question: str) -> bool:
+    return any(pattern.search(normalized_question) for pattern in PASSTHROUGH_DERIVED_OUTPUT_PATTERNS)
+
+
+def _question_requests_unchanged_copy(normalized_question: str) -> bool:
+    return any(pattern.search(normalized_question) for pattern in PASSTHROUGH_COPY_PATTERNS)
+
+
+def _question_requests_serialization(normalized_question: str) -> bool:
+    return any(pattern.search(normalized_question) for pattern in PASSTHROUGH_SERIALIZE_PATTERNS)
+
+
+def _collect_row_schema(rows: Sequence[Dict[str, Any]]) -> List[str]:
+    for row in rows or []:
+        if isinstance(row, dict):
+            return [str(field_name or '').strip() for field_name in row if str(field_name or '').strip()]
+    return []
+
+
+def evaluate_generated_file_passthrough_eligibility(
+    user_question: str,
+    rows: Optional[Sequence[Dict[str, Any]]] = None,
+    public_output_schema: Optional[Sequence[str]] = None,
+) -> Dict[str, Any]:
+    """Return whether raw rows can satisfy a requested generated file contract."""
+    normalized_question = _normalize_question_for_artifact_detection(user_question)
+    normalized_rows = [row for row in list(rows or []) if isinstance(row, dict)]
+    if not normalized_rows:
+        return {'allowed': False, 'reason_code': 'source_result_incomplete'}
+    if _question_requires_derived_output(normalized_question):
+        return {'allowed': False, 'reason_code': 'derived_output_requires_transform'}
+
+    normalized_public_schema = [
+        str(field_name or '').strip()
+        for field_name in list(public_output_schema or [])
+        if str(field_name or '').strip()
+    ]
+    if normalized_public_schema:
+        expected_schema = set(normalized_public_schema)
+        if _collect_row_schema(normalized_rows) != normalized_public_schema:
+            return {'allowed': False, 'reason_code': 'schema_not_satisfied'}
+        if any(set(row.keys()) != expected_schema for row in normalized_rows):
+            return {'allowed': False, 'reason_code': 'schema_not_satisfied'}
+
+    if _question_requests_unchanged_copy(normalized_question):
+        return {'allowed': True, 'reason_code': 'explicit_unchanged_copy'}
+    if _question_requests_serialization(normalized_question):
+        return {'allowed': True, 'reason_code': 'explicit_format_conversion'}
+    return {'allowed': False, 'reason_code': 'no_explicit_passthrough_contract'}
+
+
 def build_generated_file_output_guidance(
     user_question: str,
     requested_format: Optional[str] = None,
@@ -415,9 +483,13 @@ def build_generated_file_export(
     assistant_text = str(assistant_content or '').strip()
     assistant_rows = extract_assistant_table_entries(assistant_text)
     function_rows = extract_authorized_function_result_rows(function_results)
+    function_passthrough = evaluate_generated_file_passthrough_eligibility(
+        user_question,
+        rows=function_rows,
+    ) if function_rows else {'allowed': False, 'reason_code': 'source_result_incomplete'}
 
     if output_format == GENERATED_FILE_FORMAT_CSV:
-        rows = assistant_rows or function_rows
+        rows = assistant_rows or (function_rows if function_passthrough.get('allowed') else [])
         if not rows:
             return None
         row_source = 'assistant response' if assistant_rows else 'structured function result'
@@ -427,12 +499,15 @@ def build_generated_file_export(
             rows=rows,
             row_source=row_source,
             assistant_content=assistant_text,
+            passthrough_reason_code=(None if assistant_rows else function_passthrough.get('reason_code')),
         )
 
     if not assistant_text and not assistant_rows and not function_rows:
         return None
-    rows = function_rows or assistant_rows
-    row_source = 'structured function result' if function_rows else 'assistant response'
+    rows = function_rows if function_rows and function_passthrough.get('allowed') else assistant_rows
+    if not assistant_text and not rows:
+        return None
+    row_source = 'structured function result' if rows and rows is function_rows else 'assistant response'
     title = _build_generated_file_title(output_format)
     if output_format == GENERATED_FILE_FORMAT_DOCX:
         file_content = _render_docx_file_export(title, assistant_text, rows, row_source)
@@ -445,6 +520,7 @@ def build_generated_file_export(
         row_source=row_source,
         assistant_content=assistant_text,
         title=title,
+        passthrough_reason_code=(function_passthrough.get('reason_code') if row_source == 'structured function result' else None),
     )
 
 
@@ -545,11 +621,12 @@ def _build_generated_file_payload(
     row_source: str,
     assistant_content: str,
     title: str = '',
+    passthrough_reason_code: Optional[str] = None,
 ) -> Dict[str, Any]:
     normalized_output_format = str(output_format or '').strip().lower()
     row_count = len(rows or [])
     normalized_title = str(title or _build_generated_file_title(normalized_output_format)).strip()
-    return {
+    payload = {
         'capability': 'file_export',
         'file_name': _build_generated_file_name(normalized_output_format),
         'file_content': file_content,
@@ -566,6 +643,9 @@ def _build_generated_file_payload(
             normalized_title,
         ),
     }
+    if passthrough_reason_code:
+        payload['passthrough_reason_code'] = str(passthrough_reason_code or '').strip()[:80]
+    return payload
 
 
 def _build_generated_file_name(output_format: str) -> str:

--- a/application/single_app/functions_tabular_generated_exports.py
+++ b/application/single_app/functions_tabular_generated_exports.py
@@ -17,6 +17,7 @@ import tempfile
 import time
 import uuid
 from datetime import datetime, timedelta, timezone
+from xml.sax.saxutils import escape as escape_xml_text
 
 from azure.core import MatchConditions
 from azure.core.exceptions import ResourceExistsError
@@ -37,6 +38,10 @@ from config import (
     storage_account_user_documents_container_name,
 )
 from functions_appinsights import log_event
+from functions_analysis_deliverables import (
+    is_analysis_internal_lineage_field,
+    project_structured_deliverable_row,
+)
 from functions_assistant_table_exports import build_safe_csv_headers, neutralize_csv_spreadsheet_formula
 from functions_tabular_csv_query import (
     iter_tabular_csv_query_rows,
@@ -1109,10 +1114,84 @@ def _sync_tabular_generation_contract_fields(run):
     run.setdefault('systemic_failure_category', None)
     run.setdefault('systemic_failure_signature', None)
     run.setdefault('systemic_failure_opened_at', None)
+    run['lineage_schema'] = _get_tabular_run_lineage_schema(run)
+    run['public_output_schema'] = _get_tabular_run_public_output_schema(run)
+    run['internal_checkpoint_schema'] = _get_tabular_run_internal_checkpoint_schema(run)
     run['checkpointed_row_count'] = checkpointed_row_count
     run.setdefault('generation_started_at', run.get('started_at'))
     run.setdefault('generation_completed_at', None)
     return run
+
+
+def _get_tabular_run_lineage_schema(run):
+    raw_schema = list((run or {}).get('lineage_schema') or [
+        TABULAR_EXPORT_OUTPUT_ROW_NUMBER_FIELD,
+        TABULAR_EXPORT_OUTPUT_ROW_IDENTITY_FIELD,
+    ])
+    normalized_schema = []
+    seen_fields = set()
+    for field_name in raw_schema:
+        normalized_field = str(field_name or '').strip()
+        if not normalized_field or normalized_field in seen_fields:
+            continue
+        if not is_analysis_internal_lineage_field(normalized_field):
+            continue
+        seen_fields.add(normalized_field)
+        normalized_schema.append(normalized_field)
+    return normalized_schema or [
+        TABULAR_EXPORT_OUTPUT_ROW_NUMBER_FIELD,
+        TABULAR_EXPORT_OUTPUT_ROW_IDENTITY_FIELD,
+    ]
+
+
+def _get_tabular_run_public_output_schema(run):
+    raw_public_schema = list((run or {}).get('public_output_schema') or [])
+    if not raw_public_schema:
+        deliverable_contract = (
+            ((run or {}).get('tabular_planner_metadata') or {}).get('deliverable_contract')
+            if isinstance((run or {}).get('tabular_planner_metadata'), dict)
+            else {}
+        )
+        raw_public_schema = list((deliverable_contract or {}).get('public_output_schema') or [])
+    if not raw_public_schema:
+        raw_public_schema = [
+            field_name
+            for field_name in list((run or {}).get('output_schema') or [])
+            if not is_analysis_internal_lineage_field(field_name)
+        ]
+
+    normalized_schema = []
+    seen_fields = set()
+    for field_name in raw_public_schema:
+        normalized_field = str(field_name or '').strip()
+        if not normalized_field or normalized_field in seen_fields:
+            continue
+        if is_analysis_internal_lineage_field(normalized_field):
+            continue
+        seen_fields.add(normalized_field)
+        normalized_schema.append(normalized_field)
+    return normalized_schema
+
+
+def _get_tabular_run_internal_checkpoint_schema(run):
+    raw_internal_schema = list((run or {}).get('internal_checkpoint_schema') or [])
+    if raw_internal_schema:
+        return [str(field_name or '').strip() for field_name in raw_internal_schema if str(field_name or '').strip()]
+    output_schema = list((run or {}).get('output_schema') or [])
+    if output_schema:
+        return [str(field_name or '').strip() for field_name in output_schema if str(field_name or '').strip()]
+    return _get_tabular_run_lineage_schema(run) + _get_tabular_run_public_output_schema(run)
+
+
+def _get_tabular_run_serialized_public_schema(run):
+    public_schema = _get_tabular_run_public_output_schema(run)
+    if public_schema:
+        return public_schema
+    return [
+        field_name
+        for field_name in list((run or {}).get('output_schema') or [])
+        if not is_analysis_internal_lineage_field(field_name)
+    ]
 
 
 def _build_generation_progress_contract_fields(run, completed_batches, processed_rows):
@@ -1438,6 +1517,24 @@ def _serialize_generated_output_value(value):
         except TypeError:
             pass
     return neutralize_csv_spreadsheet_formula(value)
+
+
+def _sanitize_generated_xml_tag_name(value, fallback_value='Field'):
+    normalized_name = re.sub(r'[^A-Za-z0-9_.-]+', '_', str(value or '').strip()).strip('._-')
+    if not normalized_name:
+        normalized_name = fallback_value
+    if not re.match(r'^[A-Za-z_]', normalized_name):
+        normalized_name = f'{fallback_value}_{normalized_name}'
+    return normalized_name
+
+
+def _write_generated_xml_row(output_stream, row):
+    output_stream.write('  <Row>\n')
+    for field_name, field_value in (row or {}).items():
+        tag_name = _sanitize_generated_xml_tag_name(field_name)
+        serialized_value = _serialize_generated_output_value(field_value)
+        output_stream.write(f'    <{tag_name}>{escape_xml_text(serialized_value)}</{tag_name}>\n')
+    output_stream.write('  </Row>\n')
 
 
 def _normalize_source_identity_label(value):
@@ -3820,6 +3917,12 @@ def _apply_active_tabular_generation_plan(run, plan):
     if current_output_schema and current_output_schema != planned_output_schema:
         raise ValueError('Active generation plan schema does not match the persisted run schema')
     run['output_schema'] = planned_output_schema
+    run['lineage_schema'] = _get_tabular_run_lineage_schema(run)
+    run['public_output_schema'] = [
+        str(output_field.get('name') or '').strip()
+        for output_field in _get_tabular_generation_plan_llm_fields(plan)
+    ]
+    run['internal_checkpoint_schema'] = planned_output_schema
 
 
 def _recover_tabular_generation_plan(run, input_contract, plan_blob_path, plan_mode):
@@ -5601,7 +5704,7 @@ def _normalize_tabular_run_planner_metadata(planner_metadata):
     if not planner_metadata:
         return {}
 
-    return {
+    normalized_metadata = {
         'planner_contract_version': str(planner_metadata.get('planner_contract_version') or '').strip()[:80],
         'execution_contract': str(planner_metadata.get('execution_contract') or '').strip().lower()[:80],
         'execution_state': str(planner_metadata.get('execution_state') or '').strip().lower()[:40],
@@ -5615,6 +5718,39 @@ def _normalize_tabular_run_planner_metadata(planner_metadata):
             planner_metadata.get('rollout_assignment'),
         ),
     }
+    deliverable_contract = planner_metadata.get('deliverable_contract')
+    if isinstance(deliverable_contract, dict):
+        normalized_metadata['deliverable_contract'] = {
+            'contract_version': str(deliverable_contract.get('contract_version') or '').strip()[:80],
+            'action_mode': str(deliverable_contract.get('action_mode') or '').strip().lower()[:40],
+            'analysis_required': bool(deliverable_contract.get('analysis_required')),
+            'primary_artifact_role': str(deliverable_contract.get('primary_artifact_role') or '').strip().lower()[:80],
+            'public_output_schema': [
+                str(field_name or '').strip()
+                for field_name in list(deliverable_contract.get('public_output_schema') or [])[:TABULAR_GENERATION_PLAN_MAX_FIELDS]
+                if str(field_name or '').strip()
+                and not is_analysis_internal_lineage_field(field_name)
+            ],
+            'internal_checkpoint_schema': [
+                str(field_name or '').strip()
+                for field_name in list(deliverable_contract.get('internal_checkpoint_schema') or [])[
+                    :TABULAR_GENERATION_PLAN_MAX_FIELDS + 2
+                ]
+                if str(field_name or '').strip()
+            ],
+            'lineage_schema': [
+                str(field_name or '').strip()
+                for field_name in list(deliverable_contract.get('lineage_schema') or [])[:8]
+                if str(field_name or '').strip()
+                and is_analysis_internal_lineage_field(field_name)
+            ],
+            'row_cardinality': str(deliverable_contract.get('row_cardinality') or '').strip().lower()[:80],
+            'ordering': str(deliverable_contract.get('ordering') or '').strip().lower()[:80],
+            'transformation_mode': str(deliverable_contract.get('transformation_mode') or '').strip().lower()[:80],
+            'validation_profile': str(deliverable_contract.get('validation_profile') or '').strip().lower()[:80],
+            'publication_policy': str(deliverable_contract.get('publication_policy') or '').strip().lower()[:80],
+        }
+    return normalized_metadata
 
 
 def _normalize_tabular_run_source_format(run):
@@ -6856,17 +6992,22 @@ def _write_ordered_output_stream(run, output_stream):
     expected_row_count = _safe_int(run.get('row_count'))
     output_format = str(run.get('output_format') or 'json').strip().lower() or 'json'
     output_schema = list(run.get('output_schema') or [])
+    public_output_schema = _get_tabular_run_serialized_public_schema(run)
     if not output_schema:
         raise ValueError('Generated output schema is missing')
+    if not public_output_schema:
+        raise ValueError('Generated public output schema is missing')
     if TABULAR_EXPORT_OUTPUT_ROW_NUMBER_FIELD not in output_schema:
         raise ValueError('Generated output schema is missing source row order')
 
     csv_writer = None
     safe_output_schema = None
     if output_format == 'csv':
-        safe_output_schema = build_safe_csv_headers(output_schema)
+        safe_output_schema = build_safe_csv_headers(public_output_schema)
         csv_writer = csv.DictWriter(output_stream, fieldnames=safe_output_schema, lineterminator='\n')
         csv_writer.writeheader()
+    elif output_format == 'xml':
+        output_stream.write('<?xml version="1.0" encoding="UTF-8"?>\n<GeneratedOutput>\n')
     else:
         output_stream.write('[\n')
 
@@ -6899,20 +7040,29 @@ def _write_ordered_output_stream(run, output_stream):
                 field_name: entry.get(field_name)
                 for field_name in output_schema
             }
+            public_entry = project_structured_deliverable_row(
+                ordered_entry,
+                public_output_schema,
+                require_all_fields=True,
+            )
             if csv_writer:
                 csv_writer.writerow({
-                    safe_field_name: _serialize_generated_output_value(ordered_entry.get(field_name))
-                    for field_name, safe_field_name in zip(output_schema, safe_output_schema)
+                    safe_field_name: _serialize_generated_output_value(public_entry.get(field_name))
+                    for field_name, safe_field_name in zip(public_output_schema, safe_output_schema)
                 })
+            elif output_format == 'xml':
+                _write_generated_xml_row(output_stream, public_entry)
             else:
                 if written_row_count:
                     output_stream.write(',\n')
-                output_stream.write(json.dumps(ordered_entry, default=str, ensure_ascii=False))
+                output_stream.write(json.dumps(public_entry, default=str, ensure_ascii=False))
 
             written_row_count += 1
             expected_source_row_number += 1
 
-    if output_format != 'csv':
+    if output_format == 'xml':
+        output_stream.write('</GeneratedOutput>\n')
+    elif output_format != 'csv':
         output_stream.write('\n]\n')
     if written_row_count != expected_row_count:
         raise ValueError(
@@ -6923,14 +7073,17 @@ def _write_ordered_output_stream(run, output_stream):
 
 def _build_structured_export_preview_rows(run):
     output_schema = list((run or {}).get('output_schema') or [])
+    public_output_schema = _get_tabular_run_serialized_public_schema(run)
     if not output_schema:
+        return []
+    if not public_output_schema:
         return []
 
     output_format = str((run or {}).get('output_format') or 'json').strip().lower() or 'json'
     preview_schema = (
-        build_safe_csv_headers(output_schema)
+        build_safe_csv_headers(public_output_schema)
         if output_format == 'csv'
-        else output_schema
+        else public_output_schema
     )
     preview_rows = []
     preview_char_count = 0
@@ -6961,8 +7114,13 @@ def _build_structured_export_preview_rows(run):
                 )
 
             preview_row = {}
-            for field_name, preview_field_name in zip(output_schema, preview_schema):
-                rendered_value = _serialize_generated_output_value(entry.get(field_name))
+            public_entry = project_structured_deliverable_row(
+                entry,
+                public_output_schema,
+                require_all_fields=True,
+            )
+            for field_name, preview_field_name in zip(public_output_schema, preview_schema):
+                rendered_value = _serialize_generated_output_value(public_entry.get(field_name))
                 if len(rendered_value) > TABULAR_EXPORT_ARTIFACT_PREVIEW_CELL_MAX_CHARS:
                     rendered_value = (
                         f'{rendered_value[:TABULAR_EXPORT_ARTIFACT_PREVIEW_CELL_MAX_CHARS - 3]}...'
@@ -7699,6 +7857,8 @@ def _checkpoint_generated_batch_results(run, generated_results):
     run_contract_changed = False
     if list(run.get('output_schema') or []) != expected_output_schema:
         run['output_schema'] = expected_output_schema
+        run['public_output_schema'] = _get_tabular_run_public_output_schema(run)
+        run['internal_checkpoint_schema'] = _get_tabular_run_internal_checkpoint_schema(run)
         run_contract_changed = True
     if _record_shadow_tabular_generation_plan_comparison(run, expected_output_schema):
         run_contract_changed = True
@@ -8885,6 +9045,11 @@ def queue_tabular_generated_output_run(
         'chunk_gpt_model': str(chunk_gpt_model or '').strip(),
         'chunk_model_context': chunk_model_context if isinstance(chunk_model_context, dict) else {},
         'passthrough_input_rows': bool(passthrough_input_rows),
+        'passthrough_reason_code': (
+            str(source_candidate.get('passthrough_reason_code') or '').strip()[:80]
+            if passthrough_input_rows
+            else None
+        ),
         'generated_file_name': generated_file_name,
         'analysis_generated_file_name': analysis_generated_file_name,
         'row_count': staged_row_count,
@@ -8919,6 +9084,12 @@ def queue_tabular_generated_output_run(
         'planner_completed_at': None,
         'processed_rows': 0,
         'output_schema': None,
+        'public_output_schema': [],
+        'internal_checkpoint_schema': [],
+        'lineage_schema': [
+            TABULAR_EXPORT_OUTPUT_ROW_NUMBER_FIELD,
+            TABULAR_EXPORT_OUTPUT_ROW_IDENTITY_FIELD,
+        ],
         'source_descriptor': source_descriptor or None,
         'batch_budget': model_batch_budget,
         'source_authorization': source_authorization or None,

--- a/application/single_app/functions_workflow_runner.py
+++ b/application/single_app/functions_workflow_runner.py
@@ -5298,6 +5298,7 @@ def _maybe_create_workflow_generated_file_output(
                 source_candidate={
                     'filename': generated_file_name,
                     'selected_sheet': '',
+                    'passthrough_reason_code': export_payload.get('passthrough_reason_code'),
                     'source_authorization': {
                         'source': 'chat',
                     },

--- a/application/single_app/route_backend_chats.py
+++ b/application/single_app/route_backend_chats.py
@@ -147,6 +147,7 @@ from functions_generated_file_exports import (
     build_generated_file_artifact_metadata,
     build_generated_file_export,
     build_generated_file_output_guidance,
+    evaluate_generated_file_passthrough_eligibility,
     get_generated_file_export_content,
     get_requested_generated_file_format,
     get_requested_structured_artifact_format,
@@ -2301,6 +2302,7 @@ def maybe_create_generated_file_output(
                 source_candidate={
                     'filename': generated_file_name,
                     'selected_sheet': '',
+                    'passthrough_reason_code': export_payload.get('passthrough_reason_code'),
                     'source_authorization': {
                         'source': 'chat',
                     },
@@ -5037,6 +5039,11 @@ def question_requests_tabular_structured_object_output(user_question):
         'one row per comment',
         'one object per submission',
         'one object for each row',
+        'one output row for each source row',
+        'one output row per source row',
+        'one output row for every source row',
+        'one output row for each row',
+        'exactly one output row',
         'for each row',
         'for every row',
         'every row',
@@ -7294,6 +7301,7 @@ async def maybe_create_tabular_generated_output(
     if not output_format or not rows:
         return None
 
+    passthrough_reason_code = None
     if question_requests_tabular_structured_object_output(user_question):
         raise_if_mixed_source_cancelled(
             cancel_requested,
@@ -7325,6 +7333,31 @@ async def maybe_create_tabular_generated_output(
         if isinstance(output_entries, dict) and output_entries.get('background_export'):
             return output_entries
     else:
+        passthrough_eligibility = evaluate_generated_file_passthrough_eligibility(
+            user_question,
+            rows=rows,
+        )
+        if not passthrough_eligibility.get('allowed'):
+            reason_code = str(passthrough_eligibility.get('reason_code') or 'schema_not_satisfied').strip()
+            log_event(
+                '[TABULAR_GENERATED_OUTPUT] Refused source-row passthrough for generated export',
+                {
+                    'conversation_id': conversation_id,
+                    'source_file_name': source_candidate.get('filename'),
+                    'output_format': output_format,
+                    'row_count': len(rows),
+                    'passthrough_reason_code': reason_code,
+                },
+                level=logging.WARNING,
+            )
+            return _build_failed_tabular_generated_output_metadata(
+                source_candidate,
+                output_format,
+                'The requested export requires generated output and could not be safely created from raw source rows. No partial file was created.',
+            )
+        passthrough_reason_code = str(
+            passthrough_eligibility.get('reason_code') or 'explicit_format_conversion'
+        ).strip()[:80]
         output_entries = rows
 
     if output_format == 'csv':
@@ -7364,6 +7397,7 @@ async def maybe_create_tabular_generated_output(
             'generated_file_name': generated_file_name,
             'output_format': output_format,
             'row_count': len(output_entries),
+            'passthrough_reason_code': passthrough_reason_code,
         },
         debug_only=True,
     )
@@ -7414,6 +7448,7 @@ async def maybe_create_tabular_generated_output(
             'generated_file_name': uploaded_file_name,
             'output_format': output_format,
             'row_count': len(output_entries),
+            'passthrough_reason_code': passthrough_reason_code,
         },
         debug_only=True,
     )
@@ -7429,6 +7464,7 @@ async def maybe_create_tabular_generated_output(
         'source_file_name': source_candidate.get('filename'),
         'selected_sheet': source_candidate.get('selected_sheet'),
         'preview_rows': preview_rows,
+        'passthrough_reason_code': passthrough_reason_code,
         'summary': (
             f"Saved {len(output_entries)} row(s) to {uploaded_file_name} "
             'in this chat as a downloadable export.'

--- a/docs/explanation/features/ANALYZE_DELIVERABLE_CONTRACT.md
+++ b/docs/explanation/features/ANALYZE_DELIVERABLE_CONTRACT.md
@@ -4,32 +4,40 @@ Implemented in version: **0.250.171**
 
 Phase 2 updated in version: **0.250.172**
 
+Phase 3 updated in version: **0.250.173**
+
 ## Overview
 
 The Analyze deliverable contract defines a server-owned, versioned plan for analysis artifacts before production routing changes are made. It records whether an action requires a primary Markdown analysis artifact, which sibling artifacts were explicitly requested, the public structured schema, row cardinality, ordering, transformation mode, validation profile, and publication policy.
 
 Phase 2 keeps the contract additive, but begins enforcing intent admission for shared tabular planning and bounded document Analyze finalization. Successful bounded Analyze results now publish a primary Markdown artifact. Explicit JSON, XML, or CSV requests are represented as ordered sibling artifacts, and Analyze plus structured output can no longer silently downgrade to structured-only export work when analysis is required.
 
+Phase 3 separates public structured schemas from internal checkpoint lineage. Durable tabular checkpoints still retain source row number and identity for validation, retries, audit, and restart, but final CSV, JSON, XML, preview rows, and preview columns are projected through the persisted public schema. Raw source or function rows are no longer accepted as a derived generated-output artifact unless the request is an explicit unchanged copy, serialization, or format conversion and the rows satisfy the public schema contract.
+
 ## Dependencies
 
 - `application/single_app/functions_analysis_deliverables.py` for contract construction, artifact-set validation, structured-row validation, and gated shadow telemetry.
 - `application/single_app/functions_generated_file_exports.py` for ordered, negation-aware requested artifact format detection.
 - `application/single_app/functions_tabular_orchestration.py` for attaching the contract to shared tabular planner results and selecting Analyze-safe execution contracts.
+- `application/single_app/functions_tabular_generated_exports.py` for durable checkpoint lineage, public projection, and final artifact serialization.
 - `application/single_app/functions_workflow_runner.py` for bounded Analyze Markdown artifact finalization.
 - `functional_tests/test_analyze_deliverable_contract.py` for the executable regression oracle.
+- `functional_tests/test_tabular_phase3_public_schema_projection.py` for public schema projection and passthrough guard coverage.
 - `functional_tests/test_document_analysis_lossless_artifacts.py` for document-analysis artifact finalizer behavior.
-- `application/single_app/config.py` version `0.250.172`.
+- `application/single_app/config.py` version `0.250.173`.
 
 ## Technical Specifications
 
 ### Contract Fields
 
-- `contract_version`: currently `analysis-deliverables-v1`.
+- `contract_version`: currently `analysis-deliverables-v2`.
 - `action_mode`: normalized caller action such as `analyze` or `search`.
 - `analysis_required`: true for Analyze by server policy.
 - `requested_artifacts`: ordered artifact descriptors with role, format, required state, and request order.
 - `primary_artifact_role`: `primary_analysis` when Analyze requires Markdown.
 - `public_output_schema`: ordered public fields for a requested structured output.
+- `internal_checkpoint_schema`: lineage fields followed by public fields for durable validation and resume.
+- `lineage_schema`: server-owned row lineage fields such as `source_row_number` and `source_row_identity`.
 - `row_cardinality` and `ordering`: row coverage expectations for structured deliverables.
 - `transformation_mode`: `passthrough`, `deterministic`, `semantic`, or `hybrid`.
 - `validation_profile`: artifact-only, exact row/schema, or exact row/schema/rule validation.
@@ -43,6 +51,40 @@ Phase 2 keeps the contract additive, but begins enforcing intent admission for s
 - `supporting_output`: optional server-generated supporting material.
 
 Roles are product semantics, not formats. A Search-requested Markdown file is `requested_output`; an Analyze-required Markdown file is `primary_analysis`.
+
+### Public Schema Projection
+
+Durable structured export checkpoints keep the internal schema required by the runner:
+
+```text
+source_row_number, source_row_identity, <public fields...>
+```
+
+Published artifacts and browser metadata use only `public_output_schema`:
+
+- CSV headers and row values
+- JSON object fields and order
+- XML row elements and escaped text
+- preview rows and preview columns
+- generated artifact summaries consumed by the chat UI
+
+Reserved fields such as `source_row_number`, `source_row_identity`, and `__simplechat_*` cannot be requested as public output fields. Legacy runs that only have `output_schema` are interpreted by filtering reserved lineage fields at publication time; old checkpoints are not rewritten.
+
+### Passthrough Eligibility
+
+Raw source or function rows can satisfy a generated file request only when the request is explicitly an unchanged copy, serialization, or format conversion, and any supplied public schema matches the row fields. Derived requests are refused instead of publishing source-shaped output.
+
+Refusal reason codes include:
+
+- `derived_output_requires_transform`
+- `source_result_incomplete`
+- `schema_not_satisfied`
+- `no_explicit_passthrough_contract`
+
+Allowed passthrough reason codes include:
+
+- `explicit_unchanged_copy`
+- `explicit_format_conversion`
 
 ### Validation
 
@@ -89,6 +131,14 @@ The committed 200-row fixture builder in `functional_tests/test_support/analyze_
 - The Search-shaped output with `source_row_number`, `source_row_identity`, and five known rule mismatches is rejected.
 - Safe telemetry excludes prompt text, row values, file names, and storage paths.
 
+`functional_tests/test_tabular_phase3_public_schema_projection.py` verifies:
+
+- Contract version `analysis-deliverables-v2` persists distinct public, internal checkpoint, and lineage schemas.
+- Reserved lineage fields are rejected in public schemas.
+- Durable CSV, JSON, XML, and preview metadata expose only public fields in order.
+- XML output escapes projected values without leaking lineage fields.
+- Generic generated-file finalizers refuse raw function rows for derived requests but allow explicit serialization.
+
 ## Known Limitations
 
-Phase 2 decides and preserves the required artifact set, but it does not implement deterministic rule execution, semantic repair, atomic multi-artifact durable publication, public-schema lineage separation, or plural artifact UI rendering. Those remain in later phases.
+Phase 3 enforces structural schema fidelity and passthrough safety. It does not implement deterministic rule execution, semantic repair, atomic multi-artifact durable publication, or plural artifact UI rendering. Those remain in later phases.

--- a/functional_tests/test_tabular_phase3_public_schema_projection.py
+++ b/functional_tests/test_tabular_phase3_public_schema_projection.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+# test_tabular_phase3_public_schema_projection.py
+"""
+Functional test for Phase 3 public schema projection and passthrough safety.
+Version: 0.250.173
+Implemented in: 0.250.173
+
+This test ensures generated tabular artifacts expose only the persisted public
+schema while retaining internal checkpoint lineage, and that raw row passthrough
+is refused for derived generated-output requests.
+"""
+
+import ast
+import io
+import json
+import sys
+import traceback
+from pathlib import Path
+from xml.etree import ElementTree
+from xml.sax.saxutils import escape as escape_xml_text
+
+from test_support.versioning import assert_app_version_at_least
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+APP_ROOT = REPO_ROOT / "application" / "single_app"
+TABULAR_EXPORTS = APP_ROOT / "functions_tabular_generated_exports.py"
+IMPLEMENTED_VERSION = "0.250.173"
+sys.path.insert(0, str(APP_ROOT))
+
+from functions_analysis_deliverables import (  # noqa: E402
+    build_analysis_deliverable_contract,
+    project_structured_deliverable_row,
+)
+from functions_assistant_table_exports import (  # noqa: E402
+    build_safe_csv_headers,
+    neutralize_csv_spreadsheet_formula,
+)
+from functions_generated_file_exports import (  # noqa: E402
+    build_generated_file_export,
+    evaluate_generated_file_passthrough_eligibility,
+)
+
+
+def assert_equal(actual, expected, label):
+    if actual != expected:
+        raise AssertionError(f"{label}: expected {expected!r}, got {actual!r}")
+
+
+def assert_true(value, label):
+    if not value:
+        raise AssertionError(f"Expected truthy value for {label}")
+
+
+def assert_false(value, label):
+    if value:
+        raise AssertionError(f"Expected falsy value for {label}")
+
+
+def load_tabular_export_namespace(checkpoint_rows):
+    source = TABULAR_EXPORTS.read_text(encoding="utf-8")
+    module_tree = ast.parse(source, filename=str(TABULAR_EXPORTS))
+    function_names = {
+        "_safe_int",
+        "_serialize_generated_output_value",
+        "_sanitize_generated_xml_tag_name",
+        "_write_generated_xml_row",
+        "_get_tabular_run_lineage_schema",
+        "_get_tabular_run_public_output_schema",
+        "_get_tabular_run_internal_checkpoint_schema",
+        "_get_tabular_run_serialized_public_schema",
+        "_write_ordered_output_stream",
+        "_build_structured_export_preview_rows",
+    }
+    selected_nodes = [
+        node
+        for node in module_tree.body
+        if isinstance(node, ast.FunctionDef) and node.name in function_names
+    ]
+    assert_equal({node.name for node in selected_nodes}, function_names, "loaded function set")
+
+    namespace = {
+        "TABULAR_EXPORT_OUTPUT_ROW_NUMBER_FIELD": "source_row_number",
+        "TABULAR_EXPORT_OUTPUT_ROW_IDENTITY_FIELD": "source_row_identity",
+        "TABULAR_EXPORT_ARTIFACT_PREVIEW_MAX_ROWS": 10,
+        "TABULAR_EXPORT_ARTIFACT_PREVIEW_MAX_CHARS": 24000,
+        "TABULAR_EXPORT_ARTIFACT_PREVIEW_CELL_MAX_CHARS": 240,
+        "build_safe_csv_headers": build_safe_csv_headers,
+        "csv": __import__("csv"),
+        "escape_xml_text": escape_xml_text,
+        "io": io,
+        "is_analysis_internal_lineage_field": lambda field_name: str(field_name or "").strip() in {
+            "source_row_number",
+            "source_row_identity",
+        } or str(field_name or "").strip().startswith("__simplechat"),
+        "json": json,
+        "neutralize_csv_spreadsheet_formula": neutralize_csv_spreadsheet_formula,
+        "project_structured_deliverable_row": project_structured_deliverable_row,
+        "re": __import__("re"),
+        "_download_json_blob": lambda blob_path: checkpoint_rows[blob_path],
+        "_output_blob_path": lambda user_id, conversation_id, run_id, batch_number: f"batch-{batch_number}",
+        "_validate_tabular_output_checkpoint_metadata": lambda run, blob_path, batch_number: None,
+    }
+    exec(compile(ast.Module(body=selected_nodes, type_ignores=[]), str(TABULAR_EXPORTS), "exec"), namespace)
+    return namespace
+
+
+def build_internal_run(output_format):
+    return {
+        "user_id": "user-1",
+        "conversation_id": "conversation-1",
+        "id": "run-1",
+        "batch_count": 1,
+        "row_count": 2,
+        "output_format": output_format,
+        "output_schema": ["source_row_number", "source_row_identity", "Decision", "Amount"],
+        "public_output_schema": ["Decision", "Amount"],
+        "lineage_schema": ["source_row_number", "source_row_identity"],
+        "internal_checkpoint_schema": ["source_row_number", "source_row_identity", "Decision", "Amount"],
+    }
+
+
+def test_contract_separates_public_internal_and_lineage_schema():
+    print("Testing deliverable contract schema separation...")
+    assert_app_version_at_least(IMPLEMENTED_VERSION)
+    contract = build_analysis_deliverable_contract(
+        action_mode="search",
+        requested_output_format="csv",
+        public_output_schema=["Decision", "Amount"],
+        row_cardinality="one_per_source_row",
+        ordering="source_order",
+    ).to_dict()
+
+    assert_equal(contract["contract_version"], "analysis-deliverables-v2", "contract version")
+    assert_equal(contract["public_output_schema"], ["Decision", "Amount"], "public schema")
+    assert_equal(contract["lineage_schema"], ["source_row_number", "source_row_identity"], "lineage schema")
+    assert_equal(
+        contract["internal_checkpoint_schema"],
+        ["source_row_number", "source_row_identity", "Decision", "Amount"],
+        "internal checkpoint schema",
+    )
+
+    for reserved_field in ("source_row_number", "source_row_identity", "__simplechat_row_token"):
+        try:
+            build_analysis_deliverable_contract(
+                action_mode="search",
+                requested_output_format="csv",
+                public_output_schema=[reserved_field],
+            )
+        except ValueError:
+            continue
+        raise AssertionError(f"Reserved field {reserved_field!r} was accepted in the public schema")
+
+
+def test_public_projection_drives_csv_json_xml_and_preview():
+    print("Testing public projection across durable output formats and preview metadata...")
+    checkpoint_rows = {
+        "batch-1": [
+            {
+                "source_row_number": 1,
+                "source_row_identity": "FRI-001",
+                "Decision": "Monitor",
+                "Amount": "100",
+            },
+            {
+                "source_row_number": 2,
+                "source_row_identity": "FRI-002",
+                "Decision": "High <Attention>",
+                "Amount": "=2+2",
+            },
+        ],
+    }
+    namespace = load_tabular_export_namespace(checkpoint_rows)
+
+    csv_stream = io.StringIO()
+    namespace["_write_ordered_output_stream"](build_internal_run("csv"), csv_stream)
+    csv_payload = csv_stream.getvalue()
+    assert_true(csv_payload.startswith("Decision,Amount\n"), "csv public headers")
+    assert_false("source_row_number" in csv_payload, "csv lineage leakage")
+    assert_true("'=2+2" in csv_payload, "csv formula neutralization")
+
+    json_stream = io.StringIO()
+    namespace["_write_ordered_output_stream"](build_internal_run("json"), json_stream)
+    json_rows = json.loads(json_stream.getvalue())
+    assert_equal(list(json_rows[0]), ["Decision", "Amount"], "json public field order")
+    assert_false("source_row_identity" in json_rows[0], "json lineage leakage")
+
+    xml_stream = io.StringIO()
+    namespace["_write_ordered_output_stream"](build_internal_run("xml"), xml_stream)
+    xml_payload = xml_stream.getvalue()
+    ElementTree.fromstring(xml_payload)
+    assert_true("<Decision>High &lt;Attention&gt;</Decision>" in xml_payload, "xml escaping")
+    assert_false("source_row_identity" in xml_payload, "xml lineage leakage")
+
+    preview_rows = namespace["_build_structured_export_preview_rows"](build_internal_run("csv"))
+    assert_equal(list(preview_rows[0]), ["Decision", "Amount"], "preview columns")
+    assert_false("source_row_number" in preview_rows[0], "preview lineage leakage")
+
+
+def test_passthrough_eligibility_and_generic_finalizer_guard():
+    print("Testing passthrough eligibility and generic finalizer guard...")
+    rows = [{"Case": "A", "Amount": 100}]
+    allowed = evaluate_generated_file_passthrough_eligibility(
+        "Export these results as CSV.",
+        rows=rows,
+    )
+    assert_true(allowed["allowed"], "explicit serialization passthrough")
+    assert_equal(allowed["reason_code"], "explicit_format_conversion", "serialization reason")
+
+    unchanged = evaluate_generated_file_passthrough_eligibility(
+        "Download an unchanged copy of the source rows as CSV.",
+        rows=rows,
+    )
+    assert_true(unchanged["allowed"], "explicit unchanged copy passthrough")
+    assert_equal(unchanged["reason_code"], "explicit_unchanged_copy", "unchanged reason")
+
+    derived = evaluate_generated_file_passthrough_eligibility(
+        "Create a CSV with exactly one output row for each source row and classify risk.",
+        rows=rows,
+    )
+    assert_false(derived["allowed"], "derived passthrough rejection")
+    assert_equal(derived["reason_code"], "derived_output_requires_transform", "derived reason")
+
+    schema_mismatch = evaluate_generated_file_passthrough_eligibility(
+        "Export these results as CSV.",
+        rows=rows,
+        public_output_schema=["Risk"],
+    )
+    assert_false(schema_mismatch["allowed"], "schema mismatch passthrough rejection")
+    assert_equal(schema_mismatch["reason_code"], "schema_not_satisfied", "schema mismatch reason")
+
+    function_results = [{
+        "success": True,
+        "plugin_name": "SimpleChatPlugin",
+        "function_name": "lookup_rows",
+        "function_result": json.dumps({"rows": rows}),
+    }]
+    guarded_payload = build_generated_file_export(
+        "Create a CSV with exactly these columns: Risk, Reason.",
+        "",
+        function_results=function_results,
+    )
+    assert_equal(guarded_payload, None, "derived function rows are not serialized")
+
+    passthrough_payload = build_generated_file_export(
+        "Export these results as CSV.",
+        "",
+        function_results=function_results,
+    )
+    assert_true(passthrough_payload, "explicit function row serialization")
+    assert_equal(passthrough_payload["row_source"], "structured function result", "function row source")
+    assert_equal(
+        passthrough_payload["passthrough_reason_code"],
+        "explicit_format_conversion",
+        "function passthrough reason",
+    )
+
+
+def run_all_tests():
+    tests = [
+        test_contract_separates_public_internal_and_lineage_schema,
+        test_public_projection_drives_csv_json_xml_and_preview,
+        test_passthrough_eligibility_and_generic_finalizer_guard,
+    ]
+    results = []
+    for test in tests:
+        try:
+            test()
+            print(f"PASS: {test.__name__}")
+            results.append(True)
+        except Exception as exc:
+            print(f"FAIL: {test.__name__}: {exc}")
+            traceback.print_exc()
+            results.append(False)
+    print(f"Results: {sum(results)}/{len(results)} tests passed")
+    return all(results)
+
+
+if __name__ == "__main__":
+    sys.exit(0 if run_all_tests() else 1)


### PR DESCRIPTION
## Phase objective

Implement Phase 3 of the Analyze artifact output contract: separate internal tabular lineage from user-facing structured schemas, project durable outputs through the public schema, and prevent raw source/function rows from being published as derived generated output.

## Explicit non-goals

- No deterministic rule execution or semantic repair; value-level correctness remains Phase 4.
- No atomic multi-artifact publication lifecycle; that remains Phase 5.
- No plural artifact UI replacement; that remains Phase 6.
- No replacement of the existing durable runner, source resolver, artifact store, or authorization path.

## Behavior flags and effective defaults

- No new admin/user-facing setting is introduced.
- Existing `analysis_deliverable_contract_mode` and `enable_analysis_deliverable_contract_telemetry` defaults remain unchanged/off.
- New run contracts use schema separation by default through the existing planner/run metadata path.
- Existing tabular generation rollout, compact protocol, worker pool, and retry flags keep their prior defaults.

## Contract-version changes

- Bumps the deliverable contract from `analysis-deliverables-v1` to `analysis-deliverables-v2`.
- Adds distinct `public_output_schema`, `internal_checkpoint_schema`, and `lineage_schema` meanings.
- Keeps source row number and identity in internal checkpoints, while final CSV/JSON/XML/download previews use only the public schema.
- Rejects reserved public field names such as `source_row_number`, `source_row_identity`, and `__simplechat_*`.

## Old-run compatibility impact

- Existing `analysis-deliverables-v1` contracts remain readable.
- Legacy durable runs that only have `output_schema` derive a compatibility public schema by filtering reserved lineage fields at publication/preview time.
- Existing checkpoints are not rewritten or reinterpreted beyond safe public projection.

## Security and source-scope coverage

- Final serializers and previews use server-persisted public schemas, not client-selected field drops.
- Internal lineage stays available for checkpoint validation, retries, auditing, and resume.
- Passthrough is allowed only for explicit unchanged-copy or format-conversion requests whose rows satisfy the public schema.
- Derived, classification, mapping, calculation, summary, or row-judgment requests fail closed instead of publishing raw source/function rows.
- Current artifact upload, download, promotion, source authorization, and source-version checks remain in place.

## Application version

- Bumped `application/single_app/config.py` to `0.250.173`.

## Validation

- `python -m py_compile application/single_app/config.py application/single_app/functions_analysis_deliverables.py application/single_app/functions_generated_file_exports.py application/single_app/functions_tabular_generated_exports.py application/single_app/functions_workflow_runner.py application/single_app/route_backend_chats.py functional_tests/test_tabular_phase3_public_schema_projection.py` - passed
- `python functional_tests/test_analyze_deliverable_contract.py` - 6/6 passed
- `python functional_tests/test_tabular_phase3_public_schema_projection.py` - 3/3 passed
- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --cached --check` - passed before commit
- Phase 3 changed-file hygiene for final newline, trailing whitespace, and Markdown fences - passed

## Rollout and rollback

- Rollout follows the existing daughter-branch PR into `feature/analyze-artifact-output-contract`.
- Rollback is to stop merging this phase or revert this commit on the integration branch; old v1 contracts and legacy runs remain readable.
- Runs already created with v2 keep their persisted schema interpretation.

## Later phases excluded

Confirmed: this PR does not add Phase 4 rule execution/repair, Phase 5 atomic artifact-set lifecycle, Phase 6 plural UI replacement, or Phase 7 rollout/legacy retirement.