### PR TITLE
Phase 4: Add tabular transformation contract

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -96,7 +96,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.250.173"
+VERSION = "0.250.174"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/functions_analysis_deliverables.py
+++ b/application/single_app/functions_analysis_deliverables.py
@@ -8,6 +8,8 @@ import re
 from dataclasses import asdict, dataclass, field
 from typing import Mapping
 
+from functions_tabular_transformations import normalize_tabular_transformation_spec
+
 
 def log_event(*args, **kwargs):
     """Lazily resolve telemetry logging so functional tests do not require Azure packages."""
@@ -18,9 +20,10 @@ def log_event(*args, **kwargs):
     return _log_event_impl(*args, **kwargs)
 
 
-ANALYSIS_DELIVERABLE_CONTRACT_VERSION = "analysis-deliverables-v2"
+ANALYSIS_DELIVERABLE_CONTRACT_VERSION = "analysis-deliverables-v3"
 ANALYSIS_DELIVERABLE_LEGACY_CONTRACT_VERSIONS = frozenset({
     "analysis-deliverables-v1",
+    "analysis-deliverables-v2",
 })
 
 ANALYSIS_DELIVERABLE_ACTION_ANALYZE = "analyze"
@@ -157,6 +160,7 @@ class AnalysisDeliverableContract:
     row_cardinality: str = ANALYSIS_ROW_CARDINALITY_NOT_APPLICABLE
     ordering: str = ANALYSIS_ORDERING_NOT_APPLICABLE
     transformation_mode: str = ANALYSIS_TRANSFORMATION_MODE_SEMANTIC
+    transformation_spec: dict = field(default_factory=dict)
     validation_profile: str = ANALYSIS_VALIDATION_PROFILE_ARTIFACT_SET
     publication_policy: str = ANALYSIS_PUBLICATION_POLICY_NO_REQUIRED_ARTIFACTS
     source_fingerprint: str = ""
@@ -171,6 +175,7 @@ class AnalysisDeliverableContract:
         payload["public_output_schema"] = list(self.public_output_schema)
         payload["internal_checkpoint_schema"] = list(self.internal_checkpoint_schema)
         payload["lineage_schema"] = list(self.lineage_schema)
+        payload["transformation_spec"] = dict(self.transformation_spec or {})
         return payload
 
 
@@ -395,6 +400,7 @@ def build_analysis_deliverable_contract(
     row_cardinality=None,
     ordering=None,
     transformation_mode=None,
+    transformation_spec=None,
     validation_profile=None,
     publication_policy=None,
     analysis_required=None,
@@ -478,6 +484,10 @@ def build_analysis_deliverable_contract(
         ANALYSIS_TRANSFORMATION_MODE_SEMANTIC,
         "transformation mode",
     )
+    normalized_transformation_spec = normalize_tabular_transformation_spec(
+        transformation_spec,
+        public_output_schema=normalized_schema,
+    )
     normalized_validation_profile = _normalize_bounded_mode(
         validation_profile,
         ANALYSIS_VALIDATION_PROFILES,
@@ -506,6 +516,7 @@ def build_analysis_deliverable_contract(
         row_cardinality=normalized_row_cardinality,
         ordering=normalized_ordering,
         transformation_mode=normalized_transformation_mode,
+        transformation_spec=normalized_transformation_spec,
         validation_profile=normalized_validation_profile,
         publication_policy=normalized_publication_policy,
         source_fingerprint=str(source_fingerprint or "").strip()[:64],
@@ -538,6 +549,7 @@ def coerce_analysis_deliverable_contract(contract):
         row_cardinality=payload.get("row_cardinality"),
         ordering=payload.get("ordering"),
         transformation_mode=payload.get("transformation_mode"),
+        transformation_spec=payload.get("transformation_spec"),
         validation_profile=payload.get("validation_profile"),
         publication_policy=payload.get("publication_policy"),
         analysis_required=payload.get("analysis_required", False),

--- a/application/single_app/functions_tabular_generated_exports.py
+++ b/application/single_app/functions_tabular_generated_exports.py
@@ -43,6 +43,12 @@ from functions_analysis_deliverables import (
     project_structured_deliverable_row,
 )
 from functions_assistant_table_exports import build_safe_csv_headers, neutralize_csv_spreadsheet_formula
+from functions_tabular_transformations import (
+    evaluate_tabular_transformation_row,
+    get_tabular_transformation_model_fields,
+    is_tabular_transformation_deterministic_only,
+    normalize_tabular_transformation_spec,
+)
 from functions_tabular_csv_query import (
     iter_tabular_csv_query_rows,
     validate_tabular_csv_query_expression,
@@ -1181,6 +1187,99 @@ def _get_tabular_run_internal_checkpoint_schema(run):
     if output_schema:
         return [str(field_name or '').strip() for field_name in output_schema if str(field_name or '').strip()]
     return _get_tabular_run_lineage_schema(run) + _get_tabular_run_public_output_schema(run)
+
+
+def _get_tabular_run_transformation_spec(run, public_output_schema=None):
+    raw_spec = (run or {}).get('transformation_spec')
+    if not raw_spec:
+        deliverable_contract = (
+            ((run or {}).get('tabular_planner_metadata') or {}).get('deliverable_contract')
+            if isinstance((run or {}).get('tabular_planner_metadata'), dict)
+            else {}
+        )
+        raw_spec = (deliverable_contract or {}).get('transformation_spec')
+    if not raw_spec:
+        return {}
+    return normalize_tabular_transformation_spec(
+        raw_spec,
+        public_output_schema=public_output_schema or _get_tabular_run_public_output_schema(run),
+    )
+
+
+def _get_public_fields_from_output_schema(output_schema):
+    return [
+        str(field_name or '').strip()
+        for field_name in list(output_schema or [])
+        if str(field_name or '').strip()
+        and not is_analysis_internal_lineage_field(field_name)
+    ]
+
+
+def _get_lineage_fields_from_output_schema(output_schema):
+    lineage_fields = [
+        str(field_name or '').strip()
+        for field_name in list(output_schema or [])
+        if str(field_name or '').strip()
+        and is_analysis_internal_lineage_field(field_name)
+    ]
+    return lineage_fields or [
+        TABULAR_EXPORT_OUTPUT_ROW_NUMBER_FIELD,
+        TABULAR_EXPORT_OUTPUT_ROW_IDENTITY_FIELD,
+    ]
+
+
+def _build_model_expected_output_schema(expected_output_schema, transformation_spec=None):
+    if not transformation_spec:
+        return list(expected_output_schema or [])
+    public_schema = _get_public_fields_from_output_schema(expected_output_schema)
+    if not public_schema:
+        return list(expected_output_schema or [])
+    model_fields = get_tabular_transformation_model_fields(
+        transformation_spec,
+        public_output_schema=public_schema,
+    )
+    return _get_lineage_fields_from_output_schema(expected_output_schema) + model_fields
+
+
+def _merge_deterministic_transformation_entries(
+    source_rows,
+    generated_entries,
+    expected_output_schema,
+    transformation_spec=None,
+):
+    if not transformation_spec:
+        return generated_entries, list(expected_output_schema or [])
+    final_output_schema = list(expected_output_schema or [])
+    public_schema = _get_public_fields_from_output_schema(final_output_schema)
+    if not public_schema:
+        return generated_entries, final_output_schema
+    normalized_spec = normalize_tabular_transformation_spec(
+        transformation_spec,
+        public_output_schema=public_schema,
+    )
+    if not normalized_spec:
+        return generated_entries, final_output_schema
+
+    merged_entries = []
+    for row_index, (source_row, generated_entry) in enumerate(
+        zip(source_rows or [], generated_entries or []),
+        start=1,
+    ):
+        deterministic_values = evaluate_tabular_transformation_row(normalized_spec, source_row)
+        merged_entry = {}
+        for field_name in final_output_schema:
+            if field_name in deterministic_values:
+                merged_entry[field_name] = deterministic_values.get(field_name)
+            elif field_name in generated_entry:
+                merged_entry[field_name] = generated_entry.get(field_name)
+            elif is_analysis_internal_lineage_field(field_name):
+                merged_entry[field_name] = generated_entry.get(field_name)
+            else:
+                raise ValueError(
+                    f'Deterministic transformation merge missing field {field_name} at row {row_index}'
+                )
+        merged_entries.append(merged_entry)
+    return merged_entries, final_output_schema
 
 
 def _get_tabular_run_serialized_public_schema(run):
@@ -3989,6 +4088,7 @@ def _ensure_tabular_generation_plan(
     if (
         task_type not in {TABULAR_RUN_TASK_STRUCTURED_EXPORT, TABULAR_RUN_TASK_COMBINED}
         or (run or {}).get('passthrough_input_rows')
+        or bool(_get_tabular_run_transformation_spec(run))
         or chat_service is None
     ):
         if (run or {}).get('plan_status') not in {'ready', 'fallback', 'not_applicable'}:
@@ -4157,10 +4257,15 @@ async def _generate_batch_entries(
     batch_timeout_seconds=TABULAR_EXPORT_DEFAULT_BATCH_TIMEOUT_SECONDS,
     response_protocol=TABULAR_RESPONSE_PROTOCOL_OBJECT_V1,
     generation_plan=None,
+    transformation_spec=None,
 ):
     batch_number = batch_index + 1
     normalized_response_protocol = str(response_protocol or TABULAR_RESPONSE_PROTOCOL_OBJECT_V1).strip()
     compact_protocol = _is_compact_row_array_protocol(normalized_response_protocol)
+    model_expected_output_schema = _build_model_expected_output_schema(
+        expected_output_schema,
+        transformation_spec=transformation_spec,
+    )
     batch_prompt = _build_batch_prompt(
         user_question,
         batch_rows,
@@ -4168,7 +4273,7 @@ async def _generate_batch_entries(
         total_batches,
         source_file_name,
         selected_sheet=selected_sheet,
-        output_schema=expected_output_schema,
+        output_schema=model_expected_output_schema,
         response_protocol=normalized_response_protocol,
         generation_plan=generation_plan,
     )
@@ -4263,10 +4368,16 @@ async def _generate_batch_entries(
                 normalized_entries, output_schema = _normalize_model_generated_batch_entries(
                     batch_rows,
                     parsed_entries,
-                    expected_output_schema=expected_output_schema,
+                    expected_output_schema=model_expected_output_schema,
                     allow_source_token_recovery=not compact_protocol,
                     run_id=run_id,
                     batch_number=batch_number,
+                )
+                normalized_entries, output_schema = _merge_deterministic_transformation_entries(
+                    batch_rows,
+                    normalized_entries,
+                    expected_output_schema or output_schema,
+                    transformation_spec=transformation_spec,
                 )
                 last_attempt_metrics['validation_seconds'] = round(
                     time.monotonic() - validation_started_at,
@@ -4323,6 +4434,7 @@ async def _generate_batch_entries_for_window(
     batch_timeout_seconds,
     response_protocol,
     generation_plan,
+    transformation_spec,
 ):
     queued_at = time.monotonic()
     async with semaphore:
@@ -4342,6 +4454,7 @@ async def _generate_batch_entries_for_window(
             batch_timeout_seconds=batch_timeout_seconds,
             response_protocol=response_protocol,
             generation_plan=generation_plan,
+            transformation_spec=transformation_spec,
         )
         elapsed_seconds = time.monotonic() - batch_started_at
         log_event(
@@ -4398,6 +4511,7 @@ async def _generate_batch_window_entries(
     batch_timeout_seconds=TABULAR_EXPORT_DEFAULT_BATCH_TIMEOUT_SECONDS,
     response_protocol=TABULAR_RESPONSE_PROTOCOL_OBJECT_V1,
     generation_plan=None,
+    transformation_spec=None,
 ):
     semaphore = asyncio.Semaphore(max(1, batch_concurrency))
     tasks = [
@@ -4415,6 +4529,7 @@ async def _generate_batch_window_entries(
             batch_timeout_seconds,
             response_protocol,
             generation_plan,
+            transformation_spec,
         )
         for batch_request in batch_requests
     ]
@@ -4491,6 +4606,7 @@ async def _generate_and_checkpoint_batch_window_entries(
     batch_timeout_seconds=TABULAR_EXPORT_DEFAULT_BATCH_TIMEOUT_SECONDS,
     response_protocol=TABULAR_RESPONSE_PROTOCOL_OBJECT_V1,
     generation_plan=None,
+    transformation_spec=None,
 ):
     semaphore = asyncio.Semaphore(max(1, batch_concurrency))
     writer_semaphore = asyncio.Semaphore(max(1, checkpoint_writer_concurrency))
@@ -4510,6 +4626,7 @@ async def _generate_and_checkpoint_batch_window_entries(
                 batch_timeout_seconds,
                 response_protocol,
                 generation_plan,
+                transformation_spec,
             )
         )
         for batch_request in batch_requests
@@ -4601,6 +4718,7 @@ async def _generate_and_checkpoint_rolling_pool_entries(
     batch_timeout_seconds=TABULAR_EXPORT_DEFAULT_BATCH_TIMEOUT_SECONDS,
     response_protocol=TABULAR_RESPONSE_PROTOCOL_OBJECT_V1,
     generation_plan=None,
+    transformation_spec=None,
 ):
     model_semaphore = asyncio.Semaphore(max(1, batch_concurrency))
     writer_semaphore = asyncio.Semaphore(max(1, checkpoint_writer_concurrency))
@@ -4814,6 +4932,7 @@ async def _generate_and_checkpoint_rolling_pool_entries(
                 batch_timeout_seconds,
                 response_protocol,
                 generation_plan,
+                transformation_spec,
             )
         )
         active_batch_requests[model_task] = batch_request
@@ -5117,9 +5236,14 @@ async def _generate_combined_chunk_result(
     retry_attempts,
     batch_timeout_seconds,
     expected_output_schema=None,
+    transformation_spec=None,
 ):
     batch_number = batch_request['batch_number']
     batch_rows = batch_request['rows']
+    model_expected_output_schema = _build_model_expected_output_schema(
+        expected_output_schema,
+        transformation_spec=transformation_spec,
+    )
     timeout_seconds = max(
         _safe_float(
             batch_timeout_seconds,
@@ -5148,7 +5272,7 @@ async def _generate_combined_chunk_result(
                 batch_rows,
                 batch_number,
                 total_batches,
-                output_schema=expected_output_schema,
+                output_schema=model_expected_output_schema,
             )
         )
 
@@ -5172,7 +5296,13 @@ async def _generate_combined_chunk_result(
                     parsed_payload,
                     batch_rows,
                     batch_number,
-                    expected_output_schema=expected_output_schema,
+                    expected_output_schema=model_expected_output_schema,
+                )
+                normalized_entries, output_schema = _merge_deterministic_transformation_entries(
+                    batch_rows,
+                    normalized_entries,
+                    expected_output_schema or output_schema,
+                    transformation_spec=transformation_spec,
                 )
                 return normalized_entries, output_schema, analysis_summary, mismatch_count
             except ValueError as exc:
@@ -5209,6 +5339,7 @@ async def _generate_combined_chunk_result_for_window(
     retry_attempts,
     batch_timeout_seconds,
     expected_output_schema,
+    transformation_spec,
 ):
     async with semaphore:
         batch_started_at = time.monotonic()
@@ -5220,6 +5351,7 @@ async def _generate_combined_chunk_result_for_window(
             retry_attempts,
             batch_timeout_seconds,
             expected_output_schema=expected_output_schema,
+            transformation_spec=transformation_spec,
         )
         return {
             'batch_number': batch_request['batch_number'],
@@ -5242,6 +5374,7 @@ async def _generate_combined_chunk_result_window(
     batch_concurrency,
     batch_timeout_seconds,
     expected_output_schema=None,
+    transformation_spec=None,
 ):
     semaphore = asyncio.Semaphore(max(1, batch_concurrency))
     tasks = [
@@ -5254,6 +5387,7 @@ async def _generate_combined_chunk_result_window(
             retry_attempts,
             batch_timeout_seconds,
             expected_output_schema,
+            transformation_spec,
         )
         for batch_request in batch_requests
     ]
@@ -5750,6 +5884,11 @@ def _normalize_tabular_run_planner_metadata(planner_metadata):
             'validation_profile': str(deliverable_contract.get('validation_profile') or '').strip().lower()[:80],
             'publication_policy': str(deliverable_contract.get('publication_policy') or '').strip().lower()[:80],
         }
+        if isinstance(deliverable_contract.get('transformation_spec'), dict):
+            normalized_metadata['deliverable_contract']['transformation_spec'] = normalize_tabular_transformation_spec(
+                deliverable_contract.get('transformation_spec'),
+                public_output_schema=normalized_metadata['deliverable_contract']['public_output_schema'],
+            )
     return normalized_metadata
 
 
@@ -8077,6 +8216,49 @@ def _build_passthrough_batch_results(run, batch_requests):
     return generated_results
 
 
+def _build_deterministic_transformation_batch_results(run, batch_requests):
+    """Create checkpoint entries directly from a deterministic transformation spec."""
+    expected_output_schema = list(run.get('output_schema') or _get_tabular_run_internal_checkpoint_schema(run))
+    public_output_schema = _get_public_fields_from_output_schema(expected_output_schema)
+    transformation_spec = _get_tabular_run_transformation_spec(
+        run,
+        public_output_schema=public_output_schema,
+    )
+    if not is_tabular_transformation_deterministic_only(
+        transformation_spec,
+        public_output_schema=public_output_schema,
+    ):
+        raise ValueError('Deterministic transformation checkpoints require a deterministic-only spec')
+
+    generated_results = []
+    for batch_request in batch_requests:
+        batch_started_at = time.monotonic()
+        batch_entries = []
+        for source_row in batch_request['rows']:
+            deterministic_values = evaluate_tabular_transformation_row(transformation_spec, source_row)
+            checkpoint_entry = {}
+            for field_name in expected_output_schema:
+                if field_name == TABULAR_EXPORT_OUTPUT_ROW_NUMBER_FIELD:
+                    checkpoint_entry[field_name] = source_row.get(TABULAR_EXPORT_INPUT_ROW_NUMBER_FIELD)
+                elif field_name == TABULAR_EXPORT_OUTPUT_ROW_IDENTITY_FIELD:
+                    checkpoint_entry[field_name] = str(source_row.get(TABULAR_EXPORT_INPUT_ROW_IDENTITY_FIELD) or '')
+                elif field_name in deterministic_values:
+                    checkpoint_entry[field_name] = deterministic_values.get(field_name)
+                else:
+                    raise ValueError(f'Deterministic transformation did not produce field {field_name}')
+            batch_entries.append(checkpoint_entry)
+        generated_results.append({
+            'batch_number': batch_request['batch_number'],
+            'batch_entries': batch_entries,
+            'batch_summary': _build_generated_batch_summary(batch_entries),
+            'batch_row_count': len(batch_entries),
+            'elapsed_seconds': time.monotonic() - batch_started_at,
+            'mismatch_count': 0,
+            'output_schema': expected_output_schema,
+        })
+    return generated_results
+
+
 def _advance_run_progress_for_window(run, batch_results, completed_batches, processed_rows, window_start, window_end):
     window_results = []
     window_rows = 0
@@ -8439,6 +8621,7 @@ def _process_combined_run(
                     batch_concurrency,
                     batch_timeout_seconds,
                     expected_output_schema=run.get('output_schema'),
+                    transformation_spec=_get_tabular_run_transformation_spec(run),
                 )
             )
             _raise_if_tabular_export_canceled(run)
@@ -8525,6 +8708,7 @@ def _process_structured_export_rolling_pool(
             batch_timeout_seconds=batch_timeout_seconds,
             response_protocol=run.get('response_protocol_version'),
             generation_plan=generation_plan,
+            transformation_spec=_get_tabular_run_transformation_spec(run),
         )
     )
     del last_logged_at
@@ -8586,8 +8770,17 @@ def process_tabular_generated_output_run(run_id, user_id):
             ),
             max(30, stale_seconds - 30),
         )
+        normalized_task_type = _normalize_tabular_run_task_type(run.get('task_type'))
+        transformation_spec = _get_tabular_run_transformation_spec(run)
+        deterministic_only_structured_export = (
+            normalized_task_type == TABULAR_RUN_TASK_STRUCTURED_EXPORT
+            and is_tabular_transformation_deterministic_only(
+                transformation_spec,
+                public_output_schema=_get_tabular_run_public_output_schema(run),
+            )
+        )
         chat_service = None
-        if not run.get('passthrough_input_rows'):
+        if not run.get('passthrough_input_rows') and not deterministic_only_structured_export:
             has_snapshotted_chunk_model = bool(str(run.get('chunk_gpt_model') or '').strip())
             chat_service = _build_chat_service(
                 run.get('chunk_gpt_model') if has_snapshotted_chunk_model else run.get('gpt_model'),
@@ -8644,7 +8837,6 @@ def process_tabular_generated_output_run(run_id, user_id):
             level=logging.INFO,
         )
 
-        normalized_task_type = _normalize_tabular_run_task_type(run.get('task_type'))
         if normalized_task_type == TABULAR_RUN_TASK_COMBINED:
             return _process_combined_run(
                 run,
@@ -8716,6 +8908,8 @@ def process_tabular_generated_output_run(run_id, user_id):
                 )
                 if run.get('passthrough_input_rows'):
                     generated_results = _build_passthrough_batch_results(run, batch_requests)
+                elif deterministic_only_structured_export:
+                    generated_results = _build_deterministic_transformation_batch_results(run, batch_requests)
                 elif _is_completion_driven_checkpointing_enabled(settings, run):
                     generated_batch_results, generation_error = asyncio.run(
                         _generate_and_checkpoint_batch_window_entries(
@@ -8734,6 +8928,7 @@ def process_tabular_generated_output_run(run_id, user_id):
                             batch_timeout_seconds=batch_timeout_seconds,
                             response_protocol=run.get('response_protocol_version'),
                             generation_plan=generation_plan,
+                            transformation_spec=_get_tabular_run_transformation_spec(run),
                         )
                     )
                     batch_results.update(generated_batch_results)
@@ -8755,6 +8950,7 @@ def process_tabular_generated_output_run(run_id, user_id):
                             batch_timeout_seconds=batch_timeout_seconds,
                             response_protocol=run.get('response_protocol_version'),
                             generation_plan=generation_plan,
+                            transformation_spec=_get_tabular_run_transformation_spec(run),
                         )
                     )
                 _raise_if_tabular_export_canceled(run)
@@ -8860,6 +9056,17 @@ def queue_tabular_generated_output_run(
     settings = settings or {}
     source_descriptor = dict(source_descriptor or {})
     tabular_planner_metadata = _normalize_tabular_run_planner_metadata(planner_metadata)
+    deliverable_contract = tabular_planner_metadata.get('deliverable_contract') or {}
+    contract_public_output_schema = list(deliverable_contract.get('public_output_schema') or [])
+    contract_internal_checkpoint_schema = list(deliverable_contract.get('internal_checkpoint_schema') or [])
+    contract_transformation_spec = dict(deliverable_contract.get('transformation_spec') or {})
+    deterministic_only_structured_export = (
+        normalized_task_type == TABULAR_RUN_TASK_STRUCTURED_EXPORT
+        and is_tabular_transformation_deterministic_only(
+            contract_transformation_spec,
+            public_output_schema=contract_public_output_schema,
+        )
+    )
     source_authorization = dict(source_candidate.get('source_authorization') or {})
     staged_row_count = 0
     staged_char_count = 0
@@ -8888,7 +9095,12 @@ def queue_tabular_generated_output_run(
         if rollout_settings.get('enable_tabular_generation_plan')
         else 'off'
     )
-    if normalized_task_type == TABULAR_RUN_TASK_HIERARCHICAL_ANALYSIS or passthrough_input_rows:
+    if (
+        normalized_task_type == TABULAR_RUN_TASK_HIERARCHICAL_ANALYSIS
+        or passthrough_input_rows
+        or deterministic_only_structured_export
+        or bool(contract_transformation_spec)
+    ):
         requested_plan_mode = 'off'
     response_protocol_version = _select_tabular_response_protocol(
         rollout_settings,
@@ -9083,13 +9295,14 @@ def queue_tabular_generated_output_run(
         'planner_started_at': None,
         'planner_completed_at': None,
         'processed_rows': 0,
-        'output_schema': None,
-        'public_output_schema': [],
-        'internal_checkpoint_schema': [],
+        'output_schema': contract_internal_checkpoint_schema or None,
+        'public_output_schema': contract_public_output_schema,
+        'internal_checkpoint_schema': contract_internal_checkpoint_schema,
         'lineage_schema': [
             TABULAR_EXPORT_OUTPUT_ROW_NUMBER_FIELD,
             TABULAR_EXPORT_OUTPUT_ROW_IDENTITY_FIELD,
         ],
+        'transformation_spec': contract_transformation_spec,
         'source_descriptor': source_descriptor or None,
         'batch_budget': model_batch_budget,
         'source_authorization': source_authorization or None,

--- a/application/single_app/functions_tabular_orchestration.py
+++ b/application/single_app/functions_tabular_orchestration.py
@@ -13,9 +13,11 @@ from functions_analysis_deliverables import (
     ANALYSIS_ORDERING_SOURCE_ORDER,
     ANALYSIS_ROW_CARDINALITY_NOT_APPLICABLE,
     ANALYSIS_ROW_CARDINALITY_ONE_PER_SOURCE_ROW,
+    ANALYSIS_TRANSFORMATION_MODE_DETERMINISTIC,
     ANALYSIS_TRANSFORMATION_MODE_SEMANTIC,
     ANALYSIS_VALIDATION_PROFILE_ARTIFACT_SET,
     ANALYSIS_VALIDATION_PROFILE_EXACT_ROWS_SCHEMA,
+    ANALYSIS_VALIDATION_PROFILE_EXACT_ROWS_SCHEMA_AND_RULES,
     build_analysis_deliverable_contract,
     emit_analysis_deliverable_contract_event,
 )
@@ -612,6 +614,19 @@ def plan_tabular_request(
         request_key=request_fingerprint,
         mode=action_mode,
     )
+    transformation_spec = output_hints.get("transformation_spec")
+    transformation_mode = output_hints.get("transformation_mode") or (
+        ANALYSIS_TRANSFORMATION_MODE_DETERMINISTIC
+        if transformation_spec
+        else ANALYSIS_TRANSFORMATION_MODE_SEMANTIC
+    )
+    validation_profile = (
+        ANALYSIS_VALIDATION_PROFILE_EXACT_ROWS_SCHEMA_AND_RULES
+        if generated_output_requested and transformation_spec
+        else ANALYSIS_VALIDATION_PROFILE_EXACT_ROWS_SCHEMA
+        if generated_output_requested
+        else ANALYSIS_VALIDATION_PROFILE_ARTIFACT_SET
+    )
     deliverable_contract = build_analysis_deliverable_contract(
         action_mode=action_mode,
         requested_output_formats=requested_output_formats,
@@ -630,12 +645,9 @@ def plan_tabular_request(
             if generated_output_requested
             else ANALYSIS_ORDERING_NOT_APPLICABLE
         ),
-        transformation_mode=ANALYSIS_TRANSFORMATION_MODE_SEMANTIC,
-        validation_profile=(
-            ANALYSIS_VALIDATION_PROFILE_EXACT_ROWS_SCHEMA
-            if generated_output_requested
-            else ANALYSIS_VALIDATION_PROFILE_ARTIFACT_SET
-        ),
+        transformation_mode=transformation_mode,
+        transformation_spec=transformation_spec,
+        validation_profile=validation_profile,
         source_fingerprint=_build_source_coverage_fingerprint(source_coverage),
         request_fingerprint=request_fingerprint,
     )

--- a/application/single_app/functions_tabular_transformations.py
+++ b/application/single_app/functions_tabular_transformations.py
@@ -1,0 +1,690 @@
+# functions_tabular_transformations.py
+"""Bounded transformation specifications for tabular generated outputs."""
+
+from datetime import date, datetime
+from decimal import Decimal, InvalidOperation
+from graphlib import CycleError, TopologicalSorter
+
+
+TABULAR_TRANSFORMATION_SPEC_VERSION = "tabular-transform-v1"
+TABULAR_TRANSFORMATION_FIELD_MODE_DETERMINISTIC = "deterministic"
+TABULAR_TRANSFORMATION_FIELD_MODE_SEMANTIC = "semantic"
+TABULAR_TRANSFORMATION_FIELD_MODE_HYBRID = "hybrid"
+TABULAR_TRANSFORMATION_FIELD_MODES = frozenset({
+    TABULAR_TRANSFORMATION_FIELD_MODE_DETERMINISTIC,
+    TABULAR_TRANSFORMATION_FIELD_MODE_SEMANTIC,
+    TABULAR_TRANSFORMATION_FIELD_MODE_HYBRID,
+})
+
+TABULAR_TRANSFORMATION_MAX_FIELDS = 200
+TABULAR_TRANSFORMATION_MAX_FIELD_NAME_LENGTH = 128
+TABULAR_TRANSFORMATION_MAX_EXPRESSION_DEPTH = 24
+TABULAR_TRANSFORMATION_MAX_EXPRESSION_STEPS = 2000
+TABULAR_TRANSFORMATION_MAX_BRANCHES = 100
+TABULAR_TRANSFORMATION_MAX_LIST_ITEMS = 200
+TABULAR_TRANSFORMATION_MAX_STRING_LENGTH = 4096
+TABULAR_TRANSFORMATION_MAX_NUMERIC_ABS = Decimal("1e18")
+TABULAR_TRANSFORMATION_INTERNAL_FIELD_PREFIX = "__simplechat"
+TABULAR_TRANSFORMATION_INTERNAL_FIELD_NAMES = frozenset({
+    "source_row_number",
+    "source_row_identity",
+})
+
+TABULAR_TRANSFORMATION_COMPARISON_OPS = frozenset({"eq", "ne", "lt", "lte", "gt", "gte"})
+TABULAR_TRANSFORMATION_BOOLEAN_OPS = frozenset({"all", "any", "not"})
+TABULAR_TRANSFORMATION_ARITHMETIC_OPS = frozenset({"add", "subtract", "multiply", "divide"})
+TABULAR_TRANSFORMATION_ALLOWED_OPS = frozenset({
+    "case",
+    "coalesce",
+    "copy",
+    "in",
+    "is_null",
+    *TABULAR_TRANSFORMATION_COMPARISON_OPS,
+    *TABULAR_TRANSFORMATION_BOOLEAN_OPS,
+    *TABULAR_TRANSFORMATION_ARITHMETIC_OPS,
+})
+
+
+class TabularTransformationSpecError(ValueError):
+    """Raised when a tabular transformation spec is unsupported or unsafe."""
+
+
+class TabularTransformationEvaluationError(ValueError):
+    """Raised when a valid transformation spec cannot evaluate one row."""
+
+
+def _is_internal_field_name(field_name):
+    normalized_field = str(field_name or "").strip()
+    return (
+        normalized_field in TABULAR_TRANSFORMATION_INTERNAL_FIELD_NAMES
+        or normalized_field.startswith(TABULAR_TRANSFORMATION_INTERNAL_FIELD_PREFIX)
+    )
+
+
+def _normalize_field_name(field_name, label="field"):
+    normalized_field = str(field_name or "").strip()
+    if not normalized_field:
+        raise TabularTransformationSpecError(f"Tabular transformation {label} name is empty")
+    if len(normalized_field) > TABULAR_TRANSFORMATION_MAX_FIELD_NAME_LENGTH:
+        raise TabularTransformationSpecError(f"Tabular transformation {label} name is too long")
+    if _is_internal_field_name(normalized_field):
+        raise TabularTransformationSpecError(f"Tabular transformation {label} uses a reserved field name")
+    return normalized_field
+
+
+def _normalize_field_list(field_names=None, label="field"):
+    normalized_fields = []
+    seen_fields = set()
+    for field_name in list(field_names or []):
+        normalized_field = _normalize_field_name(field_name, label=label)
+        if normalized_field in seen_fields:
+            raise TabularTransformationSpecError(f"Tabular transformation {label} list contains duplicates")
+        seen_fields.add(normalized_field)
+        normalized_fields.append(normalized_field)
+    if len(normalized_fields) > TABULAR_TRANSFORMATION_MAX_FIELDS:
+        raise TabularTransformationSpecError(f"Tabular transformation {label} list is too large")
+    return normalized_fields
+
+
+def _normalize_mode(mode, expression=None):
+    normalized_mode = str(mode or "").strip().lower()
+    if not normalized_mode:
+        normalized_mode = (
+            TABULAR_TRANSFORMATION_FIELD_MODE_DETERMINISTIC
+            if expression is not None
+            else TABULAR_TRANSFORMATION_FIELD_MODE_SEMANTIC
+        )
+    if normalized_mode not in TABULAR_TRANSFORMATION_FIELD_MODES:
+        raise TabularTransformationSpecError("Tabular transformation field mode is unsupported")
+    return normalized_mode
+
+
+def _validate_literal_value(value):
+    if value is None or isinstance(value, bool):
+        return value
+    if isinstance(value, int) and not isinstance(value, bool):
+        return value
+    if isinstance(value, float):
+        if value != value or value in (float("inf"), float("-inf")):
+            raise TabularTransformationSpecError("Tabular transformation literal number is not finite")
+        return value
+    if isinstance(value, str):
+        if len(value) > TABULAR_TRANSFORMATION_MAX_STRING_LENGTH:
+            raise TabularTransformationSpecError("Tabular transformation literal string is too long")
+        return value
+    if isinstance(value, list):
+        if len(value) > TABULAR_TRANSFORMATION_MAX_LIST_ITEMS:
+            raise TabularTransformationSpecError("Tabular transformation literal list is too large")
+        return [_validate_literal_value(item) for item in value]
+    if isinstance(value, dict):
+        if len(value) > TABULAR_TRANSFORMATION_MAX_LIST_ITEMS:
+            raise TabularTransformationSpecError("Tabular transformation literal object is too large")
+        normalized_object = {}
+        for key, item in value.items():
+            normalized_key = str(key or "").strip()
+            if not normalized_key or len(normalized_key) > TABULAR_TRANSFORMATION_MAX_FIELD_NAME_LENGTH:
+                raise TabularTransformationSpecError("Tabular transformation literal object key is invalid")
+            normalized_object[normalized_key] = _validate_literal_value(item)
+        return normalized_object
+    raise TabularTransformationSpecError("Tabular transformation literal type is unsupported")
+
+
+def _normalize_reference_name(expression, key_name):
+    return _normalize_field_name(expression.get(key_name), label=key_name)
+
+
+def _normalize_value_type(value_type):
+    normalized_type = str(value_type or "").strip().lower()
+    if normalized_type not in {"", "string", "number", "integer", "date", "boolean"}:
+        raise TabularTransformationSpecError("Tabular transformation value type is unsupported")
+    return normalized_type
+
+
+def _normalize_expression(expression, depth=0):
+    if depth > TABULAR_TRANSFORMATION_MAX_EXPRESSION_DEPTH:
+        raise TabularTransformationSpecError("Tabular transformation expression is too deep")
+    if not isinstance(expression, dict):
+        return _validate_literal_value(expression)
+
+    if "source" in expression and set(expression) == {"source"}:
+        return {"source": _normalize_reference_name(expression, "source")}
+    if "field" in expression and set(expression) == {"field"}:
+        return {"field": _normalize_reference_name(expression, "field")}
+    if "value" in expression and set(expression) == {"value"}:
+        return {"value": _validate_literal_value(expression.get("value"))}
+
+    op_name = str(expression.get("op") or "").strip().lower()
+    if op_name not in TABULAR_TRANSFORMATION_ALLOWED_OPS:
+        raise TabularTransformationSpecError("Tabular transformation expression operation is unsupported")
+
+    if op_name == "copy":
+        if set(expression) != {"op", "source"}:
+            raise TabularTransformationSpecError("Tabular transformation copy expression has invalid properties")
+        return {"op": op_name, "source": _normalize_reference_name(expression, "source")}
+
+    if op_name == "case":
+        if set(expression) != {"op", "branches", "else"}:
+            raise TabularTransformationSpecError("Tabular transformation case expression has invalid properties")
+        branches = expression.get("branches")
+        if not isinstance(branches, list) or not branches:
+            raise TabularTransformationSpecError("Tabular transformation case expression requires branches")
+        if len(branches) > TABULAR_TRANSFORMATION_MAX_BRANCHES:
+            raise TabularTransformationSpecError("Tabular transformation case expression has too many branches")
+        normalized_branches = []
+        for branch in branches:
+            if not isinstance(branch, dict) or set(branch) != {"when", "then"}:
+                raise TabularTransformationSpecError("Tabular transformation case branch is invalid")
+            normalized_branches.append({
+                "when": _normalize_expression(branch.get("when"), depth=depth + 1),
+                "then": _normalize_expression(branch.get("then"), depth=depth + 1),
+            })
+        return {
+            "op": op_name,
+            "branches": normalized_branches,
+            "else": _normalize_expression(expression.get("else"), depth=depth + 1),
+        }
+
+    if op_name == "coalesce":
+        if set(expression) != {"op", "values"}:
+            raise TabularTransformationSpecError("Tabular transformation coalesce expression has invalid properties")
+        values = expression.get("values")
+        if not isinstance(values, list) or not values:
+            raise TabularTransformationSpecError("Tabular transformation coalesce expression requires values")
+        if len(values) > TABULAR_TRANSFORMATION_MAX_LIST_ITEMS:
+            raise TabularTransformationSpecError("Tabular transformation coalesce expression has too many values")
+        return {
+            "op": op_name,
+            "values": [_normalize_expression(value, depth=depth + 1) for value in values],
+        }
+
+    if op_name in {"all", "any"}:
+        if set(expression) != {"op", "values"}:
+            raise TabularTransformationSpecError("Tabular transformation boolean expression has invalid properties")
+        values = expression.get("values")
+        if not isinstance(values, list) or not values:
+            raise TabularTransformationSpecError("Tabular transformation boolean expression requires values")
+        if len(values) > TABULAR_TRANSFORMATION_MAX_LIST_ITEMS:
+            raise TabularTransformationSpecError("Tabular transformation boolean expression has too many values")
+        return {
+            "op": op_name,
+            "values": [_normalize_expression(value, depth=depth + 1) for value in values],
+        }
+
+    if op_name == "not":
+        if set(expression) != {"op", "value"}:
+            raise TabularTransformationSpecError("Tabular transformation not expression has invalid properties")
+        return {"op": op_name, "value": _normalize_expression(expression.get("value"), depth=depth + 1)}
+
+    if op_name == "is_null":
+        if set(expression) != {"op", "value"}:
+            raise TabularTransformationSpecError("Tabular transformation null expression has invalid properties")
+        return {"op": op_name, "value": _normalize_expression(expression.get("value"), depth=depth + 1)}
+
+    if op_name == "in":
+        allowed_keys = {"op", "value", "values", "case_sensitive"}
+        if set(expression) - allowed_keys or not {"value", "values"}.issubset(expression):
+            raise TabularTransformationSpecError("Tabular transformation membership expression has invalid properties")
+        values = expression.get("values")
+        if not isinstance(values, list) or len(values) > TABULAR_TRANSFORMATION_MAX_LIST_ITEMS:
+            raise TabularTransformationSpecError("Tabular transformation membership expression values are invalid")
+        return {
+            "op": op_name,
+            "value": _normalize_expression(expression.get("value"), depth=depth + 1),
+            "values": [_normalize_expression(value, depth=depth + 1) for value in values],
+            "case_sensitive": bool(expression.get("case_sensitive", True)),
+        }
+
+    if op_name in TABULAR_TRANSFORMATION_COMPARISON_OPS:
+        allowed_keys = {"op", "left", "right", "value_type", "case_sensitive"}
+        if set(expression) - allowed_keys or not {"left", "right"}.issubset(expression):
+            raise TabularTransformationSpecError("Tabular transformation comparison expression has invalid properties")
+        return {
+            "op": op_name,
+            "left": _normalize_expression(expression.get("left"), depth=depth + 1),
+            "right": _normalize_expression(expression.get("right"), depth=depth + 1),
+            "value_type": _normalize_value_type(expression.get("value_type")),
+            "case_sensitive": bool(expression.get("case_sensitive", True)),
+        }
+
+    if op_name in TABULAR_TRANSFORMATION_ARITHMETIC_OPS:
+        allowed_keys = {"op", "values", "left", "right"}
+        if set(expression) - allowed_keys:
+            raise TabularTransformationSpecError("Tabular transformation arithmetic expression has invalid properties")
+        if "values" in expression:
+            values = expression.get("values")
+            if not isinstance(values, list) or not values:
+                raise TabularTransformationSpecError("Tabular transformation arithmetic values are invalid")
+            if len(values) > TABULAR_TRANSFORMATION_MAX_LIST_ITEMS:
+                raise TabularTransformationSpecError("Tabular transformation arithmetic expression has too many values")
+            return {
+                "op": op_name,
+                "values": [_normalize_expression(value, depth=depth + 1) for value in values],
+            }
+        if not {"left", "right"}.issubset(expression):
+            raise TabularTransformationSpecError("Tabular transformation arithmetic expression requires operands")
+        return {
+            "op": op_name,
+            "left": _normalize_expression(expression.get("left"), depth=depth + 1),
+            "right": _normalize_expression(expression.get("right"), depth=depth + 1),
+        }
+
+    raise TabularTransformationSpecError("Tabular transformation expression operation is unsupported")
+
+
+def _collect_expression_references(expression, source_refs, field_refs):
+    if not isinstance(expression, dict):
+        return
+    if set(expression) == {"source"}:
+        source_refs.add(expression["source"])
+        return
+    if set(expression) == {"field"}:
+        field_refs.add(expression["field"])
+        return
+    if set(expression) == {"value"}:
+        return
+
+    op_name = expression.get("op")
+    if op_name == "copy":
+        source_refs.add(expression["source"])
+    elif op_name == "case":
+        for branch in expression.get("branches") or []:
+            _collect_expression_references(branch.get("when"), source_refs, field_refs)
+            _collect_expression_references(branch.get("then"), source_refs, field_refs)
+        _collect_expression_references(expression.get("else"), source_refs, field_refs)
+    elif op_name in {"coalesce", "all", "any"}:
+        for value in expression.get("values") or []:
+            _collect_expression_references(value, source_refs, field_refs)
+    elif op_name in {"not", "is_null"}:
+        _collect_expression_references(expression.get("value"), source_refs, field_refs)
+    elif op_name == "in":
+        _collect_expression_references(expression.get("value"), source_refs, field_refs)
+        for value in expression.get("values") or []:
+            _collect_expression_references(value, source_refs, field_refs)
+    elif op_name in TABULAR_TRANSFORMATION_COMPARISON_OPS:
+        _collect_expression_references(expression.get("left"), source_refs, field_refs)
+        _collect_expression_references(expression.get("right"), source_refs, field_refs)
+    elif op_name in TABULAR_TRANSFORMATION_ARITHMETIC_OPS:
+        if "values" in expression:
+            for value in expression.get("values") or []:
+                _collect_expression_references(value, source_refs, field_refs)
+        else:
+            _collect_expression_references(expression.get("left"), source_refs, field_refs)
+            _collect_expression_references(expression.get("right"), source_refs, field_refs)
+
+
+def _normalize_field_descriptor(field_descriptor):
+    if not isinstance(field_descriptor, dict):
+        raise TabularTransformationSpecError("Tabular transformation field descriptor is invalid")
+    allowed_keys = {"name", "mode", "expression", "type", "nullable", "allowed_values"}
+    if set(field_descriptor) - allowed_keys:
+        raise TabularTransformationSpecError("Tabular transformation field descriptor has unsupported properties")
+
+    field_name = _normalize_field_name(field_descriptor.get("name"))
+    expression_present = "expression" in field_descriptor
+    mode = _normalize_mode(field_descriptor.get("mode"), expression=field_descriptor.get("expression"))
+    expression = None
+    if mode == TABULAR_TRANSFORMATION_FIELD_MODE_DETERMINISTIC:
+        if not expression_present:
+            raise TabularTransformationSpecError("Deterministic tabular transformation field requires an expression")
+        expression = _normalize_expression(field_descriptor.get("expression"))
+    elif expression_present and field_descriptor.get("expression") not in ({}, None):
+        expression = _normalize_expression(field_descriptor.get("expression"))
+
+    normalized_descriptor = {
+        "name": field_name,
+        "mode": mode,
+    }
+    if expression is not None:
+        normalized_descriptor["expression"] = expression
+    field_type = _normalize_value_type(field_descriptor.get("type"))
+    if field_type:
+        normalized_descriptor["type"] = field_type
+    if "nullable" in field_descriptor:
+        normalized_descriptor["nullable"] = bool(field_descriptor.get("nullable"))
+    if "allowed_values" in field_descriptor:
+        allowed_values = field_descriptor.get("allowed_values")
+        if not isinstance(allowed_values, list) or len(allowed_values) > TABULAR_TRANSFORMATION_MAX_LIST_ITEMS:
+            raise TabularTransformationSpecError("Tabular transformation allowed values are invalid")
+        normalized_descriptor["allowed_values"] = [_validate_literal_value(value) for value in allowed_values]
+    return normalized_descriptor
+
+
+def _build_deterministic_field_order(field_descriptors):
+    fields_by_name = {field["name"]: field for field in field_descriptors}
+    graph = {}
+    for field in field_descriptors:
+        if field["mode"] != TABULAR_TRANSFORMATION_FIELD_MODE_DETERMINISTIC:
+            continue
+        source_refs = set()
+        field_refs = set()
+        _collect_expression_references(field.get("expression"), source_refs, field_refs)
+        deterministic_dependencies = set()
+        for field_ref in field_refs:
+            referenced_field = fields_by_name.get(field_ref)
+            if referenced_field is None:
+                continue
+            if referenced_field["mode"] != TABULAR_TRANSFORMATION_FIELD_MODE_DETERMINISTIC:
+                raise TabularTransformationSpecError(
+                    "Deterministic tabular transformation field cannot depend on semantic output"
+                )
+            deterministic_dependencies.add(field_ref)
+        graph[field["name"]] = deterministic_dependencies
+    try:
+        return list(TopologicalSorter(graph).static_order())
+    except CycleError as exc:
+        raise TabularTransformationSpecError("Tabular transformation field dependencies contain a cycle") from exc
+
+
+def normalize_tabular_transformation_spec(
+    transformation_spec,
+    public_output_schema=None,
+    source_schema=None,
+):
+    """Return a bounded normalized transformation spec or an empty spec."""
+    if not transformation_spec:
+        return {}
+    if not isinstance(transformation_spec, dict):
+        raise TabularTransformationSpecError("Tabular transformation spec must be an object")
+    allowed_keys = {"version", "fields", "deterministic_field_order", "field_mode_counts"}
+    if set(transformation_spec) - allowed_keys:
+        raise TabularTransformationSpecError("Tabular transformation spec has unsupported properties")
+    if str(transformation_spec.get("version") or "").strip() != TABULAR_TRANSFORMATION_SPEC_VERSION:
+        raise TabularTransformationSpecError("Tabular transformation spec version is unsupported")
+
+    normalized_public_schema = _normalize_field_list(public_output_schema, label="public output field")
+    normalized_source_schema = _normalize_field_list(source_schema, label="source field")
+    source_schema_set = set(normalized_source_schema)
+
+    raw_fields = transformation_spec.get("fields")
+    if not isinstance(raw_fields, list) or not raw_fields:
+        raise TabularTransformationSpecError("Tabular transformation spec requires fields")
+    if len(raw_fields) > TABULAR_TRANSFORMATION_MAX_FIELDS:
+        raise TabularTransformationSpecError("Tabular transformation spec has too many fields")
+
+    normalized_fields = []
+    seen_fields = set()
+    for raw_field in raw_fields:
+        normalized_field = _normalize_field_descriptor(raw_field)
+        field_name = normalized_field["name"]
+        if field_name in seen_fields:
+            raise TabularTransformationSpecError("Tabular transformation spec contains duplicate output fields")
+        seen_fields.add(field_name)
+        normalized_fields.append(normalized_field)
+
+    if normalized_public_schema:
+        public_schema_set = set(normalized_public_schema)
+        if seen_fields != public_schema_set:
+            raise TabularTransformationSpecError("Tabular transformation spec fields must match the public schema")
+
+    for normalized_field in normalized_fields:
+        source_refs = set()
+        field_refs = set()
+        _collect_expression_references(normalized_field.get("expression"), source_refs, field_refs)
+        if source_schema_set and source_refs - source_schema_set:
+            raise TabularTransformationSpecError("Tabular transformation spec references an unknown source field")
+        unknown_field_refs = field_refs - seen_fields
+        if unknown_field_refs:
+            raise TabularTransformationSpecError("Tabular transformation spec references an unknown output field")
+
+    deterministic_order = _build_deterministic_field_order(normalized_fields)
+    mode_counts = {
+        mode: sum(1 for field in normalized_fields if field["mode"] == mode)
+        for mode in sorted(TABULAR_TRANSFORMATION_FIELD_MODES)
+    }
+    return {
+        "version": TABULAR_TRANSFORMATION_SPEC_VERSION,
+        "fields": normalized_fields,
+        "deterministic_field_order": deterministic_order,
+        "field_mode_counts": mode_counts,
+    }
+
+
+def get_tabular_transformation_deterministic_fields(transformation_spec):
+    """Return deterministic output field names in evaluation order."""
+    normalized_spec = normalize_tabular_transformation_spec(transformation_spec)
+    return list(normalized_spec.get("deterministic_field_order") or [])
+
+
+def get_tabular_transformation_model_fields(transformation_spec, public_output_schema=None):
+    """Return public fields that must still be generated or verified by the model."""
+    normalized_spec = normalize_tabular_transformation_spec(
+        transformation_spec,
+        public_output_schema=public_output_schema,
+    )
+    if not normalized_spec:
+        return list(public_output_schema or [])
+    deterministic_fields = set(normalized_spec.get("deterministic_field_order") or [])
+    ordered_public_schema = list(public_output_schema or [field["name"] for field in normalized_spec["fields"]])
+    return [field_name for field_name in ordered_public_schema if field_name not in deterministic_fields]
+
+
+def is_tabular_transformation_deterministic_only(transformation_spec, public_output_schema=None):
+    """Return True when every public field is server-computable."""
+    normalized_spec = normalize_tabular_transformation_spec(
+        transformation_spec,
+        public_output_schema=public_output_schema,
+    )
+    if not normalized_spec:
+        return False
+    return not get_tabular_transformation_model_fields(normalized_spec, public_output_schema=public_output_schema)
+
+
+def _parse_date_value(value):
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    normalized_value = str(value or "").strip()
+    if not normalized_value:
+        raise TabularTransformationEvaluationError("Date value is empty")
+    try:
+        return date.fromisoformat(normalized_value[:10])
+    except ValueError as exc:
+        raise TabularTransformationEvaluationError("Date value is not ISO formatted") from exc
+
+
+def _parse_decimal_value(value):
+    if isinstance(value, bool) or value in (None, ""):
+        raise TabularTransformationEvaluationError("Numeric value is empty or boolean")
+    try:
+        parsed_value = Decimal(str(value).strip())
+    except (InvalidOperation, ValueError) as exc:
+        raise TabularTransformationEvaluationError("Numeric value is invalid") from exc
+    if abs(parsed_value) > TABULAR_TRANSFORMATION_MAX_NUMERIC_ABS:
+        raise TabularTransformationEvaluationError("Numeric value exceeds the bounded range")
+    return parsed_value
+
+
+def _coerce_comparison_value(value, value_type):
+    if value_type == "date":
+        return _parse_date_value(value)
+    if value_type in {"number", "integer"}:
+        return _parse_decimal_value(value)
+    if value_type == "boolean":
+        if isinstance(value, bool):
+            return value
+        normalized_value = str(value or "").strip().lower()
+        if normalized_value in {"true", "1", "yes", "y"}:
+            return True
+        if normalized_value in {"false", "0", "no", "n"}:
+            return False
+        raise TabularTransformationEvaluationError("Boolean value is invalid")
+    return value
+
+
+def _decimal_to_json_value(value):
+    if value == value.to_integral_value():
+        return int(value)
+    return float(value)
+
+
+def _compare_values(left_value, right_value, op_name, value_type="", case_sensitive=True):
+    coerced_left = _coerce_comparison_value(left_value, value_type)
+    coerced_right = _coerce_comparison_value(right_value, value_type)
+    if value_type in {"", "string"} and isinstance(coerced_left, str) and isinstance(coerced_right, str):
+        if not case_sensitive:
+            coerced_left = coerced_left.casefold()
+            coerced_right = coerced_right.casefold()
+    if op_name == "eq":
+        return coerced_left == coerced_right
+    if op_name == "ne":
+        return coerced_left != coerced_right
+    if op_name == "lt":
+        return coerced_left < coerced_right
+    if op_name == "lte":
+        return coerced_left <= coerced_right
+    if op_name == "gt":
+        return coerced_left > coerced_right
+    if op_name == "gte":
+        return coerced_left >= coerced_right
+    raise TabularTransformationEvaluationError("Comparison operation is unsupported")
+
+
+def _is_empty_value(value):
+    return value is None or value == "" or value == [] or value == {}
+
+
+class _EvaluationContext:
+    def __init__(self, source_row, derived_values):
+        self.source_row = source_row if isinstance(source_row, dict) else {}
+        self.derived_values = derived_values
+        self.step_count = 0
+
+    def consume_step(self):
+        self.step_count += 1
+        if self.step_count > TABULAR_TRANSFORMATION_MAX_EXPRESSION_STEPS:
+            raise TabularTransformationEvaluationError("Transformation evaluation exceeded the step limit")
+
+
+def _evaluate_expression(expression, context):
+    context.consume_step()
+    if not isinstance(expression, dict):
+        return expression
+    if set(expression) == {"source"}:
+        return context.source_row.get(expression["source"])
+    if set(expression) == {"field"}:
+        field_name = expression["field"]
+        if field_name not in context.derived_values:
+            raise TabularTransformationEvaluationError("Referenced derived field has not been evaluated")
+        return context.derived_values.get(field_name)
+    if set(expression) == {"value"}:
+        return expression.get("value")
+
+    op_name = expression.get("op")
+    if op_name == "copy":
+        return context.source_row.get(expression["source"])
+    if op_name == "case":
+        for branch in expression.get("branches") or []:
+            if bool(_evaluate_expression(branch.get("when"), context)):
+                return _evaluate_expression(branch.get("then"), context)
+        return _evaluate_expression(expression.get("else"), context)
+    if op_name == "coalesce":
+        for value_expression in expression.get("values") or []:
+            value = _evaluate_expression(value_expression, context)
+            if not _is_empty_value(value):
+                return value
+        return None
+    if op_name == "all":
+        return all(bool(_evaluate_expression(value_expression, context)) for value_expression in expression.get("values") or [])
+    if op_name == "any":
+        return any(bool(_evaluate_expression(value_expression, context)) for value_expression in expression.get("values") or [])
+    if op_name == "not":
+        return not bool(_evaluate_expression(expression.get("value"), context))
+    if op_name == "is_null":
+        return _is_empty_value(_evaluate_expression(expression.get("value"), context))
+    if op_name == "in":
+        member_value = _evaluate_expression(expression.get("value"), context)
+        expected_values = [_evaluate_expression(value, context) for value in expression.get("values") or []]
+        if not expression.get("case_sensitive", True) and isinstance(member_value, str):
+            member_value = member_value.casefold()
+            expected_values = [value.casefold() if isinstance(value, str) else value for value in expected_values]
+        return member_value in expected_values
+    if op_name in TABULAR_TRANSFORMATION_COMPARISON_OPS:
+        return _compare_values(
+            _evaluate_expression(expression.get("left"), context),
+            _evaluate_expression(expression.get("right"), context),
+            op_name,
+            value_type=expression.get("value_type") or "",
+            case_sensitive=expression.get("case_sensitive", True),
+        )
+    if op_name in TABULAR_TRANSFORMATION_ARITHMETIC_OPS:
+        if "values" in expression:
+            numeric_values = [_parse_decimal_value(_evaluate_expression(value, context)) for value in expression.get("values") or []]
+        else:
+            numeric_values = [
+                _parse_decimal_value(_evaluate_expression(expression.get("left"), context)),
+                _parse_decimal_value(_evaluate_expression(expression.get("right"), context)),
+            ]
+        if op_name == "add":
+            result = sum(numeric_values, Decimal("0"))
+        elif op_name == "subtract":
+            result = numeric_values[0]
+            for value in numeric_values[1:]:
+                result -= value
+        elif op_name == "multiply":
+            result = Decimal("1")
+            for value in numeric_values:
+                result *= value
+        else:
+            result = numeric_values[0]
+            for value in numeric_values[1:]:
+                if value == 0:
+                    raise TabularTransformationEvaluationError("Division by zero is not allowed")
+                result /= value
+        if abs(result) > TABULAR_TRANSFORMATION_MAX_NUMERIC_ABS:
+            raise TabularTransformationEvaluationError("Numeric result exceeds the bounded range")
+        return _decimal_to_json_value(result)
+    raise TabularTransformationEvaluationError("Transformation operation is unsupported")
+
+
+def _validate_evaluated_field_value(field_descriptor, field_value):
+    if field_value is None:
+        if field_descriptor.get("nullable") is False:
+            raise TabularTransformationEvaluationError("Non-nullable deterministic field evaluated to null")
+        return None
+    field_type = str(field_descriptor.get("type") or "").strip().lower()
+    if field_type == "string" and not isinstance(field_value, str):
+        field_value = str(field_value)
+    elif field_type == "integer":
+        field_value = int(_parse_decimal_value(field_value))
+    elif field_type == "number":
+        field_value = _decimal_to_json_value(_parse_decimal_value(field_value))
+    elif field_type == "boolean" and not isinstance(field_value, bool):
+        field_value = _coerce_comparison_value(field_value, "boolean")
+    elif field_type == "date":
+        field_value = _parse_date_value(field_value).isoformat()
+    allowed_values = field_descriptor.get("allowed_values")
+    if allowed_values is not None and field_value not in allowed_values:
+        raise TabularTransformationEvaluationError("Deterministic field evaluated outside allowed values")
+    return field_value
+
+
+def evaluate_tabular_transformation_row(transformation_spec, source_row):
+    """Evaluate deterministic fields for one source row."""
+    normalized_spec = normalize_tabular_transformation_spec(transformation_spec)
+    if not normalized_spec:
+        return {}
+    normalized_fields = list(normalized_spec.get("fields") or [])
+    fields_by_name = {field["name"]: field for field in normalized_fields}
+    derived_values = {}
+    context = _EvaluationContext(source_row, derived_values)
+    for field_name in normalized_spec.get("deterministic_field_order") or []:
+        field_descriptor = fields_by_name[field_name]
+        derived_values[field_name] = _validate_evaluated_field_value(
+            field_descriptor,
+            _evaluate_expression(field_descriptor.get("expression"), context),
+        )
+    return {
+        field["name"]: derived_values[field["name"]]
+        for field in normalized_fields
+        if field["name"] in derived_values
+    }
+
+
+def evaluate_tabular_transformation_rows(transformation_spec, source_rows):
+    """Evaluate deterministic fields for source rows in source order."""
+    normalized_spec = normalize_tabular_transformation_spec(transformation_spec)
+    return [
+        evaluate_tabular_transformation_row(normalized_spec, source_row)
+        for source_row in list(source_rows or [])
+    ]

--- a/docs/explanation/features/TABULAR_TRANSFORMATION_CONTRACT.md
+++ b/docs/explanation/features/TABULAR_TRANSFORMATION_CONTRACT.md
@@ -1,0 +1,56 @@
+# Tabular Transformation Contract
+
+Implemented in version: **0.250.174**
+
+## Overview
+
+The tabular transformation contract adds a versioned, server-owned specification for row-local generated outputs. When a tabular Search or Analyze request includes a supported deterministic transformation specification, SimpleChat can compute those public fields on the server instead of asking the model to reproduce rule-based values.
+
+Analyze still uses the deliverable contract introduced by the artifact-output roadmap. The transformation contract is an additive child contract used by generated tabular artifacts when exact row rules are representable without arbitrary code.
+
+## Dependencies
+
+- `application/single_app/functions_analysis_deliverables.py`
+- `application/single_app/functions_tabular_transformations.py`
+- `application/single_app/functions_tabular_generated_exports.py`
+- `application/single_app/functions_tabular_orchestration.py`
+
+## Technical Specifications
+
+The contract version is `tabular-transform-v1`. It is persisted inside the analysis deliverable contract as `transformation_spec` and normalized before a durable generated-output run is stored.
+
+Initial supported operations are deliberately bounded:
+
+- source field copy
+- literal values
+- ordered `case` branches
+- equality and ordered comparisons
+- ISO date comparisons
+- numeric arithmetic with bounded `Decimal` values
+- null coalescing
+- boolean `all`, `any`, and `not`
+- membership checks
+- references to previously derived deterministic fields
+
+Unsupported operations fail during planning or normalization. The evaluator does not use `eval`, `exec`, dynamic imports, reflection, filesystem access, network access, database access, process access, or environment access.
+
+## Execution Behavior
+
+For deterministic-only structured exports, the durable runner checkpoints generated rows directly from the evaluator and does not call the model for row generation. For hybrid runs, deterministic fields are removed from the model-owned output schema, the model generates only remaining semantic fields, and the server merges deterministic values back into the full checkpoint schema.
+
+Combined Analyze plus structured-output runs still use the model for analysis summaries. Deterministic structured fields are computed by the same server evaluator before publication.
+
+## Validation
+
+Functional coverage is in `functional_tests/test_tabular_transformations_phase4.py`.
+
+The test verifies:
+
+- all 200 financial-review fixture rows match the independent oracle
+- unsafe operations, reserved fields, cycles, and unknown source fields are rejected
+- deliverable contracts persist and round-trip `transformation_spec`
+- deterministic-only specs produce no model-owned public fields
+
+## Limitations
+
+The first implementation accepts transformation specifications supplied through server-side requested output hints. It does not yet infer a full transformation graph from arbitrary prompt text. Semantic field verification and targeted repair remain later Phase 4 follow-up work.

--- a/functional_tests/test_tabular_transformations_phase4.py
+++ b/functional_tests/test_tabular_transformations_phase4.py
@@ -1,0 +1,449 @@
+#!/usr/bin/env python3
+# test_tabular_transformations_phase4.py
+"""
+Functional test for Phase 4 tabular transformation correctness.
+Version: 0.250.174
+Implemented in: 0.250.174
+
+This test ensures deterministic tabular transformation specs are bounded,
+server-evaluable, persisted in deliverable contracts, and sufficient to
+produce the 200-row financial review oracle without model-generated fields.
+"""
+
+from pathlib import Path
+import sys
+import traceback
+
+
+ROOT = Path(__file__).resolve().parents[1]
+APP_ROOT = ROOT / "application" / "single_app"
+if str(APP_ROOT) not in sys.path:
+    sys.path.insert(0, str(APP_ROOT))
+
+from test_support.analyze_deliverable_contract_fixture import (  # noqa: E402
+    FINANCIAL_REVIEW_OUTPUT_COLUMNS,
+    FINANCIAL_REVIEW_SOURCE_COLUMNS,
+    build_expected_financial_review_output_rows,
+    build_financial_review_source_rows,
+    find_value_mismatches,
+)
+from test_support.versioning import assert_app_version_at_least  # noqa: E402
+
+from functions_analysis_deliverables import (  # noqa: E402
+    ANALYSIS_ORDERING_SOURCE_ORDER,
+    ANALYSIS_ROW_CARDINALITY_ONE_PER_SOURCE_ROW,
+    ANALYSIS_TRANSFORMATION_MODE_DETERMINISTIC,
+    ANALYSIS_VALIDATION_PROFILE_EXACT_ROWS_SCHEMA_AND_RULES,
+    build_analysis_deliverable_contract,
+    coerce_analysis_deliverable_contract,
+)
+from functions_tabular_orchestration import plan_tabular_request  # noqa: E402
+from functions_tabular_transformations import (  # noqa: E402
+    TABULAR_TRANSFORMATION_SPEC_VERSION,
+    TabularTransformationSpecError,
+    evaluate_tabular_transformation_rows,
+    get_tabular_transformation_model_fields,
+    is_tabular_transformation_deterministic_only,
+    normalize_tabular_transformation_spec,
+)
+
+
+IMPLEMENTED_VERSION = "0.250.174"
+
+
+def _source(name):
+    return {"source": name}
+
+
+def _field(name):
+    return {"field": name}
+
+
+def _eq(left, right, value_type="", case_sensitive=True):
+    expression = {"op": "eq", "left": left, "right": right, "case_sensitive": case_sensitive}
+    if value_type:
+        expression["value_type"] = value_type
+    return expression
+
+
+def _ne(left, right):
+    return {"op": "ne", "left": left, "right": right}
+
+
+def _gte(left, right, value_type="number"):
+    return {"op": "gte", "left": left, "right": right, "value_type": value_type}
+
+
+def _lt_date(left, right):
+    return {"op": "lt", "left": left, "right": right, "value_type": "date"}
+
+
+def _lte_date(left, right):
+    return {"op": "lte", "left": left, "right": right, "value_type": "date"}
+
+
+def _any(*values):
+    return {"op": "any", "values": list(values)}
+
+
+def _all(*values):
+    return {"op": "all", "values": list(values)}
+
+
+def _case(branches, else_value):
+    return {"op": "case", "branches": branches, "else": else_value}
+
+
+def _branch(when, then):
+    return {"when": when, "then": then}
+
+
+def build_financial_review_transformation_spec():
+    return {
+        "version": TABULAR_TRANSFORMATION_SPEC_VERSION,
+        "fields": [
+            {
+                "name": "Item_ID",
+                "mode": "deterministic",
+                "type": "string",
+                "nullable": False,
+                "expression": {"op": "copy", "source": "Item_ID"},
+            },
+            {
+                "name": "Timeline_Status",
+                "mode": "deterministic",
+                "type": "string",
+                "nullable": False,
+                "allowed_values": ["Overdue", "Due Soon", "On Track"],
+                "expression": _case(
+                    [
+                        _branch(_lt_date(_source("Due_Date"), "2026-08-12"), "Overdue"),
+                        _branch(_lte_date(_source("Due_Date"), "2026-09-11"), "Due Soon"),
+                    ],
+                    "On Track",
+                ),
+            },
+            {
+                "name": "Spend_Risk",
+                "mode": "deterministic",
+                "type": "string",
+                "nullable": False,
+                "allowed_values": ["High Spend Risk", "Moderate Spend Risk", "Low Spend Risk"],
+                "expression": _case(
+                    [
+                        _branch(
+                            _any(
+                                _gte(_source("Invoice_Amount"), 75000),
+                                _eq(_source("Vendor_Risk"), "High"),
+                            ),
+                            "High Spend Risk",
+                        ),
+                        _branch(
+                            _any(
+                                _gte(_source("Invoice_Amount"), 25000),
+                                _eq(_source("Vendor_Risk"), "Medium"),
+                            ),
+                            "Moderate Spend Risk",
+                        ),
+                    ],
+                    "Low Spend Risk",
+                ),
+            },
+            {
+                "name": "Control_Concern",
+                "mode": "deterministic",
+                "type": "string",
+                "nullable": False,
+                "allowed_values": ["Control Concern", "No Control Concern"],
+                "expression": _case(
+                    [
+                        _branch(
+                            _any(
+                                {
+                                    "op": "in",
+                                    "value": _source("Control_Status"),
+                                    "values": ["Missing Approval", "Policy Exception"],
+                                },
+                                _gte(_source("Exception_Count"), 2),
+                            ),
+                            "Control Concern",
+                        ),
+                    ],
+                    "No Control Concern",
+                ),
+            },
+            {
+                "name": "Owner_Response_Status",
+                "mode": "deterministic",
+                "type": "string",
+                "nullable": False,
+                "allowed_values": ["Responded", "Needs Response"],
+                "expression": _case(
+                    [_branch(_eq(_source("Owner_Response"), "Received"), "Responded")],
+                    "Needs Response",
+                ),
+            },
+            {
+                "name": "Escalation_Required",
+                "mode": "deterministic",
+                "type": "string",
+                "nullable": False,
+                "allowed_values": ["Yes", "No"],
+                "expression": _case(
+                    [
+                        _branch(
+                            _any(
+                                _eq(_source("Escalation_Flag"), "Y"),
+                                _all(
+                                    _eq(_field("Timeline_Status"), "Overdue"),
+                                    _eq(_field("Owner_Response_Status"), "Needs Response"),
+                                ),
+                            ),
+                            "Yes",
+                        ),
+                    ],
+                    "No",
+                ),
+            },
+            {
+                "name": "Overall_Attention",
+                "mode": "deterministic",
+                "type": "string",
+                "nullable": False,
+                "allowed_values": ["High Attention", "Monitor", "Low Attention"],
+                "expression": _case(
+                    [
+                        _branch(
+                            _any(
+                                _eq(_field("Escalation_Required"), "Yes"),
+                                _all(
+                                    _eq(_field("Control_Concern"), "Control Concern"),
+                                    _eq(_field("Owner_Response_Status"), "Needs Response"),
+                                ),
+                                _eq(_field("Spend_Risk"), "High Spend Risk"),
+                            ),
+                            "High Attention",
+                        ),
+                        _branch(
+                            _any(
+                                _ne(_field("Timeline_Status"), "On Track"),
+                                _eq(_field("Spend_Risk"), "Moderate Spend Risk"),
+                                _eq(_field("Control_Concern"), "Control Concern"),
+                            ),
+                            "Monitor",
+                        ),
+                    ],
+                    "Low Attention",
+                ),
+            },
+            {
+                "name": "Review_Window",
+                "mode": "deterministic",
+                "type": "string",
+                "nullable": False,
+                "allowed_values": ["Past Due", "Due Today", "Within 30 Days", "Beyond 30 Days"],
+                "expression": _case(
+                    [
+                        _branch(_lt_date(_source("Due_Date"), "2026-08-12"), "Past Due"),
+                        _branch(_eq(_source("Due_Date"), "2026-08-12", value_type="date"), "Due Today"),
+                        _branch(_lte_date(_source("Due_Date"), "2026-09-11"), "Within 30 Days"),
+                    ],
+                    "Beyond 30 Days",
+                ),
+            },
+            {
+                "name": "Recommended_Action",
+                "mode": "deterministic",
+                "type": "string",
+                "nullable": False,
+                "allowed_values": [
+                    "Escalate review",
+                    "Review overdue item",
+                    "Schedule follow-up",
+                    "Routine monitoring",
+                ],
+                "expression": _case(
+                    [
+                        _branch(_eq(_field("Overall_Attention"), "High Attention"), "Escalate review"),
+                        _branch(_eq(_field("Timeline_Status"), "Overdue"), "Review overdue item"),
+                        _branch(_eq(_field("Timeline_Status"), "Due Soon"), "Schedule follow-up"),
+                    ],
+                    "Routine monitoring",
+                ),
+            },
+        ],
+    }
+
+
+def test_financial_review_transformation_matches_oracle():
+    print("Testing deterministic transformation against the 200-row financial review oracle...")
+    assert_app_version_at_least(IMPLEMENTED_VERSION)
+
+    source_rows = build_financial_review_source_rows()
+    expected_rows = build_expected_financial_review_output_rows(source_rows)
+    transformation_spec = build_financial_review_transformation_spec()
+    normalized_spec = normalize_tabular_transformation_spec(
+        transformation_spec,
+        public_output_schema=FINANCIAL_REVIEW_OUTPUT_COLUMNS,
+        source_schema=FINANCIAL_REVIEW_SOURCE_COLUMNS,
+    )
+    actual_rows = evaluate_tabular_transformation_rows(normalized_spec, source_rows)
+
+    assert len(actual_rows) == 200
+    assert list(actual_rows[0].keys()) == FINANCIAL_REVIEW_OUTPUT_COLUMNS
+    assert find_value_mismatches(expected_rows, actual_rows, FINANCIAL_REVIEW_OUTPUT_COLUMNS) == []
+    assert normalized_spec["field_mode_counts"]["deterministic"] == 9
+    assert is_tabular_transformation_deterministic_only(
+        normalized_spec,
+        public_output_schema=FINANCIAL_REVIEW_OUTPUT_COLUMNS,
+    )
+
+
+def test_transformation_spec_rejects_unsafe_and_ambiguous_contracts():
+    print("Testing transformation spec safety checks...")
+    assert_app_version_at_least(IMPLEMENTED_VERSION)
+
+    unsafe_spec = {
+        "version": TABULAR_TRANSFORMATION_SPEC_VERSION,
+        "fields": [{"name": "X", "mode": "deterministic", "expression": {"op": "eval", "value": "1"}}],
+    }
+    try:
+        normalize_tabular_transformation_spec(unsafe_spec, public_output_schema=["X"])
+    except TabularTransformationSpecError:
+        pass
+    else:
+        raise AssertionError("Unsupported operation was not rejected")
+
+    reserved_spec = {
+        "version": TABULAR_TRANSFORMATION_SPEC_VERSION,
+        "fields": [{"name": "__simplechat_secret", "mode": "deterministic", "expression": "x"}],
+    }
+    try:
+        normalize_tabular_transformation_spec(reserved_spec)
+    except TabularTransformationSpecError:
+        pass
+    else:
+        raise AssertionError("Reserved output field was not rejected")
+
+    cycle_spec = {
+        "version": TABULAR_TRANSFORMATION_SPEC_VERSION,
+        "fields": [
+            {"name": "A", "mode": "deterministic", "expression": {"field": "B"}},
+            {"name": "B", "mode": "deterministic", "expression": {"field": "A"}},
+        ],
+    }
+    try:
+        normalize_tabular_transformation_spec(cycle_spec, public_output_schema=["A", "B"])
+    except TabularTransformationSpecError:
+        pass
+    else:
+        raise AssertionError("Derived-field cycle was not rejected")
+
+    missing_source_spec = {
+        "version": TABULAR_TRANSFORMATION_SPEC_VERSION,
+        "fields": [{"name": "A", "mode": "deterministic", "expression": {"source": "Missing"}}],
+    }
+    try:
+        normalize_tabular_transformation_spec(
+            missing_source_spec,
+            public_output_schema=["A"],
+            source_schema=["Known"],
+        )
+    except TabularTransformationSpecError:
+        pass
+    else:
+        raise AssertionError("Unknown source field was not rejected")
+
+
+def test_contract_and_planner_persist_transformation_spec():
+    print("Testing deliverable contract and planner transformation-spec persistence...")
+    assert_app_version_at_least(IMPLEMENTED_VERSION)
+
+    transformation_spec = build_financial_review_transformation_spec()
+    contract = build_analysis_deliverable_contract(
+        action_mode="analyze",
+        requested_output_format="csv",
+        public_output_schema=FINANCIAL_REVIEW_OUTPUT_COLUMNS,
+        row_cardinality=ANALYSIS_ROW_CARDINALITY_ONE_PER_SOURCE_ROW,
+        ordering=ANALYSIS_ORDERING_SOURCE_ORDER,
+        transformation_mode=ANALYSIS_TRANSFORMATION_MODE_DETERMINISTIC,
+        transformation_spec=transformation_spec,
+        validation_profile=ANALYSIS_VALIDATION_PROFILE_EXACT_ROWS_SCHEMA_AND_RULES,
+        source_fingerprint="source-fixture",
+        request_fingerprint="request-fixture",
+    )
+    payload = contract.to_dict()
+    assert payload["contract_version"] == "analysis-deliverables-v3"
+    assert payload["transformation_spec"]["version"] == TABULAR_TRANSFORMATION_SPEC_VERSION
+    assert payload["transformation_spec"]["field_mode_counts"]["deterministic"] == 9
+    assert coerce_analysis_deliverable_contract(payload).to_dict() == payload
+
+    plan = plan_tabular_request(
+        "Analyze every row and download the result as CSV.",
+        [{"file_name": "financial_review.csv", "document_id": "doc-1", "source_version": "v1"}],
+        action_mode="analyze",
+        settings={"enable_tabular_hierarchical_analysis": True},
+        requested_output_hints={
+            "public_output_schema": FINANCIAL_REVIEW_OUTPUT_COLUMNS,
+            "transformation_spec": transformation_spec,
+        },
+    )
+    planned_contract = plan["deliverable_contract"]
+    assert planned_contract["transformation_mode"] == ANALYSIS_TRANSFORMATION_MODE_DETERMINISTIC
+    assert planned_contract["validation_profile"] == ANALYSIS_VALIDATION_PROFILE_EXACT_ROWS_SCHEMA_AND_RULES
+    assert planned_contract["transformation_spec"]["version"] == TABULAR_TRANSFORMATION_SPEC_VERSION
+    assert plan["durable_task_type"] == "combined"
+
+
+def test_model_field_selection_excludes_deterministic_fields():
+    print("Testing model-owned field selection for deterministic and hybrid specs...")
+    assert_app_version_at_least(IMPLEMENTED_VERSION)
+
+    deterministic_spec = normalize_tabular_transformation_spec(
+        build_financial_review_transformation_spec(),
+        public_output_schema=FINANCIAL_REVIEW_OUTPUT_COLUMNS,
+    )
+    assert get_tabular_transformation_model_fields(
+        deterministic_spec,
+        public_output_schema=FINANCIAL_REVIEW_OUTPUT_COLUMNS,
+    ) == []
+
+    hybrid_spec = {
+        "version": TABULAR_TRANSFORMATION_SPEC_VERSION,
+        "fields": [
+            {"name": "Item_ID", "mode": "deterministic", "expression": {"op": "copy", "source": "Item_ID"}},
+            {"name": "Narrative", "mode": "semantic"},
+        ],
+    }
+    assert get_tabular_transformation_model_fields(
+        hybrid_spec,
+        public_output_schema=["Item_ID", "Narrative"],
+    ) == ["Narrative"]
+
+
+def run_tests():
+    tests = [
+        test_financial_review_transformation_matches_oracle,
+        test_transformation_spec_rejects_unsafe_and_ambiguous_contracts,
+        test_contract_and_planner_persist_transformation_spec,
+        test_model_field_selection_excludes_deterministic_fields,
+    ]
+    results = []
+    for test in tests:
+        print(f"\nRunning {test.__name__}...")
+        try:
+            test()
+            print("PASS")
+            results.append(True)
+        except Exception as exc:
+            print(f"FAIL: {exc}")
+            traceback.print_exc()
+            results.append(False)
+
+    success = all(results)
+    print(f"\nResults: {sum(results)}/{len(results)} tests passed")
+    return success
+
+
+if __name__ == "__main__":
+    sys.exit(0 if run_tests() else 1)


### PR DESCRIPTION
## Phase Objective

Phase 4 slice for the Analyze artifact/output-fidelity roadmap: add a bounded, versioned tabular transformation contract and use it to compute representable deterministic generated-output fields server-side.

## Explicit Non-Goals

- Does not infer arbitrary transformation graphs from prompt text.
- Does not implement the semantic verifier or targeted repair loop yet.
- Does not add dataset-specific finance rules to production code.
- Does not change artifact-set lifecycle or plural UI behavior from later phases.

## Behavior Flags And Effective Defaults

- No new admin/user-facing setting is introduced.
- Transformation specs are additive server-owned metadata supplied through requested output hints / deliverable contracts.
- Runs without a `transformation_spec` continue on the existing semantic/model path.
- Runs with a server-owned transformation spec skip model schema planning so the contract-owned schema is not overwritten.

## Contract-Version Changes

- `analysis-deliverables-v3` adds persisted `transformation_spec`.
- `analysis-deliverables-v1` and `analysis-deliverables-v2` remain legacy-readable.
- Adds `tabular-transform-v1` for bounded row-local transformation specs.
- Application version bumped to `0.250.174`.

## Old-Run Compatibility Impact

Existing durable runs that do not carry `transformation_spec` are interpreted as before. Legacy deliverable contracts without the new field coerce to an empty spec and preserve the existing semantic path.

## Implementation Summary

- Adds `functions_tabular_transformations.py` with a bounded allowlisted evaluator.
- Supports copy, literals, ordered case, comparisons, ISO date comparisons, bounded numeric arithmetic, coalesce, boolean composition, membership, and derived-field references.
- Rejects unsupported operations, reserved fields, cycles, unknown source fields, excessive sizes, and unsafe expression shapes.
- Computes deterministic-only structured exports without model row generation.
- For hybrid structured runs, removes deterministic fields from the model-owned schema and merges server-computed values back into checkpoint rows.
- Combined Analyze/export chunks still use the model for analysis summaries while computing deterministic structured fields server-side.

## Validation Commands And Results

- `python -m py_compile application/single_app/functions_tabular_transformations.py application/single_app/functions_analysis_deliverables.py application/single_app/functions_tabular_orchestration.py application/single_app/functions_tabular_generated_exports.py application/single_app/config.py functional_tests/test_tabular_transformations_phase4.py functional_tests/test_analyze_deliverable_contract.py` - passed
- `python functional_tests/test_tabular_transformations_phase4.py` - 4/4 passed
- `python functional_tests/test_analyze_deliverable_contract.py` - 6/6 passed
- VS Code diagnostics for touched Python files - no errors
- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check` - passed
- New-file final-newline/trailing-whitespace hygiene - passed

## Security And Source-Scope Coverage

- No `eval`, `exec`, dynamic imports, reflection, arbitrary callables, filesystem/process/network/database/environment access.
- Expression depth, step count, branch count, field count, list size, string size, and numeric range are bounded.
- Public schema rejects internal lineage and `__simplechat*` fields.
- Planner/verifier outputs are treated as untrusted structured input and normalized before persistence.
- Existing source authorization and source-version checks remain in the durable runner.
- No source row values are added to telemetry or browser metadata by this change.

## Rollout And Rollback

Rollout is additive: only runs with a persisted `transformation_spec` use the new path. Rollback can stop supplying specs to new runs; old/new readers keep empty-spec legacy behavior and accepted transformation specs remain evaluable for persisted runs.

## Later Phases Excluded

Semantic field verification, bounded targeted repair, atomic artifact-set lifecycle, plural artifact UI, scale/canary rollout, and legacy fallback retirement remain outside this PR.
