### PR TITLE
Phase 5: Add durable artifact-set lifecycle

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -96,7 +96,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.250.174"
+VERSION = "0.250.175"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/functions_tabular_generated_exports.py
+++ b/application/single_app/functions_tabular_generated_exports.py
@@ -39,8 +39,12 @@ from config import (
 )
 from functions_appinsights import log_event
 from functions_analysis_deliverables import (
+    ANALYSIS_ARTIFACT_ROLE_PRIMARY_ANALYSIS,
+    ANALYSIS_ARTIFACT_ROLE_REQUESTED_OUTPUT,
+    ANALYSIS_ARTIFACT_ROLE_SUPPORTING_OUTPUT,
     is_analysis_internal_lineage_field,
     project_structured_deliverable_row,
+    validate_analysis_artifact_set,
 )
 from functions_assistant_table_exports import build_safe_csv_headers, neutralize_csv_spreadsheet_formula
 from functions_tabular_transformations import (
@@ -123,6 +127,52 @@ TABULAR_EXPORT_TERMINAL_STATUSES = {
     TABULAR_EXPORT_STATUS_COMPLETED,
     TABULAR_EXPORT_STATUS_FAILED,
     TABULAR_EXPORT_STATUS_CANCELED,
+}
+TABULAR_ARTIFACT_SET_CONTRACT_VERSION = 'tabular-artifact-set-v1'
+TABULAR_ARTIFACT_SET_LIFECYCLE_PLANNED = 'planned'
+TABULAR_ARTIFACT_SET_LIFECYCLE_GENERATING = 'generating'
+TABULAR_ARTIFACT_SET_LIFECYCLE_VALIDATING = 'validating'
+TABULAR_ARTIFACT_SET_LIFECYCLE_READY_TO_PUBLISH = 'ready_to_publish'
+TABULAR_ARTIFACT_SET_LIFECYCLE_PUBLISHING = 'publishing'
+TABULAR_ARTIFACT_SET_LIFECYCLE_COMPLETED = 'completed'
+TABULAR_ARTIFACT_SET_LIFECYCLE_FAILED = 'failed'
+TABULAR_ARTIFACT_SET_LIFECYCLE_CANCELED = 'canceled'
+TABULAR_ARTIFACT_SET_LIFECYCLE_ROLLBACK_REQUIRED = 'rollback_required'
+TABULAR_ARTIFACT_SET_LIFECYCLE_ROLLED_BACK = 'rolled_back'
+TABULAR_ARTIFACT_SET_LIFECYCLE_STATES = {
+    TABULAR_ARTIFACT_SET_LIFECYCLE_PLANNED,
+    TABULAR_ARTIFACT_SET_LIFECYCLE_GENERATING,
+    TABULAR_ARTIFACT_SET_LIFECYCLE_VALIDATING,
+    TABULAR_ARTIFACT_SET_LIFECYCLE_READY_TO_PUBLISH,
+    TABULAR_ARTIFACT_SET_LIFECYCLE_PUBLISHING,
+    TABULAR_ARTIFACT_SET_LIFECYCLE_COMPLETED,
+    TABULAR_ARTIFACT_SET_LIFECYCLE_FAILED,
+    TABULAR_ARTIFACT_SET_LIFECYCLE_CANCELED,
+    TABULAR_ARTIFACT_SET_LIFECYCLE_ROLLBACK_REQUIRED,
+    TABULAR_ARTIFACT_SET_LIFECYCLE_ROLLED_BACK,
+}
+TABULAR_ARTIFACT_MEMBER_LIFECYCLE_PLANNED = 'planned'
+TABULAR_ARTIFACT_MEMBER_LIFECYCLE_GENERATING = 'generating'
+TABULAR_ARTIFACT_MEMBER_LIFECYCLE_STAGED = 'staged'
+TABULAR_ARTIFACT_MEMBER_LIFECYCLE_VALIDATED = 'validated'
+TABULAR_ARTIFACT_MEMBER_LIFECYCLE_PUBLISHING = 'publishing'
+TABULAR_ARTIFACT_MEMBER_LIFECYCLE_PUBLISHED = 'published'
+TABULAR_ARTIFACT_MEMBER_LIFECYCLE_FAILED = 'failed'
+TABULAR_ARTIFACT_MEMBER_LIFECYCLE_CANCELED = 'canceled'
+TABULAR_ARTIFACT_MEMBER_LIFECYCLE_ROLLED_BACK = 'rolled_back'
+TABULAR_ARTIFACT_MEMBER_LIFECYCLE_STATES = {
+    TABULAR_ARTIFACT_MEMBER_LIFECYCLE_PLANNED,
+    TABULAR_ARTIFACT_MEMBER_LIFECYCLE_GENERATING,
+    TABULAR_ARTIFACT_MEMBER_LIFECYCLE_STAGED,
+    TABULAR_ARTIFACT_MEMBER_LIFECYCLE_VALIDATED,
+    TABULAR_ARTIFACT_MEMBER_LIFECYCLE_PUBLISHING,
+    TABULAR_ARTIFACT_MEMBER_LIFECYCLE_PUBLISHED,
+    TABULAR_ARTIFACT_MEMBER_LIFECYCLE_FAILED,
+    TABULAR_ARTIFACT_MEMBER_LIFECYCLE_CANCELED,
+    TABULAR_ARTIFACT_MEMBER_LIFECYCLE_ROLLED_BACK,
+}
+TABULAR_ARTIFACT_MEMBER_PUBLIC_LIFECYCLE_STATES = {
+    TABULAR_ARTIFACT_MEMBER_LIFECYCLE_PUBLISHED,
 }
 
 TABULAR_EXPORT_DEFAULT_INLINE_MAX_BATCHES = 75
@@ -6273,57 +6323,31 @@ def _build_run_public_status(run, settings=None):
     deferred_composition = _build_tabular_run_deferred_composition_reference(run)
     rollout_assignment = _build_tabular_run_rollout_assignment_public_fields(run)
     checkpoint_summary = _build_checkpoint_summary(completed_batches, batch_count, processed_rows, row_count)
-    generated_artifacts = []
-
-    def append_generated_artifact(artifact, fallback_file_name, fallback_output_format, summary):
-        artifact = artifact if isinstance(artifact, dict) else {}
-        if not artifact.get('artifact_message_id'):
-            return
-        generated_artifacts.append({
-            'capability': artifact.get('capability') or 'tabular',
-            'artifact_message_id': artifact.get('artifact_message_id'),
-            'conversation_id': run.get('conversation_id'),
-            'file_name': artifact.get('file_name') or fallback_file_name,
-            'output_format': artifact.get('output_format') or fallback_output_format,
-            'row_count': processed_rows or row_count,
-            'storage_scope': 'chat',
-            'source_file_name': run.get('source_file_name'),
-            'selected_sheet': run.get('selected_sheet'),
-            'summary': summary,
-            'preview_rows': list(artifact.get('preview_rows') or [])[
-                :TABULAR_EXPORT_ARTIFACT_PREVIEW_MAX_ROWS
-            ],
-            'preview_columns': list(artifact.get('preview_columns') or [])[
-                :TABULAR_GENERATION_PLAN_MAX_FIELDS + 2
-            ],
-            'preview_text': str(artifact.get('preview_text') or '')[
-                :TABULAR_EXPORT_ARTIFACT_PREVIEW_MAX_CHARS
-            ],
-            'suppress_assistant_text': bool(artifact.get('suppress_assistant_text')),
-            'suppress_assistant_table_export': True,
-        })
-
-    if task_type == TABULAR_RUN_TASK_COMBINED:
-        append_generated_artifact(
-            run.get('structured_export_artifact') or final_artifact,
-            run.get('generated_file_name'),
-            run.get('output_format'),
-            run.get('post_run_export_summary'),
-        )
-        append_generated_artifact(
-            run.get('analysis_artifact'),
-            run.get('analysis_generated_file_name'),
-            'md',
-            run.get('post_run_summary'),
-        )
-    else:
-        append_generated_artifact(
-            final_artifact,
-            run.get('generated_file_name'),
-            run.get('output_format'),
-            run.get('post_run_summary'),
-        )
+    artifact_set_manifest = _build_or_update_artifact_set_manifest(run)
+    generated_artifacts = _build_public_generated_artifacts_from_manifest(run, artifact_set_manifest)
     generated_artifact = generated_artifacts[0] if generated_artifacts else None
+    primary_final_artifact = generated_artifact or (
+        _build_public_artifact_projection(final_artifact)
+        if (
+            run.get('status') == TABULAR_EXPORT_STATUS_COMPLETED
+            and artifact_set_manifest.get('lifecycle_state') == TABULAR_ARTIFACT_SET_LIFECYCLE_COMPLETED
+        )
+        else None
+    ) or {}
+    structured_export_public_artifact = next(
+        (
+            artifact for artifact in generated_artifacts
+            if artifact.get('role') == ANALYSIS_ARTIFACT_ROLE_REQUESTED_OUTPUT
+        ),
+        None,
+    )
+    analysis_public_artifact = next(
+        (
+            artifact for artifact in generated_artifacts
+            if artifact.get('role') == ANALYSIS_ARTIFACT_ROLE_PRIMARY_ANALYSIS
+        ),
+        None,
+    )
 
     return {
         'run_id': run.get('id'),
@@ -6403,12 +6427,22 @@ def _build_run_public_status(run, settings=None):
         'can_resume': can_resume,
         'can_cancel': _can_cancel_run(run),
         'retryable_failure': retryable_failure,
-        'artifact_message_id': final_artifact.get('artifact_message_id'),
-        'file_name': final_artifact.get('file_name') or run.get('generated_file_name'),
+        'artifact_message_id': primary_final_artifact.get('artifact_message_id'),
+        'file_name': primary_final_artifact.get('file_name') or run.get('generated_file_name'),
         'generated_artifact': generated_artifact,
         'generated_artifacts': generated_artifacts,
-        'structured_export_artifact': run.get('structured_export_artifact'),
-        'analysis_artifact': run.get('analysis_artifact'),
+        'artifact_set': {
+            'contract_version': artifact_set_manifest.get('contract_version'),
+            'set_id': artifact_set_manifest.get('set_id'),
+            'lifecycle_state': artifact_set_manifest.get('lifecycle_state'),
+            'validation_state': artifact_set_manifest.get('validation_state'),
+            'primary_artifact_id': artifact_set_manifest.get('primary_artifact_id'),
+            'member_count': len(artifact_set_manifest.get('members') or []),
+            'published_member_count': len(generated_artifacts),
+            'publication_generation': _safe_int(artifact_set_manifest.get('publication_generation'), minimum=0),
+        },
+        'structured_export_artifact': structured_export_public_artifact,
+        'analysis_artifact': analysis_public_artifact,
         'capability': 'tabular',
         'suppress_assistant_table_export': True,
         'background_export': not (
@@ -7305,6 +7339,465 @@ def _build_artifact_metadata(
     }
 
 
+def _normalize_tabular_artifact_lifecycle_state(value, allowed_states, default_state):
+    normalized_state = str(value or '').strip().lower()
+    if normalized_state in allowed_states:
+        return normalized_state
+    return default_state
+
+
+def _normalize_tabular_artifact_format(value, fallback_format='json'):
+    normalized_format = str(value or '').strip().lower().lstrip('.')
+    if normalized_format:
+        return normalized_format[:20]
+    return str(fallback_format or 'json').strip().lower().lstrip('.')[:20] or 'json'
+
+
+def _normalize_tabular_artifact_role(value, fallback_role=ANALYSIS_ARTIFACT_ROLE_REQUESTED_OUTPUT):
+    normalized_role = str(value or '').strip().lower()
+    if normalized_role in {
+        ANALYSIS_ARTIFACT_ROLE_PRIMARY_ANALYSIS,
+        ANALYSIS_ARTIFACT_ROLE_REQUESTED_OUTPUT,
+        ANALYSIS_ARTIFACT_ROLE_SUPPORTING_OUTPUT,
+    }:
+        return normalized_role
+    return fallback_role
+
+
+def _normalize_tabular_artifact_member_id(value, role, output_format, request_order):
+    normalized_value = re.sub(r'[^a-z0-9_-]+', '-', str(value or '').strip().lower())
+    normalized_value = re.sub(r'-+', '-', normalized_value).strip('-')
+    if normalized_value:
+        return normalized_value[:96]
+    if role == ANALYSIS_ARTIFACT_ROLE_PRIMARY_ANALYSIS:
+        return 'analysis'
+    return f'requested-{output_format or request_order}'[:96]
+
+
+def _get_tabular_run_deliverable_contract(run):
+    planner_metadata = (run or {}).get('tabular_planner_metadata')
+    if not isinstance(planner_metadata, dict):
+        return {}
+    deliverable_contract = planner_metadata.get('deliverable_contract')
+    if not isinstance(deliverable_contract, dict):
+        return {}
+    return deliverable_contract
+
+
+def _normalize_artifact_descriptor(raw_descriptor, fallback_order=0):
+    raw_descriptor = raw_descriptor if isinstance(raw_descriptor, dict) else {}
+    request_order = _safe_int(raw_descriptor.get('request_order'), default=fallback_order, minimum=0)
+    role = _normalize_tabular_artifact_role(raw_descriptor.get('role'))
+    output_format = _normalize_tabular_artifact_format(
+        raw_descriptor.get('format') or raw_descriptor.get('output_format'),
+        fallback_format='md' if role == ANALYSIS_ARTIFACT_ROLE_PRIMARY_ANALYSIS else 'json',
+    )
+    member_id = _normalize_tabular_artifact_member_id(
+        raw_descriptor.get('artifact_id') or raw_descriptor.get('member_id'),
+        role,
+        output_format,
+        request_order,
+    )
+    return {
+        'member_id': member_id,
+        'artifact_id': member_id,
+        'role': role,
+        'format': output_format,
+        'required': bool(raw_descriptor.get('required', True)),
+        'request_order': request_order,
+    }
+
+
+def _default_artifact_descriptors_for_run(run):
+    task_type = _normalize_tabular_run_task_type((run or {}).get('task_type'))
+    output_format = _normalize_tabular_artifact_format((run or {}).get('output_format'), fallback_format='json')
+    if task_type == TABULAR_RUN_TASK_HIERARCHICAL_ANALYSIS:
+        return [{
+            'artifact_id': 'analysis',
+            'role': ANALYSIS_ARTIFACT_ROLE_PRIMARY_ANALYSIS,
+            'format': 'md',
+            'required': True,
+            'request_order': 0,
+        }]
+    if task_type == TABULAR_RUN_TASK_COMBINED:
+        return [
+            {
+                'artifact_id': 'analysis',
+                'role': ANALYSIS_ARTIFACT_ROLE_PRIMARY_ANALYSIS,
+                'format': 'md',
+                'required': True,
+                'request_order': 0,
+            },
+            {
+                'artifact_id': f'requested-{output_format}',
+                'role': ANALYSIS_ARTIFACT_ROLE_REQUESTED_OUTPUT,
+                'format': output_format,
+                'required': True,
+                'request_order': 1,
+            },
+        ]
+    return [{
+        'artifact_id': f'requested-{output_format}',
+        'role': ANALYSIS_ARTIFACT_ROLE_REQUESTED_OUTPUT,
+        'format': output_format,
+        'required': True,
+        'request_order': 0,
+    }]
+
+
+def _get_artifact_descriptors_for_run(run):
+    deliverable_contract = _get_tabular_run_deliverable_contract(run)
+    contract_artifacts = list(deliverable_contract.get('requested_artifacts') or [])
+    if not contract_artifacts:
+        contract_artifacts = _default_artifact_descriptors_for_run(run)
+    descriptors = [
+        _normalize_artifact_descriptor(raw_descriptor, fallback_order=index)
+        for index, raw_descriptor in enumerate(contract_artifacts)
+    ]
+    return sorted(descriptors, key=lambda descriptor: (
+        _safe_int(descriptor.get('request_order'), minimum=0),
+        str(descriptor.get('member_id') or ''),
+    ))
+
+
+def _get_primary_artifact_member_id(run, descriptors):
+    deliverable_contract = _get_tabular_run_deliverable_contract(run)
+    primary_role = str(deliverable_contract.get('primary_artifact_role') or '').strip().lower()
+    if not primary_role:
+        task_type = _normalize_tabular_run_task_type((run or {}).get('task_type'))
+        primary_role = (
+            ANALYSIS_ARTIFACT_ROLE_PRIMARY_ANALYSIS
+            if task_type in {TABULAR_RUN_TASK_HIERARCHICAL_ANALYSIS, TABULAR_RUN_TASK_COMBINED}
+            else ANALYSIS_ARTIFACT_ROLE_REQUESTED_OUTPUT
+        )
+    for descriptor in descriptors:
+        if descriptor.get('role') == primary_role:
+            return descriptor.get('member_id')
+    return descriptors[0].get('member_id') if descriptors else ''
+
+
+def _get_structured_artifact_member_id(run):
+    output_format = _normalize_tabular_artifact_format((run or {}).get('output_format'), fallback_format='json')
+    for descriptor in _get_artifact_descriptors_for_run(run):
+        if (
+            descriptor.get('role') == ANALYSIS_ARTIFACT_ROLE_REQUESTED_OUTPUT
+            and descriptor.get('format') == output_format
+        ):
+            return descriptor.get('member_id')
+    return f'requested-{output_format}'
+
+
+def _get_analysis_artifact_member_id(run):
+    for descriptor in _get_artifact_descriptors_for_run(run):
+        if descriptor.get('role') == ANALYSIS_ARTIFACT_ROLE_PRIMARY_ANALYSIS:
+            return descriptor.get('member_id')
+    return 'analysis'
+
+
+def _build_artifact_member_idempotency_key(run, member):
+    role = str((member or {}).get('role') or '').strip().lower()
+    output_format = str((member or {}).get('format') or '').strip().lower()
+    member_id = str((member or {}).get('member_id') or '').strip()
+    run_id = (run or {}).get('id')
+    if role == ANALYSIS_ARTIFACT_ROLE_PRIMARY_ANALYSIS and output_format == 'md':
+        return f'tabular-hierarchical-analysis:{run_id}'
+    if role == ANALYSIS_ARTIFACT_ROLE_REQUESTED_OUTPUT and output_format == (run or {}).get('output_format'):
+        return f'tabular-generated-output:{run_id}'
+    return f'tabular-artifact-set:{run_id}:{member_id}'
+
+
+def _build_artifact_set_member(run, descriptor, existing_member=None):
+    existing_member = existing_member if isinstance(existing_member, dict) else {}
+    lifecycle_state = _normalize_tabular_artifact_lifecycle_state(
+        existing_member.get('lifecycle_state'),
+        TABULAR_ARTIFACT_MEMBER_LIFECYCLE_STATES,
+        TABULAR_ARTIFACT_MEMBER_LIFECYCLE_PLANNED,
+    )
+    validation_state = str(existing_member.get('validation_state') or '').strip().lower()[:40]
+    member = {
+        'member_id': descriptor.get('member_id'),
+        'artifact_id': descriptor.get('artifact_id') or descriptor.get('member_id'),
+        'role': descriptor.get('role'),
+        'format': descriptor.get('format'),
+        'required': bool(descriptor.get('required', True)),
+        'request_order': _safe_int(descriptor.get('request_order'), minimum=0),
+        'lifecycle_state': lifecycle_state,
+        'validation_state': validation_state or TABULAR_ARTIFACT_MEMBER_LIFECYCLE_PLANNED,
+        'artifact_message_id': existing_member.get('artifact_message_id'),
+        'file_name': existing_member.get('file_name'),
+        'capability': existing_member.get('capability') or 'tabular',
+        'output_format': existing_member.get('output_format') or descriptor.get('format'),
+        'row_count': _safe_int(existing_member.get('row_count'), default=_safe_int((run or {}).get('row_count'))),
+        'preview_rows': list(existing_member.get('preview_rows') or [])[:TABULAR_EXPORT_ARTIFACT_PREVIEW_MAX_ROWS],
+        'preview_columns': list(existing_member.get('preview_columns') or [])[:TABULAR_GENERATION_PLAN_MAX_FIELDS + 2],
+        'preview_text': str(existing_member.get('preview_text') or '')[:TABULAR_EXPORT_ARTIFACT_PREVIEW_MAX_CHARS],
+        'suppress_assistant_text': bool(existing_member.get('suppress_assistant_text', True)),
+    }
+    member['idempotency_key'] = existing_member.get('idempotency_key') or _build_artifact_member_idempotency_key(
+        run,
+        member,
+    )
+    return member
+
+
+def _artifact_lifecycle_for_existing_run_artifact(run, artifact):
+    artifact = artifact if isinstance(artifact, dict) else {}
+    status = str((run or {}).get('status') or '').strip().lower()
+    if not artifact.get('artifact_message_id'):
+        return TABULAR_ARTIFACT_MEMBER_LIFECYCLE_PLANNED
+    if status == TABULAR_EXPORT_STATUS_COMPLETED:
+        return TABULAR_ARTIFACT_MEMBER_LIFECYCLE_PUBLISHED
+    if status == TABULAR_EXPORT_STATUS_CANCELED:
+        return TABULAR_ARTIFACT_MEMBER_LIFECYCLE_CANCELED
+    if status == TABULAR_EXPORT_STATUS_FAILED:
+        return TABULAR_ARTIFACT_MEMBER_LIFECYCLE_FAILED
+    return TABULAR_ARTIFACT_MEMBER_LIFECYCLE_STAGED
+
+
+def _artifact_set_lifecycle_for_run(run, members):
+    status = str((run or {}).get('status') or '').strip().lower()
+    member_states = {
+        str((member or {}).get('lifecycle_state') or '').strip().lower()
+        for member in list(members or [])
+        if isinstance(member, dict)
+    }
+    if status == TABULAR_EXPORT_STATUS_COMPLETED:
+        return TABULAR_ARTIFACT_SET_LIFECYCLE_COMPLETED
+    if status == TABULAR_EXPORT_STATUS_CANCELED:
+        return TABULAR_ARTIFACT_SET_LIFECYCLE_CANCELED
+    if status == TABULAR_EXPORT_STATUS_FAILED:
+        if TABULAR_ARTIFACT_MEMBER_LIFECYCLE_PUBLISHED in member_states:
+            return TABULAR_ARTIFACT_SET_LIFECYCLE_ROLLBACK_REQUIRED
+        return TABULAR_ARTIFACT_SET_LIFECYCLE_FAILED
+    if (run or {}).get('publishing_started_at'):
+        return TABULAR_ARTIFACT_SET_LIFECYCLE_PUBLISHING
+    if TABULAR_ARTIFACT_MEMBER_LIFECYCLE_STAGED in member_states:
+        return TABULAR_ARTIFACT_SET_LIFECYCLE_VALIDATING
+    return TABULAR_ARTIFACT_SET_LIFECYCLE_GENERATING if status == TABULAR_EXPORT_STATUS_RUNNING else TABULAR_ARTIFACT_SET_LIFECYCLE_PLANNED
+
+
+def _merge_artifact_metadata_into_member(member, artifact, lifecycle_state=None, validation_state=None):
+    artifact = artifact if isinstance(artifact, dict) else {}
+    if not artifact:
+        return member
+    member.update({
+        'artifact_message_id': artifact.get('artifact_message_id') or member.get('artifact_message_id'),
+        'file_name': artifact.get('file_name') or member.get('file_name'),
+        'capability': artifact.get('capability') or member.get('capability') or 'tabular',
+        'output_format': artifact.get('output_format') or member.get('output_format') or member.get('format'),
+        'row_count': _safe_int(artifact.get('row_count'), default=_safe_int(member.get('row_count'))),
+        'preview_rows': list(artifact.get('preview_rows') or member.get('preview_rows') or [])[
+            :TABULAR_EXPORT_ARTIFACT_PREVIEW_MAX_ROWS
+        ],
+        'preview_columns': list(artifact.get('preview_columns') or member.get('preview_columns') or [])[
+            :TABULAR_GENERATION_PLAN_MAX_FIELDS + 2
+        ],
+        'preview_text': str(artifact.get('preview_text') or member.get('preview_text') or '')[
+            :TABULAR_EXPORT_ARTIFACT_PREVIEW_MAX_CHARS
+        ],
+        'suppress_assistant_text': bool(artifact.get('suppress_assistant_text', member.get('suppress_assistant_text', True))),
+    })
+    if lifecycle_state:
+        member['lifecycle_state'] = _normalize_tabular_artifact_lifecycle_state(
+            lifecycle_state,
+            TABULAR_ARTIFACT_MEMBER_LIFECYCLE_STATES,
+            member.get('lifecycle_state') or TABULAR_ARTIFACT_MEMBER_LIFECYCLE_PLANNED,
+        )
+    if validation_state:
+        member['validation_state'] = str(validation_state or '').strip().lower()[:40]
+    return member
+
+
+def _build_or_update_artifact_set_manifest(run):
+    run = run if isinstance(run, dict) else {}
+    existing_manifest = run.get('artifact_set_manifest') if isinstance(run.get('artifact_set_manifest'), dict) else {}
+    descriptors = _get_artifact_descriptors_for_run(run)
+    existing_members = {
+        str(member.get('member_id') or '').strip(): member
+        for member in list(existing_manifest.get('members') or [])
+        if isinstance(member, dict)
+    }
+    members = []
+    for descriptor in descriptors:
+        member = _build_artifact_set_member(
+            run,
+            descriptor,
+            existing_members.get(descriptor.get('member_id')),
+        )
+        if member.get('role') == ANALYSIS_ARTIFACT_ROLE_PRIMARY_ANALYSIS:
+            artifact = run.get('analysis_artifact') if isinstance(run.get('analysis_artifact'), dict) else {}
+            _merge_artifact_metadata_into_member(
+                member,
+                artifact,
+                lifecycle_state=_artifact_lifecycle_for_existing_run_artifact(run, artifact),
+                validation_state='validated' if artifact.get('artifact_message_id') else None,
+            )
+        elif member.get('role') == ANALYSIS_ARTIFACT_ROLE_REQUESTED_OUTPUT:
+            artifact = run.get('structured_export_artifact') if isinstance(run.get('structured_export_artifact'), dict) else {}
+            if not artifact and _normalize_tabular_run_task_type(run.get('task_type')) != TABULAR_RUN_TASK_COMBINED:
+                artifact = run.get('final_artifact') if isinstance(run.get('final_artifact'), dict) else {}
+            _merge_artifact_metadata_into_member(
+                member,
+                artifact,
+                lifecycle_state=_artifact_lifecycle_for_existing_run_artifact(run, artifact),
+                validation_state='validated' if artifact.get('artifact_message_id') else None,
+            )
+        members.append(member)
+
+    primary_member_id = existing_manifest.get('primary_artifact_id') or _get_primary_artifact_member_id(run, descriptors)
+    lifecycle_state = _normalize_tabular_artifact_lifecycle_state(
+        existing_manifest.get('lifecycle_state'),
+        TABULAR_ARTIFACT_SET_LIFECYCLE_STATES,
+        _artifact_set_lifecycle_for_run(run, members),
+    )
+    if lifecycle_state == TABULAR_ARTIFACT_SET_LIFECYCLE_PLANNED:
+        lifecycle_state = _artifact_set_lifecycle_for_run(run, members)
+    manifest = {
+        'contract_version': TABULAR_ARTIFACT_SET_CONTRACT_VERSION,
+        'set_id': existing_manifest.get('set_id') or f"tabular-artifact-set:{run.get('id')}",
+        'run_id': run.get('id'),
+        'conversation_id': run.get('conversation_id'),
+        'user_id': run.get('user_id'),
+        'task_type': _normalize_tabular_run_task_type(run.get('task_type')),
+        'source_fingerprint': str(_get_tabular_run_deliverable_contract(run).get('source_fingerprint') or '')[:64],
+        'request_fingerprint': str(_get_tabular_run_deliverable_contract(run).get('request_fingerprint') or '')[:64],
+        'lifecycle_state': lifecycle_state,
+        'publication_generation': _safe_int(existing_manifest.get('publication_generation'), minimum=0),
+        'primary_artifact_id': primary_member_id,
+        'validation_state': str(existing_manifest.get('validation_state') or '').strip().lower()[:40] or 'planned',
+        'rollback_state': str(existing_manifest.get('rollback_state') or '').strip().lower()[:40],
+        'members': members,
+    }
+    return manifest
+
+
+def _set_artifact_set_member_state(run, member_id, artifact=None, lifecycle_state=None, validation_state=None):
+    manifest = _build_or_update_artifact_set_manifest(run)
+    for member in manifest.get('members') or []:
+        if member.get('member_id') == member_id:
+            _merge_artifact_metadata_into_member(
+                member,
+                artifact,
+                lifecycle_state=lifecycle_state,
+                validation_state=validation_state,
+            )
+            break
+    manifest['lifecycle_state'] = _artifact_set_lifecycle_for_run(run, manifest.get('members') or [])
+    run['artifact_set_manifest'] = manifest
+    return manifest
+
+
+def _publish_artifact_set_members(run, published_member_ids):
+    published_ids = {str(member_id or '').strip() for member_id in list(published_member_ids or []) if member_id}
+    manifest = _build_or_update_artifact_set_manifest(run)
+    for member in manifest.get('members') or []:
+        if member.get('member_id') in published_ids and member.get('artifact_message_id'):
+            member['lifecycle_state'] = TABULAR_ARTIFACT_MEMBER_LIFECYCLE_PUBLISHED
+            member['validation_state'] = 'validated'
+    validation_artifacts = [
+        {
+            'artifact_id': member.get('artifact_id') or member.get('member_id'),
+            'role': member.get('role'),
+            'format': member.get('format'),
+            'status': member.get('lifecycle_state'),
+        }
+        for member in manifest.get('members') or []
+    ]
+    deliverable_contract = _get_tabular_run_deliverable_contract(run)
+    artifact_set_valid = True
+    if deliverable_contract:
+        validation_report = validate_analysis_artifact_set(deliverable_contract, validation_artifacts)
+        artifact_set_valid = validation_report.valid
+        manifest['validation_state'] = 'validated' if validation_report.valid else 'invalid'
+        manifest['validation_report'] = validation_report.to_dict()
+    else:
+        manifest['validation_state'] = 'validated'
+    manifest['lifecycle_state'] = (
+        TABULAR_ARTIFACT_SET_LIFECYCLE_COMPLETED
+        if artifact_set_valid
+        else TABULAR_ARTIFACT_SET_LIFECYCLE_ROLLBACK_REQUIRED
+    )
+    manifest['publication_generation'] = _safe_int(manifest.get('publication_generation'), minimum=0) + 1
+    run['artifact_set_manifest'] = manifest
+    return manifest
+
+
+def _build_public_generated_artifact_from_member(run, manifest, member):
+    if not isinstance(member, dict) or not member.get('artifact_message_id'):
+        return None
+    if member.get('lifecycle_state') not in TABULAR_ARTIFACT_MEMBER_PUBLIC_LIFECYCLE_STATES:
+        return None
+    return {
+        'artifact_id': member.get('artifact_id') or member.get('member_id'),
+        'artifact_set_id': manifest.get('set_id'),
+        'artifact_set_contract_version': manifest.get('contract_version'),
+        'role': member.get('role'),
+        'required': bool(member.get('required', True)),
+        'request_order': _safe_int(member.get('request_order'), minimum=0),
+        'lifecycle_state': member.get('lifecycle_state'),
+        'validation_state': member.get('validation_state'),
+        'capability': member.get('capability') or 'tabular',
+        'artifact_message_id': member.get('artifact_message_id'),
+        'conversation_id': run.get('conversation_id'),
+        'file_name': member.get('file_name') or run.get('generated_file_name'),
+        'output_format': member.get('output_format') or member.get('format'),
+        'row_count': _safe_int(member.get('row_count'), default=_safe_int(run.get('processed_rows'), default=_safe_int(run.get('row_count')))),
+        'storage_scope': 'chat',
+        'source_file_name': run.get('source_file_name'),
+        'selected_sheet': run.get('selected_sheet'),
+        'summary': run.get('post_run_summary') if member.get('role') == ANALYSIS_ARTIFACT_ROLE_PRIMARY_ANALYSIS else run.get('post_run_export_summary') or run.get('post_run_summary'),
+        'preview_rows': list(member.get('preview_rows') or [])[:TABULAR_EXPORT_ARTIFACT_PREVIEW_MAX_ROWS],
+        'preview_columns': list(member.get('preview_columns') or [])[:TABULAR_GENERATION_PLAN_MAX_FIELDS + 2],
+        'preview_text': str(member.get('preview_text') or '')[:TABULAR_EXPORT_ARTIFACT_PREVIEW_MAX_CHARS],
+        'suppress_assistant_text': bool(member.get('suppress_assistant_text')),
+        'suppress_assistant_table_export': True,
+    }
+
+
+def _build_public_generated_artifacts_from_manifest(run, manifest):
+    manifest = manifest if isinstance(manifest, dict) else {}
+    if manifest.get('lifecycle_state') != TABULAR_ARTIFACT_SET_LIFECYCLE_COMPLETED:
+        return []
+    public_artifacts = []
+    for member in sorted(
+        list(manifest.get('members') or []),
+        key=lambda item: (_safe_int(item.get('request_order'), minimum=0), str(item.get('member_id') or '')),
+    ):
+        public_artifact = _build_public_generated_artifact_from_member(run, manifest, member)
+        if public_artifact:
+            public_artifacts.append(public_artifact)
+    primary_member_id = str(manifest.get('primary_artifact_id') or '').strip()
+    primary_artifact = next(
+        (
+            artifact for artifact in public_artifacts
+            if str(artifact.get('artifact_id') or '').strip() == primary_member_id
+        ),
+        public_artifacts[0] if public_artifacts else None,
+    )
+    if primary_artifact and public_artifacts and public_artifacts[0] != primary_artifact:
+        public_artifacts = [primary_artifact] + [
+            artifact for artifact in public_artifacts
+            if artifact.get('artifact_id') != primary_artifact.get('artifact_id')
+        ]
+    return public_artifacts
+
+
+def _build_public_artifact_projection(artifact):
+    artifact = artifact if isinstance(artifact, dict) else {}
+    if not artifact.get('artifact_message_id'):
+        return None
+    return {
+        'artifact_message_id': artifact.get('artifact_message_id'),
+        'file_name': artifact.get('file_name'),
+        'capability': artifact.get('capability') or 'tabular',
+        'output_format': artifact.get('output_format'),
+        'preview_rows': list(artifact.get('preview_rows') or [])[:TABULAR_EXPORT_ARTIFACT_PREVIEW_MAX_ROWS],
+        'preview_columns': list(artifact.get('preview_columns') or [])[:TABULAR_GENERATION_PLAN_MAX_FIELDS + 2],
+        'preview_text': str(artifact.get('preview_text') or '')[:TABULAR_EXPORT_ARTIFACT_PREVIEW_MAX_CHARS],
+        'suppress_assistant_text': bool(artifact.get('suppress_assistant_text')),
+    }
+
+
 def _publish_structured_export_artifact(run):
     output_format = normalize_generated_output_format(run.get('output_format'))
     generated_file_name = run.get('generated_file_name') or _build_generated_file_name(
@@ -7384,6 +7877,7 @@ def _complete_run(run):
         ),
         'estimated_remaining_seconds': 0,
     })
+    _publish_artifact_set_members(run, [_get_structured_artifact_member_id(run)])
     run.update(_build_generation_progress_contract_fields(
         run,
         run.get('batch_count'),
@@ -7548,6 +8042,7 @@ def _complete_analysis_run(run, final_summary):
         ),
         'estimated_remaining_seconds': 0,
     })
+    _publish_artifact_set_members(run, [_get_analysis_artifact_member_id(run)])
     run.update(_build_generation_progress_contract_fields(
         run,
         run.get('batch_count'),
@@ -7603,6 +8098,13 @@ def _publish_combined_structured_export_phase(run):
         'final_artifact': structured_artifact,
         'estimated_remaining_seconds': None,
     })
+    _set_artifact_set_member_state(
+        run,
+        _get_structured_artifact_member_id(run),
+        artifact=structured_artifact,
+        lifecycle_state=TABULAR_ARTIFACT_MEMBER_LIFECYCLE_STAGED,
+        validation_state='validated',
+    )
     run = _replace_claimed_run(run)
     log_event(
         '[TABULAR_GENERATED_OUTPUT] Combined structured export artifact published',
@@ -7631,6 +8133,7 @@ def _complete_combined_analysis_run(run, final_summary):
         )
         analysis_artifact = existing_analysis_artifact
         generated_file_name = existing_analysis_artifact.get('file_name') or run.get('analysis_generated_file_name')
+        uploaded_message = {'file_name': generated_file_name}
     else:
         run, uploaded_message, final_summary, generated_file_name = _publish_analysis_artifact(run, final_summary)
         analysis_artifact = _build_artifact_metadata(
@@ -7642,6 +8145,20 @@ def _complete_combined_analysis_run(run, final_summary):
         )
 
     structured_artifact = run.get('structured_export_artifact') or run.get('final_artifact') or {}
+    _set_artifact_set_member_state(
+        run,
+        _get_structured_artifact_member_id(run),
+        artifact=structured_artifact,
+        lifecycle_state=TABULAR_ARTIFACT_MEMBER_LIFECYCLE_STAGED,
+        validation_state='validated',
+    )
+    _set_artifact_set_member_state(
+        run,
+        _get_analysis_artifact_member_id(run),
+        artifact=analysis_artifact,
+        lifecycle_state=TABULAR_ARTIFACT_MEMBER_LIFECYCLE_STAGED,
+        validation_state='validated',
+    )
     now = _now_iso()
     run.update({
         'status': TABULAR_EXPORT_STATUS_COMPLETED,
@@ -7660,11 +8177,15 @@ def _complete_combined_analysis_run(run, final_summary):
         'structured_export_artifact': structured_artifact,
         'analysis_artifact': analysis_artifact,
         'combined_artifacts': [
-            artifact for artifact in (structured_artifact, analysis_artifact) if artifact
+            artifact for artifact in (analysis_artifact, structured_artifact) if artifact
         ],
-        'final_artifact': structured_artifact or analysis_artifact,
+        'final_artifact': analysis_artifact or structured_artifact,
         'estimated_remaining_seconds': 0,
     })
+    _publish_artifact_set_members(
+        run,
+        [_get_analysis_artifact_member_id(run), _get_structured_artifact_member_id(run)],
+    )
     run.update(_build_generation_progress_contract_fields(
         run,
         run.get('batch_count'),
@@ -9341,6 +9862,7 @@ def queue_tabular_generated_output_run(
         'analysis_artifact': None,
         'combined_artifacts': [],
     }
+    run['artifact_set_manifest'] = _build_or_update_artifact_set_manifest(run)
     cosmos_tabular_export_runs_container.create_item(body=run)
     submitted = submit_tabular_generated_output_run(run_id, normalized_user_id)
     run['submitted_to_executor'] = submitted

--- a/docs/explanation/features/ANALYZE_DELIVERABLE_CONTRACT.md
+++ b/docs/explanation/features/ANALYZE_DELIVERABLE_CONTRACT.md
@@ -6,6 +6,8 @@ Phase 2 updated in version: **0.250.172**
 
 Phase 3 updated in version: **0.250.173**
 
+Phase 5 updated in version: **0.250.175**
+
 ## Overview
 
 The Analyze deliverable contract defines a server-owned, versioned plan for analysis artifacts before production routing changes are made. It records whether an action requires a primary Markdown analysis artifact, which sibling artifacts were explicitly requested, the public structured schema, row cardinality, ordering, transformation mode, validation profile, and publication policy.
@@ -13,6 +15,8 @@ The Analyze deliverable contract defines a server-owned, versioned plan for anal
 Phase 2 keeps the contract additive, but begins enforcing intent admission for shared tabular planning and bounded document Analyze finalization. Successful bounded Analyze results now publish a primary Markdown artifact. Explicit JSON, XML, or CSV requests are represented as ordered sibling artifacts, and Analyze plus structured output can no longer silently downgrade to structured-only export work when analysis is required.
 
 Phase 3 separates public structured schemas from internal checkpoint lineage. Durable tabular checkpoints still retain source row number and identity for validation, retries, audit, and restart, but final CSV, JSON, XML, preview rows, and preview columns are projected through the persisted public schema. Raw source or function rows are no longer accepted as a derived generated-output artifact unless the request is an explicit unchanged copy, serialization, or format conversion and the rows satisfy the public schema contract.
+
+Phase 5 adds a versioned durable artifact-set manifest for tabular generated-output runs. Combined Analyze runs can stage a requested structured sibling while hierarchical reduction continues, but public status withholds generated artifacts until every required member is validated and the set lifecycle reaches `completed`. New completed combined runs project Markdown as the primary artifact and requested structured files as ordered siblings.
 
 ## Dependencies
 
@@ -23,14 +27,15 @@ Phase 3 separates public structured schemas from internal checkpoint lineage. Du
 - `application/single_app/functions_workflow_runner.py` for bounded Analyze Markdown artifact finalization.
 - `functional_tests/test_analyze_deliverable_contract.py` for the executable regression oracle.
 - `functional_tests/test_tabular_phase3_public_schema_projection.py` for public schema projection and passthrough guard coverage.
+- `functional_tests/test_tabular_phase5_artifact_set_lifecycle.py` for durable artifact-set lifecycle and public projection coverage.
 - `functional_tests/test_document_analysis_lossless_artifacts.py` for document-analysis artifact finalizer behavior.
-- `application/single_app/config.py` version `0.250.173`.
+- `application/single_app/config.py` version `0.250.175`.
 
 ## Technical Specifications
 
 ### Contract Fields
 
-- `contract_version`: currently `analysis-deliverables-v2`.
+- `contract_version`: currently `analysis-deliverables-v3`.
 - `action_mode`: normalized caller action such as `analyze` or `search`.
 - `analysis_required`: true for Analyze by server policy.
 - `requested_artifacts`: ordered artifact descriptors with role, format, required state, and request order.
@@ -99,6 +104,21 @@ Pure validators report safe counts and reason codes for:
 
 Validation reports intentionally omit prompts, row values, storage paths, credentials, and provider errors.
 
+### Artifact-Set Publication
+
+Durable tabular generated-output runs now persist an `artifact_set_manifest` with contract version `tabular-artifact-set-v1`. The manifest records:
+
+- set, run, conversation, user, source, and request identifiers
+- ordered member descriptors with role, format, required state, request order, and idempotency key
+- member lifecycle state, validation state, and staged artifact metadata
+- set lifecycle state, validation state, publication generation, rollback state, and primary artifact id
+
+Member lifecycle states include `planned`, `generating`, `staged`, `validated`, `publishing`, `published`, `failed`, `canceled`, and `rolled_back`. Set lifecycle states include `planned`, `generating`, `validating`, `ready_to_publish`, `publishing`, `completed`, `failed`, `canceled`, `rollback_required`, and `rolled_back`.
+
+Public generated-output status treats `generated_artifacts` as the authoritative ordered projection. A member appears there only when the full set lifecycle is `completed` and the member lifecycle is `published`. For new combined Analyze runs, the primary member is the Markdown analysis artifact and requested structured outputs follow as siblings. Singular compatibility fields are derived from the same primary projection and do not expose staged or invalid members.
+
+If a required member remains missing or unpublished, the set validation state becomes `invalid`, the lifecycle becomes `rollback_required`, and no generated artifact is projected as a completed request.
+
 ## Usage
 
 Shared tabular planning attaches a `deliverable_contract` field to planner results. When `enable_analysis_deliverable_contract_telemetry` is true and `analysis_deliverable_contract_mode` is `observe` or `shadow`, the planner emits debug-only `[ANALYSIS_DELIVERABLE_CONTRACT]` events with safe dimensions.
@@ -139,6 +159,12 @@ The committed 200-row fixture builder in `functional_tests/test_support/analyze_
 - XML output escapes projected values without leaking lineage fields.
 - Generic generated-file finalizers refuse raw function rows for derived requests but allow explicit serialization.
 
+`functional_tests/test_tabular_phase5_artifact_set_lifecycle.py` verifies:
+
+- A staged structured sibling in a running combined Analyze set is not public.
+- A completed combined set publishes Markdown first and the requested structured sibling second.
+- An invalid required set fails closed with `rollback_required` and no public generated artifacts.
+
 ## Known Limitations
 
-Phase 3 enforces structural schema fidelity and passthrough safety. It does not implement deterministic rule execution, semantic repair, atomic multi-artifact durable publication, or plural artifact UI rendering. Those remain in later phases.
+Phase 5 introduces manifest-backed atomic visibility for the existing durable tabular publication path. It does not yet add full cleanup sweepers for abandoned staged members, expand durable execution to every requested format, or render every plural artifact in the browser completion card; those remain later-phase work.

--- a/functional_tests/test_tabular_phase3_public_schema_projection.py
+++ b/functional_tests/test_tabular_phase3_public_schema_projection.py
@@ -2,7 +2,7 @@
 # test_tabular_phase3_public_schema_projection.py
 """
 Functional test for Phase 3 public schema projection and passthrough safety.
-Version: 0.250.173
+Version: 0.250.175
 Implemented in: 0.250.173
 
 This test ensures generated tabular artifacts expose only the persisted public
@@ -131,7 +131,7 @@ def test_contract_separates_public_internal_and_lineage_schema():
         ordering="source_order",
     ).to_dict()
 
-    assert_equal(contract["contract_version"], "analysis-deliverables-v2", "contract version")
+    assert_equal(contract["contract_version"], "analysis-deliverables-v3", "contract version")
     assert_equal(contract["public_output_schema"], ["Decision", "Amount"], "public schema")
     assert_equal(contract["lineage_schema"], ["source_row_number", "source_row_identity"], "lineage schema")
     assert_equal(

--- a/functional_tests/test_tabular_phase5_artifact_set_lifecycle.py
+++ b/functional_tests/test_tabular_phase5_artifact_set_lifecycle.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+# test_tabular_phase5_artifact_set_lifecycle.py
+"""
+Functional test for Phase 5 tabular artifact-set lifecycle publication.
+Version: 0.250.175
+Implemented in: 0.250.175
+
+This test ensures durable tabular artifact sets hide staged members until the
+whole required set is valid, publish Analyze Markdown as the primary member,
+and fail closed when a required sibling is missing.
+"""
+
+import ast
+import re
+import sys
+from pathlib import Path
+
+from test_support.versioning import assert_app_version_at_least
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+APP_ROOT = REPO_ROOT / "application" / "single_app"
+EXPORT_MODULE = APP_ROOT / "functions_tabular_generated_exports.py"
+if str(APP_ROOT) not in sys.path:
+    sys.path.insert(0, str(APP_ROOT))
+
+from functions_analysis_deliverables import (  # noqa: E402
+    ANALYSIS_ARTIFACT_ROLE_PRIMARY_ANALYSIS,
+    ANALYSIS_ARTIFACT_ROLE_REQUESTED_OUTPUT,
+    build_analysis_deliverable_contract,
+    validate_analysis_artifact_set,
+)
+
+
+IMPLEMENTED_VERSION = "0.250.175"
+
+
+def load_artifact_set_helpers():
+    source = EXPORT_MODULE.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(EXPORT_MODULE))
+    helper_names = {
+        "_safe_int",
+        "_normalize_tabular_run_task_type",
+        "_normalize_tabular_artifact_lifecycle_state",
+        "_normalize_tabular_artifact_format",
+        "_normalize_tabular_artifact_role",
+        "_normalize_tabular_artifact_member_id",
+        "_get_tabular_run_deliverable_contract",
+        "_normalize_artifact_descriptor",
+        "_default_artifact_descriptors_for_run",
+        "_get_artifact_descriptors_for_run",
+        "_get_primary_artifact_member_id",
+        "_get_structured_artifact_member_id",
+        "_get_analysis_artifact_member_id",
+        "_build_artifact_member_idempotency_key",
+        "_build_artifact_set_member",
+        "_artifact_lifecycle_for_existing_run_artifact",
+        "_artifact_set_lifecycle_for_run",
+        "_merge_artifact_metadata_into_member",
+        "_build_or_update_artifact_set_manifest",
+        "_set_artifact_set_member_state",
+        "_publish_artifact_set_members",
+        "_build_public_generated_artifact_from_member",
+        "_build_public_generated_artifacts_from_manifest",
+        "_build_public_artifact_projection",
+    }
+    selected_functions = [
+        node for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name in helper_names
+    ]
+    namespace = {
+        "re": re,
+        "validate_analysis_artifact_set": validate_analysis_artifact_set,
+        "ANALYSIS_ARTIFACT_ROLE_PRIMARY_ANALYSIS": ANALYSIS_ARTIFACT_ROLE_PRIMARY_ANALYSIS,
+        "ANALYSIS_ARTIFACT_ROLE_REQUESTED_OUTPUT": ANALYSIS_ARTIFACT_ROLE_REQUESTED_OUTPUT,
+        "ANALYSIS_ARTIFACT_ROLE_SUPPORTING_OUTPUT": "supporting_output",
+        "TABULAR_RUN_TASK_STRUCTURED_EXPORT": "structured_export",
+        "TABULAR_RUN_TASK_HIERARCHICAL_ANALYSIS": "hierarchical_analysis",
+        "TABULAR_RUN_TASK_COMBINED": "combined",
+        "TABULAR_RUN_TASK_TYPES": {"structured_export", "hierarchical_analysis", "combined"},
+        "TABULAR_EXPORT_STATUS_RUNNING": "running",
+        "TABULAR_EXPORT_STATUS_COMPLETED": "completed",
+        "TABULAR_EXPORT_STATUS_FAILED": "failed",
+        "TABULAR_EXPORT_STATUS_CANCELED": "canceled",
+        "TABULAR_EXPORT_ARTIFACT_PREVIEW_MAX_ROWS": 10,
+        "TABULAR_EXPORT_ARTIFACT_PREVIEW_MAX_CHARS": 24000,
+        "TABULAR_GENERATION_PLAN_MAX_FIELDS": 50,
+        "TABULAR_ARTIFACT_SET_CONTRACT_VERSION": "tabular-artifact-set-v1",
+        "TABULAR_ARTIFACT_SET_LIFECYCLE_PLANNED": "planned",
+        "TABULAR_ARTIFACT_SET_LIFECYCLE_GENERATING": "generating",
+        "TABULAR_ARTIFACT_SET_LIFECYCLE_VALIDATING": "validating",
+        "TABULAR_ARTIFACT_SET_LIFECYCLE_READY_TO_PUBLISH": "ready_to_publish",
+        "TABULAR_ARTIFACT_SET_LIFECYCLE_PUBLISHING": "publishing",
+        "TABULAR_ARTIFACT_SET_LIFECYCLE_COMPLETED": "completed",
+        "TABULAR_ARTIFACT_SET_LIFECYCLE_FAILED": "failed",
+        "TABULAR_ARTIFACT_SET_LIFECYCLE_CANCELED": "canceled",
+        "TABULAR_ARTIFACT_SET_LIFECYCLE_ROLLBACK_REQUIRED": "rollback_required",
+        "TABULAR_ARTIFACT_SET_LIFECYCLE_ROLLED_BACK": "rolled_back",
+        "TABULAR_ARTIFACT_SET_LIFECYCLE_STATES": {
+            "planned",
+            "generating",
+            "validating",
+            "ready_to_publish",
+            "publishing",
+            "completed",
+            "failed",
+            "canceled",
+            "rollback_required",
+            "rolled_back",
+        },
+        "TABULAR_ARTIFACT_MEMBER_LIFECYCLE_PLANNED": "planned",
+        "TABULAR_ARTIFACT_MEMBER_LIFECYCLE_GENERATING": "generating",
+        "TABULAR_ARTIFACT_MEMBER_LIFECYCLE_STAGED": "staged",
+        "TABULAR_ARTIFACT_MEMBER_LIFECYCLE_VALIDATED": "validated",
+        "TABULAR_ARTIFACT_MEMBER_LIFECYCLE_PUBLISHING": "publishing",
+        "TABULAR_ARTIFACT_MEMBER_LIFECYCLE_PUBLISHED": "published",
+        "TABULAR_ARTIFACT_MEMBER_LIFECYCLE_FAILED": "failed",
+        "TABULAR_ARTIFACT_MEMBER_LIFECYCLE_CANCELED": "canceled",
+        "TABULAR_ARTIFACT_MEMBER_LIFECYCLE_ROLLED_BACK": "rolled_back",
+        "TABULAR_ARTIFACT_MEMBER_LIFECYCLE_STATES": {
+            "planned",
+            "generating",
+            "staged",
+            "validated",
+            "publishing",
+            "published",
+            "failed",
+            "canceled",
+            "rolled_back",
+        },
+        "TABULAR_ARTIFACT_MEMBER_PUBLIC_LIFECYCLE_STATES": {"published"},
+    }
+    module = ast.Module(body=selected_functions, type_ignores=[])
+    ast.fix_missing_locations(module)
+    exec(compile(module, str(EXPORT_MODULE), "exec"), namespace)
+    return namespace
+
+
+def build_combined_contract():
+    return build_analysis_deliverable_contract(
+        action_mode="analyze",
+        requested_output_format="csv",
+        source_fingerprint="source-fingerprint",
+        request_fingerprint="request-fingerprint",
+    ).to_dict()
+
+
+def build_run(status="running"):
+    return {
+        "id": "run-1",
+        "conversation_id": "conversation-1",
+        "user_id": "user-1",
+        "task_type": "combined",
+        "status": status,
+        "output_format": "csv",
+        "source_file_name": "financial_review.csv",
+        "row_count": 200,
+        "processed_rows": 200,
+        "post_run_summary": "Analysis completed.",
+        "post_run_export_summary": "CSV export completed.",
+        "tabular_planner_metadata": {
+            "deliverable_contract": build_combined_contract(),
+        },
+    }
+
+
+def build_artifact(message_id, file_name, output_format):
+    return {
+        "artifact_message_id": message_id,
+        "file_name": file_name,
+        "capability": "tabular",
+        "output_format": output_format,
+        "preview_rows": [{"Column": "Value"}],
+        "preview_columns": ["Column"],
+        "preview_text": "# Preview" if output_format == "md" else "",
+        "suppress_assistant_text": True,
+    }
+
+
+def test_staged_structured_member_is_not_public_until_set_completion():
+    print("Testing staged structured member visibility...")
+    assert_app_version_at_least(IMPLEMENTED_VERSION)
+    helpers = load_artifact_set_helpers()
+    run = build_run(status="running")
+    run["structured_export_artifact"] = build_artifact("csv-message", "financial_review.csv", "csv")
+
+    manifest = helpers["_build_or_update_artifact_set_manifest"](run)
+    members_by_id = {member["member_id"]: member for member in manifest["members"]}
+    assert manifest["lifecycle_state"] == "validating"
+    assert members_by_id["analysis"]["lifecycle_state"] == "planned"
+    assert members_by_id["requested-csv"]["lifecycle_state"] == "staged"
+    assert helpers["_build_public_generated_artifacts_from_manifest"](run, manifest) == []
+
+
+def test_completed_combined_set_publishes_markdown_primary_then_sibling():
+    print("Testing completed combined artifact-set publication order...")
+    assert_app_version_at_least(IMPLEMENTED_VERSION)
+    helpers = load_artifact_set_helpers()
+    run = build_run(status="running")
+    structured_artifact = build_artifact("csv-message", "financial_review.csv", "csv")
+    analysis_artifact = build_artifact("md-message", "financial_review.md", "md")
+
+    helpers["_set_artifact_set_member_state"](
+        run,
+        "requested-csv",
+        artifact=structured_artifact,
+        lifecycle_state="staged",
+        validation_state="validated",
+    )
+    run["structured_export_artifact"] = structured_artifact
+    helpers["_set_artifact_set_member_state"](
+        run,
+        "analysis",
+        artifact=analysis_artifact,
+        lifecycle_state="staged",
+        validation_state="validated",
+    )
+    run["analysis_artifact"] = analysis_artifact
+    run["status"] = "completed"
+
+    manifest = helpers["_publish_artifact_set_members"](run, ["analysis", "requested-csv"])
+    assert manifest["lifecycle_state"] == "completed"
+    assert manifest["validation_state"] == "validated"
+    assert manifest["primary_artifact_id"] == "analysis"
+    assert manifest["publication_generation"] == 1
+
+    public_artifacts = helpers["_build_public_generated_artifacts_from_manifest"](run, manifest)
+    assert [artifact["artifact_id"] for artifact in public_artifacts] == ["analysis", "requested-csv"]
+    assert public_artifacts[0]["role"] == ANALYSIS_ARTIFACT_ROLE_PRIMARY_ANALYSIS
+    assert public_artifacts[0]["output_format"] == "md"
+    assert public_artifacts[1]["role"] == ANALYSIS_ARTIFACT_ROLE_REQUESTED_OUTPUT
+    assert public_artifacts[1]["output_format"] == "csv"
+
+
+def test_invalid_required_set_fails_closed_without_public_artifacts():
+    print("Testing invalid artifact-set fail-closed behavior...")
+    assert_app_version_at_least(IMPLEMENTED_VERSION)
+    helpers = load_artifact_set_helpers()
+    run = build_run(status="completed")
+    run["structured_export_artifact"] = build_artifact("csv-message", "financial_review.csv", "csv")
+
+    manifest = helpers["_publish_artifact_set_members"](run, ["requested-csv"])
+    assert manifest["lifecycle_state"] == "rollback_required"
+    assert manifest["validation_state"] == "invalid"
+    assert "required_artifact_not_valid" in manifest["validation_report"]["reason_codes"]
+    assert helpers["_build_public_generated_artifacts_from_manifest"](run, manifest) == []
+
+
+if __name__ == "__main__":
+    tests = [
+        test_staged_structured_member_is_not_public_until_set_completion,
+        test_completed_combined_set_publishes_markdown_primary_then_sibling,
+        test_invalid_required_set_fails_closed_without_public_artifacts,
+    ]
+    results = []
+    for test in tests:
+        print(f"\nRunning {test.__name__}...")
+        try:
+            test()
+            results.append(True)
+        except Exception as exc:
+            print(f"Test failed: {exc}")
+            results.append(False)
+    passed_count = sum(1 for result in results if result)
+    print(f"\nResults: {passed_count}/{len(results)} tests passed")
+    sys.exit(0 if all(results) else 1)


### PR DESCRIPTION
## Phase Objective

Phase 5 adds a versioned durable artifact-set lifecycle contract for tabular generated-output runs. It makes combined Analyze publication Markdown-primary and prevents staged or invalid required siblings from being projected as completed generated artifacts.

## Explicit Non-Goals

- Does not add a second durable runner, artifact store, source resolver, or authorization path.
- Does not implement full cleanup sweepers for abandoned staged members.
- Does not expand durable execution to every requested format.
- Does not implement the Phase 6 plural artifact UI card work.

## Behavior Flags And Effective Defaults

- Uses the existing durable tabular runner and deliverable-plan plumbing.
- No new runtime setting is introduced in this phase.
- Existing runs without `artifact_set_manifest` are projected through additive fallback helpers.
- New queued runs persist `artifact_set_manifest` using the accepted deliverable contract or a conservative default descriptor set.

## Contract-Version Changes

- Adds `tabular-artifact-set-v1` for durable tabular artifact-set manifests.
- Keeps `analysis-deliverables-v3` as the current Analyze/Search deliverable contract version.
- Adds public status `artifact_set` metadata with contract version, set id, lifecycle state, validation state, primary artifact id, member count, published member count, and publication generation.

## Old-Run Compatibility

- Existing singular fields remain available.
- `generated_artifact` remains the compatibility projection of the authoritative primary member.
- `generated_artifacts` remains the authoritative ordered list when available.
- Runs without an artifact-set manifest are interpreted through the existing `final_artifact`, `structured_export_artifact`, and `analysis_artifact` fields without rewriting old data.

## Validation

- `python functional_tests/test_tabular_phase5_artifact_set_lifecycle.py` -> 3/3 passed
- `python functional_tests/test_analyze_deliverable_contract.py` -> 6/6 passed
- `python functional_tests/test_tabular_phase3_public_schema_projection.py` -> 3/3 passed
- `python -m py_compile application/single_app/functions_tabular_generated_exports.py functional_tests/test_tabular_phase5_artifact_set_lifecycle.py functional_tests/test_tabular_phase3_public_schema_projection.py application/single_app/config.py` -> passed
- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check` -> passed
- VS Code diagnostics on edited Python files -> no errors

## Security And Source-Scope Coverage

- No Flask routes or authorization decorators changed.
- The existing upload, conversation ownership, source authorization, and source-version revalidation paths remain in place.
- Public status withholds staged members and invalid required sets, avoiding accidental completed-artifact exposure.
- Public status does not expose storage paths or provider errors in the new `artifact_set` metadata.

## Application Version

- Bumped `application/single_app/config.py` from `0.250.174` to `0.250.175`.

## Rollout And Rollback

- Rollout is additive for new durable tabular runs.
- Rollback can stop accepting this branch; old run readers remain compatible with existing fields.
- If a required artifact-set validation fails, status moves to `rollback_required` and no completed generated artifact is projected.

## Later Phases Excluded

Phase 6 UI rendering, complete staged-member cleanup policy, broader multi-format durable fan-out, and final integration/scale retirement work are intentionally excluded.

No GitHub issue is associated with this private roadmap phase.