### PR TITLE
Phase 6: Render plural artifact sets

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -96,7 +96,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.250.175"
+VERSION = "0.250.176"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/static/js/chat/chat-messages.js
+++ b/application/single_app/static/js/chat/chat-messages.js
@@ -3394,6 +3394,274 @@ function renderReplyQuoteHtml(fullMessageObject = null) {
     return getGeneratedAnalysisArtifacts(fullMessageObject).filter(output => output.capability === 'tabular');
   }
 
+  function getGeneratedArtifactSetDedupeKey(outputMetadata) {
+    const artifactMessageId = String(outputMetadata?.artifact_message_id || '').trim();
+    if (artifactMessageId) {
+      return `message:${artifactMessageId}`;
+    }
+
+    const stableArtifactId = String(
+      outputMetadata?.artifact_id
+      || outputMetadata?.member_id
+      || outputMetadata?.id
+      || outputMetadata?.document_id
+      || ''
+    ).trim();
+    if (stableArtifactId) {
+      return `artifact:${stableArtifactId}`;
+    }
+
+    const fileName = String(outputMetadata?.file_name || '').trim();
+    const outputFormat = String(outputMetadata?.output_format || '').trim().toLowerCase();
+    return `${fileName}:${outputFormat}`;
+  }
+
+  function isGeneratedArtifactSetComplete(statusMetadata = {}) {
+    const normalizedRunStatus = String(statusMetadata?.status || '').trim().toLowerCase();
+    if (normalizedRunStatus !== 'completed') {
+      return false;
+    }
+
+    const artifactSet = statusMetadata?.artifact_set && typeof statusMetadata.artifact_set === 'object'
+      ? statusMetadata.artifact_set
+      : null;
+    if (!artifactSet) {
+      return true;
+    }
+
+    const lifecycleState = String(artifactSet.lifecycle_state || '').trim().toLowerCase();
+    if (lifecycleState && lifecycleState !== 'completed') {
+      return false;
+    }
+
+    const validationState = String(artifactSet.validation_state || '').trim().toLowerCase();
+    return !['failed', 'invalid', 'rollback_required', 'rolled_back'].includes(validationState);
+  }
+
+  function normalizeGeneratedArtifactSetMember(rawMember, statusMetadata = {}, fallbackMetadata = {}) {
+    if (!rawMember || typeof rawMember !== 'object') {
+      return null;
+    }
+
+    const runId = String(statusMetadata?.run_id || fallbackMetadata?.run_id || fallbackMetadata?.export_run_id || '').trim();
+    const defaultCapability = String(
+      rawMember.capability
+      || fallbackMetadata?.capability
+      || statusMetadata?.capability
+      || 'tabular'
+    ).trim().toLowerCase() || 'tabular';
+    return normalizeGeneratedAnalysisArtifact({
+      ...fallbackMetadata,
+      ...statusMetadata,
+      ...rawMember,
+      capability: defaultCapability,
+      status: 'completed',
+      export_run_id: runId,
+      run_id: runId,
+      background_export: false,
+      suppress_assistant_table_export: Boolean(
+        rawMember.suppress_assistant_table_export
+        || fallbackMetadata?.suppress_assistant_table_export
+        || statusMetadata?.suppress_assistant_table_export
+      ),
+    }, defaultCapability);
+  }
+
+  function sortGeneratedArtifactSetMembers(members, primaryArtifactId) {
+    const normalizedPrimaryArtifactId = String(primaryArtifactId || '').trim();
+    const primaryAnalysisIndex = members.findIndex(member => {
+      const role = String(member?.role || member?.artifact_role || '').trim().toLowerCase();
+      if (role === 'primary_analysis') {
+        return true;
+      }
+      return Boolean(
+        normalizedPrimaryArtifactId
+        && String(member?.artifact_id || member?.member_id || member?.id || '').trim() === normalizedPrimaryArtifactId
+        && isGeneratedMarkdownArtifact(member, member?.output_format)
+      );
+    });
+
+    if (primaryAnalysisIndex <= 0) {
+      return members;
+    }
+
+    const sortedMembers = members.slice();
+    const primaryMember = sortedMembers.splice(primaryAnalysisIndex, 1)[0];
+    sortedMembers.unshift(primaryMember);
+    return sortedMembers;
+  }
+
+  function normalizeGeneratedArtifactSet(statusMetadata = {}, fallbackMetadata = {}) {
+    const artifactSet = statusMetadata?.artifact_set && typeof statusMetadata.artifact_set === 'object'
+      ? statusMetadata.artifact_set
+      : {};
+    const pluralMembers = Array.isArray(statusMetadata?.generated_artifacts)
+      ? statusMetadata.generated_artifacts
+      : [];
+    const singularMember = statusMetadata?.generated_artifact && typeof statusMetadata.generated_artifact === 'object'
+      ? statusMetadata.generated_artifact
+      : null;
+    const legacyAnalysisMembers = Array.isArray(statusMetadata?.generated_analysis_artifacts)
+      ? statusMetadata.generated_analysis_artifacts
+      : [];
+    const legacyTabularMembers = Array.isArray(statusMetadata?.generated_tabular_outputs)
+      ? statusMetadata.generated_tabular_outputs
+      : [];
+    const rawMembers = pluralMembers.length
+      ? pluralMembers
+      : (singularMember ? [singularMember] : [...legacyAnalysisMembers, ...legacyTabularMembers]);
+    const seenMemberKeys = new Set();
+    const members = [];
+    let duplicateSuppressedCount = 0;
+
+    rawMembers.forEach(rawMember => {
+      const normalizedMember = normalizeGeneratedArtifactSetMember(rawMember, statusMetadata, fallbackMetadata);
+      if (!normalizedMember) {
+        return;
+      }
+      const dedupeKey = getGeneratedArtifactSetDedupeKey(normalizedMember);
+      if (dedupeKey && seenMemberKeys.has(dedupeKey)) {
+        duplicateSuppressedCount += 1;
+        return;
+      }
+      if (dedupeKey) {
+        seenMemberKeys.add(dedupeKey);
+      }
+      members.push(normalizedMember);
+    });
+
+    const orderedMembers = sortGeneratedArtifactSetMembers(members, artifactSet.primary_artifact_id);
+    return {
+      contractVersion: String(artifactSet.contract_version || statusMetadata?.contract_version || '').trim(),
+      setId: String(artifactSet.set_id || statusMetadata?.artifact_set_id || '').trim(),
+      status: String(statusMetadata?.status || '').trim().toLowerCase(),
+      lifecycleState: String(artifactSet.lifecycle_state || '').trim().toLowerCase(),
+      validationState: String(artifactSet.validation_state || '').trim().toLowerCase(),
+      primaryArtifactId: String(artifactSet.primary_artifact_id || '').trim(),
+      publicationGeneration: Number.parseInt(artifactSet.publication_generation, 10) || 0,
+      isComplete: isGeneratedArtifactSetComplete(statusMetadata),
+      legacyFallbackUsed: !pluralMembers.length && Boolean(singularMember),
+      duplicateSuppressedCount,
+      members: orderedMembers,
+    };
+  }
+
+  function recordGeneratedArtifactSetUiEvent(eventType, details = {}) {
+    const boundedFormats = Array.isArray(details.formats)
+      ? details.formats.map(format => String(format || '').trim().toLowerCase()).filter(Boolean).slice(0, 8)
+      : [];
+    const eventDetail = {
+      eventType: String(eventType || '').trim().toLowerCase().slice(0, 80),
+      runId: String(details.runId || '').trim().slice(0, 96),
+      status: String(details.status || '').trim().toLowerCase().slice(0, 40),
+      lifecycleState: String(details.lifecycleState || '').trim().toLowerCase().slice(0, 40),
+      memberCount: Number.isFinite(Number.parseInt(details.memberCount, 10))
+        ? Math.max(0, Number.parseInt(details.memberCount, 10))
+        : 0,
+      formats: boundedFormats,
+      primaryRendered: Boolean(details.primaryRendered),
+      legacyFallbackUsed: Boolean(details.legacyFallbackUsed),
+      duplicateSuppressedCount: Number.isFinite(Number.parseInt(details.duplicateSuppressedCount, 10))
+        ? Math.max(0, Number.parseInt(details.duplicateSuppressedCount, 10))
+        : 0,
+    };
+
+    document.dispatchEvent(new CustomEvent('simplechat:generated-artifact-set', { detail: eventDetail }));
+  }
+
+  function createGeneratedArtifactSetGroup(artifactSet, runId = '') {
+    const group = document.createElement('div');
+    group.className = 'generated-artifact-set-group d-grid gap-3 mt-3';
+    group.dataset.generatedArtifactSet = 'true';
+    if (artifactSet.setId) {
+      group.dataset.generatedArtifactSetId = artifactSet.setId;
+    }
+    if (runId) {
+      group.dataset.generatedArtifactRunId = runId;
+    }
+    group.setAttribute('role', 'group');
+    group.setAttribute('aria-label', artifactSet.members.length === 1 ? 'Generated artifact' : 'Generated artifacts');
+
+    if (artifactSet.members.length > 1) {
+      const heading = document.createElement('div');
+      heading.className = 'small fw-semibold';
+      heading.textContent = `${artifactSet.members.length.toLocaleString()} generated artifacts`;
+      group.appendChild(heading);
+    }
+
+    artifactSet.members.forEach(memberMetadata => {
+      group.appendChild(createGeneratedAnalysisArtifactCard(memberMetadata));
+    });
+
+    return group;
+  }
+
+  function replaceBackgroundGeneratedOutputCardWithArtifacts(outputMetadata, card, artifactSet) {
+    if (!(card instanceof HTMLElement) || !document.body.contains(card) || !artifactSet?.isComplete || !artifactSet.members.length) {
+      return false;
+    }
+
+    const runId = String(outputMetadata?.export_run_id || outputMetadata?.run_id || artifactSet.members[0]?.run_id || '').trim();
+    const primaryMember = artifactSet.members.find(member => {
+      const role = String(member?.role || member?.artifact_role || '').trim().toLowerCase();
+      return role === 'primary_analysis';
+    }) || artifactSet.members[0];
+    const group = createGeneratedArtifactSetGroup(artifactSet, runId);
+    const formats = artifactSet.members.map(member => member?.output_format || '');
+    const primaryRendered = Boolean(primaryMember);
+
+    card.dataset.generatedArtifactSetCompleted = 'true';
+    card.replaceWith(group);
+    hideCompletedGeneratedArtifactHandoff(group, primaryMember || outputMetadata);
+
+    recordGeneratedArtifactSetUiEvent('set_card_hydrated', {
+      runId,
+      status: artifactSet.status,
+      lifecycleState: artifactSet.lifecycleState,
+      memberCount: artifactSet.members.length,
+      formats,
+      primaryRendered,
+      legacyFallbackUsed: artifactSet.legacyFallbackUsed,
+      duplicateSuppressedCount: artifactSet.duplicateSuppressedCount,
+    });
+    recordGeneratedArtifactSetUiEvent('plural_completion_rendered', {
+      runId,
+      status: artifactSet.status,
+      lifecycleState: artifactSet.lifecycleState,
+      memberCount: artifactSet.members.length,
+      formats,
+      primaryRendered,
+      legacyFallbackUsed: artifactSet.legacyFallbackUsed,
+      duplicateSuppressedCount: artifactSet.duplicateSuppressedCount,
+    });
+
+    if (artifactSet.legacyFallbackUsed) {
+      recordGeneratedArtifactSetUiEvent('legacy_singular_fallback_used', {
+        runId,
+        status: artifactSet.status,
+        lifecycleState: artifactSet.lifecycleState,
+        memberCount: artifactSet.members.length,
+        formats,
+        primaryRendered,
+        legacyFallbackUsed: true,
+      });
+    }
+
+    if (artifactSet.duplicateSuppressedCount > 0) {
+      recordGeneratedArtifactSetUiEvent('duplicate_member_suppressed', {
+        runId,
+        status: artifactSet.status,
+        lifecycleState: artifactSet.lifecycleState,
+        memberCount: artifactSet.members.length,
+        formats,
+        primaryRendered,
+        duplicateSuppressedCount: artifactSet.duplicateSuppressedCount,
+      });
+    }
+
+    return true;
+  }
+
   function getGeneratedTabularStorageNote(outputMetadata) {
     if (outputMetadata?.background_export) {
       return 'Continuing in the background. Progress is checkpointed and the download will appear here when complete.';
@@ -4804,24 +5072,27 @@ function renderReplyQuoteHtml(fullMessageObject = null) {
         throw new Error(responseData?.error || `Server responded with status ${response.status}`);
       }
 
+      if (!document.body.contains(card)) {
+        return;
+      }
+
       const runStatus = responseData?.run || {};
-      const generatedArtifact = runStatus?.generated_artifact || null;
+      const artifactSet = normalizeGeneratedArtifactSet(runStatus, outputMetadata);
+      const hasCompletedArtifactSet = Boolean(artifactSet.isComplete && artifactSet.members.length);
       Object.assign(outputMetadata, runStatus, {
         export_run_id: runStatus.run_id || runId,
         run_id: runStatus.run_id || runId,
-        background_export: String(runStatus.status || '').toLowerCase() !== 'completed' || !generatedArtifact,
+        background_export: !hasCompletedArtifactSet,
       });
 
-      if (String(runStatus.status || '').toLowerCase() === 'completed' && generatedArtifact) {
-        Object.assign(outputMetadata, generatedArtifact, {
+      if (hasCompletedArtifactSet) {
+        Object.assign(outputMetadata, artifactSet.members[0], {
           background_export: false,
           status: 'completed',
           export_run_id: runStatus.run_id || runId,
           run_id: runStatus.run_id || runId,
         });
-        const refreshedCard = createGeneratedAnalysisArtifactCard(outputMetadata);
-        hideCompletedGeneratedArtifactHandoff(card, outputMetadata);
-        card.replaceWith(refreshedCard);
+        replaceBackgroundGeneratedOutputCardWithArtifacts(outputMetadata, card, artifactSet);
         return;
       }
 
@@ -4862,23 +5133,22 @@ function renderReplyQuoteHtml(fullMessageObject = null) {
       }
 
       const runStatus = responseData?.run || {};
-      const generatedArtifact = runStatus?.generated_artifact || null;
+      const artifactSet = normalizeGeneratedArtifactSet(runStatus, outputMetadata);
+      const hasCompletedArtifactSet = Boolean(artifactSet.isComplete && artifactSet.members.length);
       Object.assign(outputMetadata, runStatus, {
         export_run_id: runStatus.run_id || runId,
         run_id: runStatus.run_id || runId,
-        background_export: String(runStatus.status || '').toLowerCase() !== 'completed' || !generatedArtifact,
+        background_export: !hasCompletedArtifactSet,
       });
 
-      if (String(runStatus.status || '').toLowerCase() === 'completed' && generatedArtifact) {
-        Object.assign(outputMetadata, generatedArtifact, {
+      if (hasCompletedArtifactSet) {
+        Object.assign(outputMetadata, artifactSet.members[0], {
           background_export: false,
           status: 'completed',
           export_run_id: runStatus.run_id || runId,
           run_id: runStatus.run_id || runId,
         });
-        const refreshedCard = createGeneratedAnalysisArtifactCard(outputMetadata);
-        hideCompletedGeneratedArtifactHandoff(card, outputMetadata);
-        card.replaceWith(refreshedCard);
+        replaceBackgroundGeneratedOutputCardWithArtifacts(outputMetadata, card, artifactSet);
         showToast(responseData?.message || 'Background export is already complete.', 'success');
         return;
       }
@@ -5176,7 +5446,14 @@ function renderReplyQuoteHtml(fullMessageObject = null) {
     downloadButton.type = 'button';
     downloadButton.className = 'btn btn-sm btn-outline-primary generated-tabular-download-btn';
     downloadButton.textContent = `Download ${outputFormat.toUpperCase()}`;
+    downloadButton.setAttribute('aria-label', `Download ${fileName}`);
     downloadButton.addEventListener('click', () => {
+      recordGeneratedArtifactSetUiEvent('member_download_action', {
+        runId: outputMetadata?.run_id || outputMetadata?.export_run_id,
+        status: outputMetadata?.status,
+        memberCount: 1,
+        formats: [outputFormat],
+      });
       triggerGeneratedTabularOutputDownload(outputMetadata);
     });
     actions.appendChild(downloadButton);
@@ -5186,8 +5463,14 @@ function renderReplyQuoteHtml(fullMessageObject = null) {
       viewButton.type = 'button';
       viewButton.className = 'btn btn-sm btn-outline-secondary generated-artifact-view-btn';
       viewButton.textContent = `View ${outputFormat.toUpperCase()}`;
-      viewButton.setAttribute('aria-label', `View generated ${outputFormat.toUpperCase()} preview`);
+      viewButton.setAttribute('aria-label', `View ${fileName}`);
       viewButton.addEventListener('click', () => {
+        recordGeneratedArtifactSetUiEvent('member_view_action', {
+          runId: outputMetadata?.run_id || outputMetadata?.export_run_id,
+          status: outputMetadata?.status,
+          memberCount: 1,
+          formats: [outputFormat],
+        });
         showGeneratedArtifactPreviewModal(outputMetadata, outputFormat);
       });
       actions.appendChild(viewButton);
@@ -5201,9 +5484,16 @@ function renderReplyQuoteHtml(fullMessageObject = null) {
         exportPowerPointButton.type = 'button';
         exportPowerPointButton.className = 'btn btn-sm btn-outline-primary generated-artifact-export-ppt-btn';
         exportPowerPointButton.textContent = 'Create PowerPoint';
+        exportPowerPointButton.setAttribute('aria-label', `Create PowerPoint from ${fileName}`);
         exportPowerPointButton.dataset.artifactMessageId = normalizedArtifactMessageId;
         exportPowerPointButton.dataset.conversationId = normalizedConversationId;
         exportPowerPointButton.addEventListener('click', () => {
+          recordGeneratedArtifactSetUiEvent('member_powerpoint_action', {
+            runId: outputMetadata?.run_id || outputMetadata?.export_run_id,
+            status: outputMetadata?.status,
+            memberCount: 1,
+            formats: [outputFormat],
+          });
           exportGeneratedMarkdownArtifactAsPowerPoint(outputMetadata, exportPowerPointButton);
         });
         actions.appendChild(exportPowerPointButton);
@@ -5213,7 +5503,14 @@ function renderReplyQuoteHtml(fullMessageObject = null) {
       viewButton.type = 'button';
       viewButton.className = 'btn btn-sm btn-outline-secondary generated-artifact-view-md-btn';
       viewButton.textContent = 'View MD';
+      viewButton.setAttribute('aria-label', `View ${fileName}`);
       viewButton.addEventListener('click', () => {
+        recordGeneratedArtifactSetUiEvent('member_view_action', {
+          runId: outputMetadata?.run_id || outputMetadata?.export_run_id,
+          status: outputMetadata?.status,
+          memberCount: 1,
+          formats: [outputFormat],
+        });
         viewGeneratedMarkdownArtifact(outputMetadata, viewButton);
       });
       actions.appendChild(viewButton);
@@ -5226,7 +5523,14 @@ function renderReplyQuoteHtml(fullMessageObject = null) {
       promoteButton.type = 'button';
       promoteButton.className = 'btn btn-sm btn-outline-secondary generated-artifact-promote-btn';
       promoteButton.textContent = 'Add to Workspace';
+      promoteButton.setAttribute('aria-label', `Add ${fileName} to workspace`);
       promoteButton.addEventListener('click', () => {
+        recordGeneratedArtifactSetUiEvent('member_promotion_action', {
+          runId: outputMetadata?.run_id || outputMetadata?.export_run_id,
+          status: outputMetadata?.status,
+          memberCount: 1,
+          formats: [outputFormat],
+        });
         promoteGeneratedArtifactToWorkspace(outputMetadata, promoteButton);
       });
       actions.appendChild(promoteButton);

--- a/docs/explanation/features/ANALYZE_DELIVERABLE_CONTRACT.md
+++ b/docs/explanation/features/ANALYZE_DELIVERABLE_CONTRACT.md
@@ -8,6 +8,8 @@ Phase 3 updated in version: **0.250.173**
 
 Phase 5 updated in version: **0.250.175**
 
+Phase 6 updated in version: **0.250.176**
+
 ## Overview
 
 The Analyze deliverable contract defines a server-owned, versioned plan for analysis artifacts before production routing changes are made. It records whether an action requires a primary Markdown analysis artifact, which sibling artifacts were explicitly requested, the public structured schema, row cardinality, ordering, transformation mode, validation profile, and publication policy.
@@ -17,6 +19,8 @@ Phase 2 keeps the contract additive, but begins enforcing intent admission for s
 Phase 3 separates public structured schemas from internal checkpoint lineage. Durable tabular checkpoints still retain source row number and identity for validation, retries, audit, and restart, but final CSV, JSON, XML, preview rows, and preview columns are projected through the persisted public schema. Raw source or function rows are no longer accepted as a derived generated-output artifact unless the request is an explicit unchanged copy, serialization, or format conversion and the rows satisfy the public schema contract.
 
 Phase 5 adds a versioned durable artifact-set manifest for tabular generated-output runs. Combined Analyze runs can stage a requested structured sibling while hierarchical reduction continues, but public status withholds generated artifacts until every required member is validated and the set lifecycle reaches `completed`. New completed combined runs project Markdown as the primary artifact and requested structured files as ordered siblings.
+
+Phase 6 updates the chat browser completion path to consume the plural artifact-set projection. When polling or Continue receives a completed set, the progress card is replaced by one unframed generated-artifact group that renders every published member. Analyze Markdown is shown first, requested siblings retain their server order, and old singular `generated_artifact` responses still render as one compatible card.
 
 ## Dependencies
 
@@ -28,8 +32,9 @@ Phase 5 adds a versioned durable artifact-set manifest for tabular generated-out
 - `functional_tests/test_analyze_deliverable_contract.py` for the executable regression oracle.
 - `functional_tests/test_tabular_phase3_public_schema_projection.py` for public schema projection and passthrough guard coverage.
 - `functional_tests/test_tabular_phase5_artifact_set_lifecycle.py` for durable artifact-set lifecycle and public projection coverage.
+- `ui_tests/test_chat_background_generated_export_status.py` for plural completion rendering, ordering, actions, and safe UI event coverage.
 - `functional_tests/test_document_analysis_lossless_artifacts.py` for document-analysis artifact finalizer behavior.
-- `application/single_app/config.py` version `0.250.175`.
+- `application/single_app/config.py` version `0.250.176`.
 
 ## Technical Specifications
 
@@ -119,11 +124,25 @@ Public generated-output status treats `generated_artifacts` as the authoritative
 
 If a required member remains missing or unpublished, the set validation state becomes `invalid`, the lifecycle becomes `rollback_required`, and no generated artifact is projected as a completed request.
 
+### Browser Artifact-Set Rendering
+
+The chat UI treats `generated_artifacts` as the authoritative completed set when present. It falls back to the legacy singular `generated_artifact` only for old status payloads. The client deduplicates members by artifact message id first, then stable artifact id, and only renders completed artifacts when the run status is `completed` and any supplied artifact-set lifecycle is also `completed`.
+
+Completed Analyze sets render as one grouped region:
+
+1. Primary Markdown analysis artifact.
+2. Explicitly requested siblings in server order.
+3. Optional supporting outputs when supplied by the backend.
+
+Each member keeps its own Download, View, PowerPoint, and workspace-promotion actions when the backing metadata supports those actions. Download, view, and promotion controls use filename-specific accessible names, but filenames are not included in the bounded UI event payloads emitted for rendering and member actions.
+
 ## Usage
 
 Shared tabular planning attaches a `deliverable_contract` field to planner results. When `enable_analysis_deliverable_contract_telemetry` is true and `analysis_deliverable_contract_mode` is `observe` or `shadow`, the planner emits debug-only `[ANALYSIS_DELIVERABLE_CONTRACT]` events with safe dimensions.
 
 The planner preserves explicit requested artifact order and direct negation. For example, Analyze with CSV plans Markdown first and CSV second. Analyze with JSON and XML preserves both requested siblings in order, but declines durable tabular execution until multi-artifact publication is available. Search can request Markdown as a normal requested output, but Search does not receive automatic primary Markdown.
+
+After Phase 6, a completed combined Analyze plus CSV run visibly presents both artifacts after live polling, after Continue, and when compatible completed metadata is hydrated. The progress card remains visible for queued, running, retry-waiting, failed, canceled, rollback, or otherwise nonterminal sets and does not expose staged or rolled-back downloads.
 
 When Analyze requests a structured tabular artifact, the shared planner selects `combined` only when hierarchical analysis is enabled. If the required analysis capability is disabled, the request is declined before durable execution rather than being reinterpreted as `structured_export`.
 
@@ -165,6 +184,13 @@ The committed 200-row fixture builder in `functional_tests/test_support/analyze_
 - A completed combined set publishes Markdown first and the requested structured sibling second.
 - An invalid required set fails closed with `rollback_required` and no public generated artifacts.
 
+`ui_tests/test_chat_background_generated_export_status.py` verifies:
+
+- Completed combined status replaces one progress card with a plural generated-artifact group.
+- Analyze Markdown is rendered before a requested CSV sibling even when the status response lists the CSV first.
+- Each member retains unique Download and View actions.
+- The client emits bounded artifact-set UI events without filenames or storage details.
+
 ## Known Limitations
 
-Phase 5 introduces manifest-backed atomic visibility for the existing durable tabular publication path. It does not yet add full cleanup sweepers for abandoned staged members, expand durable execution to every requested format, or render every plural artifact in the browser completion card; those remain later-phase work.
+Phase 6 introduces plural rendering for the existing chat completion paths. It does not yet expand durable execution to every requested format or add full cleanup sweepers for abandoned staged members; those remain later-phase work.

--- a/functional_tests/test_tabular_background_generated_exports.py
+++ b/functional_tests/test_tabular_background_generated_exports.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """
 Functional test for durable tabular generated-output background exports.
-Version: 0.250.152
-Implemented in: 0.241.060; throughput and timeout hardening in: 0.250.070; unified durable run contract in: 0.250.128; Phase 6 rolling worker pool compatibility in: 0.250.142; safe retry reason status text in: 0.250.147; collapsed operational details in: 0.250.150; simplified completed artifact cards in: 0.250.151; balanced batches and foreground JSON/XML cards in: 0.250.152
+Version: 0.250.176
+Implemented in: 0.241.060; throughput and timeout hardening in: 0.250.070; unified durable run contract in: 0.250.128; Phase 6 rolling worker pool compatibility in: 0.250.142; safe retry reason status text in: 0.250.147; collapsed operational details in: 0.250.150; simplified completed artifact cards in: 0.250.151; balanced batches and foreground JSON/XML cards in: 0.250.152; plural artifact-set completion rendering in: 0.250.176
 
 This test ensures that large tabular structured exports are wired through the
 durable background queue, status API, queued retry recovery, and chat progress
@@ -181,6 +181,9 @@ def test_background_batch_timeout_prevents_indefinite_model_wait():
         'time': __import__('time'),
         '_safe_float': lambda value, default=0.0: float(value) if value is not None else default,
         '_is_compact_row_array_protocol': lambda _response_protocol: False,
+        '_build_model_expected_output_schema': (
+            lambda expected_output_schema, transformation_spec=None: list(expected_output_schema or [])
+        ),
         '_build_batch_prompt': lambda *args, **kwargs: 'test prompt',
     }
     extracted_module = ast.Module(body=[helper_node], type_ignores=[])
@@ -294,6 +297,12 @@ def test_chat_ui_renders_and_polls_background_exports():
     assert_contains(source_text, 'generated-artifact-view-btn', 'completed artifact View action')
     assert_contains(source_text, 'generated-artifact-preview-modal', 'bounded artifact preview modal')
     assert_contains(source_text, 'hideCompletedGeneratedArtifactHandoff', 'stale completion handoff suppression')
+    assert_contains(source_text, 'normalizeGeneratedArtifactSet', 'plural artifact-set normalizer')
+    assert_contains(source_text, 'replaceBackgroundGeneratedOutputCardWithArtifacts', 'plural completion replacement path')
+    assert_contains(source_text, "role === 'primary_analysis'", 'Analyze Markdown primary ordering')
+    assert_contains(source_text, 'generated_artifacts', 'authoritative plural status field')
+    assert_contains(source_text, 'simplechat:generated-artifact-set', 'safe artifact-set UI event')
+    assert_contains(source_text, 'Download ${fileName}', 'unique download accessible name')
     if 'details.open = true' in source_text:
         raise AssertionError('Background export operational details must remain collapsed until the user expands them')
     if 'generated-tabular-refresh-status-btn' in source_text or 'Refresh Status' in source_text:
@@ -332,11 +341,24 @@ def test_completed_artifact_preview_is_bounded_and_ordered():
         'TABULAR_EXPORT_ARTIFACT_PREVIEW_CELL_MAX_CHARS': 12,
         'TABULAR_EXPORT_OUTPUT_ROW_NUMBER_FIELD': 'source_row_number',
         '_safe_int': lambda value: int(value or 0),
+        '_get_tabular_run_serialized_public_schema': (
+            lambda run: [
+                field_name
+                for field_name in list((run or {}).get('output_schema') or [])
+                if field_name not in {'source_row_number', 'source_row_identity'}
+            ]
+        ),
         '_output_blob_path': lambda user_id, conversation_id, run_id, batch_number: f'output-{batch_number}',
         '_validate_tabular_output_checkpoint_metadata': (
             lambda run, path, batch_number: validated_batches.append((path, batch_number))
         ),
         '_download_json_blob': lambda path: batches[path],
+        'project_structured_deliverable_row': (
+            lambda entry, public_schema, require_all_fields=True: {
+                field_name: entry[field_name]
+                for field_name in public_schema
+            }
+        ),
         '_serialize_generated_output_value': lambda value: '' if value is None else str(value),
         'build_safe_csv_headers': lambda values: list(values),
         'json': __import__('json'),
@@ -364,11 +386,12 @@ def test_completed_artifact_preview_is_bounded_and_ordered():
         suppress_assistant_text=True,
     )
 
-    assert [row['source_row_number'] for row in preview_rows] == ['1', '2', '3']
-    assert preview_rows[1]['answer'] == 'xxxxxxxxx...'
+    assert [row['answer'] for row in preview_rows] == ['first', 'xxxxxxxxx...', 'third']
+    assert 'source_row_number' not in preview_rows[0]
+    assert 'source_row_identity' not in preview_rows[0]
     assert validated_batches == [('output-1', 1), ('output-2', 2)]
     assert artifact['preview_rows'] == preview_rows
-    assert artifact['preview_columns'] == ['source_row_number', 'source_row_identity', 'answer']
+    assert artifact['preview_columns'] == ['answer']
     assert len(artifact['preview_text']) == 24000
     assert artifact['suppress_assistant_text'] is True
 

--- a/ui_tests/test_chat_background_generated_export_status.py
+++ b/ui_tests/test_chat_background_generated_export_status.py
@@ -1,8 +1,8 @@
 # test_chat_background_generated_export_status.py
 """
 UI test for chat background generated export status cards.
-Version: 0.250.169
-Implemented in: 0.241.046; cancellation in 0.250.060; automatic-only refresh in 0.250.061; combined progress and large-run confirmation in 0.250.131; throughput and concurrency status in 0.250.136; truthful background handoff in 0.250.138; collapsed operational details in 0.250.150; confirmation deduplication in 0.250.169
+Version: 0.250.176
+Implemented in: 0.241.046; cancellation in 0.250.060; automatic-only refresh in 0.250.061; combined progress and large-run confirmation in 0.250.131; throughput and concurrency status in 0.250.136; truthful background handoff in 0.250.138; collapsed operational details in 0.250.150; confirmation deduplication in 0.250.169; plural artifact-set completion rendering in 0.250.176
 
 This test ensures queued tabular generated exports render progress in chat and
 turn into a downloadable artifact when complete or a visible canceled state.
@@ -27,6 +27,34 @@ BASE_URL = os.getenv("SIMPLECHAT_UI_BASE_URL", "").rstrip("/")
 STORAGE_STATE = os.getenv("SIMPLECHAT_UI_STORAGE_STATE", "")
 REPO_ROOT = Path(__file__).resolve().parents[1]
 HARNESS_PATH = "ui_tests/fixtures/chat_thought_progress_harness.html"
+
+
+def _install_minimal_chat_dom(page) -> None:
+    """Install the minimum chat DOM and globals needed by chat-messages.js."""
+    page.evaluate(
+        """
+        () => {
+            window.appSettings = {
+                enable_text_to_speech: false,
+                enable_thoughts: false,
+                documentActionCapabilities: {},
+            };
+            window.enable_document_classification = false;
+            window.currentConversationId = 'conversation-ui-test';
+            window.marked = { parse: value => String(value || '') };
+            window.DOMPurify = { sanitize: value => String(value || '') };
+            window.Prism = { highlightElement: () => {} };
+            window.scrollChatToBottom = () => {};
+            window.showToast = () => {};
+
+            const root = document.getElementById('test-root');
+            root.replaceChildren();
+            const chatbox = document.createElement('div');
+            chatbox.id = 'chatbox';
+            root.appendChild(chatbox);
+        }
+        """
+    )
 
 
 def _get_free_local_port() -> int:
@@ -174,6 +202,334 @@ def test_chat_background_generated_export_status_card_auto_refreshes_to_download
 
         expect(message.get_by_role("button", name="Download JSON")).to_be_visible(timeout=15000)
         expect(message.get_by_text("Saved to this chat for download in this conversation.")).to_be_visible()
+    finally:
+        context.close()
+        browser.close()
+
+
+@pytest.mark.ui
+def test_chat_combined_completion_renders_plural_artifact_set(playwright) -> None:
+    """Validate completed combined runs render every artifact with Analyze Markdown first."""
+    browser = playwright.chromium.launch()
+    context = browser.new_context(viewport={"width": 1440, "height": 900})
+    page = context.new_page()
+    page_errors = []
+    page.on("pageerror", lambda error: page_errors.append(str(error)))
+
+    try:
+        with _start_static_test_server() as server_base_url:
+            page.route(
+                "**/api/tabular/generated-output/runs/run-plural-artifacts",
+                lambda route: route.fulfill(
+                    status=200,
+                    content_type="application/json",
+                    json={
+                        "success": True,
+                        "run": {
+                            "run_id": "run-plural-artifacts",
+                            "conversation_id": "conversation-ui-test",
+                            "task_type": "combined",
+                            "status": "completed",
+                            "row_count": 200,
+                            "processed_rows": 200,
+                            "batch_count": 4,
+                            "completed_batches": 4,
+                            "progress_percent": 100,
+                            "artifact_set": {
+                                "contract_version": "tabular-artifact-set-v1",
+                                "set_id": "artifact-set-ui-test",
+                                "lifecycle_state": "completed",
+                                "validation_state": "validated",
+                                "primary_artifact_id": "analysis-md",
+                                "member_count": 2,
+                                "published_member_count": 2,
+                                "publication_generation": 1,
+                            },
+                            "generated_artifacts": [
+                                {
+                                    "artifact_id": "requested-csv",
+                                    "role": "requested_output",
+                                    "capability": "tabular",
+                                    "artifact_message_id": "artifact-csv-ui-test",
+                                    "conversation_id": "conversation-ui-test",
+                                    "file_name": "financial_review.csv",
+                                    "output_format": "csv",
+                                    "row_count": 200,
+                                    "storage_scope": "chat",
+                                    "preview_rows": [
+                                        {"Item_ID": "FRI-001", "Overall_Attention": "Monitor"}
+                                    ],
+                                },
+                                {
+                                    "artifact_id": "analysis-md",
+                                    "role": "primary_analysis",
+                                    "capability": "analyze",
+                                    "artifact_message_id": "artifact-md-ui-test",
+                                    "conversation_id": "conversation-ui-test",
+                                    "file_name": "financial_review_analysis.md",
+                                    "output_format": "md",
+                                    "storage_scope": "chat",
+                                    "preview_lines": ["# Financial review", "All rows were analyzed."],
+                                },
+                            ],
+                            "generated_artifact": {
+                                "artifact_id": "requested-csv",
+                                "role": "requested_output",
+                                "capability": "tabular",
+                                "artifact_message_id": "artifact-csv-ui-test",
+                                "conversation_id": "conversation-ui-test",
+                                "file_name": "financial_review.csv",
+                                "output_format": "csv",
+                                "row_count": 200,
+                                "storage_scope": "chat",
+                            },
+                        },
+                    },
+                ),
+            )
+            response = page.goto(
+                f"{server_base_url}/{HARNESS_PATH}",
+                wait_until="domcontentloaded",
+            )
+            assert response is not None and response.ok
+            _install_minimal_chat_dom(page)
+            page.evaluate(
+                """
+                async () => {
+                    window.generatedArtifactSetEvents = [];
+                    document.addEventListener('simplechat:generated-artifact-set', event => {
+                        window.generatedArtifactSetEvents.push(event.detail);
+                    });
+
+                    const module = await import('/application/single_app/static/js/chat/chat-messages.js');
+                    module.appendMessage(
+                        'AI',
+                        'The combined Analyze run is continuing in the background.',
+                        null,
+                        'message-plural-artifacts',
+                        false,
+                        [],
+                        [],
+                        [],
+                        null,
+                        null,
+                        {
+                            metadata: {
+                                generated_tabular_outputs: [
+                                    {
+                                        capability: 'tabular',
+                                        background_export: true,
+                                        export_run_id: 'run-plural-artifacts',
+                                        run_id: 'run-plural-artifacts',
+                                        task_type: 'combined',
+                                        status: 'running',
+                                        file_name: 'financial_review.csv',
+                                        output_format: 'csv',
+                                        row_count: 200,
+                                        processed_rows: 40,
+                                        batch_count: 4,
+                                        completed_batches: 1,
+                                        source_file_name: 'financial_review.xlsx',
+                                        suppress_assistant_text: true,
+                                    }
+                                ]
+                            }
+                        },
+                        false
+                    );
+                }
+                """
+            )
+
+            message = page.locator('[data-message-id="message-plural-artifacts"]')
+            expect(message.get_by_text("Background analysis + export")).to_be_visible()
+            expect(message.get_by_role("button", name="Download financial_review_analysis.md")).to_be_visible(timeout=15000)
+            expect(message.get_by_role("button", name="Download financial_review.csv")).to_be_visible()
+            expect(message.locator('[data-generated-artifact-set="true"]')).to_have_count(1)
+            expect(message.get_by_text("2 generated artifacts", exact=True)).to_be_visible()
+
+            cards = message.locator('.generated-tabular-output-card')
+            expect(cards).to_have_count(2)
+            expect(cards.nth(0).get_by_text("Analyze MD artifact", exact=True)).to_be_visible()
+            expect(cards.nth(1).get_by_text("Generated CSV export", exact=True)).to_be_visible()
+            expect(message.get_by_role("button", name="View financial_review_analysis.md")).to_be_visible()
+            expect(message.get_by_role("button", name="View financial_review.csv")).to_be_visible()
+            expect(message.get_by_role("button", name="Cancel background export")).to_have_count(0)
+            expect(message.get_by_role("button", name="Continue")).to_have_count(0)
+
+            events = page.evaluate("() => window.generatedArtifactSetEvents")
+            completion_events = [
+                event for event in events if event.get("eventType") == "plural_completion_rendered"
+            ]
+            assert completion_events
+            assert completion_events[-1]["memberCount"] == 2
+            assert completion_events[-1]["formats"] == ["md", "csv"]
+            assert completion_events[-1]["primaryRendered"] is True
+            assert page_errors == []
+    finally:
+        context.close()
+        browser.close()
+
+
+@pytest.mark.ui
+def test_chat_continue_completion_renders_plural_artifact_set(playwright) -> None:
+    """Validate Continue uses the same plural artifact-set replacement path."""
+    browser = playwright.chromium.launch()
+    context = browser.new_context(viewport={"width": 1440, "height": 900})
+    page = context.new_page()
+    page_errors = []
+    page.on("pageerror", lambda error: page_errors.append(str(error)))
+
+    try:
+        with _start_static_test_server() as server_base_url:
+            page.route(
+                "**/api/tabular/generated-output/runs/run-plural-continue/resume",
+                lambda route: route.fulfill(
+                    status=200,
+                    content_type="application/json",
+                    json={
+                        "success": True,
+                        "message": "Background export is already complete.",
+                        "run": {
+                            "run_id": "run-plural-continue",
+                            "conversation_id": "conversation-ui-test",
+                            "task_type": "combined",
+                            "status": "completed",
+                            "row_count": 12,
+                            "processed_rows": 12,
+                            "batch_count": 2,
+                            "completed_batches": 2,
+                            "progress_percent": 100,
+                            "artifact_set": {
+                                "contract_version": "tabular-artifact-set-v1",
+                                "set_id": "artifact-set-continue-test",
+                                "lifecycle_state": "completed",
+                                "validation_state": "validated",
+                                "primary_artifact_id": "analysis-md",
+                                "member_count": 2,
+                                "published_member_count": 2,
+                                "publication_generation": 1,
+                            },
+                            "generated_artifacts": [
+                                {
+                                    "artifact_id": "analysis-md",
+                                    "role": "primary_analysis",
+                                    "capability": "analyze",
+                                    "artifact_message_id": "artifact-md-continue-test",
+                                    "conversation_id": "conversation-ui-test",
+                                    "file_name": "continue_analysis.md",
+                                    "output_format": "md",
+                                    "storage_scope": "chat",
+                                    "preview_lines": ["# Continue analysis"],
+                                },
+                                {
+                                    "artifact_id": "requested-json",
+                                    "role": "requested_output",
+                                    "capability": "tabular",
+                                    "artifact_message_id": "artifact-json-continue-test",
+                                    "conversation_id": "conversation-ui-test",
+                                    "file_name": "continue_output.json",
+                                    "output_format": "json",
+                                    "row_count": 12,
+                                    "storage_scope": "chat",
+                                    "preview_rows": [{"id": "row-1", "status": "ready"}],
+                                },
+                            ],
+                            "generated_artifact": {
+                                "artifact_id": "analysis-md",
+                                "role": "primary_analysis",
+                                "capability": "analyze",
+                                "artifact_message_id": "artifact-md-continue-test",
+                                "conversation_id": "conversation-ui-test",
+                                "file_name": "continue_analysis.md",
+                                "output_format": "md",
+                                "storage_scope": "chat",
+                            },
+                        },
+                    },
+                ),
+            )
+            response = page.goto(
+                f"{server_base_url}/{HARNESS_PATH}",
+                wait_until="domcontentloaded",
+            )
+            assert response is not None and response.ok
+            _install_minimal_chat_dom(page)
+            page.evaluate(
+                """
+                async () => {
+                    window.generatedArtifactSetEvents = [];
+                    document.addEventListener('simplechat:generated-artifact-set', event => {
+                        window.generatedArtifactSetEvents.push(event.detail);
+                    });
+
+                    const module = await import('/application/single_app/static/js/chat/chat-messages.js');
+                    module.appendMessage(
+                        'AI',
+                        'The combined run needs a manual continue.',
+                        null,
+                        'message-plural-continue',
+                        false,
+                        [],
+                        [],
+                        [],
+                        null,
+                        null,
+                        {
+                            metadata: {
+                                generated_tabular_outputs: [
+                                    {
+                                        capability: 'tabular',
+                                        background_export: true,
+                                        export_run_id: 'run-plural-continue',
+                                        run_id: 'run-plural-continue',
+                                        task_type: 'combined',
+                                        status: 'failed',
+                                        status_label: 'Retry waiting',
+                                        status_tone: 'warning',
+                                        status_detail: 'A retryable batch needs a manual continue.',
+                                        retryable_failure: true,
+                                        can_resume: true,
+                                        can_cancel: false,
+                                        waiting_for_retry: true,
+                                        file_name: 'continue_output.json',
+                                        output_format: 'json',
+                                        row_count: 12,
+                                        processed_rows: 6,
+                                        batch_count: 2,
+                                        completed_batches: 1,
+                                    }
+                                ]
+                            }
+                        },
+                        false
+                    );
+                }
+                """
+            )
+
+            message = page.locator('[data-message-id="message-plural-continue"]')
+            continue_button = message.get_by_role("button", name="Continue Now")
+            expect(continue_button).to_be_visible()
+            continue_button.click()
+
+            expect(message.get_by_role("button", name="Download continue_analysis.md")).to_be_visible(timeout=15000)
+            expect(message.get_by_role("button", name="Download continue_output.json")).to_be_visible()
+            cards = message.locator('.generated-tabular-output-card')
+            expect(cards).to_have_count(2)
+            expect(cards.nth(0).get_by_text("Analyze MD artifact", exact=True)).to_be_visible()
+            expect(cards.nth(1).get_by_text("Generated JSON export", exact=True)).to_be_visible()
+            expect(message.get_by_role("button", name="Continue Now")).to_have_count(0)
+            expect(message.get_by_role("button", name="Cancel background export")).to_have_count(0)
+
+            events = page.evaluate("() => window.generatedArtifactSetEvents")
+            completion_events = [
+                event for event in events if event.get("eventType") == "plural_completion_rendered"
+            ]
+            assert completion_events
+            assert completion_events[-1]["memberCount"] == 2
+            assert completion_events[-1]["formats"] == ["md", "json"]
+            assert page_errors == []
     finally:
         context.close()
         browser.close()


### PR DESCRIPTION
## Phase Objective

Render every completed generated artifact-set member in the chat UI after background completion and manual Continue. Analyze primary Markdown is shown first, requested sibling artifacts retain server order, and old singular `generated_artifact` payloads remain compatible.

## Explicit Non-Goals

- Does not add a second durable runner, artifact store, source resolver, or authorization path.
- Does not expand durable execution to every requested output format.
- Does not add cleanup sweepers for abandoned staged artifact members.
- Does not change Search to emit automatic Markdown artifacts.
- Does not redesign generated artifact cards beyond plural grouping and accessibility/action naming.

## Behavior Flags And Effective Defaults

- No new backend or admin behavior flag is introduced.
- The browser prefers authoritative `generated_artifacts[]` when present.
- The browser falls back to singular `generated_artifact` for legacy completed runs.
- Nonterminal, failed, canceled, rollback, invalid, or incomplete artifact sets remain progress/status cards and do not expose completed downloads.

## Contract-Version Changes

- Application version incremented to `0.250.176`.
- No new backend artifact-set contract version is introduced.
- Client now consumes existing `tabular-artifact-set-v1` status metadata, including `artifact_set.lifecycle_state`, `validation_state`, `primary_artifact_id`, and ordered `generated_artifacts[]`.

## Old-Run Compatibility Impact

- Existing singular completed status payloads still render one generated artifact card.
- Legacy hydrated metadata remains supported through the existing generated artifact array hydration path.
- Duplicate compatibility members are suppressed by artifact message id, then stable artifact id.

## Validation

Passed locally:

```powershell
node --check application/single_app/static/js/chat/chat-messages.js
python -m py_compile application/single_app/config.py functional_tests/test_tabular_background_generated_exports.py ui_tests/test_chat_background_generated_export_status.py
python functional_tests/test_tabular_background_generated_exports.py
pytest ui_tests/test_chat_background_generated_export_status.py::test_chat_combined_completion_renders_plural_artifact_set ui_tests/test_chat_background_generated_export_status.py::test_chat_continue_completion_renders_plural_artifact_set -q
git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check
```

Results:

- Functional marker suite: 8/8 passed.
- Phase 6 self-contained Playwright regressions: 2/2 passed.
- JavaScript syntax, Python compile, diagnostics, and Windows-safe whitespace checks passed.

## Security And Source-Scope Coverage

- Rendered artifact metadata uses DOM APIs and `textContent`; no new external browser runtime asset was added.
- Existing authenticated download, view, PowerPoint, and workspace-promotion paths are reused.
- Browser completion ignores staged, invalid, rollback, canceled, and nonterminal sets as downloadable completed artifacts.
- Bounded UI events omit filenames, storage paths, source locations, prompts, and row values.
- Raw settings are not sent to the browser by this change.

## Rollout And Rollback

Rollout is additive on the client: new plural status payloads render all completed members, while old singular payloads continue to work. Rollback can revert the plural replacement helper and return to singular projection without changing accepted durable run storage or backend status fields.

## Later Phases Excluded

Phase 7 scale, rollout proof, legacy retirement, and broader format equivalence are intentionally excluded from this PR.