### PR TITLE
Phase 7A: stabilize Analyze artifact closure baseline

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -96,7 +96,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.250.177"
+VERSION = "0.250.178"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/functions_generated_file_exports.py
+++ b/application/single_app/functions_generated_file_exports.py
@@ -188,8 +188,8 @@ PASSTHROUGH_COPY_PATTERNS = (
     re.compile(r'\b(?:copy|export|download|save)\b[\w\s,.:;\-/]{0,100}\b(?:unchanged|as-is|as\s+is|verbatim|raw|original|source)\b'),
 )
 PASSTHROUGH_SERIALIZE_PATTERNS = (
-    re.compile(r'\b(?:build|create|download|export|format|generate|make|prepare|save|serialize|convert)\b[\w\s,.:;\-/]{0,100}\b(?:csv|json|xml|docx|pdf|spreadsheet)\b'),
-    re.compile(r'\b(?:csv|json|xml|docx|pdf|spreadsheet)\b[\w\s,.:;\-/]{0,100}\b(?:export|download|file|format|copy)\b'),
+    re.compile(r'\b(?:build|create|download|export|format|generate|make|prepare|save|serialize|convert)\b[\w\s,.:;\-/]{0,100}\b(?:csv|json|xml|docx|word|pdf|spreadsheet)\b'),
+    re.compile(r'\b(?:csv|json|xml|docx|word|pdf|spreadsheet)\b[\w\s,.:;\-/]{0,100}\b(?:export|download|file|format|copy)\b'),
 )
 
 

--- a/docs/explanation/features/ANALYZE_DELIVERABLE_CONTRACT.md
+++ b/docs/explanation/features/ANALYZE_DELIVERABLE_CONTRACT.md
@@ -12,6 +12,8 @@ Phase 6 updated in version: **0.250.176**
 
 Phase 7 updated in version: **0.250.177**
 
+Phase 7A stabilization updated in version: **0.250.178**
+
 ## Overview
 
 The Analyze deliverable contract defines a server-owned, versioned plan for analysis artifacts before production routing changes are made. It records whether an action requires a primary Markdown analysis artifact, which sibling artifacts were explicitly requested, the public structured schema, row cardinality, ordering, transformation mode, validation profile, and publication policy.
@@ -25,6 +27,8 @@ Phase 5 adds a versioned durable artifact-set manifest for tabular generated-out
 Phase 6 updates the chat browser completion path to consume the plural artifact-set projection. When polling or Continue receives a completed set, the progress card is replaced by one unframed generated-artifact group that renders every published member. Analyze Markdown is shown first, requested siblings retain their server order, and old singular `generated_artifact` responses still render as one compatible card.
 
 Phase 7 adds an explicit rollout state for new shared tabular parity assignments. Administrators can pause or roll back new assignment while preserving accepted run contracts, readers, status endpoints, and artifact-set recovery for already queued work.
+
+Phase 7A restores explicit Word/DOCX serialization of authorized current-turn non-tabular function-result rows. The passthrough guard still rejects derived requests before serialization, keeps tabular tool rows on their coverage-aware durable path, and omits sensitive fields. It also restores the cumulative lifecycle and scale harnesses to the current schema, planner, and artifact-set contracts.
 
 ## Dependencies
 

--- a/docs/explanation/fixes/ANALYZE_ARTIFACT_PHASE_7A_STABILIZATION_FIX.md
+++ b/docs/explanation/fixes/ANALYZE_ARTIFACT_PHASE_7A_STABILIZATION_FIX.md
@@ -1,0 +1,61 @@
+# Analyze Artifact Phase 7A Stabilization Fix
+
+Fixed in version: **0.250.178**
+
+Related issue: **#1233**
+
+## Issue Description
+
+The Analyze artifact integration branch had three stabilization failures after
+the first seven implementation slices:
+
+- Word/DOCX requests that explicitly serialized authorized current-turn action
+  results created a document but silently omitted the structured rows.
+- The Phase 7 lifecycle test stub did not expose the ordered artifact-format
+  API required by the shared planner.
+- The cumulative scale harness omitted schema, transformation, and projection
+  dependencies added to production helpers in later phases.
+
+## Root Cause Analysis
+
+The DOCX intent detector accepted both `word` and `docx`, while the guarded
+passthrough serializer accepted only `docx`. The test harnesses intentionally
+load narrow function slices, but their dependency inventories had not been
+updated when the production functions gained public-schema, lineage,
+transformation, action-mode, and artifact-set projection dependencies.
+
+## Technical Details
+
+Files modified:
+
+- `application/single_app/functions_generated_file_exports.py`
+- `functional_tests/test_assistant_table_csv_artifact.py`
+- `functional_tests/test_tabular_phase7_lifecycle_coverage.py`
+- `functional_tests/test_tabular_row_orchestration_scale.py`
+- `docs/explanation/features/ANALYZE_DELIVERABLE_CONTRACT.md`
+- `application/single_app/config.py`
+
+The serializer now treats `word` as the same explicit format-conversion alias
+as `docx`. Derived-output detection still runs before serialization, tabular
+plugin results remain excluded, and sensitive function-result fields continue
+to be removed by the existing authorization and projection path.
+
+The isolated lifecycle and scale harnesses now load the same ordered artifact
+format, schema, lineage, transformation, stream projection, and route-neutral
+task-classifier dependencies used by production.
+
+## Validation
+
+- DOCX/PDF function-result serialization includes authorized structured rows.
+- Derived Word requests do not publish untransformed function rows.
+- The complete Phase 7 lifecycle coverage suite passes.
+- The cumulative scale suite passes through 100,000-row planning, 30,000-row
+  bounded streaming finalization, authorization revalidation, cancellation,
+  restart, lease fencing, artifact projection, and legacy migration checks.
+
+## Impact Analysis
+
+Users regain the documented Word export behavior for explicit action-result
+serialization. No new source or authorization path is introduced, and the fix
+does not activate unfinished transformation planning, semantic repair,
+multi-format publication, or legacy retirement work.

--- a/functional_tests/test_assistant_table_csv_artifact.py
+++ b/functional_tests/test_assistant_table_csv_artifact.py
@@ -2,8 +2,8 @@
 #!/usr/bin/env python3
 """
 Functional test for assistant-rendered table CSV artifacts.
-Version: 0.250.172
-Implemented in: 0.241.050; non-tabular document CSV parsing in 0.250.065; generated file export framework in 0.250.072; updated in 0.250.073; linear fence parsing coverage in 0.250.112; version assertion compatibility updated in 0.250.172
+Version: 0.250.178
+Implemented in: 0.241.050; non-tabular document CSV parsing in 0.250.065; generated file export framework in 0.250.072; updated in 0.250.073; linear fence parsing coverage in 0.250.112; version assertion compatibility updated in 0.250.172; Word function-result serialization restored in 0.250.178
 
 This test ensures that explicit table-format requests with assistant-rendered
 tables, including CSV rows extracted from non-tabular documents, are converted
@@ -301,6 +301,7 @@ def test_tabular_action_result_does_not_bypass_coverage_aware_exports():
 
 def test_function_results_render_docx_and_pdf_capabilities():
     print('Testing DOCX and PDF function-result export capabilities...')
+    assert_app_version_at_least('0.250.178')
 
     function_results = [{
         'plugin_name': 'DirectoryPlugin',
@@ -327,6 +328,35 @@ def test_function_results_render_docx_and_pdf_capabilities():
     assert_true(pdf_export is not None and pdf_export['file_content'].startswith(b'%PDF'), 'Expected a PDF file export.')
     assert_true(docx_export['row_source'] == 'structured function result', 'Expected DOCX to include function-result rows.')
     assert_true(pdf_export['row_source'] == 'structured function result', 'Expected PDF to include function-result rows.')
+    assert_true(
+        docx_export.get('passthrough_reason_code') == 'explicit_format_conversion',
+        'Expected Word function-result serialization to record its explicit format-conversion contract.',
+    )
+    assert_true(
+        pdf_export.get('passthrough_reason_code') == 'explicit_format_conversion',
+        'Expected PDF function-result serialization to record its explicit format-conversion contract.',
+    )
+
+
+def test_derived_word_export_does_not_serialize_function_rows():
+    print('Testing derived Word export function-result exclusion...')
+    assert_app_version_at_least('0.250.178')
+
+    export_payload = build_generated_file_export(
+        'create a Word document from the action results and classify each person by risk',
+        'The directory action completed successfully.',
+        function_results=[{
+            'plugin_name': 'DirectoryPlugin',
+            'function_name': 'list_people',
+            'success': True,
+            'function_result': {'value': [{'Name': 'Ada', 'Department': 'Engineering'}]},
+        }],
+    )
+
+    assert_true(export_payload is not None, 'Expected the assistant response to remain exportable as a Word document.')
+    assert_true(export_payload['row_source'] == 'assistant response', 'Expected derived function rows to remain excluded.')
+    assert_true(export_payload['row_count'] == 0, 'Expected no untransformed function rows in the derived Word export.')
+    assert_true('passthrough_reason_code' not in export_payload, 'Expected no passthrough claim for a derived request.')
 
 
 def test_plain_document_csv_response_excludes_surrounding_prose_and_citation():
@@ -1121,6 +1151,7 @@ def run_tests() -> bool:
         test_structured_action_results_combine_and_preserve_assistant_priority,
         test_tabular_action_result_does_not_bypass_coverage_aware_exports,
         test_function_results_render_docx_and_pdf_capabilities,
+        test_derived_word_export_does_not_serialize_function_rows,
         test_plain_document_csv_response_excludes_surrounding_prose_and_citation,
         test_document_csv_response_preserves_multiline_and_escaped_quotes,
         test_fenced_document_csv_preserves_sentence_shaped_rows,

--- a/functional_tests/test_tabular_phase7_lifecycle_coverage.py
+++ b/functional_tests/test_tabular_phase7_lifecycle_coverage.py
@@ -2,8 +2,8 @@
 # test_tabular_phase7_lifecycle_coverage.py
 """
 Functional test for Phase 7 tabular lifecycle coverage hardening.
-Version: 0.250.167
-Implemented in: 0.250.163
+Version: 0.250.178
+Implemented in: 0.250.163; planner dependency compatibility updated in 0.250.178
 
 This test ensures shared tabular planner coverage starts as planned pending
 evidence, canceled durable tabular evidence remains terminal but incomplete,
@@ -38,8 +38,20 @@ def install_lightweight_planner_dependency_stubs():
                 return output_format
         return None
 
+    def get_requested_artifact_formats(prompt):
+        normalized_prompt = str(prompt or "").lower()
+        return [
+            output_format
+            for output_format in ("json", "xml", "csv")
+            if output_format in normalized_prompt
+        ]
+
+    generated_exports_module.get_requested_artifact_formats = get_requested_artifact_formats
     generated_exports_module.get_requested_structured_artifact_format = (
         get_requested_structured_artifact_format
+    )
+    generated_exports_module.get_requested_structured_artifact_formats = (
+        get_requested_artifact_formats
     )
     sys.modules.setdefault("functions_assistant_table_exports", assistant_exports_module)
     sys.modules.setdefault("functions_generated_file_exports", generated_exports_module)

--- a/functional_tests/test_tabular_row_orchestration_scale.py
+++ b/functional_tests/test_tabular_row_orchestration_scale.py
@@ -1,8 +1,8 @@
 # test_tabular_row_orchestration_scale.py
 """
 Functional test for scalable per-row tabular orchestration.
-Version: 0.250.167
-Implemented in: 0.250.060; generated CSV formula safety in 0.250.065; generated file export routing in 0.250.072; source descriptor generalization in 0.250.127; unified durable run contract in 0.250.128; hierarchical analysis in 0.250.129; combined analysis and export in 0.250.130; scale validation in 0.250.132; direct source-backed exhaustive queueing in 0.250.133; direct queue call-site hardening in 0.250.134; model-validation auto retry in 0.250.135; model-aware parallel throughput in 0.250.136; Phase 1 acceleration contracts and observability in 0.250.137; Phase 2 truthful background handoff in 0.250.138; Phase 3 durable LLM generation planning in 0.250.139; Phase 4 compact row response protocol in 0.250.140; Phase 5 completion-driven checkpointing in 0.250.141; Phase 6 rolling worker pool in 0.250.142; Phase 7 independent batch retries in 0.250.143; Phase 8 scale, chaos, and rollout in 0.250.144; background metadata streaming fix in 0.250.145; source-token echo recovery in 0.250.146; fixed-window stale heartbeat fix in 0.250.147; nested CSV output recovery in 0.250.148; generic tabular artifact routing and fast startup in 0.250.149; balanced concurrency waves and default completion checkpoints in 0.250.152; Search shared preflight adapter in 0.250.159; aggregate route-helper harness coverage in 0.250.166
+Version: 0.250.178
+Implemented in: 0.250.060; generated CSV formula safety in 0.250.065; generated file export routing in 0.250.072; source descriptor generalization in 0.250.127; unified durable run contract in 0.250.128; hierarchical analysis in 0.250.129; combined analysis and export in 0.250.130; scale validation in 0.250.132; direct source-backed exhaustive queueing in 0.250.133; direct queue call-site hardening in 0.250.134; model-validation auto retry in 0.250.135; model-aware parallel throughput in 0.250.136; Phase 1 acceleration contracts and observability in 0.250.137; Phase 2 truthful background handoff in 0.250.138; Phase 3 durable LLM generation planning in 0.250.139; Phase 4 compact row response protocol in 0.250.140; Phase 5 completion-driven checkpointing in 0.250.141; Phase 6 rolling worker pool in 0.250.142; Phase 7 independent batch retries in 0.250.143; Phase 8 scale, chaos, and rollout in 0.250.144; background metadata streaming fix in 0.250.145; source-token echo recovery in 0.250.146; fixed-window stale heartbeat fix in 0.250.147; nested CSV output recovery in 0.250.148; generic tabular artifact routing and fast startup in 0.250.149; balanced concurrency waves and default completion checkpoints in 0.250.152; Search shared preflight adapter in 0.250.159; aggregate route-helper harness coverage in 0.250.166; Analyze artifact Phase 7A harness compatibility updated in 0.250.178
 
 This test ensures generated exports preserve source identity and row order while
 enforcing one stable output schema across independently generated batches.
@@ -57,6 +57,11 @@ from functions_generated_file_exports import (  # noqa: E402
     get_requested_generated_file_format,
     get_requested_structured_artifact_format,
 )
+from functions_analysis_deliverables import (  # noqa: E402
+    is_analysis_internal_lineage_field,
+    project_structured_deliverable_row,
+)
+from functions_tabular_transformations import normalize_tabular_transformation_spec  # noqa: E402
 from functions_tabular_orchestration import (  # noqa: E402
     build_tabular_legacy_post_tool_fallback_decision,
     get_tabular_generated_output_format,
@@ -91,6 +96,8 @@ CANDIDATE_FUNCTIONS = {
 STREAM_FUNCTIONS = {
     '_serialize_generated_output_value',
     '_validate_tabular_output_checkpoint_metadata',
+    '_get_tabular_run_public_output_schema',
+    '_get_tabular_run_serialized_public_schema',
     '_write_ordered_output_stream',
 }
 SOURCE_VERSION_FUNCTIONS = {'_revalidate_tabular_source_version_for_publication'}
@@ -210,6 +217,9 @@ PERFORMANCE_FUNCTIONS = {
     '_build_tabular_generation_rollout_assignment',
     '_get_tabular_generation_rollout_settings_for_run',
     '_sync_tabular_generation_contract_fields',
+    '_get_tabular_run_lineage_schema',
+    '_get_tabular_run_public_output_schema',
+    '_get_tabular_run_internal_checkpoint_schema',
     '_build_generation_progress_contract_fields',
     '_extract_tabular_response_usage',
     '_resolve_tabular_batch_concurrency',
@@ -249,6 +259,10 @@ GENERATION_PLAN_FUNCTIONS = {
     '_build_tabular_generation_plan',
     '_validate_tabular_generation_plan',
     '_get_tabular_generation_plan_output_schema',
+    '_get_tabular_generation_plan_llm_fields',
+    '_get_tabular_run_lineage_schema',
+    '_get_tabular_run_public_output_schema',
+    '_get_tabular_run_transformation_spec',
     '_tabular_generation_plan_blob_path',
     '_get_tabular_generation_plan_source_etag',
     '_build_tabular_output_checkpoint_metadata',
@@ -780,6 +794,8 @@ def _load_stream_writer(download_json_blob):
         '_output_blob_path': lambda user_id, conversation_id, run_id, batch_number: batch_number,
         '_download_json_blob': download_json_blob,
         'TABULAR_EXPORT_OUTPUT_ROW_NUMBER_FIELD': 'source_row_number',
+        'is_analysis_internal_lineage_field': is_analysis_internal_lineage_field,
+        'project_structured_deliverable_row': project_structured_deliverable_row,
     }
     extracted_module = ast.Module(body=selected_nodes, type_ignores=[])
     exec(compile(extracted_module, str(EXPORT_MODULE), 'exec'), namespace)
@@ -1451,6 +1467,7 @@ def _load_performance_helpers(progress_updates=None):
         'os': os,
         're': re,
         'timezone': timezone,
+        'is_analysis_internal_lineage_field': is_analysis_internal_lineage_field,
     }
     extracted_module = ast.Module(body=selected_nodes, type_ignores=[])
     exec(compile(extracted_module, str(EXPORT_MODULE), 'exec'), namespace)
@@ -1571,6 +1588,8 @@ def _load_generation_plan_helpers():
             (input_batches or run['_test_batches'])[batch_number - 1]
         ),
         '_normalize_tabular_run_task_type': lambda value: value or 'structured_export',
+        'is_analysis_internal_lineage_field': is_analysis_internal_lineage_field,
+        'normalize_tabular_transformation_spec': normalize_tabular_transformation_spec,
         '_resolve_tabular_generation_planner_model': lambda run, settings: {
             'endpoint_id': 'endpoint-1',
             'model_id': 'gpt-plan',
@@ -4573,6 +4592,7 @@ def test_direct_source_backed_queue_supports_all_workbook_formats():
     fake_module.TabularProcessingPlugin = FakeWorkbookPlugin
     sys.modules['semantic_kernel_plugins.tabular_processing_plugin'] = fake_module
     queued_runs = []
+    log_events = []
     try:
         helpers = _load_direct_source_queue_helpers({
             '_safe_int': lambda value: int(value or 0),
@@ -4580,7 +4600,7 @@ def test_direct_source_backed_queue_supports_all_workbook_formats():
                 'max_rows': 60,
                 'max_chars': 60000,
             },
-            '_get_tabular_generated_output_task_type': lambda *args: None,
+            '_get_tabular_generated_output_task_type': lambda *args, **kwargs: None,
             'question_requests_tabular_generated_output': lambda question: True,
             'question_requests_tabular_hierarchical_analysis': lambda question: False,
             'get_tabular_generated_output_format': lambda question: 'csv',
@@ -4601,7 +4621,7 @@ def test_direct_source_backed_queue_supports_all_workbook_formats():
                 'status': 'failed',
             },
             'logging': logging,
-            'log_event': lambda *args, **kwargs: None,
+            'log_event': lambda *args, **kwargs: log_events.append((args, kwargs)),
         })
         for source_format in ('xlsx', 'xls', 'xlsm'):
             output_metadata = helpers['maybe_queue_direct_tabular_generated_output'](
@@ -4615,7 +4635,7 @@ def test_direct_source_backed_queue_supports_all_workbook_formats():
                 gpt_model='test-model',
                 settings={},
             )
-            assert output_metadata['background_export'] is True
+            assert output_metadata.get('background_export') is True, log_events
     finally:
         if original_module is None:
             sys.modules.pop('semantic_kernel_plugins.tabular_processing_plugin', None)
@@ -4702,7 +4722,10 @@ def test_direct_source_backed_csv_queue_bypasses_tool_paging():
                 'max_rows': 60,
                 'max_chars': 60000,
             },
-            '_get_tabular_generated_output_task_type': lambda generated, analysis, settings: 'combined' if generated and analysis else None,
+            '_get_tabular_generated_output_task_type': (
+                lambda generated, analysis, settings, action_mode=None:
+                'combined' if generated and analysis else None
+            ),
             'question_requests_tabular_generated_output': lambda question: True,
             'question_requests_tabular_hierarchical_analysis': lambda question: True,
             'get_tabular_generated_output_format': lambda question: 'csv',
@@ -4783,7 +4806,9 @@ def test_direct_source_backed_queue_failure_suppresses_inline_exhaustive_output(
                 'max_rows': 60,
                 'max_chars': 60000,
             },
-            '_get_tabular_generated_output_task_type': lambda generated, analysis, settings: None,
+            '_get_tabular_generated_output_task_type': (
+                lambda generated, analysis, settings, action_mode=None: None
+            ),
             'question_requests_tabular_generated_output': lambda question: True,
             'question_requests_tabular_hierarchical_analysis': lambda question: False,
             'get_tabular_generated_output_format': lambda question: 'csv',
@@ -5666,8 +5691,10 @@ def test_runner_routes_combined_analysis_and_export_once():
     )
     assert '_analysis_chunk_summary_blob_path' in load_summaries_source
     assert "'generated_artifacts': generated_artifacts" in public_status_source
-    assert "'structured_export_artifact': run.get('structured_export_artifact')" in public_status_source
-    assert "'analysis_artifact': run.get('analysis_artifact')" in public_status_source
+    assert "'structured_export_artifact': structured_export_public_artifact" in public_status_source
+    assert "'analysis_artifact': analysis_public_artifact" in public_status_source
+    assert "'structured_export_artifact': run.get('structured_export_artifact')" not in public_status_source
+    assert "'analysis_artifact': run.get('analysis_artifact')" not in public_status_source
     assert 'analysis_generated_file_name' in queue_source
     assert '_generate_combined_chunk_result_window' in export_source
     assert 'tabular_combined_analysis_summary' in export_source


### PR DESCRIPTION
## Phase Objective

Phase 7A stabilizes the Analyze artifact output-contract integration branch before correctness and publication follow-ups. It restores explicit Word/DOCX serialization of authorized current-turn non-tabular function results and brings cumulative lifecycle and scale harnesses up to the current planner, schema, and artifact-set contracts.

Refs #1233

## Explicit Non-Goals

- Does not infer transformation rules from prompts.
- Does not add semantic verification or targeted repair.
- Does not change artifact-set publication or direct artifact authorization.
- Does not enable multi-format durable fan-out.
- Does not retire legacy readers, executors, or fallback code.
- Does not update public release notes in this PR.

## Behavior And Compatibility

- Treats `word` as the existing `docx` explicit format-conversion alias.
- Derived-output detection still runs before passthrough eligibility.
- Tabular plugin rows remain on the coverage-aware durable path.
- Sensitive current-turn function-result fields remain excluded.
- No rollout defaults or persisted contract versions change.
- Existing runs and artifacts are not reinterpreted.

## Application Version

- `application/single_app/config.py`: `0.250.177` -> `0.250.178`.

## Validation

- Python `py_compile` for all changed Python and functional test files - passed.
- `functional_tests/test_assistant_table_csv_artifact.py` - 35/35 passed.
- `functional_tests/test_tabular_phase7_lifecycle_coverage.py` - 3/3 passed.
- `functional_tests/test_tabular_row_orchestration_scale.py` - complete suite passed, including 30,000-row bounded finalization and 100,000-row planning/hardening contracts.
- Analyze deliverable, public schema, transformation, artifact-set, rollback, background export, and shared planner suites - 35/35 passed.
- Search/Analyze parity and shared-preflight adapter suites - 18/18 passed.
- VS Code diagnostics - clean.
- Markdown hygiene and Windows-safe `git diff --check` - passed.

## Security And Source Scope

- No new authorization or source-resolution path is introduced.
- The positive path is limited to already-authorized current-turn non-tabular function results.
- The new negative regression test proves a derived Word request cannot serialize untransformed function rows.
- Existing sensitive-field filtering and tabular coverage protections remain active.

## Rollback

Revert this PR to restore the prior Word alias behavior and isolated test-loader inventories. No persisted data or run migration is required.

## Remaining Closure Slices

- Phase 7B: production rule planning, independent semantic verification, and targeted repair.
- Phase 7C: recoverable artifact-set visibility, cleanup, and multi-format publication.
- Phase 7D: final integration, scale, chaos, authenticated UI, and canary evidence.