### PR TITLE
Phase 7C: enforce artifact-set publication lifecycle

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -96,7 +96,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.250.179"
+VERSION = "0.250.180"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/functions_simplechat_operations.py
+++ b/application/single_app/functions_simplechat_operations.py
@@ -23,6 +23,7 @@ from config import (
     cosmos_conversations_container,
     cosmos_groups_container,
     cosmos_messages_container,
+    cosmos_tabular_export_runs_container,
     storage_account_personal_chat_container_name,
     TABULAR_EXTENSIONS,
 )
@@ -71,6 +72,10 @@ from utils_cache import invalidate_group_search_cache, invalidate_personal_searc
 
 SIMPLECHAT_PLUGIN_TYPE = "simplechat"
 SIMPLECHAT_DEFAULT_ENDPOINT = "simplechat://internal"
+GENERATED_CHAT_ARTIFACT_LIFECYCLE_STAGED = "staged"
+GENERATED_CHAT_ARTIFACT_LIFECYCLE_PUBLISHED = "published"
+GENERATED_CHAT_ARTIFACT_LIFECYCLE_ROLLED_BACK = "rolled_back"
+GENERATED_CHAT_ARTIFACT_VALIDATION_VALIDATED = "validated"
 FORKABLE_SINGLE_USER_CHAT_TYPES = {
     "",
     "new",
@@ -1295,6 +1300,7 @@ def upload_generated_analysis_artifact_for_user(
     capability: str = "analysis",
     output_format: str = "",
     summary: str = "",
+    artifact_lifecycle_metadata: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """Upload generated analysis content for a known authorized user outside request context."""
     normalized_user_id = str(current_user_id or "").strip()
@@ -1340,6 +1346,7 @@ def upload_generated_analysis_artifact_for_user(
             "capability": normalized_capability,
             "output_format": normalized_output_format,
             "summary": normalized_summary,
+            **(artifact_lifecycle_metadata if isinstance(artifact_lifecycle_metadata, dict) else {}),
         },
     )
 
@@ -1354,6 +1361,7 @@ def upload_generated_analysis_artifact_stream_for_user(
     output_format: str = "",
     summary: str = "",
     artifact_idempotency_key: str = "",
+    artifact_lifecycle_metadata: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """Upload a bounded-memory generated artifact stream for an authorized user."""
     normalized_user_id = str(current_user_id or "").strip()
@@ -1399,6 +1407,7 @@ def upload_generated_analysis_artifact_stream_for_user(
             "capability": normalized_capability,
             "output_format": normalized_output_format,
             "summary": normalized_summary,
+            **(artifact_lifecycle_metadata if isinstance(artifact_lifecycle_metadata, dict) else {}),
         },
         artifact_idempotency_key=artifact_idempotency_key,
     )
@@ -2567,6 +2576,7 @@ def _upload_generated_chat_artifact_for_current_user(
     artifact_capability = str(artifact_metadata.get("capability") or "analysis").strip().lower() or "analysis"
     artifact_output_format = str(artifact_metadata.get("output_format") or file_extension).strip().lower() or file_extension
     artifact_summary = str(artifact_metadata.get("summary") or "").strip()
+    lifecycle_metadata = _build_generated_chat_artifact_lifecycle_metadata(artifact_metadata)
 
     message_doc = {
         "id": artifact_message_id,
@@ -2586,6 +2596,7 @@ def _upload_generated_chat_artifact_for_current_user(
             "generated_artifact_output_format": artifact_output_format,
             "generated_artifact_summary": artifact_summary,
             "generated_artifact_idempotency_key": normalized_idempotency_key or None,
+            **lifecycle_metadata,
             "thread_info": {
                 "thread_id": current_thread_id,
                 "previous_thread_id": previous_thread_id,
@@ -2618,9 +2629,178 @@ def _upload_generated_chat_artifact_for_current_user(
             "blob_path": blob_path,
             "capability": artifact_capability,
             "output_format": artifact_output_format,
+            **_build_generated_chat_artifact_lifecycle_response(message_doc.get("metadata")),
         },
         "conversation_id": conversation_id,
     }
+
+
+def _safe_positive_int(value: Any) -> int:
+    try:
+        return max(0, int(value or 0))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _build_generated_chat_artifact_lifecycle_metadata(artifact_metadata: Dict[str, Any]) -> Dict[str, Any]:
+    metadata = artifact_metadata if isinstance(artifact_metadata, dict) else {}
+    run_id = str(metadata.get("artifact_run_id") or metadata.get("run_id") or "").strip()
+    set_id = str(metadata.get("artifact_set_id") or "").strip()
+    member_id = str(metadata.get("artifact_member_id") or "").strip()
+    if not run_id and not set_id and not member_id:
+        return {}
+
+    lifecycle_state = str(
+        metadata.get("artifact_lifecycle_state") or GENERATED_CHAT_ARTIFACT_LIFECYCLE_STAGED
+    ).strip().lower()
+    if lifecycle_state not in {
+        GENERATED_CHAT_ARTIFACT_LIFECYCLE_STAGED,
+        GENERATED_CHAT_ARTIFACT_LIFECYCLE_PUBLISHED,
+        GENERATED_CHAT_ARTIFACT_LIFECYCLE_ROLLED_BACK,
+    }:
+        lifecycle_state = GENERATED_CHAT_ARTIFACT_LIFECYCLE_STAGED
+    validation_state = str(metadata.get("artifact_validation_state") or lifecycle_state).strip().lower()[:40]
+    return {
+        "generated_artifact_run_id": run_id,
+        "generated_artifact_set_id": set_id,
+        "generated_artifact_member_id": member_id,
+        "generated_artifact_lifecycle_state": lifecycle_state,
+        "generated_artifact_validation_state": validation_state,
+        "generated_artifact_publication_generation": _safe_positive_int(
+            metadata.get("artifact_publication_generation")
+        ),
+        "generated_artifact_staged_at": str(metadata.get("artifact_staged_at") or datetime.now(timezone.utc).isoformat()),
+        "generated_artifact_committed_at": metadata.get("artifact_committed_at"),
+    }
+
+
+def _build_generated_chat_artifact_lifecycle_response(metadata: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    normalized_metadata = metadata if isinstance(metadata, dict) else {}
+    response = {}
+    for key in (
+        "generated_artifact_run_id",
+        "generated_artifact_set_id",
+        "generated_artifact_member_id",
+        "generated_artifact_lifecycle_state",
+        "generated_artifact_validation_state",
+        "generated_artifact_publication_generation",
+    ):
+        if key in normalized_metadata:
+            response[key] = normalized_metadata.get(key)
+    return response
+
+
+def _generated_artifact_has_lifecycle_contract(metadata: Dict[str, Any]) -> bool:
+    return bool(
+        metadata.get("generated_artifact_run_id")
+        or metadata.get("generated_artifact_set_id")
+        or metadata.get("generated_artifact_member_id")
+        or metadata.get("generated_artifact_lifecycle_state")
+    )
+
+
+def assert_generated_chat_artifact_is_published_for_user(current_user_id: str, message_item: Dict[str, Any]) -> None:
+    """Reauthorize a generated artifact against its committed artifact-set manifest."""
+    metadata = message_item.get("metadata") if isinstance(message_item.get("metadata"), dict) else {}
+    if not _generated_artifact_has_lifecycle_contract(metadata):
+        return
+
+    lifecycle_state = str(metadata.get("generated_artifact_lifecycle_state") or "").strip().lower()
+    validation_state = str(metadata.get("generated_artifact_validation_state") or "").strip().lower()
+    publication_generation = _safe_positive_int(metadata.get("generated_artifact_publication_generation"))
+    if (
+        lifecycle_state != GENERATED_CHAT_ARTIFACT_LIFECYCLE_PUBLISHED
+        or validation_state != GENERATED_CHAT_ARTIFACT_VALIDATION_VALIDATED
+        or publication_generation <= 0
+    ):
+        raise PermissionError("Artifact is not published")
+
+    run_id = str(metadata.get("generated_artifact_run_id") or "").strip()
+    set_id = str(metadata.get("generated_artifact_set_id") or "").strip()
+    member_id = str(metadata.get("generated_artifact_member_id") or "").strip()
+    conversation_id = str(message_item.get("conversation_id") or "").strip()
+    if not run_id or not set_id or not member_id or not conversation_id:
+        raise PermissionError("Artifact publication metadata is incomplete")
+
+    try:
+        run = cosmos_tabular_export_runs_container.read_item(
+            item=run_id,
+            partition_key=str(current_user_id or "").strip(),
+        )
+    except CosmosResourceNotFoundError as exc:
+        raise PermissionError("Artifact publication run is unavailable") from exc
+
+    manifest = run.get("artifact_set_manifest") if isinstance(run.get("artifact_set_manifest"), dict) else {}
+    if (
+        str(run.get("conversation_id") or "").strip() != conversation_id
+        or str(run.get("user_id") or "").strip() != str(current_user_id or "").strip()
+        or str(manifest.get("set_id") or "").strip() != set_id
+        or str(manifest.get("lifecycle_state") or "").strip().lower() != "completed"
+        or str(manifest.get("validation_state") or "").strip().lower() != GENERATED_CHAT_ARTIFACT_VALIDATION_VALIDATED
+        or _safe_positive_int(manifest.get("publication_generation")) < publication_generation
+    ):
+        raise PermissionError("Artifact is not published")
+
+    for member in list(manifest.get("members") or []):
+        if not isinstance(member, dict) or str(member.get("member_id") or "").strip() != member_id:
+            continue
+        if (
+            str(member.get("artifact_message_id") or "").strip() == str(message_item.get("id") or "").strip()
+            and str(member.get("lifecycle_state") or "").strip().lower() == GENERATED_CHAT_ARTIFACT_LIFECYCLE_PUBLISHED
+            and str(member.get("validation_state") or "").strip().lower() == GENERATED_CHAT_ARTIFACT_VALIDATION_VALIDATED
+        ):
+            return
+        break
+    raise PermissionError("Artifact is not published")
+
+
+def commit_generated_chat_artifact_publication_for_user(
+    current_user_id: str,
+    conversation_id: str,
+    artifact_message_id: str,
+    artifact_set_id: str,
+    artifact_member_id: str,
+    publication_generation: int,
+) -> Dict[str, Any]:
+    """Mark one staged generated artifact message as published after manifest validation."""
+    current_user_id = str(current_user_id or "").strip()
+    normalized_conversation_id = str(conversation_id or "").strip()
+    normalized_message_id = str(artifact_message_id or "").strip()
+    normalized_set_id = str(artifact_set_id or "").strip()
+    normalized_member_id = str(artifact_member_id or "").strip()
+    if not current_user_id or not normalized_conversation_id or not normalized_message_id:
+        raise ValueError("Artifact publication target is incomplete")
+
+    conversation_item = cosmos_conversations_container.read_item(
+        item=normalized_conversation_id,
+        partition_key=normalized_conversation_id,
+    )
+    if str(conversation_item.get("user_id") or "").strip() != current_user_id:
+        raise PermissionError("Forbidden")
+    message_item = cosmos_messages_container.read_item(
+        item=normalized_message_id,
+        partition_key=normalized_conversation_id,
+    )
+    metadata = message_item.get("metadata") if isinstance(message_item.get("metadata"), dict) else {}
+    if (
+        str(message_item.get("conversation_id") or "").strip() != normalized_conversation_id
+        or message_item.get("role") != "file"
+        or not metadata.get("is_generated_chat_artifact")
+        or str(metadata.get("generated_artifact_set_id") or "").strip() != normalized_set_id
+        or str(metadata.get("generated_artifact_member_id") or "").strip() != normalized_member_id
+    ):
+        raise PermissionError("Forbidden")
+
+    metadata.update({
+        "generated_artifact_lifecycle_state": GENERATED_CHAT_ARTIFACT_LIFECYCLE_PUBLISHED,
+        "generated_artifact_validation_state": GENERATED_CHAT_ARTIFACT_VALIDATION_VALIDATED,
+        "generated_artifact_publication_generation": _safe_positive_int(publication_generation),
+        "generated_artifact_committed_at": datetime.now(timezone.utc).isoformat(),
+    })
+    message_item["metadata"] = metadata
+    cosmos_messages_container.upsert_item(message_item)
+    return message_item
+
 
 
 def _resolve_group_upload_target_for_current_user(

--- a/application/single_app/functions_tabular_generated_exports.py
+++ b/application/single_app/functions_tabular_generated_exports.py
@@ -69,7 +69,10 @@ from functions_generated_file_exports import (
 from functions_model_endpoint_runtime import build_semantic_kernel_chat_service_for_model
 from functions_public_workspaces import get_user_visible_public_workspace_ids_from_settings
 from functions_settings import get_settings
-from functions_simplechat_operations import upload_generated_analysis_artifact_stream_for_user
+from functions_simplechat_operations import (
+    commit_generated_chat_artifact_publication_for_user,
+    upload_generated_analysis_artifact_stream_for_user,
+)
 from functions_tabular_semantic_validation import (
     TABULAR_SEMANTIC_VALIDATION_CONTRACT_VERSION,
     build_safe_semantic_validation_counts,
@@ -6686,12 +6689,34 @@ def _can_resume_run(run, settings=None):
     if status == TABULAR_EXPORT_STATUS_RUNNING:
         return _is_stale_running_run(run, settings or {})
     if status == TABULAR_EXPORT_STATUS_FAILED:
-        return _is_retryable_failed_run(run) or _has_exhausted_independent_batch_retries(run)
+        return (
+            _is_artifact_publication_recoverable(run)
+            or _is_retryable_failed_run(run)
+            or _has_exhausted_independent_batch_retries(run)
+        )
     return False
+
+
+def _is_artifact_publication_recoverable(run):
+    status = str((run or {}).get('status') or '').strip().lower()
+    manifest = (run or {}).get('artifact_set_manifest') if isinstance((run or {}).get('artifact_set_manifest'), dict) else {}
+    manifest_state = str(manifest.get('lifecycle_state') or '').strip().lower()
+    return bool(
+        status == TABULAR_EXPORT_STATUS_FAILED
+        and (run or {}).get('publishing_started_at')
+        and manifest_state in {
+            TABULAR_ARTIFACT_SET_LIFECYCLE_VALIDATING,
+            TABULAR_ARTIFACT_SET_LIFECYCLE_PUBLISHING,
+            TABULAR_ARTIFACT_SET_LIFECYCLE_ROLLBACK_REQUIRED,
+            TABULAR_ARTIFACT_SET_LIFECYCLE_FAILED,
+        }
+    )
 
 
 def _can_cancel_run(run):
     status = str((run or {}).get('status') or '').strip().lower()
+    if _is_artifact_publication_recoverable(run):
+        return True
     return not run.get('publishing_started_at') and status not in {
         TABULAR_EXPORT_STATUS_COMPLETED,
         TABULAR_EXPORT_STATUS_CANCELED,
@@ -7549,6 +7574,7 @@ def resume_tabular_generated_output_run(user_id, run_id):
         'lease_holder_id': None,
         'lease_expires_at': None,
         'next_attempt_at': now,
+        'publishing_started_at': None,
         'last_message': 'Manual resume queued; export will continue from completed checkpoints',
         'transient_failure_count': 0,
         'auto_retry_exhausted': False,
@@ -8448,6 +8474,40 @@ def _get_structured_artifact_member_id(run):
     return f'requested-{output_format}'
 
 
+def _get_structured_artifact_descriptors_for_run(run):
+    descriptors = [
+        descriptor for descriptor in _get_artifact_descriptors_for_run(run)
+        if descriptor.get('role') == ANALYSIS_ARTIFACT_ROLE_REQUESTED_OUTPUT
+    ]
+    if descriptors:
+        return descriptors
+    output_format = _normalize_tabular_artifact_format((run or {}).get('output_format'), fallback_format='json')
+    return [{
+        'member_id': f'requested-{output_format}',
+        'artifact_id': f'requested-{output_format}',
+        'role': ANALYSIS_ARTIFACT_ROLE_REQUESTED_OUTPUT,
+        'format': output_format,
+        'required': True,
+        'request_order': 0,
+    }]
+
+
+def _get_structured_export_artifact_for_member(run, member):
+    member_id = str((member or {}).get('member_id') or '').strip()
+    member_format = str((member or {}).get('format') or '').strip().lower()
+    for artifact in list((run or {}).get('structured_export_artifacts') or []):
+        if not isinstance(artifact, dict):
+            continue
+        if str(artifact.get('artifact_id') or artifact.get('member_id') or '').strip() == member_id:
+            return artifact
+    artifact = (run or {}).get('structured_export_artifact') if isinstance((run or {}).get('structured_export_artifact'), dict) else {}
+    if artifact and str(artifact.get('output_format') or '').strip().lower() == member_format:
+        return artifact
+    if artifact and not (run or {}).get('structured_export_artifacts'):
+        return artifact
+    return {}
+
+
 def _get_analysis_artifact_member_id(run):
     for descriptor in _get_artifact_descriptors_for_run(run):
         if descriptor.get('role') == ANALYSIS_ARTIFACT_ROLE_PRIMARY_ANALYSIS:
@@ -8594,7 +8654,7 @@ def _build_or_update_artifact_set_manifest(run):
                 validation_state='validated' if artifact.get('artifact_message_id') else None,
             )
         elif member.get('role') == ANALYSIS_ARTIFACT_ROLE_REQUESTED_OUTPUT:
-            artifact = run.get('structured_export_artifact') if isinstance(run.get('structured_export_artifact'), dict) else {}
+            artifact = _get_structured_export_artifact_for_member(run, member)
             if not artifact and _normalize_tabular_run_task_type(run.get('task_type')) != TABULAR_RUN_TASK_COMBINED:
                 artifact = run.get('final_artifact') if isinstance(run.get('final_artifact'), dict) else {}
             _merge_artifact_metadata_into_member(
@@ -8648,6 +8708,18 @@ def _set_artifact_set_member_state(run, member_id, artifact=None, lifecycle_stat
     return manifest
 
 
+def _build_artifact_member_upload_metadata(run, member_id):
+    manifest = _build_or_update_artifact_set_manifest(run)
+    return {
+        'artifact_run_id': run.get('id'),
+        'artifact_set_id': manifest.get('set_id'),
+        'artifact_member_id': member_id,
+        'artifact_lifecycle_state': TABULAR_ARTIFACT_MEMBER_LIFECYCLE_STAGED,
+        'artifact_validation_state': TABULAR_ARTIFACT_MEMBER_LIFECYCLE_STAGED,
+        'artifact_publication_generation': _safe_int(manifest.get('publication_generation'), minimum=0),
+    }
+
+
 def _publish_artifact_set_members(run, published_member_ids):
     published_ids = {str(member_id or '').strip() for member_id in list(published_member_ids or []) if member_id}
     manifest = _build_or_update_artifact_set_manifest(run)
@@ -8678,7 +8750,20 @@ def _publish_artifact_set_members(run, published_member_ids):
         if artifact_set_valid
         else TABULAR_ARTIFACT_SET_LIFECYCLE_ROLLBACK_REQUIRED
     )
-    manifest['publication_generation'] = _safe_int(manifest.get('publication_generation'), minimum=0) + 1
+    next_publication_generation = _safe_int(manifest.get('publication_generation'), minimum=0) + 1
+    if artifact_set_valid:
+        for member in manifest.get('members') or []:
+            if member.get('member_id') not in published_ids or not member.get('artifact_message_id'):
+                continue
+            commit_generated_chat_artifact_publication_for_user(
+                run.get('user_id'),
+                run.get('conversation_id'),
+                member.get('artifact_message_id'),
+                manifest.get('set_id'),
+                member.get('member_id'),
+                next_publication_generation,
+            )
+    manifest['publication_generation'] = next_publication_generation
     run['artifact_set_manifest'] = manifest
     return manifest
 
@@ -8759,12 +8844,17 @@ def _build_public_artifact_projection(artifact):
     }
 
 
-def _publish_structured_export_artifact(run):
-    output_format = normalize_generated_output_format(run.get('output_format'))
+def _publish_structured_export_artifact(run, descriptor=None):
+    descriptor = descriptor if isinstance(descriptor, dict) else {}
+    member_id = str(descriptor.get('member_id') or _get_structured_artifact_member_id(run)).strip()
+    output_format = normalize_generated_output_format(descriptor.get('format') or run.get('output_format'))
     generated_file_name = run.get('generated_file_name') or _build_generated_file_name(
         run.get('source_file_name'),
         output_format,
     )
+    run_for_output = dict(run)
+    run_for_output['output_format'] = output_format
+    run_for_output['generated_file_name'] = generated_file_name
     with tempfile.SpooledTemporaryFile(
         max_size=TABULAR_EXPORT_FINAL_SPOOL_MAX_MEMORY_BYTES,
         mode='w+b',
@@ -8776,18 +8866,21 @@ def _publish_structured_export_artifact(run):
             write_through=True,
         )
         try:
-            output_entry_count = _write_ordered_output_stream(run, text_output_stream)
-            post_run_summary = _build_compact_post_run_summary(run)
-            _authorize_tabular_export_run_execution(run)
-            _raise_if_tabular_export_canceled(run)
+            output_entry_count = _write_ordered_output_stream(run_for_output, text_output_stream)
+            post_run_summary = _build_compact_post_run_summary(run_for_output)
+            _authorize_tabular_export_run_execution(run_for_output)
+            _raise_if_tabular_export_canceled(run_for_output)
             if not run.get('publishing_started_at'):
                 run.update({
                     'publishing_started_at': _now_iso(),
                     'last_message': 'Final validation passed; publishing the generated artifact',
                 })
                 run = _replace_claimed_run(run)
-            _authorize_tabular_export_run_execution(run)
-            _revalidate_tabular_source_version_for_publication(run)
+                run_for_output.update(run)
+                run_for_output['output_format'] = output_format
+                run_for_output['generated_file_name'] = generated_file_name
+            _authorize_tabular_export_run_execution(run_for_output)
+            _revalidate_tabular_source_version_for_publication(run_for_output)
             text_output_stream.flush()
             output_size = binary_output_stream.tell()
             binary_output_stream.seek(0)
@@ -8800,21 +8893,64 @@ def _publish_structured_export_artifact(run):
                 capability='tabular',
                 output_format=output_format,
                 summary=post_run_summary,
-                artifact_idempotency_key=f"tabular-generated-output:{run.get('id')}",
+                artifact_idempotency_key=_build_artifact_member_idempotency_key(run, {
+                    'role': ANALYSIS_ARTIFACT_ROLE_REQUESTED_OUTPUT,
+                    'format': output_format,
+                    'member_id': member_id,
+                }),
+                artifact_lifecycle_metadata=_build_artifact_member_upload_metadata(
+                    run,
+                    member_id,
+                ),
             )
-            _raise_if_tabular_export_canceled(run)
+            _raise_if_tabular_export_canceled(run_for_output)
         finally:
             text_output_stream.detach()
 
     uploaded_message = upload_result.get('message') or {}
-    return run, uploaded_message, post_run_summary, output_entry_count, output_format, generated_file_name
+    artifact_metadata = _build_artifact_metadata(
+        uploaded_message,
+        generated_file_name,
+        output_format,
+        preview_rows=_build_structured_export_preview_rows(run_for_output),
+        suppress_assistant_text=True,
+    )
+    artifact_metadata['artifact_id'] = member_id
+    artifact_metadata['member_id'] = member_id
+    artifact_metadata['request_order'] = _safe_int(descriptor.get('request_order'), minimum=0)
+    return run, artifact_metadata, post_run_summary, output_entry_count, output_format, generated_file_name
+
+
+def _publish_structured_export_artifacts(run):
+    artifacts = []
+    first_summary = ''
+    first_entry_count = None
+    first_output_format = normalize_generated_output_format(run.get('output_format'))
+    first_file_name = run.get('generated_file_name') or _build_generated_file_name(
+        run.get('source_file_name'),
+        first_output_format,
+    )
+    for descriptor in _get_structured_artifact_descriptors_for_run(run):
+        run, artifact, post_run_summary, output_entry_count, output_format, generated_file_name = _publish_structured_export_artifact(
+            run,
+            descriptor=descriptor,
+        )
+        if first_entry_count is None:
+            first_entry_count = output_entry_count
+            first_summary = post_run_summary
+            first_output_format = output_format
+            first_file_name = generated_file_name
+        elif first_entry_count != output_entry_count:
+            raise ValueError('Structured artifact sibling row counts do not match')
+        artifacts.append(artifact)
+    return run, artifacts, first_summary, _safe_int(first_entry_count), first_output_format, first_file_name
 
 
 def _complete_run(run):
-    run, uploaded_message, post_run_summary, output_entry_count, output_format, generated_file_name = (
-        _publish_structured_export_artifact(run)
+    run, structured_artifacts, post_run_summary, output_entry_count, output_format, generated_file_name = (
+        _publish_structured_export_artifacts(run)
     )
-    artifact_preview_rows = _build_structured_export_preview_rows(run)
+    structured_artifact = structured_artifacts[0] if structured_artifacts else {}
     now = _now_iso()
     run.update({
         'status': TABULAR_EXPORT_STATUS_COMPLETED,
@@ -8828,17 +8964,16 @@ def _complete_run(run):
         'failed_chunk_count': 0,
         'last_message': 'Background structured export completed',
         'post_run_summary': post_run_summary,
-        'generated_file_name': uploaded_message.get('file_name') or generated_file_name,
-        'final_artifact': _build_artifact_metadata(
-            uploaded_message,
-            generated_file_name,
-            output_format,
-            preview_rows=artifact_preview_rows,
-            suppress_assistant_text=True,
-        ),
+        'generated_file_name': structured_artifact.get('file_name') or generated_file_name,
+        'structured_export_artifacts': structured_artifacts,
+        'structured_export_artifact': structured_artifact,
+        'final_artifact': structured_artifact,
         'estimated_remaining_seconds': 0,
     })
-    _publish_artifact_set_members(run, [_get_structured_artifact_member_id(run)])
+    _publish_artifact_set_members(
+        run,
+        [artifact.get('artifact_id') or artifact.get('member_id') for artifact in structured_artifacts],
+    )
     run.update(_build_generation_progress_contract_fields(
         run,
         run.get('batch_count'),
@@ -8860,8 +8995,8 @@ def _complete_run(run):
             'checkpointed_row_count': run.get('checkpointed_row_count'),
             'generation_contract_version': run.get('generation_contract_version'),
             'response_protocol_version': run.get('response_protocol_version'),
-            'artifact_message_id': uploaded_message.get('id'),
-            'generated_file_name': uploaded_message.get('file_name') or generated_file_name,
+            'artifact_message_id': structured_artifact.get('artifact_message_id'),
+            'generated_file_name': structured_artifact.get('file_name') or generated_file_name,
             **run.get('performance_summary', {}),
         },
         level=logging.INFO,
@@ -8968,6 +9103,10 @@ def _publish_analysis_artifact(run, final_summary):
             output_format='md',
             summary=final_summary.get('summary'),
             artifact_idempotency_key=f"tabular-hierarchical-analysis:{run.get('id')}",
+            artifact_lifecycle_metadata=_build_artifact_member_upload_metadata(
+                run,
+                _get_analysis_artifact_member_id(run),
+            ),
         )
         _raise_if_tabular_export_canceled(run)
 
@@ -9033,16 +9172,10 @@ def _publish_combined_structured_export_phase(run):
     if isinstance(run.get('structured_export_artifact'), dict) and run.get('structured_export_artifact'):
         return run
 
-    run, uploaded_message, post_run_summary, output_entry_count, output_format, generated_file_name = (
-        _publish_structured_export_artifact(run)
+    run, structured_artifacts, post_run_summary, output_entry_count, output_format, generated_file_name = (
+        _publish_structured_export_artifacts(run)
     )
-    structured_artifact = _build_artifact_metadata(
-        uploaded_message,
-        generated_file_name,
-        output_format,
-        preview_rows=_build_structured_export_preview_rows(run),
-        suppress_assistant_text=True,
-    )
+    structured_artifact = structured_artifacts[0] if structured_artifacts else {}
     now = _now_iso()
     run.update({
         'updated_at': now,
@@ -9054,18 +9187,20 @@ def _publish_combined_structured_export_phase(run):
         'analysis_phase': 'reducing',
         'last_message': 'Combined structured export published; reducing tabular analysis summaries',
         'post_run_export_summary': post_run_summary,
-        'generated_file_name': uploaded_message.get('file_name') or generated_file_name,
+        'generated_file_name': structured_artifact.get('file_name') or generated_file_name,
+        'structured_export_artifacts': structured_artifacts,
         'structured_export_artifact': structured_artifact,
         'final_artifact': structured_artifact,
         'estimated_remaining_seconds': None,
     })
-    _set_artifact_set_member_state(
-        run,
-        _get_structured_artifact_member_id(run),
-        artifact=structured_artifact,
-        lifecycle_state=TABULAR_ARTIFACT_MEMBER_LIFECYCLE_STAGED,
-        validation_state='validated',
-    )
+    for artifact in structured_artifacts:
+        _set_artifact_set_member_state(
+            run,
+            artifact.get('artifact_id') or artifact.get('member_id'),
+            artifact=artifact,
+            lifecycle_state=TABULAR_ARTIFACT_MEMBER_LIFECYCLE_STAGED,
+            validation_state='validated',
+        )
     run = _replace_claimed_run(run)
     log_event(
         '[TABULAR_GENERATED_OUTPUT] Combined structured export artifact published',
@@ -9077,8 +9212,8 @@ def _publish_combined_structured_export_phase(run):
             'output_format': output_format,
             'row_count': output_entry_count,
             'batch_count': run.get('batch_count'),
-            'artifact_message_id': uploaded_message.get('id'),
-            'generated_file_name': uploaded_message.get('file_name') or generated_file_name,
+            'artifact_message_id': structured_artifact.get('artifact_message_id'),
+            'generated_file_name': structured_artifact.get('file_name') or generated_file_name,
         },
         level=logging.INFO,
     )
@@ -9105,14 +9240,18 @@ def _complete_combined_analysis_run(run, final_summary):
             suppress_assistant_text=True,
         )
 
+    structured_artifacts = list(run.get('structured_export_artifacts') or [])
     structured_artifact = run.get('structured_export_artifact') or run.get('final_artifact') or {}
-    _set_artifact_set_member_state(
-        run,
-        _get_structured_artifact_member_id(run),
-        artifact=structured_artifact,
-        lifecycle_state=TABULAR_ARTIFACT_MEMBER_LIFECYCLE_STAGED,
-        validation_state='validated',
-    )
+    if not structured_artifacts and structured_artifact:
+        structured_artifacts = [structured_artifact]
+    for artifact in structured_artifacts:
+        _set_artifact_set_member_state(
+            run,
+            artifact.get('artifact_id') or artifact.get('member_id') or _get_structured_artifact_member_id(run),
+            artifact=artifact,
+            lifecycle_state=TABULAR_ARTIFACT_MEMBER_LIFECYCLE_STAGED,
+            validation_state='validated',
+        )
     _set_artifact_set_member_state(
         run,
         _get_analysis_artifact_member_id(run),
@@ -9135,17 +9274,24 @@ def _complete_combined_analysis_run(run, final_summary):
         'last_message': 'Background combined tabular analysis and export completed',
         'post_run_summary': final_summary.get('summary'),
         'analysis_generated_file_name': uploaded_message.get('file_name') or generated_file_name,
+        'structured_export_artifacts': structured_artifacts,
         'structured_export_artifact': structured_artifact,
         'analysis_artifact': analysis_artifact,
         'combined_artifacts': [
-            artifact for artifact in (analysis_artifact, structured_artifact) if artifact
+            artifact for artifact in [analysis_artifact, *structured_artifacts] if artifact
         ],
         'final_artifact': analysis_artifact or structured_artifact,
         'estimated_remaining_seconds': 0,
     })
     _publish_artifact_set_members(
         run,
-        [_get_analysis_artifact_member_id(run), _get_structured_artifact_member_id(run)],
+        [
+            _get_analysis_artifact_member_id(run),
+            *[
+                artifact.get('artifact_id') or artifact.get('member_id')
+                for artifact in structured_artifacts
+            ],
+        ],
     )
     run.update(_build_generation_progress_contract_fields(
         run,

--- a/application/single_app/functions_tabular_orchestration.py
+++ b/application/single_app/functions_tabular_orchestration.py
@@ -569,13 +569,12 @@ def plan_tabular_request(
         action_mode=normalized_action_mode,
     )
     output_format = structured_output_formats[0] if structured_output_formats else None
-    unsupported_multi_artifact_request = len(structured_output_formats) > 1
     analysis_durable_capability_disabled = bool(
         analysis_required
         and generated_output_requested
         and not settings_flag_enabled(settings, "enable_tabular_hierarchical_analysis", False)
     )
-    if unsupported_multi_artifact_request or analysis_durable_capability_disabled:
+    if analysis_durable_capability_disabled:
         durable_task_type = None
     execution_contract = durable_task_type or TABULAR_EXECUTION_CONTRACT_FOREGROUND_AGGREGATE
     source_coverage = _build_source_coverage(normalized_contexts)
@@ -610,10 +609,6 @@ def plan_tabular_request(
     if durable_task_type:
         execution_state = TABULAR_EXECUTION_STATE_DECLINED
         reason_code = "durable_intent"
-    elif unsupported_multi_artifact_request:
-        execution_state = TABULAR_EXECUTION_STATE_DECLINED
-        reason_code = "unsupported_multi_artifact_request"
-        safe_failure_details = "Multiple durable tabular artifact formats are not yet supported for one request."
     elif analysis_durable_capability_disabled:
         execution_state = TABULAR_EXECUTION_STATE_DECLINED
         reason_code = "analysis_required_durable_capability_disabled"

--- a/application/single_app/route_enhanced_citations.py
+++ b/application/single_app/route_enhanced_citations.py
@@ -24,7 +24,11 @@ from functions_visio import render_vsdx_page_preview
 from functions_group import check_group_status_allows_operation, find_group_by_id, get_user_groups, require_active_group
 from functions_notifications import create_group_notification, create_notification, create_public_workspace_notification
 from functions_public_workspaces import check_public_workspace_status_allows_operation, get_user_visible_public_workspace_ids_from_settings, require_active_public_workspace
-from functions_simplechat_operations import download_blob_content, upload_generated_document_for_current_user
+from functions_simplechat_operations import (
+    assert_generated_chat_artifact_is_published_for_user,
+    download_blob_content,
+    upload_generated_document_for_current_user,
+)
 from swagger_wrapper import swagger_route, get_auth_security
 from config import CLIENTS, storage_account_user_documents_container_name, storage_account_group_documents_container_name, storage_account_public_documents_container_name, storage_account_personal_chat_container_name, IMAGE_EXTENSIONS, VIDEO_EXTENSIONS, AUDIO_EXTENSIONS, TABULAR_EXTENSIONS, VISIO_EXTENSIONS, cosmos_messages_container, cosmos_conversations_container
 from functions_debug import debug_print
@@ -65,6 +69,7 @@ def _get_authorized_chat_artifact_message(user_id, conversation_id, message_id):
     if not str(message_item.get('blob_container') or '').strip() or not str(message_item.get('blob_path') or '').strip():
         raise LookupError('Chat artifact content is unavailable')
 
+    assert_generated_chat_artifact_is_published_for_user(user_id, message_item)
     return message_item
 
 

--- a/docs/explanation/features/ANALYZE_DELIVERABLE_CONTRACT.md
+++ b/docs/explanation/features/ANALYZE_DELIVERABLE_CONTRACT.md
@@ -16,6 +16,8 @@ Phase 7A stabilization updated in version: **0.250.178**
 
 Phase 7B correctness updated in version: **0.250.179**
 
+Phase 7C publication updated in version: **0.250.180**
+
 ## Overview
 
 The Analyze deliverable contract defines a server-owned, versioned plan for analysis artifacts before production routing changes are made. It records whether an action requires a primary Markdown analysis artifact, which sibling artifacts were explicitly requested, the public structured schema, row cardinality, ordering, transformation mode, validation profile, and publication policy.
@@ -33,6 +35,8 @@ Phase 7 adds an explicit rollout state for new shared tabular parity assignments
 Phase 7A restores explicit Word/DOCX serialization of authorized current-turn non-tabular function-result rows. The passthrough guard still rejects derived requests before serialization, keeps tabular tool rows on their coverage-aware durable path, and omits sensitive fields. It also restores the cumulative lifecycle and scale harnesses to the current schema, planner, and artifact-set contracts.
 
 Phase 7B makes the production durable runner own rule-faithful structured output planning. Generation plan version 2 carries one normalized allowlisted transformation specification, deterministic or semantic field ownership, and an independent bounded review result. Active plans update the persisted deliverable contract before row generation. Deterministic fields execute server-side, semantic fields receive isolated field-level verification, and only failed or uncertain row-field pairs enter bounded targeted repair before canonical checkpoints are written.
+
+Phase 7C makes artifact-set publication the visibility boundary for new generated tabular artifacts. Uploaded artifact messages are staged with server-owned run, set, member, and publication-generation metadata. Direct download and workspace promotion reauthorize the caller against the committed run manifest before serving the blob. Completed manifests commit every required member in one publication generation, while staged, rolled-back, stale-generation, or incomplete members remain inaccessible through direct artifact routes. The same validated checkpoint set can now publish multiple requested durable structured siblings, such as JSON and XML, in request order.
 
 ## Dependencies
 
@@ -229,7 +233,7 @@ The committed 200-row fixture builder in `functional_tests/test_support/analyze_
 - Analyze requires Markdown while Search does not receive automatic Markdown.
 - The requested structured contract is shared across Search and Analyze.
 - Analyze plus CSV maps to Markdown plus CSV and selects `combined` when hierarchical analysis is enabled.
-- Analyze plus JSON and XML preserves both requested siblings in order and fails before unsupported multi-artifact durable execution.
+- Analyze plus JSON and XML preserves both requested siblings in order and selects durable combined execution when hierarchical analysis is enabled.
 - Analyze plus structured output does not silently downgrade to `structured_export` when the hierarchical capability is disabled.
 - Bounded document Analyze publishes Markdown, and explicit JSON is a sibling rather than a replacement.
 - JSON serialization round trips and unknown additive fields are ignored for forward compatibility.
@@ -272,4 +276,4 @@ pre-checkpoint ownership, and safe count-only batch summaries.
 
 ## Known Limitations
 
-Phase 7B does not yet expand durable execution to every requested format or add full cleanup sweepers and direct-route lifecycle authorization for abandoned staged members. Those publication concerns remain Phase 7C work.
+Phase 7C does not yet add long-running cleanup sweepers for abandoned staged members. Broader lifecycle race, authenticated UI, and canary validation remain Phase 7D work.

--- a/docs/explanation/fixes/ANALYZE_ARTIFACT_PHASE_7C_PUBLICATION_FIX.md
+++ b/docs/explanation/fixes/ANALYZE_ARTIFACT_PHASE_7C_PUBLICATION_FIX.md
@@ -1,0 +1,82 @@
+# Analyze Artifact Phase 7C Publication Fix
+
+Fixed in version: **0.250.180**
+
+Related issue: **#1233**
+
+## Issue Description
+
+Combined durable Analyze runs could stage a requested structured artifact before
+the Markdown analysis member was validated. Public status hid the staged member,
+but direct generated-artifact download and workspace-promotion routes authorized
+only conversation ownership and generated-artifact metadata. A user with the
+staged artifact message id could therefore access a sibling before the required
+artifact set completed.
+
+Multi-format durable requests were also rejected even though the artifact-set
+contract could represent multiple requested siblings.
+
+## Root Cause Analysis
+
+Generated artifact messages did not carry server-owned artifact-set lifecycle
+metadata, and direct artifact routes had no way to distinguish legacy published
+artifacts from new staged artifact-set members. Publication validation updated
+the run manifest but did not commit the backing generated message metadata.
+
+The durable publisher also serialized only one structured requested format from
+the canonical checkpoint set.
+
+## Technical Details
+
+Files modified:
+
+- `application/single_app/functions_simplechat_operations.py`
+- `application/single_app/functions_tabular_generated_exports.py`
+- `application/single_app/functions_tabular_orchestration.py`
+- `application/single_app/route_enhanced_citations.py`
+- `functional_tests/test_generated_artifact_lifecycle_authorization.py`
+- `functional_tests/test_tabular_phase5_artifact_set_lifecycle.py`
+- `functional_tests/test_analyze_deliverable_contract.py`
+- `functional_tests/test_tabular_row_orchestration_scale.py`
+- `docs/explanation/features/ANALYZE_DELIVERABLE_CONTRACT.md`
+- `application/single_app/config.py`
+
+New generated tabular artifact messages include run id, artifact-set id,
+member id, lifecycle state, validation state, and publication generation.
+Legacy generated artifacts without those fields retain existing visibility.
+
+Direct generated-artifact download and promotion now reauthorize new
+artifact-set members against the owning run's completed and validated manifest.
+The route rejects staged, rolled-back, stale-generation, incomplete, or
+cross-object members before serving or promoting blob content.
+
+The durable structured publisher now serializes each requested CSV, JSON, or XML
+sibling from the same validated ordered checkpoints. The manifest publishes all
+required members in one generation and preserves Markdown as the primary Analyze
+artifact.
+
+Failed post-staging publication states can pass the resume/cancel guard when
+their artifact-set manifest is still validating, publishing, failed, or
+rollback-required, preventing runs from being stranded behind
+`publishing_started_at`.
+
+## Validation
+
+- Staged generated artifacts are rejected by direct artifact authorization.
+- Legacy generated artifacts without artifact-set metadata remain accessible.
+- Committed artifacts require a completed, validated run manifest with matching
+  set id, member id, message id, and publication generation.
+- Valid combined artifact sets commit every member in one publication generation.
+- Invalid required sets fail closed without committing backing messages.
+- Analyze plus multiple requested structured formats selects durable combined
+  execution and publishes Markdown plus each requested sibling in order.
+- The cumulative scale suite passes through 30,000-row bounded finalization,
+  100,000-row planning and hardening, publication idempotency, cancellation,
+  restart, authorization, and route suppression checks.
+
+## Impact Analysis
+
+New artifact-set members are no longer directly accessible before the set is
+valid and completed. Users can request multiple durable structured siblings for
+supported formats without rerunning generation. Existing generated artifacts and
+old run readers are preserved.

--- a/functional_tests/test_analyze_deliverable_contract.py
+++ b/functional_tests/test_analyze_deliverable_contract.py
@@ -2,8 +2,8 @@
 # test_analyze_deliverable_contract.py
 """
 Functional test for Analyze deliverable contract baselines.
-Version: 0.250.172
-Implemented in: 0.250.171
+Version: 0.250.180
+Implemented in: 0.250.171; multi-format durable admission updated in 0.250.180
 
 This test ensures Phase 1 defines a versioned Analyze deliverable contract,
 keeps Analyze Markdown distinct from requested structured siblings, and uses
@@ -264,14 +264,17 @@ def test_phase2_planner_normalizes_ordered_artifact_intent():
         action_mode="analyze",
         settings={"enable_tabular_hierarchical_analysis": True},
     )
+    assert_app_version_at_least("0.250.180")
     assert multi_plan["requested_output_formats"] == ["json", "xml"]
     assert [artifact["format"] for artifact in multi_plan["deliverable_contract"]["requested_artifacts"]] == [
         "md",
         "json",
         "xml",
     ]
+    assert multi_plan["durable_task_type"] == "combined"
+    assert multi_plan["execution_contract"] == "combined"
     assert multi_plan["execution_state"] == "declined"
-    assert multi_plan["reason_code"] == "unsupported_multi_artifact_request"
+    assert multi_plan["reason_code"] == "durable_intent"
 
     disabled_plan = plan_tabular_request(
         "Analyze every row and create a CSV artifact.",

--- a/functional_tests/test_generated_artifact_lifecycle_authorization.py
+++ b/functional_tests/test_generated_artifact_lifecycle_authorization.py
@@ -1,0 +1,302 @@
+# test_generated_artifact_lifecycle_authorization.py
+#!/usr/bin/env python3
+"""
+Functional test for generated artifact lifecycle authorization.
+Version: 0.250.180
+Implemented in: 0.250.180
+
+This test ensures staged artifact-set members are not directly downloadable or
+promotable, committed members require a completed artifact-set manifest, and
+legacy generated artifacts without artifact-set metadata remain compatible.
+"""
+
+import ast
+from pathlib import Path
+from typing import Any, Dict, Optional
+from datetime import datetime, timezone
+
+from test_support.versioning import assert_app_version_at_least
+
+
+ROOT = Path(__file__).resolve().parents[1]
+APP_ROOT = ROOT / "application" / "single_app"
+OPERATIONS_FILE = APP_ROOT / "functions_simplechat_operations.py"
+ROUTE_FILE = APP_ROOT / "route_enhanced_citations.py"
+EXPORT_MODULE = APP_ROOT / "functions_tabular_generated_exports.py"
+IMPLEMENTED_VERSION = "0.250.180"
+
+
+class FakeNotFound(Exception):
+    pass
+
+
+class FakeContainer:
+    def __init__(self, items=None):
+        self.items = dict(items or {})
+        self.upserted = []
+
+    def read_item(self, item, partition_key):
+        del partition_key
+        if item not in self.items:
+            raise FakeNotFound(item)
+        return self.items[item]
+
+    def upsert_item(self, body):
+        self.items[body["id"]] = body
+        self.upserted.append(body)
+        return body
+
+
+def load_operation_helpers(conversation_item, message_item, run_item=None):
+    source = OPERATIONS_FILE.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(OPERATIONS_FILE))
+    helper_names = {
+        "_safe_positive_int",
+        "_build_generated_chat_artifact_lifecycle_metadata",
+        "_build_generated_chat_artifact_lifecycle_response",
+        "_generated_artifact_has_lifecycle_contract",
+        "assert_generated_chat_artifact_is_published_for_user",
+        "commit_generated_chat_artifact_publication_for_user",
+    }
+    selected_nodes = []
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            assigned_names = {target.id for target in node.targets if isinstance(target, ast.Name)}
+            if any(name.startswith("GENERATED_CHAT_ARTIFACT_") for name in assigned_names):
+                selected_nodes.append(node)
+        elif isinstance(node, ast.FunctionDef) and node.name in helper_names:
+            selected_nodes.append(node)
+    namespace = {
+        "Any": Any,
+        "Dict": Dict,
+        "Optional": Optional,
+        "datetime": datetime,
+        "timezone": timezone,
+        "CosmosResourceNotFoundError": FakeNotFound,
+        "cosmos_conversations_container": FakeContainer({"conversation-1": conversation_item}),
+        "cosmos_messages_container": FakeContainer({"message-1": message_item}),
+        "cosmos_tabular_export_runs_container": FakeContainer({"run-1": run_item} if run_item else {}),
+    }
+    module = ast.Module(body=selected_nodes, type_ignores=[])
+    ast.fix_missing_locations(module)
+    exec(compile(module, str(OPERATIONS_FILE), "exec"), namespace)
+    return namespace
+
+
+def load_route_helper(message_item, publication_assertion):
+    source = ROUTE_FILE.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(ROUTE_FILE))
+    helper = next(
+        node for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == "_get_authorized_chat_artifact_message"
+    )
+    namespace = {
+        "CosmosResourceNotFoundError": FakeNotFound,
+        "cosmos_conversations_container": FakeContainer({"conversation-1": {"user_id": "user-1"}}),
+        "cosmos_messages_container": FakeContainer({"message-1": message_item}),
+        "assert_generated_chat_artifact_is_published_for_user": publication_assertion,
+    }
+    module = ast.Module(body=[helper], type_ignores=[])
+    ast.fix_missing_locations(module)
+    exec(compile(module, str(ROUTE_FILE), "exec"), namespace)
+    return namespace["_get_authorized_chat_artifact_message"]
+
+
+def load_recovery_helpers():
+    source = EXPORT_MODULE.read_text(encoding="utf-8")
+    tree = ast.parse(source, filename=str(EXPORT_MODULE))
+    helper_names = {
+        "_is_artifact_publication_recoverable",
+        "_can_resume_run",
+        "_can_cancel_run",
+    }
+    selected_nodes = [
+        node for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name in helper_names
+    ]
+    namespace = {
+        "TABULAR_EXPORT_STATUS_COMPLETED": "completed",
+        "TABULAR_EXPORT_STATUS_CANCELED": "canceled",
+        "TABULAR_EXPORT_STATUS_FAILED": "failed",
+        "TABULAR_EXPORT_STATUS_QUEUED": "queued",
+        "TABULAR_EXPORT_STATUS_RUNNING": "running",
+        "TABULAR_ARTIFACT_SET_LIFECYCLE_VALIDATING": "validating",
+        "TABULAR_ARTIFACT_SET_LIFECYCLE_PUBLISHING": "publishing",
+        "TABULAR_ARTIFACT_SET_LIFECYCLE_ROLLBACK_REQUIRED": "rollback_required",
+        "TABULAR_ARTIFACT_SET_LIFECYCLE_FAILED": "failed",
+        "_is_waiting_for_retry": lambda run: False,
+        "_is_due_queued_retry_run": lambda run: False,
+        "_is_stale_queued_run": lambda run, settings: False,
+        "_is_stale_running_run": lambda run, settings: False,
+        "_is_retryable_failed_run": lambda run: False,
+        "_has_exhausted_independent_batch_retries": lambda run: False,
+    }
+    module = ast.Module(body=selected_nodes, type_ignores=[])
+    ast.fix_missing_locations(module)
+    exec(compile(module, str(EXPORT_MODULE), "exec"), namespace)
+    return namespace
+
+
+def build_message(metadata):
+    return {
+        "id": "message-1",
+        "conversation_id": "conversation-1",
+        "role": "file",
+        "file_content_source": "blob",
+        "blob_container": "chat",
+        "blob_path": "user-1/conversation-1/generated/message-1/output.csv",
+        "metadata": {
+            "is_generated_chat_artifact": True,
+            **metadata,
+        },
+    }
+
+
+def test_lifecycle_metadata_defaults_to_staged_and_legacy_is_visible():
+    assert_app_version_at_least(IMPLEMENTED_VERSION)
+    helpers = load_operation_helpers({"user_id": "user-1"}, build_message({}))
+    metadata = helpers["_build_generated_chat_artifact_lifecycle_metadata"]({
+        "artifact_run_id": "run-1",
+        "artifact_set_id": "set-1",
+        "artifact_member_id": "requested-csv",
+    })
+    assert metadata["generated_artifact_lifecycle_state"] == "staged"
+    assert metadata["generated_artifact_publication_generation"] == 0
+
+    helpers["assert_generated_chat_artifact_is_published_for_user"]("user-1", build_message({}))
+
+
+def test_staged_artifact_is_not_published_until_manifest_commits():
+    assert_app_version_at_least(IMPLEMENTED_VERSION)
+    staged_message = build_message({
+        "generated_artifact_run_id": "run-1",
+        "generated_artifact_set_id": "set-1",
+        "generated_artifact_member_id": "requested-csv",
+        "generated_artifact_lifecycle_state": "staged",
+        "generated_artifact_validation_state": "staged",
+        "generated_artifact_publication_generation": 0,
+    })
+    helpers = load_operation_helpers({"user_id": "user-1"}, staged_message)
+    try:
+        helpers["assert_generated_chat_artifact_is_published_for_user"]("user-1", staged_message)
+    except PermissionError:
+        pass
+    else:
+        raise AssertionError("Staged artifact was authorized for direct access")
+
+
+def test_committed_artifact_requires_completed_manifest_member():
+    assert_app_version_at_least(IMPLEMENTED_VERSION)
+    published_message = build_message({
+        "generated_artifact_run_id": "run-1",
+        "generated_artifact_set_id": "set-1",
+        "generated_artifact_member_id": "requested-csv",
+        "generated_artifact_lifecycle_state": "published",
+        "generated_artifact_validation_state": "validated",
+        "generated_artifact_publication_generation": 2,
+    })
+    run = {
+        "id": "run-1",
+        "user_id": "user-1",
+        "conversation_id": "conversation-1",
+        "artifact_set_manifest": {
+            "set_id": "set-1",
+            "lifecycle_state": "completed",
+            "validation_state": "validated",
+            "publication_generation": 2,
+            "members": [{
+                "member_id": "requested-csv",
+                "artifact_message_id": "message-1",
+                "lifecycle_state": "published",
+                "validation_state": "validated",
+            }],
+        },
+    }
+    helpers = load_operation_helpers({"user_id": "user-1"}, published_message, run)
+    helpers["assert_generated_chat_artifact_is_published_for_user"]("user-1", published_message)
+
+
+def test_commit_updates_message_lifecycle_metadata():
+    assert_app_version_at_least(IMPLEMENTED_VERSION)
+    staged_message = build_message({
+        "generated_artifact_run_id": "run-1",
+        "generated_artifact_set_id": "set-1",
+        "generated_artifact_member_id": "analysis",
+        "generated_artifact_lifecycle_state": "staged",
+        "generated_artifact_validation_state": "staged",
+        "generated_artifact_publication_generation": 0,
+    })
+    helpers = load_operation_helpers({"user_id": "user-1"}, staged_message)
+    committed = helpers["commit_generated_chat_artifact_publication_for_user"](
+        "user-1",
+        "conversation-1",
+        "message-1",
+        "set-1",
+        "analysis",
+        3,
+    )
+    metadata = committed["metadata"]
+    assert metadata["generated_artifact_lifecycle_state"] == "published"
+    assert metadata["generated_artifact_validation_state"] == "validated"
+    assert metadata["generated_artifact_publication_generation"] == 3
+    assert metadata["generated_artifact_committed_at"]
+
+
+def test_route_helper_enforces_publication_gate():
+    assert_app_version_at_least(IMPLEMENTED_VERSION)
+    calls = []
+
+    def deny_staged(user_id, message_item):
+        calls.append((user_id, message_item["id"]))
+        raise PermissionError("Artifact is not published")
+
+    route_helper = load_route_helper(build_message({"generated_artifact_lifecycle_state": "staged"}), deny_staged)
+    try:
+        route_helper("user-1", "conversation-1", "message-1")
+    except PermissionError:
+        pass
+    else:
+        raise AssertionError("Route helper returned a staged artifact")
+    assert calls == [("user-1", "message-1")]
+
+
+def test_failed_post_staging_runs_can_resume_or_cancel():
+    assert_app_version_at_least(IMPLEMENTED_VERSION)
+    helpers = load_recovery_helpers()
+    recoverable_run = {
+        "status": "failed",
+        "publishing_started_at": "2026-08-12T00:00:00+00:00",
+        "artifact_set_manifest": {"lifecycle_state": "rollback_required"},
+    }
+    completed_failed_run = {
+        "status": "failed",
+        "publishing_started_at": "2026-08-12T00:00:00+00:00",
+        "artifact_set_manifest": {"lifecycle_state": "completed"},
+    }
+    running_publish_run = {
+        "status": "running",
+        "publishing_started_at": "2026-08-12T00:00:00+00:00",
+        "artifact_set_manifest": {"lifecycle_state": "publishing"},
+    }
+
+    assert helpers["_is_artifact_publication_recoverable"](recoverable_run) is True
+    assert helpers["_can_resume_run"](recoverable_run, {}) is True
+    assert helpers["_can_cancel_run"](recoverable_run) is True
+    assert helpers["_can_resume_run"](completed_failed_run, {}) is False
+    assert helpers["_can_cancel_run"](running_publish_run) is False
+
+
+if __name__ == "__main__":
+    tests = [
+        test_lifecycle_metadata_defaults_to_staged_and_legacy_is_visible,
+        test_staged_artifact_is_not_published_until_manifest_commits,
+        test_committed_artifact_requires_completed_manifest_member,
+        test_commit_updates_message_lifecycle_metadata,
+        test_route_helper_enforces_publication_gate,
+        test_failed_post_staging_runs_can_resume_or_cancel,
+    ]
+    for test in tests:
+        print(f"Running {test.__name__}...")
+        test()
+        print(f"PASS {test.__name__}")
+    print(f"Results: {len(tests)}/{len(tests)} tests passed")

--- a/functional_tests/test_tabular_phase5_artifact_set_lifecycle.py
+++ b/functional_tests/test_tabular_phase5_artifact_set_lifecycle.py
@@ -2,8 +2,8 @@
 # test_tabular_phase5_artifact_set_lifecycle.py
 """
 Functional test for Phase 5 tabular artifact-set lifecycle publication.
-Version: 0.250.175
-Implemented in: 0.250.175
+Version: 0.250.180
+Implemented in: 0.250.175; publication commit compatibility updated in 0.250.180
 
 This test ensures durable tabular artifact sets hide staged members until the
 whole required set is valid, publish Analyze Markdown as the primary member,
@@ -32,7 +32,7 @@ from functions_analysis_deliverables import (  # noqa: E402
 )
 
 
-IMPLEMENTED_VERSION = "0.250.175"
+IMPLEMENTED_VERSION = "0.250.180"
 
 
 def load_artifact_set_helpers():
@@ -51,6 +51,7 @@ def load_artifact_set_helpers():
         "_get_artifact_descriptors_for_run",
         "_get_primary_artifact_member_id",
         "_get_structured_artifact_member_id",
+        "_get_structured_export_artifact_for_member",
         "_get_analysis_artifact_member_id",
         "_build_artifact_member_idempotency_key",
         "_build_artifact_set_member",
@@ -68,9 +69,23 @@ def load_artifact_set_helpers():
         node for node in tree.body
         if isinstance(node, ast.FunctionDef) and node.name in helper_names
     ]
+    publication_commits = []
+
+    def commit_publication(current_user_id, conversation_id, artifact_message_id, artifact_set_id, artifact_member_id, publication_generation):
+        publication_commits.append({
+            "current_user_id": current_user_id,
+            "conversation_id": conversation_id,
+            "artifact_message_id": artifact_message_id,
+            "artifact_set_id": artifact_set_id,
+            "artifact_member_id": artifact_member_id,
+            "publication_generation": publication_generation,
+        })
+
     namespace = {
         "re": re,
         "validate_analysis_artifact_set": validate_analysis_artifact_set,
+        "commit_generated_chat_artifact_publication_for_user": commit_publication,
+        "publication_commits": publication_commits,
         "ANALYSIS_ARTIFACT_ROLE_PRIMARY_ANALYSIS": ANALYSIS_ARTIFACT_ROLE_PRIMARY_ANALYSIS,
         "ANALYSIS_ARTIFACT_ROLE_REQUESTED_OUTPUT": ANALYSIS_ARTIFACT_ROLE_REQUESTED_OUTPUT,
         "ANALYSIS_ARTIFACT_ROLE_SUPPORTING_OUTPUT": "supporting_output",
@@ -140,6 +155,15 @@ def build_combined_contract():
     return build_analysis_deliverable_contract(
         action_mode="analyze",
         requested_output_format="csv",
+        source_fingerprint="source-fingerprint",
+        request_fingerprint="request-fingerprint",
+    ).to_dict()
+
+
+def build_multi_format_combined_contract():
+    return build_analysis_deliverable_contract(
+        action_mode="analyze",
+        requested_output_formats=["json", "xml"],
         source_fingerprint="source-fingerprint",
         request_fingerprint="request-fingerprint",
     ).to_dict()
@@ -223,6 +247,24 @@ def test_completed_combined_set_publishes_markdown_primary_then_sibling():
     assert manifest["validation_state"] == "validated"
     assert manifest["primary_artifact_id"] == "analysis"
     assert manifest["publication_generation"] == 1
+    assert helpers["publication_commits"] == [
+        {
+            "current_user_id": "user-1",
+            "conversation_id": "conversation-1",
+            "artifact_message_id": "md-message",
+            "artifact_set_id": "tabular-artifact-set:run-1",
+            "artifact_member_id": "analysis",
+            "publication_generation": 1,
+        },
+        {
+            "current_user_id": "user-1",
+            "conversation_id": "conversation-1",
+            "artifact_message_id": "csv-message",
+            "artifact_set_id": "tabular-artifact-set:run-1",
+            "artifact_member_id": "requested-csv",
+            "publication_generation": 1,
+        },
+    ]
 
     public_artifacts = helpers["_build_public_generated_artifacts_from_manifest"](run, manifest)
     assert [artifact["artifact_id"] for artifact in public_artifacts] == ["analysis", "requested-csv"]
@@ -230,6 +272,43 @@ def test_completed_combined_set_publishes_markdown_primary_then_sibling():
     assert public_artifacts[0]["output_format"] == "md"
     assert public_artifacts[1]["role"] == ANALYSIS_ARTIFACT_ROLE_REQUESTED_OUTPUT
     assert public_artifacts[1]["output_format"] == "csv"
+
+
+def test_completed_combined_set_publishes_multiple_requested_siblings():
+    print("Testing completed multi-sibling artifact-set publication order...")
+    assert_app_version_at_least("0.250.180")
+    helpers = load_artifact_set_helpers()
+    run = build_run(status="running")
+    run["output_format"] = "json"
+    run["tabular_planner_metadata"]["deliverable_contract"] = build_multi_format_combined_contract()
+    json_artifact = build_artifact("json-message", "financial_review.json", "json")
+    json_artifact["artifact_id"] = "requested-json"
+    xml_artifact = build_artifact("xml-message", "financial_review.xml", "xml")
+    xml_artifact["artifact_id"] = "requested-xml"
+    analysis_artifact = build_artifact("md-message", "financial_review.md", "md")
+
+    run["structured_export_artifacts"] = [json_artifact, xml_artifact]
+    run["structured_export_artifact"] = json_artifact
+    run["analysis_artifact"] = analysis_artifact
+    run["status"] = "completed"
+
+    manifest = helpers["_publish_artifact_set_members"](run, ["analysis", "requested-json", "requested-xml"])
+    assert manifest["lifecycle_state"] == "completed"
+    assert manifest["validation_state"] == "validated"
+    assert manifest["publication_generation"] == 1
+    assert [commit["artifact_member_id"] for commit in helpers["publication_commits"]] == [
+        "analysis",
+        "requested-json",
+        "requested-xml",
+    ]
+
+    public_artifacts = helpers["_build_public_generated_artifacts_from_manifest"](run, manifest)
+    assert [artifact["artifact_id"] for artifact in public_artifacts] == [
+        "analysis",
+        "requested-json",
+        "requested-xml",
+    ]
+    assert [artifact["output_format"] for artifact in public_artifacts] == ["md", "json", "xml"]
 
 
 def test_invalid_required_set_fails_closed_without_public_artifacts():
@@ -243,6 +322,7 @@ def test_invalid_required_set_fails_closed_without_public_artifacts():
     assert manifest["lifecycle_state"] == "rollback_required"
     assert manifest["validation_state"] == "invalid"
     assert "required_artifact_not_valid" in manifest["validation_report"]["reason_codes"]
+    assert helpers["publication_commits"] == []
     assert helpers["_build_public_generated_artifacts_from_manifest"](run, manifest) == []
 
 
@@ -250,6 +330,7 @@ if __name__ == "__main__":
     tests = [
         test_staged_structured_member_is_not_public_until_set_completion,
         test_completed_combined_set_publishes_markdown_primary_then_sibling,
+        test_completed_combined_set_publishes_multiple_requested_siblings,
         test_invalid_required_set_fails_closed_without_public_artifacts,
     ]
     results = []

--- a/functional_tests/test_tabular_row_orchestration_scale.py
+++ b/functional_tests/test_tabular_row_orchestration_scale.py
@@ -1,8 +1,8 @@
 # test_tabular_row_orchestration_scale.py
 """
 Functional test for scalable per-row tabular orchestration.
-Version: 0.250.179
-Implemented in: 0.250.060; generated CSV formula safety in 0.250.065; generated file export routing in 0.250.072; source descriptor generalization in 0.250.127; unified durable run contract in 0.250.128; hierarchical analysis in 0.250.129; combined analysis and export in 0.250.130; scale validation in 0.250.132; direct source-backed exhaustive queueing in 0.250.133; direct queue call-site hardening in 0.250.134; model-validation auto retry in 0.250.135; model-aware parallel throughput in 0.250.136; Phase 1 acceleration contracts and observability in 0.250.137; Phase 2 truthful background handoff in 0.250.138; Phase 3 durable LLM generation planning in 0.250.139; Phase 4 compact row response protocol in 0.250.140; Phase 5 completion-driven checkpointing in 0.250.141; Phase 6 rolling worker pool in 0.250.142; Phase 7 independent batch retries in 0.250.143; Phase 8 scale, chaos, and rollout in 0.250.144; background metadata streaming fix in 0.250.145; source-token echo recovery in 0.250.146; fixed-window stale heartbeat fix in 0.250.147; nested CSV output recovery in 0.250.148; generic tabular artifact routing and fast startup in 0.250.149; balanced concurrency waves and default completion checkpoints in 0.250.152; Search shared preflight adapter in 0.250.159; aggregate route-helper harness coverage in 0.250.166; Analyze artifact Phase 7A harness compatibility updated in 0.250.178; reviewed correctness planning and semantic validation updated in 0.250.179
+Version: 0.250.180
+Implemented in: 0.250.060; generated CSV formula safety in 0.250.065; generated file export routing in 0.250.072; source descriptor generalization in 0.250.127; unified durable run contract in 0.250.128; hierarchical analysis in 0.250.129; combined analysis and export in 0.250.130; scale validation in 0.250.132; direct source-backed exhaustive queueing in 0.250.133; direct queue call-site hardening in 0.250.134; model-validation auto retry in 0.250.135; model-aware parallel throughput in 0.250.136; Phase 1 acceleration contracts and observability in 0.250.137; Phase 2 truthful background handoff in 0.250.138; Phase 3 durable LLM generation planning in 0.250.139; Phase 4 compact row response protocol in 0.250.140; Phase 5 completion-driven checkpointing in 0.250.141; Phase 6 rolling worker pool in 0.250.142; Phase 7 independent batch retries in 0.250.143; Phase 8 scale, chaos, and rollout in 0.250.144; background metadata streaming fix in 0.250.145; source-token echo recovery in 0.250.146; fixed-window stale heartbeat fix in 0.250.147; nested CSV output recovery in 0.250.148; generic tabular artifact routing and fast startup in 0.250.149; balanced concurrency waves and default completion checkpoints in 0.250.152; Search shared preflight adapter in 0.250.159; aggregate route-helper harness coverage in 0.250.166; Analyze artifact Phase 7A harness compatibility updated in 0.250.178; reviewed correctness planning and semantic validation updated in 0.250.179; artifact publication lifecycle updated in 0.250.180
 
 This test ensures generated exports preserve source identity and row order while
 enforcing one stable output schema across independently generated batches.
@@ -113,6 +113,7 @@ SOURCE_READER_FUNCTIONS = {
 }
 AUTHORIZATION_FUNCTIONS = {'_authorize_tabular_export_run_execution'}
 CANCELLATION_FUNCTIONS = {
+    '_is_artifact_publication_recoverable',
     '_can_cancel_run',
     'cancel_tabular_generated_output_run',
 }
@@ -135,6 +136,7 @@ RETRY_FUNCTIONS = {
     '_has_exhausted_independent_batch_retries',
     '_is_auto_retry_exhausted',
     '_can_auto_retry_failed_run',
+    '_is_artifact_publication_recoverable',
     '_can_resume_run',
     '_mark_run_failed',
     '_get_auto_retry_limit_for_category',
@@ -171,7 +173,12 @@ FAILURE_FUNCTIONS = {
 }
 BACKGROUND_METADATA_FUNCTIONS = {'build_background_tabular_generated_output_metadata'}
 STATUS_DETAIL_FUNCTIONS = {'_build_run_status_detail'}
-ARTIFACT_FUNCTIONS = {'_upload_generated_chat_artifact_for_current_user'}
+ARTIFACT_FUNCTIONS = {
+    '_safe_positive_int',
+    '_build_generated_chat_artifact_lifecycle_metadata',
+    '_build_generated_chat_artifact_lifecycle_response',
+    '_upload_generated_chat_artifact_for_current_user',
+}
 SCHEDULER_FUNCTIONS = {'_query_scheduler_candidates_by_status'}
 MANIFEST_FUNCTIONS = {
     '_normalize_tabular_run_task_type',
@@ -974,8 +981,13 @@ def _load_cancellation_helpers(initial_run):
     namespace = {
         'logging': logging,
         'CosmosResourceNotFoundError': CosmosResourceNotFoundError,
+        'TABULAR_EXPORT_STATUS_FAILED': 'failed',
         'TABULAR_EXPORT_STATUS_COMPLETED': 'completed',
         'TABULAR_EXPORT_STATUS_CANCELED': 'canceled',
+        'TABULAR_ARTIFACT_SET_LIFECYCLE_VALIDATING': 'validating',
+        'TABULAR_ARTIFACT_SET_LIFECYCLE_PUBLISHING': 'publishing',
+        'TABULAR_ARTIFACT_SET_LIFECYCLE_ROLLBACK_REQUIRED': 'rollback_required',
+        'TABULAR_ARTIFACT_SET_LIFECYCLE_FAILED': 'failed',
         'get_settings': lambda: {},
         '_read_run': read_run,
         '_replace_run': replace_run,
@@ -1374,13 +1386,19 @@ def _load_idempotent_artifact_helper():
             return self.clients.setdefault((container, blob), BlobClient())
 
     module_tree = ast.parse(SIMPLECHAT_OPERATIONS.read_text(encoding='utf-8'), filename=str(SIMPLECHAT_OPERATIONS))
-    selected_nodes = [
-        node
-        for node in module_tree.body
-        if isinstance(node, ast.FunctionDef) and node.name in ARTIFACT_FUNCTIONS
-    ]
-    if len(selected_nodes) != len(ARTIFACT_FUNCTIONS):
-        raise AssertionError('Missing idempotent artifact helper')
+    selected_nodes = []
+    found_functions = set()
+    for node in module_tree.body:
+        if isinstance(node, ast.Assign):
+            assigned_names = {target.id for target in node.targets if isinstance(target, ast.Name)}
+            if any(name.startswith('GENERATED_CHAT_ARTIFACT_') for name in assigned_names):
+                selected_nodes.append(node)
+        elif isinstance(node, ast.FunctionDef) and node.name in ARTIFACT_FUNCTIONS:
+            selected_nodes.append(node)
+            found_functions.add(node.name)
+    missing_functions = ARTIFACT_FUNCTIONS - found_functions
+    if missing_functions:
+        raise AssertionError(f'Missing idempotent artifact helpers: {sorted(missing_functions)}')
 
     message_container = MessageContainer()
     blob_service_client = BlobServiceClient()


### PR DESCRIPTION
## Phase Objective

Phase 7C implements the artifact-set publication lifecycle slice for #1233. New generated tabular artifact-set members are staged until the owning run manifest completes and validates, direct artifact download/promotion reauthorize against that committed manifest generation, and supported durable structured siblings are published from one canonical checkpoint set in request order.

Refs #1233

## Explicit Non-Goals

- Does not add long-running staged-artifact cleanup sweepers; broader cleanup remains Phase 7D/follow-up.
- Does not change semantic planning, verification, or repair behavior from Phase 7B.
- Does not add paid live semantic scale evidence.
- Does not delete legacy generated-artifact or durable-run compatibility paths.
- Does not update public release notes in this PR.

## Behavior And Compatibility

- New generated tabular artifact messages carry run id, artifact-set id, member id, lifecycle state, validation state, and publication generation metadata.
- Legacy generated artifacts without artifact-set metadata remain accessible through existing direct routes.
- Direct chat artifact download and workspace promotion now require the new member to match a completed and validated manifest generation.
- Staged, rolled-back, stale-generation, incomplete, and cross-object artifact-set members are rejected before blob content is served or promoted.
- Failed post-staging publication states can pass the resume/cancel guard when the set is still validating, publishing, failed, or rollback-required.
- Durable structured publication can fan out one validated checkpoint set to every requested CSV, JSON, or XML sibling, preserving Analyze Markdown as primary.

## Application Version

- `application/single_app/config.py`: `0.250.179` -> `0.250.180`.

## Validation Commands And Results

- `python -m py_compile` for changed app/test Python files - passed.
- `python functional_tests/test_generated_artifact_lifecycle_authorization.py` - 6/6 passed.
- `python functional_tests/test_tabular_phase5_artifact_set_lifecycle.py` - 4/4 passed.
- `python functional_tests/test_analyze_deliverable_contract.py` - 6/6 passed.
- `python functional_tests/test_tabular_background_generated_exports.py` - 8/8 passed.
- `python functional_tests/test_tabular_row_orchestration_scale.py` - complete suite passed through 30,000-row bounded finalization and 100,000-row planning/hardening contracts.
- Route policy inventory, unauthenticated contract, and coverage tests - 12/12 passed.
- `functional_tests/test_generated_artifact_workspace_promotion_modal.py` - 1/1 passed.
- VS Code diagnostics for touched files - clean.
- `scripts/check_broken_access_control.py --full-file` on touched Python paths - passed.
- `scripts/check_xss_sinks.py --full-file` on touched Python paths - passed.
- Markdown hygiene, direct final-newline/trailing-whitespace checks, and Windows-safe `git diff --check` - passed.

## Security And Source Scope

- Direct artifact routes continue to reauthorize personal conversation ownership before reading a message.
- New artifact-set members additionally require run ownership, conversation match, set/member/message match, completed set lifecycle, validated set state, and sufficient publication generation.
- Caller-supplied run, set, member, or lifecycle values are not trusted.
- No new route is added.
- Public status remains the authoritative completed artifact projection.

## Rollback

Revert this PR to return to status-only artifact-set visibility and single-structured durable publication. No data migration is required. Legacy generated artifacts remain readable either way because they do not carry artifact-set lifecycle metadata.

## Remaining Closure Slice

- Phase 7D: final integration, deterministic scale/chaos matrix, authenticated UI, canary evidence, approved live semantic-through-3k validation, release notes, and final PR to `Development`.