### PR TITLE
Fix Admin Settings sidebar card parity

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -96,7 +96,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.250.191"
+VERSION = "0.250.192"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/static/js/admin/admin_sidebar_nav.js
+++ b/application/single_app/static/js/admin/admin_sidebar_nav.js
@@ -184,18 +184,32 @@ function scrollToSection(sectionId) {
         'gpt-config': 'gpt-configuration',
         'embeddings-config': 'embeddings-configuration', 
         'image-config': 'image-generation-configuration',
+        'multi-endpoint-configuration': 'multi-endpoint-configuration',
+        'document-action-capabilities-card': 'document-action-capabilities-card',
         'agents-config': 'agents-configuration',
+        'agent-template-approvals-section': 'agent-template-approvals-section',
         'actions-config': 'actions-configuration',
+        // Governance tab sections
+        'governance-feature-toggles-section': 'governance-feature-toggles-section',
+        'governance-mcp-destination-section': 'governance-mcp-destination-section',
+        'governance-inbound-mcp-section': 'governance-inbound-mcp-section',
+        'governance-feature-policies-section': 'governance-feature-policies-section',
+        'governance-item-policies-section': 'governance-item-policies-section',
         // General tab sections
         'branding-section': 'branding-section',
         'home-page-text-section': 'home-page-text-section',
         'appearance-section': 'appearance-section',
         'classification-banner-section': 'classification-banner-section',
+        'ai-notice-section': 'ai-notice-section',
+        'terms-of-use-section': 'terms-of-use-section',
         'custom-pages-section': 'custom-pages-section',
         'external-links-section': 'external-links-section',
         'health-check-section': 'health-check-section',
         'system-settings-section': 'system-settings-section',
         'control-center-admin-section': 'control-center-admin-section',
+        // Control Center tab sections
+        'control-center-auto-refresh-section': 'control-center-auto-refresh-section',
+        'control-center-overview-section': 'control-center-overview-section',
         // Logging tab sections
         'application-insights-section': 'application-insights-section',
         'debug-logging-section': 'debug-logging-section',
@@ -203,6 +217,7 @@ function scrollToSection(sectionId) {
         // Scale tab sections
         'redis-cache-section': 'redis-cache-section',
         'redis-monitoring-section': 'redis-monitoring-section',
+        'conversation-cache-section': 'conversation-cache-section',
         'document-access-index-section': 'document-access-index-section',
         'cosmos-maintenance-section': 'cosmos-maintenance-section',
         'cosmos-throughput-section': 'cosmos-throughput-section',
@@ -213,14 +228,19 @@ function scrollToSection(sectionId) {
         'group-workspaces-section': 'group-workspaces-section',
         'public-workspaces-section': 'public-workspaces-section',
         'file-sharing-section': 'file-sharing-section',
+        'file-download-settings-section': 'file-download-settings-section',
+        'chat-file-uploads-section': 'chat-file-uploads-section',
         'metadata-extraction-section': 'metadata-extraction-section',
+        'multimodal-vision-section': 'multimodal-vision-section',
         'document-classification-section': 'document-classification-section',
+        'workspace-scope-lock-section': 'workspace-scope-lock-section',
         // Citations tab sections
         'standard-citations-section': 'standard-citations-section',
         'enhanced-citations-section': 'enhanced-citations-section',
         // Safety tab sections
         'content-safety-section': 'content-safety-section',
         'user-feedback-section': 'user-feedback-section',
+        'desktop-notifications-section': 'desktop-notifications-section',
         'permissions-section': 'permissions-section',
         'conversation-archiving-section': 'conversation-archiving-section',
         // Security tab sections
@@ -237,9 +257,13 @@ function scrollToSection(sectionId) {
         'data-management-jobs-section': 'data-management-jobs-section',
         // Search & Extract tab sections
         'web-search-section': 'web-search-foundry-section',
+        'url-access-section': 'url-access-section',
+        'source-review-section': 'source-review-section',
         'azure-ai-search-section': 'azure-ai-search-section',
         'document-intelligence-section': 'document-intelligence-section',
-        'multimedia-support-section': 'multimedia-support-section'
+        'chunk-size-section': 'chunk-size-section',
+        'video-intelligence-section': 'video-intelligence-section',
+        'ai-voice-chat-section': 'ai-voice-chat-section'
     };
     
     const targetElementId = sectionMap[sectionId] || sectionId;
@@ -420,12 +444,15 @@ function showSearchResults(hasResults, searchTerm) {
     if (!hasResults && searchTerm) {
         const adminSection = document.getElementById('admin-settings-section');
         const noResultsDiv = document.createElement('div');
+        const searchIcon = document.createElement('i');
+        const message = document.createElement('span');
+
         noResultsDiv.id = 'admin-search-no-results';
         noResultsDiv.className = 'px-3 py-2 text-muted text-center small';
-        noResultsDiv.innerHTML = `
-            <i class="bi bi-search me-1"></i>
-            No settings found for "${searchTerm}"
-        `;
+        searchIcon.className = 'bi bi-search me-1';
+        searchIcon.setAttribute('aria-hidden', 'true');
+        message.textContent = `No settings found for "${searchTerm}"`;
+        noResultsDiv.append(searchIcon, message);
         adminSection.appendChild(noResultsDiv);
     }
 }

--- a/application/single_app/templates/_sidebar_nav.html
+++ b/application/single_app/templates/_sidebar_nav.html
@@ -505,8 +505,28 @@
                 </a>
               </li>
               <li class="nav-item">
+                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="general" data-section="health-check-section">
+                  <i class="bi bi-heart-pulse me-2" style="font-size: 0.8em;"></i><span class="nav-text">Health Check</span>
+                </a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="general" data-section="swagger-section">
+                  <i class="bi bi-file-earmark-code me-2" style="font-size: 0.8em;"></i><span class="nav-text">API Documentation</span>
+                </a>
+              </li>
+              <li class="nav-item">
                 <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="general" data-section="classification-banner-section">
                   <i class="bi bi-shield-exclamation me-2" style="font-size: 0.8em;"></i><span class="nav-text">Classification Banner</span>
+                </a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="general" data-section="ai-notice-section">
+                  <i class="bi bi-robot me-2" style="font-size: 0.8em;"></i><span class="nav-text">Chat AI Notice</span>
+                </a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="general" data-section="terms-of-use-section">
+                  <i class="bi bi-door-open me-2" style="font-size: 0.8em;"></i><span class="nav-text">Terms of Use</span>
                 </a>
               </li>
               <li class="nav-item">
@@ -517,16 +537,6 @@
               <li class="nav-item">
                 <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="general" data-section="external-links-section">
                   <i class="bi bi-box-arrow-up-right me-2" style="font-size: 0.8em;"></i><span class="nav-text">External Links</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="general" data-section="health-check-section">
-                  <i class="bi bi-heart-pulse me-2" style="font-size: 0.8em;"></i><span class="nav-text">Health Check</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="general" data-section="swagger-section">
-                  <i class="bi bi-file-earmark-code me-2" style="font-size: 0.8em;"></i><span class="nav-text">API Documentation</span>
                 </a>
               </li>
               <li class="nav-item">
@@ -554,8 +564,8 @@
             </a>
             <ul class="nav flex-column ms-3" style="display: none;" id="ai-models-submenu">
               <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="ai-models" data-section="gpt-config">
-                  <i class="bi bi-chat-square-text me-2" style="font-size: 0.8em;"></i><span class="nav-text">Chat Model</span>
+                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="ai-models" data-section="multi-endpoint-configuration">
+                  <i class="bi bi-hdd-network me-2" style="font-size: 0.8em;"></i><span class="nav-text">Model Endpoints</span>
                 </a>
               </li>
               <li class="nav-item">
@@ -573,6 +583,11 @@
                   <i class="bi bi-image me-2" style="font-size: 0.8em;"></i><span class="nav-text">Image Generation</span>
                 </a>
               </li>
+              <li class="nav-item">
+                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="ai-models" data-section="gpt-config">
+                  <i class="bi bi-chat-square-text me-2" style="font-size: 0.8em;"></i><span class="nav-text">Chat Model</span>
+                </a>
+              </li>
             </ul>
           </li>
           <li class="nav-item">
@@ -581,10 +596,22 @@
             </a>
             <ul class="nav flex-column ms-3" style="display: none;" id="agents-submenu">
               <li class="nav-item">
+                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="agents" data-section="document-action-capabilities-card">
+                  <i class="bi bi-files me-2" style="font-size: 0.8em;"></i><span class="nav-text">Document Action Capabilities</span>
+                </a>
+              </li>
+              <li class="nav-item">
                 <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="agents" data-section="agents-config">
                   <i class="bi bi-robot me-2" style="font-size: 0.8em;"></i><span class="nav-text">Agents Configuration</span>
                 </a>
               </li>
+              {% if app_settings.enable_agent_template_gallery %}
+              <li class="nav-item">
+                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="agents" data-section="agent-template-approvals-section">
+                  <i class="bi bi-layers me-2" style="font-size: 0.8em;"></i><span class="nav-text">Agent Template Approvals</span>
+                </a>
+              </li>
+              {% endif %}
               <li class="nav-item">
                 <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="agents" data-section="actions-config">
                   <i class="bi bi-plugin me-2" style="font-size: 0.8em;"></i><span class="nav-text">Actions Configuration</span>
@@ -637,6 +664,11 @@
                 </a>
               </li>
               <li class="nav-item">
+                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="scale" data-section="conversation-cache-section">
+                  <i class="bi bi-chat-square-text me-2" style="font-size: 0.8em;"></i><span class="nav-text">Conversation Cache</span>
+                </a>
+              </li>
+              <li class="nav-item">
                 <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="scale" data-section="document-access-index-section">
                   <i class="bi bi-diagram-3 me-2" style="font-size: 0.8em;"></i><span class="nav-text">DAI Metrics</span>
                 </a>
@@ -667,6 +699,18 @@
             <a class="nav-link d-flex align-items-center admin-nav-tab" href="#" data-tab="control-center-config">
               <i class="bi bi-speedometer2 me-2"></i><span class="nav-text">Control Center</span>
             </a>
+            <ul class="nav flex-column ms-3" style="display: none;" id="control-center-config-submenu">
+              <li class="nav-item">
+                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="control-center-config" data-section="control-center-auto-refresh-section">
+                  <i class="bi bi-calendar-check me-2" style="font-size: 0.8em;"></i><span class="nav-text">Automatic Data Refresh</span>
+                </a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="control-center-config" data-section="control-center-overview-section">
+                  <i class="bi bi-gear-wide-connected me-2" style="font-size: 0.8em;"></i><span class="nav-text">Control Center Access</span>
+                </a>
+              </li>
+            </ul>
           </li>
           <li class="nav-item">
             <a class="nav-link d-flex align-items-center admin-nav-tab" href="#" data-tab="data-management">
@@ -724,6 +768,33 @@
             <a class="nav-link d-flex align-items-center admin-nav-tab" href="#" data-tab="governance">
               <i class="bi bi-braces-asterisk me-2"></i><span class="nav-text">Governance</span>
             </a>
+            <ul class="nav flex-column ms-3" style="display: none;" id="governance-submenu">
+              <li class="nav-item">
+                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="governance" data-section="governance-feature-toggles-section">
+                  <i class="bi bi-braces-asterisk me-2" style="font-size: 0.8em;"></i><span class="nav-text">Governance Feature Toggles</span>
+                </a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="governance" data-section="governance-mcp-destination-section">
+                  <i class="bi bi-diagram-3 me-2" style="font-size: 0.8em;"></i><span class="nav-text">MCP Action Destination Governance</span>
+                </a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="governance" data-section="governance-inbound-mcp-section">
+                  <i class="bi bi-box-arrow-in-down-right me-2" style="font-size: 0.8em;"></i><span class="nav-text">Inbound MCP Source Governance</span>
+                </a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="governance" data-section="governance-feature-policies-section">
+                  <i class="bi bi-sliders2 me-2" style="font-size: 0.8em;"></i><span class="nav-text">Feature Policies</span>
+                </a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="governance" data-section="governance-item-policies-section">
+                  <i class="bi bi-list-check me-2" style="font-size: 0.8em;"></i><span class="nav-text">Delegated Item Policies</span>
+                </a>
+              </li>
+            </ul>
           </li>
           <li class="nav-item">
             <a class="nav-link d-flex align-items-center admin-nav-tab" href="#" data-tab="workspaces">
@@ -738,6 +809,11 @@
               <li class="nav-item">
                 <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="workspaces" data-section="workflow-settings-section">
                   <i class="bi bi-diagram-3 me-2" style="font-size: 0.8em;"></i><span class="nav-text">Workflow</span>
+                </a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="workspaces" data-section="file-download-settings-section">
+                  <i class="bi bi-download me-2" style="font-size: 0.8em;"></i><span class="nav-text">File Downloads</span>
                 </a>
               </li>
               <li class="nav-item">
@@ -756,8 +832,18 @@
                 </a>
               </li>
               <li class="nav-item">
+                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="workspaces" data-section="chat-file-uploads-section">
+                  <i class="bi bi-paperclip me-2" style="font-size: 0.8em;"></i><span class="nav-text">Chat File Uploads</span>
+                </a>
+              </li>
+              <li class="nav-item">
                 <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="workspaces" data-section="metadata-extraction-section">
                   <i class="bi bi-file-earmark-code me-2" style="font-size: 0.8em;"></i><span class="nav-text">Metadata Extraction</span>
+                </a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="workspaces" data-section="multimodal-vision-section">
+                  <i class="bi bi-eye me-2" style="font-size: 0.8em;"></i><span class="nav-text">Multi-Modal Vision Analysis</span>
                 </a>
               </li>
               <li class="nav-item">
@@ -768,6 +854,11 @@
               <li class="nav-item">
                 <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="workspaces" data-section="retention-policy-section">
                   <i class="bi bi-hourglass-split me-2" style="font-size: 0.8em;"></i><span class="nav-text">Retention Policy</span>
+                </a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="workspaces" data-section="workspace-scope-lock-section">
+                  <i class="bi bi-lock me-2" style="font-size: 0.8em;"></i><span class="nav-text">Workspace Scope Lock</span>
                 </a>
               </li>
               <li class="nav-item">
@@ -820,6 +911,11 @@
                 </a>
               </li>
               <li class="nav-item">
+                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="safety" data-section="desktop-notifications-section">
+                  <i class="bi bi-bell me-2" style="font-size: 0.8em;"></i><span class="nav-text">Desktop Conversation Notifications</span>
+                </a>
+              </li>
+              <li class="nav-item">
                 <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="safety" data-section="permissions-section">
                   <i class="bi bi-person-check me-2" style="font-size: 0.8em;"></i><span class="nav-text">Permissions</span>
                 </a>
@@ -854,6 +950,16 @@
                 </a>
               </li>
               <li class="nav-item">
+                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="search-extract" data-section="url-access-section">
+                  <i class="bi bi-link-45deg me-2" style="font-size: 0.8em;"></i><span class="nav-text">URL Access</span>
+                </a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="search-extract" data-section="source-review-section">
+                  <i class="bi bi-binoculars me-2" style="font-size: 0.8em;"></i><span class="nav-text">Deep Research</span>
+                </a>
+              </li>
+              <li class="nav-item">
                 <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="search-extract" data-section="azure-ai-search-section">
                   <i class="bi bi-search me-2" style="font-size: 0.8em;"></i><span class="nav-text">Azure AI Search</span>
                 </a>
@@ -864,8 +970,18 @@
                 </a>
               </li>
               <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="search-extract" data-section="multimedia-support-section">
-                  <i class="bi bi-play-circle me-2" style="font-size: 0.8em;"></i><span class="nav-text">Multimedia Support</span>
+                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="search-extract" data-section="chunk-size-section">
+                  <i class="bi bi-collection me-2" style="font-size: 0.8em;"></i><span class="nav-text">Chunk Sizes</span>
+                </a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="search-extract" data-section="video-intelligence-section">
+                  <i class="bi bi-play-circle me-2" style="font-size: 0.8em;"></i><span class="nav-text">AI Video Intelligence</span>
+                </a>
+              </li>
+              <li class="nav-item">
+                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="search-extract" data-section="ai-voice-chat-section">
+                  <i class="bi bi-mic me-2" style="font-size: 0.8em;"></i><span class="nav-text">AI Voice Conversations</span>
                 </a>
               </li>
             </ul>

--- a/application/single_app/templates/admin_settings.html
+++ b/application/single_app/templates/admin_settings.html
@@ -1642,7 +1642,7 @@
                 </div>
 
                 {% if settings.enable_agent_template_gallery %}
-                <div class="card p-3 mb-4">
+                <div class="card p-3 mb-4" id="agent-template-approvals-section">
                     <div class="row g-3 mb-3">
                         <div class="col-xl-6">
                             <div class="form-check form-switch mb-0">

--- a/docs/explanation/fixes/ADMIN_SETTINGS_SIDEBAR_CARD_PARITY_FIX.md
+++ b/docs/explanation/fixes/ADMIN_SETTINGS_SIDEBAR_CARD_PARITY_FIX.md
@@ -1,0 +1,58 @@
+# Admin Settings Sidebar Card Parity Fix
+
+Fixed/Implemented in version: **0.250.192**
+
+## Issue Description
+
+Top-level configuration cards in Admin Settings did not consistently have matching left-sidebar links. Missing links also made those settings undiscoverable through the sidebar search. Examples included Desktop Conversation Notifications, URL Access, Deep Research, AI Video Intelligence, and AI Voice Conversations.
+
+## Root Cause Analysis
+
+The Admin Settings cards and left-sidebar navigation are maintained in separate templates. New cards were added over time without corresponding `.admin-nav-section` entries, and no regression check enforced parity between the two surfaces. Search & Extract also retained a `Multimedia Support` shortcut whose target ID no longer existed.
+
+## Technical Details
+
+### Files Modified
+
+- `application/single_app/config.py`
+- `application/single_app/templates/admin_settings.html`
+- `application/single_app/templates/_sidebar_nav.html`
+- `application/single_app/static/js/admin/admin_sidebar_nav.js`
+- `functional_tests/test_admin_settings_sidebar_card_parity.py`
+- `ui_tests/test_admin_settings_sidebar_card_navigation.py`
+- `docs/explanation/fixes/ADMIN_SETTINGS_SIDEBAR_CARD_PARITY_FIX.md`
+
+### Code Changes Summary
+
+- Added 23 missing top-level card destinations across Agents and Actions, Governance, General, AI Models, Control Center, Scale, Workspaces, Safety, and Search & Extract.
+- Preserved each tab's card order in its sidebar submenu so the navigation matches the settings page.
+- Added a stable `agent-template-approvals-section` target and applied the same Agent Template Gallery condition to its card and sidebar link.
+- Replaced the unresolved `Multimedia Support` shortcut with concrete Chunk Sizes, AI Video Intelligence, and AI Voice Conversations links.
+- Added explicit section mappings for every new destination while retaining the existing tab activation and smooth-scroll behavior.
+- Changed the sidebar search no-results message to render the search term with `textContent` instead of HTML interpolation.
+
+### Testing Approach
+
+- The functional parity test parses the Admin Settings and sidebar templates, identifies top-level configuration cards, verifies card IDs and sidebar destinations, checks relative ordering, and rejects unresolved static targets.
+- The UI contract test verifies every new label, tab, section target, and JavaScript mapping.
+- The optional authenticated Playwright workflow searches for and opens every new destination, then verifies the target card is visible and in the viewport.
+
+### Impact Analysis
+
+No settings schema, API, route, or database change is required. The change affects only Admin Settings navigation, search discoverability, target resolution, and regression coverage.
+
+## Validation
+
+### Before
+
+Admins had to open a broad tab and manually scan its cards for settings that were absent from the sidebar. Searching the sidebar for those card names returned no match, and the Multimedia Support shortcut did not resolve to an element.
+
+### After
+
+Every top-level configuration card has an equivalent sidebar destination, with single-card tabs continuing to use their parent tab link. Sidebar search can discover the added settings, every static section target resolves, and selecting a result opens and scrolls to the matching card.
+
+### User Experience Improvement
+
+Administrators can locate and open settings directly by card name instead of knowing which broad tab contains them.
+
+The application version in `application/single_app/config.py` was updated to `0.250.192` for traceability.

--- a/functional_tests/test_admin_settings_sidebar_card_parity.py
+++ b/functional_tests/test_admin_settings_sidebar_card_parity.py
@@ -1,0 +1,250 @@
+# test_admin_settings_sidebar_card_parity.py
+"""
+Functional test for Admin Settings sidebar card parity.
+Version: 0.250.192
+Implemented in: 0.250.192
+
+This test ensures every top-level Admin Settings configuration card has an
+equivalent left-sidebar destination and every static destination resolves.
+"""
+
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+from bs4 import BeautifulSoup
+
+from test_support.versioning import assert_app_version_at_least
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+ADMIN_TEMPLATE = (
+    ROOT_DIR / "application" / "single_app" / "templates" / "admin_settings.html"
+)
+SIDEBAR_TEMPLATE = (
+    ROOT_DIR / "application" / "single_app" / "templates" / "_sidebar_nav.html"
+)
+SIDEBAR_SCRIPT = (
+    ROOT_DIR
+    / "application"
+    / "single_app"
+    / "static"
+    / "js"
+    / "admin"
+    / "admin_sidebar_nav.js"
+)
+EXCLUDED_TAB_IDS = {"latest-features"}
+
+
+def _read(path):
+    """Read a repository text file."""
+    return path.read_text(encoding="utf-8")
+
+
+def _parse_section_map(script_source):
+    """Return sidebar section aliases from the JavaScript map."""
+    match = re.search(
+        r"const sectionMap = \{(?P<body>.*?)^\s*\};",
+        script_source,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    assert match is not None, "Admin sidebar sectionMap was not found"
+    return dict(
+        re.findall(
+            r"'([^']+)'\s*:\s*'([^']+)'",
+            match.group("body"),
+        )
+    )
+
+
+def _is_top_level_configuration_card(card, pane):
+    """Return whether a card is top-level within its tab and outside a modal."""
+    for parent in card.parents:
+        if parent is pane:
+            return True
+        classes = parent.get("class", []) if hasattr(parent, "get") else []
+        if "modal" in classes or "card" in classes:
+            return False
+    return False
+
+
+def _top_level_cards(pane):
+    """Return top-level configuration cards in document order."""
+    return [
+        card
+        for card in pane.select(".card")
+        if _is_top_level_configuration_card(card, pane)
+    ]
+
+
+def _card_title(card):
+    """Return a readable card title for assertion output."""
+    heading = card.find(["h1", "h2", "h3", "h4", "h5", "h6"])
+    if heading is None:
+        return card.get("id", "<unknown card>")
+    return " ".join(heading.get_text(" ", strip=True).split())
+
+
+def _navigation_contract():
+    """Parse the admin template, sidebar template, and section alias map."""
+    admin_source = _read(ADMIN_TEMPLATE)
+    sidebar_source = _read(SIDEBAR_TEMPLATE)
+    script_source = _read(SIDEBAR_SCRIPT)
+    admin_soup = BeautifulSoup(admin_source, "html.parser")
+    sidebar_soup = BeautifulSoup(sidebar_source, "html.parser")
+    section_map = _parse_section_map(script_source)
+
+    tab_targets = {
+        link["data-tab"]
+        for link in sidebar_soup.select(".admin-nav-tab[data-tab]")
+    }
+    section_targets = defaultdict(list)
+    for link in sidebar_soup.select(
+        ".admin-nav-section[data-tab][data-section]"
+    ):
+        raw_target = link["data-section"]
+        section_targets[link["data-tab"]].append(
+            section_map.get(raw_target, raw_target)
+        )
+
+    return {
+        "admin_source": admin_source,
+        "sidebar_source": sidebar_source,
+        "script_source": script_source,
+        "admin_soup": admin_soup,
+        "sidebar_soup": sidebar_soup,
+        "section_map": section_map,
+        "tab_targets": tab_targets,
+        "section_targets": section_targets,
+    }
+
+
+def test_every_top_level_card_has_sidebar_destination():
+    """Require card parity and preserve card order within each submenu."""
+    assert_app_version_at_least("0.250.192")
+    contract = _navigation_contract()
+    tab_content = contract["admin_soup"].find(id="adminSettingsTabContent")
+    assert tab_content is not None, "Admin Settings tab content was not found"
+
+    errors = []
+    panes = tab_content.find_all("div", class_="tab-pane", recursive=False)
+    for pane in panes:
+        tab_id = pane.get("id")
+        if not tab_id or tab_id in EXCLUDED_TAB_IDS:
+            continue
+
+        cards = _top_level_cards(pane)
+        card_ids = []
+        for card in cards:
+            card_id = card.get("id")
+            if not card_id:
+                errors.append(
+                    f"{tab_id}: top-level card '{_card_title(card)}' has no id"
+                )
+                continue
+            card_ids.append(card_id)
+
+        if len(card_ids) == 1 and tab_id in contract["tab_targets"]:
+            continue
+
+        targets = contract["section_targets"][tab_id]
+        for card_id in card_ids:
+            if card_id not in targets:
+                errors.append(
+                    f"{tab_id}: card '{card_id}' has no sidebar destination"
+                )
+
+        ordered_card_targets = [
+            target for target in targets if target in set(card_ids)
+        ]
+        if ordered_card_targets != card_ids:
+            errors.append(
+                f"{tab_id}: card/sidebar order differs: "
+                f"{card_ids} != {ordered_card_targets}"
+            )
+
+    assert not errors, "\n".join(errors)
+
+
+def test_every_static_sidebar_section_target_resolves():
+    """Reject sidebar links that cannot resolve to rendered template IDs."""
+    contract = _navigation_contract()
+    template_ids = {
+        element["id"] for element in contract["admin_soup"].select("[id]")
+    }
+    errors = []
+
+    for link in contract["sidebar_soup"].select(
+        ".admin-nav-section[data-section]"
+    ):
+        raw_target = link["data-section"]
+        if "{{" in raw_target:
+            continue
+        resolved_target = contract["section_map"].get(raw_target, raw_target)
+        if resolved_target not in template_ids:
+            errors.append(
+                f"Sidebar target '{raw_target}' resolves to missing "
+                f"'{resolved_target}'"
+            )
+        nav_text = link.select_one(".nav-text")
+        if nav_text is None or not nav_text.get_text(strip=True):
+            errors.append(f"Sidebar target '{raw_target}' has no search label")
+
+    assert not errors, "\n".join(errors)
+
+
+def test_conditional_agent_template_destination_matches_card():
+    """Keep the optional Agent Template Approvals card and link in sync."""
+    contract = _navigation_contract()
+    card_marker = 'id="agent-template-approvals-section"'
+    link_marker = 'data-section="agent-template-approvals-section"'
+
+    card_condition = contract["admin_source"].index(
+        "{% if settings.enable_agent_template_gallery %}"
+    )
+    card_position = contract["admin_source"].index(card_marker)
+    card_end = contract["admin_source"].index("{% endif %}", card_position)
+    assert card_condition < card_position < card_end
+
+    link_condition = contract["sidebar_source"].index(
+        "{% if app_settings.enable_agent_template_gallery %}"
+    )
+    link_position = contract["sidebar_source"].index(link_marker)
+    link_end = contract["sidebar_source"].index("{% endif %}", link_position)
+    assert link_condition < link_position < link_end
+
+
+def test_sidebar_search_no_results_uses_safe_text_rendering():
+    """Prevent sidebar search input from being interpolated into HTML."""
+    script_source = _read(SIDEBAR_SCRIPT)
+
+    assert "noResultsDiv.innerHTML" not in script_source
+    assert (
+        'message.textContent = `No settings found for "${searchTerm}"`;'
+        in script_source
+    )
+    assert "noResultsDiv.append(searchIcon, message);" in script_source
+
+
+if __name__ == "__main__":
+    tests = [
+        test_every_top_level_card_has_sidebar_destination,
+        test_every_static_sidebar_section_target_resolves,
+        test_conditional_agent_template_destination_matches_card,
+        test_sidebar_search_no_results_uses_safe_text_rendering,
+    ]
+    results = []
+
+    for test in tests:
+        print(f"Running {test.__name__}...")
+        try:
+            test()
+            print("PASS")
+            results.append(True)
+        except Exception as exc:
+            print(f"FAIL: {exc}")
+            results.append(False)
+
+    print(f"Results: {sum(results)}/{len(results)} tests passed")
+    sys.exit(0 if all(results) else 1)

--- a/ui_tests/test_admin_settings_sidebar_card_navigation.py
+++ b/ui_tests/test_admin_settings_sidebar_card_navigation.py
@@ -1,0 +1,200 @@
+# test_admin_settings_sidebar_card_navigation.py
+"""
+UI tests for Admin Settings sidebar card navigation.
+Version: 0.250.192
+Implemented in: 0.250.192
+
+These tests ensure newly linked configuration cards are searchable and open
+the matching tab and section from the Admin Settings left sidebar.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ADMIN_TEMPLATE = (
+    REPO_ROOT / "application" / "single_app" / "templates" / "admin_settings.html"
+)
+SIDEBAR_TEMPLATE = (
+    REPO_ROOT / "application" / "single_app" / "templates" / "_sidebar_nav.html"
+)
+SIDEBAR_SCRIPT = (
+    REPO_ROOT
+    / "application"
+    / "single_app"
+    / "static"
+    / "js"
+    / "admin"
+    / "admin_sidebar_nav.js"
+)
+BASE_URL = os.getenv("SIMPLECHAT_UI_BASE_URL", "").rstrip("/")
+ADMIN_STORAGE_STATE = (
+    os.getenv("SIMPLECHAT_UI_ADMIN_STORAGE_STATE", "")
+    or os.getenv("SIMPLECHAT_UI_STORAGE_STATE", "")
+)
+EXPECTED_DESTINATIONS = [
+    (
+        "Document Action Capabilities",
+        "agents",
+        "document-action-capabilities-card",
+    ),
+    (
+        "Agent Template Approvals",
+        "agents",
+        "agent-template-approvals-section",
+    ),
+    (
+        "Governance Feature Toggles",
+        "governance",
+        "governance-feature-toggles-section",
+    ),
+    (
+        "MCP Action Destination Governance",
+        "governance",
+        "governance-mcp-destination-section",
+    ),
+    (
+        "Inbound MCP Source Governance",
+        "governance",
+        "governance-inbound-mcp-section",
+    ),
+    (
+        "Feature Policies",
+        "governance",
+        "governance-feature-policies-section",
+    ),
+    (
+        "Delegated Item Policies",
+        "governance",
+        "governance-item-policies-section",
+    ),
+    ("Chat AI Notice", "general", "ai-notice-section"),
+    ("Terms of Use", "general", "terms-of-use-section"),
+    ("Model Endpoints", "ai-models", "multi-endpoint-configuration"),
+    (
+        "Automatic Data Refresh",
+        "control-center-config",
+        "control-center-auto-refresh-section",
+    ),
+    (
+        "Control Center Access",
+        "control-center-config",
+        "control-center-overview-section",
+    ),
+    ("Conversation Cache", "scale", "conversation-cache-section"),
+    ("File Downloads", "workspaces", "file-download-settings-section"),
+    ("Chat File Uploads", "workspaces", "chat-file-uploads-section"),
+    (
+        "Multi-Modal Vision Analysis",
+        "workspaces",
+        "multimodal-vision-section",
+    ),
+    ("Workspace Scope Lock", "workspaces", "workspace-scope-lock-section"),
+    (
+        "Desktop Conversation Notifications",
+        "safety",
+        "desktop-notifications-section",
+    ),
+    ("URL Access", "search-extract", "url-access-section"),
+    ("Deep Research", "search-extract", "source-review-section"),
+    ("Chunk Sizes", "search-extract", "chunk-size-section"),
+    (
+        "AI Video Intelligence",
+        "search-extract",
+        "video-intelligence-section",
+    ),
+    (
+        "AI Voice Conversations",
+        "search-extract",
+        "ai-voice-chat-section",
+    ),
+]
+
+
+def _require_ui_environment():
+    """Skip authenticated browser coverage unless its environment is ready."""
+    if not BASE_URL:
+        pytest.skip("Set SIMPLECHAT_UI_BASE_URL to run this UI test.")
+    if not ADMIN_STORAGE_STATE or not Path(ADMIN_STORAGE_STATE).exists():
+        pytest.skip(
+            "Set SIMPLECHAT_UI_ADMIN_STORAGE_STATE or "
+            "SIMPLECHAT_UI_STORAGE_STATE to a valid admin storage state file."
+        )
+
+
+@pytest.mark.ui
+def test_admin_sidebar_exposes_every_new_card_destination():
+    """Validate the versioned HTML and JavaScript navigation contract."""
+    admin_source = ADMIN_TEMPLATE.read_text(encoding="utf-8")
+    sidebar_source = SIDEBAR_TEMPLATE.read_text(encoding="utf-8")
+    script_source = SIDEBAR_SCRIPT.read_text(encoding="utf-8")
+
+    for label, tab_id, section_id in EXPECTED_DESTINATIONS:
+        assert f'id="{section_id}"' in admin_source
+        assert (
+            f'data-tab="{tab_id}" data-section="{section_id}"'
+            in sidebar_source
+        )
+        assert f'<span class="nav-text">{label}</span>' in sidebar_source
+        assert f"'{section_id}': '{section_id}'" in script_source
+
+    assert 'data-section="multimedia-support-section"' not in sidebar_source
+    assert "noResultsDiv.innerHTML" not in script_source
+    assert "message.textContent" in script_source
+
+
+@pytest.mark.ui
+def test_admin_sidebar_search_opens_every_new_card_destination():
+    """Search for and open each new destination in an authenticated browser."""
+    _require_ui_environment()
+
+    # Keep Playwright optional so the source-contract test runs without UI deps.
+    try:
+        from playwright.sync_api import expect, sync_playwright
+    except ModuleNotFoundError:
+        pytest.skip("Install ui_tests requirements to run Playwright UI tests.")
+
+    with sync_playwright() as playwright:
+        browser = playwright.chromium.launch()
+        context = browser.new_context(storage_state=ADMIN_STORAGE_STATE)
+        page = context.new_page()
+        response = page.goto(
+            f"{BASE_URL}/admin/settings",
+            wait_until="domcontentloaded",
+        )
+        assert response is not None and response.ok
+
+        page.locator("#admin-search-btn").click()
+        search_input = page.locator("#admin-search-input")
+        expect(search_input).to_be_visible()
+
+        for label, tab_id, section_id in EXPECTED_DESTINATIONS:
+            search_input.fill(label)
+            link = page.locator(
+                ".admin-nav-section"
+                f'[data-tab="{tab_id}"]'
+                f'[data-section="{section_id}"]'
+            )
+            target = page.locator(f"#{section_id}")
+
+            if section_id == "agent-template-approvals-section":
+                if link.count() == 0:
+                    expect(target).to_have_count(0)
+                    continue
+
+            expect(link).to_be_visible()
+            expect(link.locator(".nav-text")).to_have_text(label)
+            link.click()
+            expect(target).to_be_visible()
+            expect(target).to_be_in_viewport()
+
+        search_input.fill("sidebar-card-parity-no-result")
+        expect(page.locator("#admin-search-no-results")).to_have_text(
+            'No settings found for "sidebar-card-parity-no-result"'
+        )
+
+        context.close()
+        browser.close()


### PR DESCRIPTION
## Summary
- add sidebar destinations for all 23 missing top-level Admin Settings cards
- replace the unresolved Multimedia Support shortcut with concrete search/extraction destinations
- add card/sidebar parity regression coverage and safe search no-results rendering
- document the fix and bump the app version to `0.250.195`

## Testing
- targeted Admin Settings sidebar suite: 20 passed, 1 authenticated UI test skipped because no storage state was configured
- Jinja template parsing
- `node --check application/single_app/static/js/admin/admin_sidebar_nav.js`
- XSS sink and diff whitespace checks