### PR TITLE
fix: complete tabular outputs and public workspace chat grounding

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -96,7 +96,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.250.200"
+VERSION = "0.250.201"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/functions_tabular_generated_exports.py
+++ b/application/single_app/functions_tabular_generated_exports.py
@@ -6,6 +6,7 @@ from collections import Counter, deque
 import csv
 import heapq
 import hashlib
+import html
 import io
 import json
 import logging
@@ -282,6 +283,8 @@ TABULAR_ANALYSIS_MAX_REDUCE_FAN_IN = 50
 TABULAR_ANALYSIS_SUMMARY_MAX_CHARS = 24000
 TABULAR_ANALYSIS_MAX_FINDINGS = 12
 TABULAR_ANALYSIS_MAX_NOTABLE_ROWS = 25
+TABULAR_ROW_ANALYSIS_MAX_QUESTIONS = 20
+TABULAR_ROW_ANALYSIS_ANSWER_ESTIMATED_CHARS = 180
 TABULAR_EXPORT_SUMMARY_MAX_FIELDS = 25
 TABULAR_EXPORT_SUMMARY_MAX_VALUES_PER_FIELD = 5
 TABULAR_EXPORT_SUMMARY_AGGREGATE_MAX_VALUES = 25
@@ -1872,8 +1875,13 @@ def _sanitize_file_base_name(file_name):
 
 def _build_generated_file_name(source_file_name, output_format):
     timestamp_suffix = datetime.utcnow().strftime('%Y%m%d_%H%M%S')
-    normalized_extension = normalize_generated_output_format(output_format)
+    normalized_extension = _normalize_tabular_artifact_format(output_format)
     return f"{_sanitize_file_base_name(source_file_name)}_generated_{timestamp_suffix}.{normalized_extension}"
+
+
+def _build_row_analysis_file_name(source_file_name):
+    timestamp_suffix = datetime.utcnow().strftime('%Y%m%d_%H%M%S')
+    return f"{_sanitize_file_base_name(source_file_name)}_row_analysis_{timestamp_suffix}.md"
 
 
 def _build_analysis_file_name(source_file_name):
@@ -1892,6 +1900,17 @@ def _serialize_generated_output_value(value):
         except TypeError:
             pass
     return neutralize_csv_spreadsheet_formula(value)
+
+
+def _escape_markdown_text(value):
+    """Render untrusted values as literal Markdown text, not active markup."""
+    normalized_value = str(value or '').replace('\r\n', '\n').replace('\r', '\n').replace('\t', '    ')
+    escaped_lines = []
+    for line in normalized_value.split('\n'):
+        escaped_line = html.escape(line, quote=False).replace('\\', '\\\\')
+        escaped_line = re.sub(r'([`*_[\]{}()#+\-.!|>])', r'\\\1', escaped_line)
+        escaped_lines.append(escaped_line)
+    return '\n'.join(escaped_lines)
 
 
 def _sanitize_generated_xml_tag_name(value, fallback_value='Field'):
@@ -2054,6 +2073,58 @@ def _normalize_generated_batch_entries(
         for entry in normalized_entries
     ]
     return ordered_entries, output_schema
+
+
+def _validate_exhaustive_row_analysis_entries(entries, output_schema):
+    public_fields = [
+        str(field_name or '').strip().lower()
+        for field_name in list(output_schema or [])
+        if str(field_name or '').strip()
+        and not is_analysis_internal_lineage_field(field_name)
+    ]
+    exact_row_fields = (
+        public_fields == ['row_analysis']
+        or any(re.fullmatch(r'answer_\d+', field_name) for field_name in public_fields)
+    )
+    if not exact_row_fields:
+        return
+    if public_fields != ['row_analysis']:
+        expected_fields = [f'answer_{field_index}' for field_index in range(1, len(public_fields) + 1)]
+        if public_fields != expected_fields:
+            raise ValueError(
+                f'Exhaustive row analysis fields must be consecutive answer_1 through answer_N; got {public_fields}'
+            )
+    for row_index, entry in enumerate(entries or [], start=1):
+        for field_name in public_fields:
+            if (entry or {}).get(field_name) in (None, '', [], {}):
+                raise ValueError(
+                    f'Generated exhaustive row analysis left {field_name} empty at row {row_index}'
+                )
+
+
+def _validate_exhaustive_row_analysis_contract(row_analysis_mode, questions, public_output_schema):
+    if str(row_analysis_mode or '').strip().lower() != 'exhaustive':
+        return
+    normalized_questions = [
+        str(question or '').strip()
+        for question in list(questions or [])[:TABULAR_ROW_ANALYSIS_MAX_QUESTIONS]
+        if str(question or '').strip()
+    ]
+    normalized_public_schema = [
+        str(field_name or '').strip().lower()
+        for field_name in list(public_output_schema or [])
+        if str(field_name or '').strip()
+        and not is_analysis_internal_lineage_field(field_name)
+    ]
+    expected_schema = (
+        [f'answer_{question_index}' for question_index in range(1, len(normalized_questions) + 1)]
+        if normalized_questions
+        else ['row_analysis']
+    )
+    if normalized_public_schema != expected_schema:
+        raise ValueError(
+            'Exhaustive row analysis questions do not match the persisted public output schema'
+        )
 
 
 def _generated_entry_has_source_position_conflict(source_row, generated_entry):
@@ -3259,6 +3330,15 @@ def _build_combined_chunk_prompt(run, batch_rows, batch_number, batch_count, out
         if model_output_schema
         else ''
     )
+    answer_field_line = (
+        'Fields named answer_N map to the Nth question in the user instructions. '
+        'Answer every answer_N field independently and do not combine or omit questions.\n'
+        if any(
+            re.fullmatch(r'answer_\d+', str(field_name or '').strip().lower())
+            for field_name in model_output_schema
+        )
+        else ''
+    )
     return (
         'Transform and analyze the bounded tabular chunk below for the user.\n\n'
         f'User structured-output instructions:\n{user_question}\n\n'
@@ -3266,6 +3346,7 @@ def _build_combined_chunk_prompt(run, batch_rows, batch_number, batch_count, out
         'Return ONLY a valid JSON object with exactly these top-level fields: structured_rows, analysis_summary.\n'
         f'structured_rows must be an array of exactly {len(batch_rows)} object(s), one per input row, in the same order.\n'
         f'{output_schema_line}'
+        f'{answer_field_line}'
         f'Each structured row must copy {TABULAR_EXPORT_INPUT_ROW_TOKEN_FIELD} exactly from the matching input row. '
         f'Do not include {TABULAR_EXPORT_INPUT_ROW_NUMBER_FIELD} or {TABULAR_EXPORT_INPUT_ROW_IDENTITY_FIELD} in structured rows.\n'
         'Do not drop, merge, summarize, or cap structured rows. If a requested field cannot be derived, include it with null or an empty string.\n'
@@ -3740,6 +3821,15 @@ def _build_batch_prompt(
         if model_output_schema
         else ''
     )
+    answer_field_line = (
+        'Fields named answer_N map to the Nth question in the user instructions. '
+        'Answer every answer_N field independently and do not combine or omit questions.\n'
+        if any(
+            re.fullmatch(r'answer_\d+', str(field_name or '').strip().lower())
+            for field_name in model_output_schema
+        )
+        else ''
+    )
 
     return (
         'Transform the tabular input rows below into structured output for the user.\n\n'
@@ -3747,6 +3837,7 @@ def _build_batch_prompt(
         'Return ONLY a valid JSON array.\n'
         f'Return exactly {len(batch_rows)} JSON object(s), one per input row, in the same order.\n'
         f'{output_schema_line}'
+        f'{answer_field_line}'
         f'Copy {TABULAR_EXPORT_INPUT_ROW_TOKEN_FIELD} exactly from each input row into its matching output object. '
         f'The {TABULAR_EXPORT_INPUT_ROW_NUMBER_FIELD} and {TABULAR_EXPORT_INPUT_ROW_IDENTITY_FIELD} fields are internal; '
         'do not include those two fields in generated objects.\n'
@@ -5220,6 +5311,7 @@ async def _generate_batch_entries(
                     expected_output_schema or output_schema,
                     transformation_spec=transformation_spec,
                 )
+                _validate_exhaustive_row_analysis_entries(normalized_entries, output_schema)
                 semantic_validation_counts = {}
                 semantic_validation_attempts = []
                 if transformation_spec:
@@ -6213,6 +6305,7 @@ async def _generate_combined_chunk_result(
                     expected_output_schema or output_schema,
                     transformation_spec=transformation_spec,
                 )
+                _validate_exhaustive_row_analysis_entries(normalized_entries, output_schema)
                 candidate_checkpoint = None
                 if transformation_spec and semantic_mode in {'shadow', 'active'}:
                     candidate_checkpoint = _load_tabular_semantic_candidate_checkpoint(
@@ -6842,6 +6935,12 @@ def _normalize_tabular_run_planner_metadata(planner_metadata):
         'execution_state': str(planner_metadata.get('execution_state') or '').strip().lower()[:40],
         'durable_task_type': _normalize_tabular_run_task_type(planner_metadata.get('durable_task_type')),
         'reason_code': str(planner_metadata.get('reason_code') or '').strip().lower()[:80],
+        'row_analysis_mode': str(planner_metadata.get('row_analysis_mode') or '').strip().lower()[:40],
+        'row_analysis_questions': [
+            str(question or '').strip()[:500]
+            for question in list(planner_metadata.get('row_analysis_questions') or [])[:TABULAR_ROW_ANALYSIS_MAX_QUESTIONS]
+            if str(question or '').strip()
+        ],
         'execution_group_id': str(planner_metadata.get('execution_group_id') or '').strip()[:128],
         'source_coverage_summary': _build_planner_source_coverage_summary(
             planner_metadata.get('source_coverage'),
@@ -8282,6 +8381,12 @@ def _write_ordered_output_stream(run, output_stream):
         csv_writer.writeheader()
     elif output_format == 'xml':
         output_stream.write('<?xml version="1.0" encoding="UTF-8"?>\n<GeneratedOutput>\n')
+    elif output_format == 'md':
+        output_stream.write('# Row-by-Row Tabular Analysis\n\n')
+        output_stream.write(
+            f"Source file: {run.get('source_file_name') or 'unknown file'}  \n"
+            f"Rows: {expected_row_count:,}\n\n"
+        )
     else:
         output_stream.write('[\n')
 
@@ -8326,6 +8431,31 @@ def _write_ordered_output_stream(run, output_stream):
                 })
             elif output_format == 'xml':
                 _write_generated_xml_row(output_stream, public_entry)
+            elif output_format == 'md':
+                source_row_identity = _normalize_analysis_text(
+                    ordered_entry.get(TABULAR_EXPORT_OUTPUT_ROW_IDENTITY_FIELD),
+                    max_chars=200,
+                )
+                identity_suffix = f": {source_row_identity}" if source_row_identity else ''
+                output_stream.write(
+                    f"## Row {source_row_number}{_escape_markdown_text(identity_suffix)}\n\n"
+                )
+                row_questions = list((run or {}).get('row_analysis_questions') or [])
+                for field_index, field_name in enumerate(public_output_schema, start=1):
+                    question_label = (
+                        _normalize_analysis_text(row_questions[field_index - 1], max_chars=500)
+                        if field_index <= len(row_questions)
+                        else str(field_name or '').replace('_', ' ').strip().title()
+                    )
+                    field_value = _escape_markdown_text(
+                        _serialize_generated_output_value(public_entry.get(field_name))
+                    )
+                    output_stream.write(
+                        f"{field_index}. **{_escape_markdown_text(question_label)}**\n\n"
+                    )
+                    for value_line in field_value.split('\n'):
+                        output_stream.write(f"   {value_line}\n")
+                    output_stream.write('\n')
             else:
                 if written_row_count:
                     output_stream.write(',\n')
@@ -8336,7 +8466,7 @@ def _write_ordered_output_stream(run, output_stream):
 
     if output_format == 'xml':
         output_stream.write('</GeneratedOutput>\n')
-    elif output_format != 'csv':
+    elif output_format not in {'csv', 'md'}:
         output_stream.write('\n]\n')
     if written_row_count != expected_row_count:
         raise ValueError(
@@ -9070,7 +9200,11 @@ def _build_public_artifact_projection(artifact):
 def _publish_structured_export_artifact(run, descriptor=None):
     descriptor = descriptor if isinstance(descriptor, dict) else {}
     member_id = str(descriptor.get('member_id') or _get_structured_artifact_member_id(run)).strip()
-    output_format = normalize_generated_output_format(descriptor.get('format') or run.get('output_format'))
+    output_format = _normalize_tabular_artifact_format(
+        descriptor.get('format') or run.get('output_format')
+    )
+    if output_format not in {'csv', 'json', 'xml', 'md'}:
+        raise ValueError(f'Unsupported tabular structured artifact format: {output_format}')
     generated_file_name = run.get('generated_file_name') or _build_generated_file_name(
         run.get('source_file_name'),
         output_format,
@@ -9148,7 +9282,7 @@ def _publish_structured_export_artifacts(run):
     artifacts = []
     first_summary = ''
     first_entry_count = None
-    first_output_format = normalize_generated_output_format(run.get('output_format'))
+    first_output_format = _normalize_tabular_artifact_format(run.get('output_format'))
     first_file_name = run.get('generated_file_name') or _build_generated_file_name(
         run.get('source_file_name'),
         first_output_format,
@@ -10623,6 +10757,11 @@ def process_tabular_generated_output_run(run_id, user_id):
         run = _migrate_legacy_tabular_export_run(run)
         if run.get('source_descriptor') and not run.get('source_staging_complete'):
             run = _stage_tabular_generated_output_source(run, settings)
+        _validate_exhaustive_row_analysis_contract(
+            run.get('row_analysis_mode'),
+            run.get('row_analysis_questions'),
+            _get_tabular_run_public_output_schema(run),
+        )
 
         retry_attempts = _settings_int(
             settings,
@@ -10940,6 +11079,8 @@ def queue_tabular_generated_output_run(
         normalized_analysis_objective = str(user_question or '').strip()
     if normalized_task_type == TABULAR_RUN_TASK_HIERARCHICAL_ANALYSIS:
         generated_file_name = _build_analysis_file_name(source_file_name)
+    elif normalized_output_format == 'md':
+        generated_file_name = _build_row_analysis_file_name(source_file_name)
     else:
         generated_file_name = _build_generated_file_name(source_file_name, normalized_output_format)
     analysis_generated_file_name = (
@@ -10973,6 +11114,28 @@ def queue_tabular_generated_output_run(
         task_type=normalized_task_type,
         user_question=user_question,
     )
+    row_analysis_mode = str(tabular_planner_metadata.get('row_analysis_mode') or '').strip().lower()
+    row_analysis_questions = list(tabular_planner_metadata.get('row_analysis_questions') or [])
+    _validate_exhaustive_row_analysis_contract(
+        row_analysis_mode,
+        row_analysis_questions,
+        contract_public_output_schema,
+    )
+    if row_analysis_mode == 'exhaustive':
+        question_count = max(1, len(row_analysis_questions))
+        estimated_output_chars_per_row = max(
+            600,
+            question_count * TABULAR_ROW_ANALYSIS_ANSWER_ESTIMATED_CHARS,
+        )
+        output_char_budget = max(
+            1000,
+            _safe_int(model_batch_budget.get('output_token_budget'), minimum=1)
+            * TABULAR_EXPORT_APPROXIMATE_CHARS_PER_TOKEN,
+        )
+        model_batch_budget['max_rows'] = min(
+            _safe_int(model_batch_budget.get('max_rows'), minimum=1),
+            max(1, output_char_budget // estimated_output_chars_per_row),
+        )
     chunk_gpt_model, chunk_model_context = _resolve_tabular_chunk_model_selection(
         gpt_model,
         settings,
@@ -11141,6 +11304,8 @@ def queue_tabular_generated_output_run(
         'tabular_planner_metadata': tabular_planner_metadata,
         'task_type': normalized_task_type,
         'analysis_objective': normalized_analysis_objective,
+        'row_analysis_mode': row_analysis_mode,
+        'row_analysis_questions': row_analysis_questions,
         'user_id': normalized_user_id,
         'conversation_id': normalized_conversation_id,
         'status': TABULAR_EXPORT_STATUS_QUEUED,

--- a/application/single_app/functions_tabular_orchestration.py
+++ b/application/single_app/functions_tabular_orchestration.py
@@ -4,9 +4,12 @@
 import hashlib
 import json
 import os
+import re
 from typing import Mapping
 
 from functions_analysis_deliverables import (
+    ANALYSIS_ARTIFACT_ROLE_PRIMARY_ANALYSIS,
+    ANALYSIS_ARTIFACT_ROLE_REQUESTED_OUTPUT,
     ANALYSIS_DELIVERABLE_EVENT_FINALIZED,
     ANALYSIS_DELIVERABLE_EVENT_PLANNED,
     ANALYSIS_ORDERING_NOT_APPLICABLE,
@@ -18,6 +21,7 @@ from functions_analysis_deliverables import (
     ANALYSIS_VALIDATION_PROFILE_ARTIFACT_SET,
     ANALYSIS_VALIDATION_PROFILE_EXACT_ROWS_SCHEMA,
     ANALYSIS_VALIDATION_PROFILE_EXACT_ROWS_SCHEMA_AND_RULES,
+    build_analysis_deliverable_artifact,
     build_analysis_deliverable_contract,
     emit_analysis_deliverable_contract_event,
 )
@@ -323,11 +327,76 @@ def question_requests_tabular_hierarchical_analysis(user_question):
     )
 
 
+def question_requests_tabular_exhaustive_row_output(user_question):
+    """Return True when the user requires one narrative result per source row."""
+    normalized_question = str(user_question or "").strip().lower()
+    if not normalized_question:
+        return False
+
+    row_output_markers = (
+        "for each row",
+        "for every row",
+        "for each line",
+        "for every line",
+        "line by line",
+        "row by row",
+        "each line item",
+        "each row individually",
+        "each line individually",
+        "individually for each row",
+        "individually for each line",
+        "one answer per row",
+        "one answer per line",
+        "one result per row",
+        "one result per line",
+        "one output per row",
+        "one output per line",
+        "one markdown section per row",
+        "one markdown section per line",
+    )
+    return any(marker in normalized_question for marker in row_output_markers)
+
+
+def extract_tabular_row_analysis_questions(user_question, max_questions=20):
+    """Extract an ordered, bounded question list for exact-row narrative output."""
+    question_text = str(user_question or "").strip()
+    if not question_text:
+        return []
+
+    marker_match = re.search(
+        r"(?is)\b(?:questions?\s+(?:are|is)\s+as\s+follows|answer\s+(?:the\s+)?following\s+questions?)\s*:?",
+        question_text,
+    )
+    candidate_text = question_text[marker_match.end():] if marker_match else question_text
+    line_candidates = []
+    for raw_line in candidate_text.splitlines():
+        normalized_line = re.sub(r"^\s*(?:[-*•]|\d+[.)])\s*", "", raw_line).strip()
+        if normalized_line:
+            line_candidates.append(normalized_line)
+    if len(line_candidates) >= 2:
+        return line_candidates[:max_questions]
+
+    split_candidates = re.split(
+        r"(?i)(?=\b(?:what|why|how|when|where|who|which|does|do|is|are|can|could|should|would|concerns?)\b)",
+        candidate_text,
+    )
+    questions = []
+    for candidate in split_candidates:
+        normalized_candidate = re.sub(r"\s+", " ", candidate).strip(" :-\t\r\n")
+        if not normalized_candidate:
+            continue
+        questions.append(normalized_candidate[:500])
+        if len(questions) >= max_questions:
+            break
+    return questions
+
+
 def get_tabular_generated_output_task_type(
     generated_output_requested,
     hierarchical_analysis_requested,
     settings,
     action_mode=None,
+    exhaustive_row_output_requested=False,
 ):
     """Map request intent to the existing durable generated-output task type."""
     hierarchical_analysis_enabled = settings_flag_enabled(
@@ -336,6 +405,10 @@ def get_tabular_generated_output_task_type(
         False,
     )
     analysis_required = str(action_mode or "").strip().lower() == "analyze"
+    if exhaustive_row_output_requested and hierarchical_analysis_enabled:
+        return TABULAR_RUN_TASK_COMBINED if analysis_required else TABULAR_RUN_TASK_STRUCTURED_EXPORT
+    if exhaustive_row_output_requested:
+        return None
     if generated_output_requested and analysis_required:
         return TABULAR_RUN_TASK_COMBINED
     if generated_output_requested and hierarchical_analysis_requested and hierarchical_analysis_enabled:
@@ -575,13 +648,29 @@ def plan_tabular_request(
     structured_output_formats = get_tabular_generated_output_formats(user_question)
     generated_output_requested = question_requests_tabular_generated_output(user_question)
     hierarchical_analysis_requested = question_requests_tabular_hierarchical_analysis(user_question)
+    exhaustive_row_output_requested = question_requests_tabular_exhaustive_row_output(user_question)
+    exhaustive_narrative_row_output_requested = bool(
+        exhaustive_row_output_requested and not structured_output_formats
+    )
+    row_analysis_questions = (
+        extract_tabular_row_analysis_questions(user_question)
+        if exhaustive_narrative_row_output_requested
+        else []
+    )
     durable_task_type = get_tabular_generated_output_task_type(
         generated_output_requested,
         hierarchical_analysis_requested,
         settings,
         action_mode=normalized_action_mode,
+        exhaustive_row_output_requested=exhaustive_narrative_row_output_requested,
     )
-    output_format = structured_output_formats[0] if structured_output_formats else None
+    output_format = (
+        structured_output_formats[0]
+        if structured_output_formats
+        else "md"
+        if exhaustive_narrative_row_output_requested
+        else None
+    )
     execution_contract = durable_task_type or TABULAR_EXECUTION_CONTRACT_FOREGROUND_AGGREGATE
     source_coverage = _build_source_coverage(normalized_contexts)
     execution_group_id = _build_execution_group_id(
@@ -642,16 +731,42 @@ def plan_tabular_request(
         if transformation_spec
         else ANALYSIS_TRANSFORMATION_MODE_SEMANTIC
     )
+    exact_row_output_requested = generated_output_requested or exhaustive_narrative_row_output_requested
     validation_profile = (
         ANALYSIS_VALIDATION_PROFILE_EXACT_ROWS_SCHEMA_AND_RULES
-        if generated_output_requested and transformation_spec
+        if exact_row_output_requested and transformation_spec
         else ANALYSIS_VALIDATION_PROFILE_EXACT_ROWS_SCHEMA
-        if generated_output_requested
+        if exact_row_output_requested
         else ANALYSIS_VALIDATION_PROFILE_ARTIFACT_SET
     )
+    row_analysis_output_schema = [
+        f"answer_{question_index}"
+        for question_index in range(1, len(row_analysis_questions) + 1)
+    ] or (["row_analysis"] if exhaustive_narrative_row_output_requested else [])
+    requested_artifacts = None
+    if exhaustive_narrative_row_output_requested:
+        requested_artifacts = []
+        request_order = 0
+        if normalized_action_mode == "analyze":
+            requested_artifacts.append(build_analysis_deliverable_artifact(
+                "analysis-summary",
+                ANALYSIS_ARTIFACT_ROLE_PRIMARY_ANALYSIS,
+                "md",
+                required=True,
+                request_order=request_order,
+            ))
+            request_order += 1
+        requested_artifacts.append(build_analysis_deliverable_artifact(
+            "row-analysis-md",
+            ANALYSIS_ARTIFACT_ROLE_REQUESTED_OUTPUT,
+            "md",
+            required=True,
+            request_order=request_order,
+        ))
     deliverable_contract = build_analysis_deliverable_contract(
         action_mode=action_mode,
         requested_output_formats=requested_output_formats,
+        requested_artifacts=requested_artifacts,
         analysis_required=(
             normalized_action_mode == "analyze"
             or durable_task_type in {
@@ -660,18 +775,19 @@ def plan_tabular_request(
             }
         ),
         public_output_schema=(
-            output_hints.get("public_output_schema")
+            row_analysis_output_schema
+            or output_hints.get("public_output_schema")
             or output_hints.get("output_schema")
             or []
         ),
         row_cardinality=(
             ANALYSIS_ROW_CARDINALITY_ONE_PER_SOURCE_ROW
-            if generated_output_requested
+            if exact_row_output_requested
             else ANALYSIS_ROW_CARDINALITY_NOT_APPLICABLE
         ),
         ordering=(
             ANALYSIS_ORDERING_SOURCE_ORDER
-            if generated_output_requested
+            if exact_row_output_requested
             else ANALYSIS_ORDERING_NOT_APPLICABLE
         ),
         transformation_mode=transformation_mode,
@@ -689,6 +805,9 @@ def plan_tabular_request(
         "durable_task_type": durable_task_type,
         "generated_output_requested": generated_output_requested,
         "hierarchical_analysis_requested": hierarchical_analysis_requested,
+        "exhaustive_row_output_requested": exhaustive_narrative_row_output_requested,
+        "row_analysis_mode": "exhaustive" if exhaustive_narrative_row_output_requested else "summary",
+        "row_analysis_questions": row_analysis_questions,
         "requested_output_formats": requested_output_formats,
         "output_format": output_format,
         "action_mode": normalized_action_mode,

--- a/application/single_app/route_backend_chats.py
+++ b/application/single_app/route_backend_chats.py
@@ -63,6 +63,7 @@ from functions_tabular_orchestration import (
     build_tabular_legacy_post_tool_fallback_decision as _shared_build_tabular_legacy_post_tool_fallback_decision,
     get_tabular_generated_output_format as _shared_get_tabular_generated_output_format,
     get_tabular_generated_output_task_type as _shared_get_tabular_generated_output_task_type,
+    question_requests_tabular_exhaustive_row_output as _shared_question_requests_tabular_exhaustive_row_output,
     question_requests_tabular_generated_output as _shared_question_requests_tabular_generated_output,
     question_requests_tabular_hierarchical_analysis as _shared_question_requests_tabular_hierarchical_analysis,
     settings_flag_enabled as _shared_settings_flag_enabled,
@@ -5016,16 +5017,28 @@ def question_requests_tabular_hierarchical_analysis(user_question):
     return _shared_question_requests_tabular_hierarchical_analysis(user_question)
 
 
+def question_requests_tabular_exhaustive_row_output(user_question):
+    """Return True when the prompt requires one narrative result per source row."""
+    return _shared_question_requests_tabular_exhaustive_row_output(user_question)
+
+
 def _settings_flag_enabled(settings, key, default=False):
     return _shared_settings_flag_enabled(settings, key, default=default)
 
 
-def _get_tabular_generated_output_task_type(generated_output_requested, hierarchical_analysis_requested, settings, action_mode=None):
+def _get_tabular_generated_output_task_type(
+    generated_output_requested,
+    hierarchical_analysis_requested,
+    settings,
+    action_mode=None,
+    exhaustive_row_output_requested=False,
+):
     return _shared_get_tabular_generated_output_task_type(
         generated_output_requested,
         hierarchical_analysis_requested,
         settings,
         action_mode=action_mode,
+        exhaustive_row_output_requested=exhaustive_row_output_requested,
     )
 
 
@@ -5760,23 +5773,38 @@ def _build_tabular_generated_output_query_descriptor(
     return descriptor
 
 
-def _build_direct_tabular_generated_output_source(user_question, file_contexts, user_id, conversation_id, settings, action_mode=None):
+def _build_direct_tabular_generated_output_source(
+    user_question,
+    file_contexts,
+    user_id,
+    conversation_id,
+    settings,
+    action_mode=None,
+    planner_metadata=None,
+):
     """Build a replayable full-tabular source descriptor without requiring a prior tool page."""
     generated_output_requested = question_requests_tabular_generated_output(user_question)
     hierarchical_analysis_requested = question_requests_tabular_hierarchical_analysis(user_question)
+    exhaustive_row_output_requested = question_requests_tabular_exhaustive_row_output(user_question)
     durable_task_type = _get_tabular_generated_output_task_type(
         generated_output_requested,
         hierarchical_analysis_requested,
         settings,
         action_mode=action_mode,
+        exhaustive_row_output_requested=exhaustive_row_output_requested,
     )
     analysis_only_requested = durable_task_type == TABULAR_RUN_TASK_HIERARCHICAL_ANALYSIS
     combined_requested = durable_task_type == TABULAR_RUN_TASK_COMBINED
     if generated_output_requested and str(action_mode or '').strip().lower() == 'analyze' and not durable_task_type:
         return None
-    if not generated_output_requested and not analysis_only_requested:
+    if not generated_output_requested and not analysis_only_requested and not exhaustive_row_output_requested:
         return None
-    if hierarchical_analysis_requested and not generated_output_requested and not analysis_only_requested:
+    if (
+        hierarchical_analysis_requested
+        and not generated_output_requested
+        and not analysis_only_requested
+        and not exhaustive_row_output_requested
+    ):
         return None
 
     normalized_contexts = dedupe_tabular_file_contexts(file_contexts)
@@ -5920,7 +5948,11 @@ def _build_direct_tabular_generated_output_source(user_question, file_contexts, 
             )
         ),
     })
-    output_format = get_tabular_generated_output_format(user_question) or 'md'
+    output_format = (
+        str((planner_metadata or {}).get('output_format') or '').strip().lower()
+        or get_tabular_generated_output_format(user_question)
+        or 'md'
+    )
     queued_output_format = 'md' if analysis_only_requested else output_format
     return {
         'file_context': file_context,
@@ -5958,6 +5990,7 @@ def _build_direct_tabular_generated_output_source(user_question, file_contexts, 
         'batch_count_estimate': max(1, math.ceil(row_count / max(batch_budget['max_rows'], 1))),
         'analysis_only_requested': analysis_only_requested,
         'combined_requested': combined_requested,
+        'exhaustive_row_output_requested': exhaustive_row_output_requested,
     }
 
 
@@ -6014,6 +6047,7 @@ def maybe_queue_direct_tabular_generated_output(
             conversation_id,
             settings,
             action_mode=planner_action_mode,
+            planner_metadata=planner_metadata,
         )
         if not direct_source:
             emit_direct_parity_event(
@@ -6044,6 +6078,10 @@ def maybe_queue_direct_tabular_generated_output(
             planner_metadata=planner_metadata,
         )
         background_metadata = build_background_tabular_generated_output_metadata(background_run)
+        actual_batch_count = (
+            _safe_int(background_metadata.get('batch_count'))
+            or direct_source['batch_count_estimate']
+        )
         accepted_parity_result = parity_result
         if callable(parity_result_builder):
             accepted_parity_result = parity_result_builder(
@@ -6061,7 +6099,7 @@ def maybe_queue_direct_tabular_generated_output(
             metrics={
                 'source_count': len(file_contexts or []),
                 'row_count': direct_source.get('row_count'),
-                'batch_count_estimate': direct_source.get('batch_count_estimate'),
+                'batch_count_estimate': actual_batch_count,
             },
         )
         emit_direct_parity_event(
@@ -6082,7 +6120,7 @@ def maybe_queue_direct_tabular_generated_output(
                 'content': title,
                 'detail': (
                     f"run_id={background_metadata.get('export_run_id')}; "
-                    f"rows={direct_source['row_count']}; batches~={direct_source['batch_count_estimate']}; checkpointed=true"
+                    f"rows={direct_source['row_count']}; batches={actual_batch_count}; checkpointed=true"
                 ),
                 'activity': build_tabular_post_processing_activity_payload(
                     'tabular.generated_output',
@@ -6092,7 +6130,7 @@ def maybe_queue_direct_tabular_generated_output(
                     output_format=direct_source['output_format'],
                     file_name=direct_source['source_candidate'].get('filename'),
                     batch_index=0,
-                    batch_count=direct_source['batch_count_estimate'],
+                    batch_count=actual_batch_count,
                 ),
             }
             maybe_callback_result = thought_callback(thought_payload)
@@ -6105,7 +6143,7 @@ def maybe_queue_direct_tabular_generated_output(
                 'conversation_id': conversation_id,
                 'source_file_name': direct_source['source_candidate'].get('filename'),
                 'row_count': direct_source['row_count'],
-                'batch_count_estimate': direct_source['batch_count_estimate'],
+                'batch_count_estimate': actual_batch_count,
                 'task_type': direct_source.get('task_type') or 'structured_export',
                 'output_format': direct_source['output_format'],
                 'export_run_id': background_metadata.get('export_run_id'),

--- a/application/single_app/static/js/chat/chat-messages.js
+++ b/application/single_app/static/js/chat/chat-messages.js
@@ -4311,6 +4311,13 @@ function renderReplyQuoteHtml(fullMessageObject = null) {
   }
 
   function getGeneratedAnalysisArtifactTitle(outputMetadata, outputFormat) {
+    const artifactId = String(outputMetadata?.artifact_id || outputMetadata?.member_id || '').trim().toLowerCase();
+    if (artifactId === 'analysis-summary') {
+      return 'Analyze Markdown summary';
+    }
+    if (artifactId === 'row-analysis-md') {
+      return 'Row-by-row Markdown output';
+    }
     const capability = String(outputMetadata?.capability || '').trim().toLowerCase();
     if (capability === 'analyze') {
       return `Analyze ${outputFormat.toUpperCase()} artifact`;

--- a/docs/explanation/fixes/TABULAR_DURABLE_ARTIFACT_LIFECYCLE_FIX.md
+++ b/docs/explanation/fixes/TABULAR_DURABLE_ARTIFACT_LIFECYCLE_FIX.md
@@ -20,6 +20,8 @@ The intended output contract is:
 - Search exhaustive analysis without an explicit format: one primary Markdown analysis artifact.
 - Analyze exhaustive analysis without an explicit format: one primary Markdown analysis artifact.
 
+> **Superseded for explicit row-by-row prompts in 0.250.201:** Search now publishes one exhaustive row Markdown artifact, while Analyze publishes a summary Markdown artifact plus an exhaustive row Markdown sibling. Aggregate whole-dataset analysis remains summary-only.
+
 ## Root Cause Analysis
 
 The production failures had seven related causes:

--- a/docs/explanation/fixes/TABULAR_EXHAUSTIVE_ROW_MARKDOWN_FIX.md
+++ b/docs/explanation/fixes/TABULAR_EXHAUSTIVE_ROW_MARKDOWN_FIX.md
@@ -1,0 +1,76 @@
+# TABULAR EXHAUSTIVE ROW MARKDOWN FIX
+
+Fixed in version: **0.250.201**
+
+## Issue Description
+
+Durable Search and Analyze runs correctly read all 200 rows and published Markdown, but the Markdown contained only 12 row findings. The artifact still reported `Rows analyzed: 200`, which described input coverage rather than output cardinality.
+
+For the customer prompt requesting eight individual answers for every line, the required outputs are:
+
+- **Search:** one exhaustive Markdown file containing all 200 rows and all eight answers per row.
+- **Analyze:** one concise Markdown analysis summary plus one exhaustive Markdown file containing all 200 rows and all eight answers per row.
+
+Aggregate prompts such as analyzing all rows for themes or risks continue to produce the bounded summary artifact.
+
+## Root Cause Analysis
+
+The no-format row request was routed to the hierarchical summary lane. That lane intentionally:
+
+- asks each chunk for `summary`, `findings`, `counts`, and `notable_rows`;
+- caps findings at 12 and notable rows at 25;
+- recursively reduces chunk summaries;
+- renders only the bounded reduced fields into Markdown.
+
+It guaranteed that all source rows were read, but never guaranteed one output entry per row. The 200-row run happened to use one chunk, and the model returned 12 findings, exactly matching the server cap.
+
+## Technical Details
+
+### Files Modified
+
+- `application/single_app/functions_tabular_orchestration.py`
+- `application/single_app/route_backend_chats.py`
+- `application/single_app/functions_tabular_generated_exports.py`
+- `application/single_app/static/js/chat/chat-messages.js`
+- `application/single_app/config.py`
+- Related functional and Playwright tests
+
+### Code Changes Summary
+
+- Added explicit per-row narrative intent detection, separate from aggregate whole-dataset analysis.
+- Extracted the user's ordered, bounded question list and planned `answer_1` through `answer_N` fields.
+- Routed no-format per-row Search to `structured_export(md)` and Analyze to `combined(md)`.
+- Planned distinct artifact IDs so Analyze can require two same-format siblings: `analysis-summary` and `row-analysis-md`.
+- Reused the durable exact-row checkpoint engine, including source tokens, exact row counts, stable schemas, source order, retries, and idempotent publication.
+- Sized batches using estimated narrative output per row so a 200-row/eight-question request is split into multiple bounded model calls.
+- Required every expected answer field to be non-empty and consecutive before checkpoint acceptance.
+- Added an ordered Markdown stream finalizer that writes every source row and original question label, then verifies the final row count.
+- Escaped source identities, user question labels, and model-generated answers as literal Markdown text.
+- Added distinct UI titles for the summary and row-by-row Markdown artifacts.
+- Preserved the existing hierarchical summary lane for aggregate prompts and the existing CSV/JSON/XML behavior for explicit structured formats.
+
+## Validation
+
+- Exact customer prompt extracts all eight questions and plans:
+  - Search: `row-analysis-md`.
+  - Analyze: `analysis-summary` plus `row-analysis-md`.
+- A deterministic 200-row test streams four checkpoints into Markdown and asserts:
+  - 200 row headings;
+  - each of eight questions appears 200 times;
+  - the final row and final eighth answer are present;
+  - 1,600 answers are represented;
+  - missing answers and malformed answer sequences fail validation.
+- Adversarial row identities, questions, and answers verify active Markdown links and raw HTML are escaped.
+- Queue-level testing verifies output-aware batching creates multiple batches and persists exact schemas.
+- Full 70-test tabular scale coverage passes, including 100,000-row planning and idempotent publication.
+- Full background-card UI suite passes, including Search's one Markdown card and Analyze's two distinct Markdown cards.
+
+## Impact Analysis
+
+- "All rows analyzed" now means all rows are also present in the exhaustive deliverable when the user asks for individual per-row output.
+- Summary and exhaustive output remain separate concerns, preventing concise analysis from truncating row deliverables.
+- Large requests remain bounded and checkpointed instead of attempting one unbounded model response or in-memory artifact.
+
+## Related Version Updates
+
+- `application/single_app/config.py` was updated to version **0.250.201**.

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,16 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](/explanation/features/) and [Fixes by Version](/explanation/fixes/).
 
+### **(v0.250.201)**
+
+#### Bug Fixes
+
+*   **Exhaustive Row-by-Row Markdown Output**
+    *   Fixed line-by-line Markdown analysis reading every source row but publishing only 12 summarized findings because the previous hierarchical lane intentionally bounded findings and notable rows.
+    *   Search now produces one exhaustive Markdown artifact containing every source row and every requested answer; Analyze produces a concise Markdown summary plus a separate exhaustive row-by-row Markdown artifact.
+    *   Exact-row Markdown uses ordered checkpoints, output-aware batching, consecutive answer-field validation, non-empty answer enforcement, final row-count/source-order checks, and literal Markdown escaping for untrusted content.
+    *   (Ref: `functions_tabular_orchestration.py`, `functions_tabular_generated_exports.py`, `route_backend_chats.py`, `TABULAR_EXHAUSTIVE_ROW_MARKDOWN_FIX.md`)
+
 ### **(v0.250.200)**
 
 #### Bug Fixes

--- a/functional_tests/test_tabular_line_terminology_routing_fix.py
+++ b/functional_tests/test_tabular_line_terminology_routing_fix.py
@@ -2,8 +2,8 @@
 # test_tabular_line_terminology_routing_fix.py
 """
 Functional test for tabular exhaustive per-line terminology routing.
-Version: 0.250.199
-Implemented in: 0.250.197; updated in 0.250.199
+Version: 0.250.201
+Implemented in: 0.250.197; updated in 0.250.199 and 0.250.201
 
 A customer reported that a prompt phrased as "For each line in this document,
 I need eight questions answered... Go line by line and make sure all eight
@@ -41,7 +41,7 @@ APP_ROOT = REPO_ROOT / "application" / "single_app"
 if str(APP_ROOT) not in sys.path:
     sys.path.insert(0, str(APP_ROOT))
 
-IMPLEMENTED_VERSION = "0.250.197"
+IMPLEMENTED_VERSION = "0.250.201"
 
 CUSTOMER_PROMPT = (
     "For each line in this document, I need eight questions answered. I want "
@@ -83,8 +83,10 @@ def _install_lightweight_planner_dependency_stubs():
 _install_lightweight_planner_dependency_stubs()
 
 from functions_tabular_orchestration import (  # noqa: E402
+    extract_tabular_row_analysis_questions,
     get_tabular_generated_output_task_type,
     plan_tabular_request,
+    question_requests_tabular_exhaustive_row_output,
     question_requests_tabular_generated_output,
     question_requests_tabular_hierarchical_analysis,
 )
@@ -106,46 +108,80 @@ def test_line_phrasing_is_recognized_as_hierarchical_analysis_intent():
     assert question_requests_tabular_hierarchical_analysis(row_prompt) is True, row_prompt
 
 
-def test_customer_prompt_routes_to_durable_hierarchical_analysis_for_analyze_and_search():
-    """The exact reported prompt must resolve to the hierarchical_analysis task
-    type for both Analyze and Search action modes once the feature default is
-    active, and must fall back to no durable routing when the flag is off
-    (reproducing the reported bug)."""
-    print("Testing customer prompt routes to durable hierarchical analysis...")
+def test_customer_prompt_routes_to_exact_row_markdown_for_analyze_and_search():
+    """The exact prompt must preserve every row while keeping Analyze's summary sibling."""
+    print("Testing customer prompt routes to exact-row Markdown...")
     assert_app_version_at_least(IMPLEMENTED_VERSION)
 
     generated_output_requested = question_requests_tabular_generated_output(CUSTOMER_PROMPT)
     hierarchical_analysis_requested = question_requests_tabular_hierarchical_analysis(CUSTOMER_PROMPT)
+    exhaustive_row_output_requested = question_requests_tabular_exhaustive_row_output(CUSTOMER_PROMPT)
     assert hierarchical_analysis_requested is True
+    assert exhaustive_row_output_requested is True
+    assert len(extract_tabular_row_analysis_questions(CUSTOMER_PROMPT)) == 8
 
     active_settings = {"enable_tabular_hierarchical_analysis": True}
     assert get_tabular_generated_output_task_type(
-        generated_output_requested, hierarchical_analysis_requested, active_settings, action_mode="analyze"
-    ) == "hierarchical_analysis"
+        generated_output_requested,
+        hierarchical_analysis_requested,
+        active_settings,
+        action_mode="analyze",
+        exhaustive_row_output_requested=exhaustive_row_output_requested,
+    ) == "combined"
     assert get_tabular_generated_output_task_type(
-        generated_output_requested, hierarchical_analysis_requested, active_settings, action_mode="search"
-    ) == "hierarchical_analysis"
-    for action_mode in ("analyze", "search"):
+        generated_output_requested,
+        hierarchical_analysis_requested,
+        active_settings,
+        action_mode="search",
+        exhaustive_row_output_requested=exhaustive_row_output_requested,
+    ) == "structured_export"
+    expected_plans = {
+        "search": {
+            "task_type": "structured_export",
+            "artifact_ids": ["row-analysis-md"],
+            "analysis_required": False,
+        },
+        "analyze": {
+            "task_type": "combined",
+            "artifact_ids": ["analysis-summary", "row-analysis-md"],
+            "analysis_required": True,
+        },
+    }
+    for action_mode, expected in expected_plans.items():
         plan = plan_tabular_request(
             CUSTOMER_PROMPT,
             [{"file_name": "simple_financial_review_test_200.csv", "document_id": "doc-1"}],
             action_mode=action_mode,
             settings=active_settings,
         )
-        assert plan["durable_task_type"] == "hierarchical_analysis"
-        assert plan["deliverable_contract"]["analysis_required"] is True
-        assert [
-            artifact["format"]
-            for artifact in plan["deliverable_contract"]["requested_artifacts"]
-        ] == ["md"]
+        contract = plan["deliverable_contract"]
+        assert plan["durable_task_type"] == expected["task_type"]
+        assert plan["output_format"] == "md"
+        assert plan["row_analysis_mode"] == "exhaustive"
+        assert len(plan["row_analysis_questions"]) == 8
+        assert contract["analysis_required"] is expected["analysis_required"]
+        assert [artifact["artifact_id"] for artifact in contract["requested_artifacts"]] == expected["artifact_ids"]
+        assert [artifact["format"] for artifact in contract["requested_artifacts"]] == ["md"] * len(expected["artifact_ids"])
+        assert contract["public_output_schema"] == [f"answer_{index}" for index in range(1, 9)]
+        assert contract["row_cardinality"] == "one_per_source_row"
+        assert contract["ordering"] == "source_order"
+        assert contract["validation_profile"] == "exact_rows_schema"
 
     # Reproduce the reported bug: with the flag off, no durable task type is selected.
     disabled_settings = {"enable_tabular_hierarchical_analysis": False}
     assert get_tabular_generated_output_task_type(
-        generated_output_requested, hierarchical_analysis_requested, disabled_settings, action_mode="analyze"
+        generated_output_requested,
+        hierarchical_analysis_requested,
+        disabled_settings,
+        action_mode="analyze",
+        exhaustive_row_output_requested=exhaustive_row_output_requested,
     ) is None
     assert get_tabular_generated_output_task_type(
-        generated_output_requested, hierarchical_analysis_requested, disabled_settings, action_mode="search"
+        generated_output_requested,
+        hierarchical_analysis_requested,
+        disabled_settings,
+        action_mode="search",
+        exhaustive_row_output_requested=exhaustive_row_output_requested,
     ) is None
 
 
@@ -219,7 +255,7 @@ def test_enable_tabular_hierarchical_analysis_defaults_active():
 if __name__ == "__main__":
     tests = [
         test_line_phrasing_is_recognized_as_hierarchical_analysis_intent,
-        test_customer_prompt_routes_to_durable_hierarchical_analysis_for_analyze_and_search,
+        test_customer_prompt_routes_to_exact_row_markdown_for_analyze_and_search,
         test_enable_tabular_hierarchical_analysis_defaults_active,
     ]
     results = []

--- a/functional_tests/test_tabular_phase3_public_schema_projection.py
+++ b/functional_tests/test_tabular_phase3_public_schema_projection.py
@@ -2,8 +2,8 @@
 # test_tabular_phase3_public_schema_projection.py
 """
 Functional test for Phase 3 public schema projection and passthrough safety.
-Version: 0.250.182
-Implemented in: 0.250.173; request-order and unchanged-copy guard compatibility updated in 0.250.182
+Version: 0.250.201
+Implemented in: 0.250.173; request-order and unchanged-copy guard compatibility updated in 0.250.182; exhaustive Markdown updated in 0.250.201
 
 This test ensures generated tabular artifacts expose only the persisted public
 schema while retaining internal checkpoint lineage, and that raw row passthrough
@@ -11,8 +11,10 @@ is refused for derived generated-output requests.
 """
 
 import ast
+import html
 import io
 import json
+import re
 import sys
 import traceback
 from pathlib import Path
@@ -63,6 +65,9 @@ def load_tabular_export_namespace(checkpoint_rows):
     module_tree = ast.parse(source, filename=str(TABULAR_EXPORTS))
     function_names = {
         "_safe_int",
+        "_normalize_analysis_text",
+        "_escape_markdown_text",
+        "_validate_exhaustive_row_analysis_entries",
         "_serialize_generated_output_value",
         "_sanitize_generated_xml_tag_name",
         "_write_generated_xml_row",
@@ -89,6 +94,7 @@ def load_tabular_export_namespace(checkpoint_rows):
         "build_safe_csv_headers": build_safe_csv_headers,
         "csv": __import__("csv"),
         "escape_xml_text": escape_xml_text,
+        "html": html,
         "io": io,
         "is_analysis_internal_lineage_field": lambda field_name: str(field_name or "").strip() in {
             "source_row_number",
@@ -198,6 +204,104 @@ def test_public_projection_drives_csv_json_xml_and_preview():
     assert_false("source_row_number" in preview_rows[0], "preview lineage leakage")
 
 
+def test_exact_row_markdown_serializes_all_200_rows_and_eight_answers():
+    print("Testing exhaustive row-by-row Markdown serialization...")
+    assert_app_version_at_least("0.250.201")
+    questions = [
+        "What [is this](javascript:alert(1)) and what is it trying to accomplish?",
+        "Why are we doing it?",
+        "What value does it produce?",
+        "What resources are identified or implied?",
+        "What is the timeline or schedule?",
+        "What happens if we stop?",
+        "Does this appear reasonable? Concerns / duplication / measurable outcomes",
+        "What information is missing to assess this activity?",
+    ]
+    answer_fields = [f"answer_{index}" for index in range(1, 9)]
+    checkpoint_rows = {}
+    for batch_number in range(1, 5):
+        batch_start = ((batch_number - 1) * 50) + 1
+        checkpoint_rows[f"batch-{batch_number}"] = [
+            {
+                "source_row_number": row_number,
+                "source_row_identity": f"FRI-{row_number:03d}",
+                **{
+                    answer_field: f"FRI-{row_number:03d} answer {answer_index}"
+                    for answer_index, answer_field in enumerate(answer_fields, start=1)
+                },
+            }
+            for row_number in range(batch_start, batch_start + 50)
+        ]
+    checkpoint_rows["batch-1"][0]["source_row_identity"] = "FRI-001 <script>alert(1)</script>"
+    checkpoint_rows["batch-1"][0]["answer_1"] = "[Open](javascript:alert(1)) <img src=x onerror=alert(1)>"
+
+    namespace = load_tabular_export_namespace(checkpoint_rows)
+    run = {
+        "user_id": "user-1",
+        "conversation_id": "conversation-1",
+        "id": "run-row-markdown",
+        "batch_count": 4,
+        "row_count": 200,
+        "output_format": "md",
+        "source_file_name": "financial_review.csv",
+        "output_schema": ["source_row_number", "source_row_identity", *answer_fields],
+        "public_output_schema": answer_fields,
+        "lineage_schema": ["source_row_number", "source_row_identity"],
+        "internal_checkpoint_schema": ["source_row_number", "source_row_identity", *answer_fields],
+        "row_analysis_questions": questions,
+    }
+    markdown_stream = io.StringIO()
+
+    all_checkpoint_rows = [
+        row
+        for batch_rows in checkpoint_rows.values()
+        for row in batch_rows
+    ]
+    namespace["_validate_exhaustive_row_analysis_entries"](
+        all_checkpoint_rows,
+        run["output_schema"],
+    )
+    invalid_rows = [dict(row) for row in all_checkpoint_rows]
+    invalid_rows[-1]["answer_8"] = ""
+    try:
+        namespace["_validate_exhaustive_row_analysis_entries"](
+            invalid_rows,
+            run["output_schema"],
+        )
+    except ValueError as exc:
+        assert_true("answer_8 empty at row 200" in str(exc), "empty final answer rejection")
+    else:
+        raise AssertionError("An empty row answer was accepted")
+    try:
+        namespace["_validate_exhaustive_row_analysis_entries"](
+            all_checkpoint_rows,
+            ["source_row_number", "source_row_identity", "answer_1", "answer_3"],
+        )
+    except ValueError as exc:
+        assert_true("consecutive answer_1 through answer_N" in str(exc), "answer sequence rejection")
+    else:
+        raise AssertionError("A skipped answer field sequence was accepted")
+
+    written_row_count = namespace["_write_ordered_output_stream"](run, markdown_stream)
+    markdown = markdown_stream.getvalue()
+
+    assert_equal(written_row_count, 200, "Markdown written row count")
+    assert_equal(len(re.findall(r"(?m)^## Row \d+", markdown)), 200, "Markdown row headings")
+    for answer_index, question in enumerate(questions, start=1):
+        escaped_question = namespace["_escape_markdown_text"](question)
+        assert_equal(
+            markdown.count(f"{answer_index}. **{escaped_question}**"),
+            200,
+            f"question {answer_index} occurrence count",
+        )
+    assert_true(r"## Row 1: FRI\-001 &lt;script&gt;alert\(1\)&lt;/script&gt;" in markdown, "escaped first row present")
+    assert_true("## Row 200: FRI\\-200" in markdown, "last row present")
+    assert_true("FRI\\-200 answer 8" in markdown, "last row final answer present")
+    assert_false("](javascript:" in markdown, "active Markdown links excluded")
+    assert_false("<script>" in markdown, "raw script tags excluded")
+    assert_false("<img" in markdown, "raw image tags excluded")
+
+
 def test_passthrough_eligibility_and_generic_finalizer_guard():
     print("Testing passthrough eligibility and generic finalizer guard...")
     assert_app_version_at_least("0.250.182")
@@ -272,6 +376,7 @@ def run_all_tests():
     tests = [
         test_contract_separates_public_internal_and_lineage_schema,
         test_public_projection_drives_csv_json_xml_and_preview,
+        test_exact_row_markdown_serializes_all_200_rows_and_eight_answers,
         test_passthrough_eligibility_and_generic_finalizer_guard,
     ]
     results = []

--- a/functional_tests/test_tabular_phase5_artifact_set_lifecycle.py
+++ b/functional_tests/test_tabular_phase5_artifact_set_lifecycle.py
@@ -2,8 +2,8 @@
 # test_tabular_phase5_artifact_set_lifecycle.py
 """
 Functional test for Phase 5 tabular artifact-set lifecycle publication.
-Version: 0.250.180
-Implemented in: 0.250.175; publication commit compatibility updated in 0.250.180
+Version: 0.250.201
+Implemented in: 0.250.175; publication commit compatibility updated in 0.250.180; exhaustive Markdown compatibility updated in 0.250.201
 
 This test ensures durable tabular artifact sets hide staged members until the
 whole required set is valid, publish Analyze Markdown as the primary member,
@@ -122,6 +122,7 @@ def load_artifact_set_helpers():
         "TABULAR_EXPORT_ARTIFACT_PREVIEW_MAX_ROWS": 10,
         "TABULAR_EXPORT_ARTIFACT_PREVIEW_MAX_CHARS": 24000,
         "TABULAR_GENERATION_PLAN_MAX_FIELDS": 50,
+        "TABULAR_ROW_ANALYSIS_MAX_QUESTIONS": 20,
         "TABULAR_ARTIFACT_SET_CONTRACT_VERSION": "tabular-artifact-set-v1",
         "TABULAR_ARTIFACT_SET_LIFECYCLE_PLANNED": "planned",
         "TABULAR_ARTIFACT_SET_LIFECYCLE_GENERATING": "generating",

--- a/functional_tests/test_tabular_phase8_ui_telemetry_rollout.py
+++ b/functional_tests/test_tabular_phase8_ui_telemetry_rollout.py
@@ -2,8 +2,8 @@
 # test_tabular_phase8_ui_telemetry_rollout.py
 """
 Functional test for Phase 8 tabular UI telemetry and rollout metadata.
-Version: 0.250.199
-Implemented in: 0.250.164; planning-only metadata hardening in 0.250.167; Phase 7 harness compatibility in 0.250.177; safe failure metadata in 0.250.199
+Version: 0.250.201
+Implemented in: 0.250.164; planning-only metadata hardening in 0.250.167; Phase 7 harness compatibility in 0.250.177; safe failure metadata in 0.250.199; exhaustive Markdown compatibility in 0.250.201
 
 This test ensures shared tabular planner rollout assignment is stable and
 redacted, backend-only rollout controls remain sanitized from frontend
@@ -161,6 +161,7 @@ def load_public_status_helpers():
         "ANALYSIS_ARTIFACT_ROLE_PRIMARY_ANALYSIS": "primary_analysis",
         "TABULAR_EXPORT_ARTIFACT_PREVIEW_MAX_ROWS": 3,
         "TABULAR_GENERATION_PLAN_MAX_FIELDS": 50,
+        "TABULAR_ROW_ANALYSIS_MAX_QUESTIONS": 20,
         "TABULAR_EXPORT_ARTIFACT_PREVIEW_MAX_CHARS": 1200,
     }
     exec(compile(ast.Module(body=selected_nodes, type_ignores=[]), str(EXPORT_MODULE), "exec"), namespace)

--- a/functional_tests/test_tabular_queue_run_output_schema_end_to_end.py
+++ b/functional_tests/test_tabular_queue_run_output_schema_end_to_end.py
@@ -2,8 +2,8 @@
 #!/usr/bin/env python3
 """
 Functional test for queue_tabular_generated_output_run() itself.
-Version: 0.250.189
-Implemented in: 0.250.189
+Version: 0.250.201
+Implemented in: 0.250.189; output-aware Markdown batching updated in 0.250.201
 
 Unlike the other tabular fix tests, this one calls the *actual*
 queue_tabular_generated_output_run() function (the function containing the
@@ -185,6 +185,7 @@ class _FakeCosmosContainer:
 
 
 def _build_namespace():
+    import html
     import logging
     import math
     import os
@@ -208,6 +209,7 @@ def _build_namespace():
         "os": os,
         "uuid": uuid,
         "json": json_module,
+        "html": html,
         "math": math,
         "logging": logging,
         "time": time,
@@ -372,10 +374,105 @@ def test_combined_run_with_known_output_schema_still_locks_it_up_front():
     assert run["output_schema"] == persisted_run["output_schema"]
 
 
+def test_exhaustive_markdown_run_uses_output_aware_batches_and_exact_schema():
+    """Eight narrative answers per row must not be attempted as one 200-row model response."""
+    assert_app_version_at_least("0.250.201")
+    namespace, fake_container = _build_namespace()
+    queue_run = namespace["queue_tabular_generated_output_run"]
+    questions = [f"Question {index}?" for index in range(1, 9)]
+    public_schema = [f"answer_{index}" for index in range(1, 9)]
+    internal_schema = ["source_row_number", "source_row_identity", *public_schema]
+    planner_metadata = {
+        "planner_contract_version": "tabular-orchestration-v1",
+        "execution_contract": "structured_export",
+        "execution_state": "queued",
+        "durable_task_type": "structured_export",
+        "reason_code": "active_execution_accepted",
+        "row_analysis_mode": "exhaustive",
+        "row_analysis_questions": questions,
+        "deliverable_contract": {
+            "contract_version": "analysis-deliverables-v3",
+            "action_mode": "search",
+            "analysis_required": False,
+            "primary_artifact_role": "",
+            "requested_artifacts": [{
+                "artifact_id": "row-analysis-md",
+                "role": "requested_output",
+                "format": "md",
+                "required": True,
+                "request_order": 0,
+            }],
+            "public_output_schema": public_schema,
+            "internal_checkpoint_schema": internal_schema,
+            "lineage_schema": ["source_row_number", "source_row_identity"],
+            "row_cardinality": "one_per_source_row",
+            "ordering": "source_order",
+            "transformation_mode": "semantic",
+            "validation_profile": "exact_rows_schema",
+            "publication_policy": "all_required_artifacts",
+        },
+    }
+
+    run = queue_run(
+        user_id="user-1",
+        conversation_id="conversation-1",
+        user_question="For each line, answer all eight questions individually.",
+        source_candidate={"filename": "financial_review.csv"},
+        output_format="md",
+        row_batches=None,
+        gpt_model="gpt-5.6-luna",
+        settings={},
+        source_descriptor=_build_financial_review_source_descriptor(),
+        task_type="structured_export",
+        planner_metadata=planner_metadata,
+    )
+
+    persisted_run = fake_container.created_items[0]
+    assert persisted_run["row_analysis_mode"] == "exhaustive"
+    assert persisted_run["row_analysis_questions"] == questions
+    assert persisted_run["output_format"] == "md"
+    assert "_row_analysis_" in persisted_run["generated_file_name"]
+    assert persisted_run["generated_file_name"].endswith(".md")
+    assert persisted_run["output_schema"] == internal_schema
+    assert persisted_run["public_output_schema"] == public_schema
+    assert persisted_run["batch_budget"]["max_rows"] < 200
+    assert persisted_run["batch_count"] > 1
+    assert run["batch_count"] == persisted_run["batch_count"]
+
+    mismatched_metadata = dict(planner_metadata)
+    mismatched_contract = dict(planner_metadata["deliverable_contract"])
+    mismatched_contract["public_output_schema"] = public_schema[:-1]
+    mismatched_contract["internal_checkpoint_schema"] = [
+        "source_row_number",
+        "source_row_identity",
+        *public_schema[:-1],
+    ]
+    mismatched_metadata["deliverable_contract"] = mismatched_contract
+    try:
+        queue_run(
+            user_id="user-1",
+            conversation_id="conversation-2",
+            user_question="For each line, answer all eight questions individually.",
+            source_candidate={"filename": "financial_review.csv"},
+            output_format="md",
+            row_batches=None,
+            gpt_model="gpt-5.6-luna",
+            settings={},
+            source_descriptor=_build_financial_review_source_descriptor(),
+            task_type="structured_export",
+            planner_metadata=mismatched_metadata,
+        )
+    except ValueError as exc:
+        assert "questions do not match" in str(exc)
+    else:
+        raise AssertionError("A mismatched question and output schema contract was accepted")
+
+
 if __name__ == "__main__":
     tests = [
         test_combined_run_with_no_output_hints_is_created_with_deferred_schema,
         test_combined_run_with_known_output_schema_still_locks_it_up_front,
+        test_exhaustive_markdown_run_uses_output_aware_batches_and_exact_schema,
     ]
     failures = 0
     for test in tests:

--- a/functional_tests/test_tabular_row_orchestration_scale.py
+++ b/functional_tests/test_tabular_row_orchestration_scale.py
@@ -1,8 +1,9 @@
 # test_tabular_row_orchestration_scale.py
 """
 Functional test for scalable per-row tabular orchestration.
-Version: 0.250.199
-Implemented in: 0.250.060; generated CSV formula safety in 0.250.065; generated file export routing in 0.250.072; source descriptor generalization in 0.250.127; unified durable run contract in 0.250.128; hierarchical analysis in 0.250.129; combined analysis and export in 0.250.130; scale validation in 0.250.132; direct source-backed exhaustive queueing in 0.250.133; direct queue call-site hardening in 0.250.134; model-validation auto retry in 0.250.135; model-aware parallel throughput in 0.250.136; Phase 1 acceleration contracts and observability in 0.250.137; Phase 2 truthful background handoff in 0.250.138; Phase 3 durable LLM generation planning in 0.250.139; Phase 4 compact row response protocol in 0.250.140; Phase 5 completion-driven checkpointing in 0.250.141; Phase 6 rolling worker pool in 0.250.142; Phase 7 independent batch retries in 0.250.143; Phase 8 scale, chaos, and rollout in 0.250.144; background metadata streaming fix in 0.250.145; source-token echo recovery in 0.250.146; fixed-window stale heartbeat fix in 0.250.147; nested CSV output recovery in 0.250.148; generic tabular artifact routing and fast startup in 0.250.149; balanced concurrency waves and default completion checkpoints in 0.250.152; Search shared preflight adapter in 0.250.159; aggregate route-helper harness coverage in 0.250.166; Analyze artifact Phase 7A harness compatibility updated in 0.250.178; reviewed correctness planning and semantic validation updated in 0.250.179; artifact publication lifecycle updated in 0.250.180; safe failure helper compatibility updated in 0.250.199
+Version: 0.250.201
+Updated in: 0.250.201 for exhaustive Markdown compatibility.
+Implemented in: 0.250.060; generated CSV formula safety in 0.250.065; generated file export routing in 0.250.072; source descriptor generalization in 0.250.127; unified durable run contract in 0.250.128; hierarchical analysis in 0.250.129; combined analysis and export in 0.250.130; scale validation in 0.250.132; direct source-backed exhaustive queueing in 0.250.133; direct queue call-site hardening in 0.250.134; model-validation auto retry in 0.250.135; model-aware parallel throughput in 0.250.136; Phase 1 acceleration contracts and observability in 0.250.137; Phase 2 truthful background handoff in 0.250.138; Phase 3 durable LLM generation planning in 0.250.139; Phase 4 compact row response protocol in 0.250.140; Phase 5 completion-driven checkpointing in 0.250.141; Phase 6 rolling worker pool in 0.250.142; Phase 7 independent batch retries in 0.250.143; Phase 8 scale, chaos, and rollout in 0.250.144; background metadata streaming fix in 0.250.145; source-token echo recovery in 0.250.146; fixed-window stale heartbeat fix in 0.250.147; nested CSV output recovery in 0.250.148; generic tabular artifact routing and fast startup in 0.250.149; balanced concurrency waves and default completion checkpoints in 0.250.152; Search shared preflight adapter in 0.250.159; aggregate route-helper harness coverage in 0.250.166; Analyze artifact Phase 7A harness compatibility updated in 0.250.178; reviewed correctness planning and semantic validation updated in 0.250.179; artifact publication lifecycle updated in 0.250.180; safe failure helper compatibility updated in 0.250.199; exhaustive Markdown scale compatibility updated in 0.250.200
 
 This test ensures generated exports preserve source identity and row order while
 enforcing one stable output schema across independently generated batches.
@@ -566,6 +567,7 @@ def _load_direct_source_queue_helpers(route_dependencies):
     namespace.setdefault('TABULAR_RUN_TASK_HIERARCHICAL_ANALYSIS', 'hierarchical_analysis')
     namespace.setdefault('TABULAR_RUN_TASK_COMBINED', 'combined')
     namespace.setdefault('TABULAR_EXTENSIONS', {'csv', 'xlsx', 'xls', 'xlsm'})
+    namespace.setdefault('question_requests_tabular_exhaustive_row_output', lambda question: False)
     namespace.setdefault(
         '_dump_tabular_generated_output_json',
         lambda value: json.dumps(value, default=str, ensure_ascii=False, separators=(',', ':')),
@@ -5095,7 +5097,7 @@ def test_direct_source_backed_csv_queue_bypasses_tool_paging():
                 'max_chars': 60000,
             },
             '_get_tabular_generated_output_task_type': (
-                lambda generated, analysis, settings, action_mode=None:
+                lambda generated, analysis, settings, action_mode=None, exhaustive_row_output_requested=False:
                 'combined' if generated and analysis else None
             ),
             'question_requests_tabular_generated_output': lambda question: True,
@@ -5179,7 +5181,7 @@ def test_direct_source_backed_queue_failure_suppresses_inline_exhaustive_output(
                 'max_chars': 60000,
             },
             '_get_tabular_generated_output_task_type': (
-                lambda generated, analysis, settings, action_mode=None: None
+                lambda generated, analysis, settings, action_mode=None, exhaustive_row_output_requested=False: None
             ),
             'question_requests_tabular_generated_output': lambda question: True,
             'question_requests_tabular_hierarchical_analysis': lambda question: False,

--- a/functional_tests/test_tabular_search_analyze_artifact_matrix.py
+++ b/functional_tests/test_tabular_search_analyze_artifact_matrix.py
@@ -2,8 +2,8 @@
 #!/usr/bin/env python3
 """
 Functional matrix for Search and Analyze durable tabular artifact ownership.
-Version: 0.250.199
-Implemented in: 0.250.199
+Version: 0.250.201
+Implemented in: 0.250.199; updated in 0.250.201
 
 This test drives the real shared planner, persisted-metadata sanitizer,
 artifact-set manifest, validation, and public projection for four customer
@@ -19,7 +19,7 @@ from test_support.versioning import assert_app_version_at_least
 ROOT_DIR = Path(__file__).resolve().parents[1]
 APP_ROOT = ROOT_DIR / "application" / "single_app"
 TEST_ROOT = Path(__file__).resolve().parent
-IMPLEMENTED_VERSION = "0.250.199"
+IMPLEMENTED_VERSION = "0.250.201"
 
 for import_path in (APP_ROOT, TEST_ROOT):
     if str(import_path) not in sys.path:
@@ -38,7 +38,15 @@ from test_tabular_phase5_artifact_set_lifecycle import (  # noqa: E402
 
 LINE_BY_LINE_PROMPT = (
     "For each line in this document, answer all eight questions individually. "
-    "Go line by line and do not consolidate or omit any line."
+    "Go line by line and do not consolidate or omit any line. The questions are as follows:\n"
+    "What is this and what is it trying to accomplish?\n"
+    "Why are we doing it?\n"
+    "What value does it produce?\n"
+    "What resources are identified or implied?\n"
+    "What is the timeline or schedule?\n"
+    "What happens if we stop?\n"
+    "Does this appear reasonable? Concerns / duplication / measurable outcomes\n"
+    "What information is missing to assess this activity?"
 )
 
 SETTINGS = {
@@ -135,15 +143,17 @@ def test_search_analyze_artifact_matrix():
             "name": "search_implicit_markdown",
             "action_mode": "search",
             "prompt": LINE_BY_LINE_PROMPT,
-            "task_type": "hierarchical_analysis",
+            "task_type": "structured_export",
             "formats": ["md"],
+            "artifact_ids": ["row-analysis-md"],
         },
         {
             "name": "analyze_implicit_markdown",
             "action_mode": "analyze",
             "prompt": LINE_BY_LINE_PROMPT,
-            "task_type": "hierarchical_analysis",
-            "formats": ["md"],
+            "task_type": "combined",
+            "formats": ["md", "md"],
+            "artifact_ids": ["analysis-summary", "row-analysis-md"],
         },
     ]
 
@@ -160,9 +170,20 @@ def test_search_analyze_artifact_matrix():
             for artifact in plan["deliverable_contract"]["requested_artifacts"]
         ]
         assert contract_formats == scenario["formats"], scenario["name"]
+        if "artifact_ids" in scenario:
+            assert [
+                artifact["artifact_id"]
+                for artifact in plan["deliverable_contract"]["requested_artifacts"]
+            ] == scenario["artifact_ids"], scenario["name"]
         assert plan["deliverable_contract"]["analysis_required"] is (
-            scenario["task_type"] != "structured_export"
+            scenario["action_mode"] == "analyze"
         )
+        if scenario["name"].endswith("implicit_markdown"):
+            assert plan["deliverable_contract"]["public_output_schema"] == [
+                f"answer_{index}" for index in range(1, 9)
+            ]
+            assert plan["deliverable_contract"]["row_cardinality"] == "one_per_source_row"
+            assert plan["deliverable_contract"]["ordering"] == "source_order"
         _publish_planned_artifacts(plan, scenario["formats"])
 
 

--- a/ui_tests/test_chat_background_generated_export_status.py
+++ b/ui_tests/test_chat_background_generated_export_status.py
@@ -1,8 +1,9 @@
 # test_chat_background_generated_export_status.py
 """
 UI test for chat background generated export status cards.
-Version: 0.250.199
-Implemented in: 0.241.046; cancellation in 0.250.060; automatic-only refresh in 0.250.061; combined progress and large-run confirmation in 0.250.131; throughput and concurrency status in 0.250.136; truthful background handoff in 0.250.138; collapsed operational details in 0.250.150; confirmation deduplication in 0.250.169; plural artifact-set completion rendering in 0.250.176; empty plural artifact-set fallback suppression in 0.250.182; hierarchical completion and safe failure details in 0.250.199
+Version: 0.250.201
+Updated in: 0.250.201 for distinct summary and exhaustive Markdown cards.
+Implemented in: 0.241.046; cancellation in 0.250.060; automatic-only refresh in 0.250.061; combined progress and large-run confirmation in 0.250.131; throughput and concurrency status in 0.250.136; truthful background handoff in 0.250.138; collapsed operational details in 0.250.150; confirmation deduplication in 0.250.169; plural artifact-set completion rendering in 0.250.176; empty plural artifact-set fallback suppression in 0.250.182; hierarchical completion and safe failure details in 0.250.199; distinct summary and exhaustive Markdown cards in 0.250.200
 
 This test ensures queued tabular generated exports render progress in chat and
 turn into a downloadable artifact when complete or a visible canceled state.
@@ -374,8 +375,8 @@ def test_chat_combined_completion_renders_plural_artifact_set(playwright) -> Non
 
 
 @pytest.mark.ui
-def test_chat_hierarchical_completion_renders_markdown_download(playwright) -> None:
-    """Validate completed hierarchical analysis replaces progress with its Markdown artifact."""
+def test_chat_exact_row_search_renders_markdown_download(playwright) -> None:
+    """Validate exact-row Search replaces progress with its all-row Markdown artifact."""
     browser = playwright.chromium.launch()
     context = browser.new_context(viewport={"width": 1440, "height": 900})
     page = context.new_page()
@@ -394,7 +395,7 @@ def test_chat_hierarchical_completion_renders_markdown_download(playwright) -> N
                         "run": {
                             "run_id": "run-hierarchical-md",
                             "conversation_id": "conversation-ui-test",
-                            "task_type": "hierarchical_analysis",
+                            "task_type": "structured_export",
                             "status": "completed",
                             "row_count": 200,
                             "processed_rows": 200,
@@ -404,17 +405,17 @@ def test_chat_hierarchical_completion_renders_markdown_download(playwright) -> N
                             "artifact_set": {
                                 "lifecycle_state": "completed",
                                 "validation_state": "validated",
-                                "primary_artifact_id": "analysis",
+                                "primary_artifact_id": "row-analysis-md",
                                 "member_count": 1,
                                 "published_member_count": 1,
                             },
                             "generated_artifacts": [{
-                                "artifact_id": "analysis",
-                                "role": "primary_analysis",
-                                "capability": "analyze",
+                                "artifact_id": "row-analysis-md",
+                                "role": "requested_output",
+                                "capability": "tabular",
                                 "artifact_message_id": "artifact-md-ui-test",
                                 "conversation_id": "conversation-ui-test",
-                                "file_name": "financial_review_analysis.md",
+                                "file_name": "financial_review_row_analysis.md",
                                 "output_format": "md",
                                 "row_count": 200,
                                 "storage_scope": "chat",
@@ -445,7 +446,7 @@ def test_chat_hierarchical_completion_renders_markdown_download(playwright) -> N
                                     background_export: true,
                                     export_run_id: 'run-hierarchical-md',
                                     run_id: 'run-hierarchical-md',
-                                    task_type: 'hierarchical_analysis',
+                                    task_type: 'structured_export',
                                     status: 'running',
                                     output_format: 'md',
                                     row_count: 200,
@@ -463,11 +464,124 @@ def test_chat_hierarchical_completion_renders_markdown_download(playwright) -> N
             )
 
             message = page.locator('[data-message-id="message-hierarchical-md"]')
-            expect(message.get_by_text("Background analysis")).to_be_visible()
+            expect(message.get_by_text("Background export")).to_be_visible()
             expect(
-                message.get_by_role("button", name="Download financial_review_analysis.md")
+                message.get_by_role("button", name="Download financial_review_row_analysis.md")
             ).to_be_visible(timeout=15000)
-            expect(message.get_by_text("Analyze MD artifact", exact=True)).to_be_visible()
+            expect(message.get_by_text("Row-by-row Markdown output", exact=True)).to_be_visible()
+            assert page_errors == []
+    finally:
+        context.close()
+        browser.close()
+
+
+@pytest.mark.ui
+def test_chat_exact_row_analyze_renders_summary_and_row_markdown(playwright) -> None:
+    """Validate Analyze renders separate summary and exhaustive row Markdown artifacts."""
+    browser = playwright.chromium.launch()
+    context = browser.new_context(viewport={"width": 1440, "height": 900})
+    page = context.new_page()
+    page_errors = []
+    page.on("pageerror", lambda error: page_errors.append(str(error)))
+
+    try:
+        with _start_static_test_server() as server_base_url:
+            page.route(
+                "**/api/tabular/generated-output/runs/run-analyze-two-md",
+                lambda route: route.fulfill(
+                    status=200,
+                    content_type="application/json",
+                    json={
+                        "success": True,
+                        "run": {
+                            "run_id": "run-analyze-two-md",
+                            "conversation_id": "conversation-ui-test",
+                            "task_type": "combined",
+                            "status": "completed",
+                            "row_count": 200,
+                            "processed_rows": 200,
+                            "batch_count": 8,
+                            "completed_batches": 8,
+                            "progress_percent": 100,
+                            "artifact_set": {
+                                "lifecycle_state": "completed",
+                                "validation_state": "validated",
+                                "primary_artifact_id": "analysis-summary",
+                                "member_count": 2,
+                                "published_member_count": 2,
+                            },
+                            "generated_artifacts": [
+                                {
+                                    "artifact_id": "row-analysis-md",
+                                    "role": "requested_output",
+                                    "capability": "tabular",
+                                    "artifact_message_id": "artifact-row-md",
+                                    "conversation_id": "conversation-ui-test",
+                                    "file_name": "financial_review_row_analysis.md",
+                                    "output_format": "md",
+                                    "row_count": 200,
+                                    "storage_scope": "chat",
+                                },
+                                {
+                                    "artifact_id": "analysis-summary",
+                                    "role": "primary_analysis",
+                                    "capability": "analyze",
+                                    "artifact_message_id": "artifact-summary-md",
+                                    "conversation_id": "conversation-ui-test",
+                                    "file_name": "financial_review_analysis.md",
+                                    "output_format": "md",
+                                    "row_count": 200,
+                                    "storage_scope": "chat",
+                                },
+                            ],
+                        },
+                    },
+                ),
+            )
+            response = page.goto(f"{server_base_url}/{HARNESS_PATH}", wait_until="domcontentloaded")
+            assert response is not None and response.ok
+            _install_minimal_chat_dom(page)
+            page.evaluate(
+                """
+                async () => {
+                    const module = await import('/application/single_app/static/js/chat/chat-messages.js');
+                    module.appendMessage(
+                        'AI',
+                        'The full-source analysis is continuing in the background.',
+                        null,
+                        'message-analyze-two-md',
+                        false,
+                        [], [], [], null, null,
+                        {
+                            metadata: {
+                                generated_tabular_outputs: [{
+                                    capability: 'tabular',
+                                    background_export: true,
+                                    export_run_id: 'run-analyze-two-md',
+                                    run_id: 'run-analyze-two-md',
+                                    task_type: 'combined',
+                                    status: 'running',
+                                    output_format: 'md',
+                                    row_count: 200,
+                                    processed_rows: 0,
+                                    batch_count: 8,
+                                    completed_batches: 0,
+                                    suppress_assistant_text: true,
+                                }]
+                            }
+                        },
+                        false
+                    );
+                }
+                """
+            )
+
+            message = page.locator('[data-message-id="message-analyze-two-md"]')
+            expect(message.get_by_text("Analyze Markdown summary", exact=True)).to_be_visible(timeout=15000)
+            expect(message.get_by_text("Row-by-row Markdown output", exact=True)).to_be_visible()
+            expect(message.get_by_role("button", name="Download financial_review_analysis.md")).to_be_visible()
+            expect(message.get_by_role("button", name="Download financial_review_row_analysis.md")).to_be_visible()
+            expect(message.locator('.generated-tabular-output-card')).to_have_count(2)
             assert page_errors == []
     finally:
         context.close()


### PR DESCRIPTION
## Summary

- recognizes row/line terminology and activates durable tabular routing for upgraded deployments by migrating stale backend-only settings
- preserves the selected model endpoint through Analyze preflight, hardens artifact-set publication/recovery, and returns safe failure details
- makes explicit per-row narrative requests exhaustive: Search returns one all-row Markdown artifact, while Analyze returns a concise Markdown summary plus an all-row Markdown sibling
- preserves explicit structured behavior: Search CSV/JSON/XML returns the requested artifact; Analyze returns Markdown plus requested structured siblings
- restores grounded chat for explicitly selected documents in accessible public workspaces hidden from the public directory

## Tabular behavior matrix

| Request | Search | Analyze |
|---|---|---|
| Explicit CSV/JSON/XML | Requested structured artifact | Markdown summary plus requested structured artifact |
| Explicit per-row/per-line narrative, no format | One exhaustive row-by-row Markdown artifact | Markdown summary plus exhaustive row-by-row Markdown artifact |
| Aggregate all-row themes/risks | Bounded hierarchical Markdown summary | Bounded hierarchical Markdown summary |

Exact-row Markdown persists ordered questions as `answer_1` through `answer_N`, uses one checkpointed result per source row, requires every answer to be non-empty, validates source order and final row count, and escapes untrusted data as literal Markdown.

## Validation

- Python compilation and JavaScript syntax checks pass
- deterministic 200-row × 8-question test validates 200 row sections and 1,600 answers, including the final row/final answer
- malformed answer sequences, missing answers, question/schema mismatch, active Markdown links, and raw HTML are rejected or escaped
- Search/Analyze planner, preflight, artifact lifecycle, public status, document-action, and production-correctness suites pass
- full tabular scale suite passes 70/70, including 100,000-row planning, retries, leases, resumability, and idempotent publication
- full background output Playwright suite passes 7 tests with 4 environment-dependent skips
- `git diff --check` and untracked EOF/whitespace checks pass
- independent final review found no critical or high-severity blockers

Fixes #1233
Fixes #1245