### PR TITLE
Reorder workspace section tabs into a consistent order of operations

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -96,7 +96,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.250.210"
+VERSION = "0.250.211"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/templates/_sidebar_nav.html
+++ b/application/single_app/templates/_sidebar_nav.html
@@ -120,7 +120,7 @@
           <li class="nav-item">
             {% if request.endpoint == 'workspace' %}
             <!-- Personal workspace with expandable sub-menu when on workspace page -->
-            <a class="nav-link d-flex align-items-center workspace-nav-toggle" href="#" data-target="personal-workspace-submenu" title="Open your personal workspace for private documents, prompts, agents, actions, workflows, endpoints, sync, and identities.">
+            <a class="nav-link d-flex align-items-center workspace-nav-toggle" href="#" data-target="personal-workspace-submenu" title="Open your personal workspace for private documents, prompts, identities, sync, endpoints, actions, agents, and workflows.">
               <i class="bi bi-folder me-2"></i><span class="nav-text"> Personal</span>
               <i class="bi bi-caret-right-fill ms-auto transition workspace-caret" style="font-size: 0.8em; transition: transform 0.2s;"></i>
             </a>
@@ -135,29 +135,10 @@
                   <i class="bi bi-lightbulb me-2" style="font-size: 0.8em;"></i><span class="nav-text">Your Prompts</span>
                 </a>
               </li>
-              {% if sidebar_settings.allow_user_workflows %}
+              {% if file_sync_enabled or sidebar_settings.enable_semantic_kernel %}
               <li class="nav-item">
-                <a class="nav-link d-flex align-items-center workspace-nav-tab" href="#" data-tab="workflows-tab" title="Save repeatable personal tasks that run manually or on a schedule using a selected model or agent, with optional document actions and run history.">
-                  <i class="bi bi-diagram-3 me-2" style="font-size: 0.8em;"></i><span class="nav-text">Your Workflows</span>
-                </a>
-              </li>
-              {% endif %}
-              {% if sidebar_settings.per_user_semantic_kernel and sidebar_settings.enable_semantic_kernel %}
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center workspace-nav-tab" href="#" data-tab="agents-tab" title="Reusable, specialized AI assistants that combine instructions, approved knowledge, and optional actions. Actions are tasks an agent is allowed to perform.">
-                  <i class="bi bi-robot me-2" style="font-size: 0.8em;"></i><span class="nav-text">Your Agents</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center workspace-nav-tab" href="#" data-tab="plugins-tab" title="Configure governed tools that agents can call, such as APIs, databases, or other connected systems.">
-                  <i class="bi bi-plugin me-2" style="font-size: 0.8em;"></i><span class="nav-text">Your Actions</span>
-                </a>
-              </li>
-              {% endif %}
-              {% if sidebar_settings.allow_user_custom_endpoints and sidebar_settings.enable_multi_model_endpoints %}
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center workspace-nav-tab" href="#" data-tab="endpoints-tab" title="Manage model endpoints available to personal agents and workflows alongside admin-managed global endpoints.">
-                  <i class="bi bi-hdd-network me-2" style="font-size: 0.8em;"></i><span class="nav-text">Your Endpoints</span>
+                <a class="nav-link d-flex align-items-center workspace-nav-tab" href="#" data-tab="identities-tab" title="Manage reusable authentication profiles for File Sync and Actions so credentials stay scoped and resolved server-side.">
+                  <i class="bi bi-person-badge me-2" style="font-size: 0.8em;"></i><span class="nav-text">Identities</span>
                 </a>
               </li>
               {% endif %}
@@ -168,17 +149,38 @@
                 </a>
               </li>
               {% endif %}
-              {% if file_sync_enabled or sidebar_settings.enable_semantic_kernel or sidebar_settings.enable_multi_model_endpoints %}
+              {% if sidebar_settings.allow_user_custom_endpoints and sidebar_settings.enable_multi_model_endpoints %}
               <li class="nav-item">
-                <a class="nav-link d-flex align-items-center workspace-nav-tab" href="#" data-tab="identities-tab" title="Manage reusable authentication profiles for File Sync and Actions so credentials stay scoped and resolved server-side.">
-                  <i class="bi bi-person-badge me-2" style="font-size: 0.8em;"></i><span class="nav-text">Identities</span>
+                <a class="nav-link d-flex align-items-center workspace-nav-tab" href="#" data-tab="endpoints-tab" title="Manage model endpoints available to personal agents and workflows alongside admin-managed global endpoints.">
+                  <i class="bi bi-hdd-network me-2" style="font-size: 0.8em;"></i><span class="nav-text">Your Endpoints</span>
+                </a>
+              </li>
+              {% endif %}
+              {% if sidebar_settings.per_user_semantic_kernel and sidebar_settings.enable_semantic_kernel and sidebar_settings.allow_user_agents %}
+              {% if sidebar_settings.allow_user_plugins %}
+              <li class="nav-item">
+                <a class="nav-link d-flex align-items-center workspace-nav-tab" href="#" data-tab="plugins-tab" title="Configure governed tools that agents can call, such as APIs, databases, or other connected systems.">
+                  <i class="bi bi-plugin me-2" style="font-size: 0.8em;"></i><span class="nav-text">Your Actions</span>
+                </a>
+              </li>
+              {% endif %}
+              <li class="nav-item">
+                <a class="nav-link d-flex align-items-center workspace-nav-tab" href="#" data-tab="agents-tab" title="Reusable, specialized AI assistants that combine instructions, approved knowledge, and optional actions. Actions are tasks an agent is allowed to perform.">
+                  <i class="bi bi-robot me-2" style="font-size: 0.8em;"></i><span class="nav-text">Your Agents</span>
+                </a>
+              </li>
+              {% endif %}
+              {% if sidebar_settings.allow_user_workflows %}
+              <li class="nav-item">
+                <a class="nav-link d-flex align-items-center workspace-nav-tab" href="#" data-tab="workflows-tab" title="Save repeatable personal tasks that run manually or on a schedule using a selected model or agent, with optional document actions and run history.">
+                  <i class="bi bi-diagram-3 me-2" style="font-size: 0.8em;"></i><span class="nav-text">Your Workflows</span>
                 </a>
               </li>
               {% endif %}
             </ul>
             {% else %}
             <!-- Regular Personal workspace link when not on workspace page -->
-            <a class="nav-link d-flex align-items-center" href="{{ url_for('frontend_workspace.workspace') }}" title="Open your personal workspace for private documents, prompts, agents, actions, workflows, endpoints, sync, and identities.">
+            <a class="nav-link d-flex align-items-center" href="{{ url_for('frontend_workspace.workspace') }}" title="Open your personal workspace for private documents, prompts, identities, sync, endpoints, actions, agents, and workflows.">
               <i class="bi bi-folder me-2"></i><span class="nav-text"> Personal</span>
             </a>
             {% endif %}
@@ -188,7 +190,7 @@
           <li class="nav-item">
             {% if request.endpoint == 'group_workspaces' %}
             <!-- Group workspace with expandable sub-menu when on group workspace page -->
-            <a class="nav-link d-flex align-items-center workspace-nav-toggle" href="#" data-target="group-workspace-submenu" title="Open group workspaces for shared documents, prompts, agents, actions, workflows, endpoints, sync, and identities.">
+            <a class="nav-link d-flex align-items-center workspace-nav-toggle" href="#" data-target="group-workspace-submenu" title="Open group workspaces for shared documents, prompts, identities, sync, endpoints, actions, agents, and workflows.">
               <i class="bi bi-folder me-2"></i><span class="nav-text"> Groups</span>
               <i class="bi bi-caret-right-fill ms-auto transition workspace-caret" style="font-size: 0.8em; transition: transform 0.2s;"></i>
             </a>
@@ -203,22 +205,10 @@
                   <i class="bi bi-lightbulb me-2" style="font-size: 0.8em;"></i><span class="nav-text">Group Prompts</span>
                 </a>
               </li>
-              {% if sidebar_settings.allow_group_agents and sidebar_settings.enable_semantic_kernel %}
-                <li class="nav-item">
-                  <a class="nav-link d-flex align-items-center workspace-nav-tab" href="#" data-tab="group-agents-tab" title="Reusable, specialized AI assistants that combine instructions, approved knowledge, and optional actions. Actions are tasks an agent is allowed to perform.">
-                    <i class="bi bi-robot me-2" style="font-size: 0.8em;"></i><span class="nav-text">Group Agents</span>
-                  </a>
-                </li>
-                <li class="nav-item">
-                  <a class="nav-link d-flex align-items-center workspace-nav-tab" href="#" data-tab="group-plugins-tab" title="Configure governed group tools that agents can call, such as APIs, databases, or other connected systems.">
-                    <i class="bi bi-plugin me-2" style="font-size: 0.8em;"></i><span class="nav-text">Group Actions</span>
-                  </a>
-                </li>
-              {% endif %}
-              {% if sidebar_settings.per_user_semantic_kernel and sidebar_settings.enable_semantic_kernel and sidebar_settings.allow_group_custom_endpoints and sidebar_settings.enable_multi_model_endpoints %}
-                <li class="nav-item">
-                  <a class="nav-link d-flex align-items-center workspace-nav-tab" href="#" data-tab="group-endpoints-tab" title="Manage model endpoints available to group agents and workflows alongside admin-managed global endpoints.">
-                    <i class="bi bi-hdd-network me-2" style="font-size: 0.8em;"></i><span class="nav-text">Group Endpoints</span>
+              {% if file_sync_enabled or sidebar_settings.enable_semantic_kernel %}
+                <li class="nav-item d-none" data-group-identities-sidebar-nav>
+                  <a class="nav-link d-flex align-items-center workspace-nav-tab" href="#" data-tab="identities-tab" title="Manage reusable group authentication profiles for File Sync and Actions so credentials stay scoped and resolved server-side.">
+                    <i class="bi bi-person-badge me-2" style="font-size: 0.8em;"></i><span class="nav-text">Identities</span>
                   </a>
                 </li>
               {% endif %}
@@ -229,17 +219,38 @@
                   </a>
                 </li>
               {% endif %}
-              {% if file_sync_enabled or sidebar_settings.enable_semantic_kernel or sidebar_settings.enable_multi_model_endpoints %}
-                <li class="nav-item d-none" data-group-identities-sidebar-nav>
-                  <a class="nav-link d-flex align-items-center workspace-nav-tab" href="#" data-tab="identities-tab" title="Manage reusable group authentication profiles for File Sync and Actions so credentials stay scoped and resolved server-side.">
-                    <i class="bi bi-person-badge me-2" style="font-size: 0.8em;"></i><span class="nav-text">Identities</span>
+              {% if sidebar_settings.per_user_semantic_kernel and sidebar_settings.enable_semantic_kernel and sidebar_settings.allow_group_custom_endpoints and sidebar_settings.enable_multi_model_endpoints %}
+                <li class="nav-item">
+                  <a class="nav-link d-flex align-items-center workspace-nav-tab" href="#" data-tab="group-endpoints-tab" title="Manage model endpoints available to group agents and workflows alongside admin-managed global endpoints.">
+                    <i class="bi bi-hdd-network me-2" style="font-size: 0.8em;"></i><span class="nav-text">Group Endpoints</span>
+                  </a>
+                </li>
+              {% endif %}
+              {% if sidebar_settings.per_user_semantic_kernel and sidebar_settings.enable_semantic_kernel and sidebar_settings.allow_group_agents %}
+                {% if sidebar_settings.allow_group_plugins %}
+                  <li class="nav-item">
+                    <a class="nav-link d-flex align-items-center workspace-nav-tab" href="#" data-tab="group-plugins-tab" title="Configure governed group tools that agents can call, such as APIs, databases, or other connected systems.">
+                      <i class="bi bi-plugin me-2" style="font-size: 0.8em;"></i><span class="nav-text">Group Actions</span>
+                    </a>
+                  </li>
+                {% endif %}
+                <li class="nav-item">
+                  <a class="nav-link d-flex align-items-center workspace-nav-tab" href="#" data-tab="group-agents-tab" title="Reusable, specialized AI assistants that combine instructions, approved knowledge, and optional actions. Actions are tasks an agent is allowed to perform.">
+                    <i class="bi bi-robot me-2" style="font-size: 0.8em;"></i><span class="nav-text">Group Agents</span>
+                  </a>
+                </li>
+              {% endif %}
+              {% if sidebar_settings.allow_group_workflows %}
+                <li class="nav-item">
+                  <a class="nav-link d-flex align-items-center workspace-nav-tab" href="#" data-tab="workflows-tab" title="Create repeatable group tasks that run manually, on a schedule, or after File Sync changes using group agents, documents, or models.">
+                    <i class="bi bi-diagram-3 me-2" style="font-size: 0.8em;"></i><span class="nav-text">Group Workflows</span>
                   </a>
                 </li>
               {% endif %}
             </ul>
             {% else %}
             <!-- Regular Groups workspace link when not on group workspace page -->
-            <a class="nav-link d-flex align-items-center" href="{{ url_for('frontend_group_workspaces.group_workspaces') }}" title="Open group workspaces for shared documents, prompts, agents, actions, workflows, endpoints, sync, and identities.">
+            <a class="nav-link d-flex align-items-center" href="{{ url_for('frontend_group_workspaces.group_workspaces') }}" title="Open group workspaces for shared documents, prompts, identities, sync, endpoints, actions, agents, and workflows.">
               <i class="bi bi-folder me-2"></i><span class="nav-text"> Groups</span>
             </a>
             {% endif %}

--- a/application/single_app/templates/group_workspaces.html
+++ b/application/single_app/templates/group_workspaces.html
@@ -491,26 +491,26 @@ app_settings.app_title }} {% endblock %} {% block head %}
       <label class="form-label" for="group-workspace-section-select">Section</label>
       <select class="form-select" id="group-workspace-section-select" data-workspace-section-select aria-label="Select group workspace section">
         <option value="documents-tab-btn">Group Documents</option>
-        {% if file_sync_enabled %}
-          <option value="sync-tab-btn">Sync</option>
-        {% endif %}
+        <option value="prompts-tab-btn">Group Prompts</option>
         {% if group_workspace_identities_enabled %}
           <option value="identities-tab-btn" data-group-identities-section-option hidden disabled>Identities</option>
         {% endif %}
-        <option value="prompts-tab-btn">Group Prompts</option>
-        {% if settings.allow_group_workflows %}
-          <option value="workflows-tab-btn">Workflows</option>
+        {% if file_sync_enabled %}
+          <option value="sync-tab-btn">Sync</option>
         {% endif %}
         {% if settings.per_user_semantic_kernel and settings.enable_semantic_kernel %}
-          {% if settings.allow_group_agents %}
-            <option value="group-agents-tab-btn">Group Agents</option>
-            {% if settings.enable_semantic_kernel and settings.allow_group_plugins %}
-              <option value="group-plugins-tab-btn">Group Actions</option>
-            {% endif %}
-          {% endif %}
           {% if settings.enable_semantic_kernel and settings.allow_group_custom_endpoints and settings.enable_multi_model_endpoints %}
             <option value="group-endpoints-tab-btn">Group Endpoints</option>
           {% endif %}
+          {% if settings.allow_group_agents %}
+            {% if settings.enable_semantic_kernel and settings.allow_group_plugins %}
+              <option value="group-plugins-tab-btn">Group Actions</option>
+            {% endif %}
+            <option value="group-agents-tab-btn">Group Agents</option>
+          {% endif %}
+        {% endif %}
+        {% if settings.allow_group_workflows %}
+          <option value="workflows-tab-btn">Workflows</option>
         {% endif %}
       </select>
     </div>
@@ -533,23 +533,21 @@ app_settings.app_title }} {% endblock %} {% block head %}
         Documents
       </button>
     </li>
-    {% if file_sync_enabled %}
     <li class="nav-item" role="presentation">
       <button
         class="nav-link"
-        id="sync-tab-btn"
+        id="prompts-tab-btn"
         data-bs-toggle="tab"
-        data-bs-target="#sync-tab"
-        title="Configure group-scoped file sources that bring approved files into this workspace and run them through the document processing pipeline."
+        data-bs-target="#prompts-tab"
+        title="Create and manage reusable prompts shared within the active group, with role-based editing."
         type="button"
         role="tab"
-        aria-controls="sync-tab"
+        aria-controls="prompts-tab"
         aria-selected="false"
       >
-        Sync
+        Prompts
       </button>
     </li>
-    {% endif %}
     {% if group_workspace_identities_enabled %}
     <li class="nav-item d-none" role="presentation" data-group-identities-tab-nav>
       <button
@@ -567,74 +565,24 @@ app_settings.app_title }} {% endblock %} {% block head %}
       </button>
     </li>
     {% endif %}
+    {% if file_sync_enabled %}
     <li class="nav-item" role="presentation">
       <button
         class="nav-link"
-        id="prompts-tab-btn"
+        id="sync-tab-btn"
         data-bs-toggle="tab"
-        data-bs-target="#prompts-tab"
-        title="Create and manage reusable prompts shared within the active group, with role-based editing."
+        data-bs-target="#sync-tab"
+        title="Configure group-scoped file sources that bring approved files into this workspace and run them through the document processing pipeline."
         type="button"
         role="tab"
-        aria-controls="prompts-tab"
+        aria-controls="sync-tab"
         aria-selected="false"
       >
-        Prompts
-      </button>
-    </li>
-    {% if settings.allow_group_workflows %}
-    <li class="nav-item" role="presentation">
-      <button
-        class="nav-link"
-        id="workflows-tab-btn"
-        data-bs-toggle="tab"
-        data-bs-target="#workflows-tab"
-        title="Create repeatable group tasks that run manually, on a schedule, or after File Sync changes using group agents, documents, or models."
-        type="button"
-        role="tab"
-        aria-controls="workflows-tab"
-        aria-selected="false"
-      >
-        Workflows
+        Sync
       </button>
     </li>
     {% endif %}
     {% if settings.per_user_semantic_kernel and settings.enable_semantic_kernel %}
-      {% if settings.allow_group_agents %}
-        <li class="nav-item" role="presentation">
-          <button
-            class="nav-link"
-            id="group-agents-tab-btn"
-            data-bs-toggle="tab"
-            data-bs-target="#group-agents-tab"
-            title="Reusable, specialized AI assistants that combine instructions, approved knowledge, and optional actions. Actions are tasks an agent is allowed to perform."
-            type="button"
-            role="tab"
-            aria-controls="group-agents-tab"
-            aria-selected="false"
-          >
-            Agents
-          </button>
-        </li>
-
-        {% if settings.enable_semantic_kernel and settings.allow_group_plugins %}
-          <li class="nav-item" role="presentation">
-            <button
-              class="nav-link"
-              id="group-plugins-tab-btn"
-              data-bs-toggle="tab"
-              data-bs-target="#group-plugins-tab"
-              title="Configure governed group tools that agents can call, such as APIs, databases, or other connected systems."
-              type="button"
-              role="tab"
-              aria-controls="group-plugins-tab"
-              aria-selected="false"
-            >
-              Actions
-            </button>
-          </li>
-        {% endif %}
-      {% endif %}
       {% if settings.enable_semantic_kernel and settings.allow_group_custom_endpoints and settings.enable_multi_model_endpoints %}
         <li class="nav-item" role="presentation">
           <button
@@ -652,6 +600,58 @@ app_settings.app_title }} {% endblock %} {% block head %}
           </button>
         </li>
       {% endif %}
+      {% if settings.allow_group_agents %}
+        {% if settings.enable_semantic_kernel and settings.allow_group_plugins %}
+          <li class="nav-item" role="presentation">
+            <button
+              class="nav-link"
+              id="group-plugins-tab-btn"
+              data-bs-toggle="tab"
+              data-bs-target="#group-plugins-tab"
+              title="Configure governed group tools that agents can call, such as APIs, databases, or other connected systems."
+              type="button"
+              role="tab"
+              aria-controls="group-plugins-tab"
+              aria-selected="false"
+            >
+              Actions
+            </button>
+          </li>
+        {% endif %}
+
+        <li class="nav-item" role="presentation">
+          <button
+            class="nav-link"
+            id="group-agents-tab-btn"
+            data-bs-toggle="tab"
+            data-bs-target="#group-agents-tab"
+            title="Reusable, specialized AI assistants that combine instructions, approved knowledge, and optional actions. Actions are tasks an agent is allowed to perform."
+            type="button"
+            role="tab"
+            aria-controls="group-agents-tab"
+            aria-selected="false"
+          >
+            Agents
+          </button>
+        </li>
+      {% endif %}
+    {% endif %}
+    {% if settings.allow_group_workflows %}
+    <li class="nav-item" role="presentation">
+      <button
+        class="nav-link"
+        id="workflows-tab-btn"
+        data-bs-toggle="tab"
+        data-bs-target="#workflows-tab"
+        title="Create repeatable group tasks that run manually, on a schedule, or after File Sync changes using group agents, documents, or models."
+        type="button"
+        role="tab"
+        aria-controls="workflows-tab"
+        aria-selected="false"
+      >
+        Workflows
+      </button>
+    </li>
     {% endif %}
   </ul>
 

--- a/application/single_app/templates/workspace.html
+++ b/application/single_app/templates/workspace.html
@@ -604,26 +604,26 @@
         <label class="form-label" for="workspace-section-select">Section</label>
         <select class="form-select" id="workspace-section-select" data-workspace-section-select aria-label="Select workspace section">
           <option value="documents-tab-btn">Your Documents</option>
-          {% if file_sync_enabled %}
-            <option value="sync-tab-btn">Sync</option>
-          {% endif %}
+          <option value="prompts-tab-btn">Your Prompts</option>
           {% if workspace_identities_enabled %}
             <option value="identities-tab-btn">Identities</option>
           {% endif %}
-          <option value="prompts-tab-btn">Your Prompts</option>
+          {% if file_sync_enabled %}
+            <option value="sync-tab-btn">Sync</option>
+          {% endif %}
+          {% if settings.allow_user_custom_endpoints and settings.enable_multi_model_endpoints %}
+            <option value="endpoints-tab-btn">Your Endpoints</option>
+          {% endif %}
           {% if settings.per_user_semantic_kernel and settings.enable_semantic_kernel %}
             {% if settings.allow_user_agents %}
-              <option value="agents-tab-btn">Your Agents</option>
               {% if settings.allow_user_plugins %}
                 <option value="plugins-tab-btn">Your Actions</option>
               {% endif %}
+              <option value="agents-tab-btn">Your Agents</option>
             {% endif %}
           {% endif %}
           {% if settings.allow_user_workflows %}
             <option value="workflows-tab-btn">Workflows</option>
-          {% endif %}
-          {% if settings.allow_user_custom_endpoints and settings.enable_multi_model_endpoints %}
-            <option value="endpoints-tab-btn">Your Endpoints</option>
           {% endif %}
         </select>
       </div>
@@ -646,23 +646,21 @@
           Documents
         </button>
       </li>
-      {% if file_sync_enabled %}
       <li class="nav-item" role="presentation">
         <button
           class="nav-link"
-          id="sync-tab-btn"
+          id="prompts-tab-btn"
           data-bs-toggle="tab"
-          data-bs-target="#sync-tab"
-          title="Configure external file sources that bring approved files into this workspace and run them through the document processing pipeline."
+          data-bs-target="#prompts-tab"
+          title="Create, search, view, and reuse prompt templates for consistent chat instructions."
           type="button"
           role="tab"
-          aria-controls="sync-tab"
+          aria-controls="prompts-tab"
           aria-selected="false"
         >
-          Sync
+          Prompts
         </button>
       </li>
-      {% endif %}
       {% if workspace_identities_enabled %}
       <li class="nav-item" role="presentation">
         <button
@@ -680,39 +678,42 @@
         </button>
       </li>
       {% endif %}
+      {% if file_sync_enabled %}
       <li class="nav-item" role="presentation">
         <button
           class="nav-link"
-          id="prompts-tab-btn"
+          id="sync-tab-btn"
           data-bs-toggle="tab"
-          data-bs-target="#prompts-tab"
-          title="Create, search, view, and reuse prompt templates for consistent chat instructions."
+          data-bs-target="#sync-tab"
+          title="Configure external file sources that bring approved files into this workspace and run them through the document processing pipeline."
           type="button"
           role="tab"
-          aria-controls="prompts-tab"
+          aria-controls="sync-tab"
           aria-selected="false"
         >
-          Prompts
+          Sync
         </button>
       </li>
+      {% endif %}
+      {% if settings.allow_user_custom_endpoints and settings.enable_multi_model_endpoints %}
+        <li class="nav-item" role="presentation">
+          <button
+            class="nav-link"
+            id="endpoints-tab-btn"
+            data-bs-toggle="tab"
+            data-bs-target="#endpoints-tab"
+            title="Manage model endpoints available to personal agents and workflows alongside admin-managed global endpoints."
+            type="button"
+            role="tab"
+            aria-controls="endpoints-tab"
+            aria-selected="false"
+          >
+            Endpoints
+          </button>
+        </li>
+      {% endif %}
       {% if settings.per_user_semantic_kernel and settings.enable_semantic_kernel %}
         {% if settings.allow_user_agents %}
-          <li class="nav-item" role="presentation">
-            <button
-              class="nav-link"
-              id="agents-tab-btn"
-              data-bs-toggle="tab"
-              data-bs-target="#agents-tab"
-              title="Reusable, specialized AI assistants that combine instructions, approved knowledge, and optional actions. Actions are tasks an agent is allowed to perform."
-              type="button"
-              role="tab"
-              aria-controls="agents-tab"
-              aria-selected="false"
-            >
-              Agents
-            </button>
-          </li>
-      
           {% if settings.allow_user_plugins %}
             <li class="nav-item" role="presentation">
               <button
@@ -730,6 +731,22 @@
               </button>
             </li>
           {% endif %}
+
+          <li class="nav-item" role="presentation">
+            <button
+              class="nav-link"
+              id="agents-tab-btn"
+              data-bs-toggle="tab"
+              data-bs-target="#agents-tab"
+              title="Reusable, specialized AI assistants that combine instructions, approved knowledge, and optional actions. Actions are tasks an agent is allowed to perform."
+              type="button"
+              role="tab"
+              aria-controls="agents-tab"
+              aria-selected="false"
+            >
+              Agents
+            </button>
+          </li>
         {% endif %}
       {% endif %}
       {% if settings.allow_user_workflows %}
@@ -746,23 +763,6 @@
             aria-selected="false"
           >
             Workflows
-          </button>
-        </li>
-      {% endif %}
-      {% if settings.allow_user_custom_endpoints and settings.enable_multi_model_endpoints %}
-        <li class="nav-item" role="presentation">
-          <button
-            class="nav-link"
-            id="endpoints-tab-btn"
-            data-bs-toggle="tab"
-            data-bs-target="#endpoints-tab"
-            title="Manage model endpoints available to personal agents and workflows alongside admin-managed global endpoints."
-            type="button"
-            role="tab"
-            aria-controls="endpoints-tab"
-            aria-selected="false"
-          >
-            Endpoints
           </button>
         </li>
       {% endif %}

--- a/docs/explanation/features/index.md
+++ b/docs/explanation/features/index.md
@@ -47,6 +47,7 @@ category: Version History
 - [Data Management Durable Backup Jobs](DATA_MANAGEMENT_BACKUP_MIGRATION.md)
 - [Data Management Migration Resilience](DATA_MANAGEMENT_MIGRATION_RESILIENCE.md)
 - [Migration Provenance](MIGRATION_PROVENANCE.md)
+- [Workspace Section Order](v0.250.211/WORKSPACE_SECTION_ORDER.md)
 - [Microsoft Teams App SSO](v0.242.072/TEAMS_APP_SSO.md)
 - [Tabular SK Large Result Pagination](v0.242.067/TABULAR_SK_LARGE_RESULT_PAGINATION.md)
 - [Model Endpoint Model Icon Picker](v0.242.060/MODEL_ENDPOINT_MODEL_ICON_PICKER.md)

--- a/docs/explanation/features/v0.250.211/WORKSPACE_SECTION_ORDER.md
+++ b/docs/explanation/features/v0.250.211/WORKSPACE_SECTION_ORDER.md
@@ -1,0 +1,174 @@
+# Workspace Section Order
+
+## Overview
+
+Workspace sections now render in a single canonical order of operations across every surface
+that lists them. Previously each surface used its own ordering, which made it hard for users and
+admins to see how the pieces relate — that Identities feed both Sync and Actions, that Actions
+belong to Agents, and that Workflows consume Agents.
+
+- **Version implemented:** 0.250.211
+- **Related issue:** [#1255](https://github.com/microsoft/simplechat/issues/1255)
+- **Dependencies:** none — this change is presentation-only and adds no new settings
+
+## Canonical order
+
+Sections still appear only when their existing feature gates are enabled. When a section is
+enabled it always appears in this position relative to the others:
+
+| # | Section | Why it sits here |
+|---|---------|------------------|
+| 1 | **Documents** | The knowledge you bring into the workspace |
+| 2 | **Prompts** | The instructions you reuse against that knowledge |
+| 3 | **Identities** | The credentials both Sync and Actions resolve against |
+| 4 | **Sync** | Uses Identities to pull Documents in automatically |
+| 5 | **Endpoints** | The models that Actions, Agents, and Workflows run on |
+| 6 | **Actions** | Governed tools, built on Identities and Endpoints |
+| 7 | **Agents** | Assemble Documents, Prompts, Actions, and Endpoints |
+| 8 | **Workflows** | Run Agents manually, on a schedule, or on a trigger |
+
+Each entry depends on the ones above it, so reading the tab strip left to right now describes how
+a workspace is actually built up.
+
+## Architecture
+
+### Surfaces kept in sync
+
+Three separate surfaces list workspace sections, and all three now use the canonical order:
+
+| Surface | Personal | Group |
+|---------|----------|-------|
+| Top `nav-tabs` bar | `#workspaceTab` in `templates/workspace.html` | `#groupWorkspaceTab` in `templates/group_workspaces.html` |
+| Collapsed/mobile **Section** dropdown | `#workspace-section-select` | `#group-workspace-section-select` |
+| Left-hand sidebar submenu | `#personal-workspace-submenu` in `templates/_sidebar_nav.html` | `#group-workspace-submenu` in `templates/_sidebar_nav.html` |
+
+`static/js/workspace_section_switcher.js` maps the dropdown's option values onto tab button ids,
+so the dropdown and the tab strip must be edited together — the switcher does not derive one from
+the other.
+
+### Public workspaces
+
+Public workspaces already satisfied the canonical relative order and were left unchanged:
+
+- `templates/public_workspaces.html` lists **Documents** then **Prompts**.
+- `templates/manage_public_workspace.html` lists **Identities** before **Sync** among its
+  management tabs (General, Membership, Stats, Identities, Sync, Settings).
+
+### Tab panes are deliberately not reordered
+
+Bootstrap resolves tab panes by `id` / `data-bs-target`, and inactive panes are hidden, so pane
+DOM order has no visual or accessibility effect. Panes were left in place to keep the change
+reviewable — `group_workspaces.html` alone is roughly 389 KB.
+
+### Gate restructuring
+
+Moving Actions ahead of Agents, and Endpoints ahead of both, required unwinding nested Jinja
+conditionals without changing their effective conditions. For example, the personal workspace
+Actions tab was nested inside the Agents gate:
+
+```jinja
+{% if settings.per_user_semantic_kernel and settings.enable_semantic_kernel %}
+  {% if settings.allow_user_agents %}
+    {% if settings.allow_user_plugins %}
+      {# Actions #}
+    {% endif %}
+    {# Agents #}
+  {% endif %}
+{% endif %}
+```
+
+Actions still requires `per_user_semantic_kernel`, `enable_semantic_kernel`, `allow_user_agents`,
+and `allow_user_plugins` — only its render position changed.
+
+## Navigation gating fixes
+
+The sidebar previously used gates that did not match the tabs they linked to, so a sidebar link
+could point at a tab that was never rendered. Those gates are now aligned:
+
+| Navigation item | Previous gate | Corrected gate |
+|-----------------|---------------|----------------|
+| Personal → Your Agents | `per_user_semantic_kernel and enable_semantic_kernel` | added `allow_user_agents` |
+| Personal → Your Actions | `per_user_semantic_kernel and enable_semantic_kernel` | added `allow_user_agents and allow_user_plugins` |
+| Personal → Identities | `file_sync_enabled or enable_semantic_kernel or enable_multi_model_endpoints` | `file_sync_enabled or enable_semantic_kernel` |
+| Group → Group Agents | `allow_group_agents and enable_semantic_kernel` | added `per_user_semantic_kernel` |
+| Group → Group Actions | `allow_group_agents and enable_semantic_kernel` | added `per_user_semantic_kernel and allow_group_plugins` |
+| Group → Identities | `file_sync_enabled or enable_semantic_kernel or enable_multi_model_endpoints` | `file_sync_enabled or enable_semantic_kernel` |
+| Group → Group Workflows | *link did not exist* | added, gated by `allow_group_workflows` |
+
+The group sidebar had no Workflows entry at all even though the group Workflows tab has shipped
+for some time, so group workflows were unreachable from the left-hand navigation.
+
+## Configuration
+
+No new configuration. The sections that appear continue to be controlled by the existing settings:
+
+| Section | Personal gate | Group gate |
+|---------|---------------|------------|
+| Documents | always | always |
+| Prompts | always | always |
+| Identities | `enable_file_sync*` or `enable_semantic_kernel` | `enable_file_sync*` or `enable_semantic_kernel` |
+| Sync | `enable_file_sync*` | `enable_file_sync*` |
+| Endpoints | `allow_user_custom_endpoints` + `enable_multi_model_endpoints` | `per_user_semantic_kernel` + `enable_semantic_kernel` + `allow_group_custom_endpoints` + `enable_multi_model_endpoints` |
+| Actions | `per_user_semantic_kernel` + `enable_semantic_kernel` + `allow_user_agents` + `allow_user_plugins` | `per_user_semantic_kernel` + `enable_semantic_kernel` + `allow_group_agents` + `allow_group_plugins` |
+| Agents | `per_user_semantic_kernel` + `enable_semantic_kernel` + `allow_user_agents` | `per_user_semantic_kernel` + `enable_semantic_kernel` + `allow_group_agents` |
+| Workflows | `allow_user_workflows` | `allow_group_workflows` |
+
+`enable_file_sync*` is the resolved per-scope File Sync availability computed by
+`is_file_sync_enabled_for_user` / `is_file_sync_enabled_for_group`.
+
+## File structure
+
+| File | Change |
+|------|--------|
+| `application/single_app/templates/workspace.html` | Reordered `#workspaceTab` and `#workspace-section-select` |
+| `application/single_app/templates/group_workspaces.html` | Reordered `#groupWorkspaceTab` and `#group-workspace-section-select` |
+| `application/single_app/templates/_sidebar_nav.html` | Reordered both submenus, added the group Workflows link, aligned gates, refreshed parent tooltips |
+| `application/single_app/config.py` | `VERSION` bumped to `0.250.211` |
+| `functional_tests/test_workspace_section_order.py` | New coverage for the canonical order and gating parity |
+| `functional_tests/test_endpoints_tab_order_visibility.py` | Updated for the new Endpoints → Actions → Agents order |
+
+## Usage
+
+Nothing to enable. Users see the new order the next time they open a workspace page. Sections that
+an admin has disabled remain hidden, and the remaining sections close up while preserving their
+relative positions.
+
+## Testing and validation
+
+`functional_tests/test_workspace_section_order.py` renders each of the six section lists in
+isolation with Jinja and checks:
+
+1. **Canonical order when everything is enabled** — all six surfaces render exactly the eight
+   sections in the canonical order.
+2. **Disabled features only remove sections** — every combination of the eight relevant feature
+   flags (256 per scope) still yields a subsequence of the canonical order, with no duplicates and
+   with Documents and Prompts always leading.
+3. **Gating lockstep** — for every flag combination, the tab strip, the Section dropdown, and the
+   sidebar submenu expose an identical set of sections. This is what guards the navigation gating
+   fixes above.
+4. **Permission markers survive** — the permission-aware group Identities markers
+   (`data-group-identities-tab-nav`, `data-group-identities-sidebar-nav`,
+   `data-group-identities-section-option`) are still present after the reordering.
+5. **Public workspaces** — Documents precedes Prompts, and Identities precedes Sync on the manage
+   page.
+
+The test was verified against the pre-change templates and fails there, confirming it is not
+vacuous.
+
+### Known limitations
+
+- Tab pane DOM order still reflects the historical ordering. This is intentional and has no user
+  impact, but it means pane order and tab order no longer visually correspond when reading the
+  template source.
+- The personal workspace guided tutorial (`static/js/workspace/workspace-tutorial.js`) still walks
+  Documents → Prompts → Agents → Actions. Its selectors are id-based so it functions correctly,
+  but its narrative sequence no longer mirrors the tab order.
+- Section grouping (dividers or group labels such as Content / Connections / Automation) is a
+  possible follow-up; this change establishes the ordering those groups would build on.
+
+## Related documentation
+
+- `docs/explanation/fixes/v0.241.001/ENDPOINTS_TAB_ORDER_VISIBILITY_FIX.md` — earlier work that
+  introduced the endpoints tab gating this change reorders
+- `docs/explanation/features/v0.229.001/LEFT_HAND_NAVIGATION_MENU.md` — the left-hand navigation
+  this change keeps in sync with the tab strip

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,28 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](/explanation/features/) and [Fixes by Version](/explanation/fixes/).
 
+### **(v0.250.211)**
+
+#### User Interface Enhancements
+
+*   **Consistent Workspace Section Order**
+    *   Workspace sections now follow a single order of operations everywhere they are listed: Documents, Prompts, Identities, Sync, Endpoints, Actions, Agents, Workflows.
+    *   The order reflects how a workspace is actually built up, so it is clearer that Identities feed both Sync and Actions, that Actions belong to Agents, and that Workflows run Agents.
+    *   Applied to the tab strip, the collapsed Section dropdown, and the left-hand sidebar submenus for personal and group workspaces. Public workspaces already matched this order and were left unchanged.
+    *   Sections that an admin has disabled stay hidden; the remaining sections simply close up while keeping their relative positions.
+    *   (Ref: #1255, `workspace.html`, `group_workspaces.html`, `_sidebar_nav.html`, `WORKSPACE_SECTION_ORDER.md`)
+
+#### Bug Fixes
+
+*   **Group Workflows Missing From Sidebar Navigation**
+    *   Added the missing Group Workflows link to the left-hand group workspace submenu. Group workflows previously had a working tab but no way to reach it from the sidebar.
+    *   (Ref: #1255, `_sidebar_nav.html`, group workflows navigation)
+
+*   **Sidebar Links Pointing At Unrendered Workspace Tabs**
+    *   Fixed left-hand navigation links whose visibility rules did not match the tabs they opened, so a link could appear for a section that was never rendered.
+    *   Personal Agents and Actions links now respect the user agent and plugin permissions, group Agents and Actions links now respect per-user Semantic Kernel and group plugin permissions, and both Identities links now match their tab's File Sync and Semantic Kernel conditions.
+    *   (Ref: #1255, `_sidebar_nav.html`, `test_workspace_section_order.py`)
+
 ### **(v0.250.210)**
 
 #### Bug Fixes

--- a/functional_tests/test_endpoints_tab_order_visibility.py
+++ b/functional_tests/test_endpoints_tab_order_visibility.py
@@ -2,13 +2,20 @@
 # test_endpoints_tab_order_visibility.py
 """
 Functional test for workspace/group endpoints tab order and visibility.
-Version: 0.239.197
+Version: 0.250.211
 Implemented in: 0.239.197
+Reordered in: 0.250.211
 
 This test ensures endpoints tabs only render when multi-endpoint management is
 enabled, the personal and group admin-controlled toggles stay hidden, and the
 admin multi-endpoint toggle is removed after migration while its script keeps
 the endpoint editor initialized.
+
+Since 0.250.211 the workspace sections follow a canonical order of operations
+(Documents, Prompts, Identities, Sync, Endpoints, Actions, Agents, Workflows), so
+Endpoints now renders ahead of Actions and Agents. Tab pane DOM order is
+deliberately not asserted: Bootstrap resolves panes by id and hides inactive ones,
+so pane order has no visual or accessibility effect.
 """
 
 import os
@@ -29,20 +36,17 @@ def read_file_text(file_path):
 def test_workspace_endpoints_tab_order_visibility():
     content = read_file_text(WORKSPACE_TEMPLATE)
 
-    agents_idx = content.find('id="agents-tab-btn"')
-    actions_idx = content.find('id="plugins-tab-btn"')
     endpoints_idx = content.find('id="endpoints-tab-btn"')
+    actions_idx = content.find('id="plugins-tab-btn"')
+    agents_idx = content.find('id="agents-tab-btn"')
 
-    assert agents_idx != -1, "Agents tab button missing in workspace template."
-    assert actions_idx != -1, "Actions tab button missing in workspace template."
     assert endpoints_idx != -1, "Endpoints tab button missing in workspace template."
-    assert agents_idx < actions_idx < endpoints_idx, "Workspace tab order should be Agents -> Actions -> Endpoints."
+    assert actions_idx != -1, "Actions tab button missing in workspace template."
+    assert agents_idx != -1, "Agents tab button missing in workspace template."
+    assert endpoints_idx < actions_idx < agents_idx, "Workspace tab order should be Endpoints -> Actions -> Agents."
 
-    actions_pane_idx = content.find('id="plugins-tab"')
-    endpoints_pane_idx = content.find('id="endpoints-tab"')
-    assert actions_pane_idx != -1, "Actions tab pane missing in workspace template."
-    assert endpoints_pane_idx != -1, "Endpoints tab pane missing in workspace template."
-    assert actions_pane_idx < endpoints_pane_idx, "Endpoints tab pane should appear after actions pane."
+    assert content.find('id="plugins-tab"') != -1, "Actions tab pane missing in workspace template."
+    assert content.find('id="endpoints-tab"') != -1, "Endpoints tab pane missing in workspace template."
 
     expected_gate = "{% if settings.allow_user_custom_endpoints and settings.enable_multi_model_endpoints %}"
     assert content.count(expected_gate) >= 2, "Workspace endpoints tab button and pane should share the multi-endpoint gate."
@@ -55,20 +59,17 @@ def test_workspace_endpoints_tab_order_visibility():
 def test_group_endpoints_tab_order_visibility():
     content = read_file_text(GROUP_TEMPLATE)
 
-    agents_idx = content.find('id="group-agents-tab-btn"')
-    actions_idx = content.find('id="group-plugins-tab-btn"')
     endpoints_idx = content.find('id="group-endpoints-tab-btn"')
+    actions_idx = content.find('id="group-plugins-tab-btn"')
+    agents_idx = content.find('id="group-agents-tab-btn"')
 
-    assert agents_idx != -1, "Group agents tab button missing in group workspace template."
-    assert actions_idx != -1, "Group actions tab button missing in group workspace template."
     assert endpoints_idx != -1, "Group endpoints tab button missing in group workspace template."
-    assert agents_idx < actions_idx < endpoints_idx, "Group tab order should be Agents -> Actions -> Endpoints."
+    assert actions_idx != -1, "Group actions tab button missing in group workspace template."
+    assert agents_idx != -1, "Group agents tab button missing in group workspace template."
+    assert endpoints_idx < actions_idx < agents_idx, "Group tab order should be Endpoints -> Actions -> Agents."
 
-    actions_pane_idx = content.find('id="group-plugins-tab"')
-    endpoints_pane_idx = content.find('id="group-endpoints-tab"')
-    assert actions_pane_idx != -1, "Group actions tab pane missing in group workspace template."
-    assert endpoints_pane_idx != -1, "Group endpoints tab pane missing in group workspace template."
-    assert actions_pane_idx < endpoints_pane_idx, "Group endpoints tab pane should appear after actions pane."
+    assert content.find('id="group-plugins-tab"') != -1, "Group actions tab pane missing in group workspace template."
+    assert content.find('id="group-endpoints-tab"') != -1, "Group endpoints tab pane missing in group workspace template."
 
     expected_gate = "{% if settings.enable_semantic_kernel and settings.allow_group_custom_endpoints and settings.enable_multi_model_endpoints %}"
     assert content.count(expected_gate) >= 2, "Group endpoints tab button and pane should share the multi-endpoint gate."

--- a/functional_tests/test_workspace_section_order.py
+++ b/functional_tests/test_workspace_section_order.py
@@ -1,0 +1,404 @@
+#!/usr/bin/env python3
+# test_workspace_section_order.py
+"""
+Functional test for the canonical workspace section order.
+Version: 0.250.211
+Implemented in: 0.250.211
+
+This test ensures every surface that lists workspace sections renders them in the
+canonical order of operations (Documents, Prompts, Identities, Sync, Endpoints,
+Actions, Agents, Workflows), and that each surface shows exactly the same sections
+for a given set of feature flags so a navigation link can never point at a tab that
+was never rendered.
+"""
+
+import itertools
+import re
+import traceback
+from pathlib import Path
+
+from jinja2 import Environment
+
+from test_support.versioning import assert_app_version_at_least
+
+IMPLEMENTED_VERSION = "0.250.211"
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TEMPLATE_DIR = REPO_ROOT / "application" / "single_app" / "templates"
+WORKSPACE_TEMPLATE = TEMPLATE_DIR / "workspace.html"
+GROUP_TEMPLATE = TEMPLATE_DIR / "group_workspaces.html"
+SIDEBAR_TEMPLATE = TEMPLATE_DIR / "_sidebar_nav.html"
+PUBLIC_TEMPLATE = TEMPLATE_DIR / "public_workspaces.html"
+MANAGE_PUBLIC_TEMPLATE = TEMPLATE_DIR / "manage_public_workspace.html"
+
+CANONICAL_ORDER = [
+    "documents",
+    "prompts",
+    "identities",
+    "sync",
+    "endpoints",
+    "actions",
+    "agents",
+    "workflows",
+]
+
+NAV_BUTTON_RE = re.compile(r'\bid="([a-z-]+-tab-btn)"')
+SELECT_OPTION_RE = re.compile(r'<option value="([a-z-]+-tab-btn)"')
+SIDEBAR_LINK_RE = re.compile(r'\bdata-tab="([a-z-]+-tab)"')
+
+PERSONAL_FLAG_NAMES = (
+    "file_sync_enabled",
+    "enable_semantic_kernel",
+    "per_user_semantic_kernel",
+    "allow_user_agents",
+    "allow_user_plugins",
+    "allow_user_workflows",
+    "allow_user_custom_endpoints",
+    "enable_multi_model_endpoints",
+)
+
+GROUP_FLAG_NAMES = (
+    "file_sync_enabled",
+    "enable_semantic_kernel",
+    "per_user_semantic_kernel",
+    "allow_group_agents",
+    "allow_group_plugins",
+    "allow_group_workflows",
+    "allow_group_custom_endpoints",
+    "enable_multi_model_endpoints",
+)
+
+
+def read_template(template_path):
+    return template_path.read_text(encoding="utf-8")
+
+
+def extract_block(source, start_pattern, end_token, label):
+    """Return the template source for a single markup block, including its wrapper tags."""
+    start_match = re.search(start_pattern, source)
+    assert start_match, f"Could not locate the opening tag for {label}."
+
+    end_index = source.find(end_token, start_match.end())
+    assert end_index != -1, f"Could not locate the closing {end_token} for {label}."
+
+    return source[start_match.start():end_index + len(end_token)]
+
+
+def extract_set_statement(source, variable_name):
+    """Return the template's own {% set %} statement so gating is exercised as written."""
+    set_match = re.search(r"\{%-?\s*set\s+" + re.escape(variable_name) + r"\s*=.*?%\}", source)
+    assert set_match, f"Could not locate the {variable_name} set statement."
+    return set_match.group(0)
+
+
+def section_key(token):
+    """Normalize a tab identifier into its canonical section key."""
+    name = token
+    for suffix in ("-tab-btn", "-tab"):
+        if name.endswith(suffix):
+            name = name[: -len(suffix)]
+            break
+
+    if name.startswith("group-"):
+        name = name[len("group-"):]
+
+    # The Actions section is still wired up under its historical "plugins" identifier.
+    if name == "plugins":
+        name = "actions"
+
+    return name
+
+
+def render_sections(block_source, pattern, context, prelude=""):
+    """Render a section list under the given flags and return its section keys in DOM order."""
+    template = Environment(autoescape=True).from_string(prelude + block_source)
+    rendered = template.render(**context)
+    return [section_key(token) for token in pattern.findall(rendered)]
+
+
+def build_flags(flag_names, values):
+    return dict(zip(flag_names, values))
+
+
+def build_context(flags, settings_keys):
+    settings = {key: flags[key] for key in settings_keys}
+    return {
+        "settings": settings,
+        "sidebar_settings": settings,
+        "file_sync_enabled": flags["file_sync_enabled"],
+        "nav_layout": "",
+    }
+
+
+def personal_context(flags):
+    return build_context(flags, [name for name in PERSONAL_FLAG_NAMES if name != "file_sync_enabled"])
+
+
+def group_context(flags):
+    return build_context(flags, [name for name in GROUP_FLAG_NAMES if name != "file_sync_enabled"])
+
+
+def assert_canonical_subsequence(sections, label, flags):
+    """Assert the rendered sections follow the canonical order and contain no duplicates."""
+    unknown = [section for section in sections if section not in CANONICAL_ORDER]
+    assert not unknown, f"{label} rendered unknown sections {unknown} with flags {flags}."
+
+    assert len(set(sections)) == len(sections), (
+        f"{label} rendered duplicate sections {sections} with flags {flags}."
+    )
+
+    positions = [CANONICAL_ORDER.index(section) for section in sections]
+    assert positions == sorted(positions), (
+        f"{label} order {sections} does not follow the canonical order "
+        f"{CANONICAL_ORDER} with flags {flags}."
+    )
+
+
+def build_personal_surfaces():
+    workspace_source = read_template(WORKSPACE_TEMPLATE)
+    sidebar_source = read_template(SIDEBAR_TEMPLATE)
+    identities_set = extract_set_statement(workspace_source, "workspace_identities_enabled")
+
+    return {
+        "personal nav tabs": {
+            "block": extract_block(
+                workspace_source,
+                r'<ul class="nav nav-tabs[^>]*id="workspaceTab"[^>]*>',
+                "</ul>",
+                "the personal workspace nav tabs",
+            ),
+            "pattern": NAV_BUTTON_RE,
+            "prelude": identities_set,
+        },
+        "personal section select": {
+            "block": extract_block(
+                workspace_source,
+                r'<select[^>]*id="workspace-section-select"[^>]*>',
+                "</select>",
+                "the personal workspace section select",
+            ),
+            "pattern": SELECT_OPTION_RE,
+            "prelude": identities_set,
+        },
+        "personal sidebar submenu": {
+            "block": extract_block(
+                sidebar_source,
+                r'<ul[^>]*id="personal-workspace-submenu"[^>]*>',
+                "</ul>",
+                "the personal sidebar submenu",
+            ),
+            "pattern": SIDEBAR_LINK_RE,
+            "prelude": "",
+        },
+    }
+
+
+def build_group_surfaces():
+    group_source = read_template(GROUP_TEMPLATE)
+    sidebar_source = read_template(SIDEBAR_TEMPLATE)
+    identities_set = extract_set_statement(group_source, "group_workspace_identities_enabled")
+
+    return {
+        "group nav tabs": {
+            "block": extract_block(
+                group_source,
+                r'<ul class="nav nav-tabs[^>]*id="groupWorkspaceTab"[^>]*>',
+                "</ul>",
+                "the group workspace nav tabs",
+            ),
+            "pattern": NAV_BUTTON_RE,
+            "prelude": identities_set,
+        },
+        "group section select": {
+            "block": extract_block(
+                group_source,
+                r'<select[^>]*id="group-workspace-section-select"[^>]*>',
+                "</select>",
+                "the group workspace section select",
+            ),
+            "pattern": SELECT_OPTION_RE,
+            "prelude": identities_set,
+        },
+        "group sidebar submenu": {
+            "block": extract_block(
+                sidebar_source,
+                r'<ul[^>]*id="group-workspace-submenu"[^>]*>',
+                "</ul>",
+                "the group sidebar submenu",
+            ),
+            "pattern": SIDEBAR_LINK_RE,
+            "prelude": "",
+        },
+    }
+
+
+def render_surfaces(surfaces, context):
+    return {
+        label: render_sections(surface["block"], surface["pattern"], context, surface["prelude"])
+        for label, surface in surfaces.items()
+    }
+
+
+def test_version_reflects_workspace_section_order():
+    """Verify the application version is at least the implementation version."""
+    print("Testing workspace section order version marker...")
+
+    assert_app_version_at_least(
+        IMPLEMENTED_VERSION,
+        reason="Workspace section reordering shipped in this version.",
+    )
+
+    print("Version marker verified.")
+
+
+def test_every_section_surface_uses_the_canonical_order():
+    """Verify all six workspace section lists render the canonical order when fully enabled."""
+    print("Testing canonical workspace section order...")
+
+    personal_flags = build_flags(PERSONAL_FLAG_NAMES, [True] * len(PERSONAL_FLAG_NAMES))
+    group_flags = build_flags(GROUP_FLAG_NAMES, [True] * len(GROUP_FLAG_NAMES))
+
+    rendered = render_surfaces(build_personal_surfaces(), personal_context(personal_flags))
+    rendered.update(render_surfaces(build_group_surfaces(), group_context(group_flags)))
+
+    for label, sections in rendered.items():
+        assert sections == CANONICAL_ORDER, (
+            f"{label} should render {CANONICAL_ORDER} when every feature is enabled, got {sections}."
+        )
+
+    print("Canonical workspace section order verified across all six surfaces.")
+
+
+def test_disabled_features_only_remove_sections():
+    """Verify every flag combination keeps the canonical order and only hides sections."""
+    print("Testing workspace section order across feature flag combinations...")
+
+    personal_surfaces = build_personal_surfaces()
+    group_surfaces = build_group_surfaces()
+    always_present = ["documents", "prompts"]
+
+    for values in itertools.product([True, False], repeat=len(PERSONAL_FLAG_NAMES)):
+        flags = build_flags(PERSONAL_FLAG_NAMES, values)
+        for label, sections in render_surfaces(personal_surfaces, personal_context(flags)).items():
+            assert_canonical_subsequence(sections, label, flags)
+            assert sections[:2] == always_present, (
+                f"{label} should always start with {always_present}, got {sections} with flags {flags}."
+            )
+
+    for values in itertools.product([True, False], repeat=len(GROUP_FLAG_NAMES)):
+        flags = build_flags(GROUP_FLAG_NAMES, values)
+        for label, sections in render_surfaces(group_surfaces, group_context(flags)).items():
+            assert_canonical_subsequence(sections, label, flags)
+            assert sections[:2] == always_present, (
+                f"{label} should always start with {always_present}, got {sections} with flags {flags}."
+            )
+
+    print("Workspace section order verified across all feature flag combinations.")
+
+
+def test_section_surfaces_stay_in_gating_lockstep():
+    """Verify tabs, the section select, and the sidebar expose identical sections."""
+    print("Testing workspace section gating parity...")
+
+    personal_surfaces = build_personal_surfaces()
+    group_surfaces = build_group_surfaces()
+
+    for values in itertools.product([True, False], repeat=len(PERSONAL_FLAG_NAMES)):
+        flags = build_flags(PERSONAL_FLAG_NAMES, values)
+        rendered = render_surfaces(personal_surfaces, personal_context(flags))
+        expected = rendered["personal nav tabs"]
+        for label, sections in rendered.items():
+            assert sections == expected, (
+                f"{label} exposes {sections} but the personal nav tabs expose {expected} "
+                f"with flags {flags}."
+            )
+
+    for values in itertools.product([True, False], repeat=len(GROUP_FLAG_NAMES)):
+        flags = build_flags(GROUP_FLAG_NAMES, values)
+        rendered = render_surfaces(group_surfaces, group_context(flags))
+        expected = rendered["group nav tabs"]
+        for label, sections in rendered.items():
+            assert sections == expected, (
+                f"{label} exposes {sections} but the group nav tabs expose {expected} "
+                f"with flags {flags}."
+            )
+
+    print("Workspace section gating parity verified for personal and group surfaces.")
+
+
+def test_group_identities_navigation_markers_survive_reordering():
+    """Verify the permission-aware group Identities markers are preserved after the move."""
+    print("Testing group identities navigation markers...")
+
+    group_source = read_template(GROUP_TEMPLATE)
+    sidebar_source = read_template(SIDEBAR_TEMPLATE)
+
+    assert 'data-group-identities-section-option hidden disabled' in group_source, (
+        "Group identities section option marker missing after reordering."
+    )
+    assert 'class="nav-item d-none" role="presentation" data-group-identities-tab-nav' in group_source, (
+        "Group identities tab nav marker missing after reordering."
+    )
+    assert '<li class="nav-item d-none" data-group-identities-sidebar-nav>' in sidebar_source, (
+        "Group identities sidebar nav marker missing after reordering."
+    )
+
+    print("Group identities navigation markers verified.")
+
+
+def test_public_workspace_surfaces_follow_the_canonical_order():
+    """Verify the public workspace pages already satisfy the canonical relative order."""
+    print("Testing public workspace section order...")
+
+    public_source = read_template(PUBLIC_TEMPLATE)
+    documents_index = public_source.find('id="public-docs-tab-btn"')
+    prompts_index = public_source.find('id="public-prompts-tab-btn"')
+
+    assert documents_index != -1, "Public workspace documents tab button missing."
+    assert prompts_index != -1, "Public workspace prompts tab button missing."
+    assert documents_index < prompts_index, (
+        "Public workspace order should be Documents -> Prompts."
+    )
+
+    manage_source = read_template(MANAGE_PUBLIC_TEMPLATE)
+    identities_index = manage_source.find('id="identities-tab"')
+    sync_index = manage_source.find('id="sync-tab"')
+
+    assert identities_index != -1, "Public workspace management identities tab missing."
+    assert sync_index != -1, "Public workspace management sync tab missing."
+    assert identities_index < sync_index, (
+        "Public workspace management order should place Identities before Sync."
+    )
+
+    print("Public workspace section order verified.")
+
+
+def run_tests():
+    tests = [
+        test_version_reflects_workspace_section_order,
+        test_every_section_surface_uses_the_canonical_order,
+        test_disabled_features_only_remove_sections,
+        test_section_surfaces_stay_in_gating_lockstep,
+        test_group_identities_navigation_markers_survive_reordering,
+        test_public_workspace_surfaces_follow_the_canonical_order,
+    ]
+    results = []
+
+    for test in tests:
+        print(f"\nRunning {test.__name__}...")
+        try:
+            test()
+            print("Test passed")
+            results.append(True)
+        except Exception as exc:
+            print(f"Test failed: {exc}")
+            traceback.print_exc()
+            results.append(False)
+
+    success = all(results)
+    print(f"\nResults: {sum(results)}/{len(results)} tests passed")
+    return success
+
+
+if __name__ == "__main__":
+    raise SystemExit(0 if run_tests() else 1)


### PR DESCRIPTION
Fixes #1255

## What this does

Workspace sections were ordered differently on every surface that listed them, and none of those orders communicated how the pieces relate. This adopts a single canonical order everywhere:

**Documents → Prompts → Identities → Sync → Endpoints → Actions → Agents → Workflows**

Each section depends on the ones before it, so the list now reads as how a workspace is actually built up: Identities feed both Sync *and* Actions, Endpoints feed Actions and Agents, Agents assemble everything, and Workflows run Agents. This came out of user and admin confusion about those relationships.

Sections still appear only when their existing feature gates are enabled — disabled ones simply close up while the rest keep their relative positions.

### Before / after

| Surface | Before | After |
|---|---|---|
| Personal tabs | Documents, Sync, Identities, Prompts, Agents, Actions, Workflows, Endpoints | canonical |
| Personal Section dropdown | Documents, Sync, Identities, Prompts, Agents, Actions, Workflows, Endpoints | canonical |
| Personal sidebar submenu | Documents, Prompts, Workflows, Agents, Actions, Endpoints, Sync, Identities | canonical |
| Group tabs | Documents, Sync, Identities, Prompts, Workflows, Agents, Actions, Endpoints | canonical |
| Group Section dropdown | Documents, Sync, Identities, Prompts, Workflows, Agents, Actions, Endpoints | canonical |
| Group sidebar submenu | Documents, Prompts, Agents, Actions, Endpoints, Sync, Identities (**no Workflows**) | canonical |

Public workspaces already satisfied the canonical relative order (Documents → Prompts on the browse page, Identities before Sync on the manage page) and are unchanged.

## Sidebar gating bugs fixed

The sidebar used visibility rules that didn't match the tabs they linked to, so a link could appear for a section that was never rendered:

| Navigation item | Before | After |
|---|---|---|
| Personal → Your Agents | `per_user_semantic_kernel and enable_semantic_kernel` | + `allow_user_agents` |
| Personal → Your Actions | `per_user_semantic_kernel and enable_semantic_kernel` | + `allow_user_agents and allow_user_plugins` |
| Personal → Identities | `... or enable_multi_model_endpoints` | matches tab gate |
| Group → Group Agents | `allow_group_agents and enable_semantic_kernel` | + `per_user_semantic_kernel` |
| Group → Group Actions | `allow_group_agents and enable_semantic_kernel` | + `per_user_semantic_kernel and allow_group_plugins` |
| Group → Identities | `... or enable_multi_model_endpoints` | matches tab gate |
| Group → Group Workflows | **missing entirely** | added, gated by `allow_group_workflows` |

The group sidebar had no Workflows entry at all, so group workflows were unreachable from the left-hand navigation despite the tab having shipped.

## Implementation notes

**Tab panes are deliberately not reordered.** Bootstrap resolves panes by `id` / `data-bs-target` and hides inactive ones, so pane DOM order has no visual or accessibility effect. Leaving them in place keeps the diff reviewable — `group_workspaces.html` alone is ~389 KB.

**Gate restructuring preserves effective conditions.** Moving Actions ahead of Agents and Endpoints ahead of both required unwinding nested Jinja conditionals. For example, personal Actions was nested inside the Agents gate; it still requires `per_user_semantic_kernel`, `enable_semantic_kernel`, `allow_user_agents`, and `allow_user_plugins` — only its render position changed.

**The dropdown and tab strip must move together.** `workspace_section_switcher.js` maps option values onto tab button ids rather than deriving one from the other, so both were updated in lockstep.

## Validation

- **New `functional_tests/test_workspace_section_order.py`** renders each of the six section lists through Jinja and asserts: the canonical order when everything is enabled; that disabled features only *remove* sections (never reorder or duplicate); and that the tab strip, Section dropdown, and sidebar submenu expose an identical set of sections across **every combination of the eight relevant feature flags per scope** (512 renders). It also checks the permission-aware group Identities markers survived the move, and that public workspaces still conform.
- **Verified non-vacuous** — the new test was run against the pre-change templates and fails there on all three order/parity assertions.
- **No regressions** — all 74 functional tests referencing the edited templates produce an *identical failure set* to the `Development` baseline (re-verified after rebasing). The 50 failures in that set are pre-existing and unrelated (stale assertions about `app.py` route registration, `admin_settings.js` helpers, hardcoded old version numbers, etc.).
- `functional_tests/route_tests/` passes 12/12.
- All 50 templates parse cleanly through Jinja.
- `test_endpoints_tab_order_visibility.py` updated for the new Endpoints → Actions → Agents order; its pane assertions reduced to presence-only.

## Also included

- Version bumped to `0.250.211` — rebased twice past `Development`, which claimed `0.250.209` (Cosmos backup fixes, #1259) and `0.250.210` (chat document search, #1260) while this was in flight
- `docs/explanation/features/v0.250.211/WORKSPACE_SECTION_ORDER.md`
- Release notes entry under User Interface Enhancements and Bug Fixes

## Follow-ups (tracked in #1255, not in this PR)

- **Visual grouping of sections** — dividers or group labels (e.g. Content / Connections / Automation) building on this ordering
- **Orphan `#group-settings-tab` pane** in `group_workspaces.html` with no corresponding nav button anywhere in the codebase
