### PR TITLE
Support legacy Office images and optional formula extraction

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -96,7 +96,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.250.223"
+VERSION = "0.250.224"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/functions_content.py
+++ b/application/single_app/functions_content.py
@@ -10,6 +10,7 @@ from bs4 import BeautifulSoup
 
 from functions_debug import debug_print
 from config import *
+from azure.ai.documentintelligence.models import DocumentAnalysisFeature
 from functions_office_media import extract_office_embedded_images
 import functions_settings
 from functions_settings import *
@@ -453,6 +454,11 @@ def extract_content_with_azure_di(file_path, extraction_mode='read', pages=None)
             analyze_options["output_content_format"] = "markdown"
         if pages:
             analyze_options["pages"] = str(pages)
+
+        # Formula extraction is a billed Document Intelligence add-on, so it is opt-in and only
+        # applies to Layout, which is the model that supports it.
+        if normalized_extraction_mode == "layout" and functions_settings.is_document_intelligence_formula_extraction_enabled():
+            analyze_options["features"] = [DocumentAnalysisFeature.FORMULAS]
         
         # Debug logging for troubleshooting
         debug_print(f"Starting Azure DI extraction for: {os.path.basename(file_path)}")

--- a/application/single_app/functions_documents.py
+++ b/application/single_app/functions_documents.py
@@ -7498,10 +7498,11 @@ def process_di_document(document_id, user_id, temp_file_path, original_filename,
                  final_chunks_to_save = di_extracted_pages
             else: final_chunks_to_save = [] # No text extracted
 
-        # --- Embedded Office image analysis (DOCX/DOC/PPTX) ---
+        # --- Embedded Office image analysis (DOCX/DOC/PPTX/PPT) ---
         # Neither extraction engine describes figures inside Office files, so embedded images are
-        # analyzed separately and appended as their own citable chunks.
-        if (is_word or is_ppt) and not is_legacy_doc and not is_legacy_ppt:
+        # analyzed separately and appended as their own citable chunks. Legacy binary formats are
+        # included because their pictures are carved from the OLE container by signature.
+        if is_word or is_ppt:
             next_chunk_page_number = max(
                 (int(chunk.get('page_number') or 0) for chunk in final_chunks_to_save),
                 default=0,

--- a/application/single_app/functions_office_media.py
+++ b/application/single_app/functions_office_media.py
@@ -12,6 +12,7 @@ This module deliberately keeps its imports light so it stays importable without 
 import hashlib
 import os
 import re
+import struct
 import zipfile
 from io import BytesIO
 
@@ -46,6 +47,9 @@ OFFICE_ZIP_MAX_ENTRIES = 5000
 OFFICE_ZIP_MAX_RELS_ENTRIES = 500
 # Only the compression methods real OOXML packages use.
 OFFICE_ZIP_ALLOWED_COMPRESSION = (zipfile.ZIP_STORED, zipfile.ZIP_DEFLATED)
+# Legacy .doc/.ppt are OLE compound documents, so their pictures are carved by signature instead.
+OLE_COMPOUND_FILE_SIGNATURE = b'\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1'
+OFFICE_BINARY_SCAN_MAX_BYTES = 256 * 1024 * 1024
 
 _OFFICE_MEDIA_INDEX_PATTERN = re.compile(r'(\d+)')
 _PPTX_SLIDE_RELS_PATTERN = re.compile(r'^ppt/slides/_rels/slide(\d+)\.xml\.rels$', re.IGNORECASE)
@@ -200,6 +204,130 @@ def extract_office_embedded_images(file_path, output_dir, min_pixels=150, max_im
     return extracted_images
 
 
+def _carve_metafiles_from_binary(data, max_metafiles):
+    """Locate EMF and placeable WMF blobs inside a non-zip Office container.
+
+    Legacy ``.doc`` and ``.ppt`` files are OLE compound documents rather than zip packages, so
+    there is no ``word/media`` part to enumerate. Their pictures and embedded equation previews are
+    still stored as intact metafile blobs, which can be located by signature and carved using the
+    length recorded in the metafile's own header.
+
+    Validation is deliberately strict -- record type, signature position, and a length that fits
+    inside the remaining bytes -- so a coincidental byte sequence is not mistaken for an image.
+    """
+    carved = []
+    offset = 0
+    length = len(data)
+
+    while offset < length and len(carved) < max_metafiles:
+        emf_index = data.find(b' EMF', offset)
+        wmf_index = data.find(b'\xd7\xcd\xc6\x9a', offset)
+
+        candidates = [index for index in (emf_index, wmf_index) if index != -1]
+        if not candidates:
+            break
+        next_index = min(candidates)
+
+        if next_index == emf_index:
+            record_start = emf_index - 40
+            offset = emf_index + 4
+            if record_start < 0 or record_start + 88 > length:
+                continue
+            record_type, _record_size = struct.unpack_from('<II', data, record_start)
+            if record_type != 1:
+                continue
+            total_bytes = struct.unpack_from('<I', data, record_start + 48)[0]
+            if not (88 <= total_bytes <= OFFICE_EMBEDDED_IMAGE_MAX_BYTES):
+                continue
+            if record_start + total_bytes > length:
+                continue
+            carved.append(('emf', data[record_start:record_start + total_bytes]))
+            offset = record_start + total_bytes
+        else:
+            record_start = wmf_index
+            offset = wmf_index + 4
+            if record_start + 30 > length:
+                continue
+            # Placeable header is 22 bytes; the standard header's mtSize is measured in words.
+            size_words = struct.unpack_from('<I', data, record_start + 28)[0]
+            total_bytes = 22 + size_words * 2
+            if not (30 <= total_bytes <= OFFICE_EMBEDDED_IMAGE_MAX_BYTES):
+                continue
+            if record_start + total_bytes > length:
+                continue
+            carved.append(('wmf', data[record_start:record_start + total_bytes]))
+            offset = record_start + total_bytes
+
+    return carved
+
+
+def _extract_from_binary_office_file(file_path, output_dir, min_pixels, max_images, diagnostics):
+    """Extract embedded metafiles from a legacy binary Office document."""
+    try:
+        file_size = os.path.getsize(file_path)
+        if file_size > OFFICE_BINARY_SCAN_MAX_BYTES:
+            return []
+        with open(file_path, 'rb') as handle:
+            data = handle.read()
+    except OSError:
+        return []
+
+    if not data.startswith(OLE_COMPOUND_FILE_SIGNATURE):
+        return []
+
+    carved = _carve_metafiles_from_binary(data, max_images * 4)
+    diagnostics['candidates'] = len(carved)
+
+    extracted_images = []
+    seen_digests = set()
+
+    for source_format, blob in carved:
+        if len(extracted_images) >= max_images:
+            _record_skip(diagnostics, 'per_document_cap_reached')
+            continue
+
+        if len(blob) < OFFICE_EMBEDDED_IMAGE_MIN_BYTES:
+            _record_skip(diagnostics, 'below_minimum_bytes')
+            continue
+
+        digest = hashlib.sha256(blob).hexdigest()
+        if digest in seen_digests:
+            _record_skip(diagnostics, 'duplicate_image')
+            continue
+
+        png_bytes, width, height, embedded_text, reason = _rasterize_vector_image(blob)
+        if png_bytes is None:
+            _record_skip(diagnostics, reason or 'vector_not_rasterizable')
+            continue
+
+        if width < min_pixels or height < min_pixels:
+            _record_skip(diagnostics, 'below_minimum_pixels')
+            continue
+
+        seen_digests.add(digest)
+        output_path = os.path.join(output_dir, f"{len(extracted_images) + 1:03d}.png")
+        try:
+            with open(output_path, 'wb') as output_file:
+                output_file.write(png_bytes)
+        except OSError:
+            _record_skip(diagnostics, 'write_failed')
+            continue
+
+        diagnostics['analyzed'] += 1
+        extracted_images.append({
+            'name': f"embedded_{len(extracted_images) + 1}.{source_format}",
+            'path': output_path,
+            'width': width,
+            'height': height,
+            'slide_number': None,
+            'source_format': source_format,
+            'rasterized': True,
+            'embedded_text': embedded_text,
+        })
+
+    return extracted_images
+
+
 def extract_office_embedded_images_with_diagnostics(file_path, output_dir, min_pixels=150, max_images=25):
     """Extract embedded images and report what was skipped and why.
 
@@ -215,6 +343,15 @@ def extract_office_embedded_images_with_diagnostics(file_path, output_dir, min_p
 
     if max_images <= 0:
         return [], diagnostics
+
+    # Legacy .doc and .ppt are OLE compound documents, not zip packages.
+    if not zipfile.is_zipfile(file_path):
+        try:
+            return _extract_from_binary_office_file(
+                file_path, output_dir, min_pixels, max_images, diagnostics
+            ), diagnostics
+        except (OSError, ValueError, struct.error):
+            return [], diagnostics
 
     extracted_images = []
     seen_digests = set()

--- a/application/single_app/functions_settings.py
+++ b/application/single_app/functions_settings.py
@@ -866,6 +866,15 @@ def normalize_extraction_engine(value):
     return normalized_value
 
 
+def is_document_intelligence_formula_extraction_enabled(settings=None):
+    """Return whether the Document Intelligence formula add-on should be requested.
+
+    Formula extraction is a billed add-on, so it defaults to off and must be enabled explicitly.
+    """
+    resolved_settings = settings if settings is not None else get_settings()
+    return bool((resolved_settings or {}).get('enable_document_intelligence_formula_extraction', False))
+
+
 def normalize_app_role_claims(user_roles):
     """Normalize app role claims into a flat string list."""
     if not user_roles:
@@ -1727,6 +1736,8 @@ def get_settings(use_cosmos=False, include_source=False):
         'azure_document_intelligence_authentication_type': 'key',
         'document_intelligence_pdf_image_extraction_mode': 'read',
         'document_intelligence_auto_sample_pages': DOCUMENT_INTELLIGENCE_AUTO_SAMPLE_PAGES_DEFAULT,
+        # Formula extraction is a billed Document Intelligence add-on, so it stays off by default.
+        'enable_document_intelligence_formula_extraction': False,
         'enable_document_intelligence_apim': False,
         'azure_apim_document_intelligence_endpoint': '',
         'azure_apim_document_intelligence_subscription_key': '',

--- a/application/single_app/route_frontend_admin_settings.py
+++ b/application/single_app/route_frontend_admin_settings.py
@@ -2761,6 +2761,7 @@ def register_route_frontend_admin_settings(bp):
                 'azure_document_intelligence_authentication_type': form_data.get('azure_document_intelligence_authentication_type', 'key'),
                 'document_intelligence_pdf_image_extraction_mode': document_intelligence_pdf_image_extraction_mode,
                 'document_intelligence_auto_sample_pages': document_intelligence_auto_sample_pages,
+                'enable_document_intelligence_formula_extraction': form_data.get('enable_document_intelligence_formula_extraction') == 'on',
                 'enable_document_intelligence_apim': form_data.get('enable_document_intelligence_apim') == 'on',
                 'azure_apim_document_intelligence_endpoint': form_data.get('azure_apim_document_intelligence_endpoint', '').strip(),
                 'azure_apim_document_intelligence_subscription_key': admin_secret('azure_apim_document_intelligence_subscription_key'),

--- a/application/single_app/static/js/admin/admin_settings.js
+++ b/application/single_app/static/js/admin/admin_settings.js
@@ -10552,6 +10552,7 @@ function setupWalkthroughFieldListeners() {
             {selector: '#azure_content_understanding_analyzer_id', event: 'input'},
             {selector: '#azure_content_understanding_image_analyzer_id', event: 'input'},
             {selector: '#enable_office_embedded_image_analysis', event: 'change'},
+            {selector: '#enable_document_intelligence_formula_extraction', event: 'change'},
             {selector: '#office_embedded_image_min_pixels', event: 'input'},
             {selector: '#office_embedded_image_max_per_document', event: 'input'}
         ],

--- a/application/single_app/templates/admin_settings.html
+++ b/application/single_app/templates/admin_settings.html
@@ -11798,6 +11798,26 @@
                             </div>
                         </div>
 
+                        <div class="form-group form-check form-switch mb-3 d-flex align-items-center">
+                            <input
+                                type="checkbox"
+                                class="form-check-input me-2"
+                                id="enable_document_intelligence_formula_extraction"
+                                name="enable_document_intelligence_formula_extraction"
+                                {% if settings.enable_document_intelligence_formula_extraction %}checked{% endif %}
+                            >
+                            <label class="form-check-label" for="enable_document_intelligence_formula_extraction">
+                                Extract mathematical formulas
+                            </label>
+                            <i class="bi bi-info-circle ms-2" data-bs-toggle="tooltip" title="Requests the Document Intelligence formulas add-on so equations are captured as LaTeX instead of approximated as OCR text."></i>
+                        </div>
+                        <div class="form-text mb-3">
+                            Captures equations in PDFs and images as LaTeX rather than approximate OCR text. This is a
+                            <strong>billed Document Intelligence add-on</strong> that adds per-page cost to every Enhanced
+                            extraction, so it is off by default. It applies to the Layout model only, so it has no effect
+                            while extraction is set to Standard.
+                        </div>
+
                         {% if content_understanding_supported %}
                         <div class="card p-3 mb-3 bg-body-tertiary" id="content-understanding-section">
                             <div class="d-flex align-items-center gap-2 flex-wrap mb-2">

--- a/docs/explanation/features/CONTENT_UNDERSTANDING_ENHANCED_EXTRACTION.md
+++ b/docs/explanation/features/CONTENT_UNDERSTANDING_ENHANCED_EXTRACTION.md
@@ -94,6 +94,7 @@ All settings live in **Admin Settings → Extract**.
 | Enable Enhanced extraction | `enable_enhanced_extraction` | `False` |
 | PDF and Image Extraction Mode | `document_intelligence_pdf_image_extraction_mode` | `read` |
 | Auto Sample Pages | `document_intelligence_auto_sample_pages` | `3` |
+| Extract mathematical formulas | `enable_document_intelligence_formula_extraction` | `False` |
 | Content Understanding Endpoint | `azure_content_understanding_endpoint` | `""` |
 | Authentication Type | `azure_content_understanding_authentication_type` | `key` |
 | Content Understanding Key | `azure_content_understanding_key` | `""` |
@@ -175,7 +176,10 @@ them separately.
   `ppt/slides/_rels/slideN.xml.rels`.
 - Each analyzed image becomes its own citable chunk with a heading such as
   `### Embedded image 2 of 5: image2.png on slide 3`.
-- Legacy `.doc` and `.ppt` files are OLE containers rather than zip packages, so they are skipped.
+- Legacy `.doc` and `.ppt` files are OLE compound documents rather than zip packages, so their
+  pictures are carved out by metafile signature instead of being enumerated from media parts. The
+  carve validates the record type, signature position, and declared length before accepting a blob,
+  so a coincidental byte sequence is not mistaken for an image.
 
 Embedded image analysis never fails a document. Individual image failures are logged and skipped.
 
@@ -284,9 +288,13 @@ Enhanced extraction is disabled.
 - There is no APIM passthrough option for Content Understanding yet.
 - Content Understanding markdown is denser than Document Intelligence Read output because it
   includes HTML tables and figure descriptions, so chunks are larger.
-- Legacy `.doc` and `.ppt` files do not support embedded image analysis.
 - Metafile rasterization covers the drawing records Office emits for diagrams. Gradients, complex
   clipping regions, and embedded bitmap blits inside a metafile are not reproduced, and text is
   drawn with a default font rather than the original typeface, so a rasterized diagram is a
   faithful-enough likeness rather than an exact reproduction. The text drawn inside the metafile is
   extracted separately and attached to the chunk, so labels remain accurate regardless.
+- Equations authored in modern Word are stored as OMML markup rather than images, so they are not
+  covered by embedded image analysis. Legacy Equation Editor and MathType objects are stored with a
+  metafile preview and are covered.
+- Formula extraction requires the billed Document Intelligence add-on and applies to the Layout
+  model only, so it has no effect while extraction is set to Standard.

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,23 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](/explanation/features/) and [Fixes by Version](/explanation/fixes/).
 
+### **(v0.250.224)**
+
+#### New Features
+
+*   **Optional Mathematical Formula Extraction**
+    *   Added an **Extract mathematical formulas** toggle to the Document Intelligence settings. When enabled, equations in PDFs and images are captured as LaTeX instead of being approximated as OCR text.
+    *   This requests a **billed Document Intelligence add-on**, so it is off by default and must be turned on deliberately. It applies to the Layout model only, so it has no effect while extraction is set to Standard.
+    *   (Ref: #1277, `functions_content.py`, `functions_settings.py`, `admin_settings.html`, Document Intelligence formulas add-on)
+
+#### Bug Fixes
+
+*   **Images in Legacy `.doc` and `.ppt` Files Are Now Analyzed**
+    *   Embedded image analysis previously covered only DOCX and PPTX, because legacy Office files are OLE compound documents rather than zip packages and have no media parts to enumerate.
+    *   Pictures and embedded equation previews are now carved out of the legacy container by metafile signature, using the length recorded in the metafile's own header, then rasterized and analyzed like any other embedded image.
+    *   Validation is strict — record type, signature position, and a length that fits the remaining bytes — so a coincidental byte sequence is not mistaken for an image. Duplicate images are still collapsed and the per-document cap still applies.
+    *   (Ref: #1277, `functions_office_media.py`, `functions_documents.py`, legacy Office image extraction)
+
 ### **(v0.250.223)**
 
 #### Bug Fixes

--- a/functional_tests/test_content_understanding_extraction_engine.py
+++ b/functional_tests/test_content_understanding_extraction_engine.py
@@ -2,7 +2,7 @@
 # test_content_understanding_extraction_engine.py
 """
 Functional test for Enhanced extraction backed by Azure AI Content Understanding.
-Version: 0.250.223
+Version: 0.250.224
 Implemented in: 0.250.221
 
 This test ensures that the Content Understanding client parses analyzer results into the same
@@ -759,6 +759,32 @@ def test_figures_survive_when_the_result_has_no_pages():
     return True
 
 
+def test_formula_extraction_is_opt_in_and_layout_only():
+    """The Document Intelligence formula add-on is billed, so it must default off and be opt-in."""
+    print("Testing formula extraction opt-in contract...")
+
+    settings = read_repo_file("application/single_app/functions_settings.py")
+    content = read_repo_file("application/single_app/functions_content.py")
+    admin_route = read_repo_file("application/single_app/route_frontend_admin_settings.py")
+    admin_html = read_repo_file("application/single_app/templates/admin_settings.html")
+
+    assert_contains(settings, "'enable_document_intelligence_formula_extraction': False", "formula add-on defaults to off")
+    assert_contains(settings, "def is_document_intelligence_formula_extraction_enabled", "formula gate helper")
+    assert_contains(content, "DocumentAnalysisFeature.FORMULAS", "formula add-on requested")
+    assert_contains(admin_route, "'enable_document_intelligence_formula_extraction': form_data.get(", "formula toggle persisted")
+    assert_contains(admin_html, 'id="enable_document_intelligence_formula_extraction"', "formula toggle input")
+    assert_contains(admin_html, "billed Document Intelligence add-on", "cost warning shown to admins")
+
+    # The add-on only applies to Layout, so it must sit behind the layout branch.
+    formula_index = content.index("DocumentAnalysisFeature.FORMULAS")
+    guard_index = content.index('if normalized_extraction_mode == "layout" and functions_settings.is_document_intelligence_formula_extraction_enabled()')
+    if guard_index > formula_index:
+        raise AssertionError("Formula feature must be guarded by the layout-mode check.")
+
+    print("Formula extraction opt-in test passed!")
+    return True
+
+
 def test_version_is_at_least_implementation_version():
     """The app version must be at or beyond the version this feature shipped in."""
     print("Testing application version...")
@@ -786,6 +812,7 @@ if __name__ == "__main__":
         test_settings_and_admin_surface_contract,
         test_auto_mode_detects_figures,
         test_enhanced_extraction_upgrade_migration_contract,
+        test_formula_extraction_is_opt_in_and_layout_only,
         test_version_is_at_least_implementation_version,
     ]
 

--- a/functional_tests/test_office_embedded_image_extraction.py
+++ b/functional_tests/test_office_embedded_image_extraction.py
@@ -2,7 +2,7 @@
 # test_office_embedded_image_extraction.py
 """
 Functional test for embedded image extraction from Office files.
-Version: 0.250.223
+Version: 0.250.224
 Implemented in: 0.250.221
 
 This test ensures that images embedded in DOCX and PPTX packages are pulled out for analysis,
@@ -526,8 +526,12 @@ def test_emf_metafiles_are_rasterized_and_text_recovered():
     return True
 
 
-def _build_minimal_emf():
-    """Build a small valid EMF containing one filled polygon."""
+def _build_minimal_emf(min_total_bytes=4096):
+    """Build a small valid EMF containing one filled polygon.
+
+    Padded past the minimum-bytes filter with a comment record, because real diagrams are far
+    larger than the floor and the filter exists to drop icons and spacers.
+    """
     import struct
 
     records = []
@@ -540,6 +544,14 @@ def _build_minimal_emf():
         poly_payload += struct.pack('<2h', x, y)
     poly_size = 8 + len(poly_payload)
     records.append(struct.pack('<II', 86, poly_size) + poly_payload)
+
+    # EMR_COMMENT padding so the file clears the minimum-bytes filter.
+    body_so_far = sum(len(record) for record in records)
+    padding_needed = max(0, min_total_bytes - (88 + body_so_far + 20))
+    if padding_needed:
+        comment_data = b'\x00' * padding_needed
+        comment_size = 12 + len(comment_data)
+        records.append(struct.pack('<III', 70, comment_size, len(comment_data)) + comment_data)
 
     # EMR_EOF
     records.append(struct.pack('<IIIII', 14, 20, 0, 16, 20))
@@ -622,6 +634,102 @@ def test_diagnostics_distinguish_no_images_from_all_skipped():
     return True
 
 
+def _build_fake_ole_document(path, payloads, filler=2048):
+    """Write an OLE-signature file containing intact metafile blobs, like a legacy .doc."""
+    with open(path, "wb") as handle:
+        handle.write(b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1")
+        handle.write(b"\x00" * filler)
+        for payload in payloads:
+            handle.write(payload)
+            handle.write(b"\x00" * 256)
+
+
+def test_legacy_binary_office_metafiles_are_carved():
+    """Legacy .doc/.ppt are OLE containers, so images are carved by signature rather than unzipped."""
+    print("Testing legacy binary Office metafile carving...")
+
+    from functions_office_media import extract_office_embedded_images_with_diagnostics
+
+    emf_bytes = _build_minimal_emf()
+
+    with tempfile.TemporaryDirectory() as work_dir:
+        doc_path = os.path.join(work_dir, "legacy.doc")
+        output_dir = os.path.join(work_dir, "out")
+        os.makedirs(output_dir)
+
+        # Two copies of the same metafile: the duplicate must be collapsed.
+        _build_fake_ole_document(doc_path, [emf_bytes, emf_bytes])
+
+        images, diagnostics = extract_office_embedded_images_with_diagnostics(
+            doc_path, output_dir, min_pixels=100, max_images=25
+        )
+
+        # Checked inside the context manager, while the output directory still exists.
+        if images and not os.path.exists(images[0]["path"]):
+            raise AssertionError("Carved image was not written to disk.")
+
+    if diagnostics["candidates"] != 2:
+        raise AssertionError(f"Expected 2 carved candidates, got {diagnostics}")
+    if len(images) != 1:
+        raise AssertionError(f"Expected the duplicate to be collapsed, got {len(images)} images")
+    if images[0]["source_format"] != "emf":
+        raise AssertionError(f"Unexpected source format: {images[0]}")
+    if not images[0]["rasterized"]:
+        raise AssertionError("Carved metafiles must be rasterized.")
+
+    print("Legacy binary carving test passed!")
+    return True
+
+
+def test_non_office_binary_is_ignored_safely():
+    """A binary that is neither zip nor OLE must yield nothing instead of raising."""
+    print("Testing non-Office binary handling...")
+
+    from functions_office_media import extract_office_embedded_images_with_diagnostics
+
+    with tempfile.TemporaryDirectory() as work_dir:
+        junk_path = os.path.join(work_dir, "junk.doc")
+        output_dir = os.path.join(work_dir, "out")
+        os.makedirs(output_dir)
+        with open(junk_path, "wb") as handle:
+            handle.write(b"definitely not an office document" * 500)
+
+        images, diagnostics = extract_office_embedded_images_with_diagnostics(
+            junk_path, output_dir, min_pixels=150, max_images=25
+        )
+
+    if images or diagnostics["candidates"]:
+        raise AssertionError(f"Non-Office binary should yield nothing, got {diagnostics}")
+
+    print("Non-Office binary test passed!")
+    return True
+
+
+def test_carving_rejects_false_signature_matches():
+    """A stray ' EMF' byte sequence must not be mistaken for an image."""
+    print("Testing carving signature validation...")
+
+    from functions_office_media import _carve_metafiles_from_binary
+
+    # ' EMF' present, but no valid record header or length in front of it.
+    decoy = b"\x00" * 100 + b" EMF" + b"\x00" * 100
+    carved = _carve_metafiles_from_binary(decoy, 10)
+    if carved:
+        raise AssertionError(f"A decoy signature must not be carved, got {len(carved)} blob(s)")
+
+    # A real metafile in the same buffer is still found.
+    emf_bytes = _build_minimal_emf()
+    mixed = decoy + emf_bytes + decoy
+    carved = _carve_metafiles_from_binary(mixed, 10)
+    if len(carved) != 1:
+        raise AssertionError(f"Expected exactly one carved metafile, got {len(carved)}")
+    if carved[0][1] != emf_bytes:
+        raise AssertionError("Carved bytes did not match the embedded metafile exactly.")
+
+    print("Carving signature validation test passed!")
+    return True
+
+
 def test_version_is_at_least_implementation_version():
     """The app version must be at or beyond the version this feature shipped in."""
     print("Testing application version...")
@@ -647,6 +755,9 @@ if __name__ == "__main__":
         test_emf_metafiles_are_rasterized_and_text_recovered,
         test_unrenderable_metafile_reports_a_reason,
         test_diagnostics_distinguish_no_images_from_all_skipped,
+        test_legacy_binary_office_metafiles_are_carved,
+        test_non_office_binary_is_ignored_safely,
+        test_carving_rejects_false_signature_matches,
         test_pipeline_wires_embedded_image_analysis,
         test_version_is_at_least_implementation_version,
     ]


### PR DESCRIPTION
Refs #1277

Two gaps surfaced while answering questions about equation and legacy-format coverage. Both are verified fixes, not speculative.

## 1. Images in legacy `.doc` and `.ppt` are now analyzed

Embedded image analysis covered only DOCX and PPTX. Legacy Office files are OLE compound documents rather than zip packages, so there is no `word/media` part to enumerate — the extractor found nothing and the files were excluded outright.

Their pictures and embedded equation previews are still stored as intact metafile blobs, so they are now carved out by signature using the length recorded in the metafile's own header, then rasterized and analyzed like any other embedded image.

Validation is deliberately strict — record type, signature position, and a declared length that fits inside the remaining bytes — so a coincidental byte sequence is not mistaken for an image. There is a test that plants a decoy `" EMF"` sequence and asserts it is rejected while a real metafile in the same buffer is still carved byte-exactly.

Verified against a synthetic legacy container built from two of the real diagrams plus a duplicate:

```
diagnostics: {'candidates': 3, 'analyzed': 2, 'skipped': 1, 'skipped_reasons': {'duplicate_image': 1}}
  embedded_1.emf 989x831  27 labels
  embedded_2.emf 1285x831 38 labels
```

Duplicate collapsing and the per-document cap still apply, and a file that is neither zip nor OLE yields nothing rather than raising.

## 2. Optional mathematical formula extraction

Equations were never extracted. Grepping the app confirmed no formula feature was requested anywhere, so equations arrived as whatever OCR guessed — usually garbled for real math.

Document Intelligence exposes a `FORMULAS` add-on, already present in the pinned SDK, which returns equations as LaTeX. **It is billed per page**, so:

- it sits behind a new admin toggle that **defaults to off**
- it is guarded by the layout-mode check, because the add-on applies to that model only
- the admin UI states plainly that it is a billed add-on that adds per-page cost

A test asserts the default-off value, the persistence path, the cost warning in the UI, and that the feature is positioned behind the layout guard rather than applied unconditionally.

## Scope note

This does **not** cover equations authored in modern Word, which are stored as OMML markup rather than images and so are outside embedded image analysis entirely. Legacy Equation Editor and MathType objects *are* stored with a metafile preview, and those are covered by the carving change above. The feature doc records both facts so the boundary is not misremembered later.

## Testing

Four new tests (legacy carving, non-Office binary safety, decoy signature rejection, formula opt-in contract). The embedded image suite is 20/20; Content Understanding, legacy Word, Document Intelligence, and route policy suites all still pass.

One fixture bug worth mentioning: the synthetic EMF used in tests was ~158 bytes and was correctly rejected by the 2 KB minimum-size filter. I padded the fixture with a valid comment record to make it realistic rather than lowering the threshold, since that filter exists to drop icons and spacers.

Version bumped to `0.250.224`.