### PR TITLE
Fix shared multi-user conversation reload and AI streaming

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -96,7 +96,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.250.223"
+VERSION = "0.250.224"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/route_backend_collaboration.py
+++ b/application/single_app/route_backend_collaboration.py
@@ -306,6 +306,26 @@ def _serialize_stream_error(error_message, **extra_fields):
     return f'data: {json.dumps(payload)}\n\n'
 
 
+def _resolve_internal_view_function(endpoint_name):
+    """Resolve a registered Flask view function, tolerating Blueprint endpoint prefixes.
+
+    Route modules are registered through Blueprints, so a view declared as ``chat_stream_api``
+    is stored in ``view_functions`` under its qualified endpoint (``backend_chats.chat_stream_api``).
+    Fall back to matching the final endpoint segment so internal bridges keep working whether the
+    route was registered on a Blueprint or directly on the application.
+    """
+    view_functions = getattr(current_app, 'view_functions', None) or {}
+    view_function = view_functions.get(endpoint_name)
+    if callable(view_function):
+        return view_function
+
+    for registered_endpoint, registered_view in view_functions.items():
+        if str(registered_endpoint).rsplit('.', 1)[-1] == endpoint_name and callable(registered_view):
+            return registered_view
+
+    return None
+
+
 def _build_collaboration_stream_request_payload(data, source_conversation_id, message_content):
     return {
         'message': message_content,
@@ -1457,8 +1477,16 @@ def register_route_backend_collaboration(bp):
                         conversation_id,
                         serialized_user_message.get('id'),
                     )
-                    internal_stream_view = current_app.view_functions.get('chat_stream_api')
+                    internal_stream_view = _resolve_internal_view_function('chat_stream_api')
                     if not callable(internal_stream_view):
+                        log_event(
+                            '[COLLABORATION] Chat streaming view function could not be resolved for the collaboration stream bridge',
+                            extra={
+                                'conversation_id': conversation_id,
+                                'endpoint_name': 'chat_stream_api',
+                            },
+                            level=logging.ERROR,
+                        )
                         yield _serialize_stream_error(
                             'Chat streaming endpoint is unavailable',
                             user_message_id=serialized_user_message.get('id'),

--- a/application/single_app/static/js/chat/chat-collaboration.js
+++ b/application/single_app/static/js/chat/chat-collaboration.js
@@ -2,15 +2,19 @@
 
 import {
     appendMessage,
+    applySearchHighlight,
+    clearSearchHighlight,
     getCollaborativeTagSuggestions,
     getGeneratedImageProposalSourceMessageId,
     groupGeneratedImageProposalMessages,
     setUserMessageStreamingActionsDisabled,
+    updateComparisonChatUploadCatalog,
     updateSendButtonVisibility,
     updateUserMessageId,
     userInput,
 } from './chat-messages.js';
 import { applyConversationMetadataUpdate } from './chat-conversations.js';
+import { updateConversationTaskDocumentsFromMessages } from './chat-documents.js';
 import { attachGeneratedImageProposalResults } from './chat-inline-image-proposals.js';
 import { loadUserSettings, saveUserSetting } from './chat-layout.js';
 import { showToast } from './chat-toast.js';
@@ -19,6 +23,7 @@ import { sendMessageWithStreaming } from './chat-streaming.js';
 const RECENT_COLLABORATORS_KEY = 'recentCollaborators';
 const MAX_RECENT_COLLABORATORS = 12;
 const DEFAULT_SUGGESTION_LIMIT = 8;
+const SEARCH_HIGHLIGHT_MAX_AGE_MS = 30000;
 
 const mentionMenu = document.getElementById('collaboration-mention-menu');
 const participantModalEl = document.getElementById('collaboration-participant-modal');
@@ -956,7 +961,22 @@ function applyCollaborationMessageMaskUpdate(message = {}) {
     }
 }
 
+function reapplyPendingSearchHighlight() {
+    const pendingHighlight = window.searchHighlight;
+    if (!pendingHighlight?.term) {
+        return;
+    }
+
+    if (Date.now() - pendingHighlight.timestamp >= SEARCH_HIGHLIGHT_MAX_AGE_MS) {
+        window.searchHighlight = null;
+        return;
+    }
+
+    window.setTimeout(() => applySearchHighlight(pendingHighlight.term), 100);
+}
+
 async function loadConversationMessages(conversationId) {
+    clearSearchHighlight();
     const payload = await fetchJson(`/api/collaboration/conversations/${conversationId}/messages`);
     const chatbox = document.getElementById('chatbox');
     if (!chatbox) {
@@ -968,6 +988,8 @@ async function loadConversationMessages(conversationId) {
     clearMessageCache();
 
     const messages = Array.isArray(payload.messages) ? payload.messages : [];
+    updateConversationTaskDocumentsFromMessages(messages, conversationId);
+    updateComparisonChatUploadCatalog(messages);
     const generatedImageProposalMessages = groupGeneratedImageProposalMessages(messages);
     const assistantMessageIds = new Set(
         messages
@@ -989,6 +1011,7 @@ async function loadConversationMessages(conversationId) {
         renderCollaborationMessage(decoratedMessage);
         cacheCollaborationMessage(message);
     });
+    reapplyPendingSearchHighlight();
     return messages;
 }
 

--- a/application/single_app/static/js/chat/chat-conversations.js
+++ b/application/single_app/static/js/chat/chat-conversations.js
@@ -1685,9 +1685,8 @@ export async function selectConversation(conversationId) {
   }
 
   if (isCollaborativeConversation && window.chatCollaboration?.activateConversation) {
-    await loadMessages(conversationId);
-    scrollConversationViewToBottom();
     await window.chatCollaboration.activateConversation(conversationId, metadata);
+    scrollConversationViewToBottom();
   } else {
     window.chatCollaboration?.deactivateConversation?.();
     await loadMessages(conversationId);

--- a/application/single_app/static/js/chat/chat-messages.js
+++ b/application/single_app/static/js/chat/chat-messages.js
@@ -1263,7 +1263,7 @@ function toggleComparisonDropzoneHighlight(dropzone, isHighlighted) {
   dropzone.classList.toggle('bg-primary-subtle', isHighlighted);
 }
 
-function updateComparisonChatUploadCatalog(messages = []) {
+export function updateComparisonChatUploadCatalog(messages = []) {
   const preferredLeftSelection = String(documentComparisonLeftSelect?.value || '').trim();
   comparisonChatUploadCatalog = buildComparisonChatUploadCatalog(messages);
   syncComparisonSelectionState(preferredLeftSelection);

--- a/docs/explanation/fixes/COLLABORATION_MULTI_USER_RELOAD_AND_STREAM_FIX.md
+++ b/docs/explanation/fixes/COLLABORATION_MULTI_USER_RELOAD_AND_STREAM_FIX.md
@@ -1,0 +1,185 @@
+# Shared (Multi-User) Conversation Reload and Streaming Fix
+
+**Fixed in version: 0.250.224**
+**Tracking issue: [#1281](https://github.com/microsoft/simplechat/issues/1281)**
+
+## Issue Description
+
+Once a personal conversation was shared with another user (`chat_type = personal_multi_user`), the conversation became unusable end to end. Two independent defects were involved.
+
+### Symptom 1 — 404 on every reload or conversation click
+
+Every page reload or sidebar click on a shared conversation produced a failed request and a `Conversation not found` danger toast:
+
+```
+addChatTypeBadges: chatType="personal_multi_user", groupName="null"
+GET /conversation/9f615422-f4d8-4352-ad09-016cb3d735c1/messages?ts=... 404 (Not Found)
+Error loading messages: Error: Conversation not found
+    at chat-messages.js:2140
+    at async selectConversation (chat-conversations.js:1688)
+```
+
+### Symptom 2 — AI never responded
+
+Every AI request in a shared conversation short-circuited before the model was called:
+
+```
+AI
+Stream interrupted before any content was received.
+⚠ Stream interrupted: Chat streaming endpoint is unavailable
+Response may be incomplete. The partial content above has been saved.
+```
+
+## Root Cause Analysis
+
+### Root cause 1 — the personal-only messages endpoint was used for shared conversations
+
+`selectConversation()` in `chat-conversations.js` called the personal message loader inside its collaborative branch:
+
+```js
+if (isCollaborativeConversation && window.chatCollaboration?.activateConversation) {
+    await loadMessages(conversationId);          // personal-only endpoint
+    scrollConversationViewToBottom();
+    await window.chatCollaboration.activateConversation(conversationId, metadata);
+}
+```
+
+`loadMessages()` fetches `/conversation/<id>/messages`. That handler (`route_frontend_conversations.get_conversation_messages`) reads only `cosmos_conversations_container`. A collaborative conversation lives in `cosmos_collaboration_conversations_container` under a **different id** than its hidden `source_conversation_id` — see `ensure_personal_collaboration_for_legacy_conversation()`, which creates a brand new collaboration document and links back to the original. The read therefore always raised `CosmosResourceNotFoundError`, producing a guaranteed `404`.
+
+The call was also redundant. `activateConversation()` calls `loadConversationMessages()`, which already clears `#chatbox` and renders the shared messages from `/api/collaboration/conversations/<id>/messages`.
+
+Two side effects regressed as a consequence of the failing call:
+
+| Side effect | Behavior before the fix |
+|---|---|
+| `updateComparisonChatUploadCatalog()` | Called with `[]` from the `catch` block, so chat uploads in shared conversations never reached the Compare/Analyze picker. |
+| `updateConversationTaskDocumentsFromMessages()` | Never ran, so task documents from the previously viewed conversation stayed cached against the wrong conversation. |
+
+### Root cause 2 — the Blueprint migration broke the internal stream endpoint lookup
+
+`route_backend_collaboration.py` bridged shared AI requests into the single-user chat pipeline by looking the view function up by name:
+
+```python
+internal_stream_view = current_app.view_functions.get('chat_stream_api')
+```
+
+Commit `094424bc` ("Harden route blueprint security policies") moved every route module onto Blueprints. `app.py` now registers chat routes with `register_route_blueprint('backend_chats', register_route_backend_chats, user_required_blueprint)`, so `/api/chat/stream` is declared with `@bp.route(...)` and Flask stores it under the qualified endpoint **`backend_chats.chat_stream_api`**.
+
+The unqualified lookup returned `None`, so the bridge emitted `Chat streaming endpoint is unavailable` and the model was never invoked. This affected both personal and group collaborative conversations, which share the same bridge.
+
+`current_app.view_functions` was the only remaining Blueprint-prefix assumption in the application — every `url_for()` call was already dotted.
+
+## Files Modified
+
+| File | Change |
+|---|---|
+| `application/single_app/route_backend_collaboration.py` | Added `_resolve_internal_view_function()` and used it for the chat stream bridge; added a `[COLLABORATION]` log event when resolution fails. |
+| `application/single_app/static/js/chat/chat-conversations.js` | Removed the personal `loadMessages()` call from the collaborative branch of `selectConversation()`. |
+| `application/single_app/static/js/chat/chat-collaboration.js` | `loadConversationMessages()` now clears stale search highlights, rehydrates conversation task documents, refreshes the comparison chat upload catalog, and reapplies a pending search highlight. |
+| `application/single_app/static/js/chat/chat-messages.js` | Exported `updateComparisonChatUploadCatalog` so the collaboration loader can reuse it. |
+| `application/single_app/config.py` | `VERSION` bumped to `0.250.224`. |
+
+## Code Changes
+
+### Blueprint-tolerant view resolution
+
+```python
+def _resolve_internal_view_function(endpoint_name):
+    """Resolve a registered Flask view function, tolerating Blueprint endpoint prefixes."""
+    view_functions = getattr(current_app, 'view_functions', None) or {}
+    view_function = view_functions.get(endpoint_name)
+    if callable(view_function):
+        return view_function
+
+    for registered_endpoint, registered_view in view_functions.items():
+        if str(registered_endpoint).rsplit('.', 1)[-1] == endpoint_name and callable(registered_view):
+            return registered_view
+
+    return None
+```
+
+The exact-match fast path is kept first so views registered directly on an application (as in several existing collaboration test harnesses) continue to resolve unchanged.
+
+### Shared conversation selection
+
+```js
+if (isCollaborativeConversation && window.chatCollaboration?.activateConversation) {
+    await window.chatCollaboration.activateConversation(conversationId, metadata);
+    scrollConversationViewToBottom();
+} else {
+    // unchanged personal path
+}
+```
+
+### Side-effect parity in the collaboration loader
+
+```js
+async function loadConversationMessages(conversationId) {
+    clearSearchHighlight();
+    const payload = await fetchJson(`/api/collaboration/conversations/${conversationId}/messages`);
+    ...
+    const messages = Array.isArray(payload.messages) ? payload.messages : [];
+    updateConversationTaskDocumentsFromMessages(messages, conversationId);
+    updateComparisonChatUploadCatalog(messages);
+    ...
+    reapplyPendingSearchHighlight();
+    return messages;
+}
+```
+
+`buildComparisonChatUploadCatalog()` already reads only fields that `serialize_collaboration_message()` emits (`role`, `filename`, `extracted_text`, `file_content_source`, `vision_analysis`, `metadata.is_user_upload`), so no shape adapter was required.
+
+## Testing
+
+### Functional tests
+
+`functional_tests/test_collaboration_multi_user_reload_and_stream_fix.py`
+
+* Builds a Flask app registering `chat_stream_api` on a Blueprint named `backend_chats` — exactly like production — and asserts the resolver finds it even though `chat_stream_api` is not a `view_functions` key.
+* Asserts a directly registered (unprefixed) view still resolves and that an unknown endpoint name resolves to `None`.
+* Asserts the collaborative branch of `selectConversation()` no longer calls `loadMessages(` while the personal branch still does.
+* Asserts `loadConversationMessages()` performs all four side effects.
+* Uses `assert_app_version_at_least()` from `functional_tests/test_support/versioning.py`.
+
+The resolver is loaded by compiling just its AST node out of `route_backend_collaboration.py`, so its real behavior is exercised without standing up Cosmos, Search, and OpenAI clients.
+
+`functional_tests/test_collaboration_shared_ai_workflow.py` was repaired: it asserted `@app.route(...)` for the collaboration stream route and two `route_backend_chats.py` snippets that had drifted, so it had been failing since the Blueprint migration.
+
+### UI test
+
+`ui_tests/test_chat_collaboration_conversation_load.py` extracts the shipped `loadConversationMessages()` source, runs it in Chromium against a static harness, and asserts:
+
+* `/conversation/<id>/messages` is never requested.
+* `/api/collaboration/conversations/<id>/messages` is requested exactly once, with the shared conversation id.
+* Stale highlights are cleared before loading.
+* Task documents are hydrated against the shared conversation id.
+* Shared chat uploads reach the comparison catalog.
+* A fresh pending search highlight is reapplied after rendering.
+* No browser console errors occur.
+
+### Validation results
+
+| Check | Result |
+|---|---|
+| `test_collaboration_multi_user_reload_and_stream_fix.py` | 6/6 passed |
+| `test_collaboration_shared_ai_workflow.py` | passed |
+| `ui_tests/test_chat_collaboration_conversation_load.py` | passed |
+| `route_tests/test_route_blueprint_policy_inventory.py` | 6/6 passed |
+| `route_tests/test_route_unauthenticated_policy_contract.py` | 4/4 passed |
+| `route_tests/test_route_policy_test_coverage.py` | 2/2 passed |
+| Both new tests against pre-fix source | failed as expected |
+| Chat ES module graph loaded in Chromium | resolved with no console or page errors |
+
+## Before / After
+
+| Scenario | Before | After |
+|---|---|---|
+| Reload or click a shared conversation | `404` on `/conversation/<id>/messages` plus a `Conversation not found` danger toast | Messages load from the collaboration endpoint only; no failed request, no toast |
+| Send a message in a shared conversation | `Stream interrupted: Chat streaming endpoint is unavailable`, model never called | Request bridges into the chat stream pipeline and streams normally |
+| Chat uploads in a shared conversation | Never appeared in the Compare/Analyze picker | Available like they are in personal conversations |
+| Task documents after switching to a shared conversation | Stale entries from the previously viewed conversation | Rehydrated against the shared conversation |
+
+## Related
+
+* Fix note: this also restores group collaborative conversations, which use the same stream bridge.
+* Feature documentation: `docs/explanation/features/COLLABORATIVE_CONVERSATIONS_FOUNDATION.md`

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,25 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](/explanation/features/) and [Fixes by Version](/explanation/fixes/).
 
+### **(v0.250.224)**
+
+#### Bug Fixes
+
+*   **Shared Conversations Load and Answer Again**
+    *   Sharing a personal conversation left it unusable. Every reload or click on the shared conversation raised a "Conversation not found" error, because the chat page was still asking for its messages from the personal conversation endpoint — and a shared conversation is stored separately, under its own id.
+    *   Shared conversations now load their messages only from the collaboration endpoint, so the failed request and the error banner are gone.
+    *   (Ref: #1281, `chat-conversations.js`, `chat-collaboration.js`, shared conversation loading)
+
+*   **AI Responses Work Again in Shared Conversations**
+    *   Asking the AI anything in a shared conversation failed immediately with "Stream interrupted: Chat streaming endpoint is unavailable" and no answer was ever generated.
+    *   The recent Blueprint security hardening renamed the internal chat streaming endpoint, and the shared-conversation bridge was still looking for the old name. The bridge now resolves the endpoint correctly and logs a diagnostic if it ever cannot, so this fails loudly instead of silently. Group shared conversations are restored by the same fix.
+    *   (Ref: #1281, `route_backend_collaboration.py`, `app.py`, collaborative AI streaming)
+
+*   **Chat Uploads and Task Documents in Shared Conversations**
+    *   Files uploaded inside a shared conversation never showed up in the Analyze and Compare document pickers, and task documents from the previously opened conversation stayed attached after switching to a shared one.
+    *   Shared conversations now refresh both when their messages load, matching personal conversation behavior.
+    *   (Ref: #1281, `chat-collaboration.js`, `chat-messages.js`, Compare and Analyze document pickers)
+
 ### **(v0.250.223)**
 
 #### Bug Fixes

--- a/functional_tests/test_chat_layered_message_masking.py
+++ b/functional_tests/test_chat_layered_message_masking.py
@@ -25,7 +25,9 @@ COLLABORATION_ROUTE = APP_DIR / "route_backend_collaboration.py"
 FEATURE_DOC = ROOT_DIR / "docs" / "explanation" / "features" / "MESSAGE_LAYERED_MASKING.md"
 
 sys.path.insert(0, str(APP_DIR))
+sys.path.insert(0, str(ROOT_DIR / "functional_tests"))
 
+from test_support.versioning import assert_app_version_at_least  # noqa: E402
 from functions_message_masking import (  # noqa: E402
     apply_message_mask_action,
     remove_masked_content,
@@ -307,7 +309,7 @@ def test_frontend_and_routes_use_layered_masking_contract() -> None:
 
 def test_documentation_and_version_are_in_sync() -> None:
     """Verify version tracking for layered message masking."""
-    assert read_version() == "0.250.029"
+    assert_app_version_at_least("0.250.029")
     assert FEATURE_DOC.exists(), f"Expected feature documentation at {FEATURE_DOC}"
     feature_doc = read_text(FEATURE_DOC)
     assert "Implemented in version: **0.241.098**" in feature_doc

--- a/functional_tests/test_collaboration_multi_user_reload_and_stream_fix.py
+++ b/functional_tests/test_collaboration_multi_user_reload_and_stream_fix.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+# test_collaboration_multi_user_reload_and_stream_fix.py
+"""
+Functional test for shared (multi-user) conversation reload and AI streaming.
+Version: 0.250.224
+Implemented in: 0.250.224
+
+This test ensures that:
+
+1. The collaboration stream bridge resolves the internal chat streaming view function
+   even though route modules are registered through Blueprints, so shared conversations
+   no longer fail with "Chat streaming endpoint is unavailable" (issue #1281).
+2. selectConversation() no longer calls the personal-only /conversation/<id>/messages
+   endpoint for collaborative conversations, which always returned 404 because shared
+   conversations live in the collaboration container under a different id.
+3. loadConversationMessages() performs the search-highlight, task-document, and
+   comparison-catalog side effects that the personal loader used to provide, so shared
+   conversations keep parity instead of silently losing them.
+"""
+
+import ast
+import os
+import sys
+
+from flask import Blueprint, Flask, current_app
+
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+
+from test_support.versioning import assert_app_version_at_least
+
+ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+IMPLEMENTED_IN_VERSION = "0.250.224"
+RESOLVER_FUNCTION_NAME = "_resolve_internal_view_function"
+
+
+def read_repo_file(*parts):
+    file_path = os.path.join(ROOT_DIR, *parts)
+    with open(file_path, "r", encoding="utf-8") as file_handle:
+        return file_handle.read()
+
+
+def load_resolver():
+    """Load the collaboration route module's internal view resolver in isolation.
+
+    route_backend_collaboration imports the full application config graph, which needs live
+    Azure credentials. Compile just the resolver definition so its real behavior can be
+    exercised without standing up Cosmos, Search, and OpenAI clients.
+    """
+    route_source = read_repo_file("application", "single_app", "route_backend_collaboration.py")
+    module_ast = ast.parse(route_source)
+    resolver_nodes = [
+        node for node in module_ast.body
+        if isinstance(node, ast.FunctionDef) and node.name == RESOLVER_FUNCTION_NAME
+    ]
+
+    assert len(resolver_nodes) == 1, (
+        f"Expected exactly one module-level {RESOLVER_FUNCTION_NAME} definition, "
+        f"found {len(resolver_nodes)}."
+    )
+
+    resolver_module = ast.Module(body=resolver_nodes, type_ignores=[])
+    resolver_namespace = {"current_app": current_app}
+    exec(compile(resolver_module, "route_backend_collaboration.py", "exec"), resolver_namespace)
+    return resolver_namespace[RESOLVER_FUNCTION_NAME]
+
+
+def build_blueprint_registered_app():
+    """Build an app whose chat stream view is registered exactly like production."""
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+
+    chats_blueprint = Blueprint("backend_chats", __name__)
+
+    @chats_blueprint.route("/api/chat/stream", methods=["POST"])
+    def chat_stream_api():
+        return "streamed"
+
+    app.register_blueprint(chats_blueprint)
+    return app
+
+
+def build_app_registered_app():
+    """Build an app whose chat stream view is registered directly on the app."""
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+
+    @app.route("/api/chat/stream", methods=["POST"])
+    def chat_stream_api():
+        return "streamed"
+
+    return app
+
+
+def test_stream_view_resolves_through_blueprint_endpoint():
+    """Blueprint-registered chat streaming views must resolve for the collaboration bridge."""
+    print("Testing blueprint-prefixed chat stream endpoint resolution...")
+
+    resolve_internal_view_function = load_resolver()
+    app = build_blueprint_registered_app()
+
+    assert "chat_stream_api" not in app.view_functions, (
+        "Expected the Blueprint-registered view to be keyed as backend_chats.chat_stream_api."
+    )
+    assert "backend_chats.chat_stream_api" in app.view_functions, (
+        "Expected the test app to mirror the production Blueprint endpoint name."
+    )
+
+    with app.test_request_context("/api/chat/stream", method="POST"):
+        resolved_view = resolve_internal_view_function("chat_stream_api")
+
+    assert callable(resolved_view), (
+        "Expected the collaboration bridge to resolve backend_chats.chat_stream_api."
+    )
+    assert resolved_view is app.view_functions["backend_chats.chat_stream_api"], (
+        "Expected the resolver to return the registered Blueprint view function."
+    )
+
+    print("Blueprint endpoint resolution passed!")
+    return True
+
+
+def test_stream_view_resolves_unprefixed_and_rejects_unknown():
+    """Directly registered views still resolve, and unknown endpoints return None."""
+    print("Testing unprefixed resolution and unknown endpoint handling...")
+
+    resolve_internal_view_function = load_resolver()
+    app = build_app_registered_app()
+
+    with app.test_request_context("/api/chat/stream", method="POST"):
+        resolved_view = resolve_internal_view_function("chat_stream_api")
+        unknown_view = resolve_internal_view_function("definitely_not_registered_api")
+
+    assert resolved_view is app.view_functions["chat_stream_api"], (
+        "Expected an app-registered view function to resolve by its bare endpoint name."
+    )
+    assert unknown_view is None, (
+        "Expected an unregistered endpoint name to resolve to None."
+    )
+
+    print("Unprefixed and unknown endpoint handling passed!")
+    return True
+
+
+def test_collaboration_route_uses_resolver_and_logs_failures():
+    """The collaboration stream route must use the resolver and log resolution failures."""
+    print("Testing collaboration stream route wiring...")
+
+    route_source = read_repo_file("application", "single_app", "route_backend_collaboration.py")
+
+    assert "def _resolve_internal_view_function(endpoint_name):" in route_source, (
+        "Expected the Blueprint-tolerant view resolver helper to exist."
+    )
+    assert "internal_stream_view = _resolve_internal_view_function('chat_stream_api')" in route_source, (
+        "Expected the collaboration stream bridge to use the Blueprint-tolerant resolver."
+    )
+    assert "current_app.view_functions.get('chat_stream_api')" not in route_source, (
+        "Expected the Blueprint-unaware view lookup to be removed."
+    )
+    assert (
+        "'[COLLABORATION] Chat streaming view function could not be resolved for the collaboration stream bridge'"
+        in route_source
+    ), "Expected a tagged log event when the chat streaming view cannot be resolved."
+
+    print("Collaboration stream route wiring passed!")
+    return True
+
+
+def test_select_conversation_skips_personal_messages_endpoint():
+    """Collaborative conversations must not call the personal messages endpoint."""
+    print("Testing collaborative conversation selection wiring...")
+
+    conversations_source = read_repo_file(
+        "application", "single_app", "static", "js", "chat", "chat-conversations.js"
+    )
+
+    collaborative_branch_marker = (
+        "if (isCollaborativeConversation && window.chatCollaboration?.activateConversation) {"
+    )
+    branch_start = conversations_source.find(collaborative_branch_marker)
+    assert branch_start != -1, "Expected the collaborative branch in selectConversation()."
+
+    branch_end = conversations_source.find("} else {", branch_start)
+    assert branch_end != -1, "Expected an else branch after the collaborative branch."
+
+    collaborative_branch = conversations_source[branch_start:branch_end]
+    assert "loadMessages(" not in collaborative_branch, (
+        "Collaborative conversations must not call the personal /conversation/<id>/messages endpoint."
+    )
+    assert "window.chatCollaboration.activateConversation(conversationId, metadata)" in collaborative_branch, (
+        "Expected collaborative conversations to load through activateConversation()."
+    )
+
+    # The personal branch must keep using the personal loader.
+    personal_branch = conversations_source[branch_end:branch_end + 1200]
+    assert "await loadMessages(conversationId);" in personal_branch, (
+        "Expected non-collaborative conversations to keep using loadMessages()."
+    )
+
+    print("Collaborative conversation selection wiring passed!")
+    return True
+
+
+def test_collaboration_loader_keeps_personal_loader_side_effects():
+    """loadConversationMessages() must retain the side effects loadMessages() provided."""
+    print("Testing collaboration message loader side effects...")
+
+    collaboration_source = read_repo_file(
+        "application", "single_app", "static", "js", "chat", "chat-collaboration.js"
+    )
+    messages_source = read_repo_file(
+        "application", "single_app", "static", "js", "chat", "chat-messages.js"
+    )
+
+    assert "export function updateComparisonChatUploadCatalog(" in messages_source, (
+        "Expected updateComparisonChatUploadCatalog to be exported for collaboration reuse."
+    )
+
+    assert "import { updateConversationTaskDocumentsFromMessages } from './chat-documents.js';" in collaboration_source, (
+        "Expected the collaboration module to import the task document hydrator."
+    )
+
+    loader_start = collaboration_source.find("async function loadConversationMessages(conversationId) {")
+    assert loader_start != -1, "Expected loadConversationMessages() in chat-collaboration.js."
+
+    loader_end = collaboration_source.find("\n}", loader_start)
+    assert loader_end != -1, "Expected loadConversationMessages() to be a closed function block."
+
+    loader_body = collaboration_source[loader_start:loader_end]
+    assert "clearSearchHighlight();" in loader_body, (
+        "Expected loadConversationMessages() to clear stale search highlights."
+    )
+    assert "updateConversationTaskDocumentsFromMessages(messages, conversationId);" in loader_body, (
+        "Expected loadConversationMessages() to rehydrate conversation task documents."
+    )
+    assert "updateComparisonChatUploadCatalog(messages);" in loader_body, (
+        "Expected loadConversationMessages() to refresh the comparison chat upload catalog."
+    )
+    assert "reapplyPendingSearchHighlight();" in loader_body, (
+        "Expected loadConversationMessages() to reapply a pending search highlight."
+    )
+
+    assert "function reapplyPendingSearchHighlight() {" in collaboration_source, (
+        "Expected a search highlight reapplication helper in chat-collaboration.js."
+    )
+    assert "SEARCH_HIGHLIGHT_MAX_AGE_MS" in collaboration_source, (
+        "Expected the shared 30 second search highlight freshness window."
+    )
+
+    print("Collaboration message loader side effects passed!")
+    return True
+
+
+def test_version_supports_fix():
+    """The application version must be at least the fix implementation version."""
+    print("Testing application version...")
+    assert_app_version_at_least(
+        IMPLEMENTED_IN_VERSION,
+        reason="Shared conversation reload and streaming fix requires this version or later.",
+    )
+    print("Application version check passed!")
+    return True
+
+
+if __name__ == "__main__":
+    tests = [
+        test_stream_view_resolves_through_blueprint_endpoint,
+        test_stream_view_resolves_unprefixed_and_rejects_unknown,
+        test_collaboration_route_uses_resolver_and_logs_failures,
+        test_select_conversation_skips_personal_messages_endpoint,
+        test_collaboration_loader_keeps_personal_loader_side_effects,
+        test_version_supports_fix,
+    ]
+
+    results = []
+    for test in tests:
+        print(f"\nRunning {test.__name__}...")
+        try:
+            results.append(bool(test()))
+        except Exception as error:
+            print(f"Test failed: {error}")
+            import traceback
+
+            traceback.print_exc()
+            results.append(False)
+
+    print(f"\nResults: {sum(results)}/{len(results)} tests passed")
+    sys.exit(0 if all(results) else 1)

--- a/functional_tests/test_collaboration_shared_ai_workflow.py
+++ b/functional_tests/test_collaboration_shared_ai_workflow.py
@@ -2,7 +2,7 @@
 # test_collaboration_shared_ai_workflow.py
 """
 Functional test for collaboration shared AI workflow parity.
-Version: 0.241.068
+Version: 0.250.224
 Implemented in: 0.241.068
 
 This test ensures collaborative conversations route shared AI requests through
@@ -32,9 +32,9 @@ def test_backend_collaboration_stream_bridge():
     route_source = read_repo_file('application', 'single_app', 'route_backend_collaboration.py')
     functions_source = read_repo_file('application', 'single_app', 'functions_collaboration.py')
 
-    assert "@app.route('/api/collaboration/conversations/<conversation_id>/stream', methods=['POST'])" in route_source
+    assert "@bp.route('/api/collaboration/conversations/<conversation_id>/stream', methods=['POST'])" in route_source
     assert 'ensure_collaboration_source_conversation(' in route_source
-    assert "current_app.view_functions.get('chat_stream_api')" in route_source
+    assert "_resolve_internal_view_function('chat_stream_api')" in route_source
     assert 'mirror_source_message_to_collaboration(' in route_source
     assert 'message_kind=MESSAGE_KIND_AI_REQUEST' in route_source
 
@@ -87,8 +87,8 @@ def test_streaming_metadata_alignment_for_explicit_agent_targets():
     assert "'chat_type': source_chat_type" in collaboration_functions_source
     assert "conversation_item.get('conversation_kind') == 'collaboration_source'" in metadata_functions_source
 
-    assert 'if request_agent_info and isinstance(request_agent_info, dict):' in chat_route_source
-    assert "user_metadata['agent_selection'] = {" in chat_route_source
+    assert 'if isinstance(request_agent_info, dict):' in chat_route_source
+    assert "user_metadata['agent_selection'] = agent_selection_metadata" in chat_route_source
     assert "user_message_doc['metadata']['model_selection']['selected_model'] = final_model_used if use_agent_streaming else gpt_model" in chat_route_source
     assert "model_deployment=final_model_used if use_agent_streaming else gpt_model" in chat_route_source
 

--- a/functional_tests/test_get_messages_agent_citation_hydration.py
+++ b/functional_tests/test_get_messages_agent_citation_hydration.py
@@ -9,12 +9,17 @@ payloads before it filters those child records from the visible message list,
 so externalized agent citations still hydrate to their full frontend payload.
 """
 
+import sys
 from pathlib import Path
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 ROUTE_FILE = REPO_ROOT / 'application' / 'single_app' / 'route_backend_conversations.py'
 CONFIG_FILE = REPO_ROOT / 'application' / 'single_app' / 'config.py'
+
+sys.path.insert(0, str(REPO_ROOT / 'functional_tests'))
+
+from test_support.versioning import assert_app_version_at_least  # noqa: E402
 
 
 def read_text(path):
@@ -58,7 +63,7 @@ def test_get_messages_route_rehydrates_agent_citation_artifacts():
 
 def test_version_alignment():
     print('🔍 Testing version alignment...')
-    assert read_version() == '0.241.116'
+    assert_app_version_at_least('0.241.116')
     print('✅ Version alignment passed')
     return True
 

--- a/functional_tests/test_group_file_share_approval_notifications.py
+++ b/functional_tests/test_group_file_share_approval_notifications.py
@@ -12,6 +12,7 @@ Remove/Approve behavior instead of owner-only delete/share controls.
 """
 
 from pathlib import Path
+import sys
 import traceback
 
 
@@ -22,6 +23,10 @@ DOCUMENTS_ROUTE_FILE = ROOT / "application" / "single_app" / "route_backend_docu
 GROUP_DOCUMENTS_ROUTE_FILE = ROOT / "application" / "single_app" / "route_backend_group_documents.py"
 GROUP_WORKSPACE_TEMPLATE = ROOT / "application" / "single_app" / "templates" / "group_workspaces.html"
 FUNCTIONS_DOCUMENTS_FILE = ROOT / "application" / "single_app" / "functions_documents.py"
+
+sys.path.insert(0, str(ROOT / "functional_tests"))
+
+from test_support.versioning import assert_app_version_at_least  # noqa: E402
 
 
 def read_text(path: Path) -> str:
@@ -45,7 +50,7 @@ def assert_contains(source: str, snippets: list[str], description: str) -> None:
 
 def test_version_header_matches_config() -> None:
     """Verify this regression test tracks the config.py version."""
-    assert read_version() == "0.241.111", "Expected config.py VERSION to be 0.241.111."
+    assert_app_version_at_least("0.241.111")
 
 
 def test_notification_types_and_personal_share_decisions() -> None:

--- a/functional_tests/test_message_metadata_loading_fix.py
+++ b/functional_tests/test_message_metadata_loading_fix.py
@@ -129,7 +129,7 @@ def test_all_streaming_paths_acknowledge_persistence_early() -> None:
         collaboration_stream_source,
         "persist_collaboration_message(",
         "yield build_user_message_persisted_stream_event(",
-        "current_app.view_functions.get('chat_stream_api')",
+        "_resolve_internal_view_function('chat_stream_api')",
     )
     assert "if stream_payload.get('type') == USER_MESSAGE_PERSISTED_EVENT_TYPE:" in collaboration_stream_source
 

--- a/functional_tests/test_simplechat_group_creation_wrapper.py
+++ b/functional_tests/test_simplechat_group_creation_wrapper.py
@@ -11,12 +11,17 @@ plugin callers depend on.
 """
 
 import ast
+import sys
 from pathlib import Path
 
 
 ROOT_DIR = Path(__file__).resolve().parent.parent
 OPERATIONS_FILE = ROOT_DIR / 'application' / 'single_app' / 'functions_simplechat_operations.py'
 CONFIG_FILE = ROOT_DIR / 'application' / 'single_app' / 'config.py'
+
+sys.path.insert(0, str(ROOT_DIR / 'functional_tests'))
+
+from test_support.versioning import assert_app_version_at_least  # noqa: E402
 
 
 def read_text(path):
@@ -102,7 +107,7 @@ def test_create_group_wrapper_exists_and_normalizes_inputs():
 
 def test_version_alignment():
     print('Testing version alignment...')
-    assert read_version() == '0.241.121'
+    assert_app_version_at_least('0.241.121')
     print('Version alignment passed.')
     return True
 

--- a/ui_tests/fixtures/collaboration_conversation_load_harness.html
+++ b/ui_tests/fixtures/collaboration_conversation_load_harness.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Collaboration Conversation Load Harness</title>
+    <style>
+        .d-none {
+            display: none !important;
+        }
+    </style>
+</head>
+<body>
+    <main id="test-root">
+        <div id="chatbox"></div>
+        <div class="toast-container position-fixed top-0 end-0 p-3" id="toast-container"></div>
+    </main>
+</body>
+</html>

--- a/ui_tests/test_chat_collaboration_conversation_load.py
+++ b/ui_tests/test_chat_collaboration_conversation_load.py
@@ -1,0 +1,315 @@
+# test_chat_collaboration_conversation_load.py
+"""
+UI test for shared (multi-user) conversation message loading.
+Version: 0.250.224
+Implemented in: 0.250.224
+
+This test ensures the shipped collaboration message loader fetches shared
+conversation messages from the collaboration endpoint only, never from the
+personal /conversation/<id>/messages endpoint that always returned 404 for
+shared conversations, and that it still performs the search highlight, task
+document, and comparison chat upload side effects the personal loader provided.
+
+Regression coverage for issue #1281.
+"""
+
+from contextlib import contextmanager
+from functools import partial
+from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+import json
+import socket
+from threading import Thread
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HARNESS_PATH = "ui_tests/fixtures/collaboration_conversation_load_harness.html"
+COLLABORATION_JS = (
+    REPO_ROOT / "application" / "single_app" / "static" / "js" / "chat" / "chat-collaboration.js"
+)
+CONVERSATION_ID = "9f615422-f4d8-4352-ad09-016cb3d735c1"
+
+COLLABORATION_MESSAGES = [
+    {
+        "id": "shared-user-message-001",
+        "conversation_id": CONVERSATION_ID,
+        "role": "user",
+        "content": "How many TM packets have arrived since startup?",
+        "timestamp": "2026-08-18T14:00:00+00:00",
+        "metadata": {"sender": {"user_id": "user-a", "display_name": "Ada"}},
+    },
+    {
+        "id": "shared-assistant-message-001",
+        "conversation_id": CONVERSATION_ID,
+        "role": "assistant",
+        "content": "4,182 telemetry packets have arrived since startup.",
+        "timestamp": "2026-08-18T14:00:05+00:00",
+        "metadata": {"sender": {"user_id": "assistant", "display_name": "AI"}},
+    },
+    {
+        "id": "shared-file-message-001",
+        "conversation_id": CONVERSATION_ID,
+        "role": "file",
+        "content": "",
+        "filename": "telemetry-log.csv",
+        "extracted_text": "packet_id,received_at",
+        "timestamp": "2026-08-18T14:00:10+00:00",
+        "metadata": {
+            "sender": {"user_id": "user-a", "display_name": "Ada"},
+            "workspace_attachment": {"document_id": "workspace-doc-001"},
+        },
+    },
+]
+
+
+def _get_free_local_port():
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+@contextmanager
+def _start_static_test_server():
+    port = _get_free_local_port()
+    handler = partial(SimpleHTTPRequestHandler, directory=str(REPO_ROOT))
+    server = ThreadingHTTPServer(("127.0.0.1", port), handler)
+    server.daemon_threads = True
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    try:
+        yield f"http://127.0.0.1:{port}"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def _extract_loader_source():
+    """Slice the shipped loader functions out of chat-collaboration.js."""
+    collaboration_source = COLLABORATION_JS.read_text(encoding="utf-8")
+
+    start_marker = "function reapplyPendingSearchHighlight() {"
+    end_marker = "    return messages;\n}"
+    start_index = collaboration_source.find(start_marker)
+    assert start_index != -1, "Expected reapplyPendingSearchHighlight() in chat-collaboration.js."
+
+    end_index = collaboration_source.find(end_marker, start_index)
+    assert end_index != -1, "Expected loadConversationMessages() to end with 'return messages;'."
+
+    loader_source = collaboration_source[start_index:end_index + len(end_marker)]
+    assert "async function loadConversationMessages(conversationId) {" in loader_source, (
+        "Expected the extracted slice to contain loadConversationMessages()."
+    )
+    assert "const SEARCH_HIGHLIGHT_MAX_AGE_MS = 30000;" in collaboration_source, (
+        "Expected the 30 second search highlight freshness window constant."
+    )
+    return loader_source
+
+
+def _build_harness_script(loader_source):
+    """Wrap the shipped loader with spies so browser behavior can be observed."""
+    return (
+        """
+window.__spyCalls = [];
+
+const SEARCH_HIGHLIGHT_MAX_AGE_MS = 30000;
+
+function recordCall(name, payload) {
+    window.__spyCalls.push({ name, ...payload });
+}
+
+function clearSearchHighlight() {
+    recordCall('clearSearchHighlight', {});
+}
+
+function applySearchHighlight(term) {
+    recordCall('applySearchHighlight', { term });
+}
+
+function clearTypingState() {
+    recordCall('clearTypingState', {});
+}
+
+function clearMessageCache() {
+    recordCall('clearMessageCache', {});
+}
+
+function updateConversationTaskDocumentsFromMessages(messages, conversationId) {
+    recordCall('updateConversationTaskDocumentsFromMessages', {
+        conversationId,
+        workspaceAttachmentCount: messages.filter(
+            message => message?.metadata?.workspace_attachment
+        ).length,
+    });
+}
+
+function updateComparisonChatUploadCatalog(messages) {
+    recordCall('updateComparisonChatUploadCatalog', {
+        uploadCount: messages.filter(message => message?.role === 'file').length,
+    });
+}
+
+function groupGeneratedImageProposalMessages() {
+    return new Map();
+}
+
+function getGeneratedImageProposalSourceMessageId() {
+    return '';
+}
+
+function decorateReplyMessage(message) {
+    return { ...message };
+}
+
+function renderCollaborationMessage(message) {
+    const chatbox = document.getElementById('chatbox');
+    const messageElement = document.createElement('div');
+    messageElement.className = 'collaboration-message';
+    messageElement.dataset.messageId = message.id;
+    messageElement.textContent = message.content || message.filename || '';
+    chatbox.appendChild(messageElement);
+}
+
+function cacheCollaborationMessage(message) {
+    recordCall('cacheCollaborationMessage', { messageId: message.id });
+}
+
+async function fetchJson(url, options = {}) {
+    const response = await fetch(url, { credentials: 'same-origin', ...options });
+    if (!response.ok) {
+        throw new Error(`Request failed with status ${response.status}`);
+    }
+    return response.json();
+}
+
+"""
+        + loader_source
+        + """
+
+window.__loadConversationMessages = loadConversationMessages;
+"""
+    )
+
+
+@pytest.mark.ui
+def test_shared_conversation_loads_only_from_collaboration_endpoint(playwright):
+    """Validate shared conversations never hit the personal messages endpoint."""
+    loader_source = _extract_loader_source()
+    harness_script = _build_harness_script(loader_source)
+
+    browser = playwright.chromium.launch()
+    context = browser.new_context(viewport={"width": 1440, "height": 900})
+    page = context.new_page()
+
+    personal_endpoint_requests = []
+    collaboration_endpoint_requests = []
+    console_errors = []
+
+    page.on(
+        "console",
+        lambda message: console_errors.append(message.text) if message.type == "error" else None,
+    )
+
+    def handle_personal_messages(route):
+        personal_endpoint_requests.append(route.request.url)
+        route.fulfill(
+            status=404,
+            content_type="application/json",
+            body=json.dumps({"error": "Conversation not found"}),
+        )
+
+    def handle_collaboration_messages(route):
+        collaboration_endpoint_requests.append(route.request.url)
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({"messages": COLLABORATION_MESSAGES}),
+        )
+
+    page.route("**/conversation/*/messages*", handle_personal_messages)
+    page.route(
+        "**/api/collaboration/conversations/*/messages",
+        handle_collaboration_messages,
+    )
+
+    try:
+        with _start_static_test_server() as base_url:
+            page.goto(f"{base_url}/{HARNESS_PATH}", wait_until="domcontentloaded")
+            page.add_script_tag(content=harness_script)
+
+            page.evaluate(
+                "() => { window.searchHighlight = { term: 'telemetry', timestamp: Date.now() }; }"
+            )
+
+            loaded_message_ids = page.evaluate(
+                """
+                async (conversationId) => {
+                    const messages = await window.__loadConversationMessages(conversationId);
+                    return messages.map(message => message.id);
+                }
+                """,
+                CONVERSATION_ID,
+            )
+
+            # Highlight reapplication is scheduled on a 100ms timer.
+            page.wait_for_function(
+                "() => window.__spyCalls.some(call => call.name === 'applySearchHighlight')"
+            )
+
+            spy_calls = page.evaluate("() => window.__spyCalls")
+            rendered_message_ids = page.eval_on_selector_all(
+                "#chatbox .collaboration-message",
+                "elements => elements.map(element => element.dataset.messageId)",
+            )
+    finally:
+        context.close()
+        browser.close()
+
+    assert personal_endpoint_requests == [], (
+        "Shared conversations must never request the personal /conversation/<id>/messages endpoint, "
+        f"but saw: {personal_endpoint_requests}"
+    )
+    assert len(collaboration_endpoint_requests) == 1, (
+        "Expected exactly one request to the collaboration messages endpoint, "
+        f"saw: {collaboration_endpoint_requests}"
+    )
+    assert CONVERSATION_ID in collaboration_endpoint_requests[0]
+
+    assert loaded_message_ids == [message["id"] for message in COLLABORATION_MESSAGES]
+    assert rendered_message_ids == [message["id"] for message in COLLABORATION_MESSAGES]
+
+    call_names = [call["name"] for call in spy_calls]
+    assert call_names[0] == "clearSearchHighlight", (
+        f"Expected stale highlights to be cleared before loading, got order: {call_names}"
+    )
+
+    task_document_calls = [
+        call for call in spy_calls if call["name"] == "updateConversationTaskDocumentsFromMessages"
+    ]
+    assert len(task_document_calls) == 1, (
+        "Expected conversation task documents to be rehydrated exactly once."
+    )
+    assert task_document_calls[0]["conversationId"] == CONVERSATION_ID, (
+        "Task documents must be hydrated against the shared conversation id."
+    )
+    assert task_document_calls[0]["workspaceAttachmentCount"] == 1
+
+    comparison_calls = [
+        call for call in spy_calls if call["name"] == "updateComparisonChatUploadCatalog"
+    ]
+    assert len(comparison_calls) == 1, (
+        "Expected the comparison chat upload catalog to be refreshed exactly once."
+    )
+    assert comparison_calls[0]["uploadCount"] == 1, (
+        "Shared conversation chat uploads must reach the Compare/Analyze picker."
+    )
+
+    highlight_calls = [call for call in spy_calls if call["name"] == "applySearchHighlight"]
+    assert highlight_calls and highlight_calls[0]["term"] == "telemetry", (
+        "Expected a fresh pending search highlight to be reapplied after rendering."
+    )
+
+    assert console_errors == [], f"Unexpected browser console errors: {console_errors}"

--- a/ui_tests/test_chat_message_layered_mask_controls.py
+++ b/ui_tests/test_chat_message_layered_mask_controls.py
@@ -10,6 +10,7 @@ reload.
 """
 
 from pathlib import Path
+import sys
 
 
 ROOT_DIR = Path(__file__).resolve().parents[1]
@@ -17,6 +18,10 @@ CHAT_MESSAGES_JS = ROOT_DIR / "application" / "single_app" / "static" / "js" / "
 CHAT_COLLABORATION_JS = ROOT_DIR / "application" / "single_app" / "static" / "js" / "chat" / "chat-collaboration.js"
 STYLES_CSS = ROOT_DIR / "application" / "single_app" / "static" / "css" / "styles.css"
 CONFIG_FILE = ROOT_DIR / "application" / "single_app" / "config.py"
+
+sys.path.insert(0, str(ROOT_DIR / "functional_tests"))
+
+from test_support.versioning import assert_app_version_at_least  # noqa: E402
 
 
 def read_text(path: Path) -> str:
@@ -112,4 +117,4 @@ def test_collaboration_mask_events_apply_to_visible_messages() -> None:
 
 def test_ui_mask_control_version_matches_config() -> None:
     """Verify UI test version tracking matches config.py."""
-    assert read_version() == "0.241.098"
+    assert_app_version_at_least("0.241.098")


### PR DESCRIPTION
Fixes #1281

Sharing a personal conversation left it unusable end to end. Two independent defects were involved.

## Root cause 1 — the personal-only messages endpoint was used for shared conversations

`selectConversation()` called the personal `loadMessages()` inside its collaborative branch:

```js
if (isCollaborativeConversation && window.chatCollaboration?.activateConversation) {
    await loadMessages(conversationId);          // personal-only endpoint
    scrollConversationViewToBottom();
    await window.chatCollaboration.activateConversation(conversationId, metadata);
}
```

`loadMessages()` fetches `/conversation/<id>/messages`, whose handler reads only `cosmos_conversations_container`. A shared conversation lives in `cosmos_collaboration_conversations_container` under a **different id** than its hidden `source_conversation_id`, so the read always raised `CosmosResourceNotFoundError` → guaranteed `404` plus a "Conversation not found" danger toast on every reload and sidebar click.

The call was also redundant — `activateConversation()` → `loadConversationMessages()` already clears `#chatbox` and renders the shared messages. Two side effects regressed because of it:

- `updateComparisonChatUploadCatalog([])` ran from the `catch`, so chat uploads in shared conversations never reached the Compare/Analyze picker.
- `updateConversationTaskDocumentsFromMessages()` never ran, so task documents from the previously viewed conversation stayed cached against the wrong conversation.

## Root cause 2 — the Blueprint migration broke the internal stream endpoint lookup

```python
internal_stream_view = current_app.view_functions.get('chat_stream_api')
```

Commit `094424bc` ("Harden route blueprint security policies") moved every route module onto Blueprints. `app.py` registers chat routes via `register_route_blueprint('backend_chats', ...)`, so `/api/chat/stream` is declared with `@bp.route(...)` and Flask stores it under **`backend_chats.chat_stream_api`**. The unqualified lookup returned `None`, so every collaborative AI request failed with `Stream interrupted: Chat streaming endpoint is unavailable` before the model was ever called. Group collaborative conversations share the same bridge and were broken too.

`current_app.view_functions` was the only remaining Blueprint-prefix assumption in the app — every `url_for()` call was already dotted.

## Changes (v0.250.224)

| File | Change |
|---|---|
| `route_backend_collaboration.py` | Added `_resolve_internal_view_function()` (exact-match fast path first, then last-segment match) and a `[COLLABORATION]` log event when resolution fails. |
| `chat-conversations.js` | Removed the personal `loadMessages()` call from the collaborative branch. |
| `chat-collaboration.js` | `loadConversationMessages()` now clears stale search highlights, rehydrates task documents, refreshes the comparison chat upload catalog, and reapplies a pending highlight. |
| `chat-messages.js` | Exported `updateComparisonChatUploadCatalog` for reuse. |

---

## Follow-up hardening (v0.250.225)

Three further defects surfaced while tracing this bug. None caused the reported symptoms, so they were split out rather than mixed into the fix above.

### Shared stream errors now always carry `conversation_kind`

`chat-streaming.js` picks its post-error recovery endpoint from `conversation_kind`, falling back to the personal endpoint when absent. None of the seven `_serialize_stream_error()` call sites in the bridge set it — so a shared conversation would have hit the exact 404 this PR removes.

It could not fire in practice: the surrounding guard also requires `message_id`, and those error payloads never carried one. A latent trap rather than a live defect — but one that returns the moment anyone adds `message_id` to an error payload.

Rather than repeating the field seven times, all failures now funnel through one nested helper that cannot omit it. `test_collaboration_stream_errors_always_carry_conversation_kind` walks the AST of `stream_collaboration_message_api` and asserts exactly one raw `_serialize_stream_error` call remains, that it sets `conversation_kind=COLLABORATION_KIND`, and that every failure path routes through the helper — so a new error path without the tag now fails CI.

### Repaired 59 stale `@app.route` assertions across 32 test files

Production has **exactly one** `@app.route` left — an example inside a `swagger_wrapper.py` docstring. The test suite still asserted the old form in 82 places across 40 files.

**This is how root cause 2 shipped.** `test_collaboration_shared_ai_workflow.py` existed specifically to guard this bridge, but broke on line 35 (an `@app.route` assertion) and died *before reaching line 37*, which checked the endpoint lookup. The test that should have caught the bug was standing right there, red for an unrelated reason.

Each rewrite was verified against a real `@bp.route` path in `application/single_app` before being changed. **14 occurrences were deliberately left alone** because no matching production route exists — those point at routes that appear to have been removed or renamed, which is a separate problem that must not be papered over with a passing assertion.

Measured on the affected files: **47 failures → 34, zero newly broken.**

### Dead post-stream reload guard — filed as #1286, not fixed here

`chat-streaming.js:1449` and `:1515` guard on `typeof window.chatMessages?.loadMessages === 'function'`, but `loadMessages` is not among the six functions assigned to `window.chatMessages`, and `git log -S` confirms it never was. Dead since commit `54e37c87`.

The backend sets `reload_messages: true` when an agent plugin persists extra message documents into Cosmos, so those stay invisible until a manual reload. Impact is probably narrow — the final payload renders `image_url` separately — but sizing it needs a repro, and switching on a path that has never executed in production is not a safe blind change.

---

## Tests

**New** `functional_tests/test_collaboration_multi_user_reload_and_stream_fix.py` (7 checks) — builds a Flask app registering `chat_stream_api` on a Blueprint named `backend_chats` exactly like production and asserts the resolver finds it even though `chat_stream_api` is not a `view_functions` key; asserts the unprefixed case still resolves and unknown names return `None`; asserts the frontend wiring and the error-tagging contract. The resolver is loaded by compiling just its AST node, so real behavior is exercised without standing up Cosmos/Search/OpenAI.

**New** `ui_tests/test_chat_collaboration_conversation_load.py` — extracts the shipped `loadConversationMessages()` source, runs it in Chromium, and asserts `/conversation/<id>/messages` is never requested, the collaboration endpoint is called exactly once, all four side effects fire, and no console errors occur.

Both new tests were verified to **fail against pre-fix source** and pass after.

### Other test repairs (all already failing before this PR)

- `test_collaboration_shared_ai_workflow.py` and `test_message_metadata_loading_fix.py` asserted pre-Blueprint `@app.route` / `view_functions.get(...)` forms.
- Five tests asserted `config.py` VERSION with exact equality, which `.github/instructions` explicitly forbids and which any version bump breaks. Converted to `assert_app_version_at_least()`.

### Validation

| Check | Result |
|---|---|
| New functional test | 7/7 passed |
| New UI test | passed |
| `test_collaboration_shared_ai_workflow.py` | passed (was failing) |
| `test_chat_layered_message_masking.py` | passed (was failing) |
| Route policy tests (3) | 12/12 passed |
| Full `ui_tests/` suite | 28 → **27** failures |
| Functional tests referencing changed JS | 13 → **10** failures |
| Functional tests with repaired route assertions | 47 → **34** failures |
| Chat ES module graph loaded in Chromium | resolved, no console or page errors |

**Zero newly broken tests in any suite.** Every remaining failure was confirmed identical against stashed pre-change source (Azure Cosmos credentials required at import, or unrelated stale assertions). All checks re-run after the Development merge at `194e3f75`.
