### PR TITLE
Admin Settings IA stage A+B: card-targeted links and dependency announcements

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -96,7 +96,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.260.007"
+VERSION = "0.260.008"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/static/js/admin/admin_card_links.js
+++ b/application/single_app/static/js/admin/admin_card_links.js
@@ -1,0 +1,103 @@
+// admin_card_links.js
+// Resolves links that point at an Admin Settings card rather than at a tab.
+//
+// Cross-tab links used to name a tab button directly, for example
+// switchTab(event, 'workspaces-tab'). That couples the link to a tab id, so a
+// tab rename or an information-architecture change silently breaks the link:
+// the button no longer exists, no pane is activated, and the URL hash is left
+// pointing at nothing.
+//
+// A link declares the card it wants instead:
+//
+//     <a href="#redis-cache-section" data-admin-link="redis-cache-section">
+//
+// The owning tab is resolved from the DOM at click time, so card ids are the
+// only contract. Cards can move between tabs, and tabs can be renamed or
+// regrouped, without touching a single link.
+
+const HIGHLIGHT_CLASS = 'admin-card-link-target';
+const HIGHLIGHT_MS = 1600;
+
+/**
+ * Find the tab pane that contains a card.
+ * @param {string} cardId Element id of the target card.
+ * @returns {{card: HTMLElement, paneId: string|null}|null}
+ */
+export function resolveAdminCard(cardId) {
+    const card = document.getElementById(cardId);
+    if (!card) {
+        return null;
+    }
+
+    const pane = card.closest('.tab-pane');
+    return { card, paneId: pane ? pane.id : null };
+}
+
+/**
+ * Activate the tab owning a card, scroll to it, and highlight it briefly.
+ * @param {string} cardId Element id of the target card.
+ * @returns {boolean} Whether the card was found.
+ */
+export function openAdminCard(cardId) {
+    const resolved = resolveAdminCard(cardId);
+    if (!resolved) {
+        console.warn(`openAdminCard: no card with id "${cardId}"`);
+        return false;
+    }
+
+    const { card, paneId } = resolved;
+
+    if (paneId && typeof window.showAdminTab === 'function') {
+        window.showAdminTab(paneId);
+        syncSidebarActiveState(paneId);
+    }
+
+    // Let the pane become visible before measuring scroll position.
+    window.setTimeout(() => {
+        card.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        card.classList.add(HIGHLIGHT_CLASS);
+        window.setTimeout(() => card.classList.remove(HIGHLIGHT_CLASS), HIGHLIGHT_MS);
+    }, 120);
+
+    return true;
+}
+
+/**
+ * Mirror the activated tab in the sidebar, when the sidebar layout is in use.
+ * @param {string} paneId Tab pane id that was activated.
+ */
+function syncSidebarActiveState(paneId) {
+    const navLink = document.querySelector(`.admin-nav-tab[data-tab="${paneId}"]`);
+    if (!navLink) {
+        return;
+    }
+
+    document.querySelectorAll('.admin-nav-tab, .admin-nav-section').forEach((link) => {
+        link.classList.remove('active');
+    });
+    navLink.classList.add('active');
+}
+
+/**
+ * Delegate clicks so links added after load keep working.
+ */
+export function initAdminCardLinks() {
+    document.addEventListener('click', (event) => {
+        const link = event.target.closest('[data-admin-link]');
+        if (!link) {
+            return;
+        }
+
+        const cardId = link.getAttribute('data-admin-link');
+        if (!cardId) {
+            return;
+        }
+
+        event.preventDefault();
+        openAdminCard(cardId);
+    });
+}
+
+window.openAdminCard = openAdminCard;
+
+document.addEventListener('DOMContentLoaded', initAdminCardLinks);

--- a/application/single_app/static/js/admin/admin_settings.js
+++ b/application/single_app/static/js/admin/admin_settings.js
@@ -9227,31 +9227,6 @@ function clearStatusAlert(statusAlert) {
 }
 
 
-function switchTab(event, tabButtonId) {
-    event.preventDefault();
-    const triggerEl = document.getElementById(tabButtonId);
-    if (triggerEl) {
-        const tabObj = new bootstrap.Tab(triggerEl);
-        tabObj.show();
-        return;
-    }
-
-    const inferredTabId = tabButtonId.replace(/-tab$/, '');
-    if (typeof window.showAdminTab === 'function') {
-        window.showAdminTab(inferredTabId);
-
-        const navLink = document.querySelector(`.admin-nav-tab[data-tab="${inferredTabId}"]`);
-        if (navLink) {
-            document.querySelectorAll('.admin-nav-tab, .admin-nav-section').forEach(link => {
-                link.classList.remove('active');
-            });
-            navLink.classList.add('active');
-        }
-    }
-}
-
-window.switchTab = switchTab;
-
 function togglePassword(btnId, inputId) {
     const btn = document.getElementById(btnId);
     const inp = document.getElementById(inputId);

--- a/application/single_app/static/js/admin/admin_settings_dependencies.js
+++ b/application/single_app/static/js/admin/admin_settings_dependencies.js
@@ -1,0 +1,220 @@
+// admin_settings_dependencies.js
+// Announces and enforces Admin Settings options that require another option.
+//
+// Some settings only work when a different setting is enabled, and those two
+// settings often live in different tabs. Previously that was communicated in
+// prose, or in a tooltip, or only by a flash message after saving, so an admin
+// could turn something on and have nothing happen with no visible reason.
+//
+// A dependent card declares what it needs:
+//
+//     <div class="card" id="file-sync-section"
+//          data-requires="enable_redis_cache"
+//          data-requires-label="Redis Cache"
+//          data-requires-target="redis-cache-section"
+//          data-requires-mode="warn">
+//
+// When the prerequisite is off, a notice is inserted at the top of the card
+// containing a mirror of the prerequisite control and a link to its card, so
+// the admin can satisfy it inline or jump to the full configuration.
+//
+// Modes:
+//   block (default) disables the dependent inputs until the prerequisite is on
+//   warn            leaves inputs usable, for prerequisites the backend already
+//                   accepts as intent and reconciles later
+//
+// This is a usability layer only. The backend remains authoritative and still
+// refuses or flashes on unmet prerequisites.
+
+const NOTICE_CLASS = 'admin-dependency-notice';
+const DISABLED_FLAG = 'data-dependency-disabled';
+
+/**
+ * Read every dependency declared in the document.
+ * @returns {Array<object>} Parsed dependency descriptors.
+ */
+function collectDependencies() {
+    return Array.from(document.querySelectorAll('[data-requires]')).map((card) => ({
+        card,
+        prerequisiteId: card.getAttribute('data-requires'),
+        label: card.getAttribute('data-requires-label') || 'another setting',
+        targetCardId: card.getAttribute('data-requires-target') || '',
+        mode: card.getAttribute('data-requires-mode') === 'warn' ? 'warn' : 'block',
+        description: card.getAttribute('data-requires-description') || '',
+        // Optional selector limiting which controls the dependency guards, for
+        // cards that hold a mix of dependent and independent settings.
+        scope: card.getAttribute('data-requires-scope') || '',
+    }));
+}
+
+/**
+ * Whether a prerequisite control is currently satisfied.
+ * @param {HTMLElement|null} control Prerequisite input.
+ * @returns {boolean}
+ */
+function isSatisfied(control) {
+    if (!control) {
+        return true;
+    }
+    if (control.type === 'checkbox' || control.type === 'radio') {
+        return control.checked;
+    }
+    return Boolean(control.value);
+}
+
+/**
+ * Build the notice shown when a prerequisite is unmet.
+ * @param {object} dependency Dependency descriptor.
+ * @param {HTMLElement} prerequisite Prerequisite control.
+ * @returns {HTMLElement}
+ */
+function buildNotice(dependency, prerequisite) {
+    const notice = document.createElement('div');
+    notice.className = `alert ${dependency.mode === 'warn' ? 'alert-warning' : 'alert-info'} ${NOTICE_CLASS}`;
+    notice.setAttribute('role', 'note');
+
+    const heading = document.createElement('div');
+    heading.className = 'fw-semibold mb-1';
+    const icon = document.createElement('i');
+    icon.className = 'bi bi-info-circle me-2';
+    icon.setAttribute('aria-hidden', 'true');
+    heading.append(icon, document.createTextNode(`This needs ${dependency.label}`));
+    notice.appendChild(heading);
+
+    const body = document.createElement('p');
+    body.className = 'mb-2';
+    body.textContent = dependency.description
+        || (dependency.mode === 'warn'
+            ? `These settings are saved, but stay inactive until ${dependency.label} is enabled and configured.`
+            : `These settings are unavailable until ${dependency.label} is enabled.`);
+    notice.appendChild(body);
+
+    const actions = document.createElement('div');
+    actions.className = 'd-flex flex-wrap align-items-center gap-3';
+
+    // Inline mirror: satisfy the prerequisite without leaving this tab. It
+    // carries no name attribute, so only the canonical input is submitted.
+    if (prerequisite && prerequisite.type === 'checkbox') {
+        const wrapper = document.createElement('div');
+        wrapper.className = 'form-check form-switch mb-0';
+
+        const proxy = document.createElement('input');
+        proxy.type = 'checkbox';
+        proxy.className = 'form-check-input';
+        proxy.id = `${dependency.card.id}-requires-proxy`;
+        proxy.checked = prerequisite.checked;
+        proxy.setAttribute('data-dependency-proxy-for', prerequisite.id);
+        proxy.setAttribute('data-ignore-settings-change', 'true');
+
+        proxy.addEventListener('change', () => {
+            prerequisite.checked = proxy.checked;
+            prerequisite.dispatchEvent(new Event('change', { bubbles: true }));
+        });
+
+        const proxyLabel = document.createElement('label');
+        proxyLabel.className = 'form-check-label ms-2';
+        proxyLabel.setAttribute('for', proxy.id);
+        proxyLabel.textContent = `Enable ${dependency.label}`;
+
+        wrapper.append(proxy, proxyLabel);
+        actions.appendChild(wrapper);
+    }
+
+    if (dependency.targetCardId) {
+        const link = document.createElement('a');
+        link.href = `#${dependency.targetCardId}`;
+        link.setAttribute('data-admin-link', dependency.targetCardId);
+        link.className = 'small';
+        link.textContent = `Go to ${dependency.label}`;
+        actions.appendChild(link);
+    }
+
+    notice.appendChild(actions);
+    return notice;
+}
+
+/**
+ * Enable or disable the controls a dependency guards.
+ * @param {object} dependency Dependency descriptor.
+ * @param {boolean} satisfied Whether the prerequisite is met.
+ */
+function setControlsDisabled(dependency, satisfied) {
+    if (dependency.mode === 'warn') {
+        return;
+    }
+
+    const selector = dependency.scope || 'input, select, textarea, button';
+    dependency.card.querySelectorAll(selector).forEach((control) => {
+        if (control.closest(`.${NOTICE_CLASS}`)) {
+            return;
+        }
+
+        if (!satisfied) {
+            // Remember controls that were already disabled for other
+            // reasons so re-enabling does not override them.
+            if (!control.disabled) {
+                control.setAttribute(DISABLED_FLAG, 'true');
+                control.disabled = true;
+            }
+        } else if (control.getAttribute(DISABLED_FLAG) === 'true') {
+            control.removeAttribute(DISABLED_FLAG);
+            control.disabled = false;
+        }
+    });
+}
+
+/**
+ * Apply the current state of one dependency.
+ * @param {object} dependency Dependency descriptor.
+ */
+function applyDependency(dependency) {
+    const prerequisite = document.getElementById(dependency.prerequisiteId);
+    const satisfied = isSatisfied(prerequisite);
+
+    const existing = dependency.card.querySelector(`:scope > .${NOTICE_CLASS}`);
+    if (existing) {
+        existing.remove();
+    }
+
+    setControlsDisabled(dependency, satisfied);
+
+    if (satisfied) {
+        return;
+    }
+
+    const notice = buildNotice(dependency, prerequisite);
+    const heading = dependency.card.querySelector('h4, h5, h6');
+    if (heading && heading.parentElement === dependency.card) {
+        heading.insertAdjacentElement('afterend', notice);
+    } else {
+        dependency.card.prepend(notice);
+    }
+}
+
+/**
+ * Wire up every declared dependency and keep it live.
+ */
+export function initAdminSettingsDependencies() {
+    const dependencies = collectDependencies();
+    if (!dependencies.length) {
+        return;
+    }
+
+    dependencies.forEach((dependency) => {
+        applyDependency(dependency);
+
+        const prerequisite = document.getElementById(dependency.prerequisiteId);
+        if (!prerequisite) {
+            console.warn(
+                `admin dependencies: "${dependency.card.id}" requires missing control `
+                + `"${dependency.prerequisiteId}"`,
+            );
+            return;
+        }
+
+        prerequisite.addEventListener('change', () => applyDependency(dependency));
+        prerequisite.addEventListener('input', () => applyDependency(dependency));
+    });
+}
+
+document.addEventListener('DOMContentLoaded', initAdminSettingsDependencies);

--- a/application/single_app/templates/admin/_panes/citation.html
+++ b/application/single_app/templates/admin/_panes/citation.html
@@ -192,10 +192,10 @@
                                 <p class="mt-2 mb-0">
                                     <small class="text-muted">
                                         Reference:
-                                        <a href="#workspaces" onclick="switchTab(event, 'workspaces-tab')">
+                                        <a href="#video-intelligence-section" data-admin-link="video-intelligence-section">
                                             Enable Video File Support
                                         </a>
-                                        (see the Workspaces tab)
+                                        (see AI Video Intelligence under Search and Extract)
                                     </small>
                                 </p>
                             {% endif %}
@@ -231,10 +231,10 @@
                                 <p class="mt-2 mb-0">
                                     <small class="text-muted">
                                         Reference:
-                                        <a href="#workspaces" onclick="switchTab(event, 'workspaces-tab')">
+                                        <a href="#ai-voice-chat-section" data-admin-link="ai-voice-chat-section">
                                             Enable Audio File Support
                                         </a>
-                                        (see the Workspaces tab)
+                                        (see AI Voice Conversations under Search and Extract)
                                     </small>
                                 </p>
                             {% endif %}

--- a/application/single_app/templates/admin/_panes/file-sync.html
+++ b/application/single_app/templates/admin/_panes/file-sync.html
@@ -3,7 +3,12 @@
                     Configure file synchronization for personal, group, and public workspaces.
                 </p>
 
-                <div class="card mb-3 p-3" id="file-sync-section">
+                <div class="card mb-3 p-3" id="file-sync-section"
+                    data-requires="enable_redis_cache"
+                    data-requires-label="Redis Cache"
+                    data-requires-target="redis-cache-section"
+                    data-requires-mode="warn"
+                    data-requires-description="File Sync settings can be saved now, but sync runs stay inactive until Redis Cache is enabled and configured.">
                     <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-2">
                         <h5 class="mb-0">
                             <i class="bi bi-arrow-repeat me-2"></i>File Sync
@@ -20,9 +25,9 @@
                         File Sync can scan large remote shares and create many document versions. Start with narrow filters, conservative schedules, and low per-run limits before enabling broad workspace access.
                     </div>
 
-                    {% if not settings.file_sync_redis_ready %}
+                    {% if settings.enable_redis_cache and not settings.file_sync_redis_ready %}
                     <div class="alert alert-danger" role="alert">
-                        Redis Cache must be enabled and configured before File Sync can run. Saved File Sync settings remain inactive until Redis is ready.
+                        Redis Cache is enabled but not fully configured, so File Sync cannot run yet. Check the Redis URL and credentials.
                     </div>
                     {% elif settings.requested_enable_file_sync and not settings.file_sync_effective_enabled %}
                     <div class="alert alert-warning" role="alert">

--- a/application/single_app/templates/admin/_panes/latest-features.html
+++ b/application/single_app/templates/admin/_panes/latest-features.html
@@ -382,7 +382,7 @@
                                 <strong>Admin-only workflow:</strong> The review modal is intended for administrators who need to standardize agents on a new default model, control cost, or intentionally replace older explicit bindings as new models are released.
                             </div>
                             <div class="alert alert-secondary mb-3" role="alert">
-                                Review endpoint and fallback configuration in the <a href="#ai-models" onclick="switchTab(event, 'ai-models-tab')">AI Models</a> tab.
+                                Review endpoint and fallback configuration in the <a href="#multi-endpoint-configuration" data-admin-link="multi-endpoint-configuration">AI Models</a> tab.
                             </div>
                             <div class="latest-feature-gallery">
                                 <button
@@ -456,7 +456,7 @@
                                 <li>Admins can right-size tabular preview limits based on the memory profile of their runtime.</li>
                             </ul>
                             <div class="alert alert-secondary mb-3" role="alert">
-                                These controls mirror the saved values in the <a href="#citation" onclick="switchTab(event, 'citation-tab')">Citations</a> tab.
+                                These controls mirror the saved values in the <a href="#enhanced-citations-section" data-admin-link="enhanced-citations-section">Citations</a> tab.
                             </div>
                             <div class="form-check form-switch mb-3">
                                 <input
@@ -590,7 +590,7 @@
                                 <li>This is especially useful for larger or tabular outputs where users often ask multiple follow-up questions against the same evidence chain.</li>
                             </ul>
                             <div class="alert alert-secondary mb-3" role="alert">
-                                These improvements complement the <a href="#citation" onclick="switchTab(event, 'citation-tab')">Citations</a> configuration and the enhanced-citation storage flow.
+                                These improvements complement the <a href="#enhanced-citations-section" data-admin-link="enhanced-citations-section">Citations</a> configuration and the enhanced-citation storage flow.
                             </div>
                             <div class="latest-feature-gallery">
                                 <button
@@ -832,7 +832,7 @@
                         <div class="card card-body">
                             <p class="mb-2">Admins can enable this once and let users see more of the model pipeline, including sending, generating, and responded states with clearer timing information.</p>
                             <div class="alert alert-secondary mb-3" role="alert">
-                                This toggle mirrors the saved value in the <a href="#ai-models" onclick="switchTab(event, 'ai-models-tab')">AI Models</a> tab.
+                                This toggle mirrors the saved value in the <a href="#processing-thoughts-section" data-admin-link="processing-thoughts-section">AI Models</a> tab.
                             </div>
                             <div class="form-check form-switch mb-3">
                                 <input
@@ -894,7 +894,7 @@
                                 <li>Admins can choose whether this announcement is visible on the user-facing Latest Features page from <strong>General > User-Facing Latest Features</strong>.</li>
                             </ul>
                             <div class="alert alert-secondary mb-3" role="alert">
-                                Use the <a href="#general" onclick="switchTab(event, 'general-tab')">General</a> tab when you want to show or hide the Fact Memory announcement for end users.
+                                Use the <a href="#support-menu-section" data-admin-link="support-menu-section">General</a> tab when you want to show or hide the Fact Memory announcement for end users.
                             </div>
                             <div class="latest-feature-gallery">
                                 <button
@@ -967,7 +967,7 @@
                                 <li>This works best when Key Vault is already configured for the app.</li>
                             </ul>
                             <div class="alert alert-secondary mb-3" role="alert">
-                                These controls mirror the saved values in the <a href="#scale" onclick="switchTab(event, 'scale-tab')">Scale</a> tab.
+                                These controls mirror the saved values in the <a href="#redis-cache-section" data-admin-link="redis-cache-section">Scale</a> tab.
                             </div>
                             <div class="form-check form-switch mb-3">
                                 <input
@@ -1092,7 +1092,7 @@
                                 <li>Logs the action to the activity log so admins can audit when feedback emails were prepared.</li>
                                 <li>Keeps the workflow simple by using text-only email content with no confusing pseudo-attachment step.</li>
                             </ul>
-                            <a href="#send-feedback" onclick="switchTab(event, 'send-feedback-tab')" class="btn btn-outline-primary align-self-start">
+                            <a href="#send-feedback-overview-card" data-admin-link="send-feedback-overview-card" class="btn btn-outline-primary align-self-start">
                                 <i class="bi bi-envelope-paper me-1"></i>Open Send Feedback
                             </a>
                         </div>
@@ -1122,7 +1122,7 @@
                                 <li>The user-facing Latest Features page can be curated feature-by-feature so teams only share the items they want visible.</li>
                                 <li>The General tab now includes a dedicated User-Facing Latest Features checklist so admins can quickly confirm which announcements will be visible to end users.</li>
                             </ul>
-                            <a href="#general" onclick="switchTab(event, 'general-tab')" class="btn btn-outline-primary align-self-start mb-3">
+                            <a href="#support-menu-section" data-admin-link="support-menu-section" class="btn btn-outline-primary align-self-start mb-3">
                                 <i class="bi bi-gear me-1"></i>Open General Settings
                             </a>
                             <div class="latest-feature-gallery">

--- a/application/single_app/templates/admin/_panes/safety.html
+++ b/application/single_app/templates/admin/_panes/safety.html
@@ -216,7 +216,12 @@
                 </div>
 
 
-                <div class="card p-3 mb-3" id="permissions-section">
+                <div class="card p-3 mb-3" id="permissions-section"
+                    data-requires="enable_user_feedback"
+                    data-requires-label="User Feedback"
+                    data-requires-target="user-feedback-section"
+                    data-requires-scope="#require_member_of_feedback_admin"
+                    data-requires-description="The FeedbackAdmin role only controls access to the User Feedback report, so it does nothing until User Feedback is enabled.">
                     <h5>
                         <i class="bi bi-person-check me-2"></i>Permissions
                     </h5>

--- a/application/single_app/templates/admin/_panes/scale.html
+++ b/application/single_app/templates/admin/_panes/scale.html
@@ -50,7 +50,7 @@
                                 <button type="button" class="btn btn-outline-secondary" id="toggle_redis_key">Show</button>
                             </div>
                             <div id="redis_key_vault_hint" class="form-text text-muted {% if settings.redis_auth_type != 'key_vault' %}d-none{% endif %}">
-                                Enter the full Key Vault secret name. <a href="#security" onclick="switchTab(event, 'security-tab')">
+                                Enter the full Key Vault secret name. <a href="#keyvault-section" data-admin-link="keyvault-section">
                                 Enable Key Vault for Agent and Action Secrets
                             </a> must be enabled and configured.
                             </div>

--- a/application/single_app/templates/admin/_panes/search-extract.html
+++ b/application/single_app/templates/admin/_panes/search-extract.html
@@ -1688,7 +1688,7 @@
                     </div>
                     <p class="mt-2 mb-0">
                         <small class="text-muted">
-                            <a href="#citation" onclick="switchTab(event, 'citation-tab')">
+                            <a href="#enhanced-citations-section" data-admin-link="enhanced-citations-section">
                                 Enhanced Citations
                             </a>
                              will dramatically improve the citation experience for video and audio files.

--- a/application/single_app/templates/admin_settings.html
+++ b/application/single_app/templates/admin_settings.html
@@ -39,6 +39,14 @@
             vertical-align: middle;
         }
 
+        /* Brief highlight when a data-admin-link jumps to a card, so the
+           destination is obvious after the tab switch and scroll. */
+        .admin-card-link-target {
+            outline: 2px solid var(--bs-primary, #0d6efd);
+            outline-offset: 3px;
+            transition: outline-color 0.4s ease-out;
+        }
+
         /* Floating Save Button */
         .floating-save-btn {
             position: fixed;
@@ -1847,6 +1855,7 @@
 <script type="module" src="{{ url_for('static', filename='js/admin/admin_model_endpoints.js') }}"></script>
 <script type="module" src="{{ url_for('static', filename='js/admin/admin_governance.js') }}"></script>
 <script type="module" src="{{ url_for('static', filename='js/admin/admin_sidebar_nav.js') }}"></script>
+<script type="module" src="{{ url_for('static', filename='js/admin/admin_card_links.js') }}?v={{ config['VERSION'] }}"></script>
 <script type="module" src="{{ url_for('static', filename='js/admin/admin_custom_pages.js') }}"></script>
 <script type="module" src="{{ url_for('static', filename='js/plugin_modal_stepper.js') }}"></script>
 {% if settings.enable_semantic_kernel %}
@@ -2532,14 +2541,11 @@
             // Render markdown to HTML
             const previewContent = document.getElementById('userAgreementPreviewContent');
             if (previewContent) {
-                // Use marked if available, otherwise show raw text
+                // marked and DOMPurify are both loaded globally from base.html,
+                // so sanitize inline at the sink rather than through a guarded
+                // reassignment, which reads as unsanitized to static analysis.
                 if (typeof marked !== 'undefined') {
-                    let html = marked.parse(agreementText);
-                    // Sanitize if DOMPurify is available
-                    if (typeof DOMPurify !== 'undefined') {
-                        html = DOMPurify.sanitize(html);
-                    }
-                    previewContent.innerHTML = html;
+                    previewContent.innerHTML = DOMPurify.sanitize(marked.parse(agreementText));
                 } else {
                     previewContent.textContent = agreementText;
                 }

--- a/application/single_app/templates/admin_settings.html
+++ b/application/single_app/templates/admin_settings.html
@@ -1856,6 +1856,7 @@
 <script type="module" src="{{ url_for('static', filename='js/admin/admin_governance.js') }}"></script>
 <script type="module" src="{{ url_for('static', filename='js/admin/admin_sidebar_nav.js') }}"></script>
 <script type="module" src="{{ url_for('static', filename='js/admin/admin_card_links.js') }}?v={{ config['VERSION'] }}"></script>
+<script type="module" src="{{ url_for('static', filename='js/admin/admin_settings_dependencies.js') }}?v={{ config['VERSION'] }}"></script>
 <script type="module" src="{{ url_for('static', filename='js/admin/admin_custom_pages.js') }}"></script>
 <script type="module" src="{{ url_for('static', filename='js/plugin_modal_stepper.js') }}"></script>
 {% if settings.enable_semantic_kernel %}

--- a/docs/explanation/features/ADMIN_SETTINGS_DEPENDENCY_ANNOUNCEMENTS.md
+++ b/docs/explanation/features/ADMIN_SETTINGS_DEPENDENCY_ANNOUNCEMENTS.md
@@ -1,0 +1,160 @@
+# Admin Settings Dependency Announcements
+
+**Implemented in version:** 0.260.008
+**Area:** Admin Settings information architecture, stage B
+**Related:** `ADMIN_SETTINGS_CARD_TARGETED_LINKS_FIX.md`
+
+## Overview
+
+Several Admin Settings options only take effect when a different option is
+enabled. Those relationships were previously communicated inconsistently, and
+in the weakest cases not until after saving. This adds a declarative way for a
+card to state what it needs, with an inline notice that lets an admin satisfy
+the prerequisite without hunting for it.
+
+This matters more after the information architecture rework, because settings
+that are currently one tab apart end up in different top-level groups.
+
+## Problem
+
+Dependencies were expressed in four different ways, none of them actionable:
+
+| Dependency | How it was communicated |
+|---|---|
+| File Sync needs Redis Cache | Server-rendered alert, plus a `flash()` after saving |
+| FeedbackAdmin role needs User Feedback | One sentence of prose |
+| Backup source blobs need Enhanced Citations | Tooltip text |
+| Web Search needs consent | `flash()` after saving |
+
+The File Sync alert was accurate but static: it reflected saved state, so
+toggling Redis in another tab did not update it. The prose and tooltip cases
+offered no way to act, and no indication of where the prerequisite lived.
+
+## Design
+
+A dependent card declares its prerequisite in markup:
+
+```html
+<div class="card" id="file-sync-section"
+     data-requires="enable_redis_cache"
+     data-requires-label="Redis Cache"
+     data-requires-target="redis-cache-section"
+     data-requires-mode="warn"
+     data-requires-description="File Sync settings can be saved now, but sync runs stay inactive until Redis Cache is enabled and configured.">
+```
+
+| Attribute | Purpose |
+|---|---|
+| `data-requires` | Element id of the prerequisite control |
+| `data-requires-label` | Human name used in the notice |
+| `data-requires-target` | Card id to link to, resolved via `data-admin-link` |
+| `data-requires-mode` | `block` disables the dependent controls, `warn` only announces |
+| `data-requires-scope` | Optional selector limiting which controls are gated |
+| `data-requires-description` | Optional custom explanation |
+
+`static/js/admin/admin_settings_dependencies.js` evaluates each declaration on
+load and whenever the prerequisite changes, then renders a notice containing:
+
+1. **An inline mirror** of the prerequisite switch, so it can be satisfied
+   without leaving the tab.
+2. **A link to the prerequisite's card**, using the stage A resolver, so the
+   full configuration is one click away.
+
+### Why the mirror cannot corrupt a save
+
+Admin Settings posts one form, and the backend reads values by field name. A
+second control sharing a name would submit the value twice. The mirror is
+therefore created with **no `name` attribute**; it carries
+`data-dependency-proxy-for` instead and drives the canonical input directly.
+Exactly one named control per setting is ever submitted. This mirrors the
+convention the Latest Features tab already uses, where proxies are named with a
+`_proxy` suffix that the backend never reads.
+
+### Why some dependencies warn instead of block
+
+File Sync is deliberately `warn`. The backend already accepts File Sync as
+*requested* and reconciles it once Redis is ready, tracked as
+`requested_enable_file_sync` versus `file_sync_effective_enabled`. Hard
+disabling the toggle would remove a behaviour the backend supports on purpose:
+configure now, satisfy the infrastructure dependency after. Everything else
+blocks, because there is no equivalent deferred-intent path.
+
+### Field-level scoping
+
+`permissions-section` holds both the SafetyViolationAdmin and FeedbackAdmin
+role toggles, and only the latter depends on User Feedback. Blanket-disabling
+the card would switch off an unrelated control, so that dependency declares
+`data-requires-scope="#require_member_of_feedback_admin"`. A test asserts this
+specific scoping, because getting it wrong is silent and user-visible.
+
+### The backend remains authoritative
+
+Client-side gating is a usability layer. A disabled input is a courtesy, never
+a control. `route_frontend_admin_settings.py` still validates the File Sync
+Redis prerequisite and still flashes when it is unmet, and a test asserts that
+validation is still present so the client-side notice cannot be mistaken for
+enforcement.
+
+## Dependencies wired
+
+| Card | Requires | Mode | Notes |
+|---|---|---|---|
+| `file-sync-section` | `enable_redis_cache` | warn | Preserves save-then-reconcile |
+| `permissions-section` | `enable_user_feedback` | block, scoped | Only the FeedbackAdmin toggle |
+
+Deliberately **not** wired:
+
+- **Backup source blobs → Enhanced Citations.** Already handled in
+  `admin_data_management.js`, which drives the control from
+  `settings.enhanced_citations_enabled` and shows a lock message. Adding a
+  second mechanism would risk the two disagreeing.
+- **Multi-modal vision → multi-endpoint management.** This is a fallback, not a
+  requirement: vision uses Global Endpoints when multi-endpoint is on and the
+  legacy GPT deployment otherwise. Gating it would misrepresent the behaviour.
+- **Redis Key Vault auth → Key Vault storage.** Conditional on a select value
+  rather than a boolean, and the existing inline hint already links correctly
+  after the stage A conversion.
+
+## Related change
+
+The File Sync server-rendered alert previously fired whenever Redis was not
+"ready", which now overlaps with the live notice. It is narrowed to the case it
+uniquely covers — Redis enabled but not fully configured, which the client
+cannot detect because readiness also depends on the URL and credentials being
+present. The two messages no longer double up.
+
+## Files modified
+
+| File | Change |
+|---|---|
+| `application/single_app/static/js/admin/admin_settings_dependencies.js` | New module |
+| `application/single_app/templates/admin_settings.html` | Loads the module |
+| `application/single_app/templates/admin/_panes/file-sync.html` | Declares the Redis dependency; narrows the server alert |
+| `application/single_app/templates/admin/_panes/safety.html` | Declares the scoped User Feedback dependency |
+| `functional_tests/test_admin_settings_dependencies.py` | New contract test |
+| `application/single_app/config.py` | Version to 0.260.008 |
+
+## Validation
+
+`test_admin_settings_dependencies.py` pins five properties:
+
+1. Every declared prerequisite control exists in the composed template.
+2. Every declared link target is a real card.
+3. The mirror control is never given a `name`, so it cannot double-post.
+4. The Permissions dependency is scoped to the FeedbackAdmin toggle.
+5. The module is loaded, and the backend prerequisite validation still exists.
+
+Regression evidence:
+
+- Form field names and card ids unchanged: **462 names, 110 card ids identical**.
+- 75 functional test files covering `admin_settings.html`: **33 pre-existing
+  failures before and after, identical sets**.
+- All 20 admin templates parse under Jinja.
+- `scripts/check_xss_sinks.py` passes a full-file scan of every touched file.
+  The notice is built with DOM APIs and `textContent`, never string HTML.
+
+## Follow-up
+
+Stage C adds the group navigation level. The 10 hand-written Latest Features
+mirrors can then migrate onto this module's proxy handling, replacing roughly
+120 lines of per-field `addEventListener` pairs with one declarative attribute.

--- a/docs/explanation/fixes/ADMIN_SETTINGS_CARD_TARGETED_LINKS_FIX.md
+++ b/docs/explanation/fixes/ADMIN_SETTINGS_CARD_TARGETED_LINKS_FIX.md
@@ -1,0 +1,144 @@
+# Admin Settings Card-Targeted Navigation Links
+
+**Implemented in version:** 0.260.008
+**Area:** Admin Settings information architecture, stage A
+**Related:** `ADMIN_SETTINGS_NAVIGATION_AND_TEMPLATE_STRUCTURE_FIX.md`
+
+## Issue
+
+Admin Settings contains cross-references between related settings, for example
+Citations pointing at the video and audio file-support toggles, or the Redis
+Key Vault hint pointing at the Key Vault card. Each of those links named a tab
+button directly:
+
+```html
+<a href="#workspaces" onclick="switchTab(event, 'workspaces-tab')">
+```
+
+`switchTab` looked up `document.getElementById('workspaces-tab')`. That couples
+every link to a tab id, with two consequences.
+
+### 1. Links break silently on any tab change
+
+If the tab id changes, the lookup returns `null`, `switchTab` falls through to
+`showAdminTab('workspaces')`, no pane matches, and the only symptom is a console
+warning plus a URL hash pointing at nothing. Nothing fails loudly, so the
+breakage survives review.
+
+This was about to happen at scale: the information architecture rework renames
+and regroups most tabs.
+
+### 2. Two links were already wrong
+
+The Citations tab referenced **Enable Video File Support** and **Enable Audio
+File Support** with `#workspaces`, and the surrounding prose said "see the
+Workspaces tab". Both settings actually live in **Search and Extract**:
+
+| Setting | Card | Pane |
+|---|---|---|
+| `enable_video_file_support` | `video-intelligence-section` | `search-extract` |
+| `enable_audio_file_support` | `ai-voice-chat-section` | `search-extract` |
+
+So an admin following either link landed on the wrong tab with no indication
+why.
+
+## Root cause
+
+The link contract pointed at *navigation structure* (a tab button id) rather
+than at *content* (the setting being referenced). Navigation structure changes;
+the identity of a settings card does not.
+
+## Fix
+
+Links now declare the card they want:
+
+```html
+<a href="#video-intelligence-section" data-admin-link="video-intelligence-section">
+    Enable Video File Support
+</a>
+```
+
+`static/js/admin/admin_card_links.js` resolves the owning tab from the DOM at
+click time:
+
+```js
+const card = document.getElementById(cardId);
+const pane = card.closest('.tab-pane');
+window.showAdminTab(pane.id);
+```
+
+Because the tab is derived rather than declared, cards can move between tabs and
+tabs can be renamed or regrouped without touching a single link. Card ids are
+the only contract, and they are already stable — the template split preserved
+all 110 of them byte-identically.
+
+Behaviour on click:
+
+1. Resolve the card and activate its tab, in either the top-tab or sidebar layout.
+2. Mirror the active state in the sidebar when that layout is in use.
+3. Scroll the card into view.
+4. Highlight it for 1.6 seconds so the destination is obvious after the jump.
+
+Clicks are handled by delegation, so links rendered later still work.
+
+`switchTab` had no remaining callers and was removed, which makes the old
+coupling impossible to reintroduce by copy-paste.
+
+## Files modified
+
+| File | Change |
+|---|---|
+| `application/single_app/static/js/admin/admin_card_links.js` | New resolver module |
+| `application/single_app/static/js/admin/admin_settings.js` | Removed the dead `switchTab` helper |
+| `application/single_app/templates/admin_settings.html` | Loads the resolver; adds the highlight style; sanitizes the User Agreement preview at the sink |
+| `application/single_app/templates/admin/_panes/citation.html` | Two corrected links plus corrected prose |
+| `application/single_app/templates/admin/_panes/latest-features.html` | Eight links converted |
+| `application/single_app/templates/admin/_panes/scale.html` | Key Vault link converted |
+| `application/single_app/templates/admin/_panes/search-extract.html` | Enhanced Citations link converted |
+| `functional_tests/test_admin_card_links.py` | New contract test |
+| `application/single_app/config.py` | Version to 0.260.008 |
+
+## Link inventory
+
+| Source | Target card |
+|---|---|
+| Citations → video support | `video-intelligence-section` *(was wrong)* |
+| Citations → audio support | `ai-voice-chat-section` *(was wrong)* |
+| Latest Features → model endpoints | `multi-endpoint-configuration` |
+| Latest Features → citations ×2 | `enhanced-citations-section` |
+| Latest Features → processing thoughts | `processing-thoughts-section` |
+| Latest Features → support menu ×2 | `support-menu-section` |
+| Latest Features → Redis | `redis-cache-section` |
+| Latest Features → send feedback | `send-feedback-overview-card` |
+| Scale → Key Vault | `keyvault-section` |
+| Search and Extract → enhanced citations | `enhanced-citations-section` |
+
+## Validation
+
+`functional_tests/test_admin_card_links.py` pins four properties:
+
+1. Every `data-admin-link` target is a real element id in the composed template.
+2. Every such link carries a matching `href="#<target>"`, so it degrades
+   sensibly without JavaScript and stays copy-pasteable.
+3. No link reintroduces the tab-coupled `switchTab` pattern.
+4. The resolver module exists, is loaded by the page, and derives the tab from
+   the DOM rather than from a hardcoded map.
+
+Property 1 is the one that matters: it fails the build if a card is renamed or
+removed without updating the links that point at it, which is precisely the
+failure mode that went unnoticed before.
+
+Regression evidence:
+
+- Form field names and card ids unchanged: **462 names, 110 card ids identical**.
+- 75 functional test files covering `admin_settings.html`: **33 pre-existing
+  failures before and after, identical sets**.
+- All 20 admin templates parse under Jinja.
+- `scripts/check_xss_sinks.py` passes a full-file scan of every touched file,
+  which it did not before the User Agreement preview change.
+
+## Follow-up
+
+Stage B introduces declarative dependency gating, where a setting that requires
+another one announces it inline with a mirror control and a link to the
+prerequisite. That link uses the resolver added here.

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -4,6 +4,16 @@ For feature-focused and fix-focused drill-downs by version, see [Features by Ver
 
 ### **(v0.260.008)**
 
+#### New Features
+
+*   **Settings That Need Another Setting Now Say So**
+    *   Some Admin Settings options only work when a different option is enabled, and the two often live in different tabs. That was previously explained only in prose, in a tooltip, or in a warning after saving, so you could switch something on and have nothing happen with no visible reason.
+    *   Affected cards now show an inline notice naming what they need, with a switch to enable the prerequisite without leaving the tab and a link straight to its full configuration.
+    *   **File Sync** announces its **Redis Cache** requirement live, and keeps its save-your-intent behaviour: settings can still be saved and activate once Redis is ready.
+    *   The **FeedbackAdmin** role control is disabled until **User Feedback** is enabled, since the role only governs access to the User Feedback report. The unrelated SafetyViolationAdmin control in the same card stays usable.
+    *   These notices are guidance only. The server still validates every prerequisite.
+    *   (Ref: `admin_settings_dependencies.js`, `data-requires`, File Sync, Permissions)
+
 #### Bug Fixes
 
 *   **Cross-Tab Links In Admin Settings Now Point At The Right Place**

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,21 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](/explanation/features/) and [Fixes by Version](/explanation/fixes/).
 
+### **(v0.260.008)**
+
+#### Bug Fixes
+
+*   **Cross-Tab Links In Admin Settings Now Point At The Right Place**
+    *   Links that send you from one Admin Settings tab to a related setting used to name a tab button directly, so they broke silently whenever a tab was renamed or reorganised: no tab opened, and the address bar was left pointing at nothing.
+    *   Two were already wrong. The **Video File Support** and **Audio File Support** references in Citations sent you to the **Workspaces** tab, but those settings live under **Search and Extract**. Both now open the correct card.
+    *   All twelve cross-tab links now name the card they want, and the owning tab is worked out when you click. The destination card is briefly highlighted so it is obvious where you landed.
+    *   (Ref: `admin_card_links.js`, `data-admin-link`, `openAdminCard`, `test_admin_card_links.py`)
+
+*   **User Agreement Preview Sanitized At The Sink**
+    *   The User Agreement preview rendered Markdown through a guarded reassignment, which reads as unsanitized to static analysis and matched the pattern already corrected for the Home Page Text preview.
+    *   Now sanitized inline with `DOMPurify.sanitize(...)` at the point of rendering. `marked` and DOMPurify are both loaded globally, so the availability guards were redundant.
+    *   (Ref: User Agreement, `admin_settings.html` preview handler, DOMPurify)
+
 ### **(v0.260.007)**
 
 #### User Interface Enhancements

--- a/functional_tests/test_admin_card_links.py
+++ b/functional_tests/test_admin_card_links.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+# test_admin_card_links.py
+"""
+Functional test for Admin Settings card-targeted navigation links.
+Version: 0.260.008
+Implemented in: 0.260.008
+
+Cross-tab links used to name a tab button directly, for example
+switchTab(event, 'workspaces-tab'). That couples every link to a tab id, so an
+information-architecture change silently breaks it: the button no longer
+exists, no pane is activated, and the URL hash points at nothing. Two links
+were already wrong this way, pointing at the Workspaces tab for video and audio
+settings that live under Search and Extract.
+
+Links now name the card they want with data-admin-link, and the owning tab is
+resolved from the DOM at click time. This test pins that contract:
+
+  1. Every data-admin-link target is a real element id in the composed template.
+  2. Every such link carries a matching href fragment, so it degrades sensibly
+     without JavaScript and remains copy-pasteable.
+  3. No link reintroduces the tab-coupled switchTab pattern.
+  4. The resolver module is wired into the page.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+from test_support.templates import (
+    ADMIN_SETTINGS_TEMPLATE,
+    read_admin_settings_template,
+)
+from test_support.versioning import assert_app_version_at_least
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CARD_LINKS_JS = (
+    REPO_ROOT
+    / "application"
+    / "single_app"
+    / "static"
+    / "js"
+    / "admin"
+    / "admin_card_links.js"
+)
+
+LINK_RE = re.compile(r'<a\b[^>]*\bdata-admin-link="(?P<target>[^"]+)"[^>]*>')
+HREF_RE = re.compile(r'\bhref="#(?P<fragment>[^"]+)"')
+
+
+def _links(markup):
+    """Return every anchor tag that declares a card target."""
+    return [(m.group("target"), m.group(0)) for m in LINK_RE.finditer(markup)]
+
+
+def test_every_card_link_target_exists():
+    """A link that resolves to nothing is a dead end for the admin."""
+    print("Testing Admin Settings card link targets...")
+
+    assert_app_version_at_least("0.260.008")
+    composed = read_admin_settings_template()
+    element_ids = set(re.findall(r'\sid="([^"]+)"', composed))
+
+    links = _links(composed)
+    assert links, "Expected Admin Settings to declare card-targeted links"
+
+    missing = sorted({target for target, _ in links if target not in element_ids})
+    assert not missing, (
+        "data-admin-link targets do not exist in the composed template: "
+        f"{missing}"
+    )
+
+    print(f"All {len(links)} card link(s) resolve to real elements.")
+
+
+def test_card_links_keep_a_matching_href():
+    """The href is the no-JavaScript fallback and should match the target."""
+    print("Testing Admin Settings card link href fallbacks...")
+
+    composed = read_admin_settings_template()
+    mismatched = []
+
+    for target, tag in _links(composed):
+        href = HREF_RE.search(tag)
+        if href is None:
+            mismatched.append(f"{target} (no href)")
+        elif href.group("fragment") != target:
+            mismatched.append(f"{target} (href points at {href.group('fragment')})")
+
+    assert not mismatched, (
+        "Card links should carry href=\"#<same-target>\": " f"{mismatched}"
+    )
+
+    print("Every card link href matches its data-admin-link target.")
+
+
+def test_no_tab_coupled_links_remain():
+    """switchTab links break silently whenever a tab is renamed or regrouped."""
+    print("Testing that no tab-coupled admin links remain...")
+
+    composed = read_admin_settings_template()
+    offenders = re.findall(r'onclick="switchTab\(event,\s*\'([^\']+)\'\)"', composed)
+
+    assert not offenders, (
+        "These links still name a tab button, so they break when the tab id "
+        "changes. Use data-admin-link with a card id instead: "
+        f"{sorted(set(offenders))}"
+    )
+
+    print("No tab-coupled links remain.")
+
+
+def test_card_link_resolver_is_wired_in():
+    """The markup contract is useless if the resolver never loads."""
+    print("Testing Admin Settings card link resolver wiring...")
+
+    assert CARD_LINKS_JS.is_file(), f"Missing resolver module at {CARD_LINKS_JS}"
+
+    parent = ADMIN_SETTINGS_TEMPLATE.read_text(encoding="utf-8")
+    assert "js/admin/admin_card_links.js" in parent, (
+        "admin_card_links.js is not loaded by admin_settings.html"
+    )
+
+    source = CARD_LINKS_JS.read_text(encoding="utf-8")
+    for marker in (
+        "export function openAdminCard",
+        "data-admin-link",
+        "closest('.tab-pane')",
+    ):
+        assert marker in source, f"Resolver is missing expected logic: {marker}"
+
+    # The resolver must derive the tab from the DOM rather than hardcode a map,
+    # which is the whole reason the links survive an IA change. Comments are
+    # stripped first so the explanation of the old pattern does not trip this.
+    code = re.sub(r"^\s*//.*$", "", source, flags=re.MULTILINE)
+    assert "switchTab(" not in code, (
+        "Resolver should not depend on the tab-coupled switchTab helper"
+    )
+
+    print("Card link resolver is present and wired into the page.")
+
+
+if __name__ == "__main__":
+    tests = [
+        test_every_card_link_target_exists,
+        test_card_links_keep_a_matching_href,
+        test_no_tab_coupled_links_remain,
+        test_card_link_resolver_is_wired_in,
+    ]
+
+    results = []
+    for test in tests:
+        try:
+            test()
+            results.append(True)
+        except Exception as exc:
+            print(f"FAILED {test.__name__}: {exc}")
+            import traceback
+            traceback.print_exc()
+            results.append(False)
+
+    print(f"\nResults: {sum(results)}/{len(results)} passed")
+    sys.exit(0 if all(results) else 1)

--- a/functional_tests/test_admin_settings_dependencies.py
+++ b/functional_tests/test_admin_settings_dependencies.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+# test_admin_settings_dependencies.py
+"""
+Functional test for Admin Settings dependency announcements.
+Version: 0.260.008
+Implemented in: 0.260.008
+
+Some Admin Settings options only work when a different option is enabled, and
+those two options often live in different tabs. That relationship used to be
+communicated only in prose, in a tooltip, or in a flash message after saving,
+so an admin could switch something on and have nothing happen with no visible
+reason.
+
+A dependent card now declares its prerequisite, and a shared module renders an
+inline notice containing a mirror of the prerequisite control plus a link to
+its card. This test pins the contract:
+
+  1. Every declared prerequisite control exists.
+  2. Every declared link target is a real card.
+  3. The mirror control cannot double-post the prerequisite's value.
+  4. Field-level dependencies declare a scope so unrelated controls in the same
+     card are not disabled.
+  5. The module is wired into the page and the backend stays authoritative.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+from test_support.templates import (
+    ADMIN_SETTINGS_TEMPLATE,
+    read_admin_settings_template,
+)
+from test_support.versioning import assert_app_version_at_least
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+APP_ROOT = REPO_ROOT / "application" / "single_app"
+DEPENDENCIES_JS = APP_ROOT / "static" / "js" / "admin" / "admin_settings_dependencies.js"
+ADMIN_ROUTE = APP_ROOT / "route_frontend_admin_settings.py"
+
+CARD_RE = re.compile(r'<div[^>]*\bid="(?P<card>[^"]+)"[^>]*\bdata-requires="(?P<req>[^"]+)"[^>]*>')
+ATTR_RE = re.compile(r'(?P<name>data-requires-[\w-]+)="(?P<value>[^"]*)"')
+
+
+def _declared_dependencies(markup):
+    """Return every card that declares a prerequisite, with its attributes."""
+    found = []
+    for match in re.finditer(r"<div\b[^>]*data-requires=[^>]*>", markup):
+        tag = match.group(0)
+        card_id = re.search(r'\bid="([^"]+)"', tag)
+        prerequisite = re.search(r'\bdata-requires="([^"]+)"', tag)
+        if not card_id or not prerequisite:
+            continue
+        attrs = {m.group("name"): m.group("value") for m in ATTR_RE.finditer(tag)}
+        found.append(
+            {
+                "card": card_id.group(1),
+                "requires": prerequisite.group(1),
+                "attrs": attrs,
+            }
+        )
+    return found
+
+
+def test_declared_dependencies_resolve():
+    """A dependency pointing at a missing control or card is dead weight."""
+    print("Testing Admin Settings dependency declarations...")
+
+    assert_app_version_at_least("0.260.008")
+    composed = read_admin_settings_template()
+    element_ids = set(re.findall(r'\sid="([^"]+)"', composed))
+
+    dependencies = _declared_dependencies(composed)
+    assert dependencies, "Expected Admin Settings to declare dependencies"
+
+    problems = []
+    for dep in dependencies:
+        if dep["requires"] not in element_ids:
+            problems.append(
+                f"{dep['card']} requires missing control '{dep['requires']}'"
+            )
+
+        target = dep["attrs"].get("data-requires-target", "")
+        if target and target not in element_ids:
+            problems.append(f"{dep['card']} links to missing card '{target}'")
+
+        if not dep["attrs"].get("data-requires-label"):
+            problems.append(f"{dep['card']} has no data-requires-label")
+
+    assert not problems, "\n  ".join(["Dependency declaration problems:"] + problems)
+
+    print(f"All {len(dependencies)} dependency declaration(s) resolve.")
+
+
+def test_dependency_mirror_cannot_double_post():
+    """The inline mirror must never carry a name, or settings post twice."""
+    print("Testing Admin Settings dependency mirror safety...")
+
+    source = DEPENDENCIES_JS.read_text(encoding="utf-8")
+
+    # The proxy is built in JavaScript, so assert on how it is constructed.
+    assert "proxy.setAttribute('data-dependency-proxy-for'" in source, (
+        "Mirror control should record which input it proxies"
+    )
+    assert "proxy.name" not in source and 'proxy.setAttribute("name"' not in source, (
+        "Mirror control must not be given a name attribute, otherwise the "
+        "prerequisite would be submitted twice"
+    )
+    assert "data-ignore-settings-change" in source, (
+        "Mirror control should be excluded from unsaved-change tracking"
+    )
+
+    print("Mirror control is name-less and cannot double-post.")
+
+
+def test_field_level_dependencies_declare_scope():
+    """Blanket-disabling a mixed card would switch off unrelated settings."""
+    print("Testing Admin Settings dependency scoping...")
+
+    composed = read_admin_settings_template()
+
+    for dep in _declared_dependencies(composed):
+        mode = dep["attrs"].get("data-requires-mode", "block")
+        scope = dep["attrs"].get("data-requires-scope", "")
+
+        if dep["card"] != "permissions-section":
+            continue
+
+        # Permissions holds both the SafetyViolationAdmin and FeedbackAdmin
+        # toggles, and only the latter depends on User Feedback.
+        assert mode == "block", "Permissions dependency should gate its control"
+        assert scope == "#require_member_of_feedback_admin", (
+            "Permissions dependency must scope to the FeedbackAdmin toggle so "
+            f"the SafetyViolationAdmin toggle stays usable, got '{scope}'"
+        )
+
+    print("Field-level dependencies are correctly scoped.")
+
+
+def test_dependency_module_is_wired_and_advisory_only():
+    """Client-side gating is a courtesy; the backend must still enforce."""
+    print("Testing Admin Settings dependency wiring...")
+
+    assert DEPENDENCIES_JS.is_file(), f"Missing module at {DEPENDENCIES_JS}"
+
+    parent = ADMIN_SETTINGS_TEMPLATE.read_text(encoding="utf-8")
+    assert "js/admin/admin_settings_dependencies.js" in parent, (
+        "Dependency module is not loaded by admin_settings.html"
+    )
+
+    # File Sync remains save-then-reconcile, so the backend keeps warning.
+    route = ADMIN_ROUTE.read_text(encoding="utf-8")
+    assert "file_sync_settings['redis_ready']" in route, (
+        "Backend must still validate the File Sync Redis prerequisite; the "
+        "client-side notice is advisory only"
+    )
+
+    print("Dependency module is wired and the backend still enforces.")
+
+
+if __name__ == "__main__":
+    tests = [
+        test_declared_dependencies_resolve,
+        test_dependency_mirror_cannot_double_post,
+        test_field_level_dependencies_declare_scope,
+        test_dependency_module_is_wired_and_advisory_only,
+    ]
+
+    results = []
+    for test in tests:
+        try:
+            test()
+            results.append(True)
+        except Exception as exc:
+            print(f"FAILED {test.__name__}: {exc}")
+            import traceback
+            traceback.print_exc()
+            results.append(False)
+
+    print(f"\nResults: {sum(results)}/{len(results)} passed")
+    sys.exit(0 if all(results) else 1)


### PR DESCRIPTION
Stage A and B of the Admin Settings information architecture rework.

> Targets the `feature/admin-settings-ia` staging branch. **No cards move in this PR** — this is the groundwork that makes moving them safe.

## Why this comes before re-homing anything

Auditing the regroup surfaced a problem that had to be fixed first: **cross-tab links are coupled to tab ids, so the regroup would break all twelve of them at once.**

```html
<a href="#workspaces" onclick="switchTab(event, 'workspaces-tab')">
```

`switchTab` looks up `document.getElementById('workspaces-tab')`. Rename or regroup that tab and the lookup returns `null`, no pane activates, and the only symptom is a console warning plus a URL hash pointing at nothing. Nothing fails loudly.

**Two links were already broken this way.** Citations referenced *Enable Video File Support* and *Enable Audio File Support* with `#workspaces`, and the prose said "see the Workspaces tab" — but both settings live under **Search and Extract**. Anyone following either link landed on the wrong tab.

| Setting | Actually lives in |
|---|---|
| `enable_video_file_support` | `video-intelligence-section` (Search and Extract) |
| `enable_audio_file_support` | `ai-voice-chat-section` (Search and Extract) |

## Stage A — links point at cards, not tabs

Links now name the card they want, and the owning tab is resolved from the DOM at click time:

```html
<a href="#video-intelligence-section" data-admin-link="video-intelligence-section">
```
```js
const pane = document.getElementById(cardId).closest('.tab-pane');
window.showAdminTab(pane.id);
```

Because the tab is *derived* rather than declared, cards can move between tabs and tabs can be renamed or regrouped without touching a single link. Card ids are the only contract — and the template split already proved those are stable, preserving all 110 byte-identically.

The destination card is briefly highlighted so it's obvious where you landed.

`switchTab` had no callers left and is removed, so the old coupling can't be reintroduced by copy-paste.

## Stage B — settings announce what they need

Dependencies were previously communicated four different ways, none actionable:

| Dependency | How it was communicated |
|---|---|
| File Sync needs Redis Cache | Static server alert + `flash()` after saving |
| FeedbackAdmin role needs User Feedback | One sentence of prose |
| Backup source blobs need Enhanced Citations | Tooltip |
| Web Search needs consent | `flash()` after saving |

A card now declares its prerequisite, and a shared module renders an inline notice with **two ways to act** — a mirror switch to satisfy it without leaving the tab, and a link straight to its card:

```html
<div class="card" id="file-sync-section"
     data-requires="enable_redis_cache"
     data-requires-label="Redis Cache"
     data-requires-target="redis-cache-section"
     data-requires-mode="warn">
```

### Three judgement calls worth reviewing

**The mirror carries no `name` attribute.** Admin Settings posts one form read by field name, so a second named control would submit the value twice. The mirror uses `data-dependency-proxy-for` and drives the canonical input instead — exactly one named control per setting is ever submitted. A test enforces this.

**File Sync warns rather than blocks.** The backend already accepts File Sync as *requested* and reconciles once Redis is ready (`requested_enable_file_sync` vs `file_sync_effective_enabled`). Hard-disabling would remove a deferred-intent path that exists on purpose. Everything else blocks.

**Permissions is scoped.** That card holds both the SafetyViolationAdmin and FeedbackAdmin toggles, and only the latter depends on User Feedback. Blanket-disabling would switch off an unrelated control, so it declares `data-requires-scope="#require_member_of_feedback_admin"`. A test asserts this specific scoping, because getting it wrong is silent.

### Deliberately *not* wired

- **Backup source blobs → Enhanced Citations** — already handled in `admin_data_management.js` with its own lock message. A second mechanism could disagree with the first.
- **Multi-modal vision → multi-endpoint** — this is a *fallback*, not a requirement. Vision uses Global Endpoints when available and the legacy GPT deployment otherwise. Gating it would misrepresent the behaviour.
- **Redis Key Vault auth → Key Vault storage** — conditional on a select value, and its inline hint already links correctly after stage A.

### The backend stays authoritative

Client-side gating is a usability layer; a disabled input is a courtesy, never a control. `route_frontend_admin_settings.py` still validates and flashes, and a test asserts that enforcement is still present so the notice can't be mistaken for it.

## Also fixed

The User Agreement preview used the same guarded-reassignment shape already corrected for the Home Page Text preview, which reads as unsanitized to static analysis. Now sanitized inline at the sink — `admin_settings.html` passes a **full-file** XSS scan, not just a changed-lines scan.

The File Sync server alert is narrowed to the case the client genuinely can't detect (Redis enabled but missing URL or credentials), so it no longer double-reports with the live notice.

## Verification

- Field names and card ids unchanged: **462 names, 110 card ids identical**
- 75 functional test files covering `admin_settings.html`: **33 pre-existing failures before and after, identical sets**
- All 20 admin templates parse under Jinja
- `check_xss_sinks.py` and `test_xss_guardrails_checker.py` pass locally
- The dependency notice is built with DOM APIs and `textContent`, never string HTML

## New tests

`test_admin_card_links.py` — every link target exists, every href fallback matches, no `switchTab` pattern returns, resolver is wired and derives the tab from the DOM.

`test_admin_settings_dependencies.py` — every prerequisite and link target resolves, the mirror can't double-post, Permissions is correctly scoped, and backend enforcement is still in place.

The first property in each is the one that matters: they fail the build if a card is renamed or removed without updating what points at it — precisely the failure mode that went unnoticed before.

## Next

**Stage C** adds the group navigation level against the current 18 tabs, so grouping is proven before any card moves. **Stage D** re-homes cards one group per commit. **Stage E** splits `system-settings-section` and builds the Access and Roles roster on this module's proxy handling.

Docs: `docs/explanation/fixes/ADMIN_SETTINGS_CARD_TARGETED_LINKS_FIX.md`, `docs/explanation/features/ADMIN_SETTINGS_DEPENDENCY_ANNOUNCEMENTS.md`. Version `0.260.008`.
