### PR TITLE
Admin Settings IA stage C: group navigation rendered from one definition

### DIFF
--- a/application/single_app/admin_settings_nav.py
+++ b/application/single_app/admin_settings_nav.py
@@ -1,0 +1,344 @@
+# admin_settings_nav.py
+"""Single source of truth for the Admin Settings navigation.
+
+The top tab strip and the sidebar previously maintained the same
+structure twice, by hand, and had already drifted: tab order differed
+between them and three tabs carried different labels in each. Both now
+render from this one definition, so they cannot disagree.
+
+Structure is GROUP -> TAB -> SECTION. A section points at a card id in
+the rendered page; card ids are stable and are what cross-references
+resolve against, so cards can move between tabs without breaking links.
+"""
+
+
+ADMIN_NAV = [
+    {
+        "id": "appearance",
+        "label": "Appearance",
+        "icon": "bi-palette",
+        "tabs": [
+            {
+                "id": "general",
+                "label": "General",
+                "icon": "bi-gear",
+                "sections": [
+                    {"id": "branding-section", "label": "Branding", "icon": "bi-palette"},
+                    {"id": "home-page-text-section", "label": "Home Page Text", "icon": "bi-house"},
+                    {"id": "appearance-section", "label": "Appearance", "icon": "bi-brush"},
+                    {"id": "health-check-section", "label": "Health Check", "icon": "bi-heart-pulse"},
+                    {"id": "swagger-section", "label": "API Documentation", "icon": "bi-file-earmark-code"},
+                    {"id": "classification-banner-section", "label": "Classification Banner", "icon": "bi-shield-exclamation"},
+                    {"id": "ai-notice-section", "label": "Chat AI Notice", "icon": "bi-robot"},
+                    {"id": "terms-of-use-section", "label": "Terms of Use", "icon": "bi-door-open"},
+                    {"id": "support-menu-section", "label": "Support", "icon": "bi-life-preserver"},
+                    {"id": "external-links-section", "label": "External Links", "icon": "bi-box-arrow-up-right"},
+                    {"id": "system-settings-section", "label": "System Settings", "icon": "bi-gear-fill"},
+                ],
+            },
+            {
+                "id": "custom-pages",
+                "label": "Custom Pages",
+                "icon": "bi-window-plus",
+                "sections": [
+                    {"id": "custom-pages-section", "label": "Static Pages", "icon": "bi-file-earmark-richtext"},
+                ],
+            },
+        ],
+    },
+    {
+        "id": "chat",
+        "label": "Chat",
+        "icon": "bi-chat-square-text",
+        "tabs": [
+            {
+                "id": "citation",
+                "label": "Citations",
+                "icon": "bi-quote",
+                "sections": [
+                    {"id": "standard-citations-section", "label": "Standard", "icon": "bi-quote"},
+                    {"id": "enhanced-citations-section", "label": "Enhanced", "icon": "bi-star"},
+                ],
+            },
+        ],
+    },
+    {
+        "id": "ai-models",
+        "label": "AI Models",
+        "icon": "bi-cpu",
+        "tabs": [
+            {
+                "id": "ai-models",
+                "label": "AI Models",
+                "icon": "bi-cpu",
+                "sections": [
+                    {"id": "multi-endpoint-configuration", "label": "Model Endpoints", "icon": "bi-hdd-network"},
+                    {"id": "processing-thoughts-section", "label": "Processing Thoughts", "icon": "bi-stars"},
+                    {"id": "shared-conversation-file-approvals-section", "label": "Shared Conversation File Approvals", "icon": "bi-file-earmark-lock"},
+                    {"id": "embeddings-config", "label": "Embeddings", "icon": "bi-vector-pen"},
+                    {"id": "image-config", "label": "Image Generation", "icon": "bi-image"},
+                    {"id": "gpt-config", "label": "Chat Model", "icon": "bi-chat-square-text"},
+                ],
+            },
+        ],
+    },
+    {
+        "id": "agents-actions",
+        "label": "Agents & Actions",
+        "icon": "bi-robot",
+        "tabs": [
+            {
+                "id": "agents",
+                "label": "Agents and Actions",
+                "icon": "bi-robot",
+                "sections": [
+                    {"id": "document-action-capabilities-card", "label": "Document Action Capabilities", "icon": "bi-files"},
+                    {"id": "agents-config", "label": "Agents Configuration", "icon": "bi-robot"},
+                    {"id": "agent-template-approvals-section", "label": "Agent Template Approvals", "icon": "bi-layers", "condition": "enable_agent_template_gallery"},
+                    {"id": "actions-config", "label": "Actions Configuration", "icon": "bi-plugin"},
+                    {"id": "inbound-mcp-configuration", "label": "Inbound MCP", "icon": "bi-diagram-3", "condition": "mcp_ui_enabled"},
+                ],
+            },
+        ],
+    },
+    {
+        "id": "workspaces",
+        "label": "Workspaces",
+        "icon": "bi-folder",
+        "tabs": [
+            {
+                "id": "workspaces",
+                "label": "Workspaces",
+                "icon": "bi-folder",
+                "sections": [
+                    {"id": "personal-workspaces-section", "label": "Personal Workspaces", "icon": "bi-person"},
+                    {"id": "workflow-settings-section", "label": "Workflow", "icon": "bi-diagram-3"},
+                    {"id": "file-download-settings-section", "label": "File Downloads", "icon": "bi-download"},
+                    {"id": "group-workspaces-section", "label": "Group Workspaces", "icon": "bi-people"},
+                    {"id": "public-workspaces-section", "label": "Public Workspaces", "icon": "bi-globe"},
+                    {"id": "file-sharing-section", "label": "File Sharing", "icon": "bi-share"},
+                    {"id": "chat-file-uploads-section", "label": "Chat File Uploads", "icon": "bi-paperclip"},
+                    {"id": "metadata-extraction-section", "label": "Metadata Extraction", "icon": "bi-file-earmark-code"},
+                    {"id": "multimodal-vision-section", "label": "Multi-Modal Vision Analysis", "icon": "bi-eye"},
+                    {"id": "document-classification-section", "label": "Document Classification", "icon": "bi-tags"},
+                    {"id": "retention-policy-section", "label": "Retention Policy", "icon": "bi-hourglass-split"},
+                    {"id": "workspace-scope-lock-section", "label": "Workspace Scope Lock", "icon": "bi-lock"},
+                    {"id": "user-agreement-section", "label": "User Agreement", "icon": "bi-file-earmark-check"},
+                ],
+            },
+            {
+                "id": "workspace-identities",
+                "label": "Global Identities",
+                "icon": "bi-person-badge",
+                "sections": [],
+            },
+        ],
+    },
+    {
+        "id": "knowledge",
+        "label": "Knowledge",
+        "icon": "bi-search",
+        "tabs": [
+            {
+                "id": "search-extract",
+                "label": "Search & Extract",
+                "icon": "bi-search",
+                "sections": [
+                    {"id": "web-search-section", "label": "Web Search", "icon": "bi-globe"},
+                    {"id": "url-access-section", "label": "URL Access", "icon": "bi-link-45deg"},
+                    {"id": "source-review-section", "label": "Deep Research", "icon": "bi-binoculars"},
+                    {"id": "azure-ai-search-section", "label": "Azure AI Search", "icon": "bi-search"},
+                    {"id": "document-intelligence-section", "label": "Document Intelligence", "icon": "bi-file-earmark-text"},
+                    {"id": "chunk-size-section", "label": "Chunk Sizes", "icon": "bi-collection"},
+                    {"id": "video-intelligence-section", "label": "AI Video Intelligence", "icon": "bi-play-circle"},
+                    {"id": "ai-voice-chat-section", "label": "AI Voice Conversations", "icon": "bi-mic"},
+                ],
+            },
+            {
+                "id": "file-sync",
+                "label": "File Sync",
+                "icon": "bi-arrow-repeat",
+                "sections": [
+                    {"id": "file-sync-section", "label": "File Sync", "icon": "bi-arrow-repeat"},
+                    {"id": "file-sync-source-types-section", "label": "Visible Source Types", "icon": "bi-sliders"},
+                    {"id": "file-sync-personal-section", "label": "Personal Workspace Sync", "icon": "bi-person"},
+                    {"id": "file-sync-group-section", "label": "Group Workspace Sync", "icon": "bi-people"},
+                    {"id": "file-sync-public-section", "label": "Public Workspace Sync", "icon": "bi-globe"},
+                ],
+            },
+        ],
+    },
+    {
+        "id": "security",
+        "label": "Security",
+        "icon": "bi-shield-lock",
+        "tabs": [
+            {
+                "id": "security",
+                "label": "Security",
+                "icon": "bi-shield-lock",
+                "sections": [
+                    {"id": "keyvault-section", "label": "Key Vault", "icon": "bi-safe"},
+                ],
+            },
+            {
+                "id": "safety",
+                "label": "Safety",
+                "icon": "bi-shield-check",
+                "sections": [
+                    {"id": "content-safety-section", "label": "Content Safety", "icon": "bi-shield-exclamation"},
+                    {"id": "user-feedback-section", "label": "User Feedback", "icon": "bi-chat-square-heart"},
+                    {"id": "desktop-notifications-section", "label": "Desktop Conversation Notifications", "icon": "bi-bell"},
+                    {"id": "permissions-section", "label": "Permissions", "icon": "bi-person-check"},
+                    {"id": "conversation-archiving-section", "label": "Conversation Archiving", "icon": "bi-archive"},
+                ],
+            },
+        ],
+    },
+    {
+        "id": "governance",
+        "label": "Governance",
+        "icon": "bi-clipboard-check",
+        "tabs": [
+            {
+                "id": "governance",
+                "label": "Governance",
+                "icon": "bi-braces-asterisk",
+                "sections": [
+                    {"id": "governance-feature-toggles-section", "label": "Governance Feature Toggles", "icon": "bi-braces-asterisk"},
+                    {"id": "governance-mcp-destination-section", "label": "MCP Action Destination Governance", "icon": "bi-diagram-3"},
+                    {"id": "governance-inbound-mcp-section", "label": "Inbound MCP Source Governance", "icon": "bi-box-arrow-in-down-right"},
+                    {"id": "governance-feature-policies-section", "label": "Feature Policies", "icon": "bi-sliders2"},
+                    {"id": "governance-item-policies-section", "label": "Delegated Item Policies", "icon": "bi-list-check"},
+                ],
+            },
+        ],
+    },
+    {
+        "id": "backup-recovery",
+        "label": "Backup & Recovery",
+        "icon": "bi-database",
+        "tabs": [
+            {
+                "id": "data-management",
+                "label": "Backup, Migrate &amp; Restore",
+                "icon": "bi-database-check",
+                "sections": [
+                    {"id": "data-management-readiness-section", "label": "Start Here", "icon": "bi-compass"},
+                    {"id": "data-management-backup-section", "label": "Backup", "icon": "bi-archive"},
+                    {"id": "data-management-schedule-section", "label": "Schedule", "icon": "bi-calendar-event"},
+                    {"id": "data-management-storage-section", "label": "Storage", "icon": "bi-hdd"},
+                    {"id": "data-management-encryption-section", "label": "Encryption", "icon": "bi-key"},
+                    {"id": "data-management-migration-section", "label": "Migration", "icon": "bi-arrow-left-right"},
+                    {"id": "data-management-cosmos-editor-section", "label": "Cosmos Editor", "icon": "bi-database-exclamation"},
+                    {"id": "data-management-backup-inventory-section", "label": "Backup Inventory &amp; Restore", "icon": "bi-box-seam"},
+                    {"id": "data-management-jobs-section", "label": "Jobs", "icon": "bi-clock-history"},
+                ],
+            },
+        ],
+    },
+    {
+        "id": "scale",
+        "label": "Scale",
+        "icon": "bi-speedometer2",
+        "tabs": [
+            {
+                "id": "scale",
+                "label": "Scale",
+                "icon": "bi-diagram-3",
+                "sections": [
+                    {"id": "redis-cache-section", "label": "Redis Cache", "icon": "bi-database"},
+                    {"id": "redis-monitoring-section", "label": "Redis Metrics", "icon": "bi-activity"},
+                    {"id": "conversation-cache-section", "label": "Conversation Cache", "icon": "bi-chat-square-text"},
+                    {"id": "document-access-index-section", "label": "DAI Metrics", "icon": "bi-diagram-3"},
+                    {"id": "cosmos-maintenance-section", "label": "Cosmos Maintenance", "icon": "bi-tools"},
+                    {"id": "cosmos-throughput-section", "label": "Cosmos DB Throughput", "icon": "bi-speedometer2"},
+                    {"id": "cosmos-throughput-metrics-table-section", "label": "Cosmos Metrics", "icon": "bi-table"},
+                    {"id": "front-door-section", "label": "Azure Front Door", "icon": "bi-door-open"},
+                ],
+            },
+        ],
+    },
+    {
+        "id": "operations",
+        "label": "Operations",
+        "icon": "bi-activity",
+        "tabs": [
+            {
+                "id": "control-center-config",
+                "label": "Control Center",
+                "icon": "bi-speedometer2",
+                "sections": [
+                    {"id": "control-center-auto-refresh-section", "label": "Automatic Data Refresh", "icon": "bi-calendar-check"},
+                    {"id": "control-center-overview-section", "label": "Control Center Access", "icon": "bi-gear-wide-connected"},
+                ],
+            },
+            {
+                "id": "logging",
+                "label": "Logging",
+                "icon": "bi-journal-text",
+                "sections": [
+                    {"id": "application-insights-section", "label": "Application Insights", "icon": "bi-graph-up"},
+                    {"id": "debug-logging-section", "label": "Debug Logging", "icon": "bi-bug"},
+                    {"id": "file-processing-logs-section", "label": "File Process Logging", "icon": "bi-file-earmark-text"},
+                ],
+            },
+        ],
+    },
+    {
+        "id": "help",
+        "label": "Help",
+        "icon": "bi-life-preserver",
+        "tabs": [
+            {
+                "id": "send-feedback",
+                "label": "Send Feedback",
+                "icon": "bi-envelope-paper",
+                "sections": [
+                    {"id": "send-feedback-overview-card", "label": "Overview", "icon": "bi-info-circle"},
+                    {"id": "send-feedback-bug-card", "label": "Report a Bug", "icon": "bi-bug"},
+                    {"id": "send-feedback-feature-card", "label": "Request a Feature", "icon": "bi-lightbulb"},
+                ],
+            },
+            {
+                "id": "latest-features",
+                "label": "Latest Features",
+                "icon": "bi-lightning-charge",
+                "sections": [],
+                # Rendered specially: it can be hidden per user, carries a New
+                # badge and a hide/unhide menu, and its sections are generated
+                # from the release catalogue rather than declared here.
+                "render": "latest_features",
+            },
+        ],
+    },
+]
+
+
+def iter_tabs():
+    """Yield (group, tab) pairs in navigation order."""
+    for group in ADMIN_NAV:
+        for tab in group["tabs"]:
+            yield group, tab
+
+
+def get_tab_ids():
+    """Return every tab id in navigation order."""
+    return [tab["id"] for _, tab in iter_tabs()]
+
+
+def get_group_for_tab(tab_id):
+    """Return the group owning a tab, or None when the tab is unknown."""
+    for group, tab in iter_tabs():
+        if tab["id"] == tab_id:
+            return group
+    return None
+
+
+def get_section_ids():
+    """Return every section target declared across the navigation."""
+    return [
+        section["id"]
+        for _, tab in iter_tabs()
+        for section in tab["sections"]
+    ]

--- a/application/single_app/app.py
+++ b/application/single_app/app.py
@@ -31,6 +31,7 @@ from functions_authentication import *
 from functions_content import *
 from functions_documents import *
 from functions_latest_features_nav import should_hide_latest_features_nav
+from admin_settings_nav import ADMIN_NAV
 from functions_search import *
 from functions_settings import *
 from functions_mcp_server_config import is_mcp_ui_enabled
@@ -598,6 +599,7 @@ def inject_settings():
         app_settings=public_settings,
         user_settings=user_settings,
         custom_pages_nav=custom_pages_nav,
+        admin_nav=ADMIN_NAV,
         latest_features_current_version=VERSION,
         latest_features_nav_hidden=latest_features_nav_hidden,
         latest_features_nav_hidden_by_development=IS_DEVELOPMENT,

--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -96,7 +96,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.260.009"
+VERSION = "0.260.010"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/static/js/admin/admin_sidebar_nav.js
+++ b/application/single_app/static/js/admin/admin_sidebar_nav.js
@@ -1,6 +1,10 @@
 // admin_sidebar_nav.js
 // Admin Sidebar Navigation
 document.addEventListener('DOMContentLoaded', function() {
+    // The top-nav group pills exist only in the tab layout, so they are wired
+    // independently of the sidebar.
+    setupAdminGroupPills();
+
     // Only initialize if we're on admin settings page with sidebar nav
     if (!document.getElementById('admin-settings-toggle')) return;
     
@@ -77,6 +81,10 @@ function initAdminSidebarNav() {
         });
     }
     
+    // Set up group expand/collapse. Groups are the level above tabs, so a
+    // collapsed group hides its tabs without affecting which tab is active.
+    setupAdminGroupToggles();
+
     // Set up tab navigation
     document.querySelectorAll('.admin-nav-tab').forEach(tabLink => {
         tabLink.addEventListener('click', function(e) {
@@ -149,7 +157,139 @@ function initAdminSidebarNav() {
     }
 }
 
+function setupAdminGroupToggles() {
+    document.querySelectorAll('[data-admin-group-toggle]').forEach(toggle => {
+        toggle.addEventListener('click', function (e) {
+            e.preventDefault();
+            const groupId = this.getAttribute('data-admin-group-toggle');
+            setAdminGroupExpanded(groupId, !isAdminGroupExpanded(groupId), true);
+        });
+    });
+}
+
+/**
+ * Wire the top-nav group pills, which filter the tab strip to one group.
+ * Only relevant in the tab layout; the sidebar layout uses group headers.
+ */
+function setupAdminGroupPills() {
+    const pills = document.querySelectorAll('[data-admin-group-pill]');
+    if (!pills.length) {
+        return;
+    }
+
+    pills.forEach(pill => {
+        pill.addEventListener('click', function () {
+            showAdminGroupTabs(this.getAttribute('data-admin-group-pill'), true);
+        });
+    });
+}
+
+/**
+ * Show one group's tabs in the top strip.
+ * @param {string} groupId Group to reveal.
+ * @param {boolean} activateFirstTab Whether to open that group's first tab.
+ */
+function showAdminGroupTabs(groupId, activateFirstTab) {
+    document.querySelectorAll('[data-admin-group-pill]').forEach(pill => {
+        const selected = pill.getAttribute('data-admin-group-pill') === groupId;
+        pill.classList.toggle('active', selected);
+        pill.setAttribute('aria-selected', selected ? 'true' : 'false');
+    });
+
+    let firstTabButton = null;
+    document.querySelectorAll('.admin-tab-item').forEach(item => {
+        const inGroup = item.getAttribute('data-admin-group') === groupId;
+        item.hidden = !inGroup;
+        if (inGroup && !firstTabButton) {
+            firstTabButton = item.querySelector('button[data-bs-target]');
+        }
+    });
+
+    if (activateFirstTab && firstTabButton) {
+        const target = firstTabButton.getAttribute('data-bs-target') || '';
+        showAdminTab(target.replace('#', ''));
+    }
+}
+
+/**
+ * Reveal the group owning a tab in the top strip, so a deep link or a
+ * cross-reference never activates a pane whose tab is filtered out of view.
+ * @param {string} tabId Tab pane id.
+ */
+function revealAdminGroupPillForTab(tabId) {
+    const item = document.querySelector(`.admin-tab-item [data-bs-target="#${tabId}"]`);
+    const groupItem = item && item.closest('.admin-tab-item');
+    if (!groupItem) {
+        return;
+    }
+
+    const groupId = groupItem.getAttribute('data-admin-group');
+    if (groupId && groupItem.hidden) {
+        showAdminGroupTabs(groupId, false);
+    }
+}
+
+function getAdminGroupElements(groupId) {
+    return {
+        toggle: document.querySelector(`[data-admin-group-toggle="${groupId}"]`),
+        list: document.getElementById(`admin-group-${groupId}`),
+    };
+}
+
+function isAdminGroupExpanded(groupId) {
+    const { list } = getAdminGroupElements(groupId);
+    return Boolean(list) && !list.classList.contains('d-none');
+}
+
+/**
+ * Expand or collapse a nav group.
+ * @param {string} groupId Group identifier.
+ * @param {boolean} expanded Desired state.
+ * @param {boolean} persist Whether to remember the state for this user.
+ */
+function setAdminGroupExpanded(groupId, expanded, persist) {
+    const { toggle, list } = getAdminGroupElements(groupId);
+    if (!toggle || !list) {
+        return;
+    }
+
+    list.classList.toggle('d-none', !expanded);
+    toggle.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+
+    const caret = toggle.querySelector('.admin-nav-group-caret');
+    if (caret) {
+        caret.classList.toggle('collapsed', !expanded);
+    }
+
+    if (persist && typeof window.setPersistentSidebarMenuExpanded === 'function') {
+        window.setPersistentSidebarMenuExpanded(`adminGroup:${groupId}`, expanded);
+    }
+}
+
+/**
+ * Open the group that owns a tab, so activating a tab never leaves it hidden.
+ * @param {string} tabId Tab pane id.
+ */
+function revealAdminGroupForTab(tabId) {
+    const tabLink = document.querySelector(`.admin-nav-tab[data-tab="${tabId}"]`);
+    const groupItem = tabLink && tabLink.closest('[data-admin-group]');
+    if (!groupItem) {
+        return;
+    }
+
+    const groupId = groupItem.getAttribute('data-admin-group');
+    if (!isAdminGroupExpanded(groupId)) {
+        setAdminGroupExpanded(groupId, true, true);
+    }
+}
+
 function showAdminTab(tabId) {    
+    // Open the owning group first, in whichever layout is active, so
+    // activating a tab never leaves it hidden behind a collapsed group header
+    // or filtered out of the top strip.
+    revealAdminGroupForTab(tabId);
+    revealAdminGroupPillForTab(tabId);
+
     const bootstrapTabButton = document.querySelector(`button.nav-link[data-bs-target="#${tabId}"]`);
     if (bootstrapTabButton && typeof bootstrap !== 'undefined' && typeof bootstrap.Tab === 'function') {
         const tab = bootstrap.Tab.getOrCreateInstance(bootstrapTabButton);
@@ -247,112 +387,171 @@ style.textContent = `
     .admin-search-hidden {
         display: none !important;
     }
+    .admin-nav-group {
+        font-weight: 500;
+        letter-spacing: 0.01em;
+    }
+    .admin-nav-group:hover {
+        background-color: rgba(0, 0, 0, 0.05);
+    }
+    .admin-nav-group-caret {
+        font-size: 0.75em;
+        transition: transform 0.2s ease;
+    }
+    .admin-nav-group-caret.collapsed {
+        transform: rotate(-90deg);
+    }
 `;
 document.head.appendChild(style);
 
 // Admin search functionality
 function filterAdminSections(searchTerm) {
     const normalizedSearch = searchTerm.toLowerCase().trim();
-    
+
     if (!normalizedSearch) {
-        // Show all sections if search is empty
         showAllAdminSections();
         return;
     }
-    
+
     let hasVisibleSections = false;
-    
-    // Get all admin nav items
+
+    const groupItems = document.querySelectorAll('.admin-nav-group-item');
     const allTabs = document.querySelectorAll('.admin-nav-tab');
     const allSections = document.querySelectorAll('.admin-nav-section');
-    
-    // Hide all sections and tabs initially
+
+    // Start from everything hidden, then reveal what matches.
+    groupItems.forEach(group => group.classList.add('admin-search-hidden'));
+    document.querySelectorAll('.admin-nav-group').forEach(group => {
+        group.classList.remove('admin-search-highlight');
+    });
+
     allTabs.forEach(tab => {
         tab.closest('li').classList.add('admin-search-hidden');
-        // Hide submenu
+        tab.classList.remove('admin-search-highlight');
         const submenu = document.getElementById(tab.getAttribute('data-tab') + '-submenu');
         if (submenu) {
             submenu.style.display = 'none';
         }
     });
-    
+
     allSections.forEach(section => {
         section.closest('li').classList.add('admin-search-hidden');
         section.classList.remove('admin-search-highlight');
     });
-    
-    // Search through tabs and sections
+
+    /**
+     * Reveal the group containing an element and expand its tab list, so a
+     * match is never left hidden behind a collapsed group.
+     * @param {HTMLElement} element Element inside a group.
+     */
+    const revealGroupOf = (element) => {
+        const groupItem = element.closest('.admin-nav-group-item');
+        if (!groupItem) {
+            return;
+        }
+        groupItem.classList.remove('admin-search-hidden');
+        const list = groupItem.querySelector('.admin-nav-group-tabs');
+        if (list) {
+            list.classList.remove('d-none');
+        }
+    };
+
+    // A group matching by name reveals everything it holds.
+    document.querySelectorAll('.admin-nav-group').forEach(group => {
+        const label = group.querySelector('.nav-text');
+        if (!label || !label.textContent.toLowerCase().includes(normalizedSearch)) {
+            return;
+        }
+
+        group.classList.add('admin-search-highlight');
+        revealGroupOf(group);
+        hasVisibleSections = true;
+
+        const groupItem = group.closest('.admin-nav-group-item');
+        groupItem.querySelectorAll('.admin-nav-tab').forEach(tab => {
+            tab.closest('li').classList.remove('admin-search-hidden');
+        });
+    });
+
     allTabs.forEach(tab => {
-        const tabText = tab.querySelector('.nav-text').textContent.toLowerCase();
+        const label = tab.querySelector('.nav-text');
+        const tabText = label ? label.textContent.toLowerCase() : '';
         const tabId = tab.getAttribute('data-tab');
         let tabHasMatch = false;
-        
-        // Check if tab name matches
+
         if (tabText.includes(normalizedSearch)) {
             tab.closest('li').classList.remove('admin-search-hidden');
             tab.classList.add('admin-search-highlight');
+            revealGroupOf(tab);
             tabHasMatch = true;
             hasVisibleSections = true;
-            
-            // Show submenu for matched tab
+
             const submenu = document.getElementById(tabId + '-submenu');
             if (submenu) {
                 submenu.style.display = 'block';
-                // Show all sections under this tab
                 submenu.querySelectorAll('.admin-nav-section').forEach(section => {
                     section.closest('li').classList.remove('admin-search-hidden');
                 });
             }
         }
-        
-        // Check sections under this tab
+
         const sections = document.querySelectorAll(`.admin-nav-section[data-tab="${tabId}"]`);
         let sectionHasMatch = false;
-        
+
         sections.forEach(section => {
-            const sectionText = section.querySelector('.nav-text').textContent.toLowerCase();
-            
+            const sectionLabel = section.querySelector('.nav-text');
+            const sectionText = sectionLabel ? sectionLabel.textContent.toLowerCase() : '';
+
             if (sectionText.includes(normalizedSearch)) {
-                // Show the section
                 section.closest('li').classList.remove('admin-search-hidden');
                 section.classList.add('admin-search-highlight');
                 sectionHasMatch = true;
                 hasVisibleSections = true;
-                
-                // Show the parent tab
+
                 tab.closest('li').classList.remove('admin-search-hidden');
-                
-                // Show the submenu
+                revealGroupOf(tab);
+
                 const submenu = document.getElementById(tabId + '-submenu');
                 if (submenu) {
                     submenu.style.display = 'block';
                 }
             }
         });
-        
-        // If tab has matching sections but doesn't match itself, remove tab highlight
+
+        // A tab surfaced only because a section matched is not itself a hit.
         if (sectionHasMatch && !tabHasMatch) {
             tab.classList.remove('admin-search-highlight');
         }
     });
-    
-    // Show "No results" message if nothing found
+
     showSearchResults(hasVisibleSections, normalizedSearch);
 }
 
 function showAllAdminSections() {
-    // Remove all search-related classes and show all items
-    document.querySelectorAll('.admin-nav-tab, .admin-nav-section').forEach(item => {
-        item.closest('li').classList.remove('admin-search-hidden');
+    // Restore the normal browsing state: nothing hidden, nothing highlighted,
+    // submenus closed, and groups back to their persisted expansion.
+    document.querySelectorAll('.admin-nav-group-item').forEach(group => {
+        group.classList.remove('admin-search-hidden');
+    });
+
+    document.querySelectorAll('.admin-nav-tab, .admin-nav-section, .admin-nav-group').forEach(item => {
+        const listItem = item.closest('li');
+        if (listItem) {
+            listItem.classList.remove('admin-search-hidden');
+        }
         item.classList.remove('admin-search-highlight');
     });
-    
-    // Hide all submenus (normal collapsed state)
+
     document.querySelectorAll('[id$="-submenu"]').forEach(submenu => {
         submenu.style.display = 'none';
     });
-    
-    // Remove search results message
+
+    document.querySelectorAll('[data-admin-group-toggle]').forEach(toggle => {
+        const groupId = toggle.getAttribute('data-admin-group-toggle');
+        const expanded = toggle.getAttribute('aria-expanded') === 'true';
+        setAdminGroupExpanded(groupId, expanded, false);
+    });
+
     hideSearchResults();
 }
 

--- a/application/single_app/templates/_sidebar_nav.html
+++ b/application/single_app/templates/_sidebar_nav.html
@@ -441,559 +441,28 @@
         </div>
       </div>
       <div id="admin-settings-section"{% if not admin_settings_menu_expanded %} class="d-none"{% endif %} aria-hidden="{{ 'false' if admin_settings_menu_expanded else 'true' }}">
-        <ul class="nav flex-column mb-2">
-          <li class="nav-item">
-            <a class="nav-link d-flex align-items-center admin-nav-tab" href="#" data-tab="general">
-              <i class="bi bi-gear me-2"></i><span class="nav-text">General</span>
+        <ul class="nav flex-column mb-2" id="admin-nav-groups">
+          {% for admin_group in admin_nav %}
+          {% set group_state_key = 'adminGroup:' ~ admin_group.id %}
+          {% set group_expanded = sidebar_menu_state.get(group_state_key, false) %}
+          <li class="nav-item admin-nav-group-item" data-admin-group="{{ admin_group.id }}">
+            <a class="nav-link d-flex align-items-center justify-content-between admin-nav-group"
+               href="#"
+               role="button"
+               aria-expanded="{{ 'true' if group_expanded else 'false' }}"
+               aria-controls="admin-group-{{ admin_group.id }}"
+               data-admin-group-toggle="{{ admin_group.id }}">
+              <span class="d-flex align-items-center">
+                <i class="bi {{ admin_group.icon }} me-2" aria-hidden="true"></i>
+                <span class="nav-text">{{ admin_group.label }}</span>
+              </span>
+              <i class="bi bi-chevron-down admin-nav-group-caret{% if not group_expanded %} collapsed{% endif %}"
+                 aria-hidden="true"></i>
             </a>
-            <ul class="nav flex-column ms-3" style="display: none;" id="general-submenu">
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="general" data-section="branding-section">
-                  <i class="bi bi-palette me-2" style="font-size: 0.8em;"></i><span class="nav-text">Branding</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="general" data-section="home-page-text-section">
-                  <i class="bi bi-house me-2" style="font-size: 0.8em;"></i><span class="nav-text">Home Page Text</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="general" data-section="appearance-section">
-                  <i class="bi bi-brush me-2" style="font-size: 0.8em;"></i><span class="nav-text">Appearance</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="general" data-section="health-check-section">
-                  <i class="bi bi-heart-pulse me-2" style="font-size: 0.8em;"></i><span class="nav-text">Health Check</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="general" data-section="swagger-section">
-                  <i class="bi bi-file-earmark-code me-2" style="font-size: 0.8em;"></i><span class="nav-text">API Documentation</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="general" data-section="classification-banner-section">
-                  <i class="bi bi-shield-exclamation me-2" style="font-size: 0.8em;"></i><span class="nav-text">Classification Banner</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="general" data-section="ai-notice-section">
-                  <i class="bi bi-robot me-2" style="font-size: 0.8em;"></i><span class="nav-text">Chat AI Notice</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="general" data-section="terms-of-use-section">
-                  <i class="bi bi-door-open me-2" style="font-size: 0.8em;"></i><span class="nav-text">Terms of Use</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="general" data-section="support-menu-section">
-                  <i class="bi bi-life-preserver me-2" style="font-size: 0.8em;"></i><span class="nav-text">Support</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="general" data-section="external-links-section">
-                  <i class="bi bi-box-arrow-up-right me-2" style="font-size: 0.8em;"></i><span class="nav-text">External Links</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="general" data-section="system-settings-section">
-                  <i class="bi bi-gear-fill me-2" style="font-size: 0.8em;"></i><span class="nav-text">System Settings</span>
-                </a>
-              </li>
-            </ul>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link d-flex align-items-center admin-nav-tab" href="#" data-tab="custom-pages">
-              <i class="bi bi-window-plus me-2"></i><span class="nav-text">Custom Pages</span>
-            </a>
-            <ul class="nav flex-column ms-3" style="display: none;" id="custom-pages-submenu">
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="custom-pages" data-section="custom-pages-section">
-                  <i class="bi bi-file-earmark-richtext me-2" style="font-size: 0.8em;"></i><span class="nav-text">Static Pages</span>
-                </a>
-              </li>
-            </ul>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link d-flex align-items-center admin-nav-tab" href="#" data-tab="ai-models">
-              <i class="bi bi-cpu me-2"></i><span class="nav-text">AI Models</span>
-            </a>
-            <ul class="nav flex-column ms-3" style="display: none;" id="ai-models-submenu">
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="ai-models" data-section="multi-endpoint-configuration">
-                  <i class="bi bi-hdd-network me-2" style="font-size: 0.8em;"></i><span class="nav-text">Model Endpoints</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="ai-models" data-section="processing-thoughts-section">
-                  <i class="bi bi-stars me-2" style="font-size: 0.8em;"></i><span class="nav-text">Processing Thoughts</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="ai-models" data-section="embeddings-config">
-                  <i class="bi bi-vector-pen me-2" style="font-size: 0.8em;"></i><span class="nav-text">Embeddings</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="ai-models" data-section="image-config">
-                  <i class="bi bi-image me-2" style="font-size: 0.8em;"></i><span class="nav-text">Image Generation</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="ai-models" data-section="gpt-config">
-                  <i class="bi bi-chat-square-text me-2" style="font-size: 0.8em;"></i><span class="nav-text">Chat Model</span>
-                </a>
-              </li>
-            </ul>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link d-flex align-items-center admin-nav-tab" href="#" data-tab="agents">
-              <i class="bi bi-robot me-2"></i><span class="nav-text">Agents and Actions</span>
-            </a>
-            <ul class="nav flex-column ms-3" style="display: none;" id="agents-submenu">
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="agents" data-section="document-action-capabilities-card">
-                  <i class="bi bi-files me-2" style="font-size: 0.8em;"></i><span class="nav-text">Document Action Capabilities</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="agents" data-section="agents-config">
-                  <i class="bi bi-robot me-2" style="font-size: 0.8em;"></i><span class="nav-text">Agents Configuration</span>
-                </a>
-              </li>
-              {% if app_settings.enable_agent_template_gallery %}
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="agents" data-section="agent-template-approvals-section">
-                  <i class="bi bi-layers me-2" style="font-size: 0.8em;"></i><span class="nav-text">Agent Template Approvals</span>
-                </a>
-              </li>
-              {% endif %}
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="agents" data-section="actions-config">
-                  <i class="bi bi-plugin me-2" style="font-size: 0.8em;"></i><span class="nav-text">Actions Configuration</span>
-                </a>
-              </li>
-              {% if mcp_ui_enabled %}
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="agents" data-section="inbound-mcp-configuration">
-                  <i class="bi bi-diagram-3 me-2" style="font-size: 0.8em;"></i><span class="nav-text">Inbound MCP</span>
-                </a>
-              </li>
-              {% endif %}
-            </ul>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link d-flex align-items-center admin-nav-tab" href="#" data-tab="logging">
-              <i class="bi bi-journal-text me-2"></i><span class="nav-text">Logging</span>
-            </a>
-            <ul class="nav flex-column ms-3" style="display: none;" id="logging-submenu">
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="logging" data-section="application-insights-section">
-                  <i class="bi bi-graph-up me-2" style="font-size: 0.8em;"></i><span class="nav-text">Application Insights</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="logging" data-section="debug-logging-section">
-                  <i class="bi bi-bug me-2" style="font-size: 0.8em;"></i><span class="nav-text">Debug Logging</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="logging" data-section="file-processing-logs-section">
-                  <i class="bi bi-file-earmark-text me-2" style="font-size: 0.8em;"></i><span class="nav-text">File Process Logging</span>
-                </a>
-              </li>
-            </ul>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link d-flex align-items-center admin-nav-tab" href="#" data-tab="scale">
-              <i class="bi bi-diagram-3 me-2"></i><span class="nav-text">Scale</span>
-            </a>
-            <ul class="nav flex-column ms-3" style="display: none;" id="scale-submenu">
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="scale" data-section="redis-cache-section">
-                  <i class="bi bi-database me-2" style="font-size: 0.8em;"></i><span class="nav-text">Redis Cache</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="scale" data-section="redis-monitoring-section">
-                  <i class="bi bi-activity me-2" style="font-size: 0.8em;"></i><span class="nav-text">Redis Metrics</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="scale" data-section="conversation-cache-section">
-                  <i class="bi bi-chat-square-text me-2" style="font-size: 0.8em;"></i><span class="nav-text">Conversation Cache</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="scale" data-section="document-access-index-section">
-                  <i class="bi bi-diagram-3 me-2" style="font-size: 0.8em;"></i><span class="nav-text">DAI Metrics</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="scale" data-section="cosmos-maintenance-section">
-                  <i class="bi bi-tools me-2" style="font-size: 0.8em;"></i><span class="nav-text">Cosmos Maintenance</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="scale" data-section="cosmos-throughput-section">
-                  <i class="bi bi-speedometer2 me-2" style="font-size: 0.8em;"></i><span class="nav-text">Cosmos DB Throughput</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="scale" data-section="cosmos-throughput-metrics-table-section">
-                  <i class="bi bi-table me-2" style="font-size: 0.8em;"></i><span class="nav-text">Cosmos Metrics</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="scale" data-section="front-door-section">
-                  <i class="bi bi-door-open me-2" style="font-size: 0.8em;"></i><span class="nav-text">Azure Front Door</span>
-                </a>
-              </li>
-            </ul>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link d-flex align-items-center admin-nav-tab" href="#" data-tab="control-center-config">
-              <i class="bi bi-speedometer2 me-2"></i><span class="nav-text">Control Center</span>
-            </a>
-            <ul class="nav flex-column ms-3" style="display: none;" id="control-center-config-submenu">
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="control-center-config" data-section="control-center-auto-refresh-section">
-                  <i class="bi bi-calendar-check me-2" style="font-size: 0.8em;"></i><span class="nav-text">Automatic Data Refresh</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="control-center-config" data-section="control-center-overview-section">
-                  <i class="bi bi-gear-wide-connected me-2" style="font-size: 0.8em;"></i><span class="nav-text">Control Center Access</span>
-                </a>
-              </li>
-            </ul>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link d-flex align-items-center admin-nav-tab" href="#" data-tab="data-management">
-              <i class="bi bi-database-check me-2"></i><span class="nav-text">Backup, Migrate &amp; Restore</span>
-            </a>
-            <ul class="nav flex-column ms-3" style="display: none;" id="data-management-submenu">
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="data-management" data-section="data-management-readiness-section">
-                  <i class="bi bi-compass me-2" style="font-size: 0.8em;"></i><span class="nav-text">Start Here</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="data-management" data-section="data-management-backup-section">
-                  <i class="bi bi-archive me-2" style="font-size: 0.8em;"></i><span class="nav-text">Backup</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="data-management" data-section="data-management-schedule-section">
-                  <i class="bi bi-calendar-event me-2" style="font-size: 0.8em;"></i><span class="nav-text">Schedule</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="data-management" data-section="data-management-storage-section">
-                  <i class="bi bi-hdd me-2" style="font-size: 0.8em;"></i><span class="nav-text">Storage</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="data-management" data-section="data-management-encryption-section">
-                  <i class="bi bi-key me-2" style="font-size: 0.8em;"></i><span class="nav-text">Encryption</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="data-management" data-section="data-management-migration-section">
-                  <i class="bi bi-arrow-left-right me-2" style="font-size: 0.8em;"></i><span class="nav-text">Migration</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="data-management" data-section="data-management-cosmos-editor-section">
-                  <i class="bi bi-database-exclamation me-2" style="font-size: 0.8em;"></i><span class="nav-text">Cosmos Editor</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="data-management" data-section="data-management-backup-inventory-section">
-                  <i class="bi bi-box-seam me-2" style="font-size: 0.8em;"></i><span class="nav-text">Backup Inventory &amp; Restore</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="data-management" data-section="data-management-jobs-section">
-                  <i class="bi bi-clock-history me-2" style="font-size: 0.8em;"></i><span class="nav-text">Jobs</span>
-                </a>
-              </li>
-            </ul>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link d-flex align-items-center admin-nav-tab" href="#" data-tab="governance">
-              <i class="bi bi-braces-asterisk me-2"></i><span class="nav-text">Governance</span>
-            </a>
-            <ul class="nav flex-column ms-3" style="display: none;" id="governance-submenu">
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="governance" data-section="governance-feature-toggles-section">
-                  <i class="bi bi-braces-asterisk me-2" style="font-size: 0.8em;"></i><span class="nav-text">Governance Feature Toggles</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="governance" data-section="governance-mcp-destination-section">
-                  <i class="bi bi-diagram-3 me-2" style="font-size: 0.8em;"></i><span class="nav-text">MCP Action Destination Governance</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="governance" data-section="governance-inbound-mcp-section">
-                  <i class="bi bi-box-arrow-in-down-right me-2" style="font-size: 0.8em;"></i><span class="nav-text">Inbound MCP Source Governance</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="governance" data-section="governance-feature-policies-section">
-                  <i class="bi bi-sliders2 me-2" style="font-size: 0.8em;"></i><span class="nav-text">Feature Policies</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="governance" data-section="governance-item-policies-section">
-                  <i class="bi bi-list-check me-2" style="font-size: 0.8em;"></i><span class="nav-text">Delegated Item Policies</span>
-                </a>
-              </li>
-            </ul>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link d-flex align-items-center admin-nav-tab" href="#" data-tab="workspaces">
-              <i class="bi bi-folder me-2"></i><span class="nav-text">Workspaces</span>
-            </a>
-            <ul class="nav flex-column ms-3" style="display: none;" id="workspaces-submenu">
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="workspaces" data-section="personal-workspaces-section">
-                  <i class="bi bi-person me-2" style="font-size: 0.8em;"></i><span class="nav-text">Personal Workspaces</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="workspaces" data-section="workflow-settings-section">
-                  <i class="bi bi-diagram-3 me-2" style="font-size: 0.8em;"></i><span class="nav-text">Workflow</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="workspaces" data-section="file-download-settings-section">
-                  <i class="bi bi-download me-2" style="font-size: 0.8em;"></i><span class="nav-text">File Downloads</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="workspaces" data-section="group-workspaces-section">
-                  <i class="bi bi-people me-2" style="font-size: 0.8em;"></i><span class="nav-text">Group Workspaces</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="workspaces" data-section="public-workspaces-section">
-                  <i class="bi bi-globe me-2" style="font-size: 0.8em;"></i><span class="nav-text">Public Workspaces</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="workspaces" data-section="file-sharing-section">
-                  <i class="bi bi-share me-2" style="font-size: 0.8em;"></i><span class="nav-text">File Sharing</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="workspaces" data-section="chat-file-uploads-section">
-                  <i class="bi bi-paperclip me-2" style="font-size: 0.8em;"></i><span class="nav-text">Chat File Uploads</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="workspaces" data-section="metadata-extraction-section">
-                  <i class="bi bi-file-earmark-code me-2" style="font-size: 0.8em;"></i><span class="nav-text">Metadata Extraction</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="workspaces" data-section="multimodal-vision-section">
-                  <i class="bi bi-eye me-2" style="font-size: 0.8em;"></i><span class="nav-text">Multi-Modal Vision Analysis</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="workspaces" data-section="document-classification-section">
-                  <i class="bi bi-tags me-2" style="font-size: 0.8em;"></i><span class="nav-text">Document Classification</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="workspaces" data-section="retention-policy-section">
-                  <i class="bi bi-hourglass-split me-2" style="font-size: 0.8em;"></i><span class="nav-text">Retention Policy</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="workspaces" data-section="workspace-scope-lock-section">
-                  <i class="bi bi-lock me-2" style="font-size: 0.8em;"></i><span class="nav-text">Workspace Scope Lock</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="workspaces" data-section="user-agreement-section">
-                  <i class="bi bi-file-earmark-check me-2" style="font-size: 0.8em;"></i><span class="nav-text">User Agreement</span>
-                </a>
-              </li>
-            </ul>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link d-flex align-items-center admin-nav-tab" href="#" data-tab="file-sync">
-              <i class="bi bi-arrow-repeat me-2"></i><span class="nav-text">File Sync</span>
-            </a>
-            <ul class="nav flex-column ms-3" style="display: none;" id="file-sync-submenu">
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="file-sync" data-section="file-sync-section">
-                  <i class="bi bi-arrow-repeat me-2" style="font-size: 0.8em;"></i><span class="nav-text">File Sync</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="file-sync" data-section="file-sync-source-types-section">
-                  <i class="bi bi-sliders me-2" style="font-size: 0.8em;"></i><span class="nav-text">Visible Source Types</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="file-sync" data-section="file-sync-personal-section">
-                  <i class="bi bi-person me-2" style="font-size: 0.8em;"></i><span class="nav-text">Personal Workspace Sync</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="file-sync" data-section="file-sync-group-section">
-                  <i class="bi bi-people me-2" style="font-size: 0.8em;"></i><span class="nav-text">Group Workspace Sync</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="file-sync" data-section="file-sync-public-section">
-                  <i class="bi bi-globe me-2" style="font-size: 0.8em;"></i><span class="nav-text">Public Workspace Sync</span>
-                </a>
-              </li>
-            </ul>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link d-flex align-items-center admin-nav-tab" href="#" data-tab="workspace-identities">
-              <i class="bi bi-person-badge me-2"></i><span class="nav-text">Global Identities</span>
-            </a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link d-flex align-items-center admin-nav-tab" href="#" data-tab="citation">
-              <i class="bi bi-quote me-2"></i><span class="nav-text">Citations</span>
-            </a>
-            <ul class="nav flex-column ms-3" style="display: none;" id="citation-submenu">
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="citation" data-section="standard-citations-section">
-                  <i class="bi bi-quote me-2" style="font-size: 0.8em;"></i><span class="nav-text">Standard</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="citation" data-section="enhanced-citations-section">
-                  <i class="bi bi-star me-2" style="font-size: 0.8em;"></i><span class="nav-text">Enhanced</span>
-                </a>
-              </li>
-            </ul>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link d-flex align-items-center admin-nav-tab" href="#" data-tab="safety">
-              <i class="bi bi-shield-check me-2"></i><span class="nav-text">Safety</span>
-            </a>
-            <ul class="nav flex-column ms-3" style="display: none;" id="safety-submenu">
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="safety" data-section="content-safety-section">
-                  <i class="bi bi-shield-exclamation me-2" style="font-size: 0.8em;"></i><span class="nav-text">Content Safety</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="safety" data-section="user-feedback-section">
-                  <i class="bi bi-chat-square-heart me-2" style="font-size: 0.8em;"></i><span class="nav-text">User Feedback</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="safety" data-section="desktop-notifications-section">
-                  <i class="bi bi-bell me-2" style="font-size: 0.8em;"></i><span class="nav-text">Desktop Conversation Notifications</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="safety" data-section="permissions-section">
-                  <i class="bi bi-person-check me-2" style="font-size: 0.8em;"></i><span class="nav-text">Permissions</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="safety" data-section="conversation-archiving-section">
-                  <i class="bi bi-archive me-2" style="font-size: 0.8em;"></i><span class="nav-text">Conversation Archiving</span>
-                </a>
-              </li>
-            </ul>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link d-flex align-items-center admin-nav-tab" href="#" data-tab="security">
-              <i class="bi bi-shield-lock me-2"></i><span class="nav-text">Security</span>
-            </a>
-            <ul class="nav flex-column ms-3" style="display: none;" id="security-submenu">
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="security" data-section="keyvault-section">
-                  <i class="bi bi-safe me-2" style="font-size: 0.8em;"></i><span class="nav-text">Key Vault</span>
-                </a>
-              </li>
-            </ul>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link d-flex align-items-center admin-nav-tab" href="#" data-tab="search-extract">
-              <i class="bi bi-search me-2"></i><span class="nav-text">Search & Extract</span>
-            </a>
-            <ul class="nav flex-column ms-3" style="display: none;" id="search-extract-submenu">
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="search-extract" data-section="web-search-section">
-                  <i class="bi bi-globe me-2" style="font-size: 0.8em;"></i><span class="nav-text">Web Search</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="search-extract" data-section="url-access-section">
-                  <i class="bi bi-link-45deg me-2" style="font-size: 0.8em;"></i><span class="nav-text">URL Access</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="search-extract" data-section="source-review-section">
-                  <i class="bi bi-binoculars me-2" style="font-size: 0.8em;"></i><span class="nav-text">Deep Research</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="search-extract" data-section="azure-ai-search-section">
-                  <i class="bi bi-search me-2" style="font-size: 0.8em;"></i><span class="nav-text">Azure AI Search</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="search-extract" data-section="document-intelligence-section">
-                  <i class="bi bi-file-earmark-text me-2" style="font-size: 0.8em;"></i><span class="nav-text">Document Intelligence</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="search-extract" data-section="chunk-size-section">
-                  <i class="bi bi-collection me-2" style="font-size: 0.8em;"></i><span class="nav-text">Chunk Sizes</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="search-extract" data-section="video-intelligence-section">
-                  <i class="bi bi-play-circle me-2" style="font-size: 0.8em;"></i><span class="nav-text">AI Video Intelligence</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="search-extract" data-section="ai-voice-chat-section">
-                  <i class="bi bi-mic me-2" style="font-size: 0.8em;"></i><span class="nav-text">AI Voice Conversations</span>
-                </a>
-              </li>
-            </ul>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link d-flex align-items-center admin-nav-tab" href="#" data-tab="send-feedback">
-              <i class="bi bi-envelope-paper me-2"></i><span class="nav-text">Send Feedback</span>
-            </a>
-            <ul class="nav flex-column ms-3" style="display: none;" id="send-feedback-submenu">
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="send-feedback" data-section="send-feedback-overview-card">
-                  <i class="bi bi-info-circle me-2" style="font-size: 0.8em;"></i><span class="nav-text">Overview</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="send-feedback" data-section="send-feedback-bug-card">
-                  <i class="bi bi-bug me-2" style="font-size: 0.8em;"></i><span class="nav-text">Report a Bug</span>
-                </a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="send-feedback" data-section="send-feedback-feature-card">
-                  <i class="bi bi-lightbulb me-2" style="font-size: 0.8em;"></i><span class="nav-text">Request a Feature</span>
-                </a>
-              </li>
-            </ul>
-          </li>
-          {# Latest Features stays last so it never opens by default #}
+            <ul class="nav flex-column ms-2 admin-nav-group-tabs{% if not group_expanded %} d-none{% endif %}"
+                id="admin-group-{{ admin_group.id }}">
+              {% for admin_tab in admin_group.tabs %}
+              {% if admin_tab.render == 'latest_features' %}
           {% if not latest_features_nav_is_hidden %}
           <li class="nav-item latest-features-nav-item" data-latest-features-nav-item>
             <div class="d-flex align-items-center">
@@ -1047,6 +516,32 @@
             </ul>
           </li>
           {% endif %}
+              {% else %}
+              <li class="nav-item">
+                <a class="nav-link d-flex align-items-center admin-nav-tab" href="#" data-tab="{{ admin_tab.id }}">
+                  <i class="bi {{ admin_tab.icon }} me-2" aria-hidden="true"></i><span class="nav-text">{{ admin_tab.label }}</span>
+                </a>
+                {% if admin_tab.sections %}
+                <ul class="nav flex-column ms-3" style="display: none;" id="{{ admin_tab.id }}-submenu">
+                  {% for admin_section in admin_tab.sections %}
+                  {% if not admin_section.condition
+                        or (admin_section.condition == 'enable_agent_template_gallery' and app_settings.enable_agent_template_gallery)
+                        or (admin_section.condition == 'mcp_ui_enabled' and mcp_ui_enabled) %}
+                  <li class="nav-item">
+                    <a class="nav-link d-flex align-items-center admin-nav-section" href="#" data-tab="{{ admin_tab.id }}" data-section="{{ admin_section.id }}">
+                      <i class="bi {{ admin_section.icon }} me-2" style="font-size: 0.8em;" aria-hidden="true"></i><span class="nav-text">{{ admin_section.label }}</span>
+                    </a>
+                  </li>
+                  {% endif %}
+                  {% endfor %}
+                </ul>
+                {% endif %}
+              </li>
+              {% endif %}
+              {% endfor %}
+            </ul>
+          </li>
+          {% endfor %}
         </ul>
       </div>
     </div>

--- a/application/single_app/templates/admin_settings.html
+++ b/application/single_app/templates/admin_settings.html
@@ -936,127 +936,43 @@
         <!-- Hide tabs when left navigation is enabled -->
         {% set nav_layout = user_settings.get('settings', {}).get('navLayout') %}
         {% if not (nav_layout == 'sidebar' or (not nav_layout and app_settings.enable_left_nav_default)) %}
+        <ul class="nav nav-pills mb-2" id="adminSettingsGroups" role="tablist" aria-label="Admin settings groups">
+            {% for admin_group in admin_nav %}
+            <li class="nav-item" role="presentation">
+                <button class="nav-link admin-group-pill{% if loop.first %} active{% endif %}"
+                    type="button"
+                    data-admin-group-pill="{{ admin_group.id }}"
+                    aria-selected="{{ 'true' if loop.first else 'false' }}">
+                    <i class="bi {{ admin_group.icon }} me-1" aria-hidden="true"></i>{{ admin_group.label }}
+                </button>
+            </li>
+            {% endfor %}
+        </ul>
         <ul class="nav nav-tabs" id="adminSettingsTab" role="tablist">
-            <!-- Core Settings -->
-            <li class="nav-item" role="presentation">
-                <button class="nav-link active" id="general-tab" data-bs-toggle="tab" data-bs-target="#general"
-                    type="button" role="tab" aria-controls="general" aria-selected="true">
-                    General
+            {% for admin_group in admin_nav %}
+            {% set group_is_first = loop.first %}
+            {% for admin_tab in admin_group.tabs %}
+            {% set is_default_tab = group_is_first and loop.first %}
+            <li class="nav-item admin-tab-item"
+                role="presentation"
+                data-admin-group="{{ admin_group.id }}"
+                {% if not group_is_first %}hidden{% endif %}>
+                <button class="nav-link{% if is_default_tab %} active{% endif %}"
+                    id="{{ admin_tab.id }}-tab"
+                    data-bs-toggle="tab"
+                    data-bs-target="#{{ admin_tab.id }}"
+                    type="button"
+                    role="tab"
+                    aria-controls="{{ admin_tab.id }}"
+                    aria-selected="{{ 'true' if is_default_tab else 'false' }}">
+                    {{ admin_tab.label }}
+                    {% if admin_tab.render == 'latest_features' %}
+                    <span class="badge bg-warning text-dark text-uppercase ms-2 latest-feature-nav-badge">New</span>
+                    {% endif %}
                 </button>
             </li>
-            <li class="nav-item" role="presentation">
-                <button class="nav-link" id="custom-pages-tab" data-bs-toggle="tab" data-bs-target="#custom-pages"
-                    type="button" role="tab" aria-controls="custom-pages" aria-selected="false">
-                    Custom Pages
-                </button>
-            </li>
-
-            <!-- AI Models Group -->
-            <li class="nav-item" role="presentation">
-                <button class="nav-link" id="ai-models-tab" data-bs-toggle="tab" data-bs-target="#ai-models"
-                    type="button" role="tab" aria-controls="ai-models" aria-selected="false">
-                    AI Models
-                </button>
-            </li>
-
-            <!-- Content Processing Group -->
-            <li class="nav-item" role="presentation">
-                <button class="nav-link" id="search-extract-tab" data-bs-toggle="tab" data-bs-target="#search-extract"
-                    type="button" role="tab" aria-controls="search-extract" aria-selected="false">
-                    Search and Extract
-                </button>
-            </li>
-            <li class="nav-item" role="presentation">
-                <button class="nav-link" id="workspaces-tab" data-bs-toggle="tab" data-bs-target="#workspaces" type="button"
-                    role="tab" aria-controls="workspaces" aria-selected="false">
-                    Workspaces
-                </button>
-            </li>
-            <li class="nav-item" role="presentation">
-                <button class="nav-link" id="file-sync-tab" data-bs-toggle="tab" data-bs-target="#file-sync" type="button"
-                    role="tab" aria-controls="file-sync" aria-selected="false">
-                    File Sync
-                </button>
-            </li>
-            <li class="nav-item" role="presentation">
-                <button class="nav-link" id="workspace-identities-tab" data-bs-toggle="tab" data-bs-target="#workspace-identities" type="button"
-                    role="tab" aria-controls="workspace-identities" aria-selected="false">
-                    Global Identities
-                </button>
-            </li>
-            <li class="nav-item" role="presentation">
-                <button class="nav-link" id="citation-tab" data-bs-toggle="tab" data-bs-target="#citation"
-                    type="button" role="tab" aria-controls="citation" aria-selected="false">
-                    Citations
-                </button>
-            </li>
-
-            <li class="nav-item" role="presentation">
-                <button class="nav-link" id="safety-tab" data-bs-toggle="tab" data-bs-target="#safety"
-                    type="button" role="tab" aria-controls="safety" aria-selected="false">
-                    Safety
-                </button>
-            </li>
-            <li class="nav-item" role="presentation">
-                <button class="nav-link" id="security-tab" data-bs-toggle="tab" data-bs-target="#security" type="button" role="tab" aria-controls="security" aria-selected="false">
-                    Security
-                </button>
-            </li>
-
-            <li class="nav-item" role="presentation">
-                <button class="nav-link" id="agents-tab" data-bs-toggle="tab" data-bs-target="#agents"
-                    type="button" role="tab" aria-controls="agents" aria-selected="false">
-                    Agents
-                </button>
-            </li>
-
-            <li class="nav-item" role="presentation">
-                <button class="nav-link" id="scale-tab" data-bs-toggle="tab" data-bs-target="#scale"
-                    type="button" role="tab" aria-controls="scale" aria-selected="false">
-                    Scale
-                </button>
-            </li>
-
-            <li class="nav-item" role="presentation">
-                <button class="nav-link" id="control-center-config-tab" data-bs-toggle="tab" data-bs-target="#control-center-config"
-                    type="button" role="tab" aria-controls="control-center-config" aria-selected="false">
-                    Control Center
-                </button>
-            </li>
-
-            <li class="nav-item" role="presentation">
-                <button class="nav-link" id="data-management-tab" data-bs-toggle="tab" data-bs-target="#data-management"
-                    type="button" role="tab" aria-controls="data-management" aria-selected="false">
-                    Backup, Migrate &amp; Restore
-                </button>
-            </li>
-
-            <li class="nav-item" role="presentation">
-                <button class="nav-link" id="governance-tab" data-bs-toggle="tab" data-bs-target="#governance"
-                    type="button" role="tab" aria-controls="governance" aria-selected="false">
-                    Governance
-                </button>
-            </li>
-
-            <li class="nav-item" role="presentation">
-                <button class="nav-link" id="logging-tab" data-bs-toggle="tab" data-bs-target="#logging"
-                    type="button" role="tab" aria-controls="logging" aria-selected="false">
-                    Logging
-                </button>
-            </li>
-            <li class="nav-item" role="presentation">
-                <button class="nav-link" id="send-feedback-tab" data-bs-toggle="tab" data-bs-target="#send-feedback"
-                    type="button" role="tab" aria-controls="send-feedback" aria-selected="false">
-                    Send Feedback
-                </button>
-            </li>
-            <!-- Latest Features stays last so it never opens by default -->
-            <li class="nav-item" role="presentation">
-                <button class="nav-link" id="latest-features-tab" data-bs-toggle="tab" data-bs-target="#latest-features"
-                    type="button" role="tab" aria-controls="latest-features" aria-selected="false">
-                    Latest Features <span class="badge bg-warning text-dark text-uppercase ms-2 latest-feature-nav-badge">New</span>
-                </button>
-            </li>
+            {% endfor %}
+            {% endfor %}
         </ul>
         {% endif %}
 

--- a/docs/explanation/features/ADMIN_SETTINGS_IA_REWORK_STATUS.md
+++ b/docs/explanation/features/ADMIN_SETTINGS_IA_REWORK_STATUS.md
@@ -15,13 +15,14 @@ and merged in one final reviewed PR.
 ```
 Development ─── feature/admin-settings-ia ──┬── #1297 stage 1    MERGED
                                             ├── #1304 stage A+B  MERGED
-                                            ├── stage C          next
+                                            ├── #1306 guardrail   MERGED
+                                            ├── stage C          in review
                                             ├── stage D
                                             └── stage E
                                                       └──► final PR ──► Development
 ```
 
-Current version: **0.260.009**. Fingerprint: **462 field names / 110 card ids**.
+Current version: **0.260.010**. Fingerprint: **462 field names / 110 card ids**.
 
 ### Shipped
 
@@ -31,6 +32,7 @@ Current version: **0.260.009**. Fingerprint: **462 field names / 110 card ids**.
 | A | 12 cross-tab links converted from tab-coupled `switchTab` to `data-admin-link` card targets; two were already broken; `switchTab` removed |
 | B | `data-requires` dependency announcements with inline mirror and link; File Sync and Permissions wired |
 | — | Form field contract enforced in CI |
+| C | Navigation moved into `admin_settings_nav.py` as groups → tabs → sections; both navigations render from it; group level with persisted collapse state and group pills; three-level search |
 
 ---
 
@@ -44,6 +46,7 @@ silently stops a setting from saving with no error anywhere.
 |---|---|
 | **Field contract** | `python -m pytest functional_tests/test_admin_settings_field_contract.py` |
 | Regenerate baseline *(only for a deliberate removal)* | `python functional_tests/test_admin_settings_field_contract.py --update-baseline` |
+| **Navigation map** | `python -m pytest functional_tests/test_admin_settings_nav_map.py` |
 | Composition contract | `python -m pytest functional_tests/test_admin_settings_template_composition.py` |
 | Card links | `python -m pytest functional_tests/test_admin_card_links.py` |
 | Dependencies | `python -m pytest functional_tests/test_admin_settings_dependencies.py` |
@@ -51,8 +54,8 @@ silently stops a setting from saving with no error anywhere.
 | XSS | `python scripts/check_xss_sinks.py --full-file <changed files>` |
 
 **Regression baseline:** the 75 functional test files that reference
-`admin_settings.html` sit at **33 pre-existing failures**. That number must not
-change. To reproduce the list:
+`admin_settings.html` now sit at **32 pre-existing failures**, down from 33
+after stage C fixed a missing navigation entry. That number must not increase. To reproduce the list:
 
 ```
 cd functional_tests
@@ -76,25 +79,17 @@ template uncomposed while referencing a partial-backed card or field.
 
 ---
 
-## Next: Stage C
+## Next: Stage D — the risky one
 
-Add the group navigation level **against the current 18 tabs**, so grouping is
-proven before any card moves.
+Re-home cards into the 14 target groups, **one group per commit**, running the
+field contract test on each. The nav map now makes this a two-part edit: move
+the card markup between partials, and move its entry between tabs in
+`admin_settings_nav.py`. The parity test fails if the two disagree.
 
-1. Group row in the top-tab strip; collapsible group headers in
-   `_sidebar_nav.html` with persisted state.
-2. Three-level sidebar search (group → tab → card).
-3. Legacy hash redirect map inside `showAdminTab`.
+The interim grouping in the map has 12 groups, because Workflow and Data
+Lifecycle have no tabs until their cards move out of Workspaces and Safety.
 
-A server-side nav map is worth introducing here, since both navs need to render
-the same group structure. Note it is **not** needed for link resolution —
-`admin_card_links.js` resolves card → tab from the DOM via
-`closest('.tab-pane')`, which is why links already survive any IA change.
-
-## Then Stage D — the risky one
-
-Re-home cards into the 14 groups, **one group per commit**, running the field
-contract test on each. Three complications found while splitting:
+Three complications found while splitting:
 
 - **I1** Modals are interleaved *between* cards, not collected at the end. Each
   modal moves with the tab that owns its trigger.

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,29 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](/explanation/features/) and [Fixes by Version](/explanation/fixes/).
 
+### **(v0.260.010)**
+
+#### New Features
+
+*   **Admin Settings Navigation Is Now Grouped**
+    *   Admin Settings presented 18 tabs in one flat list. Related tabs are now collected under 12 groups such as Appearance, Knowledge, Security and Operations, so the list is scannable and has room to grow.
+    *   In the sidebar, groups are collapsible and remember whether you left them open. In the tab layout, a row of group pills filters the tab strip to one group at a time.
+    *   Opening a tab always reveals its group first, so a deep link or a cross-reference can never land you on a pane whose tab is hidden.
+    *   Sidebar search now matches group names as well as tab and setting names, and expands whatever it needs to show a result.
+    *   No settings moved in this release. Every tab keeps its contents; only the navigation around them changed.
+    *   (Ref: `admin_settings_nav.py`, `_sidebar_nav.html`, `admin_settings.html`, `admin_sidebar_nav.js`)
+
+#### Bug Fixes
+
+*   **Shared Conversation File Approvals Is Reachable From The Sidebar**
+    *   The Shared Conversation File Approvals card had no navigation entry, so it could only be found by scrolling the AI Models tab. It is now listed like every other setting.
+    *   (Ref: `shared-conversation-file-approvals-section`, navigation map)
+
+*   **Navigation Labels And Order Can No Longer Drift**
+    *   The tab strip and the sidebar each maintained the same structure by hand and had diverged: tab order differed between them, and Agents, Custom Pages and Search and Extract each showed a different name depending on which navigation you used.
+    *   Both now render from one definition, so a change is made once and appears in both.
+    *   (Ref: `admin_settings_nav.py`, `test_admin_settings_nav_map.py`)
+
 ### **(v0.260.009)**
 
 #### New Features

--- a/functional_tests/test_admin_latest_features_tab.py
+++ b/functional_tests/test_admin_latest_features_tab.py
@@ -10,6 +10,7 @@ admin-only Latest Features tab while the user-facing support catalog remains
 focused on features users can see and control.
 """
 
+import re
 import importlib.util
 import os
 import sys
@@ -17,6 +18,7 @@ import sys
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
 from test_support.templates import resolve_template_includes
+from test_support.nav import get_group_for_tab, get_tab_ids
 
 
 CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -248,8 +250,6 @@ def test_latest_features_template_structure():
     template_content = read_text(ADMIN_TEMPLATE)
 
     required_markers = [
-        'id="latest-features-tab"',
-        'data-bs-target="#latest-features"',
         'id="latest-features"',
         'admin_latest_feature_release_groups',
         '{% for release_group in admin_latest_feature_release_groups %}',
@@ -336,51 +336,70 @@ def test_latest_features_sidebar_navigation():
         raise AssertionError(f'Missing Latest Features sidebar markers: {missing_markers}')
 
     latest_features_index = sidebar_content.index('data-tab="latest-features"')
-    general_index = sidebar_content.index('data-tab="general"')
-    send_feedback_index = sidebar_content.index('data-tab="send-feedback"')
-    assert latest_features_index > general_index, 'Latest Features should appear after General in the admin sidebar'
-    assert latest_features_index > send_feedback_index, 'Latest Features should be the last admin sidebar destination, after Send Feedback'
     assert '<span class="badge bg-warning text-dark text-uppercase ms-2">New</span>' in sidebar_content, 'Sidebar Latest Features item should include a New badge'
+
+    # Tab order is defined once in the nav map, which the sidebar renders from,
+    # so ordering is asserted there rather than against the rendered markup.
+    tab_ids = get_tab_ids()
+    assert tab_ids.index('latest-features') > tab_ids.index('general'), 'Latest Features should appear after General'
+    assert tab_ids.index('latest-features') > tab_ids.index('send-feedback'), 'Latest Features should be the last destination, after Send Feedback'
 
     print('Latest Features sidebar navigation is present')
     return True
 
 
 def test_latest_features_top_nav_priority():
-    """Latest Features should be the last top-nav tab and never default active."""
-    print('Testing Latest Features top-nav placement...')
+    """Latest Features should be the last tab and never default active."""
+    print('Testing Latest Features navigation placement...')
 
     template_content = read_text(ADMIN_TEMPLATE)
+    tab_ids = get_tab_ids()
 
-    latest_features_tab_index = template_content.index('id="latest-features-tab"')
-    general_tab_index = template_content.index('id="general-tab"')
-    send_feedback_tab_index = template_content.index('id="send-feedback-tab"')
-    assert latest_features_tab_index > general_tab_index, 'Latest Features tab should appear after General in top nav'
-    assert latest_features_tab_index > send_feedback_tab_index, 'Latest Features tab should be the last top-nav tab, after Send Feedback'
+    # Navigation order now comes from the nav map, which both the top tab strip
+    # and the sidebar render from, so order is asserted there rather than
+    # against either rendering.
+    assert tab_ids[-1] == 'latest-features', (
+        'Latest Features should be the last tab in the navigation map, '
+        f'got {tab_ids[-1]}'
+    )
+    assert tab_ids.index('latest-features') > tab_ids.index('send-feedback'), (
+        'Latest Features should come after Send Feedback'
+    )
 
-    assert 'id="latest-features-tab" data-bs-toggle="tab" data-bs-target="#latest-features"' in template_content, 'Latest Features top-nav tab missing'
-    assert 'Latest Features <span class="badge bg-warning text-dark text-uppercase ms-2 latest-feature-nav-badge">New</span>' in template_content, 'Latest Features top-nav tab should include a New badge'
+    group = get_group_for_tab('latest-features')
+    assert group is not None and group['id'] == 'help', (
+        f"Latest Features should sit in the Help group, got {group}"
+    )
 
     # Latest Features opened on every visit to Admin Settings, which is why it
-    # now sits last and General is the landing tab instead.
+    # is pinned last and General is the landing tab instead.
     assert 'class="tab-pane fade" id="latest-features" role="tabpanel" aria-labelledby="latest-features-tab"' in template_content, 'Latest Features pane should not be the default active tab'
     assert 'class="tab-pane fade show active" id="general" role="tabpanel" aria-labelledby="general-tab"' in template_content, 'General pane should be the default active tab'
+    assert tab_ids[0] == 'general', 'General should be the first tab in the navigation map'
 
-    print('Latest Features is last in top navigation and not default active')
+    print('Latest Features is last in navigation and not default active')
     return True
 
 
 def test_admin_settings_tab_uniqueness():
-    """Admin settings template should not contain duplicate Security tab controls or extra active panes."""
+    """Every tab must appear exactly once, with exactly one default pane."""
     print('Testing admin settings tab uniqueness...')
 
     template_content = read_text(ADMIN_TEMPLATE)
     normalized_template = ''.join(template_content.split())
+    tab_ids = get_tab_ids()
 
-    assert template_content.count('id="security-tab"') == 1, 'Security tab button should appear exactly once'
+    duplicates = sorted({t for t in tab_ids if tab_ids.count(t) > 1})
+    assert not duplicates, f'Tabs listed more than once in the nav map: {duplicates}'
+
     assert template_content.count('id="security" role="tabpanel"') == 1, 'Security tab pane should appear exactly once'
-    assert template_content.count('tab-pane fade show active') == 1, 'Only one tab pane should be marked show active in top-nav markup'
+    assert template_content.count('tab-pane fade show active') == 1, 'Only one tab pane should be marked show active'
     assert 'Managesecuritysettingsforkeyvaultandothersecurityconfigurations.</p>' in normalized_template, 'Security intro paragraph should be properly closed'
+
+    # Every tab in the map must have a pane to activate.
+    panes = set(re.findall(r'<div class="tab-pane[^"]*" id="([^"]+)"', template_content))
+    missing = sorted(set(tab_ids) - panes)
+    assert not missing, f'Nav map lists tabs with no matching pane: {missing}'
 
     print('Admin settings tab structure is unique and well-formed')
     return True

--- a/functional_tests/test_admin_send_feedback_tab.py
+++ b/functional_tests/test_admin_send_feedback_tab.py
@@ -50,8 +50,6 @@ def test_send_feedback_template_structure():
 
     required_markers = [
         'id="admin-settings-form" style="padding-bottom:80px;" novalidate autocomplete="off" data-lpignore="true" data-1p-ignore="true" data-bwignore="true"',
-        'id="send-feedback-tab"',
-        'data-bs-target="#send-feedback"',
         'id="send-feedback" role="tabpanel"',
         'id="send-feedback-overview-card"',
         'id="send-feedback-bug-card"',

--- a/functional_tests/test_admin_settings_nav_map.py
+++ b/functional_tests/test_admin_settings_nav_map.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+# test_admin_settings_nav_map.py
+"""
+Functional test for the Admin Settings navigation map.
+Version: 0.260.010
+Implemented in: 0.260.010
+
+The top tab strip and the sidebar used to declare the same navigation twice, by
+hand, and had already drifted: tab order differed between them, and three tabs
+carried different labels in each. Both now render from
+``admin_settings_nav.ADMIN_NAV``, which adds a group level above tabs.
+
+This test pins the map itself, since it is now the contract both renderings
+depend on:
+
+  1. Structure is well formed and free of duplicates.
+  2. Every tab has a matching pane, and every section a matching card.
+  3. Both navigations render from the map rather than listing tabs by hand.
+  4. Latest Features stays last so it never opens by default.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+from test_support.nav import ADMIN_NAV, get_section_ids, get_tab_ids, iter_tabs
+from test_support.templates import (
+    ADMIN_SETTINGS_TEMPLATE,
+    read_admin_settings_template,
+)
+from test_support.versioning import assert_app_version_at_least
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SIDEBAR_TEMPLATE = (
+    REPO_ROOT / "application" / "single_app" / "templates" / "_sidebar_nav.html"
+)
+
+
+def test_nav_map_is_well_formed():
+    """A malformed map would break both navigations at once."""
+    print("Testing Admin Settings nav map structure...")
+
+    assert_app_version_at_least("0.260.010")
+    assert ADMIN_NAV, "Navigation map is empty"
+
+    group_ids = [group["id"] for group in ADMIN_NAV]
+    assert len(group_ids) == len(set(group_ids)), (
+        f"Duplicate group ids: {sorted({g for g in group_ids if group_ids.count(g) > 1})}"
+    )
+
+    for group in ADMIN_NAV:
+        for key in ("id", "label", "icon", "tabs"):
+            assert key in group, f"Group {group.get('id')} is missing '{key}'"
+        assert group["tabs"], f"Group {group['id']} has no tabs"
+
+    tab_ids = get_tab_ids()
+    duplicate_tabs = sorted({t for t in tab_ids if tab_ids.count(t) > 1})
+    assert not duplicate_tabs, f"Tabs listed in more than one group: {duplicate_tabs}"
+
+    section_ids = get_section_ids()
+    duplicate_sections = sorted({s for s in section_ids if section_ids.count(s) > 1})
+    assert not duplicate_sections, (
+        f"Sections listed under more than one tab: {duplicate_sections}"
+    )
+
+    for _, tab in iter_tabs():
+        for key in ("id", "label", "icon", "sections"):
+            assert key in tab, f"Tab {tab.get('id')} is missing '{key}'"
+
+    print(
+        f"Map is well formed: {len(ADMIN_NAV)} groups, "
+        f"{len(tab_ids)} tabs, {len(section_ids)} sections."
+    )
+
+
+def test_every_nav_destination_exists():
+    """A destination with nothing behind it is a dead end for the admin."""
+    print("Testing Admin Settings nav destinations...")
+
+    composed = read_admin_settings_template()
+    panes = set(re.findall(r'<div class="tab-pane[^"]*" id="([^"]+)"', composed))
+    element_ids = set(re.findall(r'\sid="([^"]+)"', composed))
+
+    missing_panes = sorted(set(get_tab_ids()) - panes)
+    assert not missing_panes, f"Tabs with no matching pane: {missing_panes}"
+
+    # Sections may use an alias resolved by the sidebar script, so accept
+    # either the declared id or its resolved target.
+    script = (
+        REPO_ROOT
+        / "application"
+        / "single_app"
+        / "static"
+        / "js"
+        / "admin"
+        / "admin_sidebar_nav.js"
+    ).read_text(encoding="utf-8")
+    alias_body = re.search(
+        r"const sectionMap = \{(.*?)^\s*\};", script, re.MULTILINE | re.DOTALL
+    )
+    aliases = dict(re.findall(r"'([^']+)'\s*:\s*'([^']+)'", alias_body.group(1)))
+
+    missing_sections = sorted(
+        section_id
+        for section_id in get_section_ids()
+        if aliases.get(section_id, section_id) not in element_ids
+    )
+    assert not missing_sections, (
+        f"Sections pointing at elements that do not exist: {missing_sections}"
+    )
+
+    print("Every tab and section destination resolves.")
+
+
+def test_both_navigations_render_from_the_map():
+    """Two hand-maintained copies of one structure will drift, and did."""
+    print("Testing Admin Settings navigation rendering...")
+
+    parent = ADMIN_SETTINGS_TEMPLATE.read_text(encoding="utf-8")
+    sidebar = SIDEBAR_TEMPLATE.read_text(encoding="utf-8")
+
+    for name, source in (("top tab strip", parent), ("sidebar", sidebar)):
+        assert "admin_nav" in source, (
+            f"The {name} does not render from the navigation map"
+        )
+
+    # Hardcoded tab buttons would reintroduce the drift this replaced.
+    hardcoded = re.findall(r'id="([a-z-]+)-tab"\s+data-bs-toggle="tab"', parent)
+    assert not hardcoded, (
+        "These tabs are hardcoded in the top strip instead of coming from the "
+        f"navigation map: {sorted(set(hardcoded))}"
+    )
+
+    print("Both navigations render from the map.")
+
+
+def test_latest_features_stays_last():
+    """Latest Features opened on every visit; it is pinned last deliberately."""
+    print("Testing Latest Features placement in the nav map...")
+
+    tab_ids = get_tab_ids()
+    assert tab_ids[-1] == "latest-features", (
+        f"Latest Features must be the last tab, got '{tab_ids[-1]}'"
+    )
+    assert tab_ids[0] == "general", (
+        f"General must be the first tab, got '{tab_ids[0]}'"
+    )
+    assert ADMIN_NAV[-1]["id"] == "help", (
+        "Latest Features should sit in the last group"
+    )
+
+    print("Latest Features is last; General leads.")
+
+
+if __name__ == "__main__":
+    tests = [
+        test_nav_map_is_well_formed,
+        test_every_nav_destination_exists,
+        test_both_navigations_render_from_the_map,
+        test_latest_features_stays_last,
+    ]
+
+    results = []
+    for test in tests:
+        try:
+            test()
+            results.append(True)
+        except Exception as exc:
+            print(f"FAILED {test.__name__}: {exc}")
+            import traceback
+            traceback.print_exc()
+            results.append(False)
+
+    print(f"\nResults: {sum(results)}/{len(results)} passed")
+    sys.exit(0 if all(results) else 1)

--- a/functional_tests/test_admin_settings_sidebar_card_parity.py
+++ b/functional_tests/test_admin_settings_sidebar_card_parity.py
@@ -19,6 +19,7 @@ from test_support.templates import (
     read_admin_settings_template,
     resolve_template_includes,
 )
+from test_support.nav import get_section_ids, get_tab_ids, iter_tabs
 from test_support.versioning import assert_app_version_at_least
 
 
@@ -91,7 +92,13 @@ def _card_title(card):
 
 
 def _navigation_contract():
-    """Parse the admin template, sidebar template, and section alias map."""
+    """Read the admin template and the navigation map.
+
+    Navigation structure now comes from ``admin_settings_nav.ADMIN_NAV`` rather
+    than from literal sidebar markup, because both the sidebar and the top tab
+    strip render from that one definition. Asserting against the map checks the
+    contract itself instead of one of its two renderings.
+    """
     admin_source = resolve_template_includes(
         _read(ADMIN_TEMPLATE), ADMIN_TEMPLATE.parent
     )
@@ -101,18 +108,13 @@ def _navigation_contract():
     sidebar_soup = BeautifulSoup(sidebar_source, "html.parser")
     section_map = _parse_section_map(script_source)
 
-    tab_targets = {
-        link["data-tab"]
-        for link in sidebar_soup.select(".admin-nav-tab[data-tab]")
-    }
+    tab_targets = set(get_tab_ids())
     section_targets = defaultdict(list)
-    for link in sidebar_soup.select(
-        ".admin-nav-section[data-tab][data-section]"
-    ):
-        raw_target = link["data-section"]
-        section_targets[link["data-tab"]].append(
-            section_map.get(raw_target, raw_target)
-        )
+    for _, tab in iter_tabs():
+        for section in tab["sections"]:
+            section_targets[tab["id"]].append(
+                section_map.get(section["id"], section["id"])
+            )
 
     return {
         "admin_source": admin_source,
@@ -211,12 +213,11 @@ def test_sidebar_section_map_contains_only_real_aliases():
     print("Testing admin sidebar sectionMap hygiene...")
 
     script = SIDEBAR_SCRIPT.read_text(encoding="utf-8")
-    sidebar = SIDEBAR_TEMPLATE.read_text(encoding="utf-8")
     composed = read_admin_settings_template()
 
     section_map = _parse_section_map(script)
     template_ids = set(re.findall(r'\sid="([^"]+)"', composed))
-    linked_sections = set(re.findall(r'data-section="([^"]+)"', sidebar))
+    linked_sections = set(get_section_ids())
 
     identity = sorted(key for key, value in section_map.items() if key == value)
     assert not identity, (
@@ -245,10 +246,14 @@ def test_sidebar_section_map_contains_only_real_aliases():
 
 
 def test_conditional_agent_template_destination_matches_card():
-    """Keep the optional Agent Template Approvals card and link in sync."""
+    """Keep the optional Agent Template Approvals card and link in sync.
+
+    The card is rendered only when the agent template gallery is enabled, so
+    its navigation entry has to carry the same condition. Otherwise the sidebar
+    offers a destination that does not exist on the page.
+    """
     contract = _navigation_contract()
     card_marker = 'id="agent-template-approvals-section"'
-    link_marker = 'data-section="agent-template-approvals-section"'
 
     card_condition = contract["admin_source"].index(
         "{% if settings.enable_agent_template_gallery %}"
@@ -257,12 +262,18 @@ def test_conditional_agent_template_destination_matches_card():
     card_end = contract["admin_source"].index("{% endif %}", card_position)
     assert card_condition < card_position < card_end
 
-    link_condition = contract["sidebar_source"].index(
-        "{% if app_settings.enable_agent_template_gallery %}"
+    conditioned = {
+        section["id"]: section.get("condition")
+        for _, tab in iter_tabs()
+        for section in tab["sections"]
+    }
+    assert conditioned.get("agent-template-approvals-section") == (
+        "enable_agent_template_gallery"
+    ), (
+        "The Agent Template Approvals nav entry must declare the same "
+        "condition as its card, otherwise the sidebar links to a destination "
+        "that is not rendered."
     )
-    link_position = contract["sidebar_source"].index(link_marker)
-    link_end = contract["sidebar_source"].index("{% endif %}", link_position)
-    assert link_condition < link_position < link_end
 
 
 def test_sidebar_search_no_results_uses_safe_text_rendering():

--- a/functional_tests/test_data_management_security_patterns.py
+++ b/functional_tests/test_data_management_security_patterns.py
@@ -34,7 +34,9 @@ import ast
 import re
 from pathlib import Path
 from test_support.versioning import assert_app_version_at_least
+from test_support.nav import iter_tabs
 from test_support.templates import compose_if_admin_settings
+from test_support.nav import iter_tabs
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -413,7 +415,6 @@ def test_admin_ui_exposes_data_management_without_external_assets():
     sidebar = read_text(SIDEBAR_TEMPLATE)
 
     for marker in [
-        'id="data-management-tab"',
         'id="data-management"',
         'id="data-management" role="tabpanel" aria-labelledby="data-management-tab" data-testid="data-management-tab-pane" data-ignore-settings-change="true"',
         'id="data-management-save-settings-btn"',
@@ -563,15 +564,40 @@ def test_admin_ui_exposes_data_management_without_external_assets():
     assert "saveButton.classList.toggle('d-none', isDataManagementActive);" in admin_settings_js
     assert "window.updateAdminSettingsSaveButtonState = updateSaveButtonState;" in admin_settings_js
     assert '<span class="nav-text">Target Cosmos</span>' not in sidebar
-    assert '<span class="nav-text">Migration</span>' in sidebar
-    assert '<span class="nav-text">Backup, Migrate &amp; Restore</span>' in sidebar
+    # Sidebar labels now come from the navigation map, which both the sidebar
+    # and the top tab strip render from.
+    data_management_sections = {
+        section["label"]
+        for _, tab in iter_tabs()
+        if tab["id"] == "data-management"
+        for section in tab["sections"]
+    }
+    assert "Target Cosmos" not in data_management_sections
+    assert "Migration" in data_management_sections
+    assert any(
+        tab["id"] == "data-management" and tab["label"] == "Backup, Migrate &amp; Restore"
+        for _, tab in iter_tabs()
+    ), "Data Management tab label missing from the navigation map"
     assert 'cdn.jsdelivr.net' not in read_text(ADMIN_JS)
-    assert 'data-tab="data-management"' in sidebar
-    assert 'data-section="data-management-readiness-section"' in sidebar
-    assert 'data-section="data-management-backup-section"' in sidebar
-    assert 'data-section="data-management-cosmos-editor-section"' in sidebar
-    assert 'data-section="data-management-backup-inventory-section"' in sidebar
-    assert 'data-section="data-management-migration-section"' in sidebar
+    assert any(tab["id"] == "data-management" for _, tab in iter_tabs()), (
+        "Data Management tab missing from the navigation map"
+    )
+    data_management_section_ids = {
+        section["id"]
+        for _, tab in iter_tabs()
+        if tab["id"] == "data-management"
+        for section in tab["sections"]
+    }
+    for expected_section in (
+        "data-management-readiness-section",
+        "data-management-backup-section",
+        "data-management-cosmos-editor-section",
+        "data-management-backup-inventory-section",
+        "data-management-migration-section",
+    ):
+        assert expected_section in data_management_section_ids, (
+            f"Navigation map is missing {expected_section}"
+        )
 
 
 if __name__ == "__main__":

--- a/functional_tests/test_inbound_mcp_admin_ui.py
+++ b/functional_tests/test_inbound_mcp_admin_ui.py
@@ -39,7 +39,9 @@ server-side endpoint check.
 import sys
 from pathlib import Path
 from test_support.versioning import assert_app_version_at_least
+from test_support.nav import iter_tabs
 from test_support.templates import compose_if_admin_settings
+from test_support.nav import iter_tabs
 
 
 ROOT_DIR = Path(__file__).resolve().parents[1]
@@ -177,9 +179,26 @@ def test_admin_settings_mcp_ui_is_gated_and_minimal():
         assert f"'{operational_setting}'," in admin_route_source
         assert f"INBOUND_MCP_SETTINGS_DEFAULTS['{operational_setting}']" in admin_route_source
 
-    assert "{% if mcp_ui_enabled %}" in sidebar_template
-    assert 'data-section="inbound-mcp-configuration"' in sidebar_template
-    assert "Inbound MCP" in sidebar_template
+    # The Inbound MCP navigation entry is gated by the same flag as its card,
+    # declared in the navigation map rather than inline in the sidebar.
+    inbound_section = next(
+        (
+            section
+            for _, tab in iter_tabs()
+            for section in tab["sections"]
+            if section["id"] == "inbound-mcp-configuration"
+        ),
+        None,
+    )
+    assert inbound_section is not None, (
+        "Inbound MCP navigation entry missing from the navigation map"
+    )
+    assert inbound_section.get("condition") == "mcp_ui_enabled", (
+        "Inbound MCP navigation entry must be gated by mcp_ui_enabled"
+    )
+    assert inbound_section["label"] == "Inbound MCP", (
+        f"Unexpected Inbound MCP navigation label: {inbound_section['label']}"
+    )
 
 
 def test_inbound_mcp_auth_uses_settings_runtime_config():

--- a/functional_tests/test_support/nav.py
+++ b/functional_tests/test_support/nav.py
@@ -1,0 +1,34 @@
+# nav.py
+"""Access to the Admin Settings navigation map from functional tests.
+
+``admin_settings_nav`` lives in ``application/single_app``, which is not on the
+test path by default. Centralising the import here keeps individual tests from
+each manipulating ``sys.path``, and gives them one place to read navigation
+structure from.
+"""
+
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+APP_ROOT = REPO_ROOT / "application" / "single_app"
+
+if str(APP_ROOT) not in sys.path:
+    sys.path.insert(0, str(APP_ROOT))
+
+from admin_settings_nav import (  # noqa: E402
+    ADMIN_NAV,
+    get_group_for_tab,
+    get_section_ids,
+    get_tab_ids,
+    iter_tabs,
+)
+
+__all__ = [
+    "ADMIN_NAV",
+    "get_group_for_tab",
+    "get_section_ids",
+    "get_tab_ids",
+    "iter_tabs",
+]

--- a/functional_tests/test_support_menu_user_feature.py
+++ b/functional_tests/test_support_menu_user_feature.py
@@ -16,6 +16,7 @@ import os
 import sys
 import importlib.util
 from test_support.templates import compose_if_admin_settings
+from test_support.nav import iter_tabs
 
 
 CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -261,7 +262,6 @@ def test_support_menu_navigation_and_routes():
     support_route_content = read_text(SUPPORT_ROUTE)
 
     sidebar_markers = [
-        'data-section="support-menu-section"',
         'id="support-menu-toggle"',
         "url_for('frontend_support.support_latest_features')",
         "url_for('frontend_support.support_send_feedback')",
@@ -269,6 +269,13 @@ def test_support_menu_navigation_and_routes():
     ]
     missing_sidebar = [marker for marker in sidebar_markers if marker not in sidebar_content]
     assert not missing_sidebar, f'Missing support menu sidebar markers: {missing_sidebar}'
+
+    # The admin destination for the Support card comes from the navigation map.
+    assert any(
+        section["id"] == "support-menu-section"
+        for _, tab in iter_tabs()
+        for section in tab["sections"]
+    ), 'Support menu admin destination missing from the navigation map'
 
     assert sidebar_content.index('id="support-menu-toggle"') < sidebar_content.index('id="external-links-toggle"'), 'Support menu should render before external links in the sidebar'
 

--- a/functional_tests/test_workflow_access_controls.py
+++ b/functional_tests/test_workflow_access_controls.py
@@ -12,7 +12,9 @@ with the WorkflowUser app role, and are enforced across UI and API surfaces.
 import json
 from pathlib import Path
 from test_support.versioning import assert_app_version_at_least
+from test_support.nav import iter_tabs
 from test_support.templates import compose_if_admin_settings
+from test_support.nav import iter_tabs
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -118,9 +120,11 @@ def test_workflow_access_control_wiring():
     assert 'id="require_member_of_workflow_user"' in admin_template_content, (
         "Expected admin WorkflowUser requirement toggle markup."
     )
-    assert 'data-section="workflow-settings-section"' in sidebar_template_content, (
-        "Expected Admin Settings sidebar navigation to link to Workflow settings."
-    )
+    assert any(
+        section["id"] == "workflow-settings-section"
+        for _, tab in iter_tabs()
+        for section in tab["sections"]
+    ), "Expected Admin Settings navigation to link to Workflow settings."
 
     assert '{% if settings.allow_user_workflows %}' in workspace_template_content, (
         "Expected workspace workflow tab and modals to be gated by effective workflow access."


### PR DESCRIPTION
Stage C of the Admin Settings information architecture rework. Targets the `feature/admin-settings-ia` staging branch.

> **No cards move in this PR.** The group level is added against the current 18 tabs, so grouping is proven against a known-good tab set before stage D starts re-homing anything.

## The problem underneath

Admin Settings presented 18 tabs in one flat list — and that list was written out **twice**, once as the top tab strip and once as the sidebar. Two hand-maintained copies of the same structure, which had predictably diverged:

| | Top tab strip | Sidebar |
|---|---|---|
| `agents` | "Agents" | "Agents and Actions" |
| `custom-pages` | "Custom Pages" | "Static Pages" |
| `search-extract` | "Search and Extract" | "Search & Extract" |
| Tab order | one order | a different order |

Adding a group level to *two* hand-maintained lists would have doubled that problem. So both now render from `admin_settings_nav.py`.

## What changed

**Navigation is one definition.** `ADMIN_NAV` describes groups → tabs → sections. Both navigations render from it, so a change is made once and appears in both.

The map was **generated from the existing sidebar markup**, not retyped — faithful by construction. I then rendered the sidebar before and after and diffed the destinations:

```
before: 18 tabs, 86 sections
after:  18 tabs, 86 sections, 12 groups
per-tab section order preserved for all 16 tabs
```

**The group level.** Sidebar groups are collapsible and remember their state per user. The tab layout gets a row of group pills that filters the strip to one group, which keeps a single row readable as tabs multiply.

Opening a tab reveals its group first in *either* layout, so a deep link or a `data-admin-link` cross-reference can never activate a pane whose tab is collapsed or filtered out of view.

**Search now spans three levels** — group, tab and setting — and expands whatever it needs to show a result.

## A gap the equivalence check found

Diffing rendered destinations surfaced something I'd otherwise have missed: **`shared-conversation-file-approvals-section` had no navigation entry at all.**

That card arrived upstream while this work was in flight, and could only be found by scrolling the AI Models tab. It's now listed like every other setting — which also clears a *pre-existing* parity failure, taking the regression baseline from 33 down to **32**.

## Tests now assert on the contract, not on one rendering

Several tests scraped literal sidebar markup that is now generated. Rather than teach them to scrape the loop, they read `ADMIN_NAV` — the thing both renderings actually depend on. That's strictly more meaningful: a test asserting `data-section="workflow-settings-section"` appears in the sidebar only ever proved one of the two navigations was right.

New `test_admin_settings_nav_map.py` rejects:
- a malformed map, or a tab/section appearing under two parents
- a tab with no pane, or a section pointing at no card
- a tab **hardcoded back into the strip**, which would reintroduce the drift
- Latest Features drifting off the end, or General losing the first slot

## Verification

- Field names and card ids unchanged: **462 names, 110 card ids** — saving untouched
- 75 functional test files: **33 → 32 failures** (one fixed, none added)
- 20/20 admin templates parse under Jinja
- `check_xss_sinks.py` passes a full-file scan of every touched file
- `node --check` on the modified JS

## Note on the interim grouping

The map currently has **12** groups, not the 14 in the target structure. Workflow and Data Lifecycle have no tabs yet, because their content still lives inside Workspaces and Safety — they appear in stage D when those cards move.

## What this sets up

Stage D becomes a two-part edit per card: move the markup between partials, and move its entry between tabs in the map. The parity test fails if the two disagree, so a card can't silently lose its navigation entry — exactly the failure this PR just fixed by accident.

Version `0.260.010`. Status doc updated at `docs/explanation/features/ADMIN_SETTINGS_IA_REWORK_STATUS.md`.
