### PR TITLE
Revert the temporary CI branch filters

### DIFF
--- a/.github/workflows/broken-access-control-check.yml
+++ b/.github/workflows/broken-access-control-check.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - Development
-      - feature/admin-settings-ia  # temporary: Admin Settings IA staging branch
     paths:
       - 'application/**/*.py'
       - 'scripts/check_broken_access_control.py'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,7 +15,7 @@ on:
   push:
     branches: [ "Development" ]
   pull_request:
-    branches: [ "Development", "feature/admin-settings-ia" ]
+    branches: [ "Development" ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/malicious-pr-security-review.yml
+++ b/.github/workflows/malicious-pr-security-review.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - Development
-      - feature/admin-settings-ia  # temporary: Admin Settings IA staging branch
     paths:
       - 'application/**'
       - 'deployers/**'

--- a/.github/workflows/python-syntax-check.yml
+++ b/.github/workflows/python-syntax-check.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - Development
-      - feature/admin-settings-ia  # temporary: Admin Settings IA staging branch
     paths:
       - 'application/single_app/**.py'
       - '.github/workflows/python-syntax-check.yml'

--- a/.github/workflows/swagger-route-check.yml
+++ b/.github/workflows/swagger-route-check.yml
@@ -6,7 +6,6 @@ on:
       - main
       - Development
       - Staging
-      - feature/admin-settings-ia  # temporary: Admin Settings IA staging branch
     paths:
       - 'application/single_app/**/*.py'
       - 'scripts/check_swagger_routes.py'

--- a/.github/workflows/xss-sink-check.yml
+++ b/.github/workflows/xss-sink-check.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - Development
-      - feature/admin-settings-ia  # temporary: Admin Settings IA staging branch
     paths:
       - 'application/**/*.js'
       - 'application/**/*.html'


### PR DESCRIPTION
Reverts the temporary CI branch filters. This is the last change before the staging branch goes to `Development`.

## What this undoes

Six workflows were gated on `branches: [Development]` only, so a pull request into `feature/admin-settings-ia` ran nothing but `enforce-branch-flow` — every real gate was skipped. The staging branch was added to each filter so all seven stages were properly checked.

That work is done, so the filters go back to what they were:

- `codeql.yml`
- `xss-sink-check.yml`
- `broken-access-control-check.yml`
- `malicious-pr-security-review.yml`
- `python-syntax-check.yml`
- `swagger-route-check.yml`

## Proof it is a clean revert

```
git diff origin/Development -- .github/workflows
```

returns **empty**. The workflow files are byte-identical to `Development`.

`release-notes-check.yml` was deliberately never touched — it fails on fork PRs and is non-blocking.

## Note on gates

This PR targets the staging branch, so with the filters removed it will run only `enforce-branch-flow` — that is the expected and correct outcome of the revert. The final staging → `Development` PR runs the full set, because it targets `Development`.
