### PR TITLE
Fix Admin Settings 500: Jinja set scope does not cross an include

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -96,7 +96,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.260.018"
+VERSION = "0.260.019"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/templates/admin/_panes/actions.html
+++ b/application/single_app/templates/admin/_panes/actions.html
@@ -1,4 +1,8 @@
             <div class="tab-pane fade{% if admin_landing_tab == 'actions' %} show active{% endif %}" id="actions" role="tabpanel" aria-labelledby="actions-tab">
+                {# Jinja set scope does not cross an include boundary, so these are
+                   derived in the pane that uses them rather than in a sibling. #}
+                {% set analyze_capability = settings.document_action_capabilities.analyze %}
+                {% set comparison_capability = settings.document_action_capabilities.comparison %}
                 <div class="card p-3 mb-4" id="document-action-capabilities-card">
                     <div class="d-flex flex-column flex-lg-row justify-content-between align-items-lg-center gap-3 mb-3">
                         <div>

--- a/application/single_app/templates/admin/_panes/agents.html
+++ b/application/single_app/templates/admin/_panes/agents.html
@@ -21,8 +21,6 @@
                     <strong>Note:</strong> All changes to global agents and actions require a restart of the web app to take effect.
                 </div>
 
-                {% set analyze_capability = settings.document_action_capabilities.analyze %}
-                {% set comparison_capability = settings.document_action_capabilities.comparison %}
                 <div class="card p-3 mb-4" id="agents-configuration">
                     <h5 class="card-title">
                         <i class="bi bi-robot me-2"></i>Agents Configuration

--- a/application/single_app/templates/admin/_panes/cosmos.html
+++ b/application/single_app/templates/admin/_panes/cosmos.html
@@ -1,4 +1,9 @@
             <div class="tab-pane fade{% if admin_landing_tab == 'cosmos' %} show active{% endif %}" id="cosmos" role="tabpanel" aria-labelledby="cosmos-tab">
+                {# Jinja set scope does not cross an include boundary, so this is
+                   derived in the pane that uses it rather than in a sibling.
+                   Undefined is falsy in a boolean test, so getting this wrong
+                   hides the debug controls silently instead of erroring. #}
+                {% set enable_dai_debug = settings.enable_dai_debug | default(false) %}
                 <div class="card p-3 mb-3" id="document-access-index-section" data-testid="document-access-index-section">
                     <div class="d-flex flex-wrap justify-content-between align-items-start gap-2 mb-3">
                         <div>

--- a/application/single_app/templates/admin/_panes/redis-caching.html
+++ b/application/single_app/templates/admin/_panes/redis-caching.html
@@ -1,5 +1,4 @@
             <div class="tab-pane fade{% if admin_landing_tab == 'redis-caching' %} show active{% endif %}" id="redis-caching" role="tabpanel" aria-labelledby="redis-caching-tab">
-                {% set enable_dai_debug = settings.enable_dai_debug | default(false) %}
                 <p class="text-muted">
                     Configure Redis cache to improve enterprise scale and performance by caching session data. Enabling Redis allows you to horizontally scale your application across multiple instances without losing session data.
                 </p>

--- a/docs/explanation/features/ADMIN_SETTINGS_IA_REWORK_STATUS.md
+++ b/docs/explanation/features/ADMIN_SETTINGS_IA_REWORK_STATUS.md
@@ -22,8 +22,30 @@ Development ─── feature/admin-settings-ia ──┬── #1297 stage 1   
                                                       └──► final PR ──► Development
 ```
 
-Current version: **0.260.017**. Fingerprint: **462 field names / 116 card ids**.
+Current version: **0.260.019**. Fingerprint: **462 field names / 116 card ids**.
 Navigation: **14 groups / 44 tabs / 93 sections**. Stages D and E are complete.
+
+### The bug that got through, and why
+
+Splitting one template into 44 partials broke a Jinja rule that never mattered
+before: **`{% set %}` scope does not cross an `{% include %}` boundary.** Three
+variables were left behind when their consuming card moved to another tab.
+
+Every static test passed. Field names, card ids, tag balance, navigation parity,
+modal placement — all green, because **none of them executed the template**.
+
+Two failure modes, and the quiet one is worse:
+
+- Attribute access on a missing name raises and takes the page down.
+- A boolean test on a missing name is **silently false**, so the controls it
+  guards never render and nothing reports a problem. `enable_dai_debug` sat in
+  this state and was only found by auditing for the pattern that caused the crash.
+
+`test_admin_settings_renders.py` now renders the whole page the way Flask does,
+and `test_admin_settings_pane_variable_scope.py` catches the silent variant a
+render cannot. Both are verified against a planted copy of the real bug.
+
+**Rule: a template is not verified until it has been rendered.**
 
 ### Shipped
 

--- a/docs/explanation/fixes/ADMIN_SETTINGS_PANE_VARIABLE_SCOPE_FIX.md
+++ b/docs/explanation/fixes/ADMIN_SETTINGS_PANE_VARIABLE_SCOPE_FIX.md
@@ -1,0 +1,120 @@
+# Admin Settings Pane Variable Scope Fix
+
+Admin Settings raised `jinja2.exceptions.UndefinedError: 'analyze_capability' is
+undefined` and returned a 500 for every visit.
+
+Fixed in version: **0.260.019**
+
+## Issue
+
+Loading `/admin/settings` failed outright:
+
+```
+File "templates/admin/_panes/actions.html", line 17, in top-level template code
+  <input ... name="document_action_analyze_enabled"
+         {% if analyze_capability.enabled %}checked{% endif %}>
+jinja2.exceptions.UndefinedError: 'analyze_capability' is undefined
+```
+
+## Root cause
+
+**Jinja `{% set %}` scope does not cross an `{% include %}` boundary.**
+
+While Admin Settings was a single 14,000-line template this never mattered: a
+variable derived near the top of the file was visible everywhere below it. The
+information architecture rework split that template into 44 per-tab partials,
+and a variable derived in one partial is simply not visible in another.
+
+Three variables were left behind when their consuming card moved to a new tab:
+
+| Variable | Declared in | Used in | Failure |
+|---|---|---|---|
+| `analyze_capability` | `agents.html` | `actions.html` | 500 error |
+| `comparison_capability` | `agents.html` | `actions.html` | 500 error |
+| `enable_dai_debug` | `redis-caching.html` | `cosmos.html` | **silent** |
+
+### Two very different failure modes
+
+The distinction matters more than the fix:
+
+- **Attribute access** on a missing name (`analyze_capability.enabled`) raises
+  `UndefinedError` and takes the page down. Loud, and found immediately.
+- **A boolean test** on a missing name (`{% if enable_dai_debug %}`) silently
+  evaluates false, because Jinja's default `Undefined` is falsy. Nothing errors.
+  The controls it guards simply never render.
+
+The `enable_dai_debug` case was therefore invisible: the Cosmos tab's debug
+controls and shadow-validation diagnostics would never have appeared, no matter
+how the setting was configured, and nothing would have reported a problem. It
+was found only by auditing for the same pattern that caused the crash.
+
+## Why existing tests did not catch it
+
+Every Admin Settings test inspected the template **as text** — field names, card
+ids, tag balance, navigation parity, modal placement. All of them passed.
+
+None of them **executed** the template. A template can satisfy every static
+check and still raise the moment Flask renders it.
+
+## Files modified
+
+| File | Change |
+|---|---|
+| `templates/admin/_panes/actions.html` | Declares `analyze_capability` and `comparison_capability` |
+| `templates/admin/_panes/agents.html` | Removed the two now-orphaned declarations |
+| `templates/admin/_panes/cosmos.html` | Declares `enable_dai_debug` |
+| `templates/admin/_panes/redis-caching.html` | Removed the now-orphaned declaration |
+
+Each declaration is a pure derivation from `settings`, which the route supplies
+to every template, so moving it to the consuming pane is safe and self-contained.
+
+## Testing
+
+Two new test files, both verified against a deliberately planted version of the
+real bug so they are known to fail when they should.
+
+### `test_admin_settings_renders.py`
+
+Renders the entire page through Jinja with the same undefined handling Flask
+uses, so an `UndefinedError` surfaces in the test suite rather than in a browser.
+This is the test that would have caught the bug immediately.
+
+It also asserts every navigation tab renders a pane, and that exactly one pane is
+active and it is the landing tab.
+
+The render context is derived from the route's own `render_template` call and the
+app context processors, so it cannot drift as those change.
+
+### `test_admin_settings_pane_variable_scope.py`
+
+Static scope analysis using `jinja2.meta.find_undeclared_variables`. For every
+pane it reports the variables needed from outside, then fails if any of them is
+declared only in a **sibling pane**:
+
+```
+'analyze_capability' is used in 'actions' but only declared in ['agents']
+```
+
+This catches the silent variant that a render cannot, because a boolean test on
+an undefined name renders perfectly happily.
+
+Variables declared inside a `{% for %}` loop are correctly treated as local.
+
+## Validation
+
+| Check | Result |
+|---|---|
+| Page renders | 1,383,741 characters, no error |
+| Navigation tabs rendering a pane | 44 / 44 |
+| Active panes | exactly 1, and it is the landing tab |
+| Cross-pane variable leaks | none |
+| Field names vs `Development` | 452 → 452, zero lost, zero added |
+| Regression set (75 files) | 32 pre-existing failures, unchanged |
+
+## Before and after
+
+**Before**: every visit to Admin Settings returned a 500, and the Cosmos debug
+controls were silently unreachable.
+
+**After**: the page loads, the Cosmos debug controls honour their setting, and
+both failure modes are covered by tests that fail when the bug is reintroduced.

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,26 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](/explanation/features/) and [Fixes by Version](/explanation/fixes/).
 
+### **(v0.260.019)**
+
+#### Bug Fixes
+
+*   **Admin Settings Failed To Load**
+    *   Opening Admin Settings returned an error page instead of the settings.
+    *   Three settings groups depended on a value worked out in a different tab. That was fine while Admin Settings was one large page, but each tab is now its own file and a value worked out in one is not available in another.
+    *   Each value is now worked out in the tab that uses it. No setting changed and nothing needs re-entering.
+    *   (Ref: `actions`, `agents`, `cosmos`, `redis-caching` tabs, [Admin Settings Pane Variable Scope Fix](fixes/ADMIN_SETTINGS_PANE_VARIABLE_SCOPE_FIX.md))
+
+*   **Cosmos Debug Controls Were Silently Missing**
+    *   The debug controls and shadow validation diagnostics on the Cosmos tab would never appear, whatever the debug setting was set to, and nothing reported a problem. This came from the same cause as the error above, but with no visible symptom.
+    *   They now appear whenever debug mode is enabled.
+    *   (Ref: `enable_dai_debug`, Scale → Cosmos)
+
+*   **Admin Settings Is Now Tested By Actually Loading It**
+    *   The existing checks read the Admin Settings page as text and all passed, because none of them opened the page. A page can look correct and still fail to load.
+    *   The test suite now builds the whole page the way the app does, so this kind of failure is caught before release rather than on a visit.
+    *   (Ref: `test_admin_settings_renders.py`, `test_admin_settings_pane_variable_scope.py`)
+
 ### **(v0.260.018)**
 
 #### Bug Fixes

--- a/functional_tests/test_admin_settings_pane_variable_scope.py
+++ b/functional_tests/test_admin_settings_pane_variable_scope.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""
+Functional test for Admin Settings pane template variable scope.
+Version: 0.260.019
+Implemented in: 0.260.019
+
+Jinja `{% set %}` scope does not cross an `{% include %}` boundary. While Admin
+Settings was one template that never mattered, because a variable derived near
+the top was visible everywhere below it. Splitting the template into per-tab
+partials made it matter a great deal: a card can move to a new pane and leave
+the variable it depends on behind in its old one.
+
+That happened three times, and the two failure modes are very different:
+
+  Attribute access on the missing name raises UndefinedError and takes the whole
+  Admin Settings page down. Loud, obvious, found immediately.
+
+  A boolean test on the missing name silently evaluates false, because Jinja's
+  default Undefined is falsy. Nothing errors. The controls it guards simply
+  never appear, and no one notices.
+
+The second kind is why this test exists rather than relying on a page load.
+
+This test ensures every variable a pane uses is either declared in that pane or
+supplied by the render context, and never borrowed from a sibling pane.
+"""
+
+import os
+import re
+import sys
+
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+
+from jinja2 import Environment, FileSystemLoader, meta  # noqa: E402
+
+APP_ROOT = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "application",
+    "single_app",
+)
+TEMPLATE_DIR = os.path.join(APP_ROOT, "templates")
+PANES_DIR = os.path.join(TEMPLATE_DIR, "admin", "_panes")
+ROUTE_FILE = os.path.join(APP_ROOT, "route_frontend_admin_settings.py")
+APP_FILE = os.path.join(APP_ROOT, "app.py")
+
+SET_PATTERN = re.compile(r"{%-?\s*set\s+([A-Za-z_][A-Za-z0-9_]*)\s*[=,]")
+
+# Provided by Flask and Jinja to every template.
+FRAMEWORK_GLOBALS = {
+    "config",
+    "request",
+    "session",
+    "g",
+    "url_for",
+    "get_flashed_messages",
+    "current_user",
+    "csrf_token",
+    "range",
+    "dict",
+    "lipsum",
+    "cycler",
+    "joiner",
+    "namespace",
+}
+
+
+def _read(path):
+    with open(path, "r", encoding="utf-8") as handle:
+        return handle.read()
+
+
+def _route_context_keys():
+    """Keyword arguments the Admin Settings route passes to render_template."""
+    source = _read(ROUTE_FILE)
+    anchor = source.index("render_template(\n                'admin_settings.html'")
+    block = source[anchor:source.index("\n            )", anchor)]
+    return set(re.findall(r"^\s+([a-z_][a-z0-9_]*)=", block, re.M))
+
+
+def _context_processor_keys():
+    """Names injected into every template by an app context processor."""
+    source = _read(APP_FILE)
+    keys = set()
+    for match in re.finditer(r"@app\.context_processor", source):
+        block = source[match.start():match.start() + 6000]
+        end = block.find("\n@")
+        if end != -1:
+            block = block[:end]
+        keys.update(re.findall(r"^\s+([a-z_][a-z0-9_]*)=", block, re.M))
+    return keys
+
+
+def _pane_files():
+    return sorted(
+        os.path.join(PANES_DIR, name)
+        for name in os.listdir(PANES_DIR)
+        if name.endswith(".html")
+    )
+
+
+def _analyse():
+    """Return (external_needs, declared) per pane.
+
+    external_needs excludes names the pane declares itself. A `{% set %}` inside
+    a `{% for %}` is block scoped, so Jinja reports it as undeclared even though
+    it is perfectly valid and local; those are filtered out by checking whether
+    the pane declares the name anywhere.
+    """
+    env = Environment(loader=FileSystemLoader(TEMPLATE_DIR))
+    external, declared = {}, {}
+    for path in _pane_files():
+        pane = os.path.basename(path)[: -len(".html")]
+        source = _read(path)
+        local = set(SET_PATTERN.findall(source))
+        declared[pane] = local
+        external[pane] = set(meta.find_undeclared_variables(env.parse(source))) - local
+    return external, declared
+
+
+def test_no_pane_borrows_a_variable_from_a_sibling():
+    """The exact bug: a card moved tabs and left its `{% set %}` behind."""
+    print("Testing panes do not borrow variables from sibling panes...")
+
+    external, declared = _analyse()
+    owner = {}
+    for pane, names in declared.items():
+        for name in names:
+            owner.setdefault(name, set()).add(pane)
+
+    borrowed = []
+    for pane, names in sorted(external.items()):
+        for name in sorted(names):
+            elsewhere = owner.get(name, set()) - {pane}
+            if elsewhere:
+                borrowed.append(
+                    f"'{name}' is used in '{pane}' but only declared in {sorted(elsewhere)}"
+                )
+
+    assert not borrowed, (
+        "Panes borrowing a variable across an include boundary, which Jinja does "
+        "not support. Declare it in the pane that uses it:\n  " + "\n  ".join(borrowed)
+    )
+
+    print(f"No pane borrows a variable from a sibling ({len(external)} panes checked).")
+    return True
+
+
+def test_every_pane_variable_is_supplied():
+    """Anything not declared locally must come from the render context."""
+    print("Testing every pane variable is supplied by the render context...")
+
+    available = _route_context_keys() | _context_processor_keys() | FRAMEWORK_GLOBALS
+    assert "settings" in available, "Sanity check failed: route context not parsed"
+    assert "admin_landing_tab" in available, "Sanity check failed: context processors not parsed"
+
+    external, _ = _analyse()
+    missing = []
+    for pane, names in sorted(external.items()):
+        for name in sorted(names - available):
+            missing.append(f"{pane}: '{name}'")
+
+    assert not missing, (
+        "Pane variables that are neither declared locally nor supplied by the "
+        "Admin Settings render context:\n  " + "\n  ".join(missing)
+    )
+
+    print(f"All pane variables are supplied ({len(available)} names available).")
+    return True
+
+
+def test_analyser_detects_a_planted_leak():
+    """A guard that cannot fail is worthless, so prove it catches the real bug."""
+    print("Testing the scope analyser detects a planted leak...")
+
+    env = Environment(loader=FileSystemLoader(TEMPLATE_DIR))
+    source = _read(os.path.join(PANES_DIR, "actions.html"))
+    assert "{% set analyze_capability" in source, (
+        "Expected actions.html to declare analyze_capability locally"
+    )
+
+    # Reproduce the original bug: remove the local declaration and confirm the
+    # analyser reports the name as needed from outside.
+    planted = re.sub(r"{%-?\s*set\s+analyze_capability\s*=.*?%}", "", source)
+    needs = meta.find_undeclared_variables(env.parse(planted))
+    assert "analyze_capability" in needs, (
+        "The analyser failed to detect a removed declaration, so it would not "
+        "have caught the original bug"
+    )
+
+    print("The analyser detects a planted leak.")
+    return True
+
+
+if __name__ == "__main__":
+    tests = [
+        test_no_pane_borrows_a_variable_from_a_sibling,
+        test_every_pane_variable_is_supplied,
+        test_analyser_detects_a_planted_leak,
+    ]
+    results = []
+    for test in tests:
+        print(f"\nRunning {test.__name__}...")
+        try:
+            results.append(bool(test()))
+        except Exception as error:  # noqa: BLE001 - report and continue
+            print(f"Test failed: {error}")
+            import traceback
+
+            traceback.print_exc()
+            results.append(False)
+
+    print(f"\nResults: {sum(results)}/{len(results)} tests passed")
+    sys.exit(0 if all(results) else 1)

--- a/functional_tests/test_admin_settings_renders.py
+++ b/functional_tests/test_admin_settings_renders.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""
+Functional test that the Admin Settings page actually renders.
+Version: 0.260.019
+Implemented in: 0.260.019
+
+Every other Admin Settings test inspects the template as text: field names, card
+ids, tag balance, navigation parity. None of them execute it. A template can
+satisfy all of those and still raise the moment Flask renders it, which is
+exactly what happened when a card moved to a new tab and left the `{% set %}` it
+depended on behind in its old pane.
+
+This test renders the whole page through Jinja with the same undefined handling
+Flask uses, so an UndefinedError surfaces here instead of as a 500 in the
+browser.
+
+The context is built from the route's own render_template call and the app
+context processors, so it cannot drift as those change. Values are permissive
+stand-ins: the point is to prove the template executes and that every name it
+reaches for exists, not to assert on rendered content.
+"""
+
+import os
+import re
+import sys
+
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+
+from jinja2 import Environment, FileSystemLoader  # noqa: E402
+
+APP_ROOT = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "application",
+    "single_app",
+)
+TEMPLATE_DIR = os.path.join(APP_ROOT, "templates")
+ROUTE_FILE = os.path.join(APP_ROOT, "route_frontend_admin_settings.py")
+APP_FILE = os.path.join(APP_ROOT, "app.py")
+
+if APP_ROOT not in sys.path:
+    sys.path.insert(0, APP_ROOT)
+
+import admin_settings_nav as admin_nav_module  # noqa: E402
+
+
+class Permissive(dict):
+    """Stand-in that yields another Permissive for any access.
+
+    Settings are deeply nested and optional, so a fixed fixture would either be
+    enormous or wrong. This lets the template walk any path it likes while still
+    failing on a name that was never supplied at all.
+    """
+
+    def __getattr__(self, name):
+        if name.startswith("__"):
+            raise AttributeError(name)
+        return Permissive()
+
+    def __getitem__(self, name):
+        return Permissive()
+
+    def get(self, name, default=None):
+        return Permissive()
+
+    def __iter__(self):
+        return iter(())
+
+    def __bool__(self):
+        return False
+
+    def __str__(self):
+        return ""
+
+    def __html__(self):
+        return ""
+
+    def __call__(self, *args, **kwargs):
+        return Permissive()
+
+    def items(self):
+        return []
+
+    def keys(self):
+        return []
+
+
+def _read(path):
+    with open(path, "r", encoding="utf-8") as handle:
+        return handle.read()
+
+
+def _context_names():
+    """Names the real page is rendered with, read from the app rather than listed."""
+    names = set()
+
+    route = _read(ROUTE_FILE)
+    anchor = route.index("render_template(\n                'admin_settings.html'")
+    block = route[anchor:route.index("\n            )", anchor)]
+    names.update(re.findall(r"^\s+([a-z_][a-z0-9_]*)=", block, re.M))
+
+    app_source = _read(APP_FILE)
+    for match in re.finditer(r"@app\.context_processor", app_source):
+        chunk = app_source[match.start():match.start() + 6000]
+        end = chunk.find("\n@")
+        names.update(re.findall(r"^\s+([a-z_][a-z0-9_]*)=", chunk[:end if end != -1 else len(chunk)], re.M))
+
+    return names
+
+
+def _render():
+    """Render admin_settings.html the way Flask would."""
+    # Default undefined, matching Flask: attribute access on a missing name
+    # raises, which is the failure this test exists to catch.
+    env = Environment(loader=FileSystemLoader(TEMPLATE_DIR), autoescape=True)
+    env.globals.update(
+        url_for=lambda *a, **k: "/static/stub",
+        get_flashed_messages=lambda *a, **k: [],
+        config={"VERSION": "0.0.0-test"},
+        session=Permissive(),
+        request=Permissive(),
+        g=Permissive(),
+        csrf_token=lambda: "test-token",
+    )
+
+    names = _context_names()
+    assert "settings" in names, "Sanity check failed: route context not parsed"
+    assert "admin_landing_tab" in names, "Sanity check failed: context processors not parsed"
+
+    context = {name: Permissive() for name in names}
+    # The navigation drives which tabs and panes exist, so use the real thing.
+    context["admin_nav"] = admin_nav_module.ADMIN_NAV
+    context["admin_landing_tab"] = admin_nav_module.get_landing_tab_id()
+    context["mcp_ui_enabled"] = True
+
+    return env.get_template("admin_settings.html").render(**context)
+
+
+def test_admin_settings_renders_without_error():
+    """The page must execute, not merely parse."""
+    print("Testing Admin Settings renders...")
+
+    markup = _render()
+    assert len(markup) > 100_000, f"Rendered output looks truncated: {len(markup)} chars"
+
+    print(f"Admin Settings rendered ({len(markup):,} characters).")
+    return True
+
+
+def test_every_navigation_tab_renders_a_pane():
+    """A tab in the map with no pane is a dead end in the UI."""
+    print("Testing every navigation tab renders a pane...")
+
+    markup = _render()
+    rendered = set(re.findall(r'<div class="tab-pane[^"]*" id="([a-z0-9-]+)" role="tabpanel"', markup))
+
+    missing = sorted(set(admin_nav_module.get_tab_ids()) - rendered)
+    assert not missing, f"Tabs in the navigation map that rendered no pane: {missing}"
+
+    print(f"All {len(admin_nav_module.get_tab_ids())} navigation tabs rendered a pane.")
+    return True
+
+
+def test_exactly_one_admin_pane_is_active():
+    """Landing on no tab, or on two, are both broken states."""
+    print("Testing exactly one Admin Settings pane is active...")
+
+    markup = _render()
+    active = re.findall(
+        r'<div class="tab-pane fade show active" id="([a-z0-9-]+)" role="tabpanel"', markup
+    )
+
+    # Nested tab widgets, such as the governance info panel, carry their own
+    # active tab and are not part of the Admin Settings navigation.
+    tab_ids = set(admin_nav_module.get_tab_ids())
+    active_admin = [tab for tab in active if tab in tab_ids]
+
+    assert len(active_admin) == 1, (
+        f"Expected exactly one active Admin Settings pane, got {active_admin}"
+    )
+    assert active_admin[0] == admin_nav_module.get_landing_tab_id(), (
+        f"Active pane '{active_admin[0]}' is not the landing tab "
+        f"'{admin_nav_module.get_landing_tab_id()}'"
+    )
+    assert active_admin[0] != "latest-features", (
+        "Latest Features must never be the pane an admin lands on"
+    )
+
+    print(f"Exactly one active pane, and it is the landing tab '{active_admin[0]}'.")
+    return True
+
+
+def test_render_catches_a_planted_undefined():
+    """A guard that cannot fail is worthless, so prove it catches the real bug."""
+    print("Testing the render catches a planted undefined variable...")
+
+    pane = os.path.join(TEMPLATE_DIR, "admin", "_panes", "actions.html")
+    original = _read(pane)
+    assert "{% set analyze_capability" in original, (
+        "Expected actions.html to declare analyze_capability locally"
+    )
+
+    planted = re.sub(r"{%-?\s*set\s+analyze_capability\s*=.*?%}", "", original)
+    try:
+        with open(pane, "w", encoding="utf-8", newline="") as handle:
+            handle.write(planted)
+        try:
+            _render()
+        except Exception as error:  # noqa: BLE001 - this is the expected path
+            assert "analyze_capability" in str(error), (
+                f"Render failed, but not for the planted reason: {error}"
+            )
+            print("The render catches a planted undefined variable.")
+            return True
+        raise AssertionError(
+            "Removing a required declaration did not break the render, so this "
+            "test would not have caught the original bug"
+        )
+    finally:
+        with open(pane, "w", encoding="utf-8", newline="") as handle:
+            handle.write(original)
+
+
+if __name__ == "__main__":
+    tests = [
+        test_admin_settings_renders_without_error,
+        test_every_navigation_tab_renders_a_pane,
+        test_exactly_one_admin_pane_is_active,
+        test_render_catches_a_planted_undefined,
+    ]
+    results = []
+    for test in tests:
+        print(f"\nRunning {test.__name__}...")
+        try:
+            results.append(bool(test()))
+        except Exception as error:  # noqa: BLE001 - report and continue
+            print(f"Test failed: {error}")
+            import traceback
+
+            traceback.print_exc()
+            results.append(False)
+
+    print(f"\nResults: {sum(results)}/{len(results)} tests passed")
+    sys.exit(0 if all(results) else 1)


### PR DESCRIPTION
Fixes the 500 on Admin Settings, plus a silent variant of the same bug found while investigating.

Base: `feature/admin-settings-ia`.

## The failure

```
File "templates/admin/_panes/actions.html", line 17, in top-level template code
  <input ... {% if analyze_capability.enabled %}checked{% endif %}>
jinja2.exceptions.UndefinedError: 'analyze_capability' is undefined
```

## Root cause

**Jinja `{% set %}` scope does not cross an `{% include %}` boundary.**

While Admin Settings was one 14,000-line template this never mattered — a variable derived near the top was visible everywhere below it. Splitting it into 44 per-tab partials made it matter: a variable derived in one partial is simply not visible in another.

Three variables were left behind when their consuming card moved to a different tab:

| Variable | Declared in | Used in | Failure |
|---|---|---|---|
| `analyze_capability` | `agents` | `actions` | 500 |
| `comparison_capability` | `agents` | `actions` | 500 |
| `enable_dai_debug` | `redis-caching` | `cosmos` | **silent** |

Each is a pure derivation from `settings`, which the route supplies to every template, so moving the declaration into the consuming pane is safe and self-contained.

## The one you didn't see

The two failure modes are very different, and the quiet one is worse:

- **Attribute access** on a missing name raises and takes the page down. Loud, found immediately.
- **A boolean test** on a missing name is *silently false*, because Jinja's default `Undefined` is falsy.

`enable_dai_debug` is used as `{% if enable_dai_debug %}` in six places on the Cosmos tab. Those debug controls and shadow-validation diagnostics **would never have rendered**, whatever the setting was, and nothing would have reported a problem. It was found only by auditing for the pattern that caused the crash — not by the error.

## Why every existing test passed

All the Admin Settings tests inspect the template **as text**: field names, card ids, tag balance, navigation parity, modal placement. Every one was green.

**None of them execute the template.** A template can satisfy every static check and still raise the moment Flask renders it. That is the real gap this PR closes.

### `test_admin_settings_renders.py`

Renders the whole page through Jinja using the same undefined handling Flask uses, so an `UndefinedError` surfaces in the suite instead of in a browser. This is the test that would have caught the bug immediately.

It also asserts every navigation tab renders a pane, and that exactly one pane is active and it is the landing tab.

The render context is derived from the route's own `render_template` call and the app context processors, so it cannot drift as those change.

### `test_admin_settings_pane_variable_scope.py`

Static scope analysis via `jinja2.meta.find_undeclared_variables`, which catches the silent variant a render cannot. It names the offender precisely:

```
'analyze_capability' is used in 'actions' but only declared in ['agents']
```

Variables declared inside a `{% for %}` loop are correctly treated as local.

**Both tests are verified against a planted copy of the real bug**, so they are known to fail when they should.

## Verification

| Check | Result |
|---|---|
| Page renders | 1,383,741 chars, no error |
| Navigation tabs rendering a pane | 44 / 44 |
| Active panes | exactly 1, and it is the landing tab |
| Cross-pane variable leaks | none |
| Field names vs `Development` | 452 → 452, zero lost, zero added |
| Regression set (75 files) | 32 pre-existing failures, unchanged |
| Jinja compile | 46/46 admin templates |
| XSS sinks | pass |

No setting changed and nothing needs re-entering.

Version **0.260.019**. Full write-up in [ADMIN_SETTINGS_PANE_VARIABLE_SCOPE_FIX.md](https://github.com/microsoft/simplechat/blob/admin-ia-fix-pane-scope/docs/explanation/fixes/ADMIN_SETTINGS_PANE_VARIABLE_SCOPE_FIX.md).

The rule worth keeping: **a template is not verified until it has been rendered.**
