### PR TITLE
Fix Backup &amp; Recovery save button never enabling

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -96,7 +96,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.260.028"
+VERSION = "0.261.001"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/static/js/admin/admin_data_management.js
+++ b/application/single_app/static/js/admin/admin_data_management.js
@@ -9,6 +9,11 @@ const targetCosmosDatabaseName = "SimpleChat";
 const cosmosEditorConfirmationPhrase = "I understand this can damage system data";
 const migrationMirrorConfirmationPhrase = "MAKE DESTINATION MATCH SOURCE";
 const restoreOverwriteConfirmationPhrase = "RESTORE WITH OVERWRITE";
+// Backup & Recovery was a single tab until the Admin Settings information
+// architecture was split. Its controls now live in five sibling panes, so the
+// module binds across every pane that declares the group rather than looking
+// for one root element that no longer exists.
+const dataManagementPaneSelector = "[data-admin-group-pane='backup-recovery']";
 const elements = {};
 let dataManagementModified = false;
 let storedBackupConnectionStringAvailable = false;
@@ -69,7 +74,7 @@ const migrationWorkflowState = {
 };
 document.addEventListener("DOMContentLoaded", () => {
     bindElements();
-    if (!elements.tabPane) {
+    if (!elements.tabPanes.length) {
         return;
     }
 
@@ -84,7 +89,6 @@ document.addEventListener("DOMContentLoaded", () => {
 
 function bindElements() {
     const ids = [
-        "data-management",
         "data-management-migration-section",
         "data-management-migration-readiness",
         "data-management-migration-step-error",
@@ -305,7 +309,7 @@ function bindElements() {
         elements[key] = document.getElementById(id);
     });
 
-    elements.tabPane = elements.dataManagement;
+    elements.tabPanes = Array.from(document.querySelectorAll(dataManagementPaneSelector));
 }
 
 function bindEvents() {
@@ -552,12 +556,14 @@ function activateMigrationScopeTab(targetType) {
 }
 
 function bindDataManagementChangeTracking() {
-    elements.tabPane?.querySelectorAll("input, select, textarea").forEach((element) => {
-        if (element.closest("[data-ignore-data-management-change='true']")) {
-            return;
-        }
-        const eventName = element.type === "checkbox" || element.type === "radio" || element.tagName === "SELECT" ? "change" : "input";
-        element.addEventListener(eventName, markDataManagementModified);
+    elements.tabPanes.forEach((pane) => {
+        pane.querySelectorAll("input, select, textarea").forEach((element) => {
+            if (element.closest("[data-ignore-data-management-change='true']")) {
+                return;
+            }
+            const eventName = element.type === "checkbox" || element.type === "radio" || element.tagName === "SELECT" ? "change" : "input";
+            element.addEventListener(eventName, markDataManagementModified);
+        });
     });
 }
 

--- a/application/single_app/static/js/admin/admin_settings.js
+++ b/application/single_app/static/js/admin/admin_settings.js
@@ -10815,10 +10815,11 @@ window.isAdminSettingsFormModified = () => formModified;
 function updateSaveButtonState() {
     if (!saveButton) return;
 
-    const dataManagementPane = document.getElementById('data-management');
-    const isDataManagementActive = Boolean(dataManagementPane?.classList.contains('active'));
-    saveButton.classList.toggle('d-none', isDataManagementActive);
-    if (isDataManagementActive) {
+    // Backup & Recovery panes carry their own save button in a group-shared
+    // region, so the global one is hidden while any of those tabs is active.
+    const isBackupRecoveryActive = Boolean(document.querySelector('[data-admin-group-pane="backup-recovery"].active'));
+    saveButton.classList.toggle('d-none', isBackupRecoveryActive);
+    if (isBackupRecoveryActive) {
         return;
     }
     

--- a/application/single_app/templates/admin/_panes/backup.html
+++ b/application/single_app/templates/admin/_panes/backup.html
@@ -1,4 +1,4 @@
-            <div class="tab-pane fade{% if admin_landing_tab == 'backup' %} show active{% endif %}" id="backup" role="tabpanel" aria-labelledby="backup-tab" data-testid="backup-tab-pane" data-ignore-settings-change="true">
+            <div class="tab-pane fade{% if admin_landing_tab == 'backup' %} show active{% endif %}" id="backup" role="tabpanel" aria-labelledby="backup-tab" data-testid="backup-tab-pane" data-admin-group-pane="backup-recovery" data-ignore-settings-change="true">
                 <div class="card p-4 mb-4 border-info shadow-sm" id="data-management-readiness-section">
                     <div class="d-flex flex-column flex-xl-row justify-content-between gap-3 mb-3">
                         <div>

--- a/application/single_app/templates/admin/_panes/cosmos-editor.html
+++ b/application/single_app/templates/admin/_panes/cosmos-editor.html
@@ -1,4 +1,4 @@
-            <div class="tab-pane fade{% if admin_landing_tab == 'cosmos-editor' %} show active{% endif %}" id="cosmos-editor" role="tabpanel" aria-labelledby="cosmos-editor-tab" data-testid="cosmos-editor-tab-pane" data-ignore-settings-change="true">
+            <div class="tab-pane fade{% if admin_landing_tab == 'cosmos-editor' %} show active{% endif %}" id="cosmos-editor" role="tabpanel" aria-labelledby="cosmos-editor-tab" data-testid="cosmos-editor-tab-pane" data-admin-group-pane="backup-recovery" data-ignore-settings-change="true">
                 <div class="card p-4 mb-4 border-danger shadow-sm" id="data-management-cosmos-editor-section" data-ignore-data-management-change="true">
                     <div class="d-flex flex-wrap align-items-start justify-content-between gap-3 mb-3">
                         <div>

--- a/application/single_app/templates/admin/_panes/jobs.html
+++ b/application/single_app/templates/admin/_panes/jobs.html
@@ -1,4 +1,4 @@
-            <div class="tab-pane fade{% if admin_landing_tab == 'jobs' %} show active{% endif %}" id="jobs" role="tabpanel" aria-labelledby="jobs-tab" data-testid="jobs-tab-pane" data-ignore-settings-change="true">
+            <div class="tab-pane fade{% if admin_landing_tab == 'jobs' %} show active{% endif %}" id="jobs" role="tabpanel" aria-labelledby="jobs-tab" data-testid="jobs-tab-pane" data-admin-group-pane="backup-recovery" data-ignore-settings-change="true">
                 <div class="card p-4 mb-4 border-dark shadow-sm" id="data-management-jobs-section">
                     <div class="d-flex align-items-center justify-content-between mb-3">
                         <h4 class="mb-0">Job History</h4>

--- a/application/single_app/templates/admin/_panes/migrate.html
+++ b/application/single_app/templates/admin/_panes/migrate.html
@@ -1,4 +1,4 @@
-            <div class="tab-pane fade{% if admin_landing_tab == 'migrate' %} show active{% endif %}" id="migrate" role="tabpanel" aria-labelledby="migrate-tab" data-testid="migrate-tab-pane" data-ignore-settings-change="true">
+            <div class="tab-pane fade{% if admin_landing_tab == 'migrate' %} show active{% endif %}" id="migrate" role="tabpanel" aria-labelledby="migrate-tab" data-testid="migrate-tab-pane" data-admin-group-pane="backup-recovery" data-ignore-settings-change="true">
                 <section class="card p-0 mb-4 shadow-sm migration-workflow" id="data-management-migration-section" aria-labelledby="data-management-migration-title">
                     <header class="migration-workflow-header">
                         <div>

--- a/application/single_app/templates/admin/_panes/restore.html
+++ b/application/single_app/templates/admin/_panes/restore.html
@@ -1,4 +1,4 @@
-            <div class="tab-pane fade{% if admin_landing_tab == 'restore' %} show active{% endif %}" id="restore" role="tabpanel" aria-labelledby="restore-tab" data-testid="restore-tab-pane" data-ignore-settings-change="true">
+            <div class="tab-pane fade{% if admin_landing_tab == 'restore' %} show active{% endif %}" id="restore" role="tabpanel" aria-labelledby="restore-tab" data-testid="restore-tab-pane" data-admin-group-pane="backup-recovery" data-ignore-settings-change="true">
                 <div class="card p-4 mb-4 border-primary shadow-sm" id="data-management-backup-inventory-section">
                     <div class="d-flex flex-wrap align-items-start justify-content-between gap-3 mb-3">
                         <div>

--- a/docs/explanation/fixes/BACKUP_SETTINGS_SAVE_BUTTON_FIX.md
+++ b/docs/explanation/fixes/BACKUP_SETTINGS_SAVE_BUTTON_FIX.md
@@ -215,6 +215,14 @@ The following suites also pass: `test_data_management_security_patterns.py`,
   `admin_settings.html` instead of the composed template, so it broke when the
   panes moved into includes. Confirmed pre-existing: it fails identically with
   the changes above stashed.
+- Around twenty functional tests assert the exact `config.py` version literal,
+  for example `assert_contains(CONFIG_FILE, 'VERSION = "0.239.129"')`. This is
+  the pattern the versioning instructions call out, and
+  `test_support.versioning.assert_app_version_at_least` exists to replace it.
+  They were already failing before this change: the highest literal in the suite
+  is `0.260.023` while `config.py` was `0.260.028`. The bump to `0.261.001`
+  breaks none of them further, since no test asserts either version, but
+  converting them to the shared helper is worthwhile follow-up work.
 - A broader probe found roughly 39 `getElementById` literals in
   `admin_settings.js` with no matching id in the composed Admin Settings
   template, for example `workspaces`, `agents-tab` and

--- a/docs/explanation/fixes/BACKUP_SETTINGS_SAVE_BUTTON_FIX.md
+++ b/docs/explanation/fixes/BACKUP_SETTINGS_SAVE_BUTTON_FIX.md
@@ -1,0 +1,223 @@
+# Backup Settings Save Button Fix
+
+**Version:** 0.261.001
+**Fixed in version:** **0.261.001**
+**Related issue:** [#1353](https://github.com/microsoft/simplechat/issues/1353)
+
+## Issue description
+
+In **Admin Settings → Backup, Migrate & Restore**, toggling **Enable scheduled
+backups** did not enable the **Save Settings** button. The button stayed greyed
+out and labelled "Saved", leaving an admin with no way to persist the change.
+
+The toggle was the visible symptom of a much wider failure. The entire Backup &
+Recovery JavaScript module was inert:
+
+- Saved settings were never loaded from the API, so every control showed its
+  static template default rather than the stored configuration.
+- The backup inventory and job history lists never populated.
+- No button in any of the five tabs was wired up, including Run Full Backup,
+  Test Storage, Generate Key, the migration workflow and the Cosmos Editor.
+
+## Root cause
+
+Commit `9bbd7bda` ("Stage D part 6: Backup & Recovery") split the single
+`admin/_panes/data-management.html` pane into five sibling panes — `backup`,
+`migrate`, `restore`, `cosmos-editor` and `jobs`. The shared save button, status
+line and operational warning moved into a `data-admin-group-shared="backup-recovery"`
+region outside the panes, because a control living in one pane would disappear
+whenever another tab of the group was active.
+
+`admin_data_management.js` was not updated as part of that split. It still
+resolved its root container from the id the split removed, and hard-stopped when
+it was missing:
+
+```js
+// bindElements()
+elements.tabPane = elements.dataManagement;   // getElementById("data-management") -> null
+
+// DOMContentLoaded
+bindElements();
+if (!elements.tabPane) {
+    return;                                   // module dies here
+}
+```
+
+`bindEvents()` therefore never ran. `bindDataManagementChangeTracking()` was
+also scoped to `elements.tabPane`, so no `change` or `input` listener was ever
+attached. `dataManagementModified` stayed `false`, and
+`updateDataManagementSaveButtonState()` kept the button disabled and labelled
+"Saved" — exactly the reported behaviour.
+
+Of the 214 element ids `bindElements()` binds, exactly one — `data-management` —
+was absent from the composed Admin Settings template.
+
+The same removed id had a second consumer. `admin_settings.js`
+`updateSaveButtonState()` hides the *global* Save Settings button while a Backup
+& Recovery tab is active, so the group's dedicated button is the only one shown:
+
+```js
+const dataManagementPane = document.getElementById('data-management');
+const isDataManagementActive = Boolean(dataManagementPane?.classList.contains('active'));
+```
+
+That lookup was always `null`, so the global save button appeared on all five
+Backup & Recovery tabs alongside the dedicated one — two save buttons, only one
+of which applied to backup settings.
+
+## Approach
+
+Re-introducing an `id="data-management"` wrapper around the panes is not
+viable. Bootstrap hides inactive panes through `.tab-content > .tab-pane`, a
+direct-child selector, so nesting the five panes one level deeper would stop
+that rule matching and display every pane at once.
+
+Instead the group membership is declared in the markup and both consumers read
+it. Each pane carries `data-admin-group-pane="backup-recovery"`, mirroring the
+existing `data-admin-group-shared="backup-recovery"` convention and tying the
+panes to the real navigation group id in `admin_settings_nav.py`. This also
+gives the functional tests a contract to enforce, so splitting or adding a
+Backup & Recovery tab in future cannot silently strand the module again.
+
+## Files modified
+
+| File | Change |
+|---|---|
+| `application/single_app/templates/admin/_panes/backup.html` | Added `data-admin-group-pane="backup-recovery"` to the tab pane |
+| `application/single_app/templates/admin/_panes/migrate.html` | Added `data-admin-group-pane="backup-recovery"` to the tab pane |
+| `application/single_app/templates/admin/_panes/restore.html` | Added `data-admin-group-pane="backup-recovery"` to the tab pane |
+| `application/single_app/templates/admin/_panes/cosmos-editor.html` | Added `data-admin-group-pane="backup-recovery"` to the tab pane |
+| `application/single_app/templates/admin/_panes/jobs.html` | Added `data-admin-group-pane="backup-recovery"` to the tab pane |
+| `application/single_app/static/js/admin/admin_data_management.js` | Resolve every declared pane, guard on the collection, bind change tracking across all panes |
+| `application/single_app/static/js/admin/admin_settings.js` | Detect the active Backup & Recovery pane through the group attribute |
+| `application/single_app/config.py` | `VERSION = "0.261.001"` |
+| `functional_tests/test_admin_data_management_pane_binding.py` | New regression test |
+| `functional_tests/test_data_management_security_patterns.py` | Updated markup and save button assertions |
+
+## Code changes
+
+`admin_data_management.js` now selects its panes by the declared group:
+
+```js
+const dataManagementPaneSelector = "[data-admin-group-pane='backup-recovery']";
+
+function bindElements() {
+    // ...
+    elements.tabPanes = Array.from(document.querySelectorAll(dataManagementPaneSelector));
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+    bindElements();
+    if (!elements.tabPanes.length) {
+        return;
+    }
+    // ...
+});
+```
+
+Change tracking iterates every pane, so a control on the Backup tab and a
+control on the Migrate tab both arm the save button. The Cosmos Editor opt-out
+is preserved, because a direct database editor is not a settings surface:
+
+```js
+function bindDataManagementChangeTracking() {
+    elements.tabPanes.forEach((pane) => {
+        pane.querySelectorAll("input, select, textarea").forEach((element) => {
+            if (element.closest("[data-ignore-data-management-change='true']")) {
+                return;
+            }
+            const eventName = element.type === "checkbox" || element.type === "radio" || element.tagName === "SELECT" ? "change" : "input";
+            element.addEventListener(eventName, markDataManagementModified);
+        });
+    });
+}
+```
+
+`admin_settings.js` hides the global save button using the same contract:
+
+```js
+const isBackupRecoveryActive = Boolean(document.querySelector('[data-admin-group-pane="backup-recovery"].active'));
+saveButton.classList.toggle('d-none', isBackupRecoveryActive);
+```
+
+## Testing
+
+`functional_tests/test_admin_data_management_pane_binding.py` covers:
+
+1. Every element id bound in `bindElements()` resolves to a real element in the
+   composed Admin Settings template. This is the general assertion that catches
+   this class of bug.
+2. Every tab in the `backup-recovery` navigation group has a pane declaring the
+   group attribute.
+3. No pane outside the group claims it.
+4. The module resolves panes from the attribute, guards on the collection, and
+   no longer references the removed id.
+5. Change tracking iterates every pane and keeps the Cosmos Editor opt-out.
+6. Settings controls that `saveDataManagementSettings()` sends, sampled across
+   both the Backup and Migrate tabs, sit inside a tracked pane.
+7. The global save button defers to the group attribute.
+8. `config.py` `VERSION` is at least `0.261.001`.
+
+## Validation
+
+Against the pre-fix state the new test fails 7 of its 8 checks, including the
+one that names the reported symptom directly:
+
+```
+Test failed: Settings controls that saveDataManagementSettings() sends are outside every
+tracked pane, so changing them cannot enable the save button: ['data_management_enabled',
+'data_management_retention_value', 'data_management_encryption_enabled']
+```
+
+After the fix:
+
+```
+Results: 8/8 tests passed
+```
+
+The following suites also pass: `test_data_management_security_patterns.py`,
+`test_admin_settings_group_shared_regions.py`,
+`test_admin_settings_template_composition.py`,
+`test_admin_settings_modal_placement.py`,
+`test_admin_settings_field_contract.py`, `test_admin_settings_nav_map.py`,
+`test_admin_settings_sidebar_card_parity.py`,
+`test_admin_settings_pane_variable_scope.py`,
+`test_admin_settings_walkthrough_targets.py` and
+`test_admin_settings_dependencies.py`.
+
+## Before and after
+
+| Behaviour | Before | After |
+|---|---|---|
+| Toggling **Enable scheduled backups** | Save button stays disabled, reads "Saved" | Save button enables, reads "Save Settings" |
+| Stored backup settings on page load | Never fetched; controls show template defaults | Loaded from `/api/admin/data-management/settings` |
+| Backup inventory and job history | Never populate | Populate on load |
+| Buttons across the five tabs | Unbound and inert | Wired up |
+| Save buttons shown on a Backup & Recovery tab | Two, the global one being inapplicable | One, the group's own |
+
+## Notes
+
+- No settings key, admin tab, action plugin or chat control was added or
+  renamed, so `docs/_data/app_surface.yml` does not need regenerating.
+- The restore and Cosmos Editor dialogs were moved to document level by the same
+  commit that caused this bug. Scoping change tracking to the panes means a
+  restore confirmation phrase is no longer treated as a settings edit, which is
+  an improvement over the pre-split behaviour.
+- `support_menu_config.py` still links to `#data-management`. That keeps working
+  through the `LEGACY_TAB_REDIRECTS` map in `admin_sidebar_nav.js`
+  (`data-management` → `backup`), which exists for exactly this purpose, so it
+  was left unchanged.
+
+## Known related issues, not addressed here
+
+- `functional_tests/test_admin_settings_tab_preservation.py` fails on
+  `Missing required HTML elements: ['class="tab-pane fade']`. It reads the raw
+  `admin_settings.html` instead of the composed template, so it broke when the
+  panes moved into includes. Confirmed pre-existing: it fails identically with
+  the changes above stashed.
+- A broader probe found roughly 39 `getElementById` literals in
+  `admin_settings.js` with no matching id in the composed Admin Settings
+  template, for example `workspaces`, `agents-tab` and
+  `enable_group_creation_setting`. Some appear to be stale leftovers from the
+  same information-architecture rework; others resolve against templates outside
+  Admin Settings. Auditing them is separate work.

--- a/functional_tests/test_admin_data_management_pane_binding.py
+++ b/functional_tests/test_admin_data_management_pane_binding.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+"""
+Functional test for Backup & Recovery pane binding in Admin Settings.
+Version: 0.261.001
+Implemented in: 0.261.001
+
+Backup & Recovery was a single "Data Management" tab until the Admin Settings
+information architecture was split into five sibling panes: Backup, Migrate,
+Restore, Cosmos Editor and Jobs. The pane element that carried
+``id="data-management"`` disappeared in that split, but admin_data_management.js
+still resolved its root from that id and returned early when it was missing.
+
+Every listener in the module, including the change tracking that enables the
+Backup & Recovery save button, was attached inside that guard. The result was a
+save button that never left its disabled "Saved" state, so an admin could toggle
+scheduled backups and had no way to persist it.
+
+These tests ensure the module and the global save button resolve the panes from
+a contract that is declared in the markup, so splitting or adding a Backup &
+Recovery tab cannot silently strand the module again.
+"""
+
+import os
+import re
+import sys
+
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+
+from test_support.nav import iter_tabs  # noqa: E402
+from test_support.templates import read_admin_settings_template  # noqa: E402
+from test_support.versioning import assert_app_version_at_least  # noqa: E402
+
+APP_ROOT = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "application",
+    "single_app",
+)
+DATA_MANAGEMENT_JS = os.path.join(APP_ROOT, "static", "js", "admin", "admin_data_management.js")
+ADMIN_SETTINGS_JS = os.path.join(APP_ROOT, "static", "js", "admin", "admin_settings.js")
+
+GROUP_ID = "backup-recovery"
+GROUP_ATTRIBUTE = f'data-admin-group-pane="{GROUP_ID}"'
+
+BOUND_IDS_PATTERN = re.compile(r"function bindElements\(\) \{\s*const ids = \[(.*?)\];", re.S)
+ELEMENT_ID_PATTERN = re.compile(r'\sid="([A-Za-z0-9_:.-]+)"')
+TAB_PANE_PATTERN = re.compile(r'<div class="tab-pane fade[^>]*?\sid="([A-Za-z0-9_:.-]+)"[^>]*>')
+
+# Representative settings controls that saveDataManagementSettings() sends. One
+# lives on the Backup tab and one on the Migrate tab, so a regression that binds
+# change tracking to only the first pane is caught.
+SETTINGS_CONTROL_IDS = (
+    "data_management_enabled",
+    "data_management_retention_value",
+    "data_management_encryption_enabled",
+    "data_management_migration_retry_count",
+)
+
+
+def _read(path):
+    with open(path, "r", encoding="utf-8") as handle:
+        return handle.read()
+
+
+def _group_tab_ids():
+    return [tab["id"] for group, tab in iter_tabs() if group["id"] == GROUP_ID]
+
+
+def _pane_regions(markup):
+    """Return {pane_id: markup} for every tab pane in the composed template."""
+    matches = list(TAB_PANE_PATTERN.finditer(markup))
+    regions = {}
+    for index, match in enumerate(matches):
+        end = matches[index + 1].start() if index + 1 < len(matches) else len(markup)
+        regions[match.group(1)] = markup[match.start():end]
+    return regions
+
+
+def test_every_bound_element_id_exists():
+    """A bound id with no element is a silently dead binding."""
+    print("Testing every bound Data Management element id exists...")
+
+    source = _read(DATA_MANAGEMENT_JS)
+    block = BOUND_IDS_PATTERN.search(source)
+    assert block, "Expected a bindElements() id list in admin_data_management.js"
+
+    bound_ids = re.findall(r'"([^"]+)"', block.group(1))
+    assert bound_ids, "Expected bindElements() to bind at least one element id"
+
+    present = set(ELEMENT_ID_PATTERN.findall(read_admin_settings_template()))
+    missing = sorted(set(bound_ids) - present)
+    assert not missing, (
+        "admin_data_management.js binds element ids that do not exist in the "
+        f"composed Admin Settings template: {missing}"
+    )
+
+    print(f"All {len(bound_ids)} bound element ids resolve to real elements.")
+    return True
+
+
+def test_every_group_tab_declares_its_pane():
+    """The module finds its panes by group, so every tab must declare it."""
+    print("Testing every Backup & Recovery tab declares its pane group...")
+
+    markup = read_admin_settings_template()
+    regions = _pane_regions(markup)
+
+    tab_ids = _group_tab_ids()
+    assert tab_ids, f"Expected the '{GROUP_ID}' group to define tabs"
+
+    undeclared = []
+    for tab_id in tab_ids:
+        region = regions.get(tab_id)
+        assert region is not None, f"No tab pane found for '{tab_id}'"
+        if GROUP_ATTRIBUTE not in region.split(">", 1)[0]:
+            undeclared.append(tab_id)
+
+    assert not undeclared, (
+        f"Backup & Recovery panes missing {GROUP_ATTRIBUTE}: {undeclared}. "
+        "admin_data_management.js binds its listeners inside these panes, so an "
+        "undeclared pane loses every control it holds."
+    )
+
+    print(f"All {len(tab_ids)} Backup & Recovery tabs declare their pane group.")
+    return True
+
+
+def test_no_unrelated_pane_claims_the_group():
+    """Claiming the group elsewhere would bind unrelated controls."""
+    print("Testing only Backup & Recovery panes claim the group...")
+
+    markup = read_admin_settings_template()
+    tab_ids = set(_group_tab_ids())
+
+    claimed = [
+        pane_id
+        for pane_id, region in _pane_regions(markup).items()
+        if GROUP_ATTRIBUTE in region.split(">", 1)[0]
+    ]
+    unexpected = sorted(set(claimed) - tab_ids)
+    assert not unexpected, (
+        f"Panes outside the '{GROUP_ID}' group declare {GROUP_ATTRIBUTE}: {unexpected}"
+    )
+    assert len(claimed) == len(tab_ids), (
+        f"Expected {len(tab_ids)} panes to declare the group, found {len(claimed)}"
+    )
+
+    print(f"Exactly the {len(claimed)} Backup & Recovery panes claim the group.")
+    return True
+
+
+def test_module_resolves_panes_from_the_group():
+    """Resolving one removed root id is what broke the module."""
+    print("Testing the module resolves its panes from the group attribute...")
+
+    source = _read(DATA_MANAGEMENT_JS)
+
+    assert 'getElementById("data-management")' not in source, (
+        "admin_data_management.js still resolves the removed 'data-management' "
+        "pane id"
+    )
+    assert '"data-management",' not in source, (
+        "The removed 'data-management' id is still in the bindElements() list"
+    )
+    assert f"data-admin-group-pane='{GROUP_ID}'" in source, (
+        "Expected the module to select its panes by the declared group attribute"
+    )
+    assert "elements.tabPanes = Array.from(document.querySelectorAll(" in source, (
+        "Expected the module to resolve every declared pane, not just the first"
+    )
+    assert "if (!elements.tabPanes.length) {" in source, (
+        "Expected the startup guard to bail only when no pane is present"
+    )
+
+    print("The module resolves and guards on the full set of panes.")
+    return True
+
+
+def test_change_tracking_covers_every_pane():
+    """Backup and Migrate settings both have to arm the save button."""
+    print("Testing change tracking is bound across every pane...")
+
+    source = _read(DATA_MANAGEMENT_JS)
+    match = re.search(
+        r"function bindDataManagementChangeTracking\(\) \{.*?\n\}", source, re.S
+    )
+    assert match, "Expected the Data Management change tracking helper"
+    body = match.group(0)
+
+    assert "elements.tabPanes.forEach(" in body, (
+        "Change tracking must iterate every pane. Binding to a single pane "
+        "leaves the other tabs unable to enable the save button."
+    )
+    assert "markDataManagementModified" in body, (
+        "Expected change tracking to mark the settings as modified"
+    )
+    # The Cosmos Editor is a direct database editor, not a settings surface, so
+    # its controls must stay out of the settings modified state.
+    assert "data-ignore-data-management-change" in body, (
+        "Expected the opt-out that keeps the Cosmos Editor out of settings changes"
+    )
+
+    print("Change tracking is bound across every Backup & Recovery pane.")
+    return True
+
+
+def test_settings_controls_live_in_a_tracked_pane():
+    """A settings control outside a tracked pane can never be saved."""
+    print("Testing saved settings controls sit inside tracked panes...")
+
+    markup = read_admin_settings_template()
+    tracked = {
+        pane_id: region
+        for pane_id, region in _pane_regions(markup).items()
+        if GROUP_ATTRIBUTE in region.split(">", 1)[0]
+    }
+
+    untracked = []
+    for control_id in SETTINGS_CONTROL_IDS:
+        needle = f'id="{control_id}"'
+        assert needle in markup, f"Expected the '{control_id}' control to exist"
+        if not any(needle in region for region in tracked.values()):
+            untracked.append(control_id)
+
+    assert not untracked, (
+        "Settings controls that saveDataManagementSettings() sends are outside "
+        f"every tracked pane, so changing them cannot enable the save button: {untracked}"
+    )
+
+    print(f"All {len(SETTINGS_CONTROL_IDS)} sampled settings controls are tracked.")
+    return True
+
+
+def test_global_save_button_defers_to_the_group():
+    """Two save buttons appeared once the removed id stopped resolving."""
+    print("Testing the global save button hides for Backup & Recovery...")
+
+    source = _read(ADMIN_SETTINGS_JS)
+    match = re.search(r"function updateSaveButtonState\(\) \{.*?\n\}", source, re.S)
+    assert match, "Expected the global save button state helper"
+    body = match.group(0)
+
+    assert "getElementById('data-management')" not in body, (
+        "The global save button still tests the removed 'data-management' pane "
+        "id, so it stays visible alongside the dedicated Backup & Recovery button"
+    )
+    assert f'[data-admin-group-pane="{GROUP_ID}"].active' in body, (
+        "Expected the global save button to hide while a Backup & Recovery pane "
+        "is active, detected through the declared group attribute"
+    )
+
+    print("The global save button defers to the Backup & Recovery group.")
+    return True
+
+
+def test_version_supports_the_fix():
+    """The fix ships from this version onward."""
+    print("Testing the application version carries the fix...")
+
+    version = assert_app_version_at_least(
+        "0.261.001",
+        reason="Backup & Recovery pane binding fix.",
+    )
+
+    print(f"config.py VERSION is {version}.")
+    return True
+
+
+if __name__ == "__main__":
+    tests = [
+        test_every_bound_element_id_exists,
+        test_every_group_tab_declares_its_pane,
+        test_no_unrelated_pane_claims_the_group,
+        test_module_resolves_panes_from_the_group,
+        test_change_tracking_covers_every_pane,
+        test_settings_controls_live_in_a_tracked_pane,
+        test_global_save_button_defers_to_the_group,
+        test_version_supports_the_fix,
+    ]
+    results = []
+    for test in tests:
+        print(f"\nRunning {test.__name__}...")
+        try:
+            results.append(bool(test()))
+        except Exception as error:  # noqa: BLE001 - report and continue
+            print(f"Test failed: {error}")
+            import traceback
+
+            traceback.print_exc()
+            results.append(False)
+
+    print(f"\nResults: {sum(results)}/{len(results)} tests passed")
+    sys.exit(0 if all(results) else 1)

--- a/functional_tests/test_data_management_security_patterns.py
+++ b/functional_tests/test_data_management_security_patterns.py
@@ -416,11 +416,11 @@ def test_admin_ui_exposes_data_management_without_external_assets():
     for marker in [
         # Backup, Migrate & Restore is now five tabs rather than one, so each
         # pane is asserted individually.
-        'id="backup" role="tabpanel" aria-labelledby="backup-tab" data-testid="backup-tab-pane" data-ignore-settings-change="true"',
-        'id="migrate" role="tabpanel" aria-labelledby="migrate-tab" data-testid="migrate-tab-pane" data-ignore-settings-change="true"',
-        'id="restore" role="tabpanel" aria-labelledby="restore-tab" data-testid="restore-tab-pane" data-ignore-settings-change="true"',
-        'id="cosmos-editor" role="tabpanel" aria-labelledby="cosmos-editor-tab" data-testid="cosmos-editor-tab-pane" data-ignore-settings-change="true"',
-        'id="jobs" role="tabpanel" aria-labelledby="jobs-tab" data-testid="jobs-tab-pane" data-ignore-settings-change="true"',
+        'id="backup" role="tabpanel" aria-labelledby="backup-tab" data-testid="backup-tab-pane" data-admin-group-pane="backup-recovery" data-ignore-settings-change="true"',
+        'id="migrate" role="tabpanel" aria-labelledby="migrate-tab" data-testid="migrate-tab-pane" data-admin-group-pane="backup-recovery" data-ignore-settings-change="true"',
+        'id="restore" role="tabpanel" aria-labelledby="restore-tab" data-testid="restore-tab-pane" data-admin-group-pane="backup-recovery" data-ignore-settings-change="true"',
+        'id="cosmos-editor" role="tabpanel" aria-labelledby="cosmos-editor-tab" data-testid="cosmos-editor-tab-pane" data-admin-group-pane="backup-recovery" data-ignore-settings-change="true"',
+        'id="jobs" role="tabpanel" aria-labelledby="jobs-tab" data-testid="jobs-tab-pane" data-admin-group-pane="backup-recovery" data-ignore-settings-change="true"',
         'id="data-management-save-settings-btn"',
         'id="data-management-save-settings-btn" disabled aria-disabled="true"',
         'id="data-management-operational-warning"',
@@ -565,7 +565,11 @@ def test_admin_ui_exposes_data_management_without_external_assets():
     assert 'data-management-migration-dry-run-btn' not in template
     admin_settings_js = read_text(APP_ROOT / "static" / "js" / "admin" / "admin_settings.js")
     assert "closest('[data-ignore-settings-change=\"true\"]')" in admin_settings_js
-    assert "saveButton.classList.toggle('d-none', isDataManagementActive);" in admin_settings_js
+    # Backup & Recovery panes are detected through the group attribute they
+    # declare, because the single 'data-management' pane id they used to share
+    # no longer exists.
+    assert '[data-admin-group-pane="backup-recovery"].active' in admin_settings_js
+    assert "saveButton.classList.toggle('d-none', isBackupRecoveryActive);" in admin_settings_js
     assert "window.updateAdminSettingsSaveButtonState = updateSaveButtonState;" in admin_settings_js
     assert '<span class="nav-text">Target Cosmos</span>' not in sidebar
     # Sidebar labels now come from the navigation map, which both the sidebar


### PR DESCRIPTION
Fixes #1353

## Summary

Toggling **Enable scheduled backups** in **Admin Settings → Backup, Migrate & Restore** never enabled the **Save Settings** button — it stayed greyed out and labelled "Saved", so the setting could not be persisted.

The reported toggle turned out to be the visible tip of a much wider failure. The entire Backup & Recovery JavaScript module was inert: saved settings were never fetched, the backup inventory and job history never populated, and no button in any of the five tabs was wired up.

## Root cause

Commit `9bbd7bda` ("Stage D part 6: Backup & Recovery") split the single `admin/_panes/data-management.html` pane into five sibling panes — `backup`, `migrate`, `restore`, `cosmos-editor`, `jobs` — and moved the shared save button, status line and warning into a `data-admin-group-shared="backup-recovery"` region outside the panes.

`admin_data_management.js` was not updated. It still resolved its root container from the id the split removed, and hard-stopped when it was missing:

```js
// bindElements()
elements.tabPane = elements.dataManagement;   // getElementById("data-management") -> null

// DOMContentLoaded
bindElements();
if (!elements.tabPane) {
    return;                                   // module dies here
}
```

`bindEvents()` therefore never ran. `bindDataManagementChangeTracking()` was also scoped to `elements.tabPane`, so no `change`/`input` listener was ever attached, `dataManagementModified` stayed `false`, and `updateDataManagementSaveButtonState()` kept the button disabled.

Measured: of the **214** element ids `bindElements()` binds, **exactly one** — `data-management` — was absent from the composed Admin Settings template.

The same removed id had a second consumer. `admin_settings.js` `updateSaveButtonState()` hides the *global* Save Settings button while a Backup & Recovery tab is active:

```js
const dataManagementPane = document.getElementById('data-management');
const isDataManagementActive = Boolean(dataManagementPane?.classList.contains('active'));
```

That lookup was always `null`, so the global save button appeared on all five Backup & Recovery tabs alongside the dedicated one — two save buttons, only one of which applied to backup settings.

## Approach

Re-introducing an `id="data-management"` wrapper is not viable: Bootstrap hides inactive panes through `.tab-content > .tab-pane`, a direct-child selector, so nesting the five panes one level deeper would stop that rule matching and display every pane at once.

Instead the group membership is declared in the markup and both consumers read it. Each pane carries `data-admin-group-pane="backup-recovery"`, mirroring the existing `data-admin-group-shared="backup-recovery"` convention and tying the panes to the real navigation group id in `admin_settings_nav.py`. That also gives the functional tests a contract to enforce, so splitting or adding a Backup & Recovery tab in future cannot silently strand the module again.

## Changes

| File | Change |
|---|---|
| `templates/admin/_panes/backup.html` | Added `data-admin-group-pane="backup-recovery"` |
| `templates/admin/_panes/migrate.html` | Added `data-admin-group-pane="backup-recovery"` |
| `templates/admin/_panes/restore.html` | Added `data-admin-group-pane="backup-recovery"` |
| `templates/admin/_panes/cosmos-editor.html` | Added `data-admin-group-pane="backup-recovery"` |
| `templates/admin/_panes/jobs.html` | Added `data-admin-group-pane="backup-recovery"` |
| `static/js/admin/admin_data_management.js` | Resolve every declared pane, guard on the collection, bind change tracking across all panes |
| `static/js/admin/admin_settings.js` | Detect the active Backup & Recovery pane through the group attribute |
| `config.py` | `VERSION = "0.261.001"` |
| `functional_tests/test_admin_data_management_pane_binding.py` | New regression test |
| `functional_tests/test_data_management_security_patterns.py` | Updated markup and save button assertions |
| `docs/explanation/fixes/BACKUP_SETTINGS_SAVE_BUTTON_FIX.md` | Fix documentation |

The Cosmos Editor `[data-ignore-data-management-change]` opt-out is preserved, so a direct database editor still does not count as a settings edit.

## Testing

New `functional_tests/test_admin_data_management_pane_binding.py` covers:

1. Every element id bound in `bindElements()` resolves to a real element in the composed template — the general assertion that catches this class of bug.
2. Every tab in the `backup-recovery` navigation group has a pane declaring the group attribute.
3. No pane outside the group claims it.
4. The module resolves panes from the attribute, guards on the collection, and no longer references the removed id.
5. Change tracking iterates every pane and keeps the Cosmos Editor opt-out.
6. Settings controls that `saveDataManagementSettings()` sends, sampled across both the Backup and Migrate tabs, sit inside a tracked pane.
7. The global save button defers to the group attribute.
8. `config.py` `VERSION` is at least `0.261.001`.

Run against the **pre-fix** state it fails 7 of 8, including the check that names the reported symptom directly:

```
Test failed: Settings controls that saveDataManagementSettings() sends are outside every
tracked pane, so changing them cannot enable the save button: ['data_management_enabled',
'data_management_retention_value', 'data_management_encryption_enabled']
```

After the fix, 13 suites pass:

```
PASS  test_admin_data_management_pane_binding.py
PASS  test_data_management_security_patterns.py
PASS  test_admin_settings_group_shared_regions.py
PASS  test_admin_settings_template_composition.py
PASS  test_admin_settings_modal_placement.py
PASS  test_admin_settings_field_contract.py
PASS  test_admin_settings_nav_map.py
PASS  test_admin_settings_sidebar_card_parity.py
PASS  test_admin_settings_pane_variable_scope.py
PASS  test_admin_settings_walkthrough_targets.py
PASS  test_admin_settings_dependencies.py
PASS  test_docs_app_surface_coverage.py
PASS  test_docs_site_quality.py
```

## Before and after

| Behaviour | Before | After |
|---|---|---|
| Toggling **Enable scheduled backups** | Save button stays disabled, reads "Saved" | Save button enables, reads "Save Settings" |
| Stored backup settings on page load | Never fetched; controls show template defaults | Loaded from `/api/admin/data-management/settings` |
| Backup inventory and job history | Never populate | Populate on load |
| Buttons across the five tabs | Unbound and inert | Wired up |
| Save buttons shown on a Backup & Recovery tab | Two, the global one being inapplicable | One, the group's own |

## Notes

- Version is deliberately set to `0.261.001` and left there for this work, rather than patch-bumped per change.
- No settings key, admin tab, action plugin or chat control was added or renamed, so `docs/_data/app_surface.yml` needs no regeneration.
- `support_menu_config.py` still links to `#data-management`, which keeps working through the `LEGACY_TAB_REDIRECTS` map in `admin_sidebar_nav.js` (`data-management` → `backup`). Left unchanged.

## Pre-existing issues found but not addressed

Both are documented in the fix doc and confirmed to predate this change:

- `functional_tests/test_admin_settings_tab_preservation.py` fails on `Missing required HTML elements: ['class="tab-pane fade']`. It reads the raw `admin_settings.html` rather than the composed template, so it broke when the panes moved into includes. Verified: fails identically with these changes stashed.
- Around twenty functional tests hard-assert an exact `config.py` version literal, the pattern the versioning instructions call out and that `test_support.versioning.assert_app_version_at_least` exists to replace. They were already failing — the highest literal in the suite is `0.260.023` while `config.py` was `0.260.028`. Verified the bump to `0.261.001` breaks none of them further, since no test asserts either version.
- Separately, a probe found roughly 39 `getElementById` literals in `admin_settings.js` with no matching id in the composed template (for example `workspaces`, `agents-tab`, `enable_group_creation_setting`). Some look like stale leftovers from the same information-architecture rework; others resolve against templates outside Admin Settings. Worth its own audit.