### PR TITLE
Fix governance split tab initialization

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -97,7 +97,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.261.001"
+VERSION = "0.261.002"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/static/js/admin/admin_governance.js
+++ b/application/single_app/static/js/admin/admin_governance.js
@@ -147,6 +147,14 @@ const GOVERNANCE_ALLOWLIST_TRUNCATE_ID_LENGTH = 35;
 
 const GOVERNANCE_ITEM_REVIEW_DEFAULT_PAGE_SIZE = 25;
 const GOVERNANCE_ITEM_EDITOR_PAGE_SIZE_DEFAULT = 50;
+const GOVERNANCE_FEATURE_TAB_HASH = '#feature-governance';
+const GOVERNANCE_POLICIES_TAB_HASH = '#governance-policies';
+const GOVERNANCE_MCP_TAB_HASH = '#mcp-governance';
+const GOVERNANCE_ADMIN_TAB_IDS = [
+    'feature-governance',
+    'governance-policies',
+    'mcp-governance',
+];
 
 const governanceItemReviewState = {
     search: '',
@@ -957,6 +965,10 @@ function showGovernanceToast(message, variant = 'success') {
     toastEl.addEventListener('hidden.bs.toast', () => {
         toastEl.remove();
     });
+}
+
+function hasGovernanceAdminSurface() {
+    return GOVERNANCE_ADMIN_TAB_IDS.some((tabId) => document.getElementById(tabId));
 }
 
 function getGovernanceFeatureToggle(featureKey) {
@@ -1854,7 +1866,7 @@ async function openGovernanceDelegatedItemEditorFromResource(options = {}) {
     }
 
     if (typeof window.openAdminSettingsTab === 'function') {
-        window.openAdminSettingsTab('#governance');
+        window.openAdminSettingsTab(GOVERNANCE_POLICIES_TAB_HASH, 'governance-item-policies-section');
     }
 
     await openGovernanceItemPolicyEditor({
@@ -4174,7 +4186,7 @@ function wireGovernanceHandlers() {
         linkButton.addEventListener('click', () => {
             const targetId = String(linkButton.getAttribute('data-governance-target') || '').trim();
             if (typeof window.openAdminSettingsTab === 'function') {
-                window.openAdminSettingsTab('#governance');
+                window.openAdminSettingsTab(GOVERNANCE_FEATURE_TAB_HASH);
             }
             window.setTimeout(() => {
                 const target = document.getElementById(targetId);
@@ -4208,7 +4220,7 @@ function wireGovernanceHandlers() {
         button.addEventListener('click', async () => {
             try {
                 if (button.dataset.governanceOpenTab === 'true' && typeof window.openAdminSettingsTab === 'function') {
-                    window.openAdminSettingsTab('#governance', 'governance-inbound-mcp-section');
+                    window.openAdminSettingsTab(GOVERNANCE_MCP_TAB_HASH, 'governance-inbound-mcp-section');
                 }
                 await openGovernanceInboundMcpPolicyEditor({
                     entityType: button.dataset.governanceInboundMcpEntity || '',
@@ -4395,7 +4407,7 @@ function wireGovernanceHandlers() {
 }
 
 async function initializeGovernanceTab() {
-    if (!document.getElementById('governance')) {
+    if (!hasGovernanceAdminSurface()) {
         return;
     }
 

--- a/docs/explanation/fixes/GOVERNANCE_SPLIT_TAB_INITIALIZATION_FIX.md
+++ b/docs/explanation/fixes/GOVERNANCE_SPLIT_TAB_INITIALIZATION_FIX.md
@@ -1,0 +1,77 @@
+# Governance Split Tab Initialization Fix
+
+**Version:** 0.261.002
+**Fixed in version:** **0.261.002**
+**Related issue:** [#1362](https://github.com/microsoft/simplechat/issues/1362)
+
+## Issue description
+
+In **Admin Settings -> Governance -> Policies**, the **New Policy** button in
+the Delegated Item Policies card did not open the delegated item policy editor
+modal.
+
+## Root cause
+
+The governance admin JavaScript still used the retired aggregate
+`id="governance"` pane as its initialization guard:
+
+```js
+if (!document.getElementById('governance')) {
+    return;
+}
+```
+
+The current Admin Settings navigation renders Governance as three split tabs:
+
+- `feature-governance`
+- `governance-policies`
+- `mcp-governance`
+
+Because the old pane no longer exists, `admin_governance.js` returned before
+`wireGovernanceHandlers()` could attach the **New Policy** click handler.
+
+## Approach
+
+The fix makes governance initialization detect the current split governance
+panes and updates governance quick links to target the correct tab:
+
+- Feature governance links open `#feature-governance`.
+- Delegated resource quick-create links open `#governance-policies`.
+- Inbound MCP quick-create links open `#mcp-governance`.
+
+## Files modified
+
+| File | Change |
+|---|---|
+| `application/single_app/static/js/admin/admin_governance.js` | Detect split governance panes and route quick links to the correct tab ids |
+| `application/single_app/config.py` | Bumped `VERSION` to `0.261.002` |
+| `functional_tests/test_governance_route_and_wiring_coverage.py` | Added regression markers for split-tab initialization and stale `#governance` references |
+| `ui_tests/test_admin_governance_tab.py` | Updated the UI workflow to navigate the split governance tabs before using **New Policy** |
+| `docs/explanation/release_notes.md` | Added a bug-fix release note |
+
+## Validation
+
+### Test results
+
+- `node --check application\single_app\static\js\admin\admin_governance.js`
+- `python -m py_compile application\single_app\config.py functional_tests\test_governance_route_and_wiring_coverage.py ui_tests\test_admin_governance_tab.py`
+- `python functional_tests\test_governance_route_and_wiring_coverage.py`
+- `python scripts\check_xss_sinks.py --full-file application\single_app\static\js\admin\admin_governance.js`
+- `git --no-pager diff --check`
+
+The targeted Playwright UI test was invoked with
+`python -m pytest ui_tests\test_admin_governance_tab.py -q`, but skipped locally
+because the local authenticated Playwright storage state was not configured.
+
+### Before / after
+
+- Before: the governance module exited during initialization and never wired the
+  delegated item **New Policy** button.
+- After: the module initializes when any split governance pane is present, and
+  the **New Policy** button opens the delegated item policy editor modal.
+
+### User experience improvements
+
+- Admins can create delegated item policies directly from the Policies tab.
+- Governance quick-create links from related admin surfaces land on the intended
+  split governance tab.

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,15 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/features) and [Fixes by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/fixes).
 
+### **(v0.261.002)**
+
+#### Bug Fixes
+
+*   **Delegated Governance New Policy Modal Opens On Split Governance Tabs**
+    *   Fixed the delegated item governance **New Policy** button so it opens the policy editor after Admin Settings governance was split into Feature Governance, Policies, and MCP Governance tabs.
+    *   Updated governance quick links to target the correct split tab panes instead of the retired aggregate Governance pane.
+    *   (Ref: `admin_governance.js`, delegated item policy editor, [#1362](https://github.com/microsoft/simplechat/issues/1362))
+
 ### **(v0.261.001)**
 
 #### New Features

--- a/functional_tests/test_governance_route_and_wiring_coverage.py
+++ b/functional_tests/test_governance_route_and_wiring_coverage.py
@@ -2,8 +2,8 @@
 #!/usr/bin/env python3
 """
 Functional test for governance route and enforcement wiring coverage.
-Version: 0.250.208
-Implemented in: 0.242.011; 0.242.012; 0.242.013; 0.242.014; 0.242.018; 0.242.019; 0.250.204; 0.250.205; 0.250.206; 0.250.207; 0.250.208
+Version: 0.261.002
+Implemented in: 0.242.011; 0.242.012; 0.242.013; 0.242.014; 0.242.018; 0.242.019; 0.250.204; 0.250.205; 0.250.206; 0.250.207; 0.250.208; 0.261.002
 
 This test ensures governance routes are registered and guarded, and that
 updated backend modules include governance enforcement hooks for endpoint,
@@ -133,6 +133,8 @@ def test_governance_enforcement_hooks_across_changed_routes():
 
     for marker in [
         "id=\"feature-governance\"",
+        "id=\"governance-policies\"",
+        "id=\"mcp-governance\"",
         "governance-feature-policies-table",
         "governance-item-policies-table",
         "governance-item-policy-card-controls",
@@ -223,10 +225,25 @@ def test_governance_enforcement_hooks_across_changed_routes():
         "openGovernanceItemPolicyUsersModal",
         "A new policy ID will be assigned when saved",
         "Allowed and blocked users/groups were swapped",
+        "GOVERNANCE_ADMIN_TAB_IDS",
+        "hasGovernanceAdminSurface()",
+        "GOVERNANCE_FEATURE_TAB_HASH",
+        "GOVERNANCE_POLICIES_TAB_HASH",
+        "GOVERNANCE_MCP_TAB_HASH",
+        "window.openAdminSettingsTab(GOVERNANCE_POLICIES_TAB_HASH, 'governance-item-policies-section')",
+        "window.openAdminSettingsTab(GOVERNANCE_FEATURE_TAB_HASH)",
+        "window.openAdminSettingsTab(GOVERNANCE_MCP_TAB_HASH, 'governance-inbound-mcp-section')",
     ]:
         assert marker in admin_governance_js_content or marker in admin_settings_template_content or marker in frontend_chats_content or marker in agents_content, (
             f"Missing governance UI visibility marker: {marker}"
         )
+
+    assert "document.getElementById('governance')" not in admin_governance_js_content, (
+        "Governance initialization must not depend on the retired aggregate #governance tab pane"
+    )
+    assert "window.openAdminSettingsTab('#governance')" not in admin_governance_js_content, (
+        "Governance quick links must target the split governance tab panes"
+    )
 
     item_policy_table_header_section = admin_settings_template_content.split(
         'id="governance-item-policies-table"',

--- a/ui_tests/test_admin_governance_tab.py
+++ b/ui_tests/test_admin_governance_tab.py
@@ -2,8 +2,8 @@
 """
 UI test for admin governance tab rendering and API wiring.
 
-Version: 0.250.208
-Implemented in: 0.241.009; 0.241.025; 0.242.012; 0.242.013; 0.242.014; 0.242.018; 0.242.019; 0.250.204; 0.250.205; 0.250.206; 0.250.207; 0.250.208
+Version: 0.261.002
+Implemented in: 0.241.009; 0.241.025; 0.242.012; 0.242.013; 0.242.014; 0.242.018; 0.242.019; 0.250.204; 0.250.205; 0.250.206; 0.250.207; 0.250.208; 0.261.002
 
 This test ensures the Governance tab is present in admin settings, the
 sidebar navigation exposes the same destination, feature policy fetch/save
@@ -191,9 +191,9 @@ def test_admin_governance_tab_and_api_wiring():
             page.goto(f"{BASE_URL}/admin/settings", wait_until="domcontentloaded")
 
             page.get_by_role("link", name="Governance").click()
-            page.wait_for_selector("#governance-feature-policies-table")
-
-            page.get_by_role("tab", name="Governance").click()
+            page.locator("#feature-governance-tab").click()
+            page.wait_for_selector("#governance-info-guide-btn")
+            page.locator("#governance-policies-tab").click()
             page.wait_for_selector("#governance-feature-policies-table")
 
             page.locator("#governance-info-guide-btn").click()


### PR DESCRIPTION
## Summary

- Fixed delegated item governance initialization after Admin Settings governance was split into Feature Governance, Policies, and MCP Governance tabs.
- Updated governance quick links to target the correct split tab pane instead of the retired aggregate `#governance` pane.
- Added regression coverage, fix documentation, release notes, and bumped the application version to `0.261.002`.

## Linked issue

Fixes #1362

## Release Notes & Latest Features

- [ ] New Feature
- [x] Bug Fix
- [ ] UI Enhancement
- [ ] Breaking Change
- [ ] Internal only

Is this visible to end users?

- [ ] Yes
- [x] No

Is this admin-facing (Admin Settings, governance, deployment, config)?

- [x] Yes
- [ ] No

Should this become a Latest Feature card?

- [ ] Yes
- [x] No
- [ ] Already added

Screenshot needed for the card?

- [ ] Yes
- [x] No
- [ ] Attached

## Version bump

- [x] `application/single_app/config.py` `VERSION` third segment bumped, or not needed because this is docs-only
- [x] `deployers/version.txt` bumped, or not needed because `deployers/` was not changed

## Testing / validation

- `node --check application\single_app\static\js\admin\admin_governance.js`
- `python -m py_compile application\single_app\config.py functional_tests\test_governance_route_and_wiring_coverage.py ui_tests\test_admin_governance_tab.py`
- `python functional_tests\test_governance_route_and_wiring_coverage.py`
- `python scripts\check_xss_sinks.py --full-file application\single_app\static\js\admin\admin_governance.js`
- `python scripts\check_xss_sinks.py --base-sha origin/Development --head-sha HEAD application\single_app\static\js\admin\admin_governance.js`
- `git --no-pager diff --check`
- `python -m pytest ui_tests\test_admin_governance_tab.py -q` skipped locally because `SIMPLECHAT_UI_BASE_URL` / authenticated Playwright storage state are not configured.

## Documentation

- [x] Release notes updated, or not needed
- [x] Feature documentation updated, or not needed
- [x] Fix documentation updated, or not needed

## Security checklist

- [x] New Flask routes include `@swagger_route(security=get_auth_security())`, or not applicable because no routes changed
- [x] Settings sent to non-admin frontends use `sanitize_settings_for_user()`, or not applicable because no frontend settings payload changed
- [x] Browser JavaScript is served from local SimpleChat static assets only; no CDN-hosted JS
- [x] No secrets, keys, connection strings, or local-only artifacts are included
