### PR TITLE
Show inbound MCP disabled UI guidance

### DIFF
--- a/application/single_app/admin_settings_nav.py
+++ b/application/single_app/admin_settings_nav.py
@@ -150,14 +150,13 @@ ADMIN_NAV = [
                 ],
             },
             {
-                # The whole tab is behind mcp_ui_enabled, so the tab carries the
-                # condition rather than the single section inside it.
+                # Keep the tab visible when the preview UI gate is off so admins
+                # can see how to enable the required App Service setting.
                 "id": "inbound-mcp",
                 "label": "Inbound MCP",
                 "icon": "bi-diagram-3",
-                "condition": "mcp_ui_enabled",
                 "sections": [
-                    {"id": "inbound-mcp-configuration", "label": "Inbound MCP", "icon": "bi-diagram-3", "condition": "mcp_ui_enabled"},
+                    {"id": "inbound-mcp-configuration", "label": "Inbound MCP", "icon": "bi-diagram-3"},
                 ],
             },
         ],

--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -97,7 +97,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.261.001"
+VERSION = "0.261.002"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/templates/admin/_panes/inbound-mcp.html
+++ b/application/single_app/templates/admin/_panes/inbound-mcp.html
@@ -531,5 +531,39 @@
                         </div>
                     </div>
                 </div>
+                {% else %}
+                <div class="card p-3 mb-4" id="inbound-mcp-configuration">
+                    <div class="d-flex flex-column flex-lg-row justify-content-between align-items-lg-start gap-3 mb-3">
+                        <div>
+                            <h5 class="card-title mb-1">
+                                <i class="bi bi-diagram-3 me-2"></i>Inbound MCP Server
+                            </h5>
+                            <p class="text-muted small mb-0">
+                                The Inbound MCP admin UI is hidden until the preview app setting is enabled for this deployment.
+                            </p>
+                        </div>
+                        <span class="badge text-bg-secondary align-self-start align-self-lg-end">Disabled</span>
+                    </div>
+
+                    <div class="alert alert-warning small" role="alert">
+                        <strong>Inbound MCP admin UI is disabled.</strong>
+                        Add an Azure App Service application setting or environment variable named
+                        <code>ENABLE_MCP_UI</code> with value <code>true</code>, then save the configuration and restart the app if your host does not restart it automatically.
+                    </div>
+
+                    <div class="border rounded-3 p-3 mb-3">
+                        <h6 class="mb-2">How to enable this tab</h6>
+                        <ol class="small mb-0">
+                            <li>Open the Azure App Service that hosts SimpleChat.</li>
+                            <li>Go to <strong>Configuration</strong> and add an application setting named <code>ENABLE_MCP_UI</code>.</li>
+                            <li>Set the value to <code>true</code>, save the change, and restart the app if needed.</li>
+                            <li>Reload Admin Settings and return to <strong>Agents &amp; Actions -> Inbound MCP</strong>.</li>
+                        </ol>
+                    </div>
+
+                    <div class="alert alert-info small mb-0" role="alert">
+                        This app setting only exposes the preview admin configuration UI. The inbound MCP runtime remains off until an admin enables <strong>Enable inbound MCP server</strong> after authentication, client allowlist, source, and governance prerequisites are configured.
+                    </div>
+                </div>
                 {% endif %}
             </div>

--- a/docs/admin/agents-actions.md
+++ b/docs/admin/agents-actions.md
@@ -116,6 +116,8 @@ The Actions Configuration section belongs to the Actions tab. Use it with the ad
 
 The Inbound MCP section belongs to the Inbound MCP tab. Use it with the adjacent settings in this group so related rollout, access, and operational choices stay aligned.
 
+If the tab shows that the Inbound MCP admin UI is disabled, add the Azure App Service application setting `ENABLE_MCP_UI=true`, save the configuration, and restart the app if your host does not restart it automatically. This only exposes the preview configuration UI; the inbound MCP runtime remains off until **Enable inbound MCP server** is turned on after authentication, client allowlist, source, and governance prerequisites are ready.
+
 #### Settings
 
 | Setting | What it does | Default | Notes |

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,15 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/features) and [Fixes by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/fixes).
 
+### **(v0.261.002)**
+
+#### User Interface Enhancements
+
+*   **Inbound MCP Enablement Guidance**
+    *   Added a visible **Inbound MCP** tab state for deployments where the preview admin UI is disabled by the missing `ENABLE_MCP_UI=true` App Service application setting.
+    *   The disabled-state card explains how to enable the preview UI while making clear that the inbound MCP runtime remains off until an admin turns on **Enable inbound MCP server** after authentication, client allowlist, source, and governance prerequisites are ready.
+    *   (Ref: `admin/_panes/inbound-mcp.html`, `admin_settings_nav.py`, [#1364](https://github.com/microsoft/simplechat/issues/1364))
+
 ### **(v0.261.001)**
 
 #### New Features

--- a/functional_tests/test_inbound_mcp_admin_ui.py
+++ b/functional_tests/test_inbound_mcp_admin_ui.py
@@ -2,7 +2,7 @@
 #!/usr/bin/env python3
 """
 Functional test for the inbound MCP admin UI settings slice.
-Version: 0.250.098
+Version: 0.261.002
 Implemented in: 0.250.071
 Easy Auth enablement guard implemented in: 0.250.072
 Cloud-aware Easy Auth script implemented in: 0.250.073
@@ -28,12 +28,13 @@ Inbound MCP source governance CTA guidance implemented in: 0.250.093
 Inbound MCP enterprise readiness hardening implemented in: 0.250.096
 Inbound MCP admin throttle controls implemented in: 0.250.097
 Inbound MCP observability query panel implemented in: 0.250.098
+Inbound MCP disabled-state guidance implemented in: 0.261.002
 
 This test ensures inbound MCP runtime configuration is stored in app_settings,
-the minimal Admin Settings UI is gated by an OS-only feature flag, and the
-feature flag itself is not exposed as an editable UI setting. It also verifies
-that enabling inbound MCP requires the Easy Auth exclusion confirmation and
-server-side endpoint check.
+the full Admin Settings UI is gated by an OS-only feature flag, the disabled
+state explains how to enable the preview UI, and the feature flag itself is not
+exposed as an editable UI setting. It also verifies that enabling inbound MCP
+requires the Easy Auth exclusion confirmation and server-side endpoint check.
 """
 
 import sys
@@ -114,14 +115,18 @@ def test_mcp_ui_gate_is_os_environment_only():
     assert "'enable_mcp_ui'" not in admin_route_source
 
 
-def test_admin_settings_mcp_ui_is_gated_and_minimal():
-    """Validate the Admin Settings card and sidebar are behind mcp_ui_enabled."""
+def test_admin_settings_mcp_ui_disabled_message_and_enabled_form():
+    """Validate the Inbound MCP tab shows guidance when the full UI is gated."""
     admin_template = read_repo_file("application/single_app/templates/admin_settings.html")
     admin_route_source = read_repo_file("application/single_app/route_frontend_admin_settings.py")
-    sidebar_template = read_repo_file("application/single_app/templates/_sidebar_nav.html")
 
     assert "{% if mcp_ui_enabled %}" in admin_template
+    assert "{% else %}" in admin_template
     assert 'id="inbound-mcp-configuration"' in admin_template
+    assert "Inbound MCP admin UI is disabled." in admin_template
+    assert "Azure App Service application setting" in admin_template
+    assert "ENABLE_MCP_UI" in admin_template
+    assert "The inbound MCP runtime remains off" in admin_template
     assert 'name="enable_inbound_mcp_server"' in admin_template
     assert 'name="inbound_mcp_required_user_role"' in admin_template
     assert 'name="inbound_mcp_required_app_role"' in admin_template
@@ -166,7 +171,6 @@ def test_admin_settings_mcp_ui_is_gated_and_minimal():
     assert "About MCP &amp; Tools" in admin_template
     assert "{% for tool in inbound_mcp_tools %}" in admin_template
     assert 'name="enable_mcp_ui"' not in admin_template
-    assert "ENABLE_MCP_UI" not in admin_template
     assert "'enable_inbound_mcp_rate_limits': form_data.get('enable_inbound_mcp_rate_limits') == 'on'" in admin_route_source
     for operational_setting in [
         "inbound_mcp_max_request_bytes",
@@ -179,8 +183,23 @@ def test_admin_settings_mcp_ui_is_gated_and_minimal():
         assert f"'{operational_setting}'," in admin_route_source
         assert f"INBOUND_MCP_SETTINGS_DEFAULTS['{operational_setting}']" in admin_route_source
 
-    # The Inbound MCP navigation entry is gated by the same flag as its card,
-    # declared in the navigation map rather than inline in the sidebar.
+    # The Inbound MCP navigation entry stays visible so admins can discover the
+    # enablement guidance even when the full preview form is gated.
+    inbound_tab = next(
+        (
+            tab
+            for _, tab in iter_tabs()
+            if tab["id"] == "inbound-mcp"
+        ),
+        None,
+    )
+    assert inbound_tab is not None, (
+        "Inbound MCP tab missing from the navigation map"
+    )
+    assert inbound_tab.get("condition") is None, (
+        "Inbound MCP tab must stay visible even when mcp_ui_enabled is false"
+    )
+
     inbound_section = next(
         (
             section
@@ -193,8 +212,8 @@ def test_admin_settings_mcp_ui_is_gated_and_minimal():
     assert inbound_section is not None, (
         "Inbound MCP navigation entry missing from the navigation map"
     )
-    assert inbound_section.get("condition") == "mcp_ui_enabled", (
-        "Inbound MCP navigation entry must be gated by mcp_ui_enabled"
+    assert inbound_section.get("condition") is None, (
+        "Inbound MCP navigation entry must stay visible even when mcp_ui_enabled is false"
     )
     assert inbound_section["label"] == "Inbound MCP", (
         f"Unexpected Inbound MCP navigation label: {inbound_section['label']}"
@@ -386,10 +405,11 @@ def test_inbound_mcp_governance_ui_policy_creation_contract():
     assert "window.openAdminSettingsTab('#governance', 'governance-inbound-mcp-section')" in governance_js
     assert "policyName: button.dataset.governanceInboundMcpPolicyName || ''" in governance_js
     assert "resourceLabel: button.dataset.governanceInboundMcpResourceLabel || ''" in governance_js
-    assert "editButton.disabled = systemManaged;" in governance_js
-    assert "deleteButton.disabled = systemManaged;" in governance_js
-    assert "editButton.dataset.policyId = policyId;" in governance_js
-    assert "policy_id: editButton.dataset.policyId || ''" in governance_js
+    assert "System-managed policies cannot be edited." in governance_js
+    assert "System-managed policies cannot be deleted." in governance_js
+    assert "disabled: systemManaged" in governance_js
+    assert "applyGovernanceItemPolicyActionDataset(button, policyDetails)" in governance_js
+    assert "policy_id: button?.dataset?.policyId || ''" in governance_js
     assert "policy_id: String(policyIdInput?.value || '').trim()" in governance_js
     assert "The wildcard inbound MCP source policy is system-managed." not in governance_js
     assert "disallowWildcard: true" in admin_js
@@ -407,7 +427,7 @@ if __name__ == "__main__":
     tests = [
         test_inbound_mcp_runtime_settings_are_app_settings,
         test_mcp_ui_gate_is_os_environment_only,
-        test_admin_settings_mcp_ui_is_gated_and_minimal,
+        test_admin_settings_mcp_ui_disabled_message_and_enabled_form,
         test_inbound_mcp_auth_uses_settings_runtime_config,
         test_inbound_mcp_easy_auth_guard_contract,
         test_inbound_mcp_governance_ui_policy_creation_contract,

--- a/ui_tests/test_admin_inbound_mcp_easy_auth_modal.py
+++ b/ui_tests/test_admin_inbound_mcp_easy_auth_modal.py
@@ -2,7 +2,7 @@
 """
 UI test for the inbound MCP Easy Auth verification modal.
 
-Version: 0.250.098
+Version: 0.261.002
 Implemented in: 0.250.072
 Cloud-aware script improvements implemented in: 0.250.073
 Script copy and authsettingsV2 GET fix implemented in: 0.250.074
@@ -14,6 +14,7 @@ Protected-resource metadata aliases implemented in: 0.250.087
 Easy Auth restart reminder implemented in: 0.250.088
 Personal workflow execution tool implemented in: 0.250.090
 Inbound MCP object-list settings implemented in: 0.250.091
+Inbound MCP disabled-state guidance implemented in: 0.261.002
 
 This test ensures enabling inbound MCP from Admin Settings requires the Easy Auth
 exclusion modal, keeps the runtime gate disabled on failed verification, and
@@ -125,16 +126,16 @@ def test_admin_inbound_mcp_easy_auth_modal_blocks_until_verified():
 
     try:
         page.route("**/api/admin/settings/inbound-mcp/easy-auth-check", fulfill_verification)
-        response = page.goto(f"{BASE_URL}/admin/settings#agents", wait_until="networkidle")
+        response = page.goto(f"{BASE_URL}/admin/settings#inbound-mcp", wait_until="networkidle")
         assert response is not None, "Expected a navigation response when loading admin settings."
 
         if response.status in SKIP_RESPONSE_CODES:
             pytest.skip(f"Admin settings page unavailable in this environment (HTTP {response.status}).")
         assert response.ok, f"Expected admin settings to load successfully, got HTTP {response.status}."
 
-        agents_tab = page.locator("#agents-tab")
-        if agents_tab.count() > 0:
-            agents_tab.click()
+        inbound_tab = page.locator("#inbound-mcp-tab")
+        if inbound_tab.count() > 0:
+            inbound_tab.click()
 
         enable_toggle = page.locator("#enable_inbound_mcp_server")
         if enable_toggle.count() == 0:

--- a/ui_tests/test_admin_inbound_mcp_governance_ui.py
+++ b/ui_tests/test_admin_inbound_mcp_governance_ui.py
@@ -2,7 +2,7 @@
 """
 UI test for inbound MCP governance policy creation controls.
 
-Version: 0.250.098
+Version: 0.261.002
 Implemented in: 0.250.077
 Inbound MCP restricted policy defaults implemented in: 0.250.078
 MCP governance help modal implemented in: 0.250.079
@@ -14,9 +14,12 @@ Inbound MCP source-only governance implemented in: 0.250.092
 Inbound MCP source governance CTA guidance implemented in: 0.250.093
 Inbound MCP admin throttle controls implemented in: 0.250.097
 Inbound MCP observability query panel implemented in: 0.250.098
+Inbound MCP disabled-state guidance implemented in: 0.261.002
 
 This test ensures Admin Settings exposes inbound MCP source governance policy
-controls and can open the delegated item policy editor for source policies.
+controls when the preview UI is enabled, explains how to enable the preview UI
+when it is disabled, and can open the delegated item policy editor for source
+policies.
 """
 
 import os
@@ -54,39 +57,46 @@ def test_admin_inbound_mcp_governance_policy_editor_controls():
     page = context.new_page()
 
     try:
-        response = page.goto(f"{BASE_URL}/admin/settings#governance", wait_until="networkidle")
+        response = page.goto(f"{BASE_URL}/admin/settings#inbound-mcp", wait_until="networkidle")
         assert response is not None, "Expected a navigation response when loading admin settings."
 
         if response.status in SKIP_RESPONSE_CODES:
             pytest.skip(f"Admin settings page unavailable in this environment (HTTP {response.status}).")
         assert response.ok, f"Expected admin settings to load successfully, got HTTP {response.status}."
 
-        agents_tab = page.locator("#agents-tab")
-        if agents_tab.count() > 0:
-            agents_tab.click()
-            inbound_config = page.locator("#inbound-mcp-configuration")
-            expect(inbound_config).to_be_visible()
-            expect(inbound_config).to_contain_text("admins must still create an inbound MCP source governance policy")
-            expect(inbound_config).to_contain_text("Create Wildcard Source Policy")
-            expect(inbound_config).to_contain_text("Create Source Policy")
-            expect(inbound_config).to_contain_text("Request Size & Throttling")
-            expect(inbound_config).to_contain_text("Enable tool throttles")
-            expect(page.locator("#enable_inbound_mcp_rate_limits")).to_be_visible()
-            expect(page.locator("#inbound_mcp_max_request_bytes")).to_be_visible()
-            expect(page.locator("#inbound_mcp_rate_limit_window_seconds")).to_be_visible()
-            expect(inbound_config).not_to_contain_text("Default on creates a locked governance policy")
-            inbound_config.locator("button[data-bs-target=\"#inboundMcpInfoModal\"]").click()
-            overview_modal = page.locator("#inboundMcpInfoModal")
-            expect(overview_modal).to_be_visible()
-            expect(overview_modal).to_contain_text("Application Insights starter queries")
-            expect(overview_modal).to_contain_text("Request and failure trends")
-            expect(overview_modal).to_contain_text("Rate-limit denials")
-            expect(overview_modal.locator(".inbound-mcp-kql-copy-btn")).to_have_count(4)
-            expect(overview_modal.locator("#inbound-mcp-kql-tool-latency")).to_contain_text("percentile")
-            page.keyboard.press("Escape")
-            expect(overview_modal).to_be_hidden()
+        inbound_tab = page.locator("#inbound-mcp-tab")
+        if inbound_tab.count() > 0:
+            inbound_tab.click()
 
-        governance_tab = page.locator("#governance-tab")
+        inbound_config = page.locator("#inbound-mcp-configuration")
+        expect(inbound_config).to_be_visible()
+        enable_toggle = page.locator("#enable_inbound_mcp_server")
+        if enable_toggle.count() == 0:
+            expect(inbound_config).to_contain_text("Inbound MCP admin UI is disabled")
+            expect(inbound_config).to_contain_text("ENABLE_MCP_UI")
+            return
+
+        expect(inbound_config).to_contain_text("admins must still create an inbound MCP source governance policy")
+        expect(inbound_config).to_contain_text("Create Wildcard Source Policy")
+        expect(inbound_config).to_contain_text("Create Source Policy")
+        expect(inbound_config).to_contain_text("Request Size & Throttling")
+        expect(inbound_config).to_contain_text("Enable tool throttles")
+        expect(page.locator("#enable_inbound_mcp_rate_limits")).to_be_visible()
+        expect(page.locator("#inbound_mcp_max_request_bytes")).to_be_visible()
+        expect(page.locator("#inbound_mcp_rate_limit_window_seconds")).to_be_visible()
+        expect(inbound_config).not_to_contain_text("Default on creates a locked governance policy")
+        inbound_config.locator("button[data-bs-target=\"#inboundMcpInfoModal\"]").click()
+        overview_modal = page.locator("#inboundMcpInfoModal")
+        expect(overview_modal).to_be_visible()
+        expect(overview_modal).to_contain_text("Application Insights starter queries")
+        expect(overview_modal).to_contain_text("Request and failure trends")
+        expect(overview_modal).to_contain_text("Rate-limit denials")
+        expect(overview_modal.locator(".inbound-mcp-kql-copy-btn")).to_have_count(4)
+        expect(overview_modal.locator("#inbound-mcp-kql-tool-latency")).to_contain_text("percentile")
+        page.keyboard.press("Escape")
+        expect(overview_modal).to_be_hidden()
+
+        governance_tab = page.locator("#mcp-governance-tab")
         if governance_tab.count() > 0:
             governance_tab.click()
 


### PR DESCRIPTION
## Summary

- Keeps the Agents & Actions -> Inbound MCP tab visible when the MCP preview UI gate is disabled.
- Adds an admin-facing disabled-state card explaining how to enable the preview UI with the Azure App Service `ENABLE_MCP_UI=true` application setting/environment variable.
- Leaves the full Inbound MCP configuration form gated behind `mcp_ui_enabled`, and leaves runtime enablement controlled by `enable_inbound_mcp_server`.

## Linked issue

Fixes #1364

## Release Notes & Latest Features

- [ ] New Feature
- [ ] Bug Fix
- [x] UI Enhancement
- [ ] Breaking Change
- [ ] Internal only

Is this visible to end users?

- [ ] Yes
- [x] No

Is this admin-facing (Admin Settings, governance, deployment, config)?

- [x] Yes
- [ ] No

Should this become a Latest Feature card?

- [ ] Yes
- [x] No
- [ ] Already added

Screenshot needed for the card?

- [ ] Yes
- [x] No
- [ ] Attached

## Version bump

- [x] `application/single_app/config.py` `VERSION` third segment bumped, or not needed because this is docs-only
- [x] `deployers/version.txt` bumped, or not needed because `deployers/` was not changed

## Testing / validation

- `python functional_tests\test_inbound_mcp_admin_ui.py`
- `python functional_tests\test_docs_app_surface_coverage.py`
- `python functional_tests\test_docs_site_quality.py`
- `python -m py_compile application\single_app\admin_settings_nav.py application\single_app\config.py functional_tests\test_inbound_mcp_admin_ui.py ui_tests\test_admin_inbound_mcp_governance_ui.py ui_tests\test_admin_inbound_mcp_easy_auth_modal.py`
- `.\.venv\Scripts\python.exe functional_tests\test_governance_route_and_wiring_coverage.py`
- `.\.venv\Scripts\python.exe functional_tests\test_markdown_chunk_size_enforcement.py`
- `.\.venv\Scripts\python.exe functional_tests\test_figure_chunk_association.py`
- `python scripts\check_xss_sinks.py --base-sha origin/Development --head-sha HEAD application\single_app\templates\admin\_panes\inbound-mcp.html application\single_app\admin_settings_nav.py`
- `python scripts\check_broken_access_control.py --base-sha origin/Development --head-sha HEAD application\single_app\admin_settings_nav.py application\single_app\config.py`
- `git --no-pager diff --check origin/Development..HEAD`
- `python -m pytest ui_tests\test_admin_inbound_mcp_governance_ui.py ui_tests\test_admin_inbound_mcp_easy_auth_modal.py -q` skipped locally because authenticated Playwright UI state is not configured.

## Documentation

- [x] Release notes updated, or not needed
- [x] Feature documentation updated, or not needed
- [x] Fix documentation updated, or not needed

## Security checklist

- [x] New Flask routes include `@swagger_route(security=get_auth_security())`, or not applicable because no routes changed
- [x] Settings sent to non-admin frontends use `sanitize_settings_for_user()`, or not applicable because no non-admin frontend settings payload changed
- [x] Browser JavaScript is served from local SimpleChat static assets only; no CDN-hosted JS
- [x] No secrets, keys, connection strings, or local-only artifacts are included
