### PR TITLE
Promote Development to Staging for v0.261.002

### DIFF
--- a/application/single_app/admin_settings_nav.py
+++ b/application/single_app/admin_settings_nav.py
@@ -150,14 +150,13 @@ ADMIN_NAV = [
                 ],
             },
             {
-                # The whole tab is behind mcp_ui_enabled, so the tab carries the
-                # condition rather than the single section inside it.
+                # Keep the tab visible when the preview UI gate is off so admins
+                # can see how to enable the required App Service setting.
                 "id": "inbound-mcp",
                 "label": "Inbound MCP",
                 "icon": "bi-diagram-3",
-                "condition": "mcp_ui_enabled",
                 "sections": [
-                    {"id": "inbound-mcp-configuration", "label": "Inbound MCP", "icon": "bi-diagram-3", "condition": "mcp_ui_enabled"},
+                    {"id": "inbound-mcp-configuration", "label": "Inbound MCP", "icon": "bi-diagram-3"},
                 ],
             },
         ],

--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -97,7 +97,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.261.001"
+VERSION = "0.261.002"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/functions_content.py
+++ b/application/single_app/functions_content.py
@@ -1015,7 +1015,98 @@ def chunk_text(text, chunk_size=2000, overlap=200):
         # Log the exception or handle it as needed
         print(f"Error in chunk_text: {e}")
         raise e  # Re-raise the exception to propagate it
-    
+
+
+# Separators ordered from strongest structural boundary to weakest, so a split lands on a blank
+# line before a line break before a space. Word-limited splitting deliberately omits the empty
+# separator so a split never lands mid-word; character-limited splitting includes it because it is
+# a hard safety bound and must be able to break an unbroken run of text.
+CHUNK_SPLIT_SEPARATORS_WORDS = ["\n\n", "\n", " "]
+CHUNK_SPLIT_SEPARATORS_CHARACTERS = ["\n\n", "\n", " ", ""]
+
+
+def count_words(text):
+    """Count words the same way chunk budgeting does elsewhere in the pipeline."""
+    if not text:
+        return 0
+    return len(text.split())
+
+
+def split_text_by_word_limit(text, max_words, overlap_ratio=0.1):
+    """Split text so no piece exceeds max_words, breaking on the strongest boundary available.
+
+    Returns the text unchanged when it already fits, so callers can apply this unconditionally.
+    Content is never truncated; a small overlap keeps context across a split.
+    """
+    if not text or not str(text).strip():
+        return []
+
+    try:
+        max_words = int(max_words)
+    except Exception:
+        return [text]
+
+    if max_words <= 0 or count_words(text) <= max_words:
+        return [text]
+
+    overlap = max(0, min(int(max_words * overlap_ratio), max_words - 1))
+
+    splitter = RecursiveCharacterTextSplitter(
+        chunk_size=max_words,
+        chunk_overlap=overlap,
+        length_function=count_words,
+        separators=CHUNK_SPLIT_SEPARATORS_WORDS,
+        is_separator_regex=False,
+    )
+
+    pieces = [piece for piece in splitter.split_text(text) if piece and piece.strip()]
+    return pieces or [text]
+
+
+def split_oversized_chunks(chunks, max_characters):
+    """Bound every chunk to max_characters, preserving order and never truncating content.
+
+    This is the authoritative backstop for the embedding token limit. It runs after any word-based
+    sizing because word counts cannot predict how badly markdown tables, code fences, or long URLs
+    tokenize, and because merging small chunks can inflate one past its intended target.
+    """
+    if not chunks:
+        return []
+
+    try:
+        max_characters = int(max_characters)
+    except Exception:
+        return list(chunks)
+
+    if max_characters <= 0:
+        return list(chunks)
+
+    splitter = None
+    bounded_chunks = []
+
+    for chunk in chunks:
+        if chunk is None:
+            continue
+
+        if len(chunk) <= max_characters:
+            bounded_chunks.append(chunk)
+            continue
+
+        if splitter is None:
+            splitter = RecursiveCharacterTextSplitter(
+                chunk_size=max_characters,
+                chunk_overlap=0,
+                length_function=len,
+                separators=CHUNK_SPLIT_SEPARATORS_CHARACTERS,
+                is_separator_regex=False,
+            )
+
+        pieces = [piece for piece in splitter.split_text(chunk) if piece and piece.strip()]
+        bounded_chunks.extend(pieces or [chunk])
+
+    return bounded_chunks
+
+
 def chunk_word_file_into_pages(di_pages, chunk_size=WORD_CHUNK_SIZE):
     """
     Chunk Azure DI Word pages into smaller word-based segments.

--- a/application/single_app/functions_documents.py
+++ b/application/single_app/functions_documents.py
@@ -258,12 +258,12 @@ DI_MARKDOWN_TABLE_ROW_PATTERN = re.compile(r'(?m)^\s*\|.+\|\s*$')
 # treats them as a signal that Enhanced extraction is worth the extra cost, because Content
 # Understanding is the only engine that describes figures.
 DI_MARKDOWN_FIGURE_PATTERN = re.compile(r'(<figure\b|</figure>|!\[[^\]]*\]\()', re.IGNORECASE)
-# Budget for image content merged into an existing chunk. The cap is token-oriented, so it is
-# converted with a conservative characters-per-token estimate before being used as a length limit.
-OFFICE_IMAGE_MERGE_CHARS_PER_TOKEN = 4
-OFFICE_IMAGE_MERGE_UTILIZATION = 0.9
-OFFICE_IMAGE_MERGE_FALLBACK_CAP = 16384
+# Budget for image content merged into an existing chunk. The limit is the embedding character
+# budget, so a merged chunk can never grow past what the embedding endpoint accepts.
 OFFICE_IMAGE_MERGE_MIN_CHAR_LIMIT = 4000
+OFFICE_IMAGE_MERGE_FALLBACK_CHAR_LIMIT = int(
+    EMBEDDING_CONTEXT_FALLBACK_TOKENS * EMBEDDING_CHUNK_UTILIZATION * EMBEDDING_CHARS_PER_TOKEN
+)
 
 
 def is_pdf_file_name(file_name):
@@ -549,13 +549,10 @@ def _merge_embedded_images_into_chunks(final_chunks, image_blocks, total_body_wo
         return merged_chunks, 0, list(image_blocks)
 
     try:
-        chunk_size_cap = int(get_chunk_size_cap(settings))
+        embedding_char_budget = int(get_embedding_safe_chunk_characters(settings))
     except Exception:
-        chunk_size_cap = OFFICE_IMAGE_MERGE_FALLBACK_CAP
-    merged_char_limit = max(
-        OFFICE_IMAGE_MERGE_MIN_CHAR_LIMIT,
-        int(chunk_size_cap * OFFICE_IMAGE_MERGE_CHARS_PER_TOKEN * OFFICE_IMAGE_MERGE_UTILIZATION),
-    )
+        embedding_char_budget = OFFICE_IMAGE_MERGE_FALLBACK_CHAR_LIMIT
+    merged_char_limit = max(OFFICE_IMAGE_MERGE_MIN_CHAR_LIMIT, embedding_char_budget)
 
     merged_count = 0
     overflow_blocks = []
@@ -3008,7 +3005,29 @@ def save_chunks(page_text_content, page_number, file_name, user_id, document_id,
     try:
         #status = f"Generating embedding for page {page_number}"
         #update_document(document_id=document_id, user_id=user_id, status=status)
-        embedding, token_usage = generate_embedding(page_text_content)
+        embedding_input = page_text_content
+        max_embedding_characters = get_embedding_safe_chunk_characters()
+
+        # Last-resort guard. Every processor bounds its own chunks, so reaching this means content
+        # tokenized far worse than estimated. Splitting is not an option here because chunk ids are
+        # derived from the page number, so a second chunk would overwrite the first in the search
+        # index. Only the embedding input is clamped: the full text is still stored below, so the
+        # chunk stays readable and citable and only its vector comes from the leading portion.
+        if embedding_input and len(embedding_input) > max_embedding_characters:
+            log_event(
+                "Chunk exceeded the embedding character budget and was clamped for embedding only.",
+                extra={
+                    "document_id": document_id,
+                    "page_number": page_number,
+                    "file_name": file_name,
+                    "original_characters": len(embedding_input),
+                    "clamped_characters": max_embedding_characters
+                },
+                level=logging.WARNING
+            )
+            embedding_input = embedding_input[:max_embedding_characters]
+
+        embedding, token_usage = generate_embedding(embedding_input)
     except Exception as e:
         print(f"Error generating embedding for page {page_number} of document {document_id}: {e}")
         raise
@@ -6378,6 +6397,7 @@ def process_html(document_id, user_id, temp_file_path, original_filename, enable
     chunk_config = get_chunk_size_config(get_settings())
     target_chunk_words = chunk_config.get('html', {}).get('value', 1200) # Target size based on requirement
     min_chunk_words = max(1, int(target_chunk_words * 0.5)) # Minimum size based on requirement
+    max_chunk_characters = get_embedding_safe_chunk_characters()
 
     if enable_enhanced_citations:
         args = {
@@ -6431,6 +6451,10 @@ def process_html(document_id, user_id, temp_file_path, original_filename, enable
             else:
                 # Chunk is too small, add to buffer and continue to next chunk
                 buffer_chunk = current_chunk_text + " " # Add space between merged chunks
+
+        # Defensive: the splitter above is character-bounded, but merging small chunks can still
+        # push one past the embedding context window.
+        final_chunks = split_oversized_chunks(final_chunks, max_chunk_characters)
 
         num_chunks_final = len(final_chunks)
         update_callback(number_of_pages=num_chunks_final) # Use number_of_pages for chunk count
@@ -6506,9 +6530,11 @@ def process_md(document_id, user_id, temp_file_path, original_filename, enable_e
     total_chunks_saved = 0
     total_embedding_tokens = 0
     embedding_model_name = None
-    chunk_config = get_chunk_size_config(get_settings())
+    settings = get_settings()
+    chunk_config = get_chunk_size_config(settings)
     target_chunk_words = chunk_config.get('md', {}).get('value', 1200) # Target size based on requirement
     min_chunk_words = max(1, int(target_chunk_words * 0.5)) # Minimum size based on requirement
+    max_chunk_characters = get_embedding_safe_chunk_characters(settings)
 
     if enable_enhanced_citations:
         args = {
@@ -6544,6 +6570,14 @@ def process_md(document_id, user_id, temp_file_path, original_filename, enable_e
 
         initial_chunks_content = [doc.page_content for doc in md_header_splits]
 
+        # A header section has no inherent size bound: a heading with no nested subheading yields a
+        # section as large as the text under it. Cap each section before merging, otherwise an
+        # oversized section is sent to the embedding endpoint whole and fails the entire upload.
+        capped_chunks_content = []
+        for section_content in initial_chunks_content:
+            capped_chunks_content.extend(split_text_by_word_limit(section_content, target_chunk_words))
+        initial_chunks_content = capped_chunks_content
+
         # TODO: Advanced Table/Code Block Handling:
         # - Table header replication requires identifying markdown tables (`|---|`),
         #   detecting splits, and injecting headers.
@@ -6569,6 +6603,11 @@ def process_md(document_id, user_id, temp_file_path, original_filename, enable_e
             else:
                 # Accumulate in buffer if below min size and not the last chunk
                 buffer_chunk = current_chunk_text + "\n\n" # Add separator when buffering
+
+        # The merge loop above can still carry a small trailing chunk onto a full one, and word
+        # counts cannot predict how badly tables, code fences, or long URLs tokenize. Bound the
+        # final list by characters so no chunk can exceed the embedding context window.
+        final_chunks = split_oversized_chunks(final_chunks, max_chunk_characters)
 
         num_chunks_final = len(final_chunks)
         update_callback(number_of_pages=num_chunks_final)

--- a/application/single_app/functions_settings.py
+++ b/application/single_app/functions_settings.py
@@ -2218,8 +2218,8 @@ def get_embedding_context_tokens(settings=None):
                     continue
                 if parsed_value > 0:
                     return parsed_value
-    except Exception:
-        pass
+    except Exception as exc:
+        log_event("get_embedding_context_tokens_failed", {"error": str(exc)})
 
     return EMBEDDING_CONTEXT_FALLBACK_TOKENS
 

--- a/application/single_app/functions_settings.py
+++ b/application/single_app/functions_settings.py
@@ -2161,6 +2161,19 @@ def coerce_multi_model_endpoint_enablement(existing_enabled, requested_enabled):
     return bool(existing_enabled) or bool(requested_enabled)
 
 
+# Embedding chunk budget. Chunk sizes are configured in words, characters, or structural units,
+# but the embedding endpoint rejects any single input past its token context window, so configured
+# units must be converted before they can act as a bound. These ratios are deliberately more
+# conservative than typical English prose (~4 characters and ~0.75 tokens per word) because
+# markdown tables, code fences, and long URLs tokenize far worse than prose.
+EMBEDDING_CONTEXT_FALLBACK_TOKENS = 8192
+EMBEDDING_CHUNK_UTILIZATION = 0.85
+EMBEDDING_CHARS_PER_TOKEN = 3
+EMBEDDING_TOKENS_PER_WORD = 2
+# Retained for structural units (pages, slides) whose token size is unknowable before extraction.
+CHUNK_SIZE_STRUCTURAL_FALLBACK_CAP = 16384
+
+
 def get_chunk_size_defaults():
     """Return the baseline chunk size configuration used when overrides are disabled."""
     return {
@@ -2185,37 +2198,95 @@ def get_chunk_size_defaults():
     }
 
 
-def get_chunk_size_cap(settings=None):
-    """Return the maximum allowed chunk size (2x embedding context window, fallback 16,384)."""
-    fallback_cap = 16384
+def get_embedding_context_tokens(settings=None):
+    """Return the selected embedding model's context window in tokens."""
     try:
-        settings = settings or get_settings()
+        settings = settings if settings is not None else get_settings()
         embedding_model = settings.get('embedding_model', {}) if isinstance(settings, dict) else {}
         selected_models = embedding_model.get('selected') or []
 
-        base_context = None
         for model in selected_models:
             if not isinstance(model, dict):
                 continue
             for key in ['context_window', 'contextWindow', 'maxContextTokens', 'context_length', 'contextLength', 'maxTokens']:
                 value = model.get(key)
-                if value is not None:
-                    try:
-                        parsed_value = int(value)
-                        if parsed_value > 0:
-                            base_context = parsed_value
-                            break
-                    except Exception:
-                        continue
-            if base_context:
-                break
+                if value is None:
+                    continue
+                try:
+                    parsed_value = int(value)
+                except Exception:
+                    continue
+                if parsed_value > 0:
+                    return parsed_value
+    except Exception:
+        pass
 
+    return EMBEDDING_CONTEXT_FALLBACK_TOKENS
+
+
+def get_embedding_usable_tokens(settings=None):
+    """Return the token budget one chunk may occupy, leaving headroom for tokenizer variance."""
+    return max(1, int(get_embedding_context_tokens(settings) * EMBEDDING_CHUNK_UTILIZATION))
+
+
+def get_embedding_safe_chunk_characters(settings=None):
+    """Return the largest chunk length in characters expected to embed successfully."""
+    return max(1, int(get_embedding_usable_tokens(settings) * EMBEDDING_CHARS_PER_TOKEN))
+
+
+def get_embedding_safe_chunk_words(settings=None):
+    """Return the largest chunk length in words expected to embed successfully."""
+    return max(1, int(get_embedding_usable_tokens(settings) / EMBEDDING_TOKENS_PER_WORD))
+
+
+def get_chunk_size_cap(settings=None, unit=None):
+    """Return the maximum allowed chunk size for a unit.
+
+    Chunk sizes are configured per file type in different units, so a single numeric cap cannot be
+    correct for all of them. Word and character caps come from the embedding token budget, because
+    a value above that can never embed successfully no matter what an admin saves. Structural units
+    such as pages and slides have no knowable token size before extraction, so they keep the
+    historical cap and are bounded at embed time instead.
+    """
+    try:
+        settings = settings if settings is not None else get_settings()
+    except Exception:
+        settings = None
+
+    normalized_unit = str(unit).strip().lower() if unit else None
+
+    try:
+        if normalized_unit == 'words':
+            return get_embedding_safe_chunk_words(settings)
+        if normalized_unit == 'characters':
+            return get_embedding_safe_chunk_characters(settings)
+
+        base_context = get_embedding_context_tokens(settings)
         if base_context and base_context > 0:
             return base_context * 2
     except Exception:
         pass
 
-    return fallback_cap
+    return CHUNK_SIZE_STRUCTURAL_FALLBACK_CAP
+
+
+def get_chunk_size_caps_by_key(settings=None):
+    """Return the effective cap for every configurable chunk size key, keyed by file type."""
+    try:
+        settings = settings if settings is not None else get_settings()
+    except Exception:
+        settings = None
+
+    defaults = get_chunk_size_defaults()
+    stored = settings.get('chunk_size', {}) if isinstance(settings, dict) else {}
+
+    caps = {}
+    for key, default_meta in defaults.items():
+        incoming_meta = stored.get(key, {}) if isinstance(stored, dict) else {}
+        unit = incoming_meta.get('unit', default_meta['unit']) if isinstance(incoming_meta, dict) else default_meta['unit']
+        caps[key] = get_chunk_size_cap(settings, unit)
+
+    return caps
 
 
 def get_chunk_size_config(settings=None):
@@ -2227,7 +2298,6 @@ def get_chunk_size_config(settings=None):
     defaults = get_chunk_size_defaults()
     use_custom = isinstance(settings, dict) and settings.get('enable_chunk_size_override', False)
     stored = settings.get('chunk_size', {}) if isinstance(settings, dict) else {}
-    cap = get_chunk_size_cap(settings)
 
     normalized = {}
     for key, default_meta in defaults.items():
@@ -2239,7 +2309,7 @@ def get_chunk_size_config(settings=None):
             raw_value = default_meta['value']
 
         value = max(1, raw_value)
-        value = min(value, cap)
+        value = min(value, get_chunk_size_cap(settings, unit))
 
         normalized[key] = {
             'value': value,

--- a/application/single_app/route_frontend_admin_settings.py
+++ b/application/single_app/route_frontend_admin_settings.py
@@ -1020,6 +1020,9 @@ def register_route_frontend_admin_settings(bp):
                 chunk_size_defaults=get_chunk_size_defaults(),
                 chunk_size_settings=settings.get('chunk_size', {}),
                 chunk_size_cap=get_chunk_size_cap(settings),
+                chunk_size_caps=get_chunk_size_caps_by_key(settings),
+                chunk_size_word_cap=get_embedding_safe_chunk_words(settings),
+                chunk_size_character_cap=get_embedding_safe_chunk_characters(settings),
                 chunk_size_effective=get_chunk_size_config(settings),
                 audio_runtime_capabilities=audio_runtime_capabilities,
                 source_review_runtime_capabilities=source_review_runtime_capabilities,
@@ -2296,7 +2299,7 @@ def register_route_frontend_admin_settings(bp):
             # --- Chunk Size Overrides ---
             chunk_size_defaults = get_chunk_size_defaults()
             existing_chunk_sizes = settings.get('chunk_size', {}) if isinstance(settings, dict) else {}
-            chunk_size_cap = get_chunk_size_cap(settings)
+            chunk_size_caps = get_chunk_size_caps_by_key(settings)
             enable_chunk_size_override = form_data.get('enable_chunk_size_override') == 'on'
             normalized_chunk_sizes = {}
             chunk_size_warning_keys = []
@@ -2311,14 +2314,19 @@ def register_route_frontend_admin_settings(bp):
                 except Exception:
                     parsed_value = meta.get('value', 1)
 
+                unit = stored_meta.get('unit', meta.get('unit', 'words'))
+                # Each unit has its own cap, because a word count and a character count cannot
+                # share one numeric limit and still stay inside the embedding token budget.
+                key_cap = chunk_size_caps.get(key, get_chunk_size_cap(settings, unit))
+
                 sanitized_value = max(1, parsed_value)
-                if sanitized_value > chunk_size_cap:
-                    chunk_size_warning_keys.append(key.upper())
-                sanitized_value = min(sanitized_value, chunk_size_cap)
+                if sanitized_value > key_cap:
+                    chunk_size_warning_keys.append(f"{key.upper()} ({key_cap} {unit})")
+                sanitized_value = min(sanitized_value, key_cap)
 
                 normalized_chunk_sizes[key] = {
                     'value': sanitized_value,
-                    'unit': stored_meta.get('unit', meta.get('unit', 'words'))
+                    'unit': unit
                 }
 
             chunk_size_changed = (
@@ -2328,7 +2336,8 @@ def register_route_frontend_admin_settings(bp):
 
             if chunk_size_warning_keys:
                 flash(
-                    f"Chunk sizes capped at {chunk_size_cap} for: {', '.join(chunk_size_warning_keys)}.",
+                    "Chunk sizes were reduced to what a single chunk can embed for: "
+                    f"{', '.join(chunk_size_warning_keys)}.",
                     'warning'
                 )
 
@@ -3230,7 +3239,7 @@ def register_route_frontend_admin_settings(bp):
                             description='Updated chunk size overrides for document processing.',
                             additional_context={
                                 'override_enabled': enable_chunk_size_override,
-                                'chunk_size_cap': chunk_size_cap,
+                                'chunk_size_caps': chunk_size_caps,
                                 'chunk_sizes': normalized_chunk_sizes
                             }
                         )
@@ -3243,7 +3252,7 @@ def register_route_frontend_admin_settings(bp):
                             message="Admins updated chunk size defaults. New uploads will use the latest limits.",
                             metadata={
                                 'override_enabled': enable_chunk_size_override,
-                                'chunk_size_cap': chunk_size_cap
+                                'chunk_size_caps': chunk_size_caps
                             }
                         )
                     except Exception as e:

--- a/application/single_app/static/js/admin/admin_governance.js
+++ b/application/single_app/static/js/admin/admin_governance.js
@@ -147,6 +147,14 @@ const GOVERNANCE_ALLOWLIST_TRUNCATE_ID_LENGTH = 35;
 
 const GOVERNANCE_ITEM_REVIEW_DEFAULT_PAGE_SIZE = 25;
 const GOVERNANCE_ITEM_EDITOR_PAGE_SIZE_DEFAULT = 50;
+const GOVERNANCE_FEATURE_TAB_HASH = '#feature-governance';
+const GOVERNANCE_POLICIES_TAB_HASH = '#governance-policies';
+const GOVERNANCE_MCP_TAB_HASH = '#mcp-governance';
+const GOVERNANCE_ADMIN_TAB_IDS = [
+    'feature-governance',
+    'governance-policies',
+    'mcp-governance',
+];
 
 const governanceItemReviewState = {
     search: '',
@@ -957,6 +965,10 @@ function showGovernanceToast(message, variant = 'success') {
     toastEl.addEventListener('hidden.bs.toast', () => {
         toastEl.remove();
     });
+}
+
+function hasGovernanceAdminSurface() {
+    return GOVERNANCE_ADMIN_TAB_IDS.some((tabId) => document.getElementById(tabId));
 }
 
 function getGovernanceFeatureToggle(featureKey) {
@@ -1854,7 +1866,7 @@ async function openGovernanceDelegatedItemEditorFromResource(options = {}) {
     }
 
     if (typeof window.openAdminSettingsTab === 'function') {
-        window.openAdminSettingsTab('#governance');
+        window.openAdminSettingsTab(GOVERNANCE_POLICIES_TAB_HASH, 'governance-item-policies-section');
     }
 
     await openGovernanceItemPolicyEditor({
@@ -4174,7 +4186,7 @@ function wireGovernanceHandlers() {
         linkButton.addEventListener('click', () => {
             const targetId = String(linkButton.getAttribute('data-governance-target') || '').trim();
             if (typeof window.openAdminSettingsTab === 'function') {
-                window.openAdminSettingsTab('#governance');
+                window.openAdminSettingsTab(GOVERNANCE_FEATURE_TAB_HASH);
             }
             window.setTimeout(() => {
                 const target = document.getElementById(targetId);
@@ -4208,7 +4220,7 @@ function wireGovernanceHandlers() {
         button.addEventListener('click', async () => {
             try {
                 if (button.dataset.governanceOpenTab === 'true' && typeof window.openAdminSettingsTab === 'function') {
-                    window.openAdminSettingsTab('#governance', 'governance-inbound-mcp-section');
+                    window.openAdminSettingsTab(GOVERNANCE_MCP_TAB_HASH, 'governance-inbound-mcp-section');
                 }
                 await openGovernanceInboundMcpPolicyEditor({
                     entityType: button.dataset.governanceInboundMcpEntity || '',
@@ -4395,7 +4407,7 @@ function wireGovernanceHandlers() {
 }
 
 async function initializeGovernanceTab() {
-    if (!document.getElementById('governance')) {
+    if (!hasGovernanceAdminSurface()) {
         return;
     }
 

--- a/application/single_app/static/js/admin/admin_settings.js
+++ b/application/single_app/static/js/admin/admin_settings.js
@@ -6389,25 +6389,30 @@ function setupChunkSizeControls() {
         return;
     }
 
-    const capValue = capInput ? parseInt(capInput.value, 10) : null;
+    const fallbackCap = capInput ? parseInt(capInput.value, 10) : NaN;
+
+    // Each field has its own cap because word, character, and page counts cannot share one limit.
+    const capForInput = input => {
+        const perFieldCap = parseInt(input.dataset.cap || '', 10);
+        return Number.isNaN(perFieldCap) ? fallbackCap : perFieldCap;
+    };
 
     const updateCapWarning = () => {
-        if (!capValue || Number.isNaN(capValue)) {
-            if (capWarning) capWarning.classList.add('d-none');
-            return;
-        }
-
         const exceeding = [];
         chunkInputs.forEach(input => {
+            const cap = capForInput(input);
+            if (Number.isNaN(cap)) {
+                return;
+            }
             const raw = parseInt(input.value || '0', 10);
-            if (!Number.isNaN(raw) && raw > capValue) {
-                exceeding.push(input.dataset.label || input.name || 'A chunk size');
+            if (!Number.isNaN(raw) && raw > cap) {
+                exceeding.push(`${input.dataset.label || input.name || 'A chunk size'} (max ${cap})`);
             }
         });
 
         if (capWarning && capWarningText) {
             if (exceeding.length > 0 && overrideToggle.checked) {
-                capWarningText.textContent = `${exceeding.join(', ')} will be reduced to ${capValue} because of the cap.`;
+                capWarningText.textContent = `${exceeding.join(', ')} will be reduced to what a single chunk can embed.`;
                 capWarning.classList.remove('d-none');
             } else {
                 capWarning.classList.add('d-none');

--- a/application/single_app/templates/admin/_panes/extraction.html
+++ b/application/single_app/templates/admin/_panes/extraction.html
@@ -489,11 +489,14 @@
                 <div class="card p-3 mb-3" id="chunk-size-section">
                     <div class="d-flex align-items-center justify-content-between mb-2">
                         <h5 class="mb-0"><i class="bi bi-collection me-2"></i>Chunk Sizes</h5>
-                        <span class="badge bg-primary-subtle text-primary-emphasis">Cap: {{ chunk_size_cap }}</span>
+                        <span class="badge bg-primary-subtle text-primary-emphasis">Caps: {{ chunk_size_word_cap }} words / {{ chunk_size_character_cap }} characters</span>
                     </div>
                     <p class="text-muted mb-2 small">Custom chunk sizes apply to new uploads only. Existing documents keep their current chunks.</p>
                     <div class="alert alert-warning small mb-3">
-                        <strong>Heads up:</strong> Overrides are capped at {{ chunk_size_cap }} (2x embedding context window, fallback 16,384).
+                        <strong>Heads up:</strong> A chunk has to fit in one embedding request, so overrides are capped at
+                        <strong>{{ chunk_size_word_cap }} words</strong> or <strong>{{ chunk_size_character_cap }} characters</strong>,
+                        derived from the embedding model's context window. Page and slide counts are structural, so they are
+                        bounded when the chunk is embedded rather than here.
                     </div>
                     <div class="form-check form-switch mb-3">
                         <input
@@ -518,72 +521,72 @@
                         <div class="row g-3">
                             <div class="col-md-6">
                                 <label for="chunk_size_txt" class="form-label">TXT (words)</label>
-                                <input type="number" min="1" class="form-control chunk-size-input" data-label="TXT" id="chunk_size_txt" name="chunk_size_txt" value="{{ chunk_settings.get('txt', {}).get('value', chunk_defaults.get('txt', {}).get('value')) }}">
+                                <input type="number" min="1" class="form-control chunk-size-input" data-label="TXT" data-cap="{{ chunk_size_caps.get('txt') }}" id="chunk_size_txt" name="chunk_size_txt" value="{{ chunk_settings.get('txt', {}).get('value', chunk_defaults.get('txt', {}).get('value')) }}">
                             </div>
                             <div class="col-md-6">
                                 <label for="chunk_size_log" class="form-label">LOG (words)</label>
-                                <input type="number" min="1" class="form-control chunk-size-input" data-label="LOG" id="chunk_size_log" name="chunk_size_log" value="{{ chunk_settings.get('log', {}).get('value', chunk_defaults.get('log', {}).get('value')) }}">
+                                <input type="number" min="1" class="form-control chunk-size-input" data-label="LOG" data-cap="{{ chunk_size_caps.get('log') }}" id="chunk_size_log" name="chunk_size_log" value="{{ chunk_settings.get('log', {}).get('value', chunk_defaults.get('log', {}).get('value')) }}">
                             </div>
                             <div class="col-md-4">
                                 <label for="chunk_size_doc" class="form-label">DOC (words)</label>
-                                <input type="number" min="1" class="form-control chunk-size-input" data-label="DOC" id="chunk_size_doc" name="chunk_size_doc" value="{{ chunk_settings.get('doc', {}).get('value', chunk_defaults.get('doc', {}).get('value')) }}">
+                                <input type="number" min="1" class="form-control chunk-size-input" data-label="DOC" data-cap="{{ chunk_size_caps.get('doc') }}" id="chunk_size_doc" name="chunk_size_doc" value="{{ chunk_settings.get('doc', {}).get('value', chunk_defaults.get('doc', {}).get('value')) }}">
                             </div>
                             <div class="col-md-4">
                                 <label for="chunk_size_docm" class="form-label">DOCM (words)</label>
-                                <input type="number" min="1" class="form-control chunk-size-input" data-label="DOCM" id="chunk_size_docm" name="chunk_size_docm" value="{{ chunk_settings.get('docm', {}).get('value', chunk_defaults.get('docm', {}).get('value')) }}">
+                                <input type="number" min="1" class="form-control chunk-size-input" data-label="DOCM" data-cap="{{ chunk_size_caps.get('docm') }}" id="chunk_size_docm" name="chunk_size_docm" value="{{ chunk_settings.get('docm', {}).get('value', chunk_defaults.get('docm', {}).get('value')) }}">
                             </div>
                             <div class="col-md-4">
                                 <label for="chunk_size_docx" class="form-label">DOCX (words)</label>
-                                <input type="number" min="1" class="form-control chunk-size-input" data-label="DOCX" id="chunk_size_docx" name="chunk_size_docx" value="{{ chunk_settings.get('docx', {}).get('value', chunk_defaults.get('docx', {}).get('value')) }}">
+                                <input type="number" min="1" class="form-control chunk-size-input" data-label="DOCX" data-cap="{{ chunk_size_caps.get('docx') }}" id="chunk_size_docx" name="chunk_size_docx" value="{{ chunk_settings.get('docx', {}).get('value', chunk_defaults.get('docx', {}).get('value')) }}">
                             </div>
                             <div class="col-md-6">
                                 <label for="chunk_size_html" class="form-label">HTML (words)</label>
-                                <input type="number" min="1" class="form-control chunk-size-input" data-label="HTML" id="chunk_size_html" name="chunk_size_html" value="{{ chunk_settings.get('html', {}).get('value', chunk_defaults.get('html', {}).get('value')) }}">
+                                <input type="number" min="1" class="form-control chunk-size-input" data-label="HTML" data-cap="{{ chunk_size_caps.get('html') }}" id="chunk_size_html" name="chunk_size_html" value="{{ chunk_settings.get('html', {}).get('value', chunk_defaults.get('html', {}).get('value')) }}">
                                 <div class="form-text">Minimum enforced at 50% of target on merge.</div>
                             </div>
                             <div class="col-md-6">
                                 <label for="chunk_size_md" class="form-label">Markdown (words)</label>
-                                <input type="number" min="1" class="form-control chunk-size-input" data-label="MD" id="chunk_size_md" name="chunk_size_md" value="{{ chunk_settings.get('md', {}).get('value', chunk_defaults.get('md', {}).get('value')) }}">
+                                <input type="number" min="1" class="form-control chunk-size-input" data-label="MD" data-cap="{{ chunk_size_caps.get('md') }}" id="chunk_size_md" name="chunk_size_md" value="{{ chunk_settings.get('md', {}).get('value', chunk_defaults.get('md', {}).get('value')) }}">
                             </div>
                             <div class="col-md-6">
                                 <label for="chunk_size_xml" class="form-label">XML (characters)</label>
-                                <input type="number" min="1" class="form-control chunk-size-input" data-label="XML" id="chunk_size_xml" name="chunk_size_xml" value="{{ chunk_settings.get('xml', {}).get('value', chunk_defaults.get('xml', {}).get('value')) }}">
+                                <input type="number" min="1" class="form-control chunk-size-input" data-label="XML" data-cap="{{ chunk_size_caps.get('xml') }}" id="chunk_size_xml" name="chunk_size_xml" value="{{ chunk_settings.get('xml', {}).get('value', chunk_defaults.get('xml', {}).get('value')) }}">
                             </div>
                             <div class="col-md-6">
                                 <label for="chunk_size_yaml" class="form-label">YAML (characters)</label>
-                                <input type="number" min="1" class="form-control chunk-size-input" data-label="YAML" id="chunk_size_yaml" name="chunk_size_yaml" value="{{ chunk_settings.get('yaml', {}).get('value', chunk_defaults.get('yaml', {}).get('value')) }}">
+                                <input type="number" min="1" class="form-control chunk-size-input" data-label="YAML" data-cap="{{ chunk_size_caps.get('yaml') }}" id="chunk_size_yaml" name="chunk_size_yaml" value="{{ chunk_settings.get('yaml', {}).get('value', chunk_defaults.get('yaml', {}).get('value')) }}">
                             </div>
                             <div class="col-md-6">
                                 <label for="chunk_size_yml" class="form-label">YML (characters)</label>
-                                <input type="number" min="1" class="form-control chunk-size-input" data-label="YML" id="chunk_size_yml" name="chunk_size_yml" value="{{ chunk_settings.get('yml', {}).get('value', chunk_defaults.get('yml', {}).get('value')) }}">
+                                <input type="number" min="1" class="form-control chunk-size-input" data-label="YML" data-cap="{{ chunk_size_caps.get('yml') }}" id="chunk_size_yml" name="chunk_size_yml" value="{{ chunk_settings.get('yml', {}).get('value', chunk_defaults.get('yml', {}).get('value')) }}">
                             </div>
                             <div class="col-md-6">
                                 <label for="chunk_size_json" class="form-label">JSON (characters)</label>
-                                <input type="number" min="1" class="form-control chunk-size-input" data-label="JSON" id="chunk_size_json" name="chunk_size_json" value="{{ chunk_settings.get('json', {}).get('value', chunk_defaults.get('json', {}).get('value')) }}">
+                                <input type="number" min="1" class="form-control chunk-size-input" data-label="JSON" data-cap="{{ chunk_size_caps.get('json') }}" id="chunk_size_json" name="chunk_size_json" value="{{ chunk_settings.get('json', {}).get('value', chunk_defaults.get('json', {}).get('value')) }}">
                             </div>
                             <!--
                             <div class="col-md-6">
                                 <label for="chunk_size_csv" class="form-label">CSV (characters)</label>
-                                <input type="number" min="1" class="form-control chunk-size-input" data-label="CSV" id="chunk_size_csv" name="chunk_size_csv" value="{{ chunk_settings.get('csv', {}).get('value', chunk_defaults.get('csv', {}).get('value')) }}">
+                                <input type="number" min="1" class="form-control chunk-size-input" data-label="CSV" data-cap="{{ chunk_size_caps.get('csv') }}" id="chunk_size_csv" name="chunk_size_csv" value="{{ chunk_settings.get('csv', {}).get('value', chunk_defaults.get('csv', {}).get('value')) }}">
                             </div>
                             <div class="col-md-6">
                                 <label for="chunk_size_excel" class="form-label">Excel (characters)</label>
-                                <input type="number" min="1" class="form-control chunk-size-input" data-label="EXCEL" id="chunk_size_excel" name="chunk_size_excel" value="{{ chunk_settings.get('excel', {}).get('value', chunk_defaults.get('excel', {}).get('value')) }}">
+                                <input type="number" min="1" class="form-control chunk-size-input" data-label="EXCEL" data-cap="{{ chunk_size_caps.get('excel') }}" id="chunk_size_excel" name="chunk_size_excel" value="{{ chunk_settings.get('excel', {}).get('value', chunk_defaults.get('excel', {}).get('value')) }}">
                             </div>
                             -->
                             <div class="col-md-6">
                                 <label for="chunk_size_transcript" class="form-label">Transcripts (words)</label>
-                                <input type="number" min="1" class="form-control chunk-size-input" data-label="TRANSCRIPT" id="chunk_size_transcript" name="chunk_size_transcript" value="{{ chunk_settings.get('transcript', {}).get('value', chunk_defaults.get('transcript', {}).get('value')) }}">
+                                <input type="number" min="1" class="form-control chunk-size-input" data-label="TRANSCRIPT" data-cap="{{ chunk_size_caps.get('transcript') }}" id="chunk_size_transcript" name="chunk_size_transcript" value="{{ chunk_settings.get('transcript', {}).get('value', chunk_defaults.get('transcript', {}).get('value')) }}">
                                 <div class="form-text">Applies to new audio transcripts.</div>
                             </div>
                             <div class="col-md-6">
                                 <label for="chunk_size_pdf" class="form-label">PDF (pages)</label>
-                                <input type="number" min="1" class="form-control chunk-size-input" data-label="PDF" id="chunk_size_pdf" name="chunk_size_pdf" value="{{ chunk_settings.get('pdf', {}).get('value', chunk_defaults.get('pdf', {}).get('value')) }}">
+                                <input type="number" min="1" class="form-control chunk-size-input" data-label="PDF" data-cap="{{ chunk_size_caps.get('pdf') }}" id="chunk_size_pdf" name="chunk_size_pdf" value="{{ chunk_settings.get('pdf', {}).get('value', chunk_defaults.get('pdf', {}).get('value')) }}">
                                 <div class="form-text">Pages per chunk after extraction.</div>
                             </div>
                             <div class="col-md-6">
                                 <label for="chunk_size_pptx" class="form-label">PPT/PPTX (slides)</label>
-                                <input type="number" min="1" class="form-control chunk-size-input" data-label="PPT/PPTX" id="chunk_size_pptx" name="chunk_size_pptx" value="{{ chunk_settings.get('pptx', {}).get('value', chunk_defaults.get('pptx', {}).get('value')) }}">
+                                <input type="number" min="1" class="form-control chunk-size-input" data-label="PPT/PPTX" data-cap="{{ chunk_size_caps.get('pptx') }}" id="chunk_size_pptx" name="chunk_size_pptx" value="{{ chunk_settings.get('pptx', {}).get('value', chunk_defaults.get('pptx', {}).get('value')) }}">
                                 <div class="form-text">Slides per chunk after extraction.</div>
                             </div>
                         </div>

--- a/application/single_app/templates/admin/_panes/inbound-mcp.html
+++ b/application/single_app/templates/admin/_panes/inbound-mcp.html
@@ -531,5 +531,39 @@
                         </div>
                     </div>
                 </div>
+                {% else %}
+                <div class="card p-3 mb-4" id="inbound-mcp-configuration">
+                    <div class="d-flex flex-column flex-lg-row justify-content-between align-items-lg-start gap-3 mb-3">
+                        <div>
+                            <h5 class="card-title mb-1">
+                                <i class="bi bi-diagram-3 me-2"></i>Inbound MCP Server
+                            </h5>
+                            <p class="text-muted small mb-0">
+                                The Inbound MCP admin UI is hidden until the preview app setting is enabled for this deployment.
+                            </p>
+                        </div>
+                        <span class="badge text-bg-secondary align-self-start align-self-lg-end">Disabled</span>
+                    </div>
+
+                    <div class="alert alert-warning small" role="alert">
+                        <strong>Inbound MCP admin UI is disabled.</strong>
+                        Add an Azure App Service application setting or environment variable named
+                        <code>ENABLE_MCP_UI</code> with value <code>true</code>, then save the configuration and restart the app if your host does not restart it automatically.
+                    </div>
+
+                    <div class="border rounded-3 p-3 mb-3">
+                        <h6 class="mb-2">How to enable this tab</h6>
+                        <ol class="small mb-0">
+                            <li>Open the Azure App Service that hosts SimpleChat.</li>
+                            <li>Go to <strong>Configuration</strong> and add an application setting named <code>ENABLE_MCP_UI</code>.</li>
+                            <li>Set the value to <code>true</code>, save the change, and restart the app if needed.</li>
+                            <li>Reload Admin Settings and return to <strong>Agents &amp; Actions -> Inbound MCP</strong>.</li>
+                        </ol>
+                    </div>
+
+                    <div class="alert alert-info small mb-0" role="alert">
+                        This app setting only exposes the preview admin configuration UI. The inbound MCP runtime remains off until an admin enables <strong>Enable inbound MCP server</strong> after authentication, client allowlist, source, and governance prerequisites are configured.
+                    </div>
+                </div>
                 {% endif %}
             </div>

--- a/docs/admin/agents-actions.md
+++ b/docs/admin/agents-actions.md
@@ -116,6 +116,8 @@ The Actions Configuration section belongs to the Actions tab. Use it with the ad
 
 The Inbound MCP section belongs to the Inbound MCP tab. Use it with the adjacent settings in this group so related rollout, access, and operational choices stay aligned.
 
+If the tab shows that the Inbound MCP admin UI is disabled, add the Azure App Service application setting `ENABLE_MCP_UI=true`, save the configuration, and restart the app if your host does not restart it automatically. This only exposes the preview configuration UI; the inbound MCP runtime remains off until **Enable inbound MCP server** is turned on after authentication, client allowlist, source, and governance prerequisites are ready.
+
 #### Settings
 
 | Setting | What it does | Default | Notes |

--- a/docs/admin/knowledge.md
+++ b/docs/admin/knowledge.md
@@ -116,7 +116,24 @@ The Document Intelligence section belongs to the Document Extraction tab. Use it
 
 ### Chunk Sizes {#chunk-size-section}
 
-The Chunk Sizes section belongs to the Document Extraction tab. Use it with the adjacent settings in this group so related rollout, access, and operational choices stay aligned.
+Documents are split into chunks before they are indexed, and each chunk is embedded as a single
+request. That makes chunk size a retrieval decision and a hard technical limit at the same time:
+smaller chunks return more precise citations, larger chunks keep more surrounding context in one
+result, and a chunk that does not fit in the embedding model's context window cannot be indexed
+at all.
+
+Because of that limit, overrides are capped per unit rather than by one shared number. Word fields
+and character fields have different ceilings, both derived from the embedding model's context
+window, and the tab shows the current values. A value above the ceiling is reduced on save and the
+page reports which fields were changed.
+
+Page and slide counts are structural: how much text a page holds is not known until extraction
+runs, so they are not capped here. If an extracted chunk still turns out to be too large to embed,
+its text is stored and remains searchable and citable while only the portion used to compute its
+vector is trimmed, and the event is logged.
+
+Custom sizes apply to new uploads only. Existing documents keep the chunks they were indexed with
+until they are uploaded again.
 
 ### Metadata Extraction {#metadata-extraction-section}
 
@@ -163,7 +180,7 @@ The Multi-Modal Vision Analysis section belongs to the Document Extraction tab. 
 | DOCM (words) | Defines a capacity or timing boundary that keeps the feature inside supported limits. | 400 words | `chunk_size_docm` |
 | DOCX (words) | Defines a capacity or timing boundary that keeps the feature inside supported limits. | configured WORD_CHUNK_SIZE words | `chunk_size_docx` |
 | HTML (words) | Minimum enforced at 50% of target on merge. | 1200 words | `chunk_size_html` |
-| Markdown (words) | Defines a capacity or timing boundary that keeps the feature inside supported limits. | 1200 words | `chunk_size_md` |
+| Markdown (words) | Target words per chunk. Heading sections larger than this are split, so a long section under one heading cannot become a single unindexable chunk. Minimum enforced at 50% of target on merge. | 1200 words | `chunk_size_md` |
 | XML (characters) | Defines a capacity or timing boundary that keeps the feature inside supported limits. | 4000 characters | `chunk_size_xml` |
 | YAML (characters) | Defines a capacity or timing boundary that keeps the feature inside supported limits. | 4000 characters | `chunk_size_yaml` |
 | YML (characters) | Defines a capacity or timing boundary that keeps the feature inside supported limits. | 4000 characters | `chunk_size_yml` |

--- a/docs/explanation/fixes/GOVERNANCE_SPLIT_TAB_INITIALIZATION_FIX.md
+++ b/docs/explanation/fixes/GOVERNANCE_SPLIT_TAB_INITIALIZATION_FIX.md
@@ -1,0 +1,77 @@
+# Governance Split Tab Initialization Fix
+
+**Version:** 0.261.002
+**Fixed in version:** **0.261.002**
+**Related issue:** [#1362](https://github.com/microsoft/simplechat/issues/1362)
+
+## Issue description
+
+In **Admin Settings -> Governance -> Policies**, the **New Policy** button in
+the Delegated Item Policies card did not open the delegated item policy editor
+modal.
+
+## Root cause
+
+The governance admin JavaScript still used the retired aggregate
+`id="governance"` pane as its initialization guard:
+
+```js
+if (!document.getElementById('governance')) {
+    return;
+}
+```
+
+The current Admin Settings navigation renders Governance as three split tabs:
+
+- `feature-governance`
+- `governance-policies`
+- `mcp-governance`
+
+Because the old pane no longer exists, `admin_governance.js` returned before
+`wireGovernanceHandlers()` could attach the **New Policy** click handler.
+
+## Approach
+
+The fix makes governance initialization detect the current split governance
+panes and updates governance quick links to target the correct tab:
+
+- Feature governance links open `#feature-governance`.
+- Delegated resource quick-create links open `#governance-policies`.
+- Inbound MCP quick-create links open `#mcp-governance`.
+
+## Files modified
+
+| File | Change |
+|---|---|
+| `application/single_app/static/js/admin/admin_governance.js` | Detect split governance panes and route quick links to the correct tab ids |
+| `application/single_app/config.py` | Bumped `VERSION` to `0.261.002` |
+| `functional_tests/test_governance_route_and_wiring_coverage.py` | Added regression markers for split-tab initialization and stale `#governance` references |
+| `ui_tests/test_admin_governance_tab.py` | Updated the UI workflow to navigate the split governance tabs before using **New Policy** |
+| `docs/explanation/release_notes.md` | Added a bug-fix release note |
+
+## Validation
+
+### Test results
+
+- `node --check application\single_app\static\js\admin\admin_governance.js`
+- `python -m py_compile application\single_app\config.py functional_tests\test_governance_route_and_wiring_coverage.py ui_tests\test_admin_governance_tab.py`
+- `python functional_tests\test_governance_route_and_wiring_coverage.py`
+- `python scripts\check_xss_sinks.py --full-file application\single_app\static\js\admin\admin_governance.js`
+- `git --no-pager diff --check`
+
+The targeted Playwright UI test was invoked with
+`python -m pytest ui_tests\test_admin_governance_tab.py -q`, but skipped locally
+because the local authenticated Playwright storage state was not configured.
+
+### Before / after
+
+- Before: the governance module exited during initialization and never wired the
+  delegated item **New Policy** button.
+- After: the module initializes when any split governance pane is present, and
+  the **New Policy** button opens the delegated item policy editor modal.
+
+### User experience improvements
+
+- Admins can create delegated item policies directly from the Policies tab.
+- Governance quick-create links from related admin surfaces land on the intended
+  split governance tab.

--- a/docs/explanation/fixes/MARKDOWN_CHUNK_SIZE_ENFORCEMENT_FIX.md
+++ b/docs/explanation/fixes/MARKDOWN_CHUNK_SIZE_ENFORCEMENT_FIX.md
@@ -1,0 +1,155 @@
+# Markdown Chunk Size Enforcement Fix
+
+**Fixed in version: 0.261.002**
+
+## Issue
+
+Uploading a Markdown file to any workspace could fail with:
+
+```
+Failed processing Markdown file <name>.md: Error code: 400 - ... maximum context length ...
+```
+
+The failure took down the **entire document**, not just the oversized part of it. Files that
+looked ordinary, such as a long release notes page, were affected. Lowering **Markdown (words)**
+in Admin Settings did not help.
+
+## Root cause
+
+`process_md` in `functions_documents.py` split Markdown with `MarkdownHeaderTextSplitter` on
+headings `#` through `#####`, then post-processed the result. The post-processing loop **only
+merged chunks that were too small**. There was no branch that split a chunk that was too large:
+
+```python
+if current_word_count >= min_chunk_words or i == len(initial_chunks_content) - 1:
+    final_chunks.append(current_chunk_text)   # emit
+else:
+    buffer_chunk = current_chunk_text + "\n\n"  # accumulate
+```
+
+`target_chunk_words` was read from settings but used **only** to derive `min_chunk_words`:
+
+```python
+target_chunk_words = chunk_config.get('md', {}).get('value', 1200)
+min_chunk_words = max(1, int(target_chunk_words * 0.5))
+```
+
+So the configured size acted purely as a *minimum*. A heading section with no nested subheading
+produced a chunk as large as the text beneath it, which was then handed whole to
+`generate_embedding`. That function retries only `RateLimitError` and re-raises everything else,
+so a single oversized section aborted the whole upload.
+
+Measured against the pre-fix code, a 120-paragraph section under one `####` heading produced:
+
+| | Chunks | Largest chunk | Approx. tokens |
+|---|---|---|---|
+| Before | 1 | 109,927 characters | ~36,600 |
+| After | 14 | 8,250 characters | ~2,750 |
+
+The embedding limit is 8,192 tokens.
+
+Markdown was the **only** unbounded ingestion path. `process_html` already used a
+character-bounded `RecursiveCharacterTextSplitter`, and the xml, yaml, json, txt, doc, log, msg,
+pdf, and pptx processors were all bounded.
+
+### Related latent bug
+
+`get_chunk_size_cap` returned `context_window * 2` (fallback 16,384) and `get_chunk_size_config`
+applied that number **without regard to the unit**. A word field could therefore be set to 16,384
+*words*, roughly 21,000–33,000 tokens, which could never embed. The same cap was used in
+`_merge_embedded_images_into_chunks` to derive `16384 x 4 x 0.9` = **58,982 characters**
+(~14,700 tokens) as an image merge budget.
+
+## Fix
+
+Three layers, so no single heuristic has to be perfect.
+
+### 1. Word cap at the source
+
+Each header section is now capped at `target_chunk_words` **before** the merge loop, so merge
+semantics are unchanged:
+
+```python
+capped_chunks_content = []
+for section_content in initial_chunks_content:
+    capped_chunks_content.extend(split_text_by_word_limit(section_content, target_chunk_words))
+initial_chunks_content = capped_chunks_content
+```
+
+Splitting prefers the strongest structural boundary available (blank line, then line break, then
+space) and never breaks mid-word, so table rows and list items stay intact.
+
+### 2. Character backstop
+
+The merge loop can still carry a trailing chunk of up to `min_chunk_words` onto a following full
+chunk, giving up to 1.5x the target. Word counts also cannot predict how badly tables, code
+fences, and long URLs tokenize. The final list is therefore bounded by characters:
+
+```python
+final_chunks = split_oversized_chunks(final_chunks, max_chunk_characters)
+```
+
+This runs **after** merging and is the authoritative bound. The same backstop was added
+defensively to `process_html`.
+
+### 3. Last-resort guard at embed time
+
+`save_chunks` now clamps the text passed to `generate_embedding`, and logs a warning when it does.
+
+Splitting is not possible at this point: `chunk_id` is built as `f"{document_id}_{page_number}"`,
+so emitting a second chunk for one page would overwrite the first in the search index. Instead
+**only the embedding input is clamped** — `page_text_content` is still stored in full, so the
+chunk stays readable and citable and only its vector is computed from the leading portion.
+
+### 4. Unit-aware cap
+
+`get_chunk_size_cap` now accepts a unit and returns the matching limit, derived from the embedding
+context window with a conservative conversion:
+
+| Unit | Cap (8,192-token model) |
+|---|---|
+| words | 3,481 |
+| characters | 20,889 |
+| pages, slides | 16,384 (unchanged; bounded at embed time instead) |
+
+Every shipping default is below these limits, so **no default behavior changed**. Only custom
+overrides that could never have embedded successfully are reduced.
+
+`tiktoken` was deliberately not introduced: it is not a dependency of this project and downloads
+BPE vocabulary files at runtime from a public endpoint, which does not suit the private-networking
+and Azure Government deployments SimpleChat supports. The conversion ratios are instead
+deliberately more conservative than English prose, because markdown tokenizes worse than prose.
+
+## Files modified
+
+| File | Change |
+|---|---|
+| `functions_settings.py` | Added embedding budget helpers and `get_chunk_size_caps_by_key`; made `get_chunk_size_cap` unit-aware and applied it per unit in `get_chunk_size_config` |
+| `functions_content.py` | Added `count_words`, `split_text_by_word_limit`, `split_oversized_chunks` |
+| `functions_documents.py` | Capped Markdown sections and added the character backstop in `process_md`; backstop in `process_html`; embedding clamp in `save_chunks`; repointed the image merge budget |
+| `route_frontend_admin_settings.py` | Per-unit cap in save validation, render context, and admin logging |
+| `templates/admin/_panes/extraction.html` | Per-input `data-cap`, corrected cap copy |
+| `static/js/admin/admin_settings.js` | Per-input cap in `setupChunkSizeControls` |
+| `config.py` | Version `0.261.002` |
+
+## Validation
+
+`functional_tests/test_markdown_chunk_size_enforcement.py` runs the **real** `process_md` against
+a stubbed namespace and covers:
+
+- an oversized single-heading section is split and every chunk stays inside both bounds
+- no source content is lost while splitting
+- ordinary Markdown still splits on headings rather than being reflowed
+- a small document still yields exactly one chunk
+- the cap is unit-aware and shipping defaults are unchanged
+- `save_chunks` clamps only the embedding input and still stores the full chunk text
+- `process_md` caps sections before merging and applies the backstop after
+
+Regression coverage re-run: `test_figure_chunk_association.py` (9/9),
+`test_chunked_image_storage.py`, `test_docs_app_surface_coverage.py`, `test_docs_site_quality.py`.
+
+## Impact on existing documents
+
+Chunking changes apply to **new uploads only**. Markdown files indexed before this fix keep the
+chunks they were indexed with. A file whose upload failed part-way through remains partially
+indexed, so re-upload any Markdown document that previously failed to process.

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,15 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/features) and [Fixes by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/fixes).
 
+### **(v0.261.002)**
+
+#### Bug Fixes
+
+*   **Delegated Governance New Policy Modal Opens On Split Governance Tabs**
+    *   Fixed the delegated item governance **New Policy** button so it opens the policy editor after Admin Settings governance was split into Feature Governance, Policies, and MCP Governance tabs.
+    *   Updated governance quick links to target the correct split tab panes instead of the retired aggregate Governance pane.
+    *   (Ref: `admin_governance.js`, delegated item policy editor, [#1362](https://github.com/microsoft/simplechat/issues/1362))
+
 ### **(v0.261.001)**
 
 #### New Features

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,15 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/features) and [Fixes by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/fixes).
 
+### **(v0.261.002)**
+
+#### User Interface Enhancements
+
+*   **Inbound MCP Enablement Guidance**
+    *   Added a visible **Inbound MCP** tab state for deployments where the preview admin UI is disabled by the missing `ENABLE_MCP_UI=true` App Service application setting.
+    *   The disabled-state card explains how to enable the preview UI while making clear that the inbound MCP runtime remains off until an admin turns on **Enable inbound MCP server** after authentication, client allowlist, source, and governance prerequisites are ready.
+    *   (Ref: `admin/_panes/inbound-mcp.html`, `admin_settings_nav.py`, [#1364](https://github.com/microsoft/simplechat/issues/1364))
+
 ### **(v0.261.001)**
 
 #### New Features

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,24 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/features) and [Fixes by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/fixes).
 
+### **(v0.261.002)**
+
+#### Bug Fixes
+
+*   **Large Markdown Files No Longer Fail To Upload**
+    *   Uploading a Markdown file could fail with `Failed processing Markdown file ...` and take down the whole document, not just the oversized part of it. Long pages with a big section under a single heading, such as a release notes file, were the usual trigger.
+    *   Markdown was the only ingestion path with no maximum chunk size. Its splitter divided the file on headings, and the step afterwards only ever merged chunks that were **too small** — nothing split a chunk that was too large. A heading with no subheading beneath it therefore became one chunk as large as all the text under it, which the embedding model refused.
+    *   Lowering **Markdown (words)** in Admin Settings did not work around this, because that value was only ever used as a minimum. It is now a real target, so the setting behaves the way its name implies.
+    *   Sections are now split to the configured size, a character limit is applied after merging to catch content such as tables and code blocks that take up more of the model's budget than their word count suggests, and a final safeguard keeps any remaining outlier inside the limit. That safeguard trims only the text used to build the chunk's search vector — the chunk itself is still stored in full, so citations and content are unaffected.
+    *   (Ref: `process_md`, `save_chunks`, `functions_content.py`, `functions_documents.py`)
+
+*   **Chunk Size Limits Now Respect Their Unit**
+    *   Chunk sizes are configured per file type in words, characters, or pages, but a single shared limit was applied to all of them. That let a word-based field be set to 16,384 words — far more than can be indexed — while implying the value was valid.
+    *   Word and character fields now have separate limits, both derived from the embedding model's context window, and the Document Extraction tab shows the current values. A value above its limit is reduced on save and the page names the fields it changed.
+    *   Page and slide counts are left uncapped here, since how much text a page holds is not known until extraction runs. They are bounded when the chunk is indexed instead.
+    *   No shipping default changed. Only custom overrides that could never have been indexed are affected.
+    *   (Ref: `get_chunk_size_cap`, `get_chunk_size_config`, Document Extraction settings, `admin_settings.js`)
+
 ### **(v0.261.001)**
 
 #### New Features

--- a/functional_tests/test_figure_chunk_association.py
+++ b/functional_tests/test_figure_chunk_association.py
@@ -51,10 +51,9 @@ def load_document_functions(function_names):
     namespace = {
         "logging": logging,
         "log_event": lambda *args, **kwargs: None,
-        "get_chunk_size_cap": lambda settings=None: 16384,
-        "OFFICE_IMAGE_MERGE_CHARS_PER_TOKEN": 4,
-        "OFFICE_IMAGE_MERGE_UTILIZATION": 0.9,
-        "OFFICE_IMAGE_MERGE_FALLBACK_CAP": 16384,
+        "get_chunk_size_cap": lambda settings=None, unit=None: 16384,
+        "get_embedding_safe_chunk_characters": lambda settings=None: 20889,
+        "OFFICE_IMAGE_MERGE_FALLBACK_CHAR_LIMIT": 20889,
         "OFFICE_IMAGE_MERGE_MIN_CHAR_LIMIT": 4000,
     }
 

--- a/functional_tests/test_governance_route_and_wiring_coverage.py
+++ b/functional_tests/test_governance_route_and_wiring_coverage.py
@@ -2,8 +2,8 @@
 #!/usr/bin/env python3
 """
 Functional test for governance route and enforcement wiring coverage.
-Version: 0.250.208
-Implemented in: 0.242.011; 0.242.012; 0.242.013; 0.242.014; 0.242.018; 0.242.019; 0.250.204; 0.250.205; 0.250.206; 0.250.207; 0.250.208
+Version: 0.261.002
+Implemented in: 0.242.011; 0.242.012; 0.242.013; 0.242.014; 0.242.018; 0.242.019; 0.250.204; 0.250.205; 0.250.206; 0.250.207; 0.250.208; 0.261.002
 
 This test ensures governance routes are registered and guarded, and that
 updated backend modules include governance enforcement hooks for endpoint,
@@ -133,6 +133,8 @@ def test_governance_enforcement_hooks_across_changed_routes():
 
     for marker in [
         "id=\"feature-governance\"",
+        "id=\"governance-policies\"",
+        "id=\"mcp-governance\"",
         "governance-feature-policies-table",
         "governance-item-policies-table",
         "governance-item-policy-card-controls",
@@ -223,10 +225,25 @@ def test_governance_enforcement_hooks_across_changed_routes():
         "openGovernanceItemPolicyUsersModal",
         "A new policy ID will be assigned when saved",
         "Allowed and blocked users/groups were swapped",
+        "GOVERNANCE_ADMIN_TAB_IDS",
+        "hasGovernanceAdminSurface()",
+        "GOVERNANCE_FEATURE_TAB_HASH",
+        "GOVERNANCE_POLICIES_TAB_HASH",
+        "GOVERNANCE_MCP_TAB_HASH",
+        "window.openAdminSettingsTab(GOVERNANCE_POLICIES_TAB_HASH, 'governance-item-policies-section')",
+        "window.openAdminSettingsTab(GOVERNANCE_FEATURE_TAB_HASH)",
+        "window.openAdminSettingsTab(GOVERNANCE_MCP_TAB_HASH, 'governance-inbound-mcp-section')",
     ]:
         assert marker in admin_governance_js_content or marker in admin_settings_template_content or marker in frontend_chats_content or marker in agents_content, (
             f"Missing governance UI visibility marker: {marker}"
         )
+
+    assert "document.getElementById('governance')" not in admin_governance_js_content, (
+        "Governance initialization must not depend on the retired aggregate #governance tab pane"
+    )
+    assert "window.openAdminSettingsTab('#governance')" not in admin_governance_js_content, (
+        "Governance quick links must target the split governance tab panes"
+    )
 
     item_policy_table_header_section = admin_settings_template_content.split(
         'id="governance-item-policies-table"',

--- a/functional_tests/test_inbound_mcp_admin_ui.py
+++ b/functional_tests/test_inbound_mcp_admin_ui.py
@@ -2,7 +2,7 @@
 #!/usr/bin/env python3
 """
 Functional test for the inbound MCP admin UI settings slice.
-Version: 0.250.098
+Version: 0.261.002
 Implemented in: 0.250.071
 Easy Auth enablement guard implemented in: 0.250.072
 Cloud-aware Easy Auth script implemented in: 0.250.073
@@ -28,12 +28,13 @@ Inbound MCP source governance CTA guidance implemented in: 0.250.093
 Inbound MCP enterprise readiness hardening implemented in: 0.250.096
 Inbound MCP admin throttle controls implemented in: 0.250.097
 Inbound MCP observability query panel implemented in: 0.250.098
+Inbound MCP disabled-state guidance implemented in: 0.261.002
 
 This test ensures inbound MCP runtime configuration is stored in app_settings,
-the minimal Admin Settings UI is gated by an OS-only feature flag, and the
-feature flag itself is not exposed as an editable UI setting. It also verifies
-that enabling inbound MCP requires the Easy Auth exclusion confirmation and
-server-side endpoint check.
+the full Admin Settings UI is gated by an OS-only feature flag, the disabled
+state explains how to enable the preview UI, and the feature flag itself is not
+exposed as an editable UI setting. It also verifies that enabling inbound MCP
+requires the Easy Auth exclusion confirmation and server-side endpoint check.
 """
 
 import sys
@@ -114,14 +115,18 @@ def test_mcp_ui_gate_is_os_environment_only():
     assert "'enable_mcp_ui'" not in admin_route_source
 
 
-def test_admin_settings_mcp_ui_is_gated_and_minimal():
-    """Validate the Admin Settings card and sidebar are behind mcp_ui_enabled."""
+def test_admin_settings_mcp_ui_disabled_message_and_enabled_form():
+    """Validate the Inbound MCP tab shows guidance when the full UI is gated."""
     admin_template = read_repo_file("application/single_app/templates/admin_settings.html")
     admin_route_source = read_repo_file("application/single_app/route_frontend_admin_settings.py")
-    sidebar_template = read_repo_file("application/single_app/templates/_sidebar_nav.html")
 
     assert "{% if mcp_ui_enabled %}" in admin_template
+    assert "{% else %}" in admin_template
     assert 'id="inbound-mcp-configuration"' in admin_template
+    assert "Inbound MCP admin UI is disabled." in admin_template
+    assert "Azure App Service application setting" in admin_template
+    assert "ENABLE_MCP_UI" in admin_template
+    assert "The inbound MCP runtime remains off" in admin_template
     assert 'name="enable_inbound_mcp_server"' in admin_template
     assert 'name="inbound_mcp_required_user_role"' in admin_template
     assert 'name="inbound_mcp_required_app_role"' in admin_template
@@ -166,7 +171,6 @@ def test_admin_settings_mcp_ui_is_gated_and_minimal():
     assert "About MCP &amp; Tools" in admin_template
     assert "{% for tool in inbound_mcp_tools %}" in admin_template
     assert 'name="enable_mcp_ui"' not in admin_template
-    assert "ENABLE_MCP_UI" not in admin_template
     assert "'enable_inbound_mcp_rate_limits': form_data.get('enable_inbound_mcp_rate_limits') == 'on'" in admin_route_source
     for operational_setting in [
         "inbound_mcp_max_request_bytes",
@@ -179,8 +183,23 @@ def test_admin_settings_mcp_ui_is_gated_and_minimal():
         assert f"'{operational_setting}'," in admin_route_source
         assert f"INBOUND_MCP_SETTINGS_DEFAULTS['{operational_setting}']" in admin_route_source
 
-    # The Inbound MCP navigation entry is gated by the same flag as its card,
-    # declared in the navigation map rather than inline in the sidebar.
+    # The Inbound MCP navigation entry stays visible so admins can discover the
+    # enablement guidance even when the full preview form is gated.
+    inbound_tab = next(
+        (
+            tab
+            for _, tab in iter_tabs()
+            if tab["id"] == "inbound-mcp"
+        ),
+        None,
+    )
+    assert inbound_tab is not None, (
+        "Inbound MCP tab missing from the navigation map"
+    )
+    assert inbound_tab.get("condition") is None, (
+        "Inbound MCP tab must stay visible even when mcp_ui_enabled is false"
+    )
+
     inbound_section = next(
         (
             section
@@ -193,8 +212,8 @@ def test_admin_settings_mcp_ui_is_gated_and_minimal():
     assert inbound_section is not None, (
         "Inbound MCP navigation entry missing from the navigation map"
     )
-    assert inbound_section.get("condition") == "mcp_ui_enabled", (
-        "Inbound MCP navigation entry must be gated by mcp_ui_enabled"
+    assert inbound_section.get("condition") is None, (
+        "Inbound MCP navigation entry must stay visible even when mcp_ui_enabled is false"
     )
     assert inbound_section["label"] == "Inbound MCP", (
         f"Unexpected Inbound MCP navigation label: {inbound_section['label']}"
@@ -386,10 +405,11 @@ def test_inbound_mcp_governance_ui_policy_creation_contract():
     assert "window.openAdminSettingsTab('#governance', 'governance-inbound-mcp-section')" in governance_js
     assert "policyName: button.dataset.governanceInboundMcpPolicyName || ''" in governance_js
     assert "resourceLabel: button.dataset.governanceInboundMcpResourceLabel || ''" in governance_js
-    assert "editButton.disabled = systemManaged;" in governance_js
-    assert "deleteButton.disabled = systemManaged;" in governance_js
-    assert "editButton.dataset.policyId = policyId;" in governance_js
-    assert "policy_id: editButton.dataset.policyId || ''" in governance_js
+    assert "System-managed policies cannot be edited." in governance_js
+    assert "System-managed policies cannot be deleted." in governance_js
+    assert "disabled: systemManaged" in governance_js
+    assert "applyGovernanceItemPolicyActionDataset(button, policyDetails)" in governance_js
+    assert "policy_id: button?.dataset?.policyId || ''" in governance_js
     assert "policy_id: String(policyIdInput?.value || '').trim()" in governance_js
     assert "The wildcard inbound MCP source policy is system-managed." not in governance_js
     assert "disallowWildcard: true" in admin_js
@@ -407,7 +427,7 @@ if __name__ == "__main__":
     tests = [
         test_inbound_mcp_runtime_settings_are_app_settings,
         test_mcp_ui_gate_is_os_environment_only,
-        test_admin_settings_mcp_ui_is_gated_and_minimal,
+        test_admin_settings_mcp_ui_disabled_message_and_enabled_form,
         test_inbound_mcp_auth_uses_settings_runtime_config,
         test_inbound_mcp_easy_auth_guard_contract,
         test_inbound_mcp_governance_ui_policy_creation_contract,

--- a/functional_tests/test_markdown_chunk_size_enforcement.py
+++ b/functional_tests/test_markdown_chunk_size_enforcement.py
@@ -1,0 +1,402 @@
+#!/usr/bin/env python3
+# test_markdown_chunk_size_enforcement.py
+"""
+Functional test for bounding Markdown chunks to the embedding token limit.
+Version: 0.261.002
+Implemented in: 0.261.002
+
+Markdown was the only ingestion path with no maximum chunk size. MarkdownHeaderTextSplitter
+splits on headings, and the post-processing loop only ever merged chunks that were too small, so
+a heading section with no nested subheading became a single arbitrarily large chunk. That chunk
+was sent to the embedding endpoint whole, exceeded the model's context window, and failed the
+entire document upload.
+
+This test runs the real process_md against a stubbed namespace and ensures that:
+  - every emitted chunk stays inside both the word target and the character budget,
+  - no source content is lost while doing so,
+  - ordinary Markdown still splits on headings rather than being reflowed,
+  - the chunk size cap is unit-aware, so a word field and a character field get different limits,
+  - save_chunks clamps only the embedding input and still stores the full chunk text.
+"""
+
+import ast
+import logging
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+APP_ROOT = REPO_ROOT / "application" / "single_app"
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+sys.path.insert(0, str(APP_ROOT))
+
+from langchain_text_splitters import (  # noqa: E402
+    MarkdownHeaderTextSplitter,
+    RecursiveCharacterTextSplitter,
+)
+
+from test_support.versioning import assert_app_version_at_least  # noqa: E402
+
+
+IMPLEMENTED_IN_VERSION = "0.261.002"
+
+
+def load_functions(source_path, function_names, namespace):
+    """Exec selected functions and module constants from a source file into a namespace.
+
+    The application modules import the full Azure configuration at load time, so the pure
+    chunking functions are extracted and run against the real repository source instead of
+    importing the module.
+    """
+    tree = ast.parse(Path(source_path).read_text(encoding="utf-8"))
+    wanted = set(function_names)
+    found = set()
+
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            names = [getattr(t, "id", "") for t in node.targets]
+            if any(n.startswith(("EMBEDDING_", "CHUNK_SIZE_", "CHUNK_SPLIT_")) for n in names):
+                exec(compile(ast.Module(body=[node], type_ignores=[]), str(source_path), "exec"), namespace)
+        if isinstance(node, ast.FunctionDef) and node.name in wanted:
+            exec(compile(ast.Module(body=[node], type_ignores=[]), str(source_path), "exec"), namespace)
+            found.add(node.name)
+
+    missing = wanted - found
+    if missing:
+        raise AssertionError(f"Could not locate functions in {source_path}: {sorted(missing)}")
+
+    return namespace
+
+
+def build_content_namespace():
+    """Load the splitting helpers from functions_content.py."""
+    namespace = {"RecursiveCharacterTextSplitter": RecursiveCharacterTextSplitter}
+    return load_functions(
+        APP_ROOT / "functions_content.py",
+        ["count_words", "split_text_by_word_limit", "split_oversized_chunks"],
+        namespace,
+    )
+
+
+def build_settings_namespace():
+    """Load the embedding budget helpers from functions_settings.py."""
+    namespace = {"WORD_CHUNK_SIZE": 400, "get_settings": lambda: {}}
+    return load_functions(
+        APP_ROOT / "functions_settings.py",
+        [
+            "get_embedding_context_tokens",
+            "get_embedding_usable_tokens",
+            "get_embedding_safe_chunk_characters",
+            "get_embedding_safe_chunk_words",
+            "get_chunk_size_cap",
+            "get_chunk_size_caps_by_key",
+            "get_chunk_size_defaults",
+            "get_chunk_size_config",
+        ],
+        namespace,
+    )
+
+
+def run_process_md(md_content, target_chunk_words=1200, max_chunk_characters=None):
+    """Run the real process_md against stubbed dependencies and return the saved chunks."""
+    content_ns = build_content_namespace()
+    settings_ns = build_settings_namespace()
+
+    if max_chunk_characters is None:
+        max_chunk_characters = settings_ns["get_embedding_safe_chunk_characters"]({})
+
+    saved_chunks = []
+
+    def fake_save_chunks(page_text_content, page_number, file_name, user_id, document_id, **kwargs):
+        saved_chunks.append({"page_number": page_number, "content": page_text_content})
+        return {"total_tokens": 1, "model_deployment_name": "test-embedding"}
+
+    namespace = {
+        "MarkdownHeaderTextSplitter": MarkdownHeaderTextSplitter,
+        "estimate_word_count": content_ns["count_words"],
+        "split_text_by_word_limit": content_ns["split_text_by_word_limit"],
+        "split_oversized_chunks": content_ns["split_oversized_chunks"],
+        "get_settings": lambda: {},
+        "get_chunk_size_config": lambda settings=None: {"md": {"value": target_chunk_words, "unit": "words"}},
+        "get_embedding_safe_chunk_characters": lambda settings=None: max_chunk_characters,
+        "save_chunks": fake_save_chunks,
+        "upload_to_blob": lambda **kwargs: None,
+        "extract_document_metadata": lambda **kwargs: None,
+        "log_event": lambda *args, **kwargs: None,
+        "logging": logging,
+    }
+
+    load_functions(APP_ROOT / "functions_documents.py", ["process_md"], namespace)
+
+    handle, temp_path = tempfile.mkstemp(suffix=".md")
+    os.close(handle)
+    Path(temp_path).write_text(md_content, encoding="utf-8")
+
+    try:
+        namespace["process_md"](
+            document_id="doc-1",
+            user_id="user-1",
+            temp_file_path=temp_path,
+            original_filename="test.md",
+            enable_enhanced_citations=False,
+            update_callback=lambda **kwargs: None,
+        )
+    finally:
+        os.unlink(temp_path)
+
+    return saved_chunks, max_chunk_characters
+
+
+def normalized(text):
+    """Collapse whitespace so comparisons survive the splitter trimming chunk edges."""
+    return " ".join(str(text).split())
+
+
+def test_oversized_section_is_bounded():
+    """A huge single-heading section must not produce one oversized chunk."""
+    print("Testing oversized Markdown section...")
+
+    paragraph = "This release corrects embedding and chunking behavior across the pipeline. " * 12
+    body = "\n\n".join(f"Paragraph {i}. {paragraph}" for i in range(120))
+    md_content = f"#### New Features\n\n{body}\n"
+
+    content_ns = build_content_namespace()
+    count_words = content_ns["count_words"]
+
+    target_words = 1200
+    chunks, max_chars = run_process_md(md_content, target_chunk_words=target_words)
+
+    if not chunks:
+        raise AssertionError("process_md produced no chunks.")
+
+    # Without the fix this is a single chunk of roughly 19,000 words.
+    if len(chunks) < 2:
+        raise AssertionError(f"Oversized section was not split, got {len(chunks)} chunk(s).")
+
+    oversized_chars = [c for c in chunks if len(c["content"]) > max_chars]
+    if oversized_chars:
+        raise AssertionError(
+            f"{len(oversized_chars)} chunk(s) exceeded the {max_chars} character budget; "
+            f"largest was {max(len(c['content']) for c in oversized_chars)}."
+        )
+
+    # The merge loop can carry a small trailing chunk onto a full one, so allow that documented
+    # 1.5x inflation but nothing beyond it.
+    word_ceiling = int(target_words * 1.5)
+    oversized_words = [c for c in chunks if count_words(c["content"]) > word_ceiling]
+    if oversized_words:
+        raise AssertionError(
+            f"{len(oversized_words)} chunk(s) exceeded {word_ceiling} words; "
+            f"largest was {max(count_words(c['content']) for c in oversized_words)}."
+        )
+
+    print(f"   {len(chunks)} chunks, max chars {max(len(c['content']) for c in chunks)}, "
+          f"max words {max(count_words(c['content']) for c in chunks)}")
+    print("Oversized section test passed!")
+    return True
+
+
+def test_no_content_is_lost():
+    """Splitting an oversized section must not drop any source content."""
+    print("Testing content preservation...")
+
+    paragraphs = [f"Paragraph {i}. " + ("Some durable sentence about chunking. " * 20) for i in range(80)]
+    md_content = "#### New Features\n\n" + "\n\n".join(paragraphs) + "\n"
+
+    chunks, _ = run_process_md(md_content, target_chunk_words=600)
+    haystack = [normalized(c["content"]) for c in chunks]
+
+    missing = [p for p in paragraphs if not any(normalized(p) in h for h in haystack)]
+    if missing:
+        raise AssertionError(f"{len(missing)} paragraph(s) were lost, first: {missing[0][:80]!r}")
+
+    print(f"   all {len(paragraphs)} paragraphs preserved across {len(chunks)} chunks")
+    print("Content preservation test passed!")
+    return True
+
+
+def test_normal_markdown_still_splits_on_headings():
+    """Ordinary Markdown must keep heading-based chunking, not be reflowed by the size cap."""
+    print("Testing heading-based splitting is preserved...")
+
+    sections = []
+    for i in range(6):
+        sections.append(f"## Section {i}\n\nShort body for section {i} with enough words to stand alone. " * 30)
+    md_content = "\n\n".join(sections)
+
+    chunks, _ = run_process_md(md_content, target_chunk_words=1200)
+
+    if len(chunks) < 2:
+        raise AssertionError(f"Expected heading-based chunks, got {len(chunks)}.")
+
+    joined = normalized(" ".join(c["content"] for c in chunks))
+    for i in range(6):
+        if f"Short body for section {i}" not in joined:
+            raise AssertionError(f"Section {i} content missing from chunks.")
+
+    print(f"   {len(chunks)} chunks produced from 6 headed sections")
+    print("Heading split test passed!")
+    return True
+
+
+def test_small_markdown_is_untouched():
+    """A small document must still produce a single chunk."""
+    print("Testing small Markdown document...")
+
+    md_content = "# Title\n\nA short paragraph that comfortably fits in one chunk.\n"
+    chunks, _ = run_process_md(md_content, target_chunk_words=1200)
+
+    if len(chunks) != 1:
+        raise AssertionError(f"Expected exactly 1 chunk for a small document, got {len(chunks)}.")
+    if "short paragraph" not in chunks[0]["content"]:
+        raise AssertionError("Small document content was altered.")
+
+    print("Small document test passed!")
+    return True
+
+
+def test_chunk_size_cap_is_unit_aware():
+    """Word and character fields must not share a single numeric cap."""
+    print("Testing unit-aware chunk size cap...")
+
+    ns = build_settings_namespace()
+    settings = {}
+
+    word_cap = ns["get_chunk_size_cap"](settings, "words")
+    char_cap = ns["get_chunk_size_cap"](settings, "characters")
+    page_cap = ns["get_chunk_size_cap"](settings, "pages")
+
+    if word_cap >= char_cap:
+        raise AssertionError(f"Word cap ({word_cap}) must be smaller than character cap ({char_cap}).")
+
+    usable_tokens = ns["get_embedding_usable_tokens"](settings)
+    if word_cap * ns["EMBEDDING_TOKENS_PER_WORD"] > usable_tokens:
+        raise AssertionError(f"Word cap {word_cap} can exceed the usable token budget {usable_tokens}.")
+    if char_cap / ns["EMBEDDING_CHARS_PER_TOKEN"] > usable_tokens:
+        raise AssertionError(f"Character cap {char_cap} can exceed the usable token budget {usable_tokens}.")
+
+    # Before the fix this permitted 16,384 words, which can never embed.
+    if word_cap >= 16384:
+        raise AssertionError(f"Word cap {word_cap} is still the unit-blind structural cap.")
+    if page_cap != ns["CHUNK_SIZE_STRUCTURAL_FALLBACK_CAP"]:
+        raise AssertionError(f"Structural units should keep the historical cap, got {page_cap}.")
+
+    over = {
+        "enable_chunk_size_override": True,
+        "chunk_size": {
+            "md": {"value": 16384, "unit": "words"},
+            "json": {"value": 999999, "unit": "characters"},
+        },
+    }
+    config = ns["get_chunk_size_config"](over)
+    if config["md"]["value"] != word_cap:
+        raise AssertionError(f"Markdown override should clamp to {word_cap}, got {config['md']['value']}.")
+    if config["json"]["value"] != char_cap:
+        raise AssertionError(f"JSON override should clamp to {char_cap}, got {config['json']['value']}.")
+
+    # Shipping defaults must be unaffected by the new caps.
+    if ns["get_chunk_size_config"]({}) != ns["get_chunk_size_defaults"]():
+        raise AssertionError("Default chunk sizes changed, which was not intended.")
+
+    print(f"   words {word_cap}, characters {char_cap}, pages {page_cap}; defaults unchanged")
+    print("Unit-aware cap test passed!")
+    return True
+
+
+def test_save_chunks_clamps_only_the_embedding_input():
+    """The embed-time guard must bound the vector input while storing the full chunk text."""
+    print("Testing save_chunks embedding guard...")
+
+    source = (APP_ROOT / "functions_documents.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+
+    save_chunks_node = next(
+        (n for n in tree.body if isinstance(n, ast.FunctionDef) and n.name == "save_chunks"),
+        None,
+    )
+    if save_chunks_node is None:
+        raise AssertionError("save_chunks not found in functions_documents.py")
+
+    body_src = ast.get_source_segment(source, save_chunks_node)
+
+    if "generate_embedding(embedding_input)" not in body_src:
+        raise AssertionError("save_chunks must embed the clamped input, not the raw chunk text.")
+    if "embedding_input = embedding_input[:max_embedding_characters]" not in body_src:
+        raise AssertionError("save_chunks must clamp the embedding input to the character budget.")
+
+    # The stored text must remain the untouched chunk, so citations keep the full content.
+    if "page_text_content = page_text_content[:" in body_src:
+        raise AssertionError("save_chunks must not truncate the stored chunk text.")
+    if "enhanced_chunk_text = page_text_content" not in body_src:
+        raise AssertionError("save_chunks should still store the full page_text_content.")
+
+    print("save_chunks guard test passed!")
+    return True
+
+
+def test_process_md_wires_both_bounds():
+    """process_md must cap sections before merging and apply the character backstop after."""
+    print("Testing process_md wiring...")
+
+    source = (APP_ROOT / "functions_documents.py").read_text(encoding="utf-8")
+    tree = ast.parse(source)
+
+    node = next((n for n in tree.body if isinstance(n, ast.FunctionDef) and n.name == "process_md"), None)
+    if node is None:
+        raise AssertionError("process_md not found in functions_documents.py")
+
+    body_src = ast.get_source_segment(source, node)
+
+    word_cap_at = body_src.find("split_text_by_word_limit(")
+    merge_at = body_src.find("buffer_chunk = \"\"")
+    backstop_at = body_src.find("split_oversized_chunks(")
+
+    if word_cap_at == -1:
+        raise AssertionError("process_md does not cap header sections by word count.")
+    if backstop_at == -1:
+        raise AssertionError("process_md does not apply the character backstop.")
+    if not word_cap_at < merge_at < backstop_at:
+        raise AssertionError(
+            "Ordering is wrong: sections must be capped before the merge loop and the character "
+            f"backstop applied after it (cap={word_cap_at}, merge={merge_at}, backstop={backstop_at})."
+        )
+
+    print("process_md wiring test passed!")
+    return True
+
+
+def test_version_is_at_least_implementation_version():
+    """The application version must be at or beyond the version this fix shipped in."""
+    print("Testing application version...")
+    assert_app_version_at_least(IMPLEMENTED_IN_VERSION)
+    print("Version test passed!")
+    return True
+
+
+if __name__ == "__main__":
+    tests = [
+        test_oversized_section_is_bounded,
+        test_no_content_is_lost,
+        test_normal_markdown_still_splits_on_headings,
+        test_small_markdown_is_untouched,
+        test_chunk_size_cap_is_unit_aware,
+        test_save_chunks_clamps_only_the_embedding_input,
+        test_process_md_wires_both_bounds,
+        test_version_is_at_least_implementation_version,
+    ]
+
+    results = []
+    for test in tests:
+        print(f"\nRunning {test.__name__}...")
+        try:
+            results.append(bool(test()))
+        except Exception as exc:
+            print(f"Test failed: {exc}")
+            import traceback
+            traceback.print_exc()
+            results.append(False)
+
+    print(f"\nResults: {sum(results)}/{len(results)} tests passed")
+    sys.exit(0 if all(results) else 1)

--- a/ui_tests/test_admin_governance_tab.py
+++ b/ui_tests/test_admin_governance_tab.py
@@ -2,8 +2,8 @@
 """
 UI test for admin governance tab rendering and API wiring.
 
-Version: 0.250.208
-Implemented in: 0.241.009; 0.241.025; 0.242.012; 0.242.013; 0.242.014; 0.242.018; 0.242.019; 0.250.204; 0.250.205; 0.250.206; 0.250.207; 0.250.208
+Version: 0.261.002
+Implemented in: 0.241.009; 0.241.025; 0.242.012; 0.242.013; 0.242.014; 0.242.018; 0.242.019; 0.250.204; 0.250.205; 0.250.206; 0.250.207; 0.250.208; 0.261.002
 
 This test ensures the Governance tab is present in admin settings, the
 sidebar navigation exposes the same destination, feature policy fetch/save
@@ -191,9 +191,9 @@ def test_admin_governance_tab_and_api_wiring():
             page.goto(f"{BASE_URL}/admin/settings", wait_until="domcontentloaded")
 
             page.get_by_role("link", name="Governance").click()
-            page.wait_for_selector("#governance-feature-policies-table")
-
-            page.get_by_role("tab", name="Governance").click()
+            page.locator("#feature-governance-tab").click()
+            page.wait_for_selector("#governance-info-guide-btn")
+            page.locator("#governance-policies-tab").click()
             page.wait_for_selector("#governance-feature-policies-table")
 
             page.locator("#governance-info-guide-btn").click()

--- a/ui_tests/test_admin_inbound_mcp_easy_auth_modal.py
+++ b/ui_tests/test_admin_inbound_mcp_easy_auth_modal.py
@@ -2,7 +2,7 @@
 """
 UI test for the inbound MCP Easy Auth verification modal.
 
-Version: 0.250.098
+Version: 0.261.002
 Implemented in: 0.250.072
 Cloud-aware script improvements implemented in: 0.250.073
 Script copy and authsettingsV2 GET fix implemented in: 0.250.074
@@ -14,6 +14,7 @@ Protected-resource metadata aliases implemented in: 0.250.087
 Easy Auth restart reminder implemented in: 0.250.088
 Personal workflow execution tool implemented in: 0.250.090
 Inbound MCP object-list settings implemented in: 0.250.091
+Inbound MCP disabled-state guidance implemented in: 0.261.002
 
 This test ensures enabling inbound MCP from Admin Settings requires the Easy Auth
 exclusion modal, keeps the runtime gate disabled on failed verification, and
@@ -125,16 +126,16 @@ def test_admin_inbound_mcp_easy_auth_modal_blocks_until_verified():
 
     try:
         page.route("**/api/admin/settings/inbound-mcp/easy-auth-check", fulfill_verification)
-        response = page.goto(f"{BASE_URL}/admin/settings#agents", wait_until="networkidle")
+        response = page.goto(f"{BASE_URL}/admin/settings#inbound-mcp", wait_until="networkidle")
         assert response is not None, "Expected a navigation response when loading admin settings."
 
         if response.status in SKIP_RESPONSE_CODES:
             pytest.skip(f"Admin settings page unavailable in this environment (HTTP {response.status}).")
         assert response.ok, f"Expected admin settings to load successfully, got HTTP {response.status}."
 
-        agents_tab = page.locator("#agents-tab")
-        if agents_tab.count() > 0:
-            agents_tab.click()
+        inbound_tab = page.locator("#inbound-mcp-tab")
+        if inbound_tab.count() > 0:
+            inbound_tab.click()
 
         enable_toggle = page.locator("#enable_inbound_mcp_server")
         if enable_toggle.count() == 0:

--- a/ui_tests/test_admin_inbound_mcp_governance_ui.py
+++ b/ui_tests/test_admin_inbound_mcp_governance_ui.py
@@ -2,7 +2,7 @@
 """
 UI test for inbound MCP governance policy creation controls.
 
-Version: 0.250.098
+Version: 0.261.002
 Implemented in: 0.250.077
 Inbound MCP restricted policy defaults implemented in: 0.250.078
 MCP governance help modal implemented in: 0.250.079
@@ -14,9 +14,12 @@ Inbound MCP source-only governance implemented in: 0.250.092
 Inbound MCP source governance CTA guidance implemented in: 0.250.093
 Inbound MCP admin throttle controls implemented in: 0.250.097
 Inbound MCP observability query panel implemented in: 0.250.098
+Inbound MCP disabled-state guidance implemented in: 0.261.002
 
 This test ensures Admin Settings exposes inbound MCP source governance policy
-controls and can open the delegated item policy editor for source policies.
+controls when the preview UI is enabled, explains how to enable the preview UI
+when it is disabled, and can open the delegated item policy editor for source
+policies.
 """
 
 import os
@@ -54,39 +57,46 @@ def test_admin_inbound_mcp_governance_policy_editor_controls():
     page = context.new_page()
 
     try:
-        response = page.goto(f"{BASE_URL}/admin/settings#governance", wait_until="networkidle")
+        response = page.goto(f"{BASE_URL}/admin/settings#inbound-mcp", wait_until="networkidle")
         assert response is not None, "Expected a navigation response when loading admin settings."
 
         if response.status in SKIP_RESPONSE_CODES:
             pytest.skip(f"Admin settings page unavailable in this environment (HTTP {response.status}).")
         assert response.ok, f"Expected admin settings to load successfully, got HTTP {response.status}."
 
-        agents_tab = page.locator("#agents-tab")
-        if agents_tab.count() > 0:
-            agents_tab.click()
-            inbound_config = page.locator("#inbound-mcp-configuration")
-            expect(inbound_config).to_be_visible()
-            expect(inbound_config).to_contain_text("admins must still create an inbound MCP source governance policy")
-            expect(inbound_config).to_contain_text("Create Wildcard Source Policy")
-            expect(inbound_config).to_contain_text("Create Source Policy")
-            expect(inbound_config).to_contain_text("Request Size & Throttling")
-            expect(inbound_config).to_contain_text("Enable tool throttles")
-            expect(page.locator("#enable_inbound_mcp_rate_limits")).to_be_visible()
-            expect(page.locator("#inbound_mcp_max_request_bytes")).to_be_visible()
-            expect(page.locator("#inbound_mcp_rate_limit_window_seconds")).to_be_visible()
-            expect(inbound_config).not_to_contain_text("Default on creates a locked governance policy")
-            inbound_config.locator("button[data-bs-target=\"#inboundMcpInfoModal\"]").click()
-            overview_modal = page.locator("#inboundMcpInfoModal")
-            expect(overview_modal).to_be_visible()
-            expect(overview_modal).to_contain_text("Application Insights starter queries")
-            expect(overview_modal).to_contain_text("Request and failure trends")
-            expect(overview_modal).to_contain_text("Rate-limit denials")
-            expect(overview_modal.locator(".inbound-mcp-kql-copy-btn")).to_have_count(4)
-            expect(overview_modal.locator("#inbound-mcp-kql-tool-latency")).to_contain_text("percentile")
-            page.keyboard.press("Escape")
-            expect(overview_modal).to_be_hidden()
+        inbound_tab = page.locator("#inbound-mcp-tab")
+        if inbound_tab.count() > 0:
+            inbound_tab.click()
 
-        governance_tab = page.locator("#governance-tab")
+        inbound_config = page.locator("#inbound-mcp-configuration")
+        expect(inbound_config).to_be_visible()
+        enable_toggle = page.locator("#enable_inbound_mcp_server")
+        if enable_toggle.count() == 0:
+            expect(inbound_config).to_contain_text("Inbound MCP admin UI is disabled")
+            expect(inbound_config).to_contain_text("ENABLE_MCP_UI")
+            return
+
+        expect(inbound_config).to_contain_text("admins must still create an inbound MCP source governance policy")
+        expect(inbound_config).to_contain_text("Create Wildcard Source Policy")
+        expect(inbound_config).to_contain_text("Create Source Policy")
+        expect(inbound_config).to_contain_text("Request Size & Throttling")
+        expect(inbound_config).to_contain_text("Enable tool throttles")
+        expect(page.locator("#enable_inbound_mcp_rate_limits")).to_be_visible()
+        expect(page.locator("#inbound_mcp_max_request_bytes")).to_be_visible()
+        expect(page.locator("#inbound_mcp_rate_limit_window_seconds")).to_be_visible()
+        expect(inbound_config).not_to_contain_text("Default on creates a locked governance policy")
+        inbound_config.locator("button[data-bs-target=\"#inboundMcpInfoModal\"]").click()
+        overview_modal = page.locator("#inboundMcpInfoModal")
+        expect(overview_modal).to_be_visible()
+        expect(overview_modal).to_contain_text("Application Insights starter queries")
+        expect(overview_modal).to_contain_text("Request and failure trends")
+        expect(overview_modal).to_contain_text("Rate-limit denials")
+        expect(overview_modal.locator(".inbound-mcp-kql-copy-btn")).to_have_count(4)
+        expect(overview_modal.locator("#inbound-mcp-kql-tool-latency")).to_contain_text("percentile")
+        page.keyboard.press("Escape")
+        expect(overview_modal).to_be_hidden()
+
+        governance_tab = page.locator("#mcp-governance-tab")
         if governance_tab.count() > 0:
             governance_tab.click()
 


### PR DESCRIPTION
## Summary

- Promotes the current `Development` branch to `Staging` for the `v0.261.002` release train.
- Includes Markdown ingestion hardening so oversized Markdown sections are bounded before embedding, plus unit-aware chunk size caps in Document Extraction settings.
- Includes governance admin fixes for split-tab navigation: delegated item **New Policy** now opens the editor, and Inbound MCP now shows enablement guidance when the `ENABLE_MCP_UI=true` App Service setting is missing.

## Linked issue

Refs #1361, #1363, #1365

## Release Notes & Latest Features

- [ ] New Feature
- [x] Bug Fix
- [x] UI Enhancement
- [ ] Breaking Change
- [ ] Internal only

Is this visible to end users?

- [x] Yes
- [ ] No

Is this admin-facing (Admin Settings, governance, deployment, config)?

- [x] Yes
- [ ] No

Should this become a Latest Feature card?

- [ ] Yes
- [x] No
- [ ] Already added

Screenshot needed for the card?

- [ ] Yes
- [x] No
- [ ] Attached

## Version bump

- [x] `application/single_app/config.py` `VERSION` third segment bumped, or not needed because this is docs-only
- [x] `deployers/version.txt` bumped, or not needed because `deployers/` was not changed

## Testing / validation

- Verified there was no existing open `Development` -> `Staging` PR before creating this draft.
- Reviewed the `origin/Staging..origin/Development` commit and file delta.
- Validation was completed in the source PRs included in this promotion: #1361, #1363, and #1365.

## Documentation

- [x] Release notes updated, or not needed
- [x] Feature documentation updated, or not needed
- [x] Fix documentation updated, or not needed

## Security checklist

- [x] New Flask routes include `@swagger_route(security=get_auth_security())`, or not applicable because this is a branch promotion PR
- [x] Settings sent to non-admin frontends use `sanitize_settings_for_user()`, or not applicable because this is a branch promotion PR
- [x] Browser JavaScript is served from local SimpleChat static assets only; no CDN-hosted JS
- [x] No secrets, keys, connection strings, or local-only artifacts are included
