### PR TITLE
V2: open a generated image in a viewer, not a new tab

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -97,7 +97,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.261.024"
+VERSION = "0.261.025"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/v2_ui/src/components/chat/ImageLightbox.tsx
+++ b/application/v2_ui/src/components/chat/ImageLightbox.tsx
@@ -1,0 +1,170 @@
+// ImageLightbox.tsx
+// Full-screen viewer for an image message, opened by clicking the image in the thread.
+//
+// This replaces what used to be a `target="_blank"` anchor around the thumbnail. Leaving the
+// app to look at an image the app already has is a poor trade, and for the small inline
+// images that arrive as `data:` URIs it did not even work, because browsers block top-level
+// navigation to a data URL. The actions the new tab used to provide -- see it full size, save
+// it, open the raw file -- are offered here instead.
+//
+// The dialog conventions match CitationChip and EnhancedCitationViewer: a click-to-close
+// backdrop, Escape to dismiss, and no focus-trap utility, since none of the other dialogs in
+// this UI use one.
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { clsx } from 'clsx';
+import { Download, ExternalLink, Maximize2, Minimize2, X } from 'lucide-react';
+import { GlassPanel } from '../ui/primitives';
+import { toast } from '../../stores/toastStore';
+import {
+    downloadImageSource,
+    openImageInNewTab,
+    type ResolvedImageSource,
+} from '../../lib/images';
+
+/** Fit shrinks the image to the panel; actual renders it at natural size and scrolls. */
+type ZoomMode = 'fit' | 'actual';
+
+export function ImageLightbox({
+    source,
+    title,
+    naming,
+    onClose,
+}: {
+    source: ResolvedImageSource;
+    /** Shown in the header and used as the image's accessible name. */
+    title: string;
+    /** Fields the download name is derived from. */
+    naming: { filename?: unknown; prompt?: unknown; id?: unknown };
+    onClose: () => void;
+}) {
+    const [zoom, setZoom] = useState<ZoomMode>('fit');
+    const [saving, setSaving] = useState(false);
+    const closeRef = useRef<HTMLButtonElement>(null);
+
+    useEffect(() => {
+        const onKeyDown = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') {
+                onClose();
+            }
+        };
+        document.addEventListener('keydown', onKeyDown);
+        return () => document.removeEventListener('keydown', onKeyDown);
+    }, [onClose]);
+
+    // Opening a dialog should move the keyboard focus into it, and closing should hand it
+    // back to whatever had it before, which is the thumbnail that was clicked.
+    useEffect(() => {
+        const previous = document.activeElement as HTMLElement | null;
+        closeRef.current?.focus();
+        return () => previous?.focus?.();
+    }, []);
+
+    const handleDownload = useCallback(async () => {
+        setSaving(true);
+        try {
+            await downloadImageSource(source, naming);
+            toast.success('Image saved.');
+        } catch (error) {
+            toast.error(
+                error instanceof Error && error.message
+                    ? `Download failed. ${error.message}`
+                    : 'Download failed.',
+            );
+        } finally {
+            setSaving(false);
+        }
+    }, [source, naming]);
+
+    const handleOpenInNewTab = useCallback(() => {
+        if (!openImageInNewTab(source)) {
+            toast.error('The browser blocked the new tab.');
+        }
+    }, [source]);
+
+    const fit = zoom === 'fit';
+
+    return (
+        <div
+            className="fixed inset-0 z-50 flex items-center justify-center p-4"
+            role="dialog"
+            aria-modal="true"
+            aria-label="Image"
+        >
+            <div className="absolute inset-0 bg-black/60" aria-hidden="true" onClick={onClose} />
+
+            <GlassPanel
+                elevation="modal"
+                edge
+                className="relative flex h-[88vh] w-full max-w-6xl flex-col overflow-hidden"
+            >
+                <div className="flex shrink-0 items-center gap-3 border-b border-edge px-5 py-3">
+                    <h2 className="min-w-0 flex-1 truncate text-sm font-semibold text-text-1">
+                        {title}
+                    </h2>
+
+                    <button
+                        type="button"
+                        onClick={() => setZoom(fit ? 'actual' : 'fit')}
+                        title={fit ? 'View at actual size' : 'Fit to the window'}
+                        aria-label={fit ? 'View at actual size' : 'Fit to the window'}
+                        aria-pressed={!fit}
+                        className="shrink-0 rounded-lg p-1.5 text-text-3 transition-colors hover:bg-surface-2 hover:text-text-1"
+                    >
+                        {fit ? <Maximize2 size={16} /> : <Minimize2 size={16} />}
+                    </button>
+                    <button
+                        type="button"
+                        onClick={() => void handleDownload()}
+                        disabled={saving}
+                        title="Save the image"
+                        aria-label="Save the image"
+                        className="shrink-0 rounded-lg p-1.5 text-text-3 transition-colors hover:bg-surface-2 hover:text-text-1 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                        <Download size={16} />
+                    </button>
+                    <button
+                        type="button"
+                        onClick={handleOpenInNewTab}
+                        title="Open the image in a new tab"
+                        aria-label="Open the image in a new tab"
+                        className="shrink-0 rounded-lg p-1.5 text-text-3 transition-colors hover:bg-surface-2 hover:text-text-1"
+                    >
+                        <ExternalLink size={16} />
+                    </button>
+                    <button
+                        ref={closeRef}
+                        type="button"
+                        onClick={onClose}
+                        title="Close"
+                        aria-label="Close the image"
+                        className="shrink-0 rounded-lg p-1.5 text-text-3 transition-colors hover:bg-surface-2 hover:text-text-1"
+                    >
+                        <X size={17} />
+                    </button>
+                </div>
+
+                <div
+                    className={clsx(
+                        'min-h-0 flex-1 p-4',
+                        // Fit centres the whole image; actual size needs to scroll in both
+                        // directions so a large image can be panned around.
+                        fit ? 'flex items-center justify-center overflow-hidden' : 'overflow-auto',
+                    )}
+                >
+                    <img
+                        src={source.src}
+                        alt={title}
+                        onClick={() => setZoom(fit ? 'actual' : 'fit')}
+                        className={clsx(
+                            'rounded-xl',
+                            fit
+                                ? 'max-h-full max-w-full cursor-zoom-in object-contain'
+                                : 'max-w-none cursor-zoom-out',
+                        )}
+                    />
+                </div>
+            </GlassPanel>
+        </div>
+    );
+}

--- a/application/v2_ui/src/components/chat/MessageList.tsx
+++ b/application/v2_ui/src/components/chat/MessageList.tsx
@@ -30,6 +30,7 @@ import {
     MASK_PLACEHOLDER_PATTERN,
     readMaskState,
 } from '../../lib/masking';
+import { ImageLightbox } from './ImageLightbox';
 import type { ChatMessage, ThoughtEntry } from '../../lib/types';
 
 function ThoughtsPanel({ thoughts }: { thoughts: ThoughtEntry[] }) {
@@ -68,8 +69,15 @@ function ThoughtsPanel({ thoughts }: { thoughts: ThoughtEntry[] }) {
 
 function ImageMessage({ message }: { message: ChatMessage }) {
     const [failed, setFailed] = useState(false);
+    const [lightboxOpen, setLightboxOpen] = useState(false);
     const chatWidth = useUiStore((state) => state.chatWidth);
     const source = resolveImageSource(message.content);
+
+    // Stable so the lightbox's download callback is not rebuilt on every render.
+    const naming = useMemo(
+        () => ({ filename: message.filename, prompt: message.prompt, id: message.id }),
+        [message.filename, message.prompt, message.id],
+    );
 
     // An unrecognised content shape, or an image that will not load, falls back to the
     // prompt text. A broken image element tells the user nothing.
@@ -94,12 +102,18 @@ function ImageMessage({ message }: { message: ChatMessage }) {
     return (
         <div id={`message-${message.id}`} className="group/message flex flex-col">
             <div className="flex justify-start">
-                <a
-                    href={source.src}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    title="Open the full-size image"
-                    className="glass-flat block overflow-hidden rounded-2xl p-1.5"
+                {/*
+                  A button rather than a link: the image opens in a dialog, not a new
+                  document. It also keeps the thumbnail keyboard operable, which a plain
+                  clickable <img> would not be.
+                */}
+                <button
+                    type="button"
+                    onClick={() => setLightboxOpen(true)}
+                    title="View the full-size image"
+                    aria-label={`View the full-size image: ${alt}`}
+                    aria-haspopup="dialog"
+                    className="glass-flat block cursor-zoom-in overflow-hidden rounded-2xl p-1.5"
                 >
                     <img
                         src={source.src}
@@ -107,11 +121,20 @@ function ImageMessage({ message }: { message: ChatMessage }) {
                         onError={() => setFailed(true)}
                         className="max-h-[28rem] max-w-md rounded-xl object-contain"
                     />
-                </a>
+                </button>
             </div>
             <div className="opacity-0 transition-opacity group-hover/message:opacity-100 focus-within:opacity-100">
                 <MessageActions message={message} />
             </div>
+
+            {lightboxOpen && (
+                <ImageLightbox
+                    source={source}
+                    title={alt}
+                    naming={naming}
+                    onClose={() => setLightboxOpen(false)}
+                />
+            )}
         </div>
     );
 }

--- a/application/v2_ui/src/lib/apiClient.ts
+++ b/application/v2_ui/src/lib/apiClient.ts
@@ -19,7 +19,7 @@
 export const API_BASE: string = import.meta.env.VITE_API_BASE ?? '';
 
 /** Cross-origin deployments must send credentials explicitly to carry the session cookie. */
-const CREDENTIALS_MODE: RequestCredentials = API_BASE ? 'include' : 'same-origin';
+export const CREDENTIALS_MODE: RequestCredentials = API_BASE ? 'include' : 'same-origin';
 
 export class ApiError extends Error {
     readonly status: number;

--- a/application/v2_ui/src/lib/endpoints.ts
+++ b/application/v2_ui/src/lib/endpoints.ts
@@ -321,7 +321,7 @@ function exportTimestamp(): string {
 }
 
 /** Hand a blob to the browser's download machinery. */
-function saveBlob(blob: Blob, filename: string): void {
+export function saveBlob(blob: Blob, filename: string): void {
     const url = URL.createObjectURL(blob);
     const link = document.createElement('a');
     link.href = url;

--- a/application/v2_ui/src/lib/images.ts
+++ b/application/v2_ui/src/lib/images.ts
@@ -1,5 +1,6 @@
 // images.ts
-// Resolving an image message's content into something an <img> can display.
+// Resolving an image message's content into something an <img> can display, and taking that
+// image back out of the app as a download or a new tab.
 //
 // Image messages do not carry a dedicated URL field. `hydrate_image_messages`
 // (functions_image_messages.py) writes the image into `content` in one of three forms, and
@@ -12,7 +13,8 @@
 // Anything else is not an image we can render, and is better shown as text than as a broken
 // image element.
 
-import { apiUrl } from './apiClient';
+import { apiUrl, CREDENTIALS_MODE } from './apiClient';
+import { saveBlob } from './endpoints';
 
 /** Where an image message's bytes actually live. */
 export type ImageSourceKind = 'data-uri' | 'endpoint' | 'external';
@@ -52,3 +54,187 @@ export function resolveImageSource(content: string | undefined): ResolvedImageSo
 
     return null;
 }
+
+/* -------------------------------------------------------------------------- */
+/* Taking an image out of the app                                              */
+/* -------------------------------------------------------------------------- */
+
+/** Extension to use for a blob whose type we recognise. */
+const MIME_EXTENSIONS: Record<string, string> = {
+    'image/png': 'png',
+    'image/jpeg': 'jpg',
+    'image/jpg': 'jpg',
+    'image/gif': 'gif',
+    'image/webp': 'webp',
+    'image/bmp': 'bmp',
+    'image/svg+xml': 'svg',
+    'image/tiff': 'tiff',
+};
+
+/** A name that already ends in an image extension does not need another one. */
+const IMAGE_EXTENSION_PATTERN = /\.(png|jpe?g|gif|webp|bmp|svg|tiff?)$/i;
+
+/** Characters a file name cannot contain on Windows, plus path separators and controls. */
+// eslint-disable-next-line no-control-regex
+const UNSAFE_FILENAME_CHARS = /[<>:"/\\|?*\u0000-\u001f]/g;
+
+/**
+ * Decode a `data:image/...;base64,...` URI to a blob, synchronously.
+ *
+ * Kept synchronous on purpose: `openImageInNewTab` calls it inside the click handler, and
+ * awaiting anything first would spend the user activation that lets `window.open` through
+ * the popup blocker.
+ *
+ * Returns null for a malformed URI rather than throwing, so callers can report one message
+ * for "cannot read this image" regardless of which step failed.
+ */
+export function decodeImageDataUri(value: string): Blob | null {
+    const separator = value.indexOf(',');
+    if (!value.startsWith('data:image/') || separator === -1) {
+        return null;
+    }
+
+    const header = value.slice(5, separator);
+    const type = header.split(';', 1)[0] || 'image/png';
+    const payload = value.slice(separator + 1);
+
+    try {
+        const binary = atob(payload);
+        const bytes = new Uint8Array(binary.length);
+        for (let i = 0; i < binary.length; i += 1) {
+            bytes[i] = binary.charCodeAt(i);
+        }
+        return new Blob([bytes], { type });
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Fetch the bytes behind a resolved image source.
+ *
+ * Every kind has to be handled separately. A data URI is decoded locally with no request at
+ * all. `/api/image/<id>` is authenticated, so it needs the same credentials mode as the rest
+ * of the client or the split-origin deployment gets a 401. An externally hosted image is
+ * fetched without credentials and may be refused by CORS, which is reported rather than
+ * papered over.
+ */
+export async function resolveImageBlob(source: ResolvedImageSource): Promise<Blob> {
+    if (source.kind === 'data-uri') {
+        const blob = decodeImageDataUri(source.src);
+        if (!blob) {
+            throw new Error('The image data could not be read.');
+        }
+        return blob;
+    }
+
+    let response: Response;
+    try {
+        response = await fetch(
+            source.src,
+            source.kind === 'endpoint' ? { credentials: CREDENTIALS_MODE } : {},
+        );
+    } catch {
+        // A cross-origin host that sends no CORS headers rejects the read here. The image
+        // still displays, because <img> is not subject to the same restriction.
+        throw new Error('The image is hosted elsewhere and would not allow a download.');
+    }
+
+    if (!response.ok) {
+        throw new Error(`The image could not be fetched (${response.status}).`);
+    }
+
+    return response.blob();
+}
+
+/** Strip anything that cannot appear in a file name, and keep it a sensible length. */
+function sanitizeFileName(value: string): string {
+    return value
+        .replace(UNSAFE_FILENAME_CHARS, ' ')
+        .replace(/\s+/g, ' ')
+        .trim()
+        .slice(0, 80)
+        .replace(/[. ]+$/, '');
+}
+
+/**
+ * Build a download name for an image message.
+ *
+ * A server-supplied file name wins when there is one. Otherwise the prompt makes a far more
+ * recognisable name in a downloads folder than an opaque message id, so it is used when it
+ * is short enough to read, with the id as the last resort.
+ */
+export function imageFileName(
+    { filename, prompt, id }: { filename?: unknown; prompt?: unknown; id?: unknown },
+    blobType?: string,
+): string {
+    const fromServer = sanitizeFileName(String(filename ?? ''));
+    const fromPrompt = sanitizeFileName(String(prompt ?? ''));
+    const fromId = sanitizeFileName(String(id ?? ''));
+
+    const base =
+        fromServer || (fromPrompt && fromPrompt.length <= 60 ? fromPrompt : '') || fromId || 'image';
+
+    if (IMAGE_EXTENSION_PATTERN.test(base)) {
+        return base;
+    }
+
+    const extension = MIME_EXTENSIONS[(blobType || '').toLowerCase()] || 'png';
+    return `${base}.${extension}`;
+}
+
+/**
+ * Open an image in a new browser tab.
+ *
+ * A data URI cannot simply be handed to `window.open`: browsers block top-level navigation
+ * to `data:` URLs, so it is republished as an object URL first. That URL is revoked on a
+ * timer because revoking it immediately would break the tab that is still loading it, and
+ * never revoking it would hold the bytes for the life of the page.
+ *
+ * The opener is severed by hand rather than by passing `noopener` in the feature string,
+ * because that feature makes `window.open` return null even when it succeeds, which would
+ * leave no way to tell a blocked popup from an opened one.
+ *
+ * Returns false when the browser refused to open the tab, so the caller can say so.
+ */
+export function openImageInNewTab(source: ResolvedImageSource): boolean {
+    const url =
+        source.kind === 'data-uri' ? objectUrlForDataUri(source.src) : source.src;
+    if (!url) {
+        return false;
+    }
+
+    const opened = window.open(url, '_blank');
+    if (opened) {
+        opened.opener = null;
+    }
+    return Boolean(opened);
+}
+
+/** Republish a data URI as a revocable object URL, or null if it cannot be decoded. */
+function objectUrlForDataUri(value: string): string | null {
+    const blob = decodeImageDataUri(value);
+    if (!blob) {
+        return null;
+    }
+
+    const objectUrl = URL.createObjectURL(blob);
+    window.setTimeout(() => URL.revokeObjectURL(objectUrl), 60_000);
+    return objectUrl;
+}
+
+/**
+ * Save an image to the user's downloads.
+ *
+ * The bytes are fetched and saved as a blob rather than pointed at with an `<a download>`,
+ * because that attribute is ignored for a cross-origin URL — which is exactly what
+ * `/api/image/<id>` becomes in the split-origin deployment.
+ */
+export async function downloadImageSource(
+    source: ResolvedImageSource,
+    naming: { filename?: unknown; prompt?: unknown; id?: unknown },
+): Promise<void> {
+    const blob = await resolveImageBlob(source);
+    saveBlob(blob, imageFileName(naming, blob.type));
+}
+

--- a/docs/explanation/features/REACT_V2_UI.md
+++ b/docs/explanation/features/REACT_V2_UI.md
@@ -228,7 +228,8 @@ Wired to the live APIs:
 - Citations rendered as inline chips that open either the cited source itself — the PDF
   page, image, media clip, spreadsheet or Visio page — or the passage that was extracted
   from it
-- Generated images rendered inline, and a conversation badge showing the group or public
+- Generated images rendered inline, opening in a viewer with fit and actual-size zoom, a
+  download and a link to the raw file, and a conversation badge showing the group or public
   workspace the conversation is working in
 
 The SSE reader in `src/lib/sse.ts` reproduces the framing rules of
@@ -324,7 +325,10 @@ source rather than inferred:
   **Copy with sources** and the saved file append the citations as a numbered reference
   list instead of interleaving them.
 - **Image messages carry the image in `content`**, as a data URI, an `/api/image/<id>` path,
-  or an external URL. There is no `image_url` field.
+  or an external URL. There is no `image_url` field. The three are not interchangeable once
+  the image leaves the page: `data:` URIs cannot be navigated to at the top level, and
+  `/api/image/<id>` is authenticated, so both saving and opening an image branch on the kind
+  rather than treating `content` as a plain URL.
 - **The three message exports are not alike.** Word and PowerPoint stream a document; the
   email draft returns JSON, whose images must be saved separately because a `mailto:` URL
   cannot carry attachments. All three require a JSON request body and reject a form post.
@@ -746,6 +750,7 @@ this entirely and is the recommended layout.
 | `functional_tests/test_v2_conversation_details_and_gating.py` | Tags split by category, source documents paged with the citation-tracking note, summary generated on demand, URL access and deep research gated on what is typed, image generation exclusivity, chat width persisted, unsafe tag values not linked |
 | `functional_tests/test_v2_model_identity_and_scope.py` | The whole model identity is sent and the picker keys on `selection_key`, the document scope is computed rather than hardcoded, and workspace ids travel with it |
 | `functional_tests/test_v2_rich_rendering.py` | Browser libraries vendored into the repository with their licences and pinned versions, no equivalent npm dependency, KaTeX fonts complete and locally resolvable, a sanitizer boundary at every HTML sink and nowhere else, KaTeX `trust: false`, mermaid strict with no autostart or icon packs, single `$` not treated as maths, fence wiring and chart language parity with the backend, charts copied as data, CSP unchanged |
+| `functional_tests/test_v2_generated_image_lightbox.py` | The image thumbnail opens a dialog rather than a new tab, the dialog is dismissable and manages focus, every source kind is handled by download and open-in-new-tab, and `window.open` is not given `noopener` |
 | `functional_tests/test_csrf_state_changing_route_guard.py` | Cross-site mutations require an explicitly trusted origin; CORS preflights answered before authentication and never wildcarded |
 | `functional_tests/route_tests/` | Blueprint policy classification for `frontend_v2`, `backend_v2`, `backend_v2_admin` |
 

--- a/docs/explanation/fixes/V2_GENERATED_IMAGE_LIGHTBOX_FIX.md
+++ b/docs/explanation/fixes/V2_GENERATED_IMAGE_LIGHTBOX_FIX.md
@@ -1,0 +1,123 @@
+# V2 Generated Image Lightbox Fix
+
+## Issue
+
+In the V2 chat view, clicking an image the assistant generated left the application. The
+image opened as a raw file in a new browser tab, dropping the user out of their conversation
+to look at something the page was already showing them. The classic chat view has never
+behaved this way — it opens the image in a modal — so V2 was the outlier.
+
+For one class of image it was worse than merely awkward: clicking did nothing at all. Small
+images are delivered inline as `data:image/...` URIs, and browsers block top-level navigation
+to a `data:` URL. Those images silently refused to respond to a click, with no error and no
+explanation.
+
+**Fixed in version:** 0.261.025
+
+## Root cause
+
+`ImageMessage` in `application/v2_ui/src/components/chat/MessageList.tsx` wrapped the
+thumbnail in an anchor:
+
+```tsx
+<a href={source.src} target="_blank" rel="noopener noreferrer" title="Open the full-size image">
+    <img src={source.src} ... />
+</a>
+```
+
+`resolveImageSource` (`src/lib/images.ts`) can return three different kinds of source — a
+`data:` URI, an `/api/image/<id>` path, or an external `https://` URL — and the anchor treated
+all three as though they were an ordinary navigable URL. Only two of them are.
+
+## The fix
+
+The thumbnail is now a button that opens `ImageLightbox`, a dialog rendered in place. Because
+the click no longer navigates anywhere, everything the new tab used to provide is offered
+inside the dialog instead:
+
+- **Fit / actual size.** The image is scaled to the panel by default and can be switched to
+  natural size, where it scrolls so the edges of a large image stay reachable. The header
+  control and the image itself both toggle it.
+- **Save the image.**
+- **Open in a new tab**, for anyone who genuinely wanted the raw file.
+
+The dialog follows the conventions already set by `CitationChip` and
+`EnhancedCitationViewer`: a click-to-close backdrop, Escape to dismiss, `role="dialog"` with
+`aria-modal="true"`, and no focus-trap utility, since no other dialog in this UI uses one.
+Focus moves to the dialog on open and returns to the thumbnail on close.
+
+### Each source kind is handled deliberately
+
+The three shapes `resolveImageSource` returns need different treatment, which is the part the
+original anchor got wrong:
+
+| Kind | Download | Open in new tab |
+|---|---|---|
+| `data-uri` | Decoded to a blob locally, no request | Republished as an object URL, because `data:` navigation is blocked |
+| `endpoint` | Fetched with the client's credentials mode | The URL directly |
+| `external` | Fetched; a CORS refusal is reported | The URL directly |
+
+Download fetches the bytes and saves a blob rather than pointing an `<a download>` at the URL.
+The `download` attribute is ignored for a cross-origin URL, which is exactly what
+`/api/image/<id>` becomes in the split-origin (`VITE_API_BASE`) deployment, so the attribute
+alone would have silently produced a navigation instead of a saved file.
+
+The object URL created for a `data:` image is revoked on a timer. Revoking it immediately
+would break the tab still loading it; never revoking it would hold the bytes for the life of
+the page.
+
+### A trap worth recording
+
+`window.open()` returns `null` when `noopener` appears in its feature string — even when the
+tab opens successfully. Passing `noopener` there would have made every successfully opened tab
+look blocked, and the UI would have reported a failure on every use. The opener is severed by
+assignment after the call instead, which keeps the return value meaningful so a genuinely
+blocked popup can still be reported. The functional test asserts this so it cannot regress.
+
+## Files modified
+
+| File | Change |
+|---|---|
+| `application/v2_ui/src/components/chat/ImageLightbox.tsx` | New dialog: zoom toggle, download, open in new tab, close |
+| `application/v2_ui/src/components/chat/MessageList.tsx` | `ImageMessage` opens the lightbox instead of a new tab |
+| `application/v2_ui/src/lib/images.ts` | `decodeImageDataUri`, `resolveImageBlob`, `downloadImageSource`, `openImageInNewTab`, `imageFileName` |
+| `application/v2_ui/src/lib/endpoints.ts` | `saveBlob` exported so the image download reuses one save path |
+| `application/v2_ui/src/lib/apiClient.ts` | `CREDENTIALS_MODE` exported for the authenticated image fetch |
+| `application/single_app/config.py` | Version to 0.261.025 |
+| `functional_tests/test_v2_generated_image_lightbox.py` | New test |
+
+The classic chat view was not touched. It already opens a modal through `showImagePopup` in
+`static/js/chat/chat-citations.js`.
+
+User-uploaded images benefit alongside generated ones, because V2 routes every message with
+`role === 'image'` through `ImageMessage` — matching the classic view, where uploaded and
+generated images share the same `.generated-image` click handler.
+
+## Validation
+
+`functional_tests/test_v2_generated_image_lightbox.py` asserts that the thumbnail is a button
+rather than an anchor and carries `aria-haspopup="dialog"`, that the broken-image fallback
+survived the rewrite with every hook still declared before its early return, that the dialog
+is dismissable by Escape and by the backdrop and manages focus in both directions, that all
+three source kinds are handled by both download and open-in-new-tab, that the download reuses
+the existing `saveBlob` rather than adding a second save path, that file names are derived
+safely, and that `noopener` is not passed to `window.open`.
+
+The test was confirmed to fail against the pre-change code: the extracted `ImageMessage` body
+at `HEAD` contains `target="_blank"` and no lightbox.
+
+The helpers were additionally exercised at runtime against the real compiled module. A
+base64 PNG data URI decoded to bytes beginning with the PNG signature
+`89 50 4E 47 0D 0A 1A 0A`; malformed URIs returned `null` rather than throwing; file names
+resolved as expected from a server filename, a short prompt, an over-long prompt falling back
+to the message id, and a prompt containing characters illegal in a filename; a `data:` source
+opened through a `blob:` URL rather than being navigated to; and a refused `window.open`
+returned `false` so a blocked popup is reported rather than assumed to have worked.
+
+`npm run typecheck` and `npm run build` both pass, and
+`functional_tests/test_v2_ui_local_assets.py` confirms no remote asset was introduced —
+the icons come from `lucide-react`, which was already a dependency.
+
+## Related
+
+- Feature documentation: `docs/explanation/features/REACT_V2_UI.md`

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,18 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/features) and [Fixes by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/fixes).
 
+### **(v0.261.025)**
+
+#### User Interface Enhancements
+
+*   **Generated Images Now Open In A Viewer Instead Of A New Tab**
+    *   In the V2 interface, clicking an image the assistant generated used to open the raw file in a new browser tab, dropping you out of your conversation. It now opens in a viewer over the page, matching how the classic interface has always behaved.
+    *   The viewer scales the image to fit and can switch to actual size, where a large image scrolls so its edges stay reachable. Clicking the image toggles between the two.
+    *   Saving the image and opening the raw file are both available from the viewer, so nothing is lost by staying in the app. Close it with the close button, the Escape key, or by clicking outside it.
+    *   Smaller images previously did nothing at all when clicked, because browsers refuse to open the inline format they arrive in. Those images now open correctly, and can be saved.
+    *   Images you upload benefit in the same way, since they are shown through the same message type.
+    *   (Ref: V2 chat image messages, image lightbox, image download)
+
 ### **(v0.261.024)**
 
 #### New Features

--- a/functional_tests/test_v2_generated_image_lightbox.py
+++ b/functional_tests/test_v2_generated_image_lightbox.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python3
+"""
+Functional test for the V2 generated-image lightbox.
+
+Version: 0.261.025
+Implemented in: 0.261.025
+
+Clicking a generated image in the V2 chat view used to leave the app. `ImageMessage` wrapped
+the thumbnail in an `<a target="_blank">`, so the browser opened the raw image in a new tab.
+The classic chat view has never done that -- `chat-citations.js` catches clicks on
+`.generated-image` and opens a modal -- so V2 was the odd one out.
+
+It was also broken outright for a whole class of images. `resolveImageSource` returns a
+`data:image/...` URI for small inline images, and browsers block top-level navigation to a
+data URL, so for those messages clicking the image did nothing at all.
+
+This test ensures the thumbnail opens an in-page dialog instead of navigating away, that the
+dialog still offers everything the new tab did (save the file, open the raw image, view it at
+actual size), and that each of the three source kinds `resolveImageSource` can return is
+handled deliberately rather than assumed to behave like a plain URL.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+V2_SRC = REPO_ROOT / "application" / "v2_ui" / "src"
+
+sys.path.insert(0, str(REPO_ROOT / "functional_tests"))
+
+from test_support.versioning import assert_app_version_at_least  # noqa: E402
+
+MESSAGE_LIST = V2_SRC / "components" / "chat" / "MessageList.tsx"
+LIGHTBOX = V2_SRC / "components" / "chat" / "ImageLightbox.tsx"
+IMAGES_LIB = V2_SRC / "lib" / "images.ts"
+ENDPOINTS_LIB = V2_SRC / "lib" / "endpoints.ts"
+API_CLIENT = V2_SRC / "lib" / "apiClient.ts"
+
+
+def _read(path):
+    return path.read_text(encoding="utf-8")
+
+
+def _image_message_body():
+    """The body of ImageMessage, up to the next top-level function."""
+    source = _read(MESSAGE_LIST)
+    match = re.search(
+        r"function ImageMessage\(.*?\n(?=function |export function )",
+        source,
+        re.DOTALL,
+    )
+    assert match, "ImageMessage could not be located in MessageList.tsx"
+    return match.group(0)
+
+
+def test_thumbnail_opens_a_dialog_rather_than_a_new_tab():
+    """The click must stay in the app."""
+    print("Testing that the thumbnail no longer navigates away...")
+
+    body = _image_message_body()
+
+    assert 'target="_blank"' not in body, (
+        "ImageMessage still opens the image in a new tab; it should open the lightbox"
+    )
+    assert "<a" not in body.replace("<article", ""), (
+        "The image thumbnail should not be an anchor at all -- it opens a dialog, "
+        "not a document"
+    )
+
+    # A button keeps the thumbnail reachable and operable from the keyboard, which a bare
+    # clickable <img> would not be.
+    assert re.search(r"<button\s+type=\"button\"\s+onClick=\{\(\) => setLightboxOpen\(true\)\}", body), (
+        "The thumbnail must be a real button that opens the lightbox"
+    )
+    assert 'aria-haspopup="dialog"' in body, (
+        "The thumbnail should announce that it opens a dialog"
+    )
+    assert "<ImageLightbox" in body and "onClose={() => setLightboxOpen(false)}" in body, (
+        "ImageMessage must render the lightbox and be able to close it"
+    )
+
+    assert "import { ImageLightbox } from './ImageLightbox';" in _read(MESSAGE_LIST), (
+        "MessageList must import the lightbox component"
+    )
+
+    print("Thumbnail test passed!")
+    return True
+
+
+def test_broken_image_fallback_survives():
+    """The existing fallback must not have been lost in the rewrite."""
+    print("Testing the broken-image fallback...")
+
+    body = _image_message_body()
+
+    assert "onError={() => setFailed(true)}" in body, (
+        "A failed image load must still be caught"
+    )
+    assert "if (!source || failed)" in body, (
+        "An unreadable or broken image must still fall back to the prompt text"
+    )
+
+    # The fallback returns early, so every hook has to run before it or React's hook order
+    # breaks on the render where an image fails.
+    hooks_then_return = re.search(
+        r"const naming = useMemo\((.|\n)*?if \(!source \|\| failed\) \{",
+        body,
+    )
+    assert hooks_then_return, (
+        "Hooks must be declared before the early return, or hook order changes when an "
+        "image fails to load"
+    )
+
+    print("Fallback test passed!")
+    return True
+
+
+def test_dialog_follows_the_existing_modal_conventions():
+    """A dialog nobody can dismiss is worse than a new tab."""
+    print("Testing dialog semantics...")
+
+    assert LIGHTBOX.exists(), "ImageLightbox.tsx should hold the viewer"
+    lightbox = _read(LIGHTBOX)
+
+    assert 'role="dialog"' in lightbox and 'aria-modal="true"' in lightbox, (
+        "The lightbox must be announced as a modal dialog"
+    )
+    assert re.search(r"event\.key === 'Escape'(.|\n)*?onClose\(\)", lightbox), (
+        "Escape must dismiss the lightbox, as it does for every other dialog in this UI"
+    )
+    assert re.search(r"absolute inset-0(.|\n)*?onClick=\{onClose\}", lightbox), (
+        "Clicking the backdrop must dismiss the lightbox"
+    )
+    assert "document.removeEventListener('keydown', onKeyDown)" in lightbox, (
+        "The Escape listener must be torn down, or it accumulates on every open"
+    )
+
+    # Focus should enter the dialog and be handed back on close.
+    assert "closeRef.current?.focus()" in lightbox, (
+        "Opening the dialog must move focus into it"
+    )
+    assert "previous?.focus?.()" in lightbox, (
+        "Closing the dialog must return focus to the thumbnail that opened it"
+    )
+
+    print("Dialog semantics test passed!")
+    return True
+
+
+def test_the_new_tab_actions_are_still_available():
+    """Nothing the new tab offered may be lost by keeping the user in the app."""
+    print("Testing lightbox actions...")
+
+    lightbox = _read(LIGHTBOX)
+
+    assert "downloadImageSource" in lightbox, "The lightbox must be able to save the image"
+    assert "openImageInNewTab" in lightbox, (
+        "Opening the raw image must still be reachable, since the click no longer does it"
+    )
+
+    # Fit versus actual size, toggled from the header and by clicking the image.
+    assert "type ZoomMode = 'fit' | 'actual'" in lightbox, (
+        "The viewer needs an explicit fit/actual-size mode"
+    )
+    assert lightbox.count("setZoom(fit ? 'actual' : 'fit')") >= 2, (
+        "Both the header control and the image itself should toggle the zoom"
+    )
+    assert "object-contain" in lightbox and "max-w-none" in lightbox, (
+        "Fit must constrain the image and actual size must not"
+    )
+    assert "overflow-auto" in lightbox, (
+        "An image shown at actual size must be scrollable, or its edges are unreachable"
+    )
+    assert 'aria-pressed={!fit}' in lightbox, (
+        "The zoom toggle must report its state to assistive technology"
+    )
+
+    # Every failure path says something rather than doing nothing visible.
+    assert "toast.error" in lightbox, "A failed action must be reported"
+
+    print("Lightbox actions test passed!")
+    return True
+
+
+def test_every_image_source_kind_is_handled():
+    """resolveImageSource returns three kinds and none of them behaves like the others."""
+    print("Testing source-kind coverage...")
+
+    images = _read(IMAGES_LIB)
+
+    for kind in ("data-uri", "endpoint", "external"):
+        assert f"'{kind}'" in images, f"The {kind} source kind is unhandled"
+
+    # A data URI cannot be navigated to at the top level, so it is republished as an object
+    # URL. Getting this wrong is the silent failure that prompted the change.
+    assert re.search(
+        r"openImageInNewTab(.|\n)*?source\.kind === 'data-uri'\s*\?\s*objectUrlForDataUri",
+        images,
+    ), (
+        "A data URI must be opened through an object URL; browsers block top-level "
+        "navigation to data: URLs"
+    )
+    assert "revokeObjectURL" in images, (
+        "The object URL must be released, or its bytes are held for the life of the page"
+    )
+
+    # `window.open` returns null when `noopener` is passed in the feature string, even on
+    # success, which would make every opened tab look blocked. The opener is severed by
+    # assignment instead so the return value stays meaningful.
+    assert not re.search(r"window\.open\([^)]*noopener", images), (
+        "`noopener` in the window.open feature string makes it return null even on "
+        "success; sever the opener by assignment instead"
+    )
+    assert "opened.opener = null" in images, (
+        "The new tab must not keep a handle back to the app"
+    )
+
+    # The authenticated endpoint needs the client's credentials mode, or the split-origin
+    # deployment gets a 401 on the download.
+    assert re.search(
+        r"source\.kind === 'endpoint' \? \{ credentials: CREDENTIALS_MODE \}",
+        images,
+    ), "The authenticated image endpoint must be fetched with the client's credentials mode"
+    assert "export const CREDENTIALS_MODE" in _read(API_CLIENT), (
+        "CREDENTIALS_MODE must be exported for the image fetch to share it"
+    )
+
+    print("Source-kind coverage test passed!")
+    return True
+
+
+def test_download_fetches_bytes_rather_than_linking_to_them():
+    """`<a download>` is ignored cross-origin, which is the split-origin deployment."""
+    print("Testing the download path...")
+
+    images = _read(IMAGES_LIB)
+
+    assert re.search(
+        r"export async function downloadImageSource(.|\n)*?resolveImageBlob\((.|\n)*?saveBlob\(",
+        images,
+    ), "The download must resolve the bytes to a blob and save that"
+
+    # One download path, not two. saveBlob already existed for the message exports.
+    assert "import { saveBlob } from './endpoints';" in images, (
+        "The image download must reuse the existing saveBlob helper"
+    )
+    assert "export function saveBlob(" in _read(ENDPOINTS_LIB), (
+        "saveBlob must be exported for images.ts to reuse it"
+    )
+
+    # A cross-origin host that sends no CORS headers cannot be read; that has to surface.
+    assert re.search(r"catch \{(.|\n)*?throw new Error\((.|\n)*?hosted elsewhere", images), (
+        "A CORS-refused external image must report why the download failed"
+    )
+
+    print("Download path test passed!")
+    return True
+
+
+def test_download_names_are_usable_and_safe():
+    """A downloads folder full of opaque ids helps nobody."""
+    print("Testing download file names...")
+
+    images = _read(IMAGES_LIB)
+
+    assert "export function imageFileName(" in images, "There must be a name derivation"
+    assert "MIME_EXTENSIONS" in images, (
+        "The extension must follow the actual image type rather than being assumed"
+    )
+    assert "IMAGE_EXTENSION_PATTERN" in images, (
+        "A name that already ends in an image extension must not get a second one"
+    )
+    assert "UNSAFE_FILENAME_CHARS" in images, (
+        "A prompt used as a file name must have illegal characters removed first"
+    )
+
+    # A whole prompt can be a paragraph; it is only usable as a name when it is short.
+    assert "fromPrompt.length <= 60" in images, (
+        "An over-long prompt must not become the file name"
+    )
+
+    print("File name test passed!")
+    return True
+
+
+def test_no_third_party_assets_were_introduced():
+    """The V2 bundle stays local-only."""
+    print("Testing that no remote assets were added...")
+
+    lightbox = _read(LIGHTBOX)
+
+    assert "lucide-react" in lightbox, "Icons should come from the bundled icon set"
+    for remote in ("http://", "https://", "cdn.", "unpkg", "jsdelivr"):
+        assert remote not in lightbox, (
+            f"The lightbox must not reference a remote asset ({remote!r} found)"
+        )
+
+    print("Local assets test passed!")
+    return True
+
+
+def test_version_is_at_least_implementation_version():
+    """The application version is at or beyond the version that added this."""
+    print("Testing application version...")
+    assert_app_version_at_least("0.261.025")
+    print("Application version test passed!")
+    return True
+
+
+if __name__ == "__main__":
+    tests = [
+        test_thumbnail_opens_a_dialog_rather_than_a_new_tab,
+        test_broken_image_fallback_survives,
+        test_dialog_follows_the_existing_modal_conventions,
+        test_the_new_tab_actions_are_still_available,
+        test_every_image_source_kind_is_handled,
+        test_download_fetches_bytes_rather_than_linking_to_them,
+        test_download_names_are_usable_and_safe,
+        test_no_third_party_assets_were_introduced,
+        test_version_is_at_least_implementation_version,
+    ]
+
+    results = []
+    for test in tests:
+        print(f"\nRunning {test.__name__}...")
+        try:
+            results.append(bool(test()))
+        except Exception as exc:  # noqa: BLE001 - surface any failure with a traceback
+            print(f"Test failed: {exc}")
+            import traceback
+
+            traceback.print_exc()
+            results.append(False)
+
+    print(f"\nResults: {sum(results)}/{len(results)} tests passed")
+    sys.exit(0 if all(results) else 1)


### PR DESCRIPTION
## What this does

Clicking an AI-generated image in the V2 chat view opened the raw file in a new browser tab, dropping the user out of their conversation. It now opens in a viewer over the page, matching how the classic chat view has always behaved.

Tracing it turned up a second, silent defect: small images are delivered inline as `data:image/...` URIs, and browsers block top-level navigation to a `data:` URL — so for those messages **clicking did nothing at all**, with no error and no explanation.

## Before / after

`ImageMessage` in `MessageList.tsx` wrapped the thumbnail in an anchor:

```tsx
<a href={source.src} target="_blank" rel="noopener noreferrer">
    <img src={source.src} ... />
</a>
```

`resolveImageSource` can return three different kinds of source — a `data:` URI, an `/api/image/<id>` path, or an external `https://` URL — and the anchor treated all three as an ordinary navigable URL. Only two of them are.

The thumbnail is now a `<button>` that opens a new `ImageLightbox` dialog. Because the click no longer navigates anywhere, everything the new tab used to provide moved inside:

- **Fit / actual size** — scaled to the panel by default, switchable to natural size where it scrolls so the edges of a large image stay reachable. The header control and the image itself both toggle it.
- **Save the image**
- **Open in a new tab**, for anyone who genuinely wanted the raw file

The dialog follows the conventions already set by `CitationChip` and `EnhancedCitationViewer`: click-to-close backdrop, Escape to dismiss, `role="dialog"` with `aria-modal="true"`, and no focus-trap utility since no other dialog in this UI uses one. Focus moves into the dialog on open and returns to the thumbnail on close.

## Each source kind is handled deliberately

| Kind | Download | Open in new tab |
|---|---|---|
| `data-uri` | Decoded to a blob locally, no request | Republished as an object URL, because `data:` navigation is blocked |
| `endpoint` | Fetched with the client's credentials mode | The URL directly |
| `external` | Fetched; a CORS refusal is reported | The URL directly |

Download fetches the bytes and saves a blob rather than pointing an `<a download>` at the URL. **That attribute is ignored for a cross-origin URL**, which is exactly what `/api/image/<id>` becomes in the split-origin (`VITE_API_BASE`) deployment — so the attribute alone would have silently produced a navigation instead of a saved file.

## A trap worth flagging for reviewers

`window.open()` returns `null` when `noopener` appears in its feature string — **even when the tab opens successfully**. My first pass passed `noopener` there, which would have made every successfully opened tab look blocked and reported a failure on every use. The opener is severed by assignment after the call instead, keeping the return value meaningful so a genuinely blocked popup can still be reported. The test asserts this so it cannot regress.

## Scope

The classic chat view is untouched — it already opens a modal via `showImagePopup` in `static/js/chat/chat-citations.js`.

User-uploaded images benefit alongside generated ones, because V2 routes every message with `role === 'image'` through `ImageMessage` — matching the classic view, where uploaded and generated images share the same `.generated-image` click handler.

## Rebased onto #1377

This branch was rebased after #1377 (TeX / Mermaid / chart rendering) merged into the base. Three files overlapped:

- **`MessageList.tsx`** — #1377 extracted `AssistantMarkdown` into its own component and dropped the `CitationChip` import from this file. Resolved by keeping that removal and adding only the `ImageLightbox` import. `ImageMessage` itself applied cleanly.
- **`release_notes.md`** — #1377 claimed `v0.261.024`, so this change moved to its own `v0.261.025` section above it. Both sections are intact.
- **`REACT_V2_UI.md`** — both added a row to the test table; both rows kept.

Because #1377 took `0.261.024`, **the version here is now `0.261.025`**, with the functional test's `assert_app_version_at_least` and the fix doc updated to match.

## Validation

Re-run after the rebase, against the current base:

- **9/9** new tests in `functional_tests/test_v2_generated_image_lightbox.py`
- **11 suites / 85 checks all passing**, including #1377's own `test_v2_rich_rendering.py` (13/13), plus `test_v2_chat_phase1_fixes`, `test_v2_citations`, `test_v2_message_copy`, `test_v2_message_actions`, `test_v2_message_masking`, `test_v2_ui_local_assets`, `test_v2_api_payload_shapes`, `test_docs_site_quality`, `test_docs_app_surface_coverage`
- **The test was confirmed to fail against the pre-change code**: the extracted `ImageMessage` body at the original merge base contains `target="_blank"` and no lightbox
- **Helpers verified at runtime against the real compiled module** (esbuild bundle run in Node): a base64 PNG data URI decoded to bytes beginning with the PNG signature `89 50 4E 47 0D 0A 1A 0A`; malformed URIs returned `null` rather than throwing; file names resolved correctly from a server filename, a short prompt, an over-long prompt falling back to the message id, and a prompt containing characters illegal in a filename; a `data:` source opened through a `blob:` URL; and a refused `window.open` returned `false`
- `npm run typecheck` and `npm run build` both clean
- No remote assets introduced — icons come from `lucide-react`, already a dependency

## Files

| File | Change |
|---|---|
| `application/v2_ui/src/components/chat/ImageLightbox.tsx` | **New** — dialog with zoom toggle, download, open in new tab, close |
| `application/v2_ui/src/components/chat/MessageList.tsx` | `ImageMessage` opens the lightbox instead of a new tab |
| `application/v2_ui/src/lib/images.ts` | `decodeImageDataUri`, `resolveImageBlob`, `downloadImageSource`, `openImageInNewTab`, `imageFileName` |
| `application/v2_ui/src/lib/endpoints.ts` | `saveBlob` exported so the image download reuses one save path |
| `application/v2_ui/src/lib/apiClient.ts` | `CREDENTIALS_MODE` exported for the authenticated image fetch |
| `application/single_app/config.py` | Version to `0.261.025` |
| `functional_tests/test_v2_generated_image_lightbox.py` | **New** test |
| `docs/explanation/fixes/V2_GENERATED_IMAGE_LIGHTBOX_FIX.md` | **New** fix documentation |
| `docs/explanation/features/REACT_V2_UI.md` | Capability bullet, image-message data-shape note, test table |
| `docs/explanation/release_notes.md` | `v0.261.025` entry |
