### PR TITLE
Render diagrams on the server when no browser is attached to the export

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -97,7 +97,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.261.026"
+VERSION = "0.261.027"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/functions_mermaid_server_render.py
+++ b/application/single_app/functions_mermaid_server_render.py
@@ -1,0 +1,344 @@
+# functions_mermaid_server_render.py
+"""Server-side Mermaid rasterization using the Chromium build already in the image.
+
+Mermaid is a browser rendering library, so a faithful diagram needs a real browser
+somewhere. The container already installs Playwright's Chromium for Source Review and
+Deep Research (``INSTALL_PLAYWRIGHT_CHROMIUM``, on by default), so rendering here costs
+no new dependency and no new install step.
+
+This exists so an export that has no browser attached still gets pictures: exports started
+from the V2 interface, and anything server-initiated. When Chromium is unavailable, because
+a deployment opted out of it, every function here reports that cleanly and the export falls
+back to the diagram's original code block.
+
+The same vendored Mermaid bundle the browser uses is loaded from disk, so a server-rendered
+diagram and a browser-rendered one come from identical library code.
+"""
+
+import importlib.util
+import os
+import threading
+from typing import Any, Dict, List, Optional
+
+from functions_export_visuals import (
+    EXPORT_VISUAL_ASSET_MAX_COUNT,
+    EXPORT_VISUAL_KIND_DIAGRAM,
+    normalize_visual_assets,
+    normalize_visual_source,
+)
+
+
+MERMAID_BUNDLE_RELATIVE_PATH = os.path.join(
+    'static', 'js', 'mermaid', 'mermaid-11.17.2.min.js',
+)
+MERMAID_SERVER_RENDER_MAX_DIAGRAMS = EXPORT_VISUAL_ASSET_MAX_COUNT
+MERMAID_SERVER_RENDER_BROWSER_TIMEOUT_MS = 20000
+MERMAID_SERVER_RENDER_PAGE_TIMEOUT_MS = 60000
+MERMAID_SERVER_RENDER_DIAGRAM_TIMEOUT_MS = 10000
+MERMAID_SERVER_RENDER_SCALE = 2
+MERMAID_SERVER_RENDER_MAX_CANVAS_EDGE = 4000
+
+_RENDER_CAPABILITIES_CACHE: Optional[Dict[str, Any]] = None
+_RENDER_LOCK = threading.Lock()
+
+# Mirrors chat-visual-rasterizer.js. htmlLabels must stay off in both: Mermaid draws labels
+# inside <foreignObject>, and that content is dropped when an SVG is painted onto a canvas,
+# which yields diagrams with shapes and arrows but no text.
+MERMAID_RENDER_SCRIPT = """
+(async (sources, options) => {
+    const results = [];
+    window.mermaid.initialize({
+        startOnLoad: false,
+        securityLevel: 'strict',
+        suppressErrorRendering: true,
+        theme: 'neutral',
+        htmlLabels: false,
+        fontFamily: 'Arial, Helvetica, sans-serif',
+        flowchart: { htmlLabels: false, useMaxWidth: false },
+        sequence: { useMaxWidth: false },
+        class: { htmlLabels: false, useMaxWidth: false },
+    });
+
+    function parseSvgLength(value) {
+        const candidate = String(value || '').trim();
+        if (!candidate || candidate.includes('%')) {
+            return 0;
+        }
+        const parsed = Number.parseFloat(candidate);
+        return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+    }
+
+    function normalizeSvgMarkup(svgMarkup) {
+        const parsed = new DOMParser().parseFromString(svgMarkup, 'image/svg+xml');
+        const svgElement = parsed.documentElement;
+        let width = parseSvgLength(svgElement.getAttribute('width'));
+        let height = parseSvgLength(svgElement.getAttribute('height'));
+        const viewBox = String(svgElement.getAttribute('viewBox') || '')
+            .split(/[\\s,]+/)
+            .map(Number);
+        if (viewBox.length === 4 && Number.isFinite(viewBox[2]) && Number.isFinite(viewBox[3])) {
+            width = width || viewBox[2];
+            height = height || viewBox[3];
+        }
+        width = width || 800;
+        height = height || 600;
+
+        svgElement.setAttribute('width', String(width));
+        svgElement.setAttribute('height', String(height));
+        svgElement.setAttribute('style', 'max-width:none;background-color:#ffffff;');
+        if (!svgElement.getAttribute('xmlns')) {
+            svgElement.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
+        }
+
+        const scale = Math.min(options.scale, options.maxEdge / Math.max(width, height));
+        const safeScale = Number.isFinite(scale) && scale > 0 ? scale : 1;
+        return {
+            markup: new XMLSerializer().serializeToString(svgElement),
+            canvasWidth: Math.max(1, Math.round(width * safeScale)),
+            canvasHeight: Math.max(1, Math.round(height * safeScale)),
+        };
+    }
+
+    function base64EncodeUnicode(text) {
+        const bytes = new TextEncoder().encode(text);
+        const chunkSize = 0x8000;
+        let binary = '';
+        for (let index = 0; index < bytes.length; index += chunkSize) {
+            binary += String.fromCharCode.apply(null, bytes.subarray(index, index + chunkSize));
+        }
+        return btoa(binary);
+    }
+
+    function svgToPngDataUri(svgMarkup) {
+        return new Promise((resolve, reject) => {
+            const normalized = normalizeSvgMarkup(svgMarkup);
+            const image = new Image();
+            image.onload = () => {
+                try {
+                    const canvas = document.createElement('canvas');
+                    canvas.width = normalized.canvasWidth;
+                    canvas.height = normalized.canvasHeight;
+                    const context = canvas.getContext('2d');
+                    context.fillStyle = '#ffffff';
+                    context.fillRect(0, 0, canvas.width, canvas.height);
+                    context.drawImage(image, 0, 0, canvas.width, canvas.height);
+                    resolve(canvas.toDataURL('image/png'));
+                } catch (err) {
+                    reject(err);
+                }
+            };
+            image.onerror = () => reject(new Error('Unable to rasterize the diagram SVG.'));
+            image.src = 'data:image/svg+xml;base64,' + base64EncodeUnicode(normalized.markup);
+        });
+    }
+
+    function withTimeout(promise, timeoutMs) {
+        return new Promise((resolve, reject) => {
+            const timer = setTimeout(() => reject(new Error('Diagram render timed out.')), timeoutMs);
+            Promise.resolve(promise).then(
+                (value) => { clearTimeout(timer); resolve(value); },
+                (err) => { clearTimeout(timer); reject(err); },
+            );
+        });
+    }
+
+    for (let index = 0; index < sources.length; index += 1) {
+        const source = sources[index];
+        try {
+            const rendered = await withTimeout(
+                window.mermaid.render('simplechat-export-server-' + index, source),
+                options.diagramTimeoutMs,
+            );
+            const svgMarkup = typeof rendered === 'string' ? rendered : (rendered && rendered.svg);
+            if (!svgMarkup) {
+                results.push({ source, error: 'Mermaid produced no SVG.' });
+                continue;
+            }
+            const dataUri = await withTimeout(svgToPngDataUri(svgMarkup), options.diagramTimeoutMs);
+            results.push({ source, dataUri });
+        } catch (err) {
+            results.push({ source, error: String((err && err.message) || err) });
+        }
+    }
+
+    return results;
+})
+"""
+
+
+def get_mermaid_server_render_capabilities(force_refresh: bool = False) -> Dict[str, Any]:
+    """Return cached runtime support details for server-side diagram rendering."""
+    global _RENDER_CAPABILITIES_CACHE
+    if _RENDER_CAPABILITIES_CACHE is not None and not force_refresh:
+        return dict(_RENDER_CAPABILITIES_CACHE)
+
+    capabilities = {
+        'server_rendering_available': False,
+        'playwright_available': False,
+        'chromium_launch_available': False,
+        'bundle_available': os.path.exists(get_mermaid_bundle_path()),
+        'message': 'Playwright is not installed in this app runtime.',
+    }
+
+    if not capabilities['bundle_available']:
+        capabilities['message'] = 'The vendored Mermaid bundle is missing from this runtime.'
+        _RENDER_CAPABILITIES_CACHE = capabilities
+        return dict(capabilities)
+
+    if importlib.util.find_spec('playwright') is None:
+        _RENDER_CAPABILITIES_CACHE = capabilities
+        return dict(capabilities)
+
+    capabilities['playwright_available'] = True
+    try:
+        from playwright.sync_api import sync_playwright
+
+        with sync_playwright() as playwright_instance:
+            browser = playwright_instance.chromium.launch(
+                headless=True,
+                args=get_chromium_launch_args(),
+                timeout=MERMAID_SERVER_RENDER_BROWSER_TIMEOUT_MS,
+            )
+            browser.close()
+        capabilities.update({
+            'server_rendering_available': True,
+            'chromium_launch_available': True,
+            'message': 'Playwright Chromium launch verified for diagram rendering.',
+        })
+    except Exception as runtime_error:
+        capabilities['message'] = (
+            f'Playwright is installed, but Chromium launch failed: {str(runtime_error)[:220]}'
+        )
+
+    _RENDER_CAPABILITIES_CACHE = capabilities
+    return dict(capabilities)
+
+
+def is_mermaid_server_rendering_available() -> bool:
+    """Return True only when this runtime can rasterize diagrams without a browser client."""
+    return bool(get_mermaid_server_render_capabilities().get('server_rendering_available'))
+
+
+def get_mermaid_bundle_path() -> str:
+    """Return the on-disk path of the vendored Mermaid bundle."""
+    return os.path.join(os.path.dirname(os.path.abspath(__file__)), MERMAID_BUNDLE_RELATIVE_PATH)
+
+
+def get_chromium_launch_args() -> List[str]:
+    """Match the Chromium flags Source Review already uses in this runtime."""
+    launch_args = ['--disable-dev-shm-usage', '--disable-gpu']
+    if _is_chromium_no_sandbox_enabled():
+        launch_args.append('--no-sandbox')
+    return launch_args
+
+
+def render_mermaid_visual_assets(
+    sources: List[Dict[str, str]],
+    max_diagrams: int = MERMAID_SERVER_RENDER_MAX_DIAGRAMS,
+) -> List[Dict[str, Any]]:
+    """Rasterize diagram sources to validated export assets, skipping any that fail.
+
+    Every diagram is rendered in one browser session. Returns an empty list when the
+    runtime cannot launch Chromium, which leaves the fences untouched.
+    """
+    normalized_sources = _normalize_render_sources(sources, max_diagrams)
+    if not normalized_sources or not is_mermaid_server_rendering_available():
+        return []
+
+    try:
+        rendered_results = _render_with_chromium([item['source'] for item in normalized_sources])
+    except Exception:
+        return []
+
+    metadata_by_source = {item['source']: item for item in normalized_sources}
+    raw_assets = []
+    for result in rendered_results:
+        if not isinstance(result, dict):
+            continue
+        source = normalize_visual_source(result.get('source'))
+        data_uri = result.get('dataUri')
+        if not source or not data_uri:
+            continue
+        metadata = metadata_by_source.get(source, {})
+        raw_assets.append({
+            'kind': EXPORT_VISUAL_KIND_DIAGRAM,
+            'source': source,
+            'data_uri': data_uri,
+            'alt': metadata.get('alt', ''),
+            'caption': metadata.get('caption', ''),
+        })
+
+    return normalize_visual_assets(raw_assets, max_count=max_diagrams)
+
+
+def _normalize_render_sources(
+    sources: Any,
+    max_diagrams: int,
+) -> List[Dict[str, str]]:
+    if not isinstance(sources, list):
+        return []
+
+    normalized_sources: List[Dict[str, str]] = []
+    seen_sources = set()
+    for source in sources:
+        if len(normalized_sources) >= max_diagrams:
+            break
+        if isinstance(source, str):
+            source = {'source': source}
+        if not isinstance(source, dict):
+            continue
+
+        normalized_source = normalize_visual_source(source.get('source'))
+        if not normalized_source or normalized_source in seen_sources:
+            continue
+        seen_sources.add(normalized_source)
+        normalized_sources.append({
+            'source': normalized_source,
+            'alt': str(source.get('alt') or ''),
+            'caption': str(source.get('caption') or ''),
+        })
+    return normalized_sources
+
+
+def _render_with_chromium(sources: List[str]) -> List[Dict[str, Any]]:
+    """Render every diagram in a single headless Chromium session."""
+    from playwright.sync_api import sync_playwright
+
+    render_options = {
+        'scale': MERMAID_SERVER_RENDER_SCALE,
+        'maxEdge': MERMAID_SERVER_RENDER_MAX_CANVAS_EDGE,
+        'diagramTimeoutMs': MERMAID_SERVER_RENDER_DIAGRAM_TIMEOUT_MS,
+    }
+
+    with _RENDER_LOCK:
+        with sync_playwright() as playwright_instance:
+            browser = playwright_instance.chromium.launch(
+                headless=True,
+                args=get_chromium_launch_args(),
+                timeout=MERMAID_SERVER_RENDER_BROWSER_TIMEOUT_MS,
+            )
+            try:
+                page = browser.new_page()
+                page.set_default_timeout(MERMAID_SERVER_RENDER_PAGE_TIMEOUT_MS)
+
+                # The page never needs the network: the bundle is inlined from disk and the
+                # diagram sources are passed in as data.
+                page.route('**/*', lambda route: route.abort())
+                page.set_content('<!doctype html><html lang="en"><head><meta charset="utf-8">'
+                                 '</head><body></body></html>')
+                page.add_script_tag(path=get_mermaid_bundle_path())
+
+                results = page.evaluate(
+                    f'([sources, options]) => ({MERMAID_RENDER_SCRIPT})(sources, options)',
+                    [sources, render_options],
+                )
+            finally:
+                browser.close()
+
+    return results if isinstance(results, list) else []
+
+
+def _is_chromium_no_sandbox_enabled() -> bool:
+    return str(os.getenv('SOURCE_REVIEW_CHROMIUM_NO_SANDBOX', 'false')).strip().lower() in (
+        '1', 'true', 'yes', 'on',
+    )

--- a/application/single_app/route_backend_conversation_export.py
+++ b/application/single_app/route_backend_conversation_export.py
@@ -35,6 +35,10 @@ from functions_export_visuals import (
     replace_inline_visual_blocks_with_export_html,
 )
 from functions_mermaid_export import extract_mermaid_sources
+from functions_mermaid_server_render import (
+    is_mermaid_server_rendering_available,
+    render_mermaid_visual_assets,
+)
 from functions_collaboration import (
     assert_user_can_view_collaboration_conversation,
     get_accessible_collaboration_message_thoughts,
@@ -218,6 +222,12 @@ def register_route_backend_conversation_export(bp):
             if not exported:
                 return jsonify({'error': 'No accessible conversations found'}), 404
 
+            if export_format != 'json':
+                visual_assets = _merge_server_rendered_visual_assets(
+                    _collect_export_entry_contents(exported),
+                    visual_assets,
+                )
+
             timestamp_str = datetime.utcnow().strftime('%Y%m%d_%H%M%S')
 
             if packaging == 'zip':
@@ -344,6 +354,10 @@ def register_route_backend_conversation_export(bp):
                 data.get('visual_assets'),
                 max_count=MESSAGE_EXPORT_VISUAL_ASSET_MAX_COUNT,
             )
+            visual_assets = _merge_server_rendered_visual_assets(
+                [message.get('content', '')],
+                visual_assets,
+            )
 
             document_bytes = _message_to_docx_bytes(message, visual_assets=visual_assets)
             timestamp_str = datetime.utcnow().strftime('%Y%m%d_%H%M%S')
@@ -420,6 +434,10 @@ def register_route_backend_conversation_export(bp):
                 data.get('visual_assets'),
                 max_count=MESSAGE_EXPORT_VISUAL_ASSET_MAX_COUNT,
             )
+            visual_assets = _merge_server_rendered_visual_assets(
+                [message.get('content', '')],
+                visual_assets,
+            )
             presentation_bytes = _message_to_pptx_bytes(
                 message,
                 settings,
@@ -489,6 +507,10 @@ def register_route_backend_conversation_export(bp):
                 data.get('visual_assets'),
                 max_count=MESSAGE_EXPORT_VISUAL_ASSET_MAX_COUNT,
             )
+            visual_assets = _merge_server_rendered_visual_assets(
+                [message.get('content', '')],
+                visual_assets,
+            )
             draft_payload = _message_to_email_draft_payload(
                 message=message,
                 settings=settings,
@@ -508,6 +530,62 @@ def register_route_backend_conversation_export(bp):
             debug_print(f"Message email draft export error: {str(exc)}")
             log_event(f"Message email draft export failed: {exc}", level="WARNING")
             return jsonify({'error': 'Email draft export failed due to a server error. Please try again later.'}), 500
+
+
+def _merge_server_rendered_visual_assets(
+    contents: List[Any],
+    visual_assets: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Render any diagram the client did not supply a picture for.
+
+    A browser attached to the export covers its own diagrams. This fills the gap for
+    everything else, such as an export started from an interface that does not rasterize,
+    using the Chromium already installed in the image. When that is unavailable the fence
+    is simply left as a code block.
+    """
+    merged_assets = list(visual_assets or [])
+    covered_sources = {
+        asset.get('normalized_source')
+        for asset in merged_assets
+        if asset.get('kind') == EXPORT_VISUAL_KIND_DIAGRAM
+    }
+
+    pending_sources: List[Dict[str, str]] = []
+    seen_sources = set(covered_sources)
+    for content in contents:
+        for source in extract_mermaid_sources(_normalize_content(content)):
+            if source['source'] in seen_sources:
+                continue
+            seen_sources.add(source['source'])
+            pending_sources.append(source)
+            if len(pending_sources) >= EXPORT_VISUAL_ASSET_MAX_COUNT:
+                break
+        if len(pending_sources) >= EXPORT_VISUAL_ASSET_MAX_COUNT:
+            break
+
+    if not pending_sources or not is_mermaid_server_rendering_available():
+        return merged_assets
+
+    try:
+        merged_assets.extend(render_mermaid_visual_assets(pending_sources))
+    except Exception as exc:
+        debug_print(f"Server-side diagram rendering failed: {exc}")
+        log_event(f"Server-side diagram rendering failed: {exc}", level="WARNING")
+
+    return merged_assets
+
+
+def _collect_export_entry_contents(exported: List[Dict[str, Any]]) -> List[str]:
+    """Return every message body an export will render."""
+    contents: List[str] = []
+    for entry in exported:
+        summary_intro = entry.get('summary_intro') or {}
+        if summary_intro.get('content'):
+            contents.append(summary_intro['content'])
+        for message in entry.get('messages', []):
+            if message.get('content_text'):
+                contents.append(message['content_text'])
+    return contents
 
 
 def _load_exportable_conversation_for_user(

--- a/docs/explanation/features/EXPORT_MERMAID_AND_TEX_RENDERING.md
+++ b/docs/explanation/features/EXPORT_MERMAID_AND_TEX_RENDERING.md
@@ -6,7 +6,7 @@ PDF unreadable for the person it was sent to. SimpleChat already converted its o
 `simplechart` blocks into pictures for every export surface; this extends the same
 treatment to Mermaid and TeX.
 
-Implemented in version: **0.261.026**
+Implemented in version: **0.261.027**
 
 Dependencies: `matplotlib` (already required, used for the existing chart renderer) and a
 vendored copy of Mermaid served from SimpleChat's own static files.
@@ -70,20 +70,27 @@ which interface started it.
 
 ### Mermaid
 
-Mermaid is a browser rendering library, so the diagram image is produced by the browser
-and sent with the export request.
+Mermaid is a browser rendering library, so a faithful diagram needs a real browser
+somewhere. SimpleChat uses two, in this order:
 
-1. For a single message, the browser reads the Mermaid blocks out of the message markdown.
-   For a conversation export it calls `POST /api/conversations/export/visual-scan`, which
-   returns the diagram sources the server found in the selected conversations. Keeping
-   detection on the server means the fence-matching rules live in one place.
-2. Each diagram is rendered to SVG, painted onto a canvas and read back as a PNG.
-3. The PNGs are sent to the export endpoint as `visual_assets`.
-4. The server matches each asset to its fence by **normalized source text** and replaces
-   the fence with the image.
+1. **The user's browser**, when one is attached to the export. It reads the Mermaid blocks
+   out of the message, or calls `POST /api/conversations/export/visual-scan` for a
+   conversation export, renders each diagram to SVG, paints it onto a canvas and reads it
+   back as a PNG. The PNGs travel with the export request as `visual_assets`.
+2. **Headless Chromium on the server**, for anything the browser did not cover — an export
+   started from an interface that does not rasterize, or a server-initiated export. The
+   container already installs Playwright's Chromium for Source Review and Deep Research
+   (`INSTALL_PLAYWRIGHT_CHROMIUM`, on by default), so this costs no new dependency.
 
-A fence with no matching asset keeps its code block. That is what happens today in the V2
-interface, which does not yet rasterize diagrams, and whenever a diagram fails to render.
+Both load the same vendored bundle and use the same configuration, so a diagram renders
+identically whichever path produced it.
+
+The server matches each asset to its fence by **normalized source text**, and only renders
+diagrams that have no asset already. A client-supplied picture is never re-rendered.
+
+A fence still keeps its code block when neither path can produce an image — for example
+when a deployment sets `INSTALL_PLAYWRIGHT_CHROMIUM=false` and the export came from an
+interface that does not rasterize.
 
 ## Architecture
 
@@ -94,6 +101,7 @@ interface, which does not yet rasterize diagrams, and whenever a diagram fails t
 | `functions_export_visuals.py` | Shared wrapper markup, `visual_assets` validation, and the `replace_inline_visual_blocks_with_export_html()` entry point |
 | `functions_tex_export.py` | TeX detection and matplotlib `mathtext` rendering |
 | `functions_mermaid_export.py` | Mermaid fence detection, source extraction and asset substitution |
+| `functions_mermaid_server_render.py` | Headless Chromium rasterization for diagrams no browser covered |
 | `functions_chart_export.py` | Existing chart rendering, now using the shared wrapper markup |
 
 Every export surface consumes the same HTML shape, so a new visual kind only has to be
@@ -204,18 +212,17 @@ PNG is rejected if it exceeds the same byte cap that browser-supplied assets use
 
 - `mathtext` does not support `align`, `matrix`, `cases` or other multi-line environments.
   Those formulas keep their original code block.
-- The V2 React interface renders Mermaid in chat but does not yet send rasterized diagrams
-  with its export requests, so a diagram exported from V2 keeps its code block. TeX works
-  there already, because it is rendered on the server.
+- A deployment that builds with `INSTALL_PLAYWRIGHT_CHROMIUM=false` has no server-side
+  renderer, so a diagram is only rendered when the export came from an interface that
+  rasterizes. Otherwise it keeps its code block.
+- Server-side rendering launches a browser, which takes roughly a second before the first
+  diagram in a request. Exports whose diagrams the client already rasterized never pay it,
+  and neither do exports with no diagrams at all.
 - V2 vendors its own copy of the same Mermaid version under
   `application/v2_ui/public/vendor/mermaid-11.17.2/` for in-chat rendering. The two
   frontends have separate vendor trees, so the bundle is currently committed twice.
-- Diagram rasterization needs a browser, so a Mermaid diagram in a scheduled or
-  server-initiated export is not rendered. The `visual_assets` contract is deliberately
-  renderer-agnostic, so a server-side renderer can supply the same assets later without an
-  API change.
-- Conversation exports rasterize at most 60 diagrams per request; a single message export
-  rasterizes at most 20.
+- Conversation exports render at most 60 diagrams per request; a single message export
+  renders at most 20.
 
 ## Testing
 
@@ -223,6 +230,8 @@ PNG is rejected if it exceeds the same byte cap that browser-supplied assets use
 |---|---|
 | `functional_tests/test_conversation_export_mermaid_tex_images.py` | TeX rendering across Markdown, PDF, Word, PowerPoint and email; false-positive guards; Mermaid substitution and degradation; asset validation and caps |
 | `functional_tests/test_export_mermaid_browser_rasterizer.py` | The vendored bundle has no external assets, and a diagram rasterizes in Chromium to a PNG that still contains its label text |
+| `functional_tests/test_export_mermaid_server_render.py` | The capability probe, server rendering with visible labels, error isolation, configuration parity with the browser renderer, and that the route only renders what the client did not |
 | `functional_tests/test_conversation_export_inline_chart_images.py` | Existing chart output is unchanged by the shared wrapper builder |
 
-The browser test skips itself when Playwright or its Chromium build is unavailable.
+The browser and server rendering tests skip themselves when Playwright or its Chromium
+build is unavailable.

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,17 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/features) and [Fixes by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/fixes).
 
+### **(v0.261.027)**
+
+#### New Features
+
+*   **Diagrams In Exports No Longer Need The Browser You Exported From**
+    *   Diagrams are drawn by your browser when you export from one that can draw them. Anything else — an export started from an interface that does not, or one the server starts on its own — previously fell back to showing the diagram's code.
+    *   Those diagrams are now drawn on the server, using the Chromium the app already installs. No new dependency was added, nothing is fetched from the internet, and a diagram looks the same whichever way it was drawn.
+    *   A diagram your browser already drew is never drawn twice, and an export containing no diagrams does no extra work.
+    *   Deployments built without the optional Chromium component are unaffected and keep showing the diagram's code, as before.
+    *   (Ref: conversation and message exports, Mermaid diagrams, server-side rendering)
+
 ### **(v0.261.026)**
 
 #### New Features

--- a/functional_tests/test_conversation_export_mermaid_tex_images.py
+++ b/functional_tests/test_conversation_export_mermaid_tex_images.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """
 Functional tests for Mermaid and TeX graphics in exports.
-Version: 0.261.026
-Implemented in: 0.261.026
+Version: 0.261.027
+Implemented in: 0.261.027
 
 This test ensures TeX math blocks are rendered to PNG server-side, and that
 browser-rasterized Mermaid diagrams supplied as `visual_assets` are embedded into

--- a/functional_tests/test_export_mermaid_browser_rasterizer.py
+++ b/functional_tests/test_export_mermaid_browser_rasterizer.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """
 Functional test for the browser-side Mermaid export rasterizer.
-Version: 0.261.026
-Implemented in: 0.261.026
+Version: 0.261.027
+Implemented in: 0.261.027
 
 This test ensures the vendored Mermaid bundle loads from its local static path with no
 external network dependency, and that chat-visual-rasterizer.js turns a diagram into a

--- a/functional_tests/test_export_mermaid_server_render.py
+++ b/functional_tests/test_export_mermaid_server_render.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python3
+"""
+Functional test for server-side Mermaid rendering in exports.
+Version: 0.261.027
+Implemented in: 0.261.027
+
+This test ensures diagrams are rasterized on the server, using the Playwright Chromium
+already installed in the image, for exports that have no browser attached to them. It
+covers the capability probe, that a rendered diagram keeps its label text, that the
+server and browser renderers are configured identically, and that the export route only
+renders diagrams the client did not already supply.
+
+The rendering assertions skip themselves when Chromium is unavailable, which is the same
+condition under which the feature degrades to leaving the diagram as a code block.
+"""
+
+import base64
+import io
+import os
+import sys
+import types
+from typing import Any, Callable, Dict, List
+from unittest import mock
+
+
+ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+APP_DIR = os.path.join(ROOT_DIR, 'application', 'single_app')
+sys.path.insert(0, APP_DIR)
+sys.modules.setdefault(
+    'olefile',
+    types.SimpleNamespace(isOleFile=lambda *_args, **_kwargs: False, OleFileIO=None),
+)
+
+from functions_export_visuals import normalize_visual_assets  # noqa: E402
+from functions_mermaid_server_render import (  # noqa: E402
+    MERMAID_RENDER_SCRIPT,
+    get_mermaid_bundle_path,
+    get_mermaid_server_render_capabilities,
+    is_mermaid_server_rendering_available,
+    render_mermaid_visual_assets,
+)
+
+RASTERIZER_PATH = os.path.join(APP_DIR, 'static', 'js', 'chat', 'chat-visual-rasterizer.js')
+
+FLOWCHART_SOURCE = (
+    'graph TD\n'
+    '    A[Ingest Documents] --> B{Needs OCR?}\n'
+    '    B -->|Yes| C[Document Intelligence]\n'
+    '    B -->|No| D[Chunk and Embed]\n'
+    '    C --> D'
+)
+SEQUENCE_SOURCE = 'sequenceDiagram\n    Alice->>Bob: Hello Bob\n    Bob-->>Alice: Hi Alice'
+INVALID_SOURCE = 'this is definitely not valid mermaid {{{'
+
+
+def _import_route_helpers():
+    """Import the export route module, stubbing Cosmos when Azure config is absent."""
+    try:
+        import route_backend_conversation_export as route_module
+
+        return route_module, None
+    except Exception:
+        pass
+
+    try:
+        import azure.cosmos as azure_cosmos_module
+
+        os.environ.setdefault('AZURE_COSMOS_ENDPOINT', 'https://example.documents.azure.com:443/')
+        os.environ.setdefault('AZURE_COSMOS_KEY', 'ZHVtbXkta2V5LWZvci1sb2NhbC10ZXN0aW5n')
+        os.environ.setdefault('AZURE_COSMOS_AUTHENTICATION_TYPE', 'key')
+
+        with mock.patch.object(azure_cosmos_module, 'CosmosClient', mock.MagicMock()):
+            import route_backend_conversation_export as route_module
+
+        return route_module, None
+    except Exception as import_error:
+        return None, import_error
+
+
+ROUTE_MODULE, ROUTE_IMPORT_ERROR = _import_route_helpers()
+
+
+def _route_helpers_available() -> bool:
+    if ROUTE_MODULE is not None:
+        return True
+
+    print(f"Skipping route-dependent assertion: {ROUTE_IMPORT_ERROR}")
+    return False
+
+
+def _server_rendering_available() -> bool:
+    if is_mermaid_server_rendering_available():
+        return True
+
+    capabilities = get_mermaid_server_render_capabilities()
+    print(f"Skipping server rendering assertion: {capabilities.get('message')}")
+    return False
+
+
+def _painted_pixel_ratio(data_uri: str):
+    from PIL import Image
+
+    image_bytes = base64.b64decode(data_uri.split(',', 1)[1])
+    with Image.open(io.BytesIO(image_bytes)) as image:
+        rgb_image = image.convert('RGB')
+        width, height = rgb_image.size
+        colors = rgb_image.getcolors(maxcolors=1_000_000) or []
+
+    painted = sum(count for count, color in colors if color != (255, 255, 255))
+    return width, height, painted / float(width * height)
+
+
+def _build_png_data_uri() -> str:
+    from PIL import Image
+
+    buffer = io.BytesIO()
+    Image.new('RGB', (12, 12), (7, 8, 9)).save(buffer, format='PNG')
+    return 'data:image/png;base64,' + base64.b64encode(buffer.getvalue()).decode('ascii')
+
+
+def test_capability_probe_reports_a_complete_shape():
+    """The probe must always answer, whether or not Chromium is present."""
+    print("Testing server render capability probe...")
+
+    capabilities = get_mermaid_server_render_capabilities()
+    for key in (
+        'server_rendering_available',
+        'playwright_available',
+        'chromium_launch_available',
+        'bundle_available',
+        'message',
+    ):
+        assert key in capabilities, capabilities
+
+    assert capabilities['bundle_available'] is True, capabilities
+    assert os.path.exists(get_mermaid_bundle_path()), get_mermaid_bundle_path()
+    assert isinstance(capabilities['message'], str) and capabilities['message'], capabilities
+
+    print("Server render capability probe passed!")
+
+
+def test_server_and_browser_renderers_share_configuration():
+    """Both renderers must disable htmlLabels, or labels vanish when drawn to canvas."""
+    print("Testing renderer configuration parity...")
+
+    with open(RASTERIZER_PATH, 'r', encoding='utf-8') as handle:
+        client_source = handle.read()
+
+    for required in (
+        'htmlLabels: false',
+        "securityLevel: 'strict'",
+        'suppressErrorRendering: true',
+    ):
+        assert required in client_source, f'missing from client rasterizer: {required}'
+        assert required in MERMAID_RENDER_SCRIPT, f'missing from server renderer: {required}'
+
+    print("Renderer configuration parity passed!")
+
+
+def test_server_renders_diagrams_with_visible_labels():
+    """A server-rendered diagram must contain its label text, not just shapes."""
+    print("Testing server diagram rendering...")
+
+    if not _server_rendering_available():
+        return
+
+    assets = render_mermaid_visual_assets([
+        {'source': FLOWCHART_SOURCE, 'alt': 'Flowchart diagram', 'caption': ''},
+        {'source': SEQUENCE_SOURCE, 'alt': 'Sequence diagram', 'caption': ''},
+    ])
+
+    assert len(assets) == 2, assets
+    for asset in assets:
+        assert asset['kind'] == 'diagram', asset
+        assert asset['data_uri'].startswith('data:image/png;base64,'), asset['data_uri'][:48]
+        width, height, painted_ratio = _painted_pixel_ratio(asset['data_uri'])
+        assert width >= 100 and height >= 50, (width, height)
+        assert painted_ratio > 0.01, painted_ratio
+
+    print("Server diagram rendering passed!")
+
+
+def test_server_skips_a_diagram_it_cannot_render():
+    """One bad diagram must not lose the good ones."""
+    print("Testing server render error isolation...")
+
+    if not _server_rendering_available():
+        return
+
+    assets = render_mermaid_visual_assets([
+        {'source': INVALID_SOURCE},
+        {'source': FLOWCHART_SOURCE},
+    ])
+
+    assert len(assets) == 1, assets
+    assert assets[0]['normalized_source'] == FLOWCHART_SOURCE, assets[0]['normalized_source']
+
+    print("Server render error isolation passed!")
+
+
+def test_server_render_deduplicates_and_caps_sources():
+    """Repeated diagrams render once, and the batch honours its cap."""
+    print("Testing server render source handling...")
+
+    if not _server_rendering_available():
+        return
+
+    assets = render_mermaid_visual_assets(
+        [{'source': FLOWCHART_SOURCE}, {'source': FLOWCHART_SOURCE}, {'source': SEQUENCE_SOURCE}],
+        max_diagrams=1,
+    )
+    assert len(assets) == 1, assets
+
+    print("Server render source handling passed!")
+
+
+def test_export_route_fills_only_uncovered_diagrams():
+    """The route renders what the client did not, and leaves what it did alone."""
+    print("Testing export route asset merging...")
+
+    if not _route_helpers_available():
+        return
+
+    content = f'Intro.\n\n```mermaid\n{FLOWCHART_SOURCE}\n```\n\n$$E = mc^2$$\n'
+
+    client_assets = normalize_visual_assets([{
+        'kind': 'diagram',
+        'source': FLOWCHART_SOURCE,
+        'data_uri': _build_png_data_uri(),
+    }])
+    assert len(client_assets) == 1, client_assets
+
+    merged = ROUTE_MODULE._merge_server_rendered_visual_assets([content], client_assets)
+    assert len(merged) == 1, merged
+    assert merged[0]['data_uri'] == client_assets[0]['data_uri'], 'client asset was replaced'
+
+    print("Export route asset merging passed!")
+
+
+def test_export_route_skips_rendering_when_there_are_no_diagrams():
+    """Content without a diagram must never reach the renderer."""
+    print("Testing export route no-diagram short circuit...")
+
+    if not _route_helpers_available():
+        return
+
+    with mock.patch.object(
+        ROUTE_MODULE,
+        'render_mermaid_visual_assets',
+        side_effect=AssertionError('renderer must not be called'),
+    ):
+        merged = ROUTE_MODULE._merge_server_rendered_visual_assets(
+            ['Plain prose with no diagram in it.'],
+            [],
+        )
+
+    assert merged == [], merged
+
+    print("Export route no-diagram short circuit passed!")
+
+
+def test_export_route_degrades_when_chromium_is_unavailable():
+    """With Chromium opted out, the fence survives instead of the export failing."""
+    print("Testing export route degradation without Chromium...")
+
+    if not _route_helpers_available():
+        return
+
+    content = f'```mermaid\n{FLOWCHART_SOURCE}\n```'
+
+    with mock.patch.object(ROUTE_MODULE, 'is_mermaid_server_rendering_available', return_value=False):
+        merged = ROUTE_MODULE._merge_server_rendered_visual_assets([content], [])
+
+    assert merged == [], merged
+
+    rendered = ROUTE_MODULE._render_message_export_content(
+        {'role': 'assistant', 'content': content},
+        visual_assets=merged,
+    )
+    assert '```mermaid' in rendered, rendered[:200]
+
+    print("Export route degradation passed!")
+
+
+def test_export_route_renderer_failure_does_not_fail_the_export():
+    """A renderer that raises must not take the export down with it."""
+    print("Testing export route renderer failure handling...")
+
+    if not _route_helpers_available():
+        return
+
+    content = f'```mermaid\n{FLOWCHART_SOURCE}\n```'
+
+    with mock.patch.object(ROUTE_MODULE, 'is_mermaid_server_rendering_available', return_value=True), \
+            mock.patch.object(
+                ROUTE_MODULE,
+                'render_mermaid_visual_assets',
+                side_effect=RuntimeError('browser exploded'),
+            ):
+        merged = ROUTE_MODULE._merge_server_rendered_visual_assets([content], [])
+
+    assert merged == [], merged
+
+    print("Export route renderer failure handling passed!")
+
+
+def test_export_entry_content_collection():
+    """Every body an export renders must be offered to the renderer."""
+    print("Testing export entry content collection...")
+
+    if not _route_helpers_available():
+        return
+
+    entries = [{
+        'summary_intro': {'content': 'Abstract body'},
+        'messages': [
+            {'content_text': 'First message'},
+            {'content_text': ''},
+            {'content_text': 'Second message'},
+        ],
+    }]
+    contents = ROUTE_MODULE._collect_export_entry_contents(entries)
+
+    assert contents == ['Abstract body', 'First message', 'Second message'], contents
+
+    print("Export entry content collection passed!")
+
+
+if __name__ == "__main__":
+    tests: List[Callable[[], None]] = [
+        test_capability_probe_reports_a_complete_shape,
+        test_server_and_browser_renderers_share_configuration,
+        test_server_renders_diagrams_with_visible_labels,
+        test_server_skips_a_diagram_it_cannot_render,
+        test_server_render_deduplicates_and_caps_sources,
+        test_export_route_fills_only_uncovered_diagrams,
+        test_export_route_skips_rendering_when_there_are_no_diagrams,
+        test_export_route_degrades_when_chromium_is_unavailable,
+        test_export_route_renderer_failure_does_not_fail_the_export,
+        test_export_entry_content_collection,
+    ]
+
+    results = []
+    for test in tests:
+        print(f"\nRunning {test.__name__}...")
+        try:
+            test()
+            results.append(True)
+        except Exception as exc:
+            print(f"Test failed: {exc}")
+            import traceback
+
+            traceback.print_exc()
+            results.append(False)
+
+    print(f"\nResults: {sum(results)}/{len(results)} tests passed")
+    sys.exit(0 if all(results) else 1)


### PR DESCRIPTION
Follow-up to #1381, which shipped Mermaid and TeX rendering in exports. That relied on the user's browser to rasterize diagrams, which leaves a gap: an export started from an interface that does not rasterize, or anything server-initiated, still fell back to a code block.

This closes the gap using the Chromium the image **already installs**.

## Why a headless browser, and not something lighter

This was the first thing I checked, because a browser is a heavy hammer:

| Option | Browserless | Verdict |
|---|---|---|
| **Chromium via Playwright** | No | **Chosen** — already installed, real mermaid.js, output matches chat |
| `mmdr` (Rust, pip) | Yes | Real package with manylinux wheels, but **v0.3.0 from a single author** and a *reimplementation* rather than Mermaid — exports would drift from what V2 draws in chat since #1377 |
| jsdom / pure Node | Yes | Not viable — Mermaid needs `getBBox()` and `getComputedTextLength()`, which jsdom does not implement |
| Kroki / mermaid.ink | Yes | Third-party service; rules out sending conversation content |

The deciding factor is that **the cost is already paid**:

```
Dockerfile:4    ARG INSTALL_PLAYWRIGHT_CHROMIUM=true
Dockerfile:194  python3 -m playwright install chromium
```

Chromium ships for Source Review and Deep Research, on by default, with a documented opt-out. So this adds **no dependency, no install step, and no image growth** — and it uses real mermaid.js, so a server-rendered diagram matches what the chat displays.

`mmdr` is worth revisiting as it matures. The `visual_assets` contract would accept it with no API change, which was the point of matching on source text rather than a hash.

## Behaviour

Server rendering is strictly a **fallback**, not a replacement:

- A diagram the client already rasterized is **never re-rendered**
- Content with **no diagram never launches a browser** (verified: 0.00s, renderer not called)
- With `INSTALL_PLAYWRIGHT_CHROMIUM=false`, behaviour is **unchanged** — the fence stays a code block
- A renderer that throws is caught and logged; the export still succeeds
- One bad diagram in a batch does not lose the good ones

Both renderers load the same vendored bundle with the same configuration, including `htmlLabels: false` — which a test now asserts for both, since `<foreignObject>` labels vanish when an SVG is painted onto a canvas.

**Verified identical output:** the server and browser PNGs for the same flowchart are byte-for-byte the same (51,293 bytes, 163,238 painted pixels).

## Implementation

`functions_mermaid_server_render.py` launches one browser per export request and renders every outstanding diagram in a single session. The page has **no network access at all** — the bundle is inlined from disk and every request is aborted.

The route layer collects the diagram sources an export will render, subtracts what the client supplied, and renders only the remainder.

## Testing

| Suite | Result |
|---|---|
| `test_export_mermaid_server_render.py` (new) | 10/10 |
| `test_conversation_export_mermaid_tex_images.py` | 18/18 |
| `test_export_mermaid_browser_rasterizer.py` | 3/3 |
| `test_per_message_export.py` | 16/16 |
| Route policy | 12/12 |
| Docs coverage + site quality | 13/13 |

The new suite covers the capability probe, rendering with visible labels, error isolation, configuration parity with the browser renderer, and that the route renders only what the client did not. Rendering assertions skip themselves when Chromium is unavailable — the same condition under which the feature degrades.

## Note

`test_deep_research_chromium_build_opt_out.py::test_deployer_version_updated_for_build_contract` fails on this branch, but it fails identically on the base: it asserts an exact deployer version `1.0.4` against the current `1.0.26`. `deployers/` is untouched here. Worth fixing separately — the repo's own guidance says version assertions should not use exact equality.
