### PR TITLE
V2: show the configured web search and AI notices

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -97,7 +97,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.261.027"
+VERSION = "0.261.028"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/functions_settings.py
+++ b/application/single_app/functions_settings.py
@@ -58,6 +58,13 @@ CHAT_COMPLETION_AUDIO_SOUND_IDS = (
 )
 DEFAULT_CHAT_COMPLETION_AUDIO_SOUND = CHAT_COMPLETION_AUDIO_SOUND_IDS[0]
 DEFAULT_CHAT_COMPLETION_AUDIO_VOLUME = 5
+# Shared so the classic chat page and the V2 bootstrap payload cannot fall back to
+# different wording when an administrator blanks web_search_user_notice_text.
+WEB_SEARCH_USER_NOTICE_DEFAULT_TEXT = (
+    "Your current message will be sent to Microsoft Bing for web search. Conversation "
+    "history is not sent for web search, but any sensitive content you paste into this "
+    "message may be sent."
+)
 USER_UI_SETTINGS_KEYS = (
     "profileImage",
     "navLayout",
@@ -1772,7 +1779,7 @@ def get_settings(use_cosmos=False, include_source=False):
         'enable_web_search': False,
         'web_search_consent_accepted': False,
         'enable_web_search_user_notice': False,  # Show popup to users explaining their message will be sent to Bing
-        'web_search_user_notice_text': 'Your current message will be sent to Microsoft Bing for web search. Conversation history is not sent for web search, but any sensitive content you paste into this message may be sent.',
+        'web_search_user_notice_text': WEB_SEARCH_USER_NOTICE_DEFAULT_TEXT,
         'web_search_agent': {
             'agent_type': 'aifoundry',
             'azure_openai_gpt_endpoint': '',

--- a/application/single_app/route_backend_v2.py
+++ b/application/single_app/route_backend_v2.py
@@ -39,6 +39,7 @@ from functions_public_workspaces import (
     get_user_visible_public_workspace_ids_from_settings,
 )
 from functions_settings import (
+    WEB_SEARCH_USER_NOTICE_DEFAULT_TEXT,
     get_settings,
     get_user_settings,
     is_chat_file_upload_enabled_for_user,
@@ -57,6 +58,7 @@ from route_frontend_chats import (
     _is_chat_agent_allowed_by_governance,
 )
 from functions_agent_catalog import build_accessible_agent_catalog
+from functions_ai_notice import get_ai_notice_config, is_ai_notice_dismissed
 from config import VERSION
 from swagger_wrapper import get_auth_security, swagger_route
 
@@ -121,6 +123,43 @@ def _build_feature_flags(public_settings, per_user_overrides):
     }
     features.update(per_user_overrides)
     return features
+
+
+def _build_notices(public_settings, user_settings_dict):
+    """Describe the administrator-configured notices the chat surface must render.
+
+    Both notices exist in the server-rendered interface, where the AI notice arrives as
+    template context and the web search notice as a Jinja condition over three settings
+    keys. The SPA can read neither, so they are resolved here rather than in the browser:
+
+    - The AI notice carries a SHA-256 of its message and frequency, and whether the caller
+      has already dismissed it depends on a stored, server-timestamped record. Recomputing
+      either client-side would let the two interfaces disagree about whether an
+      administrator's edit should re-surface a notice somebody had dismissed.
+    - The web search notice depends on ``web_search_consent_accepted``, which is not an
+      ``enable_*`` key and so never reaches the feature flags the composer branches on.
+    """
+    ai_notice = get_ai_notice_config(public_settings)
+    ai_notice["dismissed"] = is_ai_notice_dismissed(ai_notice, user_settings_dict)
+
+    # All three are required, matching the condition in chats.html: the capability, the
+    # administrator's acknowledgement that messages leave the tenant, and the notice itself.
+    web_search_notice_enabled = bool(
+        public_settings.get("enable_web_search")
+        and public_settings.get("web_search_consent_accepted")
+        and public_settings.get("enable_web_search_user_notice")
+    )
+    web_search_notice_text = str(
+        public_settings.get("web_search_user_notice_text") or ""
+    ).strip()
+
+    return {
+        "ai": ai_notice,
+        "web_search": {
+            "enabled": web_search_notice_enabled,
+            "text": web_search_notice_text or WEB_SEARCH_USER_NOTICE_DEFAULT_TEXT,
+        },
+    }
 
 
 def register_route_backend_v2(bp):
@@ -299,6 +338,7 @@ def register_route_backend_v2(bp):
                     "public_workspaces": public_workspaces,
                 },
                 "admin_nav": ADMIN_NAV if "Admin" in current_user_roles else [],
+                "notices": _build_notices(public_settings, user_settings_dict),
                 "settings": public_settings,
             }
 

--- a/application/single_app/route_frontend_admin_settings.py
+++ b/application/single_app/route_frontend_admin_settings.py
@@ -2704,7 +2704,7 @@ def register_route_frontend_admin_settings(bp):
                 'enable_web_search': enable_web_search,
                 'web_search_consent_accepted': web_search_consent_accepted,
                 'enable_web_search_user_notice': form_data.get('enable_web_search_user_notice') == 'on',
-                'web_search_user_notice_text': form_data.get('web_search_user_notice_text', 'Your current message will be sent to Microsoft Bing for web search. Conversation history is not sent for web search, but any sensitive content you paste into this message may be sent.').strip(),
+                'web_search_user_notice_text': form_data.get('web_search_user_notice_text', WEB_SEARCH_USER_NOTICE_DEFAULT_TEXT).strip(),
                 'web_search_agent': {
                     'agent_type': 'aifoundry',
                     'azure_openai_gpt_endpoint': form_data.get('web_search_foundry_endpoint', '').strip(),

--- a/application/v2_ui/src/components/chat/AiNotice.tsx
+++ b/application/v2_ui/src/components/chat/AiNotice.tsx
@@ -1,0 +1,97 @@
+// AiNotice.tsx
+// The administrator-configured notice below the composer.
+//
+// Reproduces `chat-ai-notice.js`. Where it is stored depends on how often it may be
+// dismissed, and the four frequencies are not interchangeable:
+//
+//   non_dismissible  Always visible, no dismiss control at all.
+//   every_session    A browser-session fact, so it stays in sessionStorage.
+//   daily / once     Must outlive the tab, so the server records the dismissal and decides
+//                    on the next load whether it still applies.
+//
+// Nothing is rendered when the administrator has not configured a notice. The interface
+// deliberately does not substitute a generic disclaimer of its own: an organisation that
+// turned the notice off did so on purpose, and the classic interface honours that.
+
+import { useState } from 'react';
+import { Info, X } from 'lucide-react';
+import { useBootstrapStore } from '../../stores/bootstrapStore';
+import { useToastStore } from '../../stores/toastStore';
+import { dismissAiNotice } from '../../lib/endpoints';
+import {
+    aiNoticeSessionKey,
+    dismissNoticeForSession,
+    isNoticeDismissedForSession,
+} from '../../lib/notices';
+
+export function AiNotice() {
+    const notice = useBootstrapStore((state) => state.data?.notices?.ai);
+    const pushToast = useToastStore((state) => state.push);
+
+    // Read once at mount rather than on every render: this sits inside the composer, which
+    // re-renders on each keystroke, and session storage is a synchronous browser call.
+    // `every_session` is the only frequency stored here; the daily and once windows are
+    // already resolved on the payload, and non_dismissible is never dismissed at all.
+    const [dismissed, setDismissed] = useState(
+        () =>
+            notice?.frequency === 'every_session' &&
+            isNoticeDismissedForSession(aiNoticeSessionKey(notice.hash)),
+    );
+    const [saving, setSaving] = useState(false);
+
+    if (!notice?.enabled || !notice.message || notice.dismissed || dismissed) {
+        return null;
+    }
+
+    const dismissible = notice.frequency !== 'non_dismissible';
+
+    const onDismiss = async () => {
+        if (notice.frequency === 'every_session') {
+            if (!dismissNoticeForSession(aiNoticeSessionKey(notice.hash))) {
+                pushToast('error', 'This browser cannot save the session dismissal.');
+                return;
+            }
+            setDismissed(true);
+            return;
+        }
+
+        // Stays visible until the write lands. Hiding first would tell the user the notice
+        // is gone for the day when it may be back on the next page load.
+        setSaving(true);
+        try {
+            await dismissAiNotice(notice.hash, notice.frequency);
+            setDismissed(true);
+        } catch {
+            pushToast('error', 'The AI notice could not be dismissed. Please try again.');
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    return (
+        <section
+            aria-label="AI notice"
+            aria-live="polite"
+            className="mt-2 flex items-start gap-2 px-2"
+        >
+            <Info size={13} className="mt-[3px] shrink-0 text-accent" aria-hidden="true" />
+            {/* `whitespace-pre-line` because normalize_ai_notice_message keeps the line
+                breaks an administrator typed, and the classic notice renders them. */}
+            <p className="min-w-0 flex-1 text-[11px] leading-relaxed whitespace-pre-line text-text-3">
+                {notice.message}
+            </p>
+            {dismissible && (
+                <button
+                    type="button"
+                    onClick={() => void onDismiss()}
+                    disabled={saving}
+                    aria-label="Dismiss the AI notice"
+                    title="Dismiss"
+                    className="mt-[1px] shrink-0 rounded-md p-0.5 text-text-3 transition-colors hover:bg-surface-2 hover:text-text-1 disabled:cursor-not-allowed disabled:opacity-40"
+                >
+                    <X size={12} />
+                </button>
+            )}
+        </section>
+    );
+}

--- a/application/v2_ui/src/components/chat/Composer.tsx
+++ b/application/v2_ui/src/components/chat/Composer.tsx
@@ -32,7 +32,9 @@ import {
     supportsReasoning,
 } from '../../lib/reasoning';
 import { Dropdown, type DropdownOption } from '../ui/Dropdown';
+import { AiNotice } from './AiNotice';
 import { VoiceInput } from './VoiceInput';
+import { WebSearchNotice } from './WebSearchNotice';
 
 /** A capability toggle in the composer toolbar. */
 function ToolToggle({
@@ -263,6 +265,10 @@ export function Composer() {
                     </p>
                 )}
 
+                {/* Above the input, matching the classic interface: the warning belongs
+                    next to the message it is about, not below the send button. */}
+                <WebSearchNotice active={options.webSearch} />
+
                 <div className="glass glass-edge rounded-2xl p-2">
                     <label htmlFor="composer-input" className="sr-only">
                         Message
@@ -491,9 +497,7 @@ export function Composer() {
                     </div>
                 </div>
 
-                <p className="mt-2 text-center text-[11px] text-text-3">
-                    AI responses can be inaccurate. Verify important information.
-                </p>
+                <AiNotice />
             </div>
         </div>
     );

--- a/application/v2_ui/src/components/chat/WebSearchNotice.tsx
+++ b/application/v2_ui/src/components/chat/WebSearchNotice.tsx
@@ -1,0 +1,55 @@
+// WebSearchNotice.tsx
+// The banner shown above the composer while web search is armed.
+//
+// Reproduces the notice in `chats.html` and `chat-input-actions.js`: it appears only while
+// the Web toggle is on, because the point is to warn about *this* message leaving the
+// tenant, and a banner that is always present stops being read. Turning web search off
+// hides it again without consuming the dismissal.
+
+import { Info, X } from 'lucide-react';
+import { useState } from 'react';
+import { useBootstrapStore } from '../../stores/bootstrapStore';
+import {
+    WEB_SEARCH_NOTICE_SESSION_KEY,
+    dismissNoticeForSession,
+    isNoticeDismissedForSession,
+} from '../../lib/notices';
+
+export function WebSearchNotice({ active }: { active: boolean }) {
+    const notice = useBootstrapStore((state) => state.data?.notices?.web_search);
+
+    // Seeded from session storage so a dismissal survives switching conversations, which
+    // remounts the composer.
+    const [dismissed, setDismissed] = useState(() =>
+        isNoticeDismissedForSession(WEB_SEARCH_NOTICE_SESSION_KEY),
+    );
+
+    if (!notice?.enabled || !notice.text || !active || dismissed) {
+        return null;
+    }
+
+    return (
+        <div
+            role="note"
+            aria-live="polite"
+            className="mb-2 flex items-start gap-2 rounded-xl border border-edge bg-info-soft px-3 py-2"
+        >
+            <Info size={15} className="mt-0.5 shrink-0 text-info" aria-hidden="true" />
+            <p className="min-w-0 flex-1 text-xs leading-relaxed text-text-2">{notice.text}</p>
+            <button
+                type="button"
+                onClick={() => {
+                    // A refused write still hides it here: the notice is tied to the
+                    // toggle, so it comes back the next time web search is armed.
+                    dismissNoticeForSession(WEB_SEARCH_NOTICE_SESSION_KEY);
+                    setDismissed(true);
+                }}
+                aria-label="Dismiss the web search notice"
+                title="Dismiss"
+                className="shrink-0 rounded-md p-0.5 text-text-3 transition-colors hover:bg-surface-2 hover:text-text-1"
+            >
+                <X size={14} />
+            </button>
+        </div>
+    );
+}

--- a/application/v2_ui/src/lib/endpoints.ts
+++ b/application/v2_ui/src/lib/endpoints.ts
@@ -9,6 +9,7 @@ import { api, apiUrl, uploadFile, ApiError, API_BASE } from './apiClient';
 import type { EnhancedCitationMetadata } from './enhancedCitations';
 import type { MaskAction, MaskedRange, MaskSelection } from './masking';
 import type {
+    AiNoticeFrequency,
     BootstrapPayload,
     ChatMessage,
     ChatStreamRequest,
@@ -28,6 +29,24 @@ import type {
 
 export const fetchBootstrap = (signal?: AbortSignal) =>
     api.get<BootstrapPayload>('/api/v2/bootstrap', signal);
+
+/**
+ * Record that the caller has dismissed the AI notice.
+ *
+ * Deliberately a direct write rather than one routed through `userSettingsStore`. That
+ * store debounces, and rolls a failure back silently into a preference cache -- but the
+ * route replaces the posted value with its own server-timestamped record, so the cached
+ * value would never match what was stored. The button also needs a definite success or
+ * failure to decide whether the notice may disappear, which a fire-and-forget write cannot
+ * give it.
+ *
+ * Only `daily` and `once` reach here; `every_session` is a browser-session fact and is kept
+ * in sessionStorage, and `non_dismissible` has no dismiss control at all.
+ */
+export const dismissAiNotice = (hash: string, frequency: AiNoticeFrequency) =>
+    api.post<{ message?: string }>('/api/user/settings', {
+        settings: { aiNoticeDismissal: { hash, frequency } },
+    });
 
 /* -------------------------------------------------------------------------- */
 /* Conversations                                                               */

--- a/application/v2_ui/src/lib/notices.ts
+++ b/application/v2_ui/src/lib/notices.ts
@@ -1,0 +1,57 @@
+// notices.ts
+// Browser-session state for the two administrator-configured chat notices.
+//
+// The keys are deliberately the ones the classic interface already writes
+// (`chat-input-actions.js` and `chat-ai-notice.js`). A dismissal is a statement about the
+// person, not about which interface they happened to be looking at, so namespacing these
+// the way `v2RailCollapsed` is namespaced would make a notice the user had just dismissed
+// reappear when they switched interfaces in the same tab. The V2-prefixed preferences
+// describe V2's own chrome; these describe the user.
+//
+// sessionStorage throws in some privacy modes rather than returning null, and a notice is
+// not worth taking the page down for. Reads therefore fail closed -- the notice stays
+// visible -- and writes report failure so the caller can say the dismissal did not stick
+// instead of hiding a notice that will be back on the next page load.
+
+/** Set for the session once the web search notice has been dismissed. */
+export const WEB_SEARCH_NOTICE_SESSION_KEY = 'webSearchNoticeDismissed';
+
+/** Prefix for the per-message-version AI notice dismissal. */
+export const AI_NOTICE_SESSION_KEY_PREFIX = 'simplechat.aiNoticeDismissal';
+
+/**
+ * The session key for one version of the AI notice.
+ *
+ * Keyed by hash so that editing the notice text re-shows it, matching how the stored
+ * server-side dismissals are invalidated.
+ */
+export function aiNoticeSessionKey(noticeHash: string): string {
+    return `${AI_NOTICE_SESSION_KEY_PREFIX}.${noticeHash}`;
+}
+
+/** Whether the flag is set. False when session storage cannot be read. */
+export function isNoticeDismissedForSession(key: string): boolean {
+    try {
+        return sessionStorage.getItem(key) === 'true';
+    } catch (error) {
+        if (!(error instanceof DOMException)) {
+            throw error;
+        }
+        console.warn('Session storage is unavailable; the notice will remain visible.', error);
+        return false;
+    }
+}
+
+/** Set the flag. Returns false when session storage refused the write. */
+export function dismissNoticeForSession(key: string): boolean {
+    try {
+        sessionStorage.setItem(key, 'true');
+        return true;
+    } catch (error) {
+        if (!(error instanceof DOMException)) {
+            throw error;
+        }
+        console.warn('Session storage is unavailable; the dismissal was not saved.', error);
+        return false;
+    }
+}

--- a/application/v2_ui/src/lib/types.ts
+++ b/application/v2_ui/src/lib/types.ts
@@ -221,6 +221,31 @@ export interface WorkspaceRef {
     name: string;
 }
 
+/** How the AI notice may be dismissed. Mirrors `AI_NOTICE_FREQUENCIES`. */
+export type AiNoticeFrequency = 'non_dismissible' | 'every_session' | 'daily' | 'once';
+
+/**
+ * The administrator-configured notice shown below the composer.
+ *
+ * `hash` is a SHA-256 of the message and frequency, computed by `functions_ai_notice.py`.
+ * Editing the notice changes the hash, which invalidates every stored dismissal so the new
+ * wording is shown again. It is never recomputed in the browser.
+ */
+export interface AiNoticeConfig {
+    enabled: boolean;
+    message: string;
+    frequency: AiNoticeFrequency;
+    hash: string;
+    /** Whether the caller's stored dismissal still covers this notice. Server-decided. */
+    dismissed: boolean;
+}
+
+/** The notice shown while web search is armed, warning that the message leaves the tenant. */
+export interface WebSearchNoticeConfig {
+    enabled: boolean;
+    text: string;
+}
+
 /** Response shape of GET /api/v2/bootstrap. Assembled by route_backend_v2.py. */
 export interface BootstrapPayload {
     version: string;
@@ -259,6 +284,17 @@ export interface BootstrapPayload {
         public_workspaces: WorkspaceRef[];
     };
     admin_nav: AdminNavGroup[];
+    /**
+     * Administrator-configured chat notices, resolved server-side.
+     *
+     * Not derivable from `features`: the AI notice's dismissal state depends on a stored
+     * record, and the web search notice depends on `web_search_consent_accepted`, which is
+     * not an `enable_*` key and so never appears in `features`.
+     */
+    notices: {
+        ai: AiNoticeConfig;
+        web_search: WebSearchNoticeConfig;
+    };
     /** Sanitized settings. Never contains keys, secrets or connection strings. */
     settings: Json;
 }

--- a/application/v2_ui/src/lib/userSettings.ts
+++ b/application/v2_ui/src/lib/userSettings.ts
@@ -64,6 +64,15 @@ export interface UserSettings {
     /** Read-only here; the route sets it when the user hides the shortcut. */
     latestFeaturesHiddenVersion?: string | null;
 
+    /**
+     * The AI notice dismissal.
+     *
+     * Written through `dismissAiNotice()` rather than this store, and read back in a
+     * different shape: the client posts `{ hash, frequency }` and the route stores a
+     * server-timestamped record. Only the server reads it, at bootstrap.
+     */
+    aiNoticeDismissal?: { hash: string; frequency: string };
+
     [key: string]: unknown;
 }
 
@@ -92,6 +101,9 @@ export const WRITABLE_USER_SETTING_KEYS = [
     'ttsVoice',
     'ttsSpeed',
     'ttsAutoplay',
+    // Written by dismissAiNotice() rather than the preferences store, but listed here so
+    // the whitelist test still proves the route will accept it.
+    'aiNoticeDismissal',
 ] as const;
 
 export type WritableUserSettingKey = (typeof WRITABLE_USER_SETTING_KEYS)[number];

--- a/docs/explanation/features/CUSTOM_AI_NOTICE.md
+++ b/docs/explanation/features/CUSTOM_AI_NOTICE.md
@@ -15,10 +15,11 @@ Implemented in version: **0.250.102**
 - Session-only dismissals use browser session storage.
 - Daily and once-per-version dismissals use the authenticated user-settings API and are timestamped by the server.
 - Changing the notice text or display behavior creates a new hash, invalidating older dismissals.
+- Both interfaces render the notice. The classic interface receives it as template context; the React V2 interface receives it in the `notices` block of `/api/v2/bootstrap`, built from the same helpers, and shares the session dismissal key so a dismissal is not undone by switching interfaces.
 
 ### Configuration
 
-The **General** tab in Admin Settings provides:
+The **Notices & Agreements** tab in Admin Settings provides:
 
 - **Show a custom AI notice below the chat input**
 - **Notice Text**, limited to 1,000 plain-text characters
@@ -35,7 +36,7 @@ The message is rendered as escaped plain text with line breaks preserved. The fe
 ## Usage
 
 1. Open **Admin Settings**.
-2. Select the **General** tab.
+2. Select the **Notices & Agreements** tab.
 3. Enable **Chat AI Notice**.
 4. Enter the notice text and choose a display behavior.
 5. Save the settings.
@@ -46,6 +47,7 @@ The configured notice appears beneath the chat composer for users who have not d
 
 - `functional_tests/test_ai_notice.py` covers normalization, hashing, record validation, and recurrence behavior.
 - `functional_tests/test_user_settings_allowlist_keys.py` covers dismissal persistence allowlisting.
+- `functional_tests/test_v2_chat_notices.py` covers the React V2 interface: the bootstrap `notices` block, all four frequencies, and the shared session dismissal key.
 - `ui_tests/test_chat_ai_notice_ui.py` covers admin controls and desktop/mobile placement.
 
 Known limitation: session-only dismissals are specific to the current browser tab session. Daily and once-per-version dismissals follow the signed-in user across supported clients.

--- a/docs/explanation/features/REACT_V2_UI.md
+++ b/docs/explanation/features/REACT_V2_UI.md
@@ -137,6 +137,7 @@ Response fields:
 | `catalogs` | Models, agents, prompts, and the initial model selection |
 | `scope` | Active group and public workspace, plus the lists the user can pick from |
 | `admin_nav` | The `ADMIN_NAV` structure — **only** for users holding the Admin role |
+| `notices` | The two administrator-configured chat notices, resolved server-side |
 | `settings` | Settings passed through `sanitize_settings_for_user()` |
 
 Settings returned here are always sanitized. The logo is reported as a URL rather than the
@@ -231,6 +232,7 @@ Wired to the live APIs:
 - Generated images rendered inline, opening in a viewer with fit and actual-size zoom, a
   download and a link to the raw file, and a conversation badge showing the group or public
   workspace the conversation is working in
+- The administrator-configured web search and AI notices
 
 The SSE reader in `src/lib/sse.ts` reproduces the framing rules of
 `static/js/chat/chat-streaming.js` exactly, including the repair for frames whose blank-line
@@ -484,6 +486,44 @@ rules from `chat-input-actions.js` are reproduced:
 
 A control that stops being relevant also clears its option, so a request never carries a
 capability the user can no longer see they enabled.
+
+### Notices
+
+Two notices are configured by an administrator, and both are reproduced from the classic
+interface rather than reinvented.
+
+The **web search notice** (`enable_web_search_user_notice`, text in
+`web_search_user_notice_text`) sits above the input and appears only while the Web toggle is
+armed. A banner that is always present stops being read, and the thing it warns about — this
+message leaving the tenant — only happens when web search is on. Turning web search off hides
+it again without consuming the dismissal, which is held for the browser session.
+
+The **AI notice** (`enable_ai_notice`, `ai_notice_message`, `ai_notice_frequency`) sits below
+the composer. Where a dismissal is stored depends on how long it has to last:
+`every_session` is a browser-session fact and stays in `sessionStorage`; `daily` and `once`
+outlive the tab, so they are written to `/api/user/settings` as `aiNoticeDismissal` and the
+server decides on each load whether the window still applies. `non_dismissible` renders no
+dismiss control at all. The notice is hidden only after the write succeeds — hiding first
+would tell a user the notice is gone for the day when it may be back on the next load.
+
+Neither is derivable from `features`, which is why `/api/v2/bootstrap` carries a `notices`
+block instead:
+
+- The AI notice's version hash is a SHA-256 of its message and frequency, computed by
+  `functions_ai_notice.py`. Editing the notice changes the hash and invalidates every stored
+  dismissal, so the new wording is shown again. Recomputing that in the browser would let the
+  two interfaces disagree about whether somebody had dismissed it.
+- The web search notice additionally requires `web_search_consent_accepted`, which is not an
+  `enable_*` key and therefore never reaches the feature flags.
+
+When an administrator has not enabled the AI notice, V2 shows nothing there. It deliberately
+does not substitute a generic disclaimer of its own: an organisation that turned the notice
+off did so on purpose, and the classic interface honours that.
+
+Both notices render administrator text as an ordinary React child, so it is escaped. Session
+storage is read through `src/lib/notices.ts`, which tolerates the privacy modes where
+`sessionStorage` throws instead of returning `null` — a notice is not worth taking the page
+down for, so a read that fails leaves the notice visible and a write that fails says so.
 
 ### Chat width
 
@@ -751,6 +791,7 @@ this entirely and is the recommended layout.
 | `functional_tests/test_v2_model_identity_and_scope.py` | The whole model identity is sent and the picker keys on `selection_key`, the document scope is computed rather than hardcoded, and workspace ids travel with it |
 | `functional_tests/test_v2_rich_rendering.py` | Browser libraries vendored into the repository with their licences and pinned versions, no equivalent npm dependency, KaTeX fonts complete and locally resolvable, a sanitizer boundary at every HTML sink and nowhere else, KaTeX `trust: false`, mermaid strict with no autostart or icon packs, single `$` not treated as maths, fence wiring and chart language parity with the backend, charts copied as data, CSP unchanged |
 | `functional_tests/test_v2_generated_image_lightbox.py` | The image thumbnail opens a dialog rather than a new tab, the dialog is dismissable and manages focus, every source kind is handled by download and open-in-new-tab, and `window.open` is not given `noopener` |
+| `functional_tests/test_v2_chat_notices.py` | Both notices resolved server-side from the shared helpers, the web search notice's three-key condition including consent, all four AI notice frequencies, dismissal only after a successful write, session keys shared with the classic interface, no hardcoded disclaimer, notice text escaped |
 | `functional_tests/test_csrf_state_changing_route_guard.py` | Cross-site mutations require an explicitly trusted origin; CORS preflights answered before authentication and never wildcarded |
 | `functional_tests/route_tests/` | Blueprint policy classification for `frontend_v2`, `backend_v2`, `backend_v2_admin` |
 

--- a/docs/explanation/fixes/V2_CHAT_NOTICES_FIX.md
+++ b/docs/explanation/fixes/V2_CHAT_NOTICES_FIX.md
@@ -1,0 +1,167 @@
+# V2 Chat Notices Fix
+
+## Issue
+
+The classic (V1) chat page renders two administrator-configured notices around the composer.
+The V2 React interface rendered neither, so an organisation that had configured them lost
+both the moment a user switched to V2 — including the data-handling warning that tells people
+their message is about to leave the tenant.
+
+Instead, V2 ended its composer with a hardcoded line of its own:
+
+> AI responses can be inaccurate. Verify important information.
+
+That is not the same thing. It is not the administrator's wording, it cannot be turned off,
+it cannot be dismissed, and it appeared even for organisations that had deliberately
+configured different text.
+
+**Fixed in version: 0.261.028**
+
+## Root cause
+
+Both notices reach the classic page through Jinja template context, which a single-page
+application cannot read.
+
+- **Web search notice** — `templates/chats.html` renders it behind
+  `enable_web_search and web_search_consent_accepted and enable_web_search_user_notice`, with
+  the copy from `web_search_user_notice_text`. `static/js/chat/chat-input-actions.js` shows
+  and hides it as the Web toggle changes and records a session dismissal.
+- **AI notice** — `route_frontend_chats.chats` passes an `ai_notice` dict built by
+  `functions_ai_notice.get_ai_notice_config()` and marked with
+  `is_ai_notice_dismissed()`. `static/js/chat/chat-ai-notice.js` handles the four dismissal
+  frequencies.
+
+`/api/v2/bootstrap` mirrors that template context, but neither notice had been added to it.
+Neither is derivable from what the payload already carried:
+
+- The AI notice's `hash` is a SHA-256 of its message and frequency. It is what invalidates
+  stored dismissals when an administrator edits the wording, and whether the current user's
+  dismissal still applies depends on a stored, server-timestamped record and a date window.
+- The web search notice's condition includes `web_search_consent_accepted`, which does not
+  start with `enable_` and so was never forwarded by `_build_feature_flags`.
+
+## Files modified
+
+| File | Change |
+|---|---|
+| `application/single_app/functions_settings.py` | Added `WEB_SEARCH_USER_NOTICE_DEFAULT_TEXT` and used it for the settings default |
+| `application/single_app/route_frontend_admin_settings.py` | Use the shared constant instead of a repeated literal |
+| `application/single_app/route_backend_v2.py` | New `_build_notices()`; `notices` added to the bootstrap payload |
+| `application/v2_ui/src/lib/types.ts` | `AiNoticeConfig`, `WebSearchNoticeConfig`, `notices` on `BootstrapPayload` |
+| `application/v2_ui/src/lib/endpoints.ts` | `dismissAiNotice(hash, frequency)` |
+| `application/v2_ui/src/lib/userSettings.ts` | `aiNoticeDismissal` declared as a key the client writes |
+| `application/v2_ui/src/lib/notices.ts` | **New.** Session-storage keys and fault-tolerant read/write |
+| `application/v2_ui/src/components/chat/WebSearchNotice.tsx` | **New.** Banner above the input |
+| `application/v2_ui/src/components/chat/AiNotice.tsx` | **New.** Banner below the composer |
+| `application/v2_ui/src/components/chat/Composer.tsx` | Renders both; hardcoded disclaimer removed |
+| `application/single_app/config.py` | `VERSION` → `0.261.028` |
+
+## Technical details
+
+### Notices are resolved on the server
+
+`_build_notices()` calls the same `get_ai_notice_config()` and `is_ai_notice_dismissed()`
+helpers the classic page uses, so the hash and the dismissal window are computed in exactly
+one place. `route_backend_v2.py` deliberately does not hash anything itself; the functional
+test asserts that, because a second implementation of the hash would let the two interfaces
+disagree about whether an edited notice should reappear for someone who had dismissed the
+previous wording.
+
+The web search condition is evaluated server-side for the same reason it could not be done in
+`composerGating.ts`: `web_search_consent_accepted` is not a feature flag.
+
+The block is built from `sanitize_settings_for_user()` output, not the raw settings document.
+
+```json
+"notices": {
+  "ai": {
+    "enabled": true,
+    "message": "AI generated response may contain inaccuracies",
+    "frequency": "every_session",
+    "hash": "<sha256 of message + frequency>",
+    "dismissed": false
+  },
+  "web_search": {
+    "enabled": true,
+    "text": "Your current message will be sent to Microsoft Bing for web search. ..."
+  }
+}
+```
+
+### Dismissals go where they can survive long enough
+
+| Frequency | Stored | Why |
+|---|---|---|
+| `non_dismissible` | — | No dismiss control is rendered |
+| `every_session` | `sessionStorage` | A browser-session fact; the server has nothing to add |
+| `daily`, `once` | `/api/user/settings` → `aiNoticeDismissal` | Must outlive the tab, and the window is evaluated against a server timestamp |
+
+The `daily` and `once` write goes through a dedicated `dismissAiNotice()` helper rather than
+the debounced `userSettingsStore`. That store rolls a failure back silently into a preference
+cache, but the route replaces the posted value with its own timestamped record, so the cached
+value would never match what was stored — and the button needs a definite success or failure
+to decide whether the notice may disappear. The notice therefore stays visible until the
+write lands, and a failure raises a toast rather than looking like a dead button.
+
+`aiNoticeDismissal` was already in the route's `allowed_keys`; it is now also declared in
+`WRITABLE_USER_SETTING_KEYS`, so the existing whitelist test covers it. A key outside that
+set is dropped silently, with the POST still returning success.
+
+### Session keys are shared with the classic interface
+
+`webSearchNoticeDismissed` and `simplechat.aiNoticeDismissal.<hash>` are the keys the classic
+client already writes, and V2 reuses them rather than namespacing them the way
+`v2RailCollapsed` is namespaced. A dismissal is a statement about the person, not about which
+interface they happened to be looking at; namespacing would make a notice the user had just
+dismissed reappear when they switched interfaces in the same tab. The V2-prefixed preferences
+are different — they describe V2's own chrome.
+
+`sessionStorage` throws rather than returning `null` in some privacy modes, and a notice is
+not worth taking the page down for. Reads fail closed, leaving the notice visible; writes
+report failure so the caller can say the dismissal did not stick.
+
+### Behaviour when nothing is configured
+
+Nothing renders. This was an explicit decision rather than an oversight: V2 no longer
+substitutes a generic disclaimer, because an organisation that turned the AI notice off did so
+on purpose and the classic interface honours that. The removed hardcoded line was also
+untranslatable, unconfigurable and undismissable, which is the opposite of what the notice
+feature exists to provide.
+
+## Validation
+
+| Check | Result |
+|---|---|
+| `functional_tests/test_v2_chat_notices.py` | 8/8 passed |
+| `functional_tests/test_v2_api_payload_shapes.py` | Passed |
+| `functional_tests/test_v2_settings_and_workspace_tags.py` | Passed — `aiNoticeDismissal` is whitelisted |
+| `functional_tests/test_v2_settings_tabs.py` | Passed |
+| `functional_tests/test_v2_ui_local_assets.py` | Passed — no new browser assets, CSP unchanged |
+| `functional_tests/test_docs_app_surface_coverage.py` | Passed — no new settings keys, inventory unchanged |
+| `npm run typecheck` (`application/v2_ui`) | Clean |
+
+### Before and after
+
+| | Before | After |
+|---|---|---|
+| Web search notice in V2 | Never shown | Shown above the input while Web is armed, dismissible for the session |
+| AI notice in V2 | Never shown | Shown below the composer, honouring all four frequencies |
+| AI notice disabled | V2 showed its own hardcoded line | Nothing, matching V1 |
+| Administrator edits the notice text | No effect on V2 | Hash changes, dismissals invalidated, new wording shown again |
+
+## Notes
+
+- No new settings keys were introduced. Both capabilities already exist in admin settings
+  (**Web & Research** → Web Search, and **Notices & Agreements** → Chat AI Notice) and are
+  already documented, so `docs/_data/app_surface.yml` is unchanged.
+- No new browser assets. Both components use existing `lucide-react` icons and the existing
+  `info` / `info-soft` theme tokens.
+- Notice text is administrator-entered and is rendered as a plain React child, so React
+  escapes it. There is no `dangerouslySetInnerHTML` on either component, matching the classic
+  interface's use of `textContent` and Jinja escaping.
+
+## Related
+
+- `docs/explanation/features/REACT_V2_UI.md` — "Notices"
+- `docs/explanation/features/v0.237.001/WEB_SEARCH_AZURE_AI_FOUNDRY.md`
+- `application/single_app/functions_ai_notice.py`

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,19 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/features) and [Fixes by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/fixes).
 
+### **(v0.261.028)**
+
+#### Bug Fixes
+
+*   **Your Configured Chat Notices Now Appear In The V2 Interface**
+    *   Two notices administrators can configure — the data-handling notice shown when web search is used, and the AI notice shown under the message box — appeared in the classic interface but never in V2. Anyone who switched interfaces stopped seeing them.
+    *   The web search notice now appears above the message box while web search is turned on, using your configured wording, and can be dismissed for the rest of the browser session. It requires the same three settings as before, including the consent acknowledgement.
+    *   The AI notice now appears below the message box and respects all four display behaviours: always visible, dismissible once per session, once per day, or once per message version. Editing the notice text still brings it back for everyone who had dismissed the previous wording.
+    *   A dismissal now carries across both interfaces in the same browser session, rather than reappearing when you switch.
+    *   Dismissing the notice waits for the change to save, so it no longer disappears and then return on the next page load. A failed save is now reported instead of looking like a dead button.
+    *   **Behaviour change**: V2 previously showed its own fixed line, "AI responses can be inaccurate. Verify important information.", regardless of your settings. That line has been removed. If you want a notice under the message box, enable the AI notice in Admin Settings → Notices & Agreements → Chat AI Notice and set your own wording; if the AI notice is turned off, V2 now shows nothing there, matching the classic interface.
+    *   (Ref: V2 chat composer, web search user notice, chat AI notice, `/api/v2/bootstrap`)
+
 ### **(v0.261.027)**
 
 #### New Features

--- a/functional_tests/test_v2_chat_notices.py
+++ b/functional_tests/test_v2_chat_notices.py
@@ -1,0 +1,343 @@
+#!/usr/bin/env python3
+"""
+Functional test for the V2 chat notices (web search notice and AI notice).
+
+Version: 0.261.028
+Implemented in: 0.261.028
+
+The server-rendered chat page renders two administrator-configured notices around the
+composer, and the V2 React interface rendered neither. This test pins the parts of that
+parity that are easy to lose again:
+
+- the bootstrap payload resolves both notices server-side, reusing the same helpers the
+  classic page uses rather than recomputing the AI notice hash or the dismissal window in
+  the browser;
+- the web search notice still requires all three settings keys, including
+  ``web_search_consent_accepted``, which is not an ``enable_*`` key and therefore never
+  reaches the feature flags the composer branches on;
+- the composer renders both notices and no longer substitutes a hardcoded disclaimer of its
+  own, which would have contradicted an administrator who turned the notice off;
+- all four AI notice frequencies are handled, and ``non_dismissible`` has no dismiss
+  control;
+- the session storage keys still match the ones the classic interface writes, so a
+  dismissal is not undone by switching interfaces in the same tab.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+APP_DIR = REPO_ROOT / "application" / "single_app"
+V2_SRC = REPO_ROOT / "application" / "v2_ui" / "src"
+
+sys.path.insert(0, str(REPO_ROOT / "functional_tests"))
+
+from test_support.versioning import assert_app_version_at_least  # noqa: E402
+
+
+IMPLEMENTED_IN_VERSION = "0.261.028"
+
+# Quoted from the classic client so a rename on either side is caught here.
+LEGACY_WEB_SEARCH_SESSION_KEY = "webSearchNoticeDismissed"
+LEGACY_AI_NOTICE_SESSION_PREFIX = "simplechat.aiNoticeDismissal"
+
+AI_NOTICE_FREQUENCIES = ("non_dismissible", "every_session", "daily", "once")
+
+
+def _read(path):
+    return path.read_text(encoding="utf-8")
+
+
+def test_bootstrap_resolves_both_notices_with_the_shared_helpers():
+    """The bootstrap payload carries a notices block built from functions_ai_notice."""
+    print("Testing the bootstrap notices block...")
+
+    route = _read(APP_DIR / "route_backend_v2.py")
+
+    assert "def _build_notices(" in route, (
+        "route_backend_v2.py must build the notices block; the SPA cannot read the Jinja "
+        "context the classic chat page uses"
+    )
+    assert '"notices": _build_notices(' in route, (
+        "The bootstrap payload must include a notices field, or the V2 composer has "
+        "nothing to render"
+    )
+
+    # The hash and the dismissal window must come from the same code the classic page runs.
+    assert "from functions_ai_notice import" in route, (
+        "The notices block must reuse functions_ai_notice rather than reimplementing it"
+    )
+    assert "get_ai_notice_config(public_settings)" in route, (
+        "The AI notice config must come from get_ai_notice_config"
+    )
+    assert "is_ai_notice_dismissed(ai_notice, user_settings_dict)" in route, (
+        "Whether the caller has dismissed the notice must be decided by "
+        "is_ai_notice_dismissed, not recomputed"
+    )
+
+    # Recomputing the version hash in the route (or the browser) would let the two
+    # interfaces disagree about whether an edited notice should reappear.
+    assert "sha256" not in route and "compute_ai_notice_hash" not in route, (
+        "route_backend_v2.py must not compute the AI notice hash itself; "
+        "get_ai_notice_config already provides it"
+    )
+
+    # Sanitized settings only. The notice text is safe, but the rule is the rule.
+    assert "_build_notices(public_settings" in route, (
+        "The notices block must be built from sanitize_settings_for_user() output"
+    )
+
+    print("Bootstrap notices block test passed!")
+    return True
+
+
+def test_web_search_notice_requires_all_three_settings():
+    """Consent is part of the condition, and is not an enable_ flag."""
+    print("Testing the web search notice condition...")
+
+    route = _read(APP_DIR / "route_backend_v2.py")
+    builder = route.split("def _build_notices(")[1].split("\ndef ")[0]
+
+    for key in (
+        "enable_web_search",
+        "web_search_consent_accepted",
+        "enable_web_search_user_notice",
+    ):
+        assert f'"{key}"' in builder, (
+            f"The web search notice must require {key}, matching the condition in chats.html"
+        )
+
+    # _build_feature_flags only forwards boolean keys starting with enable_, so consent
+    # never reaches `features`. That is exactly why this lives on the server.
+    assert not re.search(
+        r"features\[.web_search_consent_accepted", route
+    ), "web_search_consent_accepted is not an enable_ key and is not a feature flag"
+
+    settings_source = _read(APP_DIR / "functions_settings.py")
+    assert "WEB_SEARCH_USER_NOTICE_DEFAULT_TEXT" in settings_source, (
+        "The default notice text must be a shared constant so V1 and V2 cannot fall back "
+        "to different wording"
+    )
+    assert "WEB_SEARCH_USER_NOTICE_DEFAULT_TEXT" in route, (
+        "The bootstrap builder must reuse the shared default notice text"
+    )
+    assert (
+        "'web_search_user_notice_text': WEB_SEARCH_USER_NOTICE_DEFAULT_TEXT"
+        in settings_source
+    ), "The settings default must be the shared constant rather than a repeated literal"
+
+    print("Web search notice condition test passed!")
+    return True
+
+
+def test_the_client_types_the_notices_payload():
+    """The SPA declares the shape it reads, including the server-decided dismissal."""
+    print("Testing the client notice types...")
+
+    types_source = _read(V2_SRC / "lib" / "types.ts")
+
+    assert "export interface AiNoticeConfig" in types_source
+    assert "export interface WebSearchNoticeConfig" in types_source
+    assert "notices: {" in types_source, (
+        "BootstrapPayload must declare the notices field"
+    )
+
+    for frequency in AI_NOTICE_FREQUENCIES:
+        assert f"'{frequency}'" in types_source, (
+            f"AiNoticeFrequency must include {frequency}, which the server may send"
+        )
+
+    assert "dismissed: boolean" in types_source, (
+        "The AI notice's dismissed state is decided by the server and must be read, not "
+        "recomputed in the browser"
+    )
+
+    print("Client notice type test passed!")
+    return True
+
+
+def test_the_ai_notice_handles_every_frequency():
+    """Each frequency is stored where it belongs, and non_dismissible has no control."""
+    print("Testing AI notice dismissal handling...")
+
+    notice = _read(V2_SRC / "components" / "chat" / "AiNotice.tsx")
+
+    assert "notice.frequency !== 'non_dismissible'" in notice, (
+        "A non_dismissible notice must not render a dismiss button"
+    )
+    assert "notice.frequency === 'every_session'" in notice, (
+        "every_session must be dismissed into session storage, not sent to the server"
+    )
+    assert "dismissAiNotice(notice.hash, notice.frequency)" in notice, (
+        "daily and once must be persisted server-side, since they outlive the tab"
+    )
+
+    # The server already answered this for daily/once; ignoring it would re-show a notice
+    # the user dismissed yesterday.
+    assert "notice.dismissed" in notice, (
+        "The component must honour the server-decided dismissed flag"
+    )
+
+    # Hiding before the write lands would claim a dismissal that never happened.
+    try_block = re.search(r"try \{(.*?)\} catch", notice, re.DOTALL)
+    assert try_block, "The server-side dismissal must be guarded by try/catch"
+    assert try_block.group(1).index("await dismissAiNotice") < try_block.group(1).index(
+        "setDismissed(true)"
+    ), "The notice must only hide after the dismissal write succeeds"
+    assert "pushToast('error'" in notice, (
+        "A failed dismissal must be reported; otherwise the button looks dead"
+    )
+
+    # An unconfigured notice renders nothing at all, matching the classic interface.
+    assert "!notice?.enabled" in notice and "!notice.message" in notice, (
+        "Nothing must render when the administrator has not configured a notice"
+    )
+
+    # normalize_ai_notice_message keeps the administrator's line breaks, and the classic
+    # notice renders them with white-space: pre-line.
+    assert "whitespace-pre-line" in notice, (
+        "The notice must preserve the line breaks an administrator typed"
+    )
+    app_css = _read(APP_DIR / "static" / "css" / "chats.css")
+    assert "white-space: pre-line" in app_css.split(".ai-notice-message")[1].split("}")[0], (
+        "The classic notice no longer preserves line breaks; the V2 notice mirrors it"
+    )
+
+    print("AI notice dismissal test passed!")
+    return True
+
+
+def test_session_keys_match_the_classic_interface():
+    """A dismissal follows the person, not the interface they were looking at."""
+    print("Testing session storage key agreement...")
+
+    notices = _read(V2_SRC / "lib" / "notices.ts")
+    classic_input_actions = _read(APP_DIR / "static" / "js" / "chat" / "chat-input-actions.js")
+    classic_ai_notice = _read(APP_DIR / "static" / "js" / "chat" / "chat-ai-notice.js")
+
+    assert f'"{LEGACY_WEB_SEARCH_SESSION_KEY}"' in classic_input_actions, (
+        "The classic web search notice key changed; update the V2 client to match"
+    )
+    assert f"'{LEGACY_AI_NOTICE_SESSION_PREFIX}'" in classic_ai_notice, (
+        "The classic AI notice key changed; update the V2 client to match"
+    )
+
+    assert f"'{LEGACY_WEB_SEARCH_SESSION_KEY}'" in notices, (
+        "V2 must reuse the classic web search dismissal key so switching interfaces in "
+        "one tab does not resurrect a dismissed notice"
+    )
+    assert f"'{LEGACY_AI_NOTICE_SESSION_PREFIX}'" in notices, (
+        "V2 must reuse the classic AI notice dismissal key"
+    )
+
+    # Keyed by hash on both sides, so editing the notice re-shows it.
+    assert "${AI_NOTICE_SESSION_KEY_PREFIX}.${noticeHash}" in notices, (
+        "The AI notice session key must be scoped by the notice hash"
+    )
+
+    # sessionStorage throws rather than returning null in some privacy modes.
+    assert "DOMException" in notices, (
+        "Session storage access must tolerate privacy modes that throw"
+    )
+
+    print("Session key agreement test passed!")
+    return True
+
+
+def test_the_composer_renders_both_notices_and_no_hardcoded_disclaimer():
+    """V2 defers to the administrator instead of inventing its own disclaimer."""
+    print("Testing composer wiring...")
+
+    composer = _read(V2_SRC / "components" / "chat" / "Composer.tsx")
+
+    assert "<WebSearchNotice active={options.webSearch} />" in composer, (
+        "The web search notice must be tied to the Web toggle, matching the classic client"
+    )
+    assert "<AiNotice />" in composer, "The AI notice must render below the composer"
+
+    assert "AI responses can be inaccurate" not in composer, (
+        "The hardcoded disclaimer must be gone: an organisation that disabled the AI "
+        "notice did so deliberately, and the classic interface honours that"
+    )
+
+    web_search_notice = _read(V2_SRC / "components" / "chat" / "WebSearchNotice.tsx")
+    assert "!active" in web_search_notice, (
+        "The web search notice must only appear while web search is armed"
+    )
+
+    # Rendered as a React child, which escapes it. dangerouslySetInnerHTML on
+    # administrator-entered text would be an injection route.
+    for source in (composer, web_search_notice, _read(V2_SRC / "components" / "chat" / "AiNotice.tsx")):
+        assert "dangerouslySetInnerHTML" not in source, (
+            "Notice text is administrator-entered and must be escaped by React"
+        )
+
+    print("Composer wiring test passed!")
+    return True
+
+
+def test_the_dismissal_key_is_accepted_by_the_settings_route():
+    """An unlisted key is dropped silently, so the write has to be whitelisted."""
+    print("Testing the dismissal settings key...")
+
+    users = _read(APP_DIR / "route_backend_users.py")
+    assert "'aiNoticeDismissal'" in users, (
+        "aiNoticeDismissal must be in allowed_keys or the POST succeeds and discards it"
+    )
+    assert "build_ai_notice_dismissal_record(" in users, (
+        "The route must rewrite the posted value into a server-timestamped record"
+    )
+
+    client_settings = _read(V2_SRC / "lib" / "userSettings.ts")
+    writable = client_settings.split("WRITABLE_USER_SETTING_KEYS")[1].split("]")[0]
+    assert "'aiNoticeDismissal'" in writable, (
+        "The V2 client declares every settings key it writes, so the whitelist test covers it"
+    )
+
+    endpoints = _read(V2_SRC / "lib" / "endpoints.ts")
+    assert "export const dismissAiNotice" in endpoints, (
+        "The dismissal must have its own endpoint helper"
+    )
+    assert "aiNoticeDismissal: { hash, frequency }" in endpoints, (
+        "The dismissal payload must carry the hash and frequency the route validates"
+    )
+
+    print("Dismissal settings key test passed!")
+    return True
+
+
+def test_version_is_at_least_implementation_version():
+    """The application version is at or beyond the version that carried this work."""
+    print("Testing application version...")
+    assert_app_version_at_least(IMPLEMENTED_IN_VERSION)
+    print("Application version test passed!")
+    return True
+
+
+if __name__ == "__main__":
+    tests = [
+        test_bootstrap_resolves_both_notices_with_the_shared_helpers,
+        test_web_search_notice_requires_all_three_settings,
+        test_the_client_types_the_notices_payload,
+        test_the_ai_notice_handles_every_frequency,
+        test_session_keys_match_the_classic_interface,
+        test_the_composer_renders_both_notices_and_no_hardcoded_disclaimer,
+        test_the_dismissal_key_is_accepted_by_the_settings_route,
+        test_version_is_at_least_implementation_version,
+    ]
+
+    results = []
+    for test in tests:
+        print(f"\nRunning {test.__name__}...")
+        try:
+            results.append(bool(test()))
+        except Exception as exc:  # noqa: BLE001 - surface any failure with a traceback
+            print(f"Test failed: {exc}")
+            import traceback
+
+            traceback.print_exc()
+            results.append(False)
+
+    print(f"\nResults: {sum(results)}/{len(results)} tests passed")
+    sys.exit(0 if all(results) else 1)


### PR DESCRIPTION
## Problem

The classic chat page renders two administrator-configured notices around the composer. V2 rendered **neither**, so anyone who switched interfaces silently stopped seeing them — including the notice warning that their message is about to leave the tenant.

Instead, V2 ended its composer with a hardcoded line of its own:

> AI responses can be inaccurate. Verify important information.

That is not the same thing. It is not the administrator's wording, it cannot be turned off, it cannot be dismissed, and it appeared even for organisations that had deliberately configured different text.

| | Legacy (V1) | V2 before | V2 after |
|---|---|---|---|
| Web search notice | ✅ | ❌ | ✅ |
| AI notice | ✅ | ❌ | ✅ |
| AI notice disabled | Nothing | Hardcoded line | Nothing |

## Why it needed a server-side change

Both notices reach the classic page through Jinja template context, which a SPA cannot read — and neither was derivable from what `/api/v2/bootstrap` already carried:

- The **AI notice**'s `hash` is a SHA-256 of its message and frequency. It is what invalidates stored dismissals when an administrator edits the wording, and whether the caller's dismissal still applies depends on a stored, server-timestamped record and a date window.
- The **web search notice**'s condition includes `web_search_consent_accepted`, which does not start with `enable_` and so was never forwarded by `_build_feature_flags`. That is why it could not live in `composerGating.ts`.

So bootstrap gains a `notices` block built from the *same* `functions_ai_notice` helpers the classic page uses. `route_backend_v2.py` deliberately does not hash anything itself, and a test asserts that — a second implementation of the hash would let the two interfaces disagree about whether an edited notice should reappear for someone who had dismissed the previous wording.

```json
"notices": {
  "ai": { "enabled": true, "message": "…", "frequency": "every_session", "hash": "<sha256>", "dismissed": false },
  "web_search": { "enabled": true, "text": "…" }
}
```

## Behaviour

The **web search notice** sits above the input and appears only while the Web toggle is armed — a banner that is always present stops being read, and the thing it warns about only happens when web search is on. Turning web search off hides it without consuming the dismissal.

The **AI notice** sits below the composer. Where a dismissal is stored depends on how long it has to last:

| Frequency | Stored | Why |
|---|---|---|
| `non_dismissible` | — | No dismiss control is rendered |
| `every_session` | `sessionStorage` | A browser-session fact; the server has nothing to add |
| `daily`, `once` | `/api/user/settings` → `aiNoticeDismissal` | Must outlive the tab, and the window is evaluated against a server timestamp |

The notice hides **only after the write lands**. Hiding first would tell a user the notice is gone for the day when it may be back on the next load. A failed write raises a toast rather than looking like a dead button.

`daily`/`once` go through a dedicated `dismissAiNotice()` helper rather than the debounced `userSettingsStore`: that store rolls failures back silently into a preference cache, but the route replaces the posted value with its own timestamped record, so the cached value would never match what was stored.

Session keys are **shared with the classic interface** (`webSearchNoticeDismissed`, `simplechat.aiNoticeDismissal.<hash>`) rather than namespaced the way `v2RailCollapsed` is. A dismissal is a statement about the person, not about which interface they happened to be looking at; namespacing would make a just-dismissed notice reappear on switching interfaces in the same tab. `sessionStorage` throws rather than returning `null` in some privacy modes, so reads fail closed and writes report failure.

## ⚠️ Behaviour change

The hardcoded *"AI responses can be inaccurate. Verify important information."* line is **removed**. When the AI notice is disabled, V2 now shows nothing there, matching the classic interface — an organisation that turned the notice off did so on purpose. To get a line back, enable it under **Admin Settings → Notices & Agreements → Chat AI Notice**. Flagged in the release notes.

## Two bugs caught while building this

- V1 preserves the line breaks an administrator typed (`white-space: pre-line`); the first pass collapsed them. Fixed, and pinned by a test that reads both sides.
- `CUSTOM_AI_NOTICE.md` still said the setting lives on the **General** tab — it moved to **Notices & Agreements**. Corrected.

## Validation

- `functional_tests/test_v2_chat_notices.py` — **8/8** (new)
- `test_ai_notice`, `test_user_settings_allowlist_keys`, `test_v2_api_payload_shapes`, `test_v2_settings_and_workspace_tags`, `test_v2_settings_tabs`, `test_v2_api_security`, `test_v2_ui_local_assets`, `test_v2_conversation_details_and_gating`, `test_v2_research_voice`, `test_docs_app_surface_coverage`, `test_docs_site_quality`, and the admin-settings contract tests — all pass
- `npm run build` (tsc + vite) clean
- `_build_notices` verified at runtime, confirming that editing the notice text invalidates existing dismissals and that all three web-search keys are required

Two pre-existing failures are unrelated and untouched: `test_chat_template_json_bootstrap_safety.py` (a missing `window.multiEndpointNotice` literal in `chats.html`) and a Windows console-encoding quirk in `test_user_settings_allowlist_keys.py` that passes under `PYTHONIOENCODING=utf-8`.

## Notes

- **No new settings keys** — both capabilities already exist in admin settings and are documented, so `docs/_data/app_surface.yml` is unchanged.
- **No new browser assets** — existing `lucide-react` icons and existing `info`/`info-soft` theme tokens, so CSP is untouched.
- Notice text is administrator-entered and rendered as a plain React child, so React escapes it. No `dangerouslySetInnerHTML`, matching V1's use of `textContent`/Jinja escaping.
- Version `0.261.027` → `0.261.028`.

## Docs

- `docs/explanation/fixes/V2_CHAT_NOTICES_FIX.md` (new)
- `docs/explanation/features/REACT_V2_UI.md` — new "Notices" section, bootstrap field, test table row
- `docs/explanation/features/CUSTOM_AI_NOTICE.md` — both interfaces, corrected tab name
- `docs/explanation/release_notes.md`