### PR TITLE
Persist the V2 reasoning level per model

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -97,7 +97,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.261.033"
+VERSION = "0.261.034"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/v2_ui/src/components/chat/Composer.tsx
+++ b/application/v2_ui/src/components/chat/Composer.tsx
@@ -20,6 +20,7 @@ import {
 } from 'lucide-react';
 import { useChatStore, type ComposerOptions } from '../../stores/chatStore';
 import { useBootstrapStore } from '../../stores/bootstrapStore';
+import { useUserSettingsStore } from '../../stores/userSettingsStore';
 import { uploadDocument } from '../../lib/endpoints';
 import { agentSelectionKey } from '../../lib/agents';
 import { modelSelectionKey, findModel, type ModelCatalogEntry } from '../../lib/models';
@@ -28,10 +29,14 @@ import { useUiStore } from '../../stores/uiStore';
 import { chatWidthClass } from '../../lib/chatWidth';
 import {
     getModelSupportedLevels,
+    reasoningModelKey,
+    resolveReasoningEffort,
     REASONING_LABELS,
     supportsReasoning,
+    type ReasoningEffortSettings,
 } from '../../lib/reasoning';
 import { Dropdown, type DropdownOption } from '../ui/Dropdown';
+import { toast } from '../../stores/toastStore';
 import { AiNotice } from './AiNotice';
 import { VoiceInput } from './VoiceInput';
 import { WebSearchNotice } from './WebSearchNotice';
@@ -75,6 +80,18 @@ export function Composer() {
     const { streaming, sendMessage, stopStreaming, activeConversationId } = useChatStore();
     const bootstrap = useBootstrapStore((state) => state.data);
     const features = bootstrap?.features ?? {};
+    // The level chosen per model, shared with the classic interface. Read from the store
+    // rather than held here so a change made anywhere is reflected without a reload.
+    const reasoningEffortSettings = useUserSettingsStore(
+        (state) => state.settings.reasoningEffortSettings as ReasoningEffortSettings | undefined,
+    );
+    // Unlike every other preference V2 writes, this one is a map rather than a scalar, and
+    // the route stores it whole. The app renders as soon as the bootstrap resolves, which is
+    // not necessarily after the settings have arrived, so merging into a map that has not
+    // been read would replace every other model's level with the single entry just chosen.
+    const settingsLoading = useUserSettingsStore((state) => state.loading);
+    const settingsFailed = useUserSettingsStore((state) => state.error !== null);
+    const settingsLoaded = !settingsLoading && !settingsFailed;
 
     const textareaRef = useRef<HTMLTextAreaElement>(null);
     const fileInputRef = useRef<HTMLInputElement>(null);
@@ -187,25 +204,141 @@ export function Composer() {
     // Reasoning support is per-model, so the control appears only when the current model
     // actually offers a choice. Resolved from the catalog record rather than the label,
     // since the display name can be anything an administrator typed.
-    const reasoningLevels: DropdownOption[] = useMemo(() => {
-        const selected = findModel(
-            bootstrap?.catalogs?.models as ModelCatalogEntry[] | undefined,
+    const selectedModel = findModel(
+        bootstrap?.catalogs?.models as ModelCatalogEntry[] | undefined,
+        options.modelDeployment,
+    );
+
+    // Both the offered levels and the key the chosen level is stored under come from this
+    // one name, so the classic interface finds the same entry in the shared map.
+    const reasoningKey = reasoningModelKey(
+        selectedModel,
+        modelOptions.find((option) => option.value === options.modelDeployment)?.label ||
             options.modelDeployment,
-        );
-        const modelName =
-            (selected?.deployment_name as string) ||
-            (selected?.model_id as string) ||
-            modelOptions.find((option) => option.value === options.modelDeployment)?.label ||
-            options.modelDeployment;
-        if (!supportsReasoning(modelName)) {
+    );
+
+    const reasoningLevels: DropdownOption[] = useMemo(() => {
+        if (!supportsReasoning(reasoningKey)) {
             return [];
         }
-        return getModelSupportedLevels(modelName).map((level) => ({
+        return getModelSupportedLevels(reasoningKey).map((level) => ({
             value: level,
             label: REASONING_LABELS[level],
         }));
+    }, [reasoningKey]);
+
+    // The level in effect is derived from the model and what has been stored for it, never
+    // remembered on its own. A level chosen for one model must not follow the user to
+    // another, and a model that offers no choice must not carry one into the request at all.
+    //
+    // Nothing is derived without a model to derive it from. A single-endpoint deployment has
+    // no model catalog, so the offered levels are a guess and a default would attach a
+    // parameter to every request that the user never asked for. There the control stays
+    // opt-in for the session, as it was before.
+    const derivedReasoning =
+        reasoningKey && reasoningLevels.length > 0
+            ? resolveReasoningEffort(reasoningKey, reasoningEffortSettings)
+            : undefined;
+
+    useEffect(() => {
+        if (!reasoningKey) {
+            return;
+        }
+        setOptions((current) =>
+            current.reasoningEffort === derivedReasoning
+                ? current
+                : { ...current, reasoningEffort: derivedReasoning },
+        );
+    }, [reasoningKey, derivedReasoning]);
+
+    /**
+     * Levels chosen before the stored map arrived.
+     *
+     * Held rather than written, because the map is stored whole and merging into one that
+     * has not been read would discard every other model's level. Held rather than dropped,
+     * because a preference that quietly fails to save is the defect this change is fixing.
+     * A map rather than a single entry, so choosing for two models in that window keeps both.
+     */
+    const pendingLevels = useRef<ReasoningEffortSettings>({});
+
+    const storeReasoningLevels = (levels: ReasoningEffortSettings) => {
+        // Read at write time rather than from the render's closure, so a map that arrived
+        // between the choice and the write is merged into rather than replaced.
+        const saved = useUserSettingsStore.getState().settings
+            .reasoningEffortSettings as ReasoningEffortSettings | undefined;
+        useUserSettingsStore.getState().update({
+            reasoningEffortSettings: { ...saved, ...levels },
+        });
+    };
+
+    useEffect(() => {
+        if (!settingsLoaded || Object.keys(pendingLevels.current).length === 0) {
+            return;
+        }
+        const held = pendingLevels.current;
+        pendingLevels.current = {};
+        storeReasoningLevels(held);
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [options.modelDeployment, bootstrap]);
+    }, [settingsLoaded]);
+
+    /** Store a chosen level against the current model, for both interfaces to read back. */
+    const chooseReasoningLevel = (level: string | undefined) => {
+        if (!level) {
+            // Only reachable where the control is clearable, which is where no level is
+            // stored, so there is nothing to clear but the session's own choice.
+            setOptions((current) => ({ ...current, reasoningEffort: undefined }));
+            return;
+        }
+
+        setOptions((current) => ({ ...current, reasoningEffort: level }));
+
+        // A single-endpoint deployment has no model catalog, so there is no identity to
+        // store the choice against. It still applies for the rest of the session.
+        if (!reasoningKey) {
+            return;
+        }
+
+        if (settingsLoaded) {
+            storeReasoningLevels({ [reasoningKey]: level });
+            return;
+        }
+
+        if (settingsFailed) {
+            // The map was never read, so writing would replace it. Saying so is better than
+            // a control that appears to save and does not.
+            toast.error(
+                'Your preferences could not be loaded, so this reasoning level applies to this conversation only.',
+            );
+            return;
+        }
+
+        pendingLevels.current = { ...pendingLevels.current, [reasoningKey]: level };
+    };
+
+    /**
+     * Remember the chosen model.
+     *
+     * The bootstrap resolves `initial_model_selection` from these keys on the next visit;
+     * without them the composer silently falls back to the first entry in the catalog.
+     */
+    const rememberModelSelection = (selection: string | undefined) => {
+        const model = findModel(
+            bootstrap?.catalogs?.models as ModelCatalogEntry[] | undefined,
+            selection,
+        );
+        if (!model) {
+            return;
+        }
+
+        const deployment =
+            typeof model.deployment_name === 'string' ? model.deployment_name.trim() : '';
+        useUserSettingsStore.getState().update({
+            preferredModelId: modelSelectionKey(model),
+            // The server falls back to the deployment name when the selection key no longer
+            // resolves, which is what happens after an endpoint is replaced.
+            ...(deployment ? { preferredModelDeployment: deployment } : {}),
+        });
+    };
 
     const submit = () => {
         if (!text.trim() || streaming) {
@@ -295,12 +428,13 @@ export function Composer() {
                                 options={modelOptions}
                                 value={options.modelDeployment}
                                 placeholder="Model"
-                                onChange={(value) =>
+                                onChange={(value) => {
                                     setOptions((current) => ({
                                         ...current,
                                         modelDeployment: value,
-                                    }))
-                                }
+                                    }));
+                                    rememberModelSelection(value);
+                                }}
                             />
                         )}
 
@@ -411,20 +545,19 @@ export function Composer() {
                         )}
 
                         {/* Only shown when the selected model offers a real choice; the
-                            endpoint strips the parameter for models that reject it. */}
+                            endpoint strips the parameter for models that reject it. The
+                            level is stored per model, so it survives a reload and applies
+                            to this model alone. It is clearable only where no level is in
+                            effect — a deployment with no model catalog — because that is
+                            the one case where "no level" is a state to get back to. */}
                         {reasoningLevels.length > 0 && (
                             <Dropdown
                                 options={reasoningLevels}
                                 value={options.reasoningEffort}
                                 placeholder="Reasoning"
-                                clearable
+                                clearable={!reasoningKey}
                                 icon={<Gauge size={15} />}
-                                onChange={(value) =>
-                                    setOptions((current) => ({
-                                        ...current,
-                                        reasoningEffort: value,
-                                    }))
-                                }
+                                onChange={chooseReasoningLevel}
                             />
                         )}
 

--- a/application/v2_ui/src/lib/reasoning.ts
+++ b/application/v2_ui/src/lib/reasoning.ts
@@ -1,12 +1,25 @@
 // reasoning.ts
-// Which reasoning effort levels a model accepts.
+// Which reasoning effort levels a model accepts, and which one is in effect.
 //
-// Mirrors getModelSupportedLevels in static/js/chat/chat-reasoning.js. Offering a level a
-// model rejects produces a request the endpoint has to strip, and hiding a level a model
-// does support silently removes a capability, so the mapping is kept in step with the
-// existing client rather than guessed.
+// Mirrors getModelSupportedLevels and getCurrentModelReasoningEffort in
+// static/js/chat/chat-reasoning.js. Offering a level a model rejects produces a request the
+// endpoint has to strip, and hiding a level a model does support silently removes a
+// capability, so the mapping is kept in step with the existing client rather than guessed.
+//
+// The chosen level is stored per model in the `reasoningEffortSettings` user setting, which
+// the classic interface already owns. Sharing the setting means sharing how a model is keyed
+// in it, so both interfaces have to agree on the fallback order below.
 
 export type ReasoningEffort = 'none' | 'minimal' | 'low' | 'medium' | 'high';
+
+/**
+ * The stored per-model map, `{ 'gpt-5-mini': 'medium' }`.
+ *
+ * Values are read back as plain strings because the map is shared with another client and
+ * with whatever an older release wrote; an unrecognised level is discarded on resolution
+ * rather than trusted.
+ */
+export type ReasoningEffortSettings = Record<string, string>;
 
 export const ALL_REASONING_LEVELS: ReasoningEffort[] = [
     'none',
@@ -67,3 +80,58 @@ export const REASONING_LABELS: Record<ReasoningEffort, string> = {
     medium: 'Medium',
     high: 'High',
 };
+
+/**
+ * How a model is identified in the stored map.
+ *
+ * `model_id` first, then the deployment name, matching `getCurrentModelName()` in
+ * chat-reasoning.js. The order matters twice over. It decides the key a level is stored
+ * under, so a level chosen in one interface is found again by the other. It also decides
+ * which name the level set is derived from, and a deployment an administrator named
+ * `chat-prod` says nothing about reasoning support where its model id `gpt-5-mini` does.
+ */
+export function reasoningModelKey(
+    model: { model_id?: unknown; deployment_name?: unknown } | undefined,
+    fallback?: string,
+): string {
+    const modelId = typeof model?.model_id === 'string' ? model.model_id.trim() : '';
+    const deployment =
+        typeof model?.deployment_name === 'string' ? model.deployment_name.trim() : '';
+    return modelId || deployment || (fallback ?? '').trim();
+}
+
+/**
+ * The level in effect for a model, given what has been stored for it.
+ *
+ * Mirrors `getCurrentModelReasoningEffort()`: a model always has an effective level, so the
+ * control shows a real value rather than an empty placeholder, and a stored level that the
+ * current model does not accept is ignored instead of being sent and stripped.
+ */
+export function resolveReasoningEffort(
+    modelName: string | undefined,
+    saved?: ReasoningEffortSettings,
+): ReasoningEffort {
+    const levels = getModelSupportedLevels(modelName);
+
+    // gpt-5-pro takes `high` and nothing else, so a stored value cannot override it.
+    if (modelName && modelName.toLowerCase().includes('gpt-5-pro')) {
+        return 'high';
+    }
+
+    const stored = modelName ? saved?.[modelName] : undefined;
+    if (stored && levels.includes(stored as ReasoningEffort)) {
+        return stored as ReasoningEffort;
+    }
+
+    return levels.includes('low') ? 'low' : levels[0];
+}
+
+/**
+ * The value to send with a request, or undefined when nothing should be sent.
+ *
+ * Mirrors `getCurrentReasoningEffort()`, which returns null for `none`: the level is a real
+ * choice in the picker but not a parameter the endpoint takes.
+ */
+export function requestReasoningEffort(level: string | undefined): string | undefined {
+    return !level || level === 'none' ? undefined : level;
+}

--- a/application/v2_ui/src/lib/userSettings.ts
+++ b/application/v2_ui/src/lib/userSettings.ts
@@ -50,6 +50,26 @@ export interface UserSettings {
     v2RailCollapsed?: boolean;
     v2ChatWidth?: string;
 
+    /**
+     * The chat model last chosen in the picker, as a catalog `selection_key`.
+     *
+     * Deliberately NOT namespaced like `v2RailCollapsed`: both interfaces mean the same
+     * thing by it, and `/api/v2/bootstrap` resolves `initial_model_selection` from this key
+     * (falling back to `preferredModelDeployment`). Without it the composer restores
+     * whatever the other interface last saved, or the first entry in the catalog.
+     */
+    preferredModelId?: string;
+    preferredModelDeployment?: string;
+
+    /**
+     * The reasoning level chosen per model, `{ 'gpt-5-mini': 'medium' }`.
+     *
+     * Shared with the classic interface, which owns the same map, so a level chosen in one
+     * is in effect in the other. Keyed by model id (falling back to deployment name), which
+     * is what `getCurrentModelName()` in chat-reasoning.js uses.
+     */
+    reasoningEffortSettings?: Record<string, string>;
+
     chatCompletionAudioEnabled?: boolean;
     chatCompletionAudioMuted?: boolean;
     chatCompletionAudioSound?: string;
@@ -95,6 +115,12 @@ export const WRITABLE_USER_SETTING_KEYS = [
     'v2ChatWidth',
     'v2MermaidStyle',
     'v2ChartStyle',
+    // Shared with the classic interface rather than namespaced: the chosen model and its
+    // reasoning level mean the same thing in both, and the bootstrap resolves the initial
+    // model selection from these keys.
+    'preferredModelId',
+    'preferredModelDeployment',
+    'reasoningEffortSettings',
     'chatCompletionAudioEnabled',
     'chatCompletionAudioMuted',
     'chatCompletionAudioSound',

--- a/application/v2_ui/src/stores/chatStore.ts
+++ b/application/v2_ui/src/stores/chatStore.ts
@@ -30,6 +30,7 @@ import {
 } from '../lib/sse';
 import { agentInfoForSelection } from '../lib/agents';
 import { modelIdentityForSelection, type ModelCatalogEntry } from '../lib/models';
+import { requestReasoningEffort } from '../lib/reasoning';
 import { resolveDocumentScope } from '../lib/documentScope';
 import { messageThreadId } from '../lib/threads';
 import { proposalSourceMessageId, type ImageProposalSpec } from '../lib/imageProposalSpec';
@@ -878,8 +879,11 @@ export const useChatStore = create<ChatState>((set, get) => ({
                 requestBody.agent_info = agentInfo;
             }
         }
-        if (options.reasoningEffort) {
-            requestBody.reasoning_effort = options.reasoningEffort;
+        // `none` is a real choice in the picker but not a value the endpoint takes: the
+        // classic client sends null for it, so the parameter is omitted here too.
+        const reasoningEffort = requestReasoningEffort(options.reasoningEffort);
+        if (reasoningEffort) {
+            requestBody.reasoning_effort = reasoningEffort;
         }
 
         await runChatStream(requestBody, conversationId, { isNewConversation });
@@ -1009,7 +1013,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
             );
             const result = await retryMessageApi(messageId, {
                 model: identity.model_deployment,
-                reasoning_effort: options?.reasoningEffort,
+                reasoning_effort: requestReasoningEffort(options?.reasoningEffort),
                 agent_info:
                     agentInfoForSelection(
                         bootstrap?.catalogs?.agents as Record<string, unknown>[] | undefined,

--- a/docs/explanation/features/REACT_V2_UI.md
+++ b/docs/explanation/features/REACT_V2_UI.md
@@ -287,9 +287,13 @@ source rather than inferred:
   than reordering locally.
 - **Deep research is carried by two fields.** Both `source_review_enabled` and
   `deep_research_enabled` are sent; only one disables half the behaviour.
-- **Reasoning effort is per model family.** `gpt-4o` supports none, `gpt-5-pro` only
-  `high`, the 5.1 series skips `low`, and the o-series offers low/medium/high. The control
-  is hidden entirely when a model offers no choice.
+- **Reasoning effort is per model family, and remembered per model.** `gpt-4o` supports
+  none, `gpt-5-pro` only `high`, the 5.1 series skips `low`, and the o-series offers
+  low/medium/high. The control is hidden entirely when a model offers no choice. The chosen
+  level is stored in `reasoningEffortSettings`, the same map the classic interface writes,
+  keyed by model id — so it survives a reload, applies to that model alone, and means the
+  same thing in both interfaces. Where there is no model catalog to key on, which is a
+  single-endpoint deployment, no level is derived or sent unless one is chosen.
 - **Citation markers** follow the grammar in `chat-citations.js`; a functional test asserts
   the two patterns stay identical so markers never render as raw text.
 - **`thread_attempt` is one-based**, and `/api/get_messages` filters to the active attempt.
@@ -848,6 +852,7 @@ this entirely and is the recommended layout.
 | `functional_tests/test_v2_citations.py` | Citation marker grammar parity with `chat-citations.js`, the four link kinds |
 | `functional_tests/test_v2_enhanced_citations.py` | Extension-to-viewer map parity with `getFileType`, the permissive metadata gate, `X-Sub-PDF-Page` handling, timestamp conversion, fallback on every failure |
 | `functional_tests/test_v2_research_voice.py` | Deep research's two fields, URL access, per-model reasoning effort, voice in and out |
+| `functional_tests/test_v2_reasoning_effort_persistence.py` | The reasoning level and the model selection are stored in keys the settings route accepts, keyed the way the classic interface keys them, derived per model rather than remembered, and `none` never sent |
 | `functional_tests/test_v2_dropdown_placement.py` | Composer pickers flip above the trigger when the bottom-anchored composer leaves no room below, and clamp their height to the viewport |
 | `functional_tests/test_v2_chat_phase1_fixes.py` | Exports send JSON rather than a form, email has its own path, images resolve from `content`, attempts are one-based, the title badge comes from conversation metadata, `agent_info` is an object, newlines match across roles, and failures are announced |
 | `functional_tests/test_v2_message_inspector.py` | Role-dependent metadata shape, reasoning fetched per message, shared renderer for live and historical reasoning, citation URL scheme checking, enabled-versus-used capability reporting |

--- a/docs/explanation/fixes/V2_REASONING_EFFORT_PERSISTENCE_FIX.md
+++ b/docs/explanation/fixes/V2_REASONING_EFFORT_PERSISTENCE_FIX.md
@@ -1,0 +1,147 @@
+# V2 Reasoning Effort Persistence Fix
+
+## Issue
+
+In the V2 chat interface the reasoning level did not stick. Choosing **Medium** for a model,
+navigating to another page and coming back showed the picker empty again, and the request
+went out with whatever the model's absence of a setting implied rather than the level that
+had been chosen. Switching between models lost it in the same way: there was no per-model
+memory, so a level chosen for one model was either carried to the next or gone.
+
+The model picker appeared to behave, which made the reasoning picker look like the odd one
+out. It was not: the model was not being saved either.
+
+**Fixed in version:** 0.261.034
+
+## Root cause
+
+Two separate omissions with the same shape.
+
+**The reasoning level was never persisted.** It lived in `Composer.tsx` local component
+state:
+
+```tsx
+const [options, setOptions] = useState<ComposerOptions>({ ... });
+```
+
+Nothing read it from `/api/user/settings` and nothing wrote it back, so remounting the
+composer — which is what navigating away and returning does — reset it.
+
+**The model was never persisted either.** `/api/v2/bootstrap` returns
+`initial_model_selection`, which `_build_initial_chat_model_selection` resolves from the
+`preferredModelId` and `preferredModelDeployment` user settings. V2 read that value but never
+wrote those keys, so it was restoring whatever the classic interface had last saved, or
+falling back to the first entry in the catalog. It looked persistent only for as long as the
+chosen model happened to match one of those.
+
+A third defect followed from the first. Because the level was never cleared when the model
+changed, choosing `high` on `gpt-5` and then switching to `gpt-4o` — a model with no
+reasoning at all — still sent `reasoning_effort: "high"`. The control disappeared from the
+toolbar while its value stayed in the request for the endpoint to strip.
+
+The classic interface had already solved all of this. `chat-reasoning.js` keeps a per-model
+map in the `reasoningEffortSettings` user setting, and `chat-messages.js` saves
+`preferredModelId` when the picker changes. Both keys were already in `allowed_keys` in
+`route_backend_users.py`, so **no backend change was needed**.
+
+## The fix
+
+The level in effect is now derived rather than remembered, and the inputs it is derived from
+are stored:
+
+- `resolveReasoningEffort(modelName, saved)` reproduces
+  `getCurrentModelReasoningEffort()`: `high` for `gpt-5-pro`, the stored level when the
+  current model still accepts it, otherwise `low` when supported, otherwise the model's first
+  supported level.
+- `reasoningModelKey(model)` decides how a model is keyed in the shared map, preferring the
+  model id over the deployment name exactly as `getCurrentModelName()` does. The order is not
+  cosmetic: it is what makes a level chosen in one interface visible in the other, and it is
+  what stops a deployment an administrator named `chat-prod` from being read as a model with
+  unknown reasoning support when its model id is `gpt-5-mini`.
+- A model that offers no choice now resolves to no level at all, so nothing stale is sent to
+  a model that rejects it.
+- `requestReasoningEffort()` suppresses `none` on both the send and retry paths, matching
+  `getCurrentReasoningEffort()`, which returns null for it.
+- Choosing a level writes it into `reasoningEffortSettings` through the existing debounced
+  settings store, which reverts the control if the write fails.
+- Choosing a model writes `preferredModelId` (the catalog selection key, which is what the
+  server matches on) and `preferredModelDeployment` (its fallback when the selection key no
+  longer resolves).
+
+The reasoning picker is no longer clearable. Every model now has an effective level, and
+`None` is already an explicit option for the families that support it, so a separate "no
+value" state would only mean "fall back to the default" — which the picker cannot show.
+
+On a single-endpoint deployment there is no model catalog and therefore no model identity.
+Nothing is derived there — the offered levels would be a guess, and a default would attach a
+`reasoning_effort` to every request that the user never asked for. The control stays opt-in
+and clearable for the session, exactly as it was, and the picker is only made non-clearable
+once a model is known and a level is genuinely always in effect.
+
+A level chosen before the settings have arrived is held and written once they do. This
+setting is a map rather than a scalar and the route stores it whole, while the app renders as
+soon as the bootstrap resolves — not necessarily after the settings have loaded. Merging into
+a map that had not been read would replace every other model's level, including levels set in
+the classic interface. Dropping the choice instead would reproduce the very defect being
+fixed, so it is queued rather than discarded, and the write reads the map as it stands at that
+moment rather than as it was when the choice was made. If the settings load failed outright
+there is no map to merge into at all, and the user is told the level applies to this session
+only rather than left to discover it later.
+
+## Behaviour change
+
+A reasoning-capable model with nothing stored now shows and sends its default level — `low`
+for most families, `none` for the 5.1 series, `high` for `gpt-5-pro` — where V2 previously
+sent nothing. This is what the classic interface has always done; the two now agree.
+
+This applies only where V2 has a model catalog, which means
+`enable_multi_model_endpoints` is on. A single-endpoint deployment is unchanged: no level is
+sent unless one is chosen, and a choice lasts for the session. V2 does not yet build a model
+picker for that configuration, so it has no model name to key a stored level on.
+
+## Files modified
+
+| File | Change |
+|---|---|
+| `application/v2_ui/src/lib/reasoning.ts` | `reasoningModelKey`, `resolveReasoningEffort`, `requestReasoningEffort`, `ReasoningEffortSettings` |
+| `application/v2_ui/src/lib/userSettings.ts` | Declared the three shared keys and added them to `WRITABLE_USER_SETTING_KEYS` |
+| `application/v2_ui/src/components/chat/Composer.tsx` | Reads the stored map, resolves the level per model, clears it for models with no choice, writes the level and the model selection |
+| `application/v2_ui/src/stores/chatStore.ts` | `none` suppressed on the send and retry paths |
+| `application/single_app/config.py` | Version to 0.261.034 |
+| `functional_tests/test_v2_reasoning_effort_persistence.py` | New test |
+| `functional_tests/test_v2_reasoning_effort_logic.mjs` | New runtime test |
+
+No route or storage change was required.
+
+## Validation
+
+`functional_tests/test_v2_reasoning_effort_persistence.py` asserts that all three settings
+keys are declared by the client and present in the route's whitelist, that the storage key
+still matches `getCurrentModelName()`, that the composer reads the map and writes back into
+it, that the effort is cleared for a model with no reasoning, that the model selection is
+saved as the selection key the bootstrap matches on, and that both request paths go through
+`requestReasoningEffort`.
+
+`functional_tests/test_v2_reasoning_effort_logic.mjs` executes the resolution itself against
+the real module, covering the cases whose failures are silent: a level restored for its own
+model, a level not following the user to another model, a stored level the new model does not
+accept being discarded, the per-family defaults, `gpt-5-pro` overriding whatever was stored,
+and `none` never being sent.
+
+| Check | Before | After |
+|---|---|---|
+| Choose Medium, leave the page, return | Picker empty | Medium |
+| Choose High on `gpt-5`, switch to `o3` | High carried over | `o3`'s own level, or its default |
+| Choose High on `gpt-5`, switch to `gpt-4o` | `reasoning_effort: "high"` still sent | Nothing sent |
+| Choose `None` where supported | `"none"` sent | Parameter omitted |
+| Choose a model, reload | Server default, often a different model | The chosen model |
+| Choose a level before preferences finish loading | Lost | Held and written when they arrive |
+| Single-endpoint deployment | Nothing sent unless chosen | Unchanged |
+
+Results: 7/7 Python tests and 14/14 runtime checks pass, alongside `npm run typecheck` and
+the existing V2, reasoning and settings suites.
+
+## Related
+
+- Feature documentation: `docs/explanation/features/REACT_V2_UI.md`
+- Classic implementation: `application/single_app/static/js/chat/chat-reasoning.js`

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,18 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/features) and [Fixes by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/fixes).
 
+### **(v0.261.034)**
+
+#### Bug Fixes
+
+*   **Your Reasoning Level Now Sticks In The New Interface**
+    *   Choosing a reasoning level in the V2 chat used to be forgotten the moment you left the page and came back, and switching models either carried the level over or lost it entirely. It is now remembered per model, so each model keeps the level you chose for it.
+    *   The level is shared with the classic interface, which has always remembered it: set **Medium** for a model in one interface and it is Medium in the other.
+    *   Switching to a model that has no reasoning — `gpt-4o`, for example — no longer leaves the previous model's level attached to your request. The setting disappeared from the toolbar but was still being sent.
+    *   The model you pick is now remembered too. It previously only appeared to stick, because the page fell back to whichever model the server considered your default.
+    *   A model you have not chosen a level for shows its usual default rather than a blank control, matching the classic interface.
+    *   (Ref: V2 chat, reasoning effort, model picker, user preferences)
+
 ### **(v0.261.033)**
 
 #### New Features

--- a/functional_tests/test_v2_reasoning_effort_logic.mjs
+++ b/functional_tests/test_v2_reasoning_effort_logic.mjs
@@ -1,0 +1,150 @@
+// test_v2_reasoning_effort_logic.mjs
+//
+// Runtime test for the V2 per-model reasoning effort resolution.
+// Version: 0.261.034
+// Implemented in: 0.261.034
+//
+// The companion test, test_v2_reasoning_effort_persistence.py, asserts that the composer is
+// wired to the shared user setting and that the keys it writes are ones the route accepts.
+// Those are source assertions: they prove the pieces are connected, not that the right level
+// comes out.
+//
+// This file executes the resolution itself, because its failure modes are all silent. A level
+// stored under the wrong key is simply never found again. A stored level that the newly
+// selected model does not accept is sent and then stripped by the endpoint, so the user sees a
+// control claiming an effort that was never applied. And `none` is a real choice in the picker
+// but not a value the endpoint takes, so sending it looks like a working request.
+//
+// Run directly with `node functional_tests/test_v2_reasoning_effort_logic.mjs`. Requires Node
+// 22.6 or newer, which strips the TypeScript types so the real module can be imported rather
+// than a copy of it.
+
+import assert from 'node:assert/strict';
+import {
+    getModelSupportedLevels,
+    reasoningModelKey,
+    requestReasoningEffort,
+    resolveReasoningEffort,
+    supportsReasoning,
+} from '../application/v2_ui/src/lib/reasoning.ts';
+
+const checks = [];
+function check(name, fn) {
+    checks.push([name, fn]);
+}
+
+/* --------------------------------- the key ---------------------------------- */
+
+check('a model is keyed by its model id, not its deployment name', () => {
+    // getCurrentModelName() in chat-reasoning.js reads dataset.modelId first, so a level
+    // stored by either interface has to land on the same entry.
+    assert.equal(
+        reasoningModelKey({ model_id: 'gpt-5-mini', deployment_name: 'chat-prod' }),
+        'gpt-5-mini',
+    );
+});
+
+check('the deployment name is used when there is no model id', () => {
+    assert.equal(reasoningModelKey({ deployment_name: 'gpt-5-mini' }), 'gpt-5-mini');
+    assert.equal(reasoningModelKey({ model_id: '   ', deployment_name: 'gpt-5' }), 'gpt-5');
+});
+
+check('a missing catalog record falls back to what the picker shows', () => {
+    assert.equal(reasoningModelKey(undefined, 'gpt-5-mini'), 'gpt-5-mini');
+    assert.equal(reasoningModelKey(undefined, undefined), '');
+});
+
+/* ------------------------------ stored levels -------------------------------- */
+
+check('a stored level is restored for its own model', () => {
+    const saved = { 'gpt-5-mini': 'high' };
+    assert.equal(resolveReasoningEffort('gpt-5-mini', saved), 'high');
+});
+
+check('a level stored for one model does not follow the user to another', () => {
+    const saved = { 'gpt-5-mini': 'high' };
+    // o3 has its own entry, or it has not been chosen for and takes the default.
+    assert.equal(resolveReasoningEffort('o3', saved), 'low');
+});
+
+check('a stored level the model does not accept is ignored', () => {
+    // The 5.1 series skips `low`, so a level carried over from an o-series model cannot be
+    // honoured and must not be sent for the endpoint to strip. It falls back the way
+    // getCurrentModelReasoningEffort() does: `low` when offered, otherwise the first level,
+    // which for this family is `none`.
+    assert.equal(resolveReasoningEffort('gpt-5.1', { 'gpt-5.1': 'low' }), 'none');
+    // gpt-5 has no `none`, so a stored `none` from a 5.1 model is discarded for `low`.
+    assert.equal(resolveReasoningEffort('gpt-5', { 'gpt-5': 'none' }), 'low');
+});
+
+/* --------------------------------- defaults ---------------------------------- */
+
+check('an unset model defaults to low, as the classic client does', () => {
+    assert.equal(resolveReasoningEffort('gpt-5-mini', {}), 'low');
+    assert.equal(resolveReasoningEffort('gpt-5-mini', undefined), 'low');
+    assert.equal(resolveReasoningEffort('o3', undefined), 'low');
+});
+
+check('a model without low takes its first supported level', () => {
+    // The 5.1 series offers none, minimal, medium and high.
+    assert.equal(resolveReasoningEffort('gpt-5.1', {}), 'none');
+});
+
+check('gpt-5-pro is always high, whatever was stored', () => {
+    assert.equal(resolveReasoningEffort('gpt-5-pro', {}), 'high');
+    assert.equal(resolveReasoningEffort('gpt-5-pro', { 'gpt-5-pro': 'minimal' }), 'high');
+});
+
+check('no model selected still resolves to a level', () => {
+    assert.equal(resolveReasoningEffort(undefined, undefined), 'low');
+    assert.equal(resolveReasoningEffort('', {}), 'low');
+});
+
+/* ------------------------------- what is sent -------------------------------- */
+
+check('none is never sent to the endpoint', () => {
+    // getCurrentReasoningEffort() returns null for none; the endpoint takes no such value.
+    assert.equal(requestReasoningEffort('none'), undefined);
+    assert.equal(requestReasoningEffort(''), undefined);
+    assert.equal(requestReasoningEffort(undefined), undefined);
+});
+
+check('a real level is passed through unchanged', () => {
+    assert.equal(requestReasoningEffort('minimal'), 'minimal');
+    assert.equal(requestReasoningEffort('high'), 'high');
+});
+
+/* ------------------------- models with no choice ----------------------------- */
+
+check('a model with no reasoning offers nothing to choose', () => {
+    for (const model of ['gpt-4o', 'gpt-4.1-mini', 'gpt-5-chat', 'gpt-5-codex']) {
+        assert.deepEqual(getModelSupportedLevels(model), ['none'], model);
+        assert.equal(supportsReasoning(model), false, model);
+    }
+});
+
+check('a reasoning model does offer a choice', () => {
+    for (const model of ['gpt-5', 'gpt-5.1', 'gpt-5-pro', 'o3']) {
+        assert.equal(supportsReasoning(model), true, model);
+    }
+});
+
+/* ----------------------------------- runner ---------------------------------- */
+
+let passed = 0;
+let failed = 0;
+
+for (const [name, fn] of checks) {
+    try {
+        await fn();
+        console.log(`ok   ${name}`);
+        passed += 1;
+    } catch (error) {
+        console.log(`FAIL ${name}`);
+        console.log(`     ${error.message}`);
+        failed += 1;
+    }
+}
+
+console.log(`\n${passed}/${passed + failed} runtime checks passed`);
+process.exit(failed > 0 ? 1 : 0);

--- a/functional_tests/test_v2_reasoning_effort_persistence.py
+++ b/functional_tests/test_v2_reasoning_effort_persistence.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python3
+"""
+Functional test for V2 reasoning effort persistence.
+
+Version: 0.261.034
+Implemented in: 0.261.034
+
+The V2 reasoning level used to live only in the composer's local state. It was never read
+from or written to /api/user/settings, so it was lost on every remount -- navigating away
+and back, or reloading -- and it was never cleared when the model changed, which meant a
+level chosen for gpt-5 was still sent after switching to gpt-4o, a model that has no
+reasoning at all.
+
+The fix reuses the contract the classic interface already has rather than inventing a second
+one: the level is stored per model in the `reasoningEffortSettings` user setting, and the
+chosen model is stored in `preferredModelId` / `preferredModelDeployment`, which is what
+`_build_initial_chat_model_selection` restores the picker from.
+
+Three things are pinned here.
+
+**The keys have to be whitelisted.** /api/user/settings validates against `allowed_keys` in
+route_backend_users.py and drops anything outside it **without complaining** -- the POST
+still returns success and the value never arrives, so the preference appears to save and is
+gone on the next load.
+
+**The key a level is stored under has to match the classic interface.** Both write the same
+map, so `getCurrentModelName()` and `reasoningModelKey()` must agree on model id before
+deployment name. If they disagree, a level set in one interface is invisible in the other.
+
+**The level has to be derived, not remembered.** The composer must clear the effort for a
+model that offers no choice, or the stale value is sent to a model that rejects it.
+
+The resolution itself is exercised by the companion Node test, which is run from here.
+"""
+
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+APP_DIR = REPO_ROOT / "application" / "single_app"
+V2_SRC = REPO_ROOT / "application" / "v2_ui" / "src"
+LEGACY_CHAT_JS = APP_DIR / "static" / "js" / "chat"
+LOGIC_TEST = REPO_ROOT / "functional_tests" / "test_v2_reasoning_effort_logic.mjs"
+
+IMPLEMENTED_IN = "0.261.034"
+
+# The settings this fix depends on, all of which are shared with the classic interface.
+SHARED_SETTING_KEYS = (
+    "reasoningEffortSettings",
+    "preferredModelId",
+    "preferredModelDeployment",
+)
+
+sys.path.insert(0, str(REPO_ROOT / "functional_tests"))
+
+from test_support.versioning import assert_app_version_at_least  # noqa: E402
+
+
+def _read(path):
+    return path.read_text(encoding="utf-8")
+
+
+def _allowed_keys():
+    """The whitelist the settings route validates against."""
+    users = _read(APP_DIR / "route_backend_users.py")
+    block = re.search(r"allowed_keys = \{(.*?)\}", users, re.DOTALL)
+    assert block, "Could not find allowed_keys in route_backend_users.py"
+    return set(re.findall(r"['\"]([A-Za-z_][A-Za-z0-9_]*)['\"]", block.group(1)))
+
+
+def _writable_keys():
+    """The keys the V2 client declares it may write."""
+    settings = _read(V2_SRC / "lib" / "userSettings.ts")
+    block = re.search(
+        r"export const WRITABLE_USER_SETTING_KEYS = \[(.*?)\] as const;", settings, re.DOTALL
+    )
+    assert block, "Could not find WRITABLE_USER_SETTING_KEYS in userSettings.ts"
+    return set(re.findall(r"'([^']+)'", block.group(1)))
+
+
+def test_the_shared_keys_are_declared_and_accepted():
+    """A key outside the route's whitelist is discarded silently, so both sides must list it."""
+    print("Testing the shared settings keys...")
+
+    writable = _writable_keys()
+    allowed = _allowed_keys()
+
+    for key in SHARED_SETTING_KEYS:
+        assert key in writable, (
+            f"{key!r} is written by the V2 composer but is not declared in "
+            "WRITABLE_USER_SETTING_KEYS, so the whitelist test cannot cover it"
+        )
+        assert key in allowed, (
+            f"{key!r} is not in allowed_keys, so /api/user/settings will return success and "
+            "then discard it"
+        )
+
+    print(f"All {len(SHARED_SETTING_KEYS)} shared keys are declared and accepted!")
+    return True
+
+
+def test_the_storage_key_matches_the_classic_client():
+    """Both interfaces write the same map, so they must key a model the same way."""
+    print("Testing the per-model storage key...")
+
+    legacy = _read(LEGACY_CHAT_JS / "chat-reasoning.js")
+    # The classic client keys on dataset.modelId first, falling back to the deployment name.
+    assert "selectedOption?.dataset?.modelId || selectedOption?.dataset?.deploymentName" in legacy, (
+        "chat-reasoning.js no longer resolves the model name id-first; the V2 key must "
+        "follow whatever it does now or the shared map splits in two"
+    )
+    assert "reasoningEffortSettings[modelName]" in legacy, (
+        "chat-reasoning.js no longer stores the level per model"
+    )
+
+    reasoning = _read(V2_SRC / "lib" / "reasoning.ts")
+    assert "export function reasoningModelKey" in reasoning, (
+        "V2 needs a single place that decides how a model is keyed in the shared map"
+    )
+    assert "return modelId || deployment ||" in reasoning, (
+        "reasoningModelKey must prefer the model id, matching getCurrentModelName()"
+    )
+
+    print("Storage key test passed!")
+    return True
+
+
+def test_the_composer_reads_and_writes_the_shared_map():
+    """The level has to survive a remount, which means reading and writing the setting."""
+    print("Testing composer persistence...")
+
+    composer = _read(V2_SRC / "components" / "chat" / "Composer.tsx")
+
+    assert "state.settings.reasoningEffortSettings" in composer, (
+        "The composer must read the stored level, or it starts empty on every mount"
+    )
+    assert "reasoningEffortSettings: { ...saved, ...levels }" in composer, (
+        "A chosen level must be written back into the shared map under the model's key"
+    )
+    assert "resolveReasoningEffort(reasoningKey, reasoningEffortSettings)" in composer, (
+        "The level in effect must be resolved from the model and the stored map"
+    )
+
+    # Derived, not remembered: a model that offers no choice must carry no level at all, and
+    # a deployment with no model catalog must not have one guessed for it.
+    derived = re.search(
+        r"reasoningKey && reasoningLevels\.length > 0\s*\?\s*resolveReasoningEffort\(", composer
+    )
+    assert derived, (
+        "The effort must be cleared for a model with no reasoning and left alone when there "
+        "is no model identity, or a stale or invented level is sent"
+    )
+    assert re.search(r"if \(!reasoningKey\) \{\s*return;", composer), (
+        "The sync effect must leave the session's own choice alone when there is no model "
+        "to derive a level from"
+    )
+
+    # The route stores this setting whole, and the app renders before the settings load
+    # necessarily finishes, so an early write would replace the map with a single entry.
+    assert "pendingLevels.current = { ...pendingLevels.current, [reasoningKey]: level }" in composer, (
+        "A level chosen before the stored map arrives must be held, not written into an "
+        "empty map, which would discard every other model's level"
+    )
+    assert "if (!settingsLoaded || Object.keys(pendingLevels.current).length === 0)" in composer, (
+        "The held levels must be written once the map has been read, or the choice is lost"
+    )
+    assert "useUserSettingsStore.getState().settings" in composer, (
+        "The write must merge into the map as it stands at write time, not as it was when "
+        "the choice was made"
+    )
+    assert "settingsFailed" in composer, (
+        "A settings load that failed leaves no map to merge into; the user has to be told "
+        "the level is not being saved rather than left to discover it"
+    )
+
+    # Derived, not remembered: a model that offers no choice must carry no level at all.
+    derived = re.search(
+        r"reasoningLevels\.length > 0\s*\?\s*resolveReasoningEffort\(", composer
+    )
+    assert derived, (
+        "The effort must be cleared for a model with no reasoning, or a stale level is sent "
+        "to a model that rejects it"
+    )
+
+    # There is always an effective level once a model is known, so the control is clearable
+    # only where none is derived -- a deployment with no model catalog.
+    reasoning_control = composer.split("{reasoningLevels.length > 0 && (")[1].split(")}")[0]
+    assert "clearable={!reasoningKey}" in reasoning_control, (
+        "The reasoning picker should be clearable only where no level is in effect; a model "
+        "with a level already has `None` as an explicit option where it is supported"
+    )
+
+    print("Composer persistence test passed!")
+    return True
+
+
+def test_the_model_selection_is_remembered():
+    """Per-model memory is meaningless if the model itself is not restored."""
+    print("Testing model selection persistence...")
+
+    composer = _read(V2_SRC / "components" / "chat" / "Composer.tsx")
+    assert "preferredModelId: modelSelectionKey(model)" in composer, (
+        "The chosen model must be saved as its selection key, which is what "
+        "_build_initial_chat_model_selection matches on"
+    )
+    assert "preferredModelDeployment: deployment" in composer, (
+        "The deployment name is the server's fallback when the selection key no longer "
+        "resolves, so it is saved too"
+    )
+    assert "rememberModelSelection(value)" in composer, (
+        "The save must be wired to the model picker's change handler"
+    )
+
+    # The server side of the contract, which is what makes the saved keys matter.
+    bootstrap = _read(APP_DIR / "route_backend_v2.py")
+    assert 'user_settings_dict.get("preferredModelId")' in bootstrap, (
+        "The bootstrap must still resolve the initial model from preferredModelId"
+    )
+
+    print("Model selection test passed!")
+    return True
+
+
+def test_none_is_not_sent_to_the_endpoint():
+    """`none` is a choice in the picker but not a value the endpoint takes."""
+    print("Testing the none level...")
+
+    legacy = _read(LEGACY_CHAT_JS / "chat-reasoning.js")
+    assert "return effort === 'none' ? null : effort;" in legacy, (
+        "chat-reasoning.js no longer suppresses none; V2 should follow whatever it does now"
+    )
+
+    reasoning = _read(V2_SRC / "lib" / "reasoning.ts")
+    assert "export function requestReasoningEffort" in reasoning, (
+        "V2 needs one place that decides what is safe to send"
+    )
+
+    store = _read(V2_SRC / "stores" / "chatStore.ts")
+    sent = store.count("requestReasoningEffort(")
+    assert sent >= 2, (
+        "Both the send and the retry paths must go through requestReasoningEffort; "
+        f"found {sent} use(s)"
+    )
+    assert "reasoning_effort: options?.reasoningEffort," not in store, (
+        "The retry path still sends the raw level, so `none` reaches the endpoint"
+    )
+
+    print("None-level test passed!")
+    return True
+
+
+def test_reasoning_logic_behaves():
+    """Run the companion runtime test, which executes the resolution itself.
+
+    The assertions above prove the composer is wired to the setting. They cannot prove that
+    the right level comes out of it, because that is behaviour rather than shape. The Node
+    test does that, and is run from here so it cannot quietly rot next to a suite that never
+    invokes it.
+
+    Node is not otherwise required to work on this repository, so its absence is reported
+    rather than failed. A Node that is present and reports a failure is a failure.
+    """
+    print("Testing reasoning resolution behaviour...")
+    if not LOGIC_TEST.exists():
+        raise AssertionError(f"The runtime logic test is missing: {LOGIC_TEST}")
+
+    node = shutil.which("node")
+    if not node:
+        print("  Node is not installed; skipping the runtime logic test.")
+        print(f"  Run it with: node {LOGIC_TEST.relative_to(REPO_ROOT)}")
+        return True
+
+    completed = subprocess.run(
+        [node, str(LOGIC_TEST)],
+        capture_output=True,
+        text=True,
+        cwd=str(REPO_ROOT),
+    )
+    output = (completed.stdout or "") + (completed.stderr or "")
+
+    # Node below 22.6 cannot import TypeScript directly. That is a limitation of the
+    # environment, not a defect in the code under test.
+    if completed.returncode != 0 and "Unknown file extension" in output:
+        print("  This Node cannot import TypeScript directly (needs 22.6 or newer); skipping.")
+        return True
+
+    for line in output.splitlines():
+        if line.strip():
+            print(f"  {line}")
+
+    if completed.returncode != 0:
+        raise AssertionError("The runtime logic test failed; see the output above.")
+
+    print("Reasoning resolution test passed!")
+    return True
+
+
+def test_version_was_incremented():
+    """The application version records when this shipped."""
+    print("Testing version...")
+    version = assert_app_version_at_least(
+        IMPLEMENTED_IN,
+        reason="V2 per-model reasoning effort persistence.",
+    )
+    print(f"  config.py VERSION is {version}.")
+    print("Version test passed!")
+    return True
+
+
+if __name__ == "__main__":
+    tests = [
+        test_the_shared_keys_are_declared_and_accepted,
+        test_the_storage_key_matches_the_classic_client,
+        test_the_composer_reads_and_writes_the_shared_map,
+        test_the_model_selection_is_remembered,
+        test_none_is_not_sent_to_the_endpoint,
+        test_reasoning_logic_behaves,
+        test_version_was_incremented,
+    ]
+
+    results = []
+    for test in tests:
+        print(f"\nRunning {test.__name__}...")
+        try:
+            results.append(bool(test()))
+        except Exception as exc:  # noqa: BLE001 - surface any failure with a traceback
+            print(f"Test failed: {exc}")
+            import traceback
+
+            traceback.print_exc()
+            results.append(False)
+
+    print(f"\nResults: {sum(results)}/{len(results)} tests passed")
+    sys.exit(0 if all(results) else 1)


### PR DESCRIPTION
## Problem

In the V2 interface the reasoning level did not stick. Choosing **Medium** for a model, navigating away and coming back showed the picker empty again, and switching between models lost it in the same way.

The reasoning level lived only in `Composer.tsx` local `useState`. Nothing read it from `/api/user/settings` and nothing wrote it back, so remounting the composer — which is what leaving the page and returning does — reset it.

Two further defects surfaced while tracing it:

- **The model was not persisted either.** `/api/v2/bootstrap` returns `initial_model_selection`, which `_build_initial_chat_model_selection` resolves from `preferredModelId` / `preferredModelDeployment`. V2 read that value but never wrote those keys, so it was restoring whatever the classic interface had last saved, or falling back to the first entry in the catalog. The picker looked persistent only for as long as the chosen model happened to match.
- **The level was never cleared on model change.** Choosing `high` on `gpt-5` and switching to `gpt-4o` — a model with no reasoning at all — still sent `reasoning_effort: "high"`. The control disappeared from the toolbar while its value stayed in the request for the endpoint to strip.

## Approach

The classic interface had already solved this. `chat-reasoning.js` keeps a per-model map in the `reasoningEffortSettings` user setting, and `chat-messages.js` saves `preferredModelId` when the picker changes. All three keys were already in `allowed_keys` in `route_backend_users.py`, so **there is no backend change**.

The level in effect is now derived rather than remembered, and the inputs it derives from are stored:

- `resolveReasoningEffort()` reproduces `getCurrentModelReasoningEffort()`: `high` for `gpt-5-pro`, the stored level when the current model still accepts it, otherwise `low` when supported, otherwise the model's first supported level.
- `reasoningModelKey()` decides how a model is keyed in the shared map, preferring the model id over the deployment name exactly as `getCurrentModelName()` does. That order is what makes a level chosen in one interface visible in the other, and what stops a deployment an administrator named `chat-prod` being read as a model of unknown reasoning support when its model id is `gpt-5-mini`.
- A model that offers no choice resolves to no level at all, so nothing stale is sent to a model that rejects it.
- `requestReasoningEffort()` suppresses `none`, applied inside `buildSelectionFields()` — the single place a request's routing fields are decided, covering both the send and the retry path — matching `getCurrentReasoningEffort()`, which returns null for it.
- Choosing a model writes `preferredModelId` (the catalog selection key the server matches on) and `preferredModelDeployment` (its fallback).

Two edge cases are handled deliberately:

- **Single-endpoint deployments have no model catalog**, so no level is derived there — the offered levels would be a guess and a default would attach a `reasoning_effort` to every request the user never asked for. That configuration keeps its opt-in, clearable control, unchanged.
- **This setting is a map, not a scalar, and the route stores it whole.** The app renders as soon as the bootstrap resolves, not necessarily after the settings have loaded, so a level chosen in that window is held and written once the map arrives. Merging into a map that had not been read would replace every other model's level, including levels set in the classic interface. If the settings load failed outright, the user is told the level applies to this session only rather than left to discover it.

## Merged with the agent/model exclusivity change

The base branch gained #1391 while this was open, which refactored the same code. Resolved as follows:

- **`chatStore`** — its per-call-site handling is superseded by `buildSelectionFields`, so the `none` suppression moved into that function. This is strictly better placed: it now also keeps the level off the agent path, which sends no reasoning at all.
- **Model picker** — keeps the base's overridden state, tooltip and agent clearing, and additionally remembers the selection.
- **Reasoning picker** — keeps the base's `showReasoning` gate and this branch's per-model persistence.
- **Agent mode is deliberately not a condition of the derivation.** It hides the control and drops the level in `buildSelectionFields`, where that rule lives, while the level stays derived from the model underneath — so clearing the agent brings back whatever was chosen for that model.

## Behaviour change

A reasoning-capable model with nothing stored now shows and sends its default level — `low` for most families, `none` for the 5.1 series, `high` for `gpt-5-pro` — where V2 previously sent nothing. This is what the classic interface has always done; the two now agree. Single-endpoint deployments are unaffected.

## Validation

| Check | Before | After |
|---|---|---|
| Choose Medium, leave the page, return | Picker empty | Medium |
| Choose High on `gpt-5`, switch to `o3` | High carried over | `o3`'s own level, or its default |
| Choose High on `gpt-5`, switch to `gpt-4o` | `reasoning_effort: "high"` still sent | Nothing sent |
| Choose `None` where supported | `"none"` sent | Parameter omitted |
| Choose a model, reload | Server default, often a different model | The chosen model |
| Choose a level before preferences load | Lost | Held and written when they arrive |
| Single-endpoint deployment | Nothing sent unless chosen | Unchanged |

- `npm run typecheck` and `npm run build` clean.
- `functional_tests/test_v2_reasoning_effort_persistence.py` — 7/7. Pins the settings keys against the route whitelist, the storage key against `getCurrentModelName()`, the read/write wiring, the clearing behaviour, the deferred write, and the model-selection save.
- `functional_tests/test_v2_reasoning_effort_logic.mjs` — 14/14. Executes the resolution against the real module rather than string-matching it: a level restored for its own model, a level not following the user to another, a stored level the new model rejects being discarded, the per-family defaults, `gpt-5-pro` overriding whatever was stored, and `none` never being sent.
- The full V2 suite (27 files, including the incoming agent exclusivity test), the classic reasoning tests, and the docs coverage tests all pass post-merge.

## Documentation

- `docs/explanation/fixes/V2_REASONING_EFFORT_PERSISTENCE_FIX.md` (new)
- `docs/explanation/features/REACT_V2_UI.md` — composer contract and test table
- `docs/explanation/release_notes.md` — entry under v0.261.036

Version renumbered to `0.261.036`, since `0.261.034` was taken by the exclusivity fix on the base branch.