### PR TITLE
Give exported diagrams their labels back, and say when an export is working

### DIFF
--- a/application/single_app/Dockerfile
+++ b/application/single_app/Dockerfile
@@ -131,7 +131,11 @@ RUN set -eux; \
                 nspr \
                 nss \
                 pango; \
+            tdnf install -y dejavu-fonts || tdnf install -y dejavu-sans-fonts || true; \
+            tdnf install -y liberation-fonts || true; \
+            tdnf install -y google-noto-sans-fonts || true; \
             tdnf install -y xorg-x11-fonts-Type1 xorg-x11-fonts-misc || true; \
+            command -v fc-cache >/dev/null 2>&1 && fc-cache -f || true; \
             ;; \
         *) \
             echo "Skipping Chromium runtime package installation because INSTALL_PLAYWRIGHT_CHROMIUM=${INSTALL_PLAYWRIGHT_CHROMIUM}"; \

--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -97,7 +97,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.261.033"
+VERSION = "0.261.034"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/functions_mermaid_server_render.py
+++ b/application/single_app/functions_mermaid_server_render.py
@@ -13,16 +13,35 @@ back to the diagram's original code block.
 
 The same vendored Mermaid bundle the browser uses is loaded from disk, so a server-rendered
 diagram and a browser-rendered one come from identical library code.
+
+Two details are what make the picture actually contain its labels:
+
+- **The font is embedded, not borrowed from the operating system.** The container image
+  carries no scalable Latin typeface, so a diagram asking for ``Arial, Helvetica, sans-serif``
+  resolves to nothing: Chromium then measures every label as zero-width, Mermaid falls back
+  to its minimum node size, and the export comes out as uniform empty boxes. DejaVu Sans is
+  read from matplotlib, which is already a dependency for TeX export, and injected as an
+  ``@font-face`` so rendering does not depend on what the host happens to have installed.
+
+- **The diagram is screenshotted where it is drawn.** Serializing the SVG and repainting it
+  through an ``<img>`` onto a canvas silently drops anything the isolated image context will
+  not honour, including ``<foreignObject>`` labels, stylesheet rules Mermaid added with
+  ``insertRule`` rather than into the SVG, and any font that is not already loaded. Capturing
+  the live element with Playwright renders exactly what a browser would show.
 """
 
+import base64
 import importlib.util
+import math
 import os
+import re
 import threading
 from typing import Any, Dict, List, Optional
 
 from functions_export_visuals import (
     EXPORT_VISUAL_ASSET_MAX_COUNT,
     EXPORT_VISUAL_KIND_DIAGRAM,
+    build_export_visual_png_data_uri,
     normalize_visual_assets,
     normalize_visual_source,
 )
@@ -38,22 +57,39 @@ MERMAID_SERVER_RENDER_DIAGRAM_TIMEOUT_MS = 10000
 MERMAID_SERVER_RENDER_SCALE = 2
 MERMAID_SERVER_RENDER_MAX_CANVAS_EDGE = 4000
 
+# Named rather than borrowed from the host, so the family Mermaid asks for is always the
+# family that was embedded. Quoted wherever it is used, because it contains spaces.
+MERMAID_SERVER_RENDER_FONT_FAMILY = 'SimpleChat Export Sans'
+MERMAID_SERVER_RENDER_FONT_STACK = f"'{MERMAID_SERVER_RENDER_FONT_FAMILY}', Arial, Helvetica, sans-serif"
+
+# The element the rendered diagram is mounted into and screenshotted from.
+MERMAID_SERVER_RENDER_HOST_ID = 'simplechat-export-host'
+
+# Only real network traffic is blocked. Matching everything would also catch the data: URI
+# the embedded font is delivered through, which would put us back to no font at all.
+MERMAID_SERVER_RENDER_BLOCKED_URL_PATTERN = re.compile(r'^(?:https?|ws|wss|ftp)://', re.IGNORECASE)
+
 _RENDER_CAPABILITIES_CACHE: Optional[Dict[str, Any]] = None
+_EMBEDDED_FONT_CACHE: Optional[str] = None
+_EMBEDDED_FONT_RESOLVED = False
 _RENDER_LOCK = threading.Lock()
 
-# Mirrors chat-visual-rasterizer.js. htmlLabels must stay off in both: Mermaid draws labels
-# inside <foreignObject>, and that content is dropped when an SVG is painted onto a canvas,
-# which yields diagrams with shapes and arrows but no text.
+# Mirrors chat-visual-rasterizer.js. htmlLabels stays off in both: keeping labels as SVG
+# text removes an entire class of injection from model-authored diagram labels, and it is
+# also what lets a diagram survive being turned into a picture at all.
+#
+# This renders and mounts; it deliberately does not rasterize. Python screenshots the
+# mounted element, because a live page render is the only one guaranteed to match what a
+# reader would see.
 MERMAID_RENDER_SCRIPT = """
-(async (sources, options) => {
-    const results = [];
+(async (source, options) => {
     window.mermaid.initialize({
         startOnLoad: false,
         securityLevel: 'strict',
         suppressErrorRendering: true,
         theme: 'neutral',
         htmlLabels: false,
-        fontFamily: 'Arial, Helvetica, sans-serif',
+        fontFamily: options.fontFamily,
         flowchart: { htmlLabels: false, useMaxWidth: false },
         sequence: { useMaxWidth: false },
         class: { htmlLabels: false, useMaxWidth: false },
@@ -68,70 +104,6 @@ MERMAID_RENDER_SCRIPT = """
         return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
     }
 
-    function normalizeSvgMarkup(svgMarkup) {
-        const parsed = new DOMParser().parseFromString(svgMarkup, 'image/svg+xml');
-        const svgElement = parsed.documentElement;
-        let width = parseSvgLength(svgElement.getAttribute('width'));
-        let height = parseSvgLength(svgElement.getAttribute('height'));
-        const viewBox = String(svgElement.getAttribute('viewBox') || '')
-            .split(/[\\s,]+/)
-            .map(Number);
-        if (viewBox.length === 4 && Number.isFinite(viewBox[2]) && Number.isFinite(viewBox[3])) {
-            width = width || viewBox[2];
-            height = height || viewBox[3];
-        }
-        width = width || 800;
-        height = height || 600;
-
-        svgElement.setAttribute('width', String(width));
-        svgElement.setAttribute('height', String(height));
-        svgElement.setAttribute('style', 'max-width:none;background-color:#ffffff;');
-        if (!svgElement.getAttribute('xmlns')) {
-            svgElement.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
-        }
-
-        const scale = Math.min(options.scale, options.maxEdge / Math.max(width, height));
-        const safeScale = Number.isFinite(scale) && scale > 0 ? scale : 1;
-        return {
-            markup: new XMLSerializer().serializeToString(svgElement),
-            canvasWidth: Math.max(1, Math.round(width * safeScale)),
-            canvasHeight: Math.max(1, Math.round(height * safeScale)),
-        };
-    }
-
-    function base64EncodeUnicode(text) {
-        const bytes = new TextEncoder().encode(text);
-        const chunkSize = 0x8000;
-        let binary = '';
-        for (let index = 0; index < bytes.length; index += chunkSize) {
-            binary += String.fromCharCode.apply(null, bytes.subarray(index, index + chunkSize));
-        }
-        return btoa(binary);
-    }
-
-    function svgToPngDataUri(svgMarkup) {
-        return new Promise((resolve, reject) => {
-            const normalized = normalizeSvgMarkup(svgMarkup);
-            const image = new Image();
-            image.onload = () => {
-                try {
-                    const canvas = document.createElement('canvas');
-                    canvas.width = normalized.canvasWidth;
-                    canvas.height = normalized.canvasHeight;
-                    const context = canvas.getContext('2d');
-                    context.fillStyle = '#ffffff';
-                    context.fillRect(0, 0, canvas.width, canvas.height);
-                    context.drawImage(image, 0, 0, canvas.width, canvas.height);
-                    resolve(canvas.toDataURL('image/png'));
-                } catch (err) {
-                    reject(err);
-                }
-            };
-            image.onerror = () => reject(new Error('Unable to rasterize the diagram SVG.'));
-            image.src = 'data:image/svg+xml;base64,' + base64EncodeUnicode(normalized.markup);
-        });
-    }
-
     function withTimeout(promise, timeoutMs) {
         return new Promise((resolve, reject) => {
             const timer = setTimeout(() => reject(new Error('Diagram render timed out.')), timeoutMs);
@@ -142,26 +114,57 @@ MERMAID_RENDER_SCRIPT = """
         });
     }
 
-    for (let index = 0; index < sources.length; index += 1) {
-        const source = sources[index];
-        try {
-            const rendered = await withTimeout(
-                window.mermaid.render('simplechat-export-server-' + index, source),
-                options.diagramTimeoutMs,
-            );
-            const svgMarkup = typeof rendered === 'string' ? rendered : (rendered && rendered.svg);
-            if (!svgMarkup) {
-                results.push({ source, error: 'Mermaid produced no SVG.' });
-                continue;
-            }
-            const dataUri = await withTimeout(svgToPngDataUri(svgMarkup), options.diagramTimeoutMs);
-            results.push({ source, dataUri });
-        } catch (err) {
-            results.push({ source, error: String((err && err.message) || err) });
-        }
+    const host = document.getElementById(options.hostId);
+    host.replaceChildren();
+
+    const rendered = await withTimeout(
+        window.mermaid.render(options.renderId, source),
+        options.diagramTimeoutMs,
+    );
+    const svgMarkup = typeof rendered === 'string' ? rendered : (rendered && rendered.svg);
+    if (!svgMarkup) {
+        throw new Error('Mermaid produced no SVG.');
     }
 
-    return results;
+    // Parsed and imported rather than assigned through innerHTML, so model-derived markup
+    // is never handed to the HTML parser as script-capable content.
+    const parsed = new DOMParser().parseFromString(svgMarkup, 'image/svg+xml');
+    if (parsed.getElementsByTagName('parsererror').length > 0) {
+        throw new Error('Mermaid produced malformed SVG.');
+    }
+    const svgElement = document.importNode(parsed.documentElement, true);
+
+    let width = parseSvgLength(svgElement.getAttribute('width'));
+    let height = parseSvgLength(svgElement.getAttribute('height'));
+    const viewBox = String(svgElement.getAttribute('viewBox') || '')
+        .split(/[\\s,]+/)
+        .map(Number);
+    if (viewBox.length === 4 && Number.isFinite(viewBox[2]) && Number.isFinite(viewBox[3])) {
+        width = width || viewBox[2];
+        height = height || viewBox[3];
+    }
+    width = width || 800;
+    height = height || 600;
+
+    // The SVG is vector, so drawing it larger is what produces a high-resolution capture.
+    const scale = Math.min(options.scale, options.maxEdge / Math.max(width, height));
+    const safeScale = Number.isFinite(scale) && scale > 0 ? scale : 1;
+    const paintedWidth = Math.max(1, Math.round(width * safeScale));
+    const paintedHeight = Math.max(1, Math.round(height * safeScale));
+
+    svgElement.setAttribute('width', String(paintedWidth));
+    svgElement.setAttribute('height', String(paintedHeight));
+    svgElement.setAttribute('style', 'max-width:none;display:block;background-color:#ffffff;');
+
+    host.appendChild(svgElement);
+
+    // Labels are measured against the embedded font, so a capture taken before it is in use
+    // would record fallback metrics.
+    if (document.fonts && document.fonts.ready) {
+        await withTimeout(document.fonts.ready, options.diagramTimeoutMs);
+    }
+
+    return { width: paintedWidth, height: paintedHeight };
 })
 """
 
@@ -177,6 +180,7 @@ def get_mermaid_server_render_capabilities(force_refresh: bool = False) -> Dict[
         'playwright_available': False,
         'chromium_launch_available': False,
         'bundle_available': os.path.exists(get_mermaid_bundle_path()),
+        'embedded_font_available': get_embedded_render_font_data_uri() is not None,
         'message': 'Playwright is not installed in this app runtime.',
     }
 
@@ -222,6 +226,64 @@ def is_mermaid_server_rendering_available() -> bool:
 def get_mermaid_bundle_path() -> str:
     """Return the on-disk path of the vendored Mermaid bundle."""
     return os.path.join(os.path.dirname(os.path.abspath(__file__)), MERMAID_BUNDLE_RELATIVE_PATH)
+
+
+def get_embedded_render_font_path() -> Optional[str]:
+    """Return a scalable font file this runtime can embed into the render page.
+
+    matplotlib ships DejaVu Sans and is already required for TeX export, so the font
+    travels with the application rather than depending on a distribution package that a
+    given base image may not carry.
+    """
+    try:
+        import matplotlib
+
+        candidate = os.path.join(matplotlib.get_data_path(), 'fonts', 'ttf', 'DejaVuSans.ttf')
+        if os.path.exists(candidate):
+            return candidate
+    except Exception:
+        pass
+
+    return None
+
+
+def get_embedded_render_font_data_uri() -> Optional[str]:
+    """Return the render font as a data URI, reading it from disk at most once."""
+    global _EMBEDDED_FONT_CACHE, _EMBEDDED_FONT_RESOLVED
+    if _EMBEDDED_FONT_RESOLVED:
+        return _EMBEDDED_FONT_CACHE
+
+    font_path = get_embedded_render_font_path()
+    if font_path:
+        try:
+            with open(font_path, 'rb') as font_handle:
+                encoded_font = base64.b64encode(font_handle.read()).decode('ascii')
+            _EMBEDDED_FONT_CACHE = f'data:font/ttf;base64,{encoded_font}'
+        except Exception:
+            _EMBEDDED_FONT_CACHE = None
+
+    _EMBEDDED_FONT_RESOLVED = True
+    return _EMBEDDED_FONT_CACHE
+
+
+def build_render_page_style() -> str:
+    """Build the page stylesheet that supplies the render font and an opaque background."""
+    font_data_uri = get_embedded_render_font_data_uri()
+    font_face = ''
+    if font_data_uri:
+        font_face = (
+            '@font-face{'
+            f"font-family:'{MERMAID_SERVER_RENDER_FONT_FAMILY}';"
+            f"src:url({font_data_uri}) format('truetype');"
+            'font-weight:normal;font-style:normal;font-display:block;'
+            '}'
+        )
+
+    return (
+        f'{font_face}'
+        'html,body{margin:0;padding:0;background:#ffffff;}'
+        f'#{MERMAID_SERVER_RENDER_HOST_ID}{{display:inline-block;background:#ffffff;}}'
+    )
 
 
 def get_chromium_launch_args() -> List[str]:
@@ -301,14 +363,23 @@ def _normalize_render_sources(
 
 
 def _render_with_chromium(sources: List[str]) -> List[Dict[str, Any]]:
-    """Render every diagram in a single headless Chromium session."""
+    """Render every diagram in a single headless Chromium session.
+
+    Each diagram is mounted into the page and captured with an element screenshot, so the
+    picture is a real browser render rather than a reconstruction of one. Diagrams are
+    captured one at a time because each needs its own viewport size.
+    """
     from playwright.sync_api import sync_playwright
 
     render_options = {
         'scale': MERMAID_SERVER_RENDER_SCALE,
         'maxEdge': MERMAID_SERVER_RENDER_MAX_CANVAS_EDGE,
         'diagramTimeoutMs': MERMAID_SERVER_RENDER_DIAGRAM_TIMEOUT_MS,
+        'fontFamily': MERMAID_SERVER_RENDER_FONT_STACK,
+        'hostId': MERMAID_SERVER_RENDER_HOST_ID,
     }
+
+    results: List[Dict[str, Any]] = []
 
     with _RENDER_LOCK:
         with sync_playwright() as playwright_instance:
@@ -321,21 +392,63 @@ def _render_with_chromium(sources: List[str]) -> List[Dict[str, Any]]:
                 page = browser.new_page()
                 page.set_default_timeout(MERMAID_SERVER_RENDER_PAGE_TIMEOUT_MS)
 
-                # The page never needs the network: the bundle is inlined from disk and the
-                # diagram sources are passed in as data.
-                page.route('**/*', lambda route: route.abort())
-                page.set_content('<!doctype html><html lang="en"><head><meta charset="utf-8">'
-                                 '</head><body></body></html>')
+                # The page never needs the network: the bundle and the font are both
+                # inlined from disk and the diagram sources are passed in as data. Only
+                # real network schemes are blocked, so the font's data: URI still resolves.
+                page.route(MERMAID_SERVER_RENDER_BLOCKED_URL_PATTERN, lambda route: route.abort())
+                page.set_content(
+                    '<!doctype html><html lang="en"><head><meta charset="utf-8"></head>'
+                    f'<body><div id="{MERMAID_SERVER_RENDER_HOST_ID}"></div></body></html>'
+                )
+                page.add_style_tag(content=build_render_page_style())
                 page.add_script_tag(path=get_mermaid_bundle_path())
 
-                results = page.evaluate(
-                    f'([sources, options]) => ({MERMAID_RENDER_SCRIPT})(sources, options)',
-                    [sources, render_options],
-                )
+                host = page.locator(f'#{MERMAID_SERVER_RENDER_HOST_ID}')
+                for index, source in enumerate(sources):
+                    render_options['renderId'] = f'simplechat-export-server-{index}'
+                    try:
+                        results.append({
+                            'source': source,
+                            'dataUri': _capture_one_diagram(page, host, source, render_options),
+                        })
+                    except Exception as render_error:
+                        results.append({'source': source, 'error': str(render_error)[:220]})
             finally:
                 browser.close()
 
-    return results if isinstance(results, list) else []
+    return results
+
+
+def _capture_one_diagram(page: Any, host: Any, source: str, render_options: Dict[str, Any]) -> str:
+    """Mount one diagram in the page and return its screenshot as a PNG data URI."""
+    layout = page.evaluate(
+        f'([source, options]) => ({MERMAID_RENDER_SCRIPT})(source, options)',
+        [source, render_options],
+    )
+    if not isinstance(layout, dict):
+        raise RuntimeError('The diagram renderer returned no layout.')
+
+    # An element taller or wider than the viewport is captured by scrolling, which can seam
+    # a long diagram. Sizing the viewport to the diagram keeps every capture a single paint.
+    page.set_viewport_size({
+        'width': _clamp_viewport_edge(layout.get('width')),
+        'height': _clamp_viewport_edge(layout.get('height')),
+    })
+
+    image_bytes = host.screenshot(type='png', animations='disabled')
+    if not image_bytes:
+        raise RuntimeError('The diagram screenshot was empty.')
+
+    return build_export_visual_png_data_uri(image_bytes)
+
+
+def _clamp_viewport_edge(value: Any) -> int:
+    """Keep a viewport edge inside what Chromium will allocate."""
+    try:
+        edge = int(math.ceil(float(value)))
+    except (TypeError, ValueError):
+        edge = 0
+    return max(1, min(edge, MERMAID_SERVER_RENDER_MAX_CANVAS_EDGE))
 
 
 def _is_chromium_no_sandbox_enabled() -> bool:

--- a/application/single_app/static/js/chat/chat-message-export.js
+++ b/application/single_app/static/js/chat/chat-message-export.js
@@ -262,6 +262,15 @@ export async function exportMessageAsWord(messageDiv, messageId, role) {
         return;
     }
 
+    // The document is built entirely on the server, and diagrams the browser could not
+    // rasterize are redrawn there in a headless browser, so this can run for a while with
+    // nothing happening on the page.
+    const progressToast = showToast(
+        'Building your Word document… diagrams can make this take a while.',
+        'info',
+        { autohide: false }
+    );
+
     try {
         const response = await fetch('/api/message/export-word', {
             method: 'POST',
@@ -285,6 +294,8 @@ export async function exportMessageAsWord(messageDiv, messageId, role) {
     } catch (err) {
         console.error('Error exporting message to Word:', err);
         showToast('Failed to export message to Word.', 'danger');
+    } finally {
+        progressToast?.dismiss();
     }
 }
 
@@ -304,6 +315,14 @@ export async function exportMessageAsPowerPoint(messageDiv, messageId, role, opt
         showToast('Cannot export - no active conversation or message.', 'warning');
         return;
     }
+
+    // Slowest of the exports: the slide plan is written by a model before python-pptx builds
+    // anything, so the wait is measured in tens of seconds rather than in a spinner frame.
+    const progressToast = showToast(
+        'Building your PowerPoint… planning the slides can take a minute.',
+        'info',
+        { autohide: false }
+    );
 
     try {
         const requestBody = await buildMessageExportRequestBody(messageDiv, messageId, conversationId, role);
@@ -337,6 +356,8 @@ export async function exportMessageAsPowerPoint(messageDiv, messageId, role, opt
     } catch (err) {
         console.error('Error exporting message to PowerPoint:', err);
         showToast('Failed to export message to PowerPoint.', 'danger');
+    } finally {
+        progressToast?.dismiss();
     }
 }
 
@@ -382,6 +403,10 @@ export async function openInEmail(messageDiv, messageId, role) {
         return;
     }
 
+    // The subject line is written by a model and any diagram may need rendering, so this is
+    // not the instant hand-off to the mail client that it looks like.
+    const progressToast = showToast('Preparing your email draft…', 'info', { autohide: false });
+
     try {
         const response = await fetch('/api/message/export-email-draft', {
             method: 'POST',
@@ -412,5 +437,7 @@ export async function openInEmail(messageDiv, messageId, role) {
     } catch (err) {
         console.error('Error exporting message to email:', err);
         showToast('Failed to open email draft.', 'danger');
+    } finally {
+        progressToast?.dismiss();
     }
 }

--- a/application/single_app/static/js/chat/chat-messages.js
+++ b/application/single_app/static/js/chat/chat-messages.js
@@ -5885,11 +5885,11 @@ export function appendMessage(
     const exportMenuItemsHtml = renderCompletedAssistantActions ? `
             <li><hr class="dropdown-divider"></li>
             <li><a class="dropdown-item dropdown-export-md-btn" href="#" data-message-id="${messageId}"><i class="bi bi-markdown me-2"></i>Export to Markdown</a></li>
-            <li><a class="dropdown-item dropdown-export-word-btn" href="#" data-message-id="${messageId}"><i class="bi bi-file-earmark-word me-2"></i>Export to Word</a></li>
-            <li><a class="dropdown-item dropdown-export-ppt-btn" href="#" data-message-id="${messageId}"><i class="bi bi-file-earmark-slides me-2"></i>Export to PowerPoint</a></li>
+            <li><a class="dropdown-item dropdown-export-word-btn" href="#" data-message-id="${messageId}" data-default-label="Export to Word" data-pending-label="Building Word Document..." data-icon-class="bi bi-file-earmark-word" data-default-title="Export to Word"><i class="bi bi-file-earmark-word me-2"></i>Export to Word</a></li>
+            <li><a class="dropdown-item dropdown-export-ppt-btn" href="#" data-message-id="${messageId}" data-default-label="Export to PowerPoint" data-pending-label="Building PowerPoint..." data-icon-class="bi bi-file-earmark-slides" data-default-title="Export to PowerPoint"><i class="bi bi-file-earmark-slides me-2"></i>Export to PowerPoint</a></li>
             ${audioExportMenuItemHtml}
             <li><a class="dropdown-item dropdown-copy-prompt-btn" href="#" data-message-id="${messageId}"><i class="bi bi-clipboard-plus me-2"></i>Use as Prompt</a></li>
-            <li><a class="dropdown-item dropdown-open-email-btn" href="#" data-message-id="${messageId}"><i class="bi bi-envelope me-2"></i>Open in Email</a></li>` : '';
+            <li><a class="dropdown-item dropdown-open-email-btn" href="#" data-message-id="${messageId}" data-default-label="Open in Email" data-pending-label="Preparing Email Draft..." data-icon-class="bi bi-envelope" data-default-title="Open in Email"><i class="bi bi-envelope me-2"></i>Open in Email</a></li>` : '';
     const forkConversationMenuItemHtml = shouldRenderConversationForkAction(messageId, fullMessageObject)
       ? '<li><button class="dropdown-item dropdown-fork-conversation-btn" type="button"><i class="bi bi-signpost-split me-2"></i>Fork conversation</button></li>'
       : '';
@@ -6413,11 +6413,11 @@ export function appendMessage(
                 <li><a class="dropdown-item dropdown-retry-btn" href="#" data-message-id="${messageId}"><i class="bi bi-arrow-clockwise me-2"></i>Retry</a></li>
                 <li><hr class="dropdown-divider"></li>
                 <li><a class="dropdown-item dropdown-export-md-btn" href="#" data-message-id="${messageId}"><i class="bi bi-markdown me-2"></i>Export to Markdown</a></li>
-                <li><a class="dropdown-item dropdown-export-word-btn" href="#" data-message-id="${messageId}"><i class="bi bi-file-earmark-word me-2"></i>Export to Word</a></li>
-                <li><a class="dropdown-item dropdown-export-ppt-btn" href="#" data-message-id="${messageId}"><i class="bi bi-file-earmark-slides me-2"></i>Export to PowerPoint</a></li>
+                <li><a class="dropdown-item dropdown-export-word-btn" href="#" data-message-id="${messageId}" data-default-label="Export to Word" data-pending-label="Building Word Document..." data-icon-class="bi bi-file-earmark-word" data-default-title="Export to Word"><i class="bi bi-file-earmark-word me-2"></i>Export to Word</a></li>
+                <li><a class="dropdown-item dropdown-export-ppt-btn" href="#" data-message-id="${messageId}" data-default-label="Export to PowerPoint" data-pending-label="Building PowerPoint..." data-icon-class="bi bi-file-earmark-slides" data-default-title="Export to PowerPoint"><i class="bi bi-file-earmark-slides me-2"></i>Export to PowerPoint</a></li>
                 ${audioExportMenuItemHtml}
                 <li><a class="dropdown-item dropdown-copy-prompt-btn" href="#" data-message-id="${messageId}"><i class="bi bi-clipboard-plus me-2"></i>Use as Prompt</a></li>
-                <li><a class="dropdown-item dropdown-open-email-btn" href="#" data-message-id="${messageId}"><i class="bi bi-envelope me-2"></i>Open in Email</a></li>
+                <li><a class="dropdown-item dropdown-open-email-btn" href="#" data-message-id="${messageId}" data-default-label="Open in Email" data-pending-label="Preparing Email Draft..." data-icon-class="bi bi-envelope" data-default-title="Open in Email"><i class="bi bi-envelope me-2"></i>Open in Email</a></li>
               </ul>
             </div>
             <button class="btn btn-sm btn-link text-muted copy-user-btn" data-message-id="${messageId}" title="Copy message">

--- a/application/single_app/static/js/chat/chat-toast.js
+++ b/application/single_app/static/js/chat/chat-toast.js
@@ -1,9 +1,15 @@
 // chat-toast.js
 
+/**
+ * Show a notification through the global toast utility.
+ *
+ * Returns the toast's handle, so a caller showing progress with `{ autohide: false }` can
+ * dismiss it once the work finishes.
+ */
 export function showToast(message, variant = 'danger', options = {}) {
     if (typeof window.showToast !== 'function') {
         throw new Error('Global toast utility is unavailable.');
     }
 
-    window.showToast(message, variant, options);
+    return window.showToast(message, variant, options);
 }

--- a/application/single_app/static/js/toast.js
+++ b/application/single_app/static/js/toast.js
@@ -103,17 +103,28 @@
         }
     }
 
+    /**
+     * Show a notification.
+     *
+     * Pass `autohide: false` for work that is still running: the toast then stays until the
+     * caller dismisses it through the returned handle. A message export is rendered entirely
+     * on the server and changes nothing on the page while it runs, so without one there is
+     * no sign the click did anything.
+     *
+     * Returns a handle with `dismiss()`, or null when no toast could be shown.
+     */
     function showToast(message, variant = 'info', options = {}) {
         const container = getToastContainer();
         if (!container) {
             console.error('[Toast] Toast container is unavailable.');
-            return;
+            return null;
         }
 
         const requestedVariant = variantAliases.get(variant) || variant;
         const normalizedVariant = supportedVariants.has(requestedVariant) ? requestedVariant : 'info';
         const normalizedMessage = normalizeToastMessage(message);
         const isUrgent = normalizedVariant === 'danger' || normalizedVariant === 'warning';
+        const autohide = options.autohide !== false;
         if (options.persist === true) {
             persistToast(normalizedMessage, normalizedVariant);
         }
@@ -134,26 +145,40 @@
         bodyEl.className = 'toast-body';
         bodyEl.textContent = normalizedMessage;
 
-        const closeButtonEl = document.createElement('button');
-        closeButtonEl.type = 'button';
-        closeButtonEl.className = 'btn-close btn-close-white me-2 m-auto';
-        closeButtonEl.setAttribute('data-bs-dismiss', 'toast');
-        closeButtonEl.setAttribute('aria-label', 'Close');
+        // Work in progress cannot be cancelled, so a spinner stands in for the close button
+        // that a dismissible toast gets.
+        if (!autohide) {
+            const spinnerEl = document.createElement('span');
+            spinnerEl.className = 'spinner-border spinner-border-sm ms-3 my-auto';
+            spinnerEl.setAttribute('aria-hidden', 'true');
+            contentEl.appendChild(bodyEl);
+            contentEl.appendChild(spinnerEl);
+            toastEl.appendChild(contentEl);
+            container.appendChild(toastEl);
+        } else {
+            const closeButtonEl = document.createElement('button');
+            closeButtonEl.type = 'button';
+            closeButtonEl.className = 'btn-close btn-close-white me-2 m-auto';
+            closeButtonEl.setAttribute('data-bs-dismiss', 'toast');
+            closeButtonEl.setAttribute('aria-label', 'Close');
 
-        contentEl.appendChild(bodyEl);
-        contentEl.appendChild(closeButtonEl);
-        toastEl.appendChild(contentEl);
-        container.appendChild(toastEl);
+            contentEl.appendChild(bodyEl);
+            contentEl.appendChild(closeButtonEl);
+            toastEl.appendChild(contentEl);
+            container.appendChild(toastEl);
+        }
 
         if (!window.bootstrap?.Toast) {
             console.error('[Toast] Bootstrap Toast is unavailable.');
             toastEl.classList.add('show');
-            return;
+            return { dismiss: () => toastEl.remove() };
         }
 
         toastEl.addEventListener('hidden.bs.toast', () => toastEl.remove(), { once: true });
-        const bootstrapToast = new window.bootstrap.Toast(toastEl, { delay: 5000 });
+        const bootstrapToast = new window.bootstrap.Toast(toastEl, { delay: 5000, autohide });
         bootstrapToast.show();
+
+        return { dismiss: () => bootstrapToast.hide() };
     }
 
     window.showToast = showToast;

--- a/application/v2_ui/src/components/chat/MermaidDiagram.tsx
+++ b/application/v2_ui/src/components/chat/MermaidDiagram.tsx
@@ -24,6 +24,7 @@ import {
     type VisualStyle,
 } from '../../lib/visualPalettes';
 import { downloadDataUri, fileNameStem, svgElementToPngDataUri } from '../../lib/svgRaster';
+import { registerExportDiagram } from '../../lib/exportVisuals';
 import { VisualStyleMenu } from './VisualStyleMenu';
 
 interface MermaidRuntime {
@@ -313,6 +314,23 @@ export function MermaidDiagram({
             setDownloadError('The diagram could not be saved as an image.');
         }
     };
+
+    /**
+     * Offer this diagram to a Word, PowerPoint or email export of the same message.
+     *
+     * The SVG is read back at export time rather than captured here, so the export gets the
+     * diagram as it stands, and a message whose diagrams are all registered never makes the
+     * server start a browser to redraw them.
+     */
+    useEffect(
+        () =>
+            registerExportDiagram(messageId, blockIndex, {
+                source,
+                background,
+                getSvg: () => containerRef.current?.querySelector('svg') ?? null,
+            }),
+        [messageId, blockIndex, source, background],
+    );
 
     if (state.status === 'error') {
         return <DiagramSource source={source.trim()} reason="Diagram could not be rendered" />;

--- a/application/v2_ui/src/components/chat/MessageActions.tsx
+++ b/application/v2_ui/src/components/chat/MessageActions.tsx
@@ -49,6 +49,7 @@ import {
     saveEmailDraftAttachments,
     type MessageExportFormat,
 } from '../../lib/endpoints';
+import { buildMessageVisualAssets } from '../../lib/exportVisuals';
 import { synthesizeSpeech } from '../../lib/voice';
 
 function IconButton({
@@ -151,25 +152,50 @@ function SpeakButton({ message }: { message: ChatMessage }) {
     );
 }
 
+/** What the pending toast says while each export is being built. */
+const EXPORT_PENDING_MESSAGE: Record<MessageExportFormat, string> = {
+    word: 'Building your Word document… diagrams can make this take a while.',
+    powerpoint: 'Building your PowerPoint… planning the slides can take a minute.',
+    'email-draft': 'Preparing your email draft…',
+};
+
+const EXPORT_LABEL: Record<MessageExportFormat, string> = {
+    word: 'Word',
+    powerpoint: 'PowerPoint',
+    'email-draft': 'email',
+};
+
 /**
- * Run a server-rendered export, reporting the outcome.
+ * Run a server-rendered export, reporting progress and the outcome.
  *
  * Word and PowerPoint stream a file. Email is not a download at all: it returns a JSON
  * draft, whose images are saved separately because a `mailto:` URL cannot carry
  * attachments, before the mail client is opened.
+ *
+ * A pending toast goes up first. All three run entirely on the server, a PowerPoint also
+ * waits on a model planning its slides, and none of them change the page while they work — so
+ * without one the only visible response to the click is the menu closing.
  */
 async function runExport(format: MessageExportFormat, message: ChatMessage) {
-    const body = {
-        message_id: message.id,
-        conversation_id: message.conversation_id,
-    };
+    const pendingId = toast.pending(EXPORT_PENDING_MESSAGE[format]);
 
     try {
+        // Sending the diagrams already on screen saves the server starting a browser to
+        // redraw them, and keeps the colours the reader chose. Anything missing here is
+        // still rendered server-side, so a failure to rasterize only costs the shortcut.
+        const body = {
+            message_id: message.id,
+            conversation_id: message.conversation_id,
+            visual_assets: await buildMessageVisualAssets(message.id),
+        };
+
         if (format === 'email-draft') {
             const draft = await fetchMessageEmailDraft(body);
             const saved = saveEmailDraftAttachments(draft.attachments);
             window.location.href = emailDraftMailtoUrl(draft);
-            toast.success(
+            toast.settle(
+                pendingId,
+                'success',
                 saved > 0
                     ? `Email draft opened. ${saved} image${saved === 1 ? '' : 's'} downloaded to attach.`
                     : 'Email draft opened.',
@@ -178,11 +204,16 @@ async function runExport(format: MessageExportFormat, message: ChatMessage) {
         }
 
         await downloadMessageExport(format, body);
-        toast.success(format === 'word' ? 'Exported as a Word document.' : 'Exported as a PowerPoint.');
+        toast.settle(
+            pendingId,
+            'success',
+            format === 'word' ? 'Exported as a Word document.' : 'Exported as a PowerPoint.',
+        );
     } catch (error) {
-        const label =
-            format === 'word' ? 'Word' : format === 'powerpoint' ? 'PowerPoint' : 'email';
-        toast.error(
+        const label = EXPORT_LABEL[format];
+        toast.settle(
+            pendingId,
+            'error',
             error instanceof ApiError && error.message
                 ? `${label} export failed: ${error.message}`
                 : `${label} export failed.`,
@@ -218,6 +249,10 @@ function OverflowMenu({
     // The menu opens upward by default so it does not cover the next message, but near
     // the top of the scroll area there is no room above and it would render off-screen.
     const [placement, setPlacement] = useState<'up' | 'down'>('up');
+    // Which export is running, so its entry can show a spinner and the menu can refuse a
+    // second click. An export takes long enough that an impatient double-click would
+    // otherwise start two of them.
+    const [busyExport, setBusyExport] = useState<MessageExportFormat | null>(null);
     const containerRef = useRef<HTMLDivElement>(null);
     const { removeMessage } = useChatStore();
     const isUser = message.role === 'user';
@@ -277,6 +312,37 @@ function OverflowMenu({
         </button>
     );
 
+    /**
+     * An export entry, which stays put and spins rather than closing the menu.
+     *
+     * Closing on click would take the spinner away with it, leaving the toast as the only
+     * sign anything is happening. While one export runs every entry is disabled, because
+     * they all contend for the same server-side rendering.
+     */
+    const exportItem = (label: string, icon: React.ReactNode, format: MessageExportFormat) => {
+        const busy = busyExport === format;
+        return (
+            <button
+                key={label}
+                type="button"
+                disabled={busyExport !== null}
+                onClick={() => {
+                    setBusyExport(format);
+                    void runExport(format, message).finally(() => setBusyExport(null));
+                }}
+                className={clsx(
+                    'flex w-full items-center gap-2 rounded-lg px-2.5 py-1.5 text-left text-sm',
+                    'text-text-1 hover:bg-surface-2',
+                    'disabled:cursor-not-allowed disabled:hover:bg-transparent',
+                    busyExport !== null && !busy && 'opacity-40',
+                )}
+            >
+                {busy ? <Loader2 size={14} className="animate-spin text-accent" /> : icon}
+                {busy ? 'Working…' : label}
+            </button>
+        );
+    };
+
     return (
         <div className="relative" ref={containerRef}>
             <IconButton label="More actions" onClick={toggle}>
@@ -325,15 +391,9 @@ function OverflowMenu({
                     {item('Download Markdown', <FileDown size={14} />, () =>
                         downloadMarkdown(message),
                     )}
-                    {item('Export to Word', <FileDown size={14} />, () =>
-                        void runExport('word', message),
-                    )}
-                    {item('Export to PowerPoint', <FileDown size={14} />, () =>
-                        void runExport('powerpoint', message),
-                    )}
-                    {item('Open as email', <Mail size={14} />, () =>
-                        void runExport('email-draft', message),
-                    )}
+                    {exportItem('Export to Word', <FileDown size={14} />, 'word')}
+                    {exportItem('Export to PowerPoint', <FileDown size={14} />, 'powerpoint')}
+                    {exportItem('Open as email', <Mail size={14} />, 'email-draft')}
                     {item(
                         'Delete',
                         <Trash2 size={14} />,

--- a/application/v2_ui/src/components/ui/Toaster.tsx
+++ b/application/v2_ui/src/components/ui/Toaster.tsx
@@ -2,19 +2,21 @@
 // Renders transient notifications from the toast store.
 
 import { clsx } from 'clsx';
-import { CircleAlert, CircleCheck, Info, X } from 'lucide-react';
+import { CircleAlert, CircleCheck, Info, Loader2, X } from 'lucide-react';
 import { useToastStore, type ToastTone } from '../../stores/toastStore';
 
 const TONE_ICON: Record<ToastTone, typeof Info> = {
     success: CircleCheck,
     error: CircleAlert,
     info: Info,
+    pending: Loader2,
 };
 
 const TONE_CLASS: Record<ToastTone, string> = {
     success: 'text-ok',
     error: 'text-danger',
     info: 'text-accent',
+    pending: 'text-accent',
 };
 
 export function Toaster() {
@@ -32,22 +34,34 @@ export function Toaster() {
         >
             {toasts.map((item) => {
                 const Icon = TONE_ICON[item.tone];
+                const pending = item.tone === 'pending';
                 return (
                     <div
                         key={item.id}
                         role={item.tone === 'error' ? 'alert' : 'status'}
                         className="glass-modal pointer-events-auto flex items-start gap-2.5 rounded-xl px-3.5 py-2.5"
                     >
-                        <Icon size={16} className={clsx('mt-0.5 shrink-0', TONE_CLASS[item.tone])} />
+                        <Icon
+                            size={16}
+                            className={clsx(
+                                'mt-0.5 shrink-0',
+                                TONE_CLASS[item.tone],
+                                pending && 'animate-spin',
+                            )}
+                        />
                         <p className="min-w-0 flex-1 text-sm text-text-1">{item.message}</p>
-                        <button
-                            type="button"
-                            onClick={() => dismiss(item.id)}
-                            aria-label="Dismiss notification"
-                            className="shrink-0 rounded-md p-0.5 text-text-3 transition-colors hover:bg-surface-2 hover:text-text-1"
-                        >
-                            <X size={14} />
-                        </button>
+                        {/* Work in progress cannot be cancelled, so offering to close it would
+                            only hide the one thing telling the user it is still running. */}
+                        {!pending && (
+                            <button
+                                type="button"
+                                onClick={() => dismiss(item.id)}
+                                aria-label="Dismiss notification"
+                                className="shrink-0 rounded-md p-0.5 text-text-3 transition-colors hover:bg-surface-2 hover:text-text-1"
+                            >
+                                <X size={14} />
+                            </button>
+                        )}
                     </div>
                 );
             })}

--- a/application/v2_ui/src/lib/endpoints.ts
+++ b/application/v2_ui/src/lib/endpoints.ts
@@ -7,6 +7,7 @@
 
 import { api, apiUrl, uploadFile, ApiError, API_BASE } from './apiClient';
 import type { EnhancedCitationMetadata } from './enhancedCitations';
+import type { ExportVisualAsset } from './exportVisuals';
 import type { MaskAction, MaskedRange, MaskSelection } from './masking';
 import type {
     AiNoticeFrequency,
@@ -411,6 +412,14 @@ const EXPORT_EXTENSIONS: Record<'word' | 'powerpoint', string> = {
 interface MessageExportRequest {
     message_id: string;
     conversation_id: string;
+    /**
+     * Pictures of the diagrams already drawn on screen.
+     *
+     * The server renders any diagram this does not cover, so sending them is an optimisation
+     * and a fidelity choice rather than a requirement: it skips a headless browser launch and
+     * keeps whatever colours the reader picked.
+     */
+    visual_assets?: ExportVisualAsset[];
 }
 
 /** `YYYYMMDD_HHMMSS`, matching the server's own download naming. */

--- a/application/v2_ui/src/lib/exportVisuals.ts
+++ b/application/v2_ui/src/lib/exportVisuals.ts
@@ -1,0 +1,138 @@
+// exportVisuals.ts
+// Supplies the export endpoints with pictures of the diagrams already drawn on screen.
+//
+// Without this, a V2 export sends only the message and conversation id, so the server has to
+// re-render every diagram itself in headless Chromium. That costs roughly a second of browser
+// startup per export, and the result is whatever the *server* environment can draw rather than
+// what the reader is looking at — a container with no scalable font installed produces boxes
+// with no text in them.
+//
+// The diagram is already rendered in the page, so it is rasterized from there instead. That
+// removes the server round trip entirely for the common case and means the exported picture
+// keeps the colours the reader chose.
+//
+// Anything not covered here still falls back to server-side rendering, so a diagram that fails
+// to rasterize is omitted rather than sent broken.
+
+import { svgElementToPngDataUri } from './svgRaster';
+
+/** Matches `MESSAGE_EXPORT_VISUAL_ASSET_MAX_COUNT` in route_backend_conversation_export.py. */
+const MAX_ASSETS_PER_MESSAGE = 20;
+
+/** The only visual kind the browser rasterizes; charts and formulas are drawn server-side. */
+const VISUAL_KIND_DIAGRAM = 'diagram';
+
+/** One asset in the shape `normalize_visual_assets()` expects. */
+export interface ExportVisualAsset {
+    kind: string;
+    source: string;
+    data_uri: string;
+    alt?: string;
+    caption?: string;
+}
+
+interface RegisteredDiagram {
+    messageId: string;
+    source: string;
+    background: string;
+    /** Read at export time, so the picture matches the diagram as it is currently drawn. */
+    getSvg: () => SVGElement | null;
+}
+
+/**
+ * Diagrams currently mounted, keyed by message and block.
+ *
+ * Keyed rather than appended so a re-render replaces its own entry instead of accumulating,
+ * and so unmounting removes exactly one diagram.
+ */
+const registry = new Map<string, RegisteredDiagram>();
+
+function registryKey(messageId: string, blockIndex: number): string {
+    return `${messageId}::${blockIndex}`;
+}
+
+/** Register a mounted diagram. Returns the cleanup an effect should run on unmount. */
+export function registerExportDiagram(
+    messageId: string | undefined,
+    blockIndex: number | undefined,
+    entry: Omit<RegisteredDiagram, 'messageId'>,
+): () => void {
+    // A reply that is still streaming has neither id, and its diagram cannot be exported yet.
+    if (!messageId || blockIndex === undefined) {
+        return () => {};
+    }
+
+    const key = registryKey(messageId, blockIndex);
+    registry.set(key, { ...entry, messageId });
+
+    return () => {
+        // Guard against a later registration for the same slot having replaced this one.
+        if (registry.get(key)?.getSvg === entry.getSvg) {
+            registry.delete(key);
+        }
+    };
+}
+
+/**
+ * Normalize a fence body the way the server's `normalize_visual_source()` does.
+ *
+ * The server matches each asset back to its fence by this exact text, so the two
+ * implementations have to agree: line endings collapsed, trailing whitespace stripped per
+ * line, and blank leading and trailing lines dropped.
+ */
+export function normalizeVisualSource(value: string): string {
+    const lines = String(value ?? '')
+        .replace(/\r\n/g, '\n')
+        .replace(/\r/g, '\n')
+        .split('\n')
+        .map((line) => line.replace(/\s+$/, ''));
+
+    while (lines.length > 0 && lines[0].trim() === '') {
+        lines.shift();
+    }
+    while (lines.length > 0 && lines[lines.length - 1].trim() === '') {
+        lines.pop();
+    }
+
+    return lines.join('\n');
+}
+
+/**
+ * Rasterize the diagrams rendered for one message into export assets.
+ *
+ * Never rejects: an export must still go out when a diagram cannot be turned into a picture,
+ * because the server renders whatever this does not cover.
+ */
+export async function buildMessageVisualAssets(messageId: string): Promise<ExportVisualAsset[]> {
+    const assets: ExportVisualAsset[] = [];
+    const seenSources = new Set<string>();
+
+    for (const entry of registry.values()) {
+        if (assets.length >= MAX_ASSETS_PER_MESSAGE) {
+            break;
+        }
+        if (entry.messageId !== messageId) {
+            continue;
+        }
+
+        const source = normalizeVisualSource(entry.source);
+        if (!source || seenSources.has(source)) {
+            continue;
+        }
+
+        const svg = entry.getSvg();
+        if (!svg) {
+            continue;
+        }
+
+        try {
+            const dataUri = await svgElementToPngDataUri(svg, entry.background);
+            seenSources.add(source);
+            assets.push({ kind: VISUAL_KIND_DIAGRAM, source, data_uri: dataUri });
+        } catch {
+            /* Left for the server to render. */
+        }
+    }
+
+    return assets;
+}

--- a/application/v2_ui/src/stores/toastStore.ts
+++ b/application/v2_ui/src/stores/toastStore.ts
@@ -4,10 +4,15 @@
 // Several actions in the chat page succeed or fail entirely server-side — exports, masking,
 // attempt switching. Without somewhere to say so, a failure looks identical to a dead
 // button, which is the exact complaint that motivated this work.
+//
+// Exports needed more than a result. A message export is rendered by the server and a
+// PowerPoint additionally asks a model to plan its slides, so it can run for a long time with
+// nothing on screen. A `pending` toast stays put until the work finishes and is then settled
+// in place, so the answer replaces the progress note rather than stacking underneath it.
 
 import { create } from 'zustand';
 
-export type ToastTone = 'success' | 'error' | 'info';
+export type ToastTone = 'success' | 'error' | 'info' | 'pending';
 
 export interface Toast {
     id: number;
@@ -17,12 +22,18 @@ export interface Toast {
 
 interface ToastState {
     toasts: Toast[];
-    push: (tone: ToastTone, message: string) => void;
+    push: (tone: ToastTone, message: string) => number;
+    settle: (id: number, tone: Exclude<ToastTone, 'pending'>, message: string) => void;
     dismiss: (id: number) => void;
 }
 
-/** How long a toast stays before dismissing itself. Errors linger, since they need reading. */
-const TOAST_TTL: Record<ToastTone, number> = {
+/**
+ * How long a toast stays before dismissing itself. Errors linger, since they need reading.
+ *
+ * `pending` has no entry: it is dismissed by whoever raised it, because only the caller knows
+ * when the work is done.
+ */
+const TOAST_TTL: Record<Exclude<ToastTone, 'pending'>, number> = {
     success: 3200,
     info: 3800,
     error: 6500,
@@ -39,6 +50,30 @@ export const useToastStore = create<ToastState>((set, get) => ({
 
         set((state) => ({ toasts: [...state.toasts, { id, tone, message }] }));
 
+        if (tone !== 'pending') {
+            window.setTimeout(() => {
+                get().dismiss(id);
+            }, TOAST_TTL[tone]);
+        }
+
+        return id;
+    },
+
+    /**
+     * Turn a pending toast into its result, keeping its place in the stack.
+     *
+     * A toast the user already dismissed is not resurrected — they have said they are not
+     * interested — so the result is dropped rather than pushed as a new notification.
+     */
+    settle: (id, tone, message) => {
+        if (!get().toasts.some((item) => item.id === id)) {
+            return;
+        }
+
+        set((state) => ({
+            toasts: state.toasts.map((item) => (item.id === id ? { ...item, tone, message } : item)),
+        }));
+
         window.setTimeout(() => {
             get().dismiss(id);
         }, TOAST_TTL[tone]);
@@ -54,4 +89,9 @@ export const toast = {
     success: (message: string) => useToastStore.getState().push('success', message),
     error: (message: string) => useToastStore.getState().push('error', message),
     info: (message: string) => useToastStore.getState().push('info', message),
+    /** Raise a notification that stays until `settle` or `dismiss` is called with its id. */
+    pending: (message: string) => useToastStore.getState().push('pending', message),
+    settle: (id: number, tone: Exclude<ToastTone, 'pending'>, message: string) =>
+        useToastStore.getState().settle(id, tone, message),
+    dismiss: (id: number) => useToastStore.getState().dismiss(id),
 };

--- a/docs/explanation/features/EXPORT_MERMAID_AND_TEX_RENDERING.md
+++ b/docs/explanation/features/EXPORT_MERMAID_AND_TEX_RENDERING.md
@@ -79,14 +79,28 @@ somewhere. SimpleChat uses two, in this order:
 1. **The user's browser**, when one is attached to the export. It reads the Mermaid blocks
    out of the message, or calls `POST /api/conversations/export/visual-scan` for a
    conversation export, renders each diagram to SVG, paints it onto a canvas and reads it
-   back as a PNG. The PNGs travel with the export request as `visual_assets`.
+   back as a PNG. The PNGs travel with the export request as `visual_assets`. Both the
+   classic chat and V2 do this, so a diagram the reader can see is normally exported exactly
+   as it appears on screen, including any colours they chose for it.
 2. **Headless Chromium on the server**, for anything the browser did not cover — an export
    started from an interface that does not rasterize, or a server-initiated export. The
    container already installs Playwright's Chromium for Source Review and Deep Research
    (`INSTALL_PLAYWRIGHT_CHROMIUM`, on by default), so this costs no new dependency.
 
-Both load the same vendored bundle and use the same configuration, so a diagram renders
-identically whichever path produced it.
+The server renderer draws each diagram into its live page and captures it with a Playwright
+element screenshot. It deliberately does not repeat the browser's serialize-and-repaint
+route: an SVG reloaded through an `<img>` renders in an isolated context that drops
+`<foreignObject>` content and never loads a font that is not already available.
+
+It also **carries its own font** rather than using the host's. The application image installs
+no scalable Latin typeface, so a diagram asking for `Arial, Helvetica, sans-serif` used to
+resolve to nothing: Chromium measured every label as zero-width, Mermaid fell back to its
+minimum node size, and the export came out as a set of uniform empty boxes. DejaVu Sans is
+read from matplotlib, already a requirement for TeX export, and injected as an `@font-face`,
+so a server-rendered diagram looks the same on every deployment.
+
+Both paths load the same vendored bundle and use the same configuration, so a diagram renders
+comparably whichever produced it.
 
 The server matches each asset to its fence by **normalized source text**, and only renders
 diagrams that have no asset already. A client-supplied picture is never re-rendered.
@@ -221,6 +235,11 @@ PNG is rejected if it exceeds the same byte cap that browser-supplied assets use
 - Server-side rendering launches a browser, which takes roughly a second before the first
   diagram in a request. Exports whose diagrams the client already rasterized never pay it,
   and neither do exports with no diagrams at all.
+- Server-side rendering is serialised by a process-wide lock, so concurrent exports that both
+  need it queue behind each other. Exports whose diagrams the client supplied never take
+  the lock.
+- Server-rendered diagrams always use the embedded DejaVu Sans, so their lettering can differ
+  slightly from a browser-rendered one, which uses the reader's own font stack.
 - V2 vendors its own copy of the same Mermaid version under
   `application/v2_ui/public/vendor/mermaid-11.17.2/` for in-chat rendering. The two
   frontends have separate vendor trees, so the bundle is currently committed twice.

--- a/docs/explanation/fixes/MERMAID_EXPORT_LABEL_TEXT_FIX.md
+++ b/docs/explanation/fixes/MERMAID_EXPORT_LABEL_TEXT_FIX.md
@@ -1,0 +1,123 @@
+# Exported Mermaid Diagrams Lost Their Label Text
+
+Fixed in version: **0.261.034**
+
+## Issue
+
+Exporting a chat message containing a Mermaid diagram to Word or PowerPoint produced a
+diagram with the right shape — every node, every edge, every arrowhead — and **no text in
+any of the boxes**. The same diagram rendered correctly on screen in the chat.
+
+The export was also slow enough to look broken. A PowerPoint export ran long enough that it
+was reported as having failed, when in fact it had completed; nothing in either interface
+said an export was in progress, so the only visible response to the click was the menu
+closing.
+
+## Root cause
+
+Two independent problems that presented as one.
+
+### 1. The container has no scalable font
+
+`application/single_app/Dockerfile` installed fonts for the Chromium runtime with:
+
+```dockerfile
+tdnf install -y xorg-x11-fonts-Type1 xorg-x11-fonts-misc || true;
+```
+
+Those are legacy X11 Type1 and bitmap packages. Neither provides a scalable TrueType Latin
+face, and the trailing `|| true` meant that if the packages did not resolve at all the build
+carried on silently. Azure Linux is deliberately minimal and ships no fonts by default, so
+the deployed image had nothing Chromium could use.
+
+`functions_mermaid_server_render.py` asked Mermaid to render with
+`fontFamily: 'Arial, Helvetica, sans-serif'`. On Linux none of those exist, and the generic
+`sans-serif` fallback resolved to nothing. Chromium therefore measured every label as
+zero-width, so Mermaid fell back to its minimum node size and painted no glyphs.
+
+The giveaway in the reported files is that **every box came out the same width**, while on
+screen the same diagram had boxes of visibly different widths. That is the signature of
+zero-width text measurement, not of a colour, theme or `<foreignObject>` problem.
+
+This only ever affected server-side rendering. A browser has its own fonts, which is why the
+on-screen diagram was correct.
+
+### 2. V2 never sent the diagram it had already drawn
+
+`downloadMessageExport()` in `application/v2_ui/src/lib/endpoints.ts` posted only
+`message_id` and `conversation_id`. The classic chat sends `visual_assets`, but V2 did not,
+so every V2 export went down the server rendering path and hit the font problem — even
+though a correct picture of the diagram already existed in the page.
+
+### Why the test suite did not catch it
+
+`test_server_renders_diagrams_with_visible_labels` claimed to verify that "a rendered diagram
+keeps its label text", but only asserted `painted_ratio > 0.01`. Boxes and arrows alone clear
+that threshold easily, so a diagram with no text at all passed.
+
+## Changes
+
+| File | Change |
+|---|---|
+| `application/single_app/Dockerfile` | Install DejaVu, Liberation and Noto Sans font packages and rebuild the font cache, so everything rendering in this image has glyphs |
+| `application/single_app/functions_mermaid_server_render.py` | Embed DejaVu Sans as an `@font-face` from matplotlib; capture the diagram with a Playwright element screenshot instead of an `<img>`/canvas repaint; block only real network schemes so the font's `data:` URI resolves; report `embedded_font_available` from the capability probe |
+| `application/v2_ui/src/lib/exportVisuals.ts` | New: registry of on-screen diagrams and the rasterizer that turns them into `visual_assets` |
+| `application/v2_ui/src/components/chat/MermaidDiagram.tsx` | Register each rendered diagram for export |
+| `application/v2_ui/src/lib/endpoints.ts` | Carry `visual_assets` on the export request |
+| `application/v2_ui/src/stores/toastStore.ts` | Add a `pending` tone that does not auto-dismiss, and `settle()` to replace it in place |
+| `application/v2_ui/src/components/ui/Toaster.tsx` | Render the pending tone with a spinner and no dismiss button |
+| `application/v2_ui/src/components/chat/MessageActions.tsx` | Raise a pending toast before each export, settle it on the outcome, and disable the menu entry with a spinner while it runs |
+| `application/single_app/static/js/toast.js` | Support `{ autohide: false }` and return a `{ dismiss }` handle |
+| `application/single_app/static/js/chat/chat-toast.js` | Forward the toast handle to callers |
+| `application/single_app/static/js/chat/chat-message-export.js` | Progress toast around the Word, PowerPoint and email exports, always cleared in a `finally` |
+| `application/single_app/static/js/chat/chat-messages.js` | Give the dropdown export entries the `data-pending-label` the inline buttons already had, so they spin and disable |
+
+### Why an element screenshot
+
+The server renderer previously serialized its SVG, reloaded it through an `<img>` and painted
+it onto a canvas — a reconstruction of a browser render, performed inside a real browser that
+was already open. That isolated context silently drops `<foreignObject>` content and will not
+load a font that is not already present. Screenshotting the mounted element renders exactly
+what a browser would show, and removes the whole class of failure.
+
+## Validation
+
+- `functional_tests/test_export_mermaid_server_render.py` — 13/13. The label assertion now
+  renders the same graph with and without label text and requires the labelled one to have
+  materially more dark pixels **and** to be wider, which is what uniform minimum-width boxes
+  would fail. Measured on the fixture: 12,295 dark pixels labelled versus 0 unlabelled, and
+  945px wide versus 372px.
+- `functional_tests/test_message_export_progress_feedback.py` — 8/8. Includes a parity check
+  that executes the browser's own `normalizeVisualSource` in Node against Python's
+  `normalize_visual_source`, because a mismatch there silently discards every client asset
+  rather than failing.
+- `functional_tests/test_export_mermaid_browser_rasterizer.py` — 3/3.
+- `functional_tests/test_conversation_export_mermaid_tex_images.py` — 18/18.
+- `functional_tests/test_deep_research_chromium_build_opt_out.py` — 3/3.
+- `npm run build` in `application/v2_ui` — clean.
+
+### Before and after
+
+| | Before | After |
+|---|---|---|
+| Server-rendered diagram | Uniform empty boxes | Labels drawn in the embedded font |
+| V2 export with a diagram | Always launched headless Chromium | Sends the on-screen picture; no browser launch |
+| Exported colours | Server defaults | The colours the reader chose |
+| During an export | Nothing on screen | Pending toast plus a disabled, spinning menu entry |
+
+## Notes
+
+- Investigated and rejected: `htmlLabels` was never the problem. The rendered SVG contains 11
+  `<text>` elements and zero `<foreignObject>` elements, and a diagram using `classDef` and
+  `style` produces identical colour histograms through the canvas path and a live screenshot.
+  The browser rasterizers were correct and were left unchanged.
+- `gunicorn.conf.py` already allows 900s per request, so a slow export is not being cut off
+  server-side. The practical ceiling is the Azure App Service front-end idle timeout of
+  roughly 230 seconds, which cannot be configured from this repository. Skipping the browser
+  launch and reporting progress were the available mitigations.
+- No files under `deployers/` changed, so `deployers/version.txt` was not bumped. The
+  Dockerfile lives under `application/` and introduces no new build argument or parameter.
+- `test_deep_research_chromium_build_opt_out.py` asserted an exact deployer version of
+  `1.0.4` and had been failing since the deployer moved past it. Because it is the test
+  covering the Dockerfile changed here, it was switched to the shared
+  `assert_version_at_least` helper the repository's own versioning rules require.

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,30 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/features) and [Fixes by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/fixes).
 
+### **(v0.261.034)**
+
+#### Bug Fixes
+
+*   **Exported Diagrams Are No Longer Empty Boxes**
+    *   Exporting a message with a diagram to Word or PowerPoint produced the right shapes, arrows and layout, but **no text inside any of the boxes**, even though the same diagram read correctly on screen.
+    *   The application image ships no scalable font, so when the server drew a diagram itself the browser it uses had nothing to write with: it measured every label as zero-width, fell back to the smallest box that would fit nothing, and painted no lettering. The tell-tale sign was every box coming out the same width, while on screen they varied with their labels.
+    *   The renderer now carries its own font instead of relying on whatever the host happens to have, so a diagram exports the same way on every deployment. Real fonts were also added to the image for everything else that draws in it.
+    *   Diagrams are now captured directly from the page they are drawn on, rather than being redrawn from a copy — a step that quietly discarded anything it could not reproduce.
+    *   (Ref: message export, Mermaid diagrams, server-side rendering, container fonts)
+
+*   **Exports Say When They Are Working**
+    *   Exporting to Word, PowerPoint or email closed the menu and then appeared to do nothing, sometimes for a long time. A PowerPoint export in particular waits on the model planning your slides, and long enough that it was reasonably read as having hung or failed when it was still going.
+    *   All three now put up a notice as soon as you click, which stays until the file arrives and is then replaced by the result. The menu entry spins and greys out while it runs, so an impatient second click cannot start a duplicate export.
+    *   Both the classic and new interfaces behave the same way.
+    *   (Ref: message export, notifications, chat message menu)
+
+#### User Interface Enhancements
+
+*   **Faster Exports That Keep Your Diagram Colours**
+    *   The new interface now sends the diagram it has already drawn along with the export, so the server no longer starts a browser to draw it again. Exports containing diagrams finish noticeably sooner.
+    *   Because the exported picture is the one on your screen, any colours you picked for that diagram now come with it.
+    *   (Ref: V2 chat, message export, Mermaid diagrams)
+
 ### **(v0.261.033)**
 
 #### New Features

--- a/functional_tests/test_deep_research_chromium_build_opt_out.py
+++ b/functional_tests/test_deep_research_chromium_build_opt_out.py
@@ -2,7 +2,7 @@
 #!/usr/bin/env python3
 """
 Functional test for Deep Research Chromium build opt-out.
-Version: 0.241.069
+Version: 0.261.034
 Implemented in: 0.241.068
 
 This test ensures azd container builds can skip Playwright Chromium browser
@@ -12,11 +12,20 @@ packaging by setting SIMPLECHAT_INSTALL_CHROMIUM=false before deployment.
 import sys
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from test_support.versioning import assert_version_at_least  # noqa: E402
+
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 DOCKERFILE = REPO_ROOT / "application" / "single_app" / "Dockerfile"
 AZURE_YAML = REPO_ROOT / "deployers" / "azure.yaml"
 DEPLOYER_VERSION = REPO_ROOT / "deployers" / "version.txt"
+
+# The deployer version this build contract first shipped in. Asserted as a floor rather than
+# an exact match, because every later deployer change bumps this file and an equality check
+# would fail on all of them.
+CHROMIUM_BUILD_CONTRACT_DEPLOYER_VERSION = "1.0.4"
 
 
 def read_text(path):
@@ -51,10 +60,13 @@ def test_azd_predeploy_passes_chromium_build_arg():
 
 
 def test_deployer_version_updated_for_build_contract():
-    """Validate deployer version was bumped for the ACR build contract change."""
-    deployer_version = read_text(DEPLOYER_VERSION).strip()
-    if deployer_version != "1.0.4":
-        raise AssertionError(f"Expected deployer version 1.0.4, found {deployer_version}")
+    """Validate the deployer version carries at least the ACR build contract change."""
+    assert_version_at_least(
+        read_text(DEPLOYER_VERSION).strip(),
+        CHROMIUM_BUILD_CONTRACT_DEPLOYER_VERSION,
+        label="deployers/version.txt",
+        reason="The ACR Chromium build contract shipped in this deployer version.",
+    )
 
 
 def main():

--- a/functional_tests/test_export_mermaid_server_render.py
+++ b/functional_tests/test_export_mermaid_server_render.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 """
 Functional test for server-side Mermaid rendering in exports.
-Version: 0.261.027
+Version: 0.261.034
 Implemented in: 0.261.027
+Label-text regression coverage added in: 0.261.034
 
 This test ensures diagrams are rasterized on the server, using the Playwright Chromium
 already installed in the image, for exports that have no browser attached to them. It
@@ -34,6 +35,10 @@ sys.modules.setdefault(
 from functions_export_visuals import normalize_visual_assets  # noqa: E402
 from functions_mermaid_server_render import (  # noqa: E402
     MERMAID_RENDER_SCRIPT,
+    MERMAID_SERVER_RENDER_FONT_FAMILY,
+    build_render_page_style,
+    get_embedded_render_font_data_uri,
+    get_embedded_render_font_path,
     get_mermaid_bundle_path,
     get_mermaid_server_render_capabilities,
     is_mermaid_server_rendering_available,
@@ -42,6 +47,7 @@ from functions_mermaid_server_render import (  # noqa: E402
 
 RASTERIZER_PATH = os.path.join(APP_DIR, 'static', 'js', 'chat', 'chat-visual-rasterizer.js')
 MERMAID_RUNTIME_PATH = os.path.join(APP_DIR, 'static', 'js', 'chat', 'chat-mermaid-runtime.js')
+DOCKERFILE_PATH = os.path.join(APP_DIR, 'Dockerfile')
 
 FLOWCHART_SOURCE = (
     'graph TD\n'
@@ -52,6 +58,23 @@ FLOWCHART_SOURCE = (
 )
 SEQUENCE_SOURCE = 'sequenceDiagram\n    Alice->>Bob: Hello Bob\n    Bob-->>Alice: Hi Alice'
 INVALID_SOURCE = 'this is definitely not valid mermaid {{{'
+
+# The same graph with and without label text. Comparing the two is what distinguishes a
+# diagram that drew its labels from one that drew only boxes and arrows: a container with no
+# scalable font measures every label as zero-width, so the shapes still appear and the text
+# does not.
+LABELLED_SOURCE = (
+    'graph TD\n'
+    '    A[Microsoft Entra ID Tenant] --> B[Management Group]\n'
+    '    B --> C[Subscription Production Applications]\n'
+    '    B --> D[Resource Group prod-web-rg]'
+)
+UNLABELLED_SOURCE = (
+    'graph TD\n'
+    '    A[ ] --> B[ ]\n'
+    '    B --> C[ ]\n'
+    '    B --> D[ ]'
+)
 
 
 def _import_route_helpers():
@@ -109,6 +132,29 @@ def _painted_pixel_ratio(data_uri: str):
 
     painted = sum(count for count, color in colors if color != (255, 255, 255))
     return width, height, painted / float(width * height)
+
+
+def _dark_pixel_count(data_uri: str) -> int:
+    """Count near-black pixels, which is what label glyphs are made of.
+
+    Node fills and edges in the neutral theme are much lighter than text, so this separates
+    "the diagram has writing in it" from "the diagram has boxes in it".
+    """
+    from PIL import Image
+
+    image_bytes = base64.b64decode(data_uri.split(',', 1)[1])
+    with Image.open(io.BytesIO(image_bytes)) as image:
+        rgb_image = image.convert('RGB')
+        colors = rgb_image.getcolors(maxcolors=1_000_000) or []
+
+    return sum(count for count, color in colors if sum(color) < 300)
+
+
+def _asset_for_source(assets: List[Dict[str, Any]], source: str) -> Dict[str, Any]:
+    for asset in assets:
+        if asset.get('normalized_source') == source.strip():
+            return asset
+    raise AssertionError(f'no rendered asset for source: {source[:40]}')
 
 
 def _build_png_data_uri() -> str:
@@ -171,7 +217,13 @@ def test_server_and_browser_renderers_share_configuration():
 
 
 def test_server_renders_diagrams_with_visible_labels():
-    """A server-rendered diagram must contain its label text, not just shapes."""
+    """A server-rendered diagram must contain its label text, not just shapes.
+
+    Painted-pixel coverage alone cannot show this: boxes and arrows paint plenty of pixels
+    on their own, which is how a build that rendered every label invisibly still passed.
+    The labelled graph is therefore compared against the identical graph with its labels
+    removed, on two measures that only writing can move.
+    """
     print("Testing server diagram rendering...")
 
     if not _server_rendering_available():
@@ -190,7 +242,102 @@ def test_server_renders_diagrams_with_visible_labels():
         assert width >= 100 and height >= 50, (width, height)
         assert painted_ratio > 0.01, painted_ratio
 
+    label_comparison = render_mermaid_visual_assets([
+        {'source': LABELLED_SOURCE},
+        {'source': UNLABELLED_SOURCE},
+    ])
+    assert len(label_comparison) == 2, label_comparison
+    labelled = _asset_for_source(label_comparison, LABELLED_SOURCE)
+    unlabelled = _asset_for_source(label_comparison, UNLABELLED_SOURCE)
+
+    labelled_dark = _dark_pixel_count(labelled['data_uri'])
+    unlabelled_dark = _dark_pixel_count(unlabelled['data_uri'])
+    assert labelled_dark > unlabelled_dark + 500, (
+        'the labelled diagram drew no more dark pixels than the same diagram with empty '
+        f'labels, so its text is missing: {labelled_dark} vs {unlabelled_dark}'
+    )
+
+    # Node width follows the width of its label. Uniform, minimum-width boxes are the
+    # signature of a runtime that measured every label as zero-width.
+    labelled_width, _, _ = _painted_pixel_ratio(labelled['data_uri'])
+    unlabelled_width, _, _ = _painted_pixel_ratio(unlabelled['data_uri'])
+    assert labelled_width > unlabelled_width, (
+        'labelled and unlabelled diagrams came out the same width, so label text was never '
+        f'measured: {labelled_width} vs {unlabelled_width}'
+    )
+
     print("Server diagram rendering passed!")
+
+
+def test_render_font_is_embedded_rather_than_borrowed_from_the_host():
+    """The renderer must carry its own font.
+
+    The application image installs no scalable Latin typeface, so a diagram asking for
+    Arial or a generic sans-serif resolves to nothing there: Chromium measures every label
+    as zero-width, Mermaid falls back to its minimum node size, and the export is a set of
+    uniform empty boxes. Embedding the font removes the dependency on the host entirely.
+    """
+    print("Testing embedded render font...")
+
+    font_path = get_embedded_render_font_path()
+    assert font_path and os.path.exists(font_path), (
+        'no embeddable font was found; matplotlib supplies DejaVu Sans and is already a '
+        f'requirement, so this should not happen: {font_path}'
+    )
+
+    data_uri = get_embedded_render_font_data_uri()
+    assert data_uri and data_uri.startswith('data:font/ttf;base64,'), (data_uri or '')[:48]
+
+    page_style = build_render_page_style()
+    assert '@font-face' in page_style, page_style[:200]
+    assert MERMAID_SERVER_RENDER_FONT_FAMILY in page_style, page_style[:200]
+    assert data_uri in page_style, 'the font data URI must reach the render page'
+
+    # The render script has to ask for the family that was embedded, or the embedding is
+    # decorative and Mermaid still measures against whatever the host provides.
+    assert 'options.fontFamily' in MERMAID_RENDER_SCRIPT, MERMAID_RENDER_SCRIPT[:400]
+
+    capabilities = get_mermaid_server_render_capabilities()
+    assert capabilities.get('embedded_font_available') is True, capabilities
+
+    print("Embedded render font passed!")
+
+
+def test_container_image_installs_scalable_fonts():
+    """The image should still carry real fonts for everything else that renders in it.
+
+    Source Review and Deep Research screenshot pages in the same Chromium, and they have no
+    embedded font of their own. The legacy X11 Type1 and bitmap packages that used to be the
+    only font install provide no scalable Latin face.
+    """
+    print("Testing container font packages...")
+
+    with open(DOCKERFILE_PATH, 'r', encoding='utf-8') as handle:
+        dockerfile = handle.read()
+
+    assert 'dejavu' in dockerfile.lower(), 'no scalable font family is installed in the image'
+    assert 'fc-cache' in dockerfile, 'the font cache is never rebuilt after installing fonts'
+
+    print("Container font packages passed!")
+
+
+def test_server_renderer_captures_the_live_page():
+    """Diagrams must be screenshotted where they are drawn, not repainted onto a canvas.
+
+    Serializing an SVG and reloading it through an <img> silently drops whatever that
+    isolated context will not honour, fonts included, and it is not needed here: this
+    renderer already has a real browser page open.
+    """
+    print("Testing live-page capture...")
+
+    assert 'document.importNode' in MERMAID_RENDER_SCRIPT, MERMAID_RENDER_SCRIPT[:400]
+    assert 'document.fonts.ready' in MERMAID_RENDER_SCRIPT, MERMAID_RENDER_SCRIPT[:400]
+    for canvas_artifact in ("getContext('2d')", 'drawImage', 'toDataURL', 'new Image()'):
+        assert canvas_artifact not in MERMAID_RENDER_SCRIPT, (
+            f'the server renderer still rasterizes through a canvas: {canvas_artifact}'
+        )
+
+    print("Live-page capture passed!")
 
 
 def test_server_skips_a_diagram_it_cannot_render():
@@ -343,6 +490,9 @@ if __name__ == "__main__":
     tests: List[Callable[[], None]] = [
         test_capability_probe_reports_a_complete_shape,
         test_server_and_browser_renderers_share_configuration,
+        test_render_font_is_embedded_rather_than_borrowed_from_the_host,
+        test_container_image_installs_scalable_fonts,
+        test_server_renderer_captures_the_live_page,
         test_server_renders_diagrams_with_visible_labels,
         test_server_skips_a_diagram_it_cannot_render,
         test_server_render_deduplicates_and_caps_sources,

--- a/functional_tests/test_message_export_progress_feedback.py
+++ b/functional_tests/test_message_export_progress_feedback.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+"""
+Functional test for message export progress feedback and client-supplied diagrams.
+Version: 0.261.034
+Implemented in: 0.261.034
+
+Two things are covered here, both from the same report: a message export that contains a
+Mermaid diagram produced empty boxes, and it ran for a long time with nothing on screen to
+say it was working, so it looked like it had hung and then failed.
+
+This test ensures that:
+
+  * both interfaces raise a progress notification before an export request and clear it
+    afterwards, and disable the control while it runs so a second click cannot start a
+    duplicate export;
+  * the V2 interface sends the diagram it has already drawn, so the server does not have to
+    start a browser to redraw it;
+  * the browser's fence normalization agrees exactly with the server's
+    ``normalize_visual_source()``, which is what the server matches assets to fences by. A
+    disagreement here does not fail loudly: every asset is silently ignored and every
+    diagram is quietly re-rendered server-side.
+"""
+
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from typing import Callable, List
+
+
+ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+APP_DIR = os.path.join(ROOT_DIR, 'application', 'single_app')
+V2_SRC = os.path.join(ROOT_DIR, 'application', 'v2_ui', 'src')
+sys.path.insert(0, APP_DIR)
+
+from functions_export_visuals import normalize_visual_source  # noqa: E402
+
+TOAST_STORE_PATH = os.path.join(V2_SRC, 'stores', 'toastStore.ts')
+TOASTER_PATH = os.path.join(V2_SRC, 'components', 'ui', 'Toaster.tsx')
+MESSAGE_ACTIONS_PATH = os.path.join(V2_SRC, 'components', 'chat', 'MessageActions.tsx')
+MERMAID_DIAGRAM_PATH = os.path.join(V2_SRC, 'components', 'chat', 'MermaidDiagram.tsx')
+EXPORT_VISUALS_PATH = os.path.join(V2_SRC, 'lib', 'exportVisuals.ts')
+ENDPOINTS_PATH = os.path.join(V2_SRC, 'lib', 'endpoints.ts')
+
+GLOBAL_TOAST_PATH = os.path.join(APP_DIR, 'static', 'js', 'toast.js')
+CHAT_TOAST_PATH = os.path.join(APP_DIR, 'static', 'js', 'chat', 'chat-toast.js')
+CHAT_EXPORT_PATH = os.path.join(APP_DIR, 'static', 'js', 'chat', 'chat-message-export.js')
+CHAT_MESSAGES_PATH = os.path.join(APP_DIR, 'static', 'js', 'chat', 'chat-messages.js')
+EXPORT_ROUTE_PATH = os.path.join(APP_DIR, 'route_backend_conversation_export.py')
+
+# Fence bodies chosen for the ways normalization can disagree: line endings, per-line
+# trailing whitespace, blank lines at either end, and interior blank lines that must survive.
+NORMALIZATION_CASES = [
+    'graph TD\n    A[One] --> B[Two]',
+    '\n\ngraph TD\r\n    A --> B\r\n\n  \n',
+    'graph TD   \n    A --> B\t\n',
+    'graph TD\n\n    A --> B\n\n    B --> C',
+    '   \n\t\n',
+    'sequenceDiagram\r    Alice->>Bob: Hi\r',
+]
+
+
+def read_text(path: str) -> str:
+    with open(path, 'r', encoding='utf-8') as handle:
+        return handle.read()
+
+
+def assert_contains(haystack: str, needle: str, label: str) -> None:
+    assert needle in haystack, f'{label}: expected to find {needle!r}'
+
+
+def test_v2_toast_store_supports_pending_work():
+    """A pending toast must stay put until the caller settles it."""
+    print("Testing V2 pending toast store...")
+
+    source = read_text(TOAST_STORE_PATH)
+
+    assert_contains(source, "'pending'", 'pending tone')
+    assert_contains(source, 'settle:', 'settle action')
+    assert_contains(source, "if (tone !== 'pending')", 'pending must skip the auto-dismiss timer')
+
+    # A pending toast with no TTL entry would auto-dismiss on `undefined` milliseconds,
+    # which fires immediately and puts us back to no feedback at all.
+    ttl_block = re.search(r'TOAST_TTL[^=]*=\s*\{(.*?)\}', source, re.DOTALL)
+    assert ttl_block, 'the toast TTL table could not be found'
+    assert 'pending' not in ttl_block.group(1), 'pending must not have an auto-dismiss delay'
+
+    assert_contains(source, 'pending: (message: string)', 'toast.pending helper')
+    assert_contains(source, 'settle: (id: number', 'toast.settle helper')
+
+    print("V2 pending toast store passed!")
+
+
+def test_v2_toaster_renders_pending_state():
+    """The pending toast needs a spinner, and must not offer a close button."""
+    print("Testing V2 toaster pending rendering...")
+
+    source = read_text(TOASTER_PATH)
+
+    assert_contains(source, 'pending: Loader2', 'spinner icon for the pending tone')
+    assert_contains(source, "animate-spin", 'the spinner has to actually spin')
+    assert_contains(source, '{!pending && (', 'a running export must not offer a dismiss button')
+
+    print("V2 toaster pending rendering passed!")
+
+
+def test_v2_export_reports_progress_and_disables_itself():
+    """The V2 export must announce itself, settle in place, and refuse a second click."""
+    print("Testing V2 export progress feedback...")
+
+    source = read_text(MESSAGE_ACTIONS_PATH)
+
+    assert_contains(source, 'EXPORT_PENDING_MESSAGE', 'per-format progress wording')
+    assert_contains(source, 'toast.pending(EXPORT_PENDING_MESSAGE[format])', 'pending toast')
+
+    # Raised before the work starts, not after it: a toast that goes up once the export
+    # returns tells the user nothing while they are waiting.
+    pending_index = source.index('toast.pending(EXPORT_PENDING_MESSAGE[format])')
+    for awaited in ('await downloadMessageExport', 'await fetchMessageEmailDraft'):
+        assert source.index(awaited) > pending_index, f'{awaited} runs before the pending toast'
+
+    assert source.count('toast.settle(') >= 3, 'every outcome must settle the pending toast'
+    assert_contains(source, "'error',", 'a failed export must settle as an error')
+
+    assert_contains(source, 'busyExport', 'busy state for the running export')
+    assert_contains(source, 'disabled={busyExport !== null}', 'a running export disables the menu')
+    assert_contains(source, 'setBusyExport(null)', 'the busy state has to be cleared')
+    assert_contains(source, '.finally(', 'the busy state must clear on failure too')
+
+    print("V2 export progress feedback passed!")
+
+
+def test_v2_sends_the_diagram_it_already_drew():
+    """The V2 export should not make the server redraw what is already on screen."""
+    print("Testing V2 client-supplied diagrams...")
+
+    actions = read_text(MESSAGE_ACTIONS_PATH)
+    endpoints = read_text(ENDPOINTS_PATH)
+    diagram = read_text(MERMAID_DIAGRAM_PATH)
+    visuals = read_text(EXPORT_VISUALS_PATH)
+
+    assert_contains(actions, 'buildMessageVisualAssets(message.id)', 'export builds visual assets')
+    assert_contains(actions, 'visual_assets:', 'assets are sent on the request')
+    assert_contains(endpoints, 'visual_assets?: ExportVisualAsset[]', 'request type carries assets')
+
+    assert_contains(diagram, 'registerExportDiagram', 'diagrams register themselves for export')
+    assert_contains(diagram, 'getSvg:', 'the SVG is read back at export time')
+
+    assert_contains(visuals, "kind: VISUAL_KIND_DIAGRAM", 'assets are tagged as diagrams')
+    assert_contains(visuals, "'diagram'", 'the kind has to match the server')
+
+    # The server drops anything past its own cap, so sending more is wasted work and a
+    # silently truncated export.
+    route = read_text(EXPORT_ROUTE_PATH)
+    server_cap = re.search(r'MESSAGE_EXPORT_VISUAL_ASSET_MAX_COUNT\s*=\s*(\d+)', route)
+    client_cap = re.search(r'MAX_ASSETS_PER_MESSAGE\s*=\s*(\d+)', visuals)
+    assert server_cap and client_cap, (server_cap, client_cap)
+    assert server_cap.group(1) == client_cap.group(1), (
+        f'client sends up to {client_cap.group(1)} assets but the server keeps '
+        f'{server_cap.group(1)}'
+    )
+
+    print("V2 client-supplied diagrams passed!")
+
+
+def test_browser_and_server_normalize_fences_identically():
+    """The two normalizations must agree, or every client asset is silently discarded.
+
+    The server indexes assets by normalized fence text and re-renders anything it cannot
+    match, so a mismatch costs the whole optimisation without producing an error anywhere.
+    """
+    print("Testing fence normalization parity...")
+
+    source = read_text(EXPORT_VISUALS_PATH)
+    match = re.search(
+        r'export function normalizeVisualSource\(.*?\n\}',
+        source,
+        re.DOTALL,
+    )
+    assert match, 'normalizeVisualSource could not be located'
+
+    # Run the browser's own implementation rather than a restatement of it, with the one
+    # TypeScript annotation removed so plain Node can execute the body unchanged.
+    js_function = match.group(0).replace('export function', 'function').replace(
+        'normalizeVisualSource(value: string): string',
+        'normalizeVisualSource(value)',
+    )
+    script = (
+        f'{js_function}\n'
+        f'const cases = {json.dumps(NORMALIZATION_CASES)};\n'
+        'process.stdout.write(JSON.stringify(cases.map(normalizeVisualSource)));\n'
+    )
+
+    with tempfile.TemporaryDirectory() as work_dir:
+        script_path = os.path.join(work_dir, 'normalize.mjs')
+        with open(script_path, 'w', encoding='utf-8') as handle:
+            handle.write(script)
+        try:
+            completed = subprocess.run(
+                ['node', script_path],
+                capture_output=True,
+                text=True,
+                timeout=60,
+                check=True,
+            )
+        except FileNotFoundError:
+            print("Skipping parity assertion: Node is not available on this machine.")
+            return
+
+    browser_results = json.loads(completed.stdout)
+    server_results = [normalize_visual_source(case) for case in NORMALIZATION_CASES]
+
+    for case, from_browser, from_server in zip(
+        NORMALIZATION_CASES, browser_results, server_results
+    ):
+        assert from_browser == from_server, (
+            f'normalization disagrees for {case!r}: browser {from_browser!r} '
+            f'vs server {from_server!r}'
+        )
+
+    print("Fence normalization parity passed!")
+
+
+def test_classic_toast_supports_work_in_progress():
+    """The classic toast utility must be able to stay on screen until work finishes."""
+    print("Testing classic progress toast...")
+
+    global_toast = read_text(GLOBAL_TOAST_PATH)
+    assert_contains(global_toast, 'options.autohide !== false', 'autohide option')
+    assert_contains(global_toast, 'return { dismiss:', 'a handle to dismiss the toast')
+    assert_contains(global_toast, 'spinner-border', 'a progress toast shows a spinner')
+
+    chat_toast = read_text(CHAT_TOAST_PATH)
+    assert_contains(chat_toast, 'return window.showToast', 'the handle must be forwarded')
+
+    print("Classic progress toast passed!")
+
+
+def test_classic_export_reports_progress():
+    """Every classic export must raise a progress toast and always clear it."""
+    print("Testing classic export progress feedback...")
+
+    source = read_text(CHAT_EXPORT_PATH)
+
+    assert source.count('{ autohide: false }') >= 3, (
+        'Word, PowerPoint and email exports each need a progress toast'
+    )
+    assert source.count('progressToast?.dismiss();') >= 3, (
+        'a progress toast that is never dismissed hides the result behind it'
+    )
+    assert source.count('} finally {') >= 3, 'the toast must clear on failure as well'
+
+    print("Classic export progress feedback passed!")
+
+
+def test_classic_export_menu_items_show_a_pending_state():
+    """The classic dropdown entries need the pending state its inline buttons already have."""
+    print("Testing classic export menu pending state...")
+
+    source = read_text(CHAT_MESSAGES_PATH)
+
+    for selector in (
+        'dropdown-export-word-btn',
+        'dropdown-export-ppt-btn',
+        'dropdown-open-email-btn',
+    ):
+        for occurrence in re.findall(rf'<a class="dropdown-item {selector}"[^>]*>', source):
+            assert 'data-pending-label' in occurrence, (
+                f'{selector} has no pending label, so it never spins or disables: {occurrence}'
+            )
+
+    # The click handler only shows a pending state when the button declares a pending label,
+    # and only refuses repeat clicks once aria-busy is set by that same path.
+    assert_contains(source, 'actionButton.dataset.pendingLabel', 'pending state gate')
+    assert_contains(source, "getAttribute('aria-busy') === 'true'", 'repeat click guard')
+
+    print("Classic export menu pending state passed!")
+
+
+if __name__ == "__main__":
+    tests: List[Callable[[], None]] = [
+        test_v2_toast_store_supports_pending_work,
+        test_v2_toaster_renders_pending_state,
+        test_v2_export_reports_progress_and_disables_itself,
+        test_v2_sends_the_diagram_it_already_drew,
+        test_browser_and_server_normalize_fences_identically,
+        test_classic_toast_supports_work_in_progress,
+        test_classic_export_reports_progress,
+        test_classic_export_menu_items_show_a_pending_state,
+    ]
+
+    results = []
+    for test in tests:
+        print(f"\nRunning {test.__name__}...")
+        try:
+            test()
+            results.append(True)
+        except Exception as exc:
+            print(f"Test failed: {exc}")
+            import traceback
+
+            traceback.print_exc()
+            results.append(False)
+
+    print(f"\nResults: {sum(results)}/{len(results)} tests passed")
+    sys.exit(0 if all(results) else 1)


### PR DESCRIPTION
Exporting a message containing a Mermaid diagram produced the right shapes, arrows and layout with **no text in any of the boxes**, while the same diagram read correctly on screen. The export was also slow enough to look like it had hung.

## Root cause

Two problems that presented as one.

**1. The container has no scalable font.** The Dockerfile installed only `xorg-x11-fonts-Type1` and `xorg-x11-fonts-misc` — legacy X11 Type1 and bitmap packages, no scalable TrueType Latin face — behind a `|| true` that hid the case where they did not resolve at all. Azure Linux ships no fonts by default. The server renderer then asked Mermaid for `Arial, Helvetica, sans-serif`, none of which exist there, and the generic `sans-serif` fallback resolved to nothing. Chromium measured every label as zero-width, Mermaid fell back to its minimum node size, and no glyphs were painted.

The giveaway in the reported files is that **every box came out the same width**, while on screen the same diagram had boxes of visibly different widths. That is zero-width text measurement, not a colour, theme or `<foreignObject>` problem.

**2. V2 never sent the diagram it had already drawn.** `downloadMessageExport()` posted only `message_id` and `conversation_id`. The classic chat sends `visual_assets`; V2 did not, so every V2 export took the server path and hit the font problem — even though a correct picture already existed in the page.

## Investigated and rejected

I chased `htmlLabels`/`<foreignObject>` first and was wrong. The rendered SVG carries 11 `<text>` elements and **zero** `<foreignObject>` elements. I also checked whether the browser's serialize-and-repaint rasterizer loses the styles Mermaid adds via `insertRule`: a diagram using `classDef` and `style` produces identical colour histograms through the canvas path and a live screenshot. **The browser rasterizers were correct and are unchanged** rather than "fixed" speculatively.

## Changes

| Area | Change |
|---|---|
| `functions_mermaid_server_render.py` | Embed DejaVu Sans as an `@font-face` from matplotlib (already a TeX-export dependency); capture each diagram with a Playwright element screenshot instead of SVG → `<img>` → canvas; block only real network schemes so the font's `data:` URI resolves; report `embedded_font_available` |
| `Dockerfile` | Install DejaVu, Liberation and Noto Sans, and rebuild the font cache, so everything rendering in the image has glyphs |
| `v2_ui/src/lib/exportVisuals.ts` (new) | Registry of on-screen diagrams and the rasterizer that turns them into `visual_assets` |
| `MermaidDiagram.tsx`, `endpoints.ts` | Register each rendered diagram; carry `visual_assets` on the export request |
| `toastStore.ts`, `Toaster.tsx`, `MessageActions.tsx` | `pending` tone that does not auto-dismiss and settles in place; spinner and disabled menu entry while an export runs |
| `toast.js`, `chat-toast.js`, `chat-message-export.js`, `chat-messages.js` | Same behaviour in the classic UI: `{ autohide: false }` plus a `{ dismiss }` handle, a progress toast always cleared in `finally`, and the `data-pending-label` its inline buttons already had |

### Why an element screenshot

The renderer was serializing its SVG, reloading it through an `<img>` and painting it onto a canvas — a reconstruction of a browser render, performed inside a real browser that was already open. That isolated context drops `<foreignObject>` content and will not load a font that is not already present. Screenshotting the mounted element renders exactly what a browser would show, and is less code.

## Why this shipped broken

`test_server_renders_diagrams_with_visible_labels` claimed to verify that "a rendered diagram keeps its label text" but asserted only `painted_ratio > 0.01`. Boxes and arrows clear that easily, so a diagram with no text at all passed.

It now renders the same graph with and without label text and requires the labelled one to have materially more dark pixels **and** to be wider. On the fixture: 12,295 dark pixels vs 0, and 945px wide vs 372px.

## Validation

- `test_export_mermaid_server_render.py` — 13/13
- `test_message_export_progress_feedback.py` — 8/8, including a parity check that executes the browser's own `normalizeVisualSource` in Node against Python's `normalize_visual_source`. A mismatch there does not fail loudly: every client asset is silently discarded and every diagram quietly re-rendered server-side.
- `test_export_mermaid_browser_rasterizer.py` — 3/3
- `test_conversation_export_mermaid_tex_images.py` — 18/18
- `test_deep_research_chromium_build_opt_out.py` — 3/3
- `test_docs_app_surface_coverage.py` — 7/7, `test_docs_site_quality.py` — 6/6
- `route_tests/` — 3/3
- `npm run build` in `application/v2_ui` — clean

**End to end:** a real `.docx` generated through the actual export route embeds a 945×549 diagram with full label text and correctly varying box widths.

| | Before | After |
|---|---|---|
| Server-rendered diagram | Uniform empty boxes | Labels drawn in the embedded font |
| V2 export with a diagram | Always launched headless Chromium | Sends the on-screen picture; no browser launch |
| Exported colours | Server defaults | The colours the reader chose |
| During an export | Nothing on screen | Pending toast plus a disabled, spinning menu entry |

## Notes for review

- **Pre-existing red test repaired.** `test_deep_research_chromium_build_opt_out.py` asserted an exact deployer version of `1.0.4` and had been failing since the deployer moved past it (now `1.0.26`). It covers the Dockerfile changed here, so a red test would have masked real regressions; it now uses the repo's own `assert_version_at_least` helper, which the versioning instructions require.
- **No `deployers/` changes**, so `deployers/version.txt` is not bumped. The Dockerfile lives under `application/` and introduces no new build argument or parameter.
- **On the slowness:** `gunicorn.conf.py` already allows 900s per request, so nothing was cutting exports off server-side. The practical ceiling is the Azure App Service front-end idle timeout of roughly 230s, which cannot be configured from this repo. Skipping the browser launch and reporting progress were the available mitigations; PowerPoint remains inherently slow because a model plans the slides.
- Server-rendered diagrams now always use the embedded DejaVu Sans, so their lettering can differ slightly from a browser-rendered one that uses the reader's own font stack. That is the trade for rendering identically on every deployment.

Version bumped to `0.261.034`. Fix doc at `docs/explanation/fixes/MERMAID_EXPORT_LABEL_TEXT_FIX.md`; feature doc and release notes updated.
