### PR TITLE
Support shared conversations in the V2 interface

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -97,7 +97,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.261.033"
+VERSION = "0.261.034"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/v2_ui/src/components/chat/Composer.tsx
+++ b/application/v2_ui/src/components/chat/Composer.tsx
@@ -14,17 +14,28 @@ import {
     Link2,
     Loader2,
     Paperclip,
+    Reply,
     Search,
     Square,
     Telescope,
+    X,
 } from 'lucide-react';
 import { useChatStore, type ComposerOptions } from '../../stores/chatStore';
 import { useBootstrapStore } from '../../stores/bootstrapStore';
+import { useCollaborationStore } from '../../stores/collaborationStore';
 import { uploadDocument } from '../../lib/endpoints';
+import { sendCollaborationTyping } from '../../lib/collaboration';
 import { agentSelectionKey } from '../../lib/agents';
 import { modelSelectionKey, findModel, type ModelCatalogEntry } from '../../lib/models';
 import { resolveGating } from '../../lib/composerGating';
+import {
+    findMentionAtCaret,
+    replaceMention,
+    type MentionMatch,
+    type MentionSuggestion,
+} from '../../lib/mentions';
 import { useUiStore } from '../../stores/uiStore';
+import { toast } from '../../stores/toastStore';
 import { chatWidthClass } from '../../lib/chatWidth';
 import {
     getModelSupportedLevels,
@@ -33,6 +44,7 @@ import {
 } from '../../lib/reasoning';
 import { Dropdown, type DropdownOption } from '../ui/Dropdown';
 import { AiNotice } from './AiNotice';
+import { MentionMenu, useMentionSuggestions } from './MentionMenu';
 import { VoiceInput } from './VoiceInput';
 import { WebSearchNotice } from './WebSearchNotice';
 
@@ -76,6 +88,35 @@ export function Composer() {
     const bootstrap = useBootstrapStore((state) => state.data);
     const features = bootstrap?.features ?? {};
 
+    /**
+     * Whether this is a shared conversation, and whether the reader may write in it.
+     *
+     * `can_post_messages` is the server's decision. A pending invitee can read a shared
+     * conversation but not write in it, and a group-visibility conversation grants posting
+     * with no membership record at all, so this cannot be worked out from the participant
+     * list in the browser.
+     */
+    const shared = useChatStore((state) => state.activeConversationKind === 'collaborative');
+    const loadedCollaboration = useCollaborationStore((state) => state.conversation);
+    // Only trusted when it is this conversation's membership. The participants panel used to
+    // share this slot, and an unrelated conversation's flags gating the thread on screen was
+    // exactly the failure that split them apart.
+    const collaboration =
+        loadedCollaboration?.id === activeConversationId ? loadedCollaboration : null;
+    /**
+     * Whether the reader may write here.
+     *
+     * Deny-by-default in a shared conversation: `can_post_messages` must be explicitly true,
+     * so a membership that has not loaded yet — or failed to — leaves the composer disabled
+     * rather than offering a Send button to somebody who has not joined. A personal
+     * conversation is unaffected.
+     */
+    const canPost = !shared || collaboration?.can_post_messages === true;
+    const awaitingInvite = Boolean(shared && collaboration?.can_accept_invite);
+    const checkingAccess = shared && !collaboration;
+    const replyTo = useCollaborationStore((state) => state.replyTo);
+    const setReplyTo = useCollaborationStore((state) => state.setReplyTo);
+
     const textareaRef = useRef<HTMLTextAreaElement>(null);
     const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -83,6 +124,11 @@ export function Composer() {
     const [uploading, setUploading] = useState(false);
     const [uploadNotice, setUploadNotice] = useState<string | null>(null);
     const chatWidth = useUiStore((state) => state.chatWidth);
+
+    /** The `@` token under the caret, when the menu should be offering completions for it. */
+    const [mention, setMention] = useState<MentionMatch | null>(null);
+    const [mentionIndex, setMentionIndex] = useState(0);
+    const suggestions = useMentionSuggestions(shared && canPost ? (mention?.query ?? null) : null);
 
     const [options, setOptions] = useState<ComposerOptions>({
         documentSearch: false,
@@ -152,6 +198,69 @@ export function Composer() {
 
     useEffect(autoGrow, [text]);
 
+    /**
+     * Tell the other participants that this person is writing.
+     *
+     * Sent as a state change rather than per keystroke — one ping when typing starts and
+     * one when it stops — because the server broadcasts every one of these to every other
+     * participant's event stream. The stop is also sent on a short idle timer, so walking
+     * away mid-sentence clears the indicator instead of leaving it up until the server's own
+     * eight-second expiry.
+     */
+    const typingRef = useRef(false);
+    const typingIdleTimer = useRef<number | null>(null);
+
+    const setTyping = (isTyping: boolean) => {
+        if (!shared || !activeConversationId || !canPost || typingRef.current === isTyping) {
+            return;
+        }
+        typingRef.current = isTyping;
+        void sendCollaborationTyping(activeConversationId, isTyping).catch(() => {
+            /* Presence is advisory; a lost ping expires on its own. */
+        });
+    };
+
+    const stopTyping = () => {
+        if (typingIdleTimer.current !== null) {
+            window.clearTimeout(typingIdleTimer.current);
+            typingIdleTimer.current = null;
+        }
+        setTyping(false);
+    };
+
+    const noteTyping = (value: string) => {
+        if (!shared) {
+            return;
+        }
+        setTyping(Boolean(value.trim()));
+        if (typingIdleTimer.current !== null) {
+            window.clearTimeout(typingIdleTimer.current);
+        }
+        typingIdleTimer.current = window.setTimeout(() => {
+            typingIdleTimer.current = null;
+            setTyping(false);
+        }, 3000);
+    };
+
+    // Leaving the conversation, or the page, must not leave a stale "is typing" behind for
+    // everybody else.
+    useEffect(
+        () => () => {
+            if (typingIdleTimer.current !== null) {
+                window.clearTimeout(typingIdleTimer.current);
+            }
+            typingRef.current = false;
+        },
+        [],
+    );
+
+    useEffect(() => {
+        // A conversation change invalidates both the draft's mention state and any typing
+        // claim made in the conversation being left.
+        setMention(null);
+        typingRef.current = false;
+    }, [activeConversationId]);
+
     // A model is identified by endpoint + id + provider + deployment together, so the
     // option is keyed on `selection_key` (unique per endpoint) rather than the deployment
     // name, which can repeat across endpoints.
@@ -208,14 +317,112 @@ export function Composer() {
     }, [options.modelDeployment, bootstrap]);
 
     const submit = () => {
-        if (!text.trim() || streaming) {
+        if (!text.trim() || streaming || !canPost) {
             return;
         }
         void sendMessage(text, options);
         setText('');
+        setMention(null);
+        // Sent, so the indicator other people can see must stop now rather than when the
+        // idle timer happens to fire.
+        stopTyping();
+    };
+
+    /**
+     * Track the `@` token under the caret.
+     *
+     * Recomputed from the value and the caret on every change, rather than tracked
+     * incrementally, so editing in the middle of a line, pasting and undo all behave the
+     * same as typing.
+     */
+    const syncMention = (element: HTMLTextAreaElement) => {
+        if (!shared || !canPost) {
+            return;
+        }
+        const found = findMentionAtCaret(element.value, element.selectionStart ?? 0);
+        setMention(found);
+        setMentionIndex(0);
+    };
+
+    const applySuggestion = (suggestion: MentionSuggestion) => {
+        const element = textareaRef.current;
+        if (!element || !mention) {
+            return;
+        }
+        const { value, caretIndex } = replaceMention(text, mention, suggestion.mention_text);
+        setText(value);
+        setMention(null);
+
+        // An "Add to this conversation" row is an action, not just a completion. Inserting
+        // the name without performing it left the row dead: the person was neither added nor
+        // mentioned, because the mention list is resolved against existing participants only
+        // and the server filters it again.
+        if (suggestion.kind === 'invite' && activeConversationId) {
+            void useCollaborationStore
+                .getState()
+                .inviteParticipants([
+                    {
+                        user_id: suggestion.user_id,
+                        display_name: suggestion.display_name,
+                        email: suggestion.email,
+                    },
+                ])
+                .then(() => {
+                    toast.success(`${suggestion.display_name} was added to this conversation.`);
+                })
+                .catch((error: unknown) => {
+                    toast.error(
+                        error instanceof Error
+                            ? error.message
+                            : `${suggestion.display_name} could not be added.`,
+                    );
+                });
+        }
+
+        // Applied after the value change has been rendered, or the browser would put the
+        // caret back at the end of the new value.
+        window.requestAnimationFrame(() => {
+            element.focus();
+            element.setSelectionRange(caretIndex, caretIndex);
+        });
     };
 
     const onKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+        // The mention menu owns these keys while it is open, which is why it is handled
+        // before the send: Enter should complete the highlighted name, not send a message
+        // containing a half-typed one.
+        if (mention && suggestions.length > 0) {
+            if (event.key === 'ArrowDown') {
+                event.preventDefault();
+                setMentionIndex((index) => (index + 1) % suggestions.length);
+                return;
+            }
+            if (event.key === 'ArrowUp') {
+                event.preventDefault();
+                setMentionIndex(
+                    (index) => (index - 1 + suggestions.length) % suggestions.length,
+                );
+                return;
+            }
+            if (event.key === 'Enter' || event.key === 'Tab') {
+                event.preventDefault();
+                applySuggestion(suggestions[mentionIndex]);
+                return;
+            }
+            if (event.key === 'Escape') {
+                event.preventDefault();
+                setMention(null);
+                return;
+            }
+        }
+
+        // Escape also cancels a reply, which is otherwise easy to forget is armed.
+        if (event.key === 'Escape' && replyTo) {
+            event.preventDefault();
+            setReplyTo(null);
+            return;
+        }
+
         // Enter sends; Shift+Enter inserts a newline. Matches the classic UI.
         if (event.key === 'Enter' && !event.shiftKey) {
             event.preventDefault();
@@ -269,7 +476,35 @@ export function Composer() {
                     next to the message it is about, not below the send button. */}
                 <WebSearchNotice active={options.webSearch} />
 
-                <div className="glass glass-edge rounded-2xl p-2">
+                <div className="glass glass-edge relative rounded-2xl p-2">
+                    {mention && (
+                        <MentionMenu
+                            suggestions={suggestions}
+                            activeIndex={mentionIndex}
+                            onSelect={applySuggestion}
+                        />
+                    )}
+
+                    {replyTo && (
+                        <div className="mb-1 flex items-start gap-2 rounded-xl bg-surface-2 px-3 py-2">
+                            <Reply size={13} className="mt-0.5 shrink-0 text-text-3" />
+                            <span className="min-w-0 flex-1 text-xs text-text-2">
+                                {replyTo.display_name && (
+                                    <span className="font-medium">Replying to {replyTo.display_name}: </span>
+                                )}
+                                <span className="line-clamp-2">{replyTo.preview}</span>
+                            </span>
+                            <button
+                                type="button"
+                                onClick={() => setReplyTo(null)}
+                                aria-label="Cancel reply"
+                                className="shrink-0 rounded-md p-0.5 text-text-3 hover:bg-surface-3 hover:text-text-1"
+                            >
+                                <X size={13} />
+                            </button>
+                        </div>
+                    )}
+
                     <label htmlFor="composer-input" className="sr-only">
                         Message
                     </label>
@@ -278,12 +513,32 @@ export function Composer() {
                         ref={textareaRef}
                         rows={1}
                         value={text}
-                        onChange={(event) => setText(event.target.value)}
+                        disabled={!canPost}
+                        onChange={(event) => {
+                            setText(event.target.value);
+                            syncMention(event.target);
+                            noteTyping(event.target.value);
+                        }}
+                        // The caret can move without the value changing — clicking, or an
+                        // arrow key — and the mention under it changes with it.
+                        onSelect={(event) => syncMention(event.currentTarget)}
+                        onBlur={stopTyping}
                         onKeyDown={onKeyDown}
-                        placeholder="Send a message…"
+                        placeholder={
+                            checkingAccess
+                                ? 'Checking your access to this conversation…'
+                                : awaitingInvite
+                                  ? 'Join this conversation to reply'
+                                  : !canPost
+                                    ? 'You do not have permission to write in this conversation'
+                                    : shared
+                                      ? 'Message the group, or @mention a model or agent to ask the assistant…'
+                                      : 'Send a message…'
+                        }
                         className={clsx(
                             'w-full resize-none bg-transparent px-3 py-2.5 text-[15px] leading-relaxed',
                             'text-text-1 placeholder:text-text-3 focus:outline-none',
+                            'disabled:cursor-not-allowed',
                         )}
                     />
 
@@ -482,8 +737,12 @@ export function Composer() {
                                 <button
                                     type="button"
                                     onClick={submit}
-                                    disabled={!text.trim()}
-                                    aria-label="Send message"
+                                    disabled={!text.trim() || !canPost}
+                                    aria-label={
+                                        shared && !streaming
+                                            ? 'Send to this conversation'
+                                            : 'Send message'
+                                    }
                                     className={clsx(
                                         'inline-flex h-9 w-9 items-center justify-center rounded-xl',
                                         'bg-accent text-on-accent transition-colors hover:bg-accent-hover',

--- a/application/v2_ui/src/components/chat/ConversationRail.tsx
+++ b/application/v2_ui/src/components/chat/ConversationRail.tsx
@@ -4,10 +4,14 @@
 
 import { useEffect, useRef, useState } from 'react';
 import { clsx } from 'clsx';
-import { MoreHorizontal, Pin, Search, Trash2, EyeOff, Pencil } from 'lucide-react';
+import { MoreHorizontal, Pin, Search, Trash2, EyeOff, LogOut, Pencil, Users } from 'lucide-react';
 import { useChatStore } from '../../stores/chatStore';
+import { useCollaborationStore } from '../../stores/collaborationStore';
+import { useBootstrapStore } from '../../stores/bootstrapStore';
 import { useUserSettingsStore } from '../../stores/userSettingsStore';
 import { workspaceBadge, type WorkspaceBadgeTone } from '../../lib/conversationBadges';
+import { canShareConversation, panelTargetForConversation } from '../../lib/sharing';
+import { isCollaborative } from '../../lib/types';
 import { Skeleton } from '../ui/primitives';
 import type { Conversation } from '../../lib/types';
 
@@ -68,8 +72,14 @@ function ConversationRow({ conversation }: { conversation: Conversation }) {
     const [menuOpen, setMenuOpen] = useState(false);
     const [renaming, setRenaming] = useState(false);
     const [draftTitle, setDraftTitle] = useState(conversation.title);
+    const openPanel = useCollaborationStore((state) => state.openPanel);
+    const collaborationEnabled = useBootstrapStore((state) =>
+        Boolean(state.data?.features?.enable_collaborative_conversations),
+    );
 
     const isActive = conversation.id === activeConversationId;
+    const shareable = collaborationEnabled && canShareConversation(conversation);
+    const shared = isCollaborative(conversation);
 
     const commitRename = () => {
         const trimmed = draftTitle.trim();
@@ -166,6 +176,24 @@ function ConversationRow({ conversation }: { conversation: Conversation }) {
                         >
                             <Pencil size={14} /> Rename
                         </button>
+                        {shareable && (
+                            <button
+                                type="button"
+                                onClick={() => {
+                                    setMenuOpen(false);
+                                    // The panel loads its own copy of the membership into its
+                                    // own slot. Loading it here as well would write the
+                                    // conversation on screen's slot with a different
+                                    // conversation's document.
+                                    openPanel(
+                                        panelTargetForConversation(conversation.id, conversation),
+                                    );
+                                }}
+                                className="flex w-full items-center gap-2 rounded-lg px-2.5 py-1.5 text-sm text-text-1 hover:bg-surface-2"
+                            >
+                                <Users size={14} /> {shared ? 'People' : 'Share'}
+                            </button>
+                        )}
                         <button
                             type="button"
                             onClick={() => {
@@ -194,7 +222,18 @@ function ConversationRow({ conversation }: { conversation: Conversation }) {
                             }}
                             className="flex w-full items-center gap-2 rounded-lg px-2.5 py-1.5 text-sm text-danger hover:bg-danger-soft"
                         >
-                            <Trash2 size={14} /> Delete
+                            {/* Named for what it will actually do. Only an owner can destroy
+                                a shared conversation for everybody; anybody else leaves it,
+                                and the thread carries on without them. */}
+                            {shared && !conversation.can_delete_conversation ? (
+                                <>
+                                    <LogOut size={14} /> Leave
+                                </>
+                            ) : (
+                                <>
+                                    <Trash2 size={14} /> Delete
+                                </>
+                            )}
                         </button>
                     </div>
                 </>

--- a/application/v2_ui/src/components/chat/FileApprovals.tsx
+++ b/application/v2_ui/src/components/chat/FileApprovals.tsx
@@ -1,0 +1,92 @@
+// FileApprovals.tsx
+// Files the assistant generated in a shared conversation that are waiting on this reader's
+// decision before anyone can download them.
+//
+// A generated file in a shared conversation is staged rather than released: the request
+// came from one participant, but the file would become available to all of them, so the
+// conversation's owner (or a group manager) decides. Until that decision the content is
+// withheld from everybody, including the person who asked for it.
+//
+// Presented as a banner over the thread rather than inline on the message, because the
+// endpoint answers across conversations — a file staged in a thread the reader is not
+// currently looking at is exactly the one most likely to be forgotten.
+
+import { useEffect, useState } from 'react';
+import { FileLock2, Loader2 } from 'lucide-react';
+import { useBootstrapStore } from '../../stores/bootstrapStore';
+import { useCollaborationStore } from '../../stores/collaborationStore';
+import { GlassButton } from '../ui/primitives';
+import type { GeneratedFileApproval } from '../../lib/collaboration';
+
+function describe(approval: GeneratedFileApproval): string {
+    const requester = String(approval.approval?.requested_by_name ?? '').trim();
+    const name = String(approval.file_name ?? '').trim() || 'A file';
+    return requester
+        ? `${requester} generated ${name} in a shared conversation.`
+        : `${name} was generated in a shared conversation.`;
+}
+
+export function FileApprovals() {
+    const enabled = useBootstrapStore((state) =>
+        Boolean(state.data?.features?.enable_collaborative_conversations),
+    );
+    const approvals = useCollaborationStore((state) => state.approvals);
+    const loadApprovals = useCollaborationStore((state) => state.loadApprovals);
+    const resolveApproval = useCollaborationStore((state) => state.resolveApproval);
+    const [busyId, setBusyId] = useState<string | null>(null);
+
+    useEffect(() => {
+        if (enabled) {
+            void loadApprovals();
+        }
+    }, [enabled, loadApprovals]);
+
+    if (!enabled || approvals.length === 0) {
+        return null;
+    }
+
+    const decide = async (approval: GeneratedFileApproval, decision: 'approve' | 'deny') => {
+        setBusyId(approval.artifact_message_id);
+        await resolveApproval(approval, decision);
+        setBusyId(null);
+    };
+
+    return (
+        <div className="mx-4 mt-4 space-y-2">
+            {approvals.map((approval) => (
+                <div
+                    key={`${approval.source_conversation_id}:${approval.artifact_message_id}`}
+                    className="glass-flat flex flex-wrap items-center gap-3 rounded-xl px-4 py-3"
+                >
+                    <FileLock2 size={16} className="shrink-0 text-warn" />
+                    <p className="min-w-0 flex-1 text-sm text-text-1">
+                        {describe(approval)} Approve it to make it available to everyone in
+                        that conversation.
+                    </p>
+                    <div className="flex shrink-0 items-center gap-2">
+                        {busyId === approval.artifact_message_id ? (
+                            <Loader2 size={14} className="animate-spin text-text-3" />
+                        ) : (
+                            <>
+                                <GlassButton
+                                    size="sm"
+                                    variant="primary"
+                                    onClick={() => void decide(approval, 'approve')}
+                                >
+                                    Approve
+                                </GlassButton>
+                                <GlassButton
+                                    size="sm"
+                                    variant="danger"
+                                    onClick={() => void decide(approval, 'deny')}
+                                >
+                                    Deny
+                                </GlassButton>
+                            </>
+                        )}
+                    </div>
+                </div>
+            ))}
+        </div>
+    );
+}

--- a/application/v2_ui/src/components/chat/InviteBanner.tsx
+++ b/application/v2_ui/src/components/chat/InviteBanner.tsx
@@ -1,0 +1,70 @@
+// InviteBanner.tsx
+// The accept/decline prompt shown above a shared conversation the reader has been invited
+// to but has not answered yet.
+//
+// An invited conversation is readable before it is accepted — the server allows a pending
+// member to view it (`allow_pending=True`) so the invitation can be judged on its contents
+// rather than blind — but not writable. Without something saying so, the thread would look
+// like an ordinary conversation whose composer had inexplicably stopped working.
+
+import { useState } from 'react';
+import { Check, UserPlus, X } from 'lucide-react';
+import { useChatStore } from '../../stores/chatStore';
+import { useCollaborationStore } from '../../stores/collaborationStore';
+import { GlassButton } from '../ui/primitives';
+
+export function InviteBanner() {
+    const conversation = useCollaborationStore((state) => state.conversation);
+    const respondToInvite = useCollaborationStore((state) => state.respondToInvite);
+    const activeConversationId = useChatStore((state) => state.activeConversationId);    const loadConversations = useChatStore((state) => state.loadConversations);
+    const selectConversation = useChatStore((state) => state.selectConversation);
+    const [busy, setBusy] = useState(false);
+
+    // `can_accept_invite` is the server's own answer, computed from the membership record;
+    // it is not inferred here from the status string.
+    if (
+        !conversation?.can_accept_invite ||
+        !activeConversationId ||
+        conversation.id !== activeConversationId
+    ) {
+        return null;
+    }
+
+    const respond = async (action: 'accept' | 'decline') => {
+        setBusy(true);
+        const done = await respondToInvite(action);
+        setBusy(false);
+        if (!done) {
+            return;
+        }
+        await loadConversations({ reset: true });
+        if (action === 'decline') {
+            // Declining removes it from the reader's list, so leaving it open would show a
+            // conversation every subsequent request refuses.
+            await selectConversation(null);
+        }
+    };
+
+    return (
+        <div className="glass-flat mx-4 mt-4 flex flex-wrap items-center gap-3 rounded-xl px-4 py-3">
+            <UserPlus size={16} className="shrink-0 text-accent" />
+            <p className="min-w-0 flex-1 text-sm text-text-1">
+                You have been invited to this shared conversation. You can read it now, and
+                reply once you join.
+            </p>
+            <div className="flex shrink-0 items-center gap-2">
+                <GlassButton
+                    size="sm"
+                    variant="primary"
+                    disabled={busy}
+                    onClick={() => void respond('accept')}
+                >
+                    <Check size={14} /> Join
+                </GlassButton>
+                <GlassButton size="sm" disabled={busy} onClick={() => void respond('decline')}>
+                    <X size={14} /> Decline
+                </GlassButton>
+            </div>
+        </div>
+    );
+}

--- a/application/v2_ui/src/components/chat/MentionMenu.tsx
+++ b/application/v2_ui/src/components/chat/MentionMenu.tsx
@@ -1,0 +1,173 @@
+// MentionMenu.tsx
+// The `@` autocomplete offered while writing in a shared conversation.
+//
+// It serves three quite different purposes through one control, which is why the rows are
+// typed rather than uniform:
+//
+//   - naming a participant, which notifies them;
+//   - addressing a model or agent, which is what makes the message a question for the AI
+//     rather than a remark to the other people in it;
+//   - adding somebody who is not in the conversation yet.
+//
+// The third is the reason the menu exists at all rather than a plain participant list: in
+// the classic interface, typing a colleague's name is how you invite them.
+
+import { useEffect, useState } from 'react';
+import { clsx } from 'clsx';
+import { Bot, Cpu, UserPlus, User } from 'lucide-react';
+import { fetchCollaboratorSuggestions, fetchGroupMembers } from '../../lib/collaboration';
+import { buildMentionSuggestions, type MentionSuggestion } from '../../lib/mentions';
+import { useBootstrapStore } from '../../stores/bootstrapStore';
+import { useChatStore } from '../../stores/chatStore';
+import { useCollaborationStore } from '../../stores/collaborationStore';
+import type { CollaboratorSuggestion, ModelOption, AgentOption } from '../../lib/types';
+import type { ModelCatalogEntry } from '../../lib/models';
+
+/** How long to wait after a keystroke before asking the server for more candidates. */
+const SEARCH_DEBOUNCE_MS = 250;
+
+const ROW_ICON: Record<MentionSuggestion['kind'], React.ReactNode> = {
+    participant: <User size={14} />,
+    invite: <UserPlus size={14} />,
+    ai: <Bot size={14} />,
+};
+
+/**
+ * Assemble the rows for a query.
+ *
+ * Participants and AI targets are already in memory, so they appear immediately; invitable
+ * people require a request and arrive a moment later. Building from whatever is available
+ * at each render, rather than waiting for the search, is what keeps the menu responsive
+ * while typing a name that is already in the conversation.
+ */
+export function useMentionSuggestions(query: string | null): MentionSuggestion[] {
+    const activeConversationId = useChatStore((state) => state.activeConversationId);
+    const loaded = useCollaborationStore((state) => state.conversation);
+    // Guarded on the id for the same reason the composer is: the participants panel loads a
+    // different conversation's membership into its own slot, and an unguarded read here
+    // would offer one conversation's people while writing in another.
+    const conversation = loaded?.id === activeConversationId ? loaded : null;
+    const bootstrap = useBootstrapStore((state) => state.data);
+    const currentUserId = bootstrap?.user?.id;
+    const [invitable, setInvitable] = useState<CollaboratorSuggestion[]>([]);
+
+    const canInvite = Boolean(conversation?.can_manage_members);
+    const groupId = conversation?.group_id ?? null;
+
+    useEffect(() => {
+        if (query === null || !canInvite) {
+            setInvitable([]);
+            return;
+        }
+
+        const controller = new AbortController();
+        const timer = window.setTimeout(() => {
+            const search = groupId
+                ? fetchGroupMembers(groupId, query, controller.signal).then((members) =>
+                      (members ?? []).map((member) => ({
+                          user_id: String(member.userId ?? member.user_id ?? member.id ?? ''),
+                          display_name: String(
+                              member.displayName ?? member.display_name ?? member.name ?? '',
+                          ),
+                          email: String(member.email ?? ''),
+                          source: 'group',
+                      })),
+                  )
+                : fetchCollaboratorSuggestions(query, { limit: 8 }, controller.signal).then(
+                      (payload) => payload.results ?? [],
+                  );
+
+            search
+                .then((found) => {
+                    if (!controller.signal.aborted) {
+                        setInvitable(found);
+                    }
+                })
+                .catch(() => {
+                    // Advisory: the participant and AI rows are unaffected, and offering no
+                    // invitations is better than an error over the composer.
+                });
+        }, SEARCH_DEBOUNCE_MS);
+
+        return () => {
+            window.clearTimeout(timer);
+            controller.abort();
+        };
+    }, [query, canInvite, groupId]);
+
+    if (query === null) {
+        return [];
+    }
+
+    return buildMentionSuggestions({
+        query,
+        participants: conversation?.participants,
+        agents: bootstrap?.catalogs?.agents as AgentOption[] | undefined,
+        models: bootstrap?.catalogs?.models as (ModelOption & ModelCatalogEntry)[] | undefined,
+        invitable,
+        canInvite,
+        currentUserId,
+    });
+}
+
+export function MentionMenu({
+    suggestions,
+    activeIndex,
+    onSelect,
+}: {
+    suggestions: MentionSuggestion[];
+    activeIndex: number;
+    onSelect: (suggestion: MentionSuggestion) => void;
+}) {
+    if (suggestions.length === 0) {
+        return null;
+    }
+
+    return (
+        <div
+            role="listbox"
+            aria-label="Mention suggestions"
+            className="glass-modal absolute bottom-full left-2 z-50 mb-2 max-h-64 w-72 overflow-y-auto rounded-xl p-1"
+        >
+            {suggestions.map((suggestion, index) => (
+                <button
+                    key={`${suggestion.kind}-${
+                        suggestion.kind === 'ai' ? suggestion.display_name : suggestion.user_id
+                    }`}
+                    type="button"
+                    role="option"
+                    aria-selected={index === activeIndex}
+                    // Pointer-down rather than click: the textarea loses focus on mouse-up,
+                    // and a blur handler that closes the menu would remove the button before
+                    // the click ever landed.
+                    onMouseDown={(event) => {
+                        event.preventDefault();
+                        onSelect(suggestion);
+                    }}
+                    className={clsx(
+                        'flex w-full items-center gap-2 rounded-lg px-2.5 py-1.5 text-left text-sm',
+                        index === activeIndex
+                            ? 'bg-accent-soft text-accent'
+                            : 'text-text-1 hover:bg-surface-2',
+                    )}
+                >
+                    <span className="shrink-0 text-text-3">
+                        {suggestion.kind === 'ai' && suggestion.target.target_type === 'model' ? (
+                            <Cpu size={14} />
+                        ) : (
+                            ROW_ICON[suggestion.kind]
+                        )}
+                    </span>
+                    <span className="min-w-0 flex-1">
+                        <span className="block truncate">{suggestion.display_name}</span>
+                        {suggestion.subtitle && (
+                            <span className="block truncate text-[11px] text-text-3">
+                                {suggestion.subtitle}
+                            </span>
+                        )}
+                    </span>
+                </button>
+            ))}
+        </div>
+    );
+}

--- a/application/v2_ui/src/components/chat/MessageActions.tsx
+++ b/application/v2_ui/src/components/chat/MessageActions.tsx
@@ -24,6 +24,7 @@ import {
     Mail,
     Pencil,
     RefreshCw,
+    Reply,
     Split,
     ThumbsDown,
     ThumbsUp,
@@ -32,6 +33,7 @@ import {
     VolumeX,
 } from 'lucide-react';
 import { useChatStore } from '../../stores/chatStore';
+import { useCollaborationStore } from '../../stores/collaborationStore';
 import { useUserSettingsStore } from '../../stores/userSettingsStore';
 import { useBootstrapStore } from '../../stores/bootstrapStore';
 import { toast } from '../../stores/toastStore';
@@ -40,6 +42,7 @@ import { attemptState } from '../../lib/threads';
 import { readSources } from '../../lib/messageDetails';
 import { messageToPlainText } from '../../lib/messageText';
 import { canMask, readMaskState } from '../../lib/masking';
+import { buildReplyPreview, messageAuthorName } from '../../lib/sharedMessage';
 import type { InspectorSection } from './MessageInspector';
 import type { ChatMessage, Json } from '../../lib/types';
 import {
@@ -220,6 +223,10 @@ function OverflowMenu({
     const [placement, setPlacement] = useState<'up' | 'down'>('up');
     const containerRef = useRef<HTMLDivElement>(null);
     const { removeMessage } = useChatStore();
+    // Editing resends the message as a new thread attempt, which only the personal
+    // conversation API can do. In a shared conversation the entry is left out rather than
+    // offered and then failing.
+    const shared = useChatStore((state) => state.activeConversationKind === 'collaborative');
     const isUser = message.role === 'user';
 
     const toggle = () => {
@@ -290,7 +297,7 @@ function OverflowMenu({
                         placement === 'up' ? 'bottom-full mb-1' : 'top-full mt-1',
                     )}
                 >
-                    {isUser && onEdit && item('Edit', <Pencil size={14} />, onEdit)}
+                    {isUser && !shared && onEdit && item('Edit', <Pencil size={14} />, onEdit)}
                     {item('Copy with sources', <Copy size={14} />, () => {
                         // The plain Copy button drops citations entirely. This keeps the
                         // attribution, as a reference list under the answer rather than
@@ -351,15 +358,43 @@ export function MessageActions({
     onEdit,
     inspector,
     onInspect,
+    alignRight,
 }: {
     message: ChatMessage;
     onEdit?: () => void;
     /** Section currently open below the message, or null when the panel is closed. */
     inspector?: InspectorSection | null;
     onInspect?: (section: InspectorSection | null) => void;
+    /**
+     * Which side the message bubble sits on.
+     *
+     * Passed in rather than derived from the role, because in a shared conversation another
+     * participant's message is also `role: 'user'` but belongs on the left. Deriving it here
+     * would put the action row on the opposite side from the bubble it belongs to.
+     */
+    alignRight?: boolean;
 }) {
     const { retryMessage, changeAttempt, sendFeedback, forkFromMessage, streaming, attemptsByThread, applyMask } =
         useChatStore();
+    /**
+     * Whether this message is in a shared conversation.
+     *
+     * Retry, edit, attempt navigation and fork are all thread operations, and threads are a
+     * property of the personal conversation API — `/api/message/<id>/retry` and its siblings
+     * read from the personal messages container and have no collaboration counterpart. The
+     * classic interface leaves them out of a shared conversation for the same reason, so
+     * hiding them here is the parity rather than a reduction.
+     */
+    const shared = useChatStore((state) => state.activeConversationKind === 'collaborative');
+    const activeConversationId = useChatStore((state) => state.activeConversationId);
+    const loadedCollaboration = useCollaborationStore((state) => state.conversation);
+    // Guarded on the id, and deny-by-default, for the same reasons as the composer: the
+    // participants panel keeps its own slot now, but a membership that has not loaded must
+    // not be read as permission.
+    const canPost =
+        loadedCollaboration?.id === activeConversationId &&
+        loadedCollaboration?.can_post_messages === true;
+    const setReplyTo = useCollaborationStore((state) => state.setReplyTo);
     const feedbackEnabled = useBootstrapStore((state) =>
         Boolean(state.data?.features?.enable_user_feedback),
     );
@@ -397,10 +432,10 @@ export function MessageActions({
                 // Groups are separated by a wider gap than the buttons within them, so the
                 // row reads as related sets rather than one long undifferentiated strip.
                 'mt-1 flex items-center gap-3',
-                isUser ? 'justify-end' : 'justify-start',
+                (alignRight ?? isUser) ? 'justify-end' : 'justify-start',
             )}
         >
-            {attempts.show && (
+            {attempts.show && !shared && (
                 <div className="flex items-center gap-0.5">
                     <IconButton
                         label="Previous attempt"
@@ -441,13 +476,32 @@ export function MessageActions({
                     )}
                 </IconButton>
 
-                <IconButton
-                    label="Retry"
-                    onClick={() => void retryMessage(message.id)}
-                    disabled={streaming}
-                >
-                    <RefreshCw size={15} />
-                </IconButton>
+                {shared ? (
+                    canPost && (
+                        <IconButton
+                            label="Reply to this message"
+                            onClick={() =>
+                                setReplyTo({
+                                    message_id: message.id,
+                                    display_name:
+                                        messageAuthorName(message, currentUserId) ||
+                                        (message.role === 'assistant' ? 'Assistant' : ''),
+                                    preview: buildReplyPreview(message),
+                                })
+                            }
+                        >
+                            <Reply size={15} />
+                        </IconButton>
+                    )
+                ) : (
+                    <IconButton
+                        label="Retry"
+                        onClick={() => void retryMessage(message.id)}
+                        disabled={streaming}
+                    >
+                        <RefreshCw size={15} />
+                    </IconButton>
+                )}
 
                 {!isUser && ttsEnabled && <SpeakButton message={message} />}
             </div>
@@ -545,7 +599,7 @@ export function MessageActions({
 
             {/* Branching and everything else. */}
             <div className="flex items-center gap-0.5">
-                {!isUser && (
+                {!isUser && !shared && (
                     <IconButton
                         label="Fork conversation from here"
                         onClick={() => void forkFromMessage(message.id)}

--- a/application/v2_ui/src/components/chat/MessageList.tsx
+++ b/application/v2_ui/src/components/chat/MessageList.tsx
@@ -7,12 +7,15 @@ import {
     Brain,
     ChevronDown,
     EyeOff,
+    FileText,
     ImageOff,
     RefreshCw,
+    Reply,
     Sparkles,
     TriangleAlert,
 } from 'lucide-react';
 import { useChatStore } from '../../stores/chatStore';
+import { useCollaborationStore } from '../../stores/collaborationStore';
 import { useBootstrapStore } from '../../stores/bootstrapStore';
 import { useUiStore } from '../../stores/uiStore';
 import { bubbleWidthClass, chatWidthClass } from '../../lib/chatWidth';
@@ -37,7 +40,13 @@ import {
     findResultForSpec,
     groupProposalImages,
 } from '../../lib/imageProposalSpec';
-import type { ChatMessage, ThoughtEntry } from '../../lib/types';
+import {
+    isAiRequest,
+    isOwnMessage,
+    messageAuthorName,
+    resolveReplyContext,
+} from '../../lib/sharedMessage';
+import type { ChatMessage, CollaborationMessage, ThoughtEntry } from '../../lib/types';
 
 function ThoughtsPanel({ thoughts }: { thoughts: ThoughtEntry[] }) {
     const [open, setOpen] = useState(false);
@@ -145,6 +154,61 @@ function ImageMessage({ message }: { message: ChatMessage }) {
     );
 }
 
+/**
+ * A quotation of the message being replied to.
+ *
+ * Shared conversations are not linear the way a personal one is — several people write into
+ * the same thread — so a reply that does not show what it answers is frequently
+ * unintelligible by the time it is read.
+ */
+function ReplyQuote({ context }: { context: { display_name?: string; preview?: string } }) {
+    return (
+        <div className="mb-2 flex items-start gap-1.5 border-l-2 border-current/30 pl-2 text-[12px] opacity-70">
+            <Reply size={12} className="mt-0.5 shrink-0" />
+            <span className="min-w-0">
+                {context.display_name && (
+                    <span className="font-medium">{context.display_name}: </span>
+                )}
+                <span className="line-clamp-2">{context.preview}</span>
+            </span>
+        </div>
+    );
+}
+
+/**
+ * A file somebody attached to a shared conversation.
+ *
+ * `serialize_collaboration_message` gives an upload the display role `file`, which the
+ * personal endpoints never emit. Rendered as a named attachment rather than as message
+ * text, because `content` for one of these is extracted document text and can be the whole
+ * document.
+ */
+function FileMessage({ message }: { message: ChatMessage }) {
+    const chatWidth = useUiStore((state) => state.chatWidth);
+    const currentUserId = useBootstrapStore((state) => state.data?.user?.id);
+    const shared = message as CollaborationMessage;
+    const author = messageAuthorName(message, currentUserId);
+    const own = isOwnMessage(message, currentUserId);
+
+    return (
+        <div
+            id={`message-${message.id}`}
+            className={clsx('flex flex-col', own && 'items-end')}
+        >
+            {author && <p className="mb-1 px-1 text-[11px] text-text-3">{author}</p>}
+            <div
+                className={clsx(
+                    bubbleWidthClass(chatWidth),
+                    'glass-flat flex items-center gap-2 rounded-2xl px-4 py-3 text-[14px] text-text-1',
+                )}
+            >
+                <FileText size={16} className="shrink-0 text-text-3" />
+                <span className="truncate">{shared.filename || 'Attached file'}</span>
+            </div>
+        </div>
+    );
+}
+
 function MessageBubble({
     message,
     proposalImages,
@@ -162,9 +226,33 @@ function MessageBubble({
     const applyMask = useChatStore((state) => state.applyMask);
     const currentUserId = useBootstrapStore((state) => state.data?.user?.id);
     const chatWidth = useUiStore((state) => state.chatWidth);
+    const messages = useChatStore((state) => state.messages);
 
     const masks = readMaskState(message);
     const maskingAllowed = canMask(message, currentUserId);
+
+    /**
+     * Who wrote this, when that is a question worth answering.
+     *
+     * Empty for every personal conversation and for assistant replies, so nothing changes
+     * outside a shared thread.
+     */
+    const author = messageAuthorName(message, currentUserId);
+    const own = isOwnMessage(message, currentUserId);
+    /**
+     * Which side of the thread this message sits on.
+     *
+     * In a personal conversation that is simply "did the user write it". In a shared one it
+     * is "did *this* reader write it": another participant's message is theirs, not the
+     * reader's, and putting it on the reader's side would misattribute it at a glance.
+     * `author` is empty outside a shared conversation, so this reduces to the old rule
+     * there.
+     */
+    const alignRight = author ? own : isUser;
+    const replyContext = useMemo(
+        () => resolveReplyContext(message, messages, currentUserId),
+        [message, messages, currentUserId],
+    );
 
     // A user message is plain text, so its masked spans can be cut straight out of the
     // content rather than going through the markdown placeholder path.
@@ -184,6 +272,10 @@ function MessageBubble({
 
     if (message.role === 'image') {
         return <ImageMessage message={message} />;
+    }
+
+    if (message.role === 'file') {
+        return <FileMessage message={message} />;
     }
 
     if (editing) {
@@ -228,9 +320,20 @@ function MessageBubble({
     return (
         <div
             id={`message-${message.id}`}
-            className={clsx('group/message flex flex-col transition-shadow', isUser && 'items-end')}
+            className={clsx(
+                'group/message flex flex-col transition-shadow',
+                alignRight && 'items-end',
+            )}
         >
-            <div className={clsx('flex w-full', isUser ? 'justify-end' : 'justify-start')}>
+            {/* Only ever present in a shared conversation, where a thread with several
+                authors is unreadable without knowing who wrote what. */}
+            {author && (
+                <p className="mb-1 flex items-center gap-1.5 px-1 text-[11px] text-text-3">
+                    <span className="font-medium">{author}</span>
+                    {isAiRequest(message) && <span>asked the assistant</span>}
+                </p>
+            )}
+            <div className={clsx('flex w-full', alignRight ? 'justify-end' : 'justify-start')}>
             <div
                 ref={bodyRef}
                 className={clsx(
@@ -238,11 +341,12 @@ function MessageBubble({
                     'rounded-2xl px-4 py-3',
                     // These are repeated per message, so they use the non-blurred surface:
                     // a backdrop-filter per bubble makes long threads scroll badly.
-                    isUser
+                    alignRight
                         ? 'bg-accent text-on-accent'
                         : 'glass-flat text-text-1',
                 )}
             >
+                {replyContext && <ReplyQuote context={replyContext} />}
                 {masks.fullyMasked ? (
                     // The whole message is masked, so none of it is rendered. The server
                     // also withholds it from the model.
@@ -255,7 +359,7 @@ function MessageBubble({
                         })}
                         className={clsx(
                             'flex items-center gap-2 text-[15px] italic',
-                            isUser ? 'text-on-accent/80' : 'text-text-3',
+                            alignRight ? 'text-on-accent/80' : 'text-text-3',
                         )}
                     >
                         <EyeOff size={14} className="shrink-0" />
@@ -319,6 +423,7 @@ function MessageBubble({
                     onEdit={isUser ? () => setEditing(true) : undefined}
                     inspector={inspector}
                     onInspect={setInspector}
+                    alignRight={alignRight}
                 />
             </div>
 
@@ -394,6 +499,46 @@ function StreamingBubble() {
                     </span>
                 )}
             </div>
+        </div>
+    );
+}
+
+/**
+ * Who else is currently writing.
+ *
+ * Only ever populated in a shared conversation. It sits at the end of the thread rather
+ * than under the composer so it reads as part of the conversation — the same place the
+ * message being written will appear.
+ */
+function TypingIndicator() {
+    const typingUsers = useCollaborationStore((state) => state.typingUsers);
+
+    if (typingUsers.length === 0) {
+        return null;
+    }
+
+    const names = typingUsers.map((entry) => entry.display_name);
+    const label =
+        names.length === 1
+            ? `${names[0]} is typing`
+            : names.length === 2
+              ? `${names[0]} and ${names[1]} are typing`
+              : `${names.length} people are typing`;
+
+    return (
+        <div className="flex justify-start">
+            <p className="flex items-center gap-1.5 px-1 text-[12px] text-text-3">
+                <span className="flex gap-1">
+                    {[0, 150, 300].map((delay) => (
+                        <span
+                            key={delay}
+                            className="h-1 w-1 animate-bounce rounded-full bg-text-3"
+                            style={{ animationDelay: `${delay}ms` }}
+                        />
+                    ))}
+                </span>
+                {label}
+            </p>
         </div>
     );
 }
@@ -524,6 +669,7 @@ export function MessageList() {
                         />
                     ))}
                     {streaming && <StreamingBubble />}
+                    <TypingIndicator />
                 </div>
 
                 {streamError && (

--- a/application/v2_ui/src/components/chat/ParticipantsPanel.tsx
+++ b/application/v2_ui/src/components/chat/ParticipantsPanel.tsx
@@ -1,0 +1,509 @@
+// ParticipantsPanel.tsx
+// The People panel: who is in a shared conversation, and everything membership-related
+// that can be done to it.
+//
+// Also the entry point for *making* a conversation shared. That is why the panel is driven
+// by `panelTarget` rather than by the loaded shared conversation: it opens on ordinary
+// personal and group conversations too, where there is no membership yet and the whole
+// panel is an invite box.
+//
+// Every action here is gated on a capability flag the server computed
+// (`serialize_collaboration_conversation`), never on a rule reimplemented in the browser.
+// Those flags fold together membership status, role, visibility mode and whether membership
+// is explicit at all, and a group-visibility conversation grants posting with no membership
+// record to inspect — so a client-side guess would offer controls the server then refuses.
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import {
+    Crown,
+    Loader2,
+    LogOut,
+    Search,
+    Shield,
+    Trash2,
+    TriangleAlert,
+    UserMinus,
+    UserPlus,
+    Users,
+    X,
+} from 'lucide-react';
+import { useChatStore } from '../../stores/chatStore';
+import { useCollaborationStore, participantName } from '../../stores/collaborationStore';
+import { useBootstrapStore } from '../../stores/bootstrapStore';
+import { toast } from '../../stores/toastStore';
+import { fetchCollaboratorSuggestions, fetchGroupMembers } from '../../lib/collaboration';
+import { GlassButton, GlassPanel, Skeleton } from '../ui/primitives';
+import type { CollaborationParticipant, CollaboratorSuggestion } from '../../lib/types';
+
+/** How long to wait after a keystroke before searching. */
+const SEARCH_DEBOUNCE_MS = 250;
+
+const ROLE_ICON: Record<string, React.ReactNode> = {
+    owner: <Crown size={12} />,
+    admin: <Shield size={12} />,
+};
+
+function RoleBadge({ participant }: { participant: CollaborationParticipant }) {
+    const role = String(participant.role ?? 'member').toLowerCase();
+    const status = String(participant.membership_status ?? '').toLowerCase();
+
+    return (
+        <span className="flex shrink-0 items-center gap-1.5">
+            {status === 'pending' && (
+                <span
+                    title="This person has been invited but has not accepted yet"
+                    className="rounded-full bg-warn-soft px-2 py-0.5 text-[10px] font-medium text-warn"
+                >
+                    invited
+                </span>
+            )}
+            {role !== 'member' && (
+                <span className="flex items-center gap-1 rounded-full bg-accent-soft px-2 py-0.5 text-[10px] font-medium text-accent">
+                    {ROLE_ICON[role]}
+                    {role}
+                </span>
+            )}
+        </span>
+    );
+}
+
+/**
+ * Find people to add.
+ *
+ * Where the candidates come from depends on the conversation, and the difference matters: a
+ * group conversation may only be shared with members of that group, so offering
+ * directory-wide results there would suggest people the server refuses. Anything else draws
+ * on the caller's recent collaborators and the directory.
+ */
+function InviteSearch({
+    groupId,
+    excludeUserIds,
+    onInvite,
+    busy,
+}: {
+    groupId?: string | null;
+    excludeUserIds: Set<string>;
+    onInvite: (participant: CollaborationParticipant) => void;
+    busy: boolean;
+}) {
+    const [query, setQuery] = useState('');
+    const [results, setResults] = useState<CollaboratorSuggestion[]>([]);
+    const [searching, setSearching] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const currentUserId = useBootstrapStore((state) => state.data?.user?.id);
+    const requestRef = useRef(0);
+
+    useEffect(() => {
+        const requestId = requestRef.current + 1;
+        requestRef.current = requestId;
+        const controller = new AbortController();
+
+        const timer = window.setTimeout(() => {
+            setSearching(true);
+            setError(null);
+
+            const search = groupId
+                ? fetchGroupMembers(groupId, query, controller.signal).then((members) =>
+                      // The group route answers with a bare array and spells its fields in
+                      // camelCase, unlike everything under /api/collaboration.
+                      (members ?? []).map((member) => ({
+                          user_id: String(member.userId ?? member.user_id ?? member.id ?? ''),
+                          display_name: String(
+                              member.displayName ?? member.display_name ?? member.name ?? '',
+                          ),
+                          email: String(member.email ?? ''),
+                          source: 'group',
+                      })),
+                  )
+                : fetchCollaboratorSuggestions(query, { limit: 8 }, controller.signal).then(
+                      (payload) => payload.results ?? [],
+                  );
+
+            search
+                .then((found) => {
+                    // Discarded when a newer keystroke has already started its own search,
+                    // so a slow earlier response cannot overwrite a fresher list.
+                    if (requestRef.current !== requestId) {
+                        return;
+                    }
+                    setResults(found);
+                    setSearching(false);
+                })
+                .catch((cause) => {
+                    if (requestRef.current !== requestId || controller.signal.aborted) {
+                        return;
+                    }
+                    setSearching(false);
+                    setError(
+                        cause instanceof Error ? cause.message : 'Could not search for people.',
+                    );
+                });
+        }, SEARCH_DEBOUNCE_MS);
+
+        return () => {
+            window.clearTimeout(timer);
+            controller.abort();
+        };
+    }, [query, groupId]);
+
+    const candidates = useMemo(
+        () =>
+            results.filter((candidate) => {
+                const userId = String(candidate.user_id ?? '').trim();
+                return userId && userId !== currentUserId && !excludeUserIds.has(userId);
+            }),
+        [results, excludeUserIds, currentUserId],
+    );
+
+    return (
+        <div>
+            <div className="relative">
+                <Search
+                    size={14}
+                    className="pointer-events-none absolute top-1/2 left-2.5 -translate-y-1/2 text-text-3"
+                />
+                <input
+                    type="search"
+                    value={query}
+                    onChange={(event) => setQuery(event.target.value)}
+                    placeholder={groupId ? 'Search group members' : 'Search people'}
+                    aria-label="Search for people to add"
+                    className="w-full rounded-lg border border-edge bg-surface-sunken py-2 pr-2.5 pl-8 text-sm text-text-1 placeholder:text-text-3 focus:border-accent focus:outline-none"
+                />
+            </div>
+
+            {error && (
+                <p className="mt-2 flex items-start gap-1.5 text-xs text-danger">
+                    <TriangleAlert size={13} className="mt-0.5 shrink-0" />
+                    {error}
+                </p>
+            )}
+
+            <div className="mt-2 space-y-1">
+                {searching && candidates.length === 0 && (
+                    <Skeleton className="h-9 w-full" />
+                )}
+
+                {!searching && candidates.length === 0 && !error && (
+                    <p className="px-1 py-2 text-xs text-text-3">
+                        {query
+                            ? 'Nobody matching that name can be added.'
+                            : groupId
+                              ? 'Everyone in this group is already here.'
+                              : 'Start typing to find people to add.'}
+                    </p>
+                )}
+
+                {candidates.map((candidate) => (
+                    <button
+                        key={candidate.user_id}
+                        type="button"
+                        disabled={busy}
+                        onClick={() =>
+                            onInvite({
+                                user_id: String(candidate.user_id),
+                                display_name: candidate.display_name,
+                                email: candidate.email,
+                            })
+                        }
+                        className="flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left text-sm text-text-1 transition-colors hover:bg-surface-2 disabled:cursor-not-allowed disabled:opacity-50"
+                    >
+                        <UserPlus size={14} className="shrink-0 text-text-3" />
+                        <span className="min-w-0 flex-1">
+                            <span className="block truncate">
+                                {candidate.display_name || candidate.email}
+                            </span>
+                            {candidate.email && candidate.display_name && (
+                                <span className="block truncate text-[11px] text-text-3">
+                                    {candidate.email}
+                                </span>
+                            )}
+                        </span>
+                    </button>
+                ))}
+            </div>
+        </div>
+    );
+}
+
+export function ParticipantsPanel() {
+    const panelTarget = useCollaborationStore((state) => state.panelTarget);
+    const conversation = useCollaborationStore((state) => state.panelConversation);
+    const panelLoading = useCollaborationStore((state) => state.panelLoading);
+    const closePanel = useCollaborationStore((state) => state.closePanel);
+    const inviteParticipants = useCollaborationStore((state) => state.inviteParticipants);
+    const removeParticipant = useCollaborationStore((state) => state.removeParticipant);
+    const changeParticipantRole = useCollaborationStore((state) => state.changeParticipantRole);
+    const leaveOrDelete = useCollaborationStore((state) => state.leaveOrDelete);
+    const loadConversations = useChatStore((state) => state.loadConversations);
+    const selectConversation = useChatStore((state) => state.selectConversation);
+    const currentUserId = useBootstrapStore((state) => state.data?.user?.id);
+
+    const [busy, setBusy] = useState(false);
+
+    useEffect(() => {
+        const onKeyDown = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') {
+                closePanel();
+            }
+        };
+        document.addEventListener('keydown', onKeyDown);
+        return () => document.removeEventListener('keydown', onKeyDown);
+    }, [closePanel]);
+
+    if (!panelTarget) {
+        return null;
+    }
+
+    /**
+     * Whether this panel is showing a conversation that is already shared.
+     *
+     * An unshared conversation has no membership to load, and the panel is purely an invite
+     * box. A shared one whose membership has not arrived is a third state, and is treated as
+     * offering nothing rather than everything — the safe direction, since these flags decide
+     * whether a "Delete for everyone" button appears.
+     */
+    const isSharedTarget = panelTarget.kind === 'collaborative';
+    const shared = isSharedTarget && conversation?.id === panelTarget.conversationId;
+    const loadingMembership = isSharedTarget && !shared;
+    const participants = shared ? (conversation?.participants ?? []) : [];
+    const canManageMembers = isSharedTarget
+        ? shared && Boolean(conversation?.can_manage_members)
+        : true;
+    const canManageRoles = shared && Boolean(conversation?.can_manage_roles);
+    const canDelete = shared && Boolean(conversation?.can_delete_conversation);
+    const canLeave = shared && Boolean(conversation?.can_leave_conversation);
+    const groupId = panelTarget.groupId ?? (shared ? conversation?.group_id : null) ?? null;
+
+    const existingIds = new Set(
+        participants.map((participant) => String(participant.user_id ?? '').trim()),
+    );
+
+    const invite = async (participant: CollaborationParticipant) => {
+        setBusy(true);
+        try {
+            const result = await inviteParticipants([participant]);
+            // Sharing an unshared conversation creates a *new* one and leaves the original
+            // in place as the hidden source the AI runs in, so the reader has to be moved to
+            // the conversation that now holds the thread.
+            const nextId = result.conversation?.id;
+            await loadConversations({ reset: true });
+            if (nextId && nextId !== panelTarget.conversationId) {
+                await selectConversation(nextId, { kind: 'collaborative' });
+            }
+            toast.success(`${participantName(participant)} was invited.`);
+        } catch (error) {
+            toast.error(
+                error instanceof Error ? error.message : 'Could not add that person.',
+            );
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    const remove = async (participant: CollaborationParticipant) => {
+        setBusy(true);
+        try {
+            await removeParticipant(String(participant.user_id));
+            toast.success(`${participantName(participant)} was removed.`);
+        } catch (error) {
+            toast.error(
+                error instanceof Error ? error.message : 'Could not remove that person.',
+            );
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    const setRole = async (participant: CollaborationParticipant, role: 'admin' | 'member') => {
+        setBusy(true);
+        try {
+            await changeParticipantRole(String(participant.user_id), role);
+        } catch (error) {
+            toast.error(error instanceof Error ? error.message : 'Could not change that role.');
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    const exitConversation = async (action: 'leave' | 'delete') => {
+        setBusy(true);
+        const done = await leaveOrDelete(action);
+        setBusy(false);
+        if (done) {
+            await loadConversations({ reset: true });
+            await selectConversation(null);
+        }
+    };
+
+    return (
+        <div
+            className="fixed inset-0 z-50 flex items-center justify-center p-4"
+            role="dialog"
+            aria-modal="true"
+            aria-label="Conversation participants"
+        >
+            <div className="absolute inset-0 bg-black/40" aria-hidden="true" onClick={closePanel} />
+
+            <GlassPanel
+                elevation="modal"
+                edge
+                className="relative flex max-h-[85vh] w-full max-w-lg flex-col"
+            >
+                <div className="flex h-14 shrink-0 items-center gap-2 border-b border-edge px-5">
+                    <Users size={16} className="text-text-3" />
+                    <h2 className="min-w-0 truncate text-[15px] font-semibold text-text-1">
+                        {shared ? 'People in this conversation' : 'Share this conversation'}
+                    </h2>
+                    <button
+                        type="button"
+                        onClick={closePanel}
+                        aria-label="Close participants"
+                        className="ml-auto rounded-lg p-1.5 text-text-3 transition-colors hover:bg-surface-2 hover:text-text-1"
+                    >
+                        <X size={17} />
+                    </button>
+                </div>
+
+                <div className="min-h-0 flex-1 space-y-4 overflow-y-auto px-5 py-4">
+                    {!isSharedTarget && (
+                        <p className="text-sm text-text-2">
+                            Adding somebody turns this into a shared conversation. Everyone
+                            invited can read the whole thread and reply in it.
+                        </p>
+                    )}
+
+                    {loadingMembership && (
+                        <div className="space-y-2">
+                            {panelLoading ? (
+                                Array.from({ length: 3 }).map((_, index) => (
+                                    <Skeleton key={index} className="h-9 w-full" />
+                                ))
+                            ) : (
+                                <p className="flex items-start gap-1.5 text-sm text-danger">
+                                    <TriangleAlert size={14} className="mt-0.5 shrink-0" />
+                                    The people in this conversation could not be loaded.
+                                </p>
+                            )}
+                        </div>
+                    )}
+
+                    {shared && participants.length > 0 && (
+                        <ul className="space-y-1">
+                            {participants.map((participant) => {
+                                const userId = String(participant.user_id ?? '').trim();
+                                const isSelf = userId === currentUserId;
+                                const role = String(participant.role ?? 'member').toLowerCase();
+                                return (
+                                    <li
+                                        key={userId}
+                                        className="flex items-center gap-2 rounded-lg px-2 py-1.5 hover:bg-surface-2"
+                                    >
+                                        <span className="min-w-0 flex-1">
+                                            <span className="block truncate text-sm text-text-1">
+                                                {participantName(participant)}
+                                                {isSelf && (
+                                                    <span className="text-text-3"> (you)</span>
+                                                )}
+                                            </span>
+                                            {participant.email && (
+                                                <span className="block truncate text-[11px] text-text-3">
+                                                    {participant.email}
+                                                </span>
+                                            )}
+                                        </span>
+
+                                        <RoleBadge participant={participant} />
+
+                                        {/* Ownership is not assignable: it moves by being
+                                            handed on when an owner leaves, so an owner row
+                                            offers no role control. */}
+                                        {canManageRoles && !isSelf && role !== 'owner' && (
+                                            <button
+                                                type="button"
+                                                disabled={busy}
+                                                onClick={() =>
+                                                    void setRole(
+                                                        participant,
+                                                        role === 'admin' ? 'member' : 'admin',
+                                                    )
+                                                }
+                                                className="shrink-0 rounded-md p-1.5 text-text-3 transition-colors hover:bg-surface-3 hover:text-text-1 disabled:opacity-40"
+                                                title={
+                                                    role === 'admin'
+                                                        ? 'Make a member'
+                                                        : 'Make an admin'
+                                                }
+                                                aria-label={
+                                                    role === 'admin'
+                                                        ? `Make ${participantName(participant)} a member`
+                                                        : `Make ${participantName(participant)} an admin`
+                                                }
+                                            >
+                                                <Shield size={14} />
+                                            </button>
+                                        )}
+
+                                        {canManageMembers && !isSelf && role !== 'owner' && (
+                                            <button
+                                                type="button"
+                                                disabled={busy}
+                                                onClick={() => void remove(participant)}
+                                                className="shrink-0 rounded-md p-1.5 text-text-3 transition-colors hover:bg-danger-soft hover:text-danger disabled:opacity-40"
+                                                title="Remove from conversation"
+                                                aria-label={`Remove ${participantName(participant)}`}
+                                            >
+                                                <UserMinus size={14} />
+                                            </button>
+                                        )}
+                                    </li>
+                                );
+                            })}
+                        </ul>
+                    )}
+
+                    {canManageMembers ? (
+                        <InviteSearch
+                            groupId={groupId}
+                            excludeUserIds={existingIds}
+                            onInvite={(participant) => void invite(participant)}
+                            busy={busy}
+                        />
+                    ) : (
+                        shared && (
+                            <p className="text-xs text-text-3">
+                                Only an owner or admin of this conversation can add or remove
+                                people.
+                            </p>
+                        )
+                    )}
+                </div>
+
+                {(canLeave || canDelete) && (
+                    <div className="flex shrink-0 items-center gap-2 border-t border-edge px-5 py-3">
+                        {canLeave && (
+                            <GlassButton
+                                size="sm"
+                                disabled={busy}
+                                onClick={() => void exitConversation('leave')}
+                            >
+                                <LogOut size={14} /> Leave conversation
+                            </GlassButton>
+                        )}
+                        {canDelete && (
+                            <GlassButton
+                                size="sm"
+                                variant="danger"
+                                disabled={busy}
+                                onClick={() => void exitConversation('delete')}
+                            >
+                                <Trash2 size={14} /> Delete for everyone
+                            </GlassButton>
+                        )}
+                        {busy && <Loader2 size={14} className="ml-auto animate-spin text-text-3" />}
+                    </div>
+                )}
+            </GlassPanel>
+        </div>
+    );
+}

--- a/application/v2_ui/src/lib/apiClient.ts
+++ b/application/v2_ui/src/lib/apiClient.ts
@@ -15,8 +15,13 @@
  * When the SPA is deployed to its own App Service, VITE_API_BASE is set at build time to
  * the Flask origin. That path additionally requires V2_UI_ALLOWED_ORIGIN to be set on the
  * Flask app so it emits CORS headers and trusts the origin for CSRF.
+ *
+ * `import.meta.env` is a Vite construct and is absent under any other loader, so it is read
+ * defensively. Without that, importing any module in this graph outside a Vite build — a
+ * functional test executing the real source, for instance — throws before a single line of
+ * the module under test runs.
  */
-export const API_BASE: string = import.meta.env.VITE_API_BASE ?? '';
+export const API_BASE: string = import.meta.env?.VITE_API_BASE ?? '';
 
 /** Cross-origin deployments must send credentials explicitly to carry the session cookie. */
 export const CREDENTIALS_MODE: RequestCredentials = API_BASE ? 'include' : 'same-origin';

--- a/application/v2_ui/src/lib/collaboration.ts
+++ b/application/v2_ui/src/lib/collaboration.ts
@@ -1,0 +1,391 @@
+// collaboration.ts
+// Typed wrappers around the /api/collaboration/* endpoints the V2 UI uses for shared
+// conversations.
+//
+// Kept apart from `endpoints.ts` because these are not variants of the personal routes but
+// a parallel API over a different pair of Cosmos containers. Paths and payload shapes were
+// verified against route_backend_collaboration.py, functions_collaboration.py and
+// collaboration_models.py.
+//
+// Two conventions in this API differ from the personal one and are easy to get wrong:
+//
+//   - Most responses wrap the conversation as `{conversation: ...}`, but the rename route
+//     returns the serialized conversation *bare*. Both spellings are normalised here so
+//     callers never have to know which route they came from.
+//   - Sharing an existing conversation does not modify it. It creates a *new* collaboration
+//     conversation with its own id and leaves the original in place as the hidden source
+//     the AI actually runs in, so callers must follow the returned id.
+
+import { api, apiUrl } from './apiClient';
+import type {
+    CollaborationConversation,
+    CollaborationMessage,
+    CollaborationParticipant,
+    CollaboratorSuggestion,
+    Json,
+    MembershipRole,
+} from './types';
+import type { MaskAction, MaskedRange, MaskSelection } from './masking';
+
+/* -------------------------------------------------------------------------- */
+/* Paths                                                                       */
+/* -------------------------------------------------------------------------- */
+
+const base = (conversationId: string) =>
+    `/api/collaboration/conversations/${encodeURIComponent(conversationId)}`;
+
+/* -------------------------------------------------------------------------- */
+/* Conversations                                                               */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * List the caller's shared conversations.
+ *
+ * The conversation feed already merges these into the rail, so this is not how the list is
+ * built. It exists for the one thing the feed cannot answer: which invitations are still
+ * pending, which `include_pending` controls and which the feed omits entirely.
+ */
+export const fetchCollaborationConversations = (
+    options: { includePending?: boolean; scope?: 'all' | 'personal' | 'group' } = {},
+    signal?: AbortSignal,
+) => {
+    const params = new URLSearchParams();
+    params.set('include_pending', options.includePending === false ? 'false' : 'true');
+    if (options.scope) {
+        params.set('scope', options.scope);
+    }
+    return api.get<{ conversations: CollaborationConversation[] }>(
+        `/api/collaboration/conversations?${params.toString()}`,
+        signal,
+    );
+};
+
+/**
+ * Load one shared conversation, with its members and the caller's capability flags.
+ *
+ * This is also the existence check for a shared conversation: it answers 404 when the
+ * conversation is gone and 403 when the caller may not see it, where the messages endpoint
+ * would simply return an empty list.
+ */
+export const fetchCollaborationConversation = (conversationId: string, signal?: AbortSignal) =>
+    api.get<{ conversation: CollaborationConversation }>(base(conversationId), signal);
+
+/** Rename. Unlike its siblings this route returns the conversation unwrapped. */
+export const renameCollaborationConversation = (conversationId: string, title: string) =>
+    api.put<CollaborationConversation>(base(conversationId), { title });
+
+/** Toggle pinned. Server-side toggle with no request body, like the personal route. */
+export const toggleCollaborationPinned = (conversationId: string) =>
+    api.post<{ success: boolean; is_pinned: boolean }>(`${base(conversationId)}/pin`);
+
+/** Toggle hidden. Also a server-side toggle with no request body. */
+export const toggleCollaborationHidden = (conversationId: string) =>
+    api.post<{ success: boolean; is_hidden: boolean }>(`${base(conversationId)}/hide`);
+
+export const markCollaborationConversationRead = (conversationId: string) =>
+    api.post<Json>(`${base(conversationId)}/mark-read`);
+
+/**
+ * Remove the caller from a shared conversation, or destroy it for everybody.
+ *
+ * The two are one endpoint because they are the same decision made from different
+ * positions: an owner leaving must hand ownership on, which is what `newOwnerUserId` is
+ * for. Which of the two the caller may do is reported by `can_delete_conversation` and
+ * `can_leave_conversation` on the conversation.
+ */
+export const collaborationDeleteAction = (
+    conversationId: string,
+    action: 'delete' | 'leave',
+    newOwnerUserId?: string,
+) =>
+    api.post<{
+        success: boolean;
+        action: string;
+        conversation?: CollaborationConversation;
+        removed_participant?: CollaborationParticipant;
+        promoted_participant?: CollaborationParticipant | null;
+    }>(`${base(conversationId)}/delete-action`, {
+        action,
+        ...(newOwnerUserId ? { new_owner_user_id: newOwnerUserId } : {}),
+    });
+
+/* -------------------------------------------------------------------------- */
+/* Membership                                                                  */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Response of every route that adds people, whether or not it had to create the shared
+ * conversation first.
+ *
+ * `created` and `source_conversation_id` are only sent by the two conversion routes. They
+ * are what tells the caller the returned conversation is a *different* one from the
+ * conversation it just shared, and so must be selected in place of it.
+ */
+export interface InviteResult {
+    conversation: CollaborationConversation;
+    invited_participants?: CollaborationParticipant[];
+    created?: boolean;
+    source_conversation_id?: string;
+}
+
+/** Invite people into a conversation that is already shared. */
+export const inviteCollaborationMembers = (
+    conversationId: string,
+    participants: CollaborationParticipant[],
+) => api.post<InviteResult>(`${base(conversationId)}/members`, { participants });
+
+/**
+ * Share a personal conversation.
+ *
+ * Creates a new shared conversation seeded from this one and returns it. The original is
+ * kept as the hidden source conversation the AI runs in, so it is not renamed, moved or
+ * deleted — but it is no longer the id the reader should have open.
+ */
+export const sharePersonalConversation = (
+    conversationId: string,
+    participants: CollaborationParticipant[],
+) =>
+    api.post<InviteResult>(
+        `/api/collaboration/conversations/from-personal/${encodeURIComponent(conversationId)}/members`,
+        { participants },
+    );
+
+/** Share a group conversation. Same contract as the personal conversion. */
+export const shareGroupConversation = (
+    conversationId: string,
+    participants: CollaborationParticipant[],
+) =>
+    api.post<InviteResult>(
+        `/api/collaboration/conversations/from-group/${encodeURIComponent(conversationId)}/members`,
+        { participants },
+    );
+
+export const removeCollaborationMember = (conversationId: string, memberUserId: string) =>
+    api.delete<{
+        conversation: CollaborationConversation;
+        removed_participant?: CollaborationParticipant;
+    }>(`${base(conversationId)}/members/${encodeURIComponent(memberUserId)}`);
+
+/**
+ * Change a member's role.
+ *
+ * Only an owner may do this (`can_manage_roles`), and only `admin` and `member` are
+ * assignable — ownership moves by handing it on when leaving, not by assignment.
+ */
+export const updateCollaborationMemberRole = (
+    conversationId: string,
+    memberUserId: string,
+    role: MembershipRole,
+) =>
+    api.put<{ conversation: CollaborationConversation; participant?: CollaborationParticipant }>(
+        `${base(conversationId)}/members/${encodeURIComponent(memberUserId)}/role`,
+        { role },
+    );
+
+export const respondToCollaborationInvite = (
+    conversationId: string,
+    action: 'accept' | 'decline',
+) => api.post<{ conversation: CollaborationConversation }>(
+    `${base(conversationId)}/invite-response`,
+    { action },
+);
+
+/* -------------------------------------------------------------------------- */
+/* Messages                                                                    */
+/* -------------------------------------------------------------------------- */
+
+export const fetchCollaborationMessages = (conversationId: string, signal?: AbortSignal) =>
+    api.get<{ messages: CollaborationMessage[] }>(`${base(conversationId)}/messages`, signal);
+
+/**
+ * Post a message to the other participants without asking the AI to answer.
+ *
+ * This is the ordinary case in a shared conversation and has no equivalent in a personal
+ * one, where every message is a prompt. The AI path is `streamCollaborationUrl` below.
+ */
+export const postCollaborationMessage = (
+    conversationId: string,
+    body: {
+        content: string;
+        reply_to_message_id?: string | null;
+        mentioned_participants?: CollaborationParticipant[];
+    },
+) =>
+    api.post<{ conversation: CollaborationConversation; message: CollaborationMessage }>(
+        `${base(conversationId)}/messages`,
+        body,
+    );
+
+/**
+ * URL of the AI streaming endpoint for a shared conversation.
+ *
+ * A URL rather than a wrapper because the response is an SSE body, which `lib/sse.ts`
+ * consumes with its own reader. The frames are the ones `/api/chat/stream` emits: the route
+ * bridges to that view internally and rewrites the terminal frame, so the existing parser
+ * needs no changes.
+ *
+ * There is deliberately no reattach counterpart. `/api/chat/stream/reattach` addresses the
+ * hidden source conversation, which the browser is never told the id of, so a dropped
+ * collaboration stream cannot be resumed and must not be retried as though it could.
+ */
+export const streamCollaborationUrl = (conversationId: string) =>
+    apiUrl(`${base(conversationId)}/stream`);
+
+export const cancelCollaborationStreamUrl = (conversationId: string) =>
+    apiUrl(`${base(conversationId)}/stream/cancel`);
+
+export const deleteCollaborationMessage = (conversationId: string, messageId: string) =>
+    api.delete<{
+        success: boolean;
+        deleted_message_ids: string[];
+        conversation: CollaborationConversation;
+    }>(`${base(conversationId)}/messages/${encodeURIComponent(messageId)}`);
+
+/** Response of the collaboration mask route. Carries the whole message, unlike the personal one. */
+export interface CollaborationMaskResponse {
+    success: boolean;
+    message_id: string;
+    conversation_id: string;
+    masked: boolean;
+    masked_ranges: MaskedRange[];
+    message?: CollaborationMessage;
+}
+
+export const maskCollaborationMessage = (
+    conversationId: string,
+    messageId: string,
+    body: { action: MaskAction; selection?: MaskSelection },
+) =>
+    api.post<CollaborationMaskResponse>(
+        `${base(conversationId)}/messages/${encodeURIComponent(messageId)}/mask`,
+        body,
+    );
+
+/* -------------------------------------------------------------------------- */
+/* Presence                                                                    */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Announce that the caller is (or has stopped) typing.
+ *
+ * Fire-and-forget: the server broadcasts it to the other participants' event streams and
+ * expires it after eight seconds, so a lost ping corrects itself and a failure is never
+ * worth surfacing.
+ */
+export const sendCollaborationTyping = (conversationId: string, isTyping: boolean) =>
+    api.post<{ success: boolean }>(`${base(conversationId)}/typing`, { is_typing: isTyping });
+
+/** URL of the conversation's server-sent event stream. Consumed with `EventSource`. */
+export const collaborationEventsUrl = (conversationId: string) =>
+    apiUrl(`${base(conversationId)}/events`);
+
+/* -------------------------------------------------------------------------- */
+/* Images                                                                      */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * URL for an image posted in a shared conversation.
+ *
+ * The server already writes this path into the message's `content` when it serializes an
+ * image message, so this exists for the cases that need to rebuild it rather than read it.
+ */
+export const collaborationImageUrl = (conversationId: string, messageId: string) =>
+    apiUrl(`${base(conversationId)}/images/${encodeURIComponent(messageId)}`);
+
+/* -------------------------------------------------------------------------- */
+/* Invitable people                                                            */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * People the caller could invite, drawn from recent collaborators and the directory.
+ *
+ * Not a collaboration route: it lives on the user API because the same list backs the
+ * mention menu before a conversation has been shared at all.
+ */
+export const fetchCollaboratorSuggestions = (
+    query: string,
+    options: { limit?: number; recentOnly?: boolean } = {},
+    signal?: AbortSignal,
+) => {
+    const params = new URLSearchParams();
+    params.set('query', query);
+    params.set('limit', String(options.limit ?? 8));
+    if (options.recentOnly) {
+        params.set('recent_only', 'true');
+    }
+    return api.get<{ results: CollaboratorSuggestion[] }>(
+        `/api/user/collaboration-suggestions?${params.toString()}`,
+        signal,
+    );
+};
+
+/**
+ * Members of a group, used instead of the directory for a group-scoped conversation.
+ *
+ * A group conversation may only be shared with people already in that group, so offering
+ * directory-wide results there would suggest people the server will refuse. Returns a bare
+ * array, and spells its fields in camelCase, unlike the collaboration API.
+ */
+export const fetchGroupMembers = (groupId: string, search: string, signal?: AbortSignal) => {
+    const params = new URLSearchParams();
+    if (search) {
+        params.set('search', search);
+    }
+    const qs = params.toString();
+    return api.get<Array<Record<string, unknown>>>(
+        `/api/groups/${encodeURIComponent(groupId)}/members${qs ? `?${qs}` : ''}`,
+        signal,
+    );
+};
+
+/* -------------------------------------------------------------------------- */
+/* Generated file approvals                                                    */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * A file the AI generated inside a shared conversation, held back pending a decision.
+ *
+ * Generated files are staged rather than released because a shared thread has an audience:
+ * the conversation's owner decides whether the other participants receive a file somebody
+ * else asked the model to produce. Fields are those
+ * `list_pending_generated_file_approvals_for_user` returns.
+ */
+export interface GeneratedFileApproval {
+    artifact_message_id: string;
+    /** The conversation the file was generated in, which the decision endpoint keys on. */
+    source_conversation_id: string;
+    /** The shared conversation it would be released into, when it came from one. */
+    collaboration_conversation_id?: string;
+    file_name?: string;
+    output_format?: string;
+    approval?: {
+        state?: string;
+        is_pending?: boolean;
+        requested_by_name?: string;
+        requested_at?: string;
+        expires_at?: string;
+        resolved_by_name?: string;
+        viewer_can_approve?: boolean;
+        viewer_is_requester?: boolean;
+        [key: string]: unknown;
+    };
+    [key: string]: unknown;
+}
+
+export const fetchGeneratedFileApprovals = (signal?: AbortSignal) =>
+    api.get<{ approvals: GeneratedFileApproval[] }>('/api/collaboration/file-approvals', signal);
+
+export const resolveGeneratedFileApproval = (
+    sourceConversationId: string,
+    artifactMessageId: string,
+    decision: 'approve' | 'deny',
+) =>
+    api.post<{
+        artifact_message_id: string;
+        approval_state: string;
+        resolved_by_name?: string;
+        resolved_at?: string;
+    }>(
+        `/api/collaboration/file-approvals/${encodeURIComponent(sourceConversationId)}` +
+            `/${encodeURIComponent(artifactMessageId)}/${decision}`,
+    );

--- a/application/v2_ui/src/lib/collaborationEvents.ts
+++ b/application/v2_ui/src/lib/collaborationEvents.ts
@@ -1,0 +1,334 @@
+// collaborationEvents.ts
+// Subscribing to a shared conversation's server-sent event stream.
+//
+// The stream is what makes a shared conversation shared: another participant's message,
+// a member being added or removed, a mask being applied and somebody typing all arrive
+// here rather than being polled for.
+//
+// Two properties of the endpoint shape this module, and neither is optional to handle:
+//
+//   - **It replays.** `iter_events` starts from `start_index=0`, so attaching delivers the
+//     conversation's entire event history before any live event. Treating those as new
+//     would append the whole thread again on every reconnect. They are recognised by
+//     `occurred_at` predating the subscription and dropped.
+//   - **`EventSource` reconnects by itself,** and reattaches from the beginning, so the
+//     replay above happens again after every network blip. De-duplication is therefore by
+//     event identity and has to survive reconnects, not just the first attach.
+//
+// The frames are JSON envelopes on the default `message` event, unlike the chat stream,
+// which puts its discriminator inside the data. `event_type` is the discriminator here.
+
+import { collaborationEventsUrl } from './collaboration';
+import { API_BASE } from './apiClient';
+import type {
+    CollaborationConversation,
+    CollaborationEvent,
+    CollaborationMessage,
+    CollaborationParticipant,
+} from './types';
+
+/**
+ * How far before the subscription an event may have occurred and still count as live.
+ *
+ * Clock skew between the browser and the server is real, and an event published in the
+ * same instant the subscription opened is a genuine one. A second of tolerance matches the
+ * classic client and is far shorter than the gap to any actually-replayed history.
+ */
+const REPLAY_TOLERANCE_MS = 1000;
+
+/**
+ * How many event keys to remember.
+ *
+ * Bounded because a long-lived conversation would otherwise grow this set without limit.
+ * It only has to cover one replay window, and a replay is bounded by the conversation's
+ * own event history.
+ */
+const MAX_REMEMBERED_EVENTS = 2000;
+
+/**
+ * Fields of a serialized conversation that describe the *viewer* rather than the conversation.
+ *
+ * This distinction is why `conversationFactsOnly` exists.
+ * `serialize_collaboration_conversation` computes all of these from the `current_user_id`
+ * it is called with — and every route that publishes an event calls it with the user who
+ * *caused* the event, then broadcasts that one dict to every subscriber. So the copy
+ * arriving here carries somebody else's permissions, pin state and membership status.
+ *
+ * Taking them at face value is harmful in both directions: a participant leaving publishes
+ * a conversation serialized for themselves, in which `can_post_messages` is now false,
+ * which would disable everyone else's composer; and an owner acting publishes one in which
+ * `can_delete_conversation` is true, which would offer every member a "Delete for everyone"
+ * button the server then refuses.
+ */
+const VIEWER_SCOPED_FIELDS = [
+    'can_manage_members',
+    'can_manage_roles',
+    'can_accept_invite',
+    'can_post_messages',
+    'can_delete_conversation',
+    'can_leave_conversation',
+    'current_user_role',
+    'membership_status',
+    'is_pinned',
+    'is_hidden',
+    'has_unread_assistant_response',
+    'last_unread_assistant_message_id',
+    'last_unread_assistant_at',
+] as const;
+
+/**
+ * Strip the fields of a broadcast conversation that belong to whoever triggered the event.
+ *
+ * What remains — title, participants, counts, timestamps, scope, classification — means the
+ * same thing to every reader and is safe to apply directly. The viewer-scoped fields have to
+ * be re-read for the reader instead, which is what makes a membership change a reason to
+ * fetch rather than a payload to trust.
+ */
+export function conversationFactsOnly(
+    conversation: CollaborationConversation,
+): Partial<CollaborationConversation> {
+    const facts: Record<string, unknown> = { ...conversation };
+    for (const field of VIEWER_SCOPED_FIELDS) {
+        delete facts[field];
+    }
+    return facts as Partial<CollaborationConversation>;
+}
+
+export interface CollaborationEventHandlers {
+    onMessageCreated?: (
+        message: CollaborationMessage,
+        conversation: CollaborationConversation | undefined,
+    ) => void;
+    onMessageDeleted?: (
+        messageId: string,
+        deletedByUserId: string | undefined,
+        conversation: CollaborationConversation | undefined,
+    ) => void;
+    onMessageMasked?: (
+        message: CollaborationMessage,
+        updatedByUserId: string | undefined,
+    ) => void;
+    onConversationUpdated?: (conversation: CollaborationConversation) => void;
+    onConversationDeleted?: (conversationId: string) => void;
+    onMembersInvited?: (
+        participants: CollaborationParticipant[],
+        conversation: CollaborationConversation | undefined,
+    ) => void;
+    onMemberRemoved?: (
+        participant: CollaborationParticipant | undefined,
+        conversation: CollaborationConversation | undefined,
+    ) => void;
+    onMemberRoleUpdated?: (
+        participant: CollaborationParticipant | undefined,
+        conversation: CollaborationConversation | undefined,
+    ) => void;
+    onInviteAnswered?: (
+        participant: CollaborationParticipant | undefined,
+        accepted: boolean,
+        conversation: CollaborationConversation | undefined,
+    ) => void;
+    onTyping?: (
+        user: CollaborationParticipant | undefined,
+        isTyping: boolean,
+        expiresAt: string | undefined,
+    ) => void;
+}
+
+/**
+ * Identity of one event, for de-duplication.
+ *
+ * The envelope carries no id of its own, so identity is assembled from what distinguishes
+ * one event from another: the conversation, the kind, the subject it concerns, and when it
+ * happened. Two genuinely distinct events cannot collide on all four.
+ */
+function eventKey(event: CollaborationEvent): string {
+    const payload = event.payload ?? {};
+    const subject =
+        payload.message?.id ??
+        payload.message_id ??
+        payload.participant?.user_id ??
+        payload.user?.user_id ??
+        payload.deleted_by_user_id ??
+        '';
+    return [
+        event.conversation_id ?? payload.conversation?.id ?? '',
+        event.event_type ?? '',
+        subject,
+        event.occurred_at ?? '',
+    ].join('|');
+}
+
+/**
+ * Parse a server timestamp to epoch milliseconds.
+ *
+ * `utc_now_iso` does not always emit a zone designator, and `Date.parse` reads a bare
+ * timestamp as *local* time. On a browser west of UTC that makes every replayed event look
+ * like it happened in the future, so nothing is ever recognised as a replay. Appending `Z`
+ * when no offset is present is what stops that.
+ */
+export function parseEventTimestamp(timestamp: string | undefined): number {
+    const value = String(timestamp ?? '').trim();
+    if (!value) {
+        return Number.NaN;
+    }
+    if (/(?:Z|[+-]\d{2}:\d{2})$/i.test(value)) {
+        return Date.parse(value);
+    }
+    const asUtc = Date.parse(`${value}Z`);
+    return Number.isNaN(asUtc) ? Date.parse(value) : asUtc;
+}
+
+/** Whether this event predates the subscription and is therefore replayed history. */
+export function isReplayedEvent(event: CollaborationEvent, subscribedAt: number): boolean {
+    const occurredAt = parseEventTimestamp(event.occurred_at);
+    if (Number.isNaN(occurredAt)) {
+        // An unparseable timestamp cannot be shown to be history, and dropping a live event
+        // is worse than replaying one: de-duplication catches the repeat either way.
+        return false;
+    }
+    return occurredAt < subscribedAt - REPLAY_TOLERANCE_MS;
+}
+
+/**
+ * Route one decoded envelope to the matching handler.
+ *
+ * Exported so the dispatch can be tested without an `EventSource`.
+ */
+export function dispatchCollaborationEvent(
+    event: CollaborationEvent,
+    handlers: CollaborationEventHandlers,
+): void {
+    const payload = event.payload ?? {};
+    const conversation = payload.conversation;
+
+    switch (event.event_type) {
+        case 'collaboration.message.created':
+            if (payload.message) {
+                handlers.onMessageCreated?.(payload.message, conversation);
+            }
+            return;
+
+        case 'collaboration.message.deleted':
+            if (payload.message_id) {
+                handlers.onMessageDeleted?.(
+                    String(payload.message_id),
+                    payload.deleted_by_user_id,
+                    conversation,
+                );
+            }
+            return;
+
+        case 'collaboration.message.masked':
+            if (payload.message) {
+                handlers.onMessageMasked?.(payload.message, payload.updated_by_user_id);
+            }
+            return;
+
+        case 'collaboration.typing.updated':
+            handlers.onTyping?.(payload.user, payload.is_typing !== false, payload.expires_at);
+            return;
+
+        case 'collaboration.member.invited':
+            handlers.onMembersInvited?.(payload.participants ?? [], conversation);
+            break;
+
+        case 'collaboration.member.removed':
+            handlers.onMemberRemoved?.(payload.participant, conversation);
+            break;
+
+        case 'collaboration.member.role_updated':
+            handlers.onMemberRoleUpdated?.(payload.participant, conversation);
+            break;
+
+        case 'collaboration.invite.accepted':
+            handlers.onInviteAnswered?.(payload.participant, true, conversation);
+            break;
+
+        case 'collaboration.invite.declined':
+            handlers.onInviteAnswered?.(payload.participant, false, conversation);
+            break;
+
+        case 'collaboration.deleted':
+            handlers.onConversationDeleted?.(
+                String(event.conversation_id ?? conversation?.id ?? ''),
+            );
+            return;
+
+        case 'collaboration.created':
+        case 'collaboration.updated':
+            break;
+
+        default:
+            return;
+    }
+
+    // Every event above that falls through here carries the conversation in its payload, and
+    // it is the freshest membership the client will see — the routes serialize it *after*
+    // applying the change. Handled once here rather than in each branch.
+    if (conversation) {
+        handlers.onConversationUpdated?.(conversation);
+    }
+}
+
+/**
+ * Attach to a shared conversation's event stream.
+ *
+ * Returns a function that detaches. Calling it is required when leaving the conversation:
+ * `EventSource` reconnects on its own, so an abandoned subscription keeps a connection
+ * open and keeps feeding another conversation's messages into the handlers.
+ */
+export function subscribeToCollaborationEvents(
+    conversationId: string,
+    handlers: CollaborationEventHandlers,
+): () => void {
+    if (typeof EventSource === 'undefined' || !conversationId) {
+        return () => {};
+    }
+
+    const subscribedAt = Date.now();
+    const seen = new Set<string>();
+
+    const source = new EventSource(collaborationEventsUrl(conversationId), {
+        // Only meaningful cross-origin, where the session cookie would otherwise be
+        // withheld. Same-origin deployments send it regardless.
+        withCredentials: Boolean(API_BASE),
+    });
+
+    source.onmessage = (frame: MessageEvent<string>) => {
+        if (!frame?.data) {
+            return;
+        }
+
+        let event: CollaborationEvent;
+        try {
+            event = JSON.parse(frame.data) as CollaborationEvent;
+        } catch {
+            // A malformed frame is not worth tearing the subscription down for.
+            return;
+        }
+
+        const key = eventKey(event);
+        if (key) {
+            if (seen.has(key)) {
+                return;
+            }
+            if (seen.size >= MAX_REMEMBERED_EVENTS) {
+                seen.clear();
+            }
+            seen.add(key);
+        }
+
+        if (isReplayedEvent(event, subscribedAt)) {
+            return;
+        }
+
+        dispatchCollaborationEvent(event, handlers);
+    };
+
+    source.onerror = () => {
+        // Left to reconnect on its own. Surfacing this would flag every routine
+        // reconnection as a failure, and the thread stays readable throughout.
+    };
+
+    return () => source.close();
+}

--- a/application/v2_ui/src/lib/mentions.ts
+++ b/application/v2_ui/src/lib/mentions.ts
@@ -1,0 +1,575 @@
+// mentions.ts
+// The `@` mention grammar of a shared conversation, and the rule that decides whether a
+// message is answered by the AI or simply posted to the other participants.
+//
+// This is the one behaviour that has no counterpart in a personal conversation. There,
+// every message is a prompt. In a shared conversation most messages are people talking to
+// each other, and invoking the model is the exception — so something has to decide which a
+// given message is, and get it right, because guessing wrong either answers a message
+// nobody asked the AI about or silently swallows a question.
+//
+// The rule is taken from `buildCollaborativeInvocationTarget` in chat-messages.js and is
+// reproduced here rather than reinterpreted, so the two interfaces cannot disagree about
+// what a given message does:
+//
+//   1. An explicit `@` mention of a model or an agent invokes it.
+//   2. Otherwise, any composer option that only makes sense as a request to the AI —
+//      an agent, image generation, deep research, URL access, web search, document search,
+//      or a saved prompt — invokes the currently selected model.
+//   3. Otherwise the message is posted to the participants and the AI never sees it.
+//
+// Everything here is a pure function so the grammar can be tested without a browser.
+
+import { agentSelectionKey } from './agents';
+import { modelSelectionKey, type ModelCatalogEntry } from './models';
+import type {
+    AgentOption,
+    CollaborationConversation,
+    CollaborationParticipant,
+    CollaboratorSuggestion,
+} from './types';
+
+/** How many suggestions the mention menu offers. Matches the classic client. */
+export const MENTION_SUGGESTION_LIMIT = 8;
+
+/* -------------------------------------------------------------------------- */
+/* Detecting a mention being typed                                             */
+/* -------------------------------------------------------------------------- */
+
+/** An `@` token under the caret, and where it sits so it can be replaced. */
+export interface MentionMatch {
+    /** Text typed after the `@`, which may be empty immediately after typing it. */
+    query: string;
+    /** Index of the `@` itself. */
+    startIndex: number;
+    /** Index just past the last character of the token. */
+    endIndex: number;
+}
+
+/**
+ * Find the mention being typed at the caret, if there is one.
+ *
+ * An `@` only opens a mention at the start of the text or after whitespace, so an email
+ * address does not turn into one halfway through. The token ends at the caret rather than
+ * at the next space, which is what allows a name containing spaces to keep matching as it
+ * is typed.
+ */
+export function findMentionAtCaret(text: string, caretIndex: number): MentionMatch | null {
+    const value = String(text ?? '');
+    const caret = Math.max(0, Math.min(caretIndex, value.length));
+    const before = value.slice(0, caret);
+
+    const at = before.lastIndexOf('@');
+    if (at === -1) {
+        return null;
+    }
+
+    const preceding = at === 0 ? '' : before[at - 1];
+    if (preceding && !/\s/.test(preceding)) {
+        return null;
+    }
+
+    const query = before.slice(at + 1);
+    // A newline ends the mention: the reader has moved on to another line, and continuing
+    // to match would let the menu reappear over unrelated text.
+    if (query.includes('\n')) {
+        return null;
+    }
+
+    return { query, startIndex: at, endIndex: caret };
+}
+
+/**
+ * Replace the mention under the caret with the chosen text.
+ *
+ * Returns the new value and where the caret should end up, because the caller has to set
+ * both on the textarea and computing the offset at the call site is easy to get wrong.
+ */
+export function replaceMention(
+    text: string,
+    match: MentionMatch,
+    replacement: string,
+): { value: string; caretIndex: number } {
+    const value = String(text ?? '');
+    const before = value.slice(0, match.startIndex);
+    const after = value.slice(match.endIndex);
+    // A trailing space so the next word does not run into the name, but not a second one
+    // when the text already continues with whitespace.
+    const spacer = after.startsWith(' ') ? '' : ' ';
+    return {
+        value: `${before}${replacement}${spacer}${after}`,
+        caretIndex: before.length + replacement.length + spacer.length,
+    };
+}
+
+/* -------------------------------------------------------------------------- */
+/* Matching a mention in finished text                                         */
+/* -------------------------------------------------------------------------- */
+
+function escapeRegExp(value: string): string {
+    return String(value ?? '').replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Build the pattern that matches `@Name` in finished text.
+ *
+ * The boundaries matter and are copied from `buildAtMentionPattern`: a mention starts at
+ * the beginning or after whitespace, and ends at the end, at whitespace, or at closing
+ * punctuation. Without the trailing boundary, mentioning "@Sam" would also match "@Samantha".
+ */
+function mentionPattern(displayName: string, flags = 'i'): RegExp {
+    return new RegExp(`(^|\\s)@${escapeRegExp(displayName)}(?=$|\\s|[.,!?;:])`, flags);
+}
+
+/** Whether `text` mentions `displayName`. */
+export function mentionsName(text: string, displayName: string): boolean {
+    const name = String(displayName ?? '').trim();
+    if (!name) {
+        return false;
+    }
+    return mentionPattern(name).test(String(text ?? ''));
+}
+
+/**
+ * Character used to blank out an already-matched mention.
+ *
+ * Deliberately not whitespace, so a shorter name cannot match into the span a longer one
+ * occupied, and not something a display name can contain.
+ */
+const CONSUMED = '\u0000';
+
+/**
+ * The participants a message mentions.
+ *
+ * Longest names are matched first, and each match is struck out of the working text before
+ * shorter names are tried. That consumption is the point rather than an optimisation: where
+ * one person is called "Ada Lovelace" and another "Ada", the text "@Ada Lovelace" literally
+ * contains "@Ada" followed by a space, so testing each name independently against the
+ * original message reports both — and notifies somebody who was never addressed. Striking
+ * the longer match out first leaves nothing for the shorter name to find.
+ *
+ * A message that genuinely names both still reports both, because their matches occupy
+ * different spans.
+ */
+export function extractMentionedParticipants(
+    text: string,
+    participants: CollaborationParticipant[] | undefined,
+): CollaborationParticipant[] {
+    const message = String(text ?? '');
+    if (!message.trim() || !participants?.length) {
+        return [];
+    }
+
+    const byLength = [...participants].sort(
+        (left, right) =>
+            String(right?.display_name ?? '').length - String(left?.display_name ?? '').length,
+    );
+
+    let remaining = message;
+    const mentioned: CollaborationParticipant[] = [];
+    const seen = new Set<string>();
+
+    for (const participant of byLength) {
+        const userId = String(participant?.user_id ?? '').trim();
+        const displayName = String(participant?.display_name ?? '').trim();
+        if (!userId || !displayName || seen.has(userId)) {
+            continue;
+        }
+
+        let matched = false;
+        remaining = remaining.replace(
+            mentionPattern(displayName, 'gi'),
+            (whole: string, leading: string) => {
+                matched = true;
+                // The leading whitespace is preserved so a mention immediately after this
+                // one still has the boundary it needs.
+                return leading + CONSUMED.repeat(whole.length - leading.length);
+            },
+        );
+
+        if (!matched) {
+            continue;
+        }
+
+        seen.add(userId);
+        mentioned.push({
+            user_id: userId,
+            display_name: displayName,
+            email: String(participant?.email ?? '').trim(),
+        });
+    }
+
+    return mentioned;
+}
+
+/** Whether a message mentions the reader, used to raise a notification. */
+export function mentionsCurrentUser(
+    metadata: Record<string, unknown> | undefined,
+    currentUserId: string | undefined,
+): boolean {
+    if (!currentUserId) {
+        return false;
+    }
+    const ids = metadata?.mentioned_user_ids;
+    if (!Array.isArray(ids)) {
+        return false;
+    }
+    return ids.map((id) => String(id ?? '').trim()).includes(currentUserId);
+}
+
+/* -------------------------------------------------------------------------- */
+/* AI targets                                                                  */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Something the AI side of a shared conversation can be addressed as.
+ *
+ * Sent to the server as `invocation_target`, where it is stored on the message as
+ * `metadata.ai_invocation_target` so the thread records *what* was asked, not merely that
+ * something was.
+ */
+export interface InvocationTarget {
+    target_type: 'model' | 'agent' | 'image';
+    display_name: string;
+    mention_text: string;
+    /** How the target was chosen: an explicit tag, or the option that implied it. */
+    source_mode: string;
+    /** Set for a model target, so the send can carry the full model identity. */
+    selection_key?: string;
+    /** Set for an agent target, so the send can carry the agent selection. */
+    agent_selection_key?: string;
+    subtitle?: string;
+    [key: string]: unknown;
+}
+
+/** A row in the mention menu. */
+export type MentionSuggestion =
+    | {
+          kind: 'participant';
+          user_id: string;
+          display_name: string;
+          email?: string;
+          mention_text: string;
+          subtitle?: string;
+      }
+    | {
+          kind: 'invite';
+          user_id: string;
+          display_name: string;
+          email?: string;
+          mention_text: string;
+          subtitle?: string;
+      }
+    | {
+          kind: 'ai';
+          target: InvocationTarget;
+          display_name: string;
+          mention_text: string;
+          subtitle?: string;
+      };
+
+function text(value: unknown): string {
+    return typeof value === 'string' ? value.trim() : '';
+}
+
+function matchesQuery(haystack: string[], query: string): boolean {
+    const needle = String(query ?? '')
+        .replace(/\s+/g, ' ')
+        .trim()
+        .toLowerCase();
+    if (!needle) {
+        return true;
+    }
+    return haystack
+        .filter(Boolean)
+        .join(' ')
+        .replace(/\s+/g, ' ')
+        .toLowerCase()
+        .includes(needle);
+}
+
+/** The agents in the catalog, as mention targets. */
+export function agentTargets(agents: AgentOption[] | undefined): InvocationTarget[] {
+    return (agents ?? [])
+        .map((agent): InvocationTarget | null => {
+            const displayName = text(agent.display_name) || text(agent.name);
+            if (!displayName) {
+                return null;
+            }
+            const scope = text(agent.scope_type).toLowerCase();
+            return {
+                target_type: 'agent',
+                display_name: displayName,
+                mention_text: `@${displayName}`,
+                source_mode: 'explicit_tag',
+                agent_selection_key: agentSelectionKey(agent as Record<string, unknown>),
+                subtitle:
+                    scope === 'group'
+                        ? 'Group agent'
+                        : scope === 'global'
+                          ? 'Global agent'
+                          : 'Personal agent',
+            };
+        })
+        .filter((target): target is InvocationTarget => target !== null);
+}
+
+/** The models in the catalog, as mention targets. */
+export function modelTargets(models: ModelCatalogEntry[] | undefined): InvocationTarget[] {
+    return (models ?? [])
+        .map((model): InvocationTarget | null => {
+            const displayName =
+                text(model.display_name) || text(model.deployment_name) || text(model.model_id);
+            if (!displayName) {
+                return null;
+            }
+            return {
+                target_type: 'model',
+                display_name: displayName,
+                mention_text: `@${displayName}`,
+                source_mode: 'explicit_tag',
+                selection_key: modelSelectionKey(model),
+                subtitle: 'Model',
+            };
+        })
+        .filter((target): target is InvocationTarget => target !== null);
+}
+
+/**
+ * The AI target a finished message explicitly addresses, if any.
+ *
+ * Agents are tested before models, and longer names before shorter ones, so the most
+ * specific tag in the text is the one that wins.
+ */
+export function resolveInvocationTarget(
+    message: string,
+    agents: AgentOption[] | undefined,
+    models: ModelCatalogEntry[] | undefined,
+): InvocationTarget | null {
+    const value = String(message ?? '');
+    if (!value.includes('@')) {
+        return null;
+    }
+
+    const targets = [...agentTargets(agents), ...modelTargets(models)].sort(
+        (left, right) => right.display_name.length - left.display_name.length,
+    );
+
+    return targets.find((target) => mentionsName(value, target.display_name)) ?? null;
+}
+
+/* -------------------------------------------------------------------------- */
+/* The send decision                                                           */
+/* -------------------------------------------------------------------------- */
+
+/** The composer options that bear on whether the AI is being addressed. */
+export interface InvocationOptions {
+    agentSelection?: string;
+    promptId?: string;
+    documentSearch?: boolean;
+    webSearch?: boolean;
+    imageGeneration?: boolean;
+    deepResearch?: boolean;
+    urlAccess?: boolean;
+    modelDeployment?: string;
+}
+
+/**
+ * Decide what, if anything, this message asks the AI to do.
+ *
+ * Returns null when the message is simply for the other participants. The order of the
+ * checks is `buildCollaborativeInvocationTarget`'s and is significant: image generation
+ * outranks an agent, which outranks deep research, and so on, so a message with several
+ * options set is attributed to one of them consistently rather than to whichever happened
+ * to be tested first.
+ */
+export function resolveSendTarget(
+    message: string,
+    options: InvocationOptions,
+    catalogs: { agents?: AgentOption[]; models?: ModelCatalogEntry[] },
+): InvocationTarget | null {
+    const explicit = resolveInvocationTarget(message, catalogs.agents, catalogs.models);
+    if (explicit) {
+        return explicit;
+    }
+
+    const sourceMode = options.imageGeneration
+        ? 'image_generation'
+        : options.agentSelection
+          ? 'agent'
+          : options.deepResearch
+            ? 'deep_research'
+            : options.urlAccess
+              ? 'url_access'
+              : options.webSearch
+                ? 'web_search'
+                : options.documentSearch
+                  ? 'workspace'
+                  : options.promptId
+                    ? 'prompt'
+                    : null;
+
+    if (!sourceMode) {
+        return null;
+    }
+
+    if (options.imageGeneration) {
+        return {
+            target_type: 'image',
+            display_name: 'Image',
+            mention_text: '@Image',
+            source_mode: sourceMode,
+        };
+    }
+
+    if (options.agentSelection) {
+        const agent = (catalogs.agents ?? []).find(
+            (candidate) =>
+                agentSelectionKey(candidate as Record<string, unknown>) === options.agentSelection,
+        );
+        const label = text(agent?.display_name) || text(agent?.name) || 'Agent';
+        return {
+            target_type: 'agent',
+            display_name: label,
+            mention_text: `@${label}`,
+            source_mode: sourceMode,
+            agent_selection_key: options.agentSelection,
+        };
+    }
+
+    const model = (catalogs.models ?? []).find(
+        (candidate) => modelSelectionKey(candidate) === options.modelDeployment,
+    );
+    const label =
+        text(model?.display_name) || text(model?.deployment_name) || options.modelDeployment || 'Model';
+    return {
+        target_type: 'model',
+        display_name: label,
+        mention_text: `@${label}`,
+        source_mode: sourceMode,
+        selection_key: options.modelDeployment,
+    };
+}
+
+/** Whether this message should be streamed through the AI rather than merely posted. */
+export function shouldInvokeAi(
+    message: string,
+    options: InvocationOptions,
+    catalogs: { agents?: AgentOption[]; models?: ModelCatalogEntry[] },
+): boolean {
+    return resolveSendTarget(message, options, catalogs) !== null;
+}
+
+/* -------------------------------------------------------------------------- */
+/* The mention menu                                                            */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Build the rows the mention menu shows for a query.
+ *
+ * Ordered participants, then AI targets, then people who could be invited. That order is
+ * the classic client's and reflects how often each is wanted: naming somebody already in
+ * the conversation is the common case, and adding a new person to it from the composer is
+ * the rarest.
+ *
+ * Invitable people are only offered when the caller may actually add them, so the menu
+ * never suggests an action the server would reject.
+ */
+export function buildMentionSuggestions(input: {
+    query: string;
+    participants?: CollaborationParticipant[];
+    agents?: AgentOption[];
+    models?: ModelCatalogEntry[];
+    invitable?: CollaboratorSuggestion[];
+    canInvite?: boolean;
+    currentUserId?: string;
+    limit?: number;
+}): MentionSuggestion[] {
+    const {
+        query,
+        participants = [],
+        agents,
+        models,
+        invitable = [],
+        canInvite = false,
+        currentUserId,
+        limit = MENTION_SUGGESTION_LIMIT,
+    } = input;
+
+    const known = new Set<string>();
+    const rows: MentionSuggestion[] = [];
+
+    for (const participant of participants) {
+        const userId = String(participant?.user_id ?? '').trim();
+        const displayName = String(participant?.display_name ?? '').trim();
+        if (!userId || !displayName) {
+            continue;
+        }
+        known.add(userId);
+        if (!matchesQuery([displayName, String(participant?.email ?? '')], query)) {
+            continue;
+        }
+        rows.push({
+            kind: 'participant',
+            user_id: userId,
+            display_name: displayName,
+            email: String(participant?.email ?? '').trim(),
+            mention_text: `@${displayName}`,
+            subtitle:
+                String(participant?.membership_status ?? '') === 'pending'
+                    ? 'Invited'
+                    : String(participant?.email ?? '').trim() || undefined,
+        });
+    }
+
+    for (const target of [...agentTargets(agents), ...modelTargets(models)]) {
+        if (!matchesQuery([target.display_name, target.subtitle ?? ''], query)) {
+            continue;
+        }
+        rows.push({
+            kind: 'ai',
+            target,
+            display_name: target.display_name,
+            mention_text: target.mention_text,
+            subtitle: target.subtitle,
+        });
+    }
+
+    if (canInvite) {
+        for (const candidate of invitable) {
+            const userId = String(candidate?.user_id ?? '').trim();
+            const displayName =
+                String(candidate?.display_name ?? '').trim() ||
+                String(candidate?.email ?? '').trim();
+            if (!userId || !displayName || known.has(userId) || userId === currentUserId) {
+                continue;
+            }
+            known.add(userId);
+            rows.push({
+                kind: 'invite',
+                user_id: userId,
+                display_name: displayName,
+                email: String(candidate?.email ?? '').trim(),
+                mention_text: `@${displayName}`,
+                subtitle: 'Add to this conversation',
+            });
+        }
+    }
+
+    return rows.slice(0, limit);
+}
+
+/**
+ * Everyone in a shared conversation who can be named, including the reader.
+ *
+ * The reader is included because a message they wrote may mention them — quoting somebody
+ * else's message, for instance — and dropping them would leave the stored mention list
+ * disagreeing with the visible text.
+ */
+export function conversationParticipants(
+    conversation: CollaborationConversation | null | undefined,
+): CollaborationParticipant[] {
+    return (conversation?.participants ?? []).filter((participant) =>
+        Boolean(String(participant?.user_id ?? '').trim()),
+    );
+}

--- a/application/v2_ui/src/lib/sharedMessage.ts
+++ b/application/v2_ui/src/lib/sharedMessage.ts
@@ -1,0 +1,119 @@
+// sharedMessage.ts
+// Reading the extra facts a message carries in a shared conversation.
+//
+// A personal conversation has exactly one human, so a user message needs no attribution
+// and both interfaces label them "You" without asking. A shared conversation has several,
+// and a thread that does not say who wrote what is unreadable — so these fields are only
+// ever populated there, and every consumer has to tolerate their absence.
+
+import { messageToPlainText } from './messageText';
+import type { ChatMessage, CollaborationMessage, CollaborationReplyContext } from './types';
+
+/** How much of a message to quote when it is being replied to. */
+const REPLY_PREVIEW_LENGTH = 140;
+
+function asShared(message: ChatMessage | undefined): CollaborationMessage | undefined {
+    return message as CollaborationMessage | undefined;
+}
+
+/**
+ * The user id of whoever wrote a message, when it is known.
+ *
+ * Read from `sender`, which `serialize_collaboration_message` copies out of the message's
+ * metadata. Assistant messages have no sender, and neither does anything in a personal
+ * conversation.
+ */
+export function messageSenderId(message: ChatMessage | undefined): string {
+    const shared = asShared(message);
+    return String(
+        shared?.sender?.user_id ??
+            (shared?.metadata as { sender?: { user_id?: string } } | undefined)?.sender?.user_id ??
+            '',
+    ).trim();
+}
+
+/** Whether the reader wrote this message. */
+export function isOwnMessage(
+    message: ChatMessage | undefined,
+    currentUserId: string | undefined,
+): boolean {
+    const senderId = messageSenderId(message);
+    return Boolean(currentUserId && senderId && senderId === currentUserId);
+}
+
+/**
+ * Who to credit a message to on screen.
+ *
+ * Returns an empty string when there is nobody to name — a personal conversation, or an
+ * assistant reply — so the caller renders no attribution line rather than a placeholder.
+ * The reader's own messages are labelled "You", which is both shorter and how every other
+ * chat interface reads.
+ */
+export function messageAuthorName(
+    message: ChatMessage | undefined,
+    currentUserId: string | undefined,
+): string {
+    const shared = asShared(message);
+    const sender =
+        shared?.sender ??
+        (shared?.metadata as { sender?: { display_name?: string; email?: string } } | undefined)
+            ?.sender;
+    if (!sender) {
+        return '';
+    }
+    if (isOwnMessage(message, currentUserId)) {
+        return 'You';
+    }
+    return String(sender.display_name ?? '').trim() || String(sender.email ?? '').trim();
+}
+
+/**
+ * What a message is replying to, resolved against the messages on screen.
+ *
+ * The server stores only `reply_to_message_id`; the author and the quoted text have to be
+ * looked up, which is why this takes the whole list. Returns null when the reply target is
+ * not loaded — it may have been deleted, or be above the part of the thread in memory — so
+ * the message renders normally rather than showing an empty quote.
+ */
+export function resolveReplyContext(
+    message: ChatMessage | undefined,
+    messages: ChatMessage[],
+    currentUserId: string | undefined,
+): CollaborationReplyContext | null {
+    const replyToId = String(asShared(message)?.reply_to_message_id ?? '').trim();
+    if (!replyToId) {
+        return null;
+    }
+
+    const target = messages.find((candidate) => candidate.id === replyToId);
+    if (!target) {
+        return null;
+    }
+
+    return {
+        message_id: replyToId,
+        display_name:
+            messageAuthorName(target, currentUserId) ||
+            (target.role === 'assistant' ? 'Assistant' : ''),
+        preview: buildReplyPreview(target),
+    };
+}
+
+/** A short, plain-text quotation of a message, for a reply banner or preview. */
+export function buildReplyPreview(message: ChatMessage): string {
+    const text = messageToPlainText(message).replace(/\s+/g, ' ').trim();
+    return text.length > REPLY_PREVIEW_LENGTH
+        ? `${text.slice(0, REPLY_PREVIEW_LENGTH - 1)}\u2026`
+        : text;
+}
+
+/**
+ * Whether this message asked the AI to answer rather than only addressing the participants.
+ *
+ * Both are `role: 'user'`, so the role cannot tell them apart; `message_kind` can. Used to
+ * label the request in the thread, so a reader can see why an answer appeared after one
+ * message and not another.
+ */
+export function isAiRequest(message: ChatMessage | undefined): boolean {
+    return asShared(message)?.message_kind === 'ai_request';
+}

--- a/application/v2_ui/src/lib/sharing.ts
+++ b/application/v2_ui/src/lib/sharing.ts
@@ -1,0 +1,80 @@
+// sharing.ts
+// Deciding how a conversation can be shared, and therefore which endpoint an invite uses.
+//
+// There are three cases and they are not interchangeable. A conversation that is already
+// shared takes new members directly. A group conversation is converted through the group
+// route, which additionally restricts the invitees to that group's members. Anything else
+// is converted through the personal route. Sending an invite to the wrong one of these
+// either fails or, worse, creates a second shared conversation alongside the first.
+//
+// Mirrors `addParticipantToConversation` and `canUseParticipantFlow` in
+// chat-collaboration.js.
+
+import { isCollaborative } from './types';
+import type { Conversation, ConversationMetadata } from './types';
+import type { ParticipantsPanelTarget } from '../stores/collaborationStore';
+
+/**
+ * Chat types that can be shared.
+ *
+ * Public-workspace conversations are absent deliberately: they have no conversion route,
+ * so offering to share one would present an action with nothing behind it.
+ */
+const SHAREABLE_CHAT_TYPES = new Set([
+    '',
+    'personal_single_user',
+    'personal_multi_user',
+    'group-single-user',
+    'group_multi_user',
+]);
+
+function chatTypeOf(conversation: Conversation | ConversationMetadata | null | undefined): string {
+    return String(conversation?.chat_type ?? '')
+        .trim()
+        .toLowerCase();
+}
+
+/** Whether a Share action should be offered for this conversation at all. */
+export function canShareConversation(
+    conversation: Conversation | ConversationMetadata | null | undefined,
+): boolean {
+    if (!conversation) {
+        return false;
+    }
+    return SHAREABLE_CHAT_TYPES.has(chatTypeOf(conversation));
+}
+
+/**
+ * Describe a conversation for the participants panel.
+ *
+ * `kind` here is not the storage kind but the *invite* kind — which of the three routes
+ * applies — which is why a group conversation that is already shared reports
+ * `collaborative` rather than `group`: it takes members directly and must not be converted
+ * a second time.
+ */
+export function panelTargetForConversation(
+    conversationId: string,
+    conversation: Conversation | ConversationMetadata | null | undefined,
+): ParticipantsPanelTarget {
+    const chatType = chatTypeOf(conversation);
+    const groupId =
+        (conversation?.group_id as string | undefined) ??
+        (conversation?.scope as { group_id?: string } | undefined)?.group_id ??
+        null;
+
+    if (isCollaborative(conversation)) {
+        return {
+            conversationId,
+            kind: 'collaborative',
+            title: conversation?.title as string | undefined,
+            groupId,
+        };
+    }
+
+    return {
+        conversationId,
+        kind: chatType.startsWith('group') ? 'group' : 'personal',
+        title: conversation?.title as string | undefined,
+        groupId,
+    };
+}

--- a/application/v2_ui/src/lib/sse.ts
+++ b/application/v2_ui/src/lib/sse.ts
@@ -347,6 +347,26 @@ export async function reattachChatStream(
 }
 
 /**
+ * Options that let a shared conversation reuse this transport.
+ *
+ * A shared conversation streams through `/api/collaboration/conversations/<id>/stream`,
+ * which bridges to `/api/chat/stream` internally and re-emits its frames, so every handler
+ * and the whole parser apply unchanged and only the URL differs.
+ *
+ * Recovery is the one thing that does not carry over. `/api/chat/stream/reattach` is keyed
+ * on the conversation the generation actually runs in, which for a shared conversation is a
+ * hidden source conversation the browser is never told the id of. Reattaching with the
+ * shared conversation's id would address a conversation that endpoint has never heard of,
+ * so recovery must be switched off rather than allowed to fail.
+ */
+export interface ChatStreamOptions {
+    /** Endpoint to POST to. Defaults to the personal chat stream. */
+    url?: string;
+    /** Whether a dropped transport may be reattached to. Defaults to true. */
+    allowRecovery?: boolean;
+}
+
+/**
  * Open a chat stream and dispatch frames to the supplied handlers.
  *
  * Resolves once the stream reaches a terminal state. Aborting via `signal` resolves with
@@ -360,6 +380,7 @@ export async function streamChat(
     body: ChatStreamRequest,
     handlers: ChatStreamHandlers,
     signal?: AbortSignal,
+    options: ChatStreamOptions = {},
 ): Promise<ChatStreamResult> {
     const result: ChatStreamResult = {
         accumulated: '',
@@ -388,7 +409,7 @@ export async function streamChat(
 
     let response: Response;
     try {
-        response = await fetch(apiUrl('/api/chat/stream'), {
+        response = await fetch(options.url ?? apiUrl('/api/chat/stream'), {
             method: 'POST',
             credentials: CREDENTIALS_MODE,
             headers: {
@@ -429,7 +450,7 @@ export async function streamChat(
         await consumeStreamResponse(response, trackingHandlers, result, signal, captureError);
     }
 
-    if (pendingError && !signal?.aborted && conversationId) {
+    if (pendingError && !signal?.aborted && conversationId && options.allowRecovery !== false) {
         // The answer is generated on the server and outlives the HTTP connection, so a
         // dropped transport is recoverable. attachToLiveStream reports its own failures.
         const attached = await attachToLiveStream(
@@ -451,14 +472,22 @@ export async function streamChat(
     return result;
 }
 
-/** Ask the server to stop generating. The stream itself ends with a cancelled frame. */
-export async function cancelStream(conversationId: string): Promise<void> {
-    await fetch(apiUrl(`/api/chat/stream/cancel/${encodeURIComponent(conversationId)}`), {
-        method: 'POST',
-        credentials: CREDENTIALS_MODE,
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ reason: 'user_requested' }),
-    }).catch(() => {
+/**
+ * Ask the server to stop generating. The stream itself ends with a cancelled frame.
+ *
+ * `url` overrides the endpoint for a shared conversation, whose cancel route resolves the
+ * hidden source conversation before reaching the same stream registry.
+ */
+export async function cancelStream(conversationId: string, url?: string): Promise<void> {
+    await fetch(
+        url ?? apiUrl(`/api/chat/stream/cancel/${encodeURIComponent(conversationId)}`),
+        {
+            method: 'POST',
+            credentials: CREDENTIALS_MODE,
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ reason: 'user_requested' }),
+        },
+    ).catch(() => {
         /* Best effort: the stream is torn down client-side regardless. */
     });
 }

--- a/application/v2_ui/src/lib/types.ts
+++ b/application/v2_ui/src/lib/types.ts
@@ -40,7 +40,14 @@ export interface ConversationFeedPage {
     include_hidden?: boolean;
 }
 
-export type MessageRole = 'user' | 'assistant' | 'system' | 'safety' | 'image';
+/**
+ * `file` only ever arrives from a shared conversation.
+ *
+ * `serialize_collaboration_message` (functions_collaboration.py) overrides the stored role
+ * with a *display* role of `file` or `image` when the message carries an upload, so a
+ * shared thread can contain a role the personal endpoints never emit.
+ */
+export type MessageRole = 'user' | 'assistant' | 'system' | 'safety' | 'image' | 'file';
 
 export interface ChatMessage {
     id: string;
@@ -201,6 +208,182 @@ export interface ConversationMetadata {
     linked_workspace_documents?: UsedDocument[];
     [key: string]: unknown;
 }
+
+/* -------------------------------------------------------------------------- */
+/* Shared (collaborative) conversations                                        */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * The value `conversation_kind` takes for a shared conversation.
+ *
+ * Shared conversations are stored in their own Cosmos containers and served by
+ * `/api/collaboration/*`. Every personal conversation route either 404s on them or, worse,
+ * answers 200 with nothing: `/api/get_messages` turns its `LookupError` into
+ * `{'messages': []}`, which is why a shared thread used to open as an empty chat rather
+ * than as an error. Routing is therefore decided by this field, never inferred from a
+ * failed request.
+ */
+export const COLLABORATION_KIND = 'collaborative';
+
+/** Chat types a shared conversation can have. Mirrors `collaboration_models.py`. */
+export const PERSONAL_MULTI_USER_CHAT_TYPE = 'personal_multi_user';
+export const GROUP_MULTI_USER_CHAT_TYPE = 'group_multi_user';
+
+/** Membership lifecycle, from `collaboration_models.py`. */
+export type MembershipStatus =
+    | 'accepted'
+    | 'pending'
+    | 'declined'
+    | 'removed'
+    /**
+     * Not a stored status. `serialize_collaboration_conversation` synthesises it for a
+     * group-visibility conversation the caller can see purely by being in the group, so
+     * there is no per-user membership record to read a status from.
+     */
+    | 'group_member';
+
+export type MembershipRole = 'owner' | 'admin' | 'member';
+
+/** One person in a shared conversation, as `normalize_collaboration_user` returns them. */
+export interface CollaborationParticipant {
+    user_id: string;
+    display_name?: string;
+    email?: string;
+    role?: MembershipRole | string;
+    membership_status?: MembershipStatus | string;
+    [key: string]: unknown;
+}
+
+/**
+ * A shared conversation, from `serialize_collaboration_conversation`.
+ *
+ * Extends `Conversation` because the feed returns exactly this shape for its collaboration
+ * rows, so the rail renders shared and personal conversations from one list.
+ *
+ * The `can_*` flags are the authority on what the current user may do. They are not
+ * derivable in the browser: they fold together membership status, role, visibility mode
+ * and whether membership is explicit, and a group-visibility conversation grants posting
+ * without any membership record at all. Deriving them client-side would offer controls the
+ * server then rejects.
+ */
+export interface CollaborationConversation extends Conversation {
+    chat_type?: string;
+    status?: string;
+    created_at?: string;
+    updated_at?: string;
+    last_message_at?: string;
+    last_message_preview?: string;
+    message_count?: number;
+    participant_count?: number;
+    pending_invite_count?: number;
+    participants?: CollaborationParticipant[];
+    accepted_participant_ids?: string[];
+    pending_participant_ids?: string[];
+    owner_user_ids?: string[];
+    admin_user_ids?: string[];
+    current_user_role?: MembershipRole | string | null;
+    membership_status?: MembershipStatus | string | null;
+    can_manage_members?: boolean;
+    can_manage_roles?: boolean;
+    can_accept_invite?: boolean;
+    can_post_messages?: boolean;
+    can_delete_conversation?: boolean;
+    can_leave_conversation?: boolean;
+    visibility_mode?: string;
+    group_id?: string | null;
+    group_name?: string | null;
+    /** The hidden personal conversation the AI actually runs in. */
+    source_conversation_id?: string | null;
+}
+
+/**
+ * Who wrote a message in a shared conversation.
+ *
+ * Personal conversations have exactly one human, so the classic and V2 interfaces both
+ * label user messages "You" without asking. In a shared thread the author matters, and it
+ * arrives on the message as `sender` (also copied into `metadata.sender`).
+ */
+export interface CollaborationMessageSender {
+    user_id?: string;
+    display_name?: string;
+    email?: string;
+    [key: string]: unknown;
+}
+
+/** What a message is replying to, resolved for display by the client. */
+export interface CollaborationReplyContext {
+    message_id?: string;
+    display_name?: string;
+    preview?: string;
+    [key: string]: unknown;
+}
+
+/**
+ * A message in a shared conversation, from `serialize_collaboration_message`.
+ *
+ * `message_kind` distinguishes a message merely posted to the other participants
+ * (`human_message`) from one that asked the AI to answer (`ai_request`) and from the
+ * answer itself (`assistant_response`). The `role` field cannot carry that distinction,
+ * because a human message and an AI request are both `user`.
+ */
+export interface CollaborationMessage extends ChatMessage {
+    message_kind?: 'human_message' | 'ai_request' | 'assistant_response' | string;
+    sender?: CollaborationMessageSender;
+    reply_to_message_id?: string | null;
+    explicit_ai_invocation?: boolean;
+    filename?: string;
+    /** Attached by the client, not the server: the replied-to message resolved for display. */
+    reply_context?: CollaborationReplyContext | null;
+}
+
+/**
+ * One frame from `GET /api/collaboration/conversations/<id>/events`.
+ *
+ * Built by `_build_collaboration_event`. Unlike the chat stream, this one is a real SSE
+ * `message` event carrying a JSON envelope, and the discriminator is `event_type`.
+ */
+export interface CollaborationEvent {
+    conversation_id?: string;
+    event_type?: string;
+    occurred_at?: string;
+    payload?: {
+        conversation?: CollaborationConversation;
+        message?: CollaborationMessage;
+        message_id?: string;
+        participant?: CollaborationParticipant;
+        participants?: CollaborationParticipant[];
+        user?: CollaborationParticipant;
+        is_typing?: boolean;
+        expires_at?: string;
+        deleted_by_user_id?: string;
+        updated_by_user_id?: string;
+        [key: string]: unknown;
+    };
+    [key: string]: unknown;
+}
+
+/** A person who could be invited, from `/api/user/collaboration-suggestions`. */
+export interface CollaboratorSuggestion {
+    user_id: string;
+    display_name?: string;
+    email?: string;
+    /** Where the suggestion came from: 'recent', 'group', 'local', and so on. */
+    source?: string;
+    [key: string]: unknown;
+}
+
+/**
+ * True when a conversation must be driven through the `/api/collaboration/*` endpoints.
+ *
+ * Accepts anything carrying `conversation_kind` so the same check works on a feed row, a
+ * loaded conversation and a metadata response without the caller narrowing first.
+ */
+export function isCollaborative(
+    conversation: Record<string, unknown> | null | undefined,
+): boolean {
+    return String(conversation?.conversation_kind ?? '').trim() === COLLABORATION_KIND;
+}
+
 
 export interface AdminNavSection {
     id: string;

--- a/application/v2_ui/src/pages/ChatPage.tsx
+++ b/application/v2_ui/src/pages/ChatPage.tsx
@@ -4,8 +4,9 @@
 import { useEffect, useRef, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { clsx } from 'clsx';
-import { Files, Info, ListOrdered, Maximize2, Minimize2 } from 'lucide-react';
+import { Files, Info, ListOrdered, Maximize2, Minimize2, Users } from 'lucide-react';
 import { useChatStore } from '../stores/chatStore';
+import { useCollaborationStore } from '../stores/collaborationStore';
 import { useBootstrapStore } from '../stores/bootstrapStore';
 import { useUiStore } from '../stores/uiStore';
 import { readConversationParam, syncedConversationParams } from '../lib/conversationUrl';
@@ -14,6 +15,10 @@ import { Composer } from '../components/chat/Composer';
 import { ConversationDrawer } from '../components/chat/ConversationDrawer';
 import { ConversationDetails } from '../components/chat/ConversationDetails';
 import { ConversationBadges } from '../components/chat/ConversationBadges';
+import { ParticipantsPanel } from '../components/chat/ParticipantsPanel';
+import { InviteBanner } from '../components/chat/InviteBanner';
+import { FileApprovals } from '../components/chat/FileApprovals';
+import { panelTargetForConversation, canShareConversation } from '../lib/sharing';
 
 /**
  * Keep the address bar and the open conversation describing each other.
@@ -87,12 +92,28 @@ function ChatHeader({ onOpenDetails }: { onOpenDetails: () => void }) {
     const contentsEnabled = useBootstrapStore((state) =>
         Boolean(state.data?.features?.enable_conversation_contents_drawer),
     );
+    const collaborationEnabled = useBootstrapStore((state) =>
+        Boolean(state.data?.features?.enable_collaborative_conversations),
+    );
+    const openPanel = useCollaborationStore((state) => state.openPanel);
+    // Guarded on the id: the participants panel keeps its own slot, but this badge describes
+    // the conversation on screen and must not count another one's people.
+    const participantCount = useCollaborationStore((state) =>
+        state.conversation?.id === activeConversationId
+            ? (state.conversation?.participants?.length ?? 0)
+            : 0,
+    );
     const chatWidth = useUiStore((state) => state.chatWidth);
     const toggleChatWidth = useUiStore((state) => state.toggleChatWidth);
 
     const active = conversations.find(
         (conversation) => conversation.id === activeConversationId,
     );
+
+    // Metadata is preferred over the rail row because a conversation opened from a link may
+    // have no row yet, and the metadata response is what actually describes what it is.
+    const shareSource = metadata ?? active;
+    const shareable = collaborationEnabled && canShareConversation(shareSource);
 
     // Counted from loaded metadata so the badge stays honest: it shows nothing rather
     // than a guess until the real document list has arrived.
@@ -122,6 +143,31 @@ function ChatHeader({ onOpenDetails }: { onOpenDetails: () => void }) {
 
             {activeConversationId && (
                 <div className="ml-auto flex items-center gap-1">
+                    {shareable && (
+                        <button
+                            type="button"
+                            onClick={() =>
+                                openPanel(
+                                    panelTargetForConversation(activeConversationId, shareSource),
+                                )
+                            }
+                            title={
+                                participantCount > 0
+                                    ? 'View and manage the people in this conversation'
+                                    : 'Share this conversation with other people'
+                            }
+                            aria-label="People in this conversation"
+                            className="relative rounded-lg p-2 text-text-3 transition-colors hover:bg-surface-2 hover:text-text-1"
+                        >
+                            <Users size={17} />
+                            {participantCount > 0 && (
+                                <span className="absolute -top-0.5 -right-0.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-accent px-1 text-[10px] font-semibold text-on-accent">
+                                    {participantCount}
+                                </span>
+                            )}
+                        </button>
+                    )}
+
                     <button
                         type="button"
                         onClick={toggleChatWidth}
@@ -209,11 +255,14 @@ export function ChatPage() {
         <div className="flex min-h-0 flex-1">
             <div className="flex min-w-0 flex-1 flex-col">
                 <ChatHeader onOpenDetails={() => setDetailsOpen(true)} />
+                <FileApprovals />
+                <InviteBanner />
                 <MessageList />
                 <Composer />
             </div>
             <ConversationDrawer />
             {detailsOpen && <ConversationDetails onClose={() => setDetailsOpen(false)} />}
+            <ParticipantsPanel />
         </div>
     );
 }

--- a/application/v2_ui/src/stores/chatStore.ts
+++ b/application/v2_ui/src/stores/chatStore.ts
@@ -27,7 +27,29 @@ import {
     reattachChatStream,
     streamChat,
     type ChatStreamHandlers,
+    type ChatStreamOptions,
 } from '../lib/sse';
+import {
+    cancelCollaborationStreamUrl,
+    collaborationDeleteAction,
+    deleteCollaborationMessage,
+    fetchCollaborationConversation,
+    fetchCollaborationMessages,
+    markCollaborationConversationRead,
+    maskCollaborationMessage,
+    postCollaborationMessage,
+    renameCollaborationConversation,
+    streamCollaborationUrl,
+    toggleCollaborationHidden,
+    toggleCollaborationPinned,
+} from '../lib/collaboration';
+import { subscribeToCollaborationEvents, conversationFactsOnly } from '../lib/collaborationEvents';
+import {
+    conversationParticipants,
+    extractMentionedParticipants,
+    mentionsCurrentUser,
+    resolveSendTarget,
+} from '../lib/mentions';
 import { agentInfoForSelection } from '../lib/agents';
 import { modelIdentityForSelection, type ModelCatalogEntry } from '../lib/models';
 import { resolveDocumentScope } from '../lib/documentScope';
@@ -36,15 +58,20 @@ import { proposalSourceMessageId, type ImageProposalSpec } from '../lib/imagePro
 import { toast } from './toastStore';
 import { ApiError } from '../lib/apiClient';
 import { useBootstrapStore } from './bootstrapStore';
+import { useCollaborationStore, participantName } from './collaborationStore';
 import type { MaskAction, MaskSelection } from '../lib/masking';
 import type { VisualStyle } from '../lib/visualPalettes';
 import type {
+    AgentOption,
     ChatMessage,
     ChatStreamRequest,
+    CollaborationConversation,
+    CollaborationMessage,
     Conversation,
     ConversationMetadata,
     ThoughtEntry,
 } from '../lib/types';
+import { isCollaborative } from '../lib/types';
 import { fetchConversationMetadata } from '../lib/endpoints';
 
 const FEED_PAGE_SIZE = 30;
@@ -54,6 +81,16 @@ const STREAMING_MESSAGE_ID = '__streaming__';
 
 /** Which mode the right-hand drawer is showing, or null when it is closed. */
 export type DrawerMode = 'contents' | 'documents' | null;
+
+/**
+ * Which API family the open conversation belongs to.
+ *
+ * A shared conversation is stored in different Cosmos containers and served by
+ * `/api/collaboration/*`; sending its id to a personal route either 404s or, in the case of
+ * `/api/get_messages`, answers 200 with an empty list. Every conversation-scoped call
+ * therefore branches on this rather than trying one endpoint and falling back.
+ */
+export type ConversationKind = 'personal' | 'collaborative';
 
 /**
  * How far a stream recovery has got.
@@ -93,6 +130,14 @@ interface ChatState {
     searchTerm: string;
 
     activeConversationId: string | null;
+    /**
+     * Which API family the open conversation belongs to.
+     *
+     * Null only before anything is open. Resolved when the conversation is selected rather
+     * than looked up per call, because a deep link may name a conversation that is not in
+     * the loaded rail and answering the question costs a request.
+     */
+    activeConversationKind: ConversationKind | null;
     messages: ChatMessage[];
     messagesLoading: boolean;
     messagesError: string | null;
@@ -132,7 +177,20 @@ interface ChatState {
     loadMore: () => Promise<void>;
     setSearchTerm: (term: string) => void;
 
-    selectConversation: (conversationId: string | null) => Promise<void>;
+    selectConversation: (
+        conversationId: string | null,
+        options?: {
+            kind?: ConversationKind;
+            /**
+             * Membership already fetched for this conversation, saving a second request.
+             *
+             * Passed in rather than left in the store, because it is fetched before the
+             * conversation is open and the store now refuses writes for anything that is
+             * not.
+             */
+            prefetched?: CollaborationConversation;
+        },
+    ) => Promise<void>;
     /**
      * Open a conversation named by the URL rather than clicked in the rail.
      *
@@ -229,6 +287,31 @@ function conversationFromMetadata(
     };
 }
 
+/**
+ * Present a shared conversation as the metadata shape the header and drawer already read.
+ *
+ * The two responses overlap but are not the same: a shared conversation keys itself as `id`
+ * where metadata uses `conversation_id`, and carries membership the personal shape has no
+ * place for. Mapping here rather than teaching every consumer about both shapes keeps the
+ * badges, classification pills, document drawer and summary working on a shared thread
+ * without a single change to those components.
+ *
+ * The original is kept under `collaboration` so anything that genuinely needs the
+ * membership can reach it without a second request.
+ */
+export function metadataFromCollaboration(
+    conversation: CollaborationConversation,
+): ConversationMetadata {
+    return {
+        ...conversation,
+        conversation_id: String(conversation.id ?? ''),
+        title: conversation.title || 'Untitled conversation',
+        last_updated: conversation.updated_at ?? conversation.last_updated,
+        chat_type: conversation.chat_type ?? null,
+        collaboration: conversation,
+    } as ConversationMetadata;
+}
+
 /** Controller for the in-flight stream, kept outside the store as it is not render state. */
 let activeStreamController: AbortController | null = null;
 
@@ -240,6 +323,81 @@ let activeStreamController: AbortController | null = null;
  * streaming, not whichever one happens to be on screen.
  */
 let streamingConversationId: string | null = null;
+
+/**
+ * Whether the in-flight stream belongs to a shared conversation.
+ *
+ * Cancelling addresses a different endpoint for each, and the answer must survive the
+ * reader switching threads mid-response, so it is recorded alongside the conversation id
+ * rather than re-derived from whatever is on screen when Stop is pressed.
+ */
+let streamingConversationKind: ConversationKind = 'personal';
+
+/**
+ * Detach from the open shared conversation's event stream, if there is one.
+ *
+ * Held at module scope for the same reason as the stream controller: it is a live
+ * connection rather than render state, and leaving one attached after a thread switch
+ * would keep feeding another conversation's messages into the list.
+ */
+let detachCollaborationEvents: (() => void) | null = null;
+
+function stopCollaborationEvents(): void {
+    if (detachCollaborationEvents) {
+        detachCollaborationEvents();
+        detachCollaborationEvents = null;
+    }
+}
+
+/**
+ * Merge a message that arrived from the server into the thread.
+ *
+ * Idempotent by message id, which it has to be: the sender of an AI request receives the
+ * assistant's reply twice — once in the stream's terminal frame and once as a
+ * `collaboration.message.created` event — and a posted message comes back both in the
+ * POST response and over the event stream. Appending blindly shows each of those twice.
+ *
+ * An optimistic placeholder for the same message is replaced rather than left behind:
+ * matched on the pending id when it is known, and otherwise on the reader's own unsent
+ * text, which is how a message posted from another tab still lands in one place.
+ */
+function mergeCollaborationMessage(
+    messages: ChatMessage[],
+    incoming: CollaborationMessage,
+    options: { pendingId?: string | null; currentUserId?: string } = {},
+): ChatMessage[] {
+    const existingIndex = messages.findIndex((message) => message.id === incoming.id);
+    if (existingIndex !== -1) {
+        const merged = [...messages];
+        merged[existingIndex] = { ...merged[existingIndex], ...incoming };
+        return merged;
+    }
+
+    const senderId = String(incoming.sender?.user_id ?? '').trim();
+    const isOwnMessage = Boolean(
+        options.currentUserId && senderId && senderId === options.currentUserId,
+    );
+
+    const placeholderIndex = messages.findIndex((message) => {
+        if (options.pendingId && message.id === options.pendingId) {
+            return true;
+        }
+        return (
+            isOwnMessage &&
+            typeof message.id === 'string' &&
+            message.id.startsWith('pending-user-') &&
+            message.content === incoming.content
+        );
+    });
+
+    if (placeholderIndex !== -1) {
+        const merged = [...messages];
+        merged[placeholderIndex] = incoming;
+        return merged;
+    }
+
+    return [...messages, incoming];
+}
 
 /** Store writer used by the stream handlers, kept narrow so they can be shared. */
 type StreamStateSetter = (
@@ -257,8 +415,31 @@ function buildStreamHandlers(
     isCurrent: () => boolean,
     set: StreamStateSetter,
     getState: () => ChatState,
+    /**
+     * Id of the optimistic user message this stream was started for, when there is one.
+     *
+     * Given the server's real id as soon as the message is persisted. Without this the
+     * bubble keeps a `pending-user-…` id, and every per-message action on it — delete,
+     * mask, reply — would address a message the server has never heard of. It also lets a
+     * shared conversation recognise its own message when the same one arrives back over
+     * the event stream.
+     */
+    pendingUserMessageId?: string | null,
 ): ChatStreamHandlers {
     return {
+        onUserMessagePersisted: (event) => {
+            const persistedId = String(event.user_message_id ?? event.message_id ?? '').trim();
+            if (!persistedId || !pendingUserMessageId || !isCurrent()) {
+                return;
+            }
+            set((state) => ({
+                messages: state.messages.map((message) =>
+                    message.id === pendingUserMessageId
+                        ? { ...message, id: persistedId }
+                        : message,
+                ),
+            }));
+        },
         onContent: (_delta, accumulated) => {
             if (!isCurrent()) {
                 return;
@@ -317,7 +498,14 @@ function buildStreamHandlers(
                     getState().thoughts.length > 0 ? [...getState().thoughts] : undefined,
             };
             set((state) => ({
-                messages: [...state.messages, finalMessage],
+                // Appended by id rather than blindly: in a shared conversation the same
+                // assistant message also arrives as a `collaboration.message.created` event,
+                // and whichever of the two lands second must update the message rather than
+                // add a second copy of it.
+                messages: mergeCollaborationMessage(
+                    state.messages,
+                    finalMessage as CollaborationMessage,
+                ),
                 streaming: false,
                 streamingContent: '',
                 reconnectPhase: null,
@@ -397,7 +585,16 @@ function buildStreamHandlers(
 async function runChatStream(
     requestBody: ChatStreamRequest,
     conversationId: string,
-    options: { isNewConversation?: boolean; reloadOnDone?: boolean } = {},
+    options: {
+        isNewConversation?: boolean;
+        reloadOnDone?: boolean;
+        /** Which API family this stream belongs to, so a cancel reaches the right route. */
+        kind?: ConversationKind;
+        /** Endpoint and recovery overrides for a shared conversation. */
+        stream?: ChatStreamOptions;
+        /** Optimistic user message to reconcile with the server's id. */
+        pendingUserMessageId?: string | null;
+    } = {},
 ): Promise<void> {
     const { set, getState } = {
         set: (partial: Partial<ChatState> | ((state: ChatState) => Partial<ChatState>)) =>
@@ -408,6 +605,7 @@ async function runChatStream(
     const controller = new AbortController();
     activeStreamController = controller;
     streamingConversationId = conversationId;
+    streamingConversationKind = options.kind ?? 'personal';
 
     // A stream is "current" only while it is still the active one. If the user switches
     // threads or starts a new chat mid-response, this goes false and the remaining
@@ -416,8 +614,15 @@ async function runChatStream(
 
     await streamChat(
         requestBody,
-        buildStreamHandlers(conversationId, isCurrent, set, getState),
+        buildStreamHandlers(
+            conversationId,
+            isCurrent,
+            set,
+            getState,
+            options.pendingUserMessageId,
+        ),
         controller.signal,
+        options.stream,
     );
 
     // Only tear down if this stream is still the active one; a newer send may already have
@@ -501,6 +706,252 @@ async function resumeChatStream(conversationId: string): Promise<boolean> {
     return true;
 }
 
+/**
+ * Work out which API family a conversation belongs to by asking.
+ *
+ * Only reached for a conversation that is not in the loaded rail — a deep link, or one
+ * opened straight after being shared. The personal endpoint is tried first because it is
+ * the overwhelmingly common case, and both answer 404 for an id belonging to the other, so
+ * the sequence terminates rather than guessing.
+ *
+ * A collaboration response is handed back rather than written to a store: it is the same
+ * document the participants panel and the composer need, so returning it saves a second
+ * request — but stashing it somewhere for `selectConversation` to find would be a write for
+ * a conversation that is not open yet, which is exactly the class of stale write the
+ * collaboration store now refuses.
+ *
+ * With `requireExists`, a conversation neither endpoint recognises is a rejection rather
+ * than a default, which is what lets a dead link be reported instead of opening as an empty
+ * chat.
+ */
+async function resolveConversationKind(
+    conversationId: string,
+    options: { requireExists?: boolean } = {},
+): Promise<{ kind: ConversationKind; conversation?: CollaborationConversation }> {
+    try {
+        await fetchConversationMetadata(conversationId);
+        return { kind: 'personal' };
+    } catch (personalError) {
+        try {
+            const { conversation } = await fetchCollaborationConversation(conversationId);
+            return { kind: 'collaborative', conversation };
+        } catch {
+            if (options.requireExists) {
+                throw personalError;
+            }
+            return { kind: 'personal' };
+        }
+    }
+}
+
+/**
+ * Attach to a shared conversation's event stream and fold what arrives into the stores.
+ *
+ * This is what makes the conversation shared rather than merely visible: without it, a
+ * message written by somebody else appears only if the reader reloads.
+ */
+function attachCollaborationEvents(conversationId: string): void {
+    const set = (partial: Partial<ChatState> | ((state: ChatState) => Partial<ChatState>)) =>
+        useChatStore.setState(partial as never);
+    const getState = () => useChatStore.getState();
+    const collaboration = () => useCollaborationStore.getState();
+    const currentUserId = () => useBootstrapStore.getState().data?.user?.id;
+
+    /** Ignore anything that arrives after the reader has moved to another conversation. */
+    const stillOpen = () => getState().activeConversationId === conversationId;
+
+    /**
+     * Re-read this reader's own membership after a change to it.
+     *
+     * The event's payload cannot answer the question. Every publishing route serializes the
+     * conversation for the user who *caused* the event, so its `can_*` flags, role and
+     * membership status are theirs — an owner's action would hand every member owner
+     * permissions, and a member leaving would tell everyone else they can no longer post.
+     * Only a fetch returns the flags computed for the reader.
+     */
+    const refreshOwnMembership = () => {
+        if (stillOpen()) {
+            void collaboration().loadConversation(conversationId);
+        }
+    };
+
+    stopCollaborationEvents();
+    detachCollaborationEvents = subscribeToCollaborationEvents(conversationId, {
+        onMessageCreated: (message, conversation) => {
+            if (conversation) {
+                collaboration().applyBroadcast(conversation);
+            }
+            if (!stillOpen()) {
+                return;
+            }
+
+            set((state) => ({
+                messages: mergeCollaborationMessage(state.messages, message, {
+                    currentUserId: currentUserId(),
+                }),
+            }));
+
+            const senderId = String(message.sender?.user_id ?? '').trim();
+            if (!senderId || senderId === currentUserId()) {
+                return;
+            }
+
+            // Being named is the one thing in a shared conversation worth interrupting for;
+            // an ordinary message is already visible in the thread.
+            if (mentionsCurrentUser(message.metadata as Record<string, unknown>, currentUserId())) {
+                toast.info(
+                    `${participantName(message.sender)} mentioned you in this conversation.`,
+                );
+            }
+
+            // Somebody else has written, so the unread marker this thread may have just
+            // acquired is already satisfied by the reader looking at it.
+            void markCollaborationConversationRead(conversationId).catch(() => {
+                /* Read receipts are advisory. */
+            });
+        },
+
+        onMessageDeleted: (messageId, deletedByUserId, conversation) => {
+            if (conversation) {
+                collaboration().applyBroadcast(conversation);
+            }
+            if (!stillOpen()) {
+                return;
+            }
+            set((state) => ({
+                messages: state.messages.filter((message) => message.id !== messageId),
+            }));
+            if (deletedByUserId && deletedByUserId !== currentUserId()) {
+                toast.info('A message was deleted from this conversation.');
+            }
+        },
+
+        onMessageMasked: (message, updatedByUserId) => {
+            if (!stillOpen()) {
+                return;
+            }
+            set((state) => ({
+                messages: state.messages.map((existing) =>
+                    existing.id === message.id ? { ...existing, ...message } : existing,
+                ),
+            }));
+            if (updatedByUserId && updatedByUserId !== currentUserId()) {
+                toast.info('A message in this conversation was masked.');
+            }
+        },
+
+        onTyping: (user, isTyping, expiresAt) => {
+            if (!stillOpen()) {
+                return;
+            }
+            collaboration().applyTyping(user, isTyping, expiresAt, currentUserId());
+        },
+
+        onConversationUpdated: (conversation) => {
+            // Only the facts every reader shares. The capability flags, role, membership
+            // status and pin state in this payload are the acting user's, not this one's.
+            collaboration().applyBroadcast(conversation);
+            if (!conversation.id) {
+                return;
+            }
+            const facts = conversationFactsOnly(conversation);
+            // The rail row and the header read from the conversation list, so a change to
+            // the title or the participant count lands there too — but the reader's own pin
+            // and hide state must survive it, which is why the same stripping applies.
+            set((state) => ({
+                conversations: state.conversations.map((item) =>
+                    item.id === conversation.id ? { ...item, ...facts } : item,
+                ),
+                metadata:
+                    state.activeConversationId === conversation.id && state.metadata
+                        ? ({ ...state.metadata, ...facts } as ConversationMetadata)
+                        : state.metadata,
+            }));
+        },
+
+        onMembersInvited: (participants) => {
+            const names = participants
+                .map((participant) => participantName(participant))
+                .filter(Boolean);
+            if (names.length > 0 && stillOpen()) {
+                toast.info(
+                    names.length === 1
+                        ? `${names[0]} was invited to this conversation.`
+                        : `${names.length} people were invited to this conversation.`,
+                );
+            }
+        },
+
+        onMemberRemoved: (participant) => {
+            const removedId = String(participant?.user_id ?? '').trim();
+            if (removedId && removedId === currentUserId()) {
+                // The reader has lost access. Leaving the thread on screen would show a
+                // conversation every subsequent request will refuse.
+                toast.info('You no longer have access to this shared conversation.');
+                removeConversationLocally(conversationId);
+                return;
+            }
+            if (participant && stillOpen()) {
+                toast.info(`${participantName(participant)} was removed from this conversation.`);
+            }
+            // Somebody leaving can promote somebody else, so the reader's own role may have
+            // changed even though they were not the subject of the event.
+            refreshOwnMembership();
+        },
+
+        onMemberRoleUpdated: (participant) => {
+            if (participant && stillOpen()) {
+                const role = String(participant.role ?? 'member');
+                toast.info(`${participantName(participant)} is now ${role}.`);
+            }
+            refreshOwnMembership();
+        },
+
+        onInviteAnswered: (participant, accepted) => {
+            if (participant && accepted && stillOpen()) {
+                toast.success(`${participantName(participant)} joined the conversation.`);
+            }
+        },
+
+        onConversationDeleted: () => {
+            toast.info('This shared conversation was deleted.');
+            removeConversationLocally(conversationId);
+        },
+    });
+}
+
+/**
+ * Whether a conversation must be driven through the collaboration API.
+ *
+ * Answered from what the client already knows — the open conversation's resolved kind, or
+ * the rail row's `conversation_kind` — so no request is needed to decide which endpoint an
+ * action belongs to.
+ */
+function isCollaborativeConversation(state: ChatState, conversationId: string): boolean {
+    if (state.activeConversationId === conversationId) {
+        return state.activeConversationKind === 'collaborative';
+    }
+    const listed = state.conversations.find((item) => item.id === conversationId);
+    return isCollaborative(listed);
+}
+
+/**
+ * Drop a conversation from the interface without asking the server to delete it.
+ *
+ * Used when the server has already made it inaccessible — deleted by its owner, or the
+ * reader removed from it — where the ordinary delete path would post to a conversation that
+ * would rightly refuse.
+ */
+function removeConversationLocally(conversationId: string): void {
+    const store = useChatStore.getState();
+    useChatStore.setState({
+        conversations: store.conversations.filter((item) => item.id !== conversationId),
+    });
+    if (store.activeConversationId === conversationId) {
+        store.startNewConversation();
+    }
+}
+
 export const useChatStore = create<ChatState>((set, get) => ({
     conversations: [],
     conversationsLoading: false,
@@ -510,6 +961,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
     searchTerm: '',
 
     activeConversationId: null,
+    activeConversationKind: null,
     messages: [],
     messagesLoading: false,
     messagesError: null,
@@ -567,14 +1019,26 @@ export const useChatStore = create<ChatState>((set, get) => ({
         void get().loadConversations({ reset: true, search: searchTerm });
     },
 
-    selectConversation: async (conversationId) => {
+    selectConversation: async (conversationId, options = {}) => {
         // Any stream still running belongs to the thread being left. Without this its
         // handlers would append the finished response into the newly selected
         // conversation's message list.
         get().stopStreaming();
+        // Likewise the event stream: it is a live connection, and left attached it would
+        // keep delivering the previous conversation's messages into this one.
+        stopCollaborationEvents();
+        useCollaborationStore.getState().reset();
+
+        // Known from the rail row when there is one, which is the common case and costs no
+        // request. A conversation opened from a link is not in the list yet, so its kind is
+        // resolved below by asking the collaboration API about it.
+        const listed = get().conversations.find((item) => item.id === conversationId);
+        const knownKind: ConversationKind | null =
+            options.kind ?? (listed ? (isCollaborative(listed) ? 'collaborative' : 'personal') : null);
 
         set({
             activeConversationId: conversationId,
+            activeConversationKind: knownKind,
             messages: [],
             messagesError: null,
             streamingContent: '',
@@ -588,6 +1052,9 @@ export const useChatStore = create<ChatState>((set, get) => ({
             // Thread ids are per conversation, so learned attempt sets do not carry over.
             attemptsByThread: {},
         });
+        // Mirrored so the collaboration store can refuse a membership write that arrives for
+        // a conversation which is no longer open.
+        useCollaborationStore.getState().setActiveConversation(conversationId);
 
         if (!conversationId) {
             return;
@@ -595,7 +1062,28 @@ export const useChatStore = create<ChatState>((set, get) => ({
 
         set({ messagesLoading: true });
         try {
-            const { messages } = await fetchMessages(conversationId);
+            let prefetched = options.prefetched;
+            let kind = knownKind;
+            if (!kind) {
+                const resolved = await resolveConversationKind(conversationId);
+                kind = resolved.kind;
+                prefetched = prefetched ?? resolved.conversation;
+            }
+            // Discarded if the reader moved on while the kind was being resolved; without
+            // this the wrong thread's messages would be fetched and displayed.
+            if (get().activeConversationId !== conversationId) {
+                return;
+            }
+            set({ activeConversationKind: kind });
+
+            const { messages } =
+                kind === 'collaborative'
+                    ? await fetchCollaborationMessages(conversationId)
+                    : await fetchMessages(conversationId);
+
+            if (get().activeConversationId !== conversationId) {
+                return;
+            }
             set({ messages: messages ?? [], messagesLoading: false });
 
             // The header badges describe what this conversation is bound to, so its
@@ -603,22 +1091,35 @@ export const useChatStore = create<ChatState>((set, get) => ({
             // expanded. Advisory: a failure leaves the badges off, not the thread broken.
             void get().loadMetadata(conversationId);
 
-            // Generation outlives the connection that started it, so a thread opened while
-            // its answer is still being written picks the stream back up instead of showing
-            // a message that stops mid-sentence.
-            void resumeChatStream(conversationId).catch(() => {
-                /* Advisory: the thread is readable whether or not a resume was possible. */
-            });
+            if (kind === 'collaborative') {
+                // Membership and the capability flags that gate the composer and the
+                // participants panel.
+                if (prefetched?.id === conversationId) {
+                    useCollaborationStore.getState().setConversation(prefetched);
+                } else {
+                    void useCollaborationStore.getState().loadConversation(conversationId);
+                }
+                // Then the live stream that keeps the thread current while other people are
+                // writing in it.
+                attachCollaborationEvents(conversationId);
+            } else {
+                // Generation outlives the connection that started it, so a thread opened
+                // while its answer is still being written picks the stream back up instead of
+                // showing a message that stops mid-sentence.
+                //
+                // Deliberately not attempted for a shared conversation: the generation runs
+                // in a hidden source conversation whose id the browser is never given, so
+                // the status and reattach endpoints have nothing to address.
+                void resumeChatStream(conversationId).catch(() => {
+                    /* Advisory: the thread is readable whether or not a resume was possible. */
+                });
+            }
 
             // Only clear the marker when there is one. Calling unconditionally produced a
             // 404 for collaboration conversations, which are stored separately and have
             // their own endpoint.
-            const conversation = get().conversations.find((item) => item.id === conversationId);
-            if (conversation?.has_unread_assistant_response) {
-                void markConversationRead(
-                    conversationId,
-                    conversation.conversation_kind === 'collaborative',
-                )
+            if (listed?.has_unread_assistant_response) {
+                void markConversationRead(conversationId, kind === 'collaborative')
                     .then(() => {
                         set((state) => ({
                             conversations: state.conversations.map((item) =>
@@ -633,6 +1134,9 @@ export const useChatStore = create<ChatState>((set, get) => ({
                     });
             }
         } catch (error) {
+            if (get().activeConversationId !== conversationId) {
+                return;
+            }
             set({
                 messagesLoading: false,
                 messagesError:
@@ -648,18 +1152,22 @@ export const useChatStore = create<ChatState>((set, get) => ({
      * can name a conversation that has been deleted, or one belonging to somebody else,
      * whereas a row in the rail is one the server has just listed.
      *
-     * Existence is checked against the metadata endpoint rather than inferred from the
-     * message load, because `/api/get_messages` is not an existence check: it turns a
-     * not-found conversation into `{'messages': []}` with a 200
-     * (`route_backend_conversations.py`), so a deleted conversation would open as an empty
-     * chat, keep its id in the address bar, and remain the target of the next message sent.
-     * The metadata endpoint answers 404 when the conversation is gone and 403 when it is
-     * someone else's, which is the question actually being asked. It costs one request on
-     * a path that runs once per page load.
+     * Existence is checked against a metadata endpoint rather than inferred from the
+     * message load, because neither message endpoint is an existence check:
+     * `/api/get_messages` turns a not-found conversation into `{'messages': []}` with a 200
+     * (`route_backend_conversations.py`), and its collaboration counterpart answers the same
+     * way for a conversation with no messages yet. A deleted conversation would otherwise
+     * open as an empty chat, keep its id in the address bar, and remain the target of the
+     * next message sent.
+     *
+     * Which endpoint answers that question is itself the thing being determined, so the
+     * probe doubles as the kind resolution and its result is handed to
+     * `selectConversation` rather than being asked for twice.
      */
     openLinkedConversation: async (conversationId) => {
+        let resolved: { kind: ConversationKind; conversation?: CollaborationConversation };
         try {
-            await fetchConversationMetadata(conversationId);
+            resolved = await resolveConversationKind(conversationId, { requireExists: true });
         } catch {
             toast.error(
                 'Could not open that conversation. It may have been deleted, or you may not have access to it.',
@@ -667,7 +1175,10 @@ export const useChatStore = create<ChatState>((set, get) => ({
             return;
         }
 
-        await get().selectConversation(conversationId);
+        await get().selectConversation(conversationId, {
+            kind: resolved.kind,
+            prefetched: resolved.conversation,
+        });
 
         // Still checked: the conversation exists, but its messages may not have loaded.
         if (get().messagesError) {
@@ -682,12 +1193,17 @@ export const useChatStore = create<ChatState>((set, get) => ({
         // Stop first: the running stream belongs to the previous thread and must not
         // deliver its response into the empty new one.
         get().stopStreaming();
+        stopCollaborationEvents();
+        useCollaborationStore.getState().reset();
 
         // The conversation row is created by the server on first send, so a new chat is
         // purely a local reset until then. This avoids leaving empty conversations behind
         // when someone clicks New Chat and navigates away.
         set({
             activeConversationId: null,
+            // A new chat is always personal. Sharing is something done to a conversation
+            // that already exists, so there is no way to start one shared.
+            activeConversationKind: null,
             messages: [],
             messagesError: null,
             streamingContent: '',
@@ -697,24 +1213,42 @@ export const useChatStore = create<ChatState>((set, get) => ({
             metadata: null,
             metadataError: null,
         });
+        useCollaborationStore.getState().setActiveConversation(null);
     },
 
     renameConversation: async (conversationId, title) => {
         const previous = get().conversations;
+        const collaborative = isCollaborativeConversation(get(), conversationId);
         set({
             conversations: previous.map((conversation) =>
                 conversation.id === conversationId ? { ...conversation, title } : conversation,
             ),
         });
         try {
-            await renameConversationApi(conversationId, title);
+            if (collaborative) {
+                await renameCollaborationConversation(conversationId, title);
+            } else {
+                await renameConversationApi(conversationId, title);
+            }
         } catch {
             set({ conversations: previous });
         }
     },
 
+    /**
+     * Remove a conversation from the reader's view.
+     *
+     * For a shared conversation this is not necessarily a deletion. Only an owner may
+     * destroy one for everybody; anybody else leaves it, which removes it from their rail
+     * and leaves the conversation intact for the remaining participants. The server reports
+     * which applies, so the right one is chosen rather than assumed — posting `delete` as a
+     * member is refused, and posting `leave` as the sole owner would strand the thread.
+     */
     removeConversation: async (conversationId) => {
         const previous = get().conversations;
+        const listed = previous.find((conversation) => conversation.id === conversationId);
+        const collaborative = isCollaborativeConversation(get(), conversationId);
+
         set({
             conversations: previous.filter((conversation) => conversation.id !== conversationId),
         });
@@ -724,9 +1258,21 @@ export const useChatStore = create<ChatState>((set, get) => ({
         }
 
         try {
-            await deleteConversationApi(conversationId);
-        } catch {
+            if (collaborative) {
+                const detail =
+                    useCollaborationStore.getState().conversation?.id === conversationId
+                        ? useCollaborationStore.getState().conversation
+                        : (listed as CollaborationConversation | undefined);
+                const action = detail?.can_delete_conversation ? 'delete' : 'leave';
+                await collaborationDeleteAction(conversationId, action);
+            } else {
+                await deleteConversationApi(conversationId);
+            }
+        } catch (error) {
             set({ conversations: previous });
+            toast.error(
+                error instanceof Error ? error.message : 'Could not remove that conversation.',
+            );
         }
     },
 
@@ -744,7 +1290,9 @@ export const useChatStore = create<ChatState>((set, get) => ({
             ),
         });
         try {
-            const result = await toggleConversationPinned(conversationId);
+            const result = isCollaborative(conversation)
+                ? await toggleCollaborationPinned(conversationId)
+                : await toggleConversationPinned(conversationId);
             set({
                 conversations: get().conversations.map((item) =>
                     item.id === conversationId
@@ -774,7 +1322,11 @@ export const useChatStore = create<ChatState>((set, get) => ({
             conversations: get().conversations.filter((item) => item.id !== conversationId),
         });
         try {
-            await toggleConversationHidden(conversationId);
+            if (isCollaborative(conversation)) {
+                await toggleCollaborationHidden(conversationId);
+            } else {
+                await toggleConversationHidden(conversationId);
+            }
         } catch {
             await get().loadConversations({ reset: true });
         }
@@ -788,14 +1340,26 @@ export const useChatStore = create<ChatState>((set, get) => ({
 
         let conversationId = get().activeConversationId;
         const isNewConversation = !conversationId;
+        const collaborative = Boolean(
+            conversationId && isCollaborativeConversation(get(), conversationId),
+        );
 
         // A conversation is created up front so the streaming endpoint has a stable id to
-        // attach to and so a cancel request has something to address.
+        // attach to and so a cancel request has something to address. Only ever a personal
+        // one: a shared conversation always already exists, because sharing is done to a
+        // conversation rather than at the moment of writing into one.
         if (!conversationId) {
             try {
                 const created = await createConversation(trimmed);
                 conversationId = created.conversation_id;
-                set({ activeConversationId: conversationId });
+                set({ activeConversationId: conversationId, activeConversationKind: 'personal' });
+                // Mirrored like every other write to this field. Today the conversation just
+                // created can only be personal — this branch is reached only when nothing was
+                // open, which forces `collaborative` false above — so nothing would currently
+                // notice. Leaving it out would make the collaboration store's guard depend on
+                // that reasoning continuing to hold, and a shared conversation reachable here
+                // later would silently strand its composer at "checking access".
+                useCollaborationStore.getState().setActiveConversation(conversationId);
             } catch (error) {
                 set({
                     streamError:
@@ -807,24 +1371,100 @@ export const useChatStore = create<ChatState>((set, get) => ({
             }
         }
 
+        const bootstrap = useBootstrapStore.getState().data;
+        const loadedCollaboration = useCollaborationStore.getState().conversation;
+        // Guarded on the id: the participants panel keeps its own slot, but a stale load
+        // would still resolve this message's mentions against another conversation's people.
+        const collaborationConversation =
+            loadedCollaboration?.id === conversationId ? loadedCollaboration : null;
+        const replyTo = useCollaborationStore.getState().replyTo;
+
+        // In a shared conversation most messages are people talking to each other, so the
+        // AI is only brought in when something asks for it. `resolveSendTarget` applies the
+        // classic client's rule; null means this message is for the participants alone.
+        const invocationTarget = collaborative
+            ? resolveSendTarget(
+                  trimmed,
+                  {
+                      agentSelection: options.agentSelection,
+                      promptId: options.promptId,
+                      documentSearch: options.documentSearch,
+                      webSearch: options.webSearch,
+                      imageGeneration: options.imageGeneration,
+                      deepResearch: options.deepResearch,
+                      urlAccess: options.urlAccess,
+                      modelDeployment: options.modelDeployment,
+                  },
+                  {
+                      agents: bootstrap?.catalogs?.agents as AgentOption[] | undefined,
+                      models: bootstrap?.catalogs?.models as ModelCatalogEntry[] | undefined,
+                  },
+              )
+            : null;
+
+        const pendingUserMessageId = `pending-user-${Date.now()}`;
         const optimisticUserMessage: ChatMessage = {
-            id: `pending-user-${Date.now()}`,
+            id: pendingUserMessageId,
             conversation_id: conversationId,
             role: 'user',
             content: trimmed,
             timestamp: new Date().toISOString(),
         };
 
+        // A shared message that is not addressed to the AI produces no stream, so the
+        // interface must not sit in the streaming state waiting for one that never starts.
+        const willStream = !collaborative || invocationTarget !== null;
+
         set((state) => ({
             messages: [...state.messages, optimisticUserMessage],
-            streaming: true,
+            streaming: willStream,
             streamingContent: '',
             thoughts: [],
             streamError: null,
             reconnectPhase: null,
         }));
 
-        const bootstrap = useBootstrapStore.getState().data;
+        const mentionedParticipants = collaborative
+            ? extractMentionedParticipants(
+                  trimmed,
+                  conversationParticipants(collaborationConversation),
+              )
+            : [];
+
+        if (collaborative && !invocationTarget) {
+            // Posted rather than streamed. The response carries the stored message, which
+            // replaces the placeholder; the same message also arrives over the event stream,
+            // and `mergeCollaborationMessage` recognises it by id rather than adding it
+            // twice.
+            try {
+                const result = await postCollaborationMessage(conversationId, {
+                    content: trimmed,
+                    reply_to_message_id: replyTo?.message_id ?? null,
+                    mentioned_participants: mentionedParticipants,
+                });
+                useCollaborationStore.getState().setReplyTo(null);
+                if (result.conversation) {
+                    useCollaborationStore.getState().setConversation(result.conversation);
+                }
+                set((state) => ({
+                    messages: mergeCollaborationMessage(state.messages, result.message, {
+                        pendingId: pendingUserMessageId,
+                    }),
+                }));
+            } catch (error) {
+                // The placeholder is removed rather than left as a message that was never
+                // sent, and the text is reported so it can be retyped or the cause fixed.
+                set((state) => ({
+                    messages: state.messages.filter(
+                        (message) => message.id !== pendingUserMessageId,
+                    ),
+                    streamError:
+                        error instanceof Error ? error.message : 'Could not post that message.',
+                }));
+            }
+            return;
+        }
+
         const scope = resolveDocumentScope({
             activeGroupId: bootstrap?.scope?.active_group_id,
             activePublicWorkspaceId: bootstrap?.scope?.active_public_workspace_id,
@@ -863,16 +1503,25 @@ export const useChatStore = create<ChatState>((set, get) => ({
             requestBody,
             modelIdentityForSelection(
                 bootstrap?.catalogs?.models as ModelCatalogEntry[] | undefined,
-                options.modelDeployment,
+                // An explicit `@model` tag chooses the model for this message, overriding
+                // the picker, which is the point of tagging one.
+                invocationTarget?.target_type === 'model' && invocationTarget.selection_key
+                    ? invocationTarget.selection_key
+                    : options.modelDeployment,
             ),
         );
 
-        if (options.agentSelection) {
+        // An explicit `@agent` tag likewise selects the agent for this message alone.
+        const agentSelection =
+            invocationTarget?.target_type === 'agent' && invocationTarget.agent_selection_key
+                ? invocationTarget.agent_selection_key
+                : options.agentSelection;
+        if (agentSelection) {
             // The server reads `agent_info` and requires a dict; a bare string is silently
             // ignored, so the picker would appear to do nothing.
             const agentInfo = agentInfoForSelection(
                 bootstrap?.catalogs?.agents as Record<string, unknown>[] | undefined,
-                options.agentSelection,
+                agentSelection,
             );
             if (agentInfo) {
                 requestBody.agent_info = agentInfo;
@@ -882,18 +1531,49 @@ export const useChatStore = create<ChatState>((set, get) => ({
             requestBody.reasoning_effort = options.reasoningEffort;
         }
 
-        await runChatStream(requestBody, conversationId, { isNewConversation });
-    },
+        if (collaborative) {
+            // The collaboration stream reads the text as `content` and records who was
+            // named and what was addressed alongside it, so the thread shows what was asked
+            // rather than only that something was.
+            requestBody.content = trimmed;
+            requestBody.reply_to_message_id = replyTo?.message_id ?? null;
+            requestBody.mentioned_participants = mentionedParticipants;
+            requestBody.invocation_target = invocationTarget;
+            // The server resolves the hidden source conversation itself; sending the shared
+            // conversation's id here would point the bridge at the wrong thread.
+            delete requestBody.conversation_id;
+            useCollaborationStore.getState().setReplyTo(null);
+        }
 
+        await runChatStream(requestBody, conversationId, {
+            isNewConversation,
+            kind: collaborative ? 'collaborative' : 'personal',
+            pendingUserMessageId,
+            stream: collaborative
+                ? {
+                      url: streamCollaborationUrl(conversationId),
+                      // No reattach endpoint exists for a shared conversation, so a dropped
+                      // transport must be reported rather than retried against a route that
+                      // does not know this conversation id.
+                      allowRecovery: false,
+                  }
+                : undefined,
+        });
+    },
 
     stopStreaming: () => {
         if (!activeStreamController) {
             return;
         }
         // Addresses the conversation the stream actually belongs to, which may no longer
-        // be the one on screen.
+        // be the one on screen, through whichever cancel route that conversation uses.
         if (streamingConversationId) {
-            void cancelStream(streamingConversationId);
+            void cancelStream(
+                streamingConversationId,
+                streamingConversationKind === 'collaborative'
+                    ? cancelCollaborationStreamUrl(streamingConversationId)
+                    : undefined,
+            );
         }
         activeStreamController.abort();
         activeStreamController = null;
@@ -918,8 +1598,18 @@ export const useChatStore = create<ChatState>((set, get) => ({
 
     loadMetadata: async (conversationId) => {
         set({ metadataLoading: true, metadataError: null });
+        const collaborative = isCollaborativeConversation(get(), conversationId);
         try {
-            const metadata = await fetchConversationMetadata(conversationId);
+            // A shared conversation has no entry in the personal metadata route, and its own
+            // detail response carries everything that one does plus the membership. It is
+            // mapped onto the metadata shape so the badges, classification pills, document
+            // drawer and summary all keep working untouched.
+            const metadata = collaborative
+                ? await fetchCollaborationConversation(conversationId).then((result) => {
+                      useCollaborationStore.getState().setConversation(result.conversation);
+                      return metadataFromCollaboration(result.conversation);
+                  })
+                : await fetchConversationMetadata(conversationId);
             // Discard if the user moved on while this was in flight.
             if (get().activeConversationId !== conversationId) {
                 set({ metadataLoading: false });
@@ -937,7 +1627,15 @@ export const useChatStore = create<ChatState>((set, get) => ({
                 // older conversation into a page that has not been loaded.
                 conversations: state.conversations.some((item) => item.id === conversationId)
                     ? state.conversations
-                    : [conversationFromMetadata(conversationId, metadata), ...state.conversations],
+                    : [
+                          {
+                              ...conversationFromMetadata(conversationId, metadata),
+                              // Carried so the row's own actions keep routing to the right
+                              // API family after a reload that does not go through the feed.
+                              conversation_kind: collaborative ? 'collaborative' : undefined,
+                          },
+                          ...state.conversations,
+                      ],
             }));
         } catch (error) {
             set({
@@ -954,7 +1652,10 @@ export const useChatStore = create<ChatState>((set, get) => ({
             return;
         }
         try {
-            const { messages } = await fetchMessages(conversationId);
+            const { messages } =
+                get().activeConversationKind === 'collaborative'
+                    ? await fetchCollaborationMessages(conversationId)
+                    : await fetchMessages(conversationId);
             if (get().activeConversationId !== conversationId) {
                 return;
             }
@@ -972,9 +1673,17 @@ export const useChatStore = create<ChatState>((set, get) => ({
 
     removeMessage: async (messageId, deleteThread = false) => {
         const previous = get().messages;
+        const conversationId = get().activeConversationId;
+        const collaborative = get().activeConversationKind === 'collaborative';
         set({ messages: previous.filter((message) => message.id !== messageId) });
         try {
-            await deleteMessageApi(messageId, deleteThread);
+            if (collaborative && conversationId) {
+                // A shared conversation deletes one message at a time and has no thread
+                // model, so `deleteThread` has nothing to address there.
+                await deleteCollaborationMessage(conversationId, messageId);
+            } else {
+                await deleteMessageApi(messageId, deleteThread);
+            }
             // Deletion is soft when archiving is enabled: the server masks the message
             // rather than removing it, so the authoritative list is re-read instead of
             // trusting the optimistic removal.
@@ -1100,11 +1809,17 @@ export const useChatStore = create<ChatState>((set, get) => ({
         }
 
         try {
-            const result = await maskMessageApi(messageId, {
-                action,
-                conversation_id: conversationId,
-                selection,
-            });
+            const result =
+                get().activeConversationKind === 'collaborative'
+                    ? await maskCollaborationMessage(conversationId, messageId, {
+                          action,
+                          selection,
+                      })
+                    : await maskMessageApi(messageId, {
+                          action,
+                          conversation_id: conversationId,
+                          selection,
+                      });
 
             // The response carries the authoritative mask state, including ranges the
             // server merged or re-placed, so it replaces the local copy rather than being

--- a/application/v2_ui/src/stores/collaborationStore.ts
+++ b/application/v2_ui/src/stores/collaborationStore.ts
@@ -1,0 +1,581 @@
+// collaborationStore.ts
+// State that only exists for a shared conversation: its membership, who is typing, what
+// the composer is replying to, and the participants panel.
+//
+// Deliberately separate from `chatStore`, and deliberately importing nothing from it. A
+// shared conversation is still a conversation — its messages, streaming and rail row are
+// `chatStore`'s job exactly as for a personal one — so folding this in would put a large
+// amount of state on every reader of a thread that will never have participants. Keeping
+// the dependency one-way (chatStore -> collaborationStore) also means the event handler in
+// `lib/collaborationEvents.ts` can write to both without a cycle between the two stores.
+
+import { create } from 'zustand';
+import {
+    collaborationDeleteAction,
+    fetchCollaborationConversation,
+    fetchGeneratedFileApprovals,
+    inviteCollaborationMembers,
+    removeCollaborationMember,
+    resolveGeneratedFileApproval,
+    respondToCollaborationInvite,
+    sharePersonalConversation,
+    shareGroupConversation,
+    updateCollaborationMemberRole,
+    type GeneratedFileApproval,
+    type InviteResult,
+} from '../lib/collaboration';
+import { conversationFactsOnly } from '../lib/collaborationEvents';
+import { toast } from './toastStore';
+import { useUserSettingsStore } from './userSettingsStore';
+import type {
+    CollaborationConversation,
+    CollaborationParticipant,
+    CollaborationReplyContext,
+    MembershipRole,
+} from '../lib/types';
+
+/**
+ * How many recent collaborators to remember.
+ *
+ * Matches `MAX_RECENT_COLLABORATORS` in chat-collaboration.js so the two interfaces read
+ * and write the same preference without one of them silently truncating the other's list.
+ */
+const MAX_RECENT_COLLABORATORS = 12;
+const RECENT_COLLABORATORS_KEY = 'recentCollaborators';
+
+/**
+ * What the participants panel is acting on.
+ *
+ * The panel opens on conversations that are *not yet shared*, which is the whole point of
+ * the Share action, so it cannot simply read the loaded `CollaborationConversation` —
+ * there is not one yet. `kind` is what decides which of the three invite endpoints applies,
+ * mirroring `addParticipantToConversation` in the classic client.
+ */
+export interface ParticipantsPanelTarget {
+    conversationId: string;
+    kind: 'collaborative' | 'personal' | 'group';
+    title?: string;
+    /** Set for group-scoped conversations, whose invitees come from the group's members. */
+    groupId?: string | null;
+}
+
+/** Somebody currently typing, with the moment the server's claim stops being true. */
+export interface TypingUser {
+    user_id: string;
+    display_name: string;
+    expiresAt: number;
+}
+
+interface CollaborationState {
+    /**
+     * The conversation the chat page has open, mirrored here by `chatStore`.
+     *
+     * Held so this store can enforce its own invariant rather than trusting each caller to.
+     * Mirrored rather than imported because `chatStore` already depends on this module, and
+     * reading back the other way would make the two mutually dependent.
+     */
+    activeConversationId: string | null;
+
+    /** Membership and capabilities for the open shared conversation, or null. */
+    conversation: CollaborationConversation | null;
+    conversationLoading: boolean;
+    conversationError: string | null;
+
+    /**
+     * Membership for whatever the participants panel is showing.
+     *
+     * Deliberately a second slot rather than reusing `conversation`. The panel can be opened
+     * from the rail on a conversation that is not the one on screen, and sharing one slot
+     * meant doing so evicted the open conversation's capability flags — after which its
+     * composer, invite prompt and per-message controls were all deciding from either
+     * nothing or another conversation's permissions.
+     */
+    panelConversation: CollaborationConversation | null;
+    panelLoading: boolean;
+
+    typingUsers: TypingUser[];
+
+    /** The message the composer is replying to, or null when it is not. */
+    replyTo: CollaborationReplyContext | null;
+
+    panelTarget: ParticipantsPanelTarget | null;
+
+    approvals: GeneratedFileApproval[];
+    approvalsLoading: boolean;
+
+    /** Record which conversation the chat page has open. Called only by `chatStore`. */
+    setActiveConversation: (conversationId: string | null) => void;
+    /**
+     * Replace the loaded conversation with one fetched for this user.
+     *
+     * Ignores anything that is not the open conversation. Several callers write here after
+     * an `await` — a metadata load, a posted message, an invite response — and the reader can
+     * have moved on by then. Enforcing it once here rather than at each call site is what
+     * makes it impossible to forget: a stale write leaves the composer, the reply controls
+     * and the mention roster all deciding from another conversation's membership.
+     */
+    setConversation: (conversation: CollaborationConversation | null) => void;
+    /**
+     * Apply a conversation that arrived over the event stream.
+     *
+     * Only the fields that mean the same thing to everybody are taken; the viewer-scoped
+     * ones are left alone, because a broadcast carries the permissions of whoever triggered
+     * the event rather than the reader's. See `conversationFactsOnly`.
+     */
+    applyBroadcast: (conversation: CollaborationConversation) => void;
+    loadConversation: (conversationId: string) => Promise<void>;
+    /** Drop everything belonging to the conversation being left. */
+    reset: () => void;
+
+    applyTyping: (
+        user: CollaborationParticipant | undefined,
+        isTyping: boolean,
+        expiresAt: string | undefined,
+        currentUserId: string | undefined,
+    ) => void;
+
+    setReplyTo: (reply: CollaborationReplyContext | null) => void;
+
+    openPanel: (target: ParticipantsPanelTarget) => void;
+    closePanel: () => void;
+    /**
+     * Add people, sharing the conversation first if it is not shared yet.
+     *
+     * Resolves with the server's result so the caller can follow the conversation id it
+     * returns — sharing mints a new conversation rather than converting this one in place.
+     */
+    inviteParticipants: (participants: CollaborationParticipant[]) => Promise<InviteResult>;
+    removeParticipant: (memberUserId: string) => Promise<void>;
+    changeParticipantRole: (memberUserId: string, role: MembershipRole) => Promise<void>;
+    respondToInvite: (action: 'accept' | 'decline') => Promise<boolean>;
+    /** Leave, or delete for everybody. Resolves true when the conversation is gone for this user. */
+    leaveOrDelete: (
+        action: 'leave' | 'delete',
+        newOwnerUserId?: string,
+    ) => Promise<boolean>;
+
+    loadApprovals: () => Promise<void>;
+    resolveApproval: (
+        approval: GeneratedFileApproval,
+        decision: 'approve' | 'deny',
+    ) => Promise<void>;
+}
+
+/**
+ * Timer that sweeps expired typing entries.
+ *
+ * Held outside the store because it is bookkeeping, not render state. A single sweep is
+ * used rather than one timeout per typist so a busy conversation does not accumulate
+ * timers, and so an entry whose `expires_at` has passed disappears even if that person's
+ * "stopped typing" ping never arrived.
+ */
+let typingSweep: ReturnType<typeof setInterval> | null = null;
+
+/**
+ * The conversation id of the most recent detail request.
+ *
+ * Used to discard a response that arrives after the reader has moved to another
+ * conversation, which would otherwise apply one thread's capability flags to another.
+ */
+let latestConversationRequest: string | null = null;
+
+function stopTypingSweep() {
+    if (typingSweep !== null) {
+        clearInterval(typingSweep);
+        typingSweep = null;
+    }
+}
+
+/**
+ * Read a member's display name, falling back to something showable.
+ *
+ * Typed on the two fields it reads rather than on `CollaborationParticipant`, because it is
+ * also used on a message's `sender`, which carries the same names but no guaranteed id.
+ */
+export function participantName(
+    participant: { display_name?: string; email?: string } | undefined,
+): string {
+    const name = String(participant?.display_name ?? '').trim();
+    if (name) {
+        return name;
+    }
+    const email = String(participant?.email ?? '').trim();
+    return email || 'Unknown participant';
+}
+
+export const useCollaborationStore = create<CollaborationState>((set, get) => {
+    /** Drop typists whose claim has expired, and stop sweeping once none are left. */
+    const sweepTyping = () => {
+        const now = Date.now();
+        const remaining = get().typingUsers.filter((entry) => entry.expiresAt > now);
+        if (remaining.length !== get().typingUsers.length) {
+            set({ typingUsers: remaining });
+        }
+        if (remaining.length === 0) {
+            stopTypingSweep();
+        }
+    };
+
+    const startTypingSweep = () => {
+        if (typingSweep === null) {
+            typingSweep = setInterval(sweepTyping, 1000);
+        }
+    };
+
+    /** The conversation actions operate on, or a rejection describing why there is none. */
+    const requireConversationId = (): string => {
+        // The panel target wins over the loaded conversation. The panel can be opened on a
+        // conversation that is not the one currently loaded — sharing a personal
+        // conversation from the rail, for instance — and acting on the loaded one would
+        // silently address a different conversation from the one on screen.
+        const conversationId =
+            get().panelTarget?.conversationId ?? get().conversation?.id ?? '';
+        if (!conversationId) {
+            throw new Error('No shared conversation is open.');
+        }
+        return conversationId;
+    };
+
+    /**
+     * Apply a conversation the server serialized for *this* reader.
+     *
+     * Written to whichever slots hold that conversation. Unlike `applyBroadcast` this takes
+     * the capability flags as they stand, because a direct response is computed for the
+     * caller rather than for whoever triggered an event.
+     */
+    const applyForViewer = (conversation: CollaborationConversation) => {
+        set((state) => ({
+            conversation:
+                state.conversation?.id === conversation.id ? conversation : state.conversation,
+            panelConversation:
+                state.panelTarget?.conversationId === conversation.id
+                    ? conversation
+                    : state.panelConversation,
+        }));
+    };
+
+    return {
+        activeConversationId: null,
+        conversation: null,
+        conversationLoading: false,
+        conversationError: null,
+        panelConversation: null,
+        panelLoading: false,
+        typingUsers: [],
+        replyTo: null,
+        panelTarget: null,
+        approvals: [],
+        approvalsLoading: false,
+
+        setActiveConversation: (activeConversationId) => set({ activeConversationId }),
+
+        setConversation: (conversation) => {
+            if (conversation && conversation.id !== get().activeConversationId) {
+                return;
+            }
+            set({ conversation });
+        },
+
+        applyBroadcast: (conversation) => {
+            const facts = conversationFactsOnly(conversation);
+            set((state) => ({
+                conversation:
+                    state.conversation?.id === conversation.id
+                        ? { ...state.conversation, ...facts }
+                        : state.conversation,
+                panelConversation:
+                    state.panelConversation?.id === conversation.id
+                        ? { ...state.panelConversation, ...facts }
+                        : state.panelConversation,
+            }));
+        },
+
+        loadConversation: async (conversationId) => {
+            latestConversationRequest = conversationId;
+            set({ conversationLoading: true, conversationError: null });
+            try {
+                const { conversation } = await fetchCollaborationConversation(conversationId);
+                // The load is fired on every conversation change and the reader can move on
+                // while one is in flight. Without this check the previous thread's membership
+                // and capability flags would land on the newly opened one, which decides
+                // whether the composer is enabled.
+                if (latestConversationRequest !== conversationId) {
+                    return;
+                }
+                set({ conversationLoading: false });
+                // Through the guarded setter, so a conversation that is no longer the open
+                // one is dropped rather than applied.
+                get().setConversation(conversation);
+            } catch (error) {
+                if (latestConversationRequest !== conversationId) {
+                    return;
+                }
+                set({
+                    conversationLoading: false,
+                    conversationError:
+                        error instanceof Error
+                            ? error.message
+                            : 'Failed to load the shared conversation.',
+                });
+            }
+        },
+
+        reset: () => {
+            stopTypingSweep();
+            latestConversationRequest = null;
+            set({
+                conversation: null,
+                conversationLoading: false,
+                conversationError: null,
+                typingUsers: [],
+                replyTo: null,
+            });
+        },
+        applyTyping: (user, isTyping, expiresAt, currentUserId) => {
+            const userId = String(user?.user_id ?? '').trim();
+            // The event stream echoes the sender's own pings back. Showing "You are typing"
+            // under the composer would be absurd, so they are dropped here rather than at
+            // every read site.
+            if (!userId || userId === currentUserId) {
+                return;
+            }
+
+            if (!isTyping) {
+                set((state) => ({
+                    typingUsers: state.typingUsers.filter((entry) => entry.user_id !== userId),
+                }));
+                return;
+            }
+
+            // The server's own expiry is preferred over a local guess so every participant
+            // agrees on when the indicator goes away; eight seconds matches what
+            // `collaboration_typing_api` sets when the header is missing or unparseable.
+            const parsed = expiresAt ? Date.parse(expiresAt) : Number.NaN;
+            const expires = Number.isFinite(parsed) ? parsed : Date.now() + 8000;
+
+            set((state) => ({
+                typingUsers: [
+                    ...state.typingUsers.filter((entry) => entry.user_id !== userId),
+                    { user_id: userId, display_name: participantName(user), expiresAt: expires },
+                ],
+            }));
+            startTypingSweep();
+        },
+
+        setReplyTo: (replyTo) => set({ replyTo }),
+
+        openPanel: (panelTarget) => {
+            set({ panelTarget, panelConversation: null });
+
+            if (panelTarget.kind !== 'collaborative') {
+                // Not shared yet, so there is no membership to fetch: the panel is purely an
+                // invite box until somebody is added.
+                return;
+            }
+
+            // Reused when the panel is opened on the conversation already on screen, which
+            // is the header button's case and needs no request.
+            const open = get().conversation;
+            if (open?.id === panelTarget.conversationId) {
+                set({ panelConversation: open });
+                return;
+            }
+
+            set({ panelLoading: true });
+            void fetchCollaborationConversation(panelTarget.conversationId)
+                .then(({ conversation }) => {
+                    // Discarded if the panel has since been closed or re-pointed, so a slow
+                    // response cannot show one conversation's membership under another's
+                    // heading.
+                    if (get().panelTarget?.conversationId !== conversation.id) {
+                        return;
+                    }
+                    set({ panelConversation: conversation, panelLoading: false });
+                })
+                .catch(() => {
+                    if (get().panelTarget?.conversationId !== panelTarget.conversationId) {
+                        return;
+                    }
+                    // Left unloaded rather than guessed at: the panel treats an unloaded
+                    // shared conversation as offering nothing, which is the safe direction.
+                    set({ panelLoading: false });
+                });
+        },
+        closePanel: () => set({ panelTarget: null, panelConversation: null, panelLoading: false }),
+
+        inviteParticipants: async (participants) => {
+            const target = get().panelTarget;
+            const conversationId = target?.conversationId ?? requireConversationId();
+            const kind = target?.kind ?? 'collaborative';
+
+            const result =
+                kind === 'collaborative'
+                    ? await inviteCollaborationMembers(conversationId, participants)
+                    : kind === 'group'
+                      ? await shareGroupConversation(conversationId, participants)
+                      : await sharePersonalConversation(conversationId, participants);
+
+            // The response is serialized for the caller, so unlike a broadcast its
+            // capability flags are this reader's and can be applied as they stand.
+            applyForViewer(result.conversation);
+            // Only re-pointed when the panel is actually open. Inviting somebody from the
+            // composer's mention menu goes through here too, and setting a target there
+            // would pop the panel open over the conversation the user is writing in.
+            if (result.conversation?.id && get().panelTarget) {
+                set({
+                    panelConversation: result.conversation,
+                    // After sharing, the server has returned a *different* conversation from
+                    // the one the panel was opened on, so the panel follows it.
+                    panelTarget: {
+                        conversationId: result.conversation.id,
+                        kind: 'collaborative',
+                        title: result.conversation.title,
+                        groupId: result.conversation.group_id ?? null,
+                    },
+                });
+            }
+            rememberRecentCollaborators(participants);
+            return result;
+        },
+
+        removeParticipant: async (memberUserId) => {
+            const conversationId = requireConversationId();
+            const result = await removeCollaborationMember(conversationId, memberUserId);
+            applyForViewer(result.conversation);
+        },
+
+        changeParticipantRole: async (memberUserId, role) => {
+            const conversationId = requireConversationId();
+            const result = await updateCollaborationMemberRole(conversationId, memberUserId, role);
+            applyForViewer(result.conversation);
+        },
+
+        respondToInvite: async (action) => {
+            // Deliberately the open conversation rather than the panel's: the invitation
+            // prompt sits above the thread on screen, and a panel opened on some other
+            // conversation must not become the thing that gets joined.
+            const conversationId = String(get().conversation?.id ?? '').trim();
+            if (!conversationId) {
+                return false;
+            }
+            try {
+                const { conversation } = await respondToCollaborationInvite(conversationId, action);
+                applyForViewer(conversation);
+                toast.success(
+                    action === 'accept'
+                        ? 'You have joined the shared conversation.'
+                        : 'Invitation declined.',
+                );
+                return true;
+            } catch (error) {
+                toast.error(
+                    error instanceof Error ? error.message : 'Could not respond to the invitation.',
+                );
+                return false;
+            }
+        },
+
+        leaveOrDelete: async (action, newOwnerUserId) => {
+            const conversationId = requireConversationId();
+            try {
+                await collaborationDeleteAction(conversationId, action, newOwnerUserId);
+                // Only the thread on screen is torn down, and only when it is the one that
+                // was left: leaving a conversation from the rail must not empty a different
+                // one the reader is reading.
+                if (get().conversation?.id === conversationId) {
+                    get().reset();
+                }
+                set({ panelTarget: null, panelConversation: null });
+                toast.success(
+                    action === 'delete'
+                        ? 'Shared conversation deleted.'
+                        : 'You have left the shared conversation.',
+                );
+                return true;
+            } catch (error) {
+                toast.error(
+                    error instanceof Error
+                        ? error.message
+                        : 'Could not update your membership of this conversation.',
+                );
+                return false;
+            }
+        },
+
+        loadApprovals: async () => {
+            set({ approvalsLoading: true });
+            try {
+                const { approvals } = await fetchGeneratedFileApprovals();
+                set({ approvals: approvals ?? [], approvalsLoading: false });
+            } catch {
+                // Advisory. A conversation is perfectly readable without knowing that a
+                // generated file elsewhere is waiting on a decision.
+                set({ approvalsLoading: false });
+            }
+        },
+
+        resolveApproval: async (approval, decision) => {
+            try {
+                await resolveGeneratedFileApproval(
+                    approval.source_conversation_id,
+                    approval.artifact_message_id,
+                    decision,
+                );
+                set((state) => ({
+                    approvals: state.approvals.filter(
+                        (entry) =>
+                            entry.artifact_message_id !== approval.artifact_message_id ||
+                            entry.source_conversation_id !== approval.source_conversation_id,
+                    ),
+                }));
+                toast.success(
+                    decision === 'approve'
+                        ? 'File released to the conversation.'
+                        : 'File withheld.',
+                );
+            } catch (error) {
+                toast.error(
+                    error instanceof Error ? error.message : 'Could not resolve the file approval.',
+                );
+            }
+        },
+    };
+});
+
+/**
+ * Record people just invited so they rank first in the next mention search.
+ *
+ * Written through `userSettingsStore`, so it lands in the same `recentCollaborators`
+ * preference `/api/user/collaboration-suggestions` reads on the server. Best-effort: a
+ * failed write costs a slightly worse suggestion order and nothing else, which is why it is
+ * not awaited and its failure is not surfaced.
+ */
+function rememberRecentCollaborators(participants: CollaborationParticipant[]): void {
+    const additions = participants
+        .map((participant) => ({
+            user_id: String(participant.user_id ?? '').trim(),
+            display_name: participantName(participant),
+            email: String(participant.email ?? '').trim(),
+            last_used_at: new Date().toISOString(),
+        }))
+        .filter((participant) => participant.user_id);
+
+    if (additions.length === 0) {
+        return;
+    }
+
+    const settingsStore = useUserSettingsStore.getState();
+    const existing = Array.isArray(settingsStore.settings[RECENT_COLLABORATORS_KEY])
+        ? (settingsStore.settings[RECENT_COLLABORATORS_KEY] as Array<Record<string, unknown>>)
+        : [];
+
+    const addedIds = new Set(additions.map((participant) => participant.user_id));
+    const merged = [
+        ...additions,
+        ...existing.filter(
+            (entry) => !addedIds.has(String(entry?.user_id ?? entry?.id ?? '').trim()),
+        ),
+    ].slice(0, MAX_RECENT_COLLABORATORS);
+
+    settingsStore.update({ [RECENT_COLLABORATORS_KEY]: merged });
+}

--- a/docs/explanation/features/V2_SHARED_CONVERSATIONS.md
+++ b/docs/explanation/features/V2_SHARED_CONVERSATIONS.md
@@ -1,0 +1,266 @@
+# Shared Conversations In The V2 Interface
+
+## Overview
+
+A shared conversation is one several people read and write in together, with the assistant
+available inside it. SimpleChat has supported them since the collaborative conversations
+foundation, and the classic interface drives them from
+`application/single_app/static/js/chat/chat-collaboration.js`.
+
+The V2 interface listed them but could not open them. Clicking a shared conversation showed
+an empty thread, and every other action on one was wired to the personal conversation API,
+which does not know they exist. This change routes the V2 interface through the
+`/api/collaboration/*` API so a shared conversation can be read, replied to, invited into
+and managed there.
+
+**Implemented in version:** 0.261.034
+
+### Dependencies
+
+| Dependency | Purpose |
+|---|---|
+| `enable_collaborative_conversations` | Administrator capability that switches the whole surface on |
+| `/api/collaboration/*` | The existing collaboration API, unchanged by this work |
+| `EventSource` | Live updates from the conversation's server-sent event stream |
+
+No Flask route, Cosmos container or server behaviour was changed. Every endpoint this uses
+already existed and was already driven by the classic interface.
+
+## Why the thread was empty
+
+The V2 interface loaded every conversation's messages with
+`GET /api/get_messages?conversation_id=<id>`. That route reads only
+`cosmos_messages_container` and authorizes with `_authorize_personal_conversation_read`,
+which raises `LookupError` for a conversation that is not in it. The route catches that and
+answers:
+
+```python
+except LookupError:
+    return jsonify({'messages': []})
+```
+
+with a **200** (`route_backend_conversations.py`). So a shared conversation did not fail to
+open — it opened successfully, with nothing in it, and stayed the target of the next message
+sent. Shared conversations live in `cosmos_collaboration_conversations_container` and
+`cosmos_collaboration_messages_container`, behind their own API.
+
+The conversation **feed** already merged them, which is why the rows appeared in the rail at
+all: `functions_conversation_feed.py` combines a legacy source and a collaboration source
+into one page. Only the per-conversation operations were missing.
+
+## Architecture
+
+Routing is decided by `conversation_kind`, which the feed already returns on every row, and
+never by trying one endpoint and falling back — because the personal endpoint does not fail
+for a shared conversation.
+
+| Concern | Module |
+|---|---|
+| Endpoint wrappers | `application/v2_ui/src/lib/collaboration.ts` |
+| Event stream, replay guard, de-duplication | `application/v2_ui/src/lib/collaborationEvents.ts` |
+| Mention grammar and the send rule | `application/v2_ui/src/lib/mentions.ts` |
+| Author, reply and message-kind reading | `application/v2_ui/src/lib/sharedMessage.ts` |
+| Which invite route a conversation uses | `application/v2_ui/src/lib/sharing.ts` |
+| Membership, typing, panel and invite state | `application/v2_ui/src/stores/collaborationStore.ts` |
+| Kind-aware conversation and message actions | `application/v2_ui/src/stores/chatStore.ts` |
+| Participants panel | `application/v2_ui/src/components/chat/ParticipantsPanel.tsx` |
+| Mention autocomplete | `application/v2_ui/src/components/chat/MentionMenu.tsx` |
+| Invitation prompt | `application/v2_ui/src/components/chat/InviteBanner.tsx` |
+| Generated file approvals | `application/v2_ui/src/components/chat/FileApprovals.tsx` |
+
+### Endpoints used
+
+| Purpose | Endpoint |
+|---|---|
+| Messages | `GET /api/collaboration/conversations/<id>/messages` |
+| Post to participants | `POST /api/collaboration/conversations/<id>/messages` |
+| Ask the assistant | `POST /api/collaboration/conversations/<id>/stream` |
+| Cancel generation | `POST /api/collaboration/conversations/<id>/stream/cancel` |
+| Live updates | `GET /api/collaboration/conversations/<id>/events` |
+| Typing | `POST /api/collaboration/conversations/<id>/typing` |
+| Membership and capabilities | `GET /api/collaboration/conversations/<id>` |
+| Rename | `PUT /api/collaboration/conversations/<id>` |
+| Pin, hide, mark read | `POST /api/collaboration/conversations/<id>/{pin,hide,mark-read}` |
+| Leave or delete | `POST /api/collaboration/conversations/<id>/delete-action` |
+| Invite into a shared conversation | `POST /api/collaboration/conversations/<id>/members` |
+| Share a personal conversation | `POST /api/collaboration/conversations/from-personal/<id>/members` |
+| Share a group conversation | `POST /api/collaboration/conversations/from-group/<id>/members` |
+| Remove a member | `DELETE /api/collaboration/conversations/<id>/members/<user_id>` |
+| Change a role | `PUT /api/collaboration/conversations/<id>/members/<user_id>/role` |
+| Accept or decline | `POST /api/collaboration/conversations/<id>/invite-response` |
+| Delete a message | `DELETE /api/collaboration/conversations/<id>/messages/<message_id>` |
+| Mask a message | `POST /api/collaboration/conversations/<id>/messages/<message_id>/mask` |
+| Pending file approvals | `GET /api/collaboration/file-approvals` |
+| Resolve a file approval | `POST /api/collaboration/file-approvals/<src>/<msg>/<decision>` |
+| People who can be invited | `GET /api/user/collaboration-suggestions` |
+| Group members | `GET /api/groups/<group_id>/members` |
+
+### Capability flags
+
+What a reader may do is decided by the server and reported on the conversation by
+`serialize_collaboration_conversation`. The V2 interface reads those flags and never
+reimplements the rules behind them, because they fold together membership status, role,
+visibility mode and whether membership is explicit at all — and a group-visibility
+conversation grants posting with no membership record to inspect.
+
+| Flag | Controls |
+|---|---|
+| `can_post_messages` | Whether the composer is usable |
+| `can_manage_members` | Whether people can be invited or removed |
+| `can_manage_roles` | Whether a member can be promoted to admin |
+| `can_accept_invite` | Whether the invitation prompt is shown |
+| `can_delete_conversation` | Whether removal destroys the conversation for everybody |
+| `can_leave_conversation` | Whether removal only removes the reader from it |
+
+## What a shared conversation does differently
+
+### Messages are attributed
+
+A personal conversation has one human, so its messages need no author. A shared one shows
+who wrote each message, and puts another participant's message on the left rather than on
+the reader's own side. The reader's own messages read as "You". A message that asked the
+assistant is labelled as such, because a plain message and a request to the model are both
+stored with `role: 'user'` and only `message_kind` separates them.
+
+Shared conversations can also contain a `file` message — an upload, which
+`serialize_collaboration_message` gives a display role the personal endpoints never emit. It
+is rendered as a named attachment rather than as message text, because its `content` is the
+extracted document text.
+
+### The assistant is not addressed by default
+
+Most messages in a shared conversation are people talking to each other, so sending one does
+not invoke the model. The assistant answers only when:
+
+- the message `@`-mentions a model or an agent, or
+- an assistant-implying composer option is set: an agent, document search, web search, image
+  generation, deep research, URL access, or a saved prompt.
+
+Otherwise the message is posted to the participants and the model never sees it. This is the
+classic interface's rule, reproduced from `buildCollaborativeInvocationTarget` in
+`chat-messages.js` so the two interfaces cannot disagree about what a given message does.
+
+An explicit `@` tag overrides the pickers for that message alone: tagging `@o3` sends that
+one message to `o3` whatever the model picker holds.
+
+### Mentions
+
+Typing `@` opens a menu of, in order, the people already in the conversation, the models and
+agents that can be addressed, and — for somebody who may manage members — people who could
+be added. Choosing one of the last group invites them.
+
+A mention matches at a word boundary on both sides, so `@Sam` does not match `@Samantha` and
+an email address does not become a mention. Where one person's name is a prefix of
+another's, the longer match is struck out of the text before shorter names are tried, so
+writing `@Ada Lovelace` does not also notify somebody called `Ada`.
+
+### Live updates
+
+The conversation's event stream delivers other people's messages, deletions, masks, typing,
+membership changes and deletion of the conversation itself.
+
+Two properties of that endpoint shape the client. It **replays**: `iter_events` starts at
+index 0, so attaching delivers the conversation's whole event history first. And
+`EventSource` **reconnects by itself**, reattaching from the beginning, so that replay
+happens again after every network blip. Events that predate the subscription are therefore
+discarded, and every event is de-duplicated by identity so a repeat cannot append a second
+copy of a message.
+
+A third property matters just as much and is easy to miss. Every route that publishes an
+event calls `serialize_collaboration_conversation` with the user who **caused** the event,
+then broadcasts that single document to every subscriber. So the conversation inside an
+event carries the *actor's* permissions, role, membership status and pin state — not the
+reader's. Applying it wholesale is wrong in both directions: a participant leaving publishes
+a conversation in which `can_post_messages` is false, which would disable everyone else's
+composer, and an owner acting publishes one in which `can_delete_conversation` is true,
+which would offer every member a "Delete for everyone" button the server then refuses.
+
+`conversationFactsOnly` (`lib/collaborationEvents.ts`) therefore strips the viewer-scoped
+fields from any broadcast, leaving only what means the same to everybody — title,
+participants, counts, timestamps, scope. A membership change is treated as a reason to
+**re-read** the conversation for this reader rather than as a payload to trust.
+
+Capability flags are also **deny-by-default** while unknown: `can_post_messages` must be
+explicitly true for the composer to be usable, so a membership that has not loaded leaves
+the composer disabled rather than offering Send to somebody who has not joined.
+
+### Operations a shared conversation does not have
+
+Retry, edit, attempt navigation and fork are hidden. Those endpoints read and rewrite the
+personal messages container and have no collaboration counterpart; the classic interface
+leaves them out for the same reason.
+
+Stream recovery is also switched off. `/api/chat/stream/reattach` is keyed on the
+conversation the generation actually runs in, which for a shared conversation is a hidden
+source conversation the browser is never told the id of, so a dropped transport is reported
+rather than retried against a conversation that endpoint has never heard of.
+
+## Usage
+
+### Enabling the capability
+
+Shared conversations require **Collaborative conversations** to be enabled in admin
+settings (`enable_collaborative_conversations`). With it off, the API refuses every request
+and the V2 interface shows no sharing controls at all.
+
+### Sharing a conversation
+
+Open a conversation and choose the **people** button in the chat header, or **Share** from
+the conversation's menu in the left rail. Search for somebody and add them.
+
+Sharing does not convert the conversation in place. It creates a new shared conversation
+seeded from it and leaves the original as the hidden source the assistant runs in, so the
+interface moves you to the new one. That is why the conversation appears in the rail under a
+new entry after sharing.
+
+A group conversation may only be shared with members of that group, so the search there
+offers group members rather than the directory.
+
+### Being invited
+
+An invited conversation is readable before it is accepted, so the invitation can be judged
+on its contents. A prompt above the thread offers **Join** or **Decline**, and the composer
+stays disabled until you join.
+
+### Managing people
+
+The people panel lists everyone, shows who is an owner or admin and who has been invited but
+has not joined, and offers removal and promotion to whoever the server says may do them.
+Ownership is not assignable: it moves by being handed on when an owner leaves.
+
+### Leaving versus deleting
+
+Removing a shared conversation from the rail does different things depending on who you are.
+An owner deletes it for everybody. Anybody else leaves it, and the conversation carries on
+without them. The rail's menu says which of the two it will do.
+
+### Generated files
+
+A file the assistant generates in a shared conversation is staged rather than released,
+because it would become available to every participant. A banner above the thread lists
+files waiting on your decision, with **Approve** and **Deny**.
+
+## Testing and validation
+
+| Test | Covers |
+|---|---|
+| `functional_tests/test_v2_shared_conversations.py` | Endpoint wiring, capability gating, hidden operations, share routing, replay handling |
+| `functional_tests/test_v2_shared_conversation_logic.mjs` | The send rule, the mention grammar, event dispatch and attribution, executed against the real modules |
+
+Run them with:
+
+```powershell
+python .\functional_tests\test_v2_shared_conversations.py
+node .\functional_tests\test_v2_shared_conversation_logic.mjs
+```
+
+### Known limitations
+
+- **Deep research, URL access and source review are not applied.** They make a message a
+  request to the assistant, but `_build_collaboration_stream_request_payload` does not
+  forward `deep_research_enabled`, `source_review_enabled` or `url_access_enabled` to the
+  chat stream it bridges to. This is existing server behaviour and affects the classic
+  interface identically.
+- **A dropped stream cannot be resumed** in a shared conversation, as described above.
+- **Retry, edit, attempt navigation and fork** are unavailable, matching the classic
+  interface.

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,37 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/features) and [Fixes by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/fixes).
 
+### **(v0.261.034)**
+
+#### Bug Fixes
+
+*   **Shared Conversations Opened Empty In The V2 Interface**
+    *   Clicking a shared conversation in the new interface showed a thread with no messages in it. The interface loaded every conversation's messages from the personal chat API, which does not hold shared conversations and answers with an empty list rather than an error, so the conversation opened successfully with nothing in it — and remained the target of the next message sent.
+    *   Shared conversations are now read from the collaboration API they actually live in, in both the personal and the group case.
+    *   (Ref: V2 chat, `/api/get_messages`, `/api/collaboration/conversations`)
+
+#### New Features
+
+*   **Shared Conversations In The V2 Interface**
+    *   The new interface now supports shared conversations in full, matching the classic one. Both shared personal and shared group conversations can be read, replied to and managed there.
+    *   **Messages say who wrote them.** Another participant's message appears on the left with their name above it, and your own on the right as before. Uploads shared into the conversation are shown as named attachments, and a message that asked the assistant is labelled as such.
+    *   **The assistant only answers when asked.** As in the classic interface, a message in a shared conversation goes to the other people in it and not to the model — unless it `@`-mentions a model or an agent, or you have turned on an assistant tool such as document search, web search, image generation, deep research, reading URLs, an agent or a saved prompt. Tagging a model or agent uses that one for the message, whatever the pickers hold.
+    *   **Type `@` to mention somebody.** The menu offers the people already in the conversation, the models and agents you can address, and — if you can manage members — people you could add. Choosing one of the last group invites them.
+    *   **The conversation stays live.** Messages other people write appear as they are sent, along with a "typing" indicator, and deletions and masks applied by others are reflected straight away. You are told when somebody mentions you.
+    *   **Reply to a specific message** with the reply button on any message; the reply shows what it is answering.
+    *   **Share an existing conversation** from the new **people** button in the chat header, or **Share** in the conversation's menu in the left rail. The same panel manages who is in the conversation, promotes members to admin, removes people, and lets you leave it or delete it for everyone. What you are offered follows what you are actually allowed to do.
+    *   **Invitations** are shown above the conversation with **Join** and **Decline**. You can read an invited conversation before joining, so you can see what you are being invited to.
+    *   **Files the assistant generates** in a shared conversation are held back until approved, and anything waiting on your decision is listed above the thread with Approve and Deny.
+    *   Retry, edit, attempt navigation and fork are not offered in a shared conversation, matching the classic interface — those actions have no equivalent there.
+    *   Requires **Collaborative conversations** to be enabled in admin settings. With it off, none of these controls appear.
+    *   (Ref: V2 chat, collaboration API, participants panel, mentions, live updates)
+
+#### User Interface Enhancements
+
+*   **Mentioning Somebody No Longer Notifies The Wrong Person**
+    *   Where one person's display name is the start of another's — "Ada" and "Ada Lovelace" — writing "@Ada Lovelace" also counted as mentioning "Ada", and notified them. The longer name now claims its own text, so only the person actually named is notified. Naming both people in one message still notifies both.
+    *   (Ref: shared conversations, mentions)
+
 ### **(v0.261.033)**
 
 #### New Features

--- a/docs/guides/collaborate-in-a-conversation.md
+++ b/docs/guides/collaborate-in-a-conversation.md
@@ -57,6 +57,19 @@ Use a shared conversation when the discussion, prompts, AI responses, and genera
 
 9. Approve the file to make it downloadable, or deny it if it should not be released. Requesters cannot approve their own generated files.
 
+## In the V2 interface
+
+The same shared conversations work in the V2 interface, with the controls in different places.
+
+- **Share a conversation, or manage who is in one**: the people button in the chat header, or **Share** in the conversation's menu in the left rail. Both open the same panel, which also promotes members to admin, removes people, and lets you leave the conversation or delete it for everyone.
+- **Accept an invitation**: a prompt above the conversation offers **Join** and **Decline**. You can read an invited conversation before joining, but the composer stays disabled until you do.
+- **Mention somebody**: type `@` in the composer. The menu lists the people already in the conversation, then the models and agents you can address, then people you could add. Use the arrow keys and press **Tab** or **Enter** to accept the highlighted suggestion.
+- **Ask the assistant**: `@`-mention a model or agent, or turn on an assistant tool such as document search, web search, image generation, deep research, reading URLs, an agent, or a saved prompt. A message with none of those goes to the other participants only, exactly as in the classic interface.
+- **Reply to a specific message**: the reply button on any message. The reply shows what it is answering.
+- **Approve a generated file**: files waiting on your decision are listed above the conversation with **Approve** and **Deny**, rather than on the message that produced them.
+
+Retry, edit, attempt navigation, and fork are not offered in a shared conversation in either interface; those actions have no shared-conversation equivalent.
+
 ## Verify it worked
 
 The conversation appears with a shared or collaborative indicator, the participant list shows accepted or pending members, and new shared messages appear for each accepted participant. A completed `@` mention appears in the message text. A participant-generated file stays unavailable while approval is pending and becomes downloadable only after an authorized approver approves it.

--- a/functional_tests/test_support/tsResolve.mjs
+++ b/functional_tests/test_support/tsResolve.mjs
@@ -1,0 +1,39 @@
+// tsResolve.mjs
+//
+// Lets a functional test import the V2 TypeScript modules directly.
+//
+// Node strips TypeScript types since 22.6, so the real module can be executed rather than a
+// copy of it — which is the whole point, since a copy proves nothing about the code that
+// ships. What Node does not do is resolve an extensionless specifier: the application writes
+// `import { ... } from './agents'`, as a bundler expects, and Node looks for a file called
+// exactly `agents`.
+//
+// Rewriting every application import to carry a `.ts` extension purely so a test can run it
+// would be the test dictating the source. Registering a resolver here instead keeps the
+// application untouched and keeps each test runnable with a plain `node <file>.mjs`.
+//
+// Importing this module registers the hook. It must therefore be imported *statically*,
+// before the modules under test are pulled in with `await import(...)`, because a static
+// import is evaluated before the importing module's own body runs.
+
+import { registerHooks } from 'node:module';
+
+/** Specifiers that already name a file extension and must be left alone. */
+const HAS_EXTENSION = /\.[cm]?[jt]sx?$|\.json$/i;
+
+registerHooks({
+    resolve(specifier, context, nextResolve) {
+        if (specifier.startsWith('.') && !HAS_EXTENSION.test(specifier)) {
+            // Tried first, and only for relative specifiers: a bare specifier is a package,
+            // and appending `.ts` to one would break node_modules resolution entirely.
+            for (const candidate of [`${specifier}.ts`, `${specifier}.tsx`]) {
+                try {
+                    return nextResolve(candidate, context);
+                } catch {
+                    /* Not this extension; fall through to the next, then to the original. */
+                }
+            }
+        }
+        return nextResolve(specifier, context);
+    },
+});

--- a/functional_tests/test_v2_api_payload_shapes.py
+++ b/functional_tests/test_v2_api_payload_shapes.py
@@ -89,10 +89,10 @@ def test_mark_read_is_conditional_and_routed_by_conversation_kind():
     )
 
     chat_store = _read(V2_SRC / "stores" / "chatStore.ts")
-    assert "conversation?.has_unread_assistant_response" in chat_store, (
+    assert "listed?.has_unread_assistant_response" in chat_store, (
         "mark-read must only be called when the conversation is actually unread"
     )
-    assert "conversation.conversation_kind === 'collaborative'" in chat_store, (
+    assert "markConversationRead(conversationId, kind === 'collaborative')" in chat_store, (
         "mark-read must be routed using the conversation kind"
     )
 

--- a/functional_tests/test_v2_conversation_deep_link.py
+++ b/functional_tests/test_v2_conversation_deep_link.py
@@ -192,15 +192,47 @@ def test_a_dead_link_is_reported_and_does_not_strand_itself():
     assert action, "openLinkedConversation should be implemented"
     body = action.group(0)
 
-    # /api/get_messages is not an existence check: route_backend_conversations.py catches the
-    # not-found LookupError and answers `{'messages': []}` with a 200. Relying on it would
-    # open a deleted conversation as an empty chat, leave its id in the URL, and leave it as
-    # the target of the next message sent. The metadata endpoint 404s and 403s instead.
-    existence_check = body.index("await fetchConversationMetadata(conversationId)")
-    select = body.index("await get().selectConversation(conversationId)")
+    # Neither message endpoint is an existence check: route_backend_conversations.py catches
+    # the not-found LookupError and answers `{'messages': []}` with a 200, and the
+    # collaboration counterpart answers the same way for a conversation with no messages yet.
+    # Relying on either would open a deleted conversation as an empty chat, leave its id in
+    # the URL, and leave it as the target of the next message sent.
+    #
+    # Since v0.261.034 the probe is `resolveConversationKind`, because the question "does
+    # this exist" and the question "which API family owns it" have the same answer: it asks
+    # the personal metadata endpoint, which 404s and 403s, and then the collaboration one,
+    # which does the same. `requireExists` is what makes a conversation neither recognises a
+    # rejection rather than a default.
+    existence_check = body.index(
+        "await resolveConversationKind(conversationId, { requireExists: true })"
+    )
+    select = body.index("await get().selectConversation(conversationId, {")
+    assert "kind: resolved.kind" in body, (
+        "The kind the probe resolved must be handed to selectConversation rather than "
+        "resolved a second time"
+    )
     assert existence_check < select, (
         "The conversation must be shown to exist before it is opened, because "
         "/api/get_messages answers 200 with an empty list when it does not"
+    )
+
+    # The probe itself must still be a real existence check against both families, rather
+    # than something that quietly defaults.
+    resolver = re.search(
+        r"async function resolveConversationKind\((.|\n)*?\n\}", source
+    )
+    assert resolver, "resolveConversationKind should be implemented"
+    resolver_body = resolver.group(0)
+    assert "await fetchConversationMetadata(conversationId)" in resolver_body, (
+        "The personal metadata endpoint is what answers 404 and 403 for a personal conversation"
+    )
+    assert "await fetchCollaborationConversation(conversationId)" in resolver_body, (
+        "A shared conversation is not in the personal metadata endpoint and must be probed "
+        "through its own"
+    )
+    assert "if (options.requireExists)" in resolver_body, (
+        "A link naming a conversation neither endpoint recognises must be rejected, not "
+        "defaulted to personal"
     )
 
     assert "toast.error(" in body, "An unopenable link must say so rather than look dead"

--- a/functional_tests/test_v2_message_actions.py
+++ b/functional_tests/test_v2_message_actions.py
@@ -145,7 +145,11 @@ def test_delete_sends_its_option_in_the_body():
     )
 
     store = _read(V2_SRC / "stores" / "chatStore.ts")
-    remove_block = store[store.index("removeMessage: async") :][:900]
+    # Sliced to the end of the action rather than a fixed character budget, so the assertion
+    # survives the body growing -- it gained a branch in v0.261.034 for shared
+    # conversations, whose messages are deleted through their own endpoint.
+    remove_start = store.index("removeMessage: async")
+    remove_block = store[remove_start : store.index("retryMessage: async", remove_start)]
     assert "reloadMessages()" in remove_block, (
         "Deletion is soft when archiving is enabled, so the list must be re-read rather "
         "than trusting the optimistic removal"
@@ -181,11 +185,18 @@ def test_action_row_differs_by_role():
 
     actions = _read(V2_SRC / "components" / "chat" / "MessageActions.tsx")
 
-    assert "isUser && onEdit" in actions, "Edit must be offered only on user messages"
+    # Edit resends the message as a new thread attempt, which only the personal conversation
+    # API can do, so since v0.261.034 it additionally requires not being in a shared
+    # conversation. The role condition is what this test is about and is unchanged.
+    assert "isUser && !shared && onEdit" in actions, (
+        "Edit must be offered only on user messages"
+    )
     assert "!isUser && feedbackEnabled" in actions, (
         "Feedback must be offered only on assistant messages"
     )
-    assert "!isUser && (" in actions, "Fork must be offered only on assistant messages"
+    assert "!isUser && !shared && (" in actions, (
+        "Fork must be offered only on assistant messages"
+    )
 
     # The overflow menu opens upward by default and would render off-screen for messages
     # near the top of the scroll area, so it flips when there is no room.

--- a/functional_tests/test_v2_shared_conversation_logic.mjs
+++ b/functional_tests/test_v2_shared_conversation_logic.mjs
@@ -1,0 +1,666 @@
+// test_v2_shared_conversation_logic.mjs
+//
+// Runtime test for the pure logic behind V2 shared conversations.
+// Version: 0.261.034
+// Implemented in: 0.261.034
+//
+// The companion test, test_v2_shared_conversations.py, asserts that the V2 modules are wired
+// to the right endpoints and that the actions with no collaboration counterpart are hidden.
+// Those are source assertions: they prove the pieces are connected, not that they behave.
+//
+// This file executes the two decisions that are pure logic and where a quiet mistake is
+// invisible until somebody is harmed by it:
+//
+//   1. The send rule. Getting it wrong either sends a private remark between colleagues to
+//      the model, or silently swallows a question addressed to it.
+//   2. The mention grammar. A mention that fails to match means the named person is never
+//      notified; one that over-matches notifies the wrong person.
+//
+// Also covered is the event-stream replay guard, because failing it re-appends an entire
+// conversation on every reconnect.
+//
+// Run directly with `node functional_tests/test_v2_shared_conversation_logic.mjs`. Requires
+// Node 22.6 or newer, which strips the TypeScript types so the real modules can be imported
+// rather than a copy of them.
+
+import assert from 'node:assert/strict';
+// Registers the resolver that lets the real V2 modules be imported by their bundler-style
+// specifiers. Must be static, and must come before the dynamic imports below, because a
+// static import is evaluated before this module's own body runs.
+import './test_support/tsResolve.mjs';
+
+const {
+    buildMentionSuggestions,
+    extractMentionedParticipants,
+    findMentionAtCaret,
+    mentionsCurrentUser,
+    mentionsName,
+    replaceMention,
+    resolveInvocationTarget,
+    resolveSendTarget,
+    shouldInvokeAi,
+} = await import('../application/v2_ui/src/lib/mentions.ts');
+const {
+    conversationFactsOnly,
+    dispatchCollaborationEvent,
+    isReplayedEvent,
+    parseEventTimestamp,
+} = await import('../application/v2_ui/src/lib/collaborationEvents.ts');
+const {
+    buildReplyPreview,
+    isAiRequest,
+    isOwnMessage,
+    messageAuthorName,
+    resolveReplyContext,
+} = await import('../application/v2_ui/src/lib/sharedMessage.ts');
+const { canShareConversation, panelTargetForConversation } = await import(
+    '../application/v2_ui/src/lib/sharing.ts'
+);
+
+const checks = [];
+function check(name, fn) {
+    checks.push([name, fn]);
+}
+
+const AGENTS = [
+    { id: 'agent-1', name: 'researcher', display_name: 'Research Assistant', scope_type: 'personal' },
+    { id: 'agent-2', name: 'sam', display_name: 'Sam', scope_type: 'global' },
+];
+
+const MODELS = [
+    { selection_key: 'user::ep1::gpt-4o', display_name: 'GPT-4o', deployment_name: 'gpt-4o', endpoint_id: 'ep1' },
+    { selection_key: 'user::ep1::o3', display_name: 'o3', deployment_name: 'o3', endpoint_id: 'ep1' },
+];
+
+const CATALOGS = { agents: AGENTS, models: MODELS };
+
+const PARTICIPANTS = [
+    { user_id: 'u1', display_name: 'Ada Lovelace', email: 'ada@example.com' },
+    { user_id: 'u2', display_name: 'Ada', email: 'ada2@example.com' },
+    { user_id: 'u3', display_name: 'Grace Hopper', email: 'grace@example.com' },
+];
+
+const NOTHING_ENABLED = {
+    documentSearch: false,
+    webSearch: false,
+    imageGeneration: false,
+    deepResearch: false,
+    urlAccess: false,
+};
+
+/* ------------------------------- the send rule ------------------------------- */
+
+check('a plain remark between people does not reach the model', () => {
+    // The whole point of a shared conversation: most messages are for the other humans.
+    assert.equal(shouldInvokeAi('are we still meeting at four?', NOTHING_ENABLED, CATALOGS), false);
+    assert.equal(resolveSendTarget('nice work on that', NOTHING_ENABLED, CATALOGS), null);
+});
+
+check('mentioning a participant does not invoke the model', () => {
+    // Naming a colleague notifies them. It must not also send the message to the AI, or
+    // every "@Ada could you look at this" would produce an unwanted answer.
+    assert.equal(
+        shouldInvokeAi('@Ada Lovelace could you look at this?', NOTHING_ENABLED, CATALOGS),
+        false,
+    );
+});
+
+check('tagging an agent invokes it', () => {
+    const target = resolveSendTarget('@Sam what do you make of this?', NOTHING_ENABLED, CATALOGS);
+    assert.equal(target.target_type, 'agent');
+    assert.equal(target.display_name, 'Sam');
+    assert.equal(target.source_mode, 'explicit_tag');
+    // Carried so the send can select that agent for this message alone, overriding the picker.
+    assert.equal(target.agent_selection_key, 'agent-2');
+});
+
+check('tagging a model invokes it and carries its selection key', () => {
+    const target = resolveSendTarget('@GPT-4o summarise the thread', NOTHING_ENABLED, CATALOGS);
+    assert.equal(target.target_type, 'model');
+    assert.equal(target.selection_key, 'user::ep1::gpt-4o');
+});
+
+check('the longest matching name wins', () => {
+    // "Research Assistant" contains no other target, but a shorter name that is a prefix of
+    // a longer one must not win: tagging @Sam and @Samuel has to be distinguishable.
+    const agents = [
+        { id: 'a', name: 'sam', display_name: 'Sam' },
+        { id: 'b', name: 'samuel', display_name: 'Samuel' },
+    ];
+    const target = resolveInvocationTarget('@Samuel please help', agents, []);
+    assert.equal(target.display_name, 'Samuel');
+});
+
+check('an AI toggle invokes the model without any tag', () => {
+    // Matches buildCollaborativeInvocationTarget: an option that only makes sense as a
+    // request to the assistant is itself the request.
+    for (const [key, mode] of [
+        ['imageGeneration', 'image_generation'],
+        ['deepResearch', 'deep_research'],
+        ['urlAccess', 'url_access'],
+        ['webSearch', 'web_search'],
+        ['documentSearch', 'workspace'],
+    ]) {
+        const target = resolveSendTarget('go on then', { ...NOTHING_ENABLED, [key]: true }, CATALOGS);
+        assert.ok(target, `${key} should invoke the assistant`);
+        assert.equal(target.source_mode, mode);
+    }
+});
+
+check('a selected agent invokes the assistant', () => {
+    const target = resolveSendTarget(
+        'have a look',
+        { ...NOTHING_ENABLED, agentSelection: 'agent-1' },
+        CATALOGS,
+    );
+    assert.equal(target.source_mode, 'agent');
+    assert.equal(target.display_name, 'Research Assistant');
+});
+
+check('a saved prompt invokes the assistant', () => {
+    const target = resolveSendTarget('...', { ...NOTHING_ENABLED, promptId: 'p1' }, CATALOGS);
+    assert.equal(target.source_mode, 'prompt');
+});
+
+check('the precedence order matches the classic client', () => {
+    // Several options at once must be attributed consistently. Image generation outranks an
+    // agent, which outranks deep research, and so on.
+    const all = {
+        ...NOTHING_ENABLED,
+        imageGeneration: true,
+        deepResearch: true,
+        webSearch: true,
+        documentSearch: true,
+        agentSelection: 'agent-1',
+    };
+    assert.equal(resolveSendTarget('x', all, CATALOGS).source_mode, 'image_generation');
+
+    const withoutImage = { ...all, imageGeneration: false };
+    assert.equal(resolveSendTarget('x', withoutImage, CATALOGS).source_mode, 'agent');
+
+    const withoutAgent = { ...withoutImage, agentSelection: undefined };
+    assert.equal(resolveSendTarget('x', withoutAgent, CATALOGS).source_mode, 'deep_research');
+
+    const withoutDeep = { ...withoutAgent, deepResearch: false };
+    assert.equal(resolveSendTarget('x', withoutDeep, CATALOGS).source_mode, 'web_search');
+
+    const workspaceOnly = { ...withoutDeep, webSearch: false };
+    assert.equal(resolveSendTarget('x', workspaceOnly, CATALOGS).source_mode, 'workspace');
+});
+
+check('an explicit tag beats an enabled toggle', () => {
+    // The tag names something specific; the toggle is ambient. Reading the toggle first
+    // would send an @-addressed question to whatever the picker happened to hold.
+    const target = resolveSendTarget(
+        '@o3 have a think',
+        { ...NOTHING_ENABLED, webSearch: true, agentSelection: 'agent-1' },
+        CATALOGS,
+    );
+    assert.equal(target.target_type, 'model');
+    assert.equal(target.selection_key, 'user::ep1::o3');
+});
+
+/* ----------------------------- mention matching ------------------------------ */
+
+check('a mention needs a boundary on both sides', () => {
+    assert.equal(mentionsName('hello @Sam', 'Sam'), true);
+    assert.equal(mentionsName('@Sam hello', 'Sam'), true);
+    assert.equal(mentionsName('hi @Sam, welcome', 'Sam'), true);
+    assert.equal(mentionsName('hi @Sam.', 'Sam'), true);
+    // Without the trailing boundary, @Sam would also match @Samantha and notify the wrong
+    // person.
+    assert.equal(mentionsName('hi @Samantha', 'Sam'), false);
+    // Without the leading boundary, an email address becomes a mention.
+    assert.equal(mentionsName('write to me@Sam.example', 'Sam'), false);
+});
+
+check('the longest participant name wins when one is a prefix of another', () => {
+    // Two real people, "Ada Lovelace" and "Ada". Reporting both would notify somebody who
+    // was never addressed.
+    const mentioned = extractMentionedParticipants('@Ada Lovelace can you check', PARTICIPANTS);
+    assert.deepEqual(mentioned.map((p) => p.user_id), ['u1']);
+
+    const shorter = extractMentionedParticipants('@Ada can you check', PARTICIPANTS);
+    assert.deepEqual(shorter.map((p) => p.user_id), ['u2']);
+});
+
+check('several people can be mentioned at once', () => {
+    const mentioned = extractMentionedParticipants('@Ada Lovelace and @Grace Hopper', PARTICIPANTS);
+    assert.deepEqual(mentioned.map((p) => p.user_id).sort(), ['u1', 'u3']);
+});
+
+check('two people whose names overlap can both be named', () => {
+    // "@Ada Lovelace" strikes out its own span, so the separate "@Ada" later in the message
+    // is still found. Consuming matches must not cost a genuine second mention.
+    const mentioned = extractMentionedParticipants(
+        '@Ada Lovelace wrote it, and @Ada reviewed it',
+        PARTICIPANTS,
+    );
+    assert.deepEqual(mentioned.map((p) => p.user_id).sort(), ['u1', 'u2']);
+});
+
+check('mention matching is case insensitive', () => {
+    assert.deepEqual(
+        extractMentionedParticipants('@ada lovelace', PARTICIPANTS).map((p) => p.user_id),
+        ['u1'],
+    );
+});
+
+check('a message with no mentions reports none', () => {
+    assert.deepEqual(extractMentionedParticipants('nothing here', PARTICIPANTS), []);
+    assert.deepEqual(extractMentionedParticipants('', PARTICIPANTS), []);
+    assert.deepEqual(extractMentionedParticipants('@Ada', undefined), []);
+});
+
+check('being mentioned is read from the stored ids, not the text', () => {
+    assert.equal(mentionsCurrentUser({ mentioned_user_ids: ['u1', 'u2'] }, 'u2'), true);
+    assert.equal(mentionsCurrentUser({ mentioned_user_ids: ['u1'] }, 'u2'), false);
+    assert.equal(mentionsCurrentUser({}, 'u2'), false);
+    assert.equal(mentionsCurrentUser({ mentioned_user_ids: ['u2'] }, undefined), false);
+});
+
+/* --------------------------- typing a mention -------------------------------- */
+
+check('an @ opens a mention only at a word boundary', () => {
+    assert.deepEqual(findMentionAtCaret('@Ad', 3), { query: 'Ad', startIndex: 0, endIndex: 3 });
+    assert.deepEqual(findMentionAtCaret('hi @Ad', 6), { query: 'Ad', startIndex: 3, endIndex: 6 });
+    // An email address must not turn the rest of the line into a mention search.
+    assert.equal(findMentionAtCaret('mail me@example', 15), null);
+    assert.equal(findMentionAtCaret('no mention here', 15), null);
+});
+
+check('typing @ alone opens the menu with an empty query', () => {
+    // Otherwise the menu only appears after a character, and there is no way to browse.
+    assert.deepEqual(findMentionAtCaret('hello @', 7), { query: '', startIndex: 6, endIndex: 7 });
+});
+
+check('a mention ends at a newline', () => {
+    assert.equal(findMentionAtCaret('@Ada\nnext line', 14), null);
+});
+
+check('a name with a space keeps matching as it is typed', () => {
+    // The token runs to the caret rather than to the next space, which is what lets
+    // "Ada Lovelace" be completed.
+    assert.deepEqual(findMentionAtCaret('hi @Ada Love', 12), {
+        query: 'Ada Love',
+        startIndex: 3,
+        endIndex: 12,
+    });
+});
+
+check('replacing a mention leaves one space and a sane caret', () => {
+    const match = findMentionAtCaret('hi @Ad', 6);
+    const { value, caretIndex } = replaceMention('hi @Ad', match, '@Ada Lovelace');
+    assert.equal(value, 'hi @Ada Lovelace ');
+    assert.equal(caretIndex, value.length);
+
+    // Not a second space when the text already continues with one.
+    const midMatch = findMentionAtCaret('hi @Ad there', 6);
+    assert.equal(replaceMention('hi @Ad there', midMatch, '@Ada').value, 'hi @Ada there');
+});
+
+/* ------------------------------ the mention menu ----------------------------- */
+
+check('the menu offers participants, then AI targets, then invitations', () => {
+    const rows = buildMentionSuggestions({
+        query: '',
+        participants: PARTICIPANTS,
+        agents: AGENTS,
+        models: MODELS,
+        invitable: [{ user_id: 'u9', display_name: 'Alan Turing' }],
+        canInvite: true,
+        currentUserId: 'me',
+        limit: 20,
+    });
+    const kinds = rows.map((row) => row.kind);
+    assert.equal(kinds.indexOf('participant'), 0);
+    assert.ok(kinds.indexOf('ai') > kinds.lastIndexOf('participant'));
+    assert.ok(kinds.indexOf('invite') > kinds.lastIndexOf('ai'));
+});
+
+check('nobody already in the conversation is offered as an invitation', () => {
+    // Otherwise the menu suggests adding somebody who is already there, and the server
+    // rejects it.
+    const rows = buildMentionSuggestions({
+        query: 'Ada',
+        participants: PARTICIPANTS,
+        invitable: [{ user_id: 'u1', display_name: 'Ada Lovelace' }],
+        canInvite: true,
+        limit: 20,
+    });
+    assert.equal(rows.filter((row) => row.kind === 'invite').length, 0);
+});
+
+check('invitations are withheld from somebody who may not invite', () => {
+    const rows = buildMentionSuggestions({
+        query: '',
+        participants: PARTICIPANTS,
+        invitable: [{ user_id: 'u9', display_name: 'Alan Turing' }],
+        canInvite: false,
+        limit: 20,
+    });
+    assert.equal(rows.some((row) => row.kind === 'invite'), false);
+});
+
+check('the reader is never offered as somebody to invite', () => {
+    const rows = buildMentionSuggestions({
+        query: '',
+        invitable: [{ user_id: 'me', display_name: 'Me' }],
+        canInvite: true,
+        currentUserId: 'me',
+        limit: 20,
+    });
+    assert.equal(rows.length, 0);
+});
+
+/* ------------------------------ event handling ------------------------------- */
+
+check('a timestamp without a zone is read as UTC', () => {
+    // utc_now_iso does not always emit a designator, and Date.parse reads a bare timestamp
+    // as local time. West of UTC that makes replayed history look like the future, so
+    // nothing is ever recognised as a replay and the whole thread re-appends.
+    assert.equal(parseEventTimestamp('2026-01-01T00:00:00'), Date.parse('2026-01-01T00:00:00Z'));
+    assert.equal(parseEventTimestamp('2026-01-01T00:00:00Z'), Date.parse('2026-01-01T00:00:00Z'));
+    assert.ok(Number.isNaN(parseEventTimestamp('')));
+});
+
+check('history replayed on attach is not treated as new', () => {
+    const subscribedAt = Date.parse('2026-01-01T12:00:00Z');
+    const old = { occurred_at: '2026-01-01T11:00:00Z' };
+    const live = { occurred_at: '2026-01-01T12:00:05Z' };
+    assert.equal(isReplayedEvent(old, subscribedAt), true);
+    assert.equal(isReplayedEvent(live, subscribedAt), false);
+});
+
+check('an event in the same instant as the subscription is live', () => {
+    // Clock skew is real, and a message published as the stream opened is genuinely new.
+    const subscribedAt = Date.parse('2026-01-01T12:00:00Z');
+    assert.equal(isReplayedEvent({ occurred_at: '2026-01-01T11:59:59.500Z' }, subscribedAt), false);
+});
+
+check('an unparseable timestamp is treated as live', () => {
+    // Dropping a real message is worse than repeating one, and de-duplication catches the
+    // repeat either way.
+    assert.equal(isReplayedEvent({ occurred_at: 'not a date' }, Date.now()), false);
+});
+
+check('each event type reaches its own handler', () => {
+    const seen = [];
+    const handlers = {
+        onMessageCreated: () => seen.push('created'),
+        onMessageDeleted: () => seen.push('deleted'),
+        onMessageMasked: () => seen.push('masked'),
+        onTyping: () => seen.push('typing'),
+        onMembersInvited: () => seen.push('invited'),
+        onMemberRemoved: () => seen.push('removed'),
+        onMemberRoleUpdated: () => seen.push('role'),
+        onInviteAnswered: (_p, accepted) => seen.push(accepted ? 'accepted' : 'declined'),
+        onConversationDeleted: () => seen.push('conversation-deleted'),
+        onConversationUpdated: () => seen.push('conversation-updated'),
+    };
+
+    dispatchCollaborationEvent(
+        { event_type: 'collaboration.message.created', payload: { message: { id: 'm1' } } },
+        handlers,
+    );
+    dispatchCollaborationEvent(
+        { event_type: 'collaboration.message.deleted', payload: { message_id: 'm1' } },
+        handlers,
+    );
+    dispatchCollaborationEvent(
+        { event_type: 'collaboration.message.masked', payload: { message: { id: 'm1' } } },
+        handlers,
+    );
+    dispatchCollaborationEvent(
+        { event_type: 'collaboration.typing.updated', payload: { user: { user_id: 'u1' } } },
+        handlers,
+    );
+    dispatchCollaborationEvent(
+        { event_type: 'collaboration.invite.declined', payload: { participant: { user_id: 'u1' } } },
+        handlers,
+    );
+    dispatchCollaborationEvent({ event_type: 'collaboration.deleted', payload: {} }, handlers);
+
+    assert.deepEqual(seen, [
+        'created',
+        'deleted',
+        'masked',
+        'typing',
+        'declined',
+        'conversation-deleted',
+    ]);
+});
+
+check('membership events also refresh the conversation they carry', () => {
+    // Those routes serialize the conversation after applying the change, so it is the
+    // freshest membership the client will ever see and must not be dropped.
+    const updates = [];
+    const handlers = { onConversationUpdated: (conversation) => updates.push(conversation.id) };
+
+    dispatchCollaborationEvent(
+        {
+            event_type: 'collaboration.member.removed',
+            payload: { conversation: { id: 'c1' }, participant: { user_id: 'u1' } },
+        },
+        handlers,
+    );
+    dispatchCollaborationEvent(
+        { event_type: 'collaboration.updated', payload: { conversation: { id: 'c2' } } },
+        handlers,
+    );
+    // A message event must NOT go down this path: it fires on every message, and refetching
+    // membership each time would be pointless traffic.
+    dispatchCollaborationEvent(
+        {
+            event_type: 'collaboration.message.created',
+            payload: { conversation: { id: 'c3' }, message: { id: 'm1' } },
+        },
+        handlers,
+    );
+
+    assert.deepEqual(updates, ['c1', 'c2']);
+});
+
+check('an unknown event type is ignored rather than throwing', () => {
+    dispatchCollaborationEvent({ event_type: 'collaboration.future.thing', payload: {} }, {});
+    dispatchCollaborationEvent({}, {});
+});
+
+/* --------------------- broadcast permissions are not mine -------------------- */
+
+check("a broadcast conversation's permissions are dropped", () => {
+    // Every publishing route serializes the conversation for the user who *caused* the
+    // event and broadcasts that one dict to everybody. Applying its `can_*` verbatim means
+    // a member leaving tells everyone else they can no longer post, and an owner acting
+    // hands every member a "Delete for everyone" button the server then refuses.
+    const broadcast = {
+        id: 'c1',
+        title: 'Design review',
+        participants: [{ user_id: 'u1' }, { user_id: 'u2' }],
+        participant_count: 2,
+        message_count: 12,
+        chat_type: 'personal_multi_user',
+        can_post_messages: false,
+        can_manage_members: true,
+        can_manage_roles: true,
+        can_delete_conversation: true,
+        can_leave_conversation: true,
+        can_accept_invite: true,
+        current_user_role: 'owner',
+        membership_status: 'removed',
+        is_pinned: true,
+        is_hidden: true,
+        has_unread_assistant_response: true,
+        last_unread_assistant_message_id: 'm-99',
+        last_unread_assistant_at: '2026-01-01T00:00:00Z',
+    };
+
+    const facts = conversationFactsOnly(broadcast);
+
+    for (const viewerScoped of [
+        'can_post_messages',
+        'can_manage_members',
+        'can_manage_roles',
+        'can_delete_conversation',
+        'can_leave_conversation',
+        'can_accept_invite',
+        'current_user_role',
+        'membership_status',
+        'is_pinned',
+        'is_hidden',
+        // These three are hardcoded per-viewer by serialize_collaboration_conversation, and
+        // matter most on the hot path: applying them from a message.created broadcast would
+        // clear the reader's own unread marker every time anybody else writes.
+        'has_unread_assistant_response',
+        'last_unread_assistant_message_id',
+        'last_unread_assistant_at',
+    ]) {
+        // Asserted present on the fixture first. `hasOwnProperty === false` passes trivially
+        // for a key that was never set, so without this the test would stay green if a field
+        // were dropped from VIEWER_SCOPED_FIELDS.
+        assert.equal(
+            Object.prototype.hasOwnProperty.call(broadcast, viewerScoped),
+            true,
+            `the fixture must carry ${viewerScoped} for its removal to mean anything`,
+        );
+        assert.equal(
+            Object.prototype.hasOwnProperty.call(facts, viewerScoped),
+            false,
+            `${viewerScoped} belongs to whoever triggered the event and must not be applied`,
+        );
+    }
+
+    // Everything that means the same to every reader survives, or the title and participant
+    // list would stop updating.
+    assert.equal(facts.id, 'c1');
+    assert.equal(facts.title, 'Design review');
+    assert.equal(facts.participant_count, 2);
+    assert.equal(facts.message_count, 12);
+    assert.deepEqual(facts.participants, [{ user_id: 'u1' }, { user_id: 'u2' }]);
+
+    // The original is untouched, so a caller that legitimately holds its own copy is unharmed.
+    assert.equal(broadcast.can_post_messages, false);
+});
+
+/* ---------------------------- message attribution ---------------------------- */
+
+const sharedMessage = (id, senderId, name, extra = {}) => ({
+    id,
+    conversation_id: 'c1',
+    role: 'user',
+    content: `content of ${id}`,
+    sender: { user_id: senderId, display_name: name },
+    ...extra,
+});
+
+check('a personal message is attributed to nobody', () => {
+    // No sender means no attribution line, which is what keeps personal conversations
+    // looking exactly as they did.
+    assert.equal(messageAuthorName({ id: 'm', role: 'user', content: 'hi' }, 'me'), '');
+    assert.equal(isOwnMessage({ id: 'm', role: 'user', content: 'hi' }, 'me'), false);
+});
+
+check('the reader sees their own name as "You"', () => {
+    assert.equal(messageAuthorName(sharedMessage('m1', 'me', 'Ada'), 'me'), 'You');
+    assert.equal(messageAuthorName(sharedMessage('m2', 'u2', 'Grace'), 'me'), 'Grace');
+    assert.equal(isOwnMessage(sharedMessage('m1', 'me', 'Ada'), 'me'), true);
+});
+
+check('a sender is read from metadata when it is not on the message', () => {
+    const message = {
+        id: 'm',
+        role: 'user',
+        content: 'hi',
+        metadata: { sender: { user_id: 'u2', display_name: 'Grace' } },
+    };
+    assert.equal(messageAuthorName(message, 'me'), 'Grace');
+});
+
+check('an AI request is distinguishable from a plain message', () => {
+    // Both are role 'user'. Only message_kind separates them.
+    assert.equal(isAiRequest(sharedMessage('m', 'u1', 'Ada', { message_kind: 'ai_request' })), true);
+    assert.equal(isAiRequest(sharedMessage('m', 'u1', 'Ada', { message_kind: 'human_message' })), false);
+    assert.equal(isAiRequest({ id: 'm', role: 'user', content: 'x' }), false);
+});
+
+check('a reply resolves against the loaded thread', () => {
+    const target = sharedMessage('m1', 'u2', 'Grace');
+    const reply = sharedMessage('m2', 'me', 'Ada', { reply_to_message_id: 'm1' });
+    const context = resolveReplyContext(reply, [target, reply], 'me');
+    assert.equal(context.message_id, 'm1');
+    assert.equal(context.display_name, 'Grace');
+    assert.equal(context.preview, 'content of m1');
+});
+
+check('a reply to a message that is not loaded renders nothing', () => {
+    // It may have been deleted, or be above the loaded part of the thread. An empty quote
+    // would be worse than none.
+    const reply = sharedMessage('m2', 'me', 'Ada', { reply_to_message_id: 'gone' });
+    assert.equal(resolveReplyContext(reply, [reply], 'me'), null);
+    assert.equal(resolveReplyContext(sharedMessage('m3', 'me', 'Ada'), [], 'me'), null);
+});
+
+check('a reply preview is trimmed rather than unbounded', () => {
+    const long = { id: 'm', role: 'user', content: 'x'.repeat(500) };
+    const preview = buildReplyPreview(long);
+    assert.ok(preview.length <= 140);
+    assert.ok(preview.endsWith('\u2026'));
+});
+
+/* ------------------------------- sharing routes ------------------------------ */
+
+check('a personal conversation is shared through the personal conversion route', () => {
+    const target = panelTargetForConversation('c1', { chat_type: 'personal_single_user' });
+    assert.equal(target.kind, 'personal');
+});
+
+check('a group conversation is shared through the group conversion route', () => {
+    // The group route additionally restricts invitees to that group's members, so choosing
+    // the personal one here would offer people the server refuses.
+    const target = panelTargetForConversation('c1', {
+        chat_type: 'group-single-user',
+        group_id: 'g1',
+    });
+    assert.equal(target.kind, 'group');
+    assert.equal(target.groupId, 'g1');
+});
+
+check('an already-shared conversation takes members directly', () => {
+    // Converting a second time would create another shared conversation alongside the
+    // first, which is the failure this distinction exists to prevent.
+    const target = panelTargetForConversation('c1', {
+        conversation_kind: 'collaborative',
+        chat_type: 'group_multi_user',
+        group_id: 'g1',
+    });
+    assert.equal(target.kind, 'collaborative');
+});
+
+check('a public workspace conversation cannot be shared', () => {
+    // There is no conversion route for one, so offering to share it would be an action with
+    // nothing behind it.
+    assert.equal(canShareConversation({ chat_type: 'public' }), false);
+    assert.equal(canShareConversation({ chat_type: 'personal_single_user' }), true);
+    assert.equal(canShareConversation({ chat_type: 'group_multi_user' }), true);
+    assert.equal(canShareConversation(null), false);
+});
+
+/* ----------------------------------- runner ---------------------------------- */
+
+let passed = 0;
+let failed = 0;
+
+for (const [name, fn] of checks) {
+    try {
+        await fn();
+        console.log(`ok   ${name}`);
+        passed += 1;
+    } catch (error) {
+        console.log(`FAIL ${name}`);
+        console.log(`     ${error.message}`);
+        failed += 1;
+    }
+}
+
+console.log(`\n${passed}/${passed + failed} runtime checks passed`);
+process.exit(failed > 0 ? 1 : 0);

--- a/functional_tests/test_v2_shared_conversations.py
+++ b/functional_tests/test_v2_shared_conversations.py
@@ -1,0 +1,682 @@
+#!/usr/bin/env python3
+"""
+Functional test for shared (collaborative) conversations in the V2 interface.
+
+Version: 0.261.034
+Implemented in: 0.261.034
+
+Shared conversations opened in the V2 interface showed an empty thread. V2 loaded every
+conversation with ``/api/get_messages``, which reads only the personal messages container:
+for a conversation that is not in it, ``_authorize_personal_conversation_read`` raises
+``LookupError`` and the route converts that into ``{'messages': []}`` with a **200**
+(route_backend_conversations.py). So a shared conversation opened as an empty chat rather
+than as an error, and every other conversation-scoped action in V2 was likewise wired only
+to the personal routes.
+
+The whole ``/api/collaboration/*`` API already existed and was driven by the classic client
+in ``static/js/chat/chat-collaboration.js``. This change routes V2 through it.
+
+This test ensures the V2 source is wired to that API rather than to the personal one, that
+every collaboration route the classic client uses has a V2 counterpart, and that the
+operations with no collaboration counterpart are hidden rather than offered and then
+failing. The behaviour of the parts that are pure logic -- the send rule, the mention
+grammar and the event replay guard -- is executed by the companion test
+``test_v2_shared_conversation_logic.mjs``.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+V2_SRC = REPO_ROOT / "application" / "v2_ui" / "src"
+APP_ROOT = REPO_ROOT / "application" / "single_app"
+
+sys.path.insert(0, str(REPO_ROOT / "functional_tests"))
+
+from test_support.versioning import assert_app_version_at_least  # noqa: E402
+
+IMPLEMENTED_IN = "0.261.034"
+
+
+def _read(path):
+    return path.read_text(encoding="utf-8")
+
+
+def test_version_is_at_least_the_implementation_version():
+    """The feature cannot be present in a build older than the one that added it."""
+    print("Testing version...")
+    assert_app_version_at_least(
+        IMPLEMENTED_IN,
+        reason="Shared conversation support was added to the V2 interface in this version.",
+    )
+    print("Version test passed!")
+    return True
+
+
+def test_messages_are_read_from_the_collaboration_endpoint():
+    """The reported bug: a shared thread must not be loaded through /api/get_messages.
+
+    That route is not an existence check and not a fallback -- it answers 200 with an empty
+    list for any conversation it cannot find, which is exactly why the failure looked like
+    an empty conversation rather than an error.
+    """
+    print("Testing shared message loading...")
+
+    store = _read(V2_SRC / "stores" / "chatStore.ts")
+
+    assert "fetchCollaborationMessages" in store, (
+        "The store must load a shared conversation's messages from "
+        "/api/collaboration/conversations/<id>/messages"
+    )
+
+    # The choice is made on the conversation's kind, not by trying one endpoint and falling
+    # back, because the personal endpoint does not fail for a shared conversation.
+    assert re.search(
+        r"kind === 'collaborative'\s*\?\s*await fetchCollaborationMessages\(conversationId\)"
+        r"\s*:\s*await fetchMessages\(conversationId\)",
+        store,
+    ), "Message loading must branch on the resolved conversation kind"
+
+    endpoints = _read(V2_SRC / "lib" / "collaboration.ts")
+    assert "`${base(conversationId)}/messages`" in endpoints, (
+        "collaboration.ts must expose the shared messages endpoint"
+    )
+
+    print("Shared message loading test passed!")
+    return True
+
+
+def test_every_collaboration_route_has_a_v2_caller():
+    """Each route the classic client drives must have a V2 counterpart.
+
+    Read out of the Flask blueprint rather than hard-coded, so a route added to the API
+    later fails this test until V2 either uses it or the exemption below is justified.
+    """
+    print("Testing collaboration endpoint coverage...")
+
+    routes = _read(APP_ROOT / "route_backend_collaboration.py")
+    v2_sources = "\n".join(
+        _read(path) for path in sorted((V2_SRC).rglob("*.ts")) if path.is_file()
+    )
+
+    # Path suffixes, since the V2 module builds each URL from a shared `base()` helper and
+    # the literal path never appears in one piece.
+    suffix_by_route = {
+        "/messages": "/messages",
+        "/stream": "/stream",
+        "/stream/cancel": "/stream/cancel",
+        "/events": "/events",
+        "/typing": "/typing",
+        "/mark-read": "/mark-read",
+        "/pin": "/pin",
+        "/hide": "/hide",
+        "/delete-action": "/delete-action",
+        "/members": "/members",
+        "/invite-response": "/invite-response",
+        "/mask": "/mask",
+        "/file-approvals": "/api/collaboration/file-approvals",
+        "/from-personal": "/from-personal/",
+        "/from-group": "/from-group/",
+    }
+
+    for label, needle in suffix_by_route.items():
+        assert needle in v2_sources, (
+            f"No V2 caller found for the {label} collaboration route"
+        )
+
+    # The base collection and item routes, which carry no suffix.
+    assert "'/api/collaboration/conversations?" in v2_sources or (
+        "/api/collaboration/conversations?" in v2_sources
+    ), "V2 must be able to list shared conversations, including pending invitations"
+    assert "api.get<{ conversation: CollaborationConversation }>(base(conversationId)" in (
+        _read(V2_SRC / "lib" / "collaboration.ts")
+    ), "V2 must be able to load one shared conversation with its membership"
+
+    # Sanity check that the suffixes above were not invented: each must appear in the route
+    # definitions too, so a renamed route breaks this test rather than passing silently.
+    for suffix in ("/messages", "/stream/cancel", "/events", "/typing", "/delete-action"):
+        assert f"<conversation_id>{suffix}'" in routes, (
+            f"Expected {suffix} to be a real collaboration route"
+        )
+
+    print("Collaboration endpoint coverage test passed!")
+    return True
+
+
+def test_stream_recovery_is_disabled_for_shared_conversations():
+    """A dropped shared stream must be reported, not retried against the wrong conversation.
+
+    ``/api/chat/stream/reattach`` is keyed on the conversation the generation actually runs
+    in, which for a shared conversation is a hidden source conversation the browser is never
+    told the id of. Reattaching with the shared conversation's id addresses a conversation
+    that endpoint has never heard of. The classic client sets ``allowRecovery: false`` on
+    this path for the same reason.
+    """
+    print("Testing shared stream recovery...")
+
+    sse = _read(V2_SRC / "lib" / "sse.ts")
+    assert "options.allowRecovery !== false" in sse, (
+        "streamChat must honour an allowRecovery override"
+    )
+    assert "options.url ?? apiUrl('/api/chat/stream')" in sse, (
+        "streamChat must accept an endpoint override so the collaboration bridge can be used"
+    )
+
+    store = _read(V2_SRC / "stores" / "chatStore.ts")
+    assert re.search(
+        r"url: streamCollaborationUrl\(conversationId\),(?:.|\n)*?allowRecovery: false",
+        store,
+    ), "A shared conversation must stream with recovery disabled"
+
+    # A shared conversation is also excluded from the resume-on-open path, which calls the
+    # same personal status endpoint.
+    assert "resumeChatStream" in store
+    assert re.search(
+        r"if \(kind === 'collaborative'\)(?:.|\n)*?\} else \{(?:.|\n)*?resumeChatStream",
+        store,
+    ), "Opening a shared conversation must not attempt a personal stream resume"
+
+    print("Shared stream recovery test passed!")
+    return True
+
+
+def test_thread_operations_are_hidden_in_a_shared_conversation():
+    """Retry, edit, attempt navigation and fork have no collaboration counterpart.
+
+    Those endpoints read and rewrite the personal messages container. The classic interface
+    leaves them out of a shared conversation, so hiding them is the parity -- offering a
+    control that cannot work is worse than not offering it.
+    """
+    print("Testing hidden thread operations...")
+
+    actions = _read(V2_SRC / "components" / "chat" / "MessageActions.tsx")
+
+    assert "state.activeConversationKind === 'collaborative'" in actions, (
+        "MessageActions must know whether it is in a shared conversation"
+    )
+    assert "{attempts.show && !shared && (" in actions, (
+        "Attempt navigation must be hidden in a shared conversation"
+    )
+    assert "{!isUser && !shared && (" in actions, (
+        "Fork must be hidden in a shared conversation"
+    )
+    assert "{isUser && !shared && onEdit" in actions, (
+        "Edit must be hidden in a shared conversation"
+    )
+    assert re.search(r"\{shared \?\s*\(\s*canPost && \(", actions), (
+        "Retry must be replaced by Reply in a shared conversation"
+    )
+
+    # None of those endpoints may be reachable from the shared path.
+    for personal_only in ("/retry", "/edit", "/switch-attempt", "forkConversation"):
+        assert personal_only not in _read(V2_SRC / "lib" / "collaboration.ts"), (
+            f"{personal_only} has no collaboration counterpart and must not be called on one"
+        )
+
+    print("Hidden thread operations test passed!")
+    return True
+
+
+def test_conversation_actions_route_by_kind():
+    """Rename, pin, hide and removal must each reach the API family that owns them."""
+    print("Testing conversation action routing...")
+
+    store = _read(V2_SRC / "stores" / "chatStore.ts")
+
+    assert re.search(
+        r"if \(collaborative\) \{\s*await renameCollaborationConversation", store
+    ), "Rename must route to the collaboration endpoint"
+    assert "toggleCollaborationPinned(conversationId)" in store, (
+        "Pin must route to the collaboration endpoint"
+    )
+    assert "toggleCollaborationHidden(conversationId)" in store, (
+        "Hide must route to the collaboration endpoint"
+    )
+
+    # Removing a shared conversation is not necessarily a deletion: only an owner may
+    # destroy one for everybody, and everybody else leaves it.
+    assert "detail?.can_delete_conversation ? 'delete' : 'leave'" in store, (
+        "Removing a shared conversation must leave it unless the caller may delete it"
+    )
+    assert "collaborationDeleteAction(conversationId, action)" in store
+
+    # Per-message actions likewise.
+    assert "deleteCollaborationMessage(conversationId, messageId)" in store
+    assert "maskCollaborationMessage(conversationId, messageId" in store
+
+    print("Conversation action routing test passed!")
+    return True
+
+
+def test_capabilities_come_from_the_server():
+    """What the reader may do is the server's decision, not a rule reimplemented here.
+
+    ``serialize_collaboration_conversation`` folds together membership status, role,
+    visibility mode and whether membership is explicit at all, and a group-visibility
+    conversation grants posting with no membership record to inspect. A client-side guess
+    would offer controls the server then refuses.
+    """
+    print("Testing capability gating...")
+
+    serializer = _read(APP_ROOT / "functions_collaboration.py")
+    for flag in (
+        "can_post_messages",
+        "can_manage_members",
+        "can_manage_roles",
+        "can_accept_invite",
+        "can_delete_conversation",
+        "can_leave_conversation",
+    ):
+        assert f"'{flag}':" in serializer, (
+            f"{flag} is expected to be reported by serialize_collaboration_conversation"
+        )
+
+    composer = _read(V2_SRC / "components" / "chat" / "Composer.tsx")
+    assert "collaboration?.can_post_messages === true" in composer, (
+        "The composer must be gated on the server's can_post_messages, and deny by default: "
+        "a membership that has not loaded is not permission"
+    )
+    assert "disabled={!canPost}" in composer, (
+        "The textarea must be disabled when the reader may not post"
+    )
+    # An "Add to this conversation" row is an action. Inserting the name without performing
+    # it leaves a dead control: the mention list is resolved against existing participants
+    # only, and the server filters it again, so the person is neither added nor mentioned.
+    assert "suggestion.kind === 'invite'" in composer, (
+        "Choosing an invitable person from the mention menu must actually invite them"
+    )
+    assert ".inviteParticipants([" in composer
+
+    actions = _read(V2_SRC / "components" / "chat" / "MessageActions.tsx")
+    assert "loadedCollaboration?.can_post_messages === true" in actions, (
+        "Reply must be gated on the same flag, and on the loaded conversation being this one"
+    )
+
+    panel = _read(V2_SRC / "components" / "chat" / "ParticipantsPanel.tsx")
+    for flag in (
+        "can_manage_members",
+        "can_manage_roles",
+        "can_delete_conversation",
+        "can_leave_conversation",
+    ):
+        assert flag in panel, f"The participants panel must gate on {flag}"
+
+    banner = _read(V2_SRC / "components" / "chat" / "InviteBanner.tsx")
+    assert "conversation?.can_accept_invite" in banner, (
+        "The invite prompt must be shown on the server's can_accept_invite"
+    )
+
+    print("Capability gating test passed!")
+    return True
+
+
+def test_the_feature_is_gated_on_its_settings_key():
+    """No sharing controls appear when the capability is switched off."""
+    print("Testing the feature flag...")
+
+    settings = _read(APP_ROOT / "functions_settings.py")
+    assert "'enable_collaborative_conversations'" in settings, (
+        "The capability key is expected to exist in the settings defaults"
+    )
+
+    routes = _read(APP_ROOT / "route_backend_collaboration.py")
+    assert "settings.get('enable_collaborative_conversations', False)" in routes, (
+        "The API is expected to refuse when the capability is off"
+    )
+
+    # Forwarded to the SPA by the generic enable_* pass in the bootstrap route, so no
+    # bootstrap change is needed for the flag to reach the browser.
+    bootstrap = _read(APP_ROOT / "route_backend_v2.py")
+    assert 'key.startswith("enable_")' in bootstrap, (
+        "The bootstrap route is expected to forward every enable_* flag"
+    )
+
+    for component in ("pages/ChatPage.tsx", "components/chat/ConversationRail.tsx"):
+        source = _read(V2_SRC / component)
+        assert "features?.enable_collaborative_conversations" in source, (
+            f"{component} must hide its sharing controls when the capability is off"
+        )
+
+    print("Feature flag test passed!")
+    return True
+
+
+def test_sharing_uses_the_conversion_route_that_matches_the_conversation():
+    """There are three invite routes and they are not interchangeable.
+
+    A group conversation converted through the personal route would lose the group
+    restriction on who may be invited; an already-shared conversation converted a second
+    time would produce a second shared conversation alongside the first.
+    """
+    print("Testing share routing...")
+
+    sharing = _read(V2_SRC / "lib" / "sharing.ts")
+    assert "kind: 'collaborative'" in sharing
+    assert "chatType.startsWith('group') ? 'group' : 'personal'" in sharing
+
+    store = _read(V2_SRC / "stores" / "collaborationStore.ts")
+    assert re.search(
+        r"kind === 'collaborative'\s*\?\s*await inviteCollaborationMembers"
+        r"(?:.|\n)*?kind === 'group'\s*\?\s*await shareGroupConversation"
+        r"(?:.|\n)*?:\s*await sharePersonalConversation",
+        store,
+    ), "The invite must choose the endpoint from the conversation's share kind"
+
+    # Sharing mints a new conversation, so the reader has to be moved to the returned id.
+    panel = _read(V2_SRC / "components" / "chat" / "ParticipantsPanel.tsx")
+    assert "result.conversation?.id" in panel
+    assert "selectConversation(nextId, { kind: 'collaborative' })" in panel, (
+        "After sharing, the newly created conversation must be the one that is opened"
+    )
+
+    print("Share routing test passed!")
+    return True
+
+
+def test_live_updates_survive_reconnection():
+    """The event stream replays its whole history on every attach.
+
+    ``iter_events`` starts at index 0, and ``EventSource`` reconnects by itself, so without
+    both a replay guard and de-duplication a network blip re-appends the entire
+    conversation.
+    """
+    print("Testing live update handling...")
+
+    routes = _read(APP_ROOT / "route_backend_collaboration.py")
+    assert "def iter_events(self, start_index=0)" in routes, (
+        "The event stream is expected to replay from a start index"
+    )
+
+    events = _read(V2_SRC / "lib" / "collaborationEvents.ts")
+    assert "isReplayedEvent" in events, "Replayed history must be recognised"
+    assert "seen.has(key)" in events, "Events must be de-duplicated across reconnects"
+    assert "MAX_REMEMBERED_EVENTS" in events, (
+        "The de-duplication set must be bounded so a long conversation cannot grow it forever"
+    )
+
+    # A bare timestamp read as local time makes replayed history look like the future west
+    # of UTC, so nothing is ever recognised as a replay.
+    assert "Date.parse(`${value}Z`)" in events, (
+        "A timestamp without a zone designator must be read as UTC"
+    )
+
+    store = _read(V2_SRC / "stores" / "chatStore.ts")
+    assert "subscribeToCollaborationEvents" in store
+    assert "stopCollaborationEvents()" in store, (
+        "The subscription must be torn down when the conversation changes"
+    )
+    assert "mergeCollaborationMessage" in store, (
+        "An arriving message must be merged by id rather than appended"
+    )
+
+    print("Live update handling test passed!")
+    return True
+
+
+def test_broadcast_events_do_not_carry_the_readers_permissions():
+    """An event's conversation is serialized for whoever caused it, not for the reader.
+
+    Every publishing route calls ``serialize_collaboration_conversation`` with the acting
+    user and then broadcasts that one dict to every subscriber. Applying its ``can_*``
+    verbatim means a participant leaving tells everyone else they can no longer post, and an
+    owner acting offers every member a "Delete for everyone" button the server then refuses.
+    """
+    print("Testing broadcast permission handling...")
+
+    routes = _read(APP_ROOT / "route_backend_collaboration.py")
+    # The premise: publish sites serialize for the acting user.
+    assert re.search(
+        r"serialize_collaboration_conversation\(\s*\n?\s*\w+,\s*\n?\s*current_user_id=current_user\['user_id'\]",
+        routes,
+    ), (
+        "Publishing routes are expected to serialize the conversation for the acting user, "
+        "which is what makes a broadcast's capability flags unusable by other readers"
+    )
+
+    events = _read(V2_SRC / "lib" / "collaborationEvents.ts")
+    assert "export function conversationFactsOnly" in events, (
+        "Broadcast conversations must be stripped of their viewer-scoped fields"
+    )
+    for viewer_scoped in (
+        "can_post_messages",
+        "can_manage_members",
+        "can_manage_roles",
+        "can_delete_conversation",
+        "can_leave_conversation",
+        "can_accept_invite",
+        "current_user_role",
+        "membership_status",
+        "is_pinned",
+        "is_hidden",
+    ):
+        assert f"'{viewer_scoped}'," in events, (
+            f"{viewer_scoped} is viewer-scoped and must be stripped from a broadcast"
+        )
+
+    collaboration_store = _read(V2_SRC / "stores" / "collaborationStore.ts")
+    assert "applyBroadcast" in collaboration_store, (
+        "A broadcast must be applied through a path that strips viewer-scoped fields"
+    )
+    assert "conversationFactsOnly(conversation)" in collaboration_store
+
+    store = _read(V2_SRC / "stores" / "chatStore.ts")
+    assert "collaboration().setConversation(conversation)" not in store, (
+        "No event handler may apply a broadcast conversation wholesale"
+    )
+    assert store.count("collaboration().applyBroadcast(conversation)") >= 2, (
+        "Message events also carry a conversation and must go through the same stripping"
+    )
+    assert "refreshOwnMembership" in store, (
+        "A membership change must be re-read for this reader rather than taken from the event"
+    )
+
+    print("Broadcast permission handling test passed!")
+    return True
+
+
+def test_membership_cannot_leak_between_conversations():
+    """One conversation's membership must never decide another conversation's controls.
+
+    The capability flags gate the composer, the reply buttons and the mention roster, so a
+    membership written for the wrong conversation either locks the reader out of a thread
+    they can write in, or offers controls the server refuses. Several writers land after an
+    ``await`` — a metadata load, a posted message, an invite response — by which time the
+    reader may have moved on, so the invariant is enforced once in the store rather than at
+    each call site.
+    """
+    print("Testing membership isolation...")
+
+    collaboration_store = _read(V2_SRC / "stores" / "collaborationStore.ts")
+
+    # The store knows which conversation is open and refuses writes for any other.
+    assert "setActiveConversation" in collaboration_store, (
+        "The collaboration store must know which conversation the chat page has open"
+    )
+    assert re.search(
+        r"setConversation: \(conversation\) => \{\s*\n\s*if \(conversation "
+        r"&& conversation\.id !== get\(\)\.activeConversationId\) \{\s*\n\s*return;",
+        collaboration_store,
+    ), "setConversation must refuse a conversation that is not the open one"
+
+    # The participants panel has its own slot, so opening it on a conversation other than
+    # the one on screen cannot evict that one's membership.
+    assert "panelConversation" in collaboration_store, (
+        "The participants panel must not share the active conversation's slot"
+    )
+    panel = _read(V2_SRC / "components" / "chat" / "ParticipantsPanel.tsx")
+    assert "state.panelConversation" in panel, (
+        "The panel must read its own slot rather than the open conversation's"
+    )
+
+    rail = _read(V2_SRC / "components" / "chat" / "ConversationRail.tsx")
+    # Deliberately not a plain substring: `loadConversations` (the feed loader) legitimately
+    # appears here and contains this name.
+    assert not re.search(r"\bloadConversation\b(?!s)", rail), (
+        "The rail's People action must not load into the active conversation's slot; "
+        "openPanel already loads the panel's own copy"
+    )
+
+    store = _read(V2_SRC / "stores" / "chatStore.ts")
+
+    # The guard is worth exactly as much as the mirror being current, so every write to
+    # `activeConversationId` must be accompanied by one. Counted rather than spot-checked:
+    # a fifth writer that forgets to mirror would otherwise leave the store silently
+    # dropping that conversation's membership, stranding its composer at "checking access".
+    #
+    # Anchored on `set({` so the store's own initial-state literal is not counted as a write.
+    id_writes = re.findall(
+        r"set\(\{\s*\n?\s*activeConversationId: (?:conversationId|null)\b", store
+    )
+    mirror_calls = re.findall(r"setActiveConversation\((?:conversationId|null)\)", store)
+    assert len(id_writes) >= 3, (
+        "Expected chatStore to set activeConversationId in at least the select, new-chat "
+        f"and create-on-first-send paths; found {len(id_writes)}"
+    )
+    assert len(mirror_calls) == len(id_writes), (
+        f"Every write to activeConversationId must mirror it to the collaboration store: "
+        f"found {len(id_writes)} writes and {len(mirror_calls)} mirror calls"
+    )
+
+    # And it must be mirrored synchronously, before the first await. Mirroring after one
+    # would leave a window in which a membership response is dropped for the conversation
+    # that is actually open.
+    select_body = store[
+        store.index("selectConversation: async (conversationId, options = {})") :
+    ]
+    select_body = select_body[: select_body.index("openLinkedConversation: async")]
+    assert select_body.index("setActiveConversation(conversationId)") < select_body.index(
+        "await"
+    ), "The mirror must be set before selectConversation awaits anything"
+
+    assert "setActiveConversation(null)" in store, (
+        "Starting a new chat must clear it, or a stale membership would still apply"
+    )
+
+    # The deep-link probe hands its fetched conversation back rather than stashing it,
+    # because at that point the conversation is not open and the store would refuse it.
+    assert "prefetched?: CollaborationConversation" in store, (
+        "The kind probe's conversation must be passed to selectConversation explicitly"
+    )
+    assert "prefetched: resolved.conversation" in store, (
+        "openLinkedConversation must actually pass the conversation it already fetched"
+    )
+    assert "prefetched?.id === conversationId" in store, (
+        "selectConversation must use the prefetched conversation rather than refetching"
+    )
+
+    # Every consumer of the membership compares the id before trusting it.
+    for component, needle in (
+        ("components/chat/Composer.tsx", "loadedCollaboration?.id === activeConversationId"),
+        ("components/chat/MessageActions.tsx", "loadedCollaboration?.id === activeConversationId"),
+        ("components/chat/MentionMenu.tsx", "loaded?.id === activeConversationId"),
+        ("pages/ChatPage.tsx", "state.conversation?.id === activeConversationId"),
+    ):
+        assert needle in _read(V2_SRC / component), (
+            f"{component} must confirm the loaded membership belongs to the open conversation"
+        )
+
+    assert "loadedCollaboration?.id === conversationId" in store, (
+        "Mentions must be resolved against the open conversation's participants"
+    )
+
+    print("Membership isolation test passed!")
+    return True
+
+
+def test_a_shared_thread_says_who_wrote_each_message():
+    """A thread with several authors is unreadable without attribution.
+
+    Personal conversations are unaffected: they carry no ``sender``, so the attribution line
+    is absent and the reader's own messages stay on the right exactly as before.
+    """
+    print("Testing message attribution...")
+
+    serializer = _read(APP_ROOT / "functions_collaboration.py")
+    assert "'sender': metadata.get('sender', {})" in serializer, (
+        "A shared message is expected to carry its sender"
+    )
+
+    shared_message = _read(V2_SRC / "lib" / "sharedMessage.ts")
+    assert "export function messageAuthorName" in shared_message
+    assert "return 'You'" in shared_message, "The reader's own messages should read as You"
+
+    message_list = _read(V2_SRC / "components" / "chat" / "MessageList.tsx")
+    assert "const alignRight = author ? own : isUser;" in message_list, (
+        "Another participant's message must not be shown on the reader's own side"
+    )
+    assert "function FileMessage" in message_list, (
+        "The `file` display role only a shared conversation emits must be rendered"
+    )
+    assert "ReplyQuote" in message_list, "A reply must show what it is answering"
+
+    types = _read(V2_SRC / "lib" / "types.ts")
+    assert "'image' | 'file'" in types, (
+        "MessageRole must include the `file` role serialize_collaboration_message emits"
+    )
+
+    print("Message attribution test passed!")
+    return True
+
+
+def test_no_third_party_browser_assets_were_added():
+    """Everything the browser loads stays a local SimpleChat asset."""
+    print("Testing local browser assets...")
+
+    added = [
+        V2_SRC / "lib" / "collaboration.ts",
+        V2_SRC / "lib" / "collaborationEvents.ts",
+        V2_SRC / "lib" / "mentions.ts",
+        V2_SRC / "lib" / "sharedMessage.ts",
+        V2_SRC / "lib" / "sharing.ts",
+        V2_SRC / "stores" / "collaborationStore.ts",
+        V2_SRC / "components" / "chat" / "ParticipantsPanel.tsx",
+        V2_SRC / "components" / "chat" / "MentionMenu.tsx",
+        V2_SRC / "components" / "chat" / "InviteBanner.tsx",
+        V2_SRC / "components" / "chat" / "FileApprovals.tsx",
+    ]
+
+    for path in added:
+        assert path.exists(), f"Expected {path.name} to exist"
+        source = _read(path)
+        for forbidden in ("https://cdn.", "unpkg.com", "jsdelivr", "cdnjs", "googleapis.com"):
+            assert forbidden not in source, (
+                f"{path.name} must not reference the third-party host {forbidden}"
+            )
+
+    print("Local browser assets test passed!")
+    return True
+
+
+if __name__ == "__main__":
+    tests = [
+        test_version_is_at_least_the_implementation_version,
+        test_messages_are_read_from_the_collaboration_endpoint,
+        test_every_collaboration_route_has_a_v2_caller,
+        test_stream_recovery_is_disabled_for_shared_conversations,
+        test_thread_operations_are_hidden_in_a_shared_conversation,
+        test_conversation_actions_route_by_kind,
+        test_capabilities_come_from_the_server,
+        test_the_feature_is_gated_on_its_settings_key,
+        test_sharing_uses_the_conversion_route_that_matches_the_conversation,
+        test_live_updates_survive_reconnection,
+        test_broadcast_events_do_not_carry_the_readers_permissions,
+        test_membership_cannot_leak_between_conversations,
+        test_a_shared_thread_says_who_wrote_each_message,
+        test_no_third_party_browser_assets_were_added,
+    ]
+
+    results = []
+    for test in tests:
+        print(f"\nRunning {test.__name__}...")
+        try:
+            results.append(bool(test()))
+        except Exception as exc:
+            print(f"Test failed: {exc}")
+            import traceback
+
+            traceback.print_exc()
+            results.append(False)
+
+    print(f"\nResults: {sum(results)}/{len(results)} tests passed")
+    sys.exit(0 if all(results) else 1)


### PR DESCRIPTION
## The bug

Opening a shared conversation in the V2 interface showed an **empty thread**.

V2 loaded every thread with `GET /api/get_messages`, which reads only the personal messages container. For a conversation that is not in it, `_authorize_personal_conversation_read` raises `LookupError` and the route converts that into `{'messages': []}` with a **200**:

```python
except LookupError:
    return jsonify({'messages': []})
```

So a shared conversation did not fail to open — it opened successfully, with nothing in it, and remained the target of the next message sent.

Shared conversations live in `cosmos_collaboration_conversations_container` / `cosmos_collaboration_messages_container`, behind the existing `/api/collaboration/*` API that the classic interface already drives from `chat-collaboration.js`. The conversation **feed** already merged them, which is why the rows appeared in the rail at all — only the per-conversation operations were missing.

**Front-end only.** No Flask route, Cosmos container or server behaviour is changed. Every endpoint used already existed.

## What V2 gains

Routing is decided by `conversation_kind`, which the feed already returns on every row — never by trying one endpoint and falling back, because the personal endpoint does not fail for a shared conversation.

- **Reading** a shared thread, with sender attribution, the `file` display role, and reply quoting. Another participant's message sits on the left rather than the reader's own side.
- **Live updates** over the conversation's event stream: other people's messages, deletions, masks, membership changes and typing.
- **Sending**, under the classic rule: the assistant answers only when the message `@`-mentions a model or agent, or an assistant-implying option is set (agent, document search, web search, image generation, deep research, URL access, or a saved prompt). Otherwise the message goes to the participants and the model never sees it. Taken from `buildCollaborativeInvocationTarget` so the two interfaces cannot disagree about what a given message does.
- **An `@` mention menu** offering participants, then AI targets, then people who could be invited — and inviting them when chosen.
- **A participants panel** behind a People button and a Share item in the rail: invitations, roles, removal, and leaving versus deleting.
- **Pending generated-file approvals.**

Retry, edit, attempt navigation and fork are **hidden** in a shared conversation. Those endpoints read the personal messages container and have no collaboration counterpart, so hiding them is the parity rather than a reduction. Stream recovery is likewise off — `/api/chat/stream/reattach` is keyed on a hidden source conversation whose id the browser is never given.

Gated on `enable_collaborative_conversations`; with it off, no sharing controls appear at all.

## Three things that were easy to get wrong, and were

Caught in review and fixed:

1. **Event payloads carry the permissions of whoever *triggered* the event.** Every publishing route serializes the conversation for the acting user and broadcasts that one document. Applying it verbatim disabled every other participant's composer when somebody left, and offered every member a "Delete for everyone" button when an owner acted. `conversationFactsOnly` now strips the viewer-scoped fields, and a membership change is treated as a reason to re-read rather than a payload to trust.
2. **The participants panel evicted the open conversation's membership**, and absent flags read as permission. It now has its own slot, capability flags are deny-by-default, and the collaboration store refuses a membership write for any conversation that is not the open one.
3. **The "Add to this conversation" mention rows were dead** — they typed a name and invited nobody.

Also fixed along the way: mentions now consume their matched span, so writing `@Ada Lovelace` no longer *also* notifies somebody called `Ada`.

## Tests

| File | Covers |
|---|---|
| `test_v2_shared_conversations.py` | Endpoint wiring, capability gating, hidden operations, share routing, replay handling, broadcast-permission stripping, membership isolation |
| `test_v2_shared_conversation_logic.mjs` | The send rule, the mention grammar, event dispatch and attribution — executed against the real modules, not a copy |

- `tsc -b --noEmit` and `npm run build` clean
- `test_v2_shared_conversations.py` 14/14, `test_v2_shared_conversation_logic.mjs` 45/45
- All 29 `test_v2_*.py`, docs coverage, docs quality and version-guardrail suites pass
- **No regressions:** ran the full 928-test suite against the pre-change commit in a temporary worktree — the failures are byte-identical to baseline (pre-existing Windows console-encoding and missing-Azure-dependency errors)
- Confirmed the new "every `activeConversationId` write is mirrored" assertion actually fails when a mirror call is removed

Three existing tests were updated where they pinned source deliberately changed here; their intent is preserved and, in two cases, strengthened.

## Merges with the base

The base moved twice while this was in progress, and both merges are in the history with their resolutions explained:

- **`buildSelectionFields()`** now enforces that **an agent wins** over a model identity. The `@model` / `@agent` tag overrides feed that function rather than bypassing it, and a tagged *model* additionally clears the agent selection — without that, the exclusivity rule would silently discard the model the reader had just named.
- **`MessageBubble` was memoised** and renamed to `MessageBubbleInner`. The rename is kept; `ReplyQuote` and `FileMessage` are used from inside the bubble, so neither is affected by the memo boundary.

Renumbered to **0.261.038**.

## Known limitation

Deep research, URL access and source review make a message a request to the assistant, but `_build_collaboration_stream_request_payload` does not forward `deep_research_enabled`, `source_review_enabled` or `url_access_enabled` to the chat stream it bridges to. That is existing server behaviour affecting the classic interface identically, so it is documented rather than changed here.

## Documentation

- `docs/explanation/features/V2_SHARED_CONVERSATIONS.md`
- A V2 section in `docs/guides/collaborate-in-a-conversation.md`
- Release notes under v0.261.038