### PR TITLE
Bring V2 admin settings to parity with V1 for the Appearance group

### DIFF
--- a/application/single_app/admin_settings_fields.py
+++ b/application/single_app/admin_settings_fields.py
@@ -1,0 +1,902 @@
+# admin_settings_fields.py
+"""Declarative field definitions for the Admin Settings surface.
+
+``admin_settings_nav.py`` says which groups, tabs and sections exist. It does
+not say which settings live inside a section, because the server-rendered
+Admin Settings page answers that with hand-written markup in
+``templates/admin/_panes/``.
+
+The V2 React admin surface cannot read that markup. Without a machine-readable
+description it can only discover settings by scanning the settings document for
+``enable_*`` booleans, which is why it could render switches and nothing else:
+titles, colours, selects, ranges, uploads and repeatable lists are all
+invisible to that scan.
+
+This module supplies the missing description. Each section id from ``ADMIN_NAV``
+maps to an ordered list of fields, and each field carries everything a generic
+renderer needs -- type, label, help text, default, bounds, options and
+visibility dependencies.
+
+Two things keep this honest rather than becoming a third source of truth:
+
+``LEGACY_FIELD_NAMES``
+    Records the server-rendered form field names each entry replaces, including
+    the places where V1's form shape differs from the stored settings key. The
+    parity functional test walks the V1 panes and fails when a form field is not
+    claimed here, so a setting cannot exist in one interface only.
+
+``normalize_admin_settings_updates``
+    Validates and coerces incoming values against these definitions, delegating
+    to the same normalizers the server-rendered form uses. Both interfaces
+    therefore agree on what a valid value is.
+
+Only the Appearance group is described so far. Sections with no entry here fall
+back to the V2 surface's ``enable_*`` scan, so undescribed groups keep working
+exactly as they did.
+"""
+
+import re
+from urllib.parse import urlparse
+
+from functions_ai_notice import (
+    AI_NOTICE_MAX_MESSAGE_LENGTH,
+    normalize_ai_notice_frequency,
+    normalize_ai_notice_message,
+)
+from functions_terms_of_use import (
+    TERMS_OF_USE_DEFAULT_REDIRECT,
+    TERMS_OF_USE_MAX_BUTTON_TEXT_LENGTH,
+    TERMS_OF_USE_MAX_MESSAGE_LENGTH,
+    TERMS_OF_USE_MAX_TITLE_LENGTH,
+    normalize_terms_of_use_frequency,
+    normalize_terms_of_use_redirect_url,
+    normalize_terms_of_use_text,
+)
+
+HEX_COLOR_PATTERN = re.compile(r"^#[0-9a-fA-F]{6}$")
+
+# Field types the V2 renderer knows how to draw. A type outside this set is a
+# schema bug, and the schema test fails on it rather than the browser silently
+# rendering nothing.
+FIELD_TYPES = (
+    "text",
+    "textarea",
+    "select",
+    "switch",
+    "checkbox_set",
+    "color",
+    "range",
+    "number",
+    "image",
+    "link_list",
+    "component",
+)
+
+# Types that own their persistence outside the settings PATCH: image uploads go
+# through the multipart branding endpoint, and components talk to their own API.
+NON_PATCHABLE_TYPES = ("image", "component")
+
+LANDING_PAGE_ALIGNMENTS = ("left", "center", "right")
+USER_AGREEMENT_APPLY_TO_VALUES = ("personal", "group", "public", "chat")
+
+LOGO_SCALE_MIN_PERCENT = 50
+LOGO_SCALE_MAX_PERCENT = 500
+LOGO_SCALE_DEFAULT_PERCENT = 100
+
+# Advisory, not enforced. The server-rendered form warns and saves anyway, so
+# rejecting the value here would lock an administrator out of editing a section
+# that already holds a longer agreement.
+USER_AGREEMENT_WORD_LIMIT = 200
+
+CLASSIFICATION_BANNER_DEFAULT_COLOR = "#ffc107"
+CLASSIFICATION_BANNER_DEFAULT_TEXT_COLOR = "#ffffff"
+
+# Schemes permitted for administrator-configured navigation links. These render
+# into an anchor href, so allowing arbitrary schemes would let a saved link
+# carry javascript: into every page's navigation.
+EXTERNAL_LINK_ALLOWED_SCHEMES = ("http", "https")
+
+
+ADMIN_SETTINGS_FIELDS = {
+    "branding-section": [
+        {
+            "key": "app_title",
+            "type": "text",
+            "label": "Application Title",
+            "help": "Shown in the browser tab, the header and the landing page.",
+            "default": "Simple Chat",
+            "max_length": 120,
+        },
+        {
+            "key": "show_logo",
+            "type": "switch",
+            "label": "Show Logo",
+            "help": "Display the application logo in the header and navigation areas.",
+            "default": False,
+        },
+        {
+            "key": "hide_app_title",
+            "type": "switch",
+            "label": "Hide Application Title",
+            "help": "Show only the logo in the header and navigation.",
+            "default": False,
+        },
+        {
+            "key": "landing_page_logo_scale_percent",
+            "type": "range",
+            "label": "Main Page Logo Size",
+            "help": (
+                "Adjusts the logo on the home page only. Navigation logo size is "
+                "unaffected."
+            ),
+            "default": LOGO_SCALE_DEFAULT_PERCENT,
+            "min": LOGO_SCALE_MIN_PERCENT,
+            "max": LOGO_SCALE_MAX_PERCENT,
+            "step": 10,
+            "suffix": "%",
+            "depends_on": {"key": "show_logo", "equals": True},
+        },
+        {
+            "key": "custom_logo_base64",
+            "type": "image",
+            "label": "Custom Logo (Light Mode)",
+            "help": (
+                "Stored at up to 500px tall so the home page can enlarge it without "
+                "keeping an oversized asset in settings."
+            ),
+            "upload_target": "logo",
+            "accept": ".png,.jpg,.jpeg",
+            "version_key": "logo_version",
+        },
+        {
+            "key": "custom_logo_dark_base64",
+            "type": "image",
+            "label": "Custom Logo (Dark Mode)",
+            "help": "Falls back to the light mode logo when no dark variant is uploaded.",
+            "upload_target": "logo_dark",
+            "accept": ".png,.jpg,.jpeg",
+            "version_key": "logo_dark_version",
+        },
+        {
+            "key": "custom_favicon_base64",
+            "type": "image",
+            "label": "Custom Favicon",
+            "help": "Converted to a 32x32 ICO. Upload a square image for best results.",
+            "upload_target": "favicon",
+            "accept": ".png,.jpg,.jpeg,.ico",
+            "version_key": "favicon_version",
+        },
+    ],
+    "home-page-text-section": [
+        {
+            "key": "landing_page_alignment",
+            "type": "select",
+            "label": "Markdown Alignment",
+            "help": "How the landing page markdown is aligned on the home page.",
+            "default": "left",
+            "options": [
+                {"value": "left", "label": "Left"},
+                {"value": "center", "label": "Center"},
+                {"value": "right", "label": "Right"},
+            ],
+        },
+        {
+            "key": "enable_landing_page_editor",
+            "type": "switch",
+            "label": "Enable Markdown Editor",
+            "help": (
+                "When off, the landing page text is shown as a read-only preview "
+                "instead of an editable field."
+            ),
+            "default": False,
+        },
+        {
+            "key": "landing_page_text",
+            "type": "textarea",
+            "label": "Landing Page Text",
+            "help": "Markdown is supported.",
+            "default": "",
+            "rows": 8,
+            "markdown": True,
+            "max_length": 20000,
+            "depends_on": {"key": "enable_landing_page_editor", "equals": True},
+        },
+    ],
+    "appearance-section": [
+        {
+            "key": "enable_dark_mode_default",
+            "type": "switch",
+            "label": "Enable Dark Mode by Default",
+            "help": "Users can still switch themes individually.",
+            "default": False,
+        },
+        {
+            "key": "enable_left_nav_default",
+            "type": "switch",
+            "label": "Enable Left Nav by Default",
+            "help": "Users can still toggle the sidebar individually.",
+            "default": True,
+        },
+    ],
+    "classification-banner-section": [
+        {
+            "key": "classification_banner_enabled",
+            "type": "switch",
+            "label": "Enable Classification Banner",
+            "help": "Shows a data sensitivity banner at the top of every page.",
+            "default": False,
+        },
+        {
+            "key": "classification_banner_text",
+            "type": "text",
+            "label": "Banner Text",
+            "default": "",
+            "max_length": 200,
+            "depends_on": {"key": "classification_banner_enabled", "equals": True},
+        },
+        {
+            "key": "classification_banner_color",
+            "type": "color",
+            "label": "Banner Color",
+            "default": CLASSIFICATION_BANNER_DEFAULT_COLOR,
+            "depends_on": {"key": "classification_banner_enabled", "equals": True},
+        },
+        {
+            "key": "classification_banner_text_color",
+            "type": "color",
+            "label": "Banner Text Color",
+            "default": CLASSIFICATION_BANNER_DEFAULT_TEXT_COLOR,
+            "depends_on": {"key": "classification_banner_enabled", "equals": True},
+        },
+        {
+            "type": "component",
+            "component": "classification-banner-preview",
+            "label": "Preview",
+            "depends_on": {"key": "classification_banner_enabled", "equals": True},
+        },
+    ],
+    "ai-notice-section": [
+        {
+            "key": "enable_ai_notice",
+            "type": "switch",
+            "label": "Show a custom AI notice below the chat input",
+            "help": (
+                "Displays an administrator-provided reminder directly below the chat "
+                "composer."
+            ),
+            "default": False,
+        },
+        {
+            "key": "ai_notice_message",
+            "type": "textarea",
+            "label": "Notice Text",
+            "help": "Plain text only. Line breaks are preserved.",
+            "default": "",
+            "rows": 3,
+            "max_length": AI_NOTICE_MAX_MESSAGE_LENGTH,
+            "placeholder": (
+                "AI-generated responses may contain errors. Review important "
+                "information before relying on it."
+            ),
+            "depends_on": {"key": "enable_ai_notice", "equals": True},
+        },
+        {
+            "key": "ai_notice_frequency",
+            "type": "select",
+            "label": "Display Behavior",
+            "help": (
+                "Changing the notice text or display behavior creates a new message "
+                "version and shows it again."
+            ),
+            "default": "non_dismissible",
+            "options": [
+                {"value": "non_dismissible", "label": "Always visible; users cannot dismiss it"},
+                {"value": "every_session", "label": "Dismissible once per session"},
+                {"value": "daily", "label": "Dismissible once per day"},
+                {"value": "once", "label": "Dismissible once per message version"},
+            ],
+            "depends_on": {"key": "enable_ai_notice", "equals": True},
+        },
+    ],
+    "terms-of-use-section": [
+        {
+            "key": "enable_terms_of_use",
+            "type": "switch",
+            "label": "Require terms of use",
+            "help": (
+                "Users must accept before reaching authenticated pages or APIs. "
+                "Passive sign-in flows are gated immediately after the session is "
+                "created."
+            ),
+            "default": False,
+        },
+        {
+            "key": "terms_of_use_title",
+            "type": "text",
+            "label": "Popup Title",
+            "default": "Terms of Use",
+            "max_length": TERMS_OF_USE_MAX_TITLE_LENGTH,
+            "depends_on": {"key": "enable_terms_of_use", "equals": True},
+        },
+        {
+            "key": "terms_of_use_frequency",
+            "type": "select",
+            "label": "Show Frequency",
+            "help": (
+                "Changing the title, message or frequency creates a new terms version "
+                "that users must accept again."
+            ),
+            "default": "once",
+            "options": [
+                {"value": "every_session", "label": "At the start of every session"},
+                {"value": "daily", "label": "Once per day"},
+                {"value": "once", "label": "Just once per terms version"},
+            ],
+            "depends_on": {"key": "enable_terms_of_use", "equals": True},
+        },
+        {
+            "key": "terms_of_use_message",
+            "type": "textarea",
+            "label": "Terms of Use Message",
+            "help": "Plain text is shown to users with line breaks preserved.",
+            "default": "",
+            "rows": 7,
+            "max_length": TERMS_OF_USE_MAX_MESSAGE_LENGTH,
+            "placeholder": (
+                "Enter the terms, notice, or rules of behavior users must accept "
+                "before using the application."
+            ),
+            "depends_on": {"key": "enable_terms_of_use", "equals": True},
+        },
+        {
+            "key": "terms_of_use_decline_redirect_url",
+            "type": "text",
+            "label": "Cancel Redirect URL",
+            "help": (
+                "A local path such as / or an HTTPS URL. Signed-in users are locally "
+                "logged out before this redirect."
+            ),
+            "default": TERMS_OF_USE_DEFAULT_REDIRECT,
+            "max_length": 2000,
+            "depends_on": {"key": "enable_terms_of_use", "equals": True},
+        },
+        {
+            "key": "terms_of_use_accept_button_text",
+            "type": "text",
+            "label": "Accept Button Text",
+            "default": "Accept and continue",
+            "max_length": TERMS_OF_USE_MAX_BUTTON_TEXT_LENGTH,
+            "depends_on": {"key": "enable_terms_of_use", "equals": True},
+        },
+        {
+            "key": "terms_of_use_decline_button_text",
+            "type": "text",
+            "label": "Cancel Button Text",
+            "default": "Cancel",
+            "max_length": TERMS_OF_USE_MAX_BUTTON_TEXT_LENGTH,
+            "depends_on": {"key": "enable_terms_of_use", "equals": True},
+        },
+    ],
+    "user-agreement-section": [
+        {
+            "key": "enable_user_agreement",
+            "type": "switch",
+            "label": "Enable User Agreement",
+            "help": (
+                "Users must accept the agreement before uploading files in the "
+                "selected workspace types."
+            ),
+            "default": False,
+        },
+        {
+            "key": "user_agreement_apply_to",
+            "type": "checkbox_set",
+            "label": "Apply to",
+            "help": "Select where the user agreement should be shown.",
+            "default": [],
+            "min_selected": 1,
+            "options": [
+                {"value": "personal", "label": "Personal Workspaces"},
+                {"value": "group", "label": "Group Workspaces"},
+                {"value": "public", "label": "Public Workspaces"},
+                {"value": "chat", "label": "Chat"},
+            ],
+            "depends_on": {"key": "enable_user_agreement", "equals": True},
+        },
+        {
+            "key": "user_agreement_text",
+            "type": "textarea",
+            "label": "Agreement Text",
+            "help": "Markdown is supported.",
+            "default": "",
+            "rows": 6,
+            "markdown": True,
+            "max_length": 10000,
+            "word_limit": USER_AGREEMENT_WORD_LIMIT,
+            "placeholder": (
+                "Enter the agreement text that users must accept before uploading "
+                "files..."
+            ),
+            "depends_on": {"key": "enable_user_agreement", "equals": True},
+        },
+        {
+            "key": "enable_user_agreement_daily",
+            "type": "switch",
+            "label": "Allow users to accept once per day",
+            "help": (
+                "Users accept once per day instead of every time they upload files."
+            ),
+            "default": False,
+            "depends_on": {"key": "enable_user_agreement", "equals": True},
+        },
+        {
+            "type": "component",
+            "component": "user-agreement-preview",
+            "label": "Test Preview",
+            "depends_on": {"key": "enable_user_agreement", "equals": True},
+        },
+    ],
+    "custom-pages-section": [
+        {
+            "key": "enable_custom_pages",
+            "type": "switch",
+            "label": "Enable Custom Pages",
+            "help": (
+                "Serves trusted pages deployed under custom_pages at /custom. When "
+                "off, /custom returns Not Found before any custom metadata, file or "
+                "Python extension is loaded."
+            ),
+            "default": False,
+            # Enabling only takes full effect after an App Service restart, so the
+            # V2 surface must collect the same acknowledgement the V1 form does.
+            "requires_acknowledgement": {
+                "key": "custom_pages_restart_acknowledged",
+                "when": "enabled",
+                "title": "Custom Pages requires a restart",
+                "message": (
+                    "Custom Pages is not fully enabled until the App Service is "
+                    "restarted. Python-backed pages register their routes at startup."
+                ),
+            },
+        },
+        {
+            "key": "custom_pages_menu_name",
+            "type": "text",
+            "label": "Menu Name",
+            "help": "Shown when custom pages are grouped into a menu.",
+            "default": "Custom Pages",
+            "max_length": 60,
+            "fallback_when_empty": True,
+            "depends_on": {"key": "enable_custom_pages", "equals": True},
+        },
+        {
+            "key": "custom_pages_force_menu",
+            "type": "switch",
+            "label": "Force Menu Display",
+            "help": (
+                "When off, 1-2 pages appear as top-level nav items and 3 or more "
+                "become a menu."
+            ),
+            "default": False,
+            "depends_on": {"key": "enable_custom_pages", "equals": True},
+        },
+        {
+            "type": "component",
+            "component": "custom-pages-table",
+            "label": "Static Page Metadata",
+            "help": (
+                "Metadata contracts for pages built from files in custom_pages/html, "
+                "css, js, assets and json."
+            ),
+            "depends_on": {"key": "enable_custom_pages", "equals": True},
+        },
+    ],
+    "external-links-section": [
+        {
+            "key": "enable_external_links",
+            "type": "switch",
+            "label": "Enable External Links in Navigation",
+            "help": "Adds administrator-approved links to the navigation bar.",
+            "default": False,
+        },
+        {
+            "key": "external_links_menu_name",
+            "type": "text",
+            "label": "Menu Name",
+            "help": "Appears in the navigation bar as the menu title.",
+            "default": "External Links",
+            "max_length": 60,
+            "fallback_when_empty": True,
+            "depends_on": {"key": "enable_external_links", "equals": True},
+        },
+        {
+            "key": "external_links_force_menu",
+            "type": "switch",
+            "label": "Force Menu Display",
+            "help": (
+                "When off, 1-2 links appear as top-level nav items and 3 or more "
+                "become a dropdown."
+            ),
+            "default": False,
+            "depends_on": {"key": "enable_external_links", "equals": True},
+        },
+        {
+            "key": "external_links",
+            "type": "link_list",
+            "label": "External Links",
+            "help": "Links open in a new tab. Only http and https addresses are allowed.",
+            "default": [],
+            "item_fields": [
+                {"key": "label", "type": "text", "label": "Label", "max_length": 80},
+                {"key": "url", "type": "text", "label": "URL", "max_length": 2000},
+            ],
+            "depends_on": {"key": "enable_external_links", "equals": True},
+        },
+    ],
+}
+
+
+# Maps each schema key to the field name(s) the server-rendered form submits.
+# Most match exactly and are omitted. The entries below are the places where the
+# two shapes genuinely differ, and the parity test uses them to resolve a V1
+# form field to its V2 equivalent.
+LEGACY_FIELD_NAMES = {
+    # V1 submits four independent checkboxes and assembles the array server-side.
+    "user_agreement_apply_to": [
+        "user_agreement_apply_personal",
+        "user_agreement_apply_group",
+        "user_agreement_apply_public",
+        "user_agreement_apply_chat",
+    ],
+    # V1 round-trips the list through a hidden JSON field maintained by script.
+    "external_links": ["external_links_json"],
+    # V1 posts the images as part of the settings form; V2 uploads them
+    # separately, so the stored keys are what the schema names.
+    "custom_logo_base64": ["logo_file"],
+    "custom_logo_dark_base64": ["logo_dark_file"],
+    "custom_favicon_base64": ["favicon_file"],
+    # Collected as an acknowledgement on the toggle rather than a stored value.
+    "enable_custom_pages": ["enable_custom_pages", "custom_pages_restart_acknowledged"],
+}
+
+# Field names present in the V1 Appearance panes that intentionally have no V2
+# equivalent, with the reason. The parity test reads this, so an unexplained
+# omission fails rather than passing silently.
+LEGACY_FIELDS_WITHOUT_V2_EQUIVALENT = {}
+
+
+def get_admin_settings_fields():
+    """Return the section-id keyed field schema."""
+    return ADMIN_SETTINGS_FIELDS
+
+
+def iter_fields():
+    """Yield ``(section_id, field)`` for every declared field."""
+    for section_id, fields in ADMIN_SETTINGS_FIELDS.items():
+        for field in fields:
+            yield section_id, field
+
+
+def get_field_definition(key):
+    """Return the field definition for a settings key, or None."""
+    for _section_id, field in iter_fields():
+        if field.get("key") == key:
+            return field
+    return None
+
+
+def get_declared_setting_keys():
+    """Return every settings key the schema describes.
+
+    The V2 surface uses this to suppress its ``enable_*`` fallback scan for keys
+    that already have a proper field, so a toggle is never rendered twice.
+    """
+    return {field["key"] for _section_id, field in iter_fields() if field.get("key")}
+
+
+def get_legacy_field_names():
+    """Return the V1 form field names claimed by the schema."""
+    claimed = set()
+    for _section_id, field in iter_fields():
+        key = field.get("key")
+        if not key:
+            continue
+        claimed.update(LEGACY_FIELD_NAMES.get(key, [key]))
+    return claimed
+
+
+def _coerce_bool(value):
+    """Coerce a JSON or form-shaped truthy value into a bool."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in ("true", "on", "yes", "1")
+    return bool(value)
+
+
+def _normalize_text(value, field):
+    """Strip and truncate a single-line value, applying an empty-value fallback."""
+    text = str(value if value is not None else "").replace("\r\n", "\n").replace("\r", "\n").strip()
+    if not text and field.get("fallback_when_empty"):
+        text = str(field.get("default") or "")
+    max_length = field.get("max_length")
+    if max_length:
+        text = text[:max_length]
+    return text
+
+
+def _validate_external_link_url(url):
+    """Return an error message when a navigation link URL is not safe to render."""
+    candidate = str(url or "").strip()
+    if not candidate:
+        return "URL is required."
+    if candidate.startswith("/") and not candidate.startswith("//"):
+        return None
+
+    parsed = urlparse(candidate)
+    if parsed.scheme.lower() not in EXTERNAL_LINK_ALLOWED_SCHEMES:
+        return (
+            "URL must be a local path or use "
+            f"{' or '.join(EXTERNAL_LINK_ALLOWED_SCHEMES)}."
+        )
+    if not parsed.netloc:
+        return "URL is missing a host."
+    return None
+
+
+def _normalize_link_list(value):
+    """Return ``(links, error)`` for an administrator-managed navigation list."""
+    if not isinstance(value, list):
+        return None, "Expected a list of links."
+
+    links = []
+    for index, item in enumerate(value, start=1):
+        if not isinstance(item, dict):
+            return None, f"Link {index} is not an object."
+
+        label = str(item.get("label") or "").strip()
+        url = str(item.get("url") or "").strip()
+        if not label:
+            return None, f"Link {index} is missing a label."
+
+        url_error = _validate_external_link_url(url)
+        if url_error:
+            return None, f"Link {index}: {url_error}"
+
+        links.append({"label": label[:80], "url": url[:2000]})
+
+    return links, None
+
+
+def _normalize_checkbox_set(value, field):
+    """Return ``(selection, error)`` for a multi-select checkbox group."""
+    if isinstance(value, str):
+        value = [value]
+    if not isinstance(value, list):
+        return None, "Expected a list of values."
+
+    allowed = [option["value"] for option in field.get("options", [])]
+    # Preserve the declared option order so the stored array is stable no matter
+    # which order the browser sent the boxes in.
+    selection = [option for option in allowed if option in value]
+
+    unknown = sorted({str(item) for item in value} - set(allowed))
+    if unknown:
+        return None, f"Unsupported value(s): {', '.join(unknown)}."
+
+    return selection, None
+
+
+def _normalize_number(value, field):
+    """Return ``(number, error)`` clamped to the field's declared bounds."""
+    try:
+        number = int(float(value))
+    except (TypeError, ValueError):
+        return None, "Expected a number."
+
+    minimum = field.get("min")
+    maximum = field.get("max")
+    if minimum is not None:
+        number = max(minimum, number)
+    if maximum is not None:
+        number = min(maximum, number)
+    return number, None
+
+
+# Keys whose normalization already exists elsewhere. Reusing those functions is
+# what stops the two admin surfaces from disagreeing about, for example, which
+# frequency aliases are accepted or how a terms message is trimmed.
+_DELEGATED_NORMALIZERS = {
+    "ai_notice_message": lambda value, field: normalize_ai_notice_message(value),
+    "ai_notice_frequency": lambda value, field: normalize_ai_notice_frequency(value),
+    "terms_of_use_frequency": lambda value, field: normalize_terms_of_use_frequency(value),
+    "terms_of_use_title": lambda value, field: normalize_terms_of_use_text(
+        value, fallback="Terms of Use", max_length=TERMS_OF_USE_MAX_TITLE_LENGTH
+    ),
+    "terms_of_use_message": lambda value, field: normalize_terms_of_use_text(
+        value, max_length=TERMS_OF_USE_MAX_MESSAGE_LENGTH
+    ),
+    "terms_of_use_accept_button_text": lambda value, field: normalize_terms_of_use_text(
+        value, fallback="Accept and continue", max_length=TERMS_OF_USE_MAX_BUTTON_TEXT_LENGTH
+    ),
+    "terms_of_use_decline_button_text": lambda value, field: normalize_terms_of_use_text(
+        value, fallback="Cancel", max_length=TERMS_OF_USE_MAX_BUTTON_TEXT_LENGTH
+    ),
+}
+
+
+def _normalize_field_value(key, value, field):
+    """Return ``(normalized, error, warning)`` for one declared field."""
+    field_type = field.get("type")
+
+    if field_type in NON_PATCHABLE_TYPES:
+        return None, f"{key} cannot be changed through this endpoint.", None
+
+    if key in _DELEGATED_NORMALIZERS:
+        return _DELEGATED_NORMALIZERS[key](value, field), None, None
+
+    if field_type == "switch":
+        return _coerce_bool(value), None, None
+
+    if field_type == "select":
+        allowed = [option["value"] for option in field.get("options", [])]
+        candidate = str(value or "").strip()
+        if candidate not in allowed:
+            return None, f"Expected one of: {', '.join(allowed)}.", None
+        return candidate, None, None
+
+    if field_type == "color":
+        candidate = str(value or "").strip()
+        if not HEX_COLOR_PATTERN.match(candidate):
+            return None, "Expected a hex colour such as #ffc107.", None
+        return candidate.lower(), None, None
+
+    if field_type in ("range", "number"):
+        number, error = _normalize_number(value, field)
+        return number, error, None
+
+    if field_type == "checkbox_set":
+        selection, error = _normalize_checkbox_set(value, field)
+        return selection, error, None
+
+    if field_type == "link_list":
+        links, error = _normalize_link_list(value)
+        return links, error, None
+
+    if field_type == "textarea":
+        text = str(value if value is not None else "")
+        text = text.replace("\r\n", "\n").replace("\r", "\n").strip()
+        max_length = field.get("max_length")
+        if max_length:
+            text = text[:max_length]
+
+        warning = None
+        word_limit = field.get("word_limit")
+        if word_limit and len(text.split()) > word_limit:
+            # Advisory only, matching the server-rendered form, which warns and
+            # saves rather than blocking the whole submission.
+            warning = (
+                f"{len(text.split())} words exceeds the recommended "
+                f"{word_limit} word limit."
+            )
+        return text, None, warning
+
+    if field_type == "text":
+        return _normalize_text(value, field), None, None
+
+    return value, None, None
+
+
+def _validate_redirect_url(value):
+    """Return ``(normalized, error)`` for the Terms of Use cancel redirect.
+
+    ``normalize_terms_of_use_redirect_url`` silently substitutes ``/`` for an
+    unsafe target. That is the right behaviour when reading stored settings, but
+    on an explicit save an administrator should be told their URL was refused
+    rather than discovering later that it reverted.
+    """
+    candidate = str(value or "").strip()
+    normalized = normalize_terms_of_use_redirect_url(candidate)
+    if candidate and normalized != candidate:
+        return None, (
+            "Use a local path such as / or an HTTPS URL without credentials."
+        )
+    return normalized, None
+
+
+def _check_acknowledgements(updates, current_settings, errors):
+    """Enforce the acknowledgements a field requires before it may be enabled."""
+    for _section_id, field in iter_fields():
+        acknowledgement = field.get("requires_acknowledgement")
+        key = field.get("key")
+        if not acknowledgement or not key or key not in updates:
+            continue
+
+        turning_on = _coerce_bool(updates[key])
+        already_on = _coerce_bool(current_settings.get(key, False))
+        if not turning_on or already_on:
+            continue
+
+        if not _coerce_bool(updates.get(acknowledgement["key"])):
+            errors[key] = acknowledgement["message"]
+
+
+def normalize_admin_settings_updates(updates, current_settings=None):
+    """Validate and coerce a partial admin settings update.
+
+    Returns ``(normalized, errors, warnings)``. ``normalized`` is safe to hand to
+    ``update_settings``; it is only meaningful when ``errors`` is empty.
+
+    Keys with no declared field pass through unchanged. That is deliberate: the
+    V2 surface still renders undescribed groups from its ``enable_*`` scan, and
+    those toggles must keep saving while the remaining groups are described.
+    """
+    current = current_settings or {}
+    normalized = {}
+    errors = {}
+    warnings = {}
+
+    # Acknowledgement flags gate a change rather than being stored themselves.
+    acknowledgement_keys = {
+        field["requires_acknowledgement"]["key"]
+        for _section_id, field in iter_fields()
+        if field.get("requires_acknowledgement")
+    }
+
+    for key, value in updates.items():
+        if key in acknowledgement_keys:
+            continue
+
+        field = get_field_definition(key)
+        if field is None:
+            normalized[key] = value
+            continue
+
+        if key == "terms_of_use_decline_redirect_url":
+            redirect_value, redirect_error = _validate_redirect_url(value)
+            if redirect_error:
+                errors[key] = redirect_error
+            else:
+                normalized[key] = redirect_value
+            continue
+
+        field_value, error, warning = _normalize_field_value(key, value, field)
+        if error:
+            errors[key] = error
+            continue
+        if warning:
+            warnings[key] = warning
+        normalized[key] = field_value
+
+    _check_acknowledgements(updates, current, errors)
+
+    # "At least one" style constraints can only be judged once the whole payload
+    # is known, because the capability toggle and its selection may arrive apart.
+    _check_minimum_selections(normalized, current, errors)
+
+    return normalized, errors, warnings
+
+
+def _check_minimum_selections(normalized, current_settings, errors):
+    """Enforce ``min_selected`` once the merged state of a save is known."""
+    for _section_id, field in iter_fields():
+        key = field.get("key")
+        minimum = field.get("min_selected")
+        if not key or not minimum:
+            continue
+
+        depends_on = field.get("depends_on")
+        if depends_on:
+            gate_key = depends_on["key"]
+            gate_value = (
+                normalized[gate_key] if gate_key in normalized
+                else current_settings.get(gate_key, False)
+            )
+            if _coerce_bool(gate_value) != depends_on.get("equals", True):
+                continue
+
+        selection = (
+            normalized[key] if key in normalized else current_settings.get(key) or []
+        )
+        if len(selection) < minimum:
+            errors[key] = f"Select at least {minimum} option."

--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -97,7 +97,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.261.037"
+VERSION = "0.261.038"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/functions_branding_images.py
+++ b/application/single_app/functions_branding_images.py
@@ -1,0 +1,132 @@
+# functions_branding_images.py
+"""Image processing for administrator-supplied branding assets.
+
+Logos and favicons are uploaded by an administrator, converted to a canonical
+form, and stored base64-encoded in the settings document. Two interfaces now
+accept those uploads -- the server-rendered Admin Settings form and the V2
+React admin surface -- so the conversion lives here rather than inside either
+route module. A logo that is resized in one interface and not the other would
+render at a different size depending on where it was uploaded from.
+
+The conversion rules are the ones the server-rendered form has always applied:
+
+- Only PNG and JPEG are decoded, regardless of the file extension supplied, so
+  a renamed file cannot reach Pillow's other decoders.
+- Palette images become RGBA and anything else that is not already RGB or RGBA
+  becomes RGB, because neither PNG nor ICO can encode every Pillow mode.
+- Logos taller than ``MAX_CUSTOM_LOGO_STORAGE_HEIGHT`` are scaled down with
+  their aspect ratio preserved, which keeps the settings document small while
+  still being sharp enough for the landing page to enlarge.
+- Favicons are squared off at 32x32 and encoded as ICO.
+"""
+
+import base64
+from io import BytesIO
+
+from PIL import Image
+
+# Pillow is asked for these formats explicitly. Passing an allow-list to
+# Image.open means an attacker-supplied file cannot select a different decoder
+# by claiming a different format internally.
+ALLOWED_PIL_IMAGE_UPLOAD_FORMATS = ('PNG', 'JPEG')
+
+# Tall enough for the landing page to render a logo scaled up to 500% without
+# visible softening, small enough that the base64 copy stays a reasonable size
+# inside the settings document.
+MAX_CUSTOM_LOGO_STORAGE_HEIGHT = 500
+
+FAVICON_SIZE = (32, 32)
+
+ALLOWED_LOGO_EXTENSIONS = {'png', 'jpg', 'jpeg'}
+ALLOWED_FAVICON_EXTENSIONS = {'png', 'jpg', 'jpeg', 'ico'}
+
+
+def is_allowed_branding_image_filename(filename, allowed_extensions):
+    """Return True when ``filename`` carries one of ``allowed_extensions``.
+
+    This is a first-pass check only. The extension is attacker-controlled, so
+    the real format check happens in ``open_allowed_uploaded_image`` once the
+    bytes have been decoded.
+    """
+    if not filename or '.' not in filename:
+        return False
+    return filename.rsplit('.', 1)[1].lower() in allowed_extensions
+
+
+def open_allowed_uploaded_image(file_bytes, filename):
+    """Decode ``file_bytes`` as PNG or JPEG, or raise ``ValueError``.
+
+    Returns the loaded image and the format Pillow actually detected, which is
+    what callers should log rather than the supplied extension.
+    """
+    img = Image.open(BytesIO(file_bytes), formats=list(ALLOWED_PIL_IMAGE_UPLOAD_FORMATS))
+    img.load()
+
+    detected_format = (img.format or '').upper()
+    if detected_format not in ALLOWED_PIL_IMAGE_UPLOAD_FORMATS:
+        raise ValueError(
+            f"Unsupported image format for {filename}. Allowed formats: "
+            f"{', '.join(ALLOWED_PIL_IMAGE_UPLOAD_FORMATS)}"
+        )
+
+    return img, detected_format
+
+
+def _normalize_image_mode(img):
+    """Convert ``img`` into a mode both PNG and ICO can encode."""
+    if img.mode == 'P':
+        return img.convert('RGBA')
+    if img.mode not in ('RGB', 'RGBA'):
+        return img.convert('RGB')
+    return img
+
+
+def prepare_logo_image_for_storage(file_bytes, filename, max_height=MAX_CUSTOM_LOGO_STORAGE_HEIGHT):
+    """Return a PNG-encoded, height-capped copy of an uploaded logo.
+
+    The returned dict carries both the raw PNG bytes and their base64 form,
+    plus the original and stored dimensions so callers can record what the
+    resize actually did.
+    """
+    img, detected_format = open_allowed_uploaded_image(file_bytes, filename)
+    original_size = img.size
+
+    img = _normalize_image_mode(img)
+
+    if max_height and img.height > max_height:
+        aspect_ratio = img.width / img.height
+        resized_width = max(1, int(round(aspect_ratio * max_height)))
+        img = img.resize((resized_width, max_height), Image.Resampling.LANCZOS)
+
+    img_bytes_io = BytesIO()
+    img.save(img_bytes_io, format='PNG', optimize=True)
+    png_data = img_bytes_io.getvalue()
+
+    return {
+        'detected_format': detected_format,
+        'original_size': original_size,
+        'stored_size': img.size,
+        'png_data': png_data,
+        'base64_str': base64.b64encode(png_data).decode('utf-8'),
+    }
+
+
+def prepare_favicon_image_for_storage(file_bytes, filename, size=FAVICON_SIZE):
+    """Return an ICO-encoded 32x32 copy of an uploaded favicon."""
+    img, detected_format = open_allowed_uploaded_image(file_bytes, filename)
+    original_size = img.size
+
+    img = _normalize_image_mode(img)
+    img = img.resize(size, Image.Resampling.LANCZOS)
+
+    img_bytes_io = BytesIO()
+    img.save(img_bytes_io, format='ICO')
+    ico_data = img_bytes_io.getvalue()
+
+    return {
+        'detected_format': detected_format,
+        'original_size': original_size,
+        'stored_size': img.size,
+        'ico_data': ico_data,
+        'base64_str': base64.b64encode(ico_data).decode('utf-8'),
+    }

--- a/application/single_app/route_backend_v2.py
+++ b/application/single_app/route_backend_v2.py
@@ -21,10 +21,25 @@ Two blueprints are registered from here:
 
 import logging
 
-from flask import jsonify, request, session
+from flask import current_app, jsonify, request, session
 
+from admin_settings_fields import (
+    get_admin_settings_fields,
+    normalize_admin_settings_updates,
+)
 from admin_settings_nav import ADMIN_NAV
+from config import (
+    ensure_custom_favicon_file_exists,
+    ensure_custom_logo_file_exists,
+)
 from functions_appinsights import log_event
+from functions_branding_images import (
+    ALLOWED_FAVICON_EXTENSIONS,
+    ALLOWED_LOGO_EXTENSIONS,
+    is_allowed_branding_image_filename,
+    prepare_favicon_image_for_storage,
+    prepare_logo_image_for_storage,
+)
 from functions_authentication import (
     admin_required,
     get_current_user_id,
@@ -63,6 +78,77 @@ from config import VERSION
 from swagger_wrapper import get_auth_security, swagger_route
 
 logger = logging.getLogger(__name__)
+
+
+# Describes each branding asset an administrator can replace: how to convert the
+# upload, which settings keys hold it, and the static path it is written to.
+# ``_build_branding` returns URLs derived from these same keys, so a change here
+# cannot leave the SPA pointing at a stale path.
+BRANDING_IMAGE_TARGETS = {
+    "logo": {
+        "settings_key": "custom_logo_base64",
+        "version_key": "logo_version",
+        "static_url": "/static/images/custom_logo.png",
+        "extensions": ALLOWED_LOGO_EXTENSIONS,
+        "prepare": prepare_logo_image_for_storage,
+    },
+    "logo_dark": {
+        "settings_key": "custom_logo_dark_base64",
+        "version_key": "logo_dark_version",
+        "static_url": "/static/images/custom_logo_dark.png",
+        "extensions": ALLOWED_LOGO_EXTENSIONS,
+        "prepare": prepare_logo_image_for_storage,
+    },
+    "favicon": {
+        "settings_key": "custom_favicon_base64",
+        "version_key": "favicon_version",
+        "static_url": "/static/images/favicon.ico",
+        "extensions": ALLOWED_FAVICON_EXTENSIONS,
+        "prepare": prepare_favicon_image_for_storage,
+    },
+}
+
+
+def _build_branding_assets(settings):
+    """Describe the stored branding images without returning the encoded blobs.
+
+    The admin surface needs to show which assets exist and render a preview of
+    each. The base64 payloads are large and already served as static files, so
+    only presence, version and URL are returned.
+    """
+    assets = {}
+    for target, spec in BRANDING_IMAGE_TARGETS.items():
+        version = settings.get(spec["version_key"]) or 1
+        has_asset = bool(settings.get(spec["settings_key"]))
+        assets[target] = {
+            "present": has_asset,
+            "version": version,
+            "url": f"{spec['static_url']}?v={version}" if has_asset else None,
+        }
+    return assets
+
+
+def _refresh_branding_static_files():
+    """Rewrite the logo and favicon static files from the stored settings.
+
+    The files are generated from the settings document rather than uploaded to
+    disk directly, so any save that could have changed them has to regenerate
+    them or the browser keeps being served the previous image.
+    """
+    try:
+        refreshed_settings = get_settings()
+        if not refreshed_settings:
+            return
+        ensure_custom_logo_file_exists(current_app, refreshed_settings)
+        ensure_custom_favicon_file_exists(current_app, refreshed_settings)
+    except Exception as exc:
+        # A stale static file is a cosmetic problem; it must not turn a saved
+        # settings change into a failed request.
+        log_event(
+            f"[V2_ADMIN_SETTINGS] Could not refresh branding static files: {exc}",
+            level=logging.WARNING,
+            exceptionTraceback=True,
+        )
 
 
 def _build_branding(raw_settings, public_settings):
@@ -358,18 +444,25 @@ def register_route_backend_v2_admin(bp):
     @login_required
     @admin_required
     def v2_admin_get_settings():
-        """Return the raw settings document plus the admin navigation structure.
+        """Return the raw settings document, the admin navigation and the field schema.
 
         Admin settings are not sanitized. Sanitization removes keys, secrets and endpoint
         configuration, which are exactly the values an administrator is here to manage.
         Access is restricted to the Admin role by the blueprint guard and the decorator.
+
+        ``field_schema`` describes the concrete controls each section owns. Sections with
+        no entry are rendered by the SPA's ``enable_*`` fallback scan, so groups that have
+        not been described yet keep working.
         """
         try:
+            settings = get_settings()
             return (
                 jsonify(
                     {
-                        "settings": get_settings(),
+                        "settings": settings,
                         "admin_nav": ADMIN_NAV,
+                        "field_schema": get_admin_settings_fields(),
+                        "branding_assets": _build_branding_assets(settings),
                         "version": VERSION,
                     }
                 ),
@@ -390,8 +483,12 @@ def register_route_backend_v2_admin(bp):
     def v2_admin_patch_settings():
         """Apply a partial settings update.
 
-        The V2 admin surface edits individual capabilities rather than posting the whole
+        The V2 admin surface edits a section at a time rather than posting the whole
         settings form, so only the supplied keys are forwarded to ``update_settings``.
+
+        Values are normalized against the field schema first, which is what keeps the two
+        admin interfaces agreeing on what a valid value is. The update is applied only if
+        every supplied key validates, so a save never lands half-applied.
         """
         payload = request.get_json(silent=True) or {}
         updates = payload.get("settings")
@@ -400,13 +497,53 @@ def register_route_backend_v2_admin(bp):
             return jsonify({"error": "No settings supplied"}), 400
 
         try:
-            update_settings(updates)
+            current_settings = get_settings()
+            normalized, errors, warnings = normalize_admin_settings_updates(
+                updates, current_settings
+            )
+
+            if errors:
+                log_event(
+                    f"[V2_ADMIN_SETTINGS] Rejected update for "
+                    f"{', '.join(sorted(errors.keys()))}",
+                    level=logging.WARNING,
+                )
+                return (
+                    jsonify(
+                        {
+                            "error": "Some settings could not be saved.",
+                            "field_errors": errors,
+                        }
+                    ),
+                    400,
+                )
+
+            if not normalized:
+                return jsonify({"error": "No settings supplied"}), 400
+
+            update_settings(normalized)
             log_event(
-                f"[V2_ADMIN_SETTINGS] Updated {len(updates)} setting(s): "
-                f"{', '.join(sorted(updates.keys()))}",
+                f"[V2_ADMIN_SETTINGS] Updated {len(normalized)} setting(s): "
+                f"{', '.join(sorted(normalized.keys()))}",
                 level=logging.INFO,
             )
-            return jsonify({"success": True, "updated_keys": sorted(updates.keys())}), 200
+
+            # Logo scale and title changes are read from the settings document on the
+            # next request, but the favicon and logo static files are written from it, so
+            # a branding change has to refresh them.
+            _refresh_branding_static_files()
+
+            return (
+                jsonify(
+                    {
+                        "success": True,
+                        "updated_keys": sorted(normalized.keys()),
+                        "settings": normalized,
+                        "warnings": warnings,
+                    }
+                ),
+                200,
+            )
         except Exception as exc:
             log_event(
                 f"[V2_ADMIN_SETTINGS] Failed to update settings: {exc}",
@@ -414,3 +551,101 @@ def register_route_backend_v2_admin(bp):
                 exceptionTraceback=True,
             )
             return jsonify({"error": "Failed to update settings"}), 500
+
+    @bp.route("/api/v2/admin/settings/branding-image", methods=["POST"])
+    @swagger_route(security=get_auth_security())
+    @login_required
+    @admin_required
+    def v2_admin_upload_branding_image():
+        """Store an uploaded logo or favicon and return its new static URL.
+
+        Branding images cannot travel through the JSON settings PATCH, so they get their
+        own multipart endpoint. The conversion is the shared one in
+        ``functions_branding_images``, so an asset uploaded here is byte-for-byte what the
+        server-rendered form would have stored.
+
+        The version counter is bumped on every successful upload because the static file
+        keeps a stable name; without the counter, browsers would keep serving the previous
+        image from cache.
+        """
+        target = str(request.form.get("target") or "").strip().lower()
+        spec = BRANDING_IMAGE_TARGETS.get(target)
+        if not spec:
+            return (
+                jsonify(
+                    {
+                        "error": "Unsupported branding image target. Expected one of: "
+                        f"{', '.join(sorted(BRANDING_IMAGE_TARGETS))}."
+                    }
+                ),
+                400,
+            )
+
+        upload = request.files.get("file")
+        if not upload or not upload.filename:
+            return jsonify({"error": "No file was supplied."}), 400
+
+        if not is_allowed_branding_image_filename(upload.filename, spec["extensions"]):
+            return (
+                jsonify(
+                    {
+                        "error": "Unsupported file type. Allowed extensions: "
+                        f"{', '.join(sorted(spec['extensions']))}."
+                    }
+                ),
+                400,
+            )
+
+        try:
+            file_bytes = upload.read()
+            processed = spec["prepare"](file_bytes, upload.filename)
+        except Exception as exc:
+            # A decode failure is administrator error, not a server fault, and the
+            # existing asset must survive it.
+            log_event(
+                f"[V2_ADMIN_SETTINGS] Rejected {target} upload: {exc}",
+                level=logging.WARNING,
+            )
+            return (
+                jsonify({"error": f"That image could not be processed: {exc}"}),
+                400,
+            )
+
+        try:
+            settings = get_settings()
+            next_version = int(settings.get(spec["version_key"], 1) or 1) + 1
+
+            update_settings(
+                {
+                    spec["settings_key"]: processed["base64_str"],
+                    spec["version_key"]: next_version,
+                }
+            )
+            _refresh_branding_static_files()
+
+            log_event(
+                f"[V2_ADMIN_SETTINGS] Stored {target} image "
+                f"({processed['detected_format']}, {processed['original_size']} -> "
+                f"{processed['stored_size']}, version {next_version})",
+                level=logging.INFO,
+            )
+
+            return (
+                jsonify(
+                    {
+                        "success": True,
+                        "target": target,
+                        "url": f"{spec['static_url']}?v={next_version}",
+                        "version": next_version,
+                        "stored_size": list(processed["stored_size"]),
+                    }
+                ),
+                200,
+            )
+        except Exception as exc:
+            log_event(
+                f"[V2_ADMIN_SETTINGS] Failed to store {target} image: {exc}",
+                level=logging.ERROR,
+                exceptionTraceback=True,
+            )
+            return jsonify({"error": "Failed to store the uploaded image"}), 500

--- a/application/single_app/route_frontend_admin_settings.py
+++ b/application/single_app/route_frontend_admin_settings.py
@@ -37,6 +37,10 @@ from functions_cosmos_throughput import (
     normalize_cosmos_throughput_settings,
     validate_cosmos_throughput_policy_settings,
 )
+from functions_branding_images import (
+    prepare_favicon_image_for_storage,
+    prepare_logo_image_for_storage,
+)
 from functions_activity_logging import log_web_search_consent_acceptance, log_general_admin_action, log_governance_change
 from functions_notifications import broadcast_system_notification
 from functions_logging import *
@@ -72,8 +76,6 @@ from support_menu_config import (
     normalize_support_latest_features_visibility,
 )
 
-ALLOWED_PIL_IMAGE_UPLOAD_FORMATS = ('PNG', 'JPEG')
-MAX_CUSTOM_LOGO_STORAGE_HEIGHT = 500
 AGENTS_PAGE_DEFAULTS = {
     'agents_page_title': 'Find your next AI partner',
     'agents_page_subtitle': 'Explore specialized agents built to accelerate how you work.',
@@ -105,44 +107,6 @@ def _is_update_version_newer(latest_version, current_version):
 def allowed_file(filename, allowed_extensions):
     return '.' in filename and \
            filename.rsplit('.', 1)[1].lower() in allowed_extensions
-
-def open_allowed_uploaded_image(file_bytes, filename):
-    img = Image.open(BytesIO(file_bytes), formats=list(ALLOWED_PIL_IMAGE_UPLOAD_FORMATS))
-    img.load()
-
-    detected_format = (img.format or '').upper()
-    if detected_format not in ALLOWED_PIL_IMAGE_UPLOAD_FORMATS:
-        raise ValueError(
-            f"Unsupported image format for {filename}. Allowed formats: {', '.join(ALLOWED_PIL_IMAGE_UPLOAD_FORMATS)}"
-        )
-
-    return img, detected_format
-
-def prepare_logo_image_for_storage(file_bytes, filename, max_height=MAX_CUSTOM_LOGO_STORAGE_HEIGHT):
-    img, detected_format = open_allowed_uploaded_image(file_bytes, filename)
-    original_size = img.size
-
-    if img.mode == 'P':
-        img = img.convert('RGBA')
-    elif img.mode != 'RGB' and img.mode != 'RGBA':
-        img = img.convert('RGB')
-
-    if max_height and img.height > max_height:
-        aspect_ratio = img.width / img.height
-        resized_width = max(1, int(round(aspect_ratio * max_height)))
-        img = img.resize((resized_width, max_height), Image.Resampling.LANCZOS)
-
-    img_bytes_io = BytesIO()
-    img.save(img_bytes_io, format='PNG', optimize=True)
-    png_data = img_bytes_io.getvalue()
-
-    return {
-        'detected_format': detected_format,
-        'original_size': original_size,
-        'stored_size': img.size,
-        'png_data': png_data,
-        'base64_str': base64.b64encode(png_data).decode('utf-8'),
-    }
 
 def normalize_agents_page_color(value, fallback):
     candidate = str(value or '').strip()
@@ -3080,7 +3044,6 @@ def register_route_frontend_admin_settings(bp):
             favicon_file = request.files.get('favicon_file')
             if favicon_file and allowed_file(favicon_file.filename, ALLOWED_EXTENSIONS_IMG):
                 try:
-                    # 1) Read file fully into memory:
                     file_bytes = favicon_file.read()
                     add_file_task_to_file_processing_log(
                         document_id='Image_Upload', # Placeholder if needed
@@ -3088,58 +3051,22 @@ def register_route_frontend_admin_settings(bp):
                         content=f"Favicon file uploaded: {favicon_file.filename}"
                     )
 
-                    # 2) Load into Pillow from the original bytes for processing
-                    img, detected_format = open_allowed_uploaded_image(file_bytes, favicon_file.filename)
-                    
-                    add_file_task_to_file_processing_log(
-                        document_id='Image_Upload', # Placeholder if needed
-                        user_id='New_image',
-                        content=f"Loaded favicon image for processing: {favicon_file.filename} (format: {detected_format})"
-                    )
-
-                    # 3) Ensure image mode is compatible (e.g., convert palette modes)
-                    if img.mode == 'P':
-                        img = img.convert('RGBA')
-                    elif img.mode != 'RGB' and img.mode != 'RGBA':
-                         img = img.convert('RGB')
+                    processed_favicon = prepare_favicon_image_for_storage(file_bytes, favicon_file.filename)
 
                     add_file_task_to_file_processing_log(
                         document_id='Image_Upload', # Placeholder if needed
                         user_id='New_image',
-                        content=f"Converted favicon image mode for processing: {favicon_file.filename} (mode: {img.mode})"
-                    )
-
-                    # 4) Resize to appropriate favicon size (16x16 or 32x32)
-                    img = img.resize((32, 32), Image.Resampling.LANCZOS)
-
-                    add_file_task_to_file_processing_log(
-                        document_id='Image_Upload', # Placeholder if needed
-                        user_id='New_image',
-                        content=f"Resized favicon image for processing: {favicon_file.filename} (new size: {img.size})"
-                    )
-
-                    # 5) Convert to ICO in-memory
-                    img_bytes_io = BytesIO()
-                    img.save(img_bytes_io, format='ICO')
-                    ico_data = img_bytes_io.getvalue()
-
-                    add_file_task_to_file_processing_log(
-                        document_id='Image_Upload', # Placeholder if needed
-                        user_id='New_image',
-                        content=f"Converted favicon image to ICO for processing: {favicon_file.filename}"
-                    )
-
-                    # 6) Turn to base64
-                    base64_str = base64.b64encode(ico_data).decode('utf-8')
-
-                    add_file_task_to_file_processing_log(
-                        document_id='Image_Upload', # Placeholder if needed
-                        user_id='New_image',
-                        content=f"Converted favicon image to base64 for processing: {base64_str}"
+                        content=(
+                            f"Prepared favicon asset: {favicon_file.filename} "
+                            f"(format: {processed_favicon['detected_format']}, "
+                            f"original size: {processed_favicon['original_size']}, "
+                            f"stored size: {processed_favicon['stored_size']}, "
+                            f"ico bytes: {len(processed_favicon['ico_data'])})"
+                        )
                     )
 
                     # Update only on success
-                    new_settings['custom_favicon_base64'] = base64_str
+                    new_settings['custom_favicon_base64'] = processed_favicon['base64_str']
 
                     current_version = settings.get('favicon_version', 1) # Get version from settings loaded at start
                     new_settings['favicon_version'] = current_version + 1 # Increment

--- a/application/v2_ui/src/components/admin/AdminMarkdown.tsx
+++ b/application/v2_ui/src/components/admin/AdminMarkdown.tsx
@@ -1,0 +1,57 @@
+// AdminMarkdown.tsx
+// Markdown preview for administrator-authored content.
+//
+// Deliberately not `AssistantMarkdown`: that renderer parses citations, applies masking
+// ranges and hosts diagram and chart blocks, none of which apply to a landing page or an
+// agreement, and all of which would misread ordinary admin copy.
+//
+// `react-markdown` does not render raw HTML unless `rehype-raw` is added, which it is not
+// here. Admin-authored markdown therefore cannot inject script or event handlers into the
+// settings page.
+
+import Markdown from 'react-markdown';
+import remarkBreaks from 'remark-breaks';
+import remarkGfm from 'remark-gfm';
+import { clsx } from 'clsx';
+
+export function AdminMarkdown({
+    content,
+    className,
+    align = 'left',
+}: {
+    content: string;
+    className?: string;
+    /** Mirrors `landing_page_alignment` so the preview matches the real page. */
+    align?: 'left' | 'center' | 'right';
+}) {
+    const trimmed = content.trim();
+
+    if (!trimmed) {
+        return <p className="text-sm text-text-3 italic">Nothing to preview yet.</p>;
+    }
+
+    return (
+        <div
+            className={clsx(
+                'space-y-2 text-sm leading-relaxed text-text-2',
+                '[&_a]:text-accent [&_a]:underline',
+                '[&_code]:rounded [&_code]:bg-surface-sunken [&_code]:px-1 [&_code]:py-0.5',
+                '[&_h1]:text-base [&_h1]:font-semibold [&_h1]:text-text-1',
+                '[&_h2]:text-sm [&_h2]:font-semibold [&_h2]:text-text-1',
+                '[&_h3]:text-sm [&_h3]:font-medium [&_h3]:text-text-1',
+                '[&_li]:ml-4 [&_li]:list-disc',
+                '[&_ol_li]:list-decimal',
+                '[&_pre]:overflow-x-auto [&_pre]:rounded-lg [&_pre]:bg-surface-sunken [&_pre]:p-3',
+                '[&_strong]:font-semibold [&_strong]:text-text-1',
+                '[&_table]:w-full [&_table]:border-collapse',
+                '[&_td]:border [&_td]:border-edge [&_td]:px-2 [&_td]:py-1',
+                '[&_th]:border [&_th]:border-edge [&_th]:px-2 [&_th]:py-1 [&_th]:text-left',
+                align === 'center' && 'text-center',
+                align === 'right' && 'text-right',
+                className,
+            )}
+        >
+            <Markdown remarkPlugins={[remarkGfm, remarkBreaks]}>{trimmed}</Markdown>
+        </div>
+    );
+}

--- a/application/v2_ui/src/components/admin/AdminModal.tsx
+++ b/application/v2_ui/src/components/admin/AdminModal.tsx
@@ -1,0 +1,92 @@
+// AdminModal.tsx
+// Dialog shell shared by the Admin Settings modals.
+//
+// Follows the conventions the chat dialogs already established: a click-to-close backdrop,
+// Escape to dismiss, focus moved in on open and handed back on close, and no focus-trap
+// utility, since no other dialog in this UI uses one.
+
+import { useEffect, useRef, type ReactNode } from 'react';
+import { clsx } from 'clsx';
+import { X } from 'lucide-react';
+import { GlassPanel } from '../ui/primitives';
+
+export function AdminModal({
+    title,
+    description,
+    onClose,
+    footer,
+    size = 'md',
+    children,
+}: {
+    title: string;
+    description?: string;
+    onClose: () => void;
+    footer?: ReactNode;
+    size?: 'md' | 'lg';
+    children: ReactNode;
+}) {
+    const closeRef = useRef<HTMLButtonElement>(null);
+
+    useEffect(() => {
+        const onKeyDown = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') {
+                onClose();
+            }
+        };
+        document.addEventListener('keydown', onKeyDown);
+        return () => document.removeEventListener('keydown', onKeyDown);
+    }, [onClose]);
+
+    useEffect(() => {
+        const previous = document.activeElement as HTMLElement | null;
+        closeRef.current?.focus();
+        return () => previous?.focus?.();
+    }, []);
+
+    return (
+        <div
+            className="fixed inset-0 z-50 flex items-center justify-center p-4"
+            role="dialog"
+            aria-modal="true"
+            aria-label={title}
+        >
+            <div className="absolute inset-0 bg-black/60" aria-hidden="true" onClick={onClose} />
+
+            <GlassPanel
+                elevation="modal"
+                edge
+                className={clsx(
+                    'relative flex max-h-[88vh] w-full flex-col overflow-hidden',
+                    size === 'lg' ? 'max-w-4xl' : 'max-w-2xl',
+                )}
+            >
+                <div className="flex shrink-0 items-start gap-3 border-b border-edge px-5 py-3">
+                    <div className="min-w-0 flex-1">
+                        <h2 className="truncate text-sm font-semibold text-text-1">{title}</h2>
+                        {description ? (
+                            <p className="mt-0.5 text-xs text-text-3">{description}</p>
+                        ) : null}
+                    </div>
+                    <button
+                        ref={closeRef}
+                        type="button"
+                        onClick={onClose}
+                        title="Close"
+                        aria-label="Close"
+                        className="shrink-0 rounded-lg p-1.5 text-text-3 transition-colors hover:bg-surface-2 hover:text-text-1"
+                    >
+                        <X size={16} />
+                    </button>
+                </div>
+
+                <div className="min-h-0 flex-1 overflow-y-auto px-5 py-4">{children}</div>
+
+                {footer ? (
+                    <div className="flex shrink-0 items-center justify-end gap-2 border-t border-edge px-5 py-3">
+                        {footer}
+                    </div>
+                ) : null}
+            </GlassPanel>
+        </div>
+    );
+}

--- a/application/v2_ui/src/components/admin/BrandingImageField.tsx
+++ b/application/v2_ui/src/components/admin/BrandingImageField.tsx
@@ -1,0 +1,159 @@
+// BrandingImageField.tsx
+// Upload control for a logo or favicon.
+//
+// Branding images cannot ride along with the JSON settings PATCH, so this control saves
+// immediately through the multipart branding endpoint rather than joining the page's
+// buffered draft. That is a deliberate exception to the save-bar model: a file input has no
+// meaningful "unsaved" state to show, and the server has to convert the image before
+// anything can be previewed.
+
+import { useRef, useState } from 'react';
+import { clsx } from 'clsx';
+import { AlertCircle, Check, ImageOff, Loader2, Upload } from 'lucide-react';
+import { ApiError, uploadFile } from '../../lib/apiClient';
+import type { AdminField, BrandingAsset, BrandingUploadResponse } from '../../lib/adminFields';
+import { GlassButton } from '../ui/primitives';
+
+export function BrandingImageField({
+    field,
+    asset,
+    scalePercent,
+    onUploaded,
+}: {
+    field: AdminField;
+    asset?: BrandingAsset;
+    /** Applied to the preview so the logo size control can be judged against the real image. */
+    scalePercent?: number;
+    onUploaded: (target: string, result: BrandingUploadResponse) => void;
+}) {
+    const inputRef = useRef<HTMLInputElement>(null);
+    const [uploading, setUploading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [savedAt, setSavedAt] = useState<number | null>(null);
+
+    const target = field.upload_target;
+    const isFavicon = target === 'favicon';
+
+    const handleFile = async (file: File) => {
+        if (!target) {
+            return;
+        }
+        setUploading(true);
+        setError(null);
+        setSavedAt(null);
+
+        const formData = new FormData();
+        formData.append('target', target);
+        formData.append('file', file);
+
+        try {
+            const result = await uploadFile<BrandingUploadResponse>(
+                '/api/v2/admin/settings/branding-image',
+                formData,
+            );
+            onUploaded(target, result);
+            setSavedAt(Date.now());
+        } catch (uploadError) {
+            setError(
+                uploadError instanceof ApiError || uploadError instanceof Error
+                    ? uploadError.message
+                    : 'The upload failed.',
+            );
+        } finally {
+            setUploading(false);
+            // Clearing the input lets the same file be chosen again after a failure.
+            if (inputRef.current) {
+                inputRef.current.value = '';
+            }
+        }
+    };
+
+    return (
+        <div className="py-3">
+            <div className="mb-1.5 flex items-baseline justify-between gap-3">
+                <span className="text-sm font-medium text-text-1">{field.label}</span>
+                {asset?.present ? (
+                    <span className="text-xs text-text-3">version {asset.version}</span>
+                ) : null}
+            </div>
+
+            <div className="flex items-start gap-3">
+                <div
+                    className={clsx(
+                        'flex shrink-0 items-center justify-center overflow-hidden rounded-lg',
+                        'border border-edge bg-surface-sunken',
+                        isFavicon ? 'h-16 w-16' : 'h-16 w-28',
+                    )}
+                >
+                    {asset?.url ? (
+                        <img
+                            src={asset.url}
+                            alt={`${field.label} preview`}
+                            className="max-h-full max-w-full object-contain"
+                            style={
+                                scalePercent && !isFavicon
+                                    ? { transform: `scale(${Math.min(scalePercent, 100) / 100})` }
+                                    : undefined
+                            }
+                        />
+                    ) : (
+                        <ImageOff size={18} className="text-text-3" aria-hidden="true" />
+                    )}
+                </div>
+
+                <div className="min-w-0 flex-1">
+                    <input
+                        ref={inputRef}
+                        type="file"
+                        accept={field.accept}
+                        className="sr-only"
+                        aria-label={`Upload ${field.label}`}
+                        onChange={(event) => {
+                            const file = event.target.files?.[0];
+                            if (file) {
+                                void handleFile(file);
+                            }
+                        }}
+                    />
+                    <div className="flex items-center gap-2">
+                        <GlassButton
+                            type="button"
+                            variant="subtle"
+                            size="sm"
+                            disabled={uploading}
+                            onClick={() => inputRef.current?.click()}
+                        >
+                            {uploading ? (
+                                <Loader2 size={14} className="animate-spin" />
+                            ) : (
+                                <Upload size={14} />
+                            )}
+                            {asset?.present ? 'Replace' : 'Upload'}
+                        </GlassButton>
+
+                        {savedAt ? (
+                            <span className="flex items-center gap-1 text-xs text-ok">
+                                <Check size={13} />
+                                Saved
+                            </span>
+                        ) : null}
+                    </div>
+
+                    {field.help ? (
+                        <p className="mt-1.5 text-xs leading-relaxed text-text-3">{field.help}</p>
+                    ) : null}
+
+                    {error ? (
+                        <p
+                            role="alert"
+                            className="mt-1.5 flex items-start gap-1.5 text-xs text-danger"
+                        >
+                            <AlertCircle size={13} className="mt-0.5 shrink-0" />
+                            {error}
+                        </p>
+                    ) : null}
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/application/v2_ui/src/components/admin/CustomPageDesigner.tsx
+++ b/application/v2_ui/src/components/admin/CustomPageDesigner.tsx
@@ -1,0 +1,368 @@
+// CustomPageDesigner.tsx
+// Create and edit static custom page metadata.
+//
+// Backed by the same `/api/admin/custom-pages` CRUD the server-rendered designer uses, so a
+// page created in either interface is identical. The form only writes metadata: the HTML,
+// CSS, JS and asset files themselves are deployed with the application, and this names
+// which of them a page uses.
+
+import { useState } from 'react';
+import { clsx } from 'clsx';
+import { AlertCircle, Loader2, Plus, X } from 'lucide-react';
+import { AdminModal } from './AdminModal';
+import { GlassButton } from '../ui/primitives';
+import {
+    ACCESS_LEVEL_LABELS,
+    parseRoles,
+    validateCustomPage,
+    type CustomPage,
+} from '../../lib/customPages';
+
+const inputClass = clsx(
+    'w-full rounded-lg border border-edge bg-surface-1 px-2.5 py-1.5',
+    'text-sm text-text-1 placeholder:text-text-3',
+    'focus:border-accent focus:outline-none',
+);
+
+const FILE_FIELDS: Array<{ key: 'css_files' | 'js_files' | 'asset_files' | 'json_files'; label: string; placeholder: string }> = [
+    { key: 'css_files', label: 'CSS files', placeholder: 'my-page.css' },
+    { key: 'js_files', label: 'JavaScript files', placeholder: 'my-page.js' },
+    { key: 'asset_files', label: 'Asset files', placeholder: 'logo.png' },
+    { key: 'json_files', label: 'JSON files', placeholder: 'config.json' },
+];
+
+function Field({
+    label,
+    error,
+    help,
+    children,
+}: {
+    label: string;
+    error?: string;
+    help?: string;
+    children: React.ReactNode;
+}) {
+    return (
+        <div>
+            <label className="mb-1 block text-xs font-medium text-text-2">{label}</label>
+            {children}
+            {help ? <p className="mt-1 text-xs text-text-3">{help}</p> : null}
+            {error ? (
+                <p role="alert" className="mt-1 flex items-center gap-1 text-xs text-danger">
+                    <AlertCircle size={12} className="shrink-0" />
+                    {error}
+                </p>
+            ) : null}
+        </div>
+    );
+}
+
+/** A named list of deployed files, added one at a time. */
+function FileListEditor({
+    label,
+    placeholder,
+    files,
+    error,
+    onChange,
+}: {
+    label: string;
+    placeholder: string;
+    files: string[];
+    error?: string;
+    onChange: (next: string[]) => void;
+}) {
+    const [entry, setEntry] = useState('');
+
+    const add = () => {
+        const candidate = entry.trim();
+        if (!candidate || files.includes(candidate)) {
+            setEntry('');
+            return;
+        }
+        onChange([...files, candidate]);
+        setEntry('');
+    };
+
+    return (
+        <Field label={label} error={error}>
+            <div className="flex gap-1.5">
+                <input
+                    type="text"
+                    className={clsx(inputClass, 'font-mono text-xs')}
+                    placeholder={placeholder}
+                    value={entry}
+                    spellCheck={false}
+                    aria-label={`Add a ${label.toLowerCase()} entry`}
+                    onChange={(event) => setEntry(event.target.value)}
+                    onKeyDown={(event) => {
+                        if (event.key === 'Enter') {
+                            event.preventDefault();
+                            add();
+                        }
+                    }}
+                />
+                <GlassButton type="button" variant="subtle" size="sm" onClick={add}>
+                    <Plus size={14} />
+                </GlassButton>
+            </div>
+
+            {files.length ? (
+                <ul className="mt-1.5 flex flex-wrap gap-1.5">
+                    {files.map((file) => (
+                        <li
+                            key={file}
+                            className="flex items-center gap-1 rounded-md border border-edge bg-surface-2 px-2 py-0.5 font-mono text-xs text-text-2"
+                        >
+                            {file}
+                            <button
+                                type="button"
+                                aria-label={`Remove ${file}`}
+                                className="text-text-3 transition-colors hover:text-danger"
+                                onClick={() => onChange(files.filter((item) => item !== file))}
+                            >
+                                <X size={12} />
+                            </button>
+                        </li>
+                    ))}
+                </ul>
+            ) : null}
+        </Field>
+    );
+}
+
+export function CustomPageDesigner({
+    page,
+    isNew,
+    existingSlugs,
+    saving,
+    serverError,
+    onCancel,
+    onSave,
+}: {
+    page: CustomPage;
+    isNew: boolean;
+    existingSlugs: string[];
+    saving: boolean;
+    serverError: string | null;
+    onCancel: () => void;
+    onSave: (page: CustomPage) => void;
+}) {
+    const [draft, setDraft] = useState<CustomPage>(page);
+    const [rolesText, setRolesText] = useState(page.roles.join(', '));
+    const [showErrors, setShowErrors] = useState(false);
+
+    const errors = validateCustomPage(draft);
+    if (isNew && existingSlugs.includes(draft.slug)) {
+        errors.slug = 'A custom page with this slug already exists.';
+    }
+    const visibleErrors = showErrors ? errors : {};
+
+    const patch = (changes: Partial<CustomPage>) =>
+        setDraft((current) => ({ ...current, ...changes }));
+
+    const submit = () => {
+        setShowErrors(true);
+        if (Object.keys(errors).length) {
+            return;
+        }
+        onSave({ ...draft, roles: parseRoles(rolesText) });
+    };
+
+    return (
+        <AdminModal
+            title={isNew ? 'New static page' : `Edit ${page.slug}`}
+            description="Metadata only. The files themselves are deployed with the application."
+            size="lg"
+            onClose={onCancel}
+            footer={
+                <>
+                    <GlassButton type="button" variant="ghost" size="sm" onClick={onCancel}>
+                        Cancel
+                    </GlassButton>
+                    <GlassButton
+                        type="button"
+                        variant="primary"
+                        size="sm"
+                        disabled={saving}
+                        onClick={submit}
+                    >
+                        {saving ? <Loader2 size={14} className="animate-spin" /> : null}
+                        Save page
+                    </GlassButton>
+                </>
+            }
+        >
+            <div className="space-y-4">
+                {serverError ? (
+                    <p
+                        role="alert"
+                        className="flex items-start gap-2 rounded-lg border border-edge bg-danger-soft px-3 py-2 text-xs text-danger"
+                    >
+                        <AlertCircle size={14} className="mt-0.5 shrink-0" />
+                        {serverError}
+                    </p>
+                ) : null}
+
+                <div className="grid gap-3 sm:grid-cols-2">
+                    <Field
+                        label="Slug"
+                        error={visibleErrors.slug}
+                        help={draft.slug ? `Served at /custom/${draft.slug}` : 'Served at /custom/<slug>'}
+                    >
+                        <input
+                            type="text"
+                            className={clsx(inputClass, 'font-mono text-xs')}
+                            placeholder="team-dashboard"
+                            value={draft.slug}
+                            spellCheck={false}
+                            // Editing a slug would orphan the existing document, so it is
+                            // fixed once the page exists. V1 behaves the same way.
+                            disabled={!isNew}
+                            onChange={(event) =>
+                                patch({ slug: event.target.value.trim().toLowerCase() })
+                            }
+                        />
+                    </Field>
+
+                    <Field label="Title" error={visibleErrors.title}>
+                        <input
+                            type="text"
+                            className={inputClass}
+                            value={draft.title}
+                            onChange={(event) => patch({ title: event.target.value })}
+                        />
+                    </Field>
+                </div>
+
+                <Field label="Description">
+                    <textarea
+                        className={clsx(inputClass, 'resize-y')}
+                        rows={2}
+                        value={draft.description}
+                        onChange={(event) => patch({ description: event.target.value })}
+                    />
+                </Field>
+
+                <Field label="HTML file" error={visibleErrors.html_file}>
+                    <input
+                        type="text"
+                        className={clsx(inputClass, 'font-mono text-xs')}
+                        placeholder="my-page.html"
+                        value={draft.html_file}
+                        spellCheck={false}
+                        onChange={(event) => patch({ html_file: event.target.value })}
+                    />
+                </Field>
+
+                <div className="grid gap-3 sm:grid-cols-3">
+                    <Field label="Navigation label">
+                        <input
+                            type="text"
+                            className={inputClass}
+                            placeholder={draft.title || 'Navigation label'}
+                            value={draft.nav_label}
+                            onChange={(event) => patch({ nav_label: event.target.value })}
+                        />
+                    </Field>
+                    <Field label="Bootstrap icon">
+                        <input
+                            type="text"
+                            className={clsx(inputClass, 'font-mono text-xs')}
+                            placeholder="bi-file-earmark-text"
+                            value={draft.nav_icon}
+                            spellCheck={false}
+                            onChange={(event) => patch({ nav_icon: event.target.value })}
+                        />
+                    </Field>
+                    <Field label="Order">
+                        <input
+                            type="number"
+                            className={inputClass}
+                            value={draft.nav_order}
+                            onChange={(event) =>
+                                patch({ nav_order: Number(event.target.value) || 0 })
+                            }
+                        />
+                    </Field>
+                </div>
+
+                <div className="grid gap-3 sm:grid-cols-2">
+                    <Field label="Access level">
+                        <select
+                            className={clsx(inputClass, 'appearance-none')}
+                            value={draft.access_level}
+                            onChange={(event) =>
+                                patch({
+                                    access_level: event.target
+                                        .value as CustomPage['access_level'],
+                                })
+                            }
+                        >
+                            {Object.entries(ACCESS_LEVEL_LABELS).map(([value, label]) => (
+                                <option key={value} value={value}>
+                                    {label}
+                                </option>
+                            ))}
+                        </select>
+                    </Field>
+                    <Field
+                        label="Allowed roles"
+                        help="Comma separated. Leave blank to allow all signed-in users."
+                    >
+                        <input
+                            type="text"
+                            className={inputClass}
+                            placeholder="Admin, User"
+                            value={rolesText}
+                            onChange={(event) => setRolesText(event.target.value)}
+                        />
+                    </Field>
+                </div>
+
+                <div className="rounded-lg border border-edge p-3">
+                    <h3 className="mb-3 text-xs font-semibold text-text-1">Deployed files</h3>
+                    <div className="grid gap-3 sm:grid-cols-2">
+                        {FILE_FIELDS.map((entry) => (
+                            <FileListEditor
+                                key={entry.key}
+                                label={entry.label}
+                                placeholder={entry.placeholder}
+                                files={draft[entry.key]}
+                                error={visibleErrors[entry.key]}
+                                onChange={(next) => patch({ [entry.key]: next } as Partial<CustomPage>)}
+                            />
+                        ))}
+                    </div>
+                </div>
+
+                <div className="rounded-lg border border-edge p-3">
+                    <h3 className="mb-2 text-xs font-semibold text-text-1">Publishing</h3>
+                    <div className="grid gap-2 sm:grid-cols-3">
+                        {(
+                            [
+                                ['enabled', 'Enabled'],
+                                ['show_in_nav', 'Show in navigation'],
+                                ['open_in_new_tab', 'Open in new tab'],
+                            ] as const
+                        ).map(([key, label]) => (
+                            <label
+                                key={key}
+                                className="flex cursor-pointer items-center gap-2 text-sm text-text-2"
+                            >
+                                <input
+                                    type="checkbox"
+                                    className="accent-[var(--accent)]"
+                                    checked={draft[key]}
+                                    onChange={(event) =>
+                                        patch({ [key]: event.target.checked } as Partial<CustomPage>)
+                                    }
+                                />
+                                {label}
+                            </label>
+                        ))}
+                    </div>
+                </div>
+            </div>
+        </AdminModal>
+    );
+}

--- a/application/v2_ui/src/components/admin/CustomPagesTable.tsx
+++ b/application/v2_ui/src/components/admin/CustomPagesTable.tsx
@@ -1,0 +1,334 @@
+// CustomPagesTable.tsx
+// Lists static custom page metadata and hosts the designer and developer guide.
+//
+// This talks to `/api/admin/custom-pages` directly rather than going through the settings
+// PATCH, because page metadata lives in its own Cosmos container, not in the settings
+// document. Changes here therefore save immediately and are not part of the page's draft.
+
+import { useCallback, useEffect, useState } from 'react';
+import { clsx } from 'clsx';
+import {
+    AlertCircle,
+    BookOpen,
+    Loader2,
+    Pencil,
+    Plus,
+    Trash2,
+    UserPlus,
+} from 'lucide-react';
+import { ApiError, api } from '../../lib/apiClient';
+import {
+    emptyCustomPage,
+    isReadOnly,
+    toCustomPage,
+    type CustomPage,
+} from '../../lib/customPages';
+import { AdminMarkdown } from './AdminMarkdown';
+import { AdminModal } from './AdminModal';
+import { CustomPageDesigner } from './CustomPageDesigner';
+import { GlassButton } from '../ui/primitives';
+
+interface ListResponse {
+    pages: unknown[];
+}
+
+function Pill({ tone, children }: { tone: 'ok' | 'muted'; children: React.ReactNode }) {
+    return (
+        <span
+            className={clsx(
+                'rounded-full px-1.5 py-0.5 text-[10px] font-semibold tracking-wide uppercase',
+                tone === 'ok' ? 'bg-ok-soft text-ok' : 'bg-surface-2 text-text-3',
+            )}
+        >
+            {children}
+        </span>
+    );
+}
+
+function DeveloperGuideModal({ onClose }: { onClose: () => void }) {
+    const [markdown, setMarkdown] = useState<string | null>(null);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        let cancelled = false;
+        void (async () => {
+            try {
+                const response = await api.get<{ markdown: string }>(
+                    '/api/admin/custom-pages/developer-guide',
+                );
+                if (!cancelled) {
+                    setMarkdown(response.markdown);
+                }
+            } catch (fetchError) {
+                if (!cancelled) {
+                    setError(
+                        fetchError instanceof Error
+                            ? fetchError.message
+                            : 'The developer guide could not be loaded.',
+                    );
+                }
+            }
+        })();
+        return () => {
+            cancelled = true;
+        };
+    }, []);
+
+    return (
+        <AdminModal title="Custom Pages developer guide" size="lg" onClose={onClose}>
+            {error ? (
+                <p role="alert" className="text-sm text-danger">
+                    {error}
+                </p>
+            ) : markdown === null ? (
+                <p className="flex items-center gap-2 text-sm text-text-3">
+                    <Loader2 size={14} className="animate-spin" />
+                    Loading…
+                </p>
+            ) : (
+                <AdminMarkdown content={markdown} />
+            )}
+        </AdminModal>
+    );
+}
+
+export function CustomPagesTable({ help }: { help?: string }) {
+    const [pages, setPages] = useState<CustomPage[] | null>(null);
+    const [error, setError] = useState<string | null>(null);
+    const [editing, setEditing] = useState<{ page: CustomPage; isNew: boolean } | null>(null);
+    const [designerError, setDesignerError] = useState<string | null>(null);
+    const [busy, setBusy] = useState(false);
+    const [showGuide, setShowGuide] = useState(false);
+
+    const load = useCallback(async () => {
+        try {
+            const response = await api.get<ListResponse>('/api/admin/custom-pages');
+            setPages((response.pages ?? []).map(toCustomPage));
+            setError(null);
+        } catch (fetchError) {
+            setError(
+                fetchError instanceof Error
+                    ? fetchError.message
+                    : 'Custom pages could not be loaded.',
+            );
+            setPages([]);
+        }
+    }, []);
+
+    useEffect(() => {
+        void load();
+    }, [load]);
+
+    const save = async (page: CustomPage) => {
+        setBusy(true);
+        setDesignerError(null);
+        try {
+            if (editing?.isNew) {
+                await api.post('/api/admin/custom-pages', page);
+            } else {
+                await api.put(`/api/admin/custom-pages/${encodeURIComponent(page.slug)}`, page);
+            }
+            setEditing(null);
+            await load();
+        } catch (saveError) {
+            setDesignerError(
+                saveError instanceof ApiError || saveError instanceof Error
+                    ? saveError.message
+                    : 'The page could not be saved.',
+            );
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    const remove = async (page: CustomPage) => {
+        if (!window.confirm(`Delete the custom page "${page.slug}"?`)) {
+            return;
+        }
+        setBusy(true);
+        try {
+            await api.delete(`/api/admin/custom-pages/${encodeURIComponent(page.slug)}`);
+            await load();
+        } catch (deleteError) {
+            setError(
+                deleteError instanceof Error
+                    ? deleteError.message
+                    : 'The page could not be deleted.',
+            );
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    const addRequestAccessPage = async () => {
+        setBusy(true);
+        try {
+            await api.post('/api/admin/custom-pages/request-access-example');
+            await load();
+        } catch (createError) {
+            setError(
+                createError instanceof Error
+                    ? createError.message
+                    : 'The Request Access page could not be created.',
+            );
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    return (
+        <div className="py-3">
+            <div className="mb-2 flex flex-wrap items-start justify-between gap-2">
+                <div className="min-w-0">
+                    <span className="block text-sm font-medium text-text-1">
+                        Static page metadata
+                    </span>
+                    {help ? <p className="mt-0.5 text-xs text-text-3">{help}</p> : null}
+                </div>
+                <div className="flex shrink-0 flex-wrap gap-1.5">
+                    <GlassButton
+                        type="button"
+                        variant="subtle"
+                        size="sm"
+                        onClick={() => setShowGuide(true)}
+                    >
+                        <BookOpen size={14} />
+                        Guide
+                    </GlassButton>
+                    <GlassButton
+                        type="button"
+                        variant="subtle"
+                        size="sm"
+                        disabled={busy}
+                        onClick={() => void addRequestAccessPage()}
+                    >
+                        <UserPlus size={14} />
+                        Request Access page
+                    </GlassButton>
+                    <GlassButton
+                        type="button"
+                        variant="primary"
+                        size="sm"
+                        onClick={() => {
+                            setDesignerError(null);
+                            setEditing({ page: emptyCustomPage(), isNew: true });
+                        }}
+                    >
+                        <Plus size={14} />
+                        New page
+                    </GlassButton>
+                </div>
+            </div>
+
+            {error ? (
+                <p role="alert" className="mb-2 flex items-start gap-1.5 text-xs text-danger">
+                    <AlertCircle size={13} className="mt-0.5 shrink-0" />
+                    {error}
+                </p>
+            ) : null}
+
+            {pages === null ? (
+                <p className="flex items-center gap-2 py-4 text-sm text-text-3">
+                    <Loader2 size={14} className="animate-spin" />
+                    Loading custom pages…
+                </p>
+            ) : pages.length === 0 ? (
+                <p className="rounded-lg border border-dashed border-edge px-3 py-4 text-sm text-text-3">
+                    No custom pages defined yet.
+                </p>
+            ) : (
+                <div className="overflow-x-auto rounded-lg border border-edge">
+                    <table className="w-full text-left text-sm">
+                        <thead className="bg-surface-2 text-xs text-text-3">
+                            <tr>
+                                <th className="px-3 py-2 font-medium">Slug</th>
+                                <th className="px-3 py-2 font-medium">Title</th>
+                                <th className="px-3 py-2 font-medium">Access</th>
+                                <th className="px-3 py-2 font-medium">Status</th>
+                                <th className="px-3 py-2 font-medium">Nav</th>
+                                <th className="px-3 py-2 font-medium sr-only">Actions</th>
+                            </tr>
+                        </thead>
+                        <tbody className="divide-y divide-edge">
+                            {pages.map((page) => {
+                                const readOnly = isReadOnly(page);
+                                return (
+                                    <tr key={page.slug} className="text-text-2">
+                                        <td className="px-3 py-2 font-mono text-xs text-text-1">
+                                            {page.slug}
+                                            {readOnly ? (
+                                                <span className="ml-1.5">
+                                                    <Pill tone="muted">Python</Pill>
+                                                </span>
+                                            ) : null}
+                                        </td>
+                                        <td className="px-3 py-2">{page.title}</td>
+                                        <td className="px-3 py-2 text-xs">{page.access_level}</td>
+                                        <td className="px-3 py-2">
+                                            <Pill tone={page.enabled ? 'ok' : 'muted'}>
+                                                {page.enabled ? 'Enabled' : 'Disabled'}
+                                            </Pill>
+                                        </td>
+                                        <td className="px-3 py-2 text-xs">
+                                            {page.show_in_nav ? page.nav_label || page.title : '—'}
+                                        </td>
+                                        <td className="px-3 py-2">
+                                            <div className="flex justify-end gap-1">
+                                                <button
+                                                    type="button"
+                                                    title={
+                                                        readOnly
+                                                            ? 'Python-backed pages are managed in code'
+                                                            : 'Edit'
+                                                    }
+                                                    aria-label={`Edit ${page.slug}`}
+                                                    disabled={readOnly || busy}
+                                                    onClick={() => {
+                                                        setDesignerError(null);
+                                                        setEditing({ page, isNew: false });
+                                                    }}
+                                                    className="rounded-lg p-1.5 text-text-3 transition-colors hover:bg-surface-2 hover:text-text-1 disabled:cursor-not-allowed disabled:opacity-40"
+                                                >
+                                                    <Pencil size={14} />
+                                                </button>
+                                                <button
+                                                    type="button"
+                                                    title={
+                                                        readOnly
+                                                            ? 'Python-backed pages are managed in code'
+                                                            : 'Delete'
+                                                    }
+                                                    aria-label={`Delete ${page.slug}`}
+                                                    disabled={readOnly || busy}
+                                                    onClick={() => void remove(page)}
+                                                    className="rounded-lg p-1.5 text-text-3 transition-colors hover:bg-danger-soft hover:text-danger disabled:cursor-not-allowed disabled:opacity-40"
+                                                >
+                                                    <Trash2 size={14} />
+                                                </button>
+                                            </div>
+                                        </td>
+                                    </tr>
+                                );
+                            })}
+                        </tbody>
+                    </table>
+                </div>
+            )}
+
+            {editing ? (
+                <CustomPageDesigner
+                    key={editing.page.slug || '__new'}
+                    page={editing.page}
+                    isNew={editing.isNew}
+                    existingSlugs={(pages ?? []).map((page) => page.slug)}
+                    saving={busy}
+                    serverError={designerError}
+                    onCancel={() => setEditing(null)}
+                    onSave={(page) => void save(page)}
+                />
+            ) : null}
+
+            {showGuide ? <DeveloperGuideModal onClose={() => setShowGuide(false)} /> : null}
+        </div>
+    );
+}

--- a/application/v2_ui/src/components/admin/ExternalLinksEditor.tsx
+++ b/application/v2_ui/src/components/admin/ExternalLinksEditor.tsx
@@ -1,0 +1,211 @@
+// ExternalLinksEditor.tsx
+// Repeatable label/URL editor for the navigation links.
+//
+// The server-rendered form keeps this list in a hidden JSON field maintained by script.
+// Here it is ordinary state that flows into the page's draft like any other field, so the
+// list is saved by the same save bar as everything else in the section.
+//
+// Order is meaningful: navigation renders the links in array order, so rows can be moved.
+
+import { clsx } from 'clsx';
+import { ArrowDown, ArrowUp, Link2, Plus, Trash2 } from 'lucide-react';
+import { AlertCircle } from 'lucide-react';
+import type { AdminField } from '../../lib/adminFields';
+import { GlassButton } from '../ui/primitives';
+
+export interface ExternalLink {
+    label: string;
+    url: string;
+}
+
+/** Read the stored value defensively; it is administrator data from the database. */
+export function readExternalLinks(value: unknown): ExternalLink[] {
+    if (!Array.isArray(value)) {
+        return [];
+    }
+    return value
+        .filter((item): item is Record<string, unknown> => Boolean(item) && typeof item === 'object')
+        .map((item) => ({
+            label: typeof item.label === 'string' ? item.label : '',
+            url: typeof item.url === 'string' ? item.url : '',
+        }));
+}
+
+/**
+ * Local mirror of the server's link check, so a bad row is flagged while typing rather
+ * than only when the save is rejected. The server check remains authoritative.
+ */
+function describeRowProblem(link: ExternalLink): string | null {
+    if (!link.label.trim() && !link.url.trim()) {
+        return null;
+    }
+    if (!link.label.trim()) {
+        return 'Label is required.';
+    }
+    const url = link.url.trim();
+    if (!url) {
+        return 'URL is required.';
+    }
+    if (url.startsWith('/') && !url.startsWith('//')) {
+        return null;
+    }
+    if (!/^https?:\/\/[^/]/i.test(url)) {
+        return 'Use a local path, or an http or https address.';
+    }
+    return null;
+}
+
+const inputClass = clsx(
+    'w-full rounded-lg border border-edge bg-surface-1 px-2.5 py-1.5',
+    'text-sm text-text-1 placeholder:text-text-3',
+    'focus:border-accent focus:outline-none',
+);
+
+export function ExternalLinksEditor({
+    field,
+    value,
+    error,
+    onChange,
+}: {
+    field: AdminField;
+    value: unknown;
+    error?: string;
+    onChange: (next: ExternalLink[]) => void;
+}) {
+    const links = readExternalLinks(value);
+
+    const replace = (index: number, patch: Partial<ExternalLink>) => {
+        onChange(links.map((link, i) => (i === index ? { ...link, ...patch } : link)));
+    };
+
+    const move = (index: number, delta: number) => {
+        const target = index + delta;
+        if (target < 0 || target >= links.length) {
+            return;
+        }
+        const next = [...links];
+        [next[index], next[target]] = [next[target], next[index]];
+        onChange(next);
+    };
+
+    return (
+        <div className="py-3">
+            <div className="mb-1.5 flex items-baseline justify-between gap-3">
+                <span className="text-sm font-medium text-text-1">{field.label}</span>
+                <span className="text-xs text-text-3">
+                    {links.length} link{links.length === 1 ? '' : 's'}
+                </span>
+            </div>
+
+            {links.length === 0 ? (
+                <div className="flex items-center gap-2 rounded-lg border border-dashed border-edge px-3 py-4 text-sm text-text-3">
+                    <Link2 size={15} aria-hidden="true" />
+                    No links yet.
+                </div>
+            ) : (
+                <ul className="space-y-2">
+                    {links.map((link, index) => {
+                        const problem = describeRowProblem(link);
+                        return (
+                            <li
+                                key={index}
+                                className="rounded-lg border border-edge bg-surface-1 p-2"
+                            >
+                                <div className="flex items-start gap-2">
+                                    <div className="grid min-w-0 flex-1 gap-2 sm:grid-cols-2">
+                                        <input
+                                            type="text"
+                                            className={inputClass}
+                                            placeholder="Label"
+                                            aria-label={`Link ${index + 1} label`}
+                                            maxLength={80}
+                                            value={link.label}
+                                            onChange={(event) =>
+                                                replace(index, { label: event.target.value })
+                                            }
+                                        />
+                                        <input
+                                            type="text"
+                                            className={clsx(inputClass, 'font-mono text-xs')}
+                                            placeholder="https://example.com"
+                                            aria-label={`Link ${index + 1} URL`}
+                                            maxLength={2000}
+                                            spellCheck={false}
+                                            value={link.url}
+                                            onChange={(event) =>
+                                                replace(index, { url: event.target.value })
+                                            }
+                                        />
+                                    </div>
+
+                                    <div className="flex shrink-0 items-center">
+                                        <button
+                                            type="button"
+                                            title="Move up"
+                                            aria-label={`Move link ${index + 1} up`}
+                                            disabled={index === 0}
+                                            onClick={() => move(index, -1)}
+                                            className="rounded-lg p-1.5 text-text-3 transition-colors hover:bg-surface-2 hover:text-text-1 disabled:cursor-not-allowed disabled:opacity-40"
+                                        >
+                                            <ArrowUp size={14} />
+                                        </button>
+                                        <button
+                                            type="button"
+                                            title="Move down"
+                                            aria-label={`Move link ${index + 1} down`}
+                                            disabled={index === links.length - 1}
+                                            onClick={() => move(index, 1)}
+                                            className="rounded-lg p-1.5 text-text-3 transition-colors hover:bg-surface-2 hover:text-text-1 disabled:cursor-not-allowed disabled:opacity-40"
+                                        >
+                                            <ArrowDown size={14} />
+                                        </button>
+                                        <button
+                                            type="button"
+                                            title="Remove"
+                                            aria-label={`Remove link ${index + 1}`}
+                                            onClick={() =>
+                                                onChange(links.filter((_, i) => i !== index))
+                                            }
+                                            className="rounded-lg p-1.5 text-text-3 transition-colors hover:bg-danger-soft hover:text-danger"
+                                        >
+                                            <Trash2 size={14} />
+                                        </button>
+                                    </div>
+                                </div>
+
+                                {problem ? (
+                                    <p className="mt-1.5 flex items-center gap-1.5 text-xs text-warn">
+                                        <AlertCircle size={12} className="shrink-0" />
+                                        {problem}
+                                    </p>
+                                ) : null}
+                            </li>
+                        );
+                    })}
+                </ul>
+            )}
+
+            <GlassButton
+                type="button"
+                variant="subtle"
+                size="sm"
+                className="mt-2"
+                onClick={() => onChange([...links, { label: '', url: '' }])}
+            >
+                <Plus size={14} />
+                Add link
+            </GlassButton>
+
+            {field.help ? (
+                <p className="mt-1.5 text-xs leading-relaxed text-text-3">{field.help}</p>
+            ) : null}
+
+            {error ? (
+                <p role="alert" className="mt-1.5 flex items-start gap-1.5 text-xs text-danger">
+                    <AlertCircle size={13} className="mt-0.5 shrink-0" />
+                    {error}
+                </p>
+            ) : null}
+        </div>
+    );
+}

--- a/application/v2_ui/src/components/admin/SaveBar.tsx
+++ b/application/v2_ui/src/components/admin/SaveBar.tsx
@@ -1,0 +1,99 @@
+// SaveBar.tsx
+// Sticky bar summarising unsaved edits, with save and discard.
+//
+// The V2 admin surface buffers edits rather than saving each keystroke. That is not only a
+// UI preference: Terms of Use and the AI notice derive a content version from their text
+// and frequency, and every new version re-prompts every user. Saving per keystroke would
+// mint a version per character.
+//
+// The unload guard covers the other half of buffering: edits that only exist in memory
+// have to be defended when the tab is closed.
+
+import { useEffect } from 'react';
+import { clsx } from 'clsx';
+import { Loader2, RotateCcw, Save } from 'lucide-react';
+import { GlassButton } from '../ui/primitives';
+
+export function SaveBar({
+    dirtyCount,
+    saving,
+    onSave,
+    onDiscard,
+}: {
+    dirtyCount: number;
+    saving: boolean;
+    onSave: () => void;
+    onDiscard: () => void;
+}) {
+    const hasChanges = dirtyCount > 0;
+
+    useEffect(() => {
+        if (!hasChanges) {
+            return;
+        }
+        const onBeforeUnload = (event: BeforeUnloadEvent) => {
+            event.preventDefault();
+            // Browsers ignore custom text now, but returnValue still triggers the prompt.
+            event.returnValue = '';
+        };
+        window.addEventListener('beforeunload', onBeforeUnload);
+        return () => window.removeEventListener('beforeunload', onBeforeUnload);
+    }, [hasChanges]);
+
+    // Ctrl/Cmd+S is what an administrator editing a form will reach for.
+    useEffect(() => {
+        if (!hasChanges || saving) {
+            return;
+        }
+        const onKeyDown = (event: KeyboardEvent) => {
+            if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 's') {
+                event.preventDefault();
+                onSave();
+            }
+        };
+        document.addEventListener('keydown', onKeyDown);
+        return () => document.removeEventListener('keydown', onKeyDown);
+    }, [hasChanges, saving, onSave]);
+
+    if (!hasChanges) {
+        return null;
+    }
+
+    return (
+        <div
+            role="status"
+            className={clsx(
+                'sticky bottom-0 z-10 mt-4 flex items-center gap-3 rounded-xl',
+                'glass-raised glass-edge border border-edge px-4 py-3',
+            )}
+        >
+            <p className="min-w-0 flex-1 text-sm text-text-2">
+                <span className="font-medium text-text-1">
+                    {dirtyCount} unsaved change{dirtyCount === 1 ? '' : 's'}
+                </span>
+            </p>
+
+            <GlassButton
+                type="button"
+                variant="ghost"
+                size="sm"
+                disabled={saving}
+                onClick={onDiscard}
+            >
+                <RotateCcw size={14} />
+                Discard
+            </GlassButton>
+
+            <GlassButton
+                type="button"
+                variant="primary"
+                size="sm"
+                disabled={saving}
+                onClick={onSave}
+            >
+                {saving ? <Loader2 size={14} className="animate-spin" /> : <Save size={14} />}
+                {saving ? 'Saving…' : 'Save changes'}
+            </GlassButton>
+        </div>
+    );
+}

--- a/application/v2_ui/src/components/admin/fields.tsx
+++ b/application/v2_ui/src/components/admin/fields.tsx
@@ -1,0 +1,375 @@
+// fields.tsx
+// Generic controls that render one server-declared Admin Settings field.
+//
+// Every control here is driven entirely by the field definition, so describing a new
+// setting in `admin_settings_fields.py` is enough to make it appear and save. Nothing in
+// this file knows about a specific setting.
+//
+// Two conventions worth stating: edits are reported upward and buffered by the page rather
+// than saved per keystroke, and a field's own validation error is rendered beneath it so a
+// rejected save points at the control that caused it.
+
+import { clsx } from 'clsx';
+import { AlertCircle } from 'lucide-react';
+import type { ReactNode } from 'react';
+import {
+    asBoolean,
+    asNumber,
+    asString,
+    asStringArray,
+    countWords,
+    type AdminField,
+} from '../../lib/adminFields';
+import { Toggle } from '../ui/primitives';
+
+const inputClass = clsx(
+    'w-full rounded-lg border border-edge bg-surface-1 px-3 py-2',
+    'text-sm text-text-1 placeholder:text-text-3',
+    'focus:border-accent focus:outline-none',
+    'disabled:cursor-not-allowed disabled:opacity-60',
+);
+
+/** Label, help text, control and error, laid out consistently for every field type. */
+export function FieldShell({
+    field,
+    error,
+    warning,
+    htmlFor,
+    children,
+    trailing,
+}: {
+    field: AdminField;
+    error?: string;
+    warning?: string;
+    htmlFor?: string;
+    children: ReactNode;
+    trailing?: ReactNode;
+}) {
+    return (
+        <div className="py-3">
+            <div className="mb-1.5 flex items-baseline justify-between gap-3">
+                <label
+                    htmlFor={htmlFor}
+                    className="text-sm font-medium text-text-1"
+                >
+                    {field.label}
+                </label>
+                {trailing}
+            </div>
+
+            {children}
+
+            {field.help ? (
+                <p className="mt-1.5 text-xs leading-relaxed text-text-3">{field.help}</p>
+            ) : null}
+
+            {warning ? (
+                <p className="mt-1.5 flex items-start gap-1.5 text-xs text-warn">
+                    <AlertCircle size={13} className="mt-0.5 shrink-0" />
+                    {warning}
+                </p>
+            ) : null}
+
+            {error ? (
+                <p
+                    role="alert"
+                    className="mt-1.5 flex items-start gap-1.5 text-xs text-danger"
+                >
+                    <AlertCircle size={13} className="mt-0.5 shrink-0" />
+                    {error}
+                </p>
+            ) : null}
+        </div>
+    );
+}
+
+export interface FieldControlProps {
+    field: AdminField;
+    value: unknown;
+    error?: string;
+    warning?: string;
+    disabled?: boolean;
+    onChange: (next: unknown) => void;
+}
+
+function TextControl({ field, value, error, warning, disabled, onChange }: FieldControlProps) {
+    const id = `admin-field-${field.key}`;
+    return (
+        <FieldShell field={field} error={error} warning={warning} htmlFor={id}>
+            <input
+                id={id}
+                type="text"
+                className={inputClass}
+                value={asString(value)}
+                maxLength={field.max_length}
+                placeholder={field.placeholder}
+                disabled={disabled}
+                onChange={(event) => onChange(event.target.value)}
+            />
+        </FieldShell>
+    );
+}
+
+function TextAreaControl({ field, value, error, warning, disabled, onChange }: FieldControlProps) {
+    const id = `admin-field-${field.key}`;
+    const text = asString(value);
+    const words = field.word_limit ? countWords(text) : 0;
+    const overLimit = Boolean(field.word_limit && words > field.word_limit);
+
+    return (
+        <FieldShell
+            field={field}
+            error={error}
+            warning={warning}
+            htmlFor={id}
+            trailing={
+                field.word_limit ? (
+                    <span
+                        className={clsx(
+                            'text-xs tabular-nums',
+                            overLimit ? 'text-warn' : 'text-text-3',
+                        )}
+                    >
+                        {words} / {field.word_limit} words
+                    </span>
+                ) : field.max_length ? (
+                    <span className="text-xs tabular-nums text-text-3">
+                        {text.length} / {field.max_length}
+                    </span>
+                ) : null
+            }
+        >
+            <textarea
+                id={id}
+                className={clsx(inputClass, 'resize-y font-mono text-xs leading-relaxed')}
+                rows={field.rows ?? 4}
+                value={text}
+                maxLength={field.max_length}
+                placeholder={field.placeholder}
+                disabled={disabled}
+                onChange={(event) => onChange(event.target.value)}
+            />
+        </FieldShell>
+    );
+}
+
+function SelectControl({ field, value, error, warning, disabled, onChange }: FieldControlProps) {
+    const id = `admin-field-${field.key}`;
+    return (
+        <FieldShell field={field} error={error} warning={warning} htmlFor={id}>
+            <select
+                id={id}
+                className={clsx(inputClass, 'appearance-none pr-8')}
+                value={asString(value, asString(field.default))}
+                disabled={disabled}
+                onChange={(event) => onChange(event.target.value)}
+            >
+                {(field.options ?? []).map((option) => (
+                    <option key={option.value} value={option.value}>
+                        {option.label}
+                    </option>
+                ))}
+            </select>
+        </FieldShell>
+    );
+}
+
+function SwitchControl({ field, value, error, warning, disabled, onChange }: FieldControlProps) {
+    return (
+        <div className="py-1">
+            <Toggle
+                label={field.label}
+                description={field.help}
+                checked={asBoolean(value)}
+                disabled={disabled}
+                onChange={(next) => onChange(next)}
+            />
+            {warning ? (
+                <p className="mt-1 ml-14 text-xs text-warn">{warning}</p>
+            ) : null}
+            {error ? (
+                <p role="alert" className="mt-1 ml-14 text-xs text-danger">
+                    {error}
+                </p>
+            ) : null}
+        </div>
+    );
+}
+
+function ColorControl({ field, value, error, warning, disabled, onChange }: FieldControlProps) {
+    const id = `admin-field-${field.key}`;
+    const current = asString(value, asString(field.default, '#000000'));
+
+    return (
+        <FieldShell field={field} error={error} warning={warning} htmlFor={id}>
+            <div className="flex items-center gap-2">
+                <input
+                    id={id}
+                    type="color"
+                    className="h-9 w-14 shrink-0 cursor-pointer rounded-lg border border-edge bg-surface-1 p-1 disabled:cursor-not-allowed"
+                    value={/^#[0-9a-fA-F]{6}$/.test(current) ? current : '#000000'}
+                    disabled={disabled}
+                    onChange={(event) => onChange(event.target.value)}
+                />
+                {/* The hex is editable too: picking a brand colour by eye is harder than
+                    pasting the value from a brand guide. */}
+                <input
+                    type="text"
+                    aria-label={`${field.label} hex value`}
+                    className={clsx(inputClass, 'font-mono')}
+                    value={current}
+                    disabled={disabled}
+                    spellCheck={false}
+                    onChange={(event) => onChange(event.target.value)}
+                />
+            </div>
+        </FieldShell>
+    );
+}
+
+function RangeControl({ field, value, error, warning, disabled, onChange }: FieldControlProps) {
+    const id = `admin-field-${field.key}`;
+    const min = field.min ?? 0;
+    const max = field.max ?? 100;
+    const current = asNumber(value, asNumber(field.default, min));
+
+    return (
+        <FieldShell
+            field={field}
+            error={error}
+            warning={warning}
+            htmlFor={id}
+            trailing={
+                <span className="text-xs font-semibold tabular-nums text-text-2">
+                    {current}
+                    {field.suffix ?? ''}
+                </span>
+            }
+        >
+            <input
+                id={id}
+                type="range"
+                className="w-full accent-[var(--accent)] disabled:cursor-not-allowed"
+                min={min}
+                max={max}
+                step={field.step ?? 1}
+                value={current}
+                disabled={disabled}
+                onChange={(event) => onChange(Number(event.target.value))}
+            />
+            <div className="flex justify-between text-xs text-text-3">
+                <span>
+                    {min}
+                    {field.suffix ?? ''}
+                </span>
+                <span>
+                    {max}
+                    {field.suffix ?? ''}
+                </span>
+            </div>
+        </FieldShell>
+    );
+}
+
+function NumberControl({ field, value, error, warning, disabled, onChange }: FieldControlProps) {
+    const id = `admin-field-${field.key}`;
+    return (
+        <FieldShell field={field} error={error} warning={warning} htmlFor={id}>
+            <input
+                id={id}
+                type="number"
+                className={inputClass}
+                min={field.min}
+                max={field.max}
+                step={field.step ?? 1}
+                value={asNumber(value, asNumber(field.default, 0))}
+                disabled={disabled}
+                onChange={(event) => onChange(Number(event.target.value))}
+            />
+        </FieldShell>
+    );
+}
+
+function CheckboxSetControl({
+    field,
+    value,
+    error,
+    warning,
+    disabled,
+    onChange,
+}: FieldControlProps) {
+    const selected = asStringArray(value);
+    const options = field.options ?? [];
+
+    const toggle = (optionValue: string, checked: boolean) => {
+        const next = checked
+            ? [...selected, optionValue]
+            : selected.filter((item) => item !== optionValue);
+        // Keep the declared order so the saved array does not depend on click order.
+        onChange(options.map((option) => option.value).filter((item) => next.includes(item)));
+    };
+
+    return (
+        <FieldShell field={field} error={error} warning={warning}>
+            <div className="grid gap-1.5 sm:grid-cols-2">
+                {options.map((option) => {
+                    const id = `admin-field-${field.key}-${option.value}`;
+                    return (
+                        <label
+                            key={option.value}
+                            htmlFor={id}
+                            className={clsx(
+                                'flex items-center gap-2 rounded-lg border border-edge px-3 py-2 text-sm',
+                                disabled
+                                    ? 'cursor-not-allowed opacity-60'
+                                    : 'cursor-pointer hover:bg-surface-2',
+                                selected.includes(option.value)
+                                    ? 'bg-accent-soft text-text-1'
+                                    : 'text-text-2',
+                            )}
+                        >
+                            <input
+                                id={id}
+                                type="checkbox"
+                                className="accent-[var(--accent)]"
+                                checked={selected.includes(option.value)}
+                                disabled={disabled}
+                                onChange={(event) => toggle(option.value, event.target.checked)}
+                            />
+                            {option.label}
+                        </label>
+                    );
+                })}
+            </div>
+        </FieldShell>
+    );
+}
+
+/**
+ * Render one declared field.
+ *
+ * `image`, `link_list` and `component` fields are handled by the page, which owns the
+ * upload endpoint and the bespoke widgets, so they are not reached here.
+ */
+export function SettingField(props: FieldControlProps) {
+    switch (props.field.type) {
+        case 'text':
+            return <TextControl {...props} />;
+        case 'textarea':
+            return <TextAreaControl {...props} />;
+        case 'select':
+            return <SelectControl {...props} />;
+        case 'switch':
+            return <SwitchControl {...props} />;
+        case 'color':
+            return <ColorControl {...props} />;
+        case 'range':
+            return <RangeControl {...props} />;
+        case 'number':
+            return <NumberControl {...props} />;
+        case 'checkbox_set':
+            return <CheckboxSetControl {...props} />;
+        default:
+            return null;
+    }
+}

--- a/application/v2_ui/src/components/admin/previews.tsx
+++ b/application/v2_ui/src/components/admin/previews.tsx
@@ -1,0 +1,98 @@
+// previews.tsx
+// Live previews for the notice settings.
+//
+// Both mirror what a user will actually see, because these settings are judged visually:
+// a banner colour pair either reads clearly or it does not, and an agreement written in
+// markdown is hard to check as source. Both preview the unsaved draft, so the effect of an
+// edit is visible before it is committed.
+
+import { useState } from 'react';
+import { Eye } from 'lucide-react';
+import { AdminMarkdown } from './AdminMarkdown';
+import { AdminModal } from './AdminModal';
+import { GlassButton } from '../ui/primitives';
+
+const HEX = /^#[0-9a-fA-F]{6}$/;
+
+export function ClassificationBannerPreview({
+    text,
+    color,
+    textColor,
+}: {
+    text: string;
+    color: string;
+    textColor: string;
+}) {
+    // An invalid hex is shown as a neutral swatch rather than being passed to the style
+    // attribute, so a half-typed value cannot produce a confusing render.
+    const background = HEX.test(color) ? color : '#ffc107';
+    const foreground = HEX.test(textColor) ? textColor : '#ffffff';
+
+    return (
+        <div className="py-3">
+            <span className="mb-1.5 block text-sm font-medium text-text-1">Preview</span>
+            <div
+                className="rounded-lg px-4 py-2 text-center text-sm font-semibold"
+                style={{ background, color: foreground }}
+            >
+                {text.trim() || 'Banner Preview'}
+            </div>
+            {(!HEX.test(color) || !HEX.test(textColor)) && (
+                <p className="mt-1.5 text-xs text-warn">
+                    Showing default colours until both values are six-digit hex.
+                </p>
+            )}
+        </div>
+    );
+}
+
+export function UserAgreementPreview({ text }: { text: string }) {
+    const [open, setOpen] = useState(false);
+
+    return (
+        <div className="py-3">
+            <GlassButton
+                type="button"
+                variant="subtle"
+                size="sm"
+                onClick={() => setOpen(true)}
+            >
+                <Eye size={14} />
+                Test preview
+            </GlassButton>
+            <p className="mt-1.5 text-xs text-text-3">
+                Shows the agreement as a user will see it, including unsaved edits.
+            </p>
+
+            {open ? (
+                <AdminModal
+                    title="User Agreement"
+                    description="Preview only. Nothing is recorded."
+                    onClose={() => setOpen(false)}
+                    footer={
+                        <>
+                            <GlassButton
+                                type="button"
+                                variant="ghost"
+                                size="sm"
+                                onClick={() => setOpen(false)}
+                            >
+                                Decline
+                            </GlassButton>
+                            <GlassButton
+                                type="button"
+                                variant="primary"
+                                size="sm"
+                                onClick={() => setOpen(false)}
+                            >
+                                Accept
+                            </GlassButton>
+                        </>
+                    }
+                >
+                    <AdminMarkdown content={text} />
+                </AdminModal>
+            ) : null}
+        </div>
+    );
+}

--- a/application/v2_ui/src/lib/adminFields.ts
+++ b/application/v2_ui/src/lib/adminFields.ts
@@ -1,0 +1,202 @@
+// adminFields.ts
+// Types and helpers for the server-declared Admin Settings field schema.
+//
+// The shape here mirrors `admin_settings_fields.py`. The server is the source of truth:
+// this file only describes what arrives so the renderer can be written against real types
+// instead of `unknown`, and holds the pure helpers that decide whether a field is visible
+// and what value it currently has.
+
+import type { Json } from './types';
+
+/** Field kinds the renderer implements. Mirrors `FIELD_TYPES`. */
+export type AdminFieldType =
+    | 'text'
+    | 'textarea'
+    | 'select'
+    | 'switch'
+    | 'checkbox_set'
+    | 'color'
+    | 'range'
+    | 'number'
+    | 'image'
+    | 'link_list'
+    | 'component';
+
+export interface AdminFieldOption {
+    value: string;
+    label: string;
+}
+
+/** Shows a field only while another field holds a given value. */
+export interface AdminFieldDependency {
+    key: string;
+    equals: boolean;
+}
+
+/**
+ * A confirmation an administrator must give before a capability may be switched on.
+ *
+ * Used by Custom Pages, which does not take full effect until the App Service restarts.
+ * The flag is sent with the save and gates it; it is never stored.
+ */
+export interface AdminFieldAcknowledgement {
+    key: string;
+    when: 'enabled';
+    title: string;
+    message: string;
+}
+
+export interface AdminField {
+    key?: string;
+    type: AdminFieldType;
+    label: string;
+    help?: string;
+    placeholder?: string;
+    default?: unknown;
+    max_length?: number;
+    rows?: number;
+    markdown?: boolean;
+    word_limit?: number;
+    options?: AdminFieldOption[];
+    min?: number;
+    max?: number;
+    step?: number;
+    suffix?: string;
+    min_selected?: number;
+    fallback_when_empty?: boolean;
+    item_fields?: AdminField[];
+    /** Image fields only: which branding slot the upload endpoint should write. */
+    upload_target?: 'logo' | 'logo_dark' | 'favicon';
+    accept?: string;
+    version_key?: string;
+    /** Component fields only: which bespoke widget to render. */
+    component?: string;
+    depends_on?: AdminFieldDependency;
+    requires_acknowledgement?: AdminFieldAcknowledgement;
+}
+
+/** Section id -> ordered fields. Section ids come from `admin_settings_nav.py`. */
+export type AdminFieldSchema = Record<string, AdminField[]>;
+
+export interface BrandingAsset {
+    present: boolean;
+    version: number;
+    url: string | null;
+}
+
+export type BrandingAssets = Record<string, BrandingAsset>;
+
+export interface AdminSettingsResponse {
+    settings: Json;
+    admin_nav: import('./types').AdminNavGroup[];
+    field_schema: AdminFieldSchema;
+    branding_assets: BrandingAssets;
+    version: string;
+}
+
+export interface AdminSettingsPatchResponse {
+    success: boolean;
+    updated_keys: string[];
+    settings: Json;
+    warnings: Record<string, string>;
+}
+
+export interface BrandingUploadResponse {
+    success: boolean;
+    target: string;
+    url: string;
+    version: number;
+    stored_size: [number, number];
+}
+
+/** A `field_errors` map returned with a 400 from the settings PATCH. */
+export function extractFieldErrors(payload: unknown): Record<string, string> {
+    if (!payload || typeof payload !== 'object') {
+        return {};
+    }
+    const candidate = (payload as { field_errors?: unknown }).field_errors;
+    if (!candidate || typeof candidate !== 'object') {
+        return {};
+    }
+    return Object.fromEntries(
+        Object.entries(candidate as Record<string, unknown>).map(([key, value]) => [
+            key,
+            String(value),
+        ]),
+    );
+}
+
+/**
+ * Read a field's current value, preferring an unsaved edit over the stored value.
+ *
+ * Falls back to the schema default rather than `undefined` so a control is never
+ * uncontrolled on first render, which React would warn about and which would lose the
+ * first keystroke.
+ */
+export function readFieldValue(field: AdminField, settings: Json, draft: Json): unknown {
+    if (!field.key) {
+        return undefined;
+    }
+    if (Object.prototype.hasOwnProperty.call(draft, field.key)) {
+        return draft[field.key];
+    }
+    const stored = settings[field.key];
+    return stored === undefined || stored === null ? field.default : stored;
+}
+
+export function asString(value: unknown, fallback = ''): string {
+    if (value === undefined || value === null) {
+        return fallback;
+    }
+    return typeof value === 'string' ? value : String(value);
+}
+
+export function asBoolean(value: unknown): boolean {
+    if (typeof value === 'boolean') {
+        return value;
+    }
+    if (typeof value === 'string') {
+        return ['true', 'on', 'yes', '1'].includes(value.trim().toLowerCase());
+    }
+    return Boolean(value);
+}
+
+export function asNumber(value: unknown, fallback: number): number {
+    const parsed = typeof value === 'number' ? value : Number.parseFloat(String(value ?? ''));
+    return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+export function asStringArray(value: unknown): string[] {
+    return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : [];
+}
+
+/** Whether a field's `depends_on` condition is currently satisfied. */
+export function isFieldVisible(field: AdminField, settings: Json, draft: Json): boolean {
+    const dependency = field.depends_on;
+    if (!dependency) {
+        return true;
+    }
+    const current = Object.prototype.hasOwnProperty.call(draft, dependency.key)
+        ? draft[dependency.key]
+        : settings[dependency.key];
+    return asBoolean(current) === dependency.equals;
+}
+
+/** Turn `enable_document_classification` into `Document classification`. */
+export function humanizeKey(key: string): string {
+    const withoutPrefix = key.replace(/^enable_/, '').replace(/_/g, ' ').trim();
+    return withoutPrefix.charAt(0).toUpperCase() + withoutPrefix.slice(1);
+}
+
+/** Words in a textarea, matching the server's `len(text.split())`. */
+export function countWords(text: string): number {
+    const trimmed = text.trim();
+    return trimmed ? trimmed.split(/\s+/).length : 0;
+}
+
+/** Text a field contributes to the page search index. */
+export function fieldSearchText(field: AdminField): string {
+    return [field.key ?? '', field.label, field.help ?? '', field.component ?? '']
+        .join(' ')
+        .toLowerCase();
+}

--- a/application/v2_ui/src/lib/customPages.ts
+++ b/application/v2_ui/src/lib/customPages.ts
@@ -1,0 +1,153 @@
+// customPages.ts
+// Types and helpers for the static custom page designer.
+//
+// The shape mirrors `normalize_custom_page_metadata` in `functions_custom_pages.py`, which
+// is what the CRUD API returns and expects. Validation here is a local mirror of
+// `validate_custom_page_metadata`: it exists to catch mistakes while typing, not to replace
+// the server check, which stays authoritative.
+
+export type CustomPageEntryType = 'static' | 'python';
+export type CustomPageAccessLevel = 'app_user' | 'authenticated';
+
+export interface CustomPage {
+    id?: string;
+    slug: string;
+    title: string;
+    description: string;
+    enabled: boolean;
+    entry_type: CustomPageEntryType;
+    access_level: CustomPageAccessLevel;
+    nav_label: string;
+    nav_icon: string;
+    nav_order: number;
+    roles: string[];
+    show_in_nav: boolean;
+    open_in_new_tab: boolean;
+    html_file: string;
+    css_files: string[];
+    js_files: string[];
+    asset_files: string[];
+    json_files: string[];
+    /** 'cosmos' for pages created here; 'python' for code-registered pages. */
+    source?: string;
+}
+
+export const ACCESS_LEVEL_LABELS: Record<CustomPageAccessLevel, string> = {
+    app_user: 'App users only',
+    authenticated: 'Any signed-in user',
+};
+
+/** File extensions each folder accepts. Mirrors `ASSET_FOLDERS`. */
+export const ASSET_FOLDER_EXTENSIONS: Record<string, string[]> = {
+    css_files: ['.css'],
+    js_files: ['.js'],
+    json_files: ['.json'],
+    asset_files: ['.png', '.jpg', '.jpeg', '.gif', '.svg', '.webp', '.ico', '.woff', '.woff2'],
+};
+
+export const SLUG_PATTERN = /^[a-z0-9][a-z0-9_-]*$/;
+
+export function emptyCustomPage(): CustomPage {
+    return {
+        slug: '',
+        title: '',
+        description: '',
+        enabled: true,
+        entry_type: 'static',
+        access_level: 'app_user',
+        nav_label: '',
+        nav_icon: '',
+        nav_order: 100,
+        roles: [],
+        show_in_nav: true,
+        open_in_new_tab: false,
+        html_file: '',
+        css_files: [],
+        js_files: [],
+        asset_files: [],
+        json_files: [],
+    };
+}
+
+function asStringList(value: unknown): string[] {
+    return Array.isArray(value)
+        ? value.filter((item): item is string => typeof item === 'string')
+        : [];
+}
+
+/** Read an API page defensively into the editor's shape. */
+export function toCustomPage(raw: unknown): CustomPage {
+    const page = (raw ?? {}) as Record<string, unknown>;
+    const base = emptyCustomPage();
+    return {
+        ...base,
+        id: typeof page.id === 'string' ? page.id : undefined,
+        slug: typeof page.slug === 'string' ? page.slug : '',
+        title: typeof page.title === 'string' ? page.title : '',
+        description: typeof page.description === 'string' ? page.description : '',
+        enabled: page.enabled !== false,
+        entry_type: page.entry_type === 'python' ? 'python' : 'static',
+        access_level: page.access_level === 'authenticated' ? 'authenticated' : 'app_user',
+        nav_label: typeof page.nav_label === 'string' ? page.nav_label : '',
+        nav_icon: typeof page.nav_icon === 'string' ? page.nav_icon : '',
+        nav_order: typeof page.nav_order === 'number' ? page.nav_order : 100,
+        roles: asStringList(page.roles),
+        show_in_nav: page.show_in_nav !== false,
+        open_in_new_tab: page.open_in_new_tab === true,
+        html_file: typeof page.html_file === 'string' ? page.html_file : '',
+        css_files: asStringList(page.css_files),
+        js_files: asStringList(page.js_files),
+        asset_files: asStringList(page.asset_files),
+        json_files: asStringList(page.json_files),
+        source: typeof page.source === 'string' ? page.source : undefined,
+    };
+}
+
+/** Pages registered in Python are defined in code and cannot be edited here. */
+export function isReadOnly(page: CustomPage): boolean {
+    return page.source === 'python' || page.entry_type === 'python';
+}
+
+export function validateCustomPage(page: CustomPage): Record<string, string> {
+    const errors: Record<string, string> = {};
+
+    if (!SLUG_PATTERN.test(page.slug)) {
+        errors.slug =
+            'Start with a lowercase letter or number, then lowercase letters, numbers, hyphens or underscores.';
+    }
+    if (!page.title.trim()) {
+        errors.title = 'Title is required.';
+    }
+    if (!page.html_file.trim()) {
+        errors.html_file = 'Static pages need an HTML file.';
+    } else if (!page.html_file.trim().toLowerCase().endsWith('.html')) {
+        errors.html_file = 'The entry file must be a .html file.';
+    }
+
+    for (const [key, extensions] of Object.entries(ASSET_FOLDER_EXTENSIONS)) {
+        const files = page[key as keyof CustomPage] as string[];
+        const bad = files.filter(
+            (file) => !extensions.some((ext) => file.toLowerCase().endsWith(ext)),
+        );
+        if (bad.length) {
+            errors[key] = `Unsupported extension: ${bad.join(', ')}. Expected ${extensions.join(', ')}.`;
+        }
+    }
+
+    const unsafe = [page.html_file, ...page.css_files, ...page.js_files, ...page.asset_files, ...page.json_files]
+        .filter((file) => file)
+        .filter((file) => file.startsWith('/') || file.replace(/\\/g, '/').split('/').includes('..'));
+    if (unsafe.length) {
+        errors.html_file = `Unsafe file path: ${unsafe.join(', ')}.`;
+    }
+
+    return errors;
+}
+
+/** Roles are edited as a comma-separated string, which is how V1 presents them. */
+export function parseRoles(value: string): string[] {
+    return value
+        .split(',')
+        .map((role) => role.trim())
+        .filter(Boolean);
+}

--- a/application/v2_ui/src/pages/AdminSettingsPage.tsx
+++ b/application/v2_ui/src/pages/AdminSettingsPage.tsx
@@ -5,24 +5,62 @@
 // one toggle can take several clicks through two levels of tabs. Here the same structure
 // (still sourced from admin_settings_nav.py, so it cannot drift) is flattened: a slim
 // category rail, a single scrollable pane, and a search box that matches across every
-// section and every capability key at once.
+// section and every setting at once.
+//
+// Two sources feed the controls:
+//
+// `field_schema`
+//     Sections described in `admin_settings_fields.py` render real controls -- text,
+//     selects, colours, ranges, uploads and repeatable lists -- driven entirely by the
+//     declaration. This is the path new work should take.
+//
+// the `enable_*` fallback
+//     Sections not described yet are still discovered by scanning the settings document
+//     for booleans and matching them to a section by word stems. That is how the whole
+//     page used to work; it stays so undescribed groups keep functioning, and it retires
+//     one group at a time as each is described.
+//
+// Edits are buffered into a draft and saved together. Terms of Use and the AI notice
+// derive a content version from their text, and a new version re-prompts every user, so
+// saving per keystroke would mint a version per character.
 
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { clsx } from 'clsx';
-import { Loader2, Search, ShieldAlert, TriangleAlert, Check } from 'lucide-react';
-import { api } from '../lib/apiClient';
+import { Loader2, Search, ShieldAlert, TriangleAlert } from 'lucide-react';
+import { ApiError, api } from '../lib/apiClient';
 import { useBootstrapStore } from '../stores/bootstrapStore';
 import { PageHeader } from '../components/layout/PageHeader';
-import { GlassPanel, Skeleton, Toggle } from '../components/ui/primitives';
+import { GlassButton, GlassPanel, Skeleton, Toggle } from '../components/ui/primitives';
+import { AdminModal } from '../components/admin/AdminModal';
+import { AdminMarkdown } from '../components/admin/AdminMarkdown';
+import { BrandingImageField } from '../components/admin/BrandingImageField';
+import { CustomPagesTable } from '../components/admin/CustomPagesTable';
+import { ExternalLinksEditor } from '../components/admin/ExternalLinksEditor';
+import { SaveBar } from '../components/admin/SaveBar';
+import { SettingField } from '../components/admin/fields';
+import {
+    ClassificationBannerPreview,
+    UserAgreementPreview,
+} from '../components/admin/previews';
+import {
+    asBoolean,
+    asNumber,
+    asString,
+    extractFieldErrors,
+    fieldSearchText,
+    humanizeKey,
+    isFieldVisible,
+    readFieldValue,
+    type AdminField,
+    type AdminSettingsPatchResponse,
+    type AdminSettingsResponse,
+    type BrandingAssets,
+    type BrandingUploadResponse,
+} from '../lib/adminFields';
+import { toast } from '../stores/toastStore';
 import type { AdminNavGroup, Json } from '../lib/types';
 
-interface AdminSettingsResponse {
-    settings: Json;
-    admin_nav: AdminNavGroup[];
-    version: string;
-}
-
-/** One searchable row: a capability key rendered under its section and tab. */
+/** One fallback row: an `enable_*` key with no declared field. */
 interface CapabilityRow {
     key: string;
     label: string;
@@ -33,14 +71,22 @@ interface CapabilityRow {
     sectionLabel: string;
 }
 
-/** Turn `enable_document_classification` into `Document classification`. */
-function humanizeKey(key: string): string {
-    const withoutPrefix = key.replace(/^enable_/, '').replace(/_/g, ' ').trim();
-    return withoutPrefix.charAt(0).toUpperCase() + withoutPrefix.slice(1);
+/** A section as rendered: its declared fields, plus any fallback capability rows. */
+interface RenderedSection {
+    sectionId: string;
+    label: string;
+    groupId: string;
+    groupLabel: string;
+    tabLabel: string;
+    fields: AdminField[];
+    capabilities: CapabilityRow[];
 }
 
+/** Synthetic field definitions used to read a sibling's current value for a preview. */
+const READ_ONLY_REF = (key: string): AdminField => ({ key, type: 'text', label: '' });
+
 /**
- * Associate each `enable_*` setting with a section.
+ * Associate each undeclared `enable_*` setting with a section.
  *
  * The navigation definition names sections but does not enumerate which settings keys
  * belong to them, so keys are matched to the section whose id shares the most leading
@@ -50,9 +96,17 @@ function humanizeKey(key: string): string {
 function buildCapabilityIndex(
     nav: AdminNavGroup[],
     settings: Json,
-): { rows: CapabilityRow[]; unmatched: CapabilityRow[] } {
+    declaredKeys: Set<string>,
+): CapabilityRow[] {
     const capabilityKeys = Object.keys(settings)
-        .filter((key) => key.startsWith('enable_') && typeof settings[key] === 'boolean')
+        .filter(
+            (key) =>
+                key.startsWith('enable_') &&
+                typeof settings[key] === 'boolean' &&
+                // A key with a proper field is rendered by the schema path; rendering it
+                // here as well would put two controls on one value.
+                !declaredKeys.has(key),
+        )
         .sort();
 
     const sections = nav.flatMap((group) =>
@@ -73,10 +127,7 @@ function buildCapabilityIndex(
         ),
     );
 
-    const rows: CapabilityRow[] = [];
-    const unmatched: CapabilityRow[] = [];
-
-    for (const key of capabilityKeys) {
+    return capabilityKeys.map((key) => {
         const keyTokens = key
             .replace(/^enable_/, '')
             .split('_')
@@ -98,7 +149,7 @@ function buildCapabilityIndex(
             }
         }
 
-        const row: CapabilityRow = {
+        return {
             key,
             label: humanizeKey(key),
             groupId: best?.groupId ?? '__other',
@@ -107,27 +158,24 @@ function buildCapabilityIndex(
             sectionId: best?.sectionId ?? '__other',
             sectionLabel: best?.sectionLabel ?? 'Other capabilities',
         };
-
-        if (best) {
-            rows.push(row);
-        } else {
-            unmatched.push(row);
-        }
-    }
-
-    return { rows, unmatched };
+    });
 }
 
 export function AdminSettingsPage() {
     const isAdmin = useBootstrapStore((state) => Boolean(state.data?.user?.is_admin));
 
     const [data, setData] = useState<AdminSettingsResponse | null>(null);
+    const [brandingAssets, setBrandingAssets] = useState<BrandingAssets>({});
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
     const [query, setQuery] = useState('');
     const [activeGroup, setActiveGroup] = useState<string | null>(null);
-    const [savingKey, setSavingKey] = useState<string | null>(null);
-    const [savedKey, setSavedKey] = useState<string | null>(null);
+
+    const [draft, setDraft] = useState<Json>({});
+    const [saving, setSaving] = useState(false);
+    const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+    const [fieldWarnings, setFieldWarnings] = useState<Record<string, string>>({});
+    const [pendingAck, setPendingAck] = useState<AdminField | null>(null);
 
     const searchRef = useRef<HTMLInputElement>(null);
 
@@ -143,6 +191,7 @@ export function AdminSettingsPage() {
                 const response = await api.get<AdminSettingsResponse>('/api/v2/admin/settings');
                 if (!cancelled) {
                     setData(response);
+                    setBrandingAssets(response.branding_assets ?? {});
                     setLoading(false);
                 }
             } catch (fetchError) {
@@ -163,12 +212,14 @@ export function AdminSettingsPage() {
     }, [isAdmin]);
 
     // "/" focuses search from anywhere on the page, which is the whole point of a
-    // search-first surface.
+    // search-first surface. Ignored while typing so it can still be typed into a field.
     useEffect(() => {
         const onKeyDown = (event: KeyboardEvent) => {
             const target = event.target as HTMLElement | null;
             const typingInField =
-                target?.tagName === 'INPUT' || target?.tagName === 'TEXTAREA';
+                target?.tagName === 'INPUT' ||
+                target?.tagName === 'TEXTAREA' ||
+                target?.tagName === 'SELECT';
             if (event.key === '/' && !typingInField) {
                 event.preventDefault();
                 searchRef.current?.focus();
@@ -178,79 +229,360 @@ export function AdminSettingsPage() {
         return () => document.removeEventListener('keydown', onKeyDown);
     }, []);
 
-    const { rows, unmatched } = useMemo(() => {
-        if (!data) {
-            return { rows: [] as CapabilityRow[], unmatched: [] as CapabilityRow[] };
+    const settings = useMemo<Json>(() => data?.settings ?? {}, [data]);
+    const schema = useMemo(() => data?.field_schema ?? {}, [data]);
+
+    const declaredKeys = useMemo(() => {
+        const keys = new Set<string>();
+        for (const fields of Object.values(schema)) {
+            for (const field of fields) {
+                if (field.key) {
+                    keys.add(field.key);
+                }
+            }
         }
-        return buildCapabilityIndex(data.admin_nav, data.settings);
-    }, [data]);
+        return keys;
+    }, [schema]);
 
-    const allRows = useMemo(() => [...rows, ...unmatched], [rows, unmatched]);
+    const capabilityRows = useMemo(
+        () => (data ? buildCapabilityIndex(data.admin_nav, data.settings, declaredKeys) : []),
+        [data, declaredKeys],
+    );
 
-    const visibleRows = useMemo(() => {
+    /** Every section that has something to show, in navigation order. */
+    const sections = useMemo<RenderedSection[]>(() => {
+        if (!data) {
+            return [];
+        }
+
+        const capabilitiesBySection = new Map<string, CapabilityRow[]>();
+        for (const row of capabilityRows) {
+            const existing = capabilitiesBySection.get(row.sectionId);
+            if (existing) {
+                existing.push(row);
+            } else {
+                capabilitiesBySection.set(row.sectionId, [row]);
+            }
+        }
+
+        const rendered: RenderedSection[] = [];
+        for (const group of data.admin_nav) {
+            for (const tab of group.tabs) {
+                for (const section of tab.sections) {
+                    const fields = schema[section.id] ?? [];
+                    const capabilities = capabilitiesBySection.get(section.id) ?? [];
+                    capabilitiesBySection.delete(section.id);
+                    if (!fields.length && !capabilities.length) {
+                        continue;
+                    }
+                    rendered.push({
+                        sectionId: section.id,
+                        label: section.label,
+                        groupId: group.id,
+                        groupLabel: group.label,
+                        tabLabel: tab.label,
+                        fields,
+                        capabilities,
+                    });
+                }
+            }
+        }
+
+        // Anything the stem match could not place still has to be reachable.
+        for (const [sectionId, capabilities] of capabilitiesBySection) {
+            rendered.push({
+                sectionId,
+                label: capabilities[0]?.sectionLabel ?? 'Other capabilities',
+                groupId: capabilities[0]?.groupId ?? '__other',
+                groupLabel: capabilities[0]?.groupLabel ?? 'Other',
+                tabLabel: capabilities[0]?.tabLabel ?? '',
+                fields: [],
+                capabilities,
+            });
+        }
+
+        return rendered;
+    }, [data, schema, capabilityRows]);
+
+    const visibleSections = useMemo(() => {
         const needle = query.trim().toLowerCase();
 
-        return allRows.filter((row) => {
-            if (needle) {
-                // Search spans the key, its readable label and its location, so both
-                // "retention" and "data lifecycle" find the same setting.
-                const haystack =
-                    `${row.key} ${row.label} ${row.sectionLabel} ${row.tabLabel} ${row.groupLabel}`.toLowerCase();
-                return haystack.includes(needle);
-            }
-            if (activeGroup) {
-                return row.groupId === activeGroup;
-            }
-            return true;
-        });
-    }, [allRows, query, activeGroup]);
+        return sections
+            .map((section) => {
+                if (!needle) {
+                    return activeGroup && section.groupId !== activeGroup ? null : section;
+                }
 
-    // Group the visible rows by section, preserving the order they were indexed in.
-    const grouped = useMemo(() => {
-        const bySection = new Map<string, { label: string; group: string; rows: CapabilityRow[] }>();
-        for (const row of visibleRows) {
-            const existing = bySection.get(row.sectionId);
-            if (existing) {
-                existing.rows.push(row);
-            } else {
-                bySection.set(row.sectionId, {
-                    label: row.sectionLabel,
-                    group: row.groupLabel,
-                    rows: [row],
-                });
+                const location =
+                    `${section.label} ${section.tabLabel} ${section.groupLabel}`.toLowerCase();
+                if (location.includes(needle)) {
+                    return section;
+                }
+
+                // Search spans keys, labels and help text, so both "retention" and
+                // "data lifecycle" find the same setting.
+                const fields = section.fields.filter((field) =>
+                    fieldSearchText(field).includes(needle),
+                );
+                const capabilities = section.capabilities.filter((row) =>
+                    `${row.key} ${row.label}`.toLowerCase().includes(needle),
+                );
+                return fields.length || capabilities.length
+                    ? { ...section, fields, capabilities }
+                    : null;
+            })
+            .filter((section): section is RenderedSection => section !== null);
+    }, [sections, query, activeGroup]);
+
+    const settingCount = declaredKeys.size + capabilityRows.length;
+
+    /**
+     * Keys that gate a save rather than being stored.
+     *
+     * They ride along in the draft so they reach the PATCH, but they are not changes an
+     * administrator made and must not be counted as such.
+     */
+    const acknowledgementKeys = useMemo(() => {
+        const keys = new Set<string>();
+        for (const fields of Object.values(schema)) {
+            for (const field of fields) {
+                if (field.requires_acknowledgement) {
+                    keys.add(field.requires_acknowledgement.key);
+                }
             }
         }
-        return [...bySection.entries()];
-    }, [visibleRows]);
+        return keys;
+    }, [schema]);
 
-    const onToggle = async (key: string, next: boolean) => {
-        if (!data) {
+    const dirtyKeys = useMemo(
+        () => Object.keys(draft).filter((key) => !acknowledgementKeys.has(key)),
+        [draft, acknowledgementKeys],
+    );
+
+    const setValue = useCallback((key: string, value: unknown) => {
+        setDraft((current) => ({ ...current, [key]: value }));
+        setFieldErrors((current) => {
+            if (!(key in current)) {
+                return current;
+            }
+            const next = { ...current };
+            delete next[key];
+            return next;
+        });
+    }, []);
+
+    /**
+     * Apply a switch change, intercepting capabilities that require an acknowledgement.
+     *
+     * Custom Pages does not take full effect until the App Service restarts, so an
+     * administrator has to be told before the toggle can be turned on.
+     */
+    const onSwitchChange = useCallback(
+        (field: AdminField, next: boolean) => {
+            if (!field.key) {
+                return;
+            }
+            const acknowledgement = field.requires_acknowledgement;
+            const alreadyOn = asBoolean(settings[field.key]);
+
+            if (acknowledgement && next && !alreadyOn) {
+                setPendingAck(field);
+                return;
+            }
+
+            if (acknowledgement && !next) {
+                // Turning the capability back off before saving must not leave a stale
+                // acknowledgement behind for the next time it is switched on.
+                const fieldKey = field.key;
+                setDraft((current) => {
+                    const updated = { ...current, [fieldKey]: false };
+                    delete updated[acknowledgement.key];
+                    return updated;
+                });
+                return;
+            }
+
+            setValue(field.key, next);
+        },
+        [settings, setValue],
+    );
+
+    const discard = useCallback(() => {
+        setDraft({});
+        setFieldErrors({});
+        setFieldWarnings({});
+    }, []);
+
+    const save = useCallback(async () => {
+        if (!Object.keys(draft).length) {
             return;
         }
-
-        const previous = data.settings[key];
-        setSavingKey(key);
-        setSavedKey(null);
-        setData({ ...data, settings: { ...data.settings, [key]: next } });
+        setSaving(true);
+        setError(null);
+        setFieldErrors({});
 
         try {
-            await api.patch('/api/v2/admin/settings', { settings: { [key]: next } });
-            setSavedKey(key);
-            window.setTimeout(
-                () => setSavedKey((current) => (current === key ? null : current)),
-                1800,
+            const response = await api.patch<AdminSettingsPatchResponse>(
+                '/api/v2/admin/settings',
+                { settings: draft },
             );
-        } catch (patchError) {
-            // Roll the switch back so the UI never claims a change that did not persist.
+
             setData((current) =>
-                current ? { ...current, settings: { ...current.settings, [key]: previous } } : current,
+                current
+                    ? { ...current, settings: { ...current.settings, ...response.settings } }
+                    : current,
             );
-            setError(
-                patchError instanceof Error ? patchError.message : `Could not update ${key}.`,
+            setFieldWarnings(response.warnings ?? {});
+            setDraft({});
+
+            const warningCount = Object.keys(response.warnings ?? {}).length;
+            toast.success(
+                warningCount
+                    ? `Saved with ${warningCount} warning${warningCount === 1 ? '' : 's'}.`
+                    : `Saved ${response.updated_keys.length} setting${
+                          response.updated_keys.length === 1 ? '' : 's'
+                      }.`,
             );
+        } catch (saveError) {
+            const errors =
+                saveError instanceof ApiError ? extractFieldErrors(saveError.payload) : {};
+            if (Object.keys(errors).length) {
+                // Keep the draft so the rejected values stay on screen next to their errors.
+                setFieldErrors(errors);
+                toast.error('Some settings could not be saved.');
+            } else {
+                setError(
+                    saveError instanceof Error ? saveError.message : 'Failed to save settings.',
+                );
+            }
         } finally {
-            setSavingKey(null);
+            setSaving(false);
         }
+    }, [draft]);
+
+    const onBrandingUploaded = useCallback((target: string, result: BrandingUploadResponse) => {
+        setBrandingAssets((current) => ({
+            ...current,
+            [target]: { present: true, version: result.version, url: result.url },
+        }));
+        toast.success('Image uploaded.');
+    }, []);
+
+    /** Read another field's current value, preferring an unsaved edit. */
+    const readSibling = (key: string, fallback = '') =>
+        asString(readFieldValue(READ_ONLY_REF(key), settings, draft), fallback);
+
+    /** Render one declared field, dispatching the types the page owns. */
+    const renderField = (field: AdminField) => {
+        if (!isFieldVisible(field, settings, draft)) {
+            return null;
+        }
+
+        const key = field.key ?? field.component ?? field.label;
+        const value = readFieldValue(field, settings, draft);
+        const error = field.key ? fieldErrors[field.key] : undefined;
+        const warning = field.key ? fieldWarnings[field.key] : undefined;
+
+        if (field.type === 'image') {
+            return (
+                <BrandingImageField
+                    key={key}
+                    field={field}
+                    asset={field.upload_target ? brandingAssets[field.upload_target] : undefined}
+                    scalePercent={asNumber(
+                        readFieldValue(
+                            READ_ONLY_REF('landing_page_logo_scale_percent'),
+                            settings,
+                            draft,
+                        ),
+                        100,
+                    )}
+                    onUploaded={onBrandingUploaded}
+                />
+            );
+        }
+
+        if (field.type === 'link_list') {
+            return (
+                <ExternalLinksEditor
+                    key={key}
+                    field={field}
+                    value={value}
+                    error={error}
+                    onChange={(next) => field.key && setValue(field.key, next)}
+                />
+            );
+        }
+
+        if (field.type === 'component') {
+            switch (field.component) {
+                case 'custom-pages-table':
+                    return <CustomPagesTable key={key} help={field.help} />;
+                case 'classification-banner-preview':
+                    return (
+                        <ClassificationBannerPreview
+                            key={key}
+                            text={readSibling('classification_banner_text')}
+                            color={readSibling('classification_banner_color', '#ffc107')}
+                            textColor={readSibling(
+                                'classification_banner_text_color',
+                                '#ffffff',
+                            )}
+                        />
+                    );
+                case 'user-agreement-preview':
+                    return (
+                        <UserAgreementPreview
+                            key={key}
+                            text={readSibling('user_agreement_text')}
+                        />
+                    );
+                default:
+                    return null;
+            }
+        }
+
+        const control = (
+            <SettingField
+                field={field}
+                value={value}
+                error={error}
+                warning={warning}
+                disabled={saving}
+                onChange={(next) => {
+                    if (field.type === 'switch') {
+                        onSwitchChange(field, asBoolean(next));
+                    } else if (field.key) {
+                        setValue(field.key, next);
+                    }
+                }}
+            />
+        );
+
+        // Markdown fields show what the saved copy will look like, which is the only way
+        // to judge alignment and formatting without leaving the page.
+        if (field.markdown) {
+            const align =
+                field.key === 'landing_page_text'
+                    ? (readSibling('landing_page_alignment', 'left') as
+                          | 'left'
+                          | 'center'
+                          | 'right')
+                    : 'left';
+            return (
+                <div key={key}>
+                    {control}
+                    <div className="mb-3 rounded-lg border border-edge bg-surface-1 p-3">
+                        <span className="mb-1.5 block text-xs font-medium text-text-3">
+                            Preview
+                        </span>
+                        <AdminMarkdown content={asString(value)} align={align} />
+                    </div>
+                </div>
+            );
+        }
+
+        return <div key={key}>{control}</div>;
     };
 
     if (!isAdmin) {
@@ -272,13 +604,19 @@ export function AdminSettingsPage() {
         );
     }
 
+    // Only groups that still rely on the fallback scan should point at the classic page.
+    const activeGroupUsesFallback = sections.some(
+        (section) =>
+            section.capabilities.length > 0 && (!activeGroup || section.groupId === activeGroup),
+    );
+
     return (
         <>
             <PageHeader
                 title="Admin settings"
                 description={
                     data
-                        ? `${allRows.length} capabilities across ${data.admin_nav.length} groups`
+                        ? `${settingCount} settings across ${data.admin_nav.length} groups`
                         : undefined
                 }
             />
@@ -357,72 +695,123 @@ export function AdminSettingsPage() {
                                 </div>
                             )}
 
-                            {!loading && grouped.length === 0 && (
+                            {!loading && visibleSections.length === 0 && (
                                 <p className="py-12 text-center text-sm text-text-3">
                                     No settings match “{query}”.
                                 </p>
                             )}
 
-                            {grouped.map(([sectionId, section]) => (
-                                <GlassPanel key={sectionId} edge className="p-4">
-                                    <div className="mb-2">
+                            {visibleSections.map((section) => (
+                                <GlassPanel key={section.sectionId} edge className="p-4">
+                                    <div className="mb-1">
                                         <h2 className="text-sm font-semibold text-text-1">
                                             {section.label}
                                         </h2>
-                                        <p className="text-xs text-text-3">{section.group}</p>
+                                        <p className="text-xs text-text-3">
+                                            {section.groupLabel}
+                                            {section.tabLabel ? ` · ${section.tabLabel}` : ''}
+                                        </p>
                                     </div>
+
                                     <div className="divide-y divide-edge">
-                                        {section.rows.map((row) => (
-                                            <div
-                                                key={row.key}
-                                                className="flex items-center gap-3 py-1"
-                                            >
-                                                <div className="min-w-0 flex-1">
-                                                    <Toggle
-                                                        label={row.label}
-                                                        description={row.key}
-                                                        checked={Boolean(
-                                                            data?.settings[row.key],
-                                                        )}
-                                                        disabled={savingKey === row.key}
-                                                        onChange={(next) =>
-                                                            void onToggle(row.key, next)
-                                                        }
-                                                    />
-                                                </div>
-                                                {savingKey === row.key && (
-                                                    <Loader2
-                                                        size={14}
-                                                        className="shrink-0 animate-spin text-text-3"
-                                                    />
-                                                )}
-                                                {savedKey === row.key && (
-                                                    <Check
-                                                        size={14}
-                                                        className="shrink-0 text-ok"
-                                                        aria-label="Saved"
-                                                    />
-                                                )}
+                                        {section.fields.map(renderField)}
+
+                                        {section.capabilities.map((row) => (
+                                            <div key={row.key} className="py-1">
+                                                <Toggle
+                                                    label={row.label}
+                                                    description={row.key}
+                                                    checked={asBoolean(
+                                                        Object.prototype.hasOwnProperty.call(
+                                                            draft,
+                                                            row.key,
+                                                        )
+                                                            ? draft[row.key]
+                                                            : settings[row.key],
+                                                    )}
+                                                    disabled={saving}
+                                                    onChange={(next) => setValue(row.key, next)}
+                                                />
                                             </div>
                                         ))}
                                     </div>
                                 </GlassPanel>
                             ))}
 
-                            {!loading && (
+                            {!loading && activeGroupUsesFallback && (
                                 <p className="pb-6 text-center text-xs text-text-3">
-                                    Settings that need more than a switch — endpoints, keys,
-                                    prompts and connection tests — remain on the{' '}
+                                    Settings in this group that need more than a switch —
+                                    endpoints, keys, prompts and connection tests — are still on
+                                    the{' '}
                                     <a href="/admin/settings" className="text-accent underline">
                                         classic admin page
                                     </a>
                                     .
                                 </p>
                             )}
+
+                            <SaveBar
+                                dirtyCount={dirtyKeys.length}
+                                saving={saving}
+                                onSave={() => void save()}
+                                onDiscard={discard}
+                            />
                         </div>
                     </div>
                 </div>
             </div>
+
+            {pendingAck?.requires_acknowledgement ? (
+                <AdminModal
+                    title={pendingAck.requires_acknowledgement.title}
+                    onClose={() => setPendingAck(null)}
+                    footer={
+                        <>
+                            <GlassButton
+                                type="button"
+                                variant="ghost"
+                                size="sm"
+                                onClick={() => setPendingAck(null)}
+                            >
+                                Cancel
+                            </GlassButton>
+                            <GlassButton
+                                type="button"
+                                variant="primary"
+                                size="sm"
+                                onClick={() => {
+                                    const field = pendingAck;
+                                    const acknowledgement = field.requires_acknowledgement;
+                                    if (field.key && acknowledgement) {
+                                        const fieldKey = field.key;
+                                        setDraft((current) => ({
+                                            ...current,
+                                            [fieldKey]: true,
+                                            [acknowledgement.key]: true,
+                                        }));
+                                    }
+                                    setPendingAck(null);
+                                }}
+                            >
+                                I understand, enable it
+                            </GlassButton>
+                        </>
+                    }
+                >
+                    <p className="text-sm leading-relaxed text-text-2">
+                        {pendingAck.requires_acknowledgement.message}
+                    </p>
+                </AdminModal>
+            ) : null}
+
+            {saving ? (
+                <div className="pointer-events-none fixed inset-0 z-40 flex items-end justify-center pb-24">
+                    <span className="flex items-center gap-2 rounded-full bg-surface-solid px-3 py-1.5 text-xs text-text-2 shadow">
+                        <Loader2 size={13} className="animate-spin" />
+                        Saving…
+                    </span>
+                </div>
+            ) : null}
         </>
     );
 }

--- a/docs/explanation/features/REACT_V2_UI.md
+++ b/docs/explanation/features/REACT_V2_UI.md
@@ -185,13 +185,41 @@ images are already served as static files.
 
 Blueprint `backend_v2_admin` — `login_required`, `admin_required`.
 
-Returns the **raw** settings document plus the admin navigation. Admin settings are
-deliberately not sanitized: sanitization removes the keys, secrets and endpoint
-configuration that an administrator is there to manage. Access is gated on the Admin role
-at both the blueprint guard and the route decorator.
+Returns the **raw** settings document, the admin navigation, the field schema and a
+description of the stored branding images. Admin settings are deliberately not sanitized:
+sanitization removes the keys, secrets and endpoint configuration that an administrator is
+there to manage. Access is gated on the Admin role at both the blueprint guard and the
+route decorator.
 
-`PATCH` applies a partial update, so the V2 admin surface can toggle a single capability
-without posting the entire settings form.
+| Key | What it carries |
+| --- | --- |
+| `settings` | The raw settings document. |
+| `admin_nav` | Group → tab → section structure, from `admin_settings_nav.py`. |
+| `field_schema` | Section id → declared fields, from `admin_settings_fields.py`. |
+| `branding_assets` | Presence, version and URL of each logo and the favicon. The base64 blobs are never returned. |
+
+`PATCH` applies a partial update. Supplied values are normalized against the field schema
+before anything is written, and the update is applied only if every key validates, so a
+save never lands half-applied. A rejected save returns `400` with a `field_errors` map so
+the UI can put each message next to the control that caused it.
+
+Values that are advisory rather than invalid — an agreement longer than the recommended
+200 words, for example — are returned in a `warnings` map and still saved, matching what
+the server-rendered form does.
+
+### `POST /api/v2/admin/settings/branding-image`
+
+Blueprint `backend_v2_admin` — `login_required`, `admin_required`. Multipart.
+
+Accepts `target` (`logo`, `logo_dark` or `favicon`) and `file`. Branding images cannot ride
+along with a JSON `PATCH`, and they have to be converted before they can be stored, so they
+get their own endpoint.
+
+The conversion is `functions_branding_images.py`, shared with the server-rendered form, so
+an image uploaded through either interface is stored identically: PNG and JPEG only, logos
+capped at 500px tall, favicons squared off to a 32×32 ICO. Each successful upload bumps the
+matching version counter, because the static file keeps a stable name and browsers would
+otherwise keep serving the previous image.
 
 ## Interface
 
@@ -679,18 +707,92 @@ The server-rendered admin page nests 14 groups → 46 tabs → 96 sections, so f
 toggle can take several clicks through two levels of tabs.
 
 V2 flattens the same structure: a slim category rail for the 14 groups, a single scrollable
-pane of sections, and a search box that matches across every section, tab, group and
-capability key at once. Pressing `/` focuses search from anywhere on the page. Typing
-`retention` or `data lifecycle` both find the retention settings.
+pane of sections, and a search box that matches across every section, tab, group, setting
+key, label and help string at once. Pressing `/` focuses search from anywhere on the page.
+Typing `retention` or `data lifecycle` both find the retention settings.
 
 The structure still comes from `admin_settings_nav.py`, so it cannot drift from the classic
-page. Capability keys are associated with sections by matching word stems between the key
-and the section id; anything that cannot be matched is collected under "Other capabilities"
-rather than hidden, because a silently missing toggle is worse than a misfiled one.
+page.
 
-Toggles save individually via `PATCH`, with the switch rolling back if the request fails.
-Settings that need more than a switch — endpoints, keys, prompts, connection tests — remain
-on the classic admin page, which is linked from the bottom of the V2 page.
+#### Where the controls come from
+
+Two sources feed the page, and which one a section uses depends on whether it has been
+described yet.
+
+**Declared fields.** `admin_settings_fields.py` maps a section id to an ordered list of
+fields, each carrying the type, label, help text, default, bounds, options and visibility
+dependency a generic renderer needs. Everything in the Appearance group is described this
+way, which is what allows V2 to show titles, colour pickers, selects, ranges, markdown
+editors, image uploads and repeatable lists rather than switches alone.
+
+**The `enable_*` fallback.** A section with no declaration is still discovered by scanning
+the settings document for booleans and matching each key to a section by shared word stems.
+Anything unmatched is collected under "Other capabilities" rather than hidden, because a
+silently missing toggle is worse than a misfiled one. This is how the whole page originally
+worked; it stays so undescribed groups keep functioning, and it retires one group at a time
+as each is described.
+
+A key that has a declared field is excluded from the fallback scan, so a setting is never
+rendered twice.
+
+#### Saving
+
+Edits buffer into a draft and save together through a single `PATCH`, from a sticky bar
+that reports how many changes are pending and offers **Save changes** or **Discard**.
+`Ctrl`/`Cmd`+`S` saves, and closing the tab with pending edits prompts first.
+
+Buffering is not only a UI preference. Terms of Use and the AI notice derive a content
+version from their text and frequency, and every new version re-prompts every user. Saving
+on each keystroke would mint a version per character.
+
+Two things save immediately instead, because they are not part of the settings document:
+branding image uploads, which need server-side conversion before anything can be previewed,
+and custom page metadata, which lives in its own Cosmos container.
+
+#### Appearance group
+
+| Tab | What V2 now renders |
+| --- | --- |
+| Branding | Application title, show-logo and hide-title switches, a 50–500% home page logo size slider, light and dark logo uploads and a favicon upload, each with a live preview |
+| Branding → Home Page Text | Markdown alignment, editor toggle, and the landing page text with a live preview that follows the chosen alignment |
+| Branding → Appearance | Dark mode and left navigation defaults |
+| Notices & Agreements | Classification banner with two colour pickers and a live preview; the AI notice text and display behaviour; the full Terms of Use configuration; the user agreement with its four apply-to targets, a word counter and a **Test preview** dialog |
+| Pages & Links | Custom pages with a restart acknowledgement, menu options and the full static page designer; external links as an add, remove and reorder editor |
+
+The static page designer writes to the same `/api/admin/custom-pages` CRUD as the classic
+designer, so a page created in either interface is identical. Python-registered pages are
+listed but not editable, because they are defined in code.
+
+#### Keeping the two interfaces in step
+
+The schema is a second description of settings the server-rendered panes also describe, so
+it could drift. `functional_tests/test_v2_admin_appearance_parity.py` reads the three
+Appearance panes, collects every form field name they submit, and fails unless each one is
+claimed by the schema — directly, through the documented `LEGACY_FIELD_NAMES` aliases where
+the two shapes differ, or through an explicit exemption. It also checks the reverse
+direction, so the schema cannot invent a setting nothing reads, and compares select option
+values and range bounds between the two.
+
+`LEGACY_FIELD_NAMES` records the places the shapes genuinely differ:
+
+| Server-rendered form field | Settings key |
+| --- | --- |
+| `user_agreement_apply_personal` / `_group` / `_public` / `_chat` | `user_agreement_apply_to` (array) |
+| `external_links_json` | `external_links` (array of `{label, url}`) |
+| `logo_file` / `logo_dark_file` / `favicon_file` | `custom_logo_base64` / `custom_logo_dark_base64` / `custom_favicon_base64` |
+| `custom_pages_restart_acknowledged` | An acknowledgement on `enable_custom_pages`, never stored |
+
+#### Adding a group
+
+Describing another group is a Python-only change: add its sections to
+`ADMIN_SETTINGS_FIELDS`, extend the parity test to cover the group's panes, and the V2 page
+renders the new controls without a front-end change. A field type the renderer does not
+implement is caught by `test_v2_admin_field_renderer_coverage.py` rather than silently
+drawing nothing.
+
+Groups that still rely on the fallback scan link to the classic admin page for the settings
+that need more than a switch. That link is now shown only for those groups, since it is
+misleading once a group is fully described.
 
 ### Workspace
 

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,39 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/features) and [Fixes by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/fixes).
 
+### **(v0.261.038)**
+
+#### New Features
+
+*   **The New Admin Settings Page Now Has The Rest Of The Appearance Settings**
+    *   The new interface's admin page could only ever show on/off switches, because it worked out what to display by looking for settings that happened to be true or false. Everything else was invisible — so the whole Appearance group amounted to a handful of switches and a note telling you to go back to the classic page.
+    *   Appearance is now complete. **Branding** has the application title, the home page logo size slider, and uploads for the light logo, dark logo and favicon, each showing the image you currently have. **Home Page Text** has the alignment control and the landing page editor, with a live preview that follows the alignment you pick. **Notices & Agreements** has the classification banner with both colour pickers and a preview strip, the AI notice, the full Terms of Use configuration, and the user agreement with its four apply-to options, a word counter and a **Test preview** button. **Pages & Links** has the custom pages settings, the full static page designer, the developer guide, and an external links editor you can add to, remove from and reorder.
+    *   (Ref: V2 admin settings, Appearance group, `admin_settings_fields.py`)
+
+*   **Changes Are Saved Together, When You Say So**
+    *   Switches used to save the instant you clicked them, which does not translate to typing into a text box. Edits now collect in a bar at the bottom of the page that tells you how many changes are waiting, with **Save changes** and **Discard**. `Ctrl`/`Cmd`+`S` saves, and closing the tab with unsaved edits asks first.
+    *   This also fixes something subtler: the Terms of Use and AI notice re-prompt every user whenever their wording changes. Saving on every keystroke would have re-prompted everyone once per character typed.
+    *   (Ref: V2 admin settings, save bar)
+
+*   **Rejected Settings Now Explain Themselves**
+    *   Values are checked before anything is written, and a rejected save comes back with the reason attached to the control that caused it — a colour that is not valid hex, a link that is not an http or https address, a cancel redirect that would leave the site unsafely. Nothing is saved unless everything in the batch is valid, so a save can no longer land half-applied.
+    *   The checks reuse the same code the classic page uses, so the two interfaces agree about what a valid value is.
+    *   (Ref: V2 admin settings, settings validation)
+
+#### Bug Fixes
+
+*   **Navigation Links Can No Longer Be Given An Unsafe Address**
+    *   External navigation links saved through the new admin page are now restricted to local paths and http or https addresses. Previously any text was accepted and placed directly into the link, which allowed a `javascript:` address into the navigation bar on every page.
+    *   (Ref: external links, navigation)
+
+*   **Logo And Favicon Handling Now Lives In One Place**
+    *   Image conversion was written into the classic settings page. Both admin pages now share one implementation, so a logo is stored identically no matter where it was uploaded from, and the PNG/JPEG-only restriction that keeps unexpected image formats away from the image library applies to every upload path.
+    *   (Ref: `functions_branding_images.py`, logo and favicon uploads)
+
+*   **Three Tests That Could Not Fail Correctly**
+    *   The Pillow security test pinned an exact dependency version and the custom logo test looked for help text in a file it had moved out of, so both reported problems that were not real while no longer checking the thing they were written for. They now assert a minimum version and read the composed template.
+    *   (Ref: functional tests, version assertions)
+
 ### **(v0.261.037)**
 
 #### Bug Fixes

--- a/functional_tests/test_logo_upload_storage_resolution.py
+++ b/functional_tests/test_logo_upload_storage_resolution.py
@@ -3,43 +3,61 @@
 """
 Functional regression test for home page logo upload storage quality.
 
-Version: 0.241.059
+Version: 0.261.038
 Implemented in: 0.241.059
 
 This test ensures that uploaded logos are no longer reduced to 100px tall
 before storage. Instead, the admin upload pipeline preserves enough
 resolution for the home page logo control while capping stored height at
 500px to keep settings payloads bounded.
+
+The conversion helpers moved to ``functions_branding_images.py`` in 0.261.038
+so the V2 admin surface could accept the same uploads without a second
+implementation, so the source assertions follow them there.
 """
 
 import os
 import re
 import sys
 
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+
+from test_support.templates import read_admin_settings_template
+
 
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 ROUTE_FILE = os.path.join(REPO_ROOT, "application", "single_app", "route_frontend_admin_settings.py")
-ADMIN_TEMPLATE = os.path.join(REPO_ROOT, "application", "single_app", "templates", "admin_settings.html")
+BRANDING_IMAGES_FILE = os.path.join(
+    REPO_ROOT, "application", "single_app", "functions_branding_images.py"
+)
 
 
 def test_logo_storage_helper_exists():
-    """Route file should define a dedicated helper and 500px storage cap."""
-    print("Testing route helper for logo storage quality...")
+    """The shared branding module should define the helper and 500px storage cap."""
+    print("Testing shared helper for logo storage quality...")
     errors = []
 
-    with open(ROUTE_FILE, encoding="utf-8") as handle:
+    with open(BRANDING_IMAGES_FILE, encoding="utf-8") as handle:
         content = handle.read()
 
     if "MAX_CUSTOM_LOGO_STORAGE_HEIGHT = 500" not in content:
-        errors.append("MAX_CUSTOM_LOGO_STORAGE_HEIGHT = 500 not found in route_frontend_admin_settings.py")
+        errors.append("MAX_CUSTOM_LOGO_STORAGE_HEIGHT = 500 not found in functions_branding_images.py")
 
     if "def prepare_logo_image_for_storage" not in content:
-        errors.append("prepare_logo_image_for_storage helper not found in route_frontend_admin_settings.py")
+        errors.append("prepare_logo_image_for_storage helper not found in functions_branding_images.py")
 
     if "img.save(img_bytes_io, format='PNG', optimize=True)" not in content:
         errors.append("Logo storage helper does not save optimized PNG output")
 
-    return _summarise(errors, "route helper existence")
+    with open(ROUTE_FILE, encoding="utf-8") as handle:
+        route_content = handle.read()
+
+    # Both admin surfaces must share one conversion, or a logo would be stored
+    # at a different size depending on where it was uploaded from.
+    if "from functions_branding_images import" not in route_content:
+        errors.append("route_frontend_admin_settings.py does not import the shared branding helpers")
+
+    return _summarise(errors, "shared helper existence")
 
 
 def test_logo_upload_no_longer_forces_100px_height():
@@ -70,12 +88,15 @@ def test_logo_upload_no_longer_forces_100px_height():
 
 
 def test_admin_template_documents_500px_storage_cap():
-    """Admin branding UI should explain the higher-resolution storage behavior."""
+    """Admin branding UI should explain the higher-resolution storage behavior.
+
+    The branding controls live in ``templates/admin/_panes/branding.html``, so
+    the parent template has to be composed before the help text is visible.
+    """
     print("\nTesting admin branding help text for logo storage cap...")
     errors = []
 
-    with open(ADMIN_TEMPLATE, encoding="utf-8") as handle:
-        content = handle.read()
+    content = read_admin_settings_template()
 
     if "stored at up to 500px tall" not in content:
         errors.append("Admin settings help text does not mention the 500px logo storage cap")

--- a/functional_tests/test_pillow_psd_upload_hardening.py
+++ b/functional_tests/test_pillow_psd_upload_hardening.py
@@ -1,24 +1,44 @@
 # test_pillow_psd_upload_hardening.py
 """
 Functional test for Pillow PSD upload hardening.
-Version: 0.239.136
+Version: 0.261.038
 Implemented in: 0.239.134
 
 This test ensures the application pins Pillow to a patched version and limits
-admin image uploads to the PNG and JPEG formats that the route already allows.
+admin image uploads to the PNG and JPEG formats that the admin surfaces allow.
+
+The decoding allowlist moved into ``functions_branding_images.py`` in 0.261.038
+so the V2 admin surface shares it. That makes the property to assert stronger
+than before: every upload path must reach Pillow through the one helper that
+passes an explicit ``formats`` allowlist, so no route can decode a PSD by
+accepting a renamed file.
 """
 
 import os
+import re
 import sys
 
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from test_support.versioning import assert_app_version_at_least, assert_version_at_least
 
 
 ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 REQUIREMENTS_PATH = os.path.join(ROOT_DIR, 'application', 'single_app', 'requirements.txt')
 ROUTE_PATH = os.path.join(ROOT_DIR, 'application', 'single_app', 'route_frontend_admin_settings.py')
-CONFIG_PATH = os.path.join(ROOT_DIR, 'application', 'single_app', 'config.py')
+BRANDING_IMAGES_PATH = os.path.join(
+    ROOT_DIR, 'application', 'single_app', 'functions_branding_images.py'
+)
+
+
+PILLOW_PIN_RE = re.compile(r'^pillow==([0-9.]+)\s*$', re.MULTILINE | re.IGNORECASE)
+
+# The PSD decoder advisory this test was written for was fixed in 12.1.1.
+# Asserting a floor rather than an exact pin means an ordinary dependency
+# upgrade does not fail the test, while a downgrade past the fix still does.
+MINIMUM_PILLOW_VERSION = '12.1.1'
 
 
 def read_text(path):
@@ -30,46 +50,76 @@ def test_pillow_version_is_patched():
     print('Testing patched Pillow dependency pin...')
 
     content = read_text(REQUIREMENTS_PATH)
-    if 'pillow==12.1.1' not in content:
-        print('Patched Pillow version pin not found in requirements.txt')
+    pin_match = PILLOW_PIN_RE.search(content)
+    if not pin_match:
+        print('No pinned pillow== requirement found in requirements.txt')
         return False
 
-    print('Patched Pillow version pin found in requirements.txt')
+    pinned_version = pin_match.group(1)
+    try:
+        assert_version_at_least(
+            pinned_version,
+            MINIMUM_PILLOW_VERSION,
+            label='pinned pillow version',
+            reason='Earlier releases carry the PSD decoder advisory.',
+        )
+    except AssertionError as exc:
+        print(f'Pillow pin check failed: {exc}')
+        return False
+
+    print(f'Pillow pinned at {pinned_version}, at or beyond the patched release')
     return True
 
 
 def test_admin_image_uploads_allowlist_formats():
     print('Testing admin image upload format allowlist...')
 
-    content = read_text(ROUTE_PATH)
-    checks = [
+    branding_content = read_text(BRANDING_IMAGES_PATH)
+    route_content = read_text(ROUTE_PATH)
+
+    branding_checks = [
         "ALLOWED_PIL_IMAGE_UPLOAD_FORMATS = ('PNG', 'JPEG')",
         'Image.open(BytesIO(file_bytes), formats=list(ALLOWED_PIL_IMAGE_UPLOAD_FORMATS))',
-        'open_allowed_uploaded_image(file_bytes, logo_file.filename)',
-        'open_allowed_uploaded_image(file_bytes, logo_dark_file.filename)',
-        'open_allowed_uploaded_image(file_bytes, favicon_file.filename)'
+        # Both preparers must go through the allowlisted open, or one asset
+        # type would decode with Pillow's full decoder set.
+        'def prepare_logo_image_for_storage',
+        'def prepare_favicon_image_for_storage',
     ]
 
-    missing_checks = [check for check in checks if check not in content]
+    route_checks = [
+        'prepare_logo_image_for_storage(file_bytes, logo_file.filename)',
+        'prepare_logo_image_for_storage(file_bytes, logo_dark_file.filename)',
+        'prepare_favicon_image_for_storage(file_bytes, favicon_file.filename)',
+    ]
+
+    missing_checks = [check for check in branding_checks if check not in branding_content]
+    missing_checks += [check for check in route_checks if check not in route_content]
+
+    if branding_content.count('open_allowed_uploaded_image(file_bytes, filename)') < 2:
+        missing_checks.append(
+            'both branding preparers calling open_allowed_uploaded_image'
+        )
+
     if missing_checks:
         print('Missing upload hardening checks:')
         for missing_check in missing_checks:
             print(f'  - {missing_check}')
         return False
 
-    print('Admin image upload route restricts Pillow to PNG and JPEG parsing')
+    print('Admin image uploads restrict Pillow to PNG and JPEG parsing')
     return True
 
 
 def test_config_version_updated():
     print('Testing config version bump...')
 
-    content = read_text(CONFIG_PATH)
-    if 'VERSION = "0.239.136"' not in content:
-        print('Expected config version 0.239.136 not found')
+    try:
+        assert_app_version_at_least('0.239.136')
+    except AssertionError as exc:
+        print(f'Config version check failed: {exc}')
         return False
 
-    print('Config version updated to 0.239.136')
+    print('Config version is at or beyond the hardening release')
     return True
 
 

--- a/functional_tests/test_support/app_stubs.py
+++ b/functional_tests/test_support/app_stubs.py
@@ -1,0 +1,92 @@
+# app_stubs.py
+"""Import application modules in tests without standing up Azure clients.
+
+``config.py`` builds a Cosmos client at import time, so any module that reaches
+it transitively -- directly or through ``functions_settings`` and
+``functions_activity_logging`` -- cannot be imported by a functional test on a
+developer machine.
+
+``test_terms_of_use.py`` solved this by installing stub modules in
+``sys.modules`` before importing the module under test. This centralises that
+approach so several tests can share it, and so the stub surface is described in
+one place rather than drifting between copies.
+
+Only the seams that keep a pure-logic module from importing are stubbed. A test
+that needs real behaviour from one of these dependencies should not be using
+this helper.
+"""
+
+import importlib
+import sys
+import types
+from contextlib import contextmanager
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+APP_ROOT = REPO_ROOT / "application" / "single_app"
+
+_MISSING = object()
+
+
+def _build_stub_modules():
+    """Return the stand-in modules that break the import chain to config.py."""
+    activity_logging = types.ModuleType("functions_activity_logging")
+    activity_logging.log_terms_of_use_accepted = lambda **payload: None
+    activity_logging.log_terms_of_use_declined = lambda **payload: None
+    activity_logging.log_general_admin_action = lambda **payload: None
+    activity_logging.log_governance_change = lambda **payload: None
+    activity_logging.log_web_search_consent_acceptance = lambda **payload: None
+
+    appinsights = types.ModuleType("functions_appinsights")
+    appinsights.log_event = lambda *args, **kwargs: None
+
+    settings = types.ModuleType("functions_settings")
+    settings.get_settings = lambda: {}
+    settings.update_settings = lambda payload: True
+    settings.get_user_settings = lambda user_id: {"id": user_id, "settings": {}}
+    settings.update_user_settings = lambda user_id, payload: True
+    settings.sanitize_settings_for_user = lambda values: dict(values or {})
+
+    return {
+        "functions_activity_logging": activity_logging,
+        "functions_appinsights": appinsights,
+        "functions_settings": settings,
+    }
+
+
+@contextmanager
+def stubbed_app_imports():
+    """Temporarily install the stub modules and put the app root on sys.path."""
+    added_path = str(APP_ROOT) not in sys.path
+    if added_path:
+        sys.path.insert(0, str(APP_ROOT))
+
+    stubs = _build_stub_modules()
+    originals = {}
+    for name, module in stubs.items():
+        originals[name] = sys.modules.get(name, _MISSING)
+        sys.modules[name] = module
+
+    try:
+        yield
+    finally:
+        for name, original in originals.items():
+            if original is _MISSING:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = original
+
+
+def import_app_module(module_name):
+    """Import an application module with the Azure-dependent seams stubbed.
+
+    The module is removed from ``sys.modules`` afterwards so a later import in
+    the same process, made without stubs, is not served the stubbed copy.
+    """
+    with stubbed_app_imports():
+        previously_loaded = module_name in sys.modules
+        module = importlib.import_module(module_name)
+        if not previously_loaded:
+            sys.modules.pop(module_name, None)
+        return module

--- a/functional_tests/test_v2_admin_appearance_parity.py
+++ b/functional_tests/test_v2_admin_appearance_parity.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+# test_v2_admin_appearance_parity.py
+"""
+Functional test pinning V1/V2 parity for the Admin Settings Appearance group.
+Version: 0.261.038
+Implemented in: 0.261.038
+
+The V2 React admin surface renders from ``admin_settings_fields.py`` rather than
+from the server-rendered panes, so the two descriptions of the same settings can
+drift apart silently: a field added to a V1 pane simply never appears in V2, and
+nothing fails.
+
+This test closes that gap for the Appearance group. It reads the three panes that
+make up the group, collects the form field names V1 submits, and requires each
+one to be claimed by the schema -- either because the schema declares the same
+key, or because ``LEGACY_FIELD_NAMES`` records the shape difference, or because
+``LEGACY_FIELDS_WITHOUT_V2_EQUIVALENT`` documents why there is no equivalent.
+
+It also checks the parts of a field that a generic renderer must get right and
+that a name-only comparison would miss: select option values, numeric bounds,
+and the section ids the schema files fields under.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent))
+
+from test_support.app_stubs import import_app_module
+from test_support.nav import ADMIN_NAV
+from test_support.versioning import assert_app_version_at_least
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PANES_DIR = REPO_ROOT / "application" / "single_app" / "templates" / "admin" / "_panes"
+
+# The three tabs that make up the Appearance group, and the sections each one
+# contributes. Sourced from ADMIN_NAV, verified against it below.
+APPEARANCE_GROUP_ID = "appearance"
+APPEARANCE_PANES = {
+    "branding": ("branding-section", "home-page-text-section", "appearance-section"),
+    "notices": (
+        "classification-banner-section",
+        "ai-notice-section",
+        "terms-of-use-section",
+        "user-agreement-section",
+    ),
+    "custom-pages": ("custom-pages-section", "external-links-section"),
+}
+
+FIELD_NAME_RE = re.compile(r'\sname="([^"]+)"')
+JINJA_RE = re.compile(r"\{\{|\{%")
+
+OPTION_RE = re.compile(r'<option value="([^"]*)"')
+SELECT_BLOCK_RE = re.compile(
+    r'<select[^>]*\sname="(?P<name>[^"]+)"(?P<body>.*?)</select>',
+    re.DOTALL,
+)
+RANGE_BLOCK_RE = re.compile(
+    r'<input[^>]*type="range"(?P<attrs>[^>]*)>',
+    re.DOTALL,
+)
+ATTR_RE = re.compile(r'(\w[\w-]*)="([^"]*)"')
+
+fields_module = import_app_module("admin_settings_fields")
+
+
+def read_pane(pane_id):
+    """Return the raw markup for one Admin Settings pane."""
+    pane_path = PANES_DIR / f"{pane_id}.html"
+    assert pane_path.is_file(), f"Missing Admin Settings pane: {pane_path}"
+    return pane_path.read_text(encoding="utf-8")
+
+
+def collect_pane_field_names(markup):
+    """Return literal form field names submitted by a pane."""
+    return {
+        name
+        for name in FIELD_NAME_RE.findall(markup)
+        if not JINJA_RE.search(name)
+    }
+
+
+def test_appearance_panes_match_navigation():
+    """The panes this test reads must be the ones ADMIN_NAV puts in the group."""
+    print("Testing Appearance pane list against ADMIN_NAV...")
+
+    assert_app_version_at_least("0.261.038")
+
+    group = next((g for g in ADMIN_NAV if g["id"] == APPEARANCE_GROUP_ID), None)
+    assert group, "ADMIN_NAV no longer defines an 'appearance' group."
+
+    nav_tabs = {tab["id"]: tuple(s["id"] for s in tab["sections"]) for tab in group["tabs"]}
+
+    assert set(nav_tabs) == set(APPEARANCE_PANES), (
+        "The Appearance group's tabs changed. Update APPEARANCE_PANES and the "
+        f"schema together.\n  ADMIN_NAV: {sorted(nav_tabs)}\n  test: "
+        f"{sorted(APPEARANCE_PANES)}"
+    )
+
+    for tab_id, section_ids in nav_tabs.items():
+        assert section_ids == APPEARANCE_PANES[tab_id], (
+            f"Sections for the '{tab_id}' tab changed.\n"
+            f"  ADMIN_NAV: {section_ids}\n  test: {APPEARANCE_PANES[tab_id]}"
+        )
+
+    print(f"  {len(nav_tabs)} tab(s) and their sections match ADMIN_NAV.")
+    return True
+
+
+def test_every_v1_field_is_claimed_by_the_schema():
+    """A V1 Appearance field with no V2 equivalent is invisible in the new UI."""
+    print("\nTesting that every V1 Appearance field is claimed by the schema...")
+
+    claimed = fields_module.get_legacy_field_names()
+    documented = set(fields_module.LEGACY_FIELDS_WITHOUT_V2_EQUIVALENT)
+
+    unclaimed = {}
+    total = 0
+    for pane_id in APPEARANCE_PANES:
+        names = collect_pane_field_names(read_pane(pane_id))
+        total += len(names)
+        missing = sorted(names - claimed - documented)
+        if missing:
+            unclaimed[pane_id] = missing
+
+    assert not unclaimed, (
+        "These fields exist in the server-rendered Appearance panes but are not "
+        "described in admin_settings_fields.py, so they cannot appear in the V2 "
+        "admin UI. Add a field definition, record the name in LEGACY_FIELD_NAMES "
+        "if the shapes differ, or document the omission in "
+        "LEGACY_FIELDS_WITHOUT_V2_EQUIVALENT:\n"
+        + "\n".join(f"  {pane}: {', '.join(names)}" for pane, names in unclaimed.items())
+    )
+
+    print(f"  All {total} V1 Appearance field(s) are claimed by the schema.")
+    return True
+
+
+def test_schema_does_not_invent_appearance_fields():
+    """A schema key with no V1 counterpart would save a setting nothing reads."""
+    print("\nTesting that the schema does not invent Appearance fields...")
+
+    v1_names = set()
+    for pane_id in APPEARANCE_PANES:
+        v1_names |= collect_pane_field_names(read_pane(pane_id))
+
+    appearance_sections = {
+        section for sections in APPEARANCE_PANES.values() for section in sections
+    }
+
+    invented = []
+    for section_id, field in fields_module.iter_fields():
+        if section_id not in appearance_sections:
+            continue
+        key = field.get("key")
+        if not key:
+            continue
+        legacy = fields_module.LEGACY_FIELD_NAMES.get(key, [key])
+        if not any(name in v1_names for name in legacy):
+            invented.append(f"{section_id}.{key}")
+
+    assert not invented, (
+        "These schema fields have no matching field in the V1 Appearance panes, "
+        "so V2 would write settings the rest of the application never reads:\n  "
+        + "\n  ".join(invented)
+    )
+
+    print("  Every Appearance schema field maps back to a V1 field.")
+    return True
+
+
+def test_select_options_match_v1():
+    """A select offering different values than V1 would save unreadable state."""
+    print("\nTesting select option values against V1...")
+
+    v1_options = {}
+    for pane_id in APPEARANCE_PANES:
+        for match in SELECT_BLOCK_RE.finditer(read_pane(pane_id)):
+            name = match.group("name")
+            if JINJA_RE.search(name):
+                continue
+            v1_options[name] = OPTION_RE.findall(match.group("body"))
+
+    mismatches = []
+    checked = 0
+    for _section_id, field in fields_module.iter_fields():
+        if field.get("type") != "select":
+            continue
+        key = field.get("key")
+        if key not in v1_options:
+            continue
+        schema_values = [option["value"] for option in field["options"]]
+        if schema_values != v1_options[key]:
+            mismatches.append(
+                f"{key}: schema {schema_values} != template {v1_options[key]}"
+            )
+        checked += 1
+
+    assert not mismatches, (
+        "These selects offer different values in each interface:\n  "
+        + "\n  ".join(mismatches)
+    )
+
+    assert checked, "No select fields were compared; the extraction likely broke."
+    print(f"  {checked} select(s) offer identical values in both interfaces.")
+    return True
+
+
+def test_range_bounds_match_v1():
+    """The logo scale must span the same range in both interfaces."""
+    print("\nTesting range bounds against V1...")
+
+    v1_ranges = {}
+    for pane_id in APPEARANCE_PANES:
+        for match in RANGE_BLOCK_RE.finditer(read_pane(pane_id)):
+            attrs = dict(ATTR_RE.findall(match.group("attrs")))
+            name = attrs.get("name")
+            if not name or JINJA_RE.search(name):
+                continue
+            v1_ranges[name] = attrs
+
+    mismatches = []
+    checked = 0
+    for _section_id, field in fields_module.iter_fields():
+        if field.get("type") != "range":
+            continue
+        attrs = v1_ranges.get(field.get("key"))
+        if not attrs:
+            continue
+        for schema_prop, html_attr in (("min", "min"), ("max", "max"), ("step", "step")):
+            if str(field.get(schema_prop)) != attrs.get(html_attr):
+                mismatches.append(
+                    f"{field['key']}.{schema_prop}: schema {field.get(schema_prop)} "
+                    f"!= template {attrs.get(html_attr)}"
+                )
+        checked += 1
+
+    assert not mismatches, (
+        "These range controls differ between interfaces:\n  " + "\n  ".join(mismatches)
+    )
+    assert checked, "No range fields were compared; the extraction likely broke."
+    print(f"  {checked} range control(s) share identical bounds.")
+    return True
+
+
+def test_schema_sections_exist_in_navigation():
+    """A field filed under an unknown section id would never render."""
+    print("\nTesting schema section ids against ADMIN_NAV...")
+
+    nav_sections = {
+        section["id"]
+        for group in ADMIN_NAV
+        for tab in group["tabs"]
+        for section in tab["sections"]
+    }
+
+    unknown = sorted(set(fields_module.ADMIN_SETTINGS_FIELDS) - nav_sections)
+    assert not unknown, (
+        "These schema sections are not defined in admin_settings_nav.py, so the "
+        "V2 UI has nowhere to render them:\n  " + "\n  ".join(unknown)
+    )
+
+    print(f"  All {len(fields_module.ADMIN_SETTINGS_FIELDS)} schema section(s) exist in ADMIN_NAV.")
+    return True
+
+
+if __name__ == "__main__":
+    tests = [
+        test_appearance_panes_match_navigation,
+        test_every_v1_field_is_claimed_by_the_schema,
+        test_schema_does_not_invent_appearance_fields,
+        test_select_options_match_v1,
+        test_range_bounds_match_v1,
+        test_schema_sections_exist_in_navigation,
+    ]
+
+    results = []
+    for test in tests:
+        try:
+            results.append(bool(test()))
+        except Exception as exc:
+            print(f"FAILED {test.__name__}: {exc}")
+            results.append(False)
+
+    print(f"\nResults: {sum(results)}/{len(results)} tests passed")
+    sys.exit(0 if all(results) else 1)

--- a/functional_tests/test_v2_admin_field_renderer_coverage.py
+++ b/functional_tests/test_v2_admin_field_renderer_coverage.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+# test_v2_admin_field_renderer_coverage.py
+"""
+Functional test that the V2 admin UI renders every field the schema can declare.
+Version: 0.261.038
+Implemented in: 0.261.038
+
+The V2 admin surface is driven by ``admin_settings_fields.py``. That indirection has one
+silent failure mode: the schema can declare a field type, or name a bespoke component,
+that the React renderer has no branch for. Nothing raises. The control simply does not
+appear, and the setting becomes invisible again -- the exact problem the schema was added
+to solve.
+
+These checks read the schema from Python and the branches from the TypeScript, and require
+them to agree.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent))
+
+from test_support.app_stubs import import_app_module
+from test_support.versioning import assert_app_version_at_least
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+V2_SRC = REPO_ROOT / "application" / "v2_ui" / "src"
+FIELDS_TSX = V2_SRC / "components" / "admin" / "fields.tsx"
+PAGE_TSX = V2_SRC / "pages" / "AdminSettingsPage.tsx"
+ADMIN_COMPONENTS_DIR = V2_SRC / "components" / "admin"
+
+fields_module = import_app_module("admin_settings_fields")
+
+
+def read(path):
+    assert path.is_file(), f"Missing expected V2 source file: {path}"
+    return path.read_text(encoding="utf-8")
+
+
+def test_every_field_type_has_a_renderer():
+    """A declared type with no branch renders nothing at all."""
+    print("Testing renderer coverage for every field type...")
+
+    assert_app_version_at_least("0.261.038")
+
+    controls = read(FIELDS_TSX)
+    page = read(PAGE_TSX)
+
+    unhandled = []
+    for field_type in fields_module.FIELD_TYPES:
+        in_controls = f"case '{field_type}':" in controls
+        # The page owns the types that need an API of their own.
+        in_page = f"field.type === '{field_type}'" in page
+        if not in_controls and not in_page:
+            unhandled.append(field_type)
+
+    assert not unhandled, (
+        "These field types can be declared in admin_settings_fields.py but the V2 UI has "
+        "no branch for them, so a field using one would silently not render. Add a case "
+        "to components/admin/fields.tsx or a branch to pages/AdminSettingsPage.tsx:\n  "
+        + "\n  ".join(unhandled)
+    )
+
+    print(f"  All {len(fields_module.FIELD_TYPES)} field type(s) have a renderer.")
+    return True
+
+
+def test_every_declared_component_has_a_branch():
+    """A component field naming an unimplemented widget renders nothing."""
+    print("\nTesting renderer coverage for bespoke components...")
+
+    page = read(PAGE_TSX)
+
+    declared = sorted(
+        {
+            field["component"]
+            for _section_id, field in fields_module.iter_fields()
+            if field.get("type") == "component" and field.get("component")
+        }
+    )
+    assert declared, "No component fields found; the schema extraction likely broke."
+
+    missing = [name for name in declared if f"case '{name}':" not in page]
+
+    assert not missing, (
+        "These components are named by the schema but have no branch in "
+        "AdminSettingsPage.tsx, so their section would render an empty space:\n  "
+        + "\n  ".join(missing)
+    )
+
+    print(f"  All {len(declared)} declared component(s) have a branch.")
+    return True
+
+
+def test_renderer_does_not_claim_unknown_components():
+    """A branch for a component nobody declares is dead code that hides a typo."""
+    print("\nTesting for renderer branches without a schema entry...")
+
+    page = read(PAGE_TSX)
+    declared = {
+        field["component"]
+        for _section_id, field in fields_module.iter_fields()
+        if field.get("type") == "component" and field.get("component")
+    }
+
+    # Component names are kebab-case; field types are snake_case, so the two cannot
+    # be confused by this pattern.
+    branch_names = set(re.findall(r"case '([a-z]+(?:-[a-z]+)+)':", page))
+    orphaned = sorted(branch_names - declared)
+
+    assert not orphaned, (
+        "These component branches exist in the UI but no schema field asks for them. "
+        "Either the schema entry was removed or the name is misspelled:\n  "
+        + "\n  ".join(orphaned)
+    )
+
+    print("  No orphaned component branches.")
+    return True
+
+
+def test_admin_components_use_no_remote_assets():
+    """Browser JavaScript must be served from local static assets only."""
+    print("\nTesting that admin components load no remote assets...")
+
+    forbidden = re.compile(
+        r"""(https?:)?//(cdn|unpkg|jsdelivr|cdnjs|ajax\.googleapis|fonts\.googleapis)""",
+        re.IGNORECASE,
+    )
+
+    offenders = []
+    for path in sorted(ADMIN_COMPONENTS_DIR.glob("*.tsx")):
+        content = path.read_text(encoding="utf-8")
+        for line_number, line in enumerate(content.splitlines(), start=1):
+            if forbidden.search(line):
+                offenders.append(f"{path.name}:{line_number}: {line.strip()[:100]}")
+
+    assert not offenders, (
+        "These admin components reference a remote asset. Browser assets must be "
+        "vendored locally under static/:\n  " + "\n  ".join(offenders)
+    )
+
+    checked = len(list(ADMIN_COMPONENTS_DIR.glob("*.tsx")))
+    print(f"  {checked} admin component file(s) reference only local assets.")
+    return True
+
+
+if __name__ == "__main__":
+    tests = [
+        test_every_field_type_has_a_renderer,
+        test_every_declared_component_has_a_branch,
+        test_renderer_does_not_claim_unknown_components,
+        test_admin_components_use_no_remote_assets,
+    ]
+
+    results = []
+    for test in tests:
+        try:
+            results.append(bool(test()))
+        except Exception as exc:
+            print(f"FAILED {test.__name__}: {exc}")
+            results.append(False)
+
+    print(f"\nResults: {sum(results)}/{len(results)} tests passed")
+    sys.exit(0 if all(results) else 1)

--- a/functional_tests/test_v2_admin_settings_normalization.py
+++ b/functional_tests/test_v2_admin_settings_normalization.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python3
+# test_v2_admin_settings_normalization.py
+"""
+Functional test for Admin Settings PATCH normalization.
+Version: 0.261.038
+Implemented in: 0.261.038
+
+The V2 admin surface saves settings one section at a time through a JSON PATCH,
+so the server-rendered form's inline validation no longer runs. These checks pin
+the replacement: values are coerced and bounded, unsafe values are refused with a
+message the UI can show, and keys belonging to groups that have not been
+described yet still save unchanged.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent))
+
+from test_support.app_stubs import import_app_module
+from test_support.versioning import assert_app_version_at_least
+
+
+fields_module = import_app_module("admin_settings_fields")
+normalize = fields_module.normalize_admin_settings_updates
+
+
+def test_numeric_values_are_clamped_to_declared_bounds():
+    """An out-of-range logo scale would render an unusable home page."""
+    print("Testing numeric clamping...")
+
+    assert_app_version_at_least("0.261.038")
+
+    high, errors, _ = normalize({"landing_page_logo_scale_percent": 9000})
+    assert not errors, errors
+    assert high["landing_page_logo_scale_percent"] == 500, high
+
+    low, errors, _ = normalize({"landing_page_logo_scale_percent": -20})
+    assert not errors, errors
+    assert low["landing_page_logo_scale_percent"] == 50, low
+
+    # The browser sends range inputs as strings.
+    coerced, errors, _ = normalize({"landing_page_logo_scale_percent": "250"})
+    assert not errors, errors
+    assert coerced["landing_page_logo_scale_percent"] == 250, coerced
+
+    rejected, errors, _ = normalize({"landing_page_logo_scale_percent": "large"})
+    assert "landing_page_logo_scale_percent" in errors, errors
+
+    print("  Numeric values clamp to bounds and reject non-numbers.")
+    return True
+
+
+def test_colours_must_be_hex():
+    """A non-hex banner colour would break the classification banner style."""
+    print("\nTesting colour validation...")
+
+    valid, errors, _ = normalize({"classification_banner_color": "#ABCDEF"})
+    assert not errors, errors
+    assert valid["classification_banner_color"] == "#abcdef", valid
+
+    for candidate in ("red", "#fff", "#12345g", "", "javascript:x"):
+        _, errors, _ = normalize({"classification_banner_color": candidate})
+        assert "classification_banner_color" in errors, f"{candidate!r} was accepted"
+
+    print("  Only six-digit hex colours are accepted.")
+    return True
+
+
+def test_external_links_reject_unsafe_urls():
+    """Links render into an anchor href, so the scheme has to be constrained."""
+    print("\nTesting external link validation...")
+
+    accepted, errors, _ = normalize(
+        {
+            "external_links": [
+                {"label": "  Docs  ", "url": " https://docs.test/guide "},
+                {"label": "Home", "url": "/welcome"},
+            ]
+        }
+    )
+    assert not errors, errors
+    assert accepted["external_links"] == [
+        {"label": "Docs", "url": "https://docs.test/guide"},
+        {"label": "Home", "url": "/welcome"},
+    ], accepted
+
+    unsafe_cases = [
+        [{"label": "x", "url": "javascript:alert(1)"}],
+        [{"label": "x", "url": "data:text/html,<script>alert(1)</script>"}],
+        [{"label": "x", "url": "//evil.test"}],
+        [{"label": "", "url": "https://ok.test"}],
+        [{"label": "x", "url": ""}],
+        [{"label": "x"}],
+        "not-a-list",
+        ["not-an-object"],
+    ]
+    for case in unsafe_cases:
+        _, errors, _ = normalize({"external_links": case})
+        assert "external_links" in errors, f"{case!r} was accepted"
+
+    print("  Unsafe and malformed link lists are refused.")
+    return True
+
+
+def test_checkbox_sets_are_ordered_and_bounded():
+    """The apply-to array must be stable and non-empty while the feature is on."""
+    print("\nTesting checkbox set handling...")
+
+    # Declared option order wins, so the stored array does not depend on the
+    # order the browser happened to send.
+    ordered, errors, _ = normalize(
+        {"user_agreement_apply_to": ["chat", "personal"]},
+        {"enable_user_agreement": True},
+    )
+    assert not errors, errors
+    assert ordered["user_agreement_apply_to"] == ["personal", "chat"], ordered
+
+    _, errors, _ = normalize(
+        {"user_agreement_apply_to": []}, {"enable_user_agreement": True}
+    )
+    assert "user_agreement_apply_to" in errors, errors
+
+    # With the capability off the constraint does not apply, so an administrator
+    # can turn the feature off without first fixing its selection.
+    _, errors, _ = normalize(
+        {"user_agreement_apply_to": []}, {"enable_user_agreement": False}
+    )
+    assert not errors, errors
+
+    _, errors, _ = normalize(
+        {"user_agreement_apply_to": ["personal", "made_up"]},
+        {"enable_user_agreement": True},
+    )
+    assert "user_agreement_apply_to" in errors, errors
+
+    print("  Selections are ordered, validated and bounded by the capability toggle.")
+    return True
+
+
+def test_selects_reject_unknown_values_but_reuse_shared_aliases():
+    """Frequency fields must accept the same aliases the V1 form accepts."""
+    print("\nTesting select handling...")
+
+    _, errors, _ = normalize({"landing_page_alignment": "sideways"})
+    assert "landing_page_alignment" in errors, errors
+
+    valid, errors, _ = normalize({"landing_page_alignment": "center"})
+    assert not errors and valid["landing_page_alignment"] == "center"
+
+    # Delegated to the shared normalizers, so aliases resolve identically in both
+    # admin interfaces rather than being rejected in one of them.
+    aliased, errors, _ = normalize({"ai_notice_frequency": "ALWAYS"})
+    assert not errors and aliased["ai_notice_frequency"] == "non_dismissible", aliased
+
+    aliased, errors, _ = normalize({"terms_of_use_frequency": "per-session"})
+    assert not errors and aliased["terms_of_use_frequency"] == "every_session", aliased
+
+    print("  Unknown values are refused and shared aliases still resolve.")
+    return True
+
+
+def test_redirect_url_refuses_unsafe_targets():
+    """Silently rewriting an administrator's redirect would hide the rejection."""
+    print("\nTesting cancel redirect validation...")
+
+    for safe in ("/", "/goodbye", "https://sso.test/logout"):
+        result, errors, _ = normalize({"terms_of_use_decline_redirect_url": safe})
+        assert not errors, f"{safe!r} was refused: {errors}"
+        assert result["terms_of_use_decline_redirect_url"] == safe
+
+    for unsafe in (
+        "javascript:alert(1)",
+        "//evil.test",
+        "http://plain.test",
+        "https://user:pass@evil.test",
+        "\\\\evil.test",
+    ):
+        _, errors, _ = normalize({"terms_of_use_decline_redirect_url": unsafe})
+        assert "terms_of_use_decline_redirect_url" in errors, f"{unsafe!r} was accepted"
+
+    print("  Unsafe redirect targets are refused rather than silently rewritten.")
+    return True
+
+
+def test_text_is_bounded_and_falls_back_when_empty():
+    """Menu names have a fallback; free text is trimmed to its declared maximum."""
+    print("\nTesting text handling...")
+
+    fallback, errors, _ = normalize({"custom_pages_menu_name": "   "})
+    assert not errors and fallback["custom_pages_menu_name"] == "Custom Pages", fallback
+
+    fallback, errors, _ = normalize({"external_links_menu_name": ""})
+    assert not errors and fallback["external_links_menu_name"] == "External Links"
+
+    truncated, errors, _ = normalize({"terms_of_use_title": "T" * 400})
+    assert not errors, errors
+    assert len(truncated["terms_of_use_title"]) == 160, len(truncated["terms_of_use_title"])
+
+    # An empty title falls back rather than leaving an unlabelled dialog.
+    titled, errors, _ = normalize({"terms_of_use_title": ""})
+    assert not errors and titled["terms_of_use_title"] == "Terms of Use", titled
+
+    print("  Text is trimmed, bounded and falls back where declared.")
+    return True
+
+
+def test_word_limit_warns_without_blocking():
+    """The V1 form warns and saves, so blocking here would strand existing text."""
+    print("\nTesting the agreement word limit...")
+
+    long_text = "word " * 250
+    saved, errors, warnings = normalize({"user_agreement_text": long_text})
+    assert not errors, errors
+    assert "user_agreement_text" in warnings, warnings
+    assert saved["user_agreement_text"].startswith("word"), saved
+
+    _, _, warnings = normalize({"user_agreement_text": "short agreement"})
+    assert not warnings, warnings
+
+    print("  Over-long agreements warn but still save.")
+    return True
+
+
+def test_enabling_custom_pages_requires_acknowledgement():
+    """Custom Pages is not fully live until restart, so enabling must be acknowledged."""
+    print("\nTesting the Custom Pages restart acknowledgement...")
+
+    _, errors, _ = normalize({"enable_custom_pages": True}, {"enable_custom_pages": False})
+    assert "enable_custom_pages" in errors, errors
+
+    acknowledged, errors, _ = normalize(
+        {"enable_custom_pages": True, "custom_pages_restart_acknowledged": True},
+        {"enable_custom_pages": False},
+    )
+    assert not errors, errors
+    # The acknowledgement gates the change; it is not itself a stored setting.
+    assert acknowledged == {"enable_custom_pages": True}, acknowledged
+
+    # Disabling, and saving while already enabled, need no acknowledgement.
+    _, errors, _ = normalize({"enable_custom_pages": False}, {"enable_custom_pages": True})
+    assert not errors, errors
+    _, errors, _ = normalize({"enable_custom_pages": True}, {"enable_custom_pages": True})
+    assert not errors, errors
+
+    print("  Enabling requires acknowledgement; the flag is never persisted.")
+    return True
+
+
+def test_uploads_cannot_be_set_through_the_settings_patch():
+    """Branding blobs have their own endpoint that converts and versions them."""
+    print("\nTesting the upload guard...")
+
+    for key in ("custom_logo_base64", "custom_logo_dark_base64", "custom_favicon_base64"):
+        _, errors, _ = normalize({key: "AAAA"})
+        assert key in errors, f"{key} was accepted through PATCH"
+
+    print("  Image payloads are refused by the settings PATCH.")
+    return True
+
+
+def test_undeclared_keys_pass_through_unchanged():
+    """Groups that have not been described yet must keep saving."""
+    print("\nTesting passthrough for undescribed settings...")
+
+    payload = {
+        "enable_some_future_capability": True,
+        "some_endpoint_url": "https://api.test",
+        "some_threshold": 7,
+    }
+    result, errors, warnings = normalize(dict(payload))
+    assert not errors and not warnings, (errors, warnings)
+    assert result == payload, result
+
+    print("  Undeclared keys are forwarded untouched.")
+    return True
+
+
+def test_switches_coerce_form_shaped_truthiness():
+    """Switch values arrive as JSON booleans and, from some clients, as strings."""
+    print("\nTesting switch coercion...")
+
+    for raw, expected in (
+        (True, True),
+        (False, False),
+        ("on", True),
+        ("true", True),
+        ("", False),
+        ("false", False),
+        (None, False),
+    ):
+        result, errors, _ = normalize({"enable_dark_mode_default": raw})
+        assert not errors, errors
+        assert result["enable_dark_mode_default"] is expected, (raw, result)
+
+    print("  Switch values coerce to real booleans.")
+    return True
+
+
+if __name__ == "__main__":
+    tests = [
+        test_numeric_values_are_clamped_to_declared_bounds,
+        test_colours_must_be_hex,
+        test_external_links_reject_unsafe_urls,
+        test_checkbox_sets_are_ordered_and_bounded,
+        test_selects_reject_unknown_values_but_reuse_shared_aliases,
+        test_redirect_url_refuses_unsafe_targets,
+        test_text_is_bounded_and_falls_back_when_empty,
+        test_word_limit_warns_without_blocking,
+        test_enabling_custom_pages_requires_acknowledgement,
+        test_uploads_cannot_be_set_through_the_settings_patch,
+        test_undeclared_keys_pass_through_unchanged,
+        test_switches_coerce_form_shaped_truthiness,
+    ]
+
+    results = []
+    for test in tests:
+        try:
+            results.append(bool(test()))
+        except Exception as exc:
+            print(f"FAILED {test.__name__}: {exc}")
+            import traceback
+
+            traceback.print_exc()
+            results.append(False)
+
+    print(f"\nResults: {sum(results)}/{len(results)} tests passed")
+    sys.exit(0 if all(results) else 1)

--- a/functional_tests/test_v2_admin_settings_schema.py
+++ b/functional_tests/test_v2_admin_settings_schema.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+# test_v2_admin_settings_schema.py
+"""
+Functional test for the Admin Settings field schema shape.
+Version: 0.261.038
+Implemented in: 0.261.038
+
+The V2 admin surface renders whatever ``admin_settings_fields.py`` declares. A
+malformed entry does not raise anything server-side; it produces a control that
+silently fails to draw, or draws without the options it needs. These checks make
+a malformed entry a test failure instead.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent))
+
+from test_support.app_stubs import import_app_module
+from test_support.versioning import assert_app_version_at_least
+
+
+fields_module = import_app_module("admin_settings_fields")
+
+# Properties every field type must carry beyond the common ones, because the
+# renderer cannot draw the control without them.
+REQUIRED_PROPERTIES_BY_TYPE = {
+    "select": ("options", "default"),
+    "checkbox_set": ("options", "default"),
+    "range": ("min", "max", "step", "default"),
+    "number": ("default",),
+    "color": ("default",),
+    "text": ("default",),
+    "textarea": ("default",),
+    "switch": ("default",),
+    "link_list": ("item_fields", "default"),
+    "image": ("upload_target", "accept", "version_key"),
+    "component": ("component",),
+}
+
+EXPECTED_DEFAULT_TYPES = {
+    "switch": bool,
+    "text": str,
+    "textarea": str,
+    "select": str,
+    "color": str,
+    "range": int,
+    "number": int,
+    "checkbox_set": list,
+    "link_list": list,
+}
+
+
+def test_field_types_are_known():
+    """An unrecognised type would render as nothing at all."""
+    print("Testing that every field declares a known type...")
+
+    assert_app_version_at_least("0.261.038")
+
+    unknown = [
+        f"{section_id}.{field.get('key') or field.get('component')}: {field.get('type')!r}"
+        for section_id, field in fields_module.iter_fields()
+        if field.get("type") not in fields_module.FIELD_TYPES
+    ]
+
+    assert not unknown, (
+        "These fields declare a type the V2 renderer does not implement:\n  "
+        + "\n  ".join(unknown)
+    )
+
+    total = sum(1 for _ in fields_module.iter_fields())
+    print(f"  All {total} field(s) use a known type.")
+    return True
+
+
+def test_fields_carry_required_properties():
+    """A select without options, or a range without bounds, cannot be drawn."""
+    print("\nTesting required properties per field type...")
+
+    problems = []
+    for section_id, field in fields_module.iter_fields():
+        field_type = field.get("type")
+        identity = f"{section_id}.{field.get('key') or field.get('component')}"
+
+        if not field.get("label"):
+            problems.append(f"{identity}: missing label")
+
+        # Everything except a bespoke component must name the settings key it edits.
+        if field_type != "component" and not field.get("key"):
+            problems.append(f"{identity}: missing key")
+
+        for prop in REQUIRED_PROPERTIES_BY_TYPE.get(field_type, ()):
+            if prop not in field:
+                problems.append(f"{identity}: missing '{prop}' required by type {field_type}")
+
+    assert not problems, (
+        "These field definitions are incomplete:\n  " + "\n  ".join(problems)
+    )
+
+    print("  Every field carries the properties its type requires.")
+    return True
+
+
+def test_defaults_match_their_field_type():
+    """A default of the wrong type makes the control start in an invalid state."""
+    print("\nTesting default value types...")
+
+    problems = []
+    for section_id, field in fields_module.iter_fields():
+        expected = EXPECTED_DEFAULT_TYPES.get(field.get("type"))
+        if expected is None or "default" not in field:
+            continue
+
+        default = field["default"]
+        # bool is a subclass of int, so a switch default must not satisfy range.
+        if expected is int and isinstance(default, bool):
+            problems.append(f"{section_id}.{field['key']}: bool default for a numeric field")
+            continue
+        if not isinstance(default, expected):
+            problems.append(
+                f"{section_id}.{field['key']}: default {default!r} is not {expected.__name__}"
+            )
+
+    assert not problems, (
+        "These defaults do not match their field type:\n  " + "\n  ".join(problems)
+    )
+
+    print("  Every default matches its field type.")
+    return True
+
+
+def test_select_defaults_are_offered_as_options():
+    """A default outside the option list leaves the control with no selection."""
+    print("\nTesting that select defaults are selectable...")
+
+    problems = []
+    for section_id, field in fields_module.iter_fields():
+        if field.get("type") != "select":
+            continue
+        values = [option["value"] for option in field["options"]]
+        if field["default"] not in values:
+            problems.append(
+                f"{section_id}.{field['key']}: default {field['default']!r} not in {values}"
+            )
+
+    assert not problems, (
+        "These selects default to a value they do not offer:\n  " + "\n  ".join(problems)
+    )
+
+    print("  Every select defaults to one of its own options.")
+    return True
+
+
+def test_setting_keys_are_unique():
+    """The same key in two sections would render two controls fighting over one value."""
+    print("\nTesting settings key uniqueness...")
+
+    seen = {}
+    duplicates = []
+    for section_id, field in fields_module.iter_fields():
+        key = field.get("key")
+        if not key:
+            continue
+        if key in seen:
+            duplicates.append(f"{key}: {seen[key]} and {section_id}")
+        seen[key] = section_id
+
+    assert not duplicates, (
+        "These keys are declared in more than one section:\n  " + "\n  ".join(duplicates)
+    )
+
+    print(f"  All {len(seen)} declared key(s) are unique.")
+    return True
+
+
+def test_dependencies_reference_real_fields():
+    """A dependency on an undeclared key would hide the field permanently."""
+    print("\nTesting visibility dependencies...")
+
+    declared = fields_module.get_declared_setting_keys()
+    problems = []
+    checked = 0
+
+    for section_id, field in fields_module.iter_fields():
+        depends_on = field.get("depends_on")
+        if not depends_on:
+            continue
+        checked += 1
+        identity = f"{section_id}.{field.get('key') or field.get('component')}"
+
+        if "key" not in depends_on:
+            problems.append(f"{identity}: depends_on has no key")
+            continue
+        if depends_on["key"] not in declared:
+            problems.append(f"{identity}: depends on undeclared key {depends_on['key']!r}")
+        if field.get("key") == depends_on["key"]:
+            problems.append(f"{identity}: depends on itself")
+
+    assert not problems, (
+        "These visibility dependencies are broken:\n  " + "\n  ".join(problems)
+    )
+
+    print(f"  All {checked} dependency reference(s) resolve to declared fields.")
+    return True
+
+
+def test_option_values_are_unique_within_a_field():
+    """Duplicate option values make a control's selection ambiguous."""
+    print("\nTesting option value uniqueness...")
+
+    problems = []
+    for section_id, field in fields_module.iter_fields():
+        options = field.get("options")
+        if not options:
+            continue
+        values = [option["value"] for option in options]
+        if len(values) != len(set(values)):
+            problems.append(f"{section_id}.{field['key']}: duplicate values in {values}")
+        if any(not option.get("label") for option in options):
+            problems.append(f"{section_id}.{field['key']}: an option is missing a label")
+
+    assert not problems, (
+        "These option lists are malformed:\n  " + "\n  ".join(problems)
+    )
+
+    print("  Every option list has unique values and complete labels.")
+    return True
+
+
+if __name__ == "__main__":
+    tests = [
+        test_field_types_are_known,
+        test_fields_carry_required_properties,
+        test_defaults_match_their_field_type,
+        test_select_defaults_are_offered_as_options,
+        test_setting_keys_are_unique,
+        test_dependencies_reference_real_fields,
+        test_option_values_are_unique_within_a_field,
+    ]
+
+    results = []
+    for test in tests:
+        try:
+            results.append(bool(test()))
+        except Exception as exc:
+            print(f"FAILED {test.__name__}: {exc}")
+            results.append(False)
+
+    print(f"\nResults: {sum(results)}/{len(results)} tests passed")
+    sys.exit(0 if all(results) else 1)


### PR DESCRIPTION
## The problem

The V2 admin page could only render on/off switches. Not by design — it discovered settings by scanning the settings document for `enable_*` keys holding a boolean, so a switch was the only thing it *could* draw.

Everything else was invisible. For the Appearance group alone that meant the application title, three image uploads, a logo scale slider, two colour pickers, four selects, six text fields, three textareas, a four-way checkbox set, the external links list and the entire static page designer. The page even admitted it, with a footer telling admins to go back to `/admin/settings`.

## The approach

Rather than hand-coding the missing controls, this adds a **server-side declarative field schema** and makes V2 a generic renderer for it.

- **`admin_settings_fields.py`** declares, per section id already defined in `admin_settings_nav.py`, the concrete fields that section owns — type, label, help, default, bounds, options, visibility dependencies. It also normalizes and validates PATCH values, delegating to the existing terms-of-use and AI-notice normalizers so both admin surfaces agree on what a valid value is.
- **`GET /api/v2/admin/settings`** returns the schema plus a description of the stored branding images (presence, version, URL — never the base64 blobs).
- **`PATCH`** validates before writing and returns a `field_errors` map, applying nothing unless every key validates, so a save can't land half-applied.
- **`POST /api/v2/admin/settings/branding-image`** handles logo, dark logo and favicon uploads.
- **`functions_branding_images.py`** holds the image conversion that was previously inline in `route_frontend_admin_settings.py`.

**Describing the remaining 13 groups is now a Python-only change.** Sections with no declaration keep using the existing `enable_*` fallback scan, so nothing else in the admin page changes.

## What Appearance looks like now

| Tab | Controls |
| --- | --- |
| **Branding** | App title, show-logo / hide-title switches, 50–500% logo size slider, light + dark logo and favicon uploads with live previews |
| **Home Page Text** | Alignment select, editor toggle, landing page text with a preview that follows the chosen alignment |
| **Appearance** | Dark mode + left nav defaults |
| **Notices & Agreements** | Classification banner (2 colour pickers + live preview strip), AI notice, full Terms of Use config, user agreement with 4 apply-to targets, word counter and **Test preview** |
| **Pages & Links** | Custom pages with restart acknowledgement, the full static page designer, developer guide, and an add / remove / **reorder** external links editor |

The static page designer writes to the same `/api/admin/custom-pages` CRUD as the classic one, so a page created in either interface is identical. Python-registered pages are listed but read-only, since they're defined in code.

## Saving

Edits buffer into a draft and save together from a sticky bar, with `Ctrl`/`Cmd`+`S` and an unsaved-changes prompt on tab close.

This isn't just a UI preference. **Terms of Use and the AI notice derive a content version from their text, and each new version re-prompts every user.** Auto-saving would have minted a version per character typed. Branding uploads and custom page metadata still save immediately, because neither lives in the settings document.

## Two bugs found along the way

**External link URLs were unvalidated.** They render into a navigation `href` on every page, so `javascript:...` was accepted and stored. Now restricted to local paths and http(s).

**Two tests could no longer fail correctly.** The Pillow security test pinned an exact dependency version (`12.1.1` vs the current `12.3.0`) and the custom logo test looked for help text in a file it had moved out of. Both were silently red before this change while no longer checking what they were written for. They now assert a *minimum* version and read the composed template.

## Drift protection

The schema is a second description of settings the server-rendered panes also describe, so it could drift. Two tests prevent that:

- **`test_v2_admin_appearance_parity.py`** reads the three V1 panes, collects all **41** form field names, and fails unless each is claimed by the schema — directly or through the documented `LEGACY_FIELD_NAMES` aliases where the shapes genuinely differ (V1's four `user_agreement_apply_*` checkboxes → the `user_agreement_apply_to` array; `external_links_json` → `external_links`; the three file inputs → their stored base64 keys). It checks the reverse direction too, so the schema can't invent a setting nothing reads, and compares select option values and range bounds.
- **`test_v2_admin_field_renderer_coverage.py`** fails when the schema can declare a type or component the React renderer has no branch for — the one silent failure mode this indirection introduces.

Both were **mutation-tested** by deliberately breaking the schema, to confirm they aren't vacuous.

## Verification

- **29 new checks across 4 test files**, all passing
- **20 existing test files** re-run on the merged tree with zero failures, including the incoming shared-conversations suite from #1394
- `npm run typecheck` and `npm run build` clean
- Route policy inventory picks up the new upload endpoint with the expected `login_required` + `admin_required` classification
- No new browser assets — reuses the already-vendored markdown renderer, CSP untouched

## Notes for review

- This merges the updated base and **renumbers to `0.261.039`**, since #1394 landed and claimed `0.261.038`.
- Two pre-existing failures in `test_custom_pages_wiring.py` (an exact-version assertion and a missing `docs/how-to/custom_pages.md`) are unrelated — confirmed failing on a clean tree and left alone.
- **Removing** an uploaded logo doesn't exist in V1 either, so it's out of scope. Worth a follow-up.
- Admin settings remain deliberately unsanitized, as before — sanitization strips the very fields an administrator is there to manage. The logo base64 blobs stay out of the payload; only URLs and version counters are returned.