### PR TITLE
Refresh the V2 shell after an admin settings save so the classification banner appears without a reload

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -97,7 +97,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.261.045"
+VERSION = "0.261.046"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/v2_ui/src/pages/AdminSettingsPage.tsx
+++ b/application/v2_ui/src/pages/AdminSettingsPage.tsx
@@ -164,6 +164,16 @@ function buildCapabilityIndex(
 export function AdminSettingsPage() {
     const isAdmin = useBootstrapStore((state) => Boolean(state.data?.user?.is_admin));
 
+    /**
+     * Re-read the bootstrap payload once a save lands.
+     *
+     * The settings edited here are also what the shell draws itself from -- the
+     * classification banner, the sidebar logo and title, the feature flags -- and that
+     * payload is otherwise fetched only at startup. Without this a saved change is
+     * invisible until the browser is reloaded.
+     */
+    const refreshBootstrap = useBootstrapStore((state) => state.refresh);
+
     const [data, setData] = useState<AdminSettingsResponse | null>(null);
     const [brandingAssets, setBrandingAssets] = useState<BrandingAssets>({});
     const [loading, setLoading] = useState(true);
@@ -434,6 +444,7 @@ export function AdminSettingsPage() {
             );
             setFieldWarnings(response.warnings ?? {});
             setDraft({});
+            void refreshBootstrap();
 
             const warningCount = Object.keys(response.warnings ?? {}).length;
             toast.success(
@@ -458,15 +469,22 @@ export function AdminSettingsPage() {
         } finally {
             setSaving(false);
         }
-    }, [draft]);
+    }, [draft, refreshBootstrap]);
 
-    const onBrandingUploaded = useCallback((target: string, result: BrandingUploadResponse) => {
-        setBrandingAssets((current) => ({
-            ...current,
-            [target]: { present: true, version: result.version, url: result.url },
-        }));
-        toast.success('Image uploaded.');
-    }, []);
+    const onBrandingUploaded = useCallback(
+        (target: string, result: BrandingUploadResponse) => {
+            setBrandingAssets((current) => ({
+                ...current,
+                [target]: { present: true, version: result.version, url: result.url },
+            }));
+            // An upload is written to the settings document immediately rather than being
+            // held until Save, so the rail would otherwise keep drawing the previous logo
+            // -- and its URL is version-stamped, so only a refetch busts the cache.
+            void refreshBootstrap();
+            toast.success('Image uploaded.');
+        },
+        [refreshBootstrap],
+    );
 
     /** Read another field's current value, preferring an unsaved edit. */
     const readSibling = (key: string, fallback = '') =>

--- a/application/v2_ui/src/stores/bootstrapStore.ts
+++ b/application/v2_ui/src/stores/bootstrapStore.ts
@@ -8,6 +8,15 @@ import { fetchBootstrap } from '../lib/endpoints';
 import { ApiError } from '../lib/apiClient';
 import type { BootstrapPayload } from '../lib/types';
 
+/**
+ * Orders concurrent refreshes so a slower earlier one cannot land after a newer one.
+ *
+ * Two saves in quick succession issue two refetches, and nothing guarantees the
+ * responses arrive in the order the requests left. Without this the interface can settle
+ * on the payload from before the second save.
+ */
+let refreshSequence = 0;
+
 interface BootstrapState {
     data: BootstrapPayload | null;
     loading: boolean;
@@ -15,6 +24,15 @@ interface BootstrapState {
     /** True when the failure was an expired session rather than a server fault. */
     authExpired: boolean;
     load: () => Promise<void>;
+    /**
+     * Re-read the payload in place, leaving the current interface on screen.
+     *
+     * Everything the shell draws comes from bootstrap -- the classification banner, the
+     * sidebar logo and application title, the feature flags the chat surface branches on
+     * -- and it is otherwise fetched only at startup. An administrator who changes any of
+     * those has to reload the browser before the change is visible without this.
+     */
+    refresh: () => Promise<void>;
 }
 
 export const useBootstrapStore = create<BootstrapState>((set) => ({
@@ -38,6 +56,23 @@ export const useBootstrapStore = create<BootstrapState>((set) => ({
                         ? error.message
                         : 'Failed to load the application.',
             });
+        }
+    },
+
+    refresh: async () => {
+        const sequence = ++refreshSequence;
+        try {
+            const data = await fetchBootstrap();
+            if (sequence === refreshSequence) {
+                set({ data });
+            }
+        } catch {
+            // Advisory on purpose, and the reason this cannot be `load()`. App.tsx
+            // replaces the whole interface with the boot screen while `loading` is set
+            // and with the boot error when `error` is, so driving either from here would
+            // tear down the page being worked on -- unsaved edits included -- over a
+            // refetch the reader never asked for. The caller's own write already
+            // succeeded, so a briefly stale shell is cosmetic and the next load fixes it.
         }
     },
 }));

--- a/docs/explanation/features/REACT_V2_UI.md
+++ b/docs/explanation/features/REACT_V2_UI.md
@@ -184,6 +184,14 @@ Settings returned here are always sanitized. The logo is reported as a URL rathe
 stored base64 payload, because sanitization strips any key containing `base64` and the
 images are already served as static files.
 
+The payload is fetched at startup and re-read after an administrator saves. `bootstrapStore`
+exposes `refresh()` alongside `load()` for that second case: it replaces the payload in
+place, without touching `loading` or `error`. Those two drive the boot screen and the boot
+error, each of which replaces the entire interface, so a background refetch that used them
+would tear down the page being worked on and discard its unsaved edits. A failed refresh is
+therefore advisory rather than reported — the write it follows has already succeeded. A
+sequence guard stops a slower earlier refresh from landing after a newer one.
+
 ### `GET` and `PATCH /api/v2/admin/settings`
 
 Blueprint `backend_v2_admin` — `login_required`, `admin_required`.
@@ -802,6 +810,13 @@ on each keystroke would mint a version per character.
 Two things save immediately instead, because they are not part of the settings document:
 branding image uploads, which need server-side conversion before anything can be previewed,
 and custom page metadata, which lives in its own Cosmos container.
+
+A successful save re-reads `/api/v2/bootstrap`, and so does a branding image upload. Many of
+the settings edited here are what the shell draws itself from — the classification banner,
+the sidebar logo and application title, the feature flags the chat surface branches on —
+and that payload would otherwise be the one fetched when the page was opened. Without the
+re-read a saved change is invisible until the browser is reloaded, which reads as a save
+that did not work.
 
 #### Appearance group
 

--- a/docs/explanation/fixes/V2_ADMIN_SETTINGS_LIVE_SHELL_REFRESH_FIX.md
+++ b/docs/explanation/fixes/V2_ADMIN_SETTINGS_LIVE_SHELL_REFRESH_FIX.md
@@ -1,0 +1,127 @@
+# V2 Admin Settings Live Shell Refresh Fix
+
+## Issue
+
+An administrator enabled the classification banner in the V2 interface
+(**Admin Settings → Appearance → Notices**), gave it text and a colour, and saved. The
+save succeeded and the toast confirmed it, but no banner appeared. It only became visible
+after a full browser reload.
+
+The banner was not the visible part of the problem. Everything the V2 shell draws itself
+from behaves the same way: the application title, the sidebar logo and favicon,
+`hide_app_title`, the feature flags the chat surface branches on, the administrator-configured
+AI notice and the admin navigation all kept showing the values that were current when the
+page was first opened.
+
+**Fixed in version: 0.261.046**
+
+## Root cause
+
+The classification banner was already implemented end to end:
+
+- `route_backend_v2.py::_build_branding()` emits `branding.classification_banner` in the
+  `/api/v2/bootstrap` payload whenever `classification_banner_enabled` is set and
+  `classification_banner_text` is non-empty.
+- `AppShell.tsx::ClassificationBanner` renders it, reading it from `useBootstrapStore`.
+
+The gap was upstream of both. `/api/v2/bootstrap` is fetched exactly once, from a mount
+effect in `App.tsx`, and there was no second call anywhere in the V2 source.
+`AdminSettingsPage.save()` PATCHed the settings and merged the response into the admin
+page's own local `data.settings` state — which is what drives the form controls and the
+in-page preview, and nothing else. The bootstrap store was never told that anything had
+changed, so the shell went on rendering the payload it had held since page load.
+
+The server side was not implicated: `update_settings()` calls
+`_refresh_app_settings_cache_after_write()` immediately after the Cosmos upsert, so a
+refetch issued straight after a successful save reads the new values.
+
+## The fix
+
+`bootstrapStore` gained a `refresh()` action that re-reads `/api/v2/bootstrap` and replaces
+`data` in place. `AdminSettingsPage` calls it on both of its write paths.
+
+### Why `refresh()` is not `load()`
+
+`load()` sets `loading: true` while it runs and `error` when it fails. `App.tsx` renders
+`<BootScreen />` instead of the entire interface while `loading` is set, and `<BootError />`
+instead of the entire interface when `error` is set. Reusing `load()` for a background
+refetch would therefore tear down the admin page the moment a save landed — discarding any
+unsaved draft — and would replace a page whose save had just succeeded with a full-screen
+error if the refetch happened to fail.
+
+`refresh()` writes only `data`. A failure is swallowed deliberately: the write it follows
+has already succeeded, so a briefly stale shell is cosmetic and the next full load corrects
+it.
+
+### Ordering
+
+A module-level `refreshSequence` counter is claimed before the request and checked before
+the payload is applied. Two saves in quick succession issue two refetches, and nothing
+guarantees the responses return in the order the requests left; without the guard the
+interface can settle on the payload from before the second save.
+
+### Branding uploads
+
+Logo and favicon uploads go through `POST /api/v2/admin/settings/branding-image`, which
+writes to the settings document immediately rather than waiting for **Save**. The sidebar
+logo went stale for the same reason, and its URL is version-stamped (`?v=N`), so only a
+refetch produces the new URL and busts the browser cache. `onBrandingUploaded` refreshes
+too.
+
+## Files modified
+
+| File | Change |
+| --- | --- |
+| `application/v2_ui/src/stores/bootstrapStore.ts` | Added the `refresh()` action and the `refreshSequence` ordering guard |
+| `application/v2_ui/src/pages/AdminSettingsPage.tsx` | Calls `refresh()` after a successful settings PATCH and after a branding image upload |
+| `application/single_app/config.py` | `VERSION` `0.261.045` → `0.261.046` |
+| `functional_tests/test_v2_admin_settings_live_shell_refresh.py` | New test pinning the wiring |
+| `functional_tests/test_v2_bootstrap_refresh_logic.mjs` | New runtime test executing the real store |
+| `docs/explanation/features/REACT_V2_UI.md` | Documents that a save reaches the shell |
+| `docs/explanation/release_notes.md` | Release entry |
+
+## Alternatives considered
+
+- **Patching `branding.classification_banner` in the browser from the PATCH response.**
+  The server decides whether the banner is emitted at all — it requires both the toggle and
+  non-empty text — and applies the `#ffc107` / `#ffffff` colour defaults. Re-deriving those
+  rules client-side creates a second copy that drifts from the first.
+- **Injecting the banner into the SPA shell HTML server-side**, so it paints before the
+  bundle boots. This puts administrator-controlled text into raw HTML for a sub-second gain
+  and does not address the save case at all.
+- **Refreshing only when banner-related keys were saved.** This needs a hand-maintained list
+  of the settings that affect the shell, which goes out of date as soon as a setting is
+  added. Practically every admin setting reaches the bootstrap payload, so refreshing
+  unconditionally is both simpler and correct.
+
+## Validation
+
+```powershell
+python .\functional_tests\test_v2_admin_settings_live_shell_refresh.py
+node .\functional_tests\test_v2_bootstrap_refresh_logic.mjs
+python .\functional_tests\test_v2_admin_appearance_parity.py
+python .\functional_tests\test_v2_chat_notices.py
+cd .\application\v2_ui; npm run build   # tsc -b passes, bundle builds
+```
+
+The `.mjs` test imports and executes the real store rather than asserting on its source. It
+covers the two ways this can go quietly wrong in a way source assertions cannot: it records
+**every** intermediate state during a refresh, because `loading` only has to be set
+transiently to blank the interface, and it holds one refetch open while a second completes
+to prove the stale payload is discarded. Both were confirmed to fail against a deliberately
+broken store before being accepted.
+
+### Before
+
+1. **Admin Settings → Appearance → Notices**, enable the classification banner, set text,
+   save.
+2. Toast confirms the save. No banner.
+3. Reload the browser. Banner appears.
+
+### After
+
+1. Same steps.
+2. The banner appears at the top of the interface as the save completes. Turning it off, or
+   blanking its text, removes it just as immediately.
+3. Changing the application title, uploading a logo, or enabling a capability now reaches
+   the shell on save in the same way, without a reload.

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,17 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/features) and [Fixes by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/fixes).
 
+### **(v0.261.046)**
+
+#### Bug Fixes
+
+*   **Admin Settings Changes Did Not Appear Until The Page Was Reloaded (New Interface)**
+    *   Enabling the classification banner in the new interface and saving appeared to do nothing. The banner was saved correctly, but it only showed up after reloading the browser.
+    *   The banner was not the only thing affected. The new interface reads the application title, the sidebar logo, the classification banner and the list of enabled capabilities once, when the page first loads, and had no way of being told that any of them had changed. Every one of those went stale the moment you saved.
+    *   Saving in **Admin Settings** now refreshes what the interface knows about itself, so the banner appears — or disappears — straight away, along with a changed title or a newly enabled capability. Uploading a logo or favicon updates the sidebar immediately too, rather than waiting for the next reload.
+    *   Your unsaved edits are unaffected: the refresh happens quietly in the background and never interrupts the page you are working on.
+    *   (Ref: V2 interface, Admin Settings, classification banner, branding, `/api/v2/bootstrap`)
+
 ### **(v0.261.045)**
 
 #### Bug Fixes

--- a/functional_tests/test_v2_admin_settings_live_shell_refresh.py
+++ b/functional_tests/test_v2_admin_settings_live_shell_refresh.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""
+Functional test for the V2 interface refreshing its shell after an admin save.
+
+Version: 0.261.046
+Implemented in: 0.261.046
+
+An administrator enabled the classification banner in the V2 admin settings, saved, and
+nothing happened. The banner only appeared after reloading the browser.
+
+The banner was never missing. `/api/v2/bootstrap` is fetched exactly once, from a mount
+effect in App.tsx, and `AdminSettingsPage.save()` merged the PATCH response into its own
+local state only -- the bootstrap store was never told anything had changed. Every value
+the shell draws itself from went stale on save, not just the banner: the sidebar logo and
+application title, `hide_app_title`, the feature flags the chat surface branches on, the
+AI notice and the admin navigation.
+
+The fix re-reads bootstrap after a successful write. It cannot reuse `load()`, which sets
+`loading` and `error` -- App.tsx replaces the entire interface with the boot screen while
+`loading` is set and with the boot error when `error` is, so a background refetch driven
+through `load()` would tear down the page being edited and discard the unsaved draft.
+
+This test ensures the refresh exists, that it stays silent, that it cannot apply a stale
+payload, and that both write paths on the admin page call it.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+V2_SRC = REPO_ROOT / "application" / "v2_ui" / "src"
+
+sys.path.insert(0, str(REPO_ROOT / "functional_tests"))
+
+from test_support.versioning import assert_app_version_at_least  # noqa: E402
+
+
+IMPLEMENTED_IN_VERSION = "0.261.046"
+
+
+def _read(path):
+    return path.read_text(encoding="utf-8")
+
+
+def _strip_comments(source):
+    """Drop comments so an assertion reads the code rather than the prose beside it."""
+    without_blocks = re.sub(r"/\*(.|\n)*?\*/", "", source)
+    return re.sub(r"//[^\n]*", "", without_blocks)
+
+
+def _refresh_action():
+    """The body of the store's refresh action."""
+    source = _read(V2_SRC / "stores" / "bootstrapStore.ts")
+    action = re.search(r"    refresh: async \(\) => \{(.|\n)*?\n    \},", source)
+    assert action, (
+        "bootstrapStore must expose a refresh action. Bootstrap is fetched once at "
+        "startup, so without one an administrator's saved change is invisible until the "
+        "browser is reloaded"
+    )
+    return action.group(0)
+
+
+def test_the_store_can_reread_bootstrap():
+    """The payload the shell draws from has to be re-readable after it changes."""
+    print("Testing the bootstrap refresh action...")
+
+    source = _read(V2_SRC / "stores" / "bootstrapStore.ts")
+
+    assert "refresh: () => Promise<void>;" in source, (
+        "The refresh action must be declared on BootstrapState, or nothing outside the "
+        "store can call it"
+    )
+
+    body = _refresh_action()
+    assert "await fetchBootstrap()" in body, (
+        "The refresh must re-read /api/v2/bootstrap. The server decides whether the "
+        "classification banner exists at all -- it is emitted only when enabled and "
+        "non-empty -- and applies its colour defaults, so the browser cannot re-derive it"
+    )
+    assert "set({ data })" in body, "The refresh must apply the payload it fetched"
+
+    print("Bootstrap refresh action test passed!")
+    return True
+
+
+def test_the_refresh_never_drives_the_boot_screen():
+    """A background refetch must not take down the page the reader is working on."""
+    print("Testing that the refresh stays silent...")
+
+    body = _strip_comments(_refresh_action())
+
+    assert "loading" not in body, (
+        "The refresh must not set `loading`. App.tsx renders BootScreen instead of the "
+        "whole interface while it is set, so the admin page would be torn down mid-edit "
+        "and the unsaved draft lost"
+    )
+    assert "error" not in body and "authExpired" not in body, (
+        "The refresh must not set `error` or `authExpired`. App.tsx renders BootError "
+        "instead of the whole interface when `error` is set, so a failed background "
+        "refetch would replace a page whose save had just succeeded"
+    )
+
+    # The failure has to be swallowed deliberately rather than left to reject unhandled.
+    assert "} catch {" in body, (
+        "A failed refresh is advisory: the write it follows already succeeded, so a "
+        "briefly stale shell is cosmetic and the next full load corrects it"
+    )
+
+    # load() is what the boot sequence uses and it must keep its reporting.
+    load = re.search(r"    load: async \(\) => \{(.|\n)*?\n    \},", _read(
+        V2_SRC / "stores" / "bootstrapStore.ts"
+    ))
+    assert load and "loading: true" in load.group(0), (
+        "load() must still report progress; the silent behaviour belongs to refresh() "
+        "alone, because a first load has nothing on screen to preserve"
+    )
+
+    print("Silent refresh test passed!")
+    return True
+
+
+def test_a_slow_refresh_cannot_overwrite_a_newer_one():
+    """Two saves in a row race, and the older response must not win."""
+    print("Testing the refresh sequence guard...")
+
+    source = _read(V2_SRC / "stores" / "bootstrapStore.ts")
+    body = _refresh_action()
+
+    assert "let refreshSequence = 0;" in source, (
+        "Concurrent refreshes need ordering; nothing guarantees responses arrive in the "
+        "order their requests left"
+    )
+    assert "const sequence = ++refreshSequence;" in body, (
+        "Each refresh must claim a sequence number before it starts"
+    )
+    assert "if (sequence === refreshSequence) {" in body, (
+        "A refresh must apply its payload only while it is still the newest, or two "
+        "quick saves can leave the interface showing the state from before the second"
+    )
+
+    # The claim has to happen before the request, or every refresh looks like the newest.
+    assert body.index("const sequence") < body.index("await fetchBootstrap()"), (
+        "The sequence must be claimed before awaiting, not after"
+    )
+
+    print("Refresh sequence guard test passed!")
+    return True
+
+
+def test_the_admin_page_refreshes_the_shell_after_writing():
+    """Both admin write paths persist immediately, so both must refresh."""
+    print("Testing the admin settings save and upload...")
+
+    source = _read(V2_SRC / "pages" / "AdminSettingsPage.tsx")
+
+    assert "const refreshBootstrap = useBootstrapStore((state) => state.refresh);" in source, (
+        "The admin page must hold the refresh action to be able to call it"
+    )
+
+    save = re.search(r"    const save = useCallback\(async \(\) => \{(.|\n)*?\n    \}, \[[^\]]*\]\);", source)
+    assert save, "AdminSettingsPage should define a save callback"
+    save_body = save.group(0)
+
+    assert "void refreshBootstrap();" in save_body, (
+        "A successful save must re-read bootstrap. The settings edited here are the same "
+        "ones the shell draws itself from, and it holds the payload from page load"
+    )
+    assert "refreshBootstrap]" in save_body, (
+        "refreshBootstrap must be a dependency of the save callback"
+    )
+
+    # The refresh belongs to the success path; a rejected save changed nothing to re-read.
+    assert save_body.index("void refreshBootstrap();") < save_body.index("} catch ("), (
+        "The refresh must sit on the success path, not after the catch: a rejected save "
+        "leaves the settings document untouched"
+    )
+
+    upload = re.search(
+        r"    const onBrandingUploaded = useCallback\((.|\n)*?\n    \);", source
+    )
+    assert upload, "AdminSettingsPage should define a branding upload callback"
+    assert "void refreshBootstrap();" in upload.group(0), (
+        "A branding image upload writes to the settings document immediately rather than "
+        "waiting for Save, so the rail would keep drawing the previous logo -- and its "
+        "URL is version-stamped, so only a refetch busts the cache"
+    )
+
+    print("Admin settings save and upload test passed!")
+    return True
+
+
+def test_the_banner_is_read_from_the_refreshed_payload():
+    """The refresh only fixes the banner if the banner still reads from the store."""
+    print("Testing the classification banner source...")
+
+    shell = _read(V2_SRC / "components" / "layout" / "AppShell.tsx")
+
+    assert (
+        "useBootstrapStore((state) => state.data?.branding?.classification_banner)" in shell
+    ), (
+        "The banner must read from the bootstrap store, which is what the refresh "
+        "updates. Reading it from anywhere else would put it back out of reach of a save"
+    )
+    assert "if (!banner?.enabled || !banner.text) {" in shell, (
+        "The banner must disappear again when it is turned off or blanked, which is the "
+        "same refresh working in reverse"
+    )
+
+    print("Classification banner source test passed!")
+    return True
+
+
+def test_version_is_at_least_implementation_version():
+    """The change is present from the version that introduced it onwards."""
+    print("Testing application version...")
+    assert_app_version_at_least(IMPLEMENTED_IN_VERSION)
+    print("Application version test passed!")
+    return True
+
+
+if __name__ == "__main__":
+    tests = [
+        test_the_store_can_reread_bootstrap,
+        test_the_refresh_never_drives_the_boot_screen,
+        test_a_slow_refresh_cannot_overwrite_a_newer_one,
+        test_the_admin_page_refreshes_the_shell_after_writing,
+        test_the_banner_is_read_from_the_refreshed_payload,
+        test_version_is_at_least_implementation_version,
+    ]
+
+    results = []
+    for test in tests:
+        print(f"\nRunning {test.__name__}...")
+        try:
+            results.append(bool(test()))
+        except Exception as exc:  # noqa: BLE001 - surface any failure with a traceback
+            print(f"Test failed: {exc}")
+            import traceback
+
+            traceback.print_exc()
+            results.append(False)
+
+    print(f"\nResults: {sum(results)}/{len(results)} tests passed")
+    sys.exit(0 if all(results) else 1)

--- a/functional_tests/test_v2_bootstrap_refresh_logic.mjs
+++ b/functional_tests/test_v2_bootstrap_refresh_logic.mjs
@@ -1,0 +1,285 @@
+// test_v2_bootstrap_refresh_logic.mjs
+//
+// Runtime test for the V2 bootstrap store's refresh action.
+// Version: 0.261.046
+// Implemented in: 0.261.046
+//
+// The companion test, test_v2_admin_settings_live_shell_refresh.py, asserts that the pieces
+// are wired together. Those are source assertions: they prove the call exists, not that it
+// behaves. This file executes the real store, because the two ways this can go quietly wrong
+// both look fine in the source.
+//
+// The first is that a background refetch must never drive `loading` or `error`. App.tsx
+// replaces the entire interface with the boot screen while `loading` is set, and with the
+// boot error when `error` is, so an administrator mid-edit would lose the page and the
+// unsaved draft with it. Asserting on the final state would miss it -- the flag only has to
+// be set transiently to blank the screen -- so every intermediate state is recorded here.
+//
+// The second is ordering. Two saves in a row issue two refetches, and nothing guarantees the
+// responses return in the order the requests left. The stale one winning is invisible except
+// at the moment it happens.
+//
+// Run directly with `node functional_tests/test_v2_bootstrap_refresh_logic.mjs`. Requires
+// Node 22.6 or newer, which strips the TypeScript types so the real module is imported
+// rather than a copy.
+
+import assert from 'node:assert/strict';
+import { registerHooks } from 'node:module';
+
+// The V2 source imports without file extensions, which Vite resolves and Node's ESM
+// resolver does not. Resolving them here is what lets this test execute the real store
+// rather than a transcription of it that could drift from what ships.
+registerHooks({
+    resolve(specifier, context, nextResolve) {
+        if (specifier.startsWith('.') && !/\.[cm]?[jt]s$/.test(specifier)) {
+            try {
+                return nextResolve(`${specifier}.ts`, context);
+            } catch {
+                /* Not a TypeScript module; fall through to the default resolution. */
+            }
+        }
+        return nextResolve(specifier, context);
+    },
+});
+
+const STORE_URL = new URL(
+    '../application/v2_ui/src/stores/bootstrapStore.ts',
+    import.meta.url,
+);
+
+/** Swapped per test; every request the store makes lands here. */
+let fetchImpl = () => {
+    throw new Error('No fetch behaviour was installed for this test');
+};
+
+globalThis.fetch = (...args) => fetchImpl(...args);
+
+const { useBootstrapStore } = await import(STORE_URL);
+
+/** A minimal Response the api client is happy to read. */
+function jsonResponse(body, status = 200) {
+    return {
+        ok: status >= 200 && status < 300,
+        status,
+        headers: { get: () => 'application/json' },
+        json: async () => body,
+        text: async () => JSON.stringify(body),
+    };
+}
+
+/** A bootstrap payload carrying the classification banner in a given state. */
+function payloadWithBanner(banner) {
+    return {
+        version: '0.261.046',
+        user: { id: 'u1', display_name: 'Tester', is_admin: true, roles: ['Admin'] },
+        branding: {
+            app_title: 'SimpleChat',
+            hide_app_title: false,
+            show_logo: false,
+            logo_url: null,
+            logo_dark_url: null,
+            classification_banner: banner,
+        },
+        features: {},
+    };
+}
+
+const BANNER_OFF = null;
+const BANNER_ON = {
+    enabled: true,
+    text: 'UNCLASSIFIED',
+    color: '#ffc107',
+    text_color: '#ffffff',
+};
+
+/** Reset the store to a resolved load carrying `banner`, and return its state. */
+async function loadWith(banner) {
+    fetchImpl = async () => jsonResponse(payloadWithBanner(banner));
+    await useBootstrapStore.getState().load();
+    return useBootstrapStore.getState();
+}
+
+/** Record every state the store passes through while `run` executes. */
+async function recordStates(run) {
+    const seen = [];
+    const unsubscribe = useBootstrapStore.subscribe((state) => {
+        seen.push({ loading: state.loading, error: state.error, authExpired: state.authExpired });
+    });
+    try {
+        await run();
+    } finally {
+        unsubscribe();
+    }
+    return seen;
+}
+
+async function testRefreshAppliesTheNewPayload() {
+    console.log('Testing that a refresh applies the new payload...');
+
+    await loadWith(BANNER_OFF);
+    assert.equal(
+        useBootstrapStore.getState().data.branding.classification_banner,
+        null,
+        'The banner starts off, as it would before an administrator enabled it',
+    );
+
+    fetchImpl = async () => jsonResponse(payloadWithBanner(BANNER_ON));
+    await useBootstrapStore.getState().refresh();
+
+    assert.deepEqual(
+        useBootstrapStore.getState().data.branding.classification_banner,
+        BANNER_ON,
+        'A refresh must replace the payload the shell reads, or enabling the banner stays '
+            + 'invisible until the browser is reloaded',
+    );
+
+    // The same mechanism has to work in reverse, or a banner cannot be turned off either.
+    fetchImpl = async () => jsonResponse(payloadWithBanner(BANNER_OFF));
+    await useBootstrapStore.getState().refresh();
+
+    assert.equal(
+        useBootstrapStore.getState().data.branding.classification_banner,
+        null,
+        'Turning the banner off must reach the shell just as immediately',
+    );
+
+    console.log('Refresh payload test passed!');
+}
+
+async function testRefreshNeverBlanksTheInterface() {
+    console.log('Testing that a refresh never blanks the interface...');
+
+    await loadWith(BANNER_OFF);
+
+    fetchImpl = async () => jsonResponse(payloadWithBanner(BANNER_ON));
+    const seen = await recordStates(() => useBootstrapStore.getState().refresh());
+
+    assert.ok(seen.length > 0, 'The refresh should have produced at least one state update');
+    for (const state of seen) {
+        assert.equal(
+            state.loading,
+            false,
+            'A refresh must never set `loading`, even transiently: App.tsx swaps the whole '
+                + 'interface for the boot screen while it is set, so the page being edited '
+                + 'would be torn down and its unsaved draft lost',
+        );
+        assert.equal(state.error, null, 'A successful refresh must not report an error');
+    }
+
+    console.log('Interface blanking test passed!');
+}
+
+async function testAFailedRefreshIsAdvisory() {
+    console.log('Testing that a failed refresh is advisory...');
+
+    const before = (await loadWith(BANNER_ON)).data;
+
+    fetchImpl = async () => jsonResponse({ error: 'Failed to load application bootstrap' }, 500);
+    const seen = await recordStates(() => useBootstrapStore.getState().refresh());
+
+    const after = useBootstrapStore.getState();
+    assert.equal(
+        after.data,
+        before,
+        'A failed refresh must leave the payload alone; the write it follows already '
+            + 'succeeded, so the previous state is still the best available',
+    );
+    assert.equal(
+        after.error,
+        null,
+        'A failed refresh must not set `error`: App.tsx replaces the whole interface with '
+            + 'the boot error when it is set, so a page whose save had just succeeded would '
+            + 'be thrown away over a background refetch nobody asked for',
+    );
+    assert.equal(after.authExpired, false, 'A failed refresh must not claim the session expired');
+    assert.equal(after.loading, false, 'A failed refresh must not leave the store loading');
+
+    for (const state of seen) {
+        assert.equal(state.loading, false, 'A failing refresh must not blank the interface either');
+        assert.equal(state.error, null, 'A failing refresh must not surface an error state');
+    }
+
+    console.log('Failed refresh test passed!');
+}
+
+async function testARejectedRefreshDoesNotEscape() {
+    console.log('Testing that a refresh never rejects...');
+
+    await loadWith(BANNER_ON);
+
+    // A network-level failure rather than an HTTP error response.
+    fetchImpl = async () => {
+        throw new TypeError('Failed to fetch');
+    };
+
+    await assert.doesNotReject(
+        () => useBootstrapStore.getState().refresh(),
+        'Callers fire the refresh without awaiting it, so a rejection would surface as an '
+            + 'unhandled promise rejection rather than being reported anywhere useful',
+    );
+
+    console.log('Rejection test passed!');
+}
+
+async function testAStaleRefreshCannotOverwriteANewerOne() {
+    console.log('Testing the refresh ordering guard...');
+
+    await loadWith(BANNER_OFF);
+
+    const slowBanner = { ...BANNER_ON, text: 'FROM THE FIRST SAVE' };
+    const fastBanner = { ...BANNER_ON, text: 'FROM THE SECOND SAVE' };
+
+    let releaseSlow;
+    const slowArrived = new Promise((resolve) => {
+        releaseSlow = () => resolve(jsonResponse(payloadWithBanner(slowBanner)));
+    });
+
+    // The first refresh hangs; the second is served immediately.
+    fetchImpl = () => slowArrived;
+    const first = useBootstrapStore.getState().refresh();
+
+    fetchImpl = async () => jsonResponse(payloadWithBanner(fastBanner));
+    await useBootstrapStore.getState().refresh();
+
+    assert.equal(
+        useBootstrapStore.getState().data.branding.classification_banner.text,
+        fastBanner.text,
+        'The newer refresh should have been applied',
+    );
+
+    // Now let the older request finish. It must be discarded.
+    releaseSlow();
+    await first;
+
+    assert.equal(
+        useBootstrapStore.getState().data.branding.classification_banner.text,
+        fastBanner.text,
+        'A slower earlier refresh must not overwrite a newer one, or two saves in quick '
+            + 'succession leave the interface showing the state from before the second',
+    );
+
+    console.log('Refresh ordering test passed!');
+}
+
+const tests = [
+    testRefreshAppliesTheNewPayload,
+    testRefreshNeverBlanksTheInterface,
+    testAFailedRefreshIsAdvisory,
+    testARejectedRefreshDoesNotEscape,
+    testAStaleRefreshCannotOverwriteANewerOne,
+];
+
+let passed = 0;
+for (const test of tests) {
+    console.log(`\nRunning ${test.name}...`);
+    try {
+        await test();
+        passed += 1;
+    } catch (error) {
+        console.error(`Test failed: ${error.message}`);
+        console.error(error);
+    }
+}
+
+console.log(`\nResults: ${passed}/${tests.length} tests passed`);
+process.exit(passed === tests.length ? 0 : 1);


### PR DESCRIPTION
## The report

> Need to add banner support to v2 — it's in settings but it doesn't show up.

## What was actually wrong

The classification banner was already implemented end to end. `_build_branding()` emits `branding.classification_banner` in the bootstrap payload, and `AppShell.tsx::ClassificationBanner` renders it.

The problem was one level up: **`/api/v2/bootstrap` is fetched exactly once**, from a mount effect in `App.tsx`, and there was no second call anywhere in the V2 source. `AdminSettingsPage.save()` PATCHed the settings and merged the response into its *own* local state — which drives the form controls and the in-page preview, and nothing else. The bootstrap store was never told anything had changed.

So the banner saved correctly and then sat there invisible until the browser was reloaded, which reads as a save that didn't work.

The banner was just the visible symptom. Everything the shell draws itself from went stale on save: the application title, the sidebar logo and favicon, `hide_app_title`, the feature flags the chat surface branches on, the AI notice, and the admin navigation.

## The fix

`bootstrapStore` gains a `refresh()` action that re-reads the payload in place. `AdminSettingsPage` calls it on both of its write paths.

**`refresh()` is deliberately not `load()`.** `load()` sets `loading: true` while it runs and `error` when it fails, and `App.tsx` renders `<BootScreen />` *instead of the entire interface* while `loading` is set, and `<BootError />` instead of the entire interface when `error` is set. Reusing it for a background refetch would tear down the admin page the moment a save landed — taking any unsaved draft with it — and would replace a page whose save had just succeeded with a full-screen error if the refetch happened to fail. `refresh()` writes only `data`, and a failure is swallowed on purpose: the write it follows already succeeded, so a briefly stale shell is cosmetic and the next full load corrects it.

**Ordering.** A module-level sequence counter is claimed before the request and checked before the payload is applied. Two saves in quick succession issue two refetches and nothing guarantees the responses return in order; without the guard the interface can settle on the payload from before the second save.

**Branding uploads too.** Logo and favicon uploads write to the settings document immediately rather than waiting for **Save**, so the sidebar logo went stale the same way — and its URL is version-stamped (`?v=N`), so only a refetch produces the new URL and busts the browser cache.

## Server side needed no change

`update_settings()` calls `_refresh_app_settings_cache_after_write()` immediately after the Cosmos upsert, so a refetch issued straight after a successful save reads the new values. Verified rather than assumed — it was the obvious way for this fix to be flaky.

## Alternatives considered

- **Patching `branding.classification_banner` client-side from the PATCH response.** The server decides whether the banner is emitted at all (it requires both the toggle *and* non-empty text) and applies the `#ffc107` / `#ffffff` defaults. Re-deriving that in the browser creates a second copy of the rules that drifts from the first.
- **Injecting the banner into the SPA shell HTML server-side**, so it paints before the bundle boots. Puts admin-controlled text into raw HTML for a sub-second gain and doesn't address the save case at all.
- **Refreshing only when banner keys changed.** Needs a hand-maintained list of settings that affect the shell, which rots the moment a setting is added. Practically every admin setting reaches the bootstrap payload.

## Validation

```powershell
python .\functional_tests\test_v2_admin_settings_live_shell_refresh.py   # 6/6
node   .\functional_tests\test_v2_bootstrap_refresh_logic.mjs            # 5/5
```

`test_v2_bootstrap_refresh_logic.mjs` **imports and executes the real store** rather than asserting on its source, because the two ways this can go quietly wrong both look fine in a source scan:

- It records **every intermediate state** during a refresh. `loading` only has to be set transiently to blank the interface, so checking the final state would miss it.
- It holds one refetch open while a second completes, then releases the first, to prove the stale payload is discarded.

Both were mutation-tested — removing the ordering guard and making `refresh()` set `loading` each make the suite fail — so they aren't rubber stamps.

Also passing, unchanged: `test_v2_admin_appearance_parity.py`, `test_v2_admin_field_renderer_coverage.py`, `test_v2_admin_settings_normalization.py`, `test_v2_chat_notices.py`, `test_v2_api_payload_shapes.py`, `test_v2_ui_local_assets.py`, `test_v2_new_chat_scoping.py`, `test_docs_app_surface_coverage.py`, `test_docs_site_quality.py`. `npm run build` (`tsc -b` + Vite) is clean.

### Before

1. **Admin Settings → Appearance → Notices**, enable the classification banner, set text, save.
2. Toast confirms the save. No banner.
3. Reload the browser. Banner appears.

### After

1. Same steps.
2. The banner appears as the save completes. Turning it off, or blanking its text, removes it just as immediately.
3. A changed application title, an uploaded logo, or a newly enabled capability reaches the shell on save in the same way — no reload.

## Files

| File | Change |
| --- | --- |
| `application/v2_ui/src/stores/bootstrapStore.ts` | `refresh()` action and the ordering guard |
| `application/v2_ui/src/pages/AdminSettingsPage.tsx` | Calls it after a successful PATCH and after a branding upload |
| `application/single_app/config.py` | `VERSION` `0.261.045` → `0.261.046` |
| `functional_tests/test_v2_admin_settings_live_shell_refresh.py` | New — pins the wiring |
| `functional_tests/test_v2_bootstrap_refresh_logic.mjs` | New — runtime test of the real store |
| `docs/explanation/fixes/V2_ADMIN_SETTINGS_LIVE_SHELL_REFRESH_FIX.md` | New fix doc |
| `docs/explanation/features/REACT_V2_UI.md` | Documents that a save reaches the shell |
| `docs/explanation/release_notes.md` | `v0.261.046` entry |

No new `enable_*` key, admin tab, action plugin or chat control, so `docs/_data/app_surface.yml` did not need regenerating.