### PR TITLE
Fix V2 Appearance settings that had no visible effect

### DIFF
--- a/application/single_app/admin_settings_fields.py
+++ b/application/single_app/admin_settings_fields.py
@@ -30,9 +30,11 @@ Two things keep this honest rather than becoming a third source of truth:
     to the same normalizers the server-rendered form uses. Both interfaces
     therefore agree on what a valid value is.
 
-Only the Appearance group is described so far. Sections with no entry here fall
-back to the V2 surface's ``enable_*`` scan, so undescribed groups keep working
-exactly as they did.
+Only the Appearance group is described in full so far. Sections with no entry
+here fall back to the V2 surface's ``enable_*`` scan, so undescribed groups keep
+working exactly as they did. A handful of individual fields outside Appearance
+are also declared: that scan places a key by guessing from shared word stems,
+and declaring a field is the only way to stop it guessing wrong.
 """
 
 import re
@@ -533,6 +535,103 @@ ADMIN_SETTINGS_FIELDS = {
             "depends_on": {"key": "enable_external_links", "equals": True},
         },
     ],
+    # The sections below are not part of the Appearance group. They are described
+    # here because the V2 surface's `enable_*` fallback was filing their toggles
+    # under Appearance: it matches a key to a section by shared leading word
+    # stems and takes the first section that scores at all, so
+    # `enable_external_healthcheck` matched "external" in External Links long
+    # before it could reach Health Check, whose id splits into "health" and
+    # "check" and so never matches the single token "healthcheck". Declaring a
+    # key is what takes it out of that scan, so these five are declared rather
+    # than guessed at. Wording is taken from the V1 panes so both interfaces say
+    # the same thing.
+    "health-check-section": [
+        {
+            "key": "enable_external_healthcheck",
+            "type": "switch",
+            "label": "Enable /external/healthcheck",
+            "help": (
+                "Authenticated endpoint for external monitoring systems. Best for "
+                "internal monitors or diagnostics tooling that already signs in to "
+                "the application."
+            ),
+            "default": False,
+        },
+        {
+            "key": "enable_no_auth_external_healthcheck",
+            "type": "switch",
+            "label": "Enable /external/healthcheckz",
+            "help": (
+                "Unauthenticated endpoint for platform probes that cannot sign in. "
+                "This route is intentionally unauthenticated, so only enable it for "
+                "trusted health probes or controlled network paths."
+            ),
+            "default": False,
+        },
+    ],
+    "user-facing-latest-features-section": [
+        {
+            "key": "enable_support_latest_feature_documentation_links",
+            "type": "switch",
+            "label": "Show Simple Chat Documentation Guide Links",
+            "help": (
+                "User-facing Latest Features cards show public documentation guide "
+                "buttons in addition to the direct in-app shortcuts."
+            ),
+            "default": False,
+            # V1 hides this control entirely while the Latest Features destination
+            # is off, because the cards it affects are not reachable then.
+            "depends_on": {"key": "enable_support_latest_features", "equals": True},
+        },
+    ],
+    # Declared so the dependency above resolves to a control an administrator can
+    # actually find and flip, and so the Support Menu gate chain reads the same in
+    # both interfaces. The remaining fields in this section are still discovered
+    # by the fallback scan.
+    "support-menu-section": [
+        {
+            "key": "enable_support_menu",
+            "type": "switch",
+            "label": "Enable Support Menu for End Users",
+            "help": (
+                "Signed-in users with the User role get a Support menu in navigation, "
+                "leading to destinations such as Send Feedback and Latest Features."
+            ),
+            "default": False,
+        },
+        {
+            "key": "enable_support_latest_features",
+            "type": "switch",
+            "label": "Enable Latest Features Destination",
+            "help": "Publishes a user-facing Latest Features page from the Support menu.",
+            "default": True,
+            "depends_on": {"key": "enable_support_menu", "equals": True},
+        },
+    ],
+    "personal-workspaces-section": [
+        {
+            "key": "enable_user_workspace",
+            "type": "switch",
+            "label": "Enable Personal Workspaces",
+            "help": (
+                "Users can create and manage their own private workspace for document "
+                "storage, knowledge bases and personal AI interactions."
+            ),
+            "default": True,
+        },
+    ],
+    "actions-config": [
+        {
+            "key": "enable_text_plugin",
+            "type": "switch",
+            "label": "Enable Text Action",
+            "help": (
+                "Agents can perform text processing operations such as formatting, "
+                "validation and manipulation of strings and text content."
+            ),
+            "default": True,
+        },
+    ],
 }
 
 
@@ -642,6 +741,17 @@ def _validate_external_link_url(url):
     if not parsed.netloc:
         return "URL is missing a host."
     return None
+
+
+def is_safe_external_link_url(url):
+    """Return True when a navigation link URL is safe to render as an ``href``.
+
+    The write path already refuses anything else, but only the V2 settings PATCH goes
+    through it: the server-rendered admin form stores whatever string it is given, and a
+    settings document predates both. Any surface that turns a stored link into an anchor
+    should therefore check here rather than trust the document.
+    """
+    return _validate_external_link_url(url) is None
 
 
 def _normalize_link_list(value):

--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -97,7 +97,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.261.043"
+VERSION = "0.261.044"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/functions_branding_urls.py
+++ b/application/single_app/functions_branding_urls.py
@@ -1,0 +1,66 @@
+# functions_branding_urls.py
+"""Static URLs for the administrator-supplied branding assets.
+
+The logo and favicon are stored base64-encoded in the settings document and written out
+as static files, so every surface that wants to show one needs the same two things: the
+path the file is written to, and the version counter that busts the browser cache when an
+administrator replaces it. Those rules were previously restated in each place that needed
+them -- ``base.html`` for the server-rendered pages, ``BRANDING_IMAGE_TARGETS`` for the
+upload endpoint, and ``_build_branding`` for the SPA -- which meant a change to one path
+could leave another pointing at a file that no longer existed.
+
+This module holds the paths and the version rule once. It deliberately has no imports:
+the V2 SPA shell route is served on every page load and reads the favicon URL from here,
+so it must not have to pull in Pillow or the Azure clients to render an icon link.
+"""
+
+LOGO_STATIC_URL = "/static/images/custom_logo.png"
+LOGO_DARK_STATIC_URL = "/static/images/custom_logo_dark.png"
+FAVICON_STATIC_URL = "/static/images/favicon.ico"
+
+
+def _versioned(url, version):
+    """Append the cache-busting version counter to a branding asset URL.
+
+    The static file keeps a stable name across uploads, so without the counter a browser
+    keeps serving whichever image it cached before the replacement.
+    """
+    try:
+        resolved = int(version)
+    except (TypeError, ValueError):
+        resolved = 1
+    return f"{url}?v={resolved if resolved > 0 else 1}"
+
+
+def build_favicon_url(settings):
+    """Return the favicon URL, versioned only when a custom icon is stored.
+
+    Mirrors ``base.html``: the shipped default is served unversioned because it only
+    changes with a deploy, which already invalidates the cache.
+    """
+    settings = settings or {}
+    if settings.get("custom_favicon_base64"):
+        return _versioned(FAVICON_STATIC_URL, settings.get("favicon_version"))
+    return FAVICON_STATIC_URL
+
+
+def build_custom_logo_urls(settings):
+    """Return ``(light_url, dark_url)`` for the stored custom logos.
+
+    Either entry is ``None`` when no custom logo has been uploaded; callers decide what to
+    show instead. When only a light logo exists it is reused in dark mode, matching the
+    server-rendered templates, so a single upload still works in both themes.
+    """
+    settings = settings or {}
+
+    light_url = None
+    dark_url = None
+
+    if settings.get("custom_logo_base64"):
+        light_url = _versioned(LOGO_STATIC_URL, settings.get("logo_version"))
+    if settings.get("custom_logo_dark_base64"):
+        dark_url = _versioned(LOGO_DARK_STATIC_URL, settings.get("logo_dark_version"))
+    elif light_url:
+        dark_url = light_url
+
+    return light_url, dark_url

--- a/application/single_app/route_backend_v2.py
+++ b/application/single_app/route_backend_v2.py
@@ -24,7 +24,12 @@ import logging
 from flask import current_app, jsonify, request, session
 
 from admin_settings_fields import (
+    LANDING_PAGE_ALIGNMENTS,
+    LOGO_SCALE_DEFAULT_PERCENT,
+    LOGO_SCALE_MAX_PERCENT,
+    LOGO_SCALE_MIN_PERCENT,
     get_admin_settings_fields,
+    is_safe_external_link_url,
     normalize_admin_settings_updates,
 )
 from admin_settings_nav import ADMIN_NAV
@@ -40,6 +45,13 @@ from functions_branding_images import (
     prepare_favicon_image_for_storage,
     prepare_logo_image_for_storage,
 )
+from functions_branding_urls import (
+    FAVICON_STATIC_URL,
+    LOGO_DARK_STATIC_URL,
+    LOGO_STATIC_URL,
+    build_custom_logo_urls,
+    build_favicon_url,
+)
 from functions_authentication import (
     admin_required,
     get_current_user_id,
@@ -48,6 +60,7 @@ from functions_authentication import (
     user_required,
 )
 from functions_conversation_contents import is_conversation_contents_drawer_enabled
+from functions_custom_pages import get_custom_pages_nav
 from functions_group import find_group_by_id, get_user_groups
 from functions_public_workspaces import (
     find_public_workspace_by_id,
@@ -82,28 +95,29 @@ logger = logging.getLogger(__name__)
 
 
 # Describes each branding asset an administrator can replace: how to convert the
-# upload, which settings keys hold it, and the static path it is written to.
-# ``_build_branding` returns URLs derived from these same keys, so a change here
-# cannot leave the SPA pointing at a stale path.
+# upload, which settings keys hold it, and the static path it is written to. The
+# paths come from ``functions_branding_urls``, which is also what the bootstrap
+# payload and the SPA shell read, so a change there cannot leave one surface
+# pointing at a file another no longer writes.
 BRANDING_IMAGE_TARGETS = {
     "logo": {
         "settings_key": "custom_logo_base64",
         "version_key": "logo_version",
-        "static_url": "/static/images/custom_logo.png",
+        "static_url": LOGO_STATIC_URL,
         "extensions": ALLOWED_LOGO_EXTENSIONS,
         "prepare": prepare_logo_image_for_storage,
     },
     "logo_dark": {
         "settings_key": "custom_logo_dark_base64",
         "version_key": "logo_dark_version",
-        "static_url": "/static/images/custom_logo_dark.png",
+        "static_url": LOGO_DARK_STATIC_URL,
         "extensions": ALLOWED_LOGO_EXTENSIONS,
         "prepare": prepare_logo_image_for_storage,
     },
     "favicon": {
         "settings_key": "custom_favicon_base64",
         "version_key": "favicon_version",
-        "static_url": "/static/images/favicon.ico",
+        "static_url": FAVICON_STATIC_URL,
         "extensions": ALLOWED_FAVICON_EXTENSIONS,
         "prepare": prepare_favicon_image_for_storage,
     },
@@ -159,21 +173,12 @@ def _build_branding(raw_settings, public_settings):
     logo blobs from public settings. The blobs are not what the browser needs anyway: the
     images are already served as static files, so the URLs are derived here from the raw
     settings and only the URLs are returned.
+
+    The landing page fields ride along because the SPA renders its own home page and would
+    otherwise need a second request for three values it needs on first paint.
     """
     show_logo = bool(raw_settings.get("show_logo", False))
-    logo_version = raw_settings.get("logo_version") or 1
-    logo_dark_version = raw_settings.get("logo_dark_version") or 1
-
-    logo_url = None
-    logo_dark_url = None
-    if raw_settings.get("custom_logo_base64"):
-        logo_url = f"/static/images/custom_logo.png?v={logo_version}"
-    if raw_settings.get("custom_logo_dark_base64"):
-        logo_dark_url = f"/static/images/custom_logo_dark.png?v={logo_dark_version}"
-    elif logo_url:
-        # Matches the server-rendered template, which reuses the light logo in dark mode
-        # when no dedicated dark variant has been uploaded.
-        logo_dark_url = logo_url
+    logo_url, logo_dark_url = build_custom_logo_urls(raw_settings)
 
     classification_banner = None
     if raw_settings.get("classification_banner_enabled") and raw_settings.get(
@@ -186,13 +191,130 @@ def _build_branding(raw_settings, public_settings):
             "text_color": raw_settings.get("classification_banner_text_color") or "#ffffff",
         }
 
+    landing_alignment = raw_settings.get("landing_page_alignment") or "left"
+    if landing_alignment not in LANDING_PAGE_ALIGNMENTS:
+        landing_alignment = "left"
+
     return {
         "app_title": public_settings.get("app_title") or "SimpleChat",
         "hide_app_title": bool(raw_settings.get("hide_app_title", False)),
         "show_logo": show_logo,
         "logo_url": logo_url if show_logo else None,
         "logo_dark_url": logo_dark_url if show_logo else None,
+        "favicon_url": build_favicon_url(raw_settings),
         "classification_banner": classification_banner,
+        # Passed through as stored apart from trimming, including when that leaves it
+        # empty. ``get_settings`` merges the seeded default into every document, so a
+        # blank value is an administrator's deletion, and substituting default copy would
+        # put wording they removed -- including an acceptable-use statement -- back on
+        # the page.
+        "landing_page_text": str(raw_settings.get("landing_page_text") or "").strip(),
+        "landing_page_alignment": landing_alignment,
+        "landing_page_logo_scale_percent": _coerce_logo_scale(
+            raw_settings.get("landing_page_logo_scale_percent")
+        ),
+    }
+
+
+def _coerce_logo_scale(value):
+    """Clamp the stored home page logo scale into the range the slider offers."""
+    try:
+        scale = int(float(value))
+    except (TypeError, ValueError):
+        return LOGO_SCALE_DEFAULT_PERCENT
+    return max(LOGO_SCALE_MIN_PERCENT, min(LOGO_SCALE_MAX_PERCENT, scale))
+
+
+def _menu_name(value, fallback):
+    """Return a navigation group's heading, falling back when it is blank.
+
+    ``fallback_when_empty`` in the field schema already restores the default on save, but
+    a settings document written before that rule existed can still hold an empty string,
+    and an unlabelled group in the rail is worse than a defaulted one.
+    """
+    return str(value or "").strip() or fallback
+
+
+def _build_navigation(raw_settings, user_roles):
+    """Describe the administrator-configured navigation entries for the SPA.
+
+    Both groups exist in the server-rendered interface, where custom pages arrive as
+    template context built in ``app.py`` and external links are read straight off
+    ``app_settings`` in ``_sidebar_nav.html``. Neither is reachable from the SPA, and
+    neither can be derived from the feature flags: custom pages are filtered per page
+    against the caller's roles, and the external link list is not an ``enable_*`` key.
+
+    ``menu_name`` and ``force_menu`` travel with each group so the browser can apply the
+    same "inline below three, menu at three or more" rule the templates use.
+    """
+    custom_pages = []
+    if raw_settings.get("enable_custom_pages"):
+        try:
+            for page in get_custom_pages_nav(raw_settings):
+                url = page.get("url") or page.get("href")
+                if not page.get("slug") or not url:
+                    continue
+                custom_pages.append(
+                    {
+                        "slug": page["slug"],
+                        "label": page.get("label") or page["slug"],
+                        "icon": page.get("icon") or "bi-file-earmark-text",
+                        "url": url,
+                        "open_in_new_tab": bool(page.get("open_in_new_tab", False)),
+                    }
+                )
+        except Exception as exc:
+            # A missing navigation group is a degraded rail, not a broken app, so it
+            # must not take the whole bootstrap payload down with it.
+            log_event(
+                f"[V2_BOOTSTRAP] Could not resolve custom page navigation: {exc}",
+                level=logging.WARNING,
+                exceptionTraceback=True,
+            )
+            custom_pages = []
+
+    # Matches the role gate in _sidebar_nav.html: external links are shown to signed-in
+    # users holding a real application role, not to anyone who merely has a session.
+    may_see_external_links = any(role in ("Admin", "User") for role in user_roles or [])
+    external_links = []
+    if raw_settings.get("enable_external_links") and may_see_external_links:
+        for link in raw_settings.get("external_links") or []:
+            if not isinstance(link, dict):
+                continue
+            url = str(link.get("url") or "").strip()
+            label = str(link.get("label") or "").strip()
+            if not url or not label:
+                continue
+            # Re-checked on the way out, not just on the way in. The V2 settings PATCH
+            # is the only write path that applies the scheme rule, so a link stored
+            # through the server-rendered admin form, or already in the document, could
+            # otherwise put a javascript: URL into every user's navigation.
+            if not is_safe_external_link_url(url):
+                log_event(
+                    "[V2_BOOTSTRAP] Dropped an external link with an unsupported URL "
+                    f"scheme: {label}",
+                    level=logging.WARNING,
+                )
+                continue
+            external_links.append({"label": label, "url": url})
+
+    return {
+        "custom_pages": {
+            "enabled": bool(raw_settings.get("enable_custom_pages")),
+            "menu_name": _menu_name(
+                raw_settings.get("custom_pages_menu_name"), "Custom Pages"
+            ),
+            "force_menu": bool(raw_settings.get("custom_pages_force_menu")),
+            "items": custom_pages,
+        },
+        "external_links": {
+            "enabled": bool(raw_settings.get("enable_external_links")),
+            "menu_name": _menu_name(
+                raw_settings.get("external_links_menu_name"), "External Links"
+            ),
+            "force_menu": bool(raw_settings.get("external_links_force_menu")),
+            "items": external_links,
+        },
     }
 
 
@@ -426,6 +548,7 @@ def register_route_backend_v2(bp):
                     "roles": list(current_user_roles),
                 },
                 "branding": _build_branding(settings, public_settings),
+                "navigation": _build_navigation(settings, current_user_roles),
                 "features": _build_feature_flags(public_settings, per_user_overrides),
                 "catalogs": {
                     "models": models,

--- a/application/single_app/route_frontend_v2.py
+++ b/application/single_app/route_frontend_v2.py
@@ -11,18 +11,38 @@ any cross-origin configuration.
 Hashed bundle assets are addressed at /static/v2/... and are handled by Flask's built-in
 static route. This module only serves the SPA shell, which every /v2 path falls back to so
 that client-side routing survives deep links and page refreshes.
+
+The shell is not returned verbatim. Its ``<title>`` and favicon link are rewritten from
+settings on the way out, because the compiled ``index.html`` is a build artefact and
+cannot know an administrator's branding. The server-rendered interface does the same thing
+in ``base.html``; without it a custom favicon never replaces the shipped one, since the
+static file keeps a stable name and the browser keeps serving the copy it already cached.
 """
 
+import html
 import logging
 import os
+import re
 
 from flask import Response, render_template_string
 
 from functions_appinsights import log_event
 from functions_authentication import login_required, user_required
+from functions_branding_urls import FAVICON_STATIC_URL, build_favicon_url
 from swagger_wrapper import get_auth_security, swagger_route
 
 V2_BUILD_SUBDIR = os.path.join("static", "v2")
+
+# Matches the shell's icon link and title regardless of attribute order, so a Vite
+# upgrade that reformats index.html does not silently stop the rewrite.
+ICON_LINK_PATTERN = re.compile(r"<link\b[^>]*\brel=(\"|')icon\1[^>]*>", re.IGNORECASE)
+TITLE_PATTERN = re.compile(r"<title\b[^>]*>.*?</title>", re.IGNORECASE | re.DOTALL)
+HEAD_CLOSE_PATTERN = re.compile(r"</head>", re.IGNORECASE)
+
+# Matches the fallback in ``_build_branding`` so the tab title the shell paints is the
+# same one the SPA sets once bootstrap resolves, rather than flickering between two
+# spellings of the product name.
+DEFAULT_APP_TITLE = "SimpleChat"
 
 # Shown when Flask is running against a checkout where the SPA has not been compiled.
 # The build output is gitignored, so this is the normal state of a fresh clone and needs
@@ -69,6 +89,57 @@ def is_v2_bundle_available():
     return os.path.isfile(get_v2_index_path())
 
 
+def _resolve_shell_branding():
+    """Return ``(favicon_url, app_title)`` for the SPA shell.
+
+    ``functions_settings`` is imported here rather than at module scope so that serving
+    the shell never depends on the settings stack being importable. A failure here means
+    a default icon and title on an otherwise working application, which is the right
+    trade: the SPA replaces the title from bootstrap moments later anyway.
+    """
+    try:
+        from functions_settings import get_settings
+
+        settings = get_settings() or {}
+        app_title = str(settings.get("app_title") or "").strip() or DEFAULT_APP_TITLE
+        return build_favicon_url(settings), app_title
+    except Exception as exc:
+        log_event(
+            f"[V2_UI] Could not resolve shell branding, serving defaults: {exc}",
+            level=logging.WARNING,
+            exceptionTraceback=True,
+        )
+        return FAVICON_STATIC_URL, DEFAULT_APP_TITLE
+
+
+def _apply_shell_branding(shell_html):
+    """Rewrite the compiled shell's favicon link and title from settings.
+
+    Both values are escaped because ``app_title`` is administrator-supplied free text.
+    The replacements are passed as callables so ``re.sub`` treats them literally; a title
+    containing a backslash would otherwise be read as a group reference.
+    """
+    favicon_url, app_title = _resolve_shell_branding()
+
+    icon_link = (
+        f'<link rel="icon" href="{html.escape(favicon_url, quote=True)}" '
+        'type="image/x-icon">'
+    )
+    shell_html, replaced = ICON_LINK_PATTERN.subn(lambda _match: icon_link, shell_html, count=1)
+    if not replaced:
+        # A shell without an icon link would fall back to /favicon.ico, which is the
+        # shipped default rather than the administrator's.
+        shell_html = HEAD_CLOSE_PATTERN.sub(
+            lambda _match: f"{icon_link}</head>", shell_html, count=1
+        )
+
+    shell_html = TITLE_PATTERN.sub(
+        lambda _match: f"<title>{html.escape(app_title)}</title>", shell_html, count=1
+    )
+
+    return shell_html
+
+
 def _serve_v2_shell():
     """Return the SPA shell, or a build hint when the bundle is missing."""
     if not is_v2_bundle_available():
@@ -93,9 +164,11 @@ def _serve_v2_shell():
         )
         return Response("Failed to load the V2 interface", status=500)
 
-    response = Response(shell_html, mimetype="text/html")
+    response = Response(_apply_shell_branding(shell_html), mimetype="text/html")
     # The shell references content-hashed assets, so it must never be cached itself or a
-    # deploy would keep serving the previous bundle's asset URLs.
+    # deploy would keep serving the previous bundle's asset URLs. The branding rewrite
+    # above relies on the same header: it is per-request, and a cached copy would pin one
+    # administrator's icon and title for everybody.
     response.headers["Cache-Control"] = "no-store, must-revalidate"
     return response
 

--- a/application/v2_ui/src/App.tsx
+++ b/application/v2_ui/src/App.tsx
@@ -11,6 +11,7 @@ import { useBootstrapStore } from './stores/bootstrapStore';
 import { useUserSettingsStore } from './stores/userSettingsStore';
 import { initializeTheme, hydrateUiPreferences } from './stores/uiStore';
 import { ChatPage } from './pages/ChatPage';
+import { HomePage } from './pages/HomePage';
 import { AdminSettingsPage } from './pages/AdminSettingsPage';
 import { SettingsPage } from './pages/SettingsPage';
 import { WorkspacePage } from './pages/workspace/WorkspacePage';
@@ -87,6 +88,25 @@ export function App() {
         }
     }, [data]);
 
+    /**
+     * Keep the tab icon in step with the stored favicon.
+     *
+     * The SPA shell is a build artefact, so the server rewrites its icon link on the way
+     * out. That covers a page load but not an upload made in this session: the static file
+     * keeps a stable name, so only the version in the URL tells the browser to fetch it
+     * again.
+     */
+    useEffect(() => {
+        const faviconUrl = data?.branding?.favicon_url;
+        if (!faviconUrl) {
+            return;
+        }
+        const link = document.querySelector<HTMLLinkElement>('link[rel="icon"]');
+        if (link && link.getAttribute('href') !== faviconUrl) {
+            link.setAttribute('href', faviconUrl);
+        }
+    }, [data]);
+
     // Applied from the stored preference on every load. The attribute name and its scale
     // are shared with the classic interface, so a size chosen in either applies to both.
     useEffect(() => {
@@ -107,7 +127,7 @@ export function App() {
             and keyed on the route so navigating away clears the error. */}
             <ErrorBoundary resetKey={location.pathname}>
             <Routes>
-                <Route path="/" element={<Navigate to="/chat" replace />} />
+                <Route path="/" element={<HomePage />} />
                 <Route path="/chat" element={<ChatPage />} />
                 <Route path="/workspace" element={<WorkspacePage />} />
                 {/* Sections are real paths rather than a query parameter, so a link to one
@@ -148,7 +168,7 @@ export function App() {
                         />
                     }
                 />
-                <Route path="*" element={<Navigate to="/chat" replace />} />
+                <Route path="*" element={<Navigate to="/" replace />} />
                 </Routes>
             </ErrorBoundary>
         </AppShell>

--- a/application/v2_ui/src/components/admin/AdminMarkdown.tsx
+++ b/application/v2_ui/src/components/admin/AdminMarkdown.tsx
@@ -14,15 +14,34 @@ import remarkBreaks from 'remark-breaks';
 import remarkGfm from 'remark-gfm';
 import { clsx } from 'clsx';
 
+/**
+ * Type scale. `sm` suits a preview card inside the settings form; `md` is for the same
+ * content rendered as the page itself, where settings-preview sizing would look shrunken.
+ */
+type MarkdownSize = 'sm' | 'md';
+
+const sizeClass: Record<MarkdownSize, string> = {
+    sm: clsx(
+        'space-y-2 text-sm',
+        '[&_h1]:text-base [&_h2]:text-sm [&_h3]:text-sm',
+    ),
+    md: clsx(
+        'space-y-3 text-base',
+        '[&_h1]:text-2xl [&_h2]:text-xl [&_h3]:text-lg',
+    ),
+};
+
 export function AdminMarkdown({
     content,
     className,
     align = 'left',
+    size = 'sm',
 }: {
     content: string;
     className?: string;
     /** Mirrors `landing_page_alignment` so the preview matches the real page. */
     align?: 'left' | 'center' | 'right';
+    size?: MarkdownSize;
 }) {
     const trimmed = content.trim();
 
@@ -33,12 +52,13 @@ export function AdminMarkdown({
     return (
         <div
             className={clsx(
-                'space-y-2 text-sm leading-relaxed text-text-2',
+                'leading-relaxed text-text-2',
+                sizeClass[size],
                 '[&_a]:text-accent [&_a]:underline',
                 '[&_code]:rounded [&_code]:bg-surface-sunken [&_code]:px-1 [&_code]:py-0.5',
-                '[&_h1]:text-base [&_h1]:font-semibold [&_h1]:text-text-1',
-                '[&_h2]:text-sm [&_h2]:font-semibold [&_h2]:text-text-1',
-                '[&_h3]:text-sm [&_h3]:font-medium [&_h3]:text-text-1',
+                '[&_h1]:font-semibold [&_h1]:text-text-1',
+                '[&_h2]:font-semibold [&_h2]:text-text-1',
+                '[&_h3]:font-medium [&_h3]:text-text-1',
                 '[&_li]:ml-4 [&_li]:list-disc',
                 '[&_ol_li]:list-decimal',
                 '[&_pre]:overflow-x-auto [&_pre]:rounded-lg [&_pre]:bg-surface-sunken [&_pre]:p-3',

--- a/application/v2_ui/src/components/layout/AppShell.tsx
+++ b/application/v2_ui/src/components/layout/AppShell.tsx
@@ -2,6 +2,10 @@
 // Two-column application frame: the collapsible rail on the left, all content on the
 // right. The classification banner, when configured, is the only element allowed to span
 // the full width, matching the server-rendered interface.
+//
+// The banner carries the same `classification-banner` id the classic layout uses, so a
+// deployment styling or asserting against it does not have to know which interface it is
+// looking at.
 
 import type { ReactNode } from 'react';
 import { Sidebar } from './Sidebar';
@@ -17,6 +21,7 @@ function ClassificationBanner() {
 
     return (
         <div
+            id="classification-banner"
             role="note"
             className="flex h-8 shrink-0 items-center justify-center text-sm font-bold tracking-wide"
             style={{ background: banner.color, color: banner.text_color }}

--- a/application/v2_ui/src/components/layout/NavExtras.tsx
+++ b/application/v2_ui/src/components/layout/NavExtras.tsx
@@ -1,0 +1,153 @@
+// NavExtras.tsx
+// Administrator-configured navigation groups in the rail: custom pages and external links.
+//
+// Both exist in the classic navigation and neither had reached V2, so a deployment that
+// had configured either saw a rail with none of its own links in it. The entries come from
+// the bootstrap payload, already filtered for the signed-in user, and the rules deciding
+// what renders live in lib/navigationGroups so they can be tested directly.
+//
+// Destinations are server-rendered pages and third-party sites, not client-side routes, so
+// these are plain anchors rather than react-router links. A NavLink would try to resolve
+// them inside the SPA and land on the home page.
+
+import { useState } from 'react';
+import { clsx } from 'clsx';
+import { ChevronDown, ExternalLink, FileText } from 'lucide-react';
+import { useBootstrapStore } from '../../stores/bootstrapStore';
+import {
+    isGroupVisible,
+    shouldRenderAsMenu,
+    toCustomPageLinks,
+    toExternalLinks,
+    type NavExtraLink,
+} from '../../lib/navigationGroups';
+
+function NavAnchor({ link, collapsed }: { link: NavExtraLink; collapsed: boolean }) {
+    return (
+        <a
+            href={link.href}
+            title={link.label}
+            {...(link.newTab ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
+            className={clsx(
+                'flex items-center gap-2.5 rounded-xl px-3 py-2 text-sm transition-colors',
+                'text-text-2 hover:bg-surface-2 hover:text-text-1',
+                collapsed && 'justify-center px-0',
+            )}
+        >
+            {link.newTab ? (
+                <ExternalLink size={15} className="shrink-0" />
+            ) : (
+                <FileText size={15} className="shrink-0" />
+            )}
+            {!collapsed && <span className="truncate">{link.label}</span>}
+        </a>
+    );
+}
+
+function NavExtraGroup({
+    menuName,
+    links,
+    forceMenu,
+    collapsed,
+}: {
+    menuName: string;
+    links: NavExtraLink[];
+    forceMenu: boolean;
+    collapsed: boolean;
+}) {
+    const asMenu = shouldRenderAsMenu(links.length, forceMenu);
+    const [open, setOpen] = useState(true);
+
+    if (!links.length) {
+        return null;
+    }
+
+    // The collapsed rail is an icon strip with no room for a heading, so a menu there
+    // would hide its contents behind a label nobody can read. Entries stay flat instead.
+    if (collapsed) {
+        return (
+            <ul className="mt-1 space-y-0.5 px-3">
+                {links.map((link) => (
+                    <li key={link.key}>
+                        <NavAnchor link={link} collapsed />
+                    </li>
+                ))}
+            </ul>
+        );
+    }
+
+    const listId = `nav-extra-${menuName.replace(/\W+/g, '-').toLowerCase()}`;
+
+    return (
+        <div className="mt-3 px-3">
+            {asMenu ? (
+                <button
+                    type="button"
+                    onClick={() => setOpen((isOpen) => !isOpen)}
+                    aria-expanded={open}
+                    aria-controls={listId}
+                    className="flex w-full items-center gap-2 rounded-lg px-3 py-1 text-xs font-semibold tracking-wide text-text-3 uppercase transition-colors hover:text-text-1"
+                >
+                    <span className="min-w-0 flex-1 truncate text-left">{menuName}</span>
+                    <span className="rounded-full bg-surface-sunken px-1.5 text-[10px] leading-4 font-semibold text-text-3">
+                        {links.length}
+                    </span>
+                    <ChevronDown
+                        size={13}
+                        className={clsx('shrink-0 transition-transform', !open && '-rotate-90')}
+                    />
+                </button>
+            ) : (
+                <p className="px-3 py-1 text-xs font-semibold tracking-wide text-text-3 uppercase">
+                    {menuName}
+                </p>
+            )}
+
+            {(!asMenu || open) && (
+                <ul id={listId} className="mt-0.5 space-y-0.5">
+                    {links.map((link) => (
+                        <li key={link.key}>
+                            <NavAnchor link={link} collapsed={false} />
+                        </li>
+                    ))}
+                </ul>
+            )}
+        </div>
+    );
+}
+
+export function NavExtras({ collapsed }: { collapsed: boolean }) {
+    const navigation = useBootstrapStore((state) => state.data?.navigation);
+
+    const customPages = navigation?.custom_pages;
+    const externalLinks = navigation?.external_links;
+
+    const showCustomPages = isGroupVisible(customPages);
+    const showExternalLinks = isGroupVisible(externalLinks);
+
+    if (!showCustomPages && !showExternalLinks) {
+        return null;
+    }
+
+    return (
+        <>
+            {showCustomPages && customPages ? (
+                <NavExtraGroup
+                    menuName={customPages.menu_name}
+                    links={toCustomPageLinks(customPages)}
+                    forceMenu={customPages.force_menu}
+                    collapsed={collapsed}
+                />
+            ) : null}
+
+            {showExternalLinks && externalLinks ? (
+                <NavExtraGroup
+                    menuName={externalLinks.menu_name}
+                    links={toExternalLinks(externalLinks)}
+                    forceMenu={externalLinks.force_menu}
+                    collapsed={collapsed}
+                />
+            ) : null}
+        </>
+    );
+}

--- a/application/v2_ui/src/components/layout/Sidebar.tsx
+++ b/application/v2_ui/src/components/layout/Sidebar.tsx
@@ -10,7 +10,7 @@
 // entry has nothing left to lead to.
 
 import { useState } from 'react';
-import { NavLink, useLocation } from 'react-router-dom';
+import { NavLink, useLocation, useNavigate } from 'react-router-dom';
 import { clsx } from 'clsx';
 import {
     ChevronDown,
@@ -18,6 +18,7 @@ import {
     ChevronRight,
     FolderOpen,
     Globe2,
+    Home,
     LogOut,
     MessageSquarePlus,
     MessagesSquare,
@@ -33,6 +34,7 @@ import { useBootstrapStore } from '../../stores/bootstrapStore';
 import { useChatStore } from '../../stores/chatStore';
 import { classicChatHref } from '../../lib/conversationUrl';
 import { ConversationRail } from '../chat/ConversationRail';
+import { NavExtras } from './NavExtras';
 
 interface NavItem {
     to: string;
@@ -41,9 +43,18 @@ interface NavItem {
     /** Hover text. Two entries are easily confused without it, so both say what they are. */
     hint?: string;
     adminOnly?: boolean;
+    /** Matches the route exactly. Needed for "/", which otherwise prefixes every path. */
+    end?: boolean;
 }
 
 const NAV_ITEMS: NavItem[] = [
+    {
+        to: '/',
+        label: 'Home',
+        icon: Home,
+        hint: 'The landing page and its announcements',
+        end: true,
+    },
     { to: '/chat', label: 'Chats', icon: MessagesSquare },
     {
         to: '/agents',
@@ -74,10 +85,16 @@ function BrandMark({ collapsed }: { collapsed: boolean }) {
     return (
         <div className="flex min-w-0 items-center gap-2.5">
             {branding?.show_logo && logoUrl ? (
+                // Height-constrained with a free width, matching the classic navigation.
+                // Forcing a square would letterbox or crop the wordmark most deployments
+                // upload. The collapsed rail is only 68px wide, so the cap tightens there.
                 <img
                     src={logoUrl}
-                    alt=""
-                    className="h-8 w-8 shrink-0 rounded-lg object-contain"
+                    alt={branding.hide_app_title ? title : ''}
+                    className={clsx(
+                        'h-8 w-auto shrink-0 object-contain',
+                        collapsed ? 'max-w-[44px]' : 'max-w-[150px]',
+                    )}
                 />
             ) : (
                 <span
@@ -177,9 +194,24 @@ export function Sidebar() {
     const isAdmin = useBootstrapStore((state) => Boolean(state.data?.user?.is_admin));
     const startNewConversation = useChatStore((state) => state.startNewConversation);
     const location = useLocation();
+    const navigate = useNavigate();
 
     const onChatPage = location.pathname.startsWith('/chat');
     const collapsed = railCollapsed;
+
+    /**
+     * Clear the current thread and go where it can be typed into.
+     *
+     * The store only resets chat state, which is invisible from any other page. The rail
+     * is shown everywhere, so from the home page or a workspace the button would appear
+     * to do nothing at all.
+     */
+    const onNewChat = () => {
+        startNewConversation();
+        if (!onChatPage) {
+            navigate('/chat');
+        }
+    };
 
     return (
         <nav
@@ -222,7 +254,7 @@ export function Sidebar() {
             <div className="px-3">
                 <button
                     type="button"
-                    onClick={startNewConversation}
+                    onClick={onNewChat}
                     title="Start a new chat"
                     className={clsx(
                         'flex w-full items-center gap-2 rounded-xl bg-accent px-3 py-2.5',
@@ -240,6 +272,7 @@ export function Sidebar() {
                     <li key={item.to}>
                         <NavLink
                             to={item.to}
+                            end={item.end}
                             title={collapsed ? item.label : item.hint}
                             className={({ isActive }) =>
                                 clsx(
@@ -257,6 +290,10 @@ export function Sidebar() {
                     </li>
                 ))}
             </ul>
+
+            {/* Custom pages and external links an administrator configured. Renders
+                nothing when neither is enabled, which is the default. */}
+            <NavExtras collapsed={collapsed} />
 
             {/* The conversation list only belongs in the rail while the chat page is open,
                 so other pages get the full rail height for their own navigation. */}

--- a/application/v2_ui/src/lib/navigationGroups.ts
+++ b/application/v2_ui/src/lib/navigationGroups.ts
@@ -1,0 +1,69 @@
+// navigationGroups.ts
+// Rules for the administrator-configured navigation groups in the rail.
+//
+// Kept out of the component so the decisions can be executed by a test. Whether a group
+// appears at all, and whether it appears inline or behind a menu, is configuration
+// behaviour rather than presentation, and getting it wrong is invisible in review: a group
+// that never renders looks exactly like one nobody configured.
+
+import type { CustomPageNavItem, ExternalLinkNavItem, NavGroup } from './types';
+
+/** How many entries a group may have before it collapses behind its menu name. */
+export const INLINE_ITEM_LIMIT = 2;
+
+/**
+ * Whether a group should collapse behind its menu name.
+ *
+ * Matches the classic navigation: one or two entries read better as plain nav items, while
+ * three or more crowd the rail and become a named menu. An administrator can force the
+ * menu at any count, which is what "Force Menu Display" does in Admin Settings.
+ */
+export function shouldRenderAsMenu(itemCount: number, forceMenu: boolean): boolean {
+    return Boolean(forceMenu) || itemCount > INLINE_ITEM_LIMIT;
+}
+
+/**
+ * Whether a group has anything to show.
+ *
+ * A group that is switched on but empty would render as a heading with nothing under it,
+ * which reads as a broken menu rather than as an unused capability.
+ */
+export function isGroupVisible<TItem>(group: NavGroup<TItem> | undefined | null): boolean {
+    return Boolean(group?.enabled && group.items?.length);
+}
+
+/** One rendered rail entry, flattened from either group. */
+export interface NavExtraLink {
+    key: string;
+    label: string;
+    href: string;
+    /** Opens away from the SPA. Always true for external links. */
+    newTab: boolean;
+}
+
+export function toCustomPageLinks(
+    group: NavGroup<CustomPageNavItem> | undefined | null,
+): NavExtraLink[] {
+    return (group?.items ?? []).map((page) => ({
+        key: `custom-page:${page.slug}`,
+        label: page.label || page.slug,
+        href: page.url,
+        newTab: Boolean(page.open_in_new_tab),
+    }));
+}
+
+export function toExternalLinks(
+    group: NavGroup<ExternalLinkNavItem> | undefined | null,
+): NavExtraLink[] {
+    return (group?.items ?? []).map((link, index) => ({
+        // Labels and URLs are both administrator-supplied and may repeat, so the position
+        // is the only identity guaranteed to be unique.
+        key: `external-link:${index}:${link.url}`,
+        label: link.label,
+        href: link.url,
+        // External destinations always open in a new tab, matching the classic rail: they
+        // leave the application, and losing an in-progress conversation to a policy link
+        // would be a poor trade.
+        newTab: true,
+    }));
+}

--- a/application/v2_ui/src/lib/types.ts
+++ b/application/v2_ui/src/lib/types.ts
@@ -555,6 +555,36 @@ export interface WebSearchNoticeConfig {
     text: string;
 }
 
+/** A trusted page deployed under `custom_pages` and exposed at `/custom/<slug>`. */
+export interface CustomPageNavItem {
+    slug: string;
+    label: string;
+    /** A Bootstrap Icons class name, chosen per page in its metadata contract. */
+    icon: string;
+    url: string;
+    open_in_new_tab: boolean;
+}
+
+/** An administrator-approved link shown in the navigation rail. */
+export interface ExternalLinkNavItem {
+    label: string;
+    url: string;
+}
+
+/**
+ * One configurable navigation group.
+ *
+ * `menu_name` and `force_menu` come from settings so the rail can apply the same rule the
+ * server-rendered navigation does: a short list reads better inline, a longer one becomes
+ * a named, collapsible menu.
+ */
+export interface NavGroup<TItem> {
+    enabled: boolean;
+    menu_name: string;
+    force_menu: boolean;
+    items: TItem[];
+}
+
 /** Response shape of GET /api/v2/bootstrap. Assembled by route_backend_v2.py. */
 export interface BootstrapPayload {
     version: string;
@@ -571,12 +601,29 @@ export interface BootstrapPayload {
         show_logo: boolean;
         logo_url: string | null;
         logo_dark_url: string | null;
+        /** Versioned when a custom icon is stored, so a replacement is not served stale. */
+        favicon_url: string;
         classification_banner: {
             enabled: boolean;
             text?: string;
             color?: string;
             text_color?: string;
         } | null;
+        /** Home page copy. Falls back server-side to the same default the classic UI uses. */
+        landing_page_text: string;
+        landing_page_alignment: 'left' | 'center' | 'right';
+        landing_page_logo_scale_percent: number;
+    };
+    /**
+     * Administrator-configured navigation groups, resolved server-side.
+     *
+     * Not derivable from `features` or `settings`: custom pages are filtered per page
+     * against the caller's roles, and neither the link list nor the menu names are
+     * `enable_*` keys.
+     */
+    navigation: {
+        custom_pages: NavGroup<CustomPageNavItem>;
+        external_links: NavGroup<ExternalLinkNavItem>;
     };
     features: Record<string, boolean>;
     catalogs: {

--- a/application/v2_ui/src/pages/AdminSettingsPage.tsx
+++ b/application/v2_ui/src/pages/AdminSettingsPage.tsx
@@ -163,6 +163,14 @@ function buildCapabilityIndex(
 
 export function AdminSettingsPage() {
     const isAdmin = useBootstrapStore((state) => Boolean(state.data?.user?.is_admin));
+    /**
+     * Re-read bootstrap after a save.
+     *
+     * Branding, the classification banner and the feature flags the whole application
+     * branches on all come from that payload, which is fetched once at startup. Without
+     * this, applying a setting here changed the settings document and nothing visible.
+     */
+    const refreshBootstrap = useBootstrapStore((state) => state.refresh);
 
     const [data, setData] = useState<AdminSettingsResponse | null>(null);
     const [brandingAssets, setBrandingAssets] = useState<BrandingAssets>({});
@@ -434,6 +442,7 @@ export function AdminSettingsPage() {
             );
             setFieldWarnings(response.warnings ?? {});
             setDraft({});
+            void refreshBootstrap();
 
             const warningCount = Object.keys(response.warnings ?? {}).length;
             toast.success(
@@ -458,15 +467,21 @@ export function AdminSettingsPage() {
         } finally {
             setSaving(false);
         }
-    }, [draft]);
+    }, [draft, refreshBootstrap]);
 
-    const onBrandingUploaded = useCallback((target: string, result: BrandingUploadResponse) => {
-        setBrandingAssets((current) => ({
-            ...current,
-            [target]: { present: true, version: result.version, url: result.url },
-        }));
-        toast.success('Image uploaded.');
-    }, []);
+    const onBrandingUploaded = useCallback(
+        (target: string, result: BrandingUploadResponse) => {
+            setBrandingAssets((current) => ({
+                ...current,
+                [target]: { present: true, version: result.version, url: result.url },
+            }));
+            // Uploads save immediately rather than joining the draft, so the rail, the
+            // home page and the browser tab have to be told straight away.
+            void refreshBootstrap();
+            toast.success('Image uploaded.');
+        },
+        [refreshBootstrap],
+    );
 
     /** Read another field's current value, preferring an unsaved edit. */
     const readSibling = (key: string, fallback = '') =>

--- a/application/v2_ui/src/pages/HomePage.tsx
+++ b/application/v2_ui/src/pages/HomePage.tsx
@@ -1,0 +1,85 @@
+// HomePage.tsx
+// The V2 landing page.
+//
+// The classic interface opens on a home page that carries the logo, an administrator's
+// landing copy and a link into chat. V2 had no equivalent, so /v2 redirected straight to
+// the chat page and three Appearance settings -- the landing text, its alignment and the
+// home page logo size -- configured a page that did not exist in this interface.
+//
+// Everything here comes from the bootstrap payload, so opening the home page costs no
+// extra request.
+
+import { Link } from 'react-router-dom';
+import { MessageSquarePlus } from 'lucide-react';
+import { useBootstrapStore } from '../stores/bootstrapStore';
+import { useUiStore } from '../stores/uiStore';
+import { AdminMarkdown } from '../components/admin/AdminMarkdown';
+
+/**
+ * Map the stored alignment onto the wrapper.
+ *
+ * Only the landing copy is aligned. The logo and the call to action stay centred in both
+ * interfaces, so alignment reads as a choice about the prose rather than about the page.
+ */
+const alignmentClass: Record<'left' | 'center' | 'right', string> = {
+    left: 'text-left',
+    center: 'text-center',
+    right: 'text-right',
+};
+
+export function HomePage() {
+    const branding = useBootstrapStore((state) => state.data?.branding);
+    const theme = useUiStore((state) => state.theme);
+
+    const logoUrl = theme === 'dark' ? branding?.logo_dark_url : branding?.logo_url;
+    const showLogo = Boolean(branding?.show_logo && logoUrl);
+    const title = branding?.app_title || 'SimpleChat';
+    const alignment = branding?.landing_page_alignment ?? 'left';
+    // Checked for content rather than presence: AdminMarkdown is a settings preview and
+    // says "Nothing to preview yet" when handed nothing, which is the wrong thing for a
+    // landing page whose copy an administrator deliberately cleared.
+    const landingText = (branding?.landing_page_text ?? '').trim();
+
+    // "Main Page Logo Size" is stored as a percentage but the classic home page applies it
+    // as a pixel height, so 100 renders a 100px logo. Matched here rather than corrected,
+    // because the slider is calibrated against what an administrator already sees.
+    const logoHeight = branding?.landing_page_logo_scale_percent ?? 100;
+
+    return (
+        <div className="min-h-0 flex-1 overflow-y-auto">
+            <div className="mx-auto flex w-full max-w-3xl flex-col items-center px-6 py-16">
+                {showLogo ? (
+                    <img
+                        src={logoUrl ?? undefined}
+                        alt={title}
+                        style={{ height: `${logoHeight}px` }}
+                        className="mb-8 w-auto max-w-full object-contain"
+                    />
+                ) : null}
+
+                {!branding?.hide_app_title && (
+                    <h1 className="mb-6 text-center text-3xl font-semibold text-text-1">
+                        {title}
+                    </h1>
+                )}
+
+                {landingText ? (
+                    <AdminMarkdown
+                        content={landingText}
+                        size="md"
+                        align={alignment}
+                        className={`mb-10 w-full ${alignmentClass[alignment]}`}
+                    />
+                ) : null}
+
+                <Link
+                    to="/chat"
+                    className="inline-flex items-center gap-2 rounded-xl bg-accent px-6 py-3 text-base font-medium text-on-accent transition-colors hover:bg-accent-hover"
+                >
+                    <MessageSquarePlus size={18} />
+                    Start chatting
+                </Link>
+            </div>
+        </div>
+    );
+}

--- a/application/v2_ui/src/stores/bootstrapStore.ts
+++ b/application/v2_ui/src/stores/bootstrapStore.ts
@@ -15,6 +15,7 @@ interface BootstrapState {
     /** True when the failure was an expired session rather than a server fault. */
     authExpired: boolean;
     load: () => Promise<void>;
+    refresh: () => Promise<void>;
 }
 
 export const useBootstrapStore = create<BootstrapState>((set) => ({
@@ -38,6 +39,26 @@ export const useBootstrapStore = create<BootstrapState>((set) => ({
                         ? error.message
                         : 'Failed to load the application.',
             });
+        }
+    },
+
+    /**
+     * Re-read bootstrap after something changed it, without disturbing the running app.
+     *
+     * Administrator changes to branding, the classification banner and the feature flags
+     * all land in this payload, which is otherwise fetched exactly once at startup. Saving
+     * a setting therefore appeared to do nothing until the page was reloaded by hand.
+     *
+     * Deliberately does not touch `loading`: that flag swaps the whole application for the
+     * boot skeleton, and a background refresh must not blank the page the administrator is
+     * looking at. A failure is left silent for the same reason -- the previous payload is
+     * still valid, and the save that triggered this has already reported its own outcome.
+     */
+    refresh: async () => {
+        try {
+            set({ data: await fetchBootstrap(), error: null, authExpired: false });
+        } catch {
+            /* Keep the payload already on screen. */
         }
     },
 }));

--- a/docs/explanation/features/V2_HOME_PAGE.md
+++ b/docs/explanation/features/V2_HOME_PAGE.md
@@ -1,0 +1,158 @@
+# V2 Home Page
+
+**Implemented in version: 0.261.044**
+
+## Overview
+
+The V2 React interface now opens on a home page at `/v2`, matching the classic
+interface's landing page. It shows the application logo, the administrator's landing
+copy, and a link into chat.
+
+Before this, `/v2` redirected straight to the chat page. Three Appearance settings
+therefore configured a page that did not exist in V2:
+
+- **Landing Page Text** (`landing_page_text`)
+- **Markdown Alignment** (`landing_page_alignment`)
+- **Main Page Logo Size** (`landing_page_logo_scale_percent`)
+
+Editing any of them changed the classic home page only, with nothing in the V2
+interface to show for it.
+
+## Dependencies
+
+None beyond what the V2 interface already carries. The page renders from the
+`branding` block of `/api/v2/bootstrap`, which is fetched once at startup, so
+opening the home page costs no additional request. Markdown is rendered with the
+already-vendored `react-markdown`.
+
+## Architecture
+
+### Data
+
+`_build_branding` in `route_backend_v2.py` returns the landing fields alongside the
+logo and title:
+
+```json
+{
+  "landing_page_text": "...",
+  "landing_page_alignment": "left",
+  "landing_page_logo_scale_percent": 100
+}
+```
+
+Both values are resolved server-side rather than in the browser:
+
+- An unrecognised alignment falls back to `left`, and the logo scale is clamped to
+  the range the Admin Settings slider offers, so a settings document edited outside
+  the form cannot produce an unusable page.
+- The landing copy is passed through as stored, apart from trimming. It is
+  deliberately **not** defaulted when empty: `get_settings` merges the seeded
+  default into every settings document, so blank copy means an administrator
+  cleared it. Restoring default wording would put a statement back on the page —
+  including an acceptable-use assertion — that they removed on purpose. The classic
+  home page behaves the same way, rendering nothing.
+
+### Rendering
+
+`application/v2_ui/src/pages/HomePage.tsx` renders, in order:
+
+1. The theme-appropriate logo, shown only when **Show Logo** is on and a custom logo
+   has been uploaded.
+2. The application title, unless **Hide Application Title** is on.
+3. The landing copy.
+4. A "Start chatting" link to `/v2/chat`.
+
+Landing copy is rendered with `AdminMarkdown`, which is deliberately not the
+assistant renderer: that one parses citations, applies masking ranges and hosts
+diagram blocks, none of which apply to administrator prose. It also does not enable
+`rehype-raw`, so administrator-authored markdown cannot inject script or event
+handlers into the page.
+
+The logo size deserves a note. **Main Page Logo Size** is stored as a percentage,
+but the classic home page applies the number directly as a pixel height, so `100`
+renders a 100px logo. V2 matches that rather than correcting it, because the slider
+is calibrated against what an administrator already sees when they drag it.
+
+Only the landing copy is aligned. The logo and the call to action stay centred in
+both interfaces, so the alignment setting reads as a choice about the prose.
+
+### Routing
+
+| Route | Renders |
+|---|---|
+| `/v2` | Home |
+| `/v2/chat` | Chat |
+| anything unmatched | Redirects to `/v2` |
+
+**Home** was added as the first entry in the navigation rail.
+
+Making the home page the landing route exposed an existing gap: the rail's "New
+chat" button only reset chat state, which is invisible from any page that is not
+chat. It now navigates to the chat page as well, so the most prominent button in the
+rail does something observable from the page users now land on.
+
+## Navigation groups
+
+The same change brought the two administrator-configured navigation groups into the
+V2 rail, since neither had any representation there:
+
+- **Custom Pages** — trusted pages deployed under `custom_pages`, already filtered
+  per page against the caller's roles by `get_custom_pages_nav`.
+- **External Links** — administrator-approved links, shown only to callers holding
+  the `Admin` or `User` role, matching the gate in `_sidebar_nav.html`.
+
+Each group carries its configured menu name and its "Force Menu Display" flag, and
+the rail applies the classic rule: one or two entries render inline as ordinary nav
+items, three or more collapse behind the menu name with a count. An administrator
+can force the menu at any count.
+
+External links always open in a new tab with `rel="noopener noreferrer"`; they leave
+the application, and losing an in-progress conversation to a policy link would be a
+poor trade. Custom pages honour their own `open_in_new_tab` metadata.
+
+A link whose URL is not a local path or an `http`/`https` address is dropped before
+it reaches the browser. Only the V2 settings PATCH applies that rule on write — the
+server-rendered admin form stores any non-empty string — so a `javascript:` URL
+already in a settings document would otherwise become an anchor in every user's
+rail. The check is therefore applied on the way out as well as on the way in.
+
+A group that is enabled but empty renders nothing rather than an empty heading.
+
+In the collapsed rail there is no room for a heading, so entries stay flat as icons
+rather than hiding behind a label nobody can read.
+
+## Configuration
+
+Everything is configured under **Admin Settings > Appearance**:
+
+| Setting | Tab | Effect on the home page |
+|---|---|---|
+| Application Title | Branding | Heading, unless hidden |
+| Hide Application Title | Branding | Hides the heading |
+| Show Logo | Branding | Shows the logo |
+| Custom Logo (Light/Dark Mode) | Branding | The image shown, per theme |
+| Main Page Logo Size | Branding | Logo height in pixels |
+| Landing Page Text | Home Page Text | The copy below the title |
+| Markdown Alignment | Home Page Text | Alignment of that copy |
+
+Custom Pages and External Links are configured under **Appearance > Pages & Links**.
+
+## Testing and validation
+
+- `functional_tests/test_v2_bootstrap_branding_and_navigation.py` executes the real
+  `_build_branding` and `_build_navigation`, covering the landing defaults and
+  bounds and the navigation group rules.
+- `functional_tests/test_v2_navigation_groups_logic.mjs` executes the client's
+  inline-versus-menu and visibility decisions.
+- `ui_tests/test_v2_appearance_branding_and_nav.py` covers the rendered home page,
+  the logo height, the "Start chatting" link, the Home rail entry and the two
+  navigation groups, driven by what bootstrap reports for the deployment under test.
+
+## Known limitations
+
+- The access-denied and signed-out branches of the classic home page have no V2
+  equivalent. They cannot be reached: `/v2` is behind `login_required` and
+  `user_required`, so a caller who would see either never reaches the SPA.
+- When **Show Logo** is on but no custom logo has been uploaded, the classic home
+  page falls back to the bundled artwork. V2 shows no logo there and relies on the
+  application title instead. See `docs/explanation/fixes/V2_APPEARANCE_PARITY_FIX.md`.

--- a/docs/explanation/fixes/V2_APPEARANCE_PARITY_FIX.md
+++ b/docs/explanation/fixes/V2_APPEARANCE_PARITY_FIX.md
@@ -1,0 +1,167 @@
+# V2 Appearance Parity Fix
+
+**Fixed in version: 0.261.044**
+
+## Issue
+
+Six Appearance settings had no visible effect in the V2 React interface, and four
+settings appeared under the wrong tab.
+
+Reported symptoms:
+
+1. Custom light and dark logos never appeared anywhere in the application.
+2. The left rail showed a letter avatar instead of the uploaded logo.
+3. A custom favicon never replaced the shipped one.
+4. Enabling and applying the classification banner did not render it.
+5. Custom Pages and External Links never appeared in the left rail.
+6. Under **Appearance > Notices & Agreements > User Agreement** an unrelated
+   "User workspace" toggle appeared, and under **Appearance > Pages & Links >
+   External Links** three unrelated toggles appeared: external health check,
+   no-auth external health check, and support latest feature documentation links.
+
+## Root cause
+
+Four distinct causes, not six.
+
+### Bootstrap was never re-read (symptoms 1, 2 and 4)
+
+`/api/v2/bootstrap` carries `branding`, which holds the logo URLs, the application
+title and the classification banner. `useBootstrapStore` loads that payload once,
+from `App.tsx`, and had no way to reload it. `AdminSettingsPage.save()` merged the
+PATCH response into its own local `data.settings` and stopped there.
+
+Applying a branding change therefore updated the settings document and left every
+consumer of `branding` holding the payload fetched at sign-in. `Sidebar.BrandMark`
+and `AppShell.ClassificationBanner` were both already written correctly; neither
+ever received a fresh value. The only way to see a change was a full page reload.
+
+### The SPA shell hard-coded the shipped favicon (symptom 3)
+
+`application/v2_ui/index.html` is a build input, compiled to
+`static/v2/index.html`, and carried a literal
+`<link rel="icon" href="/static/images/favicon.ico">` with no version and a literal
+`<title>SimpleChat</title>`. `_serve_v2_shell` returned that file verbatim.
+
+The classic interface does not do this. `base.html` appends
+`?v={{ favicon_version }}` whenever `custom_favicon_base64` is set, precisely
+because the static file keeps a stable name across uploads: without the version, a
+browser keeps serving whichever icon it had already cached.
+
+### Bootstrap carried no navigation data (symptom 5)
+
+The classic rail reads `custom_pages_nav`, built by `get_custom_pages_nav` in
+`app.py`'s context processor, and `app_settings.external_links` directly in
+`_sidebar_nav.html`. Neither reaches a single-page application, and neither can be
+derived from what bootstrap already sent: custom pages are filtered per page
+against the caller's roles, and the external link list is not an `enable_*` key so
+it never appears in `features`.
+
+### The undeclared-settings fallback guessed wrong (symptom 6)
+
+Settings that `admin_settings_fields.py` does not describe are still shown in the
+V2 admin surface. `buildCapabilityIndex` in `AdminSettingsPage.tsx` scans the
+settings document for `enable_*` booleans and files each one under the navigation
+section sharing the most leading word stems, keeping the first section that scores
+at all.
+
+That guess placed five toggles in the Appearance group:
+
+| Setting | Guessed into | Actually belongs in |
+|---|---|---|
+| `enable_user_workspace` | Appearance > Notices & Agreements > User Agreement | Workspaces > Workspace Types > Personal Workspaces |
+| `enable_external_healthcheck` | Appearance > Pages & Links > External Links | Operations > Logging & Health > Health Check |
+| `enable_no_auth_external_healthcheck` | Appearance > Pages & Links > External Links | Operations > Logging & Health > Health Check |
+| `enable_support_latest_feature_documentation_links` | Appearance > Pages & Links > External Links | Help > User-Facing Latest Features |
+| `enable_text_plugin` | Appearance > Branding > Home Page Text | Agents & Actions > Actions |
+
+Each is explainable from the heuristic:
+
+- `enable_user_workspace` matches "user" in `user-agreement-section`.
+- `enable_external_healthcheck` matches "external" in `external-links-section`.
+  `health-check-section` splits into "health" and "check", neither of which matches
+  the single token "healthcheck", so the correct section could never win.
+- `enable_support_latest_feature_documentation_links` matches "links" in
+  `external-links-section`, which comes first in navigation order and so beat the
+  equally-scoring Support and Latest Features sections.
+- `enable_text_plugin` matches "text" in `home-page-text-section`.
+
+The fifth was not in the original report and was found by simulating the heuristic
+against the real settings keys.
+
+## Files modified
+
+| File | Change |
+|---|---|
+| `application/single_app/functions_branding_urls.py` | **New.** Dependency-free module holding the branding asset paths and the version rule, previously restated in three places. |
+| `application/single_app/admin_settings_fields.py` | Declared the five misfiled toggles in their real sections, plus the Support Menu gate chain the documentation-links toggle depends on. |
+| `application/single_app/route_backend_v2.py` | `_build_branding` now returns `favicon_url` and the landing page fields; new `_build_navigation` supplies the custom pages and external links groups; `BRANDING_IMAGE_TARGETS` reads its paths from the shared module. |
+| `application/single_app/route_frontend_v2.py` | `_serve_v2_shell` rewrites the shell's icon link and title from settings. |
+| `application/v2_ui/src/stores/bootstrapStore.ts` | Added `refresh()`. |
+| `application/v2_ui/src/pages/AdminSettingsPage.tsx` | Refreshes bootstrap after a save and after a branding upload. |
+| `application/v2_ui/src/components/layout/Sidebar.tsx` | Logo sized by height rather than forced square; Home nav entry; mounts `NavExtras`; New chat now navigates to chat. |
+| `application/v2_ui/src/components/layout/NavExtras.tsx` | **New.** Renders the two configured navigation groups. |
+| `application/v2_ui/src/lib/navigationGroups.ts` | **New.** The inline-versus-menu and visibility rules, kept testable. |
+| `application/v2_ui/src/pages/HomePage.tsx` | **New.** See `docs/explanation/features/V2_HOME_PAGE.md`. |
+| `application/v2_ui/src/components/admin/AdminMarkdown.tsx` | Added a `size` variant so home page copy is not rendered at settings-preview scale. |
+| `application/v2_ui/src/App.tsx` | Home route; keeps the tab icon in step with the stored favicon. |
+| `application/v2_ui/src/lib/types.ts` | Extended `branding`; added the `navigation` block. |
+| `application/single_app/config.py` | Version bump to `0.261.044`. |
+
+## Behavior changes
+
+- Applying any Admin Settings change in V2 now re-reads bootstrap, so branding, the
+  classification banner and every feature flag take effect without a page reload.
+- A custom favicon and the configured application title now reach the browser tab.
+- Custom Pages and External Links appear in the V2 rail, using the same rule as the
+  classic navigation: one or two entries inline, three or more (or "Force Menu
+  Display") behind the configured menu name.
+- An external link whose URL is not a local path or an `http`/`https` address is now
+  dropped from the bootstrap payload. Only the V2 settings PATCH applied that rule on
+  write, so a `javascript:` URL stored through the classic admin form, or already
+  present in a settings document, would have become an anchor in every V2 user's
+  rail. `EXTERNAL_LINK_ALLOWED_SCHEMES` is now enforced on the read path too.
+- The five relocated settings now appear under the tab that owns them.
+- `/v2` opens a home page rather than redirecting to chat.
+- Clearing the landing page copy leaves the home page without it. Restoring default
+  wording would put an acceptable-use statement back on a page an administrator had
+  deliberately emptied, and the classic home page does not do that either.
+
+### Deliberate divergence from the classic interface
+
+When **Show Logo** is on but no custom logo has been uploaded, the classic
+navigation falls back to the bundled `logo-lightmode.png` / `logo-darkmode.png`.
+V2 keeps its letter avatar instead. This was a deliberate choice: the avatar is
+derived from the application title, so an unbranded deployment shows its own name
+rather than the product's default artwork.
+
+## Validation
+
+New and updated tests:
+
+- `functional_tests/test_v2_admin_capability_placement.py` — ports the fallback
+  heuristic and asserts the Appearance group, which the schema fully describes,
+  receives no guessed rows at all. Verified to fail with the exact original symptom
+  when one of the relocated keys is undeclared.
+- `functional_tests/test_v2_bootstrap_branding_and_navigation.py` — lifts
+  `_build_branding` and `_build_navigation` out of the route with `ast` and executes
+  them, covering favicon versioning, the logo and dark-variant rules, the banner's
+  text requirement, landing field bounds, the external links role gate, and
+  degradation when the custom page lookup fails.
+- `functional_tests/test_v2_ui_spa_route.py` — extended with the shell branding
+  rewrite, its escaping, and its fallback when settings are unavailable.
+- `functional_tests/test_v2_navigation_groups_logic.mjs` — executes the real
+  inline-versus-menu and visibility rules.
+- `functional_tests/test_v2_admin_settings_schema.py` — extended with a check that
+  every declared default matches the default the application seeds into the settings
+  document. Added after this change declared `enable_text_plugin` as `False` when the
+  application defaults it to `True`, which would have shown the toggle off while the
+  action was on. All 30 declared defaults now agree.
+- `ui_tests/test_v2_appearance_branding_and_nav.py` — browser coverage driven by
+  what `/api/v2/bootstrap` reports for the deployment under test.
+
+Regression suite re-run and passing: `test_v2_admin_appearance_parity`,
+`test_v2_admin_settings_schema`, `test_v2_admin_settings_normalization`,
+`test_v2_admin_field_renderer_coverage`, `test_v2_api_security`,
+`test_v2_api_payload_shapes`, `test_v2_ui_local_assets`, `test_v2_chat_notices`,
+`test_v2_workspace_sections`, `test_admin_settings_field_contract`,
+`test_admin_settings_nav_map`, `test_docs_app_surface_coverage`.

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,49 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/features) and [Fixes by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/fixes).
 
+### **(v0.261.044)**
+
+#### New Features
+
+*   **A Home Page In The V2 Interface**
+    *   The new interface opened straight into chat and had no landing page, which meant three Appearance settings — **Landing Page Text**, **Markdown Alignment** and **Main Page Logo Size** — configured a page that only existed in the classic interface. Editing them appeared to do nothing.
+    *   `/v2` now opens a home page carrying your logo, your landing copy and a **Start chatting** button, and **Home** has been added to the left-hand menu. The logo is sized by **Main Page Logo Size** exactly as the classic home page sizes it.
+    *   **New chat** in the left-hand menu now opens the chat page as well as clearing the current conversation. It previously only cleared it, which was invisible from anywhere that was not already chat.
+    *   (Ref: V2 interface, home page, `landing_page_text`, `landing_page_alignment`, `landing_page_logo_scale_percent`)
+
+*   **Custom Pages And External Links In The V2 Left-Hand Menu**
+    *   Both are configured under **Appearance > Pages & Links** and neither appeared in the new interface at all, so a deployment that had set them up saw a menu with none of its own links in it.
+    *   They now appear, following the same rule as the classic navigation: one or two entries sit inline as ordinary menu items, and three or more — or any number when **Force Menu Display** is on — collapse into a group under the menu name you configured, with a count.
+    *   External links open in a new tab so they cannot take an in-progress conversation with them. Custom pages honour their own "open in new tab" setting, and are still filtered per page against your roles.
+    *   (Ref: V2 interface, left-hand menu, Custom Pages, External Links, `/api/v2/bootstrap`)
+
+#### Bug Fixes
+
+*   **Branding Changes Did Not Take Effect In The V2 Interface Until A Page Reload**
+    *   Uploading a logo, changing the application title or switching on the classification banner updated the settings but changed nothing on screen. The left-hand menu kept showing the letter avatar and the banner never appeared.
+    *   The new interface reads branding and every capability toggle from a single payload it fetched once when you signed in, and saving in Admin Settings never asked for it again. It now re-reads that payload after every save and after every image upload, so a change applies as soon as you apply it.
+    *   (Ref: V2 interface, Admin Settings, branding, classification banner)
+
+*   **Custom Favicon Was Never Shown In The V2 Interface**
+    *   An uploaded favicon replaced the browser tab icon in the classic interface but never in the new one, which also always showed "SimpleChat" as the tab title regardless of the configured application title.
+    *   The favicon file keeps the same name every time it is replaced, so the address it is served from has to change or the browser keeps showing the copy it already has. The classic interface has always done this; the new interface is compiled ahead of time and could not know your branding. The page it serves is now stamped with the current favicon and application title on the way out.
+    *   (Ref: V2 interface, favicon, application title)
+
+*   **Custom Logo Was Squashed In The V2 Left-Hand Menu**
+    *   The logo was drawn into a fixed square, so any logo that is not square — which is most of them — was compressed. It is now sized by height with its own proportions kept, as in the classic navigation.
+    *   (Ref: V2 interface, left-hand menu, custom logo)
+
+*   **Unsafe External Link URLs Are No Longer Rendered In The V2 Left-Hand Menu**
+    *   The new interface validates external link addresses when you save them, but the classic Admin Settings form does not, so a link saved through the classic form — or already stored from an earlier version — could carry an address that is not a web page.
+    *   Addresses that are neither a local path nor `http`/`https` are now removed before the menu is built, so a link that the save path would have rejected can no longer reach the menu by another route.
+    *   (Ref: V2 interface, left-hand menu, External Links, `EXTERNAL_LINK_ALLOWED_SCHEMES`)
+
+*   **Four Settings Appeared Under Appearance Instead Of Their Own Tab**
+    *   **Enable Personal Workspaces** appeared under **Appearance > Notices & Agreements > User Agreement**, and the two external health check endpoints and **Show Simple Chat Documentation Guide Links** appeared under **Appearance > Pages & Links > External Links**. A fifth, **Enable Text Action**, appeared under **Appearance > Branding**.
+    *   Settings that had not yet been described to the new admin page were placed by matching their name against the section names, and these five matched the wrong section — "external" matched External Links rather than Health Check, and "user" matched User Agreement rather than Personal Workspaces.
+    *   They are now described properly and appear where they belong: the health check endpoints under **Operations > Logging & Health > Health Check**, the documentation guide links under **Help > User-Facing Latest Features**, personal workspaces under **Workspaces > Workspace Types**, and the text action under **Agents & Actions > Actions**. Each also gained the explanatory text the classic page has always shown.
+    *   (Ref: V2 Admin Settings, `admin_settings_fields.py`, capability placement)
+
 ### **(v0.261.043)**
 
 #### Bug Fixes

--- a/functional_tests/test_v2_admin_capability_placement.py
+++ b/functional_tests/test_v2_admin_capability_placement.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+# test_v2_admin_capability_placement.py
+"""
+Functional test pinning where the V2 admin surface files each capability toggle.
+Version: 0.261.044
+Implemented in: 0.261.044
+
+Settings that ``admin_settings_fields.py`` does not describe are still shown in the
+V2 admin UI, by scanning the settings document for ``enable_*`` booleans and
+matching each one to a navigation section that shares its leading word stems
+(``buildCapabilityIndex`` in ``AdminSettingsPage.tsx``). That keeps undescribed
+groups usable, but it is a guess, and it guessed wrong in ways nobody could see
+without opening the page:
+
+  - ``enable_user_workspace`` matched "user" in ``user-agreement-section`` and
+    appeared under Appearance > Notices & Agreements.
+  - ``enable_external_healthcheck`` and ``enable_no_auth_external_healthcheck``
+    matched "external" in ``external-links-section``. ``health-check-section``
+    splits into "health" and "check", neither of which matches the single token
+    "healthcheck", so the correct home could never win.
+  - ``enable_support_latest_feature_documentation_links`` matched "links" in
+    ``external-links-section``, which comes first in navigation order and so beat
+    the equally-scoring Support and Latest Features sections.
+  - ``enable_text_plugin`` matched "text" in ``home-page-text-section`` and
+    appeared under Appearance > Branding.
+
+Declaring a field is what takes a key out of that scan. This test holds two
+invariants so the misfiling cannot come back:
+
+  1. The Appearance group is fully described by the schema, so it must receive
+     *no* guessed rows at all. A new undeclared key that lands there fails here,
+     and the fix is to declare it in its real section.
+  2. The keys that were moved stay declared where they were moved to.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent))
+
+from test_support.app_stubs import import_app_module
+from test_support.nav import ADMIN_NAV
+from test_support.versioning import assert_app_version_at_least
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+APP_ROOT = REPO_ROOT / "application" / "single_app"
+SETTINGS_MODULE = APP_ROOT / "functions_settings.py"
+RENDERER = REPO_ROOT / "application" / "v2_ui" / "src" / "pages" / "AdminSettingsPage.tsx"
+
+APPEARANCE_GROUP_ID = "appearance"
+
+# Where each relocated toggle now lives, and the V1 pane it is mirrored from. The
+# pane is checked too, because a schema field with no server-rendered counterpart
+# would write a setting the rest of the application never reads.
+RELOCATED_CAPABILITIES = {
+    "enable_external_healthcheck": ("health-check-section", "logging"),
+    "enable_no_auth_external_healthcheck": ("health-check-section", "logging"),
+    "enable_support_latest_feature_documentation_links": (
+        "user-facing-latest-features-section",
+        "user-facing-latest-features",
+    ),
+    "enable_support_latest_features": ("support-menu-section", "support-menu"),
+    "enable_support_menu": ("support-menu-section", "support-menu"),
+    "enable_user_workspace": ("personal-workspaces-section", "workspace-types"),
+    "enable_text_plugin": ("actions-config", "actions"),
+}
+
+# The rules the ported heuristic depends on. If the renderer stops doing any of
+# these, the port below no longer predicts what an administrator sees.
+RENDERER_INVARIANTS = (
+    ("strips the -section suffix", "replace(/-section$/, '')"),
+    ("splits section ids on hyphens", ".split('-')"),
+    ("splits capability keys on underscores", ".split('_')"),
+    ("ignores tokens of two characters or fewer", "token.length > 2"),
+    ("keeps the first section that scores highest", "score > bestScore"),
+    ("skips keys that have a declared field", "!declaredKeys.has(key)"),
+)
+
+DEFAULT_SETTING_RE = re.compile(
+    r"^\s*'(?P<key>enable_[a-z0-9_]+)'\s*:\s*(?:True|False)\s*,", re.MULTILINE
+)
+
+fields_module = import_app_module("admin_settings_fields")
+
+
+def read_capability_keys():
+    """Return the ``enable_*`` booleans the settings document defaults to.
+
+    ``functions_settings`` is one of the modules ``app_stubs`` replaces, because it
+    reaches ``config.py`` and a live Cosmos client, so the defaults are read out of
+    the source the same way ``scripts/build_docs_inventory.py`` reads them.
+    """
+    source = SETTINGS_MODULE.read_text(encoding="utf-8")
+    keys = sorted({match.group("key") for match in DEFAULT_SETTING_RE.finditer(source)})
+    assert keys, "No enable_* defaults were found; the extraction likely broke."
+    return keys
+
+
+def build_sections():
+    """Return every navigation section with the tokens the renderer matches on."""
+    sections = []
+    for group in ADMIN_NAV:
+        for tab in group["tabs"]:
+            for section in tab["sections"]:
+                tokens = {
+                    token
+                    for token in re.sub(r"-section$", "", section["id"]).split("-")
+                    if len(token) > 2
+                }
+                sections.append(
+                    {
+                        "group_id": group["id"],
+                        "group_label": group["label"],
+                        "tab_label": tab["label"],
+                        "section_id": section["id"],
+                        "tokens": tokens,
+                    }
+                )
+    return sections
+
+
+def place_capability(key, sections):
+    """Port of ``buildCapabilityIndex``: the section a guessed key is filed under.
+
+    Returns ``None`` when nothing matched, which the renderer collects under
+    "Other capabilities".
+    """
+    key_tokens = [
+        token for token in key[len("enable_"):].split("_") if len(token) > 2
+    ]
+
+    best = None
+    best_score = 0
+    for section in sections:
+        score = sum(1 for token in key_tokens if token in section["tokens"])
+        # Strictly greater, so the first section reaching a score keeps it. That
+        # tie-break is why navigation order decided three of the misfilings.
+        if score > best_score:
+            best_score = score
+            best = section
+    return best
+
+
+def test_ported_heuristic_still_matches_the_renderer():
+    """A rewritten renderer would leave this test asserting the wrong thing."""
+    print("Testing the ported heuristic against AdminSettingsPage.tsx...")
+
+    assert_app_version_at_least("0.261.044")
+
+    assert RENDERER.is_file(), f"Missing the V2 admin renderer: {RENDERER}"
+    source = RENDERER.read_text(encoding="utf-8")
+
+    missing = [
+        description
+        for description, fragment in RENDERER_INVARIANTS
+        if fragment not in source
+    ]
+
+    assert not missing, (
+        "The V2 capability fallback no longer works the way this test models it, so "
+        "its placement assertions are no longer meaningful. Re-read "
+        "buildCapabilityIndex and update place_capability to match:\n  "
+        + "\n  ".join(missing)
+    )
+
+    print(f"  All {len(RENDERER_INVARIANTS)} heuristic rule(s) still hold.")
+    return True
+
+
+def test_appearance_group_receives_no_guessed_capabilities():
+    """Appearance is fully described, so anything guessed into it is misfiled."""
+    print("\nTesting that no guessed capability lands in the Appearance group...")
+
+    declared = fields_module.get_declared_setting_keys()
+    sections = build_sections()
+    appearance_sections = {
+        section["section_id"]
+        for section in sections
+        if section["group_id"] == APPEARANCE_GROUP_ID
+    }
+
+    misfiled = []
+    guessed = 0
+    for key in read_capability_keys():
+        if key in declared:
+            continue
+        guessed += 1
+        placement = place_capability(key, sections)
+        if placement and placement["section_id"] in appearance_sections:
+            misfiled.append(
+                f"{key} -> {placement['group_label']} > {placement['tab_label']} "
+                f"> {placement['section_id']}"
+            )
+
+    assert not misfiled, (
+        "These settings have no declared field, so the V2 admin UI guessed a home "
+        "for them and put them in the Appearance group, where they do not belong. "
+        "Declare each one in admin_settings_fields.py under the section it really "
+        "lives in:\n  " + "\n  ".join(misfiled)
+    )
+
+    print(f"  {guessed} guessed capability row(s), none of them in Appearance.")
+    return True
+
+
+def test_relocated_capabilities_are_declared_where_they_belong():
+    """Undeclaring one of these silently returns it to the Appearance group."""
+    print("\nTesting the relocated capability declarations...")
+
+    declared_sections = {}
+    for section_id, field in fields_module.iter_fields():
+        key = field.get("key")
+        if key:
+            declared_sections[key] = (section_id, field)
+
+    problems = []
+    for key, (expected_section, _pane) in RELOCATED_CAPABILITIES.items():
+        entry = declared_sections.get(key)
+        if entry is None:
+            problems.append(f"{key}: not declared at all")
+            continue
+        section_id, field = entry
+        if section_id != expected_section:
+            problems.append(
+                f"{key}: declared under {section_id!r}, expected {expected_section!r}"
+            )
+        if field.get("type") != "switch":
+            problems.append(f"{key}: declared as {field.get('type')!r}, expected 'switch'")
+
+    assert not problems, (
+        "These capabilities were moved out of the Appearance group by declaring "
+        "them. Changing that undoes the move:\n  " + "\n  ".join(problems)
+    )
+
+    print(f"  All {len(RELOCATED_CAPABILITIES)} relocated capability declaration(s) hold.")
+    return True
+
+
+def test_relocated_capabilities_exist_in_their_v1_panes():
+    """A declared field with no V1 counterpart would save a setting nothing reads."""
+    print("\nTesting the relocated capabilities against their V1 panes...")
+
+    panes_dir = APP_ROOT / "templates" / "admin" / "_panes"
+
+    missing = []
+    for key, (_section, pane_id) in RELOCATED_CAPABILITIES.items():
+        pane_path = panes_dir / f"{pane_id}.html"
+        if not pane_path.is_file():
+            missing.append(f"{key}: pane {pane_path.name} does not exist")
+            continue
+        if f'name="{key}"' not in pane_path.read_text(encoding="utf-8"):
+            missing.append(f"{key}: no name=\"{key}\" field in {pane_path.name}")
+
+    assert not missing, (
+        "These relocated capabilities do not exist in the server-rendered pane "
+        "they were mirrored from:\n  " + "\n  ".join(missing)
+    )
+
+    print(f"  All {len(RELOCATED_CAPABILITIES)} capability field(s) exist in V1.")
+    return True
+
+
+if __name__ == "__main__":
+    tests = [
+        test_ported_heuristic_still_matches_the_renderer,
+        test_appearance_group_receives_no_guessed_capabilities,
+        test_relocated_capabilities_are_declared_where_they_belong,
+        test_relocated_capabilities_exist_in_their_v1_panes,
+    ]
+
+    results = []
+    for test in tests:
+        try:
+            results.append(bool(test()))
+        except Exception as exc:
+            print(f"FAILED {test.__name__}: {exc}")
+            import traceback
+
+            traceback.print_exc()
+            results.append(False)
+
+    print(f"\nResults: {sum(results)}/{len(results)} tests passed")
+    sys.exit(0 if all(results) else 1)

--- a/functional_tests/test_v2_admin_settings_schema.py
+++ b/functional_tests/test_v2_admin_settings_schema.py
@@ -9,8 +9,14 @@ The V2 admin surface renders whatever ``admin_settings_fields.py`` declares. A
 malformed entry does not raise anything server-side; it produces a control that
 silently fails to draw, or draws without the options it needs. These checks make
 a malformed entry a test failure instead.
+
+A declared default is also checked against the application's own default. The
+schema default is what the V2 surface shows for a key the settings document does
+not contain, so a mismatch means the toggle an administrator reads disagrees with
+the behaviour the application is actually applying.
 """
 
+import re
 import sys
 from pathlib import Path
 
@@ -19,6 +25,18 @@ sys.path.append(str(Path(__file__).resolve().parent))
 from test_support.app_stubs import import_app_module
 from test_support.versioning import assert_app_version_at_least
 
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SETTINGS_MODULE = REPO_ROOT / "application" / "single_app" / "functions_settings.py"
+
+# The literal defaults in functions_settings.py. It is one of the modules
+# ``app_stubs`` replaces, because it reaches config.py and a live Cosmos client, so
+# the values are read from source the way scripts/build_docs_inventory.py reads them.
+APP_DEFAULT_RE = re.compile(
+    r"^\s*'(?P<key>[a-z0-9_]+)'\s*:\s*"
+    r"(?P<value>True|False|'[^']*'|\[\]|-?\d+)\s*,",
+    re.MULTILINE,
+)
 
 fields_module = import_app_module("admin_settings_fields")
 
@@ -227,6 +245,61 @@ def test_option_values_are_unique_within_a_field():
     return True
 
 
+def read_application_defaults():
+    """Return the literal defaults the settings document is seeded with."""
+    defaults = {}
+    for match in APP_DEFAULT_RE.finditer(SETTINGS_MODULE.read_text(encoding="utf-8")):
+        key, raw = match.group("key"), match.group("value")
+        if key in defaults:
+            # The first occurrence is the seeded default; later ones are migrations
+            # and per-branch overrides.
+            continue
+        if raw == "True":
+            defaults[key] = True
+        elif raw == "False":
+            defaults[key] = False
+        elif raw == "[]":
+            defaults[key] = []
+        elif raw.lstrip("-").isdigit():
+            defaults[key] = int(raw)
+        else:
+            defaults[key] = raw[1:-1]
+    assert defaults, "No settings defaults were found; the extraction likely broke."
+    return defaults
+
+
+def test_declared_defaults_match_the_application():
+    """A drifted default shows a toggle that disagrees with what the app does."""
+    print("\nTesting declared defaults against functions_settings.py...")
+
+    assert_app_version_at_least("0.261.044")
+
+    app_defaults = read_application_defaults()
+
+    mismatches = []
+    compared = 0
+    for section_id, field in fields_module.iter_fields():
+        key = field.get("key")
+        if not key or "default" not in field or key not in app_defaults:
+            continue
+        compared += 1
+        if field["default"] != app_defaults[key]:
+            mismatches.append(
+                f"{section_id}.{key}: schema {field['default']!r} != "
+                f"application {app_defaults[key]!r}"
+            )
+
+    assert not mismatches, (
+        "These schema defaults disagree with the defaults the application seeds into "
+        "the settings document, so the V2 admin surface would show the wrong state "
+        "for a key the document does not contain yet:\n  " + "\n  ".join(mismatches)
+    )
+
+    assert compared, "No declared defaults were compared; the extraction likely broke."
+    print(f"  All {compared} declared default(s) match the application.")
+    return True
+
+
 if __name__ == "__main__":
     tests = [
         test_field_types_are_known,
@@ -236,6 +309,7 @@ if __name__ == "__main__":
         test_setting_keys_are_unique,
         test_dependencies_reference_real_fields,
         test_option_values_are_unique_within_a_field,
+        test_declared_defaults_match_the_application,
     ]
 
     results = []

--- a/functional_tests/test_v2_bootstrap_branding_and_navigation.py
+++ b/functional_tests/test_v2_bootstrap_branding_and_navigation.py
@@ -1,0 +1,419 @@
+#!/usr/bin/env python3
+# test_v2_bootstrap_branding_and_navigation.py
+"""
+Functional test for the V2 bootstrap branding and navigation blocks.
+Version: 0.261.044
+Implemented in: 0.261.044
+
+The V2 SPA cannot read Jinja context, so everything the classic interface gets from
+``app_settings`` and the ``inject_settings`` context processor has to arrive in the
+bootstrap payload instead. Three things were missing, and each one made an
+Appearance setting look broken rather than merely absent:
+
+  - No favicon URL, so a custom icon never replaced the shipped one. The static
+    file keeps a stable name, so only the version counter tells a browser to
+    fetch it again -- which is exactly what ``base.html`` does and the compiled
+    SPA shell could not.
+  - No landing page fields, so the landing text, its alignment and the home page
+    logo size configured a page that did not exist in V2.
+  - No navigation block, so Custom Pages and External Links were invisible in the
+    V2 rail no matter how they were configured.
+
+``route_backend_v2`` cannot be imported in a test environment: it reaches
+``config.py``, which builds live Azure clients at import time. Rather than assert
+on the shape of its source, this test lifts the three builders out with ``ast``
+and runs them against injected dependencies, so the assertions are about what the
+functions actually return.
+"""
+
+import ast
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent))
+
+from test_support.app_stubs import import_app_module
+from test_support.versioning import assert_app_version_at_least
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+APP_ROOT = REPO_ROOT / "application" / "single_app"
+BACKEND_V2 = APP_ROOT / "route_backend_v2.py"
+
+# The builders under test. There is no module-level constant to lift: the landing copy
+# is passed through exactly as stored, deliberately.
+LIFTED_FUNCTIONS = ("_build_branding", "_coerce_logo_scale", "_menu_name", "_build_navigation")
+
+branding_urls = import_app_module("functions_branding_urls")
+fields_module = import_app_module("admin_settings_fields")
+
+
+def load_builders(custom_pages_nav=None, nav_raises=False):
+    """Execute the bootstrap builders in isolation from the Flask application.
+
+    Only the names the lifted functions actually reference are provided. Anything
+    they reach for that is not supplied here raises, which keeps the injection
+    honest: the test cannot quietly diverge from the real dependency set.
+    """
+    tree = ast.parse(BACKEND_V2.read_text(encoding="utf-8"))
+
+    wanted = [
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name in LIFTED_FUNCTIONS
+    ]
+
+    lifted_names = {node.name for node in wanted}
+    missing = set(LIFTED_FUNCTIONS) - lifted_names
+    assert not missing, (
+        "route_backend_v2.py no longer defines these bootstrap builders, so the SPA "
+        f"cannot be receiving what this test checks: {sorted(missing)}"
+    )
+
+    def fake_get_custom_pages_nav(_settings):
+        if nav_raises:
+            raise RuntimeError("custom page metadata unavailable")
+        return list(custom_pages_nav or [])
+
+    namespace = {
+        "logging": __import__("logging"),
+        "log_event": lambda *args, **kwargs: None,
+        "get_custom_pages_nav": fake_get_custom_pages_nav,
+        "build_custom_logo_urls": branding_urls.build_custom_logo_urls,
+        "build_favicon_url": branding_urls.build_favicon_url,
+        "is_safe_external_link_url": fields_module.is_safe_external_link_url,
+        "LANDING_PAGE_ALIGNMENTS": fields_module.LANDING_PAGE_ALIGNMENTS,
+        "LOGO_SCALE_DEFAULT_PERCENT": fields_module.LOGO_SCALE_DEFAULT_PERCENT,
+        "LOGO_SCALE_MIN_PERCENT": fields_module.LOGO_SCALE_MIN_PERCENT,
+        "LOGO_SCALE_MAX_PERCENT": fields_module.LOGO_SCALE_MAX_PERCENT,
+    }
+
+    module = ast.Module(body=wanted, type_ignores=[])
+    exec(compile(module, str(BACKEND_V2), "exec"), namespace)
+    return namespace
+
+
+def test_favicon_url_is_versioned_only_for_a_custom_icon():
+    """Without the version, a replaced favicon keeps serving from cache."""
+    print("Testing the favicon URL...")
+
+    assert_app_version_at_least("0.261.044")
+
+    build = load_builders()["_build_branding"]
+
+    default = build({}, {})
+    assert default["favicon_url"] == "/static/images/favicon.ico", (
+        f"The shipped favicon must be served unversioned, got {default['favicon_url']!r}"
+    )
+
+    custom = build({"custom_favicon_base64": "AAAA", "favicon_version": 9}, {})
+    assert custom["favicon_url"] == "/static/images/favicon.ico?v=9", (
+        f"A custom favicon must carry its version, got {custom['favicon_url']!r}"
+    )
+
+    # An upload that has not bumped the counter yet must still produce a usable URL
+    # rather than "?v=None".
+    unversioned = build({"custom_favicon_base64": "AAAA"}, {})
+    assert unversioned["favicon_url"] == "/static/images/favicon.ico?v=1", (
+        f"A missing version must fall back to 1, got {unversioned['favicon_url']!r}"
+    )
+
+    print("  Favicon URLs are versioned exactly when a custom icon is stored.")
+    return True
+
+
+def test_logo_urls_follow_show_logo_and_the_dark_fallback():
+    """Only a stored logo is advertised, and only while Show Logo is on."""
+    print("\nTesting logo URLs...")
+
+    build = load_builders()["_build_branding"]
+
+    hidden = build(
+        {"show_logo": False, "custom_logo_base64": "AAAA", "logo_version": 2}, {}
+    )
+    assert hidden["logo_url"] is None and hidden["logo_dark_url"] is None, (
+        "Show Logo off must not advertise a logo URL"
+    )
+
+    light_only = build(
+        {"show_logo": True, "custom_logo_base64": "AAAA", "logo_version": 2}, {}
+    )
+    assert light_only["logo_url"] == "/static/images/custom_logo.png?v=2"
+    # One upload has to work in both themes, matching the server-rendered templates.
+    assert light_only["logo_dark_url"] == light_only["logo_url"], (
+        "A light-only logo must be reused in dark mode"
+    )
+
+    both = build(
+        {
+            "show_logo": True,
+            "custom_logo_base64": "AAAA",
+            "logo_version": 2,
+            "custom_logo_dark_base64": "BBBB",
+            "logo_dark_version": 5,
+        },
+        {},
+    )
+    assert both["logo_dark_url"] == "/static/images/custom_logo_dark.png?v=5", (
+        f"A dedicated dark logo must be used, got {both['logo_dark_url']!r}"
+    )
+
+    print("  Logo URLs respect Show Logo and the dark-variant fallback.")
+    return True
+
+
+def test_classification_banner_requires_text():
+    """An enabled banner with no text would render as a coloured empty strip."""
+    print("\nTesting the classification banner...")
+
+    build = load_builders()["_build_branding"]
+
+    assert build({"classification_banner_enabled": True}, {})["classification_banner"] is None, (
+        "An enabled banner with no text must not be sent"
+    )
+    assert build({"classification_banner_text": "SECRET"}, {})["classification_banner"] is None, (
+        "Banner text alone must not enable the banner"
+    )
+
+    banner = build(
+        {"classification_banner_enabled": True, "classification_banner_text": "SECRET"},
+        {},
+    )["classification_banner"]
+    assert banner == {
+        "enabled": True,
+        "text": "SECRET",
+        "color": "#ffc107",
+        "text_color": "#ffffff",
+    }, f"Unexpected banner payload: {banner!r}"
+
+    print("  The banner is sent only when it is enabled and has text.")
+    return True
+
+
+def test_landing_page_fields_are_sent_and_bounded():
+    """The home page renders from these three values on first paint."""
+    print("\nTesting the landing page fields...")
+
+    build = load_builders()["_build_branding"]
+
+    # Cleared copy stays cleared. ``get_settings`` merges the seeded default into every
+    # document, so a blank value is an administrator's deletion, and restoring default
+    # wording -- which asserts acceptance of an acceptable use policy -- would put a
+    # statement back on the page that they removed on purpose.
+    for cleared in ("", "   ", None):
+        assert build({"landing_page_text": cleared}, {})["landing_page_text"] == "", (
+            f"Cleared landing copy must stay cleared, {cleared!r} did not"
+        )
+
+    blank = build({}, {})
+    assert blank["landing_page_alignment"] == "left"
+    assert blank["landing_page_logo_scale_percent"] == fields_module.LOGO_SCALE_DEFAULT_PERCENT
+
+    configured = build(
+        {
+            "landing_page_text": "# Welcome",
+            "landing_page_alignment": "center",
+            "landing_page_logo_scale_percent": 250,
+        },
+        {},
+    )
+    assert configured["landing_page_text"] == "# Welcome"
+    assert configured["landing_page_alignment"] == "center"
+    assert configured["landing_page_logo_scale_percent"] == 250
+
+    # A value outside the slider's range would render an unusable page rather than
+    # being rejected at the door, so it is clamped to what the slider offers.
+    assert build({"landing_page_logo_scale_percent": 5000}, {})[
+        "landing_page_logo_scale_percent"
+    ] == fields_module.LOGO_SCALE_MAX_PERCENT
+    assert build({"landing_page_logo_scale_percent": "nonsense"}, {})[
+        "landing_page_logo_scale_percent"
+    ] == fields_module.LOGO_SCALE_DEFAULT_PERCENT
+    assert build({"landing_page_alignment": "diagonal"}, {})[
+        "landing_page_alignment"
+    ] == "left", "An unknown alignment must fall back rather than reach the browser"
+
+    print("  Landing page fields are passed through, defaulted and bounded.")
+    return True
+
+
+def test_unsafe_external_link_urls_are_dropped():
+    """A stored javascript: URL would execute from every user's rail."""
+    print("\nTesting external link URL schemes...")
+
+    build = load_builders()["_build_navigation"]
+
+    # Only the V2 settings PATCH applies the scheme rule on write. The server-rendered
+    # admin form stores any non-empty string, so the read path cannot assume the
+    # document is already clean.
+    unsafe = [
+        "javascript:alert(1)",
+        "JavaScript:alert(1)",
+        "  javascript:alert(1)  ",
+        "data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==",
+        "vbscript:msgbox(1)",
+    ]
+    for url in unsafe:
+        group = build(
+            {
+                "enable_external_links": True,
+                "external_links": [{"label": "Trap", "url": url}],
+            },
+            ["User"],
+        )["external_links"]
+        assert group["items"] == [], f"{url!r} should have been dropped, got {group['items']!r}"
+
+    safe = [
+        "https://example.invalid/policies",
+        "http://example.invalid/policies",
+        "/custom/handbook",
+    ]
+    for url in safe:
+        group = build(
+            {
+                "enable_external_links": True,
+                "external_links": [{"label": "Policies", "url": url}],
+            },
+            ["User"],
+        )["external_links"]
+        assert [item["url"] for item in group["items"]] == [url], (
+            f"{url!r} should have been kept, got {group['items']!r}"
+        )
+
+    print(f"  {len(unsafe)} unsafe URL scheme(s) dropped, {len(safe)} safe URL(s) kept.")
+    return True
+
+
+def test_external_links_are_gated_by_role_and_validated():
+    """The classic rail shows these only to holders of a real application role."""
+    print("\nTesting the external links group...")
+
+    build = load_builders()["_build_navigation"]
+
+    settings = {
+        "enable_external_links": True,
+        "external_links_menu_name": "Handbook",
+        "external_links_force_menu": True,
+        "external_links": [
+            {"label": "Policies", "url": "https://example.invalid/policies"},
+            {"label": "  ", "url": "https://example.invalid/blank-label"},
+            {"label": "No URL", "url": "   "},
+            "not-a-dict",
+        ],
+    }
+
+    allowed = build(settings, ["User"])["external_links"]
+    assert [item["label"] for item in allowed["items"]] == ["Policies"], (
+        f"Malformed link entries must be dropped, got {allowed['items']!r}"
+    )
+    assert allowed["menu_name"] == "Handbook"
+    assert allowed["force_menu"] is True
+
+    for roles in ([], ["Viewer"], None):
+        denied = build(settings, roles)["external_links"]
+        assert denied["items"] == [], (
+            f"External links must not be sent to roles {roles!r}"
+        )
+
+    assert build(settings, ["Admin"])["external_links"]["items"], (
+        "Administrators must still see external links"
+    )
+
+    disabled = build({**settings, "enable_external_links": False}, ["User"])
+    assert disabled["external_links"]["items"] == []
+    assert disabled["external_links"]["enabled"] is False
+
+    blank_name = build({**settings, "external_links_menu_name": "  "}, ["User"])
+    assert blank_name["external_links"]["menu_name"] == "External Links", (
+        "A blank menu name must fall back rather than render an unlabelled group"
+    )
+
+    print("  External links are role-gated, validated and named.")
+    return True
+
+
+def test_custom_pages_group_survives_a_failing_lookup():
+    """A degraded rail is acceptable; a failed bootstrap is not."""
+    print("\nTesting the custom pages group...")
+
+    pages = [
+        {
+            "slug": "handbook",
+            "label": "Handbook",
+            "icon": "bi-book",
+            "url": "/custom/handbook",
+            "open_in_new_tab": True,
+        },
+        {"slug": "broken", "label": "No URL"},
+    ]
+
+    build = load_builders(custom_pages_nav=pages)["_build_navigation"]
+    group = build(
+        {"enable_custom_pages": True, "custom_pages_menu_name": "Guides"}, ["User"]
+    )["custom_pages"]
+
+    assert [item["slug"] for item in group["items"]] == ["handbook"], (
+        f"A page with no URL cannot be linked to, got {group['items']!r}"
+    )
+    assert group["items"][0]["open_in_new_tab"] is True
+    assert group["menu_name"] == "Guides"
+
+    disabled = load_builders(custom_pages_nav=pages)["_build_navigation"](
+        {"enable_custom_pages": False}, ["User"]
+    )
+    assert disabled["custom_pages"]["items"] == [], (
+        "Custom pages must not be listed while the capability is off"
+    )
+    assert disabled["custom_pages"]["menu_name"] == "Custom Pages"
+
+    failing = load_builders(nav_raises=True)["_build_navigation"]
+    recovered = failing({"enable_custom_pages": True}, ["User"])
+    assert recovered["custom_pages"]["items"] == [], (
+        "A failed custom page lookup must degrade to an empty group"
+    )
+    assert recovered["external_links"]["items"] == []
+
+    print("  Custom pages are listed, filtered and fail safely.")
+    return True
+
+
+def test_bootstrap_payload_carries_the_navigation_block():
+    """The rail reads navigation from bootstrap; nothing else supplies it."""
+    print("\nTesting the bootstrap payload wiring...")
+
+    source = BACKEND_V2.read_text(encoding="utf-8")
+
+    assert '"navigation": _build_navigation(settings, current_user_roles)' in source, (
+        "The bootstrap payload must carry a navigation block built from the caller's "
+        "roles, or Custom Pages and External Links cannot appear in the V2 rail"
+    )
+
+    print("  The bootstrap payload includes the navigation block.")
+    return True
+
+
+if __name__ == "__main__":
+    tests = [
+        test_favicon_url_is_versioned_only_for_a_custom_icon,
+        test_logo_urls_follow_show_logo_and_the_dark_fallback,
+        test_classification_banner_requires_text,
+        test_landing_page_fields_are_sent_and_bounded,
+        test_unsafe_external_link_urls_are_dropped,
+        test_external_links_are_gated_by_role_and_validated,
+        test_custom_pages_group_survives_a_failing_lookup,
+        test_bootstrap_payload_carries_the_navigation_block,
+    ]
+
+    results = []
+    for test in tests:
+        try:
+            results.append(bool(test()))
+        except Exception as exc:
+            print(f"FAILED {test.__name__}: {exc}")
+            import traceback
+
+            traceback.print_exc()
+            results.append(False)
+
+    print(f"\nResults: {sum(results)}/{len(results)} tests passed")
+    sys.exit(0 if all(results) else 1)

--- a/functional_tests/test_v2_navigation_groups_logic.mjs
+++ b/functional_tests/test_v2_navigation_groups_logic.mjs
@@ -1,0 +1,168 @@
+// test_v2_navigation_groups_logic.mjs
+//
+// Runtime test for the V2 rail's administrator-configured navigation groups.
+// Version: 0.261.044
+// Implemented in: 0.261.044
+//
+// Custom Pages and External Links are configured in Admin Settings and had no
+// representation in the V2 rail at all, so a deployment that had set them up saw none of
+// its own links. Bringing them across means reproducing the rule the classic navigation
+// applies, and that rule is easy to get subtly wrong in ways review does not catch: an
+// off-by-one in the menu threshold, or a group that renders as an empty heading.
+//
+// The companion test, test_v2_bootstrap_branding_and_navigation.py, proves the server
+// sends the groups. This file executes the client's decisions about them.
+//
+// Run directly with `node functional_tests/test_v2_navigation_groups_logic.mjs`. Requires
+// Node 22.6 or newer, which strips the TypeScript types so the real module is imported.
+
+import assert from 'node:assert/strict';
+import {
+    INLINE_ITEM_LIMIT,
+    isGroupVisible,
+    shouldRenderAsMenu,
+    toCustomPageLinks,
+    toExternalLinks,
+} from '../application/v2_ui/src/lib/navigationGroups.ts';
+
+const checks = [];
+function check(name, fn) {
+    checks.push([name, fn]);
+}
+
+/** Build a navigation group of the shape /api/v2/bootstrap returns. */
+function group(items, overrides = {}) {
+    return {
+        enabled: true,
+        menu_name: 'Custom Pages',
+        force_menu: false,
+        items,
+        ...overrides,
+    };
+}
+
+function page(slug, overrides = {}) {
+    return {
+        slug,
+        label: slug,
+        icon: 'bi-file-earmark-text',
+        url: `/custom/${slug}`,
+        open_in_new_tab: false,
+        ...overrides,
+    };
+}
+
+/* ------------------------------ menu threshold ------------------------------ */
+
+check('one or two entries stay inline', () => {
+    assert.equal(shouldRenderAsMenu(1, false), false);
+    assert.equal(shouldRenderAsMenu(INLINE_ITEM_LIMIT, false), false);
+});
+
+check('three entries become a menu', () => {
+    // The boundary the classic navigation draws. Off by one here either crowds the rail
+    // or hides a pair of links behind a heading for no reason.
+    assert.equal(shouldRenderAsMenu(INLINE_ITEM_LIMIT + 1, false), true);
+    assert.equal(shouldRenderAsMenu(9, false), true);
+});
+
+check('force menu wins at any count', () => {
+    assert.equal(shouldRenderAsMenu(1, true), true);
+    assert.equal(shouldRenderAsMenu(0, true), true);
+});
+
+/* -------------------------------- visibility -------------------------------- */
+
+check('a group with entries and enabled is shown', () => {
+    assert.equal(isGroupVisible(group([page('handbook')])), true);
+});
+
+check('a disabled group is hidden even when it has entries', () => {
+    assert.equal(isGroupVisible(group([page('handbook')], { enabled: false })), false);
+});
+
+check('an enabled but empty group is hidden', () => {
+    // Otherwise the rail grows a heading with nothing under it, which reads as broken
+    // rather than as unused.
+    assert.equal(isGroupVisible(group([])), false);
+});
+
+check('a missing group does not throw', () => {
+    for (const value of [undefined, null, {}]) {
+        assert.equal(isGroupVisible(value), false);
+    }
+});
+
+/* --------------------------------- mapping ---------------------------------- */
+
+check('custom pages keep their own new-tab choice', () => {
+    const links = toCustomPageLinks(
+        group([page('handbook'), page('policy', { open_in_new_tab: true })]),
+    );
+    assert.deepEqual(
+        links.map((link) => link.newTab),
+        [false, true],
+    );
+    assert.deepEqual(
+        links.map((link) => link.href),
+        ['/custom/handbook', '/custom/policy'],
+    );
+});
+
+check('a custom page with no label falls back to its slug', () => {
+    const [link] = toCustomPageLinks(group([page('handbook', { label: '' })]));
+    assert.equal(link.label, 'handbook');
+});
+
+check('external links always open in a new tab', () => {
+    // They leave the application, and losing an in-progress conversation to a policy link
+    // would be a poor trade.
+    const links = toExternalLinks(
+        group([
+            { label: 'Policies', url: 'https://example.invalid/policies' },
+            { label: 'Handbook', url: 'https://example.invalid/handbook' },
+        ]),
+    );
+    assert.ok(links.every((link) => link.newTab === true));
+});
+
+check('repeated external links still get distinct keys', () => {
+    // Labels and URLs are both administrator-supplied and may legitimately repeat, so a
+    // key derived from either alone would collapse two rows into one in React.
+    const duplicate = { label: 'Policies', url: 'https://example.invalid/policies' };
+    const links = toExternalLinks(group([duplicate, duplicate]));
+    assert.equal(new Set(links.map((link) => link.key)).size, 2);
+});
+
+check('custom page keys do not collide with external link keys', () => {
+    const pageKeys = toCustomPageLinks(group([page('policies')])).map((link) => link.key);
+    const linkKeys = toExternalLinks(
+        group([{ label: 'policies', url: 'https://example.invalid/policies' }]),
+    ).map((link) => link.key);
+    assert.equal(new Set([...pageKeys, ...linkKeys]).size, 2);
+});
+
+check('an absent group maps to no links rather than throwing', () => {
+    assert.deepEqual(toCustomPageLinks(undefined), []);
+    assert.deepEqual(toExternalLinks(null), []);
+});
+
+/* ----------------------------------- runner ---------------------------------- */
+
+let passed = 0;
+let failed = 0;
+
+for (const [name, fn] of checks) {
+    try {
+        await fn();
+        console.log(`ok   ${name}`);
+        passed += 1;
+    } catch (error) {
+        console.log(`FAIL ${name}`);
+        console.log(`     ${error.message}`);
+        failed += 1;
+    }
+}
+
+console.log(`\n${passed}/${passed + failed} runtime checks passed`);
+process.exit(failed > 0 ? 1 : 0);

--- a/functional_tests/test_v2_ui_spa_route.py
+++ b/functional_tests/test_v2_ui_spa_route.py
@@ -7,8 +7,14 @@ Implemented in: 0.261.003
 
 This test ensures that /v2 and every client-side route beneath it serve the compiled
 single-page application shell, that deep links fall back to the shell so page refreshes
-work, and that the shell is never cached (the bundle it references is content-hashed, so a
-cached shell would keep pointing at a previous deploy's assets).
+work, that the shell is never cached (the bundle it references is content-hashed, so a
+cached shell would keep pointing at a previous deploy's assets), and that the shell's
+favicon link and title are rewritten from settings on the way out.
+
+That last part is what makes a custom favicon apply at all in the V2 interface. The
+compiled index.html is a build artefact and cannot know an administrator's branding, and
+the static icon file keeps a stable name, so without the version in the rewritten URL a
+browser keeps serving whichever icon it cached before the upload.
 
 The Flask application cannot be imported directly in a test environment because
 config.py builds live Azure clients at import time. The heavy dependencies of
@@ -27,8 +33,14 @@ APP_DIR = REPO_ROOT / "application" / "single_app"
 
 sys.path.insert(0, str(APP_DIR))
 
+# A realistic head, matching what Vite emits into static/v2/index.html.
+SHELL_HEAD = (
+    '<link rel="icon" href="/static/images/favicon.ico" type="image/x-icon" />\n'
+    "    <title>SimpleChat</title>"
+)
 
-def _install_dependency_stubs():
+
+def _install_dependency_stubs(settings=None):
     """Stub the modules route_frontend_v2 imports that require live Azure configuration."""
     # Werkzeug 3.x removed the module-level __version__ that Flask 2.x's test client
     # reads. The repository pins a compatible pair (Flask 3.1.3 / Werkzeug 3.1.6), but a
@@ -60,6 +72,12 @@ def _install_dependency_stubs():
     swagger.get_auth_security = lambda: [{"sessionAuth": []}]
     swagger.swagger_route = lambda **kwargs: passthrough_decorator
     sys.modules["swagger_wrapper"] = swagger
+
+    # Imported lazily by the shell branding lookup. Stubbed here so the lookup reads
+    # this test's settings rather than falling through to config.py's Azure clients.
+    settings_module = types.ModuleType("functions_settings")
+    settings_module.get_settings = lambda: dict(settings or {})
+    sys.modules["functions_settings"] = settings_module
 
 
 def _build_test_client(module):
@@ -157,11 +175,115 @@ def test_bundle_output_path_is_inside_static():
     return True
 
 
+def _serve_shell_with(settings, shell_html=None):
+    """Return the served shell body for a given settings document."""
+    _install_dependency_stubs(settings)
+    import route_frontend_v2
+
+    body = shell_html or (
+        f"<!doctype html><html><head>{SHELL_HEAD}</head><body></body></html>"
+    )
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        index_path = os.path.join(temp_dir, "index.html")
+        with open(index_path, "w", encoding="utf-8") as handle:
+            handle.write(body)
+
+        route_frontend_v2.get_v2_index_path = lambda: index_path
+        route_frontend_v2.is_v2_bundle_available = lambda: True
+
+        response = _build_test_client(route_frontend_v2).get("/v2")
+        return response.get_data(as_text=True)
+
+
+def test_shell_carries_the_configured_favicon_and_title():
+    """A custom favicon only applies if the shell's icon link is rewritten."""
+    print("Testing shell branding injection...")
+
+    served = _serve_shell_with(
+        {
+            "app_title": "Contoso Chat",
+            "custom_favicon_base64": "AAAA",
+            "favicon_version": 4,
+        }
+    )
+
+    assert '<title>Contoso Chat</title>' in served, (
+        f"The shell should carry the configured application title, got: {served}"
+    )
+    assert 'href="/static/images/favicon.ico?v=4"' in served, (
+        "The shell's icon link should carry the stored favicon version, or a browser "
+        f"keeps serving the icon it already cached. Got: {served}"
+    )
+    assert served.count("<title") == 1, "The title should be replaced, not duplicated"
+
+    print("Shell branding injection test passed!")
+    return True
+
+
+def test_shell_branding_is_escaped():
+    """The application title is administrator-supplied free text."""
+    print("Testing shell branding escaping...")
+
+    served = _serve_shell_with({"app_title": "Contoso <script>alert(1)</script>"})
+
+    assert "<script>alert(1)</script>" not in served, (
+        f"The application title must be escaped before reaching the shell: {served}"
+    )
+    assert "&lt;script&gt;" in served, f"Expected an escaped title, got: {served}"
+
+    print("Shell branding escaping test passed!")
+    return True
+
+
+def test_shell_falls_back_when_settings_are_unavailable():
+    """A settings failure must degrade to the default icon, not to a broken page."""
+    print("Testing shell branding fallback...")
+
+    _install_dependency_stubs()
+    broken = types.ModuleType("functions_settings")
+
+    def _explode():
+        raise RuntimeError("settings backend unavailable")
+
+    broken.get_settings = _explode
+    sys.modules["functions_settings"] = broken
+
+    import route_frontend_v2
+
+    body = f"<!doctype html><html><head>{SHELL_HEAD}</head><body></body></html>"
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        index_path = os.path.join(temp_dir, "index.html")
+        with open(index_path, "w", encoding="utf-8") as handle:
+            handle.write(body)
+
+        route_frontend_v2.get_v2_index_path = lambda: index_path
+        route_frontend_v2.is_v2_bundle_available = lambda: True
+
+        response = _build_test_client(route_frontend_v2).get("/v2")
+
+    served = response.get_data(as_text=True)
+    assert response.status_code == 200, (
+        f"A settings failure must not break the shell, got {response.status_code}"
+    )
+    assert 'href="/static/images/favicon.ico"' in served, (
+        f"Expected the default favicon when settings are unavailable, got: {served}"
+    )
+    assert "<title>SimpleChat</title>" in served, f"Expected the default title, got: {served}"
+
+    print("Shell branding fallback test passed!")
+    return True
+
+
 if __name__ == "__main__":
     tests = [
         test_spa_shell_is_served_for_root_and_deep_links,
         test_missing_bundle_reports_build_instructions,
         test_bundle_output_path_is_inside_static,
+        test_shell_carries_the_configured_favicon_and_title,
+        test_shell_branding_is_escaped,
+        test_shell_falls_back_when_settings_are_unavailable,
     ]
 
     results = []

--- a/ui_tests/test_v2_appearance_branding_and_nav.py
+++ b/ui_tests/test_v2_appearance_branding_and_nav.py
@@ -1,0 +1,245 @@
+# test_v2_appearance_branding_and_nav.py
+"""
+UI test for V2 Appearance branding, the classification banner, the home page and the
+administrator-configured navigation groups.
+
+Version: 0.261.044
+Implemented in: 0.261.044
+
+Six Appearance settings had no visible effect in the V2 interface:
+
+  - the custom light and dark logos and the favicon never appeared, because the
+    bootstrap payload the branding comes from was fetched once at startup and never
+    refreshed, and because the compiled SPA shell hard-coded the shipped favicon;
+  - the classification banner did not render for the same stale-payload reason;
+  - the landing copy, its alignment and the home page logo size configured a page V2
+    did not have;
+  - Custom Pages and External Links were absent from the rail entirely.
+
+Each assertion here is driven by what /api/v2/bootstrap actually reports for the
+deployment under test, so the test states the same contract on any tenant rather than
+depending on one particular configuration. Sections that a deployment has not turned on
+are reported and skipped instead of silently passing.
+"""
+
+import os
+from pathlib import Path
+from urllib.parse import urlparse
+
+import pytest
+from playwright.sync_api import expect
+
+
+BASE_URL = os.getenv("SIMPLECHAT_UI_BASE_URL", "").rstrip("/")
+STORAGE_STATE = os.getenv("SIMPLECHAT_UI_STORAGE_STATE", "") or os.getenv(
+    "SIMPLECHAT_UI_ADMIN_STORAGE_STATE",
+    "",
+)
+
+
+def _require_environment():
+    if not BASE_URL:
+        pytest.skip("Set SIMPLECHAT_UI_BASE_URL to run this UI test.")
+    if not STORAGE_STATE or not Path(STORAGE_STATE).exists():
+        pytest.skip(
+            "Set SIMPLECHAT_UI_STORAGE_STATE or SIMPLECHAT_UI_ADMIN_STORAGE_STATE to a "
+            "valid authenticated Playwright storage state file."
+        )
+
+
+@pytest.fixture
+def v2_context(playwright):
+    """An authenticated browser context pointed at the V2 interface."""
+    _require_environment()
+
+    browser = playwright.chromium.launch()
+    context = browser.new_context(
+        storage_state=STORAGE_STATE,
+        viewport={"width": 1440, "height": 900},
+    )
+    try:
+        yield context
+    finally:
+        context.close()
+        browser.close()
+
+
+def _open_v2(context, path="/v2"):
+    """Load a V2 route and return ``(page, bootstrap_payload)``."""
+    page = context.new_page()
+    response = page.goto(f"{BASE_URL}{path}", wait_until="domcontentloaded")
+
+    assert response is not None, f"Expected a navigation response for {path}."
+    if response.status in {401, 403}:
+        pytest.skip("The configured session is not authorised for the V2 interface.")
+    if response.status == 503:
+        pytest.skip("The V2 bundle is not built in the environment under test.")
+    assert response.ok, f"Expected {path} to load, got HTTP {response.status}."
+
+    bootstrap = page.request.get(f"{BASE_URL}/api/v2/bootstrap")
+    assert bootstrap.ok, f"Expected bootstrap to load, got HTTP {bootstrap.status}."
+
+    # The rail only exists once bootstrap has resolved in the browser too.
+    expect(page.get_by_role("navigation", name="Primary")).to_be_visible()
+
+    return page, bootstrap.json()
+
+
+@pytest.mark.ui
+def test_rail_shows_the_configured_brand_mark(v2_context):
+    """A custom logo must reach the rail, at its own aspect ratio."""
+    page, bootstrap = _open_v2(v2_context)
+    branding = bootstrap["branding"]
+
+    rail = page.get_by_role("navigation", name="Primary")
+    logo = rail.locator("img").first
+
+    if not branding.get("show_logo") or not branding.get("logo_url"):
+        # The letter avatar is the deliberate V2 fallback, not a missing logo.
+        expect(rail.locator("header img, > div img")).to_have_count(0)
+        pytest.skip("No custom logo is configured; the letter avatar is expected.")
+
+    expect(logo).to_be_visible()
+
+    box = logo.bounding_box()
+    assert box is not None, "The rail logo should have a layout box."
+    assert box["height"] <= 40, (
+        f"The rail logo should stay within the 32px brand slot, got {box['height']}px."
+    )
+    # A squashed logo is the symptom of a fixed square box; the rail sizes by height.
+    assert box["width"] > box["height"] * 0.5, (
+        f"The rail logo looks squashed at {box['width']}x{box['height']}."
+    )
+
+
+@pytest.mark.ui
+def test_classification_banner_renders_when_configured(v2_context):
+    """The banner spans the full width above the rail, as it does in the classic UI."""
+    page, bootstrap = _open_v2(v2_context)
+    banner_config = bootstrap["branding"].get("classification_banner")
+
+    banner = page.locator("#classification-banner")
+
+    if not banner_config:
+        expect(banner).to_have_count(0)
+        pytest.skip("No classification banner is configured.")
+
+    expect(banner).to_be_visible()
+    expect(banner).to_have_text(banner_config["text"])
+    expect(banner).to_have_attribute("role", "note")
+
+    banner_box = banner.bounding_box()
+    rail_box = page.get_by_role("navigation", name="Primary").bounding_box()
+    assert banner_box is not None and rail_box is not None
+    assert banner_box["y"] < rail_box["y"], (
+        "The classification banner should sit above the navigation rail."
+    )
+
+
+@pytest.mark.ui
+def test_home_page_renders_landing_content_and_reaches_chat(v2_context):
+    """/v2 is the home page, and its call to action opens chat."""
+    page, bootstrap = _open_v2(v2_context)
+    branding = bootstrap["branding"]
+
+    start = page.get_by_role("link", name="Start chatting")
+    expect(start).to_be_visible()
+
+    if branding.get("show_logo") and branding.get("logo_url"):
+        # The home page logo is sized by "Main Page Logo Size", which the classic home
+        # page applies as a pixel height.
+        hero = page.locator("main img").first
+        expect(hero).to_be_visible()
+        expected = branding["landing_page_logo_scale_percent"]
+        box = hero.bounding_box()
+        assert box is not None
+        assert abs(box["height"] - expected) <= 2, (
+            f"The home page logo should be {expected}px tall, got {box['height']}px."
+        )
+
+    start.click()
+    page.wait_for_url("**/v2/chat")
+    expect(page.get_by_role("navigation", name="Primary")).to_be_visible()
+
+
+@pytest.mark.ui
+def test_home_is_reachable_from_the_rail(v2_context):
+    """Home has to be navigable, since /v2 is where a deep link now lands."""
+    page, _bootstrap = _open_v2(v2_context, "/v2/chat")
+
+    rail = page.get_by_role("navigation", name="Primary")
+    home = rail.get_by_role("link", name="Home")
+    expect(home).to_be_visible()
+
+    home.click()
+    page.wait_for_url(f"{BASE_URL}/v2")
+    expect(page.get_by_role("link", name="Start chatting")).to_be_visible()
+
+
+@pytest.mark.ui
+def test_new_chat_from_the_home_page_opens_chat(v2_context):
+    """The rail is shown everywhere, so New chat has to go somewhere it can be typed."""
+    page, _bootstrap = _open_v2(v2_context)
+
+    rail = page.get_by_role("navigation", name="Primary")
+    rail.get_by_role("button", name="New chat").click()
+
+    page.wait_for_url("**/v2/chat")
+
+
+@pytest.mark.ui
+def test_navigation_groups_appear_in_the_rail(v2_context):
+    """Custom pages and external links are configured centrally and must be shown."""
+    page, bootstrap = _open_v2(v2_context)
+    navigation = bootstrap["navigation"]
+
+    rail = page.get_by_role("navigation", name="Primary")
+    checked = 0
+
+    for group_key in ("custom_pages", "external_links"):
+        group = navigation[group_key]
+        if not group["enabled"] or not group["items"]:
+            continue
+
+        checked += 1
+        expect(rail.get_by_text(group["menu_name"], exact=True)).to_be_visible()
+
+        # Three or more entries collapse behind the menu name, matching the classic rail.
+        if group["force_menu"] or len(group["items"]) > 2:
+            toggle = rail.get_by_role("button", name=group["menu_name"])
+            expect(toggle).to_have_attribute("aria-expanded", "true")
+
+        for item in group["items"]:
+            entry = rail.get_by_role("link", name=item["label"], exact=True).first
+            expect(entry).to_be_visible()
+
+            expected_path = urlparse(item["url"]).path or item["url"]
+            assert expected_path in (entry.get_attribute("href") or ""), (
+                f"{item['label']} should link to {item['url']}."
+            )
+
+            # External destinations leave the application, so they must not replace an
+            # in-progress conversation.
+            if group_key == "external_links":
+                expect(entry).to_have_attribute("target", "_blank")
+                assert "noopener" in (entry.get_attribute("rel") or ""), (
+                    f"{item['label']} must open with rel=noopener."
+                )
+
+    if not checked:
+        pytest.skip("Neither Custom Pages nor External Links is configured.")
+
+
+@pytest.mark.ui
+def test_shell_serves_the_configured_favicon(v2_context):
+    """The shell is a build artefact, so the server has to rewrite its icon link."""
+    page, bootstrap = _open_v2(v2_context)
+    expected = bootstrap["branding"]["favicon_url"]
+
+    href = page.locator('link[rel="icon"]').first.get_attribute("href")
+    assert href == expected, (
+        f"The shell should serve the configured favicon {expected!r}, got {href!r}."
+    )
+
+    icon = page.request.get(f"{BASE_URL}{expected}")
+    assert icon.ok, f"The favicon at {expected} should be served, got HTTP {icon.status}."


### PR DESCRIPTION
Fixes the V2 Admin Settings **Appearance** group: settings that had no visible effect, and five settings that appeared under the wrong tab.

> **Rebased on `paullizer-react-v2-ui` at `0.261.046`.** Two of the causes below were diagnosed and fixed in parallel on the base branch while this branch was in review, and both of those implementations are better than mine, so they are taken whole. See the *Overlap with the base branch* section at the end.

## The symptoms and their causes

**1. Bootstrap was never re-read** — the logos, the rail brand mark and the classification banner.

`useBootstrapStore` fetches `/api/v2/bootstrap` once from `App.tsx` and had no way to reload it; `AdminSettingsPage.save()` merged the PATCH response into its own local `data.settings` and stopped there. `Sidebar.BrandMark` and `AppShell.ClassificationBanner` were both already correct — neither ever received a fresh value.

**Fixed on the base branch in `0.261.046`** (#1402), whose implementation this branch now carries unchanged. Recorded here because it is what was reported against Appearance, and because the causes below are only visible once it is out of the way.

**2. The compiled SPA shell hard-coded the shipped favicon** — the favicon and the tab title.

`application/v2_ui/index.html` is a build input carrying a literal `<link rel="icon" href="/static/images/favicon.ico">` with no version, and a literal `<title>SimpleChat</title>`. `_serve_v2_shell` returned it verbatim.

`base.html` has always appended `?v={{ favicon_version }}` when a custom favicon is stored, precisely because the static file keeps a stable name across uploads — without the version a browser keeps serving whichever icon it already cached. The shell is a build artefact and cannot know an administrator's branding, so the server now rewrites both on the way out. Values are HTML-escaped, replacements are passed as callables so a title containing a backslash is not read as a group reference, and the settings import is lazy inside a `try/except` so a settings failure degrades to defaults rather than a broken page. `App.tsx` also keeps the tab icon in step with an upload made in the same session.

**3. Bootstrap carried no navigation data** — Custom Pages and External Links.

The classic rail reads `custom_pages_nav`, built by `get_custom_pages_nav` in `app.py`'s context processor, and `app_settings.external_links` directly in `_sidebar_nav.html`. Neither reaches a SPA, and neither is derivable from what bootstrap already sent: custom pages are filtered per page against the caller's roles, and the external link list is not an `enable_*` key so it never appears in `features`.

Added `_build_navigation`, reusing `get_custom_pages_nav` and reproducing the `Admin`/`User` role gate from `_sidebar_nav.html:378`.

**4. The undeclared-settings fallback guessed wrong** — the stray toggles.

`buildCapabilityIndex` scans the settings document for `enable_*` booleans and files each under the navigation section sharing the most leading word stems, keeping the first section that scores at all. Simulating it against the real settings keys found **five** misfiles, one more than reported:

| Setting | Guessed into | Now declared under |
|---|---|---|
| `enable_user_workspace` | Appearance › Notices & Agreements › User Agreement | Workspaces › Workspace Types › Personal Workspaces |
| `enable_external_healthcheck` | Appearance › Pages & Links › External Links | Operations › Logging & Health › Health Check |
| `enable_no_auth_external_healthcheck` | Appearance › Pages & Links › External Links | Operations › Logging & Health › Health Check |
| `enable_support_latest_feature_documentation_links` | Appearance › Pages & Links › External Links | Help › User-Facing Latest Features |
| `enable_text_plugin` | Appearance › Branding › Home Page Text | Agents & Actions › Actions |

Each is explainable: `enable_external_healthcheck` matches "external" in `external-links-section`, while `health-check-section` splits into `health` and `check` and can never match the single token `healthcheck`. `enable_support_latest_feature_documentation_links` matches "links" and won on navigation order. Declaring a field is what removes a key from the scan, so all five are now declared with wording copied verbatim from the V1 panes, along with the Support Menu gate chain the documentation-links toggle depends on.

## Also in this PR

**A V2 home page at `/v2`.** The landing text, its alignment and the home page logo size configured a page V2 did not have — `/v2` redirected straight to chat. Home is now the landing route with the logo, the landing markdown and a "Start chatting" link, and is the first entry in the rail. The logo is sized by "Main Page Logo Size" the way the classic home page applies it (the percentage is used as a pixel height; matched rather than corrected, since the slider is calibrated against what an administrator already sees).

**Navigation groups in the rail**, mirroring V1: one or two entries inline, three or more — or any number with "Force Menu Display" — behind the configured menu name with a count. External links always open in a new tab with `rel="noopener noreferrer"`; custom pages honour their own `open_in_new_tab`.

**The rail logo is no longer squashed.** It was drawn into a fixed `h-8 w-8` square; it is now sized by height with its own proportions kept.

**`functions_branding_urls.py`** is a new dependency-free module holding the branding static paths and the `?v=` rule, which were previously restated in `base.html`, `BRANDING_IMAGE_TARGETS` and `_build_branding`.

## Two findings from code review, fixed here

- **Blank landing copy was being replaced with default text.** `get_settings()` deep-merges defaults into every document, so a blank value means an administrator cleared it — and the default wording asserts acceptance of an acceptable use policy. Putting that back on a page somebody deliberately emptied is worse than showing nothing. The copy is now passed through as stored, matching what the classic home page renders.
- **External link URLs were re-served without re-checking their scheme.** `EXTERNAL_LINK_ALLOWED_SCHEMES` is enforced only in `_normalize_link_list`, reachable only from the V2 settings PATCH. The server-rendered admin form stores any non-empty string, so a `javascript:` URL written through the classic form — or already in a settings document — would have become an anchor in every V2 user's rail. `_build_navigation` now drops anything that is not a local path or `http`/`https`.

## Guards against recurrence

- `test_v2_admin_capability_placement.py` ports the stem-match heuristic and asserts the Appearance group, which the schema fully describes, receives **zero** guessed rows. Verified to fail with the exact original symptom (`enable_external_healthcheck -> Appearance > Pages & Links > external-links-section`) when one of the relocated keys is undeclared. It also checks the ported heuristic still matches `buildCapabilityIndex`, so the model cannot go stale silently.
- `test_v2_admin_settings_schema.py` gained a check that every declared default matches `functions_settings.py`. It caught this PR declaring `enable_text_plugin` as `False` while the application defaults it to `True`. All 30 declared defaults now agree.

## Testing

- `test_v2_bootstrap_branding_and_navigation.py` (new) lifts `_build_branding` and `_build_navigation` out of the route with `ast` and **executes** them, rather than asserting on source as the surrounding tests must. Covers favicon versioning, the logo and dark-variant rules, the banner's text requirement, landing field bounds, the role gate, the `javascript:`/`data:`/`vbscript:` filtering, and degradation when the custom page lookup raises.
- `test_v2_navigation_groups_logic.mjs` (new) executes the real inline-versus-menu and visibility rules.
- `test_v2_ui_spa_route.py` extended with the shell rewrite, its escaping, and its fallback when settings are unavailable.
- `ui_tests/test_v2_appearance_branding_and_nav.py` (new) — 7 Playwright tests driven by what `/api/v2/bootstrap` reports for the deployment under test, so they state the same contract on any tenant.

20 functional suites pass, including the base branch's `test_v2_admin_settings_live_shell_refresh.py` and `test_v2_new_chat_scoping.py`, plus both runtime `.mjs` suites, `test_docs_app_surface_coverage` and `test_docs_site_quality`. `npm run build` is clean. No new browser assets — everything reuses already-vendored packages.

## Overlap with the base branch

Two fixes landed upstream while this was open. Both upstream implementations are kept:

- **`bootstrapStore.refresh()`** (`0.261.046`, #1402) reached the same diagnosis and additionally carries a sequence guard so a slower earlier refetch cannot land after a newer one — which this branch did not have. Taken as-is.
- **New chat** (`0.261.044`, #1400) was handled better upstream. This branch made the button navigate to the chat page; upstream instead stopped drawing it anywhere it has nothing to act on, and made `Chats` start a fresh chat on arrival, which also handles the chat store outliving a route change. The navigate-on-click code is dropped. The `end` prop on the nav item is kept, since `/` is a real route now and would otherwise match every path.

## Deliberate divergence from V1

When "Show Logo" is on but no custom logo is uploaded, the classic navigation falls back to the bundled `logo-lightmode.png`. V2 keeps its letter avatar, which is derived from the application title, so an unbranded deployment shows its own name rather than the product's default artwork. Confirmed as intended.

## Docs

- `docs/explanation/fixes/V2_APPEARANCE_PARITY_FIX.md`
- `docs/explanation/features/V2_HOME_PAGE.md`
- Release notes under `v0.261.047`

Version `0.261.046` → `0.261.047`.
