### PR TITLE
Rebuild V2 workspace documents as a file explorer

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -97,7 +97,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.261.044"
+VERSION = "0.261.045"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -97,7 +97,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.261.045"
+VERSION = "0.261.046"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/functions_documents.py
+++ b/application/single_app/functions_documents.py
@@ -1123,19 +1123,63 @@ def select_current_documents(documents):
     return current_documents
 
 
-def sort_documents(documents, sort_by="_ts", sort_order="DESC"):
+def _safe_float(value):
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+# Fields the document lists may be ordered by, split by the type of value they hold.
+#
+# The split is what makes the sort safe. A document that has never been given a value for
+# the sort field still has to compare against one that has, and deriving the fallback from
+# the *field* rather than from the value is the only way to guarantee a single comparable
+# type: a missing numeric field yielding "" while a present one yields an int raises
+# TypeError in Python 3. That hazard is why this was limited to string fields.
+#
+# `upload_date` is text on purpose. It is stored as ISO 8601, which sorts correctly
+# lexicographically, so it needs no parsing to order properly.
+NUMERIC_DOCUMENT_SORT_FIELDS = frozenset({
+    "_ts",
+    "file_size",
+    "number_of_pages",
+    "version",
+})
+
+TEXT_DOCUMENT_SORT_FIELDS = frozenset({
+    "file_name",
+    "title",
+    "upload_date",
+    "document_classification",
+})
+
+ALLOWED_DOCUMENT_SORT_FIELDS = NUMERIC_DOCUMENT_SORT_FIELDS | TEXT_DOCUMENT_SORT_FIELDS
+
+DEFAULT_DOCUMENT_SORT_FIELD = "_ts"
+
+
+def sort_documents(documents, sort_by=DEFAULT_DOCUMENT_SORT_FIELD, sort_order="DESC"):
+    """Order documents by one field, keeping every sort key a single comparable type.
+
+    An unrecognised field falls back to the default rather than raising, which matches what
+    each calling route already does with its own allow-list and hardens the callers that
+    pass a field straight through.
+    """
+    if sort_by not in ALLOWED_DOCUMENT_SORT_FIELDS:
+        sort_by = DEFAULT_DOCUMENT_SORT_FIELD
+
     reverse = str(sort_order).lower() != "asc"
+    numeric = sort_by in NUMERIC_DOCUMENT_SORT_FIELDS
 
     def sort_key(document_item):
         value = document_item.get(sort_by)
-        if sort_by == "_ts":
-            return _safe_int(value)
+        if numeric:
+            return _safe_float(value)
         if value is None:
             return ""
         if isinstance(value, str):
             return value.lower()
-        if isinstance(value, (int, float)):
-            return value
         return str(value).lower()
 
     return sorted(documents or [], key=sort_key, reverse=reverse)

--- a/application/single_app/functions_workspace_sections.py
+++ b/application/single_app/functions_workspace_sections.py
@@ -34,6 +34,7 @@ from functions_settings import is_user_workflows_enabled_for_user
 # Order matters: it is the order the sections are presented in, within their groups.
 WORKSPACE_SECTION_IDS = (
     "documents",
+    "tags",
     "sync",
     "prompts",
     "agents",
@@ -48,6 +49,7 @@ WORKSPACE_SECTION_IDS = (
 # can do, and "connections" is the shared plumbing the other two reuse.
 WORKSPACE_SECTION_GROUPS = {
     "documents": "knowledge",
+    "tags": "knowledge",
     "sync": "knowledge",
     "prompts": "knowledge",
     "agents": "automation",
@@ -167,8 +169,10 @@ def build_workspace_section_availability(
 
     sections = {
         # Documents and prompts have no capability of their own: reaching the workspace at
-        # all already required enable_user_workspace.
+        # all already required enable_user_workspace. Tags is the vocabulary those documents
+        # are filed under, so it is available on exactly the same terms.
         "documents": _section(True),
+        "tags": _section(True),
         "prompts": _section(True),
         "sync": _section(
             file_sync_enabled,

--- a/application/single_app/route_backend_documents.py
+++ b/application/single_app/route_backend_documents.py
@@ -23,6 +23,10 @@ from functions_document_access_index import (
 from utils_cache import invalidate_personal_search_cache
 from functions_debug import *
 from functions_activity_logging import log_document_upload, log_document_metadata_update_transaction
+# Imported explicitly rather than relying on the star imports above: several functions in
+# this module re-import these names locally, which is a sign the star-imported bindings
+# cannot be counted on to be the classes rather than the module.
+from datetime import datetime, timedelta, timezone
 import io
 import os
 import requests
@@ -354,6 +358,260 @@ def _find_accessible_citation_document(user_id, document_id, scope_name):
 
     return None
 
+
+def _load_personal_document_for_delete(user_id, document_id):
+    """Fetch a document the caller may delete, or None when there is no such document."""
+    try:
+        return get_document_record(user_id=user_id, document_id=document_id)
+    except Exception:
+        return None
+
+
+def _personal_document_delete_guard(
+    document_record,
+    document_id,
+    user_id,
+    *,
+    conversation_linked_delete_confirmed=False,
+    file_sync_delete_action=None,
+):
+    """Return the payload that blocks deleting this document, or None to proceed.
+
+    Shared by the single and the bulk delete routes so the two cannot drift. A guard added
+    to one of them alone would otherwise turn the other into a way around it, which matters
+    here because both guards exist to stop a delete that silently damages something else:
+    a conversation that still cites the document, or a file sync pairing that would simply
+    re-create it.
+    """
+    if (
+        document_record.get('created_from_chat_upload')
+        and document_record.get('conversation_id')
+        and not conversation_linked_delete_confirmed
+    ):
+        conversation_id = document_record.get('conversation_id')
+        conversation_url = (
+            document_record.get('conversation_url')
+            or f'/chats?conversation_id={conversation_id}'
+        )
+        return {
+            'error': 'conversation_linked_document_delete_requires_confirmation',
+            'message': 'This document was uploaded through chat and is part of a conversation.',
+            'conversation': {
+                'id': conversation_id,
+                'title': document_record.get('conversation_title_at_upload') or 'Conversation',
+                'url': conversation_url,
+            },
+            'document': {
+                'id': document_id,
+                'file_name': document_record.get('file_name'),
+            },
+        }
+
+    return build_synced_document_delete_guard(
+        FILE_SYNC_SCOPE_PERSONAL,
+        document_id,
+        user_id,
+        requested_action=file_sync_delete_action,
+    ) or None
+
+
+def _load_accessible_personal_documents(user_id):
+    """Every current-revision document the user can see, with no list filters applied.
+
+    Takes the same two paths as the list route: the document access index when it is ready,
+    and the source container otherwise. Kept filter-free on purpose -- the counts built from
+    this describe the whole workspace, so the navigation rail reads as a table of contents
+    instead of shifting underneath the user as they filter.
+    """
+    index_read_result = query_document_access_index_documents(
+        source_scope=DOCUMENT_ACCESS_SCOPE_PERSONAL,
+        user_id=user_id,
+        filters={},
+    )
+    if index_read_result.get('success'):
+        return index_read_result.get('documents', []) or []
+
+    query = """
+        SELECT *
+        FROM c
+        WHERE (c.user_id = @user_id
+            OR ARRAY_CONTAINS(c.shared_user_ids, @user_id)
+            OR EXISTS(SELECT VALUE s FROM s IN c.shared_user_ids WHERE STARTSWITH(s, @user_id_prefix)))
+    """
+    parameters = [
+        {"name": "@user_id", "value": user_id},
+        {"name": "@user_id_prefix", "value": f"{user_id},"},
+    ]
+    matching_documents = list(
+        cosmos_user_documents_container.query_items(
+            query=query,
+            parameters=parameters,
+            enable_cross_partition_query=True,
+        )
+    )
+    return select_current_documents(matching_documents)
+
+
+# The standing views the workspace navigation offers, alongside the content filters. Each
+# describes the *state* of a document rather than its content.
+DOCUMENT_PLACE_FILTERS = frozenset({
+    'all',
+    'recent',
+    'shared',
+    'processing',
+    'errors',
+    'untagged',
+})
+
+DOCUMENT_RECENT_DAYS = 30
+
+
+def _document_processing_state(document_item):
+    """Classify a document as 'error', 'processing' or 'ready'.
+
+    Mirrors what the interfaces show. `status` carries the error text rather than a code, so
+    an error is detected by inspecting it; a document with no `percentage_complete` at all is
+    a legacy record that predates progress tracking and is treated as ready rather than as
+    permanently stuck.
+    """
+    status_text = str(document_item.get('status') or '').lower()
+    if 'error' in status_text or 'failed' in status_text:
+        return 'error'
+
+    percentage = document_item.get('percentage_complete')
+    if percentage is None:
+        return 'ready'
+    try:
+        return 'ready' if float(percentage) >= 100 else 'processing'
+    except (TypeError, ValueError):
+        return 'ready'
+
+
+def build_personal_document_facets(documents, user_id, recent_days=DOCUMENT_RECENT_DAYS):
+    """Count the whole accessible set along the dimensions the navigation rail offers.
+
+    Counting here rather than in the browser is what makes the rail trustworthy: the client
+    only ever holds one page, so any count it derived would describe the page rather than the
+    workspace.
+    """
+    recent_cutoff = datetime.now(timezone.utc) - timedelta(days=recent_days)
+
+    facets = {
+        'total': 0,
+        'untagged': 0,
+        'processing': 0,
+        'errors': 0,
+        'recent': 0,
+        'shared_with_me': 0,
+        'by_tag': {},
+        'by_classification': {},
+    }
+
+    for document_item in documents or []:
+        facets['total'] += 1
+
+        tags = [
+            str(tag).strip()
+            for tag in (document_item.get('tags') or [])
+            if str(tag or '').strip()
+        ]
+        if tags:
+            for tag in tags:
+                facets['by_tag'][tag] = facets['by_tag'].get(tag, 0) + 1
+        else:
+            facets['untagged'] += 1
+
+        state = _document_processing_state(document_item)
+        if state == 'processing':
+            facets['processing'] += 1
+        elif state == 'error':
+            facets['errors'] += 1
+
+        classification = str(document_item.get('document_classification') or '').strip()
+        if classification:
+            facets['by_classification'][classification] = (
+                facets['by_classification'].get(classification, 0) + 1
+            )
+
+        if document_item.get('user_id') != user_id:
+            facets['shared_with_me'] += 1
+
+        upload_date = _parse_document_timestamp(document_item)
+        if upload_date and upload_date >= recent_cutoff:
+            facets['recent'] += 1
+
+    return facets
+
+
+def _parse_document_timestamp(document_item):
+    """Best-effort upload time as an aware datetime, or None when it cannot be read.
+
+    `_ts` is preferred because Cosmos always sets it, whereas `upload_date` is written by the
+    application and is absent on the oldest records.
+    """
+    raw_ts = document_item.get('_ts')
+    if raw_ts is not None:
+        try:
+            return datetime.fromtimestamp(float(raw_ts), tz=timezone.utc)
+        except (TypeError, ValueError, OSError):
+            pass
+
+    raw_upload_date = document_item.get('upload_date')
+    if not raw_upload_date:
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(raw_upload_date).replace('Z', '+00:00'))
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+
+
+def filter_documents_by_place(documents, place, user_id, recent_days=DOCUMENT_RECENT_DAYS):
+    """Narrow a document list to one standing view.
+
+    Applied after the query rather than inside it because every one of these is derived:
+    processing state is read out of free-text `status` and `percentage_complete`, "untagged"
+    is the absence of a value rather than a value, and ownership is only meaningful relative
+    to the caller. The list route already materialises and paginates in Python, so filtering
+    here costs nothing extra.
+    """
+    if place in ('', 'all', None):
+        return documents
+
+    if place == 'untagged':
+        return [
+            document_item for document_item in documents
+            if not [
+                tag for tag in (document_item.get('tags') or [])
+                if str(tag or '').strip()
+            ]
+        ]
+
+    if place == 'shared':
+        return [
+            document_item for document_item in documents
+            if document_item.get('user_id') != user_id
+        ]
+
+    if place in ('processing', 'errors'):
+        wanted_state = 'processing' if place == 'processing' else 'error'
+        return [
+            document_item for document_item in documents
+            if _document_processing_state(document_item) == wanted_state
+        ]
+
+    if place == 'recent':
+        recent_cutoff = datetime.now(timezone.utc) - timedelta(days=recent_days)
+        recent_documents = []
+        for document_item in documents:
+            uploaded_at = _parse_document_timestamp(document_item)
+            if uploaded_at and uploaded_at >= recent_cutoff:
+                recent_documents.append(document_item)
+        return recent_documents
+
+    return documents
+
+
 def register_route_backend_documents(bp):
     @bp.route('/api/get_file_content', methods=['POST'])
     @swagger_route(security=get_auth_security())
@@ -678,6 +936,13 @@ def register_route_backend_documents(bp):
         keywords_filter = request.args.get('keywords', default=None, type=str)
         abstract_filter = request.args.get('abstract', default=None, type=str)
         tags_filter = request.args.get('tags', default=None, type=str)  # Comma-separated tags
+        # Which of the workspace's standing views to narrow to. These describe the *state* of
+        # a document rather than its content, so unlike the filters above they cannot be
+        # expressed in the Cosmos query -- processing state and tag emptiness are derived, and
+        # ownership is only known once the caller is compared against each document.
+        place_filter = str(request.args.get('place', default='', type=str) or '').strip().lower()
+        if place_filter not in DOCUMENT_PLACE_FILTERS:
+            place_filter = 'all'
         sort_by = request.args.get('sort_by', default='_ts', type=str)
         sort_order = request.args.get('sort_order', default='desc', type=str)
 
@@ -685,10 +950,10 @@ def register_route_backend_documents(bp):
         if page < 1: page = 1
         if page_size < 1: page_size = 10
 
-        # Validate sort parameters
-        allowed_sort_fields = {'_ts', 'file_name', 'title'}
-        if sort_by not in allowed_sort_fields:
-            sort_by = '_ts'
+        # Validate sort parameters against the shared allow-list, which also decides
+        # whether the field is compared as a number or as text.
+        if sort_by not in ALLOWED_DOCUMENT_SORT_FIELDS:
+            sort_by = DEFAULT_DOCUMENT_SORT_FIELD
         sort_order = sort_order.upper() if sort_order.lower() in ('asc', 'desc') else 'DESC'
         # Limit page size to prevent abuse? (Optional)
         # page_size = min(page_size, 100)
@@ -857,6 +1122,9 @@ def register_route_backend_documents(bp):
                     source_query_metrics=source_query_metrics,
                     context='api_get_user_documents',
                 )
+            # Narrow to the requested standing view before counting, so the total the client
+            # paginates against describes the view it is actually looking at.
+            current_docs = filter_documents_by_place(current_docs, place_filter, user_id)
             total_count = len(current_docs)
             docs = current_docs[offset:offset + page_size]
 
@@ -1189,43 +1457,20 @@ def register_route_backend_documents(bp):
         if delete_mode not in {'all_versions', 'current_only'}:
             return jsonify({'error': 'Invalid delete mode'}), 400
         conversation_linked_delete_confirmed = request.args.get('conversation_linked_delete_confirmed') == 'true'
-        try:
-            document_record = get_document_record(user_id=user_id, document_id=document_id)
-        except Exception:
-            document_record = None
+        document_record = _load_personal_document_for_delete(user_id, document_id)
         if not document_record:
             return jsonify({'error': 'Document not found or access denied'}), 404
 
-        if (
-            document_record.get('created_from_chat_upload')
-            and document_record.get('conversation_id')
-            and not conversation_linked_delete_confirmed
-        ):
-            conversation_id = document_record.get('conversation_id')
-            conversation_url = document_record.get('conversation_url') or f'/chats?conversation_id={conversation_id}'
-            return jsonify({
-                'error': 'conversation_linked_document_delete_requires_confirmation',
-                'message': 'This document was uploaded through chat and is part of a conversation.',
-                'conversation': {
-                    'id': conversation_id,
-                    'title': document_record.get('conversation_title_at_upload') or 'Conversation',
-                    'url': conversation_url,
-                },
-                'document': {
-                    'id': document_id,
-                    'file_name': document_record.get('file_name'),
-                },
-            }), 409
-
         file_sync_delete_action = request.args.get('file_sync_delete_action')
-        file_sync_guard = build_synced_document_delete_guard(
-            FILE_SYNC_SCOPE_PERSONAL,
+        delete_guard = _personal_document_delete_guard(
+            document_record,
             document_id,
             user_id,
-            requested_action=file_sync_delete_action,
+            conversation_linked_delete_confirmed=conversation_linked_delete_confirmed,
+            file_sync_delete_action=file_sync_delete_action,
         )
-        if file_sync_guard:
-            return jsonify(file_sync_guard), 409
+        if delete_guard:
+            return jsonify(delete_guard), 409
         
         try:
             apply_synced_document_delete_action(
@@ -1245,6 +1490,145 @@ def register_route_backend_documents(bp):
             }), 200
         except Exception as e:
             return jsonify({'error': f'Error deleting document: {str(e)}'}), 500
+
+    @bp.route('/api/documents/bulk-delete', methods=['POST'])
+    @swagger_route(security=get_auth_security())
+    @login_required
+    @user_required
+    @enabled_required("enable_user_workspace")
+    def api_bulk_delete_user_documents():
+        """Delete several documents in one request.
+
+        Request body:
+        {
+            "document_ids": ["doc1", "doc2", ...],
+            "delete_mode": "all_versions" | "current_only",
+            "conversation_linked_delete_confirmed": false,
+            "file_sync_delete_action": null
+        }
+
+        Reports per document instead of failing the batch, because the two delete guards
+        apply to individual documents: one document uploaded through chat would otherwise
+        block the deletion of everything selected alongside it. A guarded document comes back
+        in ``errors`` carrying the same payload the single delete answers 409 with, so the
+        client can ask about exactly those documents and resubmit them with the confirmation.
+        """
+        user_id = get_current_user_id()
+        if not user_id:
+            return jsonify({'error': 'User not authenticated'}), 401
+
+        data = request.get_json(silent=True) or {}
+        document_ids = data.get('document_ids')
+        if not isinstance(document_ids, list) or not document_ids:
+            return jsonify({'error': 'document_ids must be a non-empty array'}), 400
+
+        delete_mode = data.get('delete_mode', 'all_versions')
+        if delete_mode not in {'all_versions', 'current_only'}:
+            return jsonify({'error': 'Invalid delete mode'}), 400
+
+        conversation_linked_delete_confirmed = bool(
+            data.get('conversation_linked_delete_confirmed')
+        )
+        file_sync_delete_action = data.get('file_sync_delete_action')
+
+        deleted = []
+        errors = []
+        seen_document_ids = set()
+
+        for raw_document_id in document_ids:
+            document_id = str(raw_document_id or '').strip()
+            if not document_id or document_id in seen_document_ids:
+                continue
+            seen_document_ids.add(document_id)
+
+            document_record = _load_personal_document_for_delete(user_id, document_id)
+            if not document_record:
+                errors.append({
+                    'document_id': document_id,
+                    'error': 'document_not_found',
+                    'message': 'Document not found or access denied',
+                    'needs_confirmation': False,
+                })
+                continue
+
+            delete_guard = _personal_document_delete_guard(
+                document_record,
+                document_id,
+                user_id,
+                conversation_linked_delete_confirmed=conversation_linked_delete_confirmed,
+                file_sync_delete_action=file_sync_delete_action,
+            )
+            if delete_guard:
+                errors.append({
+                    'document_id': document_id,
+                    'needs_confirmation': True,
+                    **delete_guard,
+                })
+                continue
+
+            try:
+                apply_synced_document_delete_action(
+                    FILE_SYNC_SCOPE_PERSONAL,
+                    document_id,
+                    user_id,
+                    file_sync_delete_action,
+                )
+                delete_result = delete_document_revision(
+                    user_id, document_id, delete_mode=delete_mode
+                )
+                deleted.append({
+                    'document_id': document_id,
+                    **(delete_result or {}),
+                })
+            except Exception as delete_error:
+                errors.append({
+                    'document_id': document_id,
+                    'error': 'document_delete_failed',
+                    'message': str(delete_error),
+                    'needs_confirmation': False,
+                })
+
+        # Once for the batch rather than per document: the cache is keyed by user, so
+        # invalidating it inside the loop would repeat identical work for every document.
+        if deleted:
+            invalidate_personal_search_cache(user_id)
+
+        return jsonify({
+            'message': f'Deleted {len(deleted)} of {len(seen_document_ids)} documents',
+            'deleted': deleted,
+            'errors': errors,
+            'deleted_count': len(deleted),
+            'error_count': len(errors),
+        }), 200
+
+    @bp.route('/api/documents/facets', methods=['GET'])
+    @swagger_route(security=get_auth_security())
+    @login_required
+    @user_required
+    @enabled_required("enable_user_workspace")
+    def api_get_user_document_facets():
+        """Counts describing the caller's whole document workspace.
+
+        Deliberately unfiltered. These counts drive a navigation rail, and a rail whose
+        entries re-count themselves against the current filter would collapse to zeroes the
+        moment a user selected anything in it.
+        """
+        user_id = get_current_user_id()
+        if not user_id:
+            return jsonify({'error': 'User not authenticated'}), 401
+
+        try:
+            documents = _load_accessible_personal_documents(user_id)
+        except Exception as facet_error:
+            log_event(
+                f"[DOCUMENT_FACETS] Failed to load documents for facets: {facet_error}",
+                extra={'user_id': user_id},
+                level=logging.ERROR,
+                exceptionTraceback=True,
+            )
+            return jsonify({'error': 'Error building document facets'}), 500
+
+        return jsonify(build_personal_document_facets(documents, user_id)), 200
 
     @bp.route('/api/documents/<document_id>/extract_metadata', methods=['POST'])
     @swagger_route(security=get_auth_security())

--- a/application/single_app/route_backend_users.py
+++ b/application/single_app/route_backend_users.py
@@ -523,6 +523,9 @@ def register_route_backend_users(bp):
                     # dockedSidebarHidden / chatLayout, which describe the classic
                     # interface's own surfaces and would change its layout too.
                     'v2RailCollapsed', 'v2ChatWidth',
+                    # Whether the personal workspace's own section rail is collapsed to
+                    # icons. Separate from v2RailCollapsed, which is the shell's rail.
+                    'v2WorkspaceRailCollapsed',
                     # V2 document explorer: how the workspace documents list is presented
                     # (view mode, visible columns, page size, details pane) and the saved
                     # filter combinations pinned in its navigation rail.

--- a/application/single_app/route_backend_users.py
+++ b/application/single_app/route_backend_users.py
@@ -523,6 +523,10 @@ def register_route_backend_users(bp):
                     # dockedSidebarHidden / chatLayout, which describe the classic
                     # interface's own surfaces and would change its layout too.
                     'v2RailCollapsed', 'v2ChatWidth',
+                    # V2 document explorer: how the workspace documents list is presented
+                    # (view mode, visible columns, page size, details pane) and the saved
+                    # filter combinations pinned in its navigation rail.
+                    'v2DocumentsPrefs', 'v2DocumentSavedViews',
                     # Default colours for diagrams and charts rendered in the V2 chat. A block
                     # someone recolours individually stores its own style on the message.
                     'v2MermaidStyle', 'v2ChartStyle',

--- a/application/v2_ui/src/components/documents/DocumentDetailsPane.tsx
+++ b/application/v2_ui/src/components/documents/DocumentDetailsPane.tsx
@@ -9,13 +9,14 @@
 // Metadata is presented, not previewed. There is no general document-preview endpoint, so
 // promising a preview here would mean promising something the server cannot supply.
 
-import { clsx } from 'clsx';
 import {
+    Check,
     Download,
     FileStack,
     MessageSquare,
     PanelRightClose,
     Pencil,
+    RefreshCw,
     Share2,
     Sparkles,
     Tag as TagIcon,
@@ -27,11 +28,15 @@ import {
     commonTags,
     documentDate,
     documentDisplayName,
+    extractionMode as documentExtractionMode,
+    extractionModeLabel,
     formatAbsoluteDate,
     formatFileSize,
     normalizeStringList,
     normalizeTags,
+    summarizeExtraction,
     totalFileSize,
+    type ExtractionMode,
 } from '../../lib/documentExplorer';
 import { GlassButton } from '../ui/primitives';
 import {
@@ -66,6 +71,13 @@ export interface DocumentActionAvailability {
     extractMetadata: boolean;
     sharing: boolean;
     classification: boolean;
+    /**
+     * Whether Enhanced extraction is switched on for the deployment.
+     *
+     * The reprocess route rejects a request for `layout` outright when it is not, so the
+     * option is disabled with a reason rather than offered and refused.
+     */
+    enhancedExtraction: boolean;
 }
 
 export interface DocumentPaneActions {
@@ -149,6 +161,114 @@ function ActionButtons({
     );
 }
 
+/**
+ * The re-extraction control.
+ *
+ * Previously two equal buttons labelled Standard and Enhanced, with nothing saying which one
+ * the document was already on -- so changing it meant guessing and then checking. The current
+ * mode is now stated, the button for it is inert and marked as current, and the other one is
+ * the actionable choice. Documents that are neither PDFs nor images do not go through
+ * Document Intelligence at all, so the control is not offered for them.
+ */
+function ReextractSection({
+    documents,
+    enhancedEnabled,
+    onReextract,
+}: {
+    documents: WorkspaceDocument[];
+    enhancedEnabled: boolean;
+    onReextract: (documents: WorkspaceDocument[], mode: ExtractionMode) => void;
+}) {
+    const { supported, unsupported, current } = summarizeExtraction(documents);
+
+    if (supported.length === 0) {
+        return null;
+    }
+
+    const currentLabel =
+        current === 'mixed'
+            ? 'Mixed'
+            : current
+              ? extractionModeLabel(current)
+              : 'Not recorded';
+
+    const options: { mode: ExtractionMode; label: string; hint: string }[] = [
+        {
+            mode: 'read',
+            label: 'Standard',
+            hint: 'Faster and cheaper. Best for plain text PDFs and images.',
+        },
+        {
+            mode: 'layout',
+            label: 'Enhanced',
+            hint: 'Preserves tables, page structure and checkboxes. Slower and costlier.',
+        },
+    ];
+
+    return (
+        <Section title="Extraction">
+            <p className="mb-2 text-xs text-text-2">
+                Currently:{' '}
+                <span className="font-medium text-text-1">{currentLabel}</span>
+                {supported.length > 1 ? (
+                    <span className="text-text-3">
+                        {' '}
+                        across {supported.length} documents
+                    </span>
+                ) : null}
+            </p>
+
+            <div className="flex flex-wrap gap-1.5">
+                {options.map((option) => {
+                    const isCurrent = current === option.mode;
+                    const blocked = option.mode === 'layout' && !enhancedEnabled;
+
+                    if (isCurrent) {
+                        return (
+                            <span
+                                key={option.mode}
+                                className="inline-flex items-center gap-1 rounded-xl border border-edge bg-surface-2 px-3 py-1.5 text-sm text-text-3"
+                                title={`These documents were already extracted with ${option.label}.`}
+                            >
+                                <Check size={13} />
+                                {option.label}
+                                <span className="text-[11px]">(current)</span>
+                            </span>
+                        );
+                    }
+
+                    return (
+                        <GlassButton
+                            key={option.mode}
+                            variant="subtle"
+                            size="sm"
+                            disabled={blocked}
+                            onClick={() => onReextract(supported, option.mode)}
+                            title={
+                                blocked
+                                    ? 'Enhanced extraction is switched off for this deployment.'
+                                    : `${option.hint} Re-reads ${supported.length === 1 ? 'this document' : `these ${supported.length} documents`}.`
+                            }
+                        >
+                            <RefreshCw size={13} />
+                            {current ? `Switch to ${option.label}` : `Extract as ${option.label}`}
+                        </GlassButton>
+                    );
+                })}
+            </div>
+
+            {unsupported.length > 0 ? (
+                <p className="mt-1.5 text-[11px] text-text-3">
+                    {unsupported.length} of the selected{' '}
+                    {unsupported.length === 1 ? 'document is' : 'documents are'} not a PDF or
+                    image, so the extraction mode does not apply and{' '}
+                    {unsupported.length === 1 ? 'it will' : 'they will'} be left alone.
+                </p>
+            ) : null}
+        </Section>
+    );
+}
+
 export function DocumentDetailsPane({
     documents,
     availability,
@@ -229,24 +349,11 @@ export function DocumentDetailsPane({
                         )}
                     </Section>
 
-                    <Section title="Re-extract">
-                        <div className="flex gap-1.5">
-                            <GlassButton
-                                variant="subtle"
-                                size="sm"
-                                onClick={() => actions.onReextract(documents, 'read')}
-                            >
-                                Standard
-                            </GlassButton>
-                            <GlassButton
-                                variant="subtle"
-                                size="sm"
-                                onClick={() => actions.onReextract(documents, 'layout')}
-                            >
-                                Enhanced
-                            </GlassButton>
-                        </div>
-                    </Section>
+                    <ReextractSection
+                        documents={documents}
+                        enhancedEnabled={availability.enhancedExtraction}
+                        onReextract={actions.onReextract}
+                    />
                 </div>
 
                 <div className="border-t border-edge">
@@ -267,7 +374,7 @@ export function DocumentDetailsPane({
     const keywords = normalizeStringList(document.keywords);
     const classification = String(document.document_classification ?? '').trim();
     const abstract = String(document.abstract ?? '').trim();
-    const extractionMode = String(document.document_intelligence_extraction_mode ?? '').trim();
+    const currentExtraction = documentExtractionMode(document);
     const sharedCount = Array.isArray(document.shared_user_ids)
         ? document.shared_user_ids.length
         : 0;
@@ -324,9 +431,9 @@ export function DocumentDetailsPane({
                         <Field label="Uploaded">
                             {formatAbsoluteDate(documentDate(document))}
                         </Field>
-                        {extractionMode ? (
+                        {currentExtraction ? (
                             <Field label="Extraction">
-                                {extractionMode === 'layout' ? 'Enhanced' : 'Standard'}
+                                {extractionModeLabel(currentExtraction)}
                             </Field>
                         ) : null}
                     </dl>
@@ -376,29 +483,11 @@ export function DocumentDetailsPane({
                     </Section>
                 ) : null}
 
-                <Section title="Re-extract">
-                    <p className="mb-1.5 text-xs text-text-3">
-                        Read the file again, either quickly or with layout analysis.
-                    </p>
-                    <div className="flex gap-1.5">
-                        <GlassButton
-                            variant="subtle"
-                            size="sm"
-                            onClick={() => actions.onReextract([document], 'read')}
-                            className={clsx(extractionMode === 'read' && 'opacity-60')}
-                        >
-                            Standard
-                        </GlassButton>
-                        <GlassButton
-                            variant="subtle"
-                            size="sm"
-                            onClick={() => actions.onReextract([document], 'layout')}
-                            className={clsx(extractionMode === 'layout' && 'opacity-60')}
-                        >
-                            Enhanced
-                        </GlassButton>
-                    </div>
-                </Section>
+                <ReextractSection
+                    documents={[document]}
+                    enhancedEnabled={availability.enhancedExtraction}
+                    onReextract={actions.onReextract}
+                />
             </div>
 
             <div className="border-t border-edge">

--- a/application/v2_ui/src/components/documents/DocumentDetailsPane.tsx
+++ b/application/v2_ui/src/components/documents/DocumentDetailsPane.tsx
@@ -1,0 +1,413 @@
+// DocumentDetailsPane.tsx
+// The right-hand pane: what is selected, and what can be done with it.
+//
+// Three states, matching a file manager's details pane. Nothing selected, one document, or
+// several. The multi-selection state is the one that earns the pane: it is where a bulk
+// operation can state what it is about to touch -- how many documents, how large, which tags
+// they already share -- instead of a toolbar button acting on an invisible set.
+//
+// Metadata is presented, not previewed. There is no general document-preview endpoint, so
+// promising a preview here would mean promising something the server cannot supply.
+
+import { clsx } from 'clsx';
+import {
+    Download,
+    FileStack,
+    MessageSquare,
+    PanelRightClose,
+    Pencil,
+    Share2,
+    Sparkles,
+    Tag as TagIcon,
+    Trash2,
+} from 'lucide-react';
+import type { ReactNode } from 'react';
+import type { WorkspaceDocument } from '../../lib/types';
+import {
+    commonTags,
+    documentDate,
+    documentDisplayName,
+    formatAbsoluteDate,
+    formatFileSize,
+    normalizeStringList,
+    normalizeTags,
+    totalFileSize,
+} from '../../lib/documentExplorer';
+import { GlassButton } from '../ui/primitives';
+import {
+    ClassificationBadge,
+    DocumentIcon,
+    DocumentStatusBadge,
+    TagChip,
+} from './documentPresentation';
+
+function Field({ label, children }: { label: string; children: ReactNode }) {
+    return (
+        <div className="grid grid-cols-[7rem_1fr] gap-2 py-1 text-xs">
+            <dt className="text-text-3">{label}</dt>
+            <dd className="min-w-0 break-words text-text-2">{children}</dd>
+        </div>
+    );
+}
+
+function Section({ title, children }: { title: string; children: ReactNode }) {
+    return (
+        <section className="border-t border-edge px-3 py-2.5">
+            <h4 className="mb-1 text-[11px] font-semibold tracking-wide text-text-3 uppercase">
+                {title}
+            </h4>
+            {children}
+        </section>
+    );
+}
+
+export interface DocumentActionAvailability {
+    downloads: boolean;
+    extractMetadata: boolean;
+    sharing: boolean;
+    classification: boolean;
+}
+
+export interface DocumentPaneActions {
+    onChat: (documents: WorkspaceDocument[]) => void;
+    onDownload: (documents: WorkspaceDocument[]) => void;
+    onEditMetadata: (document: WorkspaceDocument) => void;
+    onExtractMetadata: (documents: WorkspaceDocument[]) => void;
+    onReextract: (documents: WorkspaceDocument[], mode: 'read' | 'layout') => void;
+    onShare: (document: WorkspaceDocument) => void;
+    onManageTags: (documents: WorkspaceDocument[]) => void;
+    onDelete: (documents: WorkspaceDocument[]) => void;
+    onSelectTag: (tag: string) => void;
+    onRemoveTag: (documents: WorkspaceDocument[], tag: string) => void;
+}
+
+function ActionButtons({
+    documents,
+    availability,
+    actions,
+}: {
+    documents: WorkspaceDocument[];
+    availability: DocumentActionAvailability;
+    actions: DocumentPaneActions;
+}) {
+    const single = documents.length === 1 ? documents[0] : null;
+
+    return (
+        <div className="flex flex-wrap gap-1.5 px-3 py-2.5">
+            <GlassButton variant="primary" size="sm" onClick={() => actions.onChat(documents)}>
+                <MessageSquare size={14} />
+                Chat
+            </GlassButton>
+
+            {availability.downloads ? (
+                <GlassButton variant="subtle" size="sm" onClick={() => actions.onDownload(documents)}>
+                    <Download size={14} />
+                    Download
+                </GlassButton>
+            ) : null}
+
+            <GlassButton variant="subtle" size="sm" onClick={() => actions.onManageTags(documents)}>
+                <TagIcon size={14} />
+                Tag
+            </GlassButton>
+
+            {single ? (
+                <GlassButton
+                    variant="subtle"
+                    size="sm"
+                    onClick={() => actions.onEditMetadata(single)}
+                >
+                    <Pencil size={14} />
+                    Edit
+                </GlassButton>
+            ) : null}
+
+            {availability.extractMetadata ? (
+                <GlassButton
+                    variant="subtle"
+                    size="sm"
+                    onClick={() => actions.onExtractMetadata(documents)}
+                    title="Ask the model to re-read the file and fill in title, authors, keywords and abstract"
+                >
+                    <Sparkles size={14} />
+                    Extract
+                </GlassButton>
+            ) : null}
+
+            {single && availability.sharing ? (
+                <GlassButton variant="subtle" size="sm" onClick={() => actions.onShare(single)}>
+                    <Share2 size={14} />
+                    Share
+                </GlassButton>
+            ) : null}
+
+            <GlassButton variant="danger" size="sm" onClick={() => actions.onDelete(documents)}>
+                <Trash2 size={14} />
+                Delete
+            </GlassButton>
+        </div>
+    );
+}
+
+export function DocumentDetailsPane({
+    documents,
+    availability,
+    actions,
+    tagColors,
+    classificationColors,
+    onClose,
+}: {
+    /** The current selection, resolved to documents. */
+    documents: WorkspaceDocument[];
+    availability: DocumentActionAvailability;
+    actions: DocumentPaneActions;
+    tagColors: Record<string, string | undefined>;
+    classificationColors: Record<string, string | undefined>;
+    onClose: () => void;
+}) {
+    const header = (
+        <div className="flex items-center justify-between gap-2 px-3 py-2">
+            <h3 className="truncate text-xs font-semibold tracking-wide text-text-3 uppercase">
+                Details
+            </h3>
+            <button
+                type="button"
+                onClick={onClose}
+                aria-label="Hide details pane"
+                className="rounded-lg p-1 text-text-3 transition-colors hover:bg-surface-2 hover:text-text-1"
+            >
+                <PanelRightClose size={15} />
+            </button>
+        </div>
+    );
+
+    if (documents.length === 0) {
+        return (
+            <aside className="flex w-80 shrink-0 flex-col overflow-hidden rounded-xl border border-edge bg-surface-1">
+                {header}
+                <p className="px-3 py-6 text-center text-xs text-text-3">
+                    Select a document to see its details.
+                </p>
+            </aside>
+        );
+    }
+
+    if (documents.length > 1) {
+        const shared = commonTags(documents);
+        return (
+            <aside className="flex w-80 shrink-0 flex-col overflow-hidden rounded-xl border border-edge bg-surface-1">
+                {header}
+                <div className="min-h-0 flex-1 overflow-y-auto">
+                    <div className="flex items-center gap-2.5 px-3 pb-3">
+                        <FileStack size={22} className="shrink-0 text-text-3" />
+                        <div className="min-w-0">
+                            <p className="text-sm font-medium text-text-1">
+                                {documents.length} documents selected
+                            </p>
+                            <p className="text-xs text-text-3">
+                                {formatFileSize(totalFileSize(documents))} total
+                            </p>
+                        </div>
+                    </div>
+
+                    <Section title="Tags on all selected">
+                        {shared.length > 0 ? (
+                            <div className="flex flex-wrap gap-1">
+                                {shared.map((tag) => (
+                                    <TagChip
+                                        key={tag}
+                                        name={tag}
+                                        color={tagColors[tag]}
+                                        onRemove={() => actions.onRemoveTag(documents, tag)}
+                                    />
+                                ))}
+                            </div>
+                        ) : (
+                            <p className="text-xs text-text-3">
+                                These documents have no tag in common.
+                            </p>
+                        )}
+                    </Section>
+
+                    <Section title="Re-extract">
+                        <div className="flex gap-1.5">
+                            <GlassButton
+                                variant="subtle"
+                                size="sm"
+                                onClick={() => actions.onReextract(documents, 'read')}
+                            >
+                                Standard
+                            </GlassButton>
+                            <GlassButton
+                                variant="subtle"
+                                size="sm"
+                                onClick={() => actions.onReextract(documents, 'layout')}
+                            >
+                                Enhanced
+                            </GlassButton>
+                        </div>
+                    </Section>
+                </div>
+
+                <div className="border-t border-edge">
+                    <ActionButtons
+                        documents={documents}
+                        availability={availability}
+                        actions={actions}
+                    />
+                </div>
+            </aside>
+        );
+    }
+
+    const document = documents[0];
+    const { primary, secondary } = documentDisplayName(document);
+    const tags = normalizeTags(document.tags);
+    const authors = normalizeStringList(document.authors);
+    const keywords = normalizeStringList(document.keywords);
+    const classification = String(document.document_classification ?? '').trim();
+    const abstract = String(document.abstract ?? '').trim();
+    const extractionMode = String(document.document_intelligence_extraction_mode ?? '').trim();
+    const sharedCount = Array.isArray(document.shared_user_ids)
+        ? document.shared_user_ids.length
+        : 0;
+
+    return (
+        <aside className="flex w-80 shrink-0 flex-col overflow-hidden rounded-xl border border-edge bg-surface-1">
+            {header}
+            <div className="min-h-0 flex-1 overflow-y-auto">
+                <div className="flex items-start gap-2.5 px-3 pb-3">
+                    <DocumentIcon document={document} size={22} className="mt-0.5" />
+                    <div className="min-w-0">
+                        <p className="text-sm font-medium break-words text-text-1">{primary}</p>
+                        {secondary ? (
+                            <p className="text-xs break-all text-text-3">{secondary}</p>
+                        ) : null}
+                        <div className="mt-1.5">
+                            <DocumentStatusBadge document={document} showProgressBar />
+                        </div>
+                    </div>
+                </div>
+
+                <Section title="Tags">
+                    {tags.length > 0 ? (
+                        <div className="flex flex-wrap gap-1">
+                            {tags.map((tag) => (
+                                <TagChip
+                                    key={tag}
+                                    name={tag}
+                                    color={tagColors[tag]}
+                                    onClick={() => actions.onSelectTag(tag)}
+                                    onRemove={() => actions.onRemoveTag([document], tag)}
+                                />
+                            ))}
+                        </div>
+                    ) : (
+                        <p className="text-xs text-text-3">Not tagged.</p>
+                    )}
+                </Section>
+
+                <Section title="File">
+                    <dl>
+                        {availability.classification && classification ? (
+                            <Field label="Classification">
+                                <ClassificationBadge
+                                    classification={classification}
+                                    color={classificationColors[classification]}
+                                />
+                            </Field>
+                        ) : null}
+                        <Field label="Size">{formatFileSize(document.file_size)}</Field>
+                        <Field label="Pages">{document.number_of_pages ?? '—'}</Field>
+                        <Field label="Version">{document.version ?? '—'}</Field>
+                        <Field label="Chunks">{document.num_chunks ?? '—'}</Field>
+                        <Field label="Uploaded">
+                            {formatAbsoluteDate(documentDate(document))}
+                        </Field>
+                        {extractionMode ? (
+                            <Field label="Extraction">
+                                {extractionMode === 'layout' ? 'Enhanced' : 'Standard'}
+                            </Field>
+                        ) : null}
+                    </dl>
+                </Section>
+
+                {authors.length > 0 || keywords.length > 0 || document.publication_date ? (
+                    <Section title="Metadata">
+                        <dl>
+                            {authors.length > 0 ? (
+                                <Field label="Authors">{authors.join(', ')}</Field>
+                            ) : null}
+                            {keywords.length > 0 ? (
+                                <Field label="Keywords">{keywords.join(', ')}</Field>
+                            ) : null}
+                            {document.publication_date ? (
+                                <Field label="Published">
+                                    {String(document.publication_date)}
+                                </Field>
+                            ) : null}
+                        </dl>
+                    </Section>
+                ) : null}
+
+                {abstract ? (
+                    <Section title="Abstract">
+                        <p className="text-xs leading-relaxed text-text-2">{abstract}</p>
+                    </Section>
+                ) : null}
+
+                {availability.sharing && sharedCount > 0 ? (
+                    <Section title="Sharing">
+                        <p className="text-xs text-text-2">
+                            Shared with {sharedCount} {sharedCount === 1 ? 'person' : 'people'}.
+                        </p>
+                    </Section>
+                ) : null}
+
+                {document.created_from_chat_upload && document.conversation_id ? (
+                    <Section title="Source">
+                        <p className="text-xs text-text-2">
+                            Uploaded through chat
+                            {document.conversation_title_at_upload
+                                ? ` in "${document.conversation_title_at_upload}"`
+                                : ''}
+                            .
+                        </p>
+                    </Section>
+                ) : null}
+
+                <Section title="Re-extract">
+                    <p className="mb-1.5 text-xs text-text-3">
+                        Read the file again, either quickly or with layout analysis.
+                    </p>
+                    <div className="flex gap-1.5">
+                        <GlassButton
+                            variant="subtle"
+                            size="sm"
+                            onClick={() => actions.onReextract([document], 'read')}
+                            className={clsx(extractionMode === 'read' && 'opacity-60')}
+                        >
+                            Standard
+                        </GlassButton>
+                        <GlassButton
+                            variant="subtle"
+                            size="sm"
+                            onClick={() => actions.onReextract([document], 'layout')}
+                            className={clsx(extractionMode === 'layout' && 'opacity-60')}
+                        >
+                            Enhanced
+                        </GlassButton>
+                    </div>
+                </Section>
+            </div>
+
+            <div className="border-t border-edge">
+                <ActionButtons
+                    documents={documents}
+                    availability={availability}
+                    actions={actions}
+                />
+            </div>
+        </aside>
+    );
+}

--- a/application/v2_ui/src/components/documents/DocumentDialogs.tsx
+++ b/application/v2_ui/src/components/documents/DocumentDialogs.tsx
@@ -1,0 +1,783 @@
+// DocumentDialogs.tsx
+// The modal surfaces the explorer opens: tagging, metadata, sharing and delete confirmation.
+//
+// Each exists because the work genuinely does not fit in the details pane. Tagging several
+// documents needs the whole vocabulary visible; editing metadata is a form with seven
+// fields; sharing is a search; and the delete confirmation has to report which documents the
+// server refused and why, which is the part the classic interface handles least well.
+
+import { useEffect, useMemo, useState } from 'react';
+import { clsx } from 'clsx';
+import { Loader2, Search, Trash2, X } from 'lucide-react';
+import type { ReactNode } from 'react';
+import type { WorkspaceDocument, WorkspaceTag } from '../../lib/types';
+import {
+    commonTags,
+    documentDisplayName,
+    normalizeStringList,
+    normalizeTags,
+} from '../../lib/documentExplorer';
+import {
+    fetchPersonalDocumentSharedUsers,
+    searchShareableUsers,
+    sharePersonalDocument,
+    unsharePersonalDocument,
+    type BulkDeleteError,
+    type SharedDocumentUser,
+} from '../../lib/endpoints';
+import { GlassButton } from '../ui/primitives';
+import { readableTextColor } from './documentPresentation';
+
+/* -------------------------------------------------------------------------- */
+/* Shell                                                                       */
+/* -------------------------------------------------------------------------- */
+
+export function Modal({
+    title,
+    description,
+    onClose,
+    children,
+    footer,
+    wide = false,
+}: {
+    title: string;
+    description?: string;
+    onClose: () => void;
+    children: ReactNode;
+    footer?: ReactNode;
+    wide?: boolean;
+}) {
+    useEffect(() => {
+        const onKeyDown = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') {
+                onClose();
+            }
+        };
+        window.addEventListener('keydown', onKeyDown);
+        return () => window.removeEventListener('keydown', onKeyDown);
+    }, [onClose]);
+
+    return (
+        <div
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+            role="dialog"
+            aria-modal="true"
+            aria-label={title}
+            onClick={onClose}
+        >
+            <div
+                onClick={(event) => event.stopPropagation()}
+                className={clsx(
+                    'glass-modal flex max-h-[85vh] w-full flex-col rounded-2xl',
+                    wide ? 'max-w-2xl' : 'max-w-lg',
+                )}
+            >
+                <div className="flex items-start justify-between gap-3 border-b border-edge px-4 py-3">
+                    <div className="min-w-0">
+                        <h2 className="text-sm font-semibold text-text-1">{title}</h2>
+                        {description ? (
+                            <p className="mt-0.5 text-xs text-text-3">{description}</p>
+                        ) : null}
+                    </div>
+                    <button
+                        type="button"
+                        onClick={onClose}
+                        aria-label="Close"
+                        className="rounded-lg p-1 text-text-3 transition-colors hover:bg-surface-2 hover:text-text-1"
+                    >
+                        <X size={16} />
+                    </button>
+                </div>
+
+                <div className="min-h-0 flex-1 overflow-y-auto px-4 py-3">{children}</div>
+
+                {footer ? (
+                    <div className="flex items-center justify-end gap-2 border-t border-edge px-4 py-3">
+                        {footer}
+                    </div>
+                ) : null}
+            </div>
+        </div>
+    );
+}
+
+function TextField({
+    label,
+    value,
+    onChange,
+    placeholder,
+    hint,
+}: {
+    label: string;
+    value: string;
+    onChange: (value: string) => void;
+    placeholder?: string;
+    hint?: string;
+}) {
+    return (
+        <label className="block">
+            <span className="mb-1 block text-xs font-medium text-text-2">{label}</span>
+            <input
+                type="text"
+                value={value}
+                placeholder={placeholder}
+                onChange={(event) => onChange(event.target.value)}
+                className="w-full rounded-lg border border-edge bg-surface-1 px-2.5 py-1.5 text-sm text-text-1 placeholder:text-text-3 focus:border-accent focus:outline-none"
+            />
+            {hint ? <span className="mt-0.5 block text-[11px] text-text-3">{hint}</span> : null}
+        </label>
+    );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Tagging                                                                     */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Apply and remove tags across a selection.
+ *
+ * A tag carried by only some of the selected documents is shown as partial rather than as
+ * present or absent, because both of those would be a lie and acting on either would quietly
+ * change documents the user was not looking at.
+ */
+export function TagDialog({
+    documents,
+    tags,
+    busy,
+    onClose,
+    onApply,
+    onCreateTag,
+}: {
+    documents: WorkspaceDocument[];
+    tags: WorkspaceTag[];
+    busy: boolean;
+    onClose: () => void;
+    onApply: (added: string[], removed: string[]) => void;
+    onCreateTag: (name: string) => Promise<void>;
+}) {
+    const shared = useMemo(() => new Set(commonTags(documents)), [documents]);
+    const present = useMemo(() => {
+        const all = new Set<string>();
+        for (const document of documents) {
+            for (const tag of normalizeTags(document.tags)) {
+                all.add(tag);
+            }
+        }
+        return all;
+    }, [documents]);
+
+    const [added, setAdded] = useState<Set<string>>(new Set());
+    const [removed, setRemoved] = useState<Set<string>>(new Set());
+    const [newTag, setNewTag] = useState('');
+    const [creating, setCreating] = useState(false);
+
+    const toggle = (name: string) => {
+        const isOnAll = shared.has(name);
+        if (isOnAll) {
+            setRemoved((current) => {
+                const next = new Set(current);
+                next.has(name) ? next.delete(name) : next.add(name);
+                return next;
+            });
+            return;
+        }
+        setAdded((current) => {
+            const next = new Set(current);
+            next.has(name) ? next.delete(name) : next.add(name);
+            return next;
+        });
+    };
+
+    const createTag = async () => {
+        const name = newTag.trim();
+        if (!name) {
+            return;
+        }
+        setCreating(true);
+        try {
+            await onCreateTag(name);
+            setAdded((current) => new Set(current).add(name));
+            setNewTag('');
+        } finally {
+            setCreating(false);
+        }
+    };
+
+    return (
+        <Modal
+            title={
+                documents.length === 1
+                    ? `Tag ${documentDisplayName(documents[0]).primary}`
+                    : `Tag ${documents.length} documents`
+            }
+            description="Tags are flat: a document can carry as many as it needs."
+            onClose={onClose}
+            footer={
+                <>
+                    <GlassButton variant="ghost" size="sm" onClick={onClose}>
+                        Cancel
+                    </GlassButton>
+                    <GlassButton
+                        variant="primary"
+                        size="sm"
+                        disabled={busy || (added.size === 0 && removed.size === 0)}
+                        onClick={() => onApply([...added], [...removed])}
+                    >
+                        {busy ? <Loader2 size={14} className="animate-spin" /> : null}
+                        Apply
+                    </GlassButton>
+                </>
+            }
+        >
+            <div className="space-y-3">
+                <div className="flex gap-2">
+                    <input
+                        type="text"
+                        value={newTag}
+                        placeholder="New tag name"
+                        onChange={(event) => setNewTag(event.target.value)}
+                        onKeyDown={(event) => {
+                            if (event.key === 'Enter') {
+                                event.preventDefault();
+                                void createTag();
+                            }
+                        }}
+                        className="flex-1 rounded-lg border border-edge bg-surface-1 px-2.5 py-1.5 text-sm text-text-1 placeholder:text-text-3 focus:border-accent focus:outline-none"
+                    />
+                    <GlassButton
+                        variant="subtle"
+                        size="sm"
+                        onClick={() => void createTag()}
+                        disabled={!newTag.trim() || creating}
+                    >
+                        {creating ? <Loader2 size={14} className="animate-spin" /> : null}
+                        Create
+                    </GlassButton>
+                </div>
+
+                {tags.length === 0 ? (
+                    <p className="py-4 text-center text-xs text-text-3">
+                        No tags yet. Create one above.
+                    </p>
+                ) : (
+                    <ul className="space-y-0.5">
+                        {tags.map((tag) => {
+                            const onAll = shared.has(tag.name);
+                            const onSome = !onAll && present.has(tag.name);
+                            const willAdd = added.has(tag.name);
+                            const willRemove = removed.has(tag.name);
+                            const checked = onAll ? !willRemove : willAdd;
+
+                            return (
+                                <li key={tag.name}>
+                                    <label className="flex cursor-pointer items-center gap-2 rounded-lg px-2 py-1.5 hover:bg-surface-2">
+                                        <input
+                                            type="checkbox"
+                                            checked={checked}
+                                            ref={(node) => {
+                                                if (node) {
+                                                    node.indeterminate = onSome && !willAdd;
+                                                }
+                                            }}
+                                            onChange={() => toggle(tag.name)}
+                                            className="h-3.5 w-3.5 accent-[var(--accent)]"
+                                        />
+                                        <span
+                                            aria-hidden="true"
+                                            className="h-2.5 w-2.5 shrink-0 rounded-full border border-edge"
+                                            style={{ backgroundColor: tag.color || 'transparent' }}
+                                        />
+                                        <span className="min-w-0 flex-1 truncate text-sm text-text-1">
+                                            {tag.name}
+                                        </span>
+                                        {onSome ? (
+                                            <span className="text-[10px] text-text-3">
+                                                on some
+                                            </span>
+                                        ) : null}
+                                        {typeof tag.count === 'number' ? (
+                                            <span className="text-[11px] tabular-nums text-text-3">
+                                                {tag.count}
+                                            </span>
+                                        ) : null}
+                                    </label>
+                                </li>
+                            );
+                        })}
+                    </ul>
+                )}
+            </div>
+        </Modal>
+    );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Metadata                                                                    */
+/* -------------------------------------------------------------------------- */
+
+export interface MetadataDraft {
+    title: string;
+    authors: string;
+    keywords: string;
+    abstract: string;
+    publication_date: string;
+    document_classification: string;
+}
+
+export function MetadataDialog({
+    document,
+    classifications,
+    classificationEnabled,
+    busy,
+    onClose,
+    onSave,
+}: {
+    document: WorkspaceDocument;
+    classifications: { label: string; color?: string }[];
+    classificationEnabled: boolean;
+    busy: boolean;
+    onClose: () => void;
+    onSave: (draft: MetadataDraft) => void;
+}) {
+    const [draft, setDraft] = useState<MetadataDraft>({
+        title: String(document.title ?? ''),
+        authors: normalizeStringList(document.authors).join(', '),
+        keywords: normalizeStringList(document.keywords).join(', '),
+        abstract: String(document.abstract ?? ''),
+        publication_date: String(document.publication_date ?? ''),
+        document_classification: String(document.document_classification ?? ''),
+    });
+
+    const update = (change: Partial<MetadataDraft>) =>
+        setDraft((current) => ({ ...current, ...change }));
+
+    return (
+        <Modal
+            title="Edit metadata"
+            description={String(document.file_name ?? '')}
+            onClose={onClose}
+            wide
+            footer={
+                <>
+                    <GlassButton variant="ghost" size="sm" onClick={onClose}>
+                        Cancel
+                    </GlassButton>
+                    <GlassButton
+                        variant="primary"
+                        size="sm"
+                        disabled={busy}
+                        onClick={() => onSave(draft)}
+                    >
+                        {busy ? <Loader2 size={14} className="animate-spin" /> : null}
+                        Save
+                    </GlassButton>
+                </>
+            }
+        >
+            <div className="space-y-3">
+                <TextField
+                    label="Title"
+                    value={draft.title}
+                    onChange={(title) => update({ title })}
+                    hint="Shown above the file name everywhere the document is listed."
+                />
+
+                <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                    <TextField
+                        label="Authors"
+                        value={draft.authors}
+                        onChange={(authors) => update({ authors })}
+                        placeholder="Comma separated"
+                    />
+                    <TextField
+                        label="Publication date"
+                        value={draft.publication_date}
+                        onChange={(publication_date) => update({ publication_date })}
+                        placeholder="YYYY-MM-DD"
+                    />
+                </div>
+
+                <TextField
+                    label="Keywords"
+                    value={draft.keywords}
+                    onChange={(keywords) => update({ keywords })}
+                    placeholder="Comma separated"
+                />
+
+                {classificationEnabled && classifications.length > 0 ? (
+                    <label className="block">
+                        <span className="mb-1 block text-xs font-medium text-text-2">
+                            Classification
+                        </span>
+                        <select
+                            value={draft.document_classification}
+                            onChange={(event) =>
+                                update({ document_classification: event.target.value })
+                            }
+                            className="w-full rounded-lg border border-edge bg-surface-1 px-2.5 py-1.5 text-sm text-text-1 focus:border-accent focus:outline-none"
+                        >
+                            <option value="">None</option>
+                            {classifications.map((classification) => (
+                                <option key={classification.label} value={classification.label}>
+                                    {classification.label}
+                                </option>
+                            ))}
+                        </select>
+                    </label>
+                ) : null}
+
+                <label className="block">
+                    <span className="mb-1 block text-xs font-medium text-text-2">Abstract</span>
+                    <textarea
+                        value={draft.abstract}
+                        rows={5}
+                        onChange={(event) => update({ abstract: event.target.value })}
+                        className="w-full resize-y rounded-lg border border-edge bg-surface-1 px-2.5 py-1.5 text-sm text-text-1 placeholder:text-text-3 focus:border-accent focus:outline-none"
+                    />
+                </label>
+            </div>
+        </Modal>
+    );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Delete                                                                      */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Confirm a delete, and report what the server refused.
+ *
+ * The second part is the reason this is a dialog rather than an inline confirm. A document
+ * uploaded through chat, or one managed by file sync, is guarded server-side and comes back
+ * unrefused with a reason. Presenting those documents by name -- and offering to go ahead
+ * anyway -- is the only way the user can act on the answer.
+ */
+export function DeleteDialog({
+    documents,
+    blocked,
+    busy,
+    onClose,
+    onConfirm,
+}: {
+    documents: WorkspaceDocument[];
+    blocked: BulkDeleteError[];
+    busy: boolean;
+    onClose: () => void;
+    onConfirm: (options: { force: boolean; deleteAllVersions: boolean }) => void;
+}) {
+    const [deleteAllVersions, setDeleteAllVersions] = useState(true);
+    const hasBlocked = blocked.length > 0;
+
+    return (
+        <Modal
+            title={hasBlocked ? 'Some documents need confirmation' : 'Delete documents'}
+            description={
+                hasBlocked
+                    ? undefined
+                    : documents.length === 1
+                      ? documentDisplayName(documents[0]).primary
+                      : `${documents.length} documents will be removed from your workspace.`
+            }
+            onClose={onClose}
+            footer={
+                <>
+                    <GlassButton variant="ghost" size="sm" onClick={onClose}>
+                        Cancel
+                    </GlassButton>
+                    <GlassButton
+                        variant="danger"
+                        size="sm"
+                        disabled={busy}
+                        onClick={() =>
+                            onConfirm({ force: hasBlocked, deleteAllVersions })
+                        }
+                    >
+                        {busy ? (
+                            <Loader2 size={14} className="animate-spin" />
+                        ) : (
+                            <Trash2 size={14} />
+                        )}
+                        {hasBlocked ? 'Delete anyway' : 'Delete'}
+                    </GlassButton>
+                </>
+            }
+        >
+            {hasBlocked ? (
+                <div className="space-y-2">
+                    <p className="text-xs text-text-2">
+                        These are referenced elsewhere. Deleting them will not remove those
+                        references.
+                    </p>
+                    <ul className="space-y-1.5">
+                        {blocked.map((entry) => {
+                            const document = documents.find(
+                                (candidate) =>
+                                    String(candidate.id ?? candidate.document_id) ===
+                                    entry.document_id,
+                            );
+                            return (
+                                <li
+                                    key={entry.document_id}
+                                    className="rounded-lg border border-edge bg-surface-1 px-2.5 py-2"
+                                >
+                                    <p className="truncate text-xs font-medium text-text-1">
+                                        {document
+                                            ? documentDisplayName(document).primary
+                                            : entry.document_id}
+                                    </p>
+                                    <p className="mt-0.5 text-[11px] text-text-3">
+                                        {entry.message ?? entry.error}
+                                    </p>
+                                </li>
+                            );
+                        })}
+                    </ul>
+                </div>
+            ) : (
+                <div className="space-y-3">
+                    <ul className="max-h-48 space-y-1 overflow-y-auto">
+                        {documents.slice(0, 20).map((document) => (
+                            <li
+                                key={String(document.id ?? document.document_id)}
+                                className="truncate text-xs text-text-2"
+                            >
+                                {documentDisplayName(document).primary}
+                            </li>
+                        ))}
+                        {documents.length > 20 ? (
+                            <li className="text-xs text-text-3">
+                                and {documents.length - 20} more
+                            </li>
+                        ) : null}
+                    </ul>
+
+                    <label className="flex cursor-pointer items-start gap-2">
+                        <input
+                            type="checkbox"
+                            checked={deleteAllVersions}
+                            onChange={(event) => setDeleteAllVersions(event.target.checked)}
+                            className="mt-0.5 h-3.5 w-3.5 accent-[var(--accent)]"
+                        />
+                        <span className="text-xs text-text-2">
+                            Delete every version
+                            <span className="mt-0.5 block text-[11px] text-text-3">
+                                Clearing this removes only the current revision and restores the
+                                one before it.
+                            </span>
+                        </span>
+                    </label>
+                </div>
+            )}
+        </Modal>
+    );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Sharing                                                                     */
+/* -------------------------------------------------------------------------- */
+
+export function ShareDialog({
+    document,
+    onClose,
+    onChanged,
+}: {
+    document: WorkspaceDocument;
+    onClose: () => void;
+    onChanged: () => void;
+}) {
+    const documentId = String(document.id ?? document.document_id ?? '');
+    const [sharedUsers, setSharedUsers] = useState<SharedDocumentUser[]>([]);
+    const [term, setTerm] = useState('');
+    const [results, setResults] = useState<SharedDocumentUser[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [searching, setSearching] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const loadSharedUsers = async () => {
+        setLoading(true);
+        try {
+            const response = await fetchPersonalDocumentSharedUsers(documentId);
+            setSharedUsers(response.shared_users ?? []);
+        } catch {
+            setError('Could not load who this is shared with.');
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        void loadSharedUsers();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [documentId]);
+
+    const search = async () => {
+        const query = term.trim();
+        if (!query) {
+            return;
+        }
+        setSearching(true);
+        setError(null);
+        try {
+            setResults(await searchShareableUsers(query));
+        } catch {
+            setError('User search failed.');
+        } finally {
+            setSearching(false);
+        }
+    };
+
+    const share = async (userId: string) => {
+        try {
+            await sharePersonalDocument(documentId, userId);
+            await loadSharedUsers();
+            onChanged();
+        } catch {
+            setError('Could not share the document with that person.');
+        }
+    };
+
+    const unshare = async (userId: string) => {
+        try {
+            await unsharePersonalDocument(documentId, userId);
+            await loadSharedUsers();
+            onChanged();
+        } catch {
+            setError('Could not stop sharing with that person.');
+        }
+    };
+
+    return (
+        <Modal
+            title="Share document"
+            description={String(document.file_name ?? '')}
+            onClose={onClose}
+            footer={
+                <GlassButton variant="ghost" size="sm" onClick={onClose}>
+                    Done
+                </GlassButton>
+            }
+        >
+            <div className="space-y-4">
+                {error ? (
+                    <p className="rounded-lg bg-danger-soft px-2.5 py-1.5 text-xs text-danger">
+                        {error}
+                    </p>
+                ) : null}
+
+                <div>
+                    <h3 className="mb-1.5 text-xs font-semibold text-text-2">Shared with</h3>
+                    {loading ? (
+                        <p className="text-xs text-text-3">Loading…</p>
+                    ) : sharedUsers.length === 0 ? (
+                        <p className="text-xs text-text-3">Not shared with anyone yet.</p>
+                    ) : (
+                        <ul className="space-y-1">
+                            {sharedUsers.map((user) => (
+                                <li
+                                    key={user.id}
+                                    className="flex items-center gap-2 rounded-lg border border-edge px-2.5 py-1.5"
+                                >
+                                    <div className="min-w-0 flex-1">
+                                        <p className="truncate text-xs text-text-1">
+                                            {user.displayName || user.id}
+                                        </p>
+                                        {user.email ? (
+                                            <p className="truncate text-[11px] text-text-3">
+                                                {user.email}
+                                            </p>
+                                        ) : null}
+                                    </div>
+                                    {user.approval_status === 'not_approved' ? (
+                                        <span className="rounded-full bg-warn-soft px-2 py-0.5 text-[10px] font-medium text-warn">
+                                            Pending
+                                        </span>
+                                    ) : null}
+                                    <button
+                                        type="button"
+                                        onClick={() => void unshare(user.id)}
+                                        className="rounded px-1.5 py-0.5 text-[11px] text-text-3 hover:bg-danger-soft hover:text-danger"
+                                    >
+                                        Remove
+                                    </button>
+                                </li>
+                            ))}
+                        </ul>
+                    )}
+                </div>
+
+                <div>
+                    <h3 className="mb-1.5 text-xs font-semibold text-text-2">Add someone</h3>
+                    <div className="flex gap-2">
+                        <div className="relative flex-1">
+                            <Search
+                                size={14}
+                                className="pointer-events-none absolute top-1/2 left-2.5 -translate-y-1/2 text-text-3"
+                            />
+                            <input
+                                type="search"
+                                value={term}
+                                onChange={(event) => setTerm(event.target.value)}
+                                onKeyDown={(event) => {
+                                    if (event.key === 'Enter') {
+                                        event.preventDefault();
+                                        void search();
+                                    }
+                                }}
+                                placeholder="Search by name or email"
+                                className="w-full rounded-lg border border-edge bg-surface-1 py-1.5 pr-2 pl-7 text-sm text-text-1 placeholder:text-text-3 focus:border-accent focus:outline-none"
+                            />
+                        </div>
+                        <GlassButton
+                            variant="subtle"
+                            size="sm"
+                            onClick={() => void search()}
+                            disabled={searching || !term.trim()}
+                        >
+                            {searching ? <Loader2 size={14} className="animate-spin" /> : null}
+                            Search
+                        </GlassButton>
+                    </div>
+
+                    {results.length > 0 ? (
+                        <ul className="mt-2 space-y-1">
+                            {results.map((user) => (
+                                <li
+                                    key={user.id}
+                                    className="flex items-center gap-2 rounded-lg border border-edge px-2.5 py-1.5"
+                                >
+                                    <div className="min-w-0 flex-1">
+                                        <p className="truncate text-xs text-text-1">
+                                            {user.displayName || user.id}
+                                        </p>
+                                        {user.email ? (
+                                            <p className="truncate text-[11px] text-text-3">
+                                                {user.email}
+                                            </p>
+                                        ) : null}
+                                    </div>
+                                    <GlassButton
+                                        variant="subtle"
+                                        size="sm"
+                                        onClick={() => void share(user.id)}
+                                    >
+                                        Add
+                                    </GlassButton>
+                                </li>
+                            ))}
+                        </ul>
+                    ) : null}
+                </div>
+            </div>
+        </Modal>
+    );
+}
+
+/** A tag swatch used by the tag manager, kept here so the colour maths has one home. */
+export function TagSwatch({ color }: { color?: string }) {
+    return (
+        <span
+            className="inline-flex h-5 w-5 items-center justify-center rounded border border-edge"
+            style={{ backgroundColor: color || 'transparent', color: readableTextColor(color) }}
+        />
+    );
+}

--- a/application/v2_ui/src/components/documents/DocumentExplorer.tsx
+++ b/application/v2_ui/src/components/documents/DocumentExplorer.tsx
@@ -1,0 +1,1005 @@
+// DocumentExplorer.tsx
+// The workspace documents explorer.
+//
+// Command bar, navigation rail, content pane, details pane and status bar. The layout is
+// borrowed deliberately: giving each concern a permanent region is what stops the toolbar
+// from becoming the dumping ground it is in the classic interface, where navigation,
+// filtering, presentation and editing all compete for one band above the list.
+//
+// This component owns the query, the selection and the loading. The pieces around it are
+// presentational, and the rules they share -- how a range selects, what a filter chip
+// removes, when a page resets -- live in lib/documentExplorer.ts so they can be tested
+// without a renderer.
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { FileText, Loader2, Upload } from 'lucide-react';
+import type {
+    DocumentExplorerPrefs,
+    DocumentQuery,
+    DocumentSavedView,
+    DocumentSortField,
+    WorkspaceDocument,
+    WorkspaceTag,
+} from '../../lib/types';
+import {
+    DEFAULT_DOCUMENT_PAGE_SIZE,
+    DEFAULT_DOCUMENT_QUERY,
+    EMPTY_SELECTION,
+    applyQueryChange,
+    applySelection,
+    clearAllFilters,
+    clearFilterChip,
+    describeActiveFilters,
+    documentId,
+    documentStatus,
+    moveSelection,
+    normalizeSortField,
+    pruneSelection,
+    toggleSelectAll,
+    toggleSort,
+    type SelectionIntent,
+    type SelectionState,
+} from '../../lib/documentExplorer';
+import {
+    applySavedView,
+    createSavedView,
+    isSaveableQuery,
+    parseSavedViews,
+    removeSavedView,
+    upsertSavedView,
+} from '../../lib/documentSavedViews';
+import {
+    bulkDeletePersonalDocuments,
+    bulkTagPersonalDocuments,
+    createPersonalDocumentTag,
+    downloadPersonalDocument,
+    downloadPersonalDocuments,
+    extractPersonalDocumentMetadata,
+    fetchPersonalDocument,
+    fetchPersonalDocumentFacets,
+    fetchPersonalDocumentTags,
+    fetchPersonalDocuments,
+    reprocessPersonalDocumentExtraction,
+    updatePersonalDocumentMetadata,
+    uploadPersonalDocuments,
+    type BulkDeleteError,
+} from '../../lib/endpoints';
+import { useBootstrapStore } from '../../stores/bootstrapStore';
+import { useUserSettingsStore } from '../../stores/userSettingsStore';
+import { toast } from '../../stores/toastStore';
+import { EmptyState, GlassButton, Skeleton } from '../ui/primitives';
+import { errorMessage } from '../workspace/useSectionResource';
+import { ExplorerRail } from './ExplorerRail';
+import {
+    ExplorerCommandBar,
+    ExplorerStatusBar,
+    FilterChips,
+} from './ExplorerCommandBar';
+import { DEFAULT_DOCUMENT_COLUMNS, DocumentTable } from './DocumentTable';
+import { DocumentTiles } from './DocumentTiles';
+import { DocumentDetailsPane } from './DocumentDetailsPane';
+import {
+    DeleteDialog,
+    MetadataDialog,
+    ShareDialog,
+    TagDialog,
+    type MetadataDraft,
+} from './DocumentDialogs';
+
+/** How often an in-flight document is re-checked. Matches the classic interface. */
+const PROGRESS_POLL_MS = 5000;
+
+const DEFAULT_PREFS: DocumentExplorerPrefs = {
+    viewMode: 'details',
+    pageSize: DEFAULT_DOCUMENT_PAGE_SIZE,
+    detailsPaneOpen: true,
+    columns: DEFAULT_DOCUMENT_COLUMNS,
+    sortBy: '_ts',
+    sortOrder: 'desc',
+};
+
+type ActiveDialog =
+    | { kind: 'tag'; documents: WorkspaceDocument[] }
+    | { kind: 'metadata'; document: WorkspaceDocument }
+    | { kind: 'share'; document: WorkspaceDocument }
+    | { kind: 'delete'; documents: WorkspaceDocument[]; blocked: BulkDeleteError[] }
+    | null;
+
+/** Hand a blob to the browser as a download without navigating the tab. */
+function saveBlob(blob: Blob, fileName: string) {
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = fileName;
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+    URL.revokeObjectURL(url);
+}
+
+export function DocumentExplorer() {
+    const features = useBootstrapStore((state) => state.data?.features);
+    const settings = useBootstrapStore((state) => state.data?.settings);
+    const userSettings = useUserSettingsStore((state) => state.settings);
+    const saveUserSettings = useUserSettingsStore((state) => state.update);
+
+    const storedPrefs = userSettings.v2DocumentsPrefs;
+    const prefs: DocumentExplorerPrefs = useMemo(
+        () => ({
+            ...DEFAULT_PREFS,
+            ...(storedPrefs ?? {}),
+            columns: storedPrefs?.columns?.length
+                ? storedPrefs.columns
+                : DEFAULT_PREFS.columns,
+        }),
+        [storedPrefs],
+    );
+
+    const savedViews = useMemo(
+        () => parseSavedViews(userSettings.v2DocumentSavedViews),
+        [userSettings.v2DocumentSavedViews],
+    );
+
+    const [query, setQuery] = useState<DocumentQuery>(() => ({
+        ...DEFAULT_DOCUMENT_QUERY,
+        pageSize: prefs.pageSize,
+        sortBy: normalizeSortField(prefs.sortBy),
+        sortOrder: prefs.sortOrder === 'asc' ? 'asc' : 'desc',
+    }));
+    const [searchDraft, setSearchDraft] = useState('');
+
+    const [documents, setDocuments] = useState<WorkspaceDocument[]>([]);
+    const [totalCount, setTotalCount] = useState(0);
+    const [downloadsEnabled, setDownloadsEnabled] = useState(false);
+    const [tags, setTags] = useState<WorkspaceTag[]>([]);
+    const [facets, setFacets] = useState<Parameters<typeof ExplorerRail>[0]['facets']>(null);
+
+    const [selection, setSelection] = useState<SelectionState>(EMPTY_SELECTION);
+    const [loading, setLoading] = useState(true);
+    const [busy, setBusy] = useState(false);
+    const [uploading, setUploading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [dialog, setDialog] = useState<ActiveDialog>(null);
+
+    const fileInputRef = useRef<HTMLInputElement>(null);
+    const containerRef = useRef<HTMLDivElement>(null);
+
+    const classifications = useMemo(() => {
+        const raw = settings?.document_classification_categories;
+        if (!Array.isArray(raw)) {
+            return [] as { label: string; color?: string }[];
+        }
+        return raw
+            .map((entry) => {
+                const record = entry as { label?: unknown; color?: unknown };
+                return {
+                    label: String(record?.label ?? '').trim(),
+                    color: record?.color ? String(record.color) : undefined,
+                };
+            })
+            .filter((entry) => entry.label);
+    }, [settings]);
+
+    const tagColors = useMemo(() => {
+        const colors: Record<string, string | undefined> = {};
+        for (const tag of tags) {
+            colors[tag.name] = tag.color;
+        }
+        return colors;
+    }, [tags]);
+
+    const classificationColors = useMemo(() => {
+        const colors: Record<string, string | undefined> = {};
+        for (const classification of classifications) {
+            colors[classification.label] = classification.color;
+        }
+        return colors;
+    }, [classifications]);
+
+    const availability = useMemo(
+        () => ({
+            downloads: downloadsEnabled,
+            extractMetadata: Boolean(features?.enable_extract_meta_data),
+            sharing: Boolean(features?.enable_file_sharing),
+            classification: Boolean(features?.enable_document_classification),
+        }),
+        [downloadsEnabled, features],
+    );
+
+    const orderedIds = useMemo(() => documents.map(documentId), [documents]);
+    const selectedDocuments = useMemo(
+        () => documents.filter((item) => selection.ids.includes(documentId(item))),
+        [documents, selection.ids],
+    );
+
+    /* ---------------------------------------------------------------------- */
+    /* Loading                                                                 */
+    /* ---------------------------------------------------------------------- */
+
+    const loadDocuments = useCallback(
+        async (signal?: AbortSignal) => {
+            setLoading(true);
+            setError(null);
+            try {
+                const response = await fetchPersonalDocuments(query, signal);
+                const items = response.documents ?? response.items ?? [];
+                setDocuments(items);
+                setTotalCount(Number(response.total_count ?? items.length));
+                setDownloadsEnabled(Boolean(response.file_downloads_enabled));
+                setSelection((current) => pruneSelection(current, items.map(documentId)));
+            } catch (loadError) {
+                if ((loadError as Error)?.name === 'AbortError') {
+                    return;
+                }
+                setError(errorMessage(loadError, 'Failed to load documents.'));
+            } finally {
+                setLoading(false);
+            }
+        },
+        [query],
+    );
+
+    const loadSidebar = useCallback(async (signal?: AbortSignal) => {
+        const [tagsResult, facetsResult] = await Promise.allSettled([
+            fetchPersonalDocumentTags(signal),
+            fetchPersonalDocumentFacets(signal),
+        ]);
+        if (tagsResult.status === 'fulfilled') {
+            setTags(tagsResult.value.tags ?? []);
+        }
+        if (facetsResult.status === 'fulfilled') {
+            setFacets(facetsResult.value);
+        }
+    }, []);
+
+    useEffect(() => {
+        const controller = new AbortController();
+        void loadDocuments(controller.signal);
+        return () => controller.abort();
+    }, [loadDocuments]);
+
+    useEffect(() => {
+        const controller = new AbortController();
+        void loadSidebar(controller.signal);
+        return () => controller.abort();
+    }, [loadSidebar]);
+
+    /** Reload the list and the rail together, after anything that changes both. */
+    const refreshAll = useCallback(async () => {
+        await Promise.all([loadDocuments(), loadSidebar()]);
+    }, [loadDocuments, loadSidebar]);
+
+    /* ---------------------------------------------------------------------- */
+    /* Progress polling                                                        */
+    /* ---------------------------------------------------------------------- */
+
+    const processingIds = useMemo(
+        () =>
+            documents
+                .filter((item) => documentStatus(item).state === 'processing')
+                .map(documentId)
+                .filter(Boolean),
+        [documents],
+    );
+
+    useEffect(() => {
+        if (processingIds.length === 0) {
+            return;
+        }
+
+        let cancelled = false;
+        const timer = window.setInterval(async () => {
+            // Refreshed one document at a time rather than by re-listing: a poll that
+            // re-fetched the page would fight the user's scroll position and selection every
+            // few seconds for as long as anything was indexing.
+            const updates = await Promise.allSettled(
+                processingIds.map((id) => fetchPersonalDocument(id)),
+            );
+            if (cancelled) {
+                return;
+            }
+
+            const byId = new Map<string, WorkspaceDocument>();
+            for (const update of updates) {
+                if (update.status === 'fulfilled') {
+                    const id = documentId(update.value);
+                    if (id) {
+                        byId.set(id, update.value);
+                    }
+                }
+            }
+            if (byId.size === 0) {
+                return;
+            }
+
+            setDocuments((current) =>
+                current.map((item) => byId.get(documentId(item)) ?? item),
+            );
+
+            const finished = [...byId.values()].some(
+                (item) => documentStatus(item).state !== 'processing',
+            );
+            if (finished) {
+                void loadSidebar();
+            }
+        }, PROGRESS_POLL_MS);
+
+        return () => {
+            cancelled = true;
+            window.clearInterval(timer);
+        };
+    }, [processingIds, loadSidebar]);
+
+    /* ---------------------------------------------------------------------- */
+    /* Preferences                                                             */
+    /* ---------------------------------------------------------------------- */
+
+    const updatePrefs = useCallback(
+        (change: Partial<DocumentExplorerPrefs>) => {
+            saveUserSettings({ v2DocumentsPrefs: { ...prefs, ...change } });
+        },
+        [prefs, saveUserSettings],
+    );
+
+    /* ---------------------------------------------------------------------- */
+    /* Query                                                                   */
+    /* ---------------------------------------------------------------------- */
+
+    const changeQuery = useCallback((change: Partial<DocumentQuery>) => {
+        setQuery((current) => applyQueryChange(current, change));
+    }, []);
+
+    // Debounced so typing does not issue a request per keystroke.
+    useEffect(() => {
+        const timer = window.setTimeout(() => {
+            setQuery((current) =>
+                current.search === searchDraft
+                    ? current
+                    : applyQueryChange(current, { search: searchDraft }),
+            );
+        }, 300);
+        return () => window.clearTimeout(timer);
+    }, [searchDraft]);
+
+    const onSort = useCallback(
+        (field: DocumentSortField) => {
+            setQuery((current) => {
+                const next = toggleSort(current, field);
+                updatePrefs({ sortBy: next.sortBy, sortOrder: next.sortOrder });
+                return { ...next, page: 1 };
+            });
+        },
+        [updatePrefs],
+    );
+
+    /* ---------------------------------------------------------------------- */
+    /* Selection                                                               */
+    /* ---------------------------------------------------------------------- */
+
+    const onSelect = useCallback(
+        (id: string, intent: SelectionIntent) => {
+            setSelection((current) => applySelection(current, id, intent, orderedIds));
+        },
+        [orderedIds],
+    );
+
+    useEffect(() => {
+        const onKeyDown = (event: KeyboardEvent) => {
+            const target = event.target as HTMLElement | null;
+            const typing =
+                target &&
+                (target.tagName === 'INPUT' ||
+                    target.tagName === 'TEXTAREA' ||
+                    target.isContentEditable);
+            if (typing || dialog) {
+                return;
+            }
+            if (!containerRef.current?.contains(document.activeElement) &&
+                document.activeElement !== document.body) {
+                return;
+            }
+
+            if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 'a') {
+                event.preventDefault();
+                setSelection({ ids: [...orderedIds], anchorId: orderedIds[0] ?? null });
+                return;
+            }
+            if (event.key === 'Escape') {
+                setSelection(EMPTY_SELECTION);
+                return;
+            }
+            if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+                event.preventDefault();
+                setSelection((current) =>
+                    moveSelection(
+                        current,
+                        orderedIds,
+                        event.key === 'ArrowDown' ? 1 : -1,
+                        event.shiftKey,
+                    ),
+                );
+            }
+        };
+
+        window.addEventListener('keydown', onKeyDown);
+        return () => window.removeEventListener('keydown', onKeyDown);
+    }, [orderedIds, dialog]);
+
+    const onDragStart = useCallback(
+        (event: React.DragEvent, id: string) => {
+            // Dragging an unselected row drags that row alone, which is what every file
+            // manager does and what stops a stale selection being filed by accident.
+            const ids = selection.ids.includes(id) ? selection.ids : [id];
+            if (!selection.ids.includes(id)) {
+                setSelection({ ids: [id], anchorId: id });
+            }
+            event.dataTransfer.setData(
+                'application/x-simplechat-documents',
+                JSON.stringify(ids),
+            );
+            event.dataTransfer.effectAllowed = 'copy';
+        },
+        [selection.ids],
+    );
+
+    /* ---------------------------------------------------------------------- */
+    /* Actions                                                                 */
+    /* ---------------------------------------------------------------------- */
+
+    const runBulkTag = useCallback(
+        async (
+            ids: string[],
+            action: 'add_tags' | 'remove_tags',
+            tagNames: string[],
+            options: { undoable?: boolean } = {},
+        ) => {
+            if (ids.length === 0 || tagNames.length === 0) {
+                return;
+            }
+            setBusy(true);
+            try {
+                await bulkTagPersonalDocuments(ids, action, tagNames);
+                await refreshAll();
+
+                const verb = action === 'add_tags' ? 'Tagged' : 'Untagged';
+                const message = `${verb} ${ids.length} ${ids.length === 1 ? 'document' : 'documents'}`;
+                if (options.undoable) {
+                    toast.success(`${message} with ${tagNames.join(', ')}`, {
+                        label: 'Undo',
+                        onAct: () => {
+                            void runBulkTag(
+                                ids,
+                                action === 'add_tags' ? 'remove_tags' : 'add_tags',
+                                tagNames,
+                            );
+                        },
+                    });
+                } else {
+                    toast.success(message);
+                }
+            } catch (tagError) {
+                toast.error(errorMessage(tagError, 'Could not update tags.'));
+            } finally {
+                setBusy(false);
+            }
+        },
+        [refreshAll],
+    );
+
+    const onDropOnTag = useCallback(
+        (tagName: string, ids: string[]) => {
+            void runBulkTag(ids, 'add_tags', [tagName], { undoable: true });
+        },
+        [runBulkTag],
+    );
+
+    const onUploadFiles = useCallback(
+        async (files: File[]) => {
+            if (files.length === 0) {
+                return;
+            }
+
+            const maxSizeMb = Number(settings?.max_file_size_mb ?? 0);
+            if (maxSizeMb > 0) {
+                const tooLarge = files.filter((file) => file.size > maxSizeMb * 1024 * 1024);
+                if (tooLarge.length > 0) {
+                    toast.error(
+                        `${tooLarge.map((file) => file.name).join(', ')} exceeds the ${maxSizeMb} MB limit.`,
+                    );
+                    files = files.filter((file) => file.size <= maxSizeMb * 1024 * 1024);
+                    if (files.length === 0) {
+                        return;
+                    }
+                }
+            }
+
+            setUploading(true);
+            const pendingId = toast.pending(
+                `Uploading ${files.length} ${files.length === 1 ? 'file' : 'files'}…`,
+            );
+            try {
+                const response = await uploadPersonalDocuments(files);
+                const uploaded = response.document_ids?.length ?? 0;
+                // The route answers 207 for a partial success, so `errors` has to be read
+                // even though the request itself succeeded.
+                if (response.errors?.length) {
+                    toast.settle(
+                        pendingId,
+                        'error',
+                        `Uploaded ${uploaded} of ${files.length}. ${response.errors[0]}`,
+                    );
+                } else {
+                    toast.settle(pendingId, 'success', `Uploaded ${uploaded} of ${files.length}.`);
+                }
+                await refreshAll();
+            } catch (uploadError) {
+                toast.settle(
+                    pendingId,
+                    'error',
+                    errorMessage(uploadError, 'Upload failed.'),
+                );
+            } finally {
+                setUploading(false);
+            }
+        },
+        [refreshAll, settings],
+    );
+
+    const onDownload = useCallback(async (targets: WorkspaceDocument[]) => {
+        const ids = targets.map(documentId).filter(Boolean);
+        if (ids.length === 0) {
+            return;
+        }
+        const pendingId = toast.pending('Preparing download…');
+        try {
+            if (ids.length === 1) {
+                const blob = await downloadPersonalDocument(ids[0]);
+                saveBlob(blob, String(targets[0].file_name ?? 'document'));
+            } else {
+                const blob = await downloadPersonalDocuments(ids);
+                saveBlob(blob, 'documents.zip');
+            }
+            toast.settle(pendingId, 'success', 'Download ready.');
+        } catch (downloadError) {
+            toast.settle(pendingId, 'error', errorMessage(downloadError, 'Download failed.'));
+        }
+    }, []);
+
+    const onChat = useCallback((targets: WorkspaceDocument[]) => {
+        const ids = targets.map(documentId).filter(Boolean);
+        if (ids.length === 0) {
+            return;
+        }
+        const params = new URLSearchParams({
+            search_documents: 'true',
+            doc_scope: 'personal',
+            document_ids: ids.join(','),
+        });
+        window.location.href = `/chats?${params.toString()}`;
+    }, []);
+
+    const onExtractMetadata = useCallback(
+        async (targets: WorkspaceDocument[]) => {
+            const ids = targets.map(documentId).filter(Boolean);
+            if (ids.length === 0) {
+                return;
+            }
+            try {
+                await extractPersonalDocumentMetadata(ids);
+                toast.info(
+                    `Metadata extraction queued for ${ids.length} ${ids.length === 1 ? 'document' : 'documents'}.`,
+                );
+                window.setTimeout(() => void refreshAll(), 1500);
+            } catch (extractError) {
+                toast.error(errorMessage(extractError, 'Could not queue metadata extraction.'));
+            }
+        },
+        [refreshAll],
+    );
+
+    const onReextract = useCallback(
+        async (targets: WorkspaceDocument[], mode: 'read' | 'layout') => {
+            const ids = targets.map(documentId).filter(Boolean);
+            if (ids.length === 0) {
+                return;
+            }
+            try {
+                await reprocessPersonalDocumentExtraction(ids, mode);
+                toast.info(
+                    `Re-extraction queued as ${mode === 'layout' ? 'enhanced' : 'standard'}.`,
+                );
+                window.setTimeout(() => void refreshAll(), 1500);
+            } catch (reextractError) {
+                toast.error(errorMessage(reextractError, 'Could not queue re-extraction.'));
+            }
+        },
+        [refreshAll],
+    );
+
+    const onSaveMetadata = useCallback(
+        async (target: WorkspaceDocument, draft: MetadataDraft) => {
+            setBusy(true);
+            try {
+                await updatePersonalDocumentMetadata(documentId(target), {
+                    title: draft.title,
+                    abstract: draft.abstract,
+                    publication_date: draft.publication_date,
+                    document_classification: draft.document_classification,
+                    authors: draft.authors
+                        .split(',')
+                        .map((entry) => entry.trim())
+                        .filter(Boolean),
+                    keywords: draft.keywords
+                        .split(',')
+                        .map((entry) => entry.trim())
+                        .filter(Boolean),
+                });
+                setDialog(null);
+                toast.success('Metadata saved.');
+                await refreshAll();
+            } catch (saveError) {
+                toast.error(errorMessage(saveError, 'Could not save metadata.'));
+            } finally {
+                setBusy(false);
+            }
+        },
+        [refreshAll],
+    );
+
+    const onConfirmDelete = useCallback(
+        async (
+            targets: WorkspaceDocument[],
+            options: { force: boolean; deleteAllVersions: boolean },
+        ) => {
+            const ids = targets.map(documentId).filter(Boolean);
+            if (ids.length === 0) {
+                return;
+            }
+            setBusy(true);
+            try {
+                const response = await bulkDeletePersonalDocuments(ids, {
+                    deleteMode: options.deleteAllVersions ? 'all_versions' : 'current_only',
+                    conversationLinkedDeleteConfirmed: options.force,
+                    fileSyncDeleteAction: options.force ? 'keep_source' : null,
+                });
+
+                const blocked = (response.errors ?? []).filter(
+                    (entry) => entry.needs_confirmation,
+                );
+                const failed = (response.errors ?? []).filter(
+                    (entry) => !entry.needs_confirmation,
+                );
+
+                if (blocked.length > 0) {
+                    // Kept open, now listing exactly what was refused and why, so the user can
+                    // decide about those documents rather than about the batch.
+                    setDialog({ kind: 'delete', documents: targets, blocked });
+                } else {
+                    setDialog(null);
+                }
+
+                const deletedCount = response.deleted_count ?? 0;
+                if (deletedCount > 0) {
+                    toast.success(
+                        `Deleted ${deletedCount} ${deletedCount === 1 ? 'document' : 'documents'}.`,
+                    );
+                }
+                if (failed.length > 0) {
+                    toast.error(failed[0].message ?? 'Some documents could not be deleted.');
+                }
+
+                setSelection(EMPTY_SELECTION);
+                await refreshAll();
+            } catch (deleteError) {
+                toast.error(errorMessage(deleteError, 'Could not delete documents.'));
+            } finally {
+                setBusy(false);
+            }
+        },
+        [refreshAll],
+    );
+
+    const onSaveView = useCallback(() => {
+        const name = window.prompt('Name this view');
+        if (!name?.trim()) {
+            return;
+        }
+        const view = createSavedView(name, query);
+        saveUserSettings({ v2DocumentSavedViews: upsertSavedView(savedViews, view) });
+        toast.success(`Saved "${view.name}" to the rail.`);
+    }, [query, savedViews, saveUserSettings]);
+
+    const onDeleteSavedView = useCallback(
+        (view: DocumentSavedView) => {
+            if (!window.confirm(`Remove the saved view "${view.name}"?`)) {
+                return;
+            }
+            saveUserSettings({
+                v2DocumentSavedViews: removeSavedView(savedViews, view.id),
+            });
+        },
+        [savedViews, saveUserSettings],
+    );
+
+    /* ---------------------------------------------------------------------- */
+    /* Render                                                                  */
+    /* ---------------------------------------------------------------------- */
+
+    const chips = describeActiveFilters(query);
+
+    const content = () => {
+        if (loading && documents.length === 0) {
+            return (
+                <div className="space-y-2 p-2">
+                    {Array.from({ length: 8 }).map((_, index) => (
+                        <Skeleton key={index} className="h-10 w-full" />
+                    ))}
+                </div>
+            );
+        }
+
+        if (documents.length === 0) {
+            const filtered = chips.length > 0;
+            return (
+                <EmptyState
+                    icon={<FileText size={28} />}
+                    title={filtered ? 'No documents match these filters' : 'No documents yet'}
+                    description={
+                        filtered
+                            ? undefined
+                            : 'Upload a file to make it available for grounded chat.'
+                    }
+                    action={
+                        filtered ? (
+                            <GlassButton
+                                variant="subtle"
+                                size="sm"
+                                onClick={() => {
+                                    setSearchDraft('');
+                                    setQuery((current) => clearAllFilters(current));
+                                }}
+                            >
+                                Clear filters
+                            </GlassButton>
+                        ) : (
+                            <GlassButton
+                                variant="primary"
+                                size="sm"
+                                onClick={() => fileInputRef.current?.click()}
+                            >
+                                <Upload size={14} />
+                                Upload a document
+                            </GlassButton>
+                        )
+                    }
+                />
+            );
+        }
+
+        return prefs.viewMode === 'tiles' ? (
+            <DocumentTiles
+                documents={documents}
+                selection={selection}
+                tagColors={tagColors}
+                classificationColors={classificationColors}
+                onSelect={onSelect}
+                onOpen={() => updatePrefs({ detailsPaneOpen: true })}
+                onDragStart={onDragStart}
+            />
+        ) : (
+            <DocumentTable
+                documents={documents}
+                columns={prefs.columns}
+                query={query}
+                selection={selection}
+                tagColors={tagColors}
+                classificationColors={classificationColors}
+                onSelect={onSelect}
+                onToggleSelectAll={() =>
+                    setSelection((current) => toggleSelectAll(current, orderedIds))
+                }
+                onSort={onSort}
+                onOpen={() => updatePrefs({ detailsPaneOpen: true })}
+                onDragStart={onDragStart}
+            />
+        );
+    };
+
+    return (
+        <div ref={containerRef} className="flex h-full min-h-0 flex-col gap-2">
+            <input
+                ref={fileInputRef}
+                type="file"
+                multiple
+                className="hidden"
+                onChange={(event) => {
+                    const files = Array.from(event.target.files ?? []);
+                    event.target.value = '';
+                    void onUploadFiles(files);
+                }}
+            />
+
+            <ExplorerCommandBar
+                query={query}
+                prefs={prefs}
+                selectionCount={selection.ids.length}
+                uploading={uploading}
+                availability={availability}
+                canSaveView={isSaveableQuery(query)}
+                onSearchChange={setSearchDraft}
+                onUpload={() => fileInputRef.current?.click()}
+                onDownload={() => void onDownload(selectedDocuments)}
+                onTag={() => setDialog({ kind: 'tag', documents: selectedDocuments })}
+                onChat={() => onChat(selectedDocuments)}
+                onExtractMetadata={() => void onExtractMetadata(selectedDocuments)}
+                onDelete={() =>
+                    setDialog({ kind: 'delete', documents: selectedDocuments, blocked: [] })
+                }
+                onSaveView={onSaveView}
+                onPrefsChange={(change) => {
+                    updatePrefs(change);
+                    if (change.pageSize) {
+                        changeQuery({ pageSize: change.pageSize });
+                    }
+                }}
+            />
+
+            {error ? (
+                <p className="rounded-lg bg-danger-soft px-3 py-2 text-sm text-danger" role="alert">
+                    {error}
+                </p>
+            ) : null}
+
+            <div className="flex min-h-0 flex-1 gap-3 overflow-hidden">
+                <ExplorerRail
+                    query={query}
+                    facets={facets}
+                    tags={tags}
+                    savedViews={savedViews}
+                    classifications={availability.classification ? classifications : []}
+                    onQueryChange={changeQuery}
+                    onApplySavedView={(view) => {
+                        setSearchDraft(view.query.search);
+                        setQuery((current) => applySavedView(current, view));
+                    }}
+                    onDeleteSavedView={onDeleteSavedView}
+                    onDropOnTag={onDropOnTag}
+                />
+
+                <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+                    <FilterChips
+                        chips={chips}
+                        onClearChip={(chip) => {
+                            if (chip.kind === 'search') {
+                                setSearchDraft('');
+                            }
+                            setQuery((current) => clearFilterChip(current, chip));
+                        }}
+                        onClearAll={() => {
+                            setSearchDraft('');
+                            setQuery((current) => clearAllFilters(current));
+                        }}
+                    />
+
+                    <div
+                        className="min-h-0 flex-1 overflow-auto rounded-xl border border-edge bg-surface-1"
+                        onDragOver={(event) => event.preventDefault()}
+                        onDrop={(event) => {
+                            const files = Array.from(event.dataTransfer.files ?? []);
+                            if (files.length > 0) {
+                                event.preventDefault();
+                                void onUploadFiles(files);
+                            }
+                        }}
+                    >
+                        {busy ? (
+                            <div className="flex items-center gap-2 border-b border-edge px-3 py-1.5 text-xs text-text-3">
+                                <Loader2 size={12} className="animate-spin" />
+                                Working…
+                            </div>
+                        ) : null}
+                        {content()}
+                    </div>
+
+                    <ExplorerStatusBar
+                        page={query.page}
+                        pageSize={query.pageSize}
+                        totalCount={totalCount}
+                        selectionCount={selection.ids.length}
+                        onPageChange={(page) => changeQuery({ page })}
+                        onPageSizeChange={(pageSize) => {
+                            updatePrefs({ pageSize });
+                            changeQuery({ pageSize });
+                        }}
+                    />
+                </div>
+
+                {prefs.detailsPaneOpen ? (
+                    <DocumentDetailsPane
+                        documents={selectedDocuments}
+                        availability={availability}
+                        actions={{
+                            onChat,
+                            onDownload: (targets) => void onDownload(targets),
+                            onEditMetadata: (target) =>
+                                setDialog({ kind: 'metadata', document: target }),
+                            onExtractMetadata: (targets) => void onExtractMetadata(targets),
+                            onReextract: (targets, mode) => void onReextract(targets, mode),
+                            onShare: (target) => setDialog({ kind: 'share', document: target }),
+                            onManageTags: (targets) =>
+                                setDialog({ kind: 'tag', documents: targets }),
+                            onDelete: (targets) =>
+                                setDialog({ kind: 'delete', documents: targets, blocked: [] }),
+                            onSelectTag: (tag) => changeQuery({ tags: [tag] }),
+                            onRemoveTag: (targets, tag) =>
+                                void runBulkTag(
+                                    targets.map(documentId).filter(Boolean),
+                                    'remove_tags',
+                                    [tag],
+                                ),
+                        }}
+                        tagColors={tagColors}
+                        classificationColors={classificationColors}
+                        onClose={() => updatePrefs({ detailsPaneOpen: false })}
+                    />
+                ) : null}
+            </div>
+
+            {dialog?.kind === 'tag' ? (
+                <TagDialog
+                    documents={dialog.documents}
+                    tags={tags}
+                    busy={busy}
+                    onClose={() => setDialog(null)}
+                    onApply={async (added, removed) => {
+                        const ids = dialog.documents.map(documentId).filter(Boolean);
+                        setDialog(null);
+                        if (added.length > 0) {
+                            await runBulkTag(ids, 'add_tags', added);
+                        }
+                        if (removed.length > 0) {
+                            await runBulkTag(ids, 'remove_tags', removed);
+                        }
+                    }}
+                    onCreateTag={async (name) => {
+                        try {
+                            await createPersonalDocumentTag(name);
+                            await loadSidebar();
+                        } catch (createError) {
+                            toast.error(errorMessage(createError, 'Could not create the tag.'));
+                        }
+                    }}
+                />
+            ) : null}
+
+            {dialog?.kind === 'metadata' ? (
+                <MetadataDialog
+                    document={dialog.document}
+                    classifications={classifications}
+                    classificationEnabled={availability.classification}
+                    busy={busy}
+                    onClose={() => setDialog(null)}
+                    onSave={(draft) => void onSaveMetadata(dialog.document, draft)}
+                />
+            ) : null}
+
+            {dialog?.kind === 'share' ? (
+                <ShareDialog
+                    document={dialog.document}
+                    onClose={() => setDialog(null)}
+                    onChanged={() => void loadDocuments()}
+                />
+            ) : null}
+
+            {dialog?.kind === 'delete' ? (
+                <DeleteDialog
+                    documents={dialog.documents}
+                    blocked={dialog.blocked}
+                    busy={busy}
+                    onClose={() => setDialog(null)}
+                    onConfirm={(options) => void onConfirmDelete(dialog.documents, options)}
+                />
+            ) : null}
+        </div>
+    );
+}

--- a/application/v2_ui/src/components/documents/DocumentExplorer.tsx
+++ b/application/v2_ui/src/components/documents/DocumentExplorer.tsx
@@ -12,7 +12,7 @@
 // without a renderer.
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { FileText, Loader2, Upload } from 'lucide-react';
+import { FileText, Upload } from 'lucide-react';
 import type {
     DocumentExplorerPrefs,
     DocumentQuery,
@@ -27,6 +27,7 @@ import {
     EMPTY_SELECTION,
     applyQueryChange,
     applySelection,
+    batched,
     clearAllFilters,
     clearFilterChip,
     describeActiveFilters,
@@ -72,6 +73,7 @@ import { errorMessage } from '../workspace/useSectionResource';
 import { ExplorerRail } from './ExplorerRail';
 import {
     ExplorerCommandBar,
+    ExplorerProgress,
     ExplorerStatusBar,
     FilterChips,
 } from './ExplorerCommandBar';
@@ -88,6 +90,23 @@ import {
 
 /** How often an in-flight document is re-checked. Matches the classic interface. */
 const PROGRESS_POLL_MS = 5000;
+
+/**
+ * How many documents each bulk request covers.
+ *
+ * Bulk tagging is not cheap server-side: every document costs a cross-partition query, a
+ * write, and an update to each of its search-index chunks. Sending one request for a large
+ * selection produced a single request that ran for minutes behind an indeterminate spinner.
+ * Batching turns that into steady, reportable progress at negligible extra cost.
+ */
+const BULK_BATCH_SIZE = 5;
+
+/** A bulk operation in flight, and how far through it is. */
+interface ExplorerTask {
+    label: string;
+    completed: number;
+    total: number;
+}
 
 const DEFAULT_PREFS: DocumentExplorerPrefs = {
     viewMode: 'details',
@@ -156,10 +175,13 @@ export function DocumentExplorer() {
 
     const [selection, setSelection] = useState<SelectionState>(EMPTY_SELECTION);
     const [loading, setLoading] = useState(true);
-    const [busy, setBusy] = useState(false);
+    const [task, setTask] = useState<ExplorerTask | null>(null);
     const [uploading, setUploading] = useState(false);
     const [error, setError] = useState<string | null>(null);
     const [dialog, setDialog] = useState<ActiveDialog>(null);
+
+    // Dialogs disable their controls while any bulk work is running.
+    const busy = task !== null;
 
     const fileInputRef = useRef<HTMLInputElement>(null);
     const containerRef = useRef<HTMLDivElement>(null);
@@ -202,6 +224,7 @@ export function DocumentExplorer() {
             extractMetadata: Boolean(features?.enable_extract_meta_data),
             sharing: Boolean(features?.enable_file_sharing),
             classification: Boolean(features?.enable_document_classification),
+            enhancedExtraction: Boolean(features?.enable_enhanced_extraction),
         }),
         [downloadsEnabled, features],
     );
@@ -446,6 +469,44 @@ export function DocumentExplorer() {
     /* Actions                                                                 */
     /* ---------------------------------------------------------------------- */
 
+    /**
+     * Run one request per batch of documents, reporting progress as each lands.
+     *
+     * Always clears the task, including when a batch throws, so a failure can never leave the
+     * progress bar up forever -- which is exactly what an indeterminate spinner around a
+     * single long request looked like.
+     */
+    const runBatched = useCallback(
+        async (
+            label: string,
+            ids: string[],
+            perBatch: (batch: string[]) => Promise<void>,
+        ): Promise<{ completed: number; failed: number }> => {
+            const batches = batched(ids, BULK_BATCH_SIZE);
+            let completed = 0;
+            let failed = 0;
+
+            setTask({ label, completed: 0, total: ids.length });
+            try {
+                for (const batch of batches) {
+                    try {
+                        await perBatch(batch);
+                        completed += batch.length;
+                    } catch (batchError) {
+                        failed += batch.length;
+                        toast.error(errorMessage(batchError, `${label} failed.`));
+                    }
+                    setTask({ label, completed: completed + failed, total: ids.length });
+                }
+            } finally {
+                setTask(null);
+            }
+
+            return { completed, failed };
+        },
+        [],
+    );
+
     const runBulkTag = useCallback(
         async (
             ids: string[],
@@ -456,34 +517,38 @@ export function DocumentExplorer() {
             if (ids.length === 0 || tagNames.length === 0) {
                 return;
             }
-            setBusy(true);
-            try {
-                await bulkTagPersonalDocuments(ids, action, tagNames);
-                await refreshAll();
 
-                const verb = action === 'add_tags' ? 'Tagged' : 'Untagged';
-                const message = `${verb} ${ids.length} ${ids.length === 1 ? 'document' : 'documents'}`;
-                if (options.undoable) {
-                    toast.success(`${message} with ${tagNames.join(', ')}`, {
-                        label: 'Undo',
-                        onAct: () => {
-                            void runBulkTag(
-                                ids,
-                                action === 'add_tags' ? 'remove_tags' : 'add_tags',
-                                tagNames,
-                            );
-                        },
-                    });
-                } else {
-                    toast.success(message);
-                }
-            } catch (tagError) {
-                toast.error(errorMessage(tagError, 'Could not update tags.'));
-            } finally {
-                setBusy(false);
+            const verb = action === 'add_tags' ? 'Tagging' : 'Untagging';
+            const { completed } = await runBatched(
+                `${verb} ${ids.length} ${ids.length === 1 ? 'document' : 'documents'}`,
+                ids,
+                (batch) => bulkTagPersonalDocuments(batch, action, tagNames).then(() => undefined),
+            );
+
+            await refreshAll();
+
+            if (completed === 0) {
+                return;
+            }
+
+            const done = action === 'add_tags' ? 'Tagged' : 'Untagged';
+            const message = `${done} ${completed} ${completed === 1 ? 'document' : 'documents'} with ${tagNames.join(', ')}`;
+            if (options.undoable) {
+                toast.success(message, {
+                    label: 'Undo',
+                    onAct: () => {
+                        void runBulkTag(
+                            ids,
+                            action === 'add_tags' ? 'remove_tags' : 'add_tags',
+                            tagNames,
+                        );
+                    },
+                });
+            } else {
+                toast.success(message);
             }
         },
-        [refreshAll],
+        [refreshAll, runBatched],
     );
 
     const onDropOnTag = useCallback(
@@ -618,7 +683,7 @@ export function DocumentExplorer() {
 
     const onSaveMetadata = useCallback(
         async (target: WorkspaceDocument, draft: MetadataDraft) => {
-            setBusy(true);
+            setTask({ label: 'Saving metadata', completed: 0, total: 1 });
             try {
                 await updatePersonalDocumentMetadata(documentId(target), {
                     title: draft.title,
@@ -640,7 +705,7 @@ export function DocumentExplorer() {
             } catch (saveError) {
                 toast.error(errorMessage(saveError, 'Could not save metadata.'));
             } finally {
-                setBusy(false);
+                setTask(null);
             }
         },
         [refreshAll],
@@ -655,46 +720,68 @@ export function DocumentExplorer() {
             if (ids.length === 0) {
                 return;
             }
-            setBusy(true);
+
+            // Batched like the tag path: deleting a document removes its search-index chunks
+            // as well as its record, so a large selection is slow enough to need reporting.
+            const blocked: BulkDeleteError[] = [];
+            const failed: BulkDeleteError[] = [];
+            let deletedCount = 0;
+
+            setTask({
+                label: `Deleting ${ids.length} ${ids.length === 1 ? 'document' : 'documents'}`,
+                completed: 0,
+                total: ids.length,
+            });
             try {
-                const response = await bulkDeletePersonalDocuments(ids, {
-                    deleteMode: options.deleteAllVersions ? 'all_versions' : 'current_only',
-                    conversationLinkedDeleteConfirmed: options.force,
-                    fileSyncDeleteAction: options.force ? 'keep_source' : null,
-                });
-
-                const blocked = (response.errors ?? []).filter(
-                    (entry) => entry.needs_confirmation,
-                );
-                const failed = (response.errors ?? []).filter(
-                    (entry) => !entry.needs_confirmation,
-                );
-
-                if (blocked.length > 0) {
-                    // Kept open, now listing exactly what was refused and why, so the user can
-                    // decide about those documents rather than about the batch.
-                    setDialog({ kind: 'delete', documents: targets, blocked });
-                } else {
-                    setDialog(null);
+                let processed = 0;
+                for (const batch of batched(ids, BULK_BATCH_SIZE)) {
+                    try {
+                        const response = await bulkDeletePersonalDocuments(batch, {
+                            deleteMode: options.deleteAllVersions
+                                ? 'all_versions'
+                                : 'current_only',
+                            conversationLinkedDeleteConfirmed: options.force,
+                            fileSyncDeleteAction: options.force ? 'keep_source' : null,
+                        });
+                        deletedCount += response.deleted_count ?? 0;
+                        for (const entry of response.errors ?? []) {
+                            (entry.needs_confirmation ? blocked : failed).push(entry);
+                        }
+                    } catch (batchError) {
+                        toast.error(
+                            errorMessage(batchError, 'Could not delete some documents.'),
+                        );
+                    }
+                    processed += batch.length;
+                    setTask({
+                        label: `Deleting ${ids.length} ${ids.length === 1 ? 'document' : 'documents'}`,
+                        completed: processed,
+                        total: ids.length,
+                    });
                 }
-
-                const deletedCount = response.deleted_count ?? 0;
-                if (deletedCount > 0) {
-                    toast.success(
-                        `Deleted ${deletedCount} ${deletedCount === 1 ? 'document' : 'documents'}.`,
-                    );
-                }
-                if (failed.length > 0) {
-                    toast.error(failed[0].message ?? 'Some documents could not be deleted.');
-                }
-
-                setSelection(EMPTY_SELECTION);
-                await refreshAll();
-            } catch (deleteError) {
-                toast.error(errorMessage(deleteError, 'Could not delete documents.'));
             } finally {
-                setBusy(false);
+                setTask(null);
             }
+
+            if (blocked.length > 0) {
+                // Kept open, now listing exactly what was refused and why, so the user can
+                // decide about those documents rather than about the batch.
+                setDialog({ kind: 'delete', documents: targets, blocked });
+            } else {
+                setDialog(null);
+            }
+
+            if (deletedCount > 0) {
+                toast.success(
+                    `Deleted ${deletedCount} ${deletedCount === 1 ? 'document' : 'documents'}.`,
+                );
+            }
+            if (failed.length > 0) {
+                toast.error(failed[0].message ?? 'Some documents could not be deleted.');
+            }
+
+            setSelection(EMPTY_SELECTION);
+            await refreshAll();
         },
         [refreshAll],
     );
@@ -820,13 +907,18 @@ export function DocumentExplorer() {
             />
 
             <ExplorerCommandBar
-                query={query}
+                searchDraft={searchDraft}
                 prefs={prefs}
                 selectionCount={selection.ids.length}
                 uploading={uploading}
                 availability={availability}
                 canSaveView={isSaveableQuery(query)}
                 onSearchChange={setSearchDraft}
+                onSearchSubmit={(value) => {
+                    // Enter searches now rather than waiting out the debounce.
+                    setSearchDraft(value);
+                    setQuery((current) => applyQueryChange(current, { search: value }));
+                }}
                 onUpload={() => fileInputRef.current?.click()}
                 onDownload={() => void onDownload(selectedDocuments)}
                 onTag={() => setDialog({ kind: 'tag', documents: selectedDocuments })}
@@ -892,12 +984,7 @@ export function DocumentExplorer() {
                             }
                         }}
                     >
-                        {busy ? (
-                            <div className="flex items-center gap-2 border-b border-edge px-3 py-1.5 text-xs text-text-3">
-                                <Loader2 size={12} className="animate-spin" />
-                                Working…
-                            </div>
-                        ) : null}
+                        {task ? <ExplorerProgress task={task} /> : null}
                         {content()}
                     </div>
 

--- a/application/v2_ui/src/components/documents/DocumentTable.tsx
+++ b/application/v2_ui/src/components/documents/DocumentTable.tsx
@@ -1,0 +1,332 @@
+// DocumentTable.tsx
+// The details view: a dense, sortable table of documents.
+//
+// Two things here are deliberate departures from the classic interface.
+//
+// Selection is not a mode. The classic page has a "Multi-select" button that must be pressed
+// before a checkbox will appear, which means the most common bulk operation starts with a
+// step no file manager has ever required. Here click, Ctrl+click and Shift+click do what
+// they do everywhere else, and the checkboxes are always reachable.
+//
+// The name column carries two lines. `file_name` alone is frequently something like
+// `MSA_v2_FINAL(3).docx`, so the extracted title leads and the file name sits under it. When
+// there is no title the file name is promoted rather than captioned with "Untitled".
+
+import { useEffect, useRef } from 'react';
+import { clsx } from 'clsx';
+import { ArrowDown, ArrowUp, ChevronsUpDown } from 'lucide-react';
+import type {
+    DocumentQuery,
+    DocumentSortField,
+    WorkspaceDocument,
+} from '../../lib/types';
+import {
+    documentDate,
+    documentDisplayName,
+    documentId,
+    formatFileSize,
+    formatRelativeDate,
+    normalizeTags,
+    type SelectionState,
+    type SelectionIntent,
+} from '../../lib/documentExplorer';
+import {
+    ClassificationBadge,
+    DocumentIcon,
+    DocumentStatusBadge,
+    TagChipList,
+} from './documentPresentation';
+
+export interface DocumentColumn {
+    id: string;
+    label: string;
+    /** Omitted when the column cannot be ordered by the server. */
+    sortField?: DocumentSortField;
+    /** Fixed width class. The name column is the one that flexes. */
+    className?: string;
+    align?: 'left' | 'right';
+}
+
+/**
+ * Every column the table can show.
+ *
+ * `sortField` is present only where the list endpoint will actually honour it. A header
+ * offering a sort the server silently replaces with `_ts` would look like it worked and
+ * quietly reorder by something else.
+ */
+export const DOCUMENT_COLUMNS: DocumentColumn[] = [
+    { id: 'name', label: 'Name', sortField: 'file_name' },
+    { id: 'tags', label: 'Tags', className: 'w-56' },
+    { id: 'status', label: 'Status', className: 'w-32' },
+    { id: 'modified', label: 'Modified', sortField: '_ts', className: 'w-32' },
+    { id: 'size', label: 'Size', sortField: 'file_size', className: 'w-24', align: 'right' },
+    {
+        id: 'classification',
+        label: 'Classification',
+        sortField: 'document_classification',
+        className: 'w-36',
+    },
+    { id: 'pages', label: 'Pages', sortField: 'number_of_pages', className: 'w-20', align: 'right' },
+    { id: 'version', label: 'Version', sortField: 'version', className: 'w-20', align: 'right' },
+];
+
+/** Shown unless the user says otherwise. Classification, pages and version are opt-in. */
+export const DEFAULT_DOCUMENT_COLUMNS = ['name', 'tags', 'status', 'modified', 'size'];
+
+function SortIndicator({
+    active,
+    direction,
+}: {
+    active: boolean;
+    direction: 'asc' | 'desc';
+}) {
+    if (!active) {
+        return <ChevronsUpDown size={12} className="opacity-0 group-hover:opacity-50" />;
+    }
+    return direction === 'asc' ? <ArrowUp size={12} /> : <ArrowDown size={12} />;
+}
+
+export function DocumentTable({
+    documents,
+    columns,
+    query,
+    selection,
+    tagColors,
+    classificationColors,
+    onSelect,
+    onToggleSelectAll,
+    onSort,
+    onOpen,
+    onDragStart,
+}: {
+    documents: WorkspaceDocument[];
+    columns: string[];
+    query: DocumentQuery;
+    selection: SelectionState;
+    tagColors: Record<string, string | undefined>;
+    classificationColors: Record<string, string | undefined>;
+    onSelect: (id: string, intent: SelectionIntent) => void;
+    onToggleSelectAll: () => void;
+    onSort: (field: DocumentSortField) => void;
+    onOpen: (document: WorkspaceDocument) => void;
+    onDragStart: (event: React.DragEvent, id: string) => void;
+}) {
+    const activeColumns = DOCUMENT_COLUMNS.filter((column) => columns.includes(column.id));
+    const selectedIds = new Set(selection.ids);
+    const allSelected = documents.length > 0 && documents.every((item) => selectedIds.has(documentId(item)));
+    const someSelected = selection.ids.length > 0 && !allSelected;
+
+    const selectAllRef = useRef<HTMLInputElement>(null);
+    useEffect(() => {
+        if (selectAllRef.current) {
+            // The indeterminate state is not expressible as an attribute, so it has to be
+            // written to the node. Without it a partial selection reads as "none selected".
+            selectAllRef.current.indeterminate = someSelected;
+        }
+    }, [someSelected]);
+
+    return (
+        <table className="w-full border-collapse text-sm">
+            <thead className="sticky top-0 z-10 bg-surface-1">
+                <tr className="border-b border-edge text-left">
+                    <th scope="col" className="w-9 px-2 py-2">
+                        <input
+                            ref={selectAllRef}
+                            type="checkbox"
+                            checked={allSelected}
+                            onChange={onToggleSelectAll}
+                            aria-label="Select all documents on this page"
+                            className="h-3.5 w-3.5 cursor-pointer accent-[var(--accent)]"
+                        />
+                    </th>
+                    {activeColumns.map((column) => {
+                        const active = column.sortField === query.sortBy;
+                        return (
+                            <th
+                                key={column.id}
+                                scope="col"
+                                aria-sort={
+                                    active
+                                        ? query.sortOrder === 'asc'
+                                            ? 'ascending'
+                                            : 'descending'
+                                        : undefined
+                                }
+                                className={clsx(
+                                    'px-2 py-2 text-[11px] font-semibold tracking-wide text-text-3 uppercase',
+                                    column.className,
+                                    column.align === 'right' && 'text-right',
+                                )}
+                            >
+                                {column.sortField ? (
+                                    <button
+                                        type="button"
+                                        onClick={() => onSort(column.sortField!)}
+                                        className={clsx(
+                                            'group inline-flex items-center gap-1 transition-colors hover:text-text-1',
+                                            active && 'text-text-1',
+                                            column.align === 'right' && 'flex-row-reverse',
+                                        )}
+                                    >
+                                        {column.label}
+                                        <SortIndicator active={active} direction={query.sortOrder} />
+                                    </button>
+                                ) : (
+                                    column.label
+                                )}
+                            </th>
+                        );
+                    })}
+                </tr>
+            </thead>
+            <tbody>
+                {documents.map((document) => {
+                    const id = documentId(document);
+                    const selected = selectedIds.has(id);
+                    const { primary, secondary } = documentDisplayName(document);
+                    const tags = normalizeTags(document.tags);
+                    const classification = String(document.document_classification ?? '').trim();
+
+                    return (
+                        <tr
+                            key={id}
+                            draggable
+                            onDragStart={(event) => onDragStart(event, id)}
+                            onClick={(event) =>
+                                onSelect(
+                                    id,
+                                    event.shiftKey
+                                        ? 'range'
+                                        : event.ctrlKey || event.metaKey
+                                          ? 'toggle'
+                                          : 'replace',
+                                )
+                            }
+                            onDoubleClick={() => onOpen(document)}
+                            aria-selected={selected}
+                            className={clsx(
+                                'group cursor-default border-b border-edge/60 transition-colors',
+                                selected ? 'bg-accent-soft' : 'hover:bg-surface-2',
+                            )}
+                        >
+                            <td className="px-2 py-2 align-middle">
+                                <input
+                                    type="checkbox"
+                                    checked={selected}
+                                    onClick={(event) => event.stopPropagation()}
+                                    onChange={(event) =>
+                                        onSelect(
+                                            id,
+                                            (event.nativeEvent as MouseEvent).shiftKey
+                                                ? 'range'
+                                                : 'toggle',
+                                        )
+                                    }
+                                    aria-label={`Select ${primary}`}
+                                    className={clsx(
+                                        'h-3.5 w-3.5 cursor-pointer accent-[var(--accent)]',
+                                        // Hidden until useful, like Explorer, but never
+                                        // removed: it stays reachable by keyboard.
+                                        !selected &&
+                                            'opacity-0 group-hover:opacity-100 focus:opacity-100',
+                                    )}
+                                />
+                            </td>
+
+                            {activeColumns.map((column) => {
+                                switch (column.id) {
+                                    case 'name':
+                                        return (
+                                            <td key={column.id} className="px-2 py-1.5">
+                                                <div className="flex min-w-0 items-center gap-2">
+                                                    <DocumentIcon document={document} />
+                                                    <div className="min-w-0">
+                                                        <div className="truncate text-text-1">
+                                                            {primary}
+                                                        </div>
+                                                        {secondary ? (
+                                                            <div className="truncate text-xs text-text-3">
+                                                                {secondary}
+                                                            </div>
+                                                        ) : null}
+                                                    </div>
+                                                </div>
+                                            </td>
+                                        );
+                                    case 'tags':
+                                        return (
+                                            <td key={column.id} className="px-2 py-1.5">
+                                                <TagChipList
+                                                    tags={tags}
+                                                    colors={tagColors}
+                                                    limit={3}
+                                                />
+                                            </td>
+                                        );
+                                    case 'status':
+                                        return (
+                                            <td key={column.id} className="px-2 py-1.5">
+                                                <DocumentStatusBadge document={document} />
+                                            </td>
+                                        );
+                                    case 'modified':
+                                        return (
+                                            <td
+                                                key={column.id}
+                                                className="px-2 py-1.5 text-xs whitespace-nowrap text-text-3"
+                                                title={documentDate(document)?.toLocaleString()}
+                                            >
+                                                {formatRelativeDate(documentDate(document))}
+                                            </td>
+                                        );
+                                    case 'size':
+                                        return (
+                                            <td
+                                                key={column.id}
+                                                className="px-2 py-1.5 text-right text-xs whitespace-nowrap tabular-nums text-text-3"
+                                            >
+                                                {formatFileSize(document.file_size)}
+                                            </td>
+                                        );
+                                    case 'classification':
+                                        return (
+                                            <td key={column.id} className="px-2 py-1.5">
+                                                {classification ? (
+                                                    <ClassificationBadge
+                                                        classification={classification}
+                                                        color={classificationColors[classification]}
+                                                    />
+                                                ) : (
+                                                    <span className="text-xs text-text-3">—</span>
+                                                )}
+                                            </td>
+                                        );
+                                    case 'pages':
+                                        return (
+                                            <td
+                                                key={column.id}
+                                                className="px-2 py-1.5 text-right text-xs tabular-nums text-text-3"
+                                            >
+                                                {document.number_of_pages ?? '—'}
+                                            </td>
+                                        );
+                                    case 'version':
+                                        return (
+                                            <td
+                                                key={column.id}
+                                                className="px-2 py-1.5 text-right text-xs tabular-nums text-text-3"
+                                            >
+                                                {document.version ?? '—'}
+                                            </td>
+                                        );
+                                    default:
+                                        return <td key={column.id} />;
+                                }
+                            })}
+                        </tr>
+                    );
+                })}
+            </tbody>
+        </table>
+    );
+}

--- a/application/v2_ui/src/components/documents/DocumentTiles.tsx
+++ b/application/v2_ui/src/components/documents/DocumentTiles.tsx
@@ -1,0 +1,133 @@
+// DocumentTiles.tsx
+// The tiles view: the same documents as cards.
+//
+// One of two views, down from the classic interface's four. The two folder modes it also
+// offers are not carried over: the rail lists tags permanently, which is what those modes
+// were reaching for, and a folder grid that has to be entered and left again is a worse way
+// to reach the same place.
+
+import { clsx } from 'clsx';
+import type { WorkspaceDocument } from '../../lib/types';
+import {
+    documentDate,
+    documentDisplayName,
+    documentId,
+    formatFileSize,
+    formatRelativeDate,
+    normalizeTags,
+    type SelectionIntent,
+    type SelectionState,
+} from '../../lib/documentExplorer';
+import {
+    ClassificationBadge,
+    DocumentIcon,
+    DocumentStatusBadge,
+    TagChipList,
+} from './documentPresentation';
+
+export function DocumentTiles({
+    documents,
+    selection,
+    tagColors,
+    classificationColors,
+    onSelect,
+    onOpen,
+    onDragStart,
+}: {
+    documents: WorkspaceDocument[];
+    selection: SelectionState;
+    tagColors: Record<string, string | undefined>;
+    classificationColors: Record<string, string | undefined>;
+    onSelect: (id: string, intent: SelectionIntent) => void;
+    onOpen: (document: WorkspaceDocument) => void;
+    onDragStart: (event: React.DragEvent, id: string) => void;
+}) {
+    const selectedIds = new Set(selection.ids);
+
+    return (
+        <ul className="grid grid-cols-1 gap-2 p-1 sm:grid-cols-2 xl:grid-cols-3">
+            {documents.map((document) => {
+                const id = documentId(document);
+                const selected = selectedIds.has(id);
+                const { primary, secondary } = documentDisplayName(document);
+                const tags = normalizeTags(document.tags);
+                const classification = String(document.document_classification ?? '').trim();
+
+                return (
+                    <li key={id}>
+                        <div
+                            draggable
+                            onDragStart={(event) => onDragStart(event, id)}
+                            onClick={(event) =>
+                                onSelect(
+                                    id,
+                                    event.shiftKey
+                                        ? 'range'
+                                        : event.ctrlKey || event.metaKey
+                                          ? 'toggle'
+                                          : 'replace',
+                                )
+                            }
+                            onDoubleClick={() => onOpen(document)}
+                            aria-selected={selected}
+                            className={clsx(
+                                'group flex h-full cursor-default flex-col gap-2 rounded-xl border p-3 transition-colors',
+                                selected
+                                    ? 'border-accent bg-accent-soft'
+                                    : 'border-edge bg-surface-1 hover:bg-surface-2',
+                            )}
+                        >
+                            <div className="flex items-start gap-2">
+                                <input
+                                    type="checkbox"
+                                    checked={selected}
+                                    onClick={(event) => event.stopPropagation()}
+                                    onChange={(event) =>
+                                        onSelect(
+                                            id,
+                                            (event.nativeEvent as MouseEvent).shiftKey
+                                                ? 'range'
+                                                : 'toggle',
+                                        )
+                                    }
+                                    aria-label={`Select ${primary}`}
+                                    className={clsx(
+                                        'mt-0.5 h-3.5 w-3.5 shrink-0 cursor-pointer accent-[var(--accent)]',
+                                        !selected &&
+                                            'opacity-0 group-hover:opacity-100 focus:opacity-100',
+                                    )}
+                                />
+                                <DocumentIcon document={document} size={20} />
+                                <div className="min-w-0 flex-1">
+                                    <p className="truncate text-sm text-text-1">{primary}</p>
+                                    {secondary ? (
+                                        <p className="truncate text-xs text-text-3">{secondary}</p>
+                                    ) : null}
+                                </div>
+                            </div>
+
+                            <div className="flex flex-wrap items-center gap-1.5">
+                                <DocumentStatusBadge document={document} showProgressBar />
+                                {classification ? (
+                                    <ClassificationBadge
+                                        classification={classification}
+                                        color={classificationColors[classification]}
+                                    />
+                                ) : null}
+                            </div>
+
+                            <TagChipList tags={tags} colors={tagColors} limit={4} />
+
+                            <p className="mt-auto text-[11px] text-text-3">
+                                {formatRelativeDate(documentDate(document))}
+                                {document.file_size
+                                    ? ` · ${formatFileSize(document.file_size)}`
+                                    : ''}
+                            </p>
+                        </div>
+                    </li>
+                );
+            })}
+        </ul>
+    );
+}

--- a/application/v2_ui/src/components/documents/ExplorerCommandBar.tsx
+++ b/application/v2_ui/src/components/documents/ExplorerCommandBar.tsx
@@ -18,6 +18,7 @@ import {
     Download,
     LayoutGrid,
     List,
+    Loader2,
     MessageSquare,
     PanelRight,
     Search,
@@ -27,7 +28,7 @@ import {
     Upload,
     X,
 } from 'lucide-react';
-import type { DocumentExplorerPrefs, DocumentQuery } from '../../lib/types';
+import type { DocumentExplorerPrefs } from '../../lib/types';
 import {
     DOCUMENT_PAGE_SIZES,
     describePage,
@@ -39,13 +40,14 @@ import { Dropdown } from '../ui/Dropdown';
 import { DOCUMENT_COLUMNS } from './DocumentTable';
 
 export function ExplorerCommandBar({
-    query,
+    searchDraft,
     prefs,
     selectionCount,
     uploading,
     availability,
     canSaveView,
     onSearchChange,
+    onSearchSubmit,
     onUpload,
     onDownload,
     onTag,
@@ -55,13 +57,15 @@ export function ExplorerCommandBar({
     onSaveView,
     onPrefsChange,
 }: {
-    query: DocumentQuery;
+    /** What the user has typed. Distinct from `query.search`, which lags it by the debounce. */
+    searchDraft: string;
     prefs: DocumentExplorerPrefs;
     selectionCount: number;
     uploading: boolean;
     availability: { downloads: boolean; extractMetadata: boolean };
     canSaveView: boolean;
     onSearchChange: (value: string) => void;
+    onSearchSubmit: (value: string) => void;
     onUpload: () => void;
     onDownload: () => void;
     onTag: () => void;
@@ -140,10 +144,24 @@ export function ExplorerCommandBar({
                     />
                     <input
                         type="search"
-                        value={query.search}
+                        // Bound to the draft, not to `query.search`. Binding a controlled
+                        // input to the debounced value meant every keystroke was reverted
+                        // until the debounce caught up, which is what dropped characters
+                        // while typing at speed.
+                        value={searchDraft}
                         onChange={(event) => onSearchChange(event.target.value)}
+                        onKeyDown={(event) => {
+                            if (event.key === 'Enter') {
+                                event.preventDefault();
+                                onSearchSubmit(event.currentTarget.value);
+                            }
+                            if (event.key === 'Escape') {
+                                event.preventDefault();
+                                onSearchSubmit('');
+                            }
+                        }}
                         placeholder="Search name or title"
-                        aria-label="Search documents"
+                        aria-label="Search documents. Press Enter to search immediately."
                         className="h-8 w-56 rounded-lg border border-edge bg-surface-1 pr-2 pl-7 text-sm text-text-1 placeholder:text-text-3 focus:border-accent focus:outline-none"
                     />
                 </div>
@@ -231,6 +249,50 @@ export function ExplorerCommandBar({
                     <PanelRight size={15} />
                 </button>
             </div>
+        </div>
+    );
+}
+
+/**
+ * A determinate progress bar for a bulk operation.
+ *
+ * Determinate rather than a spinner because these operations are genuinely slow: tagging
+ * updates each document *and* its search-index chunks, so a large selection takes long enough
+ * that an indeterminate "Working…" is indistinguishable from a hang. Saying "14 of 50" is the
+ * difference between waiting and giving up.
+ */
+export function ExplorerProgress({
+    task,
+}: {
+    task: { label: string; completed: number; total: number };
+}) {
+    const total = Math.max(1, task.total);
+    const percent = Math.min(100, Math.round((task.completed / total) * 100));
+
+    return (
+        <div
+            className="flex items-center gap-2.5 border-b border-edge px-3 py-2"
+            role="status"
+            aria-live="polite"
+        >
+            <Loader2 size={13} className="shrink-0 animate-spin text-accent" />
+            <span className="shrink-0 text-xs text-text-2">{task.label}</span>
+            <span
+                className="h-1.5 min-w-0 flex-1 overflow-hidden rounded-full bg-surface-sunken"
+                role="progressbar"
+                aria-valuenow={task.completed}
+                aria-valuemin={0}
+                aria-valuemax={task.total}
+                aria-label={task.label}
+            >
+                <span
+                    className="block h-full rounded-full bg-accent transition-[width] duration-200"
+                    style={{ width: `${percent}%` }}
+                />
+            </span>
+            <span className="shrink-0 text-xs tabular-nums text-text-3">
+                {task.completed} of {task.total}
+            </span>
         </div>
     );
 }

--- a/application/v2_ui/src/components/documents/ExplorerCommandBar.tsx
+++ b/application/v2_ui/src/components/documents/ExplorerCommandBar.tsx
@@ -1,0 +1,364 @@
+// ExplorerCommandBar.tsx
+// The command bar, filter chips and status bar.
+//
+// The classic interface stacks a search box, four metadata filters, a tag multi-select, a
+// classification select, a shared-only checkbox, two buttons, a view switcher and two page
+// size selects into one band above the list. This splits that into three: what you can *do*
+// on top, what is currently *narrowing* the list beneath it, and where you *are* in the
+// results at the bottom.
+//
+// The action group is selection-aware. Buttons that operate on documents are disabled with
+// nothing selected rather than hidden, so the bar keeps its shape and the capability stays
+// discoverable.
+
+import { clsx } from 'clsx';
+import {
+    Bookmark,
+    Columns3,
+    Download,
+    LayoutGrid,
+    List,
+    MessageSquare,
+    PanelRight,
+    Search,
+    Sparkles,
+    Tag as TagIcon,
+    Trash2,
+    Upload,
+    X,
+} from 'lucide-react';
+import type { DocumentExplorerPrefs, DocumentQuery } from '../../lib/types';
+import {
+    DOCUMENT_PAGE_SIZES,
+    describePage,
+    paginationItems,
+    type FilterChip,
+} from '../../lib/documentExplorer';
+import { GlassButton } from '../ui/primitives';
+import { Dropdown } from '../ui/Dropdown';
+import { DOCUMENT_COLUMNS } from './DocumentTable';
+
+export function ExplorerCommandBar({
+    query,
+    prefs,
+    selectionCount,
+    uploading,
+    availability,
+    canSaveView,
+    onSearchChange,
+    onUpload,
+    onDownload,
+    onTag,
+    onChat,
+    onExtractMetadata,
+    onDelete,
+    onSaveView,
+    onPrefsChange,
+}: {
+    query: DocumentQuery;
+    prefs: DocumentExplorerPrefs;
+    selectionCount: number;
+    uploading: boolean;
+    availability: { downloads: boolean; extractMetadata: boolean };
+    canSaveView: boolean;
+    onSearchChange: (value: string) => void;
+    onUpload: () => void;
+    onDownload: () => void;
+    onTag: () => void;
+    onChat: () => void;
+    onExtractMetadata: () => void;
+    onDelete: () => void;
+    onSaveView: () => void;
+    onPrefsChange: (change: Partial<DocumentExplorerPrefs>) => void;
+}) {
+    const hasSelection = selectionCount > 0;
+
+    return (
+        <div className="flex flex-wrap items-center gap-2 border-b border-edge px-1 pb-2">
+            <GlassButton variant="primary" size="sm" onClick={onUpload} disabled={uploading}>
+                <Upload size={14} />
+                Upload
+            </GlassButton>
+
+            <span aria-hidden="true" className="h-5 w-px bg-edge" />
+
+            {availability.downloads ? (
+                <GlassButton
+                    variant="ghost"
+                    size="sm"
+                    onClick={onDownload}
+                    disabled={!hasSelection}
+                    title={
+                        selectionCount > 1
+                            ? 'Download the selected documents as a ZIP'
+                            : 'Download the selected document'
+                    }
+                >
+                    <Download size={14} />
+                    Download
+                </GlassButton>
+            ) : null}
+
+            <GlassButton variant="ghost" size="sm" onClick={onTag} disabled={!hasSelection}>
+                <TagIcon size={14} />
+                Tag
+            </GlassButton>
+
+            <GlassButton variant="ghost" size="sm" onClick={onChat} disabled={!hasSelection}>
+                <MessageSquare size={14} />
+                Chat
+            </GlassButton>
+
+            {availability.extractMetadata ? (
+                <GlassButton
+                    variant="ghost"
+                    size="sm"
+                    onClick={onExtractMetadata}
+                    disabled={!hasSelection}
+                >
+                    <Sparkles size={14} />
+                    Extract
+                </GlassButton>
+            ) : null}
+
+            <GlassButton
+                variant="ghost"
+                size="sm"
+                onClick={onDelete}
+                disabled={!hasSelection}
+                className="hover:bg-danger-soft hover:text-danger"
+            >
+                <Trash2 size={14} />
+                Delete
+            </GlassButton>
+
+            <div className="ml-auto flex items-center gap-2">
+                <div className="relative">
+                    <Search
+                        size={14}
+                        className="pointer-events-none absolute top-1/2 left-2.5 -translate-y-1/2 text-text-3"
+                    />
+                    <input
+                        type="search"
+                        value={query.search}
+                        onChange={(event) => onSearchChange(event.target.value)}
+                        placeholder="Search name or title"
+                        aria-label="Search documents"
+                        className="h-8 w-56 rounded-lg border border-edge bg-surface-1 pr-2 pl-7 text-sm text-text-1 placeholder:text-text-3 focus:border-accent focus:outline-none"
+                    />
+                </div>
+
+                {canSaveView ? (
+                    <GlassButton
+                        variant="ghost"
+                        size="sm"
+                        onClick={onSaveView}
+                        title="Pin these filters to the rail as a saved view"
+                    >
+                        <Bookmark size={14} />
+                        Save view
+                    </GlassButton>
+                ) : null}
+
+                <Dropdown
+                    compact
+                    align="right"
+                    icon={<Columns3 size={15} />}
+                    placeholder="Columns"
+                    options={DOCUMENT_COLUMNS.filter((column) => column.id !== 'name').map(
+                        (column) => ({
+                            value: column.id,
+                            label: prefs.columns.includes(column.id)
+                                ? `✓ ${column.label}`
+                                : column.label,
+                        }),
+                    )}
+                    onChange={(value) => {
+                        if (!value) {
+                            return;
+                        }
+                        onPrefsChange({
+                            columns: prefs.columns.includes(value)
+                                ? prefs.columns.filter((column) => column !== value)
+                                : [...prefs.columns, value],
+                        });
+                    }}
+                />
+
+                <div
+                    role="group"
+                    aria-label="View mode"
+                    className="flex items-center rounded-lg border border-edge"
+                >
+                    {(
+                        [
+                            { mode: 'details', icon: List, label: 'Details view' },
+                            { mode: 'tiles', icon: LayoutGrid, label: 'Tiles view' },
+                        ] as const
+                    ).map(({ mode, icon: Icon, label }) => (
+                        <button
+                            key={mode}
+                            type="button"
+                            onClick={() => onPrefsChange({ viewMode: mode })}
+                            aria-label={label}
+                            aria-pressed={prefs.viewMode === mode}
+                            title={label}
+                            className={clsx(
+                                'p-1.5 transition-colors first:rounded-l-md last:rounded-r-md',
+                                prefs.viewMode === mode
+                                    ? 'bg-accent-soft text-accent'
+                                    : 'text-text-3 hover:bg-surface-2 hover:text-text-1',
+                            )}
+                        >
+                            <Icon size={15} />
+                        </button>
+                    ))}
+                </div>
+
+                <button
+                    type="button"
+                    onClick={() => onPrefsChange({ detailsPaneOpen: !prefs.detailsPaneOpen })}
+                    aria-label="Toggle details pane"
+                    aria-pressed={prefs.detailsPaneOpen}
+                    title="Toggle details pane"
+                    className={clsx(
+                        'rounded-lg border border-edge p-1.5 transition-colors',
+                        prefs.detailsPaneOpen
+                            ? 'bg-accent-soft text-accent'
+                            : 'text-text-3 hover:bg-surface-2 hover:text-text-1',
+                    )}
+                >
+                    <PanelRight size={15} />
+                </button>
+            </div>
+        </div>
+    );
+}
+
+export function FilterChips({
+    chips,
+    onClearChip,
+    onClearAll,
+}: {
+    chips: FilterChip[];
+    onClearChip: (chip: FilterChip) => void;
+    onClearAll: () => void;
+}) {
+    if (chips.length === 0) {
+        return null;
+    }
+
+    return (
+        <div className="flex flex-wrap items-center gap-1.5 px-1 py-2">
+            <span className="text-[11px] text-text-3">Filtered by</span>
+            {chips.map((chip) => (
+                <button
+                    key={`${chip.kind}:${chip.value}`}
+                    type="button"
+                    onClick={() => onClearChip(chip)}
+                    className="inline-flex items-center gap-1 rounded-full bg-accent-soft px-2 py-0.5 text-[11px] font-medium text-accent transition-opacity hover:opacity-80"
+                >
+                    <span className="max-w-[14rem] truncate">{chip.label}</span>
+                    <X size={11} />
+                </button>
+            ))}
+            <button
+                type="button"
+                onClick={onClearAll}
+                className="text-[11px] text-text-3 underline-offset-2 hover:text-text-1 hover:underline"
+            >
+                Clear all
+            </button>
+        </div>
+    );
+}
+
+export function ExplorerStatusBar({
+    page,
+    pageSize,
+    totalCount,
+    selectionCount,
+    onPageChange,
+    onPageSizeChange,
+}: {
+    page: number;
+    pageSize: number;
+    totalCount: number;
+    selectionCount: number;
+    onPageChange: (page: number) => void;
+    onPageSizeChange: (pageSize: number) => void;
+}) {
+    const range = describePage(page, pageSize, totalCount);
+    const items = paginationItems(page, range.pageCount);
+
+    return (
+        <div className="flex flex-wrap items-center justify-between gap-2 border-t border-edge px-1 pt-2 text-xs text-text-3">
+            <p>
+                {range.total === 0
+                    ? 'No documents'
+                    : `${range.from}\u2013${range.to} of ${range.total}`}
+                {selectionCount > 0 ? ` · ${selectionCount} selected` : ''}
+            </p>
+
+            <div className="flex items-center gap-2">
+                {range.pageCount > 1 ? (
+                    <nav aria-label="Pagination" className="flex items-center gap-0.5">
+                        <button
+                            type="button"
+                            onClick={() => onPageChange(page - 1)}
+                            disabled={page <= 1}
+                            className="rounded px-2 py-1 hover:bg-surface-2 hover:text-text-1 disabled:opacity-40 disabled:hover:bg-transparent"
+                        >
+                            Prev
+                        </button>
+                        {items.map((item, index) =>
+                            item === null ? (
+                                <span key={`gap-${index}`} className="px-1">
+                                    …
+                                </span>
+                            ) : (
+                                <button
+                                    key={item}
+                                    type="button"
+                                    onClick={() => onPageChange(item)}
+                                    aria-current={item === page ? 'page' : undefined}
+                                    className={clsx(
+                                        'min-w-[1.75rem] rounded px-1.5 py-1 tabular-nums',
+                                        item === page
+                                            ? 'bg-accent-soft font-medium text-accent'
+                                            : 'hover:bg-surface-2 hover:text-text-1',
+                                    )}
+                                >
+                                    {item}
+                                </button>
+                            ),
+                        )}
+                        <button
+                            type="button"
+                            onClick={() => onPageChange(page + 1)}
+                            disabled={page >= range.pageCount}
+                            className="rounded px-2 py-1 hover:bg-surface-2 hover:text-text-1 disabled:opacity-40 disabled:hover:bg-transparent"
+                        >
+                            Next
+                        </button>
+                    </nav>
+                ) : null}
+
+                <label className="flex items-center gap-1">
+                    <span className="sr-only">Documents per page</span>
+                    <select
+                        value={pageSize}
+                        onChange={(event) => onPageSizeChange(Number(event.target.value))}
+                        className="rounded border border-edge bg-surface-1 px-1.5 py-1 text-xs text-text-2 focus:border-accent focus:outline-none"
+                    >
+                        {DOCUMENT_PAGE_SIZES.map((size) => (
+                            <option key={size} value={size}>
+                                {size} per page
+                            </option>
+                        ))}
+                    </select>
+                </label>
+            </div>
+        </div>
+    );
+}

--- a/application/v2_ui/src/components/documents/ExplorerRail.tsx
+++ b/application/v2_ui/src/components/documents/ExplorerRail.tsx
@@ -1,0 +1,278 @@
+// ExplorerRail.tsx
+// The documents explorer navigation pane.
+//
+// This is where the redesign spends its main idea. The classic interface offers "folders" as
+// a view mode you switch into, which shows tags rendered as folder cards in the content
+// area -- so browsing by tag means leaving the list, and the tags are invisible the rest of
+// the time. Here the same information is a permanent rail, which is how Finder presents
+// tags and how Explorer presents libraries and saved searches.
+//
+// The rail also accepts a drop. Dragging a selection onto a tag applies it, which is the
+// filing gesture people already have for folders, offered without inventing a hierarchy the
+// data model does not have.
+
+import { useState } from 'react';
+import { clsx } from 'clsx';
+import {
+    Bookmark,
+    CircleAlert,
+    Clock,
+    FolderOpen,
+    Loader2,
+    Tag as TagIcon,
+    Users,
+} from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
+import type {
+    DocumentFacets,
+    DocumentPlace,
+    DocumentQuery,
+    DocumentSavedView,
+    WorkspaceTag,
+} from '../../lib/types';
+import {
+    DOCUMENT_PLACE_LABELS,
+    placeCount,
+    visiblePlaces,
+} from '../../lib/documentExplorer';
+import { matchesSavedView } from '../../lib/documentSavedViews';
+
+const PLACE_ICONS: Record<DocumentPlace, LucideIcon> = {
+    all: FolderOpen,
+    recent: Clock,
+    shared: Users,
+    processing: Loader2,
+    errors: CircleAlert,
+    untagged: TagIcon,
+};
+
+function RailGroup({ label, children }: { label: string; children: React.ReactNode }) {
+    return (
+        <div className="space-y-0.5">
+            <p className="px-2.5 pt-2 text-[11px] font-semibold tracking-wide text-text-3 uppercase">
+                {label}
+            </p>
+            {children}
+        </div>
+    );
+}
+
+function RailEntry({
+    icon,
+    label,
+    count,
+    active,
+    onClick,
+    onContextMenu,
+    dropActive,
+    swatch,
+    ...dropHandlers
+}: {
+    icon?: React.ReactNode;
+    label: string;
+    count?: number | null;
+    active: boolean;
+    onClick: () => void;
+    onContextMenu?: (event: React.MouseEvent) => void;
+    dropActive?: boolean;
+    swatch?: string;
+    onDragOver?: (event: React.DragEvent) => void;
+    onDragLeave?: (event: React.DragEvent) => void;
+    onDrop?: (event: React.DragEvent) => void;
+}) {
+    return (
+        <button
+            type="button"
+            onClick={onClick}
+            onContextMenu={onContextMenu}
+            aria-current={active ? 'true' : undefined}
+            className={clsx(
+                'flex w-full items-center gap-2 rounded-lg px-2.5 py-1.5 text-left text-sm transition-colors',
+                active
+                    ? 'bg-accent-soft font-medium text-accent'
+                    : 'text-text-2 hover:bg-surface-2 hover:text-text-1',
+                dropActive && 'ring-2 ring-accent ring-inset',
+            )}
+            {...dropHandlers}
+        >
+            {swatch !== undefined ? (
+                <span
+                    aria-hidden="true"
+                    className="h-2.5 w-2.5 shrink-0 rounded-full border border-edge"
+                    style={{ backgroundColor: swatch || 'transparent' }}
+                />
+            ) : null}
+            {icon}
+            <span className="min-w-0 flex-1 truncate">{label}</span>
+            {typeof count === 'number' ? (
+                <span className="shrink-0 text-[11px] tabular-nums text-text-3">{count}</span>
+            ) : null}
+        </button>
+    );
+}
+
+export function ExplorerRail({
+    query,
+    facets,
+    tags,
+    savedViews,
+    classifications,
+    onQueryChange,
+    onApplySavedView,
+    onDeleteSavedView,
+    onDropOnTag,
+}: {
+    query: DocumentQuery;
+    facets: DocumentFacets | null;
+    tags: WorkspaceTag[];
+    savedViews: DocumentSavedView[];
+    classifications: { label: string; color?: string }[];
+    onQueryChange: (change: Partial<DocumentQuery>) => void;
+    onApplySavedView: (view: DocumentSavedView) => void;
+    onDeleteSavedView: (view: DocumentSavedView) => void;
+    /** Applies a tag to the dragged documents. Undefined disables the drop target. */
+    onDropOnTag?: (tagName: string, documentIds: string[]) => void;
+}) {
+    const [dropTarget, setDropTarget] = useState<string | null>(null);
+
+    const places = visiblePlaces(facets);
+
+    /**
+     * Ctrl-click adds a tag to the filter rather than replacing it.
+     *
+     * Tags combine with AND server-side, so accumulating them narrows -- which is the useful
+     * direction and the one a plain click cannot express.
+     */
+    const selectTag = (name: string, additive: boolean) => {
+        const active = query.tags.includes(name);
+        if (additive) {
+            onQueryChange({
+                tags: active
+                    ? query.tags.filter((tag) => tag !== name)
+                    : [...query.tags, name],
+            });
+            return;
+        }
+        onQueryChange({ tags: active && query.tags.length === 1 ? [] : [name] });
+    };
+
+    const readDraggedIds = (event: React.DragEvent): string[] => {
+        const raw = event.dataTransfer.getData('application/x-simplechat-documents');
+        if (!raw) {
+            return [];
+        }
+        try {
+            const parsed = JSON.parse(raw);
+            return Array.isArray(parsed) ? parsed.map(String).filter(Boolean) : [];
+        } catch {
+            return [];
+        }
+    };
+
+    return (
+        <nav
+            aria-label="Document filters"
+            className="flex w-56 shrink-0 flex-col gap-1 overflow-y-auto pr-1"
+        >
+            <RailGroup label="Places">
+                {places.map((place) => {
+                    const Icon = PLACE_ICONS[place];
+                    return (
+                        <RailEntry
+                            key={place}
+                            icon={<Icon size={15} className="shrink-0" />}
+                            label={DOCUMENT_PLACE_LABELS[place]}
+                            count={placeCount(facets, place)}
+                            active={query.place === place}
+                            onClick={() => onQueryChange({ place })}
+                        />
+                    );
+                })}
+            </RailGroup>
+
+            {savedViews.length > 0 ? (
+                <RailGroup label="Saved views">
+                    {savedViews.map((view) => (
+                        <RailEntry
+                            key={view.id}
+                            icon={<Bookmark size={15} className="shrink-0" />}
+                            label={view.name}
+                            active={matchesSavedView(query, view)}
+                            onClick={() => onApplySavedView(view)}
+                            onContextMenu={(event) => {
+                                event.preventDefault();
+                                onDeleteSavedView(view);
+                            }}
+                        />
+                    ))}
+                    <p className="px-2.5 pt-1 pb-1 text-[10px] leading-snug text-text-3">
+                        Right-click a view to remove it.
+                    </p>
+                </RailGroup>
+            ) : null}
+
+            {tags.length > 0 ? (
+                <RailGroup label="Tags">
+                    {tags.map((tag) => (
+                        <RailEntry
+                            key={tag.name}
+                            swatch={tag.color ?? ''}
+                            label={tag.name}
+                            count={facets?.by_tag?.[tag.name] ?? tag.count ?? null}
+                            active={query.tags.includes(tag.name)}
+                            onClick={() => selectTag(tag.name, false)}
+                            dropActive={dropTarget === tag.name}
+                            onDragOver={
+                                onDropOnTag
+                                    ? (event) => {
+                                          event.preventDefault();
+                                          event.dataTransfer.dropEffect = 'copy';
+                                          setDropTarget(tag.name);
+                                      }
+                                    : undefined
+                            }
+                            onDragLeave={onDropOnTag ? () => setDropTarget(null) : undefined}
+                            onDrop={
+                                onDropOnTag
+                                    ? (event) => {
+                                          event.preventDefault();
+                                          setDropTarget(null);
+                                          const ids = readDraggedIds(event);
+                                          if (ids.length > 0) {
+                                              onDropOnTag(tag.name, ids);
+                                          }
+                                      }
+                                    : undefined
+                            }
+                        />
+                    ))}
+                    <p className="px-2.5 pt-1 pb-1 text-[10px] leading-snug text-text-3">
+                        Drag documents onto a tag to apply it. Ctrl-click to combine tags.
+                    </p>
+                </RailGroup>
+            ) : null}
+
+            {classifications.length > 0 ? (
+                <RailGroup label="Classification">
+                    {classifications.map((classification) => (
+                        <RailEntry
+                            key={classification.label}
+                            swatch={classification.color ?? ''}
+                            label={classification.label}
+                            count={facets?.by_classification?.[classification.label] ?? null}
+                            active={query.classification === classification.label}
+                            onClick={() =>
+                                onQueryChange({
+                                    classification:
+                                        query.classification === classification.label
+                                            ? null
+                                            : classification.label,
+                                })
+                            }
+                        />
+                    ))}
+                </RailGroup>
+            ) : null}
+        </nav>
+    );
+}

--- a/application/v2_ui/src/components/documents/documentPresentation.tsx
+++ b/application/v2_ui/src/components/documents/documentPresentation.tsx
@@ -1,0 +1,316 @@
+// documentPresentation.tsx
+// Shared visual vocabulary for the documents explorer.
+//
+// The icon, the tag chip and the status badge each appear in the table, the tiles and the
+// details pane. Keeping one definition of each is what stops the three surfaces from
+// drifting into three slightly different ideas of what a "processing" document looks like.
+
+import { clsx } from 'clsx';
+import {
+    FileArchive,
+    FileAudio,
+    FileChartColumn,
+    FileCode,
+    FileImage,
+    FileSpreadsheet,
+    FileText,
+    FileType,
+    FileVideo,
+    Loader2,
+    type LucideIcon,
+} from 'lucide-react';
+import type { WorkspaceDocument } from '../../lib/types';
+import { documentStatus } from '../../lib/documentExplorer';
+
+/**
+ * File-type icons, keyed by extension.
+ *
+ * A file manager is scanned rather than read, and the icon is what carries type at a glance,
+ * so the groupings follow what a user would call the file rather than its MIME family.
+ */
+const EXTENSION_ICONS: Record<string, LucideIcon> = {
+    pdf: FileType,
+    doc: FileText,
+    docx: FileText,
+    docm: FileText,
+    txt: FileText,
+    md: FileText,
+    rtf: FileText,
+    odt: FileText,
+    xls: FileSpreadsheet,
+    xlsx: FileSpreadsheet,
+    xlsm: FileSpreadsheet,
+    csv: FileSpreadsheet,
+    tsv: FileSpreadsheet,
+    ppt: FileChartColumn,
+    pptx: FileChartColumn,
+    png: FileImage,
+    jpg: FileImage,
+    jpeg: FileImage,
+    gif: FileImage,
+    bmp: FileImage,
+    webp: FileImage,
+    svg: FileImage,
+    tiff: FileImage,
+    mp3: FileAudio,
+    wav: FileAudio,
+    m4a: FileAudio,
+    flac: FileAudio,
+    ogg: FileAudio,
+    mp4: FileVideo,
+    mov: FileVideo,
+    avi: FileVideo,
+    mkv: FileVideo,
+    webm: FileVideo,
+    zip: FileArchive,
+    rar: FileArchive,
+    '7z': FileArchive,
+    tar: FileArchive,
+    gz: FileArchive,
+    json: FileCode,
+    xml: FileCode,
+    yaml: FileCode,
+    yml: FileCode,
+    html: FileCode,
+    log: FileCode,
+};
+
+/** Colour by family, so a spreadsheet and a document are told apart before being read. */
+const EXTENSION_TONES: Record<string, string> = {
+    pdf: 'text-danger',
+    doc: 'text-accent',
+    docx: 'text-accent',
+    docm: 'text-accent',
+    xls: 'text-ok',
+    xlsx: 'text-ok',
+    xlsm: 'text-ok',
+    csv: 'text-ok',
+    tsv: 'text-ok',
+    ppt: 'text-warn',
+    pptx: 'text-warn',
+};
+
+export function documentExtension(document: WorkspaceDocument): string {
+    const explicit = String(document.file_type ?? '').replace('.', '').toLowerCase();
+    if (explicit) {
+        return explicit;
+    }
+    const fileName = String(document.file_name ?? '');
+    const dotIndex = fileName.lastIndexOf('.');
+    return dotIndex === -1 ? '' : fileName.slice(dotIndex + 1).toLowerCase();
+}
+
+export function DocumentIcon({
+    document,
+    size = 18,
+    className,
+}: {
+    document: WorkspaceDocument;
+    size?: number;
+    className?: string;
+}) {
+    const extension = documentExtension(document);
+    const Icon = EXTENSION_ICONS[extension] ?? FileText;
+    return (
+        <Icon
+            size={size}
+            aria-hidden="true"
+            className={clsx('shrink-0', EXTENSION_TONES[extension] ?? 'text-text-3', className)}
+        />
+    );
+}
+
+/**
+ * Decide readable text for an arbitrary background colour.
+ *
+ * Tag colours are user-chosen and unconstrained, so a fixed foreground would be unreadable
+ * against roughly half of them. The threshold is the usual relative-luminance one.
+ */
+export function readableTextColor(background: string | undefined): string {
+    const hex = String(background ?? '').trim().replace('#', '');
+    if (hex.length !== 3 && hex.length !== 6) {
+        return 'inherit';
+    }
+    const expanded =
+        hex.length === 3
+            ? hex.split('').map((character) => character + character).join('')
+            : hex;
+    const red = parseInt(expanded.slice(0, 2), 16);
+    const green = parseInt(expanded.slice(2, 4), 16);
+    const blue = parseInt(expanded.slice(4, 6), 16);
+    if ([red, green, blue].some((channel) => Number.isNaN(channel))) {
+        return 'inherit';
+    }
+    const luminance = (0.299 * red + 0.587 * green + 0.114 * blue) / 255;
+    return luminance > 0.6 ? '#1f2933' : '#ffffff';
+}
+
+export function TagChip({
+    name,
+    color,
+    onRemove,
+    onClick,
+}: {
+    name: string;
+    color?: string;
+    onRemove?: () => void;
+    onClick?: () => void;
+}) {
+    const style = color
+        ? { backgroundColor: color, color: readableTextColor(color) }
+        : undefined;
+
+    return (
+        <span
+            className={clsx(
+                'inline-flex max-w-full items-center gap-1 rounded-full px-2 py-0.5',
+                'text-[11px] leading-none font-medium',
+                !color && 'bg-surface-2 text-text-2',
+            )}
+            style={style}
+        >
+            {onClick ? (
+                <button
+                    type="button"
+                    onClick={onClick}
+                    className="max-w-[10rem] truncate hover:underline"
+                >
+                    {name}
+                </button>
+            ) : (
+                <span className="max-w-[10rem] truncate">{name}</span>
+            )}
+            {onRemove ? (
+                <button
+                    type="button"
+                    onClick={onRemove}
+                    aria-label={`Remove tag ${name}`}
+                    className="-mr-0.5 rounded-full px-0.5 leading-none opacity-70 hover:opacity-100"
+                >
+                    &times;
+                </button>
+            ) : null}
+        </span>
+    );
+}
+
+/** A row of tag chips that stops at `limit` and reports how many it left out. */
+export function TagChipList({
+    tags,
+    colors,
+    limit,
+    onSelectTag,
+}: {
+    tags: string[];
+    colors?: Record<string, string | undefined>;
+    limit?: number;
+    onSelectTag?: (tag: string) => void;
+}) {
+    if (tags.length === 0) {
+        return <span className="text-xs text-text-3">—</span>;
+    }
+
+    const shown = limit ? tags.slice(0, limit) : tags;
+    const hidden = tags.length - shown.length;
+
+    return (
+        <span className="flex flex-wrap items-center gap-1">
+            {shown.map((tag) => (
+                <TagChip
+                    key={tag}
+                    name={tag}
+                    color={colors?.[tag]}
+                    onClick={onSelectTag ? () => onSelectTag(tag) : undefined}
+                />
+            ))}
+            {hidden > 0 ? (
+                <span className="text-[11px] text-text-3" title={tags.join(', ')}>
+                    +{hidden}
+                </span>
+            ) : null}
+        </span>
+    );
+}
+
+export function DocumentStatusBadge({
+    document,
+    showProgressBar = false,
+}: {
+    document: WorkspaceDocument;
+    showProgressBar?: boolean;
+}) {
+    const status = documentStatus(document);
+
+    if (status.state === 'ready') {
+        return (
+            <span className="rounded-full bg-ok-soft px-2 py-0.5 text-[11px] leading-none font-medium text-ok">
+                Ready
+            </span>
+        );
+    }
+
+    if (status.state === 'error') {
+        return (
+            <span
+                className="rounded-full bg-danger-soft px-2 py-0.5 text-[11px] leading-none font-medium text-danger"
+                title={String(document.status ?? 'Processing failed')}
+            >
+                Error
+            </span>
+        );
+    }
+
+    if (status.state === 'pending_approval') {
+        return (
+            <span className="rounded-full bg-warn-soft px-2 py-0.5 text-[11px] leading-none font-medium text-warn">
+                Pending approval
+            </span>
+        );
+    }
+
+    return (
+        <span className="inline-flex min-w-0 flex-col gap-1">
+            <span
+                className="inline-flex items-center gap-1 rounded-full bg-warn-soft px-2 py-0.5 text-[11px] leading-none font-medium text-warn"
+                title={String(document.status ?? 'Processing')}
+            >
+                <Loader2 size={10} className="animate-spin" />
+                {status.label}
+            </span>
+            {showProgressBar ? (
+                <span
+                    className="block h-1 w-full overflow-hidden rounded-full bg-surface-sunken"
+                    role="progressbar"
+                    aria-valuenow={status.percent}
+                    aria-valuemin={0}
+                    aria-valuemax={100}
+                >
+                    <span
+                        className="block h-full rounded-full bg-warn transition-[width] duration-500"
+                        style={{ width: `${status.percent}%` }}
+                    />
+                </span>
+            ) : null}
+        </span>
+    );
+}
+
+export function ClassificationBadge({
+    classification,
+    color,
+}: {
+    classification: string;
+    color?: string;
+}) {
+    return (
+        <span
+            className={clsx(
+                'rounded-full px-2 py-0.5 text-[11px] leading-none font-medium whitespace-nowrap',
+                !color && 'bg-surface-2 text-text-2',
+            )}
+            style={color ? { backgroundColor: color, color: readableTextColor(color) } : undefined}
+        >
+            {classification}
+        </span>
+    );
+}

--- a/application/v2_ui/src/components/ui/Toaster.tsx
+++ b/application/v2_ui/src/components/ui/Toaster.tsx
@@ -50,6 +50,18 @@ export function Toaster() {
                             )}
                         />
                         <p className="min-w-0 flex-1 text-sm text-text-1">{item.message}</p>
+                        {item.action ? (
+                            <button
+                                type="button"
+                                onClick={() => {
+                                    item.action?.onAct();
+                                    dismiss(item.id);
+                                }}
+                                className="shrink-0 rounded-md px-2 py-0.5 text-xs font-semibold text-accent transition-colors hover:bg-accent-soft"
+                            >
+                                {item.action.label}
+                            </button>
+                        ) : null}
                         {/* Work in progress cannot be cancelled, so offering to close it would
                             only hide the one thing telling the user it is still running. */}
                         {!pending && (

--- a/application/v2_ui/src/lib/documentExplorer.ts
+++ b/application/v2_ui/src/lib/documentExplorer.ts
@@ -722,6 +722,122 @@ export function paginationItems(
     return [1, null, ...range(current - half, current - half + middleRun - 1), null, pageCount];
 }
 
+/** Split a list into fixed-size batches. */
+export function batched<T>(items: readonly T[], size: number): T[][] {
+    const batchSize = Math.max(1, Math.trunc(size) || 1);
+    const batches: T[][] = [];
+    for (let index = 0; index < items.length; index += batchSize) {
+        batches.push(items.slice(index, index + batchSize));
+    }
+    return batches;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Extraction mode                                                             */
+/* -------------------------------------------------------------------------- */
+
+export type ExtractionMode = 'read' | 'layout';
+
+/**
+ * Extensions the extraction mode can be changed for.
+ *
+ * Only PDFs and images go through Document Intelligence, so offering the choice on a .docx
+ * would queue a job that changes nothing. Quoted from
+ * EXTRACTION_MODE_CHANGE_IMAGE_EXTENSIONS in workspace-documents.js.
+ */
+export const EXTRACTION_MODE_IMAGE_EXTENSIONS = [
+    '.jpg',
+    '.jpeg',
+    '.png',
+    '.bmp',
+    '.tiff',
+    '.tif',
+    '.heif',
+    '.heic',
+] as const;
+
+export function supportsExtractionModeChange(document: WorkspaceDocument): boolean {
+    const fileName = String(document.file_name ?? '').toLowerCase();
+    if (!fileName) {
+        return false;
+    }
+    return (
+        fileName.endsWith('.pdf') ||
+        EXTRACTION_MODE_IMAGE_EXTENSIONS.some((extension) => fileName.endsWith(extension))
+    );
+}
+
+/** The mode a document was last extracted with, or null when it was never recorded. */
+export function extractionMode(document: WorkspaceDocument): ExtractionMode | null {
+    const mode = String(document.document_intelligence_extraction_mode ?? '')
+        .trim()
+        .toLowerCase();
+    if (mode === 'layout' || mode === 'read') {
+        return mode;
+    }
+    return null;
+}
+
+export function extractionModeLabel(mode: ExtractionMode | null): string {
+    if (mode === 'layout') {
+        return 'Enhanced';
+    }
+    if (mode === 'read') {
+        return 'Standard';
+    }
+    return 'Unknown';
+}
+
+export interface ExtractionSummary {
+    /** Documents whose extraction mode can be changed. */
+    supported: WorkspaceDocument[];
+    /** Documents that are not PDFs or images, so the choice does not apply to them. */
+    unsupported: WorkspaceDocument[];
+    /**
+     * The mode the supported documents are currently on.
+     *
+     * `mixed` when they disagree and `null` when none of them recorded one, which are
+     * different situations: the first means switching will change some of them, the second
+     * means nothing is known about any of them.
+     */
+    current: ExtractionMode | 'mixed' | null;
+}
+
+/**
+ * Work out what to say about a selection's extraction mode.
+ *
+ * The pane previously offered Standard and Enhanced as two equal buttons without saying
+ * which one the document was already on, so the only way to change it was to guess and then
+ * check. Reporting the current mode is what turns two buttons into one meaningful choice.
+ */
+export function summarizeExtraction(
+    documents: readonly WorkspaceDocument[],
+): ExtractionSummary {
+    const supported: WorkspaceDocument[] = [];
+    const unsupported: WorkspaceDocument[] = [];
+
+    for (const document of documents) {
+        (supportsExtractionModeChange(document) ? supported : unsupported).push(document);
+    }
+
+    const modes = new Set<ExtractionMode>();
+    for (const document of supported) {
+        const mode = extractionMode(document);
+        if (mode) {
+            modes.add(mode);
+        }
+    }
+
+    let current: ExtractionMode | 'mixed' | null = null;
+    if (modes.size === 1) {
+        current = [...modes][0];
+    } else if (modes.size > 1) {
+        current = 'mixed';
+    }
+
+    return { supported, unsupported, current };
+}
+
 /* -------------------------------------------------------------------------- */
 /* Facets                                                                      */
 /* -------------------------------------------------------------------------- */

--- a/application/v2_ui/src/lib/documentExplorer.ts
+++ b/application/v2_ui/src/lib/documentExplorer.ts
@@ -1,0 +1,790 @@
+// documentExplorer.ts
+// The rules behind the workspace documents explorer, kept free of React.
+//
+// Everything here is a plain function over plain data: query state to API parameters, the
+// selection algebra behind click / Ctrl+click / Shift+click, the derived processing state,
+// and the formatting the list and details pane share. That separation is what lets the
+// awkward parts -- range selection across a re-sorted list, a tag arriving in three
+// different shapes -- be exercised directly in a test rather than through a renderer.
+
+import type {
+    DocumentFacets,
+    DocumentPlace,
+    DocumentQuery,
+    DocumentSortField,
+    WorkspaceDocument,
+} from './types';
+
+/* -------------------------------------------------------------------------- */
+/* Query state                                                                 */
+/* -------------------------------------------------------------------------- */
+
+export const DOCUMENT_PAGE_SIZES = [25, 50, 100, 250] as const;
+
+/**
+ * 50 rather than the classic interface's 10.
+ *
+ * Ten rows reads as a widget on a settings page; an explorer is expected to show you your
+ * files. The list is paginated server-side, so the larger page costs one query either way.
+ */
+export const DEFAULT_DOCUMENT_PAGE_SIZE = 50;
+
+/** Ordering fields the server will honour. Mirrors ALLOWED_DOCUMENT_SORT_FIELDS. */
+export const DOCUMENT_SORT_FIELDS: readonly DocumentSortField[] = [
+    '_ts',
+    'file_name',
+    'title',
+    'upload_date',
+    'file_size',
+    'number_of_pages',
+    'version',
+    'document_classification',
+];
+
+export const DOCUMENT_PLACES: readonly DocumentPlace[] = [
+    'all',
+    'recent',
+    'shared',
+    'processing',
+    'errors',
+    'untagged',
+];
+
+export const DEFAULT_DOCUMENT_QUERY: DocumentQuery = {
+    place: 'all',
+    search: '',
+    tags: [],
+    classification: null,
+    page: 1,
+    pageSize: DEFAULT_DOCUMENT_PAGE_SIZE,
+    sortBy: '_ts',
+    sortOrder: 'desc',
+};
+
+/**
+ * Turn query state into the list endpoint's query string.
+ *
+ * Empty values are omitted rather than sent blank: the route treats a present-but-empty
+ * `search` as a filter over the empty string, which matches everything and merely makes the
+ * request harder to read in a log.
+ */
+export function buildDocumentListParams(query: Partial<DocumentQuery>): string {
+    const resolved = { ...DEFAULT_DOCUMENT_QUERY, ...query };
+    const params = new URLSearchParams();
+
+    params.set('page', String(Math.max(1, Math.trunc(resolved.page) || 1)));
+    params.set('page_size', String(normalizePageSize(resolved.pageSize)));
+
+    const search = resolved.search.trim();
+    if (search) {
+        params.set('search', search);
+    }
+
+    const tags = normalizeTagList(resolved.tags);
+    if (tags.length > 0) {
+        params.set('tags', tags.join(','));
+    }
+
+    if (resolved.classification) {
+        params.set('classification', resolved.classification);
+    }
+
+    if (resolved.place && resolved.place !== 'all') {
+        params.set('place', resolved.place);
+    }
+
+    params.set('sort_by', normalizeSortField(resolved.sortBy));
+    params.set('sort_order', resolved.sortOrder === 'asc' ? 'asc' : 'desc');
+
+    return params.toString();
+}
+
+export function normalizeSortField(field: unknown): DocumentSortField {
+    return DOCUMENT_SORT_FIELDS.includes(field as DocumentSortField)
+        ? (field as DocumentSortField)
+        : '_ts';
+}
+
+export function normalizePageSize(pageSize: unknown): number {
+    const parsed = Math.trunc(Number(pageSize));
+    if (!Number.isFinite(parsed) || parsed < 1) {
+        return DEFAULT_DOCUMENT_PAGE_SIZE;
+    }
+    // Not clamped to DOCUMENT_PAGE_SIZES: a value restored from a saved preference written
+    // by an older build should still be honoured rather than silently reset.
+    return Math.min(parsed, 500);
+}
+
+/**
+ * Apply a change and decide whether it should send the user back to page one.
+ *
+ * Any change that alters *which* documents match has to reset the page, otherwise narrowing
+ * a filter while on page 4 lands on an empty page and reads as "no documents" rather than
+ * as "you are past the end".
+ */
+export function applyQueryChange(
+    query: DocumentQuery,
+    change: Partial<DocumentQuery>,
+): DocumentQuery {
+    const next = { ...query, ...change };
+    const changesResultSet =
+        ('place' in change && change.place !== query.place) ||
+        ('search' in change && change.search !== query.search) ||
+        ('classification' in change && change.classification !== query.classification) ||
+        ('pageSize' in change && change.pageSize !== query.pageSize) ||
+        ('tags' in change && !sameTagList(change.tags ?? [], query.tags));
+
+    if (changesResultSet && !('page' in change)) {
+        next.page = 1;
+    }
+    return next;
+}
+
+/**
+ * Toggle a column's sort, starting descending for the fields where that is the useful end.
+ *
+ * Newest-first and largest-first are what people want from a date or a size; A-Z is what
+ * they want from a name. Starting every column ascending makes half of them require two
+ * clicks to be useful.
+ */
+export function toggleSort(
+    query: DocumentQuery,
+    field: DocumentSortField,
+): DocumentQuery {
+    if (query.sortBy === field) {
+        return { ...query, sortOrder: query.sortOrder === 'asc' ? 'desc' : 'asc' };
+    }
+    const descendingFirst: DocumentSortField[] = [
+        '_ts',
+        'upload_date',
+        'file_size',
+        'number_of_pages',
+        'version',
+    ];
+    return {
+        ...query,
+        sortBy: field,
+        sortOrder: descendingFirst.includes(field) ? 'desc' : 'asc',
+    };
+}
+
+function sameTagList(left: readonly string[], right: readonly string[]): boolean {
+    if (left.length !== right.length) {
+        return false;
+    }
+    return left.every((tag, index) => tag === right[index]);
+}
+
+/* -------------------------------------------------------------------------- */
+/* Filter chips                                                                */
+/* -------------------------------------------------------------------------- */
+
+export interface FilterChip {
+    /** Identifies which part of the query the chip removes. */
+    kind: 'place' | 'search' | 'tag' | 'classification';
+    /** For a tag chip, the tag it removes. */
+    value: string;
+    label: string;
+}
+
+export const DOCUMENT_PLACE_LABELS: Record<DocumentPlace, string> = {
+    all: 'All documents',
+    recent: 'Recent',
+    shared: 'Shared with me',
+    processing: 'Processing',
+    errors: 'Needs attention',
+    untagged: 'Untagged',
+};
+
+/**
+ * Describe the active filters as removable chips.
+ *
+ * A flat, tagged workspace has no path to put in a breadcrumb, and the honest equivalent is
+ * to say what is currently narrowing the list. The classic interface shows nothing at all,
+ * which is why a filter left set on one visit looks like missing documents on the next.
+ */
+export function describeActiveFilters(query: DocumentQuery): FilterChip[] {
+    const chips: FilterChip[] = [];
+
+    if (query.place && query.place !== 'all') {
+        chips.push({
+            kind: 'place',
+            value: query.place,
+            label: DOCUMENT_PLACE_LABELS[query.place] ?? query.place,
+        });
+    }
+
+    const search = query.search.trim();
+    if (search) {
+        chips.push({ kind: 'search', value: search, label: `Search: ${search}` });
+    }
+
+    for (const tag of normalizeTagList(query.tags)) {
+        chips.push({ kind: 'tag', value: tag, label: tag });
+    }
+
+    if (query.classification) {
+        chips.push({
+            kind: 'classification',
+            value: query.classification,
+            label: query.classification,
+        });
+    }
+
+    return chips;
+}
+
+/** Remove one chip from the query, resetting to page one. */
+export function clearFilterChip(query: DocumentQuery, chip: FilterChip): DocumentQuery {
+    switch (chip.kind) {
+        case 'place':
+            return applyQueryChange(query, { place: 'all' });
+        case 'search':
+            return applyQueryChange(query, { search: '' });
+        case 'classification':
+            return applyQueryChange(query, { classification: null });
+        case 'tag':
+            return applyQueryChange(query, {
+                tags: query.tags.filter((tag) => tag !== chip.value),
+            });
+        default:
+            return query;
+    }
+}
+
+/** Reset every filter while keeping how the list is presented. */
+export function clearAllFilters(query: DocumentQuery): DocumentQuery {
+    return applyQueryChange(query, {
+        place: 'all',
+        search: '',
+        tags: [],
+        classification: null,
+    });
+}
+
+/* -------------------------------------------------------------------------- */
+/* Tags                                                                        */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Reduce a tag of any shape to its name.
+ *
+ * Tags arrive in more than one form: /api/documents/tags returns `{name, count, color}`
+ * objects, while a document's own `tags` field may be an array of strings or a
+ * comma-separated string. Rendering an object directly is what caused React error #31 on
+ * this page, so every tag is funnelled through here.
+ */
+export function tagName(tag: unknown): string {
+    if (typeof tag === 'string') {
+        return tag.trim();
+    }
+    if (tag && typeof tag === 'object' && 'name' in tag) {
+        return String((tag as { name: unknown }).name ?? '').trim();
+    }
+    return '';
+}
+
+export function normalizeTags(tags: unknown): string[] {
+    if (Array.isArray(tags)) {
+        return tags.map(tagName).filter(Boolean);
+    }
+    if (typeof tags === 'string' && tags.trim()) {
+        return tags
+            .split(',')
+            .map((tag) => tag.trim())
+            .filter(Boolean);
+    }
+    return [];
+}
+
+/** De-duplicate a tag list while keeping the order the user built it in. */
+export function normalizeTagList(tags: readonly unknown[]): string[] {
+    const seen = new Set<string>();
+    const result: string[] = [];
+    for (const tag of tags ?? []) {
+        const name = tagName(tag);
+        if (name && !seen.has(name)) {
+            seen.add(name);
+            result.push(name);
+        }
+    }
+    return result;
+}
+
+/** Tags carried by every one of the given documents, for the multi-selection pane. */
+export function commonTags(documents: readonly WorkspaceDocument[]): string[] {
+    if (documents.length === 0) {
+        return [];
+    }
+    const [first, ...rest] = documents;
+    let shared = normalizeTags(first.tags);
+    for (const document of rest) {
+        const tags = new Set(normalizeTags(document.tags));
+        shared = shared.filter((tag) => tags.has(tag));
+        if (shared.length === 0) {
+            break;
+        }
+    }
+    return shared;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Document state                                                              */
+/* -------------------------------------------------------------------------- */
+
+export type DocumentState = 'ready' | 'processing' | 'error' | 'pending_approval';
+
+export interface DocumentStatus {
+    state: DocumentState;
+    /** 0-100. Only meaningful while processing. */
+    percent: number;
+    label: string;
+}
+
+/**
+ * Work out what to show for a document's processing state.
+ *
+ * Mirrors `_document_processing_state` in route_backend_documents.py. A document with no
+ * `percentage_complete` at all predates progress tracking and is treated as ready: showing
+ * it as permanently stuck at 0% would be worse than saying nothing.
+ */
+export function documentStatus(document: WorkspaceDocument): DocumentStatus {
+    const statusText = String(document.status ?? '').toLowerCase();
+
+    if (statusText.includes('error') || statusText.includes('failed')) {
+        return { state: 'error', percent: 0, label: 'Error' };
+    }
+
+    if (document.shared_approval_status === 'not_approved') {
+        return { state: 'pending_approval', percent: 100, label: 'Pending approval' };
+    }
+
+    const raw = document.percentage_complete;
+    if (raw === undefined || raw === null) {
+        return { state: 'ready', percent: 100, label: 'Ready' };
+    }
+
+    const percent = Number(raw);
+    if (!Number.isFinite(percent) || percent >= 100) {
+        return { state: 'ready', percent: 100, label: 'Ready' };
+    }
+
+    const clamped = Math.max(0, Math.min(99, Math.round(percent)));
+    return { state: 'processing', percent: clamped, label: `${clamped}%` };
+}
+
+/** True while the document is still being indexed and its row should keep polling. */
+export function isProcessing(document: WorkspaceDocument): boolean {
+    return documentStatus(document).state === 'processing';
+}
+
+export function documentId(document: WorkspaceDocument): string {
+    return String(document.id ?? document.document_id ?? '');
+}
+
+/**
+ * The two lines of the name column.
+ *
+ * A file name is often something like `MSA_v2_FINAL(3).docx`, which says very little, so the
+ * extracted title leads when there is one. When there is not, promoting the file name is
+ * better than showing "Untitled" above it.
+ */
+export function documentDisplayName(document: WorkspaceDocument): {
+    primary: string;
+    secondary: string | null;
+} {
+    const title = String(document.title ?? '').trim();
+    const fileName = String(document.file_name ?? '').trim();
+
+    if (title && fileName && title !== fileName) {
+        return { primary: title, secondary: fileName };
+    }
+    return { primary: title || fileName || 'Untitled', secondary: null };
+}
+
+/** Split a comma-separated or already-split metadata field into a clean list. */
+export function normalizeStringList(value: unknown): string[] {
+    if (Array.isArray(value)) {
+        return value.map((entry) => String(entry ?? '').trim()).filter(Boolean);
+    }
+    if (typeof value === 'string' && value.trim()) {
+        return value
+            .split(',')
+            .map((entry) => entry.trim())
+            .filter(Boolean);
+    }
+    return [];
+}
+
+/* -------------------------------------------------------------------------- */
+/* Selection                                                                   */
+/* -------------------------------------------------------------------------- */
+
+export interface SelectionState {
+    /** Selected document ids. */
+    ids: string[];
+    /** Where a Shift+click range starts. Null when there is nothing to extend from. */
+    anchorId: string | null;
+}
+
+export const EMPTY_SELECTION: SelectionState = { ids: [], anchorId: null };
+
+export type SelectionIntent = 'replace' | 'toggle' | 'range';
+
+/**
+ * Read the intent out of a click's modifier keys.
+ *
+ * Ctrl and Cmd are treated the same so the behaviour matches the platform the user is on
+ * without the caller having to know which that is.
+ */
+export function selectionIntentFromEvent(event: {
+    shiftKey?: boolean;
+    ctrlKey?: boolean;
+    metaKey?: boolean;
+}): SelectionIntent {
+    if (event.shiftKey) {
+        return 'range';
+    }
+    if (event.ctrlKey || event.metaKey) {
+        return 'toggle';
+    }
+    return 'replace';
+}
+
+/**
+ * Apply a click to the selection.
+ *
+ * `orderedIds` is the list as currently displayed, which is what makes a Shift+click range
+ * mean what the user sees: re-sorting the table changes which documents lie between the
+ * anchor and the click, and reading the order from the rendered list rather than from the
+ * selection is what keeps the two in step.
+ *
+ * A range extends from the anchor and *replaces* the selection rather than adding to it,
+ * which is what lets a user correct an over-long range by Shift+clicking a nearer row
+ * instead of having to start again.
+ */
+export function applySelection(
+    selection: SelectionState,
+    documentIdentifier: string,
+    intent: SelectionIntent,
+    orderedIds: readonly string[],
+): SelectionState {
+    if (!documentIdentifier) {
+        return selection;
+    }
+
+    if (intent === 'range' && selection.anchorId) {
+        const anchorIndex = orderedIds.indexOf(selection.anchorId);
+        const targetIndex = orderedIds.indexOf(documentIdentifier);
+        if (anchorIndex !== -1 && targetIndex !== -1) {
+            const [start, end] =
+                anchorIndex <= targetIndex
+                    ? [anchorIndex, targetIndex]
+                    : [targetIndex, anchorIndex];
+            return {
+                ids: orderedIds.slice(start, end + 1),
+                anchorId: selection.anchorId,
+            };
+        }
+    }
+
+    if (intent === 'toggle') {
+        const selected = new Set(selection.ids);
+        if (selected.has(documentIdentifier)) {
+            selected.delete(documentIdentifier);
+        } else {
+            selected.add(documentIdentifier);
+        }
+        return {
+            ids: orderedIds.filter((id) => selected.has(id)),
+            anchorId: documentIdentifier,
+        };
+    }
+
+    return { ids: [documentIdentifier], anchorId: documentIdentifier };
+}
+
+/** Select every row on the page, or clear when they are all selected already. */
+export function toggleSelectAll(
+    selection: SelectionState,
+    orderedIds: readonly string[],
+): SelectionState {
+    const allSelected =
+        orderedIds.length > 0 && orderedIds.every((id) => selection.ids.includes(id));
+    if (allSelected) {
+        return EMPTY_SELECTION;
+    }
+    return { ids: [...orderedIds], anchorId: orderedIds[0] ?? null };
+}
+
+/**
+ * Drop ids that are no longer on the page.
+ *
+ * Called after every reload. Without it a bulk action taken after paging would apply to
+ * documents the user can no longer see, which is the kind of surprise a delete button must
+ * never produce.
+ */
+export function pruneSelection(
+    selection: SelectionState,
+    orderedIds: readonly string[],
+): SelectionState {
+    const visible = new Set(orderedIds);
+    const ids = selection.ids.filter((id) => visible.has(id));
+    if (ids.length === selection.ids.length) {
+        return selection;
+    }
+    return {
+        ids,
+        anchorId: selection.anchorId && visible.has(selection.anchorId)
+            ? selection.anchorId
+            : (ids[0] ?? null),
+    };
+}
+
+/** Move the selection by one row, optionally extending it, for arrow-key navigation. */
+export function moveSelection(
+    selection: SelectionState,
+    orderedIds: readonly string[],
+    delta: number,
+    extend: boolean,
+): SelectionState {
+    if (orderedIds.length === 0) {
+        return selection;
+    }
+
+    const current = selection.ids[selection.ids.length - 1];
+    const currentIndex = current ? orderedIds.indexOf(current) : -1;
+    const nextIndex = Math.max(
+        0,
+        Math.min(orderedIds.length - 1, currentIndex === -1 ? 0 : currentIndex + delta),
+    );
+    const nextId = orderedIds[nextIndex];
+
+    if (extend && selection.anchorId) {
+        return applySelection(selection, nextId, 'range', orderedIds);
+    }
+    return { ids: [nextId], anchorId: nextId };
+}
+
+/* -------------------------------------------------------------------------- */
+/* Formatting                                                                  */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Format a byte count the way a file manager does.
+ *
+ * Binary units with a decimal-looking label, matching what Windows and macOS both report,
+ * so a size shown here agrees with the size shown after the file is downloaded.
+ */
+export function formatFileSize(bytes: unknown): string {
+    const value = Number(bytes);
+    if (!Number.isFinite(value) || value <= 0) {
+        return '—';
+    }
+    const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+    let size = value;
+    let unitIndex = 0;
+    while (size >= 1024 && unitIndex < units.length - 1) {
+        size /= 1024;
+        unitIndex += 1;
+    }
+    const rounded = size >= 100 || unitIndex === 0 ? Math.round(size) : Number(size.toFixed(1));
+    return `${rounded} ${units[unitIndex]}`;
+}
+
+export function totalFileSize(documents: readonly WorkspaceDocument[]): number {
+    return documents.reduce((total, document) => {
+        const size = Number(document.file_size);
+        return Number.isFinite(size) && size > 0 ? total + size : total;
+    }, 0);
+}
+
+/** The document's upload time as a Date, or null when it has none that can be read. */
+export function documentDate(document: WorkspaceDocument): Date | null {
+    const ts = Number(document._ts);
+    if (Number.isFinite(ts) && ts > 0) {
+        return new Date(ts * 1000);
+    }
+    const raw = document.upload_date ?? document.last_updated;
+    if (!raw) {
+        return null;
+    }
+    const parsed = new Date(String(raw));
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+/**
+ * A short relative time, falling back to an absolute date once that stops being useful.
+ *
+ * "3 months ago" is harder to act on than the date itself, so anything beyond a month is
+ * shown as a date. The exact timestamp is available in the details pane either way.
+ */
+export function formatRelativeDate(value: Date | null, now: Date = new Date()): string {
+    if (!value) {
+        return '—';
+    }
+    const seconds = Math.round((now.getTime() - value.getTime()) / 1000);
+    if (seconds < 0) {
+        return value.toLocaleDateString();
+    }
+    if (seconds < 60) {
+        return 'Just now';
+    }
+    const minutes = Math.floor(seconds / 60);
+    if (minutes < 60) {
+        return `${minutes} min ago`;
+    }
+    const hours = Math.floor(minutes / 60);
+    if (hours < 24) {
+        return `${hours} hr ago`;
+    }
+    const days = Math.floor(hours / 24);
+    if (days === 1) {
+        return 'Yesterday';
+    }
+    if (days < 30) {
+        return `${days} days ago`;
+    }
+    return value.toLocaleDateString();
+}
+
+export function formatAbsoluteDate(value: Date | null): string {
+    if (!value) {
+        return '—';
+    }
+    return value.toLocaleString();
+}
+
+/* -------------------------------------------------------------------------- */
+/* Pagination                                                                  */
+/* -------------------------------------------------------------------------- */
+
+export interface PageRange {
+    /** 1-based index of the first item on the page, or 0 when there are none. */
+    from: number;
+    to: number;
+    total: number;
+    pageCount: number;
+}
+
+export function describePage(
+    page: number,
+    pageSize: number,
+    totalCount: number,
+): PageRange {
+    const total = Math.max(0, Math.trunc(totalCount) || 0);
+    const size = normalizePageSize(pageSize);
+    const pageCount = Math.max(1, Math.ceil(total / size));
+    if (total === 0) {
+        return { from: 0, to: 0, total: 0, pageCount: 1 };
+    }
+    const currentPage = Math.max(1, Math.min(pageCount, Math.trunc(page) || 1));
+    const from = (currentPage - 1) * size + 1;
+    const to = Math.min(total, currentPage * size);
+    return { from, to, total, pageCount };
+}
+
+/**
+ * Page numbers to offer, with nulls standing in for gaps.
+ *
+ * Always renders exactly `maxButtons` slots once there are more pages than that, counting a
+ * gap marker as a slot. Budgeting for the gaps is the whole point: sizing only the numbers
+ * lets the control change width as the window moves away from an edge, which shifts the
+ * Next button out from under the pointer on the click that moved it.
+ */
+export function paginationItems(
+    page: number,
+    pageCount: number,
+    maxButtons = 7,
+): (number | null)[] {
+    if (pageCount <= maxButtons) {
+        return Array.from({ length: pageCount }, (_, index) => index + 1);
+    }
+
+    const current = Math.max(1, Math.min(pageCount, Math.trunc(page) || 1));
+    const range = (start: number, end: number) =>
+        Array.from({ length: end - start + 1 }, (_, index) => start + index);
+
+    // One anchor and one gap at the far side leave this many contiguous pages.
+    const edgeRun = maxButtons - 2;
+    // Two anchors and two gaps leave this many, centred on the current page.
+    const middleRun = maxButtons - 4;
+
+    if (current <= maxButtons - 3) {
+        return [...range(1, edgeRun), null, pageCount];
+    }
+
+    if (current >= pageCount - middleRun) {
+        return [1, null, ...range(pageCount - edgeRun + 1, pageCount)];
+    }
+
+    const half = Math.floor(middleRun / 2);
+    return [1, null, ...range(current - half, current - half + middleRun - 1), null, pageCount];
+}
+
+/* -------------------------------------------------------------------------- */
+/* Facets                                                                      */
+/* -------------------------------------------------------------------------- */
+
+export const EMPTY_FACETS: DocumentFacets = {
+    total: 0,
+    untagged: 0,
+    processing: 0,
+    errors: 0,
+    recent: 0,
+    shared_with_me: 0,
+    by_tag: {},
+    by_classification: {},
+};
+
+/** The count to show against a place in the rail, or null when it should show none. */
+export function placeCount(facets: DocumentFacets | null, place: DocumentPlace): number | null {
+    if (!facets) {
+        return null;
+    }
+    switch (place) {
+        case 'all':
+            return facets.total;
+        case 'recent':
+            return facets.recent;
+        case 'shared':
+            return facets.shared_with_me;
+        case 'processing':
+            return facets.processing;
+        case 'errors':
+            return facets.errors;
+        case 'untagged':
+            return facets.untagged;
+        default:
+            return null;
+    }
+}
+
+/**
+ * Places worth showing in the rail.
+ *
+ * "All" is always offered; the rest appear only once they describe something, so a workspace
+ * with nothing in flight does not carry a permanent "Processing 0" entry.
+ */
+export function visiblePlaces(facets: DocumentFacets | null): DocumentPlace[] {
+    const places: DocumentPlace[] = ['all'];
+    if (!facets) {
+        return places;
+    }
+    if (facets.recent > 0) {
+        places.push('recent');
+    }
+    if (facets.shared_with_me > 0) {
+        places.push('shared');
+    }
+    if (facets.processing > 0) {
+        places.push('processing');
+    }
+    if (facets.errors > 0) {
+        places.push('errors');
+    }
+    if (facets.untagged > 0) {
+        places.push('untagged');
+    }
+    return places;
+}

--- a/application/v2_ui/src/lib/documentSavedViews.ts
+++ b/application/v2_ui/src/lib/documentSavedViews.ts
@@ -1,0 +1,191 @@
+// documentSavedViews.ts
+// Named filter combinations pinned in the documents explorer rail.
+//
+// A saved view is the honest answer to "where are my folders?" in a workspace that files by
+// tag. A folder is a place a document sits in; a saved view is a question the workspace
+// answers, which is what a flat, multi-tagged store can actually offer. Windows calls these
+// saved searches and macOS calls them smart folders, and both sit in the sidebar next to
+// real folders precisely because they are used the same way.
+//
+// They live in user settings rather than in Cosmos because they describe how one person
+// prefers to look at their own documents, which is the same class of thing as the view mode
+// and the page size stored alongside them.
+
+import type { DocumentPlace, DocumentQuery, DocumentSavedView } from './types';
+import { DOCUMENT_PLACES, normalizeTagList } from './documentExplorer';
+
+export const MAX_SAVED_VIEWS = 30;
+export const MAX_SAVED_VIEW_NAME_LENGTH = 60;
+
+/** The part of a query a saved view captures: what is shown, not how it is presented. */
+export type SavedViewQuery = DocumentSavedView['query'];
+
+/**
+ * Reduce a live query to the part worth saving.
+ *
+ * Sort order, page and page size are deliberately excluded. They describe how the user is
+ * reading the list at this moment rather than which documents the view is about, and baking
+ * a page number into a saved view would make it land somewhere arbitrary later.
+ */
+export function savedViewQueryFromQuery(query: DocumentQuery): SavedViewQuery {
+    return {
+        place: query.place,
+        search: query.search.trim(),
+        tags: normalizeTagList(query.tags),
+        classification: query.classification,
+    };
+}
+
+/** True when the query narrows anything, and so is worth offering to save. */
+export function isSaveableQuery(query: DocumentQuery): boolean {
+    const saved = savedViewQueryFromQuery(query);
+    return Boolean(
+        (saved.place && saved.place !== 'all') ||
+            saved.search ||
+            saved.tags.length > 0 ||
+            saved.classification,
+    );
+}
+
+/** True when the live query is showing exactly what this saved view describes. */
+export function matchesSavedView(query: DocumentQuery, view: DocumentSavedView): boolean {
+    const current = savedViewQueryFromQuery(query);
+    return (
+        current.place === view.query.place &&
+        current.search === view.query.search &&
+        (current.classification ?? null) === (view.query.classification ?? null) &&
+        current.tags.length === view.query.tags.length &&
+        current.tags.every((tag, index) => tag === view.query.tags[index])
+    );
+}
+
+/** Apply a saved view to the live query, returning to page one. */
+export function applySavedView(query: DocumentQuery, view: DocumentSavedView): DocumentQuery {
+    return {
+        ...query,
+        place: view.query.place,
+        search: view.query.search,
+        tags: [...view.query.tags],
+        classification: view.query.classification ?? null,
+        page: 1,
+    };
+}
+
+function newSavedViewId(): string {
+    // `crypto.randomUUID` is unavailable over plain HTTP on some hosts and in the test
+    // runner, and an id that fails to generate would take the whole save with it.
+    const cryptoRef = typeof globalThis !== 'undefined' ? globalThis.crypto : undefined;
+    if (cryptoRef && typeof cryptoRef.randomUUID === 'function') {
+        return cryptoRef.randomUUID();
+    }
+    return `view-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+export function createSavedView(name: string, query: DocumentQuery): DocumentSavedView {
+    return {
+        id: newSavedViewId(),
+        name: name.trim().slice(0, MAX_SAVED_VIEW_NAME_LENGTH),
+        query: savedViewQueryFromQuery(query),
+    };
+}
+
+function sanitizePlace(value: unknown): DocumentPlace {
+    return DOCUMENT_PLACES.includes(value as DocumentPlace) ? (value as DocumentPlace) : 'all';
+}
+
+/**
+ * Coerce whatever came back from user settings into usable saved views.
+ *
+ * Settings are stored as free-form JSON and are writable by an older or newer build, so the
+ * stored value is treated as untrusted input. A malformed entry is dropped rather than
+ * allowed to reach the rail, where it would render as a view that filters to nothing.
+ */
+export function parseSavedViews(value: unknown): DocumentSavedView[] {
+    if (!Array.isArray(value)) {
+        return [];
+    }
+
+    const views: DocumentSavedView[] = [];
+    const seenIds = new Set<string>();
+
+    for (const entry of value) {
+        if (!entry || typeof entry !== 'object') {
+            continue;
+        }
+        const record = entry as Record<string, unknown>;
+        const name = String(record.name ?? '').trim();
+        if (!name) {
+            continue;
+        }
+
+        const id = String(record.id ?? '').trim() || newSavedViewId();
+        if (seenIds.has(id)) {
+            continue;
+        }
+        seenIds.add(id);
+
+        const rawQuery = (record.query ?? {}) as Record<string, unknown>;
+        const classification = rawQuery.classification;
+
+        views.push({
+            id,
+            name: name.slice(0, MAX_SAVED_VIEW_NAME_LENGTH),
+            query: {
+                place: sanitizePlace(rawQuery.place),
+                search: String(rawQuery.search ?? '').trim(),
+                tags: normalizeTagList(
+                    Array.isArray(rawQuery.tags) ? rawQuery.tags : [],
+                ),
+                classification:
+                    typeof classification === 'string' && classification.trim()
+                        ? classification.trim()
+                        : null,
+            },
+        });
+
+        if (views.length >= MAX_SAVED_VIEWS) {
+            break;
+        }
+    }
+
+    return views;
+}
+
+/** Add a view, or replace one that has the same name, keeping the list within its cap. */
+export function upsertSavedView(
+    views: readonly DocumentSavedView[],
+    view: DocumentSavedView,
+): DocumentSavedView[] {
+    const existingIndex = views.findIndex(
+        (candidate) =>
+            candidate.id === view.id ||
+            candidate.name.toLowerCase() === view.name.toLowerCase(),
+    );
+
+    if (existingIndex !== -1) {
+        const next = [...views];
+        next[existingIndex] = { ...view, id: views[existingIndex].id };
+        return next;
+    }
+
+    return [...views, view].slice(0, MAX_SAVED_VIEWS);
+}
+
+export function removeSavedView(
+    views: readonly DocumentSavedView[],
+    viewId: string,
+): DocumentSavedView[] {
+    return views.filter((view) => view.id !== viewId);
+}
+
+export function renameSavedView(
+    views: readonly DocumentSavedView[],
+    viewId: string,
+    name: string,
+): DocumentSavedView[] {
+    const trimmed = name.trim().slice(0, MAX_SAVED_VIEW_NAME_LENGTH);
+    if (!trimmed) {
+        return [...views];
+    }
+    return views.map((view) => (view.id === viewId ? { ...view, name: trimmed } : view));
+}

--- a/application/v2_ui/src/lib/endpoints.ts
+++ b/application/v2_ui/src/lib/endpoints.ts
@@ -5,7 +5,8 @@
 // route_backend_chats.py, route_backend_documents.py and functions_conversation_feed.py.
 // Keeping them in one module means a backend path change is a one-line edit here.
 
-import { api, apiUrl, uploadFile, ApiError, API_BASE } from './apiClient';
+import { api, apiUrl, uploadFile, ApiError, API_BASE, CREDENTIALS_MODE } from './apiClient';
+import { buildDocumentListParams } from './documentExplorer';
 import type { EnhancedCitationMetadata } from './enhancedCitations';
 import type { ExportVisualAsset } from './exportVisuals';
 import type { MaskAction, MaskedRange, MaskSelection } from './masking';
@@ -19,6 +20,9 @@ import type {
     ConversationFeedPage,
     ConversationMetadata,
     ConversationSummary,
+    DocumentFacets,
+    DocumentListResponse,
+    DocumentQuery,
     Json,
     PersistedThought,
     WorkspaceDocument,
@@ -836,18 +840,282 @@ export function fetchTabularPreview(
 /* Documents                                                                   */
 /* -------------------------------------------------------------------------- */
 
-export function fetchPersonalDocuments(pageSize = 1000, signal?: AbortSignal) {
-    return api.get<{ documents?: WorkspaceDocument[]; items?: WorkspaceDocument[] }>(
-        `/api/documents?page_size=${pageSize}`,
+/**
+ * List workspace documents.
+ *
+ * Paged, filtered and sorted server-side. `total_count` describes the whole filtered set,
+ * so the pager counts against it rather than against the returned array.
+ */
+export function fetchPersonalDocuments(
+    query: Partial<DocumentQuery> = {},
+    signal?: AbortSignal,
+) {
+    return api.get<DocumentListResponse>(
+        `/api/documents?${buildDocumentListParams(query)}`,
         signal,
     );
 }
 
+/** Counts for the explorer rail, over the whole workspace rather than the current page. */
+export const fetchPersonalDocumentFacets = (signal?: AbortSignal) =>
+    api.get<DocumentFacets>('/api/documents/facets', signal);
+
+export const fetchPersonalDocument = (documentId: string, signal?: AbortSignal) =>
+    api.get<WorkspaceDocument>(`/api/documents/${encodeURIComponent(documentId)}`, signal);
+
+export const fetchPersonalDocumentVersions = (documentId: string, signal?: AbortSignal) =>
+    api.get<{ document_id?: string; revision_family_id?: string; versions?: WorkspaceDocument[] }>(
+        `/api/documents/${encodeURIComponent(documentId)}/versions`,
+        signal,
+    );
+
+export type DocumentDeleteMode = 'all_versions' | 'current_only';
+
+export function deletePersonalDocument(
+    documentId: string,
+    options: {
+        deleteMode?: DocumentDeleteMode;
+        conversationLinkedDeleteConfirmed?: boolean;
+        fileSyncDeleteAction?: string | null;
+    } = {},
+) {
+    const params = new URLSearchParams();
+    params.set('delete_mode', options.deleteMode ?? 'all_versions');
+    if (options.conversationLinkedDeleteConfirmed) {
+        params.set('conversation_linked_delete_confirmed', 'true');
+    }
+    if (options.fileSyncDeleteAction) {
+        params.set('file_sync_delete_action', options.fileSyncDeleteAction);
+    }
+    return api.delete<Json>(
+        `/api/documents/${encodeURIComponent(documentId)}?${params.toString()}`,
+    );
+}
+
+/** One entry per document the batch could not delete. */
+export interface BulkDeleteError {
+    document_id: string;
+    error?: string;
+    message?: string;
+    /** True when the caller may retry with the matching confirmation set. */
+    needs_confirmation?: boolean;
+    conversation?: { id?: string; title?: string; url?: string };
+    [key: string]: unknown;
+}
+
+export interface BulkDeleteResponse {
+    message?: string;
+    deleted?: { document_id: string }[];
+    errors?: BulkDeleteError[];
+    deleted_count?: number;
+    error_count?: number;
+}
+
+/**
+ * Delete several documents in one request.
+ *
+ * Reports per document rather than failing the batch, because a document uploaded through
+ * chat or managed by file sync is guarded individually and would otherwise block the
+ * deletion of everything selected with it.
+ */
+export function bulkDeletePersonalDocuments(
+    documentIds: string[],
+    options: {
+        deleteMode?: DocumentDeleteMode;
+        conversationLinkedDeleteConfirmed?: boolean;
+        fileSyncDeleteAction?: string | null;
+    } = {},
+) {
+    return api.post<BulkDeleteResponse>('/api/documents/bulk-delete', {
+        document_ids: documentIds,
+        delete_mode: options.deleteMode ?? 'all_versions',
+        conversation_linked_delete_confirmed: Boolean(
+            options.conversationLinkedDeleteConfirmed,
+        ),
+        file_sync_delete_action: options.fileSyncDeleteAction ?? null,
+    });
+}
+
+/** Editable metadata. Only the supplied fields are written. */
+export interface DocumentMetadataUpdate {
+    title?: string;
+    abstract?: string;
+    keywords?: string[];
+    publication_date?: string;
+    document_classification?: string;
+    authors?: string[];
+    tags?: string[];
+}
+
+export const updatePersonalDocumentMetadata = (
+    documentId: string,
+    metadata: DocumentMetadataUpdate,
+) =>
+    api.patch<Json>(
+        `/api/documents/${encodeURIComponent(documentId)}`,
+        metadata as unknown as Json,
+    );
+
+export const extractPersonalDocumentMetadata = (documentIds: string[]) =>
+    api.post<{ message?: string; queued?: string[]; errors?: unknown[] }>(
+        '/api/documents/extract_metadata',
+        { document_ids: documentIds },
+    );
+
+/** `read` is the standard extraction, `layout` the enhanced one. */
+export type ExtractionMode = 'read' | 'layout';
+
+export const reprocessPersonalDocumentExtraction = (
+    documentIds: string[],
+    extractionMode: ExtractionMode,
+) =>
+    api.post<{ message?: string; queued?: string[]; errors?: unknown[] }>(
+        '/api/documents/reprocess_extraction',
+        { document_ids: documentIds, extraction_mode: extractionMode },
+    );
+
+/* --- Tags ---------------------------------------------------------------- */
+
 export const fetchPersonalDocumentTags = (signal?: AbortSignal) =>
     api.get<{ tags?: WorkspaceTag[] }>('/api/documents/tags', signal);
 
-export const deletePersonalDocument = (documentId: string) =>
-    api.delete<Json>(`/api/documents/${encodeURIComponent(documentId)}`);
+export const createPersonalDocumentTag = (name: string, color?: string | null) =>
+    api.post<{ message?: string; tag?: WorkspaceTag }>('/api/documents/tags', {
+        tag_name: name,
+        ...(color ? { color } : {}),
+    });
+
+/**
+ * Rename or recolour a tag.
+ *
+ * A rename cascades to every document carrying the tag server-side, which is what makes
+ * renaming safe: the alternative would leave documents filed under a name that no longer
+ * exists in the vocabulary.
+ */
+export const updatePersonalDocumentTag = (
+    tagName: string,
+    changes: { new_name?: string; color?: string | null },
+) =>
+    api.patch<{ message?: string; documents_updated?: number; tag?: WorkspaceTag }>(
+        `/api/documents/tags/${encodeURIComponent(tagName)}`,
+        changes as unknown as Json,
+    );
+
+export const deletePersonalDocumentTag = (tagName: string) =>
+    api.delete<Json>(`/api/documents/tags/${encodeURIComponent(tagName)}`);
+
+export type BulkTagAction = 'add_tags' | 'remove_tags' | 'set_tags';
+
+export const bulkTagPersonalDocuments = (
+    documentIds: string[],
+    action: BulkTagAction,
+    tags: string[],
+) =>
+    api.post<{ success?: string[]; errors?: unknown[] }>('/api/documents/bulk-tag', {
+        document_ids: documentIds,
+        action,
+        tags,
+    });
+
+/* --- Sharing -------------------------------------------------------------- */
+
+export interface SharedDocumentUser {
+    id: string;
+    approval_status?: string;
+    displayName?: string;
+    email?: string;
+}
+
+export const fetchPersonalDocumentSharedUsers = (
+    documentId: string,
+    signal?: AbortSignal,
+) =>
+    api.get<{ shared_users?: SharedDocumentUser[] }>(
+        `/api/documents/${encodeURIComponent(documentId)}/shared-users`,
+        signal,
+    );
+
+export const sharePersonalDocument = (documentId: string, userId: string) =>
+    api.post<Json>(`/api/documents/${encodeURIComponent(documentId)}/share`, {
+        user_id: userId,
+    });
+
+export const unsharePersonalDocument = (documentId: string, userId: string) =>
+    api.delete<Json>(`/api/documents/${encodeURIComponent(documentId)}/unshare`, {
+        user_id: userId,
+    });
+
+export const approvePersonalDocumentShare = (documentId: string) =>
+    api.post<Json>(`/api/documents/${encodeURIComponent(documentId)}/approve-share`);
+
+export const removeSelfFromPersonalDocument = (documentId: string) =>
+    api.delete<Json>(`/api/documents/${encodeURIComponent(documentId)}/remove-self`);
+
+export const searchShareableUsers = (query: string, signal?: AbortSignal) =>
+    api.get<SharedDocumentUser[]>(
+        `/api/userSearch?query=${encodeURIComponent(query)}`,
+        signal,
+    );
+
+/* --- Files ---------------------------------------------------------------- */
+
+/**
+ * Download a document's original file.
+ *
+ * Fetched rather than linked so an expired session surfaces as an error the page can report,
+ * instead of navigating the tab to a sign-in redirect and losing the explorer's state.
+ */
+export async function downloadPersonalDocument(documentId: string): Promise<Blob> {
+    const response = await fetch(
+        apiUrl(`/api/documents/${encodeURIComponent(documentId)}/download`),
+        { credentials: CREDENTIALS_MODE },
+    );
+    if (!response.ok) {
+        throw new ApiError(
+            `Download failed with status ${response.status}`,
+            response.status,
+            null,
+        );
+    }
+    return response.blob();
+}
+
+/** Download several documents. The server returns a single file, or a ZIP for a batch. */
+export async function downloadPersonalDocuments(documentIds: string[]): Promise<Blob> {
+    const response = await fetch(apiUrl('/api/documents/download'), {
+        method: 'POST',
+        credentials: CREDENTIALS_MODE,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ document_ids: documentIds }),
+    });
+    if (!response.ok) {
+        throw new ApiError(
+            `Download failed with status ${response.status}`,
+            response.status,
+            null,
+        );
+    }
+    return response.blob();
+}
+
+/**
+ * Upload files to the personal workspace.
+ *
+ * The route accepts several files under a single `file` field and answers 207 for a partial
+ * success, so the caller has to read `errors` even when the request itself succeeded.
+ */
+export function uploadPersonalDocuments(files: File[], signal?: AbortSignal) {
+    const formData = new FormData();
+    for (const file of files) {
+        formData.append('file', file);
+    }
+    return uploadFile<{
+        message?: string;
+        document_ids?: string[];
+        processed_filenames?: string[];
+        errors?: string[];
+    }>('/api/documents/upload', formData, signal);
+}
 
 /**
  * Upload a file. When `conversationId` is supplied the file is attached to that

--- a/application/v2_ui/src/lib/types.ts
+++ b/application/v2_ui/src/lib/types.ts
@@ -112,14 +112,131 @@ export interface WorkspaceDocument {
     document_id?: string;
     file_name?: string;
     title?: string;
+    abstract?: string;
+    /** Stored as an array, but older records and form round-trips can leave a string. */
+    authors?: string[] | string;
+    keywords?: string[] | string;
+    publication_date?: string;
     percentage_complete?: number;
     status?: string;
     document_classification?: string;
     tags?: string[] | string;
     version?: number;
     num_chunks?: number;
+    number_of_pages?: number;
+    file_size?: number;
+    file_type?: string;
     upload_date?: string;
+    last_updated?: string;
+    revision_family_id?: string;
+    is_current_version?: boolean;
+    /** Entries are `"<user id>,<approval status>"`, not bare ids. */
+    shared_user_ids?: string[];
+    shared_approval_status?: 'owner' | 'approved' | 'not_approved' | 'none' | string;
+    owner_id?: string;
+    user_id?: string;
+    created_from_chat_upload?: boolean;
+    conversation_id?: string;
+    conversation_title_at_upload?: string;
+    conversation_url?: string;
+    /** `read` is the standard extraction, `layout` the enhanced one. */
+    document_intelligence_extraction_mode?: string;
+    enhanced_citations?: boolean;
+    _ts?: number;
     [key: string]: unknown;
+}
+
+/**
+ * Response of GET /api/documents.
+ *
+ * `total_count` is the size of the whole filtered set, not of the page, so it is what the
+ * pager counts against. The endpoint has used both `documents` and `items` as its collection
+ * key, so both are accepted.
+ */
+export interface DocumentListResponse {
+    documents?: WorkspaceDocument[];
+    items?: WorkspaceDocument[];
+    page?: number;
+    page_size?: number;
+    total_count?: number;
+    file_downloads_enabled?: boolean;
+    needs_legacy_update_check?: boolean;
+}
+
+/**
+ * Response of GET /api/documents/facets.
+ *
+ * Counted server-side over the caller's whole workspace and deliberately ignoring the
+ * current filters: these drive a navigation rail, and a rail that re-counted itself against
+ * the active filter would collapse to zeroes as soon as anything in it was selected.
+ */
+export interface DocumentFacets {
+    total: number;
+    untagged: number;
+    processing: number;
+    errors: number;
+    recent: number;
+    shared_with_me: number;
+    by_tag: Record<string, number>;
+    by_classification: Record<string, number>;
+}
+
+/** The standing views in the explorer rail. Sent to the API as `place`. */
+export type DocumentPlace =
+    | 'all'
+    | 'recent'
+    | 'shared'
+    | 'processing'
+    | 'errors'
+    | 'untagged';
+
+/**
+ * Fields the list endpoint will order by.
+ *
+ * Mirrors ALLOWED_DOCUMENT_SORT_FIELDS in functions_documents.py. Anything outside this set
+ * is silently replaced with `_ts` server-side, so a column offering a sort not listed here
+ * would appear to work and quietly do nothing.
+ */
+export type DocumentSortField =
+    | '_ts'
+    | 'file_name'
+    | 'title'
+    | 'upload_date'
+    | 'file_size'
+    | 'number_of_pages'
+    | 'version'
+    | 'document_classification';
+
+export type SortDirection = 'asc' | 'desc';
+
+/** Everything that decides which documents are shown, and in what order. */
+export interface DocumentQuery {
+    place: DocumentPlace;
+    search: string;
+    /** Applied with AND: a document must carry every selected tag. */
+    tags: string[];
+    classification: string | null;
+    page: number;
+    pageSize: number;
+    sortBy: DocumentSortField;
+    sortOrder: SortDirection;
+}
+
+/** A named query pinned in the rail. The flat-tag answer to folders. */
+export interface DocumentSavedView {
+    id: string;
+    name: string;
+    query: Pick<DocumentQuery, 'place' | 'search' | 'tags' | 'classification'>;
+}
+
+/** How the explorer is presented. Persisted through `v2DocumentsPrefs`. */
+export interface DocumentExplorerPrefs {
+    viewMode: 'details' | 'tiles';
+    pageSize: number;
+    detailsPaneOpen: boolean;
+    columns: string[];
+    sortBy: DocumentSortField;
+    sortOrder: SortDirection;
 }
 
 /**

--- a/application/v2_ui/src/lib/userSettings.ts
+++ b/application/v2_ui/src/lib/userSettings.ts
@@ -53,6 +53,15 @@ export interface UserSettings {
     v2ChatWidth?: string;
 
     /**
+     * Whether the personal workspace's section rail shows icons only.
+     *
+     * Deliberately separate from `v2RailCollapsed`, which is the application shell's rail.
+     * They are two different navigation surfaces stacked side by side, and collapsing one to
+     * make room should not also collapse the other.
+     */
+    v2WorkspaceRailCollapsed?: boolean;
+
+    /**
      * How the workspace documents explorer is presented, and the views pinned in its rail.
      *
      * Namespaced like the shell preferences above. The classic interface stores its own
@@ -128,6 +137,10 @@ export const WRITABLE_USER_SETTING_KEYS = [
     'v2ChatWidth',
     'v2MermaidStyle',
     'v2ChartStyle',
+    // Whether the section rail inside the personal workspace is showing icons only.
+    // Separate from v2RailCollapsed, which is the rail of the application shell:
+    // collapsing one should not collapse the other.
+    'v2WorkspaceRailCollapsed',
     // Workspace documents explorer: how the list is presented, and the saved filter
     // combinations pinned in its navigation rail.
     'v2DocumentsPrefs',

--- a/application/v2_ui/src/lib/userSettings.ts
+++ b/application/v2_ui/src/lib/userSettings.ts
@@ -12,6 +12,8 @@
 // come back from a later GET, so treating them as settings would make the store believe a
 // save had been lost. They get their own call when the workspace tabs are built.
 
+import type { DocumentExplorerPrefs, DocumentSavedView } from './types';
+
 /** Text scale, matching the values the route normalises to. */
 export type FontSizePreference = 'xs' | 's' | 'm' | 'l' | 'xl';
 
@@ -49,6 +51,17 @@ export interface UserSettings {
      */
     v2RailCollapsed?: boolean;
     v2ChatWidth?: string;
+
+    /**
+     * How the workspace documents explorer is presented, and the views pinned in its rail.
+     *
+     * Namespaced like the shell preferences above. The classic interface stores its own
+     * documents view mode in `localStorage` under `personalWorkspaceViewPreference` and
+     * offers four modes to this interface's two, so the two settings describe genuinely
+     * different things and must not be shared.
+     */
+    v2DocumentsPrefs?: Partial<DocumentExplorerPrefs>;
+    v2DocumentSavedViews?: DocumentSavedView[];
 
     /**
      * The chat model last chosen in the picker, as a catalog `selection_key`.
@@ -115,6 +128,10 @@ export const WRITABLE_USER_SETTING_KEYS = [
     'v2ChatWidth',
     'v2MermaidStyle',
     'v2ChartStyle',
+    // Workspace documents explorer: how the list is presented, and the saved filter
+    // combinations pinned in its navigation rail.
+    'v2DocumentsPrefs',
+    'v2DocumentSavedViews',
     // Shared with the classic interface rather than namespaced: the chosen model and its
     // reasoning level mean the same thing in both, and the bootstrap resolves the initial
     // model selection from these keys.

--- a/application/v2_ui/src/pages/workspace/DocumentsSection.tsx
+++ b/application/v2_ui/src/pages/workspace/DocumentsSection.tsx
@@ -1,283 +1,46 @@
 // DocumentsSection.tsx
-// Personal documents: list, search, tag filter, upload and delete.
+// Hosts the documents explorer inside the personal workspace.
 //
-// Carried over from the single-purpose workspace page this section replaced. The behaviour
-// is unchanged; only its surroundings are.
+// Thin on purpose: the explorer owns its own command bar, rail, status bar and internal
+// scrolling, so the only thing left for this section is the sentence explaining where these
+// files can come from.
 
-import { useEffect, useMemo, useRef, useState } from 'react';
-import { clsx } from 'clsx';
-import { FileText, FolderSync, Loader2, Trash2, Upload } from 'lucide-react';
+import { FolderSync } from 'lucide-react';
 import { Link } from 'react-router-dom';
-import {
-    deletePersonalDocument,
-    fetchPersonalDocumentTags,
-    fetchPersonalDocuments,
-    uploadDocument,
-} from '../../lib/endpoints';
-import { GlassButton } from '../../components/ui/primitives';
-import {
-    ConfirmAction,
-    Pill,
-    ResourceRow,
-    SectionIntro,
-    SectionList,
-    SectionSearch,
-} from '../../components/workspace/primitives';
-import { errorMessage } from '../../components/workspace/useSectionResource';
-import type { WorkspaceDocument, WorkspaceTag } from '../../lib/types';
-
-/**
- * Reduce a tag of any shape to its name.
- *
- * Tags arrive in more than one form: /api/documents/tags returns `{name, count, color}`
- * objects, while a document's own `tags` field may be an array of strings or a
- * comma-separated string. Rendering an object directly is what caused React error #31 on
- * this page, so every tag is funnelled through here.
- */
-function tagName(tag: unknown): string {
-    if (typeof tag === 'string') {
-        return tag.trim();
-    }
-    if (tag && typeof tag === 'object' && 'name' in tag) {
-        return String((tag as { name: unknown }).name ?? '').trim();
-    }
-    return '';
-}
-
-function normalizeTags(tags: unknown): string[] {
-    if (Array.isArray(tags)) {
-        return tags.map(tagName).filter(Boolean);
-    }
-    if (typeof tags === 'string' && tags.trim()) {
-        return tags.split(',').map((tag) => tag.trim()).filter(Boolean);
-    }
-    return [];
-}
-
-function ProcessingBadge({ document }: { document: WorkspaceDocument }) {
-    const percent = Number(document.percentage_complete ?? 100);
-    const complete = Number.isFinite(percent) ? percent >= 100 : true;
-
-    if (complete) {
-        return <Pill tone="ok">Ready</Pill>;
-    }
-
-    return (
-        <span className="flex items-center gap-1 rounded-full bg-warn-soft px-2 py-0.5 text-[11px] font-medium text-warn">
-            <Loader2 size={10} className="animate-spin" />
-            {Math.round(percent)}%
-        </span>
-    );
-}
+import { DocumentExplorer } from '../../components/documents/DocumentExplorer';
 
 export function DocumentsSection({ syncEnabled }: { syncEnabled: boolean }) {
-    const [documents, setDocuments] = useState<WorkspaceDocument[]>([]);
-    const [tags, setTags] = useState<WorkspaceTag[]>([]);
-    const [loading, setLoading] = useState(true);
-    const [error, setError] = useState<string | null>(null);
-    const [query, setQuery] = useState('');
-    const [activeTag, setActiveTag] = useState<string | null>(null);
-    const [uploading, setUploading] = useState(false);
-    const [deletingId, setDeletingId] = useState<string | null>(null);
-
-    const fileInputRef = useRef<HTMLInputElement>(null);
-
-    const load = async () => {
-        setLoading(true);
-        setError(null);
-        try {
-            const [documentsResponse, tagsResponse] = await Promise.all([
-                fetchPersonalDocuments(),
-                fetchPersonalDocumentTags().catch(() => ({ tags: [] })),
-            ]);
-            // The endpoint has used both `documents` and `items` as its collection key.
-            setDocuments(documentsResponse.documents ?? documentsResponse.items ?? []);
-            setTags(tagsResponse.tags ?? []);
-        } catch (loadError) {
-            setError(errorMessage(loadError, 'Failed to load documents.'));
-        } finally {
-            setLoading(false);
-        }
-    };
-
-    useEffect(() => {
-        void load();
-    }, []);
-
-    const visible = useMemo(() => {
-        const needle = query.trim().toLowerCase();
-        return documents.filter((document) => {
-            const name = String(document.file_name ?? document.title ?? '').toLowerCase();
-            if (needle && !name.includes(needle)) {
-                return false;
-            }
-            if (activeTag && !normalizeTags(document.tags).includes(activeTag)) {
-                return false;
-            }
-            return true;
-        });
-    }, [documents, query, activeTag]);
-
-    const onSelectFile = async (event: React.ChangeEvent<HTMLInputElement>) => {
-        const file = event.target.files?.[0];
-        if (!file) {
-            return;
-        }
-        setUploading(true);
-        try {
-            await uploadDocument(file, null);
-            await load();
-        } catch (uploadError) {
-            setError(errorMessage(uploadError, `Could not upload ${file.name}.`));
-        } finally {
-            setUploading(false);
-            event.target.value = '';
-        }
-    };
-
-    const onDelete = async (document: WorkspaceDocument) => {
-        const id = String(document.id ?? document.document_id ?? '');
-        if (!id) {
-            return;
-        }
-        const previous = documents;
-        setDeletingId(id);
-        setDocuments(documents.filter((item) => (item.id ?? item.document_id) !== id));
-        try {
-            await deletePersonalDocument(id);
-        } catch (deleteError) {
-            setDocuments(previous);
-            setError(errorMessage(deleteError, 'Could not delete document.'));
-        } finally {
-            setDeletingId(null);
-        }
-    };
-
     return (
-        <div className="space-y-4">
-            <SectionIntro
-                title="Documents"
-                description="Files you upload here are indexed and can be cited in chat. Everything in this section is private to you."
-                actions={
-                    <>
-                        <input
-                            ref={fileInputRef}
-                            type="file"
-                            className="hidden"
-                            onChange={onSelectFile}
-                        />
-                        <GlassButton
-                            variant="primary"
-                            size="sm"
-                            disabled={uploading}
-                            onClick={() => fileInputRef.current?.click()}
-                        >
-                            {uploading ? (
-                                <Loader2 size={14} className="animate-spin" />
-                            ) : (
-                                <Upload size={14} />
-                            )}
-                            Upload
-                        </GlassButton>
-                    </>
-                }
-            />
-
-            {syncEnabled ? (
-                <p className="text-xs text-text-3">
-                    Documents can also arrive automatically from a{' '}
-                    <Link to="/workspace/sync" className="text-accent hover:underline">
-                        file source
-                    </Link>
-                    .
-                </p>
-            ) : null}
-
-            <div className="flex flex-wrap items-center gap-2">
-                <div className="min-w-[16rem] flex-1">
-                    <SectionSearch
-                        value={query}
-                        onChange={setQuery}
-                        placeholder="Search documents"
-                    />
+        <div className="flex h-full min-h-0 flex-col gap-2">
+            <div className="flex flex-wrap items-baseline justify-between gap-2">
+                <div className="min-w-0">
+                    <h2 className="text-base font-semibold text-text-1">Documents</h2>
+                    <p className="mt-0.5 text-sm text-text-3">
+                        Files you upload here are indexed and can be cited in chat. Everything
+                        in this section is private to you.
+                    </p>
                 </div>
 
-                {tags.slice(0, 8).map((tag) => {
-                    const name = tagName(tag);
-                    if (!name) {
-                        return null;
-                    }
-                    return (
-                        <button
-                            key={name}
-                            type="button"
-                            onClick={() => setActiveTag(activeTag === name ? null : name)}
-                            className={clsx(
-                                'rounded-full border px-2.5 py-1 text-xs transition-colors',
-                                activeTag === name
-                                    ? 'border-transparent bg-accent-soft text-accent'
-                                    : 'border-edge bg-surface-1 text-text-2 hover:bg-surface-2',
-                            )}
-                        >
-                            {name}
-                            {typeof tag === 'object' && tag.count ? (
-                                <span className="ml-1 opacity-60">{tag.count}</span>
-                            ) : null}
-                        </button>
-                    );
-                })}
+                {syncEnabled ? (
+                    <p className="text-xs text-text-3">
+                        Documents can also arrive automatically from a{' '}
+                        <Link to="/workspace/sync" className="text-accent hover:underline">
+                            file source
+                        </Link>
+                        .
+                    </p>
+                ) : (
+                    <p className="flex items-center gap-1.5 text-xs text-text-3">
+                        <FolderSync size={13} />
+                        File sync is not enabled for your account, so documents can only be
+                        added by uploading them.
+                    </p>
+                )}
             </div>
 
-            <SectionList
-                items={visible}
-                loading={loading}
-                error={error}
-                emptyIcon={<FileText size={28} />}
-                emptyTitle={
-                    documents.length === 0
-                        ? 'No documents yet'
-                        : 'No documents match your filters'
-                }
-                emptyDescription={
-                    documents.length === 0
-                        ? 'Upload a file to make it available for grounded chat.'
-                        : undefined
-                }
-                getKey={(document, index) =>
-                    String(document.id ?? document.document_id ?? index)
-                }
-                renderItem={(document) => {
-                    const id = String(document.id ?? document.document_id ?? '');
-                    const documentTags = normalizeTags(document.tags);
-                    return (
-                        <ResourceRow
-                            icon={<FileText size={17} />}
-                            title={String(document.file_name ?? document.title ?? 'Untitled')}
-                            subtitle={
-                                documentTags.length > 0 ? documentTags.join(' · ') : undefined
-                            }
-                            meta={<ProcessingBadge document={document} />}
-                            actions={
-                                <ConfirmAction
-                                    icon={<Trash2 size={15} />}
-                                    label={`Delete ${document.file_name ?? 'document'}`}
-                                    confirmLabel="Delete"
-                                    busy={deletingId === id}
-                                    onConfirm={() => void onDelete(document)}
-                                />
-                            }
-                        />
-                    );
-                }}
-            />
-
-            {syncEnabled ? null : (
-                <p className="flex items-center gap-1.5 text-xs text-text-3">
-                    <FolderSync size={13} />
-                    File sync is not enabled for your account, so documents can only be added
-                    by uploading them.
-                </p>
-            )}
+            <div className="min-h-0 flex-1">
+                <DocumentExplorer />
+            </div>
         </div>
     );
 }

--- a/application/v2_ui/src/pages/workspace/OverviewSection.tsx
+++ b/application/v2_ui/src/pages/workspace/OverviewSection.tsx
@@ -14,7 +14,10 @@ import { Link } from 'react-router-dom';
 import { ArrowRight, Lock } from 'lucide-react';
 import { GlassPanel } from '../../components/ui/primitives';
 import { SectionIntro } from '../../components/workspace/primitives';
-import { fetchPersonalDocuments } from '../../lib/endpoints';
+import {
+    fetchPersonalDocumentFacets,
+    fetchPersonalDocumentTags,
+} from '../../lib/endpoints';
 import {
     fetchActions,
     fetchAgents,
@@ -33,9 +36,13 @@ type CountMap = Record<string, number | undefined>;
 /** How to count the contents of each section, for the summary on its card. */
 const COUNT_LOADERS: Record<string, (signal: AbortSignal) => Promise<number>> = {
     documents: async (signal) => {
-        const response = await fetchPersonalDocuments(1000, signal);
-        return (response.documents ?? response.items ?? []).length;
+        // Counted from the facets endpoint rather than by fetching a large page and
+        // measuring it: the count is the only thing wanted here, and the old approach
+        // pulled up to a thousand full document records to get it.
+        const facets = await fetchPersonalDocumentFacets(signal);
+        return Number(facets.total ?? 0);
     },
+    tags: async (signal) => (await fetchPersonalDocumentTags(signal)).tags?.length ?? 0,
     prompts: async (signal) => (await fetchPrompts({}, signal)).length,
     sync: async (signal) => (await fetchSyncSources(signal)).length,
     agents: async (signal) => (await fetchAgents(signal)).length,

--- a/application/v2_ui/src/pages/workspace/TagsSection.tsx
+++ b/application/v2_ui/src/pages/workspace/TagsSection.tsx
@@ -1,0 +1,393 @@
+// TagsSection.tsx
+// The personal tag vocabulary.
+//
+// Split out of the documents page on purpose. Browsing by tag and administering the set of
+// tags are different jobs done at different times, and the classic interface does both from
+// the same toolbar, which is a large part of why that page feels crowded. Here the documents
+// page keeps the tags visible and applicable, and this section owns the vocabulary itself.
+//
+// Tags are deliberately flat. A document carries as many as it needs and none of them nest,
+// which is what lets one document belong to several groupings at once -- the thing a folder
+// tree cannot express.
+
+import { useEffect, useMemo, useState } from 'react';
+import { clsx } from 'clsx';
+import { Loader2, Merge, Plus, Tag as TagIcon, Trash2 } from 'lucide-react';
+import { Link } from 'react-router-dom';
+import type { WorkspaceTag } from '../../lib/types';
+import {
+    createPersonalDocumentTag,
+    deletePersonalDocumentTag,
+    fetchPersonalDocumentTags,
+    updatePersonalDocumentTag,
+} from '../../lib/endpoints';
+import { GlassButton, EmptyState, Skeleton } from '../../components/ui/primitives';
+import { SectionError, SectionIntro, SectionSearch } from '../../components/workspace/primitives';
+import { errorMessage } from '../../components/workspace/useSectionResource';
+import { readableTextColor } from '../../components/documents/documentPresentation';
+import { toast } from '../../stores/toastStore';
+
+/** Offered as a starting palette; any hex the colour input produces is accepted. */
+const TAG_COLOR_PRESETS = [
+    '#3b82f6',
+    '#8b5cf6',
+    '#ec4899',
+    '#ef4444',
+    '#f59e0b',
+    '#10b981',
+    '#14b8a6',
+    '#64748b',
+];
+
+function TagRow({
+    tag,
+    busy,
+    existingNames,
+    onRename,
+    onRecolour,
+    onDelete,
+}: {
+    tag: WorkspaceTag;
+    busy: boolean;
+    existingNames: string[];
+    onRename: (name: string) => void;
+    onRecolour: (color: string) => void;
+    onDelete: () => void;
+}) {
+    const [editing, setEditing] = useState(false);
+    const [draftName, setDraftName] = useState(tag.name);
+
+    const trimmed = draftName.trim();
+    // Renaming onto an existing tag is how two tags are merged: the server rewrites every
+    // document carrying the old name, and documents that already had both simply keep one.
+    const willMerge =
+        Boolean(trimmed) &&
+        trimmed.toLowerCase() !== tag.name.toLowerCase() &&
+        existingNames.some((name) => name.toLowerCase() === trimmed.toLowerCase());
+
+    return (
+        <li className="flex items-center gap-2.5 rounded-xl border border-edge bg-surface-1 px-3 py-2">
+            <label className="relative shrink-0" title="Change colour">
+                <span
+                    className="block h-5 w-5 rounded border border-edge"
+                    style={{
+                        backgroundColor: tag.color || 'transparent',
+                        color: readableTextColor(tag.color),
+                    }}
+                />
+                <input
+                    type="color"
+                    value={tag.color || '#3b82f6'}
+                    onChange={(event) => onRecolour(event.target.value)}
+                    aria-label={`Colour for ${tag.name}`}
+                    className="absolute inset-0 h-full w-full cursor-pointer opacity-0"
+                />
+            </label>
+
+            <div className="min-w-0 flex-1">
+                {editing ? (
+                    <div className="flex items-center gap-1.5">
+                        <input
+                            type="text"
+                            value={draftName}
+                            autoFocus
+                            onChange={(event) => setDraftName(event.target.value)}
+                            onKeyDown={(event) => {
+                                if (event.key === 'Enter') {
+                                    event.preventDefault();
+                                    onRename(trimmed);
+                                    setEditing(false);
+                                }
+                                if (event.key === 'Escape') {
+                                    setDraftName(tag.name);
+                                    setEditing(false);
+                                }
+                            }}
+                            className="w-full rounded-lg border border-edge bg-surface-1 px-2 py-1 text-sm text-text-1 focus:border-accent focus:outline-none"
+                        />
+                        <GlassButton
+                            variant="primary"
+                            size="sm"
+                            disabled={!trimmed || busy}
+                            onClick={() => {
+                                onRename(trimmed);
+                                setEditing(false);
+                            }}
+                        >
+                            {willMerge ? <Merge size={13} /> : null}
+                            {willMerge ? 'Merge' : 'Save'}
+                        </GlassButton>
+                        <GlassButton
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => {
+                                setDraftName(tag.name);
+                                setEditing(false);
+                            }}
+                        >
+                            Cancel
+                        </GlassButton>
+                    </div>
+                ) : (
+                    <button
+                        type="button"
+                        onClick={() => setEditing(true)}
+                        className="truncate text-left text-sm text-text-1 hover:underline"
+                        title="Rename this tag"
+                    >
+                        {tag.name}
+                    </button>
+                )}
+                {editing && willMerge ? (
+                    <p className="mt-0.5 text-[11px] text-warn">
+                        A tag with that name exists. Saving merges the two.
+                    </p>
+                ) : null}
+            </div>
+
+            <span className="shrink-0 text-xs tabular-nums text-text-3">
+                {tag.count ?? 0} {tag.count === 1 ? 'document' : 'documents'}
+            </span>
+
+            <button
+                type="button"
+                onClick={onDelete}
+                disabled={busy}
+                aria-label={`Delete tag ${tag.name}`}
+                title={`Delete tag ${tag.name}`}
+                className="shrink-0 rounded-lg p-1.5 text-text-3 transition-colors hover:bg-danger-soft hover:text-danger disabled:opacity-40"
+            >
+                <Trash2 size={15} />
+            </button>
+        </li>
+    );
+}
+
+export function TagsSection({ documentsEnabled }: { documentsEnabled: boolean }) {
+    const [tags, setTags] = useState<WorkspaceTag[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [busy, setBusy] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [query, setQuery] = useState('');
+    const [newName, setNewName] = useState('');
+    const [newColor, setNewColor] = useState(TAG_COLOR_PRESETS[0]);
+
+    const load = async () => {
+        setLoading(true);
+        setError(null);
+        try {
+            const response = await fetchPersonalDocumentTags();
+            setTags(response.tags ?? []);
+        } catch (loadError) {
+            setError(errorMessage(loadError, 'Failed to load tags.'));
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        void load();
+    }, []);
+
+    const visible = useMemo(() => {
+        const needle = query.trim().toLowerCase();
+        const filtered = needle
+            ? tags.filter((tag) => tag.name.toLowerCase().includes(needle))
+            : tags;
+        return [...filtered].sort((left, right) => (right.count ?? 0) - (left.count ?? 0));
+    }, [tags, query]);
+
+    const names = useMemo(() => tags.map((tag) => tag.name), [tags]);
+    const unused = useMemo(() => tags.filter((tag) => !tag.count), [tags]);
+
+    const onCreate = async () => {
+        const name = newName.trim();
+        if (!name) {
+            return;
+        }
+        setBusy(true);
+        try {
+            await createPersonalDocumentTag(name, newColor);
+            setNewName('');
+            await load();
+            toast.success(`Created "${name}".`);
+        } catch (createError) {
+            toast.error(errorMessage(createError, 'Could not create the tag.'));
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    const onRename = async (tag: WorkspaceTag, name: string) => {
+        if (!name || name === tag.name) {
+            return;
+        }
+        setBusy(true);
+        try {
+            const response = await updatePersonalDocumentTag(tag.name, { new_name: name });
+            await load();
+            const updated = response.documents_updated ?? 0;
+            toast.success(
+                updated > 0
+                    ? `Renamed to "${name}" on ${updated} ${updated === 1 ? 'document' : 'documents'}.`
+                    : `Renamed to "${name}".`,
+            );
+        } catch (renameError) {
+            toast.error(errorMessage(renameError, 'Could not rename the tag.'));
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    const onRecolour = async (tag: WorkspaceTag, color: string) => {
+        // Applied locally first: a colour picker fires continuously while dragging, and
+        // waiting for each round trip would make the swatch lag the pointer.
+        setTags((current) =>
+            current.map((item) => (item.name === tag.name ? { ...item, color } : item)),
+        );
+        try {
+            await updatePersonalDocumentTag(tag.name, { color });
+        } catch (colourError) {
+            toast.error(errorMessage(colourError, 'Could not save the colour.'));
+            await load();
+        }
+    };
+
+    const onDelete = async (tag: WorkspaceTag) => {
+        const count = tag.count ?? 0;
+        const warning =
+            count > 0
+                ? `Delete "${tag.name}"? It will be removed from ${count} ${count === 1 ? 'document' : 'documents'}. The documents themselves are kept.`
+                : `Delete "${tag.name}"?`;
+        if (!window.confirm(warning)) {
+            return;
+        }
+        setBusy(true);
+        try {
+            await deletePersonalDocumentTag(tag.name);
+            await load();
+            toast.success(`Deleted "${tag.name}".`);
+        } catch (deleteError) {
+            toast.error(errorMessage(deleteError, 'Could not delete the tag.'));
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    return (
+        <div className="space-y-4">
+            <SectionIntro
+                title="Tags"
+                description="The vocabulary your documents are filed under. Tags are flat, so a document can carry as many as it needs and appear under each of them."
+            />
+
+            {documentsEnabled ? (
+                <p className="text-xs text-text-3">
+                    Apply tags from{' '}
+                    <Link to="/workspace/documents" className="text-accent hover:underline">
+                        Documents
+                    </Link>
+                    , where you can also drag files onto a tag to file them.
+                </p>
+            ) : null}
+
+            <div className="flex flex-wrap items-end gap-2 rounded-xl border border-edge bg-surface-1 p-3">
+                <label className="min-w-[12rem] flex-1">
+                    <span className="mb-1 block text-xs font-medium text-text-2">New tag</span>
+                    <input
+                        type="text"
+                        value={newName}
+                        onChange={(event) => setNewName(event.target.value)}
+                        onKeyDown={(event) => {
+                            if (event.key === 'Enter') {
+                                event.preventDefault();
+                                void onCreate();
+                            }
+                        }}
+                        placeholder="e.g. contracts"
+                        className="w-full rounded-lg border border-edge bg-surface-1 px-2.5 py-1.5 text-sm text-text-1 placeholder:text-text-3 focus:border-accent focus:outline-none"
+                    />
+                </label>
+
+                <div>
+                    <span className="mb-1 block text-xs font-medium text-text-2">Colour</span>
+                    <div className="flex items-center gap-1">
+                        {TAG_COLOR_PRESETS.map((color) => (
+                            <button
+                                key={color}
+                                type="button"
+                                onClick={() => setNewColor(color)}
+                                aria-label={`Use colour ${color}`}
+                                className={clsx(
+                                    'h-6 w-6 rounded border transition-transform',
+                                    newColor === color
+                                        ? 'scale-110 border-text-1'
+                                        : 'border-edge hover:scale-105',
+                                )}
+                                style={{ backgroundColor: color }}
+                            />
+                        ))}
+                    </div>
+                </div>
+
+                <GlassButton
+                    variant="primary"
+                    size="sm"
+                    onClick={() => void onCreate()}
+                    disabled={!newName.trim() || busy}
+                >
+                    {busy ? <Loader2 size={14} className="animate-spin" /> : <Plus size={14} />}
+                    Create
+                </GlassButton>
+            </div>
+
+            {error ? <SectionError message={error} /> : null}
+
+            {tags.length > 6 ? (
+                <SectionSearch value={query} onChange={setQuery} placeholder="Search tags" />
+            ) : null}
+
+            {loading ? (
+                <div className="space-y-2">
+                    {Array.from({ length: 4 }).map((_, index) => (
+                        <Skeleton key={index} className="h-12 w-full" />
+                    ))}
+                </div>
+            ) : visible.length === 0 ? (
+                <EmptyState
+                    icon={<TagIcon size={28} />}
+                    title={tags.length === 0 ? 'No tags yet' : 'No tags match your search'}
+                    description={
+                        tags.length === 0
+                            ? 'Create a tag above, then apply it to documents from the Documents section.'
+                            : undefined
+                    }
+                />
+            ) : (
+                <>
+                    <ul className="space-y-2">
+                        {visible.map((tag) => (
+                            <TagRow
+                                key={tag.name}
+                                tag={tag}
+                                busy={busy}
+                                existingNames={names}
+                                onRename={(name) => void onRename(tag, name)}
+                                onRecolour={(color) => void onRecolour(tag, color)}
+                                onDelete={() => void onDelete(tag)}
+                            />
+                        ))}
+                    </ul>
+
+                    {unused.length > 0 ? (
+                        <p className="text-xs text-text-3">
+                            {unused.length} {unused.length === 1 ? 'tag is' : 'tags are'} not
+                            applied to any document. Renaming one onto an existing tag merges
+                            the two.
+                        </p>
+                    ) : null}
+                </>
+            )}
+        </div>
+    );
+}

--- a/application/v2_ui/src/pages/workspace/WorkspacePage.tsx
+++ b/application/v2_ui/src/pages/workspace/WorkspacePage.tsx
@@ -10,10 +10,11 @@
 import { useMemo } from 'react';
 import { NavLink, useParams } from 'react-router-dom';
 import { clsx } from 'clsx';
-import { LayoutGrid, Lock } from 'lucide-react';
+import { LayoutGrid, Lock, PanelLeftClose, PanelLeftOpen } from 'lucide-react';
 import { PageHeader } from '../../components/layout/PageHeader';
 import { EmptyState } from '../../components/ui/primitives';
 import { useBootstrapStore } from '../../stores/bootstrapStore';
+import { useUserSettingsStore } from '../../stores/userSettingsStore';
 import {
     groupWorkspaceSections,
     navigableSections,
@@ -26,6 +27,11 @@ import type { WorkspaceSectionContext } from './sections';
 export function WorkspacePage() {
     const workspace = useBootstrapStore((state) => state.data?.workspace);
     const { section: requestedSection } = useParams<{ section?: string }>();
+
+    const railCollapsed = useUserSettingsStore(
+        (state) => state.settings.v2WorkspaceRailCollapsed === true,
+    );
+    const updateUserSettings = useUserSettingsStore((state) => state.update);
 
     const resolved = useMemo(
         () => resolveWorkspaceSections(WORKSPACE_SECTIONS, workspace),
@@ -99,7 +105,8 @@ export function WorkspacePage() {
 
     const linkClass = ({ isActive }: { isActive: boolean }) =>
         clsx(
-            'flex items-center gap-2.5 rounded-lg px-2.5 py-2 text-left text-sm transition-colors',
+            'flex items-center gap-2.5 rounded-lg text-left text-sm transition-colors',
+            railCollapsed ? 'justify-center px-2 py-2' : 'px-2.5 py-2',
             isActive
                 ? 'bg-accent-soft font-medium text-accent'
                 : 'text-text-2 hover:bg-surface-2 hover:text-text-1',
@@ -115,18 +122,70 @@ export function WorkspacePage() {
             <div className="flex min-h-0 flex-1 gap-4 overflow-hidden p-4">
                 <nav
                     aria-label="Workspace sections"
-                    className="flex w-52 shrink-0 flex-col gap-3 overflow-y-auto"
+                    className={clsx(
+                        'flex shrink-0 flex-col gap-3 overflow-y-auto transition-[width]',
+                        railCollapsed ? 'w-12' : 'w-52',
+                    )}
                 >
-                    <NavLink to="/workspace" end className={linkClass}>
+                    <button
+                        type="button"
+                        onClick={() =>
+                            updateUserSettings({ v2WorkspaceRailCollapsed: !railCollapsed })
+                        }
+                        aria-label={
+                            railCollapsed
+                                ? 'Expand workspace sections'
+                                : 'Collapse workspace sections'
+                        }
+                        aria-expanded={!railCollapsed}
+                        title={
+                            railCollapsed
+                                ? 'Expand workspace sections'
+                                : 'Collapse workspace sections'
+                        }
+                        className={clsx(
+                            'flex items-center gap-2 rounded-lg py-1.5 text-xs text-text-3 transition-colors hover:bg-surface-2 hover:text-text-1',
+                            railCollapsed ? 'justify-center px-2' : 'px-2.5',
+                        )}
+                    >
+                        {railCollapsed ? (
+                            <PanelLeftOpen size={15} />
+                        ) : (
+                            <>
+                                <PanelLeftClose size={15} />
+                                <span>Collapse</span>
+                            </>
+                        )}
+                    </button>
+
+                    <NavLink
+                        to="/workspace"
+                        end
+                        className={linkClass}
+                        title={railCollapsed ? 'Overview' : undefined}
+                    >
                         <LayoutGrid size={15} className="shrink-0" />
-                        <span className="truncate">Overview</span>
+                        {railCollapsed ? (
+                            <span className="sr-only">Overview</span>
+                        ) : (
+                            <span className="truncate">Overview</span>
+                        )}
                     </NavLink>
 
                     {groups.map(({ group, sections }) => (
                         <div key={group.id} className="space-y-0.5">
-                            <p className="px-2.5 text-[11px] font-semibold tracking-wide text-text-3 uppercase">
-                                {group.label}
-                            </p>
+                            {railCollapsed ? (
+                                // A rule rather than a heading: the group label has nowhere to
+                                // go at this width, but the grouping itself still reads.
+                                <div
+                                    aria-hidden="true"
+                                    className="mx-2 my-1.5 border-t border-edge"
+                                />
+                            ) : (
+                                <p className="px-2.5 text-[11px] font-semibold tracking-wide text-text-3 uppercase">
+                                    {group.label}
+                                </p>
+                            )}
                             {sections.map(({ section }) => {
                                 const Icon = section.icon;
                                 return (
@@ -134,9 +193,18 @@ export function WorkspacePage() {
                                         key={section.id}
                                         to={`/workspace/${section.id}`}
                                         className={linkClass}
+                                        title={
+                                            railCollapsed
+                                                ? `${group.label}: ${section.label}`
+                                                : undefined
+                                        }
                                     >
                                         <Icon size={15} className="shrink-0" />
-                                        <span className="truncate">{section.label}</span>
+                                        {railCollapsed ? (
+                                            <span className="sr-only">{section.label}</span>
+                                        ) : (
+                                            <span className="truncate">{section.label}</span>
+                                        )}
                                     </NavLink>
                                 );
                             })}

--- a/application/v2_ui/src/pages/workspace/WorkspacePage.tsx
+++ b/application/v2_ui/src/pages/workspace/WorkspacePage.tsx
@@ -65,6 +65,11 @@ export function WorkspacePage() {
         : null;
     const showOverview = !requestedSection;
 
+    // A full-bleed section manages its own width, height and scrolling. Wrapping one in the
+    // page's centred, page-scrolling container would give it a second scrollbar and squeeze
+    // a three-pane layout into a reading measure.
+    const fullBleed = !showOverview && activeEntry?.enabled && activeEntry.section.layout === 'full';
+
     const renderBody = () => {
         if (showOverview) {
             return <OverviewSection resolved={resolved} />;
@@ -139,8 +144,17 @@ export function WorkspacePage() {
                     ))}
                 </nav>
 
-                <div className="min-w-0 flex-1 overflow-y-auto">
-                    <div className="mx-auto max-w-4xl pb-8">{renderBody()}</div>
+                <div
+                    className={clsx(
+                        'min-w-0 flex-1',
+                        fullBleed ? 'flex min-h-0 flex-col overflow-hidden' : 'overflow-y-auto',
+                    )}
+                >
+                    {fullBleed ? (
+                        renderBody()
+                    ) : (
+                        <div className="mx-auto max-w-4xl pb-8">{renderBody()}</div>
+                    )}
                 </div>
             </div>
         </div>

--- a/application/v2_ui/src/pages/workspace/sections.tsx
+++ b/application/v2_ui/src/pages/workspace/sections.tsx
@@ -18,6 +18,7 @@ import {
     Plug,
     Server,
     Sparkles,
+    Tags,
     Workflow,
 } from 'lucide-react';
 import type { ReactNode } from 'react';
@@ -30,12 +31,23 @@ import { EndpointsSection } from './EndpointsSection';
 import { FileSourcesSection } from './FileSourcesSection';
 import { IdentitiesSection } from './IdentitiesSection';
 import { PromptsSection } from './PromptsSection';
+import { TagsSection } from './TagsSection';
 import { WorkflowsSection } from './WorkflowsSection';
 
 export interface WorkspaceSectionContext {
     /** Whether another section is available, for cross-links that should not dead-end. */
     isEnabled: (sectionId: string) => boolean;
 }
+
+/**
+ * How much room a section needs.
+ *
+ * Most sections are a column of rows and read better constrained to a comfortable measure.
+ * The documents explorer is not: it carries its own navigation rail, details pane and status
+ * bar, and it manages its own scrolling, so it needs the full width of the page and the full
+ * height rather than being centred inside a narrower one.
+ */
+export type WorkspaceSectionLayout = 'prose' | 'full';
 
 export interface WorkspaceSectionDefinition extends WorkspaceSectionDescriptor {
     id: string;
@@ -44,6 +56,7 @@ export interface WorkspaceSectionDefinition extends WorkspaceSectionDescriptor {
     icon: LucideIcon;
     /** One line on what the section is for. Shown on the overview. */
     blurb: string;
+    layout?: WorkspaceSectionLayout;
     render: (context: WorkspaceSectionContext) => ReactNode;
 }
 
@@ -54,7 +67,16 @@ export const WORKSPACE_SECTIONS: WorkspaceSectionDefinition[] = [
         group: 'knowledge',
         icon: FileText,
         blurb: 'Files you upload, indexed so the assistant can quote them.',
+        layout: 'full',
         render: (context) => <DocumentsSection syncEnabled={context.isEnabled('sync')} />,
+    },
+    {
+        id: 'tags',
+        label: 'Tags',
+        group: 'knowledge',
+        icon: Tags,
+        blurb: 'The labels your documents are filed under, and what each one is called.',
+        render: (context) => <TagsSection documentsEnabled={context.isEnabled('documents')} />,
     },
     {
         id: 'sync',

--- a/application/v2_ui/src/stores/toastStore.ts
+++ b/application/v2_ui/src/stores/toastStore.ts
@@ -14,15 +14,28 @@ import { create } from 'zustand';
 
 export type ToastTone = 'success' | 'error' | 'info' | 'pending';
 
+/**
+ * An offer to reverse what the toast is reporting.
+ *
+ * Exists for actions that are applied immediately and in bulk, where a confirmation dialog
+ * beforehand would be worse: it would interrupt every correct use of the gesture to guard
+ * against the rare wrong one. Reversing afterwards puts the cost on the mistake instead.
+ */
+export interface ToastAction {
+    label: string;
+    onAct: () => void;
+}
+
 export interface Toast {
     id: number;
     tone: ToastTone;
     message: string;
+    action?: ToastAction;
 }
 
 interface ToastState {
     toasts: Toast[];
-    push: (tone: ToastTone, message: string) => number;
+    push: (tone: ToastTone, message: string, action?: ToastAction) => number;
     settle: (id: number, tone: Exclude<ToastTone, 'pending'>, message: string) => void;
     dismiss: (id: number) => void;
 }
@@ -44,11 +57,11 @@ let nextId = 1;
 export const useToastStore = create<ToastState>((set, get) => ({
     toasts: [],
 
-    push: (tone, message) => {
+    push: (tone, message, action) => {
         const id = nextId;
         nextId += 1;
 
-        set((state) => ({ toasts: [...state.toasts, { id, tone, message }] }));
+        set((state) => ({ toasts: [...state.toasts, { id, tone, message, action }] }));
 
         if (tone !== 'pending') {
             window.setTimeout(() => {
@@ -91,9 +104,11 @@ export const useToastStore = create<ToastState>((set, get) => ({
 
 /** Convenience for non-component code, which cannot use the hook form. */
 export const toast = {
-    success: (message: string) => useToastStore.getState().push('success', message),
+    success: (message: string, action?: ToastAction) =>
+        useToastStore.getState().push('success', message, action),
     error: (message: string) => useToastStore.getState().push('error', message),
-    info: (message: string) => useToastStore.getState().push('info', message),
+    info: (message: string, action?: ToastAction) =>
+        useToastStore.getState().push('info', message, action),
     /** Raise a notification that stays until `settle` or `dismiss` is called with its id. */
     pending: (message: string) => useToastStore.getState().push('pending', message),
     settle: (id: number, tone: Exclude<ToastTone, 'pending'>, message: string) =>

--- a/docs/explanation/features/V2_DOCUMENTS_EXPLORER.md
+++ b/docs/explanation/features/V2_DOCUMENTS_EXPLORER.md
@@ -1,0 +1,276 @@
+# V2 Documents Explorer
+
+## Overview
+
+The personal workspace **Documents** section in the V2 interface is a file-explorer-style
+surface: a command bar, a navigation rail, a content pane with two views, a details pane and a
+status bar. It replaces a single flat list that offered upload, delete and one tag filter.
+
+A companion **Tags** section owns the tag vocabulary itself — renaming, recolouring, merging
+and deleting — so that browsing by tag and administering tags are no longer competing for the
+same toolbar.
+
+**Implemented in version:** `0.261.045`
+
+**Dependencies**
+
+| Requirement | Why |
+|---|---|
+| `enable_user_workspace` | Gates every personal document route |
+| `enable_document_classification` *(optional)* | Adds the Classification rail group, column and metadata field |
+| `enable_extract_meta_data` *(optional)* | Adds the Extract action |
+| `enable_file_sharing` *(optional)* | Adds the Share action and the sharing details |
+| `max_file_size_mb` | Enforced client-side before an upload is attempted |
+
+## Why it was rebuilt
+
+The V2 documents page called four endpoints. The backend already supported far more, and the
+classic interface had accumulated four view modes, a multi-select *mode*, seven filter
+controls and five modals in one band above the list.
+
+| Capability | Backend | Classic UI | V2 before | V2 now |
+|---|---|---|---|---|
+| Server-side pagination | yes | yes | no (`page_size=1000`) | yes |
+| Server-side search | yes | yes | no (client filter) | yes |
+| Server-side sorting | yes | 3 fields | no | 8 fields |
+| Tag filtering | yes | yes | one tag | many, combined with AND |
+| Bulk tag | yes | yes | no | yes, including drag-to-tag |
+| Bulk delete | **no** | no (looped) | no | yes (new endpoint) |
+| Download | yes | yes | no | single and ZIP |
+| Metadata editing | yes | yes | no | yes |
+| Re-extraction | yes | yes | no | yes |
+| Sharing | yes | yes | no | yes |
+
+## Architecture
+
+### Layout
+
+```
+┌───────────────────────────────────────────────────────────────────────────────┐
+│ Upload │ Download  Tag  Chat  Extract  Delete │ search  columns  ▤▦  details  │
+├─────────────┬─────────────────────────────────────────────┬───────────────────┤
+│ PLACES      │  Tags: alpha ✕   Search: "budget" ✕   Clear │                   │
+│ SAVED VIEWS │ ─────────────────────────────────────────── │   Details pane    │
+│ TAGS        │  Name · Tags · Status · Modified · Size     │   (0 / 1 / N)     │
+│ CLASSIF.    │                                             │                   │
+├─────────────┴─────────────────────────────────────────────┴───────────────────┤
+│ 1–50 of 142 · 3 selected                    ‹ 1 … 9 10 11 … 20 ›   50 / page  │
+└───────────────────────────────────────────────────────────────────────────────┘
+```
+
+### File structure
+
+```
+application/v2_ui/src/
+  lib/
+    documentExplorer.ts          Query state, selection algebra, formatting, facets
+    documentSavedViews.ts        Saved view shape, validation, serialisation
+  components/documents/
+    DocumentExplorer.tsx         The shell; owns query, selection and loading
+    ExplorerRail.tsx             Places, saved views, tags, classification; drop target
+    ExplorerCommandBar.tsx       Command bar, filter chips, status bar
+    DocumentTable.tsx            Details view and its column definitions
+    DocumentTiles.tsx            Tiles view
+    DocumentDetailsPane.tsx      Details pane, three selection states
+    DocumentDialogs.tsx          Tag, metadata, delete and share dialogs
+    documentPresentation.tsx     File icons, tag chips, status badges
+  pages/workspace/
+    DocumentsSection.tsx         Thin host
+    TagsSection.tsx              Tag vocabulary management
+```
+
+`documentExplorer.ts` and `documentSavedViews.ts` are deliberately free of React so their
+rules can be executed directly in a test.
+
+### API
+
+Three server changes were made. Everything else already existed.
+
+#### `GET /api/documents` — new `place` parameter
+
+| Value | Meaning |
+|---|---|
+| `all` *(default)* | No narrowing |
+| `recent` | Uploaded in the last 30 days |
+| `shared` | Owned by someone else and shared with the caller |
+| `processing` | Still being indexed |
+| `errors` | Processing failed |
+| `untagged` | Carries no tag |
+
+These describe the *state* of a document rather than its content, so they cannot be expressed
+in the Cosmos query: processing state is derived from free-text `status` and
+`percentage_complete`, "untagged" is the absence of a value, and ownership is only meaningful
+relative to the caller. The route already materialises and paginates in Python, so the filter
+is applied there, before the count.
+
+`sort_by` also accepts more fields. The allow-list moved to `functions_documents.py` as
+`ALLOWED_DOCUMENT_SORT_FIELDS`, split into `NUMERIC_DOCUMENT_SORT_FIELDS` and
+`TEXT_DOCUMENT_SORT_FIELDS`:
+
+| Field | Compared as |
+|---|---|
+| `_ts`, `file_size`, `number_of_pages`, `version` | number |
+| `file_name`, `title`, `upload_date`, `document_classification` | text |
+
+The split is what makes the sort safe. `sort_documents` previously mapped a missing value to
+`""` while leaving a present numeric value an `int`, and Python 3 raises `TypeError` comparing
+the two — invisible while the allow-list held only strings, a live crash the moment
+`file_size` became sortable.
+
+#### `GET /api/documents/facets`
+
+```json
+{ "total": 142, "untagged": 14, "processing": 2, "errors": 1, "recent": 23,
+  "shared_with_me": 5, "by_tag": {"alpha": 12}, "by_classification": {"Internal": 30} }
+```
+
+Counted over the caller's whole workspace and deliberately **ignoring** the current filters.
+These drive the navigation rail, and a rail that re-counted itself against the active filter
+would collapse to zeroes as soon as anything in it was selected.
+
+#### `POST /api/documents/bulk-delete`
+
+```json
+{ "document_ids": ["..."], "delete_mode": "all_versions",
+  "conversation_linked_delete_confirmed": false, "file_sync_delete_action": null }
+```
+
+Answers with `deleted`, `errors`, `deleted_count` and `error_count`. It reports per document
+rather than failing the batch, because the two delete guards apply individually: one document
+uploaded through chat would otherwise block the deletion of everything selected alongside it.
+A guarded document returns in `errors` with `needs_confirmation: true` and the same payload
+the single delete answers `409` with, so the client can ask about exactly those documents and
+resubmit.
+
+Both delete routes now share `_personal_document_delete_guard`, so a guard added to one cannot
+become a way around it in the other.
+
+### Settings
+
+Two new keys, whitelisted in `route_backend_users.py` and declared in
+`WRITABLE_USER_SETTING_KEYS`:
+
+| Key | Contents |
+|---|---|
+| `v2DocumentsPrefs` | View mode, visible columns, page size, details pane state, sort |
+| `v2DocumentSavedViews` | The saved views pinned in the rail |
+
+Namespaced rather than shared with the classic interface, which stores its own view mode in
+`localStorage` under `personalWorkspaceViewPreference` and offers four modes to this
+interface's two.
+
+### The Tags section
+
+Registered in `functions_workspace_sections.py` (`WORKSPACE_SECTION_IDS`,
+`WORKSPACE_SECTION_GROUPS`) and in the SPA registry. `resolveWorkspaceSections` fails closed,
+so a section the server does not report is treated as unavailable — registering it in only one
+place produces a section that never renders.
+
+The classic interface is unaffected: `route_frontend_workspace.py` reads only
+`file_sync_enabled` and `governance` from the availability payload and never iterates
+`sections`.
+
+## Usage
+
+### Browsing
+
+The rail replaces the classic interface's folder view modes. Places appear only once they
+describe something, so a workspace with nothing in flight carries no permanent "Processing 0".
+Clicking a tag filters to it; **Ctrl+click** adds a second tag, combined with AND.
+
+Active filters render as removable chips above the list with a Clear all — a flat, tagged
+workspace has no path to put in a breadcrumb, and saying what is currently narrowing the list
+is the honest equivalent.
+
+### Selecting
+
+Selection is not a mode. There is no button to press first.
+
+| Gesture | Result |
+|---|---|
+| Click | Select one |
+| Ctrl/Cmd+click | Add or remove one |
+| Shift+click | Select the range from the anchor |
+| Ctrl+A | Select the page |
+| Escape | Clear |
+| ↑ / ↓ | Move; Shift extends |
+| Double click | Open the details pane |
+
+A range follows the order currently *displayed*, so re-sorting the table changes which
+documents lie between the anchor and the click — matching what is on screen. Selecting after
+paging prunes ids that are no longer visible, so a bulk action can never reach a document the
+user cannot see.
+
+### Views
+
+Two: **Details** (a sortable table) and **Tiles** (cards). The classic interface's `grid` and
+`folders-cards` modes are deliberately not carried over; the rail lists tags permanently,
+which is what those modes were reaching for.
+
+The Name column shows the **title** on the first line and the **file name** dimmed beneath it,
+because a file name is frequently something like `MSA_v2_FINAL(3).docx`. When there is no
+title the file name is promoted rather than captioned with "Untitled".
+
+Columns beyond the default five — Classification, Pages, Version — are available from the
+column chooser. Only columns the server will actually sort by have clickable headers.
+
+### Tagging
+
+Three routes to the same operation:
+
+1. **Drag** a selection onto a tag in the rail. The confirmation toast carries an **Undo**,
+   which is why the gesture needs no confirmation beforehand — confirming would interrupt
+   every correct use of it to guard against the rare wrong one.
+2. **Tag** in the command bar, which opens the tag dialog. A tag carried by only some of the
+   selected documents shows as partial rather than present or absent.
+3. The details pane, which adds and removes tags for the current selection.
+
+### Saved views
+
+A named combination of place, search, tags and classification, pinned in the rail. This is the
+replacement for folders in a workspace that files by tag — the same idea as Windows saved
+searches and macOS smart folders. Sort order and page number are deliberately not saved: they
+describe how the list is being read at one moment, and a saved page number would land
+somewhere arbitrary later.
+
+Save with **Save view** in the command bar, which appears once anything is narrowing the list.
+Right-click a view in the rail to remove it.
+
+### Deleting
+
+Bulk delete reports per document. When the server refuses one — because it was uploaded
+through chat, or is managed by file sync — the dialog stays open, names those documents, gives
+the reason, and offers to go ahead anyway.
+
+## Testing and validation
+
+| Test | Covers |
+|---|---|
+| `functional_tests/test_v2_documents_explorer.py` | Route guards, shared delete guard, settings whitelist, section registration on both sides, V1 non-regression, endpoint coverage, composition, selection model, view modes, no CDN assets |
+| `functional_tests/test_v2_documents_explorer_logic.ts` | 58 behavioural checks over the query builder, selection algebra, filter chips, status derivation, formatting, pagination, facets and saved views |
+
+The Python test additionally *executes* the new server helpers — `sort_documents`,
+`filter_documents_by_place`, `build_personal_document_facets` — by extracting them from source
+with `ast`, because `route_backend_documents.py` imports `config`, which builds Azure clients
+at import time.
+
+Run them with:
+
+```powershell
+python .\functional_tests\test_v2_documents_explorer.py
+python .\functional_tests\route_tests\test_route_blueprint_policy_inventory.py
+cd .\application\v2_ui; npm run typecheck; npm run build
+```
+
+## Known limitations
+
+- **Personal workspace only.** Group and public workspace pages do not exist in the V2
+  interface yet. The components take their data as props rather than reading a scope, so the
+  same explorer can serve them without a rewrite.
+- **Details, not preview.** There is no general document-preview endpoint — enhanced citations
+  serve blobs only in citation context — so the right-hand pane presents metadata rather than
+  rendering the file.
+- **Facet counts are a snapshot.** They are refreshed after any mutation and when processing
+  finishes, not continuously.
+- **Tags are flat, by design.** A document carries as many as it needs and none of them nest,
+  which is what lets one document belong to several groupings at once.

--- a/docs/explanation/features/V2_DOCUMENTS_EXPLORER.md
+++ b/docs/explanation/features/V2_DOCUMENTS_EXPLORER.md
@@ -11,7 +11,6 @@ and deleting — so that browsing by tag and administering tags are no longer co
 same toolbar.
 
 **Implemented in version:** `0.261.045`
-
 **Dependencies**
 
 | Requirement | Why |
@@ -147,17 +146,20 @@ become a way around it in the other.
 
 ### Settings
 
-Two new keys, whitelisted in `route_backend_users.py` and declared in
+Three new keys, whitelisted in `route_backend_users.py` and declared in
 `WRITABLE_USER_SETTING_KEYS`:
 
 | Key | Contents |
 |---|---|
 | `v2DocumentsPrefs` | View mode, visible columns, page size, details pane state, sort |
 | `v2DocumentSavedViews` | The saved views pinned in the rail |
+| `v2WorkspaceRailCollapsed` | Whether the workspace section rail shows icons only |
 
 Namespaced rather than shared with the classic interface, which stores its own view mode in
 `localStorage` under `personalWorkspaceViewPreference` and offers four modes to this
-interface's two.
+interface's two. `v2WorkspaceRailCollapsed` is likewise separate from `v2RailCollapsed`, which
+belongs to the application shell — the two rails sit side by side, and collapsing one to make
+room should not collapse the other.
 
 ### The Tags section
 
@@ -236,6 +238,50 @@ somewhere arbitrary later.
 Save with **Save view** in the command bar, which appears once anything is narrowing the list.
 Right-click a view in the rail to remove it.
 
+### Reclaiming width
+
+The workspace section rail collapses to icons with the control at its top, remembered per
+user in `v2WorkspaceRailCollapsed`. Collapsed entries keep their labels as tooltips and as
+screen-reader text. This is separate from the application shell's own rail, so the two can be
+collapsed independently.
+
+### Searching
+
+The box searches shortly after you stop typing, or immediately on **Enter**. **Escape**
+clears it.
+
+The input is bound to what you have typed rather than to the debounced query value. Binding a
+controlled input to the debounced value reverts every keystroke until the debounce catches up,
+which drops characters when typing at speed.
+
+### Bulk operations and progress
+
+Tagging and deleting are sent in batches of `BULK_BATCH_SIZE` documents, and a determinate
+progress bar reports how far through the selection the work is.
+
+This is not cosmetic. Server-side, tagging one document costs a cross-partition query, a
+document write, and an update to every one of its search-index chunks; deleting likewise
+removes index chunks as well as the record. A single request covering a large selection
+therefore runs for a long time, and behind an indeterminate spinner that is indistinguishable
+from a hang. Batching makes the progress real and each request short.
+
+The progress task is cleared in a `finally` on every path, so a failed batch reports itself
+and the bar comes down rather than staying up forever.
+
+### Re-extraction
+
+The pane states the mode the selection is currently on, marks that option as **(current)**,
+and offers the other one as *Switch to …*. Previously it showed Standard and Enhanced as two
+equal buttons with nothing indicating which was already in effect, so changing it meant
+guessing and then checking.
+
+- Only PDFs and images go through Document Intelligence. For any other file the control is not
+  shown, and in a mixed selection the documents it does not apply to are named and left alone.
+- A selection spanning both modes reports **Mixed**; one where no mode was ever recorded
+  reports **Not recorded**. Those are different situations and are not conflated.
+- Enhanced is disabled with a reason when `enable_enhanced_extraction` is off, because the
+  reprocess route rejects a request for `layout` outright in that case.
+
 ### Deleting
 
 Bulk delete reports per document. When the server refuses one — because it was uploaded
@@ -246,8 +292,8 @@ the reason, and offers to go ahead anyway.
 
 | Test | Covers |
 |---|---|
-| `functional_tests/test_v2_documents_explorer.py` | Route guards, shared delete guard, settings whitelist, section registration on both sides, V1 non-regression, endpoint coverage, composition, selection model, view modes, no CDN assets |
-| `functional_tests/test_v2_documents_explorer_logic.ts` | 58 behavioural checks over the query builder, selection algebra, filter chips, status derivation, formatting, pagination, facets and saved views |
+| `functional_tests/test_v2_documents_explorer.py` | Route guards, shared delete guard, settings whitelist, section registration on both sides, V1 non-regression, endpoint coverage, composition, selection model, view modes, search binding, batched progress, the re-extract control, the collapsible rail, no CDN assets |
+| `functional_tests/test_v2_documents_explorer_logic.ts` | 67 behavioural checks over the query builder, selection algebra, filter chips, status derivation, formatting, pagination, facets, saved views, batching and extraction-mode summarisation |
 
 The Python test additionally *executes* the new server helpers — `sort_documents`,
 `filter_documents_by_place`, `build_personal_document_facets` — by extracting them from source

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,46 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/features) and [Fixes by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/fixes).
 
+### **(v0.261.045)**
+
+#### New Features
+
+*   **Documents In My Workspace Is Now A File Explorer**
+    *   The documents page in the new interface was one flat list that could upload a file, delete a file, and filter by one tag. It is now laid out like a file manager: a command bar across the top, a navigation rail down the left, the list in the middle, a details pane on the right and a status bar along the bottom.
+    *   **Everything the server could already do is now reachable.** The page previously asked for a thousand documents at once and sorted and searched them in the browser, ignoring the paging, searching, sorting, filtering, downloading, metadata editing, re-extraction and sharing the API has supported all along. All of it is now used.
+    *   **Tags live in the left rail instead of behind a view mode.** The classic workspace shows tags as folder cards you switch into a separate mode to see; here they are always visible, with their colour and a live count, and clicking one filters the list. Ctrl-clicking a second tag narrows to documents carrying both.
+    *   **Drag documents onto a tag to file them.** The confirmation offers an **Undo**, so tagging a batch never needs a dialog first.
+    *   **Saved views** pin a combination of search, tags, classification and status to the rail under your own name for it — the closest thing to a folder that a workspace organised by tags can honestly offer.
+    *   **Multi-select works the way it does everywhere else.** There is no longer a mode to switch on before checkboxes appear: click, Ctrl-click, Shift-click, Ctrl+A, Escape, and the arrow keys all behave as expected, and the toolbar's Download, Tag, Chat, Extract and Delete act on whatever is selected.
+    *   **Titles lead, file names follow.** A file called `MSA_v2_FINAL(3).docx` now shows its extracted title on the first line with the file name beneath it, and its tags as coloured chips in their own column rather than run together into one line of text.
+    *   **The details pane** shows a document's tags, classification, size, pages, version, dates, authors, keywords, abstract and sharing, and lets you edit them. With several documents selected it reports how many, their combined size and the tags they have in common, so a bulk action states what it is about to touch.
+    *   **Two views instead of four.** Details (a sortable table) and Tiles (cards). The two folder-shaped modes are gone, replaced by the rail.
+    *   **Active filters are visible.** Whatever is narrowing the list appears as removable chips above it, with a Clear all — previously there was no way to tell why documents seemed to be missing.
+    *   (Ref: V2 My Workspace, Documents, `GET /api/documents`, `GET /api/documents/facets`, `POST /api/documents/bulk-delete`, `POST /api/documents/bulk-tag`)
+
+*   **A Tags Section In My Workspace**
+    *   Tags now have a home of their own under Knowledge, where they can be created, renamed, recoloured, merged and deleted, with a count of how many documents use each one.
+    *   **Renaming a tag onto one that already exists merges the two**, and the page says so before you commit to it.
+    *   Deleting a tag says how many documents it will be removed from, and never deletes the documents themselves.
+    *   Applying tags stays on the Documents page. Choosing what the tags *are* and browsing *by* them are different jobs, and the classic workspace does both from the same toolbar.
+    *   (Ref: V2 My Workspace, Tags, `PATCH /api/documents/tags/<name>`, tag colours)
+
+*   **Deleting Several Documents At Once**
+    *   Removing a selection was previously one request per document. It is now a single request that reports on each document individually.
+    *   **A document the server refuses to delete is named, with the reason.** Files uploaded through chat and files managed by file sync are protected because deleting them silently damages something else; those are now listed by name with an option to go ahead anyway, instead of one protected file blocking everything selected with it.
+    *   (Ref: `POST /api/documents/bulk-delete`, conversation-linked documents, file sync)
+
+#### Bug Fixes
+
+*   **Sorting Documents By Size Or Page Count Would Have Crashed The Listing**
+    *   The document sort compared a missing value against a present one as different types, which raises an error in Python. It was harmless while documents could only be sorted by name, title and date, and would have failed the moment any numeric column became sortable.
+    *   Sort fields are now declared as numeric or textual, so a document that has never had a size, a page count or a version still sorts correctly alongside ones that do.
+    *   (Ref: `sort_documents`, `ALLOWED_DOCUMENT_SORT_FIELDS`, personal, group and public document lists)
+
+*   **The "Shared With Me" Filter Never Did Anything**
+    *   The classic workspace sends a `shared_only` filter that the document listing has never read, so ticking it changed nothing. The listing now supports filtering by document state — recent, shared with you, processing, needs attention, or untagged — and the new interface's rail uses it.
+    *   (Ref: `GET /api/documents`, `place` parameter)
+
 ### **(v0.261.044)**
 
 #### Bug Fixes

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,35 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/features) and [Fixes by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/fixes).
 
+### **(v0.261.046)**
+
+#### Bug Fixes
+
+*   **Typing In The Documents Search Box Dropped Characters**
+    *   The search box searched on every keystroke and lost letters if you typed at anything like normal speed, so a search term had to be entered slowly and checked.
+    *   The box was displaying the *searched* term rather than what you had typed, so each keystroke was undone until the search caught up. It now shows what you type, waits for you to stop before searching, and searches immediately if you press **Enter**. **Escape** clears it.
+    *   (Ref: V2 My Workspace, Documents, search)
+
+*   **Tagging Several Documents Appeared To Hang**
+    *   Applying tags to a multi-document selection showed a spinner labelled "Working…" that never went away and never refreshed the list. The tags had actually been applied — a page refresh showed them — but nothing on screen said so.
+    *   Tagging a document is expensive on the server: it rewrites the document and every one of its search index entries. Sending one request for the whole selection meant a single request that ran for a very long time behind a spinner that could not distinguish slow from stuck.
+    *   Tagging and deleting are now sent in small batches with **a real progress bar** showing how many documents of the total are done, and the list refreshes when it finishes. A batch that fails now reports itself instead of leaving the progress indicator up indefinitely.
+    *   (Ref: V2 My Workspace, Documents, bulk tagging, bulk delete, progress reporting)
+
+#### User Interface Enhancements
+
+*   **Re-Extraction Now Says Which Mode A Document Is Already On**
+    *   The details pane offered **Standard** and **Enhanced** as two identical buttons without indicating which one had been used, so the only way to change a document's extraction was to guess and then check.
+    *   It now states the current mode, marks that option as **(current)**, and presents the other as **Switch to Standard** or **Switch to Enhanced**. A selection spanning both reads **Mixed**; one where no mode was ever recorded reads **Not recorded**.
+    *   The choice is hidden for files it does not apply to — only PDFs and images are processed this way — and in a mixed selection those files are named and left alone rather than silently included.
+    *   **Enhanced** is disabled with an explanation when your administrator has not enabled enhanced extraction, instead of being offered and then refused.
+    *   (Ref: V2 My Workspace, Documents, details pane, `enable_enhanced_extraction`)
+
+*   **The My Workspace Section Menu Can Be Collapsed**
+    *   The list of workspace sections down the left can now be collapsed to icons, giving the documents explorer noticeably more room. The choice is remembered.
+    *   It collapses independently of the main application sidebar, so you can narrow either one without affecting the other. Collapsed entries keep their names as tooltips and for screen readers.
+    *   (Ref: V2 My Workspace, section navigation)
+
 ### **(v0.261.045)**
 
 #### New Features

--- a/functional_tests/test_v2_api_payload_shapes.py
+++ b/functional_tests/test_v2_api_payload_shapes.py
@@ -42,23 +42,34 @@ def test_workspace_tags_are_treated_as_objects():
         "if the contract changed, update the V2 client to match"
     )
 
-    # The tag handling moved with the documents list when the workspace page became a
-    # grouped set of sections; the guarantee it encodes is unchanged.
-    workspace_page = _read(V2_SRC / "pages" / "workspace" / "DocumentsSection.tsx")
+    # The tag handling moved again when the documents page became the explorer: the
+    # normalisation is now shared by the table, the tiles, the details pane and the rail, so
+    # it lives in the library those all draw on. The guarantee it encodes is unchanged.
+    explorer_lib = _read(V2_SRC / "lib" / "documentExplorer.ts")
 
-    assert "function tagName(" in workspace_page, (
-        "The documents section must funnel tags through tagName() so an object tag is "
-        "never rendered directly (this caused React error #31)"
+    assert "export function tagName(" in explorer_lib, (
+        "The explorer must funnel tags through tagName() so an object tag is never "
+        "rendered directly (this caused React error #31)"
     )
-    assert "'name' in tag" in workspace_page, (
+    assert "'name' in tag" in explorer_lib, (
         "tagName() must handle the object tag shape returned by /api/documents/tags"
     )
 
-    # The crash was rendering the raw tag as a JSX child. Guard against its return.
-    assert re.search(r"\{tag\}", workspace_page) is None, (
-        "The documents section renders a raw tag value as a JSX child; render "
-        "tagName(tag) instead"
-    )
+    # The crash was rendering the raw tag as a JSX child. Guard against its return across
+    # every surface that displays a tag.
+    documents_components = V2_SRC / "components" / "documents"
+    tag_surfaces = [
+        V2_SRC / "pages" / "workspace" / "DocumentsSection.tsx",
+        V2_SRC / "pages" / "workspace" / "TagsSection.tsx",
+        *sorted(documents_components.glob("*.tsx")),
+    ]
+    for surface in tag_surfaces:
+        source = _read(surface)
+        # Only a JSX *child* is the hazard. `tag={tag}` passes the object to a component
+        # that knows what to do with it, which is exactly how it should travel.
+        assert re.search(r"(?<![=\w]){tag}", source) is None, (
+            f"{surface.name} renders a raw tag value as a JSX child; render its name instead"
+        )
 
     endpoints = _read(V2_SRC / "lib" / "endpoints.ts")
     assert "tags?: WorkspaceTag[]" in endpoints, (

--- a/functional_tests/test_v2_documents_explorer.py
+++ b/functional_tests/test_v2_documents_explorer.py
@@ -71,6 +71,7 @@ RAIL_TSX = V2_SRC / "components" / "documents" / "ExplorerRail.tsx"
 TABLE_TSX = V2_SRC / "components" / "documents" / "DocumentTable.tsx"
 TILES_TSX = V2_SRC / "components" / "documents" / "DocumentTiles.tsx"
 DETAILS_TSX = V2_SRC / "components" / "documents" / "DocumentDetailsPane.tsx"
+COMMAND_BAR_TSX = V2_SRC / "components" / "documents" / "ExplorerCommandBar.tsx"
 LOGIC_CHECK_TS = REPO_ROOT / "functional_tests" / "test_v2_documents_explorer_logic.ts"
 
 # Routes added for the explorer, each with the guards its neighbours already carry.
@@ -609,6 +610,139 @@ def test_the_typescript_logic_checks_pass():
     return True
 
 
+def test_search_is_debounced_without_dropping_keystrokes():
+    """A controlled input bound to the debounced value reverts every keystroke."""
+    print("Testing search input binding...")
+
+    command_bar = _read(COMMAND_BAR_TSX)
+
+    assert "value={searchDraft}" in command_bar, (
+        "The search box must be bound to the draft. Binding it to the debounced "
+        "`query.search` meant each keystroke was reverted until the debounce caught up, "
+        "which dropped characters while typing at speed"
+    )
+    assert "value={query.search}" not in command_bar, (
+        "The search box must not be bound to the debounced value"
+    )
+    assert "onSearchSubmit" in command_bar, (
+        "Enter should search immediately rather than waiting out the debounce"
+    )
+    assert "event.key === 'Enter'" in command_bar
+    assert "event.key === 'Escape'" in command_bar, "Escape should clear the search"
+
+    explorer = _read(EXPLORER_TSX)
+    assert "searchDraft={searchDraft}" in explorer, (
+        "The explorer must pass the draft, not the committed query, to the search box"
+    )
+    assert re.search(r"setTimeout\(\s*\(\)\s*=>", explorer), (
+        "The search should still be debounced between keystrokes"
+    )
+
+    print("  ok  search is debounced, Enter commits, and no keystroke is reverted")
+    return True
+
+
+def test_bulk_work_reports_determinate_progress():
+    """An indeterminate spinner over a slow request is indistinguishable from a hang."""
+    print("Testing bulk progress reporting...")
+
+    explorer = _read(EXPLORER_TSX)
+    command_bar = _read(COMMAND_BAR_TSX)
+
+    assert "ExplorerProgress" in command_bar and "ExplorerProgress" in explorer, (
+        "Bulk operations should report determinate progress"
+    )
+    assert 'role="progressbar"' in command_bar, "The progress bar must be announced as one"
+    assert "aria-valuenow" in command_bar and "aria-valuemax" in command_bar
+
+    assert "Working…" not in explorer, (
+        "The indeterminate 'Working…' banner should be gone; bulk tagging updates each "
+        "document and its search-index chunks, so it runs long enough that a spinner "
+        "reads as a hang"
+    )
+
+    assert "BULK_BATCH_SIZE" in explorer, (
+        "Bulk work should be batched so progress can be reported as it lands"
+    )
+    assert "batched(" in explorer, "Batching should use the tested helper"
+
+    # The regression that made this necessary: a task left set forever. Every path that
+    # starts one must clear it in a finally.
+    starts = explorer.count("setTask({")
+    clears = explorer.count("setTask(null)")
+    assert clears >= 3, (
+        f"Every operation that sets a progress task must clear it; found {starts} starts "
+        f"and only {clears} clears"
+    )
+
+    print("  ok  bulk work is batched and reports determinate, always-cleared progress")
+    return True
+
+
+def test_reextract_states_the_current_mode():
+    """Two equal buttons with no current state meant guessing and then checking."""
+    print("Testing the re-extract control...")
+
+    details = _read(DETAILS_TSX)
+
+    assert "summarizeExtraction" in details, (
+        "The pane should report the mode the selection is currently on"
+    )
+    assert "(current)" in details, "The current mode must be marked as such"
+    assert "Switch to" in details, (
+        "The actionable button should say it switches, not just name a mode"
+    )
+    assert "enhancedExtraction" in details, (
+        "Enhanced must be gated on enable_enhanced_extraction; the reprocess route rejects "
+        "a request for layout outright when it is off"
+    )
+    assert "not a PDF or" in details, (
+        "Documents the extraction mode does not apply to should be called out"
+    )
+
+    explorer = _read(EXPLORER_TSX)
+    assert "enable_enhanced_extraction" in explorer, (
+        "The explorer must read the enhanced extraction flag from the bootstrap features"
+    )
+
+    lib = _read(EXPLORER_TS)
+    assert "supportsExtractionModeChange" in lib
+    assert "'.heic'" in lib, (
+        "The image extension list should match EXTRACTION_MODE_CHANGE_IMAGE_EXTENSIONS "
+        "in workspace-documents.js"
+    )
+
+    print("  ok  the re-extract control states the current mode and gates Enhanced")
+    return True
+
+
+def test_the_workspace_rail_can_be_collapsed():
+    print("Testing the collapsible workspace rail...")
+
+    page = _read(WORKSPACE_PAGE_TSX)
+
+    assert "v2WorkspaceRailCollapsed" in page, (
+        "The workspace section rail should have its own collapse preference"
+    )
+    assert "v2RailCollapsed" not in page, (
+        "The workspace rail must not reuse the application shell's collapse preference; "
+        "collapsing one should not collapse the other"
+    )
+    assert "PanelLeftClose" in page and "PanelLeftOpen" in page
+    assert 'aria-expanded={!railCollapsed}' in page
+    assert 'className="sr-only"' in page, (
+        "A collapsed entry still needs its label available to a screen reader"
+    )
+
+    # And the key has to be writable, or the preference is dropped silently.
+    users = _read(USERS_ROUTE)
+    assert "'v2WorkspaceRailCollapsed'" in users
+    assert "'v2WorkspaceRailCollapsed'" in _read(USER_SETTINGS_TS)
+
+    print("  ok  the workspace rail collapses to icons and remembers it")
+    return True
+
+
 TESTS = [
     test_version_is_at_least_the_implementing_release,
     test_new_settings_keys_are_whitelisted,
@@ -624,6 +758,10 @@ TESTS = [
     test_the_name_column_shows_the_title_over_the_file_name,
     test_only_two_views_are_offered,
     test_the_details_pane_handles_every_selection_size,
+    test_search_is_debounced_without_dropping_keystrokes,
+    test_bulk_work_reports_determinate_progress,
+    test_reextract_states_the_current_mode,
+    test_the_workspace_rail_can_be_collapsed,
     test_no_cdn_assets_were_introduced,
     test_the_typescript_logic_checks_pass,
 ]

--- a/functional_tests/test_v2_documents_explorer.py
+++ b/functional_tests/test_v2_documents_explorer.py
@@ -1,0 +1,645 @@
+#!/usr/bin/env python3
+"""
+Functional test for the V2 workspace documents explorer.
+
+Version: 0.261.045
+Implemented in: 0.261.045
+
+The behavioural half of the front end lives in ``test_v2_documents_explorer_logic.ts``, run
+from here. This file covers the parts that are only observable in the source, plus the new
+server-side helpers, which are executed directly rather than asserted about.
+
+What it pins:
+
+**Settings keys must be whitelisted.** ``/api/user/settings`` validates against
+``allowed_keys`` in route_backend_users.py and drops anything outside it **without
+complaining** -- the POST still returns success and the value simply never arrives. A view
+mode or saved view written under an unlisted key would appear to save and be gone on the next
+reload.
+
+**A new section must be registered on both sides.** ``resolveWorkspaceSections`` fails closed:
+a section the server does not report is treated as unavailable. Adding Tags to the SPA alone
+would produce a section that never renders, with no error to explain it.
+
+**The new routes must carry the same guards as their neighbours.** Every document route is
+``@swagger_route`` + ``@login_required`` + ``@user_required`` +
+``@enabled_required("enable_user_workspace")``. Bulk delete is the one that matters most: it
+removes many documents in a single unauthenticated-by-accident request.
+
+**Sorting must not raise on a document that lacks the field.** ``sort_documents`` mapped a
+missing value to ``""`` while leaving a present numeric value an ``int``, and Python 3 raises
+``TypeError`` comparing the two. That was invisible while the allow-list held only strings; it
+becomes a live crash the moment ``file_size`` is sortable.
+
+**Standing views must be derived, not guessed.** "Untagged", "Processing" and "Shared with me"
+are computed from the document rather than queried, so they are executed here against records
+shaped like the real ones, including the legacy shape that has no ``percentage_complete``.
+"""
+
+import ast
+import json
+import re
+import subprocess
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+APP_DIR = REPO_ROOT / "application" / "single_app"
+V2_DIR = REPO_ROOT / "application" / "v2_ui"
+V2_SRC = V2_DIR / "src"
+
+sys.path.insert(0, str(REPO_ROOT / "functional_tests"))
+
+from test_support.versioning import assert_app_version_at_least  # noqa: E402
+
+DOCUMENTS_ROUTE = APP_DIR / "route_backend_documents.py"
+USERS_ROUTE = APP_DIR / "route_backend_users.py"
+SECTIONS_PY = APP_DIR / "functions_workspace_sections.py"
+DOCUMENTS_FUNCTIONS = APP_DIR / "functions_documents.py"
+
+ENDPOINTS_TS = V2_SRC / "lib" / "endpoints.ts"
+EXPLORER_TS = V2_SRC / "lib" / "documentExplorer.ts"
+SAVED_VIEWS_TS = V2_SRC / "lib" / "documentSavedViews.ts"
+USER_SETTINGS_TS = V2_SRC / "lib" / "userSettings.ts"
+SECTIONS_TSX = V2_SRC / "pages" / "workspace" / "sections.tsx"
+WORKSPACE_PAGE_TSX = V2_SRC / "pages" / "workspace" / "WorkspacePage.tsx"
+DOCUMENTS_SECTION_TSX = V2_SRC / "pages" / "workspace" / "DocumentsSection.tsx"
+TAGS_SECTION_TSX = V2_SRC / "pages" / "workspace" / "TagsSection.tsx"
+EXPLORER_TSX = V2_SRC / "components" / "documents" / "DocumentExplorer.tsx"
+RAIL_TSX = V2_SRC / "components" / "documents" / "ExplorerRail.tsx"
+TABLE_TSX = V2_SRC / "components" / "documents" / "DocumentTable.tsx"
+TILES_TSX = V2_SRC / "components" / "documents" / "DocumentTiles.tsx"
+DETAILS_TSX = V2_SRC / "components" / "documents" / "DocumentDetailsPane.tsx"
+LOGIC_CHECK_TS = REPO_ROOT / "functional_tests" / "test_v2_documents_explorer_logic.ts"
+
+# Routes added for the explorer, each with the guards its neighbours already carry.
+NEW_ROUTES = [
+    ("/api/documents/bulk-delete", "POST"),
+    ("/api/documents/facets", "GET"),
+]
+
+REQUIRED_DECORATORS = [
+    "@swagger_route(security=get_auth_security())",
+    "@login_required",
+    "@user_required",
+    '@enabled_required("enable_user_workspace")',
+]
+
+NEW_SETTING_KEYS = ["v2DocumentsPrefs", "v2DocumentSavedViews"]
+
+
+def _read(path):
+    return path.read_text(encoding="utf-8")
+
+
+def _load_module_functions(path, names):
+    """Execute selected top-level functions from a module without importing it.
+
+    ``route_backend_documents`` and ``functions_documents`` both import ``config``, which
+    builds Azure clients at import time and cannot run without credentials. The helpers under
+    test depend on nothing but ``datetime``, so the module is parsed and only those
+    definitions -- plus the module-level constants they close over -- are executed.
+    """
+    tree = ast.parse(_read(path))
+    wanted = set(names)
+
+    def is_constant_assignment(node):
+        return isinstance(node, ast.Assign) and any(
+            isinstance(target, ast.Name) and target.id.isupper()
+            for target in node.targets
+        )
+
+    namespace = {
+        "datetime": datetime,
+        "timedelta": timedelta,
+        "timezone": timezone,
+    }
+
+    # Constants are executed one at a time and failures are skipped: these modules also
+    # define constants built from imports the extraction deliberately does not provide, and
+    # only the ones the helpers under test close over need to succeed.
+    for node in tree.body:
+        if not is_constant_assignment(node):
+            continue
+        try:
+            exec(
+                compile(ast.Module(body=[node], type_ignores=[]), str(path), "exec"),
+                namespace,
+            )
+        except Exception:  # noqa: BLE001
+            continue
+
+    definitions = [
+        node
+        for node in tree.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name in wanted
+    ]
+    try:
+        exec(
+            compile(ast.Module(body=definitions, type_ignores=[]), str(path), "exec"),
+            namespace,
+        )
+    except Exception as error:  # noqa: BLE001
+        raise AssertionError(
+            f"Could not execute the extracted helpers from {path.name}: {error}"
+        ) from error
+
+    missing = wanted - set(namespace)
+    assert not missing, f"Could not extract {missing} from {path.name}"
+    return namespace
+
+
+def test_version_is_at_least_the_implementing_release():
+    print("Testing version...")
+    assert_app_version_at_least("0.261.045")
+    print("  ok  version is at or beyond the implementing release")
+    return True
+
+
+def test_new_settings_keys_are_whitelisted():
+    """An unlisted key is dropped silently, so this must never regress."""
+    print("Testing settings key whitelist...")
+
+    users = _read(USERS_ROUTE)
+    block = re.search(r"allowed_keys = \{(.*?)\}", users, re.DOTALL)
+    assert block, "Could not find allowed_keys in route_backend_users.py"
+    allowed = set(re.findall(r"['\"]([A-Za-z_][A-Za-z0-9_]*)['\"]", block.group(1)))
+
+    settings_ts = _read(USER_SETTINGS_TS)
+    writable_block = re.search(
+        r"export const WRITABLE_USER_SETTING_KEYS = \[(.*?)\] as const;",
+        settings_ts,
+        re.DOTALL,
+    )
+    assert writable_block, "Could not find WRITABLE_USER_SETTING_KEYS in userSettings.ts"
+    writable = set(re.findall(r"'([^']+)'", writable_block.group(1)))
+
+    for key in NEW_SETTING_KEYS:
+        assert key in allowed, (
+            f"{key} is written by the explorer but is not in allowed_keys, so the server "
+            "will accept the request and discard it"
+        )
+        assert key in writable, f"{key} must be declared in WRITABLE_USER_SETTING_KEYS"
+
+    print(f"  ok  {', '.join(NEW_SETTING_KEYS)} are whitelisted on both sides")
+    return True
+
+
+def test_new_routes_carry_their_guards():
+    print("Testing route guards...")
+
+    source = _read(DOCUMENTS_ROUTE)
+    for path, method in NEW_ROUTES:
+        pattern = re.compile(
+            r"@bp\.route\(\s*'" + re.escape(path) + r"'\s*,\s*methods=\['" + method + r"'\]\s*\)"
+            r"(?P<decorators>(?:\s*@[^\n]+\n)+)\s*def\s+(?P<name>\w+)",
+        )
+        match = pattern.search(source)
+        assert match, f"Could not find the {method} {path} route"
+
+        decorators = match.group("decorators")
+        for decorator in REQUIRED_DECORATORS:
+            assert decorator in decorators, (
+                f"{method} {path} is missing {decorator}; every personal document route "
+                "carries all four"
+            )
+        print(f"  ok  {method} {path} carries all four guards")
+
+    return True
+
+
+def test_bulk_delete_reuses_the_single_delete_guards():
+    """A guard added to one delete path must apply to the other."""
+    print("Testing delete guard sharing...")
+
+    source = _read(DOCUMENTS_ROUTE)
+
+    assert "_personal_document_delete_guard(" in source, (
+        "The delete guards should be factored into a shared helper"
+    )
+    assert source.count("_personal_document_delete_guard(") >= 3, (
+        "The shared guard should be defined once and called by both delete routes; "
+        "otherwise bulk delete becomes a way around a guard the single delete applies"
+    )
+    assert "build_synced_document_delete_guard" in source
+    assert "conversation_linked_document_delete_requires_confirmation" in source
+
+    bulk = source.split("def api_bulk_delete_user_documents")[1].split("@bp.route")[0]
+    assert "needs_confirmation" in bulk, (
+        "Bulk delete should report which documents were refused so the client can ask "
+        "about those specifically"
+    )
+    assert "invalidate_personal_search_cache" in bulk, (
+        "The search cache must be invalidated after a bulk delete"
+    )
+
+    print("  ok  both delete routes share one guard, and blocked documents are reported")
+    return True
+
+
+def test_sort_fields_are_typed_and_shared():
+    """Sorting a numeric field must not raise on a document that lacks it."""
+    print("Testing sort field handling...")
+
+    functions = _read(DOCUMENTS_FUNCTIONS)
+    assert "NUMERIC_DOCUMENT_SORT_FIELDS" in functions
+    assert "TEXT_DOCUMENT_SORT_FIELDS" in functions
+    assert "ALLOWED_DOCUMENT_SORT_FIELDS" in functions
+
+    route = _read(DOCUMENTS_ROUTE)
+    assert "allowed_sort_fields = {'_ts', 'file_name', 'title'}" not in route, (
+        "The personal list route should use the shared allow-list rather than its own copy"
+    )
+    assert "ALLOWED_DOCUMENT_SORT_FIELDS" in route
+
+    namespace = _load_module_functions(DOCUMENTS_FUNCTIONS, ["sort_documents", "_safe_float"])
+    sort_documents = namespace["sort_documents"]
+
+    # The regression: one document has a size, the other has never had one. Comparing an int
+    # against "" is a TypeError in Python 3.
+    documents = [
+        {"id": "a", "file_size": 2048},
+        {"id": "b"},
+        {"id": "c", "file_size": 100},
+    ]
+    ordered = sort_documents(documents, sort_by="file_size", sort_order="asc")
+    assert [item["id"] for item in ordered] == ["b", "c", "a"], ordered
+
+    # Text fields still sort case-insensitively, and a missing value does not raise.
+    names = sort_documents(
+        [{"file_name": "Beta"}, {"file_name": "alpha"}, {}],
+        sort_by="file_name",
+        sort_order="asc",
+    )
+    assert [item.get("file_name") for item in names] == [None, "alpha", "Beta"], names
+
+    # An unknown field falls back rather than raising, matching what every caller does.
+    fallback = sort_documents([{"_ts": 2}, {"_ts": 1}], sort_by="nonsense", sort_order="asc")
+    assert [item["_ts"] for item in fallback] == [1, 2]
+
+    print("  ok  numeric sort fields tolerate documents that lack them")
+    return True
+
+
+def test_place_filters_and_facets_are_derived_correctly():
+    print("Testing standing views and facet counts...")
+
+    namespace = _load_module_functions(
+        DOCUMENTS_ROUTE,
+        [
+            "filter_documents_by_place",
+            "build_personal_document_facets",
+            "_document_processing_state",
+            "_parse_document_timestamp",
+        ],
+    )
+    filter_by_place = namespace["filter_documents_by_place"]
+    build_facets = namespace["build_personal_document_facets"]
+
+    now = datetime.now(timezone.utc)
+    recent_ts = int((now - timedelta(days=2)).timestamp())
+    old_ts = int((now - timedelta(days=200)).timestamp())
+
+    documents = [
+        {"id": "ready", "user_id": "me", "tags": ["alpha"], "percentage_complete": 100,
+         "status": "Processing complete", "_ts": recent_ts,
+         "document_classification": "Internal"},
+        {"id": "untagged", "user_id": "me", "tags": [], "percentage_complete": 100,
+         "status": "Processing complete", "_ts": old_ts},
+        {"id": "blank-tags", "user_id": "me", "tags": ["  "], "percentage_complete": 100,
+         "_ts": old_ts},
+        {"id": "processing", "user_id": "me", "tags": ["alpha"], "percentage_complete": 40,
+         "status": "Saving page 2 of 5", "_ts": recent_ts},
+        {"id": "failed", "user_id": "me", "tags": ["beta"], "percentage_complete": 55,
+         "status": "Error: could not read file", "_ts": recent_ts},
+        # A record predating progress tracking. It must read as ready, not as stuck.
+        {"id": "legacy", "user_id": "me", "tags": ["beta"], "_ts": old_ts},
+        {"id": "shared", "user_id": "someone-else", "tags": ["alpha"],
+         "percentage_complete": 100, "_ts": recent_ts},
+    ]
+
+    def ids(items):
+        return sorted(item["id"] for item in items)
+
+    assert ids(filter_by_place(documents, "all", "me")) == ids(documents)
+    assert ids(filter_by_place(documents, "untagged", "me")) == ["blank-tags", "untagged"], (
+        "A tag that is only whitespace should not count as tagged"
+    )
+    assert ids(filter_by_place(documents, "processing", "me")) == ["processing"]
+    assert ids(filter_by_place(documents, "errors", "me")) == ["failed"]
+    assert ids(filter_by_place(documents, "shared", "me")) == ["shared"]
+    assert ids(filter_by_place(documents, "recent", "me")) == [
+        "failed",
+        "processing",
+        "ready",
+        "shared",
+    ]
+
+    facets = build_facets(documents, "me")
+    assert facets["total"] == 7
+    assert facets["untagged"] == 2
+    assert facets["processing"] == 1
+    assert facets["errors"] == 1
+    assert facets["shared_with_me"] == 1
+    assert facets["recent"] == 4
+    assert facets["by_tag"]["alpha"] == 3
+    assert facets["by_tag"]["beta"] == 2
+    assert facets["by_classification"]["Internal"] == 1
+    assert "  " not in facets["by_tag"], "A whitespace tag should not become a facet"
+
+    print("  ok  standing views and facet counts are derived from the documents")
+    return True
+
+
+def test_the_tags_section_is_registered_on_both_sides():
+    """resolveWorkspaceSections fails closed, so a client-only section never renders."""
+    print("Testing Tags section registration...")
+
+    sections_py = _read(SECTIONS_PY)
+    assert '"tags",' in sections_py, "tags must be in WORKSPACE_SECTION_IDS"
+    assert '"tags": "knowledge"' in sections_py, "tags must be grouped under knowledge"
+    assert '"tags": _section(True)' in sections_py, (
+        "tags should be available on the same terms as documents"
+    )
+
+    sections_tsx = _read(SECTIONS_TSX)
+    assert "id: 'tags'" in sections_tsx
+    assert "TagsSection" in sections_tsx
+    assert TAGS_SECTION_TSX.exists()
+
+    print("  ok  tags is registered in both the server and the SPA registries")
+    return True
+
+
+def test_v1_does_not_grow_a_tab_from_the_new_section():
+    """The classic interface reads only two values from the availability payload."""
+    print("Testing that V1 is unaffected...")
+
+    frontend = _read(APP_DIR / "route_frontend_workspace.py")
+    assert "workspace_availability['sections']" not in frontend, (
+        "The classic workspace must not iterate the section map, or adding a V2-only "
+        "section would add a tab to it"
+    )
+    assert "workspace_availability['file_sync_enabled']" in frontend
+    assert "workspace_availability['governance']" in frontend
+
+    print("  ok  the classic workspace reads only file_sync_enabled and governance")
+    return True
+
+
+def test_the_client_calls_the_endpoints_that_exist():
+    print("Testing endpoint coverage...")
+
+    endpoints = _read(ENDPOINTS_TS)
+    route = _read(DOCUMENTS_ROUTE)
+
+    # Every path the explorer calls, and the route file that must define it.
+    expected_paths = [
+        "/api/documents?",
+        "/api/documents/facets",
+        "/api/documents/bulk-delete",
+        "/api/documents/bulk-tag",
+        "/api/documents/upload",
+        "/api/documents/download",
+        "/api/documents/extract_metadata",
+        "/api/documents/reprocess_extraction",
+        "/api/documents/tags",
+    ]
+    for path in expected_paths:
+        assert path in endpoints, f"endpoints.ts should call {path}"
+        assert path.rstrip("?") in route, (
+            f"{path} is called by the client but not defined in route_backend_documents.py"
+        )
+
+    # The old fixed-page call is the specific regression: it pulled a thousand documents and
+    # then filtered them in the browser, ignoring every server-side filter that exists.
+    assert "page_size=1000" not in endpoints, (
+        "The explorer pages server-side; a fixed 1000-row fetch defeats that"
+    )
+    assert "buildDocumentListParams" in endpoints, (
+        "List parameters should come from the tested builder, not be assembled inline"
+    )
+
+    print(f"  ok  all {len(expected_paths)} document paths exist on both sides")
+    return True
+
+
+def test_the_explorer_is_wired_to_its_parts():
+    print("Testing explorer composition...")
+
+    explorer = _read(EXPLORER_TSX)
+    for component in ("ExplorerRail", "ExplorerCommandBar", "DocumentTable", "DocumentTiles",
+                      "DocumentDetailsPane", "ExplorerStatusBar", "FilterChips"):
+        assert component in explorer, f"The explorer should render {component}"
+
+    # Selection, filtering and paging rules must come from the tested module rather than
+    # being reimplemented in the component.
+    for helper in ("applySelection", "pruneSelection", "toggleSelectAll", "applyQueryChange",
+                   "describeActiveFilters", "clearAllFilters", "toggleSort"):
+        assert helper in explorer, f"The explorer should use {helper} from documentExplorer"
+
+    assert "bulkDeletePersonalDocuments" in explorer
+    assert "bulkTagPersonalDocuments" in explorer
+    assert "onDropOnTag" in explorer, "Drag-to-tag should be wired to the rail"
+    assert "application/x-simplechat-documents" in explorer, (
+        "The drag payload needs an explicit type so unrelated drops are ignored"
+    )
+    assert "application/x-simplechat-documents" in _read(RAIL_TSX)
+
+    # The Undo is what makes an immediately-applied bulk tag safe without a confirm step.
+    assert "'Undo'" in explorer or '"Undo"' in explorer, (
+        "Drag-to-tag should offer an undo rather than confirming beforehand"
+    )
+
+    print("  ok  the explorer composes its parts and reuses the tested rules")
+    return True
+
+
+def test_selection_is_not_a_mode():
+    """The classic page requires switching multi-select on before a checkbox appears."""
+    print("Testing selection model...")
+
+    for path in (TABLE_TSX, TILES_TSX):
+        source = _read(path)
+        assert "event.shiftKey" in source, f"{path.name} should support Shift+click"
+        assert "event.ctrlKey || event.metaKey" in source, (
+            f"{path.name} should treat Ctrl and Cmd alike"
+        )
+        assert 'type="checkbox"' in source, f"{path.name} should always render a checkbox"
+
+    explorer = _read(EXPLORER_TSX)
+    assert "selectionModeActive" not in explorer, (
+        "There should be no multi-select mode; selection works like any file manager"
+    )
+    assert "'a'" in explorer and "preventDefault" in explorer, (
+        "Ctrl+A should select the page"
+    )
+
+    print("  ok  selection uses click/Ctrl/Shift with no mode to switch on")
+    return True
+
+
+def test_the_name_column_shows_the_title_over_the_file_name():
+    print("Testing the name column...")
+
+    table = _read(TABLE_TSX)
+    assert "documentDisplayName" in table, (
+        "The name column should use the shared two-line resolution"
+    )
+    assert "secondary" in table, "The file name should render beneath the title"
+
+    explorer_lib = _read(EXPLORER_TS)
+    assert "documentDisplayName" in explorer_lib
+
+    print("  ok  the name column leads with the title and captions the file name")
+    return True
+
+
+def test_only_two_views_are_offered():
+    print("Testing view modes...")
+
+    sections = _read(SECTIONS_TSX)
+    assert "layout: 'full'" in sections, (
+        "The documents section needs the full width, not the prose measure"
+    )
+
+    page = _read(WORKSPACE_PAGE_TSX)
+    assert "fullBleed" in page, "WorkspacePage should honour the full-bleed layout"
+    assert "max-w-4xl" in page, "Other sections should keep their reading measure"
+
+    explorer = _read(EXPLORER_TSX)
+    assert "'tiles'" in explorer and "DocumentTable" in explorer
+    # The classic interface's folder modes are deliberately not carried over; the rail
+    # replaces them and is always visible.
+    assert "folders-cards" not in explorer
+    assert "'grid'" not in explorer
+
+    print("  ok  two views, and the folder modes are not carried over")
+    return True
+
+
+def test_the_details_pane_handles_every_selection_size():
+    print("Testing the details pane...")
+
+    details = _read(DETAILS_TSX)
+    assert "documents.length === 0" in details, "It should say what to do with nothing selected"
+    assert "documents.length > 1" in details, "It should summarise a multi-selection"
+    assert "commonTags" in details, "A multi-selection should show the tags it has in common"
+    assert "totalFileSize" in details, "A multi-selection should report its combined size"
+
+    print("  ok  the pane covers the empty, single and multiple cases")
+    return True
+
+
+def test_no_cdn_assets_were_introduced():
+    """Browser assets must be served locally. See local_browser_assets.instructions.md."""
+    print("Testing for CDN references...")
+
+    offenders = []
+    for path in sorted((V2_SRC / "components" / "documents").glob("*.tsx")) + [
+        EXPLORER_TS,
+        SAVED_VIEWS_TS,
+        DOCUMENTS_SECTION_TSX,
+        TAGS_SECTION_TSX,
+    ]:
+        source = _read(path)
+        for match in re.finditer(r"https?://[^\s'\"`)]+", source):
+            url = match.group(0)
+            if "schemas" in url or "w3.org" in url:
+                continue
+            offenders.append(f"{path.name}: {url}")
+
+    assert not offenders, f"Remote asset references are not allowed: {offenders}"
+    print("  ok  no remote asset references")
+    return True
+
+
+def test_the_typescript_logic_checks_pass():
+    """Execute the behavioural half, skipping when the front-end toolchain is absent."""
+    print("Testing explorer logic (TypeScript)...")
+
+    if not (V2_DIR / "node_modules").exists():
+        print("  skip  application/v2_ui/node_modules is absent; run npm install to include")
+        return True
+
+    assert LOGIC_CHECK_TS.exists(), "The TypeScript logic checks are missing"
+
+    # functional_tests/ has no node_modules of its own, so the bundle is written where node
+    # can resolve bare imports from.
+    bundle = V2_DIR / "node_modules" / ".cache-documents-explorer-check.mjs"
+    try:
+        subprocess.run(
+            [
+                "npx",
+                "esbuild",
+                str(LOGIC_CHECK_TS),
+                "--bundle",
+                "--platform=node",
+                "--format=esm",
+                "--packages=external",
+                # endpoints.ts reaches apiClient.ts, which reads Vite's `import.meta.env` at
+                # module scope. Node has no such object, so it is defined away here.
+                "--define:import.meta.env={}",
+                f"--outfile={bundle}",
+                "--log-level=error",
+            ],
+            cwd=str(V2_DIR),
+            check=True,
+            shell=(sys.platform == "win32"),
+        )
+        result = subprocess.run(
+            ["node", str(bundle)],
+            cwd=str(V2_DIR),
+            capture_output=True,
+            text=True,
+            shell=(sys.platform == "win32"),
+        )
+    finally:
+        if bundle.exists():
+            bundle.unlink()
+
+    if result.returncode != 0:
+        print(result.stdout)
+        print(result.stderr)
+        raise AssertionError("the TypeScript logic checks failed")
+
+    passed = result.stdout.count("  ok  ")
+    print(f"  ok  {passed} TypeScript logic checks passed")
+    return True
+
+
+TESTS = [
+    test_version_is_at_least_the_implementing_release,
+    test_new_settings_keys_are_whitelisted,
+    test_new_routes_carry_their_guards,
+    test_bulk_delete_reuses_the_single_delete_guards,
+    test_sort_fields_are_typed_and_shared,
+    test_place_filters_and_facets_are_derived_correctly,
+    test_the_tags_section_is_registered_on_both_sides,
+    test_v1_does_not_grow_a_tab_from_the_new_section,
+    test_the_client_calls_the_endpoints_that_exist,
+    test_the_explorer_is_wired_to_its_parts,
+    test_selection_is_not_a_mode,
+    test_the_name_column_shows_the_title_over_the_file_name,
+    test_only_two_views_are_offered,
+    test_the_details_pane_handles_every_selection_size,
+    test_no_cdn_assets_were_introduced,
+    test_the_typescript_logic_checks_pass,
+]
+
+
+if __name__ == "__main__":
+    results = []
+    for test in TESTS:
+        try:
+            results.append(bool(test()))
+        except Exception as error:  # noqa: BLE001
+            print(f"FAIL  {test.__name__}: {error}")
+            import traceback
+
+            traceback.print_exc()
+            results.append(False)
+
+    print(f"\n{sum(results)}/{len(results)} tests passed")
+    sys.exit(0 if all(results) else 1)

--- a/functional_tests/test_v2_documents_explorer_logic.ts
+++ b/functional_tests/test_v2_documents_explorer_logic.ts
@@ -32,6 +32,7 @@ import {
     EMPTY_SELECTION,
     applyQueryChange,
     applySelection,
+    batched,
     buildDocumentListParams,
     clearAllFilters,
     clearFilterChip,
@@ -40,6 +41,8 @@ import {
     describePage,
     documentDisplayName,
     documentStatus,
+    extractionMode,
+    extractionModeLabel,
     formatFileSize,
     formatRelativeDate,
     moveSelection,
@@ -49,6 +52,8 @@ import {
     placeCount,
     pruneSelection,
     selectionIntentFromEvent,
+    summarizeExtraction,
+    supportsExtractionModeChange,
     toggleSelectAll,
     toggleSort,
     visiblePlaces,
@@ -552,6 +557,93 @@ check('saving a view under an existing name replaces it', () => {
 check('a view can be removed', () => {
     const view = createSavedView('Contracts', query({ tags: ['alpha'] }));
     assert.deepEqual(removeSavedView([view], view.id), []);
+});
+
+/* --------------------------------- batching ------------------------------------ */
+
+check('bulk work is split into fixed-size batches', () => {
+    // Tagging costs a query, a write and a search-index update per document, so a single
+    // request for a large selection ran long enough to be indistinguishable from a hang.
+    assert.deepEqual(batched([1, 2, 3, 4, 5], 2), [[1, 2], [3, 4], [5]]);
+    assert.deepEqual(batched([1, 2], 5), [[1, 2]]);
+    assert.deepEqual(batched([], 5), []);
+    assert.deepEqual(batched([1, 2, 3], 1), [[1], [2], [3]]);
+});
+
+check('a nonsense batch size still produces usable batches', () => {
+    assert.deepEqual(batched([1, 2], 0), [[1], [2]]);
+    assert.deepEqual(batched([1, 2], -3), [[1], [2]]);
+});
+
+/* ------------------------------ extraction mode --------------------------------- */
+
+check('only PDFs and images can have their extraction mode changed', () => {
+    // Anything else never goes through Document Intelligence, so offering the choice would
+    // queue a job that changes nothing.
+    assert.equal(supportsExtractionModeChange({ file_name: 'report.pdf' }), true);
+    assert.equal(supportsExtractionModeChange({ file_name: 'SCAN.PDF' }), true);
+    assert.equal(supportsExtractionModeChange({ file_name: 'photo.jpeg' }), true);
+    assert.equal(supportsExtractionModeChange({ file_name: 'diagram.tiff' }), true);
+    assert.equal(supportsExtractionModeChange({ file_name: 'notes.docx' }), false);
+    assert.equal(supportsExtractionModeChange({ file_name: 'data.csv' }), false);
+    assert.equal(supportsExtractionModeChange({}), false);
+});
+
+check('the current extraction mode is read back, or reported as unknown', () => {
+    assert.equal(extractionMode({ document_intelligence_extraction_mode: 'layout' }), 'layout');
+    assert.equal(extractionMode({ document_intelligence_extraction_mode: ' READ ' }), 'read');
+    assert.equal(extractionMode({}), null);
+    assert.equal(extractionMode({ document_intelligence_extraction_mode: 'other' }), null);
+    assert.equal(extractionModeLabel('layout'), 'Enhanced');
+    assert.equal(extractionModeLabel('read'), 'Standard');
+    assert.equal(extractionModeLabel(null), 'Unknown');
+});
+
+check('a selection on one mode reports that mode', () => {
+    // The pane previously offered Standard and Enhanced as two equal buttons without saying
+    // which one the document was already on, so changing it meant guessing then checking.
+    const summary = summarizeExtraction([
+        { file_name: 'a.pdf', document_intelligence_extraction_mode: 'read' },
+        { file_name: 'b.png', document_intelligence_extraction_mode: 'read' },
+    ]);
+    assert.equal(summary.current, 'read');
+    assert.equal(summary.supported.length, 2);
+    assert.equal(summary.unsupported.length, 0);
+});
+
+check('a selection on different modes reports mixed', () => {
+    const summary = summarizeExtraction([
+        { file_name: 'a.pdf', document_intelligence_extraction_mode: 'read' },
+        { file_name: 'b.pdf', document_intelligence_extraction_mode: 'layout' },
+    ]);
+    assert.equal(summary.current, 'mixed');
+});
+
+check('a selection with no recorded mode is unknown, not mixed', () => {
+    // These are different situations: mixed means switching changes some of them, unknown
+    // means nothing is known about any of them.
+    const summary = summarizeExtraction([{ file_name: 'a.pdf' }, { file_name: 'b.pdf' }]);
+    assert.equal(summary.current, null);
+});
+
+check('documents the mode does not apply to are separated out', () => {
+    const summary = summarizeExtraction([
+        { file_name: 'a.pdf', document_intelligence_extraction_mode: 'layout' },
+        { file_name: 'notes.docx' },
+        { file_name: 'sheet.xlsx' },
+    ]);
+    assert.equal(summary.current, 'layout');
+    assert.deepEqual(summary.supported.map((item) => item.file_name), ['a.pdf']);
+    assert.deepEqual(
+        summary.unsupported.map((item) => item.file_name),
+        ['notes.docx', 'sheet.xlsx'],
+    );
+});
+
+check('a selection of only unsupported documents offers nothing', () => {
+    const summary = summarizeExtraction([{ file_name: 'notes.docx' }]);
+    assert.equal(summary.supported.length, 0);
+    assert.equal(summary.current, null);
 });
 
 /* ----------------------------------- runner ---------------------------------- */

--- a/functional_tests/test_v2_documents_explorer_logic.ts
+++ b/functional_tests/test_v2_documents_explorer_logic.ts
@@ -1,0 +1,579 @@
+// test_v2_documents_explorer_logic.ts
+//
+// Runtime test for the V2 documents explorer rules.
+// Version: 0.261.045
+// Implemented in: 0.261.045
+//
+// The companion test, test_v2_documents_explorer.py, asserts that the pieces are wired
+// together: routes carry their decorators, settings keys are whitelisted, the section is
+// registered on both sides. Those are source assertions and prove connection, not behaviour.
+//
+// This file executes the behaviour, because these failure modes are all quiet ones:
+//
+//   - A sort field the server does not accept is silently replaced with `_ts`, so a column
+//     header would appear to sort and reorder by something else entirely.
+//   - A filter change that does not reset the page lands on an empty page, which reads as
+//     "you have no documents" rather than "you are past the end".
+//   - A Shift+click range read from the selection rather than from the rendered order selects
+//     a different set than the one under the pointer once the table is re-sorted.
+//   - A selection not pruned after paging leaves ids in it that the user can no longer see,
+//     which a Delete button would then act on.
+//   - Tags arrive as objects, as arrays of strings, and as one comma-separated string, and
+//     rendering the object form directly is what caused React error #31 on this page before.
+//
+// Run by test_v2_documents_explorer.py, which bundles this with the esbuild Vite already
+// brings in and executes it under node, skipping it when the front-end toolchain is absent.
+// Bundling rather than running directly is what resolves the extensionless import between
+// documentSavedViews and documentExplorer.
+
+import assert from 'node:assert/strict';
+import {
+    DEFAULT_DOCUMENT_QUERY,
+    EMPTY_SELECTION,
+    applyQueryChange,
+    applySelection,
+    buildDocumentListParams,
+    clearAllFilters,
+    clearFilterChip,
+    commonTags,
+    describeActiveFilters,
+    describePage,
+    documentDisplayName,
+    documentStatus,
+    formatFileSize,
+    formatRelativeDate,
+    moveSelection,
+    normalizeSortField,
+    normalizeTags,
+    paginationItems,
+    placeCount,
+    pruneSelection,
+    selectionIntentFromEvent,
+    toggleSelectAll,
+    toggleSort,
+    visiblePlaces,
+} from '../application/v2_ui/src/lib/documentExplorer';
+import {
+    applySavedView,
+    createSavedView,
+    isSaveableQuery,
+    matchesSavedView,
+    parseSavedViews,
+    removeSavedView,
+    upsertSavedView,
+} from '../application/v2_ui/src/lib/documentSavedViews';
+
+const checks: [string, () => void][] = [];
+function check(name: string, fn: () => void) {
+    checks.push([name, fn]);
+}
+
+const query = (overrides: Record<string, unknown> = {}): any => ({ ...DEFAULT_DOCUMENT_QUERY, ...overrides });
+const params = (input: string): Record<string, string> => Object.fromEntries(new URLSearchParams(input));
+
+/* ------------------------------ query parameters ------------------------------ */
+
+check('the default query asks for page one at the default size', () => {
+    const result = params(buildDocumentListParams(query()));
+    assert.equal(result.page, '1');
+    assert.equal(result.page_size, '50');
+    assert.equal(result.sort_by, '_ts');
+    assert.equal(result.sort_order, 'desc');
+});
+
+check('empty filters are omitted rather than sent blank', () => {
+    // A present-but-empty `search` filters on the empty string server-side, which matches
+    // everything and only makes the request harder to read.
+    const result = params(buildDocumentListParams(query({ search: '   ' })));
+    assert.equal('search' in result, false);
+    assert.equal('tags' in result, false);
+    assert.equal('classification' in result, false);
+    assert.equal('place' in result, false);
+});
+
+check('tags are sent comma separated and de-duplicated', () => {
+    const result = params(
+        buildDocumentListParams(query({ tags: ['alpha', 'beta', 'alpha'] })),
+    );
+    assert.equal(result.tags, 'alpha,beta');
+});
+
+check('the "all" place is not sent, every other place is', () => {
+    assert.equal('place' in params(buildDocumentListParams(query({ place: 'all' }))), false);
+    assert.equal(
+        params(buildDocumentListParams(query({ place: 'untagged' }))).place,
+        'untagged',
+    );
+});
+
+check('a sort field the server does not accept falls back to _ts', () => {
+    // ALLOWED_DOCUMENT_SORT_FIELDS in functions_documents.py silently replaces an unknown
+    // field, so sending one would look like it sorted and quietly order by date instead.
+    assert.equal(normalizeSortField('num_chunks'), '_ts');
+    assert.equal(normalizeSortField('file_size'), 'file_size');
+    assert.equal(params(buildDocumentListParams(query({ sortBy: 'nonsense' }))).sort_by, '_ts');
+});
+
+/* -------------------------------- query changes -------------------------------- */
+
+check('narrowing the result set returns to page one', () => {
+    for (const change of [
+        { search: 'budget' },
+        { tags: ['alpha'] },
+        { classification: 'Internal' },
+        { place: 'untagged' },
+        { pageSize: 100 },
+    ]) {
+        const next = applyQueryChange(query({ page: 4 }), change);
+        assert.equal(next.page, 1, `${JSON.stringify(change)} should reset the page`);
+    }
+});
+
+check('paging itself does not reset the page', () => {
+    assert.equal(applyQueryChange(query({ page: 1 }), { page: 3 }).page, 3);
+});
+
+check('a change that does not narrow anything keeps the page', () => {
+    const next = applyQueryChange(query({ page: 4 }), { sortOrder: 'asc' });
+    assert.equal(next.page, 4);
+});
+
+check('re-selecting the same tag list keeps the page', () => {
+    const next = applyQueryChange(query({ page: 3, tags: ['alpha'] }), { tags: ['alpha'] });
+    assert.equal(next.page, 3);
+});
+
+check('dates and sizes start descending, names start ascending', () => {
+    // Newest-first and largest-first are the useful ends; A-Z is the useful end of a name.
+    assert.equal(toggleSort(query(), 'file_size').sortOrder, 'desc');
+    assert.equal(toggleSort(query(), 'upload_date').sortOrder, 'desc');
+    assert.equal(toggleSort(query(), 'file_name').sortOrder, 'asc');
+    assert.equal(toggleSort(query(), 'title').sortOrder, 'asc');
+});
+
+check('clicking the active column flips its direction', () => {
+    const first = toggleSort(query(), 'file_name');
+    const second = toggleSort(first, 'file_name');
+    assert.equal(second.sortBy, 'file_name');
+    assert.equal(second.sortOrder, 'desc');
+});
+
+/* --------------------------------- filter chips -------------------------------- */
+
+check('every active filter is described as a chip', () => {
+    const chips = describeActiveFilters(
+        query({
+            place: 'untagged',
+            search: 'budget',
+            tags: ['alpha', 'beta'],
+            classification: 'Internal',
+        }),
+    );
+    assert.deepEqual(
+        chips.map((chip) => chip.kind),
+        ['place', 'search', 'tag', 'tag', 'classification'],
+    );
+    assert.equal(chips[0].label, 'Untagged');
+    assert.equal(chips[1].label, 'Search: budget');
+});
+
+check('an unfiltered query has no chips', () => {
+    assert.equal(describeActiveFilters(query()).length, 0);
+});
+
+check('clearing one tag chip leaves the others alone', () => {
+    const current = query({ tags: ['alpha', 'beta'], search: 'budget' });
+    const next = clearFilterChip(current, { kind: 'tag', value: 'alpha', label: 'alpha' });
+    assert.deepEqual(next.tags, ['beta']);
+    assert.equal(next.search, 'budget');
+});
+
+check('clearing everything keeps the presentation but drops the filters', () => {
+    const next = clearAllFilters(
+        query({ place: 'recent', search: 'x', tags: ['a'], classification: 'C', sortBy: 'title' }),
+    );
+    assert.equal(next.place, 'all');
+    assert.equal(next.search, '');
+    assert.deepEqual(next.tags, []);
+    assert.equal(next.classification, null);
+    assert.equal(next.sortBy, 'title', 'sort is presentation, not a filter');
+});
+
+/* ----------------------------------- selection --------------------------------- */
+
+const ids = ['a', 'b', 'c', 'd', 'e'];
+
+check('modifier keys map to the expected intent', () => {
+    assert.equal(selectionIntentFromEvent({}), 'replace');
+    assert.equal(selectionIntentFromEvent({ ctrlKey: true }), 'toggle');
+    assert.equal(selectionIntentFromEvent({ metaKey: true }), 'toggle');
+    assert.equal(selectionIntentFromEvent({ shiftKey: true }), 'range');
+});
+
+check('a plain click selects one document and anchors there', () => {
+    const next = applySelection(EMPTY_SELECTION, 'c', 'replace', ids);
+    assert.deepEqual(next.ids, ['c']);
+    assert.equal(next.anchorId, 'c');
+});
+
+check('ctrl-click adds and removes without losing the rest', () => {
+    let selection = applySelection(EMPTY_SELECTION, 'b', 'replace', ids);
+    selection = applySelection(selection, 'd', 'toggle', ids);
+    assert.deepEqual(selection.ids, ['b', 'd']);
+    selection = applySelection(selection, 'b', 'toggle', ids);
+    assert.deepEqual(selection.ids, ['d']);
+});
+
+check('a ctrl-click selection stays in the order shown, not the order clicked', () => {
+    let selection = applySelection(EMPTY_SELECTION, 'e', 'replace', ids);
+    selection = applySelection(selection, 'a', 'toggle', ids);
+    assert.deepEqual(selection.ids, ['a', 'e']);
+});
+
+check('shift-click selects the range between the anchor and the click', () => {
+    const anchored = applySelection(EMPTY_SELECTION, 'b', 'replace', ids);
+    assert.deepEqual(applySelection(anchored, 'd', 'range', ids).ids, ['b', 'c', 'd']);
+});
+
+check('a range works backwards from the anchor too', () => {
+    const anchored = applySelection(EMPTY_SELECTION, 'd', 'replace', ids);
+    assert.deepEqual(applySelection(anchored, 'b', 'range', ids).ids, ['b', 'c', 'd']);
+});
+
+check('a second shift-click replaces the range rather than growing it', () => {
+    // This is what lets an over-long range be corrected by clicking nearer, instead of the
+    // user having to start the selection again.
+    const anchored = applySelection(EMPTY_SELECTION, 'a', 'replace', ids);
+    const wide = applySelection(anchored, 'e', 'range', ids);
+    assert.equal(wide.ids.length, 5);
+    const narrowed = applySelection(wide, 'b', 'range', ids);
+    assert.deepEqual(narrowed.ids, ['a', 'b']);
+});
+
+check('a range follows the order currently displayed', () => {
+    // Re-sorting changes which documents lie between the anchor and the click. Reading the
+    // order from the rendered list is what keeps the selection matching what is on screen.
+    const reordered = ['e', 'd', 'c', 'b', 'a'];
+    const anchored = applySelection(EMPTY_SELECTION, 'e', 'replace', reordered);
+    assert.deepEqual(applySelection(anchored, 'c', 'range', reordered).ids, ['e', 'd', 'c']);
+});
+
+check('a range without an anchor falls back to selecting one row', () => {
+    assert.deepEqual(applySelection(EMPTY_SELECTION, 'c', 'range', ids).ids, ['c']);
+});
+
+check('select-all toggles the whole page', () => {
+    const all = toggleSelectAll(EMPTY_SELECTION, ids);
+    assert.deepEqual(all.ids, ids);
+    assert.deepEqual(toggleSelectAll(all, ids).ids, []);
+});
+
+check('a partial selection selects all rather than clearing', () => {
+    const partial = { ids: ['a', 'b'], anchorId: 'a' };
+    assert.deepEqual(toggleSelectAll(partial, ids).ids, ids);
+});
+
+check('documents no longer on the page drop out of the selection', () => {
+    // Without this a bulk action taken after paging would apply to documents the user can no
+    // longer see, which is exactly the surprise a Delete button must never produce.
+    const selection = { ids: ['a', 'b', 'z'], anchorId: 'z' };
+    const pruned = pruneSelection(selection, ids);
+    assert.deepEqual(pruned.ids, ['a', 'b']);
+    assert.equal(pruned.anchorId, 'a', 'the anchor moves to something still visible');
+});
+
+check('pruning nothing returns the same object', () => {
+    const selection = { ids: ['a'], anchorId: 'a' };
+    assert.equal(pruneSelection(selection, ids), selection);
+});
+
+check('arrow keys move the selection and shift extends it', () => {
+    const start = applySelection(EMPTY_SELECTION, 'b', 'replace', ids);
+    assert.deepEqual(moveSelection(start, ids, 1, false).ids, ['c']);
+    assert.deepEqual(moveSelection(start, ids, 1, true).ids, ['b', 'c']);
+    assert.deepEqual(moveSelection(start, ids, -1, false).ids, ['a']);
+});
+
+check('arrow keys stop at the ends of the list', () => {
+    const first = applySelection(EMPTY_SELECTION, 'a', 'replace', ids);
+    assert.deepEqual(moveSelection(first, ids, -1, false).ids, ['a']);
+    const last = applySelection(EMPTY_SELECTION, 'e', 'replace', ids);
+    assert.deepEqual(moveSelection(last, ids, 1, false).ids, ['e']);
+});
+
+/* ------------------------------------- tags ------------------------------------ */
+
+check('tags are read from every shape the API returns', () => {
+    // /api/documents/tags returns objects; a document carries strings, or one joined string.
+    assert.deepEqual(normalizeTags(['alpha', ' beta ']), ['alpha', 'beta']);
+    assert.deepEqual(normalizeTags('alpha, beta'), ['alpha', 'beta']);
+    assert.deepEqual(normalizeTags([{ name: 'alpha' }, { name: ' beta ' }]), ['alpha', 'beta']);
+    assert.deepEqual(normalizeTags(undefined), []);
+    assert.deepEqual(normalizeTags(null), []);
+    assert.deepEqual(normalizeTags(''), []);
+});
+
+check('only tags on every selected document count as shared', () => {
+    const documents = [
+        { tags: ['alpha', 'beta'] },
+        { tags: ['beta', 'gamma'] },
+        { tags: 'beta, delta' },
+    ];
+    assert.deepEqual(commonTags(documents), ['beta']);
+});
+
+check('no documents means no shared tags', () => {
+    assert.deepEqual(commonTags([]), []);
+});
+
+/* ---------------------------------- status ------------------------------------- */
+
+check('a complete document is ready', () => {
+    assert.equal(documentStatus({ percentage_complete: 100 }).state, 'ready');
+    assert.equal(documentStatus({ percentage_complete: 140 }).state, 'ready');
+});
+
+check('a document with no progress field at all is ready, not stuck', () => {
+    // Records that predate progress tracking have no percentage. Showing them at 0% forever
+    // would be worse than saying nothing.
+    assert.equal(documentStatus({}).state, 'ready');
+});
+
+check('an error is detected from the status text at any percentage', () => {
+    assert.equal(documentStatus({ status: 'Error: could not read file' }).state, 'error');
+    assert.equal(
+        documentStatus({ status: 'Error: x', percentage_complete: 100 }).state,
+        'error',
+    );
+});
+
+check('an in-flight document reports its percentage', () => {
+    const status = documentStatus({ percentage_complete: 62, status: 'Saving page 3 of 5' });
+    assert.equal(status.state, 'processing');
+    assert.equal(status.percent, 62);
+    assert.equal(status.label, '62%');
+});
+
+check('a document awaiting approval says so', () => {
+    assert.equal(
+        documentStatus({ percentage_complete: 100, shared_approval_status: 'not_approved' })
+            .state,
+        'pending_approval',
+    );
+});
+
+/* ------------------------------- display name ---------------------------------- */
+
+check('the title leads and the file name sits beneath it', () => {
+    const name = documentDisplayName({ title: 'Q3 Budget', file_name: 'q3_FINAL(3).xlsx' });
+    assert.equal(name.primary, 'Q3 Budget');
+    assert.equal(name.secondary, 'q3_FINAL(3).xlsx');
+});
+
+check('without a title the file name is promoted rather than captioned', () => {
+    const name = documentDisplayName({ file_name: 'notes.txt' });
+    assert.equal(name.primary, 'notes.txt');
+    assert.equal(name.secondary, null);
+});
+
+check('a title identical to the file name is not repeated', () => {
+    const name = documentDisplayName({ title: 'notes.txt', file_name: 'notes.txt' });
+    assert.equal(name.primary, 'notes.txt');
+    assert.equal(name.secondary, null);
+});
+
+/* -------------------------------- formatting ----------------------------------- */
+
+check('file sizes are formatted in binary units', () => {
+    assert.equal(formatFileSize(0), '—');
+    assert.equal(formatFileSize(undefined), '—');
+    assert.equal(formatFileSize(900), '900 B');
+    assert.equal(formatFileSize(1024), '1 KB');
+    assert.equal(formatFileSize(1536), '1.5 KB');
+    assert.equal(formatFileSize(5 * 1024 * 1024), '5 MB');
+});
+
+check('recent times are relative and older ones fall back to a date', () => {
+    const now = new Date('2026-03-01T12:00:00Z');
+    assert.equal(formatRelativeDate(new Date('2026-03-01T11:59:30Z'), now), 'Just now');
+    assert.equal(formatRelativeDate(new Date('2026-03-01T11:30:00Z'), now), '30 min ago');
+    assert.equal(formatRelativeDate(new Date('2026-03-01T09:00:00Z'), now), '3 hr ago');
+    assert.equal(formatRelativeDate(new Date('2026-02-28T12:00:00Z'), now), 'Yesterday');
+    assert.equal(formatRelativeDate(new Date('2026-02-20T12:00:00Z'), now), '9 days ago');
+    assert.equal(formatRelativeDate(null, now), '—');
+    // Beyond a month a relative label is harder to act on than the date itself.
+    assert.notEqual(formatRelativeDate(new Date('2025-06-01T12:00:00Z'), now), '');
+});
+
+/* -------------------------------- pagination ----------------------------------- */
+
+check('the status bar range counts the whole filtered set', () => {
+    const range = describePage(2, 50, 142);
+    assert.equal(range.from, 51);
+    assert.equal(range.to, 100);
+    assert.equal(range.total, 142);
+    assert.equal(range.pageCount, 3);
+});
+
+check('the last page stops at the total', () => {
+    const range = describePage(3, 50, 142);
+    assert.equal(range.from, 101);
+    assert.equal(range.to, 142);
+});
+
+check('an empty result set reports no items rather than a broken range', () => {
+    const range = describePage(1, 50, 0);
+    assert.equal(range.from, 0);
+    assert.equal(range.to, 0);
+    assert.equal(range.pageCount, 1);
+});
+
+check('a page beyond the end is clamped', () => {
+    const range = describePage(99, 50, 60);
+    assert.equal(range.from, 51);
+    assert.equal(range.to, 60);
+});
+
+check('the pager keeps a stable width and marks its gaps', () => {
+    assert.deepEqual(paginationItems(1, 3), [1, 2, 3]);
+
+    // Counting the gap markers as slots is what makes the width constant. Sizing only the
+    // numbers lets the control grow as the window leaves an edge, which moves the Next
+    // button out from under the pointer on the very click that moved it.
+    const widths = new Set<number>();
+    for (let page = 1; page <= 20; page += 1) {
+        const items = paginationItems(page, 20);
+        widths.add(items.length);
+        assert.equal(items[0], 1, 'the first page is always reachable');
+        assert.equal(items[items.length - 1], 20, 'the last page is always reachable');
+        assert.ok(items.includes(page), `page ${page} should be among its own items`);
+    }
+    assert.deepEqual([...widths], [7], 'every page renders the same number of slots');
+
+    assert.deepEqual(paginationItems(1, 20), [1, 2, 3, 4, 5, null, 20]);
+    assert.deepEqual(paginationItems(10, 20), [1, null, 9, 10, 11, null, 20]);
+    assert.deepEqual(paginationItems(20, 20), [1, null, 16, 17, 18, 19, 20]);
+});
+
+/* ----------------------------------- facets ------------------------------------ */
+
+const facets = {
+    total: 142,
+    untagged: 14,
+    processing: 0,
+    errors: 1,
+    recent: 23,
+    shared_with_me: 0,
+    by_tag: { alpha: 12 },
+    by_classification: { Internal: 30 },
+};
+
+check('rail counts come from the facets, not the page', () => {
+    assert.equal(placeCount(facets, 'all'), 142);
+    assert.equal(placeCount(facets, 'untagged'), 14);
+    assert.equal(placeCount(facets, 'shared'), 0);
+    assert.equal(placeCount(null, 'all'), null);
+});
+
+check('a place with nothing in it is not offered', () => {
+    // Otherwise the rail carries a permanent "Processing 0" for a workspace at rest.
+    const places = visiblePlaces(facets);
+    assert.ok(places.includes('all'));
+    assert.ok(places.includes('errors'));
+    assert.ok(!places.includes('processing'));
+    assert.ok(!places.includes('shared'));
+    assert.deepEqual(visiblePlaces(null), ['all']);
+});
+
+/* --------------------------------- saved views --------------------------------- */
+
+check('a view is only worth saving when it narrows something', () => {
+    assert.equal(isSaveableQuery(query()), false);
+    assert.equal(isSaveableQuery(query({ tags: ['alpha'] })), true);
+    assert.equal(isSaveableQuery(query({ place: 'untagged' })), true);
+    assert.equal(isSaveableQuery(query({ search: 'budget' })), true);
+});
+
+check('a saved view keeps the filters and drops the paging', () => {
+    // Baking a page number into a saved view would make it land somewhere arbitrary later.
+    const view = createSavedView('Contracts', query({ page: 4, tags: ['alpha'], sortBy: 'title' }));
+    assert.equal(view.name, 'Contracts');
+    assert.deepEqual(view.query.tags, ['alpha']);
+    assert.equal('page' in view.query, false);
+    assert.equal('sortBy' in view.query, false);
+});
+
+check('applying a view restores its filters and returns to page one', () => {
+    const view = createSavedView('Contracts', query({ tags: ['alpha'], place: 'recent' }));
+    const next = applySavedView(query({ page: 5, pageSize: 100 }), view);
+    assert.deepEqual(next.tags, ['alpha']);
+    assert.equal(next.place, 'recent');
+    assert.equal(next.page, 1);
+    assert.equal(next.pageSize, 100, 'presentation survives applying a view');
+});
+
+check('a view is marked active only when it matches exactly', () => {
+    const view = createSavedView('Contracts', query({ tags: ['alpha'] }));
+    assert.equal(matchesSavedView(query({ tags: ['alpha'], page: 3 }), view), true);
+    assert.equal(matchesSavedView(query({ tags: ['alpha', 'beta'] }), view), false);
+    assert.equal(matchesSavedView(query(), view), false);
+});
+
+check('stored views that are malformed are dropped rather than rendered', () => {
+    // Settings are free-form JSON and writable by an older build, so they are untrusted.
+    const parsed = parseSavedViews([
+        null,
+        'nonsense',
+        { name: '' },
+        { id: 'x', name: 'Good', query: { place: 'wat', tags: ['a', 'a', ''], search: ' b ' } },
+    ]);
+    assert.equal(parsed.length, 1);
+    assert.equal(parsed[0].name, 'Good');
+    assert.equal(parsed[0].query.place, 'all', 'an unknown place is coerced, not kept');
+    assert.deepEqual(parsed[0].query.tags, ['a']);
+    assert.equal(parsed[0].query.search, 'b');
+    assert.equal(parsed[0].query.classification, null);
+});
+
+check('a non-array of views parses to nothing', () => {
+    assert.deepEqual(parseSavedViews(undefined), []);
+    assert.deepEqual(parseSavedViews({}), []);
+});
+
+check('saving a view under an existing name replaces it', () => {
+    const first = createSavedView('Contracts', query({ tags: ['alpha'] }));
+    const second = createSavedView('contracts', query({ tags: ['beta'] }));
+    const views = upsertSavedView(upsertSavedView([], first), second);
+    assert.equal(views.length, 1);
+    assert.deepEqual(views[0].query.tags, ['beta']);
+    assert.equal(views[0].id, first.id, 'the original entry keeps its identity');
+});
+
+check('a view can be removed', () => {
+    const view = createSavedView('Contracts', query({ tags: ['alpha'] }));
+    assert.deepEqual(removeSavedView([view], view.id), []);
+});
+
+/* ----------------------------------- runner ---------------------------------- */
+
+let passed = 0;
+let failed = 0;
+
+for (const [name, fn] of checks) {
+    try {
+        fn();
+        console.log(`  ok  ${name}`);
+        passed += 1;
+    } catch (error) {
+        console.log(`FAIL  ${name}`);
+        console.log(`      ${(error as Error).message}`);
+        failed += 1;
+    }
+}
+
+console.log(
+    failed === 0
+        ? `\nAll ${passed} checks passed.`
+        : `\n${failed} of ${passed + failed} check(s) failed.`,
+);
+process.exit(failed > 0 ? 1 : 0);

--- a/functional_tests/test_v2_workspace_sections.py
+++ b/functional_tests/test_v2_workspace_sections.py
@@ -236,9 +236,16 @@ def test_every_registered_section_has_a_component():
     workspace_dir = V2_SRC / "pages" / "workspace"
     registry = _read(workspace_dir / "sections.tsx")
 
+    # Counted from the registry rather than hard-coded, so adding a section does not require
+    # editing an assertion that is really about every section being complete.
+    section_ids = re.findall(r"^\s{8}id: '([a-z_]+)',", registry, re.MULTILINE)
+    section_count = len(section_ids)
+    assert section_count >= 8, f"Expected the full section registry, found {section_ids}"
+
     components = re.findall(r"<(\w+Section)\b", registry)
-    assert len(set(components)) == 8, (
-        f"Expected eight section components, found {sorted(set(components))}"
+    assert len(set(components)) == section_count, (
+        f"Expected one component per section ({section_count}), "
+        f"found {sorted(set(components))}"
     )
 
     sources = list(workspace_dir.glob("*.tsx"))
@@ -251,8 +258,12 @@ def test_every_registered_section_has_a_component():
     # Each section needs the sentence the overview shows for it, which is the only
     # explanation a user gets for a section their administrator has switched off.
     blurbs = re.findall(r"blurb: '([^']+)'", registry)
-    assert len(blurbs) == 8, f"Every section needs a blurb; found {len(blurbs)}"
-    assert len(set(blurbs)) == 8, "Section blurbs must be distinct, not boilerplate"
+    assert len(blurbs) == section_count, (
+        f"Every section needs a blurb; found {len(blurbs)} for {section_count} sections"
+    )
+    assert len(set(blurbs)) == section_count, (
+        "Section blurbs must be distinct, not boilerplate"
+    )
 
     print("Section registry test passed!")
     return True


### PR DESCRIPTION
## Summary

The V2 Documents page was one flat list calling four endpoints, fetching 1000 documents at once and filtering them in the browser. The backend already supported far more than that page used.

- **Documents is now a file explorer** — command bar, navigation rail, content pane, details pane, status bar. Server-side paging, search, sorting, filtering, downloading, metadata editing, re-extraction and sharing are all now actually used rather than ignored.
- **Tags get a rail and a section.** Tags are permanently visible in the left rail with colour and live counts (replacing the two folder-shaped view modes), documents can be dragged onto a tag to file them, and a new **Tags** section under Knowledge owns rename/recolour/merge/delete. The flat tag model is unchanged.
- **Multi-select works like a file manager** — no mode to switch on first. Click, Ctrl+click, Shift+click, Ctrl+A, Escape, arrows. Titles now lead with the file name beneath, and active filters show as removable chips.
- **Bulk delete added**, reporting per document so one chat-uploaded or file-synced file cannot block deleting everything selected with it.

Also fixes a latent crash: `sort_documents` compared a missing value (`""`) against a present numeric one (`int`), which raises `TypeError` in Python 3. Harmless while only name/title/date were sortable, guaranteed to fail the moment a numeric column became sortable. Affects the personal, group and public document lists.

And `shared_only`, which the classic workspace has always sent and the listing has never read.

## Linked issue

None. This came out of direct design discussion rather than a filed issue — happy to open one retrospectively if that is preferred.

## Release Notes & Latest Features

- [x] New Feature
- [x] Bug Fix
- [x] UI Enhancement
- [ ] Breaking Change
- [ ] Internal only

Is this visible to end users?

- [x] Yes
- [ ] No

Is this admin-facing (Admin Settings, governance, deployment, config)?

- [ ] Yes
- [x] No

Should this become a Latest Feature card?

- [x] Yes
- [ ] No
- [ ] Already added

Screenshot needed for the card?

- [x] Yes
- [ ] No
- [ ] Attached

## Version bump

- [x] `application/single_app/config.py` `VERSION` third segment bumped — `0.261.044` → `0.261.046`
- [x] `deployers/version.txt` bumped, or not needed because `deployers/` was not changed — not changed

## Testing / validation

- `python .\functional_tests\test_v2_documents_explorer.py` — 20/20, including 67 bundled TypeScript behavioural checks
- Every `functional_tests\test_v2_*.py` — all pass
- `functional_tests\route_tests\` — all pass (blueprint policy, unauthenticated contract, coverage)
- `test_docs_app_surface_coverage.py`, `test_docs_site_quality.py` — pass
- `npm run typecheck` and `npm run build` in `application/v2_ui` — clean
- The Python test additionally *executes* the new server helpers (`sort_documents`, `filter_documents_by_place`, `build_personal_document_facets`) by extracting them with `ast`, since `route_backend_documents` imports `config` and builds Azure clients at import time
- Manual: verified against a real workspace, which surfaced four follow-up fixes now included (see below)

### Follow-up fixes from manual testing (`4486ac77`)

- **Search dropped characters.** The input was bound to `query.search`, the *debounced* value, so a controlled input reverted every keystroke until the debounce fired. Bound to the draft; Enter commits, Escape clears.
- **Bulk tagging appeared to hang.** It was slow, not hung — tagging one document costs a cross-partition query, a write, and an update to every one of its search-index chunks, and the whole selection went in a single request behind an indeterminate spinner. Now batched with a determinate progress bar, cleared in a `finally` on every path.
- **Re-extract did not state the current mode**, so changing it meant guessing then checking. Now marks the current mode `(current)`, offers the other as "Switch to …", distinguishes Mixed from Not recorded, hides itself for non-PDF/image files, and disables Enhanced with a reason when `enable_enhanced_extraction` is off.
- **The workspace section rail collapses to icons**, under its own preference so it is independent of the shell rail.

## Documentation

- [x] Release notes updated — `v0.261.045` and `v0.261.046` sections
- [x] Feature documentation updated — `docs/explanation/features/V2_DOCUMENTS_EXPLORER.md`
- [x] Fix documentation updated, or not needed — the fixes are documented in the feature page and release notes rather than as separate fix docs, since they are all in first-release code

## Security checklist

- [x] New Flask routes include `@swagger_route(security=get_auth_security())` — both new routes also carry `@login_required`, `@user_required` and `@enabled_required("enable_user_workspace")`, asserted by a test
- [x] Settings sent to non-admin frontends use `sanitize_settings_for_user()` — no new route sends settings; the two additions return counts and delete results only
- [x] Browser JavaScript is served from local SimpleChat static assets only; no CDN-hosted JS — asserted by a test over every new file
- [x] No secrets, keys, connection strings, or local-only artifacts are included

## Notes for review

- **Base is `paullizer-react-v2-ui`**, not `Development` — this stacks on the V2 UI work.
- **The classic interface is untouched.** `route_frontend_workspace.py` reads only `file_sync_enabled` and `governance` from the availability payload and never iterates `sections`, so the new `tags` section does not add a V1 tab. There is a test for this.
- **Scope is the personal workspace only.** Group and public workspace pages do not exist in V2 yet; the components take their data as props rather than reading a scope, so the same explorer can serve them later without a rewrite.
- **Known follow-up:** batching made the tagging progress honest but did not make the server faster. `propagate_tags_to_chunks` still runs per document, so very large selections stay slow. The real fix is batching the chunk-index updates server-side.