### PR TITLE
Stop V2 destroying the answer when you leave a chat mid-generation

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -97,7 +97,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.261.050"
+VERSION = "0.261.051"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -97,7 +97,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.261.049"
+VERSION = "0.261.050"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/v2_ui/src/components/layout/Sidebar.tsx
+++ b/application/v2_ui/src/components/layout/Sidebar.tsx
@@ -209,7 +209,10 @@ export function Sidebar() {
      * Two things are deliberately left alone. Clicking `Chats` while already on the chat
      * page does nothing, so a stray click on the highlighted nav item cannot throw away
      * whatever is being read. And a conversation still streaming a reply is returned to
-     * rather than reset, because the reset stops the stream and the reply would be lost.
+     * rather than reset, so a reply being watched stays on screen instead of being swapped
+     * out for an empty composer. The reply itself is no longer at stake: resetting detaches
+     * the reader without cancelling the generation, so the answer finishes and is saved
+     * either way.
      *
      * `streaming` is read from the store rather than subscribed to: it changes with every
      * token, and subscribing would re-render this rail — conversation list included —

--- a/application/v2_ui/src/stores/chatStore.ts
+++ b/application/v2_ui/src/stores/chatStore.ts
@@ -463,6 +463,36 @@ let streamingConversationId: string | null = null;
 let streamingConversationKind: ConversationKind = 'personal';
 
 /**
+ * Stop reading the in-flight stream without asking the server to stop producing it.
+ *
+ * These are two different things and only the Stop button means the second one. Generation
+ * runs in background execution and deliberately outlives the connection carrying it
+ * (`build_background_stream_response`, route_backend_chats.py:14372), so dropping the reader
+ * leaves the answer being written and saved; `resumeChatStream` picks it back up when the
+ * conversation is opened again.
+ *
+ * Cancelling instead would end the generation for good. `/api/chat/stream/cancel` reaches
+ * `request_cancel` (route_backend_chats.py:8382), which sets `cancel_requested`, and the
+ * agent loop honours it. Worse, a cancel that lands before the first content token persists
+ * no assistant message at all (`message_persisted=False`, route_backend_chats.py:15971) —
+ * so leaving a thread during the thinking phase destroyed the reply outright rather than
+ * merely truncating it. The classic client never does this: chat-conversations.js reattaches
+ * on select and only the stop control cancels.
+ */
+function detachActiveStream(): void {
+    if (!activeStreamController) {
+        return;
+    }
+    activeStreamController.abort();
+    activeStreamController = null;
+    streamingConversationId = null;
+    // Included here rather than left to callers: neither `selectConversation` nor
+    // `startNewConversation` clears `streaming` itself, so dropping it would leave the
+    // composer stuck showing Stop for a stream that is no longer being read.
+    useChatStore.setState({ streaming: false, streamingContent: '', reconnectPhase: null });
+}
+
+/**
  * Detach from the open shared conversation's event stream, if there is one.
  *
  * Held at module scope for the same reason as the stream controller: it is a live
@@ -806,11 +836,12 @@ async function resumeChatStream(conversationId: string): Promise<boolean> {
     const controller = new AbortController();
     activeStreamController = controller;
     // Deliberately NOT setting streamingConversationId. That marks a stream this tab
-    // started, and stopStreaming uses it to POST /api/chat/stream/cancel, which is a real
-    // server-side cancellation. This stream belongs to whoever started it — possibly
-    // another tab, or this page before a reload — so leaving the conversation must detach
-    // locally without killing the generation. The classic client does the same: a thread
-    // switch only aborts its own reader, and cancel is reached solely from the Stop button.
+    // started, and it is the only thing that lets Stop POST /api/chat/stream/cancel, which
+    // is a real server-side cancellation. This stream belongs to whoever started it —
+    // another tab, or this page before a reload — so Stop here detaches this reader instead
+    // of ending a generation somebody else is still waiting on. The classic client draws the
+    // same line: reattachStreamingConversation (chat-streaming.js:1157) opens its reattached
+    // stream with no cancelEndpoint at all.
     const isCurrent = () => activeStreamController === controller;
 
     set({
@@ -1204,10 +1235,16 @@ export const useChatStore = create<ChatState>((set, get) => ({
     },
 
     selectConversation: async (conversationId, options = {}) => {
-        // Any stream still running belongs to the thread being left. Without this its
-        // handlers would append the finished response into the newly selected
-        // conversation's message list.
-        get().stopStreaming();
+        // Any stream still running belongs to the thread being left, so its reader is
+        // dropped: left attached, its handlers would append the finished response into the
+        // newly selected conversation's message list.
+        //
+        // Detached rather than cancelled. The generation carries on server-side and is
+        // picked back up by `resumeChatStream` below when this thread is opened again,
+        // which is what chat-conversations.js:1695 does. Cancelling here meant that simply
+        // clicking another conversation ended the answer — and ended it with nothing saved
+        // at all when it had not yet produced its first token.
+        detachActiveStream();
         // Likewise the event stream: it is a live connection, and left attached it would
         // keep delivering the previous conversation's messages into this one.
         stopCollaborationEvents();
@@ -1374,9 +1411,11 @@ export const useChatStore = create<ChatState>((set, get) => ({
     },
 
     startNewConversation: () => {
-        // Stop first: the running stream belongs to the previous thread and must not
-        // deliver its response into the empty new one.
-        get().stopStreaming();
+        // Detach first: the running stream belongs to the previous thread and must not
+        // deliver its response into the empty new one. Detached rather than cancelled, so
+        // starting a new chat leaves the previous answer to finish and be saved rather than
+        // discarding it — reopening that thread resumes or shows the completed reply.
+        detachActiveStream();
         stopCollaborationEvents();
         useCollaborationStore.getState().reset();
 
@@ -1783,8 +1822,10 @@ export const useChatStore = create<ChatState>((set, get) => ({
         if (!activeStreamController) {
             return;
         }
-        // Addresses the conversation the stream actually belongs to, which may no longer
-        // be the one on screen, through whichever cancel route that conversation uses.
+        // The one place a cancel belongs: the reader asked for the answer to stop being
+        // written, not merely to stop being watched. Addresses the conversation the stream
+        // actually belongs to, which may no longer be the one on screen, through whichever
+        // cancel route that conversation uses.
         if (streamingConversationId) {
             void cancelStream(
                 streamingConversationId,
@@ -1793,10 +1834,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
                     : undefined,
             );
         }
-        activeStreamController.abort();
-        activeStreamController = null;
-        streamingConversationId = null;
-        set({ streaming: false, streamingContent: '', reconnectPhase: null });
+        detachActiveStream();
     },
 
     setDrawerMode: (drawerMode) => {

--- a/application/v2_ui/src/stores/chatStore.ts
+++ b/application/v2_ui/src/stores/chatStore.ts
@@ -766,10 +766,20 @@ async function runChatStream(
     streamingConversationId = conversationId;
     streamingConversationKind = options.kind ?? 'personal';
 
-    // A stream is "current" only while it is still the active one. If the user switches
-    // threads or starts a new chat mid-response, this goes false and the remaining
-    // handlers stop writing into what is now a different conversation's message list.
-    const isCurrent = () => activeStreamController === controller;
+    // Two different questions, and conflating them breaks one case each way.
+    //
+    // `ownsController` is about teardown: does this invocation still own the module's
+    // controller, or has a newer send installed its own? Only the owner may clear it.
+    //
+    // `isCurrent` is about rendering: is this stream's conversation still the one on
+    // screen? Switching threads mid-response clears the controller, so that alone used to
+    // answer both. It does not cover a brand-new conversation, where the reader can open a
+    // different thread during the round trip that creates it — before there is any
+    // controller to clear — leaving the handlers free to write this answer into whatever
+    // they opened.
+    const ownsController = () => activeStreamController === controller;
+    const isCurrent = () =>
+        ownsController() && getState().activeConversationId === conversationId;
 
     await streamChat(
         requestBody,
@@ -786,16 +796,18 @@ async function runChatStream(
 
     // Only tear down if this stream is still the active one; a newer send may already have
     // installed its own controller. Captured before the teardown because clearing the
-    // controller makes isCurrent() false for every check after it.
+    // controller makes ownsController() false for every check after it.
     const wasCurrent = isCurrent();
-    if (wasCurrent) {
+    if (ownsController()) {
         activeStreamController = null;
         streamingConversationId = null;
         set({ streaming: false, reconnectPhase: null });
     }
 
     // Retry and edit rewrite thread state server-side, so the authoritative message list
-    // has to be re-read rather than patched locally.
+    // has to be re-read rather than patched locally. Skipped when the reader is elsewhere,
+    // since reloadMessages reads whatever is on screen and would refetch a thread this
+    // stream never touched.
     if (options.reloadOnDone && wasCurrent) {
         await getState().reloadMessages();
     }
@@ -1610,14 +1622,23 @@ export const useChatStore = create<ChatState>((set, get) => ({
             try {
                 const created = await createConversation(trimmed);
                 conversationId = created.conversation_id;
-                set({ activeConversationId: conversationId, activeConversationKind: 'personal' });
-                // Mirrored like every other write to this field. Today the conversation just
-                // created can only be personal — this branch is reached only when nothing was
-                // open, which forces `collaborative` false above — so nothing would currently
-                // notice. Leaving it out would make the collaboration store's guard depend on
-                // that reasoning continuing to hold, and a shared conversation reachable here
-                // later would silently strand its composer at "checking access".
-                useCollaborationStore.getState().setActiveConversation(conversationId);
+                // The reader can open a conversation during that round trip, and if they do
+                // their click wins. The message is still sent and its answer still generated
+                // and saved — it appears in the rail and is there when they come back — but
+                // the interface stays where they put it instead of snapping back to a chat
+                // they have already left. Claiming `activeConversationId` unconditionally
+                // also let the thread they had just opened render its messages under this
+                // new one, because the list is keyed on whatever is active.
+                if (get().activeConversationId === null) {
+                    set({ activeConversationId: conversationId, activeConversationKind: 'personal' });
+                    // Mirrored like every other write to this field. Today the conversation just
+                    // created can only be personal — this branch is reached only when nothing was
+                    // open, which forces `collaborative` false above — so nothing would currently
+                    // notice. Leaving it out would make the collaboration store's guard depend on
+                    // that reasoning continuing to hold, and a shared conversation reachable here
+                    // later would silently strand its composer at "checking access".
+                    useCollaborationStore.getState().setActiveConversation(conversationId);
+                }
             } catch (error) {
                 set({
                     streamError:
@@ -1686,14 +1707,22 @@ export const useChatStore = create<ChatState>((set, get) => ({
         // interface must not sit in the streaming state waiting for one that never starts.
         const willStream = !collaborative || invocationTarget !== null;
 
-        set((state) => ({
-            messages: [...state.messages, optimisticUserMessage],
-            streaming: willStream,
-            streamingContent: '',
-            thoughts: [],
-            streamError: null,
-            reconnectPhase: null,
-        }));
+        // Only ever false when the reader opened another conversation while this one was
+        // being created. `messages`, `streaming` and the rest describe whatever is on
+        // screen, so writing them then would show this question and its answer inside a
+        // thread they have nothing to do with.
+        const ownsScreen = get().activeConversationId === conversationId;
+
+        if (ownsScreen) {
+            set((state) => ({
+                messages: [...state.messages, optimisticUserMessage],
+                streaming: willStream,
+                streamingContent: '',
+                thoughts: [],
+                streamError: null,
+                reconnectPhase: null,
+            }));
+        }
 
         const mentionedParticipants = collaborative
             ? extractMentionedParticipants(

--- a/docs/explanation/fixes/V2_NEW_CONVERSATION_SEND_RACE_FIX.md
+++ b/docs/explanation/fixes/V2_NEW_CONVERSATION_SEND_RACE_FIX.md
@@ -1,0 +1,93 @@
+# V2 Send Race While a New Conversation Is Being Created
+
+**Fixed in version:** 0.261.051
+
+## Issue
+
+Sending the **first** message in a brand-new chat and then clicking a different conversation
+within the next fraction of a second produced two wrong outcomes:
+
+* The reader was snapped back into the new chat, silently undoing the conversation they had
+  just clicked.
+* In the unluckier ordering, where the clicked conversation's messages finished loading
+  first, that conversation's history rendered underneath the new chat, with the new
+  question and its streaming answer appended below it.
+
+Nothing was lost or saved to the wrong conversation. The effect was confined to what was on
+screen, and reloading or reselecting the thread corrected it.
+
+## Root cause
+
+A new chat has no conversation until the server makes one, so the first send has to wait for
+`createConversation` before it can stream. That is the only pause in `sendMessage` between
+pressing send and the stream starting — everything after it runs synchronously — so it is
+precisely the window in which a click can land.
+
+Two things then went wrong when it did:
+
+1. `sendMessage` claimed `activeConversationId` unconditionally once the conversation came
+   back, overwriting whatever the reader had opened in the meantime. Because the message
+   list is keyed on the active conversation, an in-flight load for the clicked thread could
+   also deposit its messages under the new one.
+2. `runChatStream` decided whether its handlers should render using only
+   `activeStreamController === controller`. That is the right question for teardown, but it
+   does not cover this window: no controller exists yet while the conversation is being
+   created, so there is nothing for a thread switch to clear. The stream installed its
+   controller afterwards, the check passed, and the answer rendered into whichever thread
+   was open.
+
+This is a separate defect from
+[V2 Stream Cancelled On Conversation Leave](V2_STREAM_CANCELLED_ON_CONVERSATION_LEAVE_FIX.md),
+which addressed the same "leave straight after sending" scenario once a stream already
+existed. That fix relies on detaching a live reader, and here there is not yet one to detach.
+
+## Fix
+
+The reader's click wins. The message is still sent, and the answer is still generated and
+saved, but the interface stays where they put it.
+
+### Files modified
+
+| File | Change |
+|---|---|
+| `application/v2_ui/src/stores/chatStore.ts` | `sendMessage` claims `activeConversationId` only when nothing has been opened during the round trip; the optimistic user message and streaming state are written only when this send owns the screen; `runChatStream` separates `ownsController` from `isCurrent` |
+| `application/single_app/config.py` | Version `0.261.050` -> `0.261.051` |
+
+Two questions that had been answered by one check are now answered separately:
+
+* `ownsController()` — does this invocation still own the module's `AbortController`? This
+  governs teardown. Only the owner may clear the controller, and it must stay identity-based:
+  a stream whose conversation is off screen still owns it, and `resumeChatStream` refuses to
+  attach while one is set.
+* `isCurrent()` — is this stream's conversation still the one on screen? This governs
+  rendering, and now additionally requires
+  `getState().activeConversationId === conversationId`.
+
+## Behaviour after the fix
+
+* Clicking a conversation while a new chat is being created keeps you in the conversation
+  you clicked.
+* The backgrounded send still runs. Its answer is generated, saved, and the new chat appears
+  in the rail with its server-generated title and the usual unread marker.
+* No other thread's messages can appear under a conversation they do not belong to.
+* Ordinary sends are unaffected: the stream's conversation is the active one throughout, so
+  the added condition is always true and behaviour is unchanged.
+
+## Validation
+
+Covered by `functional_tests/test_v2_stream_leave_without_cancel.py`, which holds the whole
+"leave straight after sending" contract in one place (15 tests). The three added for this
+fix assert:
+
+* `sendMessage` guards its `activeConversationId` claim on nothing else having been opened.
+* The optimistic user message and streaming state are written only under `ownsScreen`.
+* `runChatStream` defines `ownsController` and a conversation-scoped `isCurrent`, and gates
+  teardown on `ownsController` so a backgrounded stream still clears the controller.
+
+Each was confirmed to fail against the pre-fix code. `tsc -b --noEmit` passes, and
+`functional_tests/test_v2_stream_reconnect.py` continues to pass.
+
+## Related
+
+* [V2 Stream Cancelled On Conversation Leave](V2_STREAM_CANCELLED_ON_CONVERSATION_LEAVE_FIX.md)
+  — the same scenario once a stream exists

--- a/docs/explanation/fixes/V2_STREAM_CANCELLED_ON_CONVERSATION_LEAVE_FIX.md
+++ b/docs/explanation/fixes/V2_STREAM_CANCELLED_ON_CONVERSATION_LEAVE_FIX.md
@@ -1,0 +1,123 @@
+# V2 Stream Cancelled When Leaving a Conversation
+
+**Fixed in version:** 0.261.050
+
+## Issue
+
+In the V2 interface, sending a message and then opening a different conversation while the
+answer was still being generated destroyed the answer. Returning to the original thread
+showed the question with no reply, and the response never arrived.
+
+The symptom depended on timing in a way that made it look intermittent. Leaving during the
+"thinking" phase, before the assistant had produced its first token, meant no reply was ever
+saved at all. Leaving later left a truncated one.
+
+The V1 (classic) interface does not behave this way: a generation continues after a thread
+switch, is reattached to when the thread is reopened, and several conversations can be
+generating at once.
+
+## Root cause
+
+This was a cancellation bug, not a reconnection bug. The reconnect machinery was working
+correctly; it was being asked to reattach to a stream that had already been cancelled.
+
+Leaving a conversation reached a real server-side cancellation:
+
+1. `chatStore.ts` — `selectConversation` and `startNewConversation` both opened with
+   `get().stopStreaming()`.
+2. `chatStore.ts` — `stopStreaming` POSTs `/api/chat/stream/cancel/<conversation_id>`
+   before aborting the local reader.
+3. `route_backend_chats.py` — `chat_stream_cancel_api` calls
+   `stream_session.request_cancel(...)`.
+4. `route_backend_chats.py` — `request_cancel` sets `cancel_requested`, which is surfaced
+   by `is_cancel_requested()` and threaded through the generation loop as its
+   `cancel_requested` callback. The agent genuinely stops.
+
+Because the cancel was destructive, `resumeChatStream` then found the stream in a terminal
+state, `pending` was false, and it correctly declined to reattach. There was nothing left to
+reattach to.
+
+### Why the timing changed the symptom
+
+The stream cancel event is built two different ways depending on when the cancel lands:
+
+* Before any content: `message_persisted=False` — no assistant message is written.
+* After content has started: `partial_content=...` with
+  `message_persisted=bool(payload.get('message_id'))` — a partial answer is saved.
+
+That is why leaving early looked like the response was never generated, while leaving later
+produced a truncated one.
+
+### Why detaching is safe
+
+`build_background_stream_response` is documented as running "SSE generation in background
+execution so it survives disconnects". Dropping the reader does not stop the work. Only an
+explicit cancel does. The two had been conflated.
+
+## Fix
+
+Separate *stop reading* from *stop generating*. Only the Stop button means the second one.
+
+### Files modified
+
+| File | Change |
+|---|---|
+| `application/v2_ui/src/stores/chatStore.ts` | Added module-level `detachActiveStream()`; `stopStreaming` now cancels then delegates teardown to it; `selectConversation` and `startNewConversation` call it instead of `stopStreaming` |
+| `application/v2_ui/src/components/layout/Sidebar.tsx` | Corrected a comment whose stated rationale — that resetting loses the reply — is no longer true |
+| `application/single_app/config.py` | Version `0.261.049` -> `0.261.050` |
+
+`detachActiveStream()` aborts the in-flight reader, clears `activeStreamController` and
+`streamingConversationId`, and resets `streaming`, `streamingContent`, and `reconnectPhase`.
+It issues no cancel request.
+
+The state reset belongs in the helper rather than at the call sites: neither
+`selectConversation` nor `startNewConversation` sets `streaming: false` in its own state
+update, so omitting it would leave the composer showing Stop for a stream nothing is
+reading.
+
+`stopStreaming` is unchanged from the user's point of view. It still addresses
+`streamingConversationId` through the correct cancel route for personal or shared
+conversations, and the Stop button remains its only caller.
+
+## Behaviour after the fix
+
+* Leaving a conversation mid-generation detaches. The answer finishes and is saved.
+* Reopening that conversation resumes the live stream through `resumeChatStream`, or shows
+  the completed reply if generation finished while away.
+* Several conversations can be generating at once, matching V1. V2 still displays only the
+  one on screen; the others complete in the background and are flagged by the existing
+  unread marker.
+* Stop still cancels, exactly as before.
+* Leaving a shared conversation no longer cancels a generation other participants are
+  waiting on.
+
+An abandoned generation now runs to completion instead of being cancelled. This is
+deliberate and matches V1 — it is what makes the answer still be there on return.
+
+## Validation
+
+`functional_tests/test_v2_stream_leave_without_cancel.py` (12 tests) covers:
+
+* `selectConversation` and `startNewConversation` do not reach `cancelStream`.
+* `detachActiveStream` issues no cancel, still aborts the reader, clears the ownership
+  marker, and clears `streaming` so the composer stays usable.
+* `stopStreaming` still cancels and the Stop button is still wired to it.
+* `cancelStream` has exactly one call site in the store.
+* Server premises: the cancel route reaches `request_cancel`, `request_cancel` sets
+  `cancel_requested`, the generation loop checks `is_cancel_requested()`, the pre-content
+  cancel path reports `message_persisted=False`, and streaming survives disconnects.
+* V1 parity: `chat-conversations.js` reattaches on select and never cancels;
+  `reattachStreamingConversation` opens its stream without a cancel endpoint.
+
+The assertions were confirmed to fail against the pre-fix code, so they detect the
+regression rather than merely describing the current implementation.
+
+`functional_tests/test_v2_stream_reconnect.py` (10 tests) continues to pass, confirming the
+reconnect contract this fix depends on is intact.
+
+## Related
+
+* `docs/explanation/fixes/` — reconnect behaviour is covered by
+  `functional_tests/test_v2_stream_reconnect.py`
+* `application/single_app/route_backend_chats.py` — stream session registry, cancel, status,
+  and reattach routes

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,18 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/features) and [Fixes by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/fixes).
 
+### **(v0.261.050)**
+
+#### Bug Fixes
+
+*   **Leaving A Chat No Longer Destroys The Answer Being Written**
+    *   In the new interface, sending a message and then opening a different conversation before the reply finished ended the reply. Coming back showed the question with no answer, and nothing to reconnect to.
+    *   It looked intermittent because the timing changed the symptom. Leaving during the "thinking" phase, before the assistant had produced its first word, saved no reply at all. Leaving later left a truncated one.
+    *   The cause was that switching conversations, and starting a new chat, asked the server to *cancel* the generation rather than simply stopping reading it. Those are different things, and only the Stop button should mean the second one. Answers are generated in the background and deliberately outlive the connection carrying them, so dropping the connection was always safe; cancelling was not.
+    *   Leaving a conversation now detaches. The answer finishes and is saved, reopening the thread picks the reply back up mid-flow or shows it complete, and several conversations can be generating at once — matching how the classic interface has always behaved.
+    *   Stop is unchanged and still cancels. Leaving a shared conversation also no longer cancels a reply other participants are waiting for.
+    *   (Ref: `chatStore.ts` `detachActiveStream`, `selectConversation`, `startNewConversation`, `stopStreaming`, `/api/chat/stream/cancel`, [V2 Stream Cancelled On Conversation Leave](fixes/V2_STREAM_CANCELLED_ON_CONVERSATION_LEAVE_FIX.md))
+
 ### **(v0.261.049)**
 
 #### New Features

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,17 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/features) and [Fixes by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/fixes).
 
+### **(v0.261.051)**
+
+#### Bug Fixes
+
+*   **Clicking Away Just After Starting A New Chat No Longer Bounces You Back**
+    *   The first message in a brand-new chat has to create the conversation before it can answer, and clicking a different conversation during that moment used to undo the click and drop you back into the chat you had just left.
+    *   In the unluckier version of the same timing, the conversation you clicked would have its messages shown underneath the new chat, so a thread appeared to contain a question that was asked somewhere else.
+    *   Your click now wins. The message is still sent and its answer still generated and saved — the new chat appears in the list with its title and unread marker — but the interface stays where you put it.
+    *   Nothing was ever lost or filed against the wrong conversation; the effect was limited to what was on screen.
+    *   (Ref: `chatStore.ts` `sendMessage`, `runChatStream`, [V2 New Conversation Send Race](fixes/V2_NEW_CONVERSATION_SEND_RACE_FIX.md))
+
 ### **(v0.261.050)**
 
 #### Bug Fixes

--- a/functional_tests/test_v2_stream_leave_without_cancel.py
+++ b/functional_tests/test_v2_stream_leave_without_cancel.py
@@ -2,8 +2,8 @@
 """
 Functional test for leaving a V2 conversation without cancelling its generation.
 
-Version: 0.261.050
-Implemented in: 0.261.050
+Version: 0.261.051
+Implemented in: 0.261.050 (cancellation), 0.261.051 (conversation-creation window)
 
 Sending a message and then opening a different conversation used to end the answer. Not
 because the reader was dropped -- that is harmless, generation runs in background execution
@@ -15,6 +15,12 @@ returning to the thread showed the question with no answer and nothing left to r
 The distinction this test protects is between *stopping reading* and *stopping generating*.
 Only the Stop button means the second one. Everything else -- switching threads, starting a
 new chat -- must detach.
+
+A second, narrower version of "leave straight after sending" is covered here too. The first
+message of a brand-new chat has to create the conversation before it can stream, and a
+reader who clicks away during that round trip used to be snapped back into the chat they had
+just left, sometimes with the other thread's messages rendered underneath it. Their click
+wins instead: the answer is still generated and saved, and the interface stays put.
 """
 
 import re
@@ -321,6 +327,89 @@ def test_a_reattached_stream_is_not_owned():
     return True
 
 
+def test_creating_a_conversation_does_not_take_the_screen_back():
+    """Opening another thread while a new chat is being created must not be undone.
+
+    The first message of a brand-new chat has to create the conversation before it can
+    stream, and that round trip is a window in which the reader can click elsewhere. Claiming
+    `activeConversationId` unconditionally afterwards snapped them back into the chat they
+    had just left.
+    """
+    print("Testing conversation creation does not steal the screen...")
+
+    store = _read(V2_SRC / "stores" / "chatStore.ts")
+    send = _store_action_body(store, "sendMessage")
+
+    assert re.search(
+        r"if \(get\(\)\.activeConversationId === null\) \{\s*\n\s*set\(\{ activeConversationId: conversationId",
+        send,
+    ), (
+        "sendMessage claims activeConversationId without checking whether the reader opened "
+        "something else while the conversation was being created; their click gets undone"
+    )
+
+    print("Screen ownership on creation test passed!")
+    return True
+
+
+def test_a_backgrounded_send_does_not_write_into_the_open_thread():
+    """The optimistic message and streaming state belong to whatever is on screen."""
+    print("Testing optimistic message placement...")
+
+    store = _read(V2_SRC / "stores" / "chatStore.ts")
+    send = _store_action_body(store, "sendMessage")
+
+    assert "const ownsScreen = get().activeConversationId === conversationId;" in send, (
+        "sendMessage no longer works out whether this send owns the screen"
+    )
+    assert re.search(
+        r"if \(ownsScreen\) \{\s*\n\s*set\(\(state\) => \(\{\s*\n\s*messages: \[\.\.\.state\.messages, optimisticUserMessage\]",
+        send,
+    ), (
+        "The optimistic user message is appended unconditionally, so a send whose "
+        "conversation is no longer on screen puts its question into another thread's list"
+    )
+
+    print("Optimistic message placement test passed!")
+    return True
+
+
+def test_rendering_is_gated_on_the_conversation_not_only_the_controller():
+    """Controller identity answers teardown; it does not answer where to render.
+
+    Switching threads mid-response clears the controller, so identity alone used to cover
+    both questions. It does not cover the conversation-creation window, where there is no
+    controller yet to clear -- the handlers would install one afterwards and write into
+    whatever thread the reader had opened.
+    """
+    print("Testing render gating...")
+
+    store = _read(V2_SRC / "stores" / "chatStore.ts")
+    run = _function_body(store, r"async function runChatStream\(")
+
+    assert "const ownsController = () => activeStreamController === controller;" in run, (
+        "runChatStream no longer tracks controller ownership separately from currency"
+    )
+    assert re.search(
+        r"const isCurrent = \(\)\s*=>\s*ownsController\(\) && getState\(\)\.activeConversationId === conversationId;",
+        run,
+    ), (
+        "The handlers' currency check no longer requires the stream's conversation to be "
+        "the one on screen, so a backgrounded send renders into the open thread"
+    )
+
+    # Teardown must stay on identity: a stream whose conversation is off screen still owns
+    # the module's controller and is the only thing allowed to clear it.
+    assert "if (ownsController()) {" in run, (
+        "Teardown is gated on something other than controller identity; a stream left off "
+        "screen would never clear activeStreamController, and resumeChatStream refuses to "
+        "attach while one is set"
+    )
+
+    print("Render gating test passed!")
+    return True
+
+
 def test_version_is_at_least_implementation_version():
     """The application version is at or beyond the version that added the fix."""
     print("Testing application version...")
@@ -342,6 +431,9 @@ if __name__ == "__main__":
         test_only_the_stop_button_reaches_the_cancel_route,
         test_legacy_never_cancelled_on_a_thread_switch,
         test_a_reattached_stream_is_not_owned,
+        test_creating_a_conversation_does_not_take_the_screen_back,
+        test_a_backgrounded_send_does_not_write_into_the_open_thread,
+        test_rendering_is_gated_on_the_conversation_not_only_the_controller,
         test_version_is_at_least_implementation_version,
     ]
 

--- a/functional_tests/test_v2_stream_leave_without_cancel.py
+++ b/functional_tests/test_v2_stream_leave_without_cancel.py
@@ -1,0 +1,361 @@
+#!/usr/bin/env python3
+"""
+Functional test for leaving a V2 conversation without cancelling its generation.
+
+Version: 0.261.050
+Implemented in: 0.261.050
+
+Sending a message and then opening a different conversation used to end the answer. Not
+because the reader was dropped -- that is harmless, generation runs in background execution
+and outlives the connection carrying it -- but because the thread switch POSTed
+``/api/chat/stream/cancel``, which is a real server-side cancellation. Leaving during the
+thinking phase, before the first content token, persisted no assistant message at all, so
+returning to the thread showed the question with no answer and nothing left to reattach to.
+
+The distinction this test protects is between *stopping reading* and *stopping generating*.
+Only the Stop button means the second one. Everything else -- switching threads, starting a
+new chat -- must detach.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+APP_DIR = REPO_ROOT / "application" / "single_app"
+V2_SRC = REPO_ROOT / "application" / "v2_ui" / "src"
+
+sys.path.insert(0, str(REPO_ROOT / "functional_tests"))
+
+from test_support.versioning import assert_app_version_at_least  # noqa: E402
+
+
+def _read(path):
+    return path.read_text(encoding="utf-8")
+
+
+def _function_body(source, signature_pattern):
+    """Return one top-level function body, matched to its closing brace at column zero."""
+    match = re.search(signature_pattern + r"(.|\n)*?\n\}", source)
+    assert match, f"Could not find a function matching {signature_pattern!r}"
+    return match.group(0)
+
+
+def _store_action_body(source, action_name):
+    """Return one store action's body, matched to its closing brace at store indentation.
+
+    Sliced past the `ChatState` interface first: it declares every action with the same
+    `name: (` shape as the implementation, so an unanchored search matches the type
+    signature and then runs on into unrelated code.
+    """
+    start = source.index("export const useChatStore = create")
+    implementation = source[start:]
+    match = re.search(
+        r"^    " + re.escape(action_name) + r": (?:async )?\((.|\n)*?\n    \},",
+        implementation,
+        re.MULTILINE,
+    )
+    assert match, f"Could not find the {action_name} store action"
+    return match.group(0)
+
+
+def test_cancelling_really_ends_the_generation():
+    """The premise: the cancel route is destructive, not a client-side detach."""
+    print("Testing that cancel is destructive...")
+
+    chats = _read(APP_DIR / "route_backend_chats.py")
+
+    assert "'/api/chat/stream/cancel/<conversation_id>', methods=['POST']" in chats, (
+        "The cancel route moved; this test's premise needs rechecking"
+    )
+    assert "stream_session.request_cancel(reason=cancel_reason)" in chats, (
+        "The cancel route no longer requests a real cancellation"
+    )
+    assert re.search(
+        r"def request_cancel\(self, reason='user_requested'\):(.|\n)*?metadata\['cancel_requested'\] = True",
+        chats,
+    ), "request_cancel no longer sets cancel_requested, which the generation loop honours"
+    assert "def is_cancel_requested(self):" in chats, (
+        "The generation loop's cancellation check is gone; cancel may no longer stop work"
+    )
+
+    print("Cancel destructiveness test passed!")
+    return True
+
+
+def test_an_early_cancel_persists_no_answer_at_all():
+    """Why the timing mattered: cancelling before the first token saves nothing.
+
+    A cancel that lands after content has started keeps the partial answer. One that lands
+    during the thinking phase does not, which is why leaving early looked like the response
+    was never generated rather than like it was cut short.
+    """
+    print("Testing early-cancel persistence...")
+
+    chats = _read(APP_DIR / "route_backend_chats.py")
+
+    assert "message_persisted=False," in chats, (
+        "The pre-content cancel path no longer reports message_persisted=False; the reason "
+        "an early leave left no answer behind needs rechecking"
+    )
+    assert "message_persisted=bool(payload.get('message_id'))," in chats, (
+        "The post-content cancel path no longer persists a partial answer"
+    )
+
+    print("Early-cancel persistence test passed!")
+    return True
+
+
+def test_generation_survives_a_dropped_reader():
+    """Detaching is only safe because the server keeps generating without a listener."""
+    print("Testing background execution...")
+
+    chats = _read(APP_DIR / "route_backend_chats.py")
+
+    assert re.search(
+        r"def build_background_stream_response\(event_generator_factory, stream_session=None\):\s*\n\s*\"\"\"[^\"]*survives disconnects",
+        chats,
+    ), (
+        "Streaming no longer documents surviving disconnects; if generation now dies with "
+        "its reader, detaching on a thread switch would lose the answer"
+    )
+
+    print("Background execution test passed!")
+    return True
+
+
+def test_leaving_a_conversation_detaches_rather_than_cancels():
+    """The fix: a thread switch drops the reader and leaves the generation running."""
+    print("Testing detach on conversation switch...")
+
+    store = _read(V2_SRC / "stores" / "chatStore.ts")
+
+    select = _store_action_body(store, "selectConversation")
+    assert "detachActiveStream()" in select, (
+        "selectConversation must detach the running stream's reader"
+    )
+    assert "stopStreaming()" not in select, (
+        "selectConversation calls stopStreaming again, which POSTs a real server-side "
+        "cancel; opening another conversation would once more destroy the answer being "
+        "written in the one being left"
+    )
+    assert "cancelStream(" not in select, (
+        "selectConversation must not reach the cancel route by any route"
+    )
+
+    print("Detach on conversation switch test passed!")
+    return True
+
+
+def test_starting_a_new_chat_detaches_rather_than_cancels():
+    """Same rule for New chat, which is the other way out of a generating thread."""
+    print("Testing detach on new chat...")
+
+    store = _read(V2_SRC / "stores" / "chatStore.ts")
+
+    start_new = _store_action_body(store, "startNewConversation")
+    assert "detachActiveStream()" in start_new, (
+        "startNewConversation must detach the running stream's reader"
+    )
+    assert "stopStreaming()" not in start_new, (
+        "startNewConversation calls stopStreaming again, so clicking New chat mid-answer "
+        "cancels it server-side instead of leaving it to finish"
+    )
+    assert "cancelStream(" not in start_new, (
+        "startNewConversation must not reach the cancel route by any route"
+    )
+
+    print("Detach on new chat test passed!")
+    return True
+
+
+def test_the_detach_helper_does_not_cancel():
+    """Detaching is defined by what it does not do, so that is what is pinned."""
+    print("Testing the detach helper...")
+
+    store = _read(V2_SRC / "stores" / "chatStore.ts")
+
+    detach = _function_body(store, r"function detachActiveStream\(\): void \{")
+    assert "cancelStream" not in detach, (
+        "detachActiveStream must not ask the server to stop generating; that is the whole "
+        "difference between it and stopStreaming"
+    )
+    assert "activeStreamController.abort();" in detach, (
+        "detachActiveStream must still abort the local reader, or a stream for the thread "
+        "just left keeps writing into the newly opened one"
+    )
+    assert "streamingConversationId = null;" in detach, (
+        "The ownership marker must be cleared, or Stop would later cancel a conversation "
+        "that is no longer on screen"
+    )
+
+    print("Detach helper test passed!")
+    return True
+
+
+def test_detaching_leaves_the_composer_usable():
+    """The streaming flag has to be cleared by the helper, because no caller clears it.
+
+    Neither `selectConversation` nor `startNewConversation` sets `streaming: false` in its
+    own state reset -- both relied on `stopStreaming` doing it. If the helper dropped it,
+    leaving a generating thread would strand the composer showing Stop for a stream nothing
+    is reading.
+    """
+    print("Testing composer state after detach...")
+
+    store = _read(V2_SRC / "stores" / "chatStore.ts")
+
+    detach = _function_body(store, r"function detachActiveStream\(\): void \{")
+    assert "streaming: false" in detach, (
+        "detachActiveStream must clear the streaming flag; its callers do not"
+    )
+    assert "reconnectPhase: null" in detach, (
+        "A detach must clear any reconnect phase, or the next thread opens still claiming "
+        "to be reconnecting"
+    )
+
+    for action in ("selectConversation", "startNewConversation"):
+        body = _store_action_body(store, action)
+        assert "streaming: false" not in body, (
+            f"{action} now clears `streaming` itself. That is fine, but this test's reason "
+            f"for requiring it of detachActiveStream needs rechecking"
+        )
+
+    print("Composer state test passed!")
+    return True
+
+
+def test_stop_still_cancels():
+    """The Stop button is the one control that must still end the generation."""
+    print("Testing that Stop still cancels...")
+
+    store = _read(V2_SRC / "stores" / "chatStore.ts")
+
+    stop = _store_action_body(store, "stopStreaming")
+    assert "cancelStream(" in stop, (
+        "stopStreaming no longer cancels server-side, so Stop would leave the answer being "
+        "written and billed after the reader asked for it to end"
+    )
+    assert "detachActiveStream()" in stop, (
+        "stopStreaming should share the teardown rather than repeat it"
+    )
+
+    # Stop is a user action, so it stays wired to the button rather than to navigation.
+    composer = _read(V2_SRC / "components" / "chat" / "Composer.tsx")
+    assert "onClick={stopStreaming}" in composer, (
+        "The Stop button is no longer wired to stopStreaming"
+    )
+
+    print("Stop cancellation test passed!")
+    return True
+
+
+def test_only_the_stop_button_reaches_the_cancel_route():
+    """No other caller may cancel, which is what regressed the first time."""
+    print("Testing cancel call sites...")
+
+    store = _read(V2_SRC / "stores" / "chatStore.ts")
+
+    # Two references only: the import and the single call inside stopStreaming.
+    assert store.count("cancelStream(") == 1, (
+        "cancelStream is called from more than one place in the store. Every caller other "
+        "than stopStreaming ends a generation the reader did not ask to end"
+    )
+
+    print("Cancel call site test passed!")
+    return True
+
+
+def test_legacy_never_cancelled_on_a_thread_switch():
+    """The behaviour being restored is V1's, so V1 is what it is measured against."""
+    print("Testing legacy parity...")
+
+    conversations = _read(APP_DIR / "static" / "js" / "chat" / "chat-conversations.js")
+    assert "reattachStreamingConversation(conversationId)" in conversations, (
+        "chat-conversations.js no longer reattaches on select; parity needs rechecking"
+    )
+    assert "requestStreamCancellation" not in conversations, (
+        "chat-conversations.js now cancels on a thread switch, so it is no longer the "
+        "reference behaviour this fix restores"
+    )
+
+    streaming = _read(APP_DIR / "static" / "js" / "chat" / "chat-streaming.js")
+    assert "export function cancelStreaming()" in streaming, (
+        "The explicit stop entry point moved; the claim that cancellation is user-driven "
+        "needs rechecking"
+    )
+
+    print("Legacy parity test passed!")
+    return True
+
+
+def test_a_reattached_stream_is_not_owned():
+    """Attaching to someone else's generation must not hand this tab the power to end it."""
+    print("Testing reattach ownership...")
+
+    store = _read(V2_SRC / "stores" / "chatStore.ts")
+
+    resume = _function_body(store, r"async function resumeChatStream\(")
+    assert "streamingConversationId = conversationId" not in resume, (
+        "resumeChatStream must not claim ownership of a stream it merely attached to, or "
+        "Stop would cancel a generation another tab is waiting on"
+    )
+
+    run = _function_body(store, r"async function runChatStream\(")
+    assert "streamingConversationId = conversationId;" in run, (
+        "A stream this tab started must stay owned so Stop can cancel it"
+    )
+
+    # V1 draws the same line: its reattached stream is opened without a cancel endpoint.
+    streaming = _read(APP_DIR / "static" / "js" / "chat" / "chat-streaming.js")
+    reattach = re.search(
+        r"export async function reattachStreamingConversation\((.|\n)*?\n\}", streaming
+    )
+    assert reattach, "Could not find reattachStreamingConversation"
+    assert "cancelEndpoint" not in reattach.group(0), (
+        "chat-streaming.js now gives a reattached stream a cancel endpoint; V2's matching "
+        "choice should be revisited"
+    )
+
+    print("Reattach ownership test passed!")
+    return True
+
+
+def test_version_is_at_least_implementation_version():
+    """The application version is at or beyond the version that added the fix."""
+    print("Testing application version...")
+    assert_app_version_at_least("0.261.050")
+    print("Application version test passed!")
+    return True
+
+
+if __name__ == "__main__":
+    tests = [
+        test_cancelling_really_ends_the_generation,
+        test_an_early_cancel_persists_no_answer_at_all,
+        test_generation_survives_a_dropped_reader,
+        test_leaving_a_conversation_detaches_rather_than_cancels,
+        test_starting_a_new_chat_detaches_rather_than_cancels,
+        test_the_detach_helper_does_not_cancel,
+        test_detaching_leaves_the_composer_usable,
+        test_stop_still_cancels,
+        test_only_the_stop_button_reaches_the_cancel_route,
+        test_legacy_never_cancelled_on_a_thread_switch,
+        test_a_reattached_stream_is_not_owned,
+        test_version_is_at_least_implementation_version,
+    ]
+
+    results = []
+    for test in tests:
+        print(f"\nRunning {test.__name__}...")
+        try:
+            results.append(bool(test()))
+        except Exception as exc:  # noqa: BLE001 - surface any failure with a traceback
+            print(f"Test failed: {exc}")
+            import traceback
+
+            traceback.print_exc()
+            results.append(False)
+
+    print(f"\nResults: {sum(results)}/{len(results)} tests passed")
+    sys.exit(0 if all(results) else 1)


### PR DESCRIPTION
Fixes two ways that leaving a chat straight after sending could go wrong in V2. Both were reported as "I submit a message, leave at the right point in time, and it never creates a response."

## 1. Leaving a conversation cancelled the answer server-side

**This was not a reconnect bug.** The reconnect machinery was working correctly — it was being asked to reattach to a stream that had already been cancelled.

`selectConversation` and `startNewConversation` both opened with `get().stopStreaming()`, and `stopStreaming` POSTs `/api/chat/stream/cancel/<id>` **before** aborting the local reader. That route reaches `request_cancel`, which sets `cancel_requested`, and the agent loop honours it. So clicking another conversation genuinely ended the generation.

The symptom looked intermittent because timing changed it:

| When the cancel landed | Result |
|---|---|
| Before the first content token | `message_persisted=False` — **no assistant message saved at all** |
| After content started | `partial_content=...` — truncated reply saved |

That is why leaving during the "thinking" phase destroyed the reply outright rather than merely cutting it short, and why `resumeChatStream` then correctly declined to reattach: the stream was terminal and `pending` was false.

**V1 never did this.** `chat-conversations.js` only calls `reattachStreamingConversation()` on select; `requestStreamCancellation` is reachable solely from the stop button and `cancelStreaming()`. That is why the classic interface keeps generating across thread switches and can do it for several conversations at once.

The authors had partly noticed: `Sidebar.tsx` carried a comment saying *"the reset stops the stream and the reply would be lost"*, and one call site was guarded while two were left open.

### Fix

Separate *stop reading* from *stop generating*. A new `detachActiveStream()` aborts the reader and clears the streaming state without cancelling; the two leave paths use it. `stopStreaming` keeps its cancel and delegates teardown, so the Stop button is unchanged.

Detaching is safe because `build_background_stream_response` is explicitly built so generation "survives disconnects".

## 2. Clicking away while a new chat was being created bounced you back

The first message of a brand-new chat waits on `createConversation` — the only pause between pressing send and the stream starting. A click landing in that window was undone: `sendMessage` claimed `activeConversationId` unconditionally afterwards, snapping the reader back into the chat they had just left, and an in-flight load for the thread they clicked could deposit its messages under the new conversation.

`runChatStream` compounded it by deciding whether to render using only `activeStreamController === controller`. That is the right question for teardown but does not cover this window — no controller exists yet while the conversation is being created, so a thread switch has nothing to clear.

Display-only: nothing was lost or filed against the wrong conversation, and a reload corrected it.

### Fix

The reader's click wins. The message is still sent and its answer still generated and saved — appearing in the rail with its title and unread marker — but the interface stays put.

One check was answering two questions, so they are now separate:

- `ownsController()` — still own the module's `AbortController`? Governs **teardown**, stays identity-based (a stream whose conversation is off screen still owns it, and `resumeChatStream` refuses to attach while one is set).
- `isCurrent()` — is this stream's conversation still on screen? Governs **rendering**, now also checks `activeConversationId`.

Ordinary sends are unaffected: the stream's conversation is the active one throughout, so the added condition is always true.

## Behaviour after both fixes

- Leaving a conversation mid-generation detaches. The answer finishes and is saved.
- Reopening resumes the live stream, or shows the completed reply if it finished while away.
- Several conversations can generate at once, matching V1.
- Stop still cancels, exactly as before.
- Leaving a **shared** conversation no longer cancels a reply other participants are waiting on.
- Clicking a conversation while a new chat is being created keeps you where you clicked.

An abandoned generation now runs to completion instead of being cancelled. That is deliberate, matches V1, and is what makes the answer still be there when you come back.

## Validation

- `functional_tests/test_v2_stream_leave_without_cancel.py` — **15/15**. Every assertion was confirmed to **fail against the pre-fix code**, so they detect the regression rather than merely describing the implementation.
- `functional_tests/test_v2_stream_reconnect.py` — 10/10 (the reconnect contract this depends on is intact).
- `npm run typecheck` (`tsc -b --noEmit`) — clean.
- `test_docs_site_quality.py` 6/6, `test_docs_app_surface_coverage.py` 7/7.

Coverage includes the server-side premises — the cancel route reaches `request_cancel`, `request_cancel` sets `cancel_requested`, the generation loop checks `is_cancel_requested()`, the pre-content path reports `message_persisted=False`, streaming survives disconnects — plus V1 parity, so the test fails loudly if the behaviour it is matched against ever moves.

## Notes

- Version `0.261.049` → `0.261.051`.
- Docs: `V2_STREAM_CANCELLED_ON_CONVERSATION_LEAVE_FIX.md`, `V2_NEW_CONVERSATION_SEND_RACE_FIX.md`, plus release notes for both versions.
- Not included: a "still generating" badge in the conversation rail for a thread you have left. V2 displays one streaming conversation at a time; the others now finish in the background and are flagged by the existing unread marker. That would be a separate change.