### PR TITLE
V2 rail: make the brand mark the home link, drop the Home nav item

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -97,7 +97,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.261.049"
+VERSION = "0.261.050"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/v2_ui/src/components/layout/Sidebar.tsx
+++ b/application/v2_ui/src/components/layout/Sidebar.tsx
@@ -18,7 +18,6 @@ import {
     ChevronRight,
     FolderOpen,
     Globe2,
-    Home,
     LogOut,
     MessageSquarePlus,
     MessagesSquare,
@@ -43,18 +42,12 @@ interface NavItem {
     /** Hover text. Two entries are easily confused without it, so both say what they are. */
     hint?: string;
     adminOnly?: boolean;
-    /** Matches the route exactly. Needed for "/", which otherwise prefixes every path. */
-    end?: boolean;
 }
 
+// Home is deliberately absent. The brand mark above this list is the link to it, which is
+// where a reader looks for it anyway; a nav row saying the same thing spent a slot on a
+// destination the logo already implies.
 const NAV_ITEMS: NavItem[] = [
-    {
-        to: '/',
-        label: 'Home',
-        icon: Home,
-        hint: 'The landing page and its announcements',
-        end: true,
-    },
     { to: '/chat', label: 'Chats', icon: MessagesSquare },
     {
         to: '/agents',
@@ -79,24 +72,51 @@ function BrandMark({ collapsed }: { collapsed: boolean }) {
     const branding = useBootstrapStore((state) => state.data?.branding);
     const theme = useUiStore((state) => state.theme);
 
-    const logoUrl = theme === 'dark' ? branding?.logo_dark_url : branding?.logo_url;
+    const themedLogoUrl = theme === 'dark' ? branding?.logo_dark_url : branding?.logo_url;
     const title = branding?.app_title || 'SimpleChat';
 
+    // A logo counts only when one is stored *and* switched on.
+    const logoUrl = branding?.show_logo ? themedLogoUrl : null;
+    const showTitle = !collapsed && !branding?.hide_app_title;
+    // The letter square stands in for a mark there is either no configuration or no room
+    // for, so it is drawn only where the title itself is not: in the collapsed rail, or
+    // when the title is hidden. Beside the title it was the same word twice.
+    const showInitial = !logoUrl && !showTitle;
+
     return (
-        <div className="flex min-w-0 items-center gap-2.5">
-            {branding?.show_logo && logoUrl ? (
+        // The brand is the way back to the landing page -- there is no separate Home nav
+        // item, because this is where a reader looks for one. `end` matters: without it
+        // "/" prefixes every route and this would claim aria-current on all of them.
+        //
+        // The accessible name carries the title rather than reading only "Home", so the
+        // visible label stays inside the accessible name (WCAG 2.5.3) and the link is
+        // still named when the rail is collapsed to the logo or the letter alone.
+        <NavLink
+            to="/"
+            end
+            aria-label={`${title} home`}
+            className={clsx(
+                '-mx-1.5 flex min-w-0 items-center gap-2.5 rounded-xl px-1.5 py-1.5',
+                'transition-colors hover:bg-surface-2',
+                collapsed && 'justify-center',
+            )}
+        >
+            {logoUrl && (
                 // Height-constrained with a free width, matching the classic navigation.
                 // Forcing a square would letterbox or crop the wordmark most deployments
                 // upload. The collapsed rail is only 68px wide, so the cap tightens there.
+                //
+                // Decorative: the link names itself, so alt text would announce twice.
                 <img
                     src={logoUrl}
-                    alt={branding.hide_app_title ? title : ''}
+                    alt=""
                     className={clsx(
                         'h-8 w-auto shrink-0 object-contain',
                         collapsed ? 'max-w-[44px]' : 'max-w-[150px]',
                     )}
                 />
-            ) : (
+            )}
+            {showInitial && (
                 <span
                     aria-hidden="true"
                     className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-accent text-sm font-bold text-on-accent"
@@ -104,12 +124,12 @@ function BrandMark({ collapsed }: { collapsed: boolean }) {
                     {title.slice(0, 1).toUpperCase()}
                 </span>
             )}
-            {!collapsed && !branding?.hide_app_title && (
+            {showTitle && (
                 <span className="truncate text-[15px] font-semibold text-text-1" title={title}>
                     {title}
                 </span>
             )}
-        </div>
+        </NavLink>
     );
 }
 
@@ -286,7 +306,6 @@ export function Sidebar() {
                     <li key={item.to}>
                         <NavLink
                             to={item.to}
-                            end={item.end}
                             onClick={item.to === '/chat' ? startNewChatOnArrival : undefined}
                             title={collapsed ? item.label : item.hint}
                             className={({ isActive }) =>

--- a/docs/explanation/features/REACT_V2_UI.md
+++ b/docs/explanation/features/REACT_V2_UI.md
@@ -276,6 +276,27 @@ and the conversation list sit beneath, and the theme toggle and user menu are pi
 bottom. The rail collapses to a 68px icon strip, and the collapse state is persisted. All
 content lives in the right-hand pane.
 
+The brand mark is the link to the home page; there is no separate **Home** navigation item,
+because the logo is where a reader looks for that destination anyway. What it draws depends
+on what is configured and how much room there is:
+
+| Custom logo | Rail | Application title | Brand shows |
+|---|---|---|---|
+| yes | expanded | shown | logo and title |
+| yes | expanded | hidden | logo |
+| yes | collapsed | either | logo, capped at 44px wide |
+| no | expanded | shown | the title alone |
+| no | expanded | hidden | a letter square holding the title's initial |
+| no | collapsed | either | the letter square |
+
+The letter square is a stand-in for a mark, so it appears only where the title itself
+cannot: in the collapsed rail, or when **Hide Application Title** is on. Drawn beside the
+title it was the same word twice.
+
+The link names itself for the collapsed rail — where it holds only a decorative logo or
+letter — as the application title followed by "home", rather than "Home" alone, so the
+visible label stays inside the accessible name.
+
 The classification banner, when configured, is the only element that spans the full width —
 matching the server-rendered interface.
 
@@ -1045,6 +1066,7 @@ this entirely and is the recommended layout.
 | `functional_tests/test_v2_stats_parity.py` | Every trend field, window parameter and cached-metrics key the Stats tab reads exists on the server side, each classic stats surface has a counterpart, the account menu offers one destination, and both chart consumers share the vendored runtime |
 | `functional_tests/test_v2_stats_logic.mjs` | Executes the stats logic: preset versus custom window parameters, custom-range validation, series aligned by date rather than index, formatting, and the CSV export's sections, columns and quoting |
 | `functional_tests/test_v2_new_chat_scoping.py` | **New chat** offered only where it can act and the nav list's spacing following it, **Chats** starting a fresh conversation on arrival from elsewhere, that reset guarded on both the current route and an in-flight stream with the guard preceding it, the streaming flag read rather than subscribed, the drawer and details panel closed with the conversation they describe, and enabled buttons carrying a pointer cursor |
+| `functional_tests/test_v2_brand_mark_home_link.py` | The **Home** nav item, its icon import and the exact-match field it needed all removed; the brand mark carrying the home destination with the exact matching that keeps it off every other route; the link naming itself for the collapsed rail; and the letter square gated on the title being absent rather than on the logo being absent |
 | `functional_tests/test_csrf_state_changing_route_guard.py` | Cross-site mutations require an explicitly trusted origin; CORS preflights answered before authentication and never wildcarded |
 | `functional_tests/route_tests/` | Blueprint policy classification for `frontend_v2`, `backend_v2`, `backend_v2_admin` |
 

--- a/docs/explanation/features/V2_HOME_PAGE.md
+++ b/docs/explanation/features/V2_HOME_PAGE.md
@@ -84,7 +84,11 @@ both interfaces, so the alignment setting reads as a choice about the prose.
 | `/v2/chat` | Chat |
 | anything unmatched | Redirects to `/v2` |
 
-**Home** was added as the first entry in the navigation rail.
+**Home** was reached from a nav item at the top of the rail when this page was added.
+Since `0.261.050` the rail's brand mark — the logo, the application title, or the
+letter square standing in for them — carries the destination instead, and the nav
+item is gone. See
+[V2_BRAND_MARK_HOME_LINK_FIX.md](../fixes/V2_BRAND_MARK_HOME_LINK_FIX.md).
 
 **New chat** is not shown on the home page. It is offered only on the chat page,
 because it acts on chat state that is not on screen anywhere else; clicking
@@ -146,8 +150,9 @@ Custom Pages and External Links are configured under **Appearance > Pages & Link
 - `functional_tests/test_v2_navigation_groups_logic.mjs` executes the client's
   inline-versus-menu and visibility decisions.
 - `ui_tests/test_v2_appearance_branding_and_nav.py` covers the rendered home page,
-  the logo height, the "Start chatting" link, the Home rail entry and the two
-  navigation groups, driven by what bootstrap reports for the deployment under test.
+  the logo height, the "Start chatting" link, the brand mark that reaches this page
+  and the two navigation groups, driven by what bootstrap reports for the deployment
+  under test.
 
 ## Known limitations
 

--- a/docs/explanation/fixes/V2_BRAND_MARK_HOME_LINK_FIX.md
+++ b/docs/explanation/fixes/V2_BRAND_MARK_HOME_LINK_FIX.md
@@ -1,0 +1,151 @@
+# V2 Brand Mark Home Link Fix
+
+## Issue
+
+The V2 navigation rail carried two controls for one destination and none for the one place
+everybody clicks.
+
+**Home** sat at the top of the navigation list as an ordinary entry — house icon, "Home"
+label — directly beneath the brand area holding the application logo and title. Clicking
+the logo did nothing at all, because it was not a link.
+
+Separately, a deployment with no custom logo saw its application title twice. The brand
+area fell back to an accent square holding the first letter of the title, and then rendered
+the whole title next to it: **S** SimpleChat.
+
+**Fixed in version:** 0.261.050
+
+## Root cause
+
+All three faults are in `application/v2_ui/src/components/layout/Sidebar.tsx`.
+
+### The brand area was never a control
+
+`BrandMark` rendered into a plain `<div>`:
+
+```tsx
+<div className="flex min-w-0 items-center gap-2.5">
+```
+
+Nothing in the V2 rail linked to `/`, so a **Home** navigation item was added alongside it
+when the home page shipped in `0.261.047` rather than making the brand do the job. That
+left the destination represented twice: once by a row that said so, and once by a logo that
+looked like it should and did not.
+
+### The letter square was gated on the wrong thing
+
+The fallback and the title were decided independently:
+
+```tsx
+{branding?.show_logo && logoUrl ? <img .../> : <span>{title.slice(0, 1)}</span>}
+{!collapsed && !branding?.hide_app_title && <span>{title}</span>}
+```
+
+The square was drawn whenever no logo was configured. The title was drawn whenever there
+was room for it and it had not been hidden. Those two conditions are both true in the
+default configuration — no custom logo, rail expanded, **Hide Application Title** off —
+so the square and the word it abbreviates appeared side by side.
+
+The square exists for the places the title cannot go: the 68px collapsed rail, and a
+deployment that has deliberately hidden the title. Its condition should have followed the
+title's, not the logo's.
+
+## The fix
+
+The **Home** navigation item is removed and `BrandMark` is now the link to `/`.
+
+The letter square is gated on the title being absent rather than on the logo being absent,
+which the component states as three derived flags rather than leaving it to be inferred
+from nested conditionals:
+
+```tsx
+const logoUrl = branding?.show_logo ? themedLogoUrl : null;
+const showTitle = !collapsed && !branding?.hide_app_title;
+const showInitial = !logoUrl && !showTitle;
+```
+
+### What the brand mark draws
+
+| Custom logo | Rail | Application title | Shows |
+|---|---|---|---|
+| yes | expanded | shown | logo and title |
+| yes | expanded | hidden | logo |
+| yes | collapsed | either | logo, capped at 44px wide |
+| no | expanded | shown | the title alone |
+| no | expanded | hidden | the letter square |
+| no | collapsed | either | the letter square |
+
+The fifth row is why the square is kept rather than deleted. With no logo, the title hidden
+and the rail expanded, dropping it would leave the brand slot empty and the only home link
+in the interface invisible and unclickable.
+
+### Three details in the link
+
+- **`end` is required.** `/` prefixes every other route, so without exact matching the link
+  would claim `aria-current="page"` on every page in the application. This was the only
+  reason the removed navigation item carried an `end` field, so that field comes off the
+  `NavItem` interface with it.
+- **The accessible name is the title followed by "home"**, not "Home". Collapsed, the link
+  holds only a logo or a letter, both of which are decorative, so it has to name itself or
+  it reaches a screen reader unlabelled. Naming it "Home" alone would put the accessible
+  name at odds with the visible text when that text reads "SimpleChat", which is what
+  WCAG 2.5.3 (Label in Name) is about, and would break speech input.
+- **The logo `alt` is now empty.** The link names itself, so alt text would announce the
+  application title a second time.
+
+The brand area gains a hover background so it reads as clickable, inset with a negative
+margin against its own padding so the logo and title stay on the same left alignment as
+everything else in the rail. There is deliberately no active-page highlight: a brand mark
+that leads home is a convention that does not usually carry one.
+
+## Files modified
+
+| File | Change |
+|---|---|
+| `application/v2_ui/src/components/layout/Sidebar.tsx` | **Home** nav item, its `lucide-react` icon import and the `NavItem.end` field removed; `BrandMark` wrapped in a `NavLink to="/" end` that names itself; letter square gated on `showInitial` |
+| `application/single_app/config.py` | Version to 0.261.050 |
+| `functional_tests/test_v2_brand_mark_home_link.py` | New test |
+| `ui_tests/test_v2_appearance_branding_and_nav.py` | Brand coverage extended to the home link and the letter square rule |
+
+## Validation
+
+`functional_tests/test_v2_brand_mark_home_link.py` — 4/4 checks passed. It asserts that
+`NAV_ITEMS` carries no Home entry and no `/` route, that the `Home` icon import and the
+`NavItem.end` field are gone, that `BrandMark` is a `NavLink to="/"` with `end` and an
+accessible name built from the application title, that the logo is decorative, that the
+hover affordance and its negative-margin inset are present, and that the letter square is
+the element gated on `showInitial = !logoUrl && !showTitle`.
+
+The same test was run against the pre-fix source and failed three of its four checks — the
+fourth is the version assertion, which is not source-dependent — so each check covers a
+real regression rather than restating the implementation.
+
+Five neighbouring V2 test files that read `Sidebar.tsx` or the branding builders were
+re-run and still pass: `test_v2_new_chat_scoping.py` (6/6),
+`test_v2_conversation_deep_link.py` (8/8), `test_v2_stats_parity.py` (7/7),
+`test_v2_conversation_drawer.py` (8/8) and
+`test_v2_bootstrap_branding_and_navigation.py` (8/8).
+
+`npm run typecheck` and `npm run build` both succeed. The compiled bundle contains
+`to:"/",end:!0,"aria-label":\`${a} home\`` and `u=!l&&!c` for the letter square, and no
+longer contains `label:"Home"`.
+
+### Before and after
+
+| Situation | Before | After |
+|---|---|---|
+| Clicking the logo or application title | Nothing; it was not a link | Opens the home page |
+| Ways to reach `/v2` from the rail | Two — the brand that did not work and a **Home** row | One |
+| No custom logo, rail expanded, title shown | **S** SimpleChat | SimpleChat |
+| No custom logo, rail collapsed | **S** | Unchanged |
+| No custom logo, title hidden | **S** | Unchanged |
+| Custom logo configured | Logo, plus title when there is room | Unchanged |
+| Screen reader on the collapsed rail | "Home, link", plus an unnamed brand image | "SimpleChat home, link" |
+| `aria-current` on the brand link | n/a | Set on `/v2` only |
+
+## Related
+
+- Feature documentation: [REACT_V2_UI.md](../features/REACT_V2_UI.md),
+  [V2_HOME_PAGE.md](../features/V2_HOME_PAGE.md)
+- The change that introduced the **Home** nav item this replaces:
+  [V2_APPEARANCE_PARITY_FIX.md](V2_APPEARANCE_PARITY_FIX.md)

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,24 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/features) and [Fixes by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/fixes).
 
+### **(v0.261.050)**
+
+#### User Interface Enhancements
+
+*   **The Logo Is The Way Home In The New Interface**
+    *   Clicking the logo or the application title at the top of the left rail now opens the home page. Previously it was not a link at all, and a separate **Home** row sat directly underneath it — two controls for one destination, only one of which worked.
+    *   That **Home** row has been removed. The rail is one item shorter, and the place people already click is the place that works.
+    *   The link is announced to screen readers as the application name followed by "home", so it is still identifiable when the rail is collapsed to just a logo or a single letter.
+    *   (Ref: V2 navigation rail, brand mark, [V2 Brand Mark Home Link Fix](fixes/V2_BRAND_MARK_HOME_LINK_FIX.md))
+
+#### Bug Fixes
+
+*   **The Application Title No Longer Appears Twice In The Left Rail**
+    *   With no custom logo uploaded, the new interface showed a coloured square holding the first letter of the application title *and* the full title next to it — "**S** SimpleChat".
+    *   The lettered square is a stand-in for a logo, so it now appears only where the title itself cannot: when the left rail is collapsed, or when **Hide Application Title** is turned on. An expanded rail shows the title on its own.
+    *   Deployments with a custom logo are unaffected.
+    *   (Ref: V2 navigation rail, Appearance > Branding, [V2 Brand Mark Home Link Fix](fixes/V2_BRAND_MARK_HOME_LINK_FIX.md))
+
 ### **(v0.261.049)**
 
 #### New Features

--- a/functional_tests/test_v2_brand_mark_home_link.py
+++ b/functional_tests/test_v2_brand_mark_home_link.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""
+Functional test for the V2 rail's brand mark and the removal of the Home nav item.
+
+Version: 0.261.050
+Implemented in: 0.261.050
+
+Three faults met at the top of the navigation rail.
+
+The rail led with a Home nav item -- house icon, "Home" label, `to: '/'` -- directly beneath
+a brand area holding the logo and application title. That is two controls for one
+destination, and the brand area is the one a reader reaches for.
+
+The brand area was not a control at all. It was a plain `<div>`, so the thing every user
+expects to click was inert, and removing the Home nav item without fixing that would have
+left `/v2` unreachable from the rail entirely.
+
+And the letter square was drawn beside the title it substitutes for. When no custom logo is
+configured the brand fell back to an accent square holding the first letter of the
+application title -- and then rendered the whole title next to it whenever the rail was
+expanded and "Hide Application Title" was off. "S SimpleChat" is the same word twice. The
+square exists for the places the title cannot go, not alongside it.
+
+This test ensures the Home nav item is gone, that the brand mark carries the home
+destination in its place with an accessible name that survives a collapsed rail, and that
+the letter square is gated on the title being absent rather than on the logo being absent.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+V2_SRC = REPO_ROOT / "application" / "v2_ui" / "src"
+SIDEBAR = V2_SRC / "components" / "layout" / "Sidebar.tsx"
+
+sys.path.insert(0, str(REPO_ROOT / "functional_tests"))
+
+from test_support.versioning import assert_app_version_at_least  # noqa: E402
+
+
+def _read(path):
+    return path.read_text(encoding="utf-8")
+
+
+def _nav_items():
+    """The NAV_ITEMS array literal."""
+    source = _read(SIDEBAR)
+    items = re.search(r"const NAV_ITEMS: NavItem\[\] = \[(.|\n)*?\n\];", source)
+    assert items, "Sidebar should declare a NAV_ITEMS array"
+    return items.group(0)
+
+
+def _brand_mark():
+    """The body of the BrandMark helper component."""
+    source = _read(SIDEBAR)
+    component = re.search(
+        r"function BrandMark\(\{ collapsed \}: \{ collapsed: boolean \}\)(.|\n)*?\n\}", source
+    )
+    assert component, "Sidebar should declare a BrandMark component"
+    return component.group(0)
+
+
+def test_the_home_nav_item_is_gone():
+    """One destination does not need two controls stacked on top of each other."""
+    print("Testing the Home nav item removal...")
+
+    items = _nav_items()
+
+    assert "'Home'" not in items, (
+        "The rail must not carry a Home nav item: the brand mark directly above the list "
+        "is the link to the same place, and a row repeating it spends a slot on a "
+        "destination the logo already implies"
+    )
+    assert "to: '/'," not in items, "No nav item may claim the landing route"
+
+    source = _read(SIDEBAR)
+    assert not re.search(r"^\s+Home,$", source, re.MULTILINE), (
+        "The lucide Home icon is only imported for the removed nav item"
+    )
+
+    # `end` existed on NavItem solely so "/" would not match every route. With that entry
+    # gone the field describes nothing, and a stale optional field invites a nav item to
+    # be added later that silently never matches.
+    assert "end?: boolean;" not in source, (
+        "The NavItem end field exists only for the removed '/' entry"
+    )
+    assert "end={item.end}" not in source, "No nav item needs exact matching any more"
+
+    # The one nav item that carries behaviour must be untouched by the removal.
+    assert "{ to: '/chat', label: 'Chats', icon: MessagesSquare }," in items, (
+        "Chats is what reaches a fresh conversation from elsewhere and must remain"
+    )
+
+    print("Home nav item removal test passed!")
+    return True
+
+
+def test_the_brand_mark_is_the_home_link():
+    """Removing the nav item only works because the brand took the destination over."""
+    print("Testing the brand mark home link...")
+
+    body = _brand_mark()
+
+    link = re.search(r"<NavLink\s+to=\"/\"\s+end\s+aria-label=", body)
+    assert link, (
+        "The brand mark must be a NavLink to '/'. It is the only route to the landing "
+        "page left in the rail, and `end` is required because '/' prefixes every other "
+        "path and would otherwise claim aria-current on all of them"
+    )
+
+    assert "aria-label={`${title} home`}" in body, (
+        "The link must name itself: the collapsed rail shows only a logo or a letter, "
+        "both of which are decorative, so without this the link has no accessible name. "
+        "The title is included so the visible label stays inside the accessible name, "
+        "which naming it only 'Home' would break (WCAG 2.5.3, Label in Name)"
+    )
+
+    assert 'alt=""' in body, (
+        "The logo is decorative now that the link names itself; alt text would announce "
+        "the application title twice"
+    )
+
+    assert "hover:bg-surface-2" in body, (
+        "The brand area has to look clickable now that it is: it is the only home link"
+    )
+
+    # A negative margin against the padding keeps the hover surface from shifting the
+    # logo and title off the inset they share with everything else in the rail.
+    assert "-mx-1.5" in body and "px-1.5" in body, (
+        "The hover pill must be inset with negative margin, or adding its padding moves "
+        "the brand mark away from the rail's left edge alignment"
+    )
+
+    print("Brand mark home link test passed!")
+    return True
+
+
+def test_the_letter_square_only_stands_in_for_an_absent_title():
+    """The square is a substitute for the title, so it must not appear beside it."""
+    print("Testing the letter square...")
+
+    body = _brand_mark()
+
+    assert "const showTitle = !collapsed && !branding?.hide_app_title;" in body, (
+        "Whether the title is on screen is the condition everything else keys off"
+    )
+    assert "const showInitial = !logoUrl && !showTitle;" in body, (
+        "The letter square must be gated on the title being absent, not merely on the "
+        "logo being absent. Gated on the logo alone it rendered next to the full title "
+        "in the expanded rail, showing the same word twice"
+    )
+
+    # It still has to appear where nothing else can: the collapsed rail, and a deployment
+    # with no logo that has also hidden the title. Both are covered by showInitial, which
+    # would be pointless if the square were not actually gated on it.
+    square = re.search(r"\{showInitial && \(\s*<span(.|\n)*?</span>\s*\)\}", body)
+    assert square, "The letter square must be the element gated on showInitial"
+    assert "title.slice(0, 1).toUpperCase()" in square.group(0), (
+        "The gated element must be the initial, not something else"
+    )
+    assert 'aria-hidden="true"' in square.group(0), (
+        "The square is decorative; the link's aria-label is what names the destination"
+    )
+
+    # The logo is independent of the title: a deployment showing both should keep both.
+    assert "const logoUrl = branding?.show_logo ? themedLogoUrl : null;" in body, (
+        "A stored logo that has been switched off is not a logo, and the fallback has to "
+        "treat it that way or the brand slot renders empty"
+    )
+    logo = re.search(r"\{logoUrl && \(", body)
+    assert logo, "The logo must render whenever one is configured, title or not"
+
+    print("Letter square test passed!")
+    return True
+
+
+def test_version_is_at_least_implementation_version():
+    """The change is present from the version that introduced it onwards."""
+    print("Testing application version...")
+    assert_app_version_at_least("0.261.050")
+    print("Application version test passed!")
+    return True
+
+
+if __name__ == "__main__":
+    tests = [
+        test_the_home_nav_item_is_gone,
+        test_the_brand_mark_is_the_home_link,
+        test_the_letter_square_only_stands_in_for_an_absent_title,
+        test_version_is_at_least_implementation_version,
+    ]
+
+    results = []
+    for test in tests:
+        print(f"\nRunning {test.__name__}...")
+        try:
+            results.append(bool(test()))
+        except Exception as exc:  # noqa: BLE001 - surface any failure with a traceback
+            print(f"Test failed: {exc}")
+            import traceback
+
+            traceback.print_exc()
+            results.append(False)
+
+    print(f"\nResults: {sum(results)}/{len(results)} tests passed")
+    sys.exit(0 if all(results) else 1)

--- a/ui_tests/test_v2_appearance_branding_and_nav.py
+++ b/ui_tests/test_v2_appearance_branding_and_nav.py
@@ -3,7 +3,7 @@
 UI test for V2 Appearance branding, the classification banner, the home page and the
 administrator-configured navigation groups.
 
-Version: 0.261.047
+Version: 0.261.050
 Implemented in: 0.261.047
 
 Six Appearance settings had no visible effect in the V2 interface:
@@ -15,6 +15,11 @@ Six Appearance settings had no visible effect in the V2 interface:
   - the landing copy, its alignment and the home page logo size configured a page V2
     did not have;
   - Custom Pages and External Links were absent from the rail entirely.
+
+Extended in 0.261.050, when the brand mark became the rail's home link and the separate
+Home nav item was removed: the brand coverage now also states that there is one control
+for the destination rather than two, that the link names itself for the collapsed rail,
+and that the letter square is not drawn beside the title it stands in for.
 
 Each assertion here is driven by what /api/v2/bootstrap actually reports for the
 deployment under test, so the test states the same contract on any tenant rather than
@@ -90,9 +95,17 @@ def test_rail_shows_the_configured_brand_mark(v2_context):
     """A custom logo must reach the rail, at its own aspect ratio."""
     page, bootstrap = _open_v2(v2_context)
     branding = bootstrap["branding"]
+    title = branding.get("app_title") or "SimpleChat"
 
     rail = page.get_by_role("navigation", name="Primary")
+    brand = rail.locator('a[href="/v2"], a[href="/v2/"]')
     logo = rail.locator("img").first
+
+    if not branding.get("hide_app_title"):
+        # The letter square is a stand-in for a mark, so in the expanded rail it must not
+        # be drawn beside the title it stands in for -- that showed the same word twice.
+        # The logo contributes no text, so this holds whether or not one is configured.
+        expect(brand).to_have_text(title)
 
     if not branding.get("show_logo") or not branding.get("logo_url"):
         # The letter avatar is the deliberate V2 fallback, not a missing logo.
@@ -165,11 +178,25 @@ def test_home_page_renders_landing_content_and_reaches_chat(v2_context):
 @pytest.mark.ui
 def test_home_is_reachable_from_the_rail(v2_context):
     """Home has to be navigable, since /v2 is where a deep link now lands."""
-    page, _bootstrap = _open_v2(v2_context, "/v2/chat")
+    page, bootstrap = _open_v2(v2_context, "/v2/chat")
+    title = bootstrap["branding"].get("app_title") or "SimpleChat"
 
     rail = page.get_by_role("navigation", name="Primary")
-    home = rail.get_by_role("link", name="Home")
+
+    # The brand mark carries the destination; the separate Home nav item that used to sit
+    # beneath it is gone, so there must be exactly one control leading to /v2 rather than
+    # two stacked on each other. Matching on the href keeps this independent of how the
+    # link chooses to name itself.
+    home = rail.locator('a[href="/v2"], a[href="/v2/"]')
+    expect(home).to_have_count(1)
     expect(home).to_be_visible()
+
+    # Collapsed, the link holds only a logo or a letter, both of which are decorative, so
+    # it has to name itself or it reaches a screen reader as an unlabelled link.
+    assert (home.get_attribute("aria-label") or "").strip() == f"{title} home", (
+        "The brand link should be named for the application and its destination, got "
+        f"{home.get_attribute('aria-label')!r}."
+    )
 
     home.click()
     page.wait_for_url(f"{BASE_URL}/v2")


### PR DESCRIPTION
## What this does

The V2 navigation rail had two controls for one destination and none for the one everybody actually clicks.

**Home** sat at the top of the nav list as an ordinary entry — house icon, "Home" label — directly beneath the brand area holding the logo and application title. Clicking the logo did nothing at all, because it was not a link.

Separately, a deployment with no custom logo saw its application title twice: **S** SimpleChat.

## Changes

### 1. The Home nav item is gone

Removed from `NAV_ITEMS`, along with its `lucide-react` icon import and the `NavItem.end` field — `end` existed *only* so `/` wouldn't prefix-match every route, so it goes with the entry it served.

### 2. The brand mark is now the home link

`BrandMark` is a `NavLink to="/" end`, wrapping whatever is showing — logo, title, or letter square.

Three details worth calling out:

- **`end` is required.** `/` prefixes every other route, so without exact matching the link would claim `aria-current="page"` on every page in the app.
- **The accessible name is the title followed by "home"**, not "Home". Collapsed, the link holds only a decorative logo or letter, so it has to name itself or it reaches a screen reader unlabelled. Naming it "Home" alone would put the accessible name at odds with the visible text when that text reads "SimpleChat" — that's WCAG 2.5.3 (Label in Name), and it breaks speech input.
- **The logo `alt` is now empty.** The link names itself, so alt text would announce the title twice.

Hover background so it reads as clickable, inset with a negative margin against its own padding so the logo and title stay on the same left alignment as everything else in the rail. No active-page highlight — a brand mark that leads home is a convention that doesn't usually carry one.

### 3. The letter square only stands in for an absent title

The fallback and the title were decided independently: the square was drawn whenever no logo was configured, the title whenever there was room and it hadn't been hidden. Both are true in the default configuration, so they rendered side by side.

The square is a stand-in for the title, so it's now gated on the title's condition rather than the logo's:

```tsx
const logoUrl = branding?.show_logo ? themedLogoUrl : null;
const showTitle = !collapsed && !branding?.hide_app_title;
const showInitial = !logoUrl && !showTitle;
```

| Custom logo | Rail | Application title | Shows |
|---|---|---|---|
| yes | expanded | shown | logo and title |
| yes | expanded | hidden | logo |
| yes | collapsed | either | logo, capped at 44px |
| no | expanded | **shown** | **the title alone** |
| no | expanded | hidden | the letter square |
| no | collapsed | either | the letter square |

The fifth row is why the square is kept rather than deleted: with no logo, the title hidden and the rail expanded, dropping it would leave the brand slot empty and the only home link in the interface invisible.

## Before and after

| Situation | Before | After |
|---|---|---|
| Clicking the logo or application title | Nothing; it was not a link | Opens the home page |
| Ways to reach `/v2` from the rail | Two — the brand that didn't work and a **Home** row | One |
| No custom logo, rail expanded, title shown | **S** SimpleChat | SimpleChat |
| No custom logo, rail collapsed | **S** | Unchanged |
| No custom logo, title hidden | **S** | Unchanged |
| Custom logo configured | Logo, plus title when there is room | Unchanged |
| Screen reader, collapsed rail | "Home, link", plus an unnamed brand image | "SimpleChat home, link" |

## Validation

- **`functional_tests/test_v2_brand_mark_home_link.py`** (new) — 4/4. Run against the pre-fix source it fails 3 of its 4 checks (the 4th is the version assertion, which isn't source-dependent), so each check covers a real regression rather than restating the implementation.
- **All 47 `test_v2_*` functional tests pass**, including #1406's new `test_v2_stream_leave_without_cancel.py` (15/15) and the five that read `Sidebar.tsx`.
- **Docs coverage 7/7, site quality 6/6.**
- **`npm run typecheck` and `npm run build` both succeed.** Verified in the compiled bundle: it contains ``to:"/",end:!0,"aria-label":`${a} home` ``, no longer contains `label:"Home"`, and still carries #1406's `detachActiveStream`.
- `ui_tests/test_v2_appearance_branding_and_nav.py` updated — locates the home control by href so it asserts exactly one exists rather than two, checks the link's accessible name, and asserts the brand's text is just the title. Needs a live server to run.

## Notes

- Version → `0.261.052`.
- Docs: new `V2_BRAND_MARK_HOME_LINK_FIX.md`; corrected `V2_HOME_PAGE.md`, which claimed Home was the first entry in the rail; updated the `REACT_V2_UI.md` layout section and its test table; release notes entry.
- Targets `paullizer-react-v2-ui` rather than `Development`, since that's where the V2 interface work lives.
- **Rebased onto the latest base** after #1406 landed. `Sidebar.tsx` merged cleanly — that PR's edit there is a comment inside `startNewChatOnArrival`, while this branch changes the brand mark and nav list. `config.py` and `release_notes.md` conflicted only because both sides inserted at the same point; #1406 took `0.261.050` and `0.261.051`, so this work renumbered from `0.261.050` to `0.261.052` and its release note sits above both of theirs, which are kept verbatim.
- No associated GitHub issue — happy to file one if you'd like it tracked.