### PR TITLE
Rebuild admin AI Models: global model connections (phase 1)

### DIFF
--- a/application/single_app/admin_settings_fields.py
+++ b/application/single_app/admin_settings_fields.py
@@ -45,6 +45,12 @@ from functions_ai_notice import (
     normalize_ai_notice_frequency,
     normalize_ai_notice_message,
 )
+from functions_model_endpoint_identity_header import (
+    DEFAULT_MODEL_ENDPOINT_IDENTITY_HEADER_NAME,
+    DEFAULT_MODEL_ENDPOINT_IDENTITY_HEADER_VALUE_TYPE,
+    normalize_model_endpoint_identity_header_name,
+    normalize_model_endpoint_identity_header_value_type,
+)
 from functions_terms_of_use import (
     TERMS_OF_USE_DEFAULT_REDIRECT,
     TERMS_OF_USE_MAX_BUTTON_TEXT_LENGTH,
@@ -620,6 +626,72 @@ ADMIN_SETTINGS_FIELDS = {
             "default": True,
         },
     ],
+    "multi-endpoint-configuration": [
+        {
+            "key": "enable_multi_model_endpoints",
+            "type": "switch",
+            "label": "Use connections for chat",
+            "help": (
+                "Routes chat through the connections listed below, so several Azure "
+                "OpenAI or Foundry resources can serve models at once. When off, chat "
+                "uses the single classic endpoint instead and these connections are "
+                "not consulted."
+            ),
+            "default": False,
+        },
+        {
+            "type": "component",
+            "component": "model-connections-manager",
+            "label": "Connections",
+            "help": (
+                "Each connection is one Azure OpenAI or Foundry resource: where it is, "
+                "how SimpleChat authenticates to it, and which of its deployed models "
+                "may be used."
+            ),
+        },
+        {
+            "key": "model_endpoint_identity_header_enabled",
+            "type": "switch",
+            "label": "Send an identity header with model requests",
+            "help": (
+                "Adds a header identifying the signed-in user to every model request. "
+                "Gateways in front of a model endpoint use it to attribute usage or "
+                "apply per-user quotas, which they otherwise cannot do because the "
+                "request arrives under SimpleChat's own credentials."
+            ),
+            "default": False,
+        },
+        {
+            "key": "model_endpoint_identity_header_name",
+            "type": "text",
+            "label": "Header name",
+            "help": (
+                "Rejected if it collides with a header the model call already sets, "
+                "such as authorization or api-key."
+            ),
+            "default": DEFAULT_MODEL_ENDPOINT_IDENTITY_HEADER_NAME,
+            "max_length": 128,
+            "fallback_when_empty": True,
+            "depends_on": {"key": "model_endpoint_identity_header_enabled", "equals": True},
+        },
+        {
+            "key": "model_endpoint_identity_header_value_type",
+            "type": "select",
+            "label": "Identity sent in the header",
+            "help": (
+                "Object id is stable when a user is renamed; UPN is readable in gateway "
+                "logs. The tenant variants qualify the value for a multi-tenant gateway."
+            ),
+            "default": DEFAULT_MODEL_ENDPOINT_IDENTITY_HEADER_VALUE_TYPE,
+            "options": [
+                {"value": "user_oid_tenant_id", "label": "Object id and tenant id"},
+                {"value": "user_oid", "label": "Object id"},
+                {"value": "user_upn_tenant_id", "label": "User principal name and tenant id"},
+                {"value": "user_upn", "label": "User principal name"},
+            ],
+            "depends_on": {"key": "model_endpoint_identity_header_enabled", "equals": True},
+        },
+    ],
     "actions-config": [
         {
             "key": "enable_text_plugin",
@@ -914,6 +986,27 @@ def _validate_redirect_url(value):
     return normalized, None
 
 
+def _validate_identity_header_name(value):
+    """Return ``(normalized, error)`` for the model endpoint identity header name.
+
+    ``normalize_model_endpoint_identity_header_name`` answers "" for a name that
+    collides with a header the model call already sets, such as ``authorization`` or
+    ``api-key``. Storing that silently would turn the header off without saying so, so
+    an explicit save reports the refusal instead.
+    """
+    candidate = str(value or "").strip()
+    if not candidate:
+        return DEFAULT_MODEL_ENDPOINT_IDENTITY_HEADER_NAME, None
+
+    normalized = normalize_model_endpoint_identity_header_name(candidate)
+    if not normalized:
+        return None, (
+            "That header name is reserved or malformed. Use a token such as "
+            f"{DEFAULT_MODEL_ENDPOINT_IDENTITY_HEADER_NAME}."
+        )
+    return normalized, None
+
+
 def _check_acknowledgements(updates, current_settings, errors):
     """Enforce the acknowledgements a field requires before it may be enabled."""
     for _section_id, field in iter_fields():
@@ -968,6 +1061,14 @@ def normalize_admin_settings_updates(updates, current_settings=None):
                 errors[key] = redirect_error
             else:
                 normalized[key] = redirect_value
+            continue
+
+        if key == "model_endpoint_identity_header_name":
+            header_value, header_error = _validate_identity_header_name(value)
+            if header_error:
+                errors[key] = header_error
+            else:
+                normalized[key] = header_value
             continue
 
         field_value, error, warning = _normalize_field_value(key, value, field)

--- a/application/single_app/admin_settings_fields.py
+++ b/application/single_app/admin_settings_fields.py
@@ -635,7 +635,8 @@ ADMIN_SETTINGS_FIELDS = {
                 "Routes chat through the connections listed below, so several Azure "
                 "OpenAI or Foundry resources can serve models at once. When off, chat "
                 "uses the single classic endpoint instead and these connections are "
-                "not consulted."
+                "not consulted. Switching this on cannot be undone, and carries the "
+                "classic endpoint over as the first connection."
             ),
             "default": False,
         },
@@ -1007,6 +1008,27 @@ def _validate_identity_header_name(value):
     return normalized, None
 
 
+def _validate_multi_model_endpoint_enablement(value, current_settings):
+    """Return ``(normalized, error)`` for the connections capability toggle.
+
+    ``update_settings`` runs this key through ``coerce_multi_model_endpoint_enablement``,
+    which is ``existing or requested`` -- so once connections are on they cannot be turned
+    off. The classic form reflects that by rendering the checkbox only while the flag is
+    off. The V2 surface has no such affordance, so without this an administrator could
+    switch it off, be told the save succeeded, and be shown the toggle in its new position,
+    while chat carried on routing through connections.
+    """
+    requested = _coerce_bool(value)
+    already_on = _coerce_bool(current_settings.get("enable_multi_model_endpoints", False))
+
+    if already_on and not requested:
+        return None, (
+            "Connections cannot be switched off once enabled, because existing chats, "
+            "agents and workflows may already reference a model published from one."
+        )
+    return requested, None
+
+
 def _check_acknowledgements(updates, current_settings, errors):
     """Enforce the acknowledgements a field requires before it may be enabled."""
     for _section_id, field in iter_fields():
@@ -1069,6 +1091,16 @@ def normalize_admin_settings_updates(updates, current_settings=None):
                 errors[key] = header_error
             else:
                 normalized[key] = header_value
+            continue
+
+        if key == "enable_multi_model_endpoints":
+            enablement, enablement_error = _validate_multi_model_endpoint_enablement(
+                value, current
+            )
+            if enablement_error:
+                errors[key] = enablement_error
+            else:
+                normalized[key] = enablement
             continue
 
         field_value, error, warning = _normalize_field_value(key, value, field)

--- a/application/single_app/admin_settings_nav.py
+++ b/application/single_app/admin_settings_nav.py
@@ -97,15 +97,16 @@ ADMIN_NAV = [
         "icon": "bi-cpu",
         "tabs": [
             {
-                # The Chat Model card is reached through the legacy model
-                # settings dialog opened from here, so it is listed with the
-                # endpoints rather than as a tab of its own.
+                # A connection is one Azure OpenAI or Foundry resource. The Chat
+                # Model card configures the classic single-endpoint path, which is
+                # what chat uses when connections are switched off, so it is listed
+                # alongside them.
                 "id": "model-endpoints",
-                "label": "Model Endpoints",
+                "label": "Connections",
                 "icon": "bi-hdd-network",
                 "sections": [
-                    {"id": "multi-endpoint-configuration", "label": "Model Endpoints", "icon": "bi-hdd-network"},
-                    {"id": "gpt-config", "label": "Chat Model", "icon": "bi-chat-square-text"},
+                    {"id": "multi-endpoint-configuration", "label": "Connections", "icon": "bi-hdd-network"},
+                    {"id": "gpt-config", "label": "Chat", "icon": "bi-chat-square-text"},
                 ],
             },
             {

--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -97,7 +97,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.261.059"
+VERSION = "0.261.060"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -97,7 +97,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.261.058"
+VERSION = "0.261.059"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/functions_settings.py
+++ b/application/single_app/functions_settings.py
@@ -2860,13 +2860,18 @@ def normalize_default_model_selection(selection):
     }
 
 
-def resolve_default_model_selection(selection, endpoints, multi_endpoint_enabled=True):
-    """Return a default model selection that still points at an enabled model.
+def resolve_model_selection(selection, endpoints, multi_endpoint_enabled=True, label="Default model"):
+    """Return a stored model selection that still points at an enabled model.
 
-    The stored default is a loose reference -- an endpoint id plus a model id -- so it
+    A stored selection is a loose reference -- an endpoint id plus a model id -- so it
     outlives the thing it names. Deleting an endpoint, disabling one, or turning off a
-    single model all leave a selection that resolves to nothing, and chat would then fall
-    back to a different model with no indication that it had.
+    single model all leave a selection that resolves to nothing.
+
+    What that costs depends on the selection. A dangling default model makes chat fall
+    back to a different model with no indication that it had; a dangling metadata
+    extraction model makes document ingestion raise instead, and the caller logs the
+    failure rather than surfacing it. Neither is acceptable, so both are re-resolved
+    whenever the endpoint list is written.
 
     Returns ``(selection, reason)``. ``reason`` is ``None`` when the selection survived,
     otherwise a short explanation of why it was cleared, which callers with somewhere to
@@ -2894,7 +2899,7 @@ def resolve_default_model_selection(selection, endpoints, multi_endpoint_enabled
     if not endpoint_cfg or not endpoint_cfg.get("enabled", True):
         return (
             dict(EMPTY_DEFAULT_MODEL_SELECTION),
-            "Default model endpoint is not available. Please select a valid endpoint.",
+            f"{label} endpoint is not available. Please select a valid endpoint.",
         )
 
     models = endpoint_cfg.get("models", []) or []
@@ -2909,13 +2914,91 @@ def resolve_default_model_selection(selection, endpoints, multi_endpoint_enabled
     if not model_cfg or not model_cfg.get("enabled", True):
         return (
             dict(EMPTY_DEFAULT_MODEL_SELECTION),
-            "Default model is not available. Please select a valid model.",
+            f"{label} is not available. Please select a valid model.",
         )
 
     endpoint_provider = str(endpoint_cfg.get("provider") or "").strip().lower()
     if endpoint_provider:
         normalized["provider"] = endpoint_provider
     return normalized, None
+
+
+def resolve_default_model_selection(selection, endpoints, multi_endpoint_enabled=True):
+    """Re-resolve the chat default model. See ``resolve_model_selection``."""
+    return resolve_model_selection(
+        selection, endpoints, multi_endpoint_enabled, label="Default model"
+    )
+
+
+def resolve_metadata_extraction_model_selection(selection, endpoints, multi_endpoint_enabled=True):
+    """Re-resolve the metadata extraction model. See ``resolve_model_selection``."""
+    return resolve_model_selection(
+        selection, endpoints, multi_endpoint_enabled, label="Metadata extraction model"
+    )
+
+
+def build_migrated_model_endpoints_from_legacy(settings):
+    """Seed a connection list from the classic single-endpoint chat configuration.
+
+    Turning connections on is one-way: ``coerce_multi_model_endpoint_enablement`` keeps the
+    flag true once set. A deployment that had a working classic endpoint and then enabled
+    connections without carrying it over would be left with an empty model catalog and no
+    way back, so the existing configuration is migrated into the first connection.
+
+    Returns ``[]`` when there is nothing to migrate, which is the case for a deployment
+    that never configured the classic endpoint.
+    """
+    source = settings if isinstance(settings, dict) else {}
+    gpt_model = source.get("gpt_model") or {}
+    selected_models = gpt_model.get("selected") or [] if isinstance(gpt_model, dict) else []
+
+    migrated_models = []
+    for model in selected_models:
+        if not isinstance(model, dict):
+            continue
+        deployment_name = model.get("deploymentName") or model.get("deployment") or ""
+        if not deployment_name:
+            continue
+        migrated_models.append({
+            "id": str(uuid.uuid4()),
+            "deploymentName": deployment_name,
+            "modelName": model.get("modelName") or model.get("name") or "",
+            "displayName": deployment_name,
+            "description": "",
+            "enabled": True,
+        })
+
+    if not migrated_models:
+        return []
+
+    legacy_auth_type = source.get("azure_openai_gpt_authentication_type", "key")
+    migrated_auth_type = "api_key" if legacy_auth_type == "key" else legacy_auth_type
+
+    return [{
+        "id": str(uuid.uuid4()),
+        "name": "Migrated Azure OpenAI Endpoint",
+        "provider": "aoai",
+        "enabled": True,
+        "auth": {
+            "type": migrated_auth_type,
+            "managed_identity_type": "system_assigned",
+            "managed_identity_client_id": "",
+            "tenant_id": "",
+            "client_id": "",
+            "client_secret": "",
+            "api_key": source.get("azure_openai_gpt_key", ""),
+        },
+        "connection": {
+            "endpoint": source.get("azure_openai_gpt_endpoint", ""),
+            "api_version": source.get("azure_openai_gpt_api_version", ""),
+        },
+        "management": {
+            "subscription_id": source.get("azure_openai_gpt_subscription_id", ""),
+            "resource_group": source.get("azure_openai_gpt_resource_group", ""),
+            "location": "",
+        },
+        "models": migrated_models,
+    }]
 
 
 def encrypt_key(key):

--- a/application/single_app/functions_settings.py
+++ b/application/single_app/functions_settings.py
@@ -2846,6 +2846,78 @@ def sanitize_model_endpoints_for_frontend(endpoints):
 
     return sanitized
 
+
+EMPTY_DEFAULT_MODEL_SELECTION = {"endpoint_id": "", "model_id": "", "provider": ""}
+
+
+def normalize_default_model_selection(selection):
+    """Return a default model selection dict with the three expected string fields."""
+    source = selection if isinstance(selection, dict) else {}
+    return {
+        "endpoint_id": str(source.get("endpoint_id") or "").strip(),
+        "model_id": str(source.get("model_id") or "").strip(),
+        "provider": str(source.get("provider") or "").strip().lower(),
+    }
+
+
+def resolve_default_model_selection(selection, endpoints, multi_endpoint_enabled=True):
+    """Return a default model selection that still points at an enabled model.
+
+    The stored default is a loose reference -- an endpoint id plus a model id -- so it
+    outlives the thing it names. Deleting an endpoint, disabling one, or turning off a
+    single model all leave a selection that resolves to nothing, and chat would then fall
+    back to a different model with no indication that it had.
+
+    Returns ``(selection, reason)``. ``reason`` is ``None`` when the selection survived,
+    otherwise a short explanation of why it was cleared, which callers with somewhere to
+    put it surface to the administrator.
+    """
+    normalized = normalize_default_model_selection(selection)
+
+    if not multi_endpoint_enabled:
+        # A stored selection would silently come back into force if multi-endpoint mode
+        # were re-enabled later, naming an endpoint nobody has looked at since.
+        return dict(EMPTY_DEFAULT_MODEL_SELECTION), None
+
+    if not normalized["endpoint_id"] or not normalized["model_id"]:
+        return dict(EMPTY_DEFAULT_MODEL_SELECTION), None
+
+    endpoint_list = endpoints if isinstance(endpoints, list) else []
+    endpoint_cfg = next(
+        (
+            endpoint
+            for endpoint in endpoint_list
+            if isinstance(endpoint, dict) and endpoint.get("id") == normalized["endpoint_id"]
+        ),
+        None,
+    )
+    if not endpoint_cfg or not endpoint_cfg.get("enabled", True):
+        return (
+            dict(EMPTY_DEFAULT_MODEL_SELECTION),
+            "Default model endpoint is not available. Please select a valid endpoint.",
+        )
+
+    models = endpoint_cfg.get("models", []) or []
+    model_cfg = next(
+        (
+            model
+            for model in models
+            if isinstance(model, dict) and model.get("id") == normalized["model_id"]
+        ),
+        None,
+    )
+    if not model_cfg or not model_cfg.get("enabled", True):
+        return (
+            dict(EMPTY_DEFAULT_MODEL_SELECTION),
+            "Default model is not available. Please select a valid model.",
+        )
+
+    endpoint_provider = str(endpoint_cfg.get("provider") or "").strip().lower()
+    if endpoint_provider:
+        normalized["provider"] = endpoint_provider
+    return normalized, None
+
+
 def encrypt_key(key):
     cipher_suite = Fernet(app.config['SECRET_KEY'])
     encrypted_key = cipher_suite.encrypt(key.encode())

--- a/application/single_app/route_backend_v2.py
+++ b/application/single_app/route_backend_v2.py
@@ -70,6 +70,7 @@ from functions_public_workspaces import (
 )
 from functions_settings import (
     WEB_SEARCH_USER_NOTICE_DEFAULT_TEXT,
+    build_migrated_model_endpoints_from_legacy,
     get_settings,
     get_user_settings,
     is_chat_file_upload_enabled_for_user,
@@ -77,6 +78,7 @@ from functions_settings import (
     merge_model_endpoint_payload,
     normalize_model_endpoints,
     resolve_default_model_selection,
+    resolve_metadata_extraction_model_selection,
     sanitize_settings_for_user,
     sanitize_model_endpoints_for_frontend,
     update_settings,
@@ -693,20 +695,72 @@ def _persist_global_model_endpoints(normalized, existing):
 
     settings = get_settings()
     updates = {"model_endpoints": saved_endpoints}
+    multi_endpoint_enabled = bool(settings.get("enable_multi_model_endpoints", False))
 
-    # The default model names an endpoint and a model by id, so deleting or disabling
-    # either leaves it pointing at nothing. Chat would then quietly fall back to a
-    # different model, so the selection is re-resolved against what was actually saved.
+    # Both stored selections name an endpoint and a model by id, so deleting or disabling
+    # either leaves them pointing at nothing. A dangling default makes chat fall back
+    # quietly; a dangling metadata extraction selection makes document ingestion raise,
+    # and its caller only logs that. Neither is acceptable, so both are re-resolved against
+    # what was actually saved.
     resolved_default, _ = resolve_default_model_selection(
         settings.get("default_model_selection"),
         saved_endpoints,
-        multi_endpoint_enabled=bool(settings.get("enable_multi_model_endpoints", False)),
+        multi_endpoint_enabled=multi_endpoint_enabled,
     )
     if resolved_default != settings.get("default_model_selection"):
         updates["default_model_selection"] = resolved_default
 
-    update_settings(updates)
+    resolved_metadata, _ = resolve_metadata_extraction_model_selection(
+        settings.get("metadata_extraction_model_selection"),
+        saved_endpoints,
+        multi_endpoint_enabled=multi_endpoint_enabled,
+    )
+    if resolved_metadata != settings.get("metadata_extraction_model_selection"):
+        updates["metadata_extraction_model_selection"] = resolved_metadata
+
+    # ``update_settings`` swallows its own exceptions and answers False. The Key Vault
+    # passes above have already run and cannot be undone, so reporting success on a failed
+    # write would leave an endpoint referencing a secret that no longer exists.
+    if not update_settings(updates):
+        raise RuntimeError("The settings document could not be updated.")
+
     return saved_endpoints
+
+
+def _seed_connections_on_first_enable(updates, current_settings):
+    """Carry the classic chat endpoint into the connection list when connections go on.
+
+    Enabling connections is one-way. A deployment that already had a working classic
+    endpoint, and enables connections without carrying it over, is left with an empty model
+    catalog and no way to switch back -- so chat stops working outright.
+
+    The classic form has always migrated on this transition. Mirroring it here, through the
+    same shared builder, is what stops the V2 surface from being the one path that strands
+    a deployment.
+    """
+    if not updates.get("enable_multi_model_endpoints"):
+        return
+    if current_settings.get("enable_multi_model_endpoints", False):
+        return
+    if _load_global_model_endpoints(current_settings):
+        return
+
+    migrated = build_migrated_model_endpoints_from_legacy(current_settings)
+    if not migrated:
+        return
+
+    normalized, _ = normalize_model_endpoints(migrated)
+    updates["model_endpoints"] = [
+        keyvault_model_endpoint_save_helper(
+            endpoint, endpoint.get("id"), scope="global", existing_endpoint=None
+        )
+        for endpoint in normalized
+    ]
+    log_event(
+        f"[V2_ADMIN_ENDPOINTS] Migrated the classic chat endpoint into "
+        f"{len(updates['model_endpoints'])} connection(s) on first enable",
+        level=logging.INFO,
+    )
 
 
 def register_route_backend_v2_admin(bp):
@@ -791,6 +845,8 @@ def register_route_backend_v2_admin(bp):
 
             if not normalized:
                 return jsonify({"error": "No settings supplied"}), 400
+
+            _seed_connections_on_first_enable(normalized, current_settings)
 
             update_settings(normalized)
             log_event(

--- a/application/single_app/route_backend_v2.py
+++ b/application/single_app/route_backend_v2.py
@@ -20,6 +20,7 @@ Two blueprints are registered from here:
 """
 
 import logging
+import uuid
 
 from flask import current_app, jsonify, request, session
 
@@ -73,8 +74,17 @@ from functions_settings import (
     get_user_settings,
     is_chat_file_upload_enabled_for_user,
     is_user_workflows_enabled_for_user,
+    merge_model_endpoint_payload,
+    normalize_model_endpoints,
+    resolve_default_model_selection,
     sanitize_settings_for_user,
+    sanitize_model_endpoints_for_frontend,
     update_settings,
+)
+from functions_keyvault import (
+    keyvault_model_endpoint_cleanup_helper,
+    keyvault_model_endpoint_delete_helper,
+    keyvault_model_endpoint_save_helper,
 )
 from functions_source_review import (
     is_source_review_enabled_for_user,
@@ -606,6 +616,99 @@ def register_route_backend_v2(bp):
             return jsonify({"error": "Failed to load application bootstrap"}), 500
 
 
+def _load_global_model_endpoints(settings=None):
+    """Read the stored global model endpoints as a list."""
+    source = settings if isinstance(settings, dict) else get_settings()
+    endpoints = source.get("model_endpoints", [])
+    return endpoints if isinstance(endpoints, list) else []
+
+
+def _find_model_endpoint(endpoints, endpoint_id):
+    """Return the endpoint with the given id, or None."""
+    reference = str(endpoint_id or "")
+    for endpoint in endpoints:
+        if isinstance(endpoint, dict) and str(endpoint.get("id") or "") == reference:
+            return endpoint
+    return None
+
+
+def _model_endpoint_response(saved_endpoints, endpoint_id, status):
+    """Return one saved endpoint, sanitized, as the response to a write."""
+    saved = _find_model_endpoint(saved_endpoints, endpoint_id)
+    sanitized = sanitize_model_endpoints_for_frontend([saved]) if saved else []
+    return jsonify({"endpoint": sanitized[0] if sanitized else {}}), status
+
+
+def _persist_global_model_endpoints(normalized, existing):
+    """Save the global endpoint list, moving Key Vault secrets to match.
+
+    Secrets need three passes because every endpoint can carry them: endpoints being
+    saved write theirs, endpoints whose auth changed have the superseded secret cleaned
+    up, and endpoints that are gone have theirs deleted. Without the last pass a delete
+    would leave an orphaned secret in the vault forever.
+
+    This mirrors what the classic admin form does on submit, so an endpoint saved from
+    either interface ends up stored identically.
+    """
+    existing_by_id = {
+        endpoint.get("id"): endpoint
+        for endpoint in existing
+        if isinstance(endpoint, dict) and endpoint.get("id")
+    }
+
+    saved_endpoints = [
+        keyvault_model_endpoint_save_helper(
+            endpoint,
+            endpoint.get("id"),
+            scope="global",
+            existing_endpoint=existing_by_id.get(endpoint.get("id")),
+        )
+        for endpoint in normalized
+    ]
+
+    for endpoint in saved_endpoints:
+        if not isinstance(endpoint, dict):
+            continue
+        endpoint_id = endpoint.get("id")
+        if not endpoint_id:
+            continue
+        keyvault_model_endpoint_cleanup_helper(
+            existing_by_id.get(endpoint_id),
+            endpoint,
+            endpoint_id,
+            scope="global",
+        )
+
+    saved_endpoint_ids = {
+        endpoint.get("id")
+        for endpoint in saved_endpoints
+        if isinstance(endpoint, dict) and endpoint.get("id")
+    }
+    for endpoint in existing:
+        if not isinstance(endpoint, dict):
+            continue
+        endpoint_id = endpoint.get("id")
+        if endpoint_id and endpoint_id not in saved_endpoint_ids:
+            keyvault_model_endpoint_delete_helper(endpoint, endpoint_id, scope="global")
+
+    settings = get_settings()
+    updates = {"model_endpoints": saved_endpoints}
+
+    # The default model names an endpoint and a model by id, so deleting or disabling
+    # either leaves it pointing at nothing. Chat would then quietly fall back to a
+    # different model, so the selection is re-resolved against what was actually saved.
+    resolved_default, _ = resolve_default_model_selection(
+        settings.get("default_model_selection"),
+        saved_endpoints,
+        multi_endpoint_enabled=bool(settings.get("enable_multi_model_endpoints", False)),
+    )
+    if resolved_default != settings.get("default_model_selection"):
+        updates["default_model_selection"] = resolved_default
+
+    update_settings(updates)
+    return saved_endpoints
+
+
 def register_route_backend_v2_admin(bp):
     @bp.route("/api/v2/admin/settings", methods=["GET"])
     @swagger_route(security=get_auth_security())
@@ -817,3 +920,193 @@ def register_route_backend_v2_admin(bp):
                 exceptionTraceback=True,
             )
             return jsonify({"error": "Failed to store the uploaded image"}), 500
+
+    # ---------------------------------------------------------------------
+    # Global model endpoints
+    # ---------------------------------------------------------------------
+    #
+    # Personal and group scopes have had per-endpoint REST routes for a while; global
+    # scope never did. It was written through a hidden ``model_endpoints_json`` field on
+    # the classic admin form, which means adding or editing an endpoint there stores
+    # nothing until the whole settings page is submitted. These routes give global scope
+    # the same per-resource handling the other two scopes already have, so a save is a
+    # save.
+    #
+    # Secrets never travel outward: responses go through
+    # ``sanitize_model_endpoints_for_frontend``, which strips ``auth.api_key`` and
+    # ``auth.client_secret`` and leaves ``has_api_key`` / ``has_client_secret`` behind. An
+    # omitted secret on the way back in therefore means "keep what is stored" rather than
+    # "clear it", which is what ``merge_model_endpoint_payload`` implements.
+
+    @bp.route("/api/v2/admin/model-endpoints", methods=["GET"])
+    @swagger_route(security=get_auth_security())
+    @login_required
+    @admin_required
+    def v2_admin_list_model_endpoints():
+        """Return every global model endpoint, with secrets stripped."""
+        try:
+            endpoints = _load_global_model_endpoints()
+            return (
+                jsonify(
+                    {
+                        "endpoints": sanitize_model_endpoints_for_frontend(endpoints),
+                        "multi_endpoint_enabled": bool(
+                            get_settings().get("enable_multi_model_endpoints", False)
+                        ),
+                    }
+                ),
+                200,
+            )
+        except Exception as exc:
+            log_event(
+                f"[V2_ADMIN_ENDPOINTS] Failed to list model endpoints: {exc}",
+                level=logging.ERROR,
+                exceptionTraceback=True,
+            )
+            return jsonify({"error": "Failed to load model endpoints"}), 500
+
+    @bp.route("/api/v2/admin/model-endpoints", methods=["POST"])
+    @swagger_route(security=get_auth_security())
+    @login_required
+    @admin_required
+    def v2_admin_create_model_endpoint():
+        """Add one global model endpoint."""
+        payload = request.get_json(silent=True)
+        if not isinstance(payload, dict) or not payload:
+            return jsonify({"error": "Model endpoint payload must be an object."}), 400
+
+        try:
+            existing = _load_global_model_endpoints()
+            candidate = dict(payload)
+
+            endpoint_id = str(candidate.get("id") or "").strip()
+            if not endpoint_id:
+                endpoint_id = str(uuid.uuid4())
+            elif _find_model_endpoint(existing, endpoint_id):
+                return (
+                    jsonify({"error": "A model endpoint with that id already exists."}),
+                    409,
+                )
+            candidate["id"] = endpoint_id
+
+            normalized, _ = normalize_model_endpoints(list(existing) + [candidate])
+            saved = _persist_global_model_endpoints(normalized, existing)
+            log_event(
+                f"[V2_ADMIN_ENDPOINTS] Created model endpoint {endpoint_id}",
+                level=logging.INFO,
+            )
+            return _model_endpoint_response(saved, endpoint_id, 201)
+        except Exception as exc:
+            log_event(
+                f"[V2_ADMIN_ENDPOINTS] Failed to create model endpoint: {exc}",
+                level=logging.ERROR,
+                exceptionTraceback=True,
+            )
+            return jsonify({"error": "Failed to create the model endpoint"}), 500
+
+    @bp.route("/api/v2/admin/model-endpoints/<endpoint_id>", methods=["GET"])
+    @swagger_route(security=get_auth_security())
+    @login_required
+    @admin_required
+    def v2_admin_get_model_endpoint(endpoint_id):
+        """Return one global model endpoint, with its secrets stripped."""
+        try:
+            endpoint = _find_model_endpoint(_load_global_model_endpoints(), endpoint_id)
+            if not endpoint:
+                return jsonify({"error": "Model endpoint not found."}), 404
+
+            sanitized = sanitize_model_endpoints_for_frontend([endpoint])
+            return jsonify({"endpoint": sanitized[0] if sanitized else {}}), 200
+        except Exception as exc:
+            log_event(
+                f"[V2_ADMIN_ENDPOINTS] Failed to read model endpoint: {exc}",
+                level=logging.ERROR,
+                exceptionTraceback=True,
+            )
+            return jsonify({"error": "Failed to load the model endpoint"}), 500
+
+    @bp.route("/api/v2/admin/model-endpoints/<endpoint_id>", methods=["PATCH"])
+    @swagger_route(security=get_auth_security())
+    @login_required
+    @admin_required
+    def v2_admin_update_model_endpoint(endpoint_id):
+        """Apply a partial update to one global model endpoint.
+
+        The stored endpoint is merged with the supplied keys server-side. A client only
+        ever holds a copy with the secrets stripped out, so sending that copy back must
+        not blank them -- and because the merge skips empty values, it does not.
+        """
+        updates = request.get_json(silent=True)
+        if not isinstance(updates, dict):
+            return jsonify({"error": "Model endpoint payload must be an object."}), 400
+
+        try:
+            existing = _load_global_model_endpoints()
+            current = _find_model_endpoint(existing, endpoint_id)
+            if not current:
+                return jsonify({"error": "Model endpoint not found."}), 404
+
+            merged = merge_model_endpoint_payload(
+                current, {**updates, "id": current.get("id")}
+            )
+            replaced = [
+                merged
+                if isinstance(endpoint, dict)
+                and str(endpoint.get("id") or "") == str(endpoint_id)
+                else endpoint
+                for endpoint in existing
+            ]
+
+            normalized, _ = normalize_model_endpoints(replaced)
+            saved = _persist_global_model_endpoints(normalized, existing)
+            log_event(
+                f"[V2_ADMIN_ENDPOINTS] Updated model endpoint {endpoint_id}",
+                level=logging.INFO,
+            )
+            return _model_endpoint_response(saved, current.get("id"), 200)
+        except Exception as exc:
+            log_event(
+                f"[V2_ADMIN_ENDPOINTS] Failed to update model endpoint: {exc}",
+                level=logging.ERROR,
+                exceptionTraceback=True,
+            )
+            return jsonify({"error": "Failed to update the model endpoint"}), 500
+
+    @bp.route("/api/v2/admin/model-endpoints/<endpoint_id>", methods=["DELETE"])
+    @swagger_route(security=get_auth_security())
+    @login_required
+    @admin_required
+    def v2_admin_delete_model_endpoint(endpoint_id):
+        """Remove one global model endpoint and the secrets it owned.
+
+        The stored list is read server-side rather than taken from the request, so a
+        stale copy in one browser tab cannot drop endpoints it never knew about.
+        """
+        try:
+            existing = _load_global_model_endpoints()
+            if not _find_model_endpoint(existing, endpoint_id):
+                return jsonify({"error": "Model endpoint not found."}), 404
+
+            remaining = [
+                endpoint
+                for endpoint in existing
+                if not (
+                    isinstance(endpoint, dict)
+                    and str(endpoint.get("id") or "") == str(endpoint_id)
+                )
+            ]
+
+            normalized, _ = normalize_model_endpoints(remaining)
+            _persist_global_model_endpoints(normalized, existing)
+            log_event(
+                f"[V2_ADMIN_ENDPOINTS] Deleted model endpoint {endpoint_id}",
+                level=logging.INFO,
+            )
+            return jsonify({"success": True}), 200
+        except Exception as exc:
+            log_event(
+                f"[V2_ADMIN_ENDPOINTS] Failed to delete model endpoint: {exc}",
+                level=logging.ERROR,
+                exceptionTraceback=True,
+            )
+            return jsonify({"error": "Failed to delete the model endpoint"}), 500

--- a/application/single_app/route_frontend_admin_settings.py
+++ b/application/single_app/route_frontend_admin_settings.py
@@ -1618,50 +1618,8 @@ def register_route_frontend_admin_settings(bp):
             migrated_at = settings.get('multi_endpoint_migrated_at')
 
             if should_migrate_endpoints and not parsed_model_endpoints:
-                default_endpoint_id = str(uuid.uuid4())
-                migrated_models = []
-                for model in gpt_model_obj.get('selected', []):
-                    deployment_name = model.get('deploymentName') or model.get('deployment') or ''
-                    model_name = model.get('modelName') or model.get('name') or ''
-                    if not deployment_name:
-                        continue
-                    migrated_models.append({
-                        'id': str(uuid.uuid4()),
-                        'deploymentName': deployment_name,
-                        'modelName': model_name,
-                        'displayName': deployment_name,
-                        'description': '',
-                        'enabled': True
-                    })
-
-                legacy_auth_type = settings.get('azure_openai_gpt_authentication_type', 'key')
-                migrated_auth_type = 'api_key' if legacy_auth_type == 'key' else legacy_auth_type
-
-                parsed_model_endpoints = [{
-                    'id': default_endpoint_id,
-                    'name': 'Migrated Azure OpenAI Endpoint',
-                    'provider': 'aoai',
-                    'enabled': True,
-                    'auth': {
-                        'type': migrated_auth_type,
-                        'managed_identity_type': 'system_assigned',
-                        'managed_identity_client_id': '',
-                        'tenant_id': '',
-                        'client_id': '',
-                        'client_secret': '',
-                        'api_key': settings.get('azure_openai_gpt_key', '')
-                    },
-                    'connection': {
-                        'endpoint': settings.get('azure_openai_gpt_endpoint', ''),
-                        'api_version': settings.get('azure_openai_gpt_api_version', '')
-                    },
-                    'management': {
-                        'subscription_id': settings.get('azure_openai_gpt_subscription_id', ''),
-                        'resource_group': settings.get('azure_openai_gpt_resource_group', ''),
-                        'location': ''
-                    },
-                    'models': migrated_models
-                }]
+                parsed_model_endpoints = build_migrated_model_endpoints_from_legacy(settings)
+                migrated_models = parsed_model_endpoints[0]['models'] if parsed_model_endpoints else []
                 debug_print(f"Migrated {len(migrated_models)} models to new multi-endpoint configuration.")
                 debug_print(
                     f"Migrated Model Endpoints: {json.dumps([redact_model_endpoint_secret_values(endpoint) for endpoint in parsed_model_endpoints], indent=2)}"

--- a/application/single_app/route_frontend_admin_settings.py
+++ b/application/single_app/route_frontend_admin_settings.py
@@ -1740,53 +1740,15 @@ def register_route_frontend_admin_settings(bp):
                 flash(f"Error processing default model selection: {e}. Changes not saved.", 'danger')
                 parsed_default_model_selection = settings.get('default_model_selection', {})
 
-            normalized_default_model_selection = {
-                'endpoint_id': str(parsed_default_model_selection.get('endpoint_id') or '').strip(),
-                'model_id': str(parsed_default_model_selection.get('model_id') or '').strip(),
-                'provider': str(parsed_default_model_selection.get('provider') or '').strip().lower()
-            }
-
-            if not enable_multi_model_endpoints:
-                normalized_default_model_selection = {
-                    'endpoint_id': '',
-                    'model_id': '',
-                    'provider': ''
-                }
-            elif normalized_default_model_selection['endpoint_id'] and normalized_default_model_selection['model_id']:
-                endpoint_cfg = next(
-                    (e for e in parsed_model_endpoints if e.get('id') == normalized_default_model_selection['endpoint_id']),
-                    None
+            normalized_default_model_selection, default_selection_warning = (
+                resolve_default_model_selection(
+                    parsed_default_model_selection,
+                    parsed_model_endpoints,
+                    multi_endpoint_enabled=enable_multi_model_endpoints,
                 )
-                if not endpoint_cfg or not endpoint_cfg.get('enabled', True):
-                    flash('Default model endpoint is not available. Please select a valid endpoint.', 'warning')
-                    normalized_default_model_selection = {
-                        'endpoint_id': '',
-                        'model_id': '',
-                        'provider': ''
-                    }
-                else:
-                    models = endpoint_cfg.get('models', []) or []
-                    model_cfg = next(
-                        (m for m in models if m.get('id') == normalized_default_model_selection['model_id']),
-                        None
-                    )
-                    if not model_cfg or not model_cfg.get('enabled', True):
-                        flash('Default model is not available. Please select a valid model.', 'warning')
-                        normalized_default_model_selection = {
-                            'endpoint_id': '',
-                            'model_id': '',
-                            'provider': ''
-                        }
-                    else:
-                        endpoint_provider = (endpoint_cfg.get('provider') or '').strip().lower()
-                        if endpoint_provider:
-                            normalized_default_model_selection['provider'] = endpoint_provider
-            else:
-                normalized_default_model_selection = {
-                    'endpoint_id': '',
-                    'model_id': '',
-                    'provider': ''
-                }
+            )
+            if default_selection_warning:
+                flash(default_selection_warning, 'warning')
 
             metadata_selection_json = form_data.get('metadata_extraction_model_selection_json', '{}')
             parsed_metadata_model_selection = {}

--- a/application/v2_ui/src/components/admin/ModelConnectionsManager.tsx
+++ b/application/v2_ui/src/components/admin/ModelConnectionsManager.tsx
@@ -1,0 +1,1171 @@
+// ModelConnectionsManager.tsx
+// Lists global model connections and edits one at a time.
+//
+// This talks to /api/v2/admin/model-endpoints directly rather than going through the
+// settings PATCH, for the same reason CustomPagesTable does: a connection is its own
+// resource with its own Key Vault handling, not a value in the settings blob.
+//
+// The behaviour that motivated the rewrite: in the classic interface, adding or editing a
+// connection changed an in-memory array that was serialized into a hidden form field, so
+// nothing was stored until the whole admin page was submitted -- and a half-filled
+// connection looked identical to a saved one. Here each connection saves on its own, and
+// the editor says which state it is in.
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { clsx } from 'clsx';
+import {
+    AlertCircle,
+    Check,
+    Loader2,
+    Pencil,
+    Plus,
+    Power,
+    RefreshCw,
+    Search,
+    Server,
+    Trash2,
+    Zap,
+} from 'lucide-react';
+import { ApiError } from '../../lib/apiClient';
+import {
+    AUTH_TYPE_OPTIONS,
+    IDENTITY_HEADER_MODE_OPTIONS,
+    IDENTITY_VALUE_TYPE_OPTIONS,
+    MANAGEMENT_CLOUD_OPTIONS,
+    PROVIDER_OPTIONS,
+    authTypeLabel,
+    buildConnectionPayload,
+    createModelConnection,
+    deleteModelConnection,
+    defaultOpenAiApiVersion,
+    discoverModels,
+    emptyConnection,
+    enabledModelCount,
+    fetchModelConnections,
+    isFoundryProvider,
+    mergeDiscoveredModels,
+    projectNameFromEndpoint,
+    providerLabel,
+    testConnection,
+    testConnectionModel,
+    toEditableConnection,
+    updateModelConnection,
+    validateConnection,
+    visibleFields,
+    type ConnectionModel,
+    type ModelConnection,
+} from '../../lib/modelConnections';
+import { AdminModal } from './AdminModal';
+import { GlassButton } from '../ui/primitives';
+import { toast } from '../../stores/toastStore';
+
+const inputClass = clsx(
+    'w-full rounded-lg border border-edge bg-surface-1 px-3 py-2',
+    'text-sm text-text-1 placeholder:text-text-3',
+    'focus:border-accent focus:outline-none',
+    'disabled:cursor-not-allowed disabled:opacity-60',
+);
+
+function errorMessage(error: unknown, fallback: string): string {
+    if (error instanceof ApiError || error instanceof Error) {
+        return error.message || fallback;
+    }
+    return fallback;
+}
+
+/** One labelled control in the editor, with its own validation message. */
+function Field({
+    label,
+    help,
+    error,
+    htmlFor,
+    children,
+}: {
+    label: string;
+    help?: string;
+    error?: string;
+    htmlFor?: string;
+    children: React.ReactNode;
+}) {
+    return (
+        <div className="py-2">
+            <label htmlFor={htmlFor} className="mb-1.5 block text-sm font-medium text-text-1">
+                {label}
+            </label>
+            {children}
+            {help ? <p className="mt-1.5 text-xs leading-relaxed text-text-3">{help}</p> : null}
+            {error ? (
+                <p role="alert" className="mt-1.5 flex items-start gap-1.5 text-xs text-danger">
+                    <AlertCircle size={13} className="mt-0.5 shrink-0" />
+                    {error}
+                </p>
+            ) : null}
+        </div>
+    );
+}
+
+function SectionHeading({ children, hint }: { children: React.ReactNode; hint?: string }) {
+    return (
+        <div className="mt-5 mb-1 border-t border-edge pt-4 first:mt-0 first:border-t-0 first:pt-0">
+            <h3 className="text-xs font-semibold tracking-wide text-text-2 uppercase">{children}</h3>
+            {hint ? <p className="mt-1 text-xs text-text-3">{hint}</p> : null}
+        </div>
+    );
+}
+
+function Pill({ tone, children }: { tone: 'ok' | 'muted' | 'warn'; children: React.ReactNode }) {
+    return (
+        <span
+            className={clsx(
+                'rounded-full px-1.5 py-0.5 text-[10px] font-semibold tracking-wide uppercase',
+                tone === 'ok' && 'bg-ok-soft text-ok',
+                tone === 'warn' && 'bg-warn-soft text-warn',
+                tone === 'muted' && 'bg-surface-2 text-text-3',
+            )}
+        >
+            {children}
+        </span>
+    );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Editor                                                                      */
+/* -------------------------------------------------------------------------- */
+
+function ConnectionEditor({
+    initial,
+    onClose,
+    onSaved,
+}: {
+    initial: ModelConnection;
+    onClose: () => void;
+    onSaved: (saved: ModelConnection, created: boolean) => void;
+}) {
+    const [draft, setDraft] = useState<ModelConnection>(() => toEditableConnection(initial));
+    const [errors, setErrors] = useState<Record<string, string>>({});
+    const [saving, setSaving] = useState(false);
+    const [discovering, setDiscovering] = useState(false);
+    const [testing, setTesting] = useState(false);
+    const [testingModelId, setTestingModelId] = useState<string | null>(null);
+    const [formError, setFormError] = useState<string | null>(null);
+
+    const isNew = !initial.id;
+    const foundry = isFoundryProvider(draft.provider);
+    const authType = String(draft.auth?.type ?? 'managed_identity');
+
+    const shown = useMemo(() => visibleFields(draft), [draft]);
+
+    const setField = useCallback((path: string, value: unknown) => {
+        setErrors((current) => {
+            if (!(path in current)) {
+                return current;
+            }
+            const next = { ...current };
+            delete next[path];
+            return next;
+        });
+        setDraft((current) => {
+            const next = { ...current };
+            if (path === 'name' || path === 'provider' || path === 'enabled') {
+                (next as Record<string, unknown>)[path] = value;
+                // Switching provider changes which API version default applies, and the
+                // previous provider's default would otherwise be silently carried over.
+                if (path === 'provider') {
+                    next.connection = {
+                        ...next.connection,
+                        openai_api_version: defaultOpenAiApiVersion(value),
+                    };
+                }
+                return next;
+            }
+            const [group, key] = path.split('.');
+            (next as Record<string, Record<string, unknown>>)[group] = {
+                ...((current as Record<string, Record<string, unknown>>)[group] ?? {}),
+                [key]: value,
+            };
+            return next;
+        });
+    }, []);
+
+    const setModels = useCallback((models: ConnectionModel[]) => {
+        setDraft((current) => ({ ...current, models }));
+    }, []);
+
+    const runDiscovery = async () => {
+        const validation = validateConnection(draft);
+        // Discovery needs the connection and credentials, but not the model list, so a
+        // missing name should not stop it.
+        delete validation.name;
+        if (Object.keys(validation).length) {
+            setErrors(validation);
+            setFormError('Fill in the connection and authentication details first.');
+            return;
+        }
+
+        setDiscovering(true);
+        setFormError(null);
+        try {
+            const response = await discoverModels(buildConnectionPayload(draft));
+            const discovered = Array.isArray(response.models) ? response.models : [];
+            const { models, added } = mergeDiscoveredModels(draft.models ?? [], discovered);
+            setModels(models);
+            toast.success(
+                added
+                    ? `Found ${discovered.length} deployment${discovered.length === 1 ? '' : 's'}, added ${added} new.`
+                    : `Found ${discovered.length} deployment${discovered.length === 1 ? '' : 's'}; none were new.`,
+            );
+        } catch (error) {
+            setFormError(errorMessage(error, 'Could not read the deployments for this connection.'));
+        } finally {
+            setDiscovering(false);
+        }
+    };
+
+    const runConnectionTest = async () => {
+        const validation = validateConnection(draft);
+        delete validation.name;
+        if (Object.keys(validation).length) {
+            setErrors(validation);
+            setFormError('Fill in the connection and authentication details first.');
+            return;
+        }
+
+        setTesting(true);
+        setFormError(null);
+        try {
+            const response = await testConnection(buildConnectionPayload(draft));
+            toast.success(
+                typeof response.count === 'number'
+                    ? `Connected. ${response.count} chat deployment${response.count === 1 ? '' : 's'} visible.`
+                    : 'Connected.',
+            );
+        } catch (error) {
+            setFormError(errorMessage(error, 'The connection could not be reached.'));
+        } finally {
+            setTesting(false);
+        }
+    };
+
+    const runModelTest = async (model: ConnectionModel) => {
+        const deploymentName = String(model.deploymentName ?? '').trim();
+        if (!deploymentName) {
+            setFormError('Give the model a deployment name before testing it.');
+            return;
+        }
+        setTestingModelId(String(model.id ?? deploymentName));
+        setFormError(null);
+        try {
+            await testConnectionModel(buildConnectionPayload(draft), deploymentName);
+            toast.success(`${deploymentName} answered.`);
+        } catch (error) {
+            setFormError(errorMessage(error, `${deploymentName} did not answer.`));
+        } finally {
+            setTestingModelId(null);
+        }
+    };
+
+    const save = async () => {
+        const validation = validateConnection(draft);
+        if (Object.keys(validation).length) {
+            setErrors(validation);
+            setFormError('Some details still need attention.');
+            return;
+        }
+
+        setSaving(true);
+        setFormError(null);
+        try {
+            const payload = buildConnectionPayload(draft);
+            const response = initial.id
+                ? await updateModelConnection(initial.id, payload)
+                : await createModelConnection(payload);
+            onSaved(response.endpoint ?? {}, !initial.id);
+        } catch (error) {
+            setFormError(errorMessage(error, 'The connection could not be saved.'));
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    const busy = saving || discovering || testing || testingModelId !== null;
+    const models = draft.models ?? [];
+    const projectHint = foundry ? projectNameFromEndpoint(draft.connection?.endpoint) : '';
+
+    return (
+        <AdminModal
+            title={isNew ? 'Add a connection' : `Edit ${initial.name || 'connection'}`}
+            description={
+                isNew
+                    ? 'Nothing is stored until you choose Save.'
+                    : 'Changes are stored when you choose Save.'
+            }
+            size="lg"
+            onClose={onClose}
+            footer={
+                <>
+                    <GlassButton type="button" variant="ghost" size="sm" onClick={onClose} disabled={saving}>
+                        Cancel
+                    </GlassButton>
+                    <GlassButton
+                        type="button"
+                        variant="primary"
+                        size="sm"
+                        onClick={() => void save()}
+                        disabled={busy}
+                    >
+                        {saving ? <Loader2 size={14} className="animate-spin" /> : <Check size={14} />}
+                        {isNew ? 'Create connection' : 'Save changes'}
+                    </GlassButton>
+                </>
+            }
+        >
+            {formError ? (
+                <p
+                    role="alert"
+                    className="mb-3 flex items-start gap-2 rounded-lg border border-edge bg-danger-soft p-3 text-sm text-danger"
+                >
+                    <AlertCircle size={15} className="mt-0.5 shrink-0" />
+                    {formError}
+                </p>
+            ) : null}
+
+            <SectionHeading>Identity</SectionHeading>
+
+            <Field label="Name" error={errors.name} htmlFor="connection-name" help="Shown wherever a model from this connection is offered.">
+                <input
+                    id="connection-name"
+                    type="text"
+                    className={inputClass}
+                    value={String(draft.name ?? '')}
+                    disabled={busy}
+                    onChange={(event) => setField('name', event.target.value)}
+                />
+            </Field>
+
+            <Field
+                label="Provider"
+                htmlFor="connection-provider"
+                help={PROVIDER_OPTIONS.find((option) => option.value === draft.provider)?.hint}
+            >
+                <select
+                    id="connection-provider"
+                    className={inputClass}
+                    value={String(draft.provider ?? 'aoai')}
+                    disabled={busy}
+                    onChange={(event) => setField('provider', event.target.value)}
+                >
+                    {PROVIDER_OPTIONS.map((option) => (
+                        <option key={option.value} value={option.value}>
+                            {option.label}
+                        </option>
+                    ))}
+                </select>
+            </Field>
+
+            <SectionHeading>Connection</SectionHeading>
+
+            <Field
+                label={foundry ? 'Project endpoint' : 'Endpoint URL'}
+                error={errors.endpoint}
+                htmlFor="connection-endpoint"
+                help={
+                    foundry
+                        ? 'A Foundry project URL. Including /api/projects/<name> names the project for you.'
+                        : 'The resource endpoint, for example https://my-resource.openai.azure.com.'
+                }
+            >
+                <input
+                    id="connection-endpoint"
+                    type="url"
+                    className={inputClass}
+                    placeholder={foundry ? 'https://…/api/projects/my-project' : 'https://my-resource.openai.azure.com'}
+                    value={String(draft.connection?.endpoint ?? '')}
+                    disabled={busy}
+                    spellCheck={false}
+                    onChange={(event) => setField('connection.endpoint', event.target.value)}
+                />
+            </Field>
+
+            <Field
+                label="OpenAI API version"
+                error={errors.openai_api_version}
+                htmlFor="connection-openai-version"
+            >
+                <input
+                    id="connection-openai-version"
+                    type="text"
+                    className={inputClass}
+                    value={String(draft.connection?.openai_api_version ?? '')}
+                    disabled={busy}
+                    spellCheck={false}
+                    onChange={(event) => setField('connection.openai_api_version', event.target.value)}
+                />
+            </Field>
+
+            {shown.project ? (
+                <>
+                    <Field
+                        label="Project API version"
+                        error={errors.project_api_version}
+                        htmlFor="connection-project-version"
+                    >
+                        <input
+                            id="connection-project-version"
+                            type="text"
+                            className={inputClass}
+                            value={String(draft.connection?.project_api_version ?? '')}
+                            disabled={busy}
+                            spellCheck={false}
+                            onChange={(event) =>
+                                setField('connection.project_api_version', event.target.value)
+                            }
+                        />
+                    </Field>
+
+                    <Field
+                        label="Project name"
+                        error={errors.project_name}
+                        htmlFor="connection-project-name"
+                        help={
+                            projectHint
+                                ? `Taken from the endpoint URL: ${projectHint}`
+                                : 'Only needed when the endpoint URL does not include /api/projects/.'
+                        }
+                    >
+                        <input
+                            id="connection-project-name"
+                            type="text"
+                            className={inputClass}
+                            value={String(draft.connection?.project_name ?? '')}
+                            placeholder={projectHint}
+                            disabled={busy}
+                            onChange={(event) => setField('connection.project_name', event.target.value)}
+                        />
+                    </Field>
+                </>
+            ) : null}
+
+            <SectionHeading
+                hint={AUTH_TYPE_OPTIONS.find((option) => option.value === authType)?.hint}
+            >
+                Authentication
+            </SectionHeading>
+
+            <Field label="Method" htmlFor="connection-auth-type">
+                <select
+                    id="connection-auth-type"
+                    className={inputClass}
+                    value={authType}
+                    disabled={busy}
+                    onChange={(event) => setField('auth.type', event.target.value)}
+                >
+                    {AUTH_TYPE_OPTIONS.map((option) => (
+                        <option key={option.value} value={option.value}>
+                            {option.label}
+                        </option>
+                    ))}
+                </select>
+            </Field>
+
+            {shown.managedIdentity ? (
+                <>
+                    <Field label="Identity" htmlFor="connection-mi-type">
+                        <select
+                            id="connection-mi-type"
+                            className={inputClass}
+                            value={String(draft.auth?.managed_identity_type ?? 'system_assigned')}
+                            disabled={busy}
+                            onChange={(event) => setField('auth.managed_identity_type', event.target.value)}
+                        >
+                            <option value="system_assigned">System assigned</option>
+                            <option value="user_assigned">User assigned</option>
+                        </select>
+                    </Field>
+
+                    {shown.userAssignedClientId ? (
+                        <Field label="Managed identity client id" htmlFor="connection-mi-client-id">
+                            <input
+                                id="connection-mi-client-id"
+                                type="text"
+                                className={inputClass}
+                                value={String(draft.auth?.managed_identity_client_id ?? '')}
+                                disabled={busy}
+                                spellCheck={false}
+                                onChange={(event) =>
+                                    setField('auth.managed_identity_client_id', event.target.value)
+                                }
+                            />
+                        </Field>
+                    ) : null}
+                </>
+            ) : null}
+
+            {shown.servicePrincipal ? (
+                <>
+                    <Field label="Tenant id" error={errors.tenant_id} htmlFor="connection-tenant-id">
+                        <input
+                            id="connection-tenant-id"
+                            type="text"
+                            className={inputClass}
+                            value={String(draft.auth?.tenant_id ?? '')}
+                            disabled={busy}
+                            spellCheck={false}
+                            onChange={(event) => setField('auth.tenant_id', event.target.value)}
+                        />
+                    </Field>
+                    <Field label="Client id" error={errors.client_id} htmlFor="connection-client-id">
+                        <input
+                            id="connection-client-id"
+                            type="text"
+                            className={inputClass}
+                            value={String(draft.auth?.client_id ?? '')}
+                            disabled={busy}
+                            spellCheck={false}
+                            onChange={(event) => setField('auth.client_id', event.target.value)}
+                        />
+                    </Field>
+                    <Field
+                        label="Client secret"
+                        error={errors.client_secret}
+                        htmlFor="connection-client-secret"
+                        help={
+                            draft.has_client_secret
+                                ? 'A secret is stored. Leave this blank to keep it, or type a new one to replace it.'
+                                : 'Stored in Key Vault when Key Vault is configured.'
+                        }
+                    >
+                        <input
+                            id="connection-client-secret"
+                            type="password"
+                            autoComplete="new-password"
+                            className={inputClass}
+                            placeholder={draft.has_client_secret ? '••••••••  (stored)' : ''}
+                            value={String(draft.auth?.client_secret ?? '')}
+                            disabled={busy}
+                            onChange={(event) => setField('auth.client_secret', event.target.value)}
+                        />
+                    </Field>
+                </>
+            ) : null}
+
+            {shown.apiKey ? (
+                <Field
+                    label="API key"
+                    error={errors.api_key}
+                    htmlFor="connection-api-key"
+                    help={
+                        draft.has_api_key
+                            ? 'A key is stored. Leave this blank to keep it, or type a new one to replace it.'
+                            : 'Stored in Key Vault when Key Vault is configured.'
+                    }
+                >
+                    <input
+                        id="connection-api-key"
+                        type="password"
+                        autoComplete="new-password"
+                        className={inputClass}
+                        placeholder={draft.has_api_key ? '••••••••  (stored)' : ''}
+                        value={String(draft.auth?.api_key ?? '')}
+                        disabled={busy}
+                        onChange={(event) => setField('auth.api_key', event.target.value)}
+                    />
+                </Field>
+            ) : null}
+
+            {shown.managementCloud ? (
+                <Field label="Management cloud" htmlFor="connection-cloud">
+                    <select
+                        id="connection-cloud"
+                        className={inputClass}
+                        value={String(draft.auth?.management_cloud ?? 'public')}
+                        disabled={busy}
+                        onChange={(event) => setField('auth.management_cloud', event.target.value)}
+                    >
+                        {MANAGEMENT_CLOUD_OPTIONS.map((option) => (
+                            <option key={option.value} value={option.value}>
+                                {option.label}
+                            </option>
+                        ))}
+                    </select>
+                </Field>
+            ) : null}
+
+            {shown.customAuthority ? (
+                <Field
+                    label="Custom authority"
+                    error={errors.custom_authority}
+                    htmlFor="connection-authority"
+                >
+                    <input
+                        id="connection-authority"
+                        type="text"
+                        className={inputClass}
+                        value={String(draft.auth?.custom_authority ?? '')}
+                        disabled={busy}
+                        spellCheck={false}
+                        onChange={(event) => setField('auth.custom_authority', event.target.value)}
+                    />
+                </Field>
+            ) : null}
+
+            {shown.foundryScope ? (
+                <Field
+                    label="Foundry scope"
+                    error={errors.foundry_scope}
+                    htmlFor="connection-foundry-scope"
+                    help="The token audience used when calling the project. Required only for a custom cloud."
+                >
+                    <input
+                        id="connection-foundry-scope"
+                        type="text"
+                        className={inputClass}
+                        value={String(draft.auth?.foundry_scope ?? '')}
+                        disabled={busy}
+                        spellCheck={false}
+                        onChange={(event) => setField('auth.foundry_scope', event.target.value)}
+                    />
+                </Field>
+            ) : null}
+
+            {shown.management ? (
+                <>
+                    <SectionHeading hint="Model discovery reads deployments through Azure Resource Manager, which needs the resource coordinates.">
+                        Discovery
+                    </SectionHeading>
+                    <Field
+                        label="Subscription id"
+                        error={errors.subscription_id}
+                        htmlFor="connection-subscription"
+                    >
+                        <input
+                            id="connection-subscription"
+                            type="text"
+                            className={inputClass}
+                            value={String(draft.management?.subscription_id ?? '')}
+                            disabled={busy}
+                            spellCheck={false}
+                            onChange={(event) => setField('management.subscription_id', event.target.value)}
+                        />
+                    </Field>
+                    <Field
+                        label="Resource group"
+                        error={errors.resource_group}
+                        htmlFor="connection-resource-group"
+                    >
+                        <input
+                            id="connection-resource-group"
+                            type="text"
+                            className={inputClass}
+                            value={String(draft.management?.resource_group ?? '')}
+                            disabled={busy}
+                            spellCheck={false}
+                            onChange={(event) => setField('management.resource_group', event.target.value)}
+                        />
+                    </Field>
+                </>
+            ) : null}
+
+            <SectionHeading
+                hint={
+                    shown.apiKey
+                        ? 'Discovery needs Azure credentials, so with an API key the models have to be listed by hand.'
+                        : 'Discovered models arrive switched off. Turn on the ones people may use.'
+                }
+            >
+                Models
+            </SectionHeading>
+
+            <div className="mb-3 flex flex-wrap gap-2">
+                <GlassButton
+                    type="button"
+                    variant="subtle"
+                    size="sm"
+                    onClick={() => void runDiscovery()}
+                    disabled={busy || shown.apiKey}
+                >
+                    {discovering ? (
+                        <Loader2 size={14} className="animate-spin" />
+                    ) : (
+                        <RefreshCw size={14} />
+                    )}
+                    Discover models
+                </GlassButton>
+                <GlassButton
+                    type="button"
+                    variant="subtle"
+                    size="sm"
+                    onClick={() => void runConnectionTest()}
+                    disabled={busy}
+                >
+                    {testing ? <Loader2 size={14} className="animate-spin" /> : <Zap size={14} />}
+                    Test connection
+                </GlassButton>
+                <GlassButton
+                    type="button"
+                    variant="subtle"
+                    size="sm"
+                    disabled={busy}
+                    onClick={() =>
+                        setModels([
+                            ...models,
+                            {
+                                id: `model-${models.length + 1}-${Date.now()}`,
+                                deploymentName: '',
+                                displayName: '',
+                                enabled: false,
+                            },
+                        ])
+                    }
+                >
+                    <Plus size={14} />
+                    Add manually
+                </GlassButton>
+            </div>
+
+            {models.length === 0 ? (
+                <p className="rounded-lg border border-edge bg-surface-1 p-3 text-xs text-text-3">
+                    No models yet. Discover them from the connection, or add one by deployment name.
+                </p>
+            ) : (
+                <ul className="space-y-2">
+                    {models.map((model, index) => {
+                        const key = String(model.id ?? index);
+                        return (
+                            <li
+                                key={key}
+                                className="rounded-lg border border-edge bg-surface-1 p-3"
+                            >
+                                <div className="flex items-start gap-2">
+                                    <label className="flex flex-1 items-center gap-2">
+                                        <input
+                                            type="checkbox"
+                                            className="accent-[var(--accent)]"
+                                            checked={model.enabled !== false}
+                                            disabled={busy}
+                                            aria-label={`Enable ${model.deploymentName || 'model'}`}
+                                            onChange={(event) => {
+                                                const next = [...models];
+                                                next[index] = {
+                                                    ...model,
+                                                    enabled: event.target.checked,
+                                                };
+                                                setModels(next);
+                                            }}
+                                        />
+                                        <span className="text-xs text-text-3">Available</span>
+                                    </label>
+                                    {model.isDiscovered ? <Pill tone="muted">Discovered</Pill> : null}
+                                    <button
+                                        type="button"
+                                        title={`Test ${model.deploymentName || 'model'}`}
+                                        aria-label={`Test ${model.deploymentName || 'model'}`}
+                                        disabled={busy}
+                                        onClick={() => void runModelTest(model)}
+                                        className="rounded-lg p-1 text-text-3 transition-colors hover:bg-surface-2 hover:text-text-1 disabled:opacity-50"
+                                    >
+                                        {testingModelId === String(model.id ?? model.deploymentName) ? (
+                                            <Loader2 size={14} className="animate-spin" />
+                                        ) : (
+                                            <Zap size={14} />
+                                        )}
+                                    </button>
+                                    <button
+                                        type="button"
+                                        title={`Remove ${model.deploymentName || 'model'}`}
+                                        aria-label={`Remove ${model.deploymentName || 'model'}`}
+                                        disabled={busy}
+                                        onClick={() =>
+                                            setModels(models.filter((_, at) => at !== index))
+                                        }
+                                        className="rounded-lg p-1 text-text-3 transition-colors hover:bg-danger-soft hover:text-danger disabled:opacity-50"
+                                    >
+                                        <Trash2 size={14} />
+                                    </button>
+                                </div>
+
+                                <div className="mt-2 grid gap-2 sm:grid-cols-2">
+                                    <input
+                                        type="text"
+                                        className={inputClass}
+                                        placeholder="Deployment name"
+                                        aria-label="Deployment name"
+                                        value={String(model.deploymentName ?? '')}
+                                        disabled={busy}
+                                        spellCheck={false}
+                                        onChange={(event) => {
+                                            const next = [...models];
+                                            next[index] = {
+                                                ...model,
+                                                deploymentName: event.target.value,
+                                            };
+                                            setModels(next);
+                                        }}
+                                    />
+                                    <input
+                                        type="text"
+                                        className={inputClass}
+                                        placeholder="Display name"
+                                        aria-label="Display name"
+                                        value={String(model.displayName ?? '')}
+                                        disabled={busy}
+                                        onChange={(event) => {
+                                            const next = [...models];
+                                            next[index] = {
+                                                ...model,
+                                                displayName: event.target.value,
+                                            };
+                                            setModels(next);
+                                        }}
+                                    />
+                                </div>
+                            </li>
+                        );
+                    })}
+                </ul>
+            )}
+
+            <SectionHeading hint="Overrides the identity header setting for this connection only.">
+                Identity header
+            </SectionHeading>
+
+            <Field label="Mode" htmlFor="connection-identity-mode">
+                <select
+                    id="connection-identity-mode"
+                    className={inputClass}
+                    value={String(draft.identity_header?.mode ?? 'inherit')}
+                    disabled={busy}
+                    onChange={(event) => setField('identity_header.mode', event.target.value)}
+                >
+                    {IDENTITY_HEADER_MODE_OPTIONS.map((option) => (
+                        <option key={option.value} value={option.value}>
+                            {option.label}
+                        </option>
+                    ))}
+                </select>
+            </Field>
+
+            {String(draft.identity_header?.mode ?? 'inherit') !== 'disabled' ? (
+                <>
+                    <Field
+                        label="Header name override"
+                        htmlFor="connection-identity-name"
+                        help="Leave blank to use the name configured for all connections."
+                    >
+                        <input
+                            id="connection-identity-name"
+                            type="text"
+                            className={inputClass}
+                            value={String(draft.identity_header?.header_name ?? '')}
+                            disabled={busy}
+                            spellCheck={false}
+                            onChange={(event) =>
+                                setField('identity_header.header_name', event.target.value)
+                            }
+                        />
+                    </Field>
+                    <Field label="Identity override" htmlFor="connection-identity-value">
+                        <select
+                            id="connection-identity-value"
+                            className={inputClass}
+                            value={String(draft.identity_header?.value_type ?? '')}
+                            disabled={busy}
+                            onChange={(event) =>
+                                setField('identity_header.value_type', event.target.value)
+                            }
+                        >
+                            {IDENTITY_VALUE_TYPE_OPTIONS.map((option) => (
+                                <option key={option.value} value={option.value}>
+                                    {option.label}
+                                </option>
+                            ))}
+                        </select>
+                    </Field>
+                </>
+            ) : null}
+        </AdminModal>
+    );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Manager                                                                     */
+/* -------------------------------------------------------------------------- */
+
+export function ModelConnectionsManager({ help }: { help?: string }) {
+    const [connections, setConnections] = useState<ModelConnection[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [query, setQuery] = useState('');
+    const [editing, setEditing] = useState<ModelConnection | null>(null);
+    const [busyId, setBusyId] = useState<string | null>(null);
+    const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+
+    const load = useCallback(async (signal?: AbortSignal) => {
+        try {
+            const response = await fetchModelConnections(signal);
+            setConnections(Array.isArray(response.endpoints) ? response.endpoints : []);
+            setError(null);
+        } catch (loadError) {
+            setError(errorMessage(loadError, 'Model connections could not be loaded.'));
+        } finally {
+            setLoading(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        const controller = new AbortController();
+        void load(controller.signal);
+        return () => controller.abort();
+    }, [load]);
+
+    const visible = useMemo(() => {
+        const needle = query.trim().toLowerCase();
+        if (!needle) {
+            return connections;
+        }
+        return connections.filter((connection) =>
+            `${connection.name ?? ''} ${connection.provider ?? ''} ${connection.connection?.endpoint ?? ''}`
+                .toLowerCase()
+                .includes(needle),
+        );
+    }, [connections, query]);
+
+    const onToggle = async (connection: ModelConnection) => {
+        const previous = connections;
+        const next = connection.enabled === false;
+        setBusyId(connection.id);
+        setConnections(
+            connections.map((item) =>
+                item.id === connection.id ? { ...item, enabled: next } : item,
+            ),
+        );
+        try {
+            // A partial update, so the stripped secrets in the copy held here are never
+            // sent back and cannot overwrite what is stored.
+            await updateModelConnection(connection.id, { enabled: next });
+        } catch (toggleError) {
+            setConnections(previous);
+            setError(errorMessage(toggleError, 'The connection could not be updated.'));
+        } finally {
+            setBusyId(null);
+        }
+    };
+
+    const onDelete = async (connection: ModelConnection) => {
+        const previous = connections;
+        setBusyId(connection.id);
+        setConfirmDeleteId(null);
+        setConnections(connections.filter((item) => item.id !== connection.id));
+        try {
+            await deleteModelConnection(connection.id);
+            toast.success(`Deleted ${connection.name || 'connection'}.`);
+        } catch (deleteError) {
+            setConnections(previous);
+            setError(errorMessage(deleteError, 'The connection could not be deleted.'));
+        } finally {
+            setBusyId(null);
+        }
+    };
+
+    const onSaved = (saved: ModelConnection, created: boolean) => {
+        setEditing(null);
+        setError(null);
+        if (created) {
+            setConnections((current) => [...current, saved]);
+            toast.success(`Created ${saved.name || 'connection'}.`);
+        } else {
+            setConnections((current) =>
+                current.map((item) => (item.id === saved.id ? saved : item)),
+            );
+            toast.success(`Saved ${saved.name || 'connection'}.`);
+        }
+    };
+
+    return (
+        <div className="py-3">
+            <div className="mb-2 flex items-center justify-between gap-3">
+                <span className="text-sm font-medium text-text-1">Connections</span>
+                <GlassButton
+                    type="button"
+                    variant="subtle"
+                    size="sm"
+                    onClick={() => setEditing(emptyConnection())}
+                >
+                    <Plus size={14} />
+                    Add connection
+                </GlassButton>
+            </div>
+
+            {help ? <p className="mb-3 text-xs leading-relaxed text-text-3">{help}</p> : null}
+
+            {error ? (
+                <p
+                    role="alert"
+                    className="mb-3 flex items-start gap-2 rounded-lg border border-edge bg-danger-soft p-3 text-xs text-danger"
+                >
+                    <AlertCircle size={14} className="mt-0.5 shrink-0" />
+                    {error}
+                </p>
+            ) : null}
+
+            {connections.length > 3 ? (
+                <div className="relative mb-3">
+                    <Search
+                        size={14}
+                        className="pointer-events-none absolute top-1/2 left-3 -translate-y-1/2 text-text-3"
+                    />
+                    <input
+                        type="search"
+                        value={query}
+                        onChange={(event) => setQuery(event.target.value)}
+                        placeholder="Search connections"
+                        aria-label="Search connections"
+                        className={clsx(inputClass, 'pl-8')}
+                    />
+                </div>
+            ) : null}
+
+            {loading ? (
+                <p className="flex items-center gap-2 py-4 text-xs text-text-3">
+                    <Loader2 size={14} className="animate-spin" />
+                    Loading connections…
+                </p>
+            ) : visible.length === 0 ? (
+                <p className="rounded-lg border border-edge bg-surface-1 p-4 text-xs text-text-3">
+                    {connections.length === 0
+                        ? 'No connections yet. Add one to publish models from an Azure OpenAI or Foundry resource.'
+                        : 'No connections match your search.'}
+                </p>
+            ) : (
+                <ul className="space-y-2">
+                    {visible.map((connection) => {
+                        const total = connection.models?.length ?? 0;
+                        const available = enabledModelCount(connection);
+                        return (
+                            <li
+                                key={connection.id}
+                                className="flex items-start gap-3 rounded-lg border border-edge bg-surface-1 p-3"
+                            >
+                                <span className="mt-0.5 shrink-0 text-text-3">
+                                    <Server size={17} />
+                                </span>
+
+                                <div className="min-w-0 flex-1">
+                                    <div className="flex flex-wrap items-center gap-2">
+                                        <span className="truncate text-sm font-medium text-text-1">
+                                            {connection.name || 'Untitled connection'}
+                                        </span>
+                                        <Pill tone={connection.enabled === false ? 'muted' : 'ok'}>
+                                            {connection.enabled === false ? 'Disabled' : 'Enabled'}
+                                        </Pill>
+                                        {total > 0 && available === 0 ? (
+                                            <Pill tone="warn">No models available</Pill>
+                                        ) : null}
+                                    </div>
+                                    <p className="mt-0.5 truncate text-xs text-text-3">
+                                        {providerLabel(connection.provider)} ·{' '}
+                                        {authTypeLabel(connection.auth?.type)} ·{' '}
+                                        {total === 0
+                                            ? 'no models'
+                                            : `${available} of ${total} model${total === 1 ? '' : 's'} available`}
+                                    </p>
+                                    {connection.connection?.endpoint ? (
+                                        <p className="truncate font-mono text-[11px] text-text-3">
+                                            {String(connection.connection.endpoint)}
+                                        </p>
+                                    ) : null}
+                                </div>
+
+                                <div className="flex shrink-0 items-center gap-1">
+                                    <button
+                                        type="button"
+                                        title={connection.enabled === false ? 'Enable' : 'Disable'}
+                                        aria-label={`${connection.enabled === false ? 'Enable' : 'Disable'} ${connection.name ?? 'connection'}`}
+                                        disabled={busyId === connection.id}
+                                        onClick={() => void onToggle(connection)}
+                                        className="rounded-lg p-1.5 text-text-3 transition-colors hover:bg-surface-2 hover:text-text-1 disabled:opacity-50"
+                                    >
+                                        {busyId === connection.id ? (
+                                            <Loader2 size={15} className="animate-spin" />
+                                        ) : (
+                                            <Power size={15} />
+                                        )}
+                                    </button>
+                                    <button
+                                        type="button"
+                                        title="Edit"
+                                        aria-label={`Edit ${connection.name ?? 'connection'}`}
+                                        onClick={() => setEditing(connection)}
+                                        className="rounded-lg p-1.5 text-text-3 transition-colors hover:bg-surface-2 hover:text-text-1"
+                                    >
+                                        <Pencil size={15} />
+                                    </button>
+                                    <button
+                                        type="button"
+                                        title="Delete"
+                                        aria-label={`Delete ${connection.name ?? 'connection'}`}
+                                        disabled={busyId === connection.id}
+                                        onClick={() => setConfirmDeleteId(connection.id)}
+                                        className="rounded-lg p-1.5 text-text-3 transition-colors hover:bg-danger-soft hover:text-danger disabled:opacity-50"
+                                    >
+                                        <Trash2 size={15} />
+                                    </button>
+                                </div>
+                            </li>
+                        );
+                    })}
+                </ul>
+            )}
+
+            {editing ? (
+                <ConnectionEditor
+                    initial={editing}
+                    onClose={() => setEditing(null)}
+                    onSaved={onSaved}
+                />
+            ) : null}
+
+            {confirmDeleteId ? (
+                <AdminModal
+                    title="Delete this connection?"
+                    description="Models published from it stop being offered, and any stored key or secret is removed."
+                    onClose={() => setConfirmDeleteId(null)}
+                    footer={
+                        <>
+                            <GlassButton
+                                type="button"
+                                variant="ghost"
+                                size="sm"
+                                onClick={() => setConfirmDeleteId(null)}
+                            >
+                                Cancel
+                            </GlassButton>
+                            <GlassButton
+                                type="button"
+                                variant="danger"
+                                size="sm"
+                                onClick={() => {
+                                    const target = connections.find(
+                                        (item) => item.id === confirmDeleteId,
+                                    );
+                                    if (target) {
+                                        void onDelete(target);
+                                    }
+                                }}
+                            >
+                                <Trash2 size={14} />
+                                Delete
+                            </GlassButton>
+                        </>
+                    }
+                >
+                    <p className="text-sm text-text-2">
+                        {connections.find((item) => item.id === confirmDeleteId)?.name ||
+                            'This connection'}{' '}
+                        will be removed. If it is the default model for chat, that default is
+                        cleared too.
+                    </p>
+                </AdminModal>
+            ) : null}
+        </div>
+    );
+}

--- a/application/v2_ui/src/lib/modelConnections.ts
+++ b/application/v2_ui/src/lib/modelConnections.ts
@@ -1,0 +1,570 @@
+// modelConnections.ts
+// Types, API wrappers and pure form logic for global model connections.
+//
+// A "connection" is one Azure OpenAI or Foundry resource: where it is, how SimpleChat
+// authenticates to it, and which of its deployed models may be used. The classic
+// interface calls these model endpoints, and the stored shape is unchanged -- only the
+// wording and the editing model differ.
+//
+// Why this exists as its own module rather than living in the component: the classic
+// editor's rules about which fields a provider and auth type actually need are the part
+// that made it confusing, and they are worth testing directly. Everything here is pure
+// except the four API wrappers at the bottom.
+//
+// The payload shape is pinned against `buildEndpointPayload` in
+// static/js/admin/admin_model_endpoints.js, which is what the server has always been
+// given, and against `normalize_model_endpoints` in functions_settings.py, which is what
+// it stores.
+
+import { api } from './apiClient';
+
+/* -------------------------------------------------------------------------- */
+/* Types                                                                       */
+/* -------------------------------------------------------------------------- */
+
+/** Providers offered in the editor. Matches `is_frontend_visible_model_endpoint_provider`. */
+export type ConnectionProvider = 'aoai' | 'aifoundry' | 'new_foundry';
+
+export type ConnectionAuthType = 'managed_identity' | 'service_principal' | 'api_key';
+
+export type ManagedIdentityType = 'system_assigned' | 'user_assigned';
+
+export type ManagementCloud = 'public' | 'usgovernment' | 'custom';
+
+export type IdentityHeaderMode = 'inherit' | 'enabled' | 'disabled';
+
+export interface ConnectionModel {
+    id?: string;
+    deploymentName?: string;
+    modelName?: string;
+    displayName?: string;
+    description?: string;
+    enabled?: boolean;
+    isDiscovered?: boolean;
+    responseLength?: number | string;
+    [key: string]: unknown;
+}
+
+export interface ConnectionAuth {
+    type?: ConnectionAuthType;
+    managed_identity_type?: ManagedIdentityType;
+    managed_identity_client_id?: string;
+    tenant_id?: string;
+    client_id?: string;
+    client_secret?: string;
+    api_key?: string;
+    management_cloud?: ManagementCloud;
+    custom_authority?: string;
+    foundry_scope?: string;
+    [key: string]: unknown;
+}
+
+export interface ConnectionIdentityHeader {
+    mode?: IdentityHeaderMode;
+    header_name?: string;
+    value_type?: string;
+}
+
+export interface ModelConnection {
+    id: string;
+    name?: string;
+    provider?: string;
+    enabled?: boolean;
+    connection?: {
+        endpoint?: string;
+        openai_api_version?: string;
+        project_api_version?: string;
+        project_name?: string;
+        [key: string]: unknown;
+    };
+    management?: {
+        subscription_id?: string;
+        resource_group?: string;
+        [key: string]: unknown;
+    };
+    auth?: ConnectionAuth;
+    identity_header?: ConnectionIdentityHeader;
+    models?: ConnectionModel[];
+    /**
+     * Set by `sanitize_model_endpoints_for_frontend`. The secret itself is stripped on the
+     * way out, so this flag is the only way the editor can tell "a key is stored" from
+     * "no key has ever been set" -- and therefore whether an empty input means "keep it".
+     */
+    has_api_key?: boolean;
+    has_client_secret?: boolean;
+    [key: string]: unknown;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Option lists                                                                */
+/* -------------------------------------------------------------------------- */
+
+export const DEFAULT_AOAI_OPENAI_API_VERSION = '2024-05-01-preview';
+export const DEFAULT_FOUNDRY_OPENAI_API_VERSION = 'v1';
+export const DEFAULT_FOUNDRY_PROJECT_API_VERSION = 'v1';
+
+export const PROVIDER_OPTIONS: Array<{ value: ConnectionProvider; label: string; hint: string }> = [
+    {
+        value: 'aoai',
+        label: 'Azure OpenAI',
+        hint: 'An Azure OpenAI resource. Model discovery reads its deployments through Azure Resource Manager.',
+    },
+    {
+        value: 'new_foundry',
+        label: 'Azure AI Foundry',
+        hint: 'A Foundry project endpoint. Model discovery reads the project’s deployments.',
+    },
+    {
+        value: 'aifoundry',
+        label: 'Azure AI Foundry (classic)',
+        hint: 'The earlier Foundry project shape, kept for connections created before the move.',
+    },
+];
+
+export const AUTH_TYPE_OPTIONS: Array<{
+    value: ConnectionAuthType;
+    label: string;
+    hint: string;
+}> = [
+    {
+        value: 'managed_identity',
+        label: 'Managed identity',
+        hint: 'Uses the App Service identity. No secret is stored.',
+    },
+    {
+        value: 'service_principal',
+        label: 'Service principal',
+        hint: 'An app registration. The client secret is stored in Key Vault when it is configured.',
+    },
+    {
+        value: 'api_key',
+        label: 'API key',
+        hint: 'Inference only. Model discovery needs Azure credentials, so the model list must be entered by hand.',
+    },
+];
+
+export const MANAGEMENT_CLOUD_OPTIONS: Array<{ value: ManagementCloud; label: string }> = [
+    { value: 'public', label: 'Azure public cloud' },
+    { value: 'usgovernment', label: 'Azure US Government' },
+    { value: 'custom', label: 'Custom authority' },
+];
+
+export const IDENTITY_HEADER_MODE_OPTIONS: Array<{
+    value: IdentityHeaderMode;
+    label: string;
+}> = [
+    { value: 'inherit', label: 'Use the global setting' },
+    { value: 'enabled', label: 'Always send' },
+    { value: 'disabled', label: 'Never send' },
+];
+
+export const IDENTITY_VALUE_TYPE_OPTIONS: Array<{ value: string; label: string }> = [
+    { value: '', label: 'Use the global setting' },
+    { value: 'user_oid_tenant_id', label: 'Object id and tenant id' },
+    { value: 'user_oid', label: 'Object id' },
+    { value: 'user_upn_tenant_id', label: 'User principal name and tenant id' },
+    { value: 'user_upn', label: 'User principal name' },
+];
+
+/* -------------------------------------------------------------------------- */
+/* Pure helpers                                                                */
+/* -------------------------------------------------------------------------- */
+
+function text(value: unknown): string {
+    return typeof value === 'string' ? value.trim() : '';
+}
+
+export function providerLabel(provider: unknown): string {
+    const raw = text(provider);
+    return PROVIDER_OPTIONS.find((option) => option.value === raw)?.label ?? (raw || 'Connection');
+}
+
+export function authTypeLabel(authType: unknown): string {
+    const raw = text(authType);
+    return AUTH_TYPE_OPTIONS.find((option) => option.value === raw)?.label ?? (raw || 'Managed identity');
+}
+
+export function isFoundryProvider(provider: unknown): boolean {
+    const raw = text(provider);
+    return raw === 'aifoundry' || raw === 'new_foundry';
+}
+
+/** Whether a Foundry endpoint URL already names its project. */
+export function endpointIncludesProject(endpoint: unknown): boolean {
+    return text(endpoint).toLowerCase().includes('/api/projects/');
+}
+
+/**
+ * Pull the project name out of a Foundry endpoint URL.
+ *
+ * Mirrors `getProjectNameFromEndpoint` in the classic editor, including its fallback for
+ * a value that is not a parseable URL, because an administrator pasting a half-typed
+ * endpoint should still get the hint.
+ */
+export function projectNameFromEndpoint(endpoint: unknown): string {
+    const value = text(endpoint);
+    if (!value) {
+        return '';
+    }
+
+    try {
+        const parsed = new URL(value);
+        const segments = parsed.pathname.split('/').filter(Boolean);
+        const index = segments.findIndex((segment) => segment.toLowerCase() === 'projects');
+        if (index >= 0 && segments[index + 1]) {
+            return decodeURIComponent(segments[index + 1]);
+        }
+    } catch {
+        const marker = '/api/projects/';
+        const markerIndex = value.toLowerCase().indexOf(marker);
+        if (markerIndex >= 0) {
+            return value.slice(markerIndex + marker.length).split(/[/?#]/)[0];
+        }
+    }
+    return '';
+}
+
+export function defaultOpenAiApiVersion(provider: unknown): string {
+    return isFoundryProvider(provider)
+        ? DEFAULT_FOUNDRY_OPENAI_API_VERSION
+        : DEFAULT_AOAI_OPENAI_API_VERSION;
+}
+
+/** A blank connection, shaped so every control is controlled from the first render. */
+export function emptyConnection(): ModelConnection {
+    return {
+        id: '',
+        name: '',
+        provider: 'aoai',
+        enabled: true,
+        connection: {
+            endpoint: '',
+            openai_api_version: DEFAULT_AOAI_OPENAI_API_VERSION,
+            project_api_version: DEFAULT_FOUNDRY_PROJECT_API_VERSION,
+            project_name: '',
+        },
+        management: { subscription_id: '', resource_group: '' },
+        auth: {
+            type: 'managed_identity',
+            managed_identity_type: 'system_assigned',
+            managed_identity_client_id: '',
+            tenant_id: '',
+            client_id: '',
+            client_secret: '',
+            api_key: '',
+            management_cloud: 'public',
+            custom_authority: '',
+            foundry_scope: '',
+        },
+        identity_header: { mode: 'inherit', header_name: '', value_type: '' },
+        models: [],
+        has_api_key: false,
+        has_client_secret: false,
+    };
+}
+
+/** Fill a stored connection out to the full editor shape without losing unknown keys. */
+export function toEditableConnection(source: ModelConnection): ModelConnection {
+    const blank = emptyConnection();
+    return {
+        ...blank,
+        ...source,
+        connection: { ...blank.connection, ...(source.connection ?? {}) },
+        management: { ...blank.management, ...(source.management ?? {}) },
+        auth: { ...blank.auth, ...(source.auth ?? {}) },
+        identity_header: { ...blank.identity_header, ...(source.identity_header ?? {}) },
+        models: Array.isArray(source.models) ? source.models.map((model) => ({ ...model })) : [],
+    };
+}
+
+/**
+ * Which editor fields a given provider and auth type actually use.
+ *
+ * The classic editor decided this by toggling `d-none` across two dozen elements from
+ * three separate listeners, which is why fields appeared and disappeared unpredictably
+ * while typing. Deriving it in one place makes the rule inspectable and testable.
+ */
+export function visibleFields(connection: ModelConnection): {
+    project: boolean;
+    management: boolean;
+    managedIdentity: boolean;
+    servicePrincipal: boolean;
+    apiKey: boolean;
+    managementCloud: boolean;
+    customAuthority: boolean;
+    foundryScope: boolean;
+    userAssignedClientId: boolean;
+} {
+    const provider = text(connection.provider) || 'aoai';
+    const authType = (text(connection.auth?.type) || 'managed_identity') as ConnectionAuthType;
+    const foundry = isFoundryProvider(provider);
+    const cloud = text(connection.auth?.management_cloud) || 'public';
+
+    return {
+        project: foundry,
+        // Discovery for Azure OpenAI goes through Azure Resource Manager, which needs the
+        // resource coordinates. An API key cannot reach ARM, so they serve no purpose there.
+        management: provider === 'aoai' && authType !== 'api_key',
+        managedIdentity: authType === 'managed_identity',
+        servicePrincipal: authType === 'service_principal',
+        apiKey: authType === 'api_key',
+        managementCloud: authType !== 'api_key',
+        customAuthority: authType !== 'api_key' && cloud === 'custom',
+        foundryScope: foundry && authType !== 'api_key',
+        userAssignedClientId:
+            authType === 'managed_identity' &&
+            text(connection.auth?.managed_identity_type) === 'user_assigned',
+    };
+}
+
+/**
+ * Validate a connection, returning one message per offending field.
+ *
+ * Keyed by field so the editor can mark the control that caused it, rather than the
+ * classic editor's behaviour of raising a toast that named the problem but not the place.
+ */
+export function validateConnection(connection: ModelConnection): Record<string, string> {
+    const errors: Record<string, string> = {};
+    const provider = text(connection.provider) || 'aoai';
+    const authType = (text(connection.auth?.type) || 'managed_identity') as ConnectionAuthType;
+    const foundry = isFoundryProvider(provider);
+    const shown = visibleFields(connection);
+
+    if (!text(connection.name)) {
+        errors.name = 'Give the connection a name.';
+    }
+
+    const endpoint = text(connection.connection?.endpoint);
+    if (!endpoint) {
+        errors.endpoint = 'An endpoint URL is required.';
+    } else if (!/^https?:\/\//i.test(endpoint)) {
+        errors.endpoint = 'Enter the full URL, including https://.';
+    }
+
+    if (!text(connection.connection?.openai_api_version)) {
+        errors.openai_api_version = 'An OpenAI API version is required.';
+    }
+
+    if (foundry) {
+        if (!text(connection.connection?.project_api_version)) {
+            errors.project_api_version =
+                'A project API version is required for Foundry model discovery.';
+        }
+        if (!endpointIncludesProject(endpoint) && !text(connection.connection?.project_name)) {
+            errors.project_name =
+                'Name the project, or use an endpoint URL that includes /api/projects/.';
+        }
+    }
+
+    if (shown.management) {
+        if (!text(connection.management?.subscription_id)) {
+            errors.subscription_id = 'Required so Azure OpenAI deployments can be discovered.';
+        }
+        if (!text(connection.management?.resource_group)) {
+            errors.resource_group = 'Required so Azure OpenAI deployments can be discovered.';
+        }
+    }
+
+    if (authType === 'service_principal') {
+        if (!text(connection.auth?.tenant_id)) {
+            errors.tenant_id = 'Required for service principal authentication.';
+        }
+        if (!text(connection.auth?.client_id)) {
+            errors.client_id = 'Required for service principal authentication.';
+        }
+        // An empty box means "keep the stored secret" only when one is actually stored.
+        if (!text(connection.auth?.client_secret) && !connection.has_client_secret) {
+            errors.client_secret = 'Required for service principal authentication.';
+        }
+    }
+
+    if (authType === 'api_key' && !text(connection.auth?.api_key) && !connection.has_api_key) {
+        errors.api_key = 'Required for API key authentication.';
+    }
+
+    if (shown.customAuthority && !text(connection.auth?.custom_authority)) {
+        errors.custom_authority = 'Required when the management cloud is Custom.';
+    }
+
+    if (foundry && authType === 'service_principal' && text(connection.auth?.management_cloud) === 'custom') {
+        if (!text(connection.auth?.foundry_scope)) {
+            errors.foundry_scope = 'Required when the management cloud is Custom.';
+        }
+    }
+
+    return errors;
+}
+
+/**
+ * Shape a connection for the server, dropping fields the chosen provider does not use.
+ *
+ * Blank secrets are omitted rather than sent empty: the server treats an absent secret as
+ * "keep what is stored", so sending "" would clear a key the editor was never shown.
+ */
+export function buildConnectionPayload(connection: ModelConnection): Record<string, unknown> {
+    const provider = (text(connection.provider) || 'aoai') as ConnectionProvider;
+    const authType = (text(connection.auth?.type) || 'managed_identity') as ConnectionAuthType;
+    const foundry = isFoundryProvider(provider);
+
+    const endpoint = text(connection.connection?.endpoint);
+    const connectionBlock: Record<string, unknown> = {
+        endpoint,
+        openai_api_version: text(connection.connection?.openai_api_version) || defaultOpenAiApiVersion(provider),
+    };
+
+    if (foundry) {
+        connectionBlock.project_api_version =
+            text(connection.connection?.project_api_version) || DEFAULT_FOUNDRY_PROJECT_API_VERSION;
+        const projectName =
+            projectNameFromEndpoint(endpoint) || text(connection.connection?.project_name);
+        if (projectName) {
+            connectionBlock.project_name = projectName;
+        }
+    }
+
+    const auth: Record<string, unknown> = {
+        type: authType,
+        management_cloud: text(connection.auth?.management_cloud) || 'public',
+        custom_authority: text(connection.auth?.custom_authority),
+        foundry_scope: text(connection.auth?.foundry_scope),
+    };
+
+    if (authType === 'managed_identity') {
+        auth.managed_identity_type = text(connection.auth?.managed_identity_type) || 'system_assigned';
+        auth.managed_identity_client_id = text(connection.auth?.managed_identity_client_id);
+    }
+
+    if (authType === 'service_principal') {
+        auth.tenant_id = text(connection.auth?.tenant_id);
+        auth.client_id = text(connection.auth?.client_id);
+        const clientSecret = text(connection.auth?.client_secret);
+        if (clientSecret) {
+            auth.client_secret = clientSecret;
+        }
+    }
+
+    if (authType === 'api_key') {
+        const apiKey = text(connection.auth?.api_key);
+        if (apiKey) {
+            auth.api_key = apiKey;
+        }
+    }
+
+    const payload: Record<string, unknown> = {
+        name: text(connection.name),
+        provider,
+        enabled: connection.enabled !== false,
+        connection: connectionBlock,
+        management: provider === 'aoai'
+            ? {
+                  subscription_id: text(connection.management?.subscription_id),
+                  resource_group: text(connection.management?.resource_group),
+              }
+            : {},
+        auth,
+        identity_header: {
+            mode: (text(connection.identity_header?.mode) || 'inherit') as IdentityHeaderMode,
+            header_name: text(connection.identity_header?.header_name),
+            value_type: text(connection.identity_header?.value_type),
+        },
+        models: (connection.models ?? []).map((model) => ({
+            ...model,
+            deploymentName: text(model.deploymentName),
+            displayName: text(model.displayName) || text(model.deploymentName),
+            enabled: model.enabled !== false,
+        })),
+    };
+
+    if (text(connection.id)) {
+        payload.id = text(connection.id);
+    }
+
+    return payload;
+}
+
+/**
+ * Merge discovered deployments into the model list already on the connection.
+ *
+ * Matching is by deployment name, case-insensitively, so re-running discovery does not
+ * duplicate a model or overwrite a display name that was edited by hand. New models
+ * arrive disabled, because discovery finding a deployment is not the same as an
+ * administrator choosing to publish it.
+ */
+export function mergeDiscoveredModels(
+    existing: ConnectionModel[],
+    discovered: Array<Record<string, unknown>>,
+): { models: ConnectionModel[]; added: number } {
+    const models = existing.map((model) => ({ ...model }));
+    const seen = new Set(
+        models
+            .map((model) => text(model.deploymentName).toLowerCase())
+            .filter((name) => name.length > 0),
+    );
+
+    let added = 0;
+    for (const candidate of discovered) {
+        const deploymentName = text(candidate.deploymentName) || text(candidate.deployment);
+        if (!deploymentName) {
+            continue;
+        }
+        const key = deploymentName.toLowerCase();
+        if (seen.has(key)) {
+            continue;
+        }
+        seen.add(key);
+        models.push({
+            id: deploymentName,
+            deploymentName,
+            modelName: text(candidate.modelName) || text(candidate.name),
+            displayName: deploymentName,
+            description: '',
+            enabled: false,
+            isDiscovered: true,
+        });
+        added += 1;
+    }
+
+    return { models, added };
+}
+
+export function enabledModelCount(connection: ModelConnection): number {
+    return (connection.models ?? []).filter((model) => model.enabled !== false).length;
+}
+
+/* -------------------------------------------------------------------------- */
+/* API                                                                         */
+/* -------------------------------------------------------------------------- */
+
+const BASE = '/api/v2/admin/model-endpoints';
+
+export interface ConnectionListResponse {
+    endpoints: ModelConnection[];
+    multi_endpoint_enabled?: boolean;
+}
+
+export const fetchModelConnections = (signal?: AbortSignal) =>
+    api.get<ConnectionListResponse>(BASE, signal);
+
+export const createModelConnection = (payload: Record<string, unknown>) =>
+    api.post<{ endpoint: ModelConnection }>(BASE, payload);
+
+export const updateModelConnection = (id: string, payload: Record<string, unknown>) =>
+    api.patch<{ endpoint: ModelConnection }>(`${BASE}/${encodeURIComponent(id)}`, payload);
+
+export const deleteModelConnection = (id: string) =>
+    api.delete<{ success: boolean }>(`${BASE}/${encodeURIComponent(id)}`);
+
+/** Discover the deployments a connection exposes. Admin-gated, shared with the classic UI. */
+export const discoverModels = (payload: Record<string, unknown>) =>
+    api.post<{ models?: Array<Record<string, unknown>> }>('/api/models/fetch', payload);
+
+/** Check that the connection's credentials and endpoint resolve. */
+export const testConnection = (payload: Record<string, unknown>) =>
+    api.post<{ success?: boolean; count?: number }>('/api/models/test-connection', payload);
+
+/** Check that one specific deployment answers. */
+export const testConnectionModel = (payload: Record<string, unknown>, deploymentName: string) =>
+    api.post<{ success?: boolean }>('/api/models/test-model', {
+        ...payload,
+        model: { deploymentName },
+    });

--- a/application/v2_ui/src/pages/AdminSettingsPage.tsx
+++ b/application/v2_ui/src/pages/AdminSettingsPage.tsx
@@ -36,6 +36,7 @@ import { AdminMarkdown } from '../components/admin/AdminMarkdown';
 import { BrandingImageField } from '../components/admin/BrandingImageField';
 import { CustomPagesTable } from '../components/admin/CustomPagesTable';
 import { ExternalLinksEditor } from '../components/admin/ExternalLinksEditor';
+import { ModelConnectionsManager } from '../components/admin/ModelConnectionsManager';
 import { SaveBar } from '../components/admin/SaveBar';
 import { SettingField } from '../components/admin/fields';
 import {
@@ -536,6 +537,8 @@ export function AdminSettingsPage() {
             switch (field.component) {
                 case 'custom-pages-table':
                     return <CustomPagesTable key={key} help={field.help} />;
+                case 'model-connections-manager':
+                    return <ModelConnectionsManager key={key} help={field.help} />;
                 case 'classification-banner-preview':
                     return (
                         <ClassificationBannerPreview

--- a/docs/_data/app_surface.yml
+++ b/docs/_data/app_surface.yml
@@ -413,7 +413,7 @@ admin_tabs:
   label: Migrate
   group: backup-recovery
 - id: model-endpoints
-  label: Model Endpoints
+  label: Connections
   group: ai-models
 - id: network
   label: Network
@@ -705,7 +705,7 @@ admin_sections:
   tab: mcp-governance
   group: governance
 - id: gpt-config
-  label: Chat Model
+  label: Chat
   tab: model-endpoints
   group: ai-models
 - id: group-workspaces-section
@@ -741,7 +741,7 @@ admin_sections:
   tab: extraction
   group: knowledge
 - id: multi-endpoint-configuration
-  label: Model Endpoints
+  label: Connections
   tab: model-endpoints
   group: ai-models
 - id: multimodal-vision-section

--- a/docs/admin/ai-models.md
+++ b/docs/admin/ai-models.md
@@ -59,7 +59,7 @@ Individual connections can override the global choice, which is useful when only
 
 | Setting | What it does | Default | Notes |
 | --- | --- | --- | --- |
-| Use connections for chat | Routes chat through the connections listed here instead of the single classic endpoint. | Off | `enable_multi_model_endpoints`; capability toggle |
+| Use connections for chat | Routes chat through the connections listed here instead of the single classic endpoint. Switching this on cannot be undone, and carries the classic endpoint over as the first connection. | Off | `enable_multi_model_endpoints`; capability toggle |
 | Connections | The list of model connections, each saved on its own. | Empty | `model_endpoints`; edited through its own API |
 | Send an identity header with model requests | Adds a header identifying the signed-in user to every model request. | Off | `model_endpoint_identity_header_enabled` |
 | Header name | Rejected if it collides with a header the model call already sets, such as `authorization`. | x-simplechat-identity-key | `model_endpoint_identity_header_name` |
@@ -144,6 +144,7 @@ The Image Generation section belongs to the Image Generation tab. Use it with th
 | Symptom | Likely cause | Fix |
 | --- | --- | --- |
 | A connection's models never appear in chat | **Use connections for chat** is off, so chat is running on the classic single endpoint. | Turn it on, or configure the classic endpoint under Chat instead. |
+| **Use connections for chat** will not turn off | Enabling connections is one-way, because chats, agents and workflows may already reference a model published from one. | Disable the individual connections instead, or point chat at the model you want by making it the default. |
 | **Discover models** is unavailable | The connection authenticates with an API key, which reaches inference but not Azure Resource Manager. | Switch to managed identity or a service principal, or add the deployment names by hand. |
 | Discovery returns nothing for an Azure OpenAI connection | The subscription id or resource group does not match the resource. | Correct them, then run **Test connection** before discovering again. |
 | Models are listed but nobody can choose them | Discovered models arrive switched off. | Turn on each model that should be available, then save the connection. |

--- a/docs/admin/ai-models.md
+++ b/docs/admin/ai-models.md
@@ -28,32 +28,57 @@ Model endpoints are production dependencies for every generated answer, embeddin
 - Choose key or managed identity authentication and grant required permissions.
 - Name fallback deployments deliberately so background tasks use approved models.
 
-## Model Endpoints {#model-endpoints}
+## Connections {#model-endpoints}
 
-### Model Endpoints {#multi-endpoint-configuration}
+### Connections {#multi-endpoint-configuration}
 
-The Model Endpoints section belongs to the Model Endpoints tab. Use it with the adjacent settings in this group so related rollout, access, and operational choices stay aligned.
+A connection is one Azure OpenAI or Azure AI Foundry resource: where it is, how SimpleChat authenticates to it, and which of its deployed models may be used. Several connections can serve models at once, so a deployment in one subscription and a Foundry project in another can both appear in the chat model picker.
 
-### Chat Model {#gpt-config}
+Connections are consulted only when **Use connections for chat** is on. With it off, chat runs on the single classic endpoint configured under Chat Model instead, and anything listed here is ignored.
 
-The Chat Model section belongs to the Model Endpoints tab. Use it with the adjacent settings in this group so related rollout, access, and operational choices stay aligned.
+Each connection is stored on its own. Adding, editing or deleting one takes effect when you save that connection, rather than when the surrounding settings page is saved.
+
+#### Authentication and model discovery
+
+The authentication method determines whether SimpleChat can enumerate a resource's deployments for you:
+
+- **Managed identity** and **service principal** can reach Azure Resource Manager, so **Discover models** lists the deployments the resource already has. For an Azure OpenAI resource this needs the subscription id and resource group, because that is how the deployment list is addressed.
+- **API key** authenticates to inference only. Discovery is unavailable, so deployment names have to be entered by hand.
+
+Discovered models arrive switched off. Finding a deployment is not the same as publishing it, so each one has to be turned on before people can pick it.
+
+Secrets are never returned to the browser. When a key or client secret is already stored, its field shows that it exists and stays empty; leaving it empty keeps the stored value, and typing a new one replaces it. Deleting a connection removes the secrets it owned.
+
+#### Identity header
+
+Model requests reach a gateway under SimpleChat's own credentials, so a gateway cannot tell one user's traffic from another's. The identity header adds a header naming the signed-in user, which lets a gateway attribute usage or apply per-user quotas. The value is HMAC-hashed before it leaves SimpleChat, and a request with no identity omits the header rather than sending a blank one.
+
+Individual connections can override the global choice, which is useful when only some of them sit behind a gateway that expects the header.
 
 #### Settings
 
 | Setting | What it does | Default | Notes |
 | --- | --- | --- | --- |
-| Enable multi-endpoint model management | Provides the endpoint or route SimpleChat uses for this service. | Off | `enable_multi_model_endpoints`; capability toggle |
-| Search Agents | Defines behavior for the related admin workflow; verify the affected feature after saving. | N/A (runtime control) | Runtime UI control |
-| Filter | Defines behavior for the related admin workflow; verify the affected feature after saving. | N/A (runtime control) | Runtime UI control |
-| Enable header | Provides the endpoint or route SimpleChat uses for this service. | Off | `model_endpoint_identity_header_enabled` |
-| Header Name | Provides the endpoint or route SimpleChat uses for this service. | Not specified in defaults | `model_endpoint_identity_header_name` |
-| Identity Value | The selected identity is HMAC-hashed before leaving SimpleChat. Missing identity values omit the header. | Not specified in defaults | `model_endpoint_identity_header_value_type` |
-| Default model for fallbacks | Used for tasks such as conversation summarization, fallback, and other operations when an agent is selected. | Not specified in defaults | Runtime UI control |
-| Use APIM instead of direct to Azure OpenAI endpoint | Exposes the capability after required services, permissions, and rollout policy are ready. | Off | `enable_gpt_apim`; capability toggle |
+| Use connections for chat | Routes chat through the connections listed here instead of the single classic endpoint. | Off | `enable_multi_model_endpoints`; capability toggle |
+| Connections | The list of model connections, each saved on its own. | Empty | `model_endpoints`; edited through its own API |
+| Send an identity header with model requests | Adds a header identifying the signed-in user to every model request. | Off | `model_endpoint_identity_header_enabled` |
+| Header name | Rejected if it collides with a header the model call already sets, such as `authorization`. | x-simplechat-identity-key | `model_endpoint_identity_header_name` |
+| Identity sent in the header | Object id is stable across a rename; UPN is readable in gateway logs. Tenant variants qualify the value for a multi-tenant gateway. | Object id and tenant id | `model_endpoint_identity_header_value_type` |
+| Default model for fallbacks | The model used when no other choice applies. Cleared automatically if the connection or model it names is deleted or disabled. | Not specified in defaults | `default_model_selection` |
+
+### Chat {#gpt-config}
+
+The classic single-endpoint chat configuration. It is what chat uses when **Use connections for chat** is off, and it remains available as a fallback route.
+
+#### Settings
+
+| Setting | What it does | Default | Notes |
+| --- | --- | --- | --- |
+| Use APIM instead of direct to Azure OpenAI endpoint | Sends chat requests through API Management rather than straight to the Azure OpenAI resource. | Off | `enable_gpt_apim`; capability toggle |
 | Azure OpenAI Endpoint | Provides the endpoint or route SimpleChat uses for this service. | Empty | `azure_openai_gpt_endpoint` |
 | Authentication Type | Chooses whether SimpleChat authenticates to this service with a key, managed identity, or another supported method. | key | `azure_openai_gpt_authentication_type` |
-| Subscription ID | Defines behavior for the related admin workflow; verify the affected feature after saving. | Empty | `azure_openai_gpt_subscription_id` |
-| Resource Group | Defines behavior for the related admin workflow; verify the affected feature after saving. | Empty | `azure_openai_gpt_resource_group` |
+| Subscription ID | Addresses the resource when listing its deployments. | Empty | `azure_openai_gpt_subscription_id` |
+| Resource Group | Addresses the resource when listing its deployments. | Empty | `azure_openai_gpt_resource_group` |
 | Azure OpenAI GPT Key | Provides the secret credential used when the selected authentication mode requires one. | Empty | `azure_openai_gpt_key` |
 | Azure OpenAI API Version | Pins the service API version SimpleChat sends with requests for this feature. | 2024-05-01-preview | `azure_openai_gpt_api_version` |
 | Azure APIM Endpoint | Provides the endpoint or route SimpleChat uses for this service. | Empty | `azure_apim_gpt_endpoint` |
@@ -108,14 +133,21 @@ The Image Generation section belongs to the Image Generation tab. Use it with th
 
 ## Common tasks
 
-1. **Route chat through approved endpoints.** Enable multi-endpoint management when needed and run a chat through the intended deployment. Outcome to verify: Requests reach the approved route.
-2. **Configure embeddings.** Set endpoint, authentication, API version, and deployment, then index a small document. Outcome to verify: Indexing succeeds with the configured embedding route.
-3. **Enable image generation.** Enable the capability, set endpoint values, and generate a low-risk test image. Outcome to verify: The image tool returns output from the configured deployment.
+1. **Publish models from a new resource.** Add a connection, choose its provider and authentication, run **Test connection**, then **Discover models** and turn on the ones people may use. Save the connection. Outcome to verify: the enabled models appear in the chat model picker.
+2. **Rotate a stored key.** Edit the connection, type the new key over the empty field, and save. Outcome to verify: **Test connection** succeeds with the replacement.
+3. **Retire a connection.** Disable it first and confirm chat still works, then delete it. Outcome to verify: its models stop being offered, and a default model that named it is cleared.
+4. **Configure embeddings.** Set endpoint, authentication, API version, and deployment, then index a small document. Outcome to verify: Indexing succeeds with the configured embedding route.
+5. **Enable image generation.** Enable the capability, set endpoint values, and generate a low-risk test image. Outcome to verify: The image tool returns output from the configured deployment.
 
 ## Troubleshooting
 
 | Symptom | Likely cause | Fix |
 | --- | --- | --- |
+| A connection's models never appear in chat | **Use connections for chat** is off, so chat is running on the classic single endpoint. | Turn it on, or configure the classic endpoint under Chat instead. |
+| **Discover models** is unavailable | The connection authenticates with an API key, which reaches inference but not Azure Resource Manager. | Switch to managed identity or a service principal, or add the deployment names by hand. |
+| Discovery returns nothing for an Azure OpenAI connection | The subscription id or resource group does not match the resource. | Correct them, then run **Test connection** before discovering again. |
+| Models are listed but nobody can choose them | Discovered models arrive switched off. | Turn on each model that should be available, then save the connection. |
+| The default model reverted to none | The connection or model it named was deleted or disabled, so the reference no longer resolved. | Choose a default that points at an enabled model on an enabled connection. |
 | Embeddings fail during indexing | Endpoint, deployment, API version, or authentication does not match the Azure resource. | Validate the embedding route with a small document before bulk indexing. |
 
 ## Related

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,23 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/features) and [Fixes by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/fixes).
 
+### **(v0.261.060)**
+
+#### Bug Fixes
+
+*   **Turning Connections Off Said It Worked, And Did Not**
+    *   Enabling connections for chat is one-way — the stored flag is coerced to "already on, or newly requested", so once it is true it stays true. The classic page reflects that by hiding the checkbox after it is enabled. The new admin interface showed an ordinary switch, so turning it off reported a successful save, moved the switch, and changed nothing; chat carried on routing through connections and only a page reload revealed it. The attempt is now refused with an explanation.
+    *   **Enabling connections from the new interface also used to strand a deployment.** The classic page carries the existing single chat endpoint over as the first connection when the flag is first switched on. The new interface skipped that step, so a deployment that enabled connections there was left with an empty model catalog — and, because the flag cannot be turned back off, no way to recover. Both paths now migrate through the same code.
+    *   (Ref: `admin_settings_fields.py`, `build_migrated_model_endpoints_from_legacy`, `_seed_connections_on_first_enable`)
+
+*   **Deleting A Connection Could Break Document Metadata Extraction**
+    *   Metadata extraction can be pointed at a specific model, stored as a reference to a connection and a model within it. Deleting or disabling that connection left the reference naming something that no longer existed, and unlike the chat default — which quietly falls back — extraction raises instead, and its caller only writes the failure to the processing log. Metadata extraction would therefore fail for every subsequently ingested document with nothing visible to say why. That reference is now re-checked whenever connections change, exactly as the chat default already was.
+    *   (Ref: `resolve_metadata_extraction_model_selection`, `_persist_global_model_endpoints`)
+
+*   **A Failed Settings Write Reported Success After The Secrets Were Already Gone**
+    *   Saving a connection removes superseded secrets from Key Vault before writing the settings document. The settings write reports failure by returning a value rather than raising, and that value was not checked — so if the write failed, the interface said the change had been saved while the connection was left referencing a secret that had already been deleted. A failed write is now reported as an error.
+    *   (Ref: `_persist_global_model_endpoints`, `update_settings`)
+
 ### **(v0.261.059)**
 
 #### New Features

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,33 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/features) and [Fixes by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/fixes).
 
+### **(v0.261.059)**
+
+#### New Features
+
+*   **Model Connections Can Be Managed In The New Admin Interface**
+    *   The AI Models group in the new interface previously showed nothing but a few switches. That was structural rather than cosmetic: no section in the group had a described field schema, so the page fell back to scanning the settings document for `enable_*` booleans — and endpoints, keys, API versions, authentication and model selection are none of those. All of it was invisible.
+    *   **Model endpoints are now presented as connections.** A connection is one Azure OpenAI or Azure AI Foundry resource: where it is, how SimpleChat authenticates to it, and which of its deployed models may be used. The wording and the editing model changed; what is stored did not, so a connection configured in either interface is the same record.
+    *   **Adding a connection now actually saves it.** In the classic interface, adding or editing a model endpoint changed an in-memory list that was serialized into a hidden form field, so nothing was stored until the whole admin settings page was submitted — and a half-filled endpoint looked identical to a saved one. Each connection is now its own resource with its own Save, and the editor says which state it is in.
+    *   **The editor only shows the fields the connection actually uses.** Provider and authentication method together decide what is relevant, derived in one place rather than from several listeners toggling visibility independently. Choosing an API key, for example, hides the subscription and resource group, because an API key cannot reach Azure Resource Manager and those fields would serve no purpose.
+    *   **Validation names the field that is wrong**, next to the control, instead of raising a message that described the problem but not its location.
+    *   **Discovery and testing are part of editing.** *Test connection* checks the credentials resolve, *Discover models* lists the resource's deployments, and each model can be tested individually. Discovered models arrive switched off, because finding a deployment is not the same as choosing to publish it, and re-running discovery does not duplicate a model or overwrite a display name edited by hand.
+    *   **Stored secrets survive an edit.** Keys and client secrets are never returned to the browser; a field whose secret is already stored shows that it exists and stays empty, and leaving it empty keeps the stored value. Deleting a connection removes the secrets it owned from Key Vault.
+    *   Deleting or disabling a connection no longer leaves the default model pointing at something that no longer resolves — chat would otherwise fall back to a different model with no indication that it had. The rule that decides this is now shared with the classic form, so the two interfaces cannot disagree about it.
+    *   (Ref: `route_backend_v2.py`, `/api/v2/admin/model-endpoints`, `modelConnections.ts`, `ModelConnectionsManager.tsx`, `admin_settings_fields.py`, `resolve_default_model_selection`)
+
+#### User Interface Enhancements
+
+*   **AI Models Reads As Connections And Roles**
+    *   The AI Models group conflated two different things: a place models live, and the job a model does. The Model Endpoints tab is now **Connections**, and the Chat Model section is now **Chat**, separating the resource being connected to from the purpose it serves.
+    *   (Ref: `admin_settings_nav.py`, `docs/admin/ai-models.md`)
+
+#### Bug Fixes
+
+*   **A Reserved Identity Header Name Is Now Refused Rather Than Silently Dropped**
+    *   The new admin interface accepted any identity header name. A name that collides with a header the model call already sets — `authorization` or `api-key`, for instance — was normalized away to nothing on read, which turned the header off without saying so. Such a name is now rejected at save time with an explanation.
+    *   (Ref: `admin_settings_fields.py`, `normalize_model_endpoint_identity_header_name`)
+
 ### **(v0.261.058)**
 
 #### New Features

--- a/functional_tests/test_v2_admin_model_endpoints_api.py
+++ b/functional_tests/test_v2_admin_model_endpoints_api.py
@@ -1,0 +1,501 @@
+#!/usr/bin/env python3
+# test_v2_admin_model_endpoints_api.py
+"""
+Functional test for the V2 admin global model endpoint API.
+Version: 0.261.059
+Implemented in: 0.261.059
+
+Global model endpoints were the only scope without per-resource routes. They were
+written through a hidden ``model_endpoints_json`` field on the classic admin form, so
+adding or editing one stored nothing until the whole settings page was submitted.
+
+These checks pin the replacement:
+
+  1. The five CRUD routes exist on the admin blueprint and are admin-gated.
+  2. Every path that returns an endpoint sanitizes it first, so secrets never reach
+     the browser.
+  3. Every write goes through the shared persistence helper, which is what performs
+     the Key Vault save, cleanup and delete passes.
+  4. A default model selection is re-resolved against what was actually saved, so
+     deleting or disabling the endpoint it names cannot leave it dangling.
+"""
+
+import ast
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent))
+
+from test_support.versioning import assert_app_version_at_least
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+APP_DIR = REPO_ROOT / "application" / "single_app"
+ROUTES_FILE = APP_DIR / "route_backend_v2.py"
+SETTINGS_FILE = APP_DIR / "functions_settings.py"
+
+EXPECTED_ROUTES = {
+    ("/api/v2/admin/model-endpoints", "GET"): "v2_admin_list_model_endpoints",
+    ("/api/v2/admin/model-endpoints", "POST"): "v2_admin_create_model_endpoint",
+    ("/api/v2/admin/model-endpoints/<endpoint_id>", "GET"): "v2_admin_get_model_endpoint",
+    ("/api/v2/admin/model-endpoints/<endpoint_id>", "PATCH"): "v2_admin_update_model_endpoint",
+    ("/api/v2/admin/model-endpoints/<endpoint_id>", "DELETE"): "v2_admin_delete_model_endpoint",
+}
+
+REQUIRED_DECORATORS = {"swagger_route", "login_required", "admin_required"}
+
+
+def _parse(path):
+    return ast.parse(path.read_text(encoding="utf-8"))
+
+
+def _decorator_names(node):
+    """Return the bare names of a function's decorators."""
+    names = []
+    for decorator in node.decorator_list:
+        target = decorator.func if isinstance(decorator, ast.Call) else decorator
+        if isinstance(target, ast.Name):
+            names.append(target.id)
+        elif isinstance(target, ast.Attribute):
+            names.append(target.attr)
+    return names
+
+
+def _route_declarations(node):
+    """Return (path, method) pairs declared by ``@bp.route`` on a function."""
+    declared = []
+    for decorator in node.decorator_list:
+        if not isinstance(decorator, ast.Call):
+            continue
+        target = decorator.func
+        if not (isinstance(target, ast.Attribute) and target.attr == "route"):
+            continue
+        if not decorator.args or not isinstance(decorator.args[0], ast.Constant):
+            continue
+        path = decorator.args[0].value
+        methods = ["GET"]
+        for keyword in decorator.keywords:
+            if keyword.arg == "methods" and isinstance(keyword.value, ast.List):
+                methods = [
+                    element.value
+                    for element in keyword.value.elts
+                    if isinstance(element, ast.Constant)
+                ]
+        declared.extend((path, method) for method in methods)
+    return declared
+
+
+def _find_functions(tree):
+    """Return every function definition in the module, at any nesting depth."""
+    found = {}
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            found[node.name] = node
+    return found
+
+
+def _load_selection_helpers():
+    """Exec the pure default-model helpers out of functions_settings.py.
+
+    ``functions_settings`` builds Azure clients at import time and the shared test
+    stub replaces the whole module, so the real functions cannot simply be imported.
+    They are pure, so lifting just their source is enough and keeps the test honest
+    about which implementation it is checking.
+    """
+    tree = _parse(SETTINGS_FILE)
+    wanted_functions = {
+        "normalize_default_model_selection",
+        "resolve_default_model_selection",
+    }
+    wanted_constants = {"EMPTY_DEFAULT_MODEL_SELECTION"}
+
+    selected = []
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name in wanted_functions:
+            selected.append(node)
+        elif isinstance(node, ast.Assign):
+            targets = {t.id for t in node.targets if isinstance(t, ast.Name)}
+            if targets & wanted_constants:
+                selected.append(node)
+
+    assert len(selected) == len(wanted_functions) + len(wanted_constants), (
+        "Expected to find the default-model selection helpers in functions_settings.py, "
+        f"found {[getattr(n, 'name', 'constant') for n in selected]}"
+    )
+
+    namespace = {}
+    exec(compile(ast.Module(body=selected, type_ignores=[]), str(SETTINGS_FILE), "exec"), namespace)
+    return namespace
+
+
+def test_crud_routes_exist_and_are_admin_gated():
+    """A missing admin guard here would expose stored endpoint configuration."""
+    print("Testing model endpoint route declarations...")
+
+    assert_app_version_at_least("0.261.059")
+
+    functions = _find_functions(_parse(ROUTES_FILE))
+
+    declared = {}
+    for name, node in functions.items():
+        for route in _route_declarations(node):
+            declared[route] = name
+
+    for route, expected_name in EXPECTED_ROUTES.items():
+        assert route in declared, f"Route {route[1]} {route[0]} is not declared"
+        assert declared[route] == expected_name, (
+            f"Route {route[1]} {route[0]} is handled by {declared[route]}, "
+            f"expected {expected_name}"
+        )
+
+        decorators = set(_decorator_names(functions[expected_name]))
+        missing = REQUIRED_DECORATORS - decorators
+        assert not missing, f"{expected_name} is missing decorators: {sorted(missing)}"
+
+    print(f"  All {len(EXPECTED_ROUTES)} routes declared and admin-gated.")
+    return True
+
+
+def test_endpoint_reads_are_sanitized():
+    """A raw endpoint carries auth.api_key, which must never reach the browser."""
+    print("Testing endpoint response sanitization...")
+
+    functions = _find_functions(_parse(ROUTES_FILE))
+
+    read_paths = [
+        "v2_admin_list_model_endpoints",
+        "v2_admin_get_model_endpoint",
+        "_model_endpoint_response",
+    ]
+    for name in read_paths:
+        assert name in functions, f"{name} is missing"
+        source = ast.dump(functions[name])
+        assert "sanitize_model_endpoints_for_frontend" in source, (
+            f"{name} returns endpoint data without sanitizing it"
+        )
+
+    # The create and update routes answer with the saved endpoint, and must do so
+    # through the sanitizing helper rather than jsonify-ing the stored object.
+    for name in ("v2_admin_create_model_endpoint", "v2_admin_update_model_endpoint"):
+        source = ast.dump(functions[name])
+        assert "_model_endpoint_response" in source, (
+            f"{name} should answer through _model_endpoint_response"
+        )
+
+    print("  Every endpoint read path sanitizes before responding.")
+    return True
+
+
+def test_writes_go_through_the_key_vault_persistence_helper():
+    """Bypassing the helper would orphan secrets in Key Vault on delete."""
+    print("Testing write persistence path...")
+
+    functions = _find_functions(_parse(ROUTES_FILE))
+
+    for name in (
+        "v2_admin_create_model_endpoint",
+        "v2_admin_update_model_endpoint",
+        "v2_admin_delete_model_endpoint",
+    ):
+        source = ast.dump(functions[name])
+        assert "_persist_global_model_endpoints" in source, (
+            f"{name} does not persist through _persist_global_model_endpoints"
+        )
+        assert "normalize_model_endpoints" in source, (
+            f"{name} does not normalize before persisting"
+        )
+
+    persist_source = ast.dump(functions["_persist_global_model_endpoints"])
+    for helper in (
+        "keyvault_model_endpoint_save_helper",
+        "keyvault_model_endpoint_cleanup_helper",
+        "keyvault_model_endpoint_delete_helper",
+    ):
+        assert helper in persist_source, f"_persist_global_model_endpoints skips {helper}"
+
+    assert '"global"' in persist_source or "'global'" in persist_source, (
+        "_persist_global_model_endpoints must use the global Key Vault scope"
+    )
+
+    print("  Writes normalize, persist and run all three Key Vault passes.")
+    return True
+
+
+def test_default_model_selection_is_revalidated():
+    """A default pointing at a deleted endpoint silently changes which model answers."""
+    print("Testing default model selection resolution...")
+
+    helpers = _load_selection_helpers()
+    resolve = helpers["resolve_default_model_selection"]
+
+    endpoints = [
+        {
+            "id": "ep-1",
+            "provider": "aoai",
+            "enabled": True,
+            "models": [
+                {"id": "gpt-4o", "enabled": True},
+                {"id": "gpt-4o-mini", "enabled": False},
+            ],
+        },
+        {
+            "id": "ep-2",
+            "provider": "aifoundry",
+            "enabled": False,
+            "models": [{"id": "phi-4", "enabled": True}],
+        },
+    ]
+
+    kept, reason = resolve(
+        {"endpoint_id": "ep-1", "model_id": "gpt-4o", "provider": ""}, endpoints
+    )
+    assert reason is None, reason
+    assert kept["endpoint_id"] == "ep-1" and kept["model_id"] == "gpt-4o", kept
+    # Provider is refreshed from the endpoint so a stale value cannot mis-route.
+    assert kept["provider"] == "aoai", kept
+
+    missing, reason = resolve(
+        {"endpoint_id": "ep-gone", "model_id": "gpt-4o"}, endpoints
+    )
+    assert missing["endpoint_id"] == "", missing
+    assert reason and "endpoint" in reason.lower(), reason
+
+    disabled_endpoint, reason = resolve(
+        {"endpoint_id": "ep-2", "model_id": "phi-4"}, endpoints
+    )
+    assert disabled_endpoint["endpoint_id"] == "", disabled_endpoint
+    assert reason and "endpoint" in reason.lower(), reason
+
+    disabled_model, reason = resolve(
+        {"endpoint_id": "ep-1", "model_id": "gpt-4o-mini"}, endpoints
+    )
+    assert disabled_model["model_id"] == "", disabled_model
+    assert reason and "model" in reason.lower(), reason
+
+    off, reason = resolve(
+        {"endpoint_id": "ep-1", "model_id": "gpt-4o"},
+        endpoints,
+        multi_endpoint_enabled=False,
+    )
+    assert off == {"endpoint_id": "", "model_id": "", "provider": ""}, off
+    assert reason is None, reason
+
+    partial, reason = resolve({"endpoint_id": "ep-1", "model_id": ""}, endpoints)
+    assert partial["endpoint_id"] == "", partial
+    assert reason is None, reason
+
+    print("  Selections resolve, clear and refresh provider as expected.")
+    return True
+
+
+def test_persistence_revalidates_the_default_selection():
+    """The route layer has to apply the rule, not merely have it available."""
+    print("Testing that persistence re-resolves the default...")
+
+    functions = _find_functions(_parse(ROUTES_FILE))
+    persist_source = ast.dump(functions["_persist_global_model_endpoints"])
+
+    assert "resolve_default_model_selection" in persist_source, (
+        "_persist_global_model_endpoints must re-resolve default_model_selection "
+        "after saving, or deleting an endpoint leaves the default dangling"
+    )
+    assert "default_model_selection" in persist_source, persist_source[:200]
+
+    print("  Persistence re-resolves the default model selection.")
+    return True
+
+
+def _load_persistence_helper():
+    """Exec ``_persist_global_model_endpoints`` with its collaborators faked.
+
+    The route module imports Azure clients transitively, so it cannot be imported in a
+    test. The helper itself is ordinary Python over lists and dicts, so lifting its source
+    and supplying fakes exercises the real ordering of the three Key Vault passes -- which
+    is the part that silently orphans a secret when it is wrong.
+
+    Returns ``(function, calls)`` where ``calls`` records what each fake was asked to do.
+    """
+    tree = _parse(ROUTES_FILE)
+    target = next(
+        (
+            node
+            for node in tree.body
+            if isinstance(node, ast.FunctionDef)
+            and node.name == "_persist_global_model_endpoints"
+        ),
+        None,
+    )
+    assert target is not None, "_persist_global_model_endpoints was not found"
+
+    calls = {
+        "saved": [],
+        "cleaned": [],
+        "deleted": [],
+        "updates": [],
+        "settings": {
+            "enable_multi_model_endpoints": True,
+            "default_model_selection": {},
+        },
+    }
+
+    def fake_save(endpoint, scope_value, scope="global", existing_endpoint=None):
+        calls["saved"].append((endpoint.get("id"), scope, scope_value))
+        return endpoint
+
+    def fake_cleanup(previous, current, scope_value, scope="global"):
+        calls["cleaned"].append((scope_value, scope))
+
+    def fake_delete(endpoint, scope_value, scope="global"):
+        calls["deleted"].append((scope_value, scope))
+
+    def fake_update_settings(updates):
+        calls["updates"].append(updates)
+        calls["settings"].update(updates)
+        return True
+
+    selection_helpers = _load_selection_helpers()
+
+    namespace = {
+        "keyvault_model_endpoint_save_helper": fake_save,
+        "keyvault_model_endpoint_cleanup_helper": fake_cleanup,
+        "keyvault_model_endpoint_delete_helper": fake_delete,
+        "get_settings": lambda: calls["settings"],
+        "update_settings": fake_update_settings,
+        "resolve_default_model_selection": selection_helpers[
+            "resolve_default_model_selection"
+        ],
+    }
+    exec(compile(ast.Module(body=[target], type_ignores=[]), str(ROUTES_FILE), "exec"), namespace)
+    return namespace["_persist_global_model_endpoints"], calls
+
+
+def test_persistence_runs_all_three_key_vault_passes():
+    """A removed endpoint's secret must be deleted, not merely left out of the save."""
+    print("Testing Key Vault pass ordering...")
+
+    persist, calls = _load_persistence_helper()
+
+    existing = [
+        {"id": "ep-keep", "name": "Keep", "enabled": True, "models": []},
+        {"id": "ep-drop", "name": "Drop", "enabled": True, "models": []},
+    ]
+    normalized = [{"id": "ep-keep", "name": "Keep", "enabled": True, "models": []}]
+
+    saved = persist(normalized, existing)
+
+    assert [entry[0] for entry in calls["saved"]] == ["ep-keep"], calls["saved"]
+    # Global scope keys its secrets by endpoint id, matching the classic form.
+    assert calls["saved"][0][1] == "global", calls["saved"]
+    assert calls["saved"][0][2] == "ep-keep", calls["saved"]
+    assert calls["cleaned"] == [("ep-keep", "global")], calls["cleaned"]
+    assert calls["deleted"] == [("ep-drop", "global")], calls["deleted"]
+
+    assert calls["updates"], "settings were never written"
+    assert calls["updates"][0]["model_endpoints"] == saved
+
+    print("  Save, cleanup and delete each ran over the right endpoints.")
+    return True
+
+
+def test_deleting_the_default_endpoint_clears_the_default():
+    """Otherwise chat falls back to another model without saying it has."""
+    print("Testing default clearing on delete...")
+
+    persist, calls = _load_persistence_helper()
+    calls["settings"]["default_model_selection"] = {
+        "endpoint_id": "ep-gone",
+        "model_id": "gpt-4o",
+        "provider": "aoai",
+    }
+
+    existing = [
+        {
+            "id": "ep-gone",
+            "enabled": True,
+            "provider": "aoai",
+            "models": [{"id": "gpt-4o", "enabled": True}],
+        }
+    ]
+    persist([], existing)
+
+    written = calls["updates"][0]
+    assert "default_model_selection" in written, written
+    assert written["default_model_selection"] == {
+        "endpoint_id": "",
+        "model_id": "",
+        "provider": "",
+    }, written
+
+    print("  A dangling default is cleared when its endpoint goes.")
+    return True
+
+
+def test_an_unaffected_default_is_left_alone():
+    """Rewriting an unchanged value on every save would churn the settings document."""
+    print("Testing that a valid default is not rewritten...")
+
+    persist, calls = _load_persistence_helper()
+    calls["settings"]["default_model_selection"] = {
+        "endpoint_id": "ep-1",
+        "model_id": "gpt-4o",
+        "provider": "aoai",
+    }
+
+    endpoints = [
+        {
+            "id": "ep-1",
+            "enabled": True,
+            "provider": "aoai",
+            "models": [{"id": "gpt-4o", "enabled": True}],
+        }
+    ]
+    persist(endpoints, endpoints)
+
+    written = calls["updates"][0]
+    assert "default_model_selection" not in written, written
+
+    print("  An unchanged default is not rewritten.")
+    return True
+
+
+def test_classic_form_shares_the_selection_rule():
+    """Two copies of this rule would drift, which is what the shared helper prevents."""
+    print("Testing classic form uses the shared helper...")
+
+    classic = (APP_DIR / "route_frontend_admin_settings.py").read_text(encoding="utf-8")
+    assert "resolve_default_model_selection(" in classic, (
+        "The classic admin form should resolve the default model selection through "
+        "the shared helper so the two interfaces cannot disagree"
+    )
+
+    print("  Classic form resolves through the shared helper.")
+    return True
+
+
+if __name__ == "__main__":
+    tests = [
+        test_crud_routes_exist_and_are_admin_gated,
+        test_endpoint_reads_are_sanitized,
+        test_writes_go_through_the_key_vault_persistence_helper,
+        test_default_model_selection_is_revalidated,
+        test_persistence_revalidates_the_default_selection,
+        test_persistence_runs_all_three_key_vault_passes,
+        test_deleting_the_default_endpoint_clears_the_default,
+        test_an_unaffected_default_is_left_alone,
+        test_classic_form_shares_the_selection_rule,
+    ]
+
+    results = []
+    for test in tests:
+        print(f"\nRunning {test.__name__}...")
+        try:
+            results.append(bool(test()))
+        except Exception as exc:
+            print(f"FAIL: {exc}")
+            import traceback
+
+            traceback.print_exc()
+            results.append(False)
+
+    print(f"\nResults: {sum(results)}/{len(results)} tests passed")
+    sys.exit(0 if all(results) else 1)

--- a/functional_tests/test_v2_admin_model_endpoints_api.py
+++ b/functional_tests/test_v2_admin_model_endpoints_api.py
@@ -22,10 +22,12 @@ These checks pin the replacement:
 
 import ast
 import sys
+import uuid
 from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parent))
 
+from test_support.app_stubs import import_app_module
 from test_support.versioning import assert_app_version_at_least
 
 
@@ -105,7 +107,9 @@ def _load_selection_helpers():
     tree = _parse(SETTINGS_FILE)
     wanted_functions = {
         "normalize_default_model_selection",
+        "resolve_model_selection",
         "resolve_default_model_selection",
+        "resolve_metadata_extraction_model_selection",
     }
     wanted_constants = {"EMPTY_DEFAULT_MODEL_SELECTION"}
 
@@ -126,6 +130,30 @@ def _load_selection_helpers():
     namespace = {}
     exec(compile(ast.Module(body=selected, type_ignores=[]), str(SETTINGS_FILE), "exec"), namespace)
     return namespace
+
+
+def _load_migration_builder():
+    """Exec ``build_migrated_model_endpoints_from_legacy`` out of functions_settings.py."""
+    tree = _parse(SETTINGS_FILE)
+    target = next(
+        (
+            node
+            for node in tree.body
+            if isinstance(node, ast.FunctionDef)
+            and node.name == "build_migrated_model_endpoints_from_legacy"
+        ),
+        None,
+    )
+    assert target is not None, "build_migrated_model_endpoints_from_legacy was not found"
+
+    namespace = {"uuid": uuid}
+    exec(compile(ast.Module(body=[target], type_ignores=[]), str(SETTINGS_FILE), "exec"), namespace)
+    return namespace["build_migrated_model_endpoints_from_legacy"]
+
+
+def _load_admin_fields_module():
+    """Import ``admin_settings_fields`` with the Azure-dependent seams stubbed."""
+    return import_app_module("admin_settings_fields")
 
 
 def test_crud_routes_exist_and_are_admin_gated():
@@ -350,6 +378,8 @@ def _load_persistence_helper():
 
     def fake_update_settings(updates):
         calls["updates"].append(updates)
+        if calls.get("fail_update"):
+            return False
         calls["settings"].update(updates)
         return True
 
@@ -363,6 +393,9 @@ def _load_persistence_helper():
         "update_settings": fake_update_settings,
         "resolve_default_model_selection": selection_helpers[
             "resolve_default_model_selection"
+        ],
+        "resolve_metadata_extraction_model_selection": selection_helpers[
+            "resolve_metadata_extraction_model_selection"
         ],
     }
     exec(compile(ast.Module(body=[target], type_ignores=[]), str(ROUTES_FILE), "exec"), namespace)
@@ -458,6 +491,143 @@ def test_an_unaffected_default_is_left_alone():
     return True
 
 
+def test_metadata_extraction_selection_is_revalidated():
+    """A dangling metadata selection makes document ingestion raise, not fall back."""
+    print("Testing metadata extraction selection re-resolution...")
+
+    persist, calls = _load_persistence_helper()
+    calls["settings"]["metadata_extraction_model_selection"] = {
+        "endpoint_id": "ep-gone",
+        "model_id": "gpt-4o",
+        "provider": "aoai",
+    }
+
+    existing = [
+        {
+            "id": "ep-gone",
+            "enabled": True,
+            "provider": "aoai",
+            "models": [{"id": "gpt-4o", "enabled": True}],
+        }
+    ]
+    persist([], existing)
+
+    written = calls["updates"][0]
+    assert "metadata_extraction_model_selection" in written, written
+    assert written["metadata_extraction_model_selection"] == {
+        "endpoint_id": "",
+        "model_id": "",
+        "provider": "",
+    }, written
+
+    print("  A dangling metadata selection is cleared alongside the default.")
+    return True
+
+
+def test_a_failed_settings_write_is_not_reported_as_success():
+    """Key Vault deletes already ran, so a silent failure leaves a broken endpoint."""
+    print("Testing failed settings write handling...")
+
+    persist, calls = _load_persistence_helper()
+    calls["fail_update"] = True
+
+    try:
+        persist([], [{"id": "ep-1", "enabled": True, "models": []}])
+    except RuntimeError:
+        print("  A failed settings write raises rather than reporting success.")
+        return True
+
+    raise AssertionError(
+        "_persist_global_model_endpoints ignored a failed update_settings call"
+    )
+
+
+def test_enabling_connections_cannot_be_undone_silently():
+    """update_settings coerces this key to existing-or-requested, so off never sticks."""
+    print("Testing the one-way connections toggle...")
+
+    fields_module = _load_admin_fields_module()
+    normalize = fields_module.normalize_admin_settings_updates
+
+    # Turning it on is allowed.
+    on, errors, _ = normalize(
+        {"enable_multi_model_endpoints": True},
+        {"enable_multi_model_endpoints": False},
+    )
+    assert not errors, errors
+    assert on["enable_multi_model_endpoints"] is True, on
+
+    # Turning it off once enabled must be refused rather than silently ignored, because
+    # update_settings would store True and the response would still say False.
+    _, errors, _ = normalize(
+        {"enable_multi_model_endpoints": False},
+        {"enable_multi_model_endpoints": True},
+    )
+    assert "enable_multi_model_endpoints" in errors, errors
+
+    # Leaving it off is not a change of state and must not error.
+    off, errors, _ = normalize(
+        {"enable_multi_model_endpoints": False},
+        {"enable_multi_model_endpoints": False},
+    )
+    assert not errors, errors
+    assert off["enable_multi_model_endpoints"] is False, off
+
+    print("  Switching connections off once enabled is refused with a message.")
+    return True
+
+
+def test_first_enable_carries_the_classic_endpoint_over():
+    """Enabling with an empty list would strand a deployment with no chat models."""
+    print("Testing first-enable migration...")
+
+    functions = _find_functions(_parse(ROUTES_FILE))
+    assert "_seed_connections_on_first_enable" in functions, (
+        "The V2 patch route must migrate the classic endpoint on first enable, as the "
+        "classic form does, or enabling from V2 leaves an empty model catalog"
+    )
+
+    patch_source = ast.dump(functions["v2_admin_patch_settings"])
+    assert "_seed_connections_on_first_enable" in patch_source, (
+        "v2_admin_patch_settings does not call the first-enable migration"
+    )
+
+    seed_source = ast.dump(functions["_seed_connections_on_first_enable"])
+    assert "build_migrated_model_endpoints_from_legacy" in seed_source, (
+        "The migration must reuse the shared builder so it cannot drift from the "
+        "classic form"
+    )
+    assert "keyvault_model_endpoint_save_helper" in seed_source, (
+        "A migrated endpoint carries the classic API key and must be stored through "
+        "Key Vault like any other"
+    )
+
+    # And the builder itself must actually produce the legacy configuration.
+    builder = _load_migration_builder()
+    migrated = builder(
+        {
+            "gpt_model": {"selected": [{"deploymentName": "gpt-4o", "modelName": "gpt-4o"}]},
+            "azure_openai_gpt_endpoint": "https://legacy.openai.azure.com",
+            "azure_openai_gpt_key": "legacy-key",
+            "azure_openai_gpt_authentication_type": "key",
+            "azure_openai_gpt_subscription_id": "sub",
+            "azure_openai_gpt_resource_group": "rg",
+        }
+    )
+    assert len(migrated) == 1, migrated
+    assert migrated[0]["connection"]["endpoint"] == "https://legacy.openai.azure.com"
+    # The classic form stores 'key'; the connection shape calls the same thing 'api_key'.
+    assert migrated[0]["auth"]["type"] == "api_key", migrated[0]["auth"]
+    assert migrated[0]["auth"]["api_key"] == "legacy-key"
+    assert [model["deploymentName"] for model in migrated[0]["models"]] == ["gpt-4o"]
+
+    # Nothing to migrate must not fabricate an empty endpoint.
+    assert builder({"gpt_model": {"selected": []}}) == []
+
+    print("  First enable carries the classic endpoint over, through the shared builder.")
+    return True
+
+
 def test_classic_form_shares_the_selection_rule():
     """Two copies of this rule would drift, which is what the shared helper prevents."""
     print("Testing classic form uses the shared helper...")
@@ -482,6 +652,10 @@ if __name__ == "__main__":
         test_persistence_runs_all_three_key_vault_passes,
         test_deleting_the_default_endpoint_clears_the_default,
         test_an_unaffected_default_is_left_alone,
+        test_metadata_extraction_selection_is_revalidated,
+        test_a_failed_settings_write_is_not_reported_as_success,
+        test_enabling_connections_cannot_be_undone_silently,
+        test_first_enable_carries_the_classic_endpoint_over,
         test_classic_form_shares_the_selection_rule,
     ]
 

--- a/functional_tests/test_v2_model_connections_logic.mjs
+++ b/functional_tests/test_v2_model_connections_logic.mjs
@@ -1,0 +1,359 @@
+// test_v2_model_connections_logic.mjs
+//
+// Runtime test for the V2 global model connection form logic.
+// Version: 0.261.059
+// Implemented in: 0.261.059
+//
+// The classic connection editor decided which fields a provider and auth type needed by
+// toggling `d-none` across two dozen elements from three separate listeners, and reported
+// a validation failure as a toast that named the problem but not the control. Both are why
+// it was hard to tell what a connection still needed.
+//
+// The replacement derives visibility and validation from the draft in one place, so those
+// rules can be executed here rather than inferred from the rendered DOM. The payload
+// builder is checked too, because two of its decisions are silent if wrong: sending a blank
+// secret would erase a stored key, and sending a provider's unused fields would persist
+// coordinates that no longer apply.
+//
+// Run directly with `node functional_tests/test_v2_model_connections_logic.mjs`. Requires
+// Node 22.6 or newer, which strips the TypeScript types so the real module is imported.
+
+import assert from 'node:assert/strict';
+
+import './test_support/tsResolve.mjs';
+
+const {
+    buildConnectionPayload,
+    emptyConnection,
+    enabledModelCount,
+    endpointIncludesProject,
+    isFoundryProvider,
+    mergeDiscoveredModels,
+    projectNameFromEndpoint,
+    providerLabel,
+    toEditableConnection,
+    validateConnection,
+    visibleFields,
+} = await import('../application/v2_ui/src/lib/modelConnections.ts');
+
+const checks = [];
+function check(name, fn) {
+    checks.push([name, fn]);
+}
+
+/** A connection that passes validation, so each check can break exactly one thing. */
+function validAoai(overrides = {}) {
+    const base = emptyConnection();
+    return {
+        ...base,
+        ...overrides,
+        name: 'Primary',
+        connection: {
+            ...base.connection,
+            endpoint: 'https://example.openai.azure.com',
+            ...(overrides.connection ?? {}),
+        },
+        management: {
+            subscription_id: '00000000-0000-0000-0000-000000000000',
+            resource_group: 'rg-ai',
+            ...(overrides.management ?? {}),
+        },
+        auth: { ...base.auth, ...(overrides.auth ?? {}) },
+    };
+}
+
+/* ------------------------------- provider shape ------------------------------ */
+
+check('foundry providers are recognised by both stored names', () => {
+    assert.equal(isFoundryProvider('aifoundry'), true);
+    assert.equal(isFoundryProvider('new_foundry'), true);
+    assert.equal(isFoundryProvider('aoai'), false);
+});
+
+check('provider labels fall back to the raw value rather than going blank', () => {
+    assert.equal(providerLabel('aoai'), 'Azure OpenAI');
+    assert.equal(providerLabel('anthropic'), 'anthropic');
+    assert.equal(providerLabel(''), 'Connection');
+});
+
+check('a project endpoint URL yields its project name', () => {
+    assert.equal(endpointIncludesProject('https://x.services.ai.azure.com/api/projects/proj'), true);
+    assert.equal(
+        projectNameFromEndpoint('https://x.services.ai.azure.com/api/projects/my-project'),
+        'my-project',
+    );
+    // A half-typed endpoint is not a parseable URL, but the hint should still work.
+    assert.equal(projectNameFromEndpoint('x.services.ai/api/projects/partial?x=1'), 'partial');
+    assert.equal(projectNameFromEndpoint('https://example.openai.azure.com'), '');
+});
+
+/* ------------------------------- field visibility ---------------------------- */
+
+check('an API key connection hides the Azure discovery fields', () => {
+    // Discovery goes through Azure Resource Manager, which an API key cannot reach, so
+    // asking for a subscription and resource group would be asking for nothing.
+    const shown = visibleFields(validAoai({ auth: { type: 'api_key' } }));
+    assert.equal(shown.apiKey, true);
+    assert.equal(shown.management, false);
+    assert.equal(shown.managementCloud, false);
+    assert.equal(shown.servicePrincipal, false);
+    assert.equal(shown.managedIdentity, false);
+});
+
+check('managed identity shows a client id only when user assigned', () => {
+    const system = visibleFields(validAoai({ auth: { type: 'managed_identity' } }));
+    assert.equal(system.userAssignedClientId, false);
+
+    const user = visibleFields(
+        validAoai({ auth: { type: 'managed_identity', managed_identity_type: 'user_assigned' } }),
+    );
+    assert.equal(user.userAssignedClientId, true);
+});
+
+check('a custom management cloud reveals the authority field', () => {
+    const publicCloud = visibleFields(validAoai({ auth: { type: 'service_principal' } }));
+    assert.equal(publicCloud.customAuthority, false);
+
+    const custom = visibleFields(
+        validAoai({ auth: { type: 'service_principal', management_cloud: 'custom' } }),
+    );
+    assert.equal(custom.customAuthority, true);
+});
+
+check('foundry fields appear only for foundry providers', () => {
+    assert.equal(visibleFields(validAoai()).project, false);
+    const foundry = visibleFields(validAoai({ provider: 'new_foundry' }));
+    assert.equal(foundry.project, true);
+    assert.equal(foundry.foundryScope, true);
+    // Foundry discovery does not use ARM coordinates.
+    assert.equal(foundry.management, false);
+});
+
+/* --------------------------------- validation -------------------------------- */
+
+check('a complete Azure OpenAI connection validates', () => {
+    assert.deepEqual(validateConnection(validAoai()), {});
+});
+
+check('validation reports the field, not just the failure', () => {
+    const errors = validateConnection({ ...validAoai(), name: '' });
+    assert.ok(errors.name, 'expected a name error');
+    assert.equal(Object.keys(errors).length, 1);
+});
+
+check('an endpoint without a scheme is refused', () => {
+    const errors = validateConnection(
+        validAoai({ connection: { endpoint: 'example.openai.azure.com' } }),
+    );
+    assert.ok(errors.endpoint);
+});
+
+check('Azure OpenAI discovery requires the resource coordinates', () => {
+    const errors = validateConnection(
+        validAoai({ management: { subscription_id: '', resource_group: '' } }),
+    );
+    assert.ok(errors.subscription_id);
+    assert.ok(errors.resource_group);
+});
+
+check('an API key connection does not demand the discovery coordinates', () => {
+    const errors = validateConnection(
+        validAoai({
+            auth: { type: 'api_key', api_key: 'secret-value' },
+            management: { subscription_id: '', resource_group: '' },
+        }),
+    );
+    assert.deepEqual(errors, {});
+});
+
+check('a stored secret satisfies validation when the input is left blank', () => {
+    // The server strips secrets on the way out, so the editor never holds one. Demanding a
+    // value here would force an administrator to retype the key to change anything else.
+    const stored = {
+        ...validAoai({ auth: { type: 'api_key', api_key: '' } }),
+        has_api_key: true,
+    };
+    assert.deepEqual(validateConnection(stored), {});
+
+    const absent = { ...validAoai({ auth: { type: 'api_key', api_key: '' } }), has_api_key: false };
+    assert.ok(validateConnection(absent).api_key);
+});
+
+check('service principal requires tenant, client and a secret unless one is stored', () => {
+    const missing = validateConnection(validAoai({ auth: { type: 'service_principal' } }));
+    assert.ok(missing.tenant_id);
+    assert.ok(missing.client_id);
+    assert.ok(missing.client_secret);
+
+    const withStored = {
+        ...validAoai({
+            auth: { type: 'service_principal', tenant_id: 't', client_id: 'c', client_secret: '' },
+        }),
+        has_client_secret: true,
+    };
+    assert.deepEqual(validateConnection(withStored), {});
+});
+
+check('a foundry endpoint without a project needs the project named', () => {
+    const errors = validateConnection(
+        validAoai({
+            provider: 'new_foundry',
+            connection: {
+                endpoint: 'https://x.services.ai.azure.com',
+                openai_api_version: 'v1',
+                project_api_version: 'v1',
+                project_name: '',
+            },
+        }),
+    );
+    assert.ok(errors.project_name);
+
+    const named = validateConnection(
+        validAoai({
+            provider: 'new_foundry',
+            connection: {
+                endpoint: 'https://x.services.ai.azure.com/api/projects/proj',
+                openai_api_version: 'v1',
+                project_api_version: 'v1',
+            },
+        }),
+    );
+    assert.equal(named.project_name, undefined);
+});
+
+/* ------------------------------- payload building ---------------------------- */
+
+check('a blank secret is omitted so a stored one survives the save', () => {
+    const payload = buildConnectionPayload({
+        ...validAoai({ auth: { type: 'api_key', api_key: '' } }),
+        has_api_key: true,
+    });
+    assert.equal('api_key' in payload.auth, false, 'a blank key must not be sent');
+
+    const replaced = buildConnectionPayload(
+        validAoai({ auth: { type: 'api_key', api_key: 'new-secret' } }),
+    );
+    assert.equal(replaced.auth.api_key, 'new-secret');
+});
+
+check('a provider only sends the auth fields it uses', () => {
+    const payload = buildConnectionPayload(validAoai({ auth: { type: 'api_key', api_key: 'k' } }));
+    assert.equal('tenant_id' in payload.auth, false);
+    assert.equal('managed_identity_type' in payload.auth, false);
+
+    const identity = buildConnectionPayload(validAoai());
+    assert.equal(identity.auth.managed_identity_type, 'system_assigned');
+    assert.equal('client_secret' in identity.auth, false);
+});
+
+check('foundry connections send project details and no ARM coordinates', () => {
+    const payload = buildConnectionPayload(
+        validAoai({
+            provider: 'new_foundry',
+            connection: {
+                endpoint: 'https://x.services.ai.azure.com/api/projects/proj',
+                openai_api_version: 'v1',
+                project_api_version: 'v1',
+            },
+        }),
+    );
+    assert.equal(payload.connection.project_api_version, 'v1');
+    // Derived from the endpoint rather than requiring it to be typed twice.
+    assert.equal(payload.connection.project_name, 'proj');
+    assert.deepEqual(payload.management, {});
+});
+
+check('azure openai connections send the ARM coordinates', () => {
+    const payload = buildConnectionPayload(validAoai());
+    assert.equal(payload.management.resource_group, 'rg-ai');
+    assert.equal('project_api_version' in payload.connection, false);
+});
+
+check('a model with no display name falls back to its deployment name', () => {
+    const payload = buildConnectionPayload({
+        ...validAoai(),
+        models: [{ deploymentName: 'gpt-4o', displayName: '', enabled: true }],
+    });
+    assert.equal(payload.models[0].displayName, 'gpt-4o');
+});
+
+check('an id is sent only when the connection already has one', () => {
+    assert.equal('id' in buildConnectionPayload(validAoai()), false);
+    assert.equal(buildConnectionPayload({ ...validAoai(), id: 'ep-1' }).id, 'ep-1');
+});
+
+/* ------------------------------- model discovery ----------------------------- */
+
+check('discovery does not duplicate a model already listed', () => {
+    const { models, added } = mergeDiscoveredModels(
+        [{ deploymentName: 'gpt-4o', displayName: 'Renamed by hand', enabled: true }],
+        [{ deploymentName: 'GPT-4o' }, { deploymentName: 'gpt-4o-mini' }],
+    );
+    assert.equal(added, 1);
+    assert.equal(models.length, 2);
+    // Matching is case-insensitive, so an edited display name is not overwritten.
+    assert.equal(models[0].displayName, 'Renamed by hand');
+});
+
+check('discovered models arrive switched off', () => {
+    // Discovery finding a deployment is not the same as choosing to publish it.
+    const { models } = mergeDiscoveredModels([], [{ deploymentName: 'gpt-4o' }]);
+    assert.equal(models[0].enabled, false);
+    assert.equal(models[0].isDiscovered, true);
+});
+
+check('a deployment with no name is skipped rather than added blank', () => {
+    const { models, added } = mergeDiscoveredModels([], [{ modelName: 'gpt-4o' }, {}]);
+    assert.equal(added, 0);
+    assert.equal(models.length, 0);
+});
+
+check('the deployment field is read under either name the API uses', () => {
+    const { added } = mergeDiscoveredModels([], [{ deployment: 'legacy-shape' }]);
+    assert.equal(added, 1);
+});
+
+check('available model count treats a missing flag as enabled', () => {
+    assert.equal(
+        enabledModelCount({ models: [{ enabled: true }, { enabled: false }, {}] }),
+        2,
+    );
+});
+
+/* --------------------------------- edit shape -------------------------------- */
+
+check('editing a sparse stored connection fills every control', () => {
+    // A connection saved before a field existed has no value for it, and an undefined
+    // value would make React drop the first keystroke into that control.
+    const editable = toEditableConnection({ id: 'ep-1', name: 'Old', provider: 'aoai' });
+    assert.equal(editable.auth.type, 'managed_identity');
+    assert.equal(editable.connection.endpoint, '');
+    assert.equal(editable.identity_header.mode, 'inherit');
+    assert.deepEqual(editable.models, []);
+    assert.equal(editable.id, 'ep-1');
+});
+
+check('editing preserves keys the editor does not know about', () => {
+    const editable = toEditableConnection({ id: 'ep-1', custom_future_field: 'keep me' });
+    assert.equal(editable.custom_future_field, 'keep me');
+});
+
+/* ----------------------------------- runner ---------------------------------- */
+
+let passed = 0;
+let failed = 0;
+
+for (const [name, fn] of checks) {
+    try {
+        await fn();
+        console.log(`ok   ${name}`);
+        passed += 1;
+    } catch (error) {
+        console.log(`FAIL ${name}`);
+        console.log(`     ${error.message}`);
+        failed += 1;
+    }
+}
+
+console.log(`\n${passed}/${passed + failed} runtime checks passed`);
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Why AI Models was empty in V2

The AI Models group rendered nothing but a handful of switches. That was **structural, not cosmetic**: no section in the group had a `field_schema` entry in `admin_settings_fields.py`, so the page fell back to scanning the settings document for `enable_*` booleans. Endpoints, keys, API versions, authentication and model selection are none of those, so all of it was invisible.

## Why the classic editor felt confusing

**In the classic interface, adding or editing a model endpoint saves nothing.** The modal mutates an in-memory array serialized into a hidden `model_endpoints_json` field on the monolithic admin form (`route_frontend_admin_settings.py`), so nothing persists until the *entire* settings page is submitted — and a half-filled endpoint looks identical to a saved one. Delete is a two-click toast with a 5-second timeout.

It is built that way because **global model endpoints had no REST API**. Personal scope has full CRUD (`/api/user/model-endpoints`), group scope has GET/POST, global had neither. So this could not be fixed in the UI alone.

## What this PR adds

### Backend

Five routes on the existing V2 admin blueprint, inheriting its `login_required` + `admin_required` policy:

```
GET    /api/v2/admin/model-endpoints
POST   /api/v2/admin/model-endpoints
GET    /api/v2/admin/model-endpoints/<id>
PATCH  /api/v2/admin/model-endpoints/<id>
DELETE /api/v2/admin/model-endpoints/<id>
```

They reuse `normalize_model_endpoints`, `sanitize_model_endpoints_for_frontend` and the three Key Vault passes (`save` → `cleanup` → `delete`), so an endpoint saved from either interface is stored identically, and deleting one does not orphan its secret.

Secrets are stripped on the way out and an **omitted secret on the way back in means "keep what is stored"**, so the redacted copy the browser holds can never blank a real key.

### Connections UI

`ModelConnectionsManager` — a list plus a per-connection editor that saves on its own, with explicit Save/Cancel. Grouped as Identity → Connection → Authentication → Discovery → Models → Identity header.

- **Field visibility is derived in one place** (`visibleFields`) rather than from three listeners toggling `d-none` across two dozen elements. Choosing an API key hides the subscription and resource group, because an API key cannot reach Azure Resource Manager and those fields would serve no purpose.
- **Validation names the offending field**, next to the control, instead of a toast that described the problem but not its location.
- **Discovered models arrive switched off** — finding a deployment is not the same as choosing to publish it. Re-running discovery does not duplicate a model or overwrite a hand-edited display name.
- Discovery, connection test and per-model test reuse the existing admin-gated `/api/models/fetch`, `/api/models/test-connection` and `/api/models/test-model`.
- Delete is behind a real confirm dialog.

## Bugs found and fixed along the way

A review pass over the first commit turned up three real problems, fixed in `1c7853a4`.

**1. Turning connections off reported success and did nothing.** `update_settings` coerces `enable_multi_model_endpoints` to `existing or requested`, so once true it can never be stored as false — the classic page reflects this by rendering the checkbox only while the flag is off. The new schema exposed it as an ordinary switch, so turning it off returned `200`, echoed the requested value back into the UI, and changed nothing. Now refused with an explanation.

**2. Enabling connections from V2 stranded the deployment.** The classic form seeds `model_endpoints` from the existing `azure_openai_gpt_*` config on the off→on transition. The V2 patch route skipped that, so enabling connections there left an empty model catalog — and, because the flag cannot be turned back off, no way to recover. Both paths now migrate through `build_migrated_model_endpoints_from_legacy`.

**3. Deleting a connection could silently break metadata extraction.** `metadata_extraction_model_selection` is the same kind of loose reference as `default_model_selection`, but only the latter was re-resolved. A dangling default makes chat fall back quietly; a dangling metadata selection makes `_resolve_metadata_extraction_client` *raise*, and its caller only writes that to the processing log — so deleting or disabling a connection broke extraction for every subsequently ingested document, invisibly. Both are now re-resolved through a shared `resolve_model_selection`.

**Also:** `update_settings` returns `False` rather than raising, and its result was discarded. The Key Vault passes run *before* the settings write and cannot be undone, so a failed write left an endpoint referencing an already-deleted secret while the API reported success. A failed write now raises and the route answers 500.

**And:** a reserved identity header name (`authorization`, `api-key`, …) was accepted by the V2 surface and then normalized away to nothing on read, turning the header off without saying so. Now refused at save time.

`default_model_selection` validation is shared with the classic form, so the two interfaces cannot drift on it.

## Presentation

Following the **Connections × Roles** split — a connection is *where models live*, chat/embeddings/image are *roles a model plays*. The Model Endpoints tab is now **Connections** and the Chat Model section is now **Chat**.

V2 renders no nav tabs (flat searchable section cards, groups-only rail), so this needed **no new tabs or sections** and therefore **no V1 pane or card churn** — only label changes. Section and tab **ids are untouched**.

## Scope notes

- V2 chat is Connections-only by design; the legacy single-endpoint/APIM chat form stays in the classic page.
- Agent Default Model Review is deliberately not carried to V2. Its V1 panel and both backend routes are untouched.

## Testing

| | |
|---|---|
| `test_v2_admin_model_endpoints_api.py` (new) | 13/13 — route contract, sanitization on every read path, Key Vault pass ordering executed with fakes, both selection re-resolutions, failed-write handling, one-way toggle, first-enable migration |
| `test_v2_model_connections_logic.mjs` (new) | 28/28 — executes the real TS module: visibility, validation, payload building, discovery merge |
| Admin/V2/docs/route suites | 21 files, all pass |
| `npm run build` | clean |

Three failures on this branch are **pre-existing and verified identical on a clean tree**: `test_admin_settings_sidebar_card_parity.py` (an `inbound-mcp` duplicate), `test_docs_release_notes_integrity.py` (27 older releases published but absent from source), and `test_admin_settings_tab_preservation.py` (2/3). None touch files in this change.

## This is phase 1 of 3 — stacked PRs follow

The AI Models rebuild was staged so the Connections work could land and be used before the rest followed. Each phase is a separate PR, stacked in order:

1. **This PR** — global model connection API + the Connections card.
2. **#1419 — Chat** (base: this branch). Default model picker with its own `GET`/`PUT /api/v2/admin/default-model` routes, and a notice naming which endpoint chat is actually using. Also declares `enable_gpt_apim`, which was rendering as a bare guessed toggle inside the Chat card.
3. **Embeddings + Image generation** (base: #1419). Adds a `password` field type and string-valued `depends_on`, then declares both remaining sections.

Merge in order: this → #1419 → phase 3.

## Known follow-up, deliberately not in this stack

**#1420** — the capability fallback scan renders `enable_multi_agent_orchestration` as an editable toggle in the Connections card. It is a *derived* value computed from `orchestration_type`, with no independent V1 control, so it needs to be suppressed from the scan rather than declared — which requires new machinery in both the schema module and the renderer. Left out because three stacked branches were in flight against those same files.