### PR TITLE
Bring Workflow settings into the V2 admin surface

### DIFF
--- a/application/single_app/admin_settings_fields.py
+++ b/application/single_app/admin_settings_fields.py
@@ -30,11 +30,13 @@ Two things keep this honest rather than becoming a third source of truth:
     to the same normalizers the server-rendered form uses. Both interfaces
     therefore agree on what a valid value is.
 
-Only the Appearance group is described in full so far. Sections with no entry
-here fall back to the V2 surface's ``enable_*`` scan, so undescribed groups keep
-working exactly as they did. A handful of individual fields outside Appearance
-are also declared: that scan places a key by guessing from shared word stems,
-and declaring a field is the only way to stop it guessing wrong.
+Only the Appearance and Workflow groups are described in full so far. Sections
+with no entry here fall back to the V2 surface's ``enable_*`` scan, so
+undescribed groups keep working exactly as they did. A handful of individual
+fields outside those groups are also declared: that scan places a key by guessing
+from shared word stems, and declaring a field is the only way to stop it guessing
+wrong. Workflow had the opposite problem -- none of its settings are named
+``enable_*``, so the scan had nothing to guess with and the group rendered empty.
 """
 
 import re
@@ -44,6 +46,9 @@ from functions_ai_notice import (
     AI_NOTICE_MAX_MESSAGE_LENGTH,
     normalize_ai_notice_frequency,
     normalize_ai_notice_message,
+)
+from functions_group_assignment_ids import (
+    normalize_group_workflow_allowed_group_ids,
 )
 from functions_terms_of_use import (
     TERMS_OF_USE_DEFAULT_REDIRECT,
@@ -71,6 +76,7 @@ FIELD_TYPES = (
     "number",
     "image",
     "link_list",
+    "group_picker",
     "component",
 )
 
@@ -89,6 +95,11 @@ LOGO_SCALE_DEFAULT_PERCENT = 100
 # rejecting the value here would lock an administrator out of editing a section
 # that already holds a longer agreement.
 USER_AGREEMENT_WORD_LIMIT = 200
+
+# Above this many automatic tool calls per workflow run, a run is capacity
+# sensitive rather than merely long. The server-rendered pane says so in a
+# warning block, so the same guidance is attached to the field here.
+WORKFLOW_AUTO_INVOKE_CAPACITY_THRESHOLD = 100
 
 CLASSIFICATION_BANNER_DEFAULT_COLOR = "#ffc107"
 CLASSIFICATION_BANNER_DEFAULT_TEXT_COLOR = "#ffffff"
@@ -632,6 +643,108 @@ ADMIN_SETTINGS_FIELDS = {
             "default": True,
         },
     ],
+    # The Workflow group has exactly one section, and none of its settings are
+    # named `enable_*`, so the fallback scan found nothing at all and the group
+    # rendered empty in V2. Declaring the section is what makes it reachable.
+    "workflow-settings-section": [
+        {
+            "key": "allow_user_workflows",
+            "type": "switch",
+            "label": "Enable Personal Workflows",
+            "help": (
+                "Users can create personal workflows that run a selected agent or "
+                "model manually or on an interval schedule."
+            ),
+            "default": False,
+        },
+        {
+            "key": "require_member_of_workflow_user",
+            "type": "switch",
+            "label": "Require WorkflowUser App Role",
+            "help": (
+                "Restricts personal workflows to holders of the WorkflowUser "
+                "Enterprise App role, covering opening, creating, editing, running "
+                "and inspecting them. Assign the role value WorkflowUser to users or "
+                "groups in the Enterprise App before turning this on, or everyone "
+                "loses access at once."
+            ),
+            "default": False,
+            "depends_on": {"key": "allow_user_workflows", "equals": True},
+        },
+        {
+            "key": "allow_group_workflows",
+            "type": "switch",
+            "label": "Enable Group Workflows",
+            "help": (
+                "Permitted group members can create, manage and run workflows from "
+                "group workspaces. Owners and Admins may author them unless "
+                "Workspaces > Workspace Types restricts group agent, action and "
+                "workflow management to Owners."
+            ),
+            "default": False,
+        },
+        {
+            "key": "require_group_assignment_for_group_workflows",
+            "type": "switch",
+            "label": "Require Group Assignment to Use Workflow",
+            "help": (
+                "Narrows group workflows to an explicit allow list. Every other "
+                "group loses the capability, so assign the groups that need it "
+                "before turning this on."
+            ),
+            "default": False,
+            "depends_on": {"key": "allow_group_workflows", "equals": True},
+        },
+        {
+            "key": "group_workflow_allowed_group_ids",
+            "type": "group_picker",
+            "label": "Assigned Groups",
+            "help": (
+                "The groups that may create, manage and run group workflows while "
+                "assignment is required."
+            ),
+            "default": [],
+            "search_endpoint": "/api/v2/admin/groups",
+            "depends_on": {
+                "key": "require_group_assignment_for_group_workflows",
+                "equals": True,
+            },
+        },
+        {
+            "key": "workflow_max_auto_invoke_attempts",
+            "type": "number",
+            "label": "Workflow Agent Action Limit",
+            "help": (
+                "Maximum automatic tool or action calls an agent can make during one "
+                "workflow run. Default is 60; increase for large document sets."
+            ),
+            "default": 60,
+            "min": 1,
+            "max": 500,
+            "step": 1,
+            "notice_level": "warning",
+            "notice": (
+                f"Values above {WORKFLOW_AUTO_INVOKE_CAPACITY_THRESHOLD} are "
+                "capacity-sensitive. Enable Cosmos DB Throughput automation in "
+                "SimpleChat so the app can monitor RU pressure and scale up Cosmos "
+                "when needed, and also monitor Azure OpenAI throttling, App Service "
+                "CPU and memory, and downstream service latency."
+            ),
+        },
+        {
+            "key": "workflow_max_tasks",
+            "type": "number",
+            "label": "Workflow Task Limit",
+            "help": (
+                "Maximum ordered instruction tasks users can add to one workflow. "
+                "Default is 50; supported range is 1-100."
+            ),
+            "default": 50,
+            "min": 1,
+            "max": 100,
+            "step": 1,
+        },
+    ],
 }
 
 
@@ -872,6 +985,12 @@ def _normalize_field_value(key, value, field):
     if field_type == "link_list":
         links, error = _normalize_link_list(value)
         return links, error, None
+
+    if field_type == "group_picker":
+        # Delegated so an assignment saved from V2 is byte-for-byte what the
+        # server-rendered form would have stored, including how it drops ids that
+        # are not canonical group UUIDs.
+        return normalize_group_workflow_allowed_group_ids(value), None, None
 
     if field_type == "textarea":
         text = str(value if value is not None else "")

--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -97,7 +97,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.261.058"
+VERSION = "0.261.059"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/functions_group.py
+++ b/application/single_app/functions_group.py
@@ -107,6 +107,94 @@ def search_all_groups(search_query, limit=10):
     ))
     return results[:max(1, min(int(limit or 10), 50))]
 
+GROUP_DIRECTORY_MAX_LIMIT = 200
+GROUP_DIRECTORY_DEFAULT_LIMIT = 50
+
+GROUP_DIRECTORY_TYPE_FILTER = "(c.type = 'group' OR NOT IS_DEFINED(c.type))"
+
+
+def _to_group_directory_row(group_doc):
+    """Project a group document down to the fields an assignment picker needs."""
+    return {
+        "id": str(group_doc.get("id") or ""),
+        "name": group_doc.get("name") or "",
+        "description": group_doc.get("description") or "",
+        "member_count": len(group_doc.get("users") or []),
+    }
+
+
+def find_groups_by_ids(group_ids):
+    """Return directory rows for specific group ids, skipping ids that no longer exist.
+
+    Used to label an assignment an administrator has already saved. Ids that
+    resolve to nothing are simply absent from the result, which lets the caller
+    tell a live assignment apart from one pointing at a deleted group.
+    """
+    wanted_ids = [str(group_id or "").strip() for group_id in (group_ids or [])]
+    wanted_ids = [group_id for group_id in wanted_ids if group_id]
+    if not wanted_ids:
+        return []
+
+    query = f"""
+        SELECT c.id, c.name, c.description, c.users
+        FROM c
+        WHERE {GROUP_DIRECTORY_TYPE_FILTER} AND ARRAY_CONTAINS(@ids, c.id)
+    """
+    results = list(cosmos_groups_container.query_items(
+        query=query,
+        parameters=[{"name": "@ids", "value": wanted_ids}],
+        enable_cross_partition_query=True
+    ))
+
+    rows_by_id = {row["id"]: row for row in (_to_group_directory_row(doc) for doc in results)}
+    # Preserve the order the caller asked in, so a saved assignment keeps the
+    # order an administrator built it in rather than Cosmos's storage order.
+    return [rows_by_id[group_id] for group_id in wanted_ids if group_id in rows_by_id]
+
+
+def list_groups_for_admin_directory(search_query="", limit=GROUP_DIRECTORY_DEFAULT_LIMIT):
+    """Return ``(rows, truncated)`` for an administrator's group assignment picker.
+
+    An empty search browses the directory. The query asks for one row more than
+    ``limit`` so a truncated result can be reported instead of silently hiding
+    groups, which matters because an administrator who cannot see a group has no
+    way to tell whether it is missing or merely beyond the cap.
+    """
+    normalized_query = str(search_query or "").strip().lower()
+    capped_limit = max(1, min(int(limit or GROUP_DIRECTORY_DEFAULT_LIMIT), GROUP_DIRECTORY_MAX_LIMIT))
+
+    filters = [GROUP_DIRECTORY_TYPE_FILTER]
+    parameters = []
+    if normalized_query:
+        filters.append(
+            "(CONTAINS(LOWER(c.name), @search)"
+            " OR (IS_DEFINED(c.description) AND CONTAINS(LOWER(c.description), @search))"
+            " OR LOWER(c.id) = @search)"
+        )
+        parameters.append({"name": "@search", "value": normalized_query})
+
+    # No ORDER BY: Cosmos drops documents that lack the sorted property, which
+    # would hide legacy groups saved without a name. The page is sorted below.
+    query = f"""
+        SELECT c.id, c.name, c.description, c.users
+        FROM c
+        WHERE {' AND '.join(filters)}
+        OFFSET 0 LIMIT @limit
+    """
+    parameters.append({"name": "@limit", "value": capped_limit + 1})
+
+    results = list(cosmos_groups_container.query_items(
+        query=query,
+        parameters=parameters,
+        enable_cross_partition_query=True
+    ))
+
+    truncated = len(results) > capped_limit
+    rows = [_to_group_directory_row(doc) for doc in results[:capped_limit]]
+    rows.sort(key=lambda row: (row["name"].lower(), row["id"]))
+    return rows, truncated
+
+
 def get_user_groups(user_id):
     """
     Fetch all groups for which this user is a member.

--- a/application/single_app/functions_group_assignment_ids.py
+++ b/application/single_app/functions_group_assignment_ids.py
@@ -1,0 +1,81 @@
+# functions_group_assignment_ids.py
+"""Normalization for administrator-managed group assignment lists.
+
+Several admin capabilities are scoped by a list of SimpleChat group ids: group
+workflows, File Sync and file downloads all store one. The stored value has to
+tolerate more shapes than it produces, because the server-rendered admin form
+round-trips the list through a hidden textarea and older saves left behind
+comma-separated text, JSON strings, and JSON strings nested inside JSON strings.
+
+These functions live here rather than in ``functions_settings`` because
+``admin_settings_fields`` needs them and cannot import that module: it builds a
+Cosmos client at import time through ``config``. ``functions_settings``
+re-exports everything below, so existing callers are unaffected.
+"""
+
+import json
+import uuid
+
+GROUP_WORKFLOW_ALLOWED_GROUP_ID_PARSE_DEPTH_LIMIT = 5
+
+
+def _iter_group_workflow_allowed_group_id_candidates(value, depth=0):
+    """Yield raw assignment candidates from legacy text, JSON, and nested JSON strings."""
+    if value is None or depth > GROUP_WORKFLOW_ALLOWED_GROUP_ID_PARSE_DEPTH_LIMIT:
+        return
+
+    if isinstance(value, str):
+        stripped_value = value.strip()
+        if not stripped_value:
+            return
+
+        if stripped_value.startswith('[') or stripped_value.startswith('"'):
+            try:
+                parsed_value = json.loads(stripped_value)
+            except (TypeError, ValueError):
+                parsed_value = None
+
+            if isinstance(parsed_value, list):
+                for candidate in parsed_value:
+                    yield from _iter_group_workflow_allowed_group_id_candidates(candidate, depth + 1)
+                return
+
+            if isinstance(parsed_value, str) and parsed_value != stripped_value:
+                yield from _iter_group_workflow_allowed_group_id_candidates(parsed_value, depth + 1)
+                return
+
+        for candidate in stripped_value.replace('\r', '\n').replace(',', '\n').replace(';', '\n').split('\n'):
+            yield candidate
+        return
+
+    if isinstance(value, (list, tuple, set)):
+        for candidate in value:
+            yield from _iter_group_workflow_allowed_group_id_candidates(candidate, depth + 1)
+        return
+
+    yield value
+
+
+def normalize_group_workflow_allowed_group_id(value):
+    """Return a canonical SimpleChat group id or an empty string for invalid values."""
+    group_id = str(value or '').strip()
+    if not group_id:
+        return ''
+
+    try:
+        return str(uuid.UUID(group_id))
+    except (AttributeError, TypeError, ValueError):
+        return ''
+
+
+def normalize_group_workflow_allowed_group_ids(value):
+    """Normalize group workflow assignment settings into unique group ids."""
+    normalized_ids = []
+    seen_ids = set()
+    for candidate in _iter_group_workflow_allowed_group_id_candidates(value):
+        group_id = normalize_group_workflow_allowed_group_id(candidate)
+        if not group_id or group_id in seen_ids:
+            continue
+        normalized_ids.append(group_id)
+        seen_ids.add(group_id)
+    return normalized_ids

--- a/application/single_app/functions_settings.py
+++ b/application/single_app/functions_settings.py
@@ -11,6 +11,15 @@ from functions_content_safety import (
 )
 from functions_cosmos_throughput import get_default_cosmos_throughput_settings
 from functions_document_actions import get_default_document_action_capabilities
+# Re-exported so callers keep importing these from functions_settings. They live
+# in a leaf module because admin_settings_fields needs them and cannot import
+# this one, which builds a Cosmos client at import time through config.
+from functions_group_assignment_ids import (
+    GROUP_WORKFLOW_ALLOWED_GROUP_ID_PARSE_DEPTH_LIMIT,
+    _iter_group_workflow_allowed_group_id_candidates,
+    normalize_group_workflow_allowed_group_id,
+    normalize_group_workflow_allowed_group_ids,
+)
 from functions_icon_utils import normalize_icon_payload
 from functions_latest_features_nav import LATEST_FEATURES_HIDDEN_VERSION_SETTING
 from functions_model_endpoint_identity_header import (
@@ -913,71 +922,6 @@ def has_workflow_user_app_role(user_roles):
     """Return True when authenticated claims include the workflow user app role."""
     normalized_roles = {role.lower() for role in normalize_app_role_claims(user_roles)}
     return WORKFLOW_USER_APP_ROLE.lower() in normalized_roles
-
-
-GROUP_WORKFLOW_ALLOWED_GROUP_ID_PARSE_DEPTH_LIMIT = 5
-
-
-def _iter_group_workflow_allowed_group_id_candidates(value, depth=0):
-    """Yield raw assignment candidates from legacy text, JSON, and nested JSON strings."""
-    if value is None or depth > GROUP_WORKFLOW_ALLOWED_GROUP_ID_PARSE_DEPTH_LIMIT:
-        return
-
-    if isinstance(value, str):
-        stripped_value = value.strip()
-        if not stripped_value:
-            return
-
-        if stripped_value.startswith('[') or stripped_value.startswith('"'):
-            try:
-                parsed_value = json.loads(stripped_value)
-            except (TypeError, ValueError):
-                parsed_value = None
-
-            if isinstance(parsed_value, list):
-                for candidate in parsed_value:
-                    yield from _iter_group_workflow_allowed_group_id_candidates(candidate, depth + 1)
-                return
-
-            if isinstance(parsed_value, str) and parsed_value != stripped_value:
-                yield from _iter_group_workflow_allowed_group_id_candidates(parsed_value, depth + 1)
-                return
-
-        for candidate in stripped_value.replace('\r', '\n').replace(',', '\n').replace(';', '\n').split('\n'):
-            yield candidate
-        return
-
-    if isinstance(value, (list, tuple, set)):
-        for candidate in value:
-            yield from _iter_group_workflow_allowed_group_id_candidates(candidate, depth + 1)
-        return
-
-    yield value
-
-
-def normalize_group_workflow_allowed_group_id(value):
-    """Return a canonical SimpleChat group id or an empty string for invalid values."""
-    group_id = str(value or '').strip()
-    if not group_id:
-        return ''
-
-    try:
-        return str(uuid.UUID(group_id))
-    except (AttributeError, TypeError, ValueError):
-        return ''
-
-
-def normalize_group_workflow_allowed_group_ids(value):
-    """Normalize group workflow assignment settings into unique group ids."""
-    normalized_ids = []
-    seen_ids = set()
-    for candidate in _iter_group_workflow_allowed_group_id_candidates(value):
-        group_id = normalize_group_workflow_allowed_group_id(candidate)
-        if not group_id or group_id in seen_ids:
-            continue
-        normalized_ids.append(group_id)
-        seen_ids.add(group_id)
-    return normalized_ids
 
 
 def normalize_group_workflow_assignment_settings(settings):

--- a/application/single_app/route_backend_v2.py
+++ b/application/single_app/route_backend_v2.py
@@ -61,7 +61,15 @@ from functions_authentication import (
 )
 from functions_conversation_contents import is_conversation_contents_drawer_enabled
 from functions_custom_pages import get_custom_pages_nav
-from functions_group import find_group_by_id, get_user_groups
+from functions_group import (
+    GROUP_DIRECTORY_DEFAULT_LIMIT,
+    GROUP_DIRECTORY_MAX_LIMIT,
+    find_group_by_id,
+    find_groups_by_ids,
+    get_user_groups,
+    list_groups_for_admin_directory,
+)
+from functions_group_assignment_ids import normalize_group_workflow_allowed_group_ids
 from functions_image_edit import resolve_image_edit_capability
 from functions_public_workspaces import (
     find_public_workspace_by_id,
@@ -817,3 +825,73 @@ def register_route_backend_v2_admin(bp):
                 exceptionTraceback=True,
             )
             return jsonify({"error": "Failed to store the uploaded image"}), 500
+
+    @bp.route("/api/v2/admin/groups", methods=["GET"])
+    @swagger_route(security=get_auth_security())
+    @login_required
+    @admin_required
+    def v2_admin_list_groups():
+        """Return group directory rows for an administrator's assignment picker.
+
+        Settings such as ``group_workflow_allowed_group_ids`` store group ids. An
+        id is not something an administrator can recognise, so the picker needs to
+        resolve one to a name, and needs to search the directory to add another.
+
+        This exists rather than reusing ``/api/groups/discover`` because that
+        endpoint answers a different question: it is a member-facing directory,
+        gated on the User role and on group workspaces being enabled, it returns
+        every group in one unbounded response, and it cannot resolve a specific
+        set of ids. An administrator managing an assignment may hold neither the
+        User role nor a membership in the groups being assigned.
+
+        ``ids`` resolves an existing assignment; ids that no longer exist are
+        absent from the response, which is how the caller detects a stale entry.
+        Otherwise ``search`` matches on name, description or id.
+        """
+        raw_ids = str(request.args.get("ids") or "").strip()
+        if raw_ids:
+            requested_ids = normalize_group_workflow_allowed_group_ids(raw_ids)
+            if not requested_ids:
+                return jsonify({"groups": [], "truncated": False}), 200
+            if len(requested_ids) > GROUP_DIRECTORY_MAX_LIMIT:
+                return (
+                    jsonify(
+                        {
+                            "error": "Too many group ids requested. Limit is "
+                            f"{GROUP_DIRECTORY_MAX_LIMIT}."
+                        }
+                    ),
+                    400,
+                )
+
+            try:
+                return (
+                    jsonify({"groups": find_groups_by_ids(requested_ids), "truncated": False}),
+                    200,
+                )
+            except Exception as exc:
+                log_event(
+                    f"[V2_ADMIN_GROUPS] Failed to resolve {len(requested_ids)} group id(s): {exc}",
+                    level=logging.ERROR,
+                    exceptionTraceback=True,
+                )
+                return jsonify({"error": "Failed to load groups"}), 500
+
+        try:
+            limit = int(request.args.get("limit") or GROUP_DIRECTORY_DEFAULT_LIMIT)
+        except (TypeError, ValueError):
+            limit = GROUP_DIRECTORY_DEFAULT_LIMIT
+
+        try:
+            groups, truncated = list_groups_for_admin_directory(
+                search_query=request.args.get("search", ""),
+                limit=limit,
+            )
+            return jsonify({"groups": groups, "truncated": truncated}), 200
+        except Exception as exc:
+            log_event(
+                f"[V2_ADMIN_GROUPS] Failed to list groups: {exc}",
+                level=logging.ERROR,
+                exceptionTraceback=True,
+            )
+            return jsonify({"error": "Failed to load groups"}), 500

--- a/application/v2_ui/src/components/admin/GroupAssignmentField.tsx
+++ b/application/v2_ui/src/components/admin/GroupAssignmentField.tsx
@@ -1,0 +1,388 @@
+// GroupAssignmentField.tsx
+// Picker for a settings value that stores a list of SimpleChat group ids.
+//
+// The server-rendered form puts this behind a modal that can only report "3 groups
+// assigned": it searches the member-facing directory, keeps the result in a hidden JSON
+// textarea, and never resolves an assigned id back to a name. An administrator therefore
+// cannot tell which groups hold the capability without assigning them again.
+//
+// Here the assignment is visible. Saved ids are resolved to names through the admin
+// directory endpoint and shown as removable chips, an id that no longer resolves is
+// called out as stale rather than left to rot, and search is inline instead of modal.
+//
+// Edits are reported upward and buffered into the page's draft like any other field, so
+// the assignment saves with the same save bar as the toggle that gates it. That matters:
+// requiring assignment and choosing the assigned groups are one decision, and saving them
+// apart would leave every group locked out in between.
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { clsx } from 'clsx';
+import { AlertCircle, Loader2, Search, Users, X } from 'lucide-react';
+import { asStringArray, type AdminField } from '../../lib/adminFields';
+import {
+    resolveAdminGroups,
+    searchAdminGroups,
+    type AdminGroup,
+} from '../../lib/adminGroups';
+import { FieldNotice } from './fields';
+import { GlassButton } from '../ui/primitives';
+
+const SEARCH_DEBOUNCE_MS = 300;
+
+function errorMessage(error: unknown, fallback: string): string {
+    return error instanceof Error ? error.message : fallback;
+}
+
+export function GroupAssignmentField({
+    field,
+    value,
+    error,
+    disabled,
+    onChange,
+}: {
+    field: AdminField;
+    value: unknown;
+    error?: string;
+    disabled?: boolean;
+    onChange: (next: string[]) => void;
+}) {
+    const endpoint = field.search_endpoint ?? '/api/v2/admin/groups';
+    const assignedIds = useMemo(() => asStringArray(value), [value]);
+
+    // Names accumulate across resolves and searches. Keeping them keyed by id means a
+    // group stays labelled after the search that named it has been cleared.
+    const [knownGroups, setKnownGroups] = useState<Record<string, AdminGroup>>({});
+    // Ids already looked up, so a lookup is attempted once rather than on every render,
+    // and the subset the directory confirmed do not exist. The two are separate because
+    // "we asked and it is gone" and "the request failed" must not read the same on screen.
+    const [attemptedIds, setAttemptedIds] = useState<ReadonlySet<string>>(new Set());
+    const [missingIds, setMissingIds] = useState<ReadonlySet<string>>(new Set());
+    const [resolveError, setResolveError] = useState<string | null>(null);
+
+    const [query, setQuery] = useState('');
+    const [browsing, setBrowsing] = useState(false);
+    const [results, setResults] = useState<AdminGroup[] | null>(null);
+    const [truncated, setTruncated] = useState(false);
+    const [searching, setSearching] = useState(false);
+    const [searchError, setSearchError] = useState<string | null>(null);
+
+    const learn = useCallback((groups: AdminGroup[]) => {
+        if (!groups.length) {
+            return;
+        }
+        setKnownGroups((current) => {
+            const next = { ...current };
+            for (const group of groups) {
+                next[group.id] = group;
+            }
+            return next;
+        });
+    }, []);
+
+    const unresolvedIds = useMemo(
+        () => assignedIds.filter((id) => !knownGroups[id] && !attemptedIds.has(id)),
+        [assignedIds, knownGroups, attemptedIds],
+    );
+    const unresolvedKey = unresolvedIds.join(',');
+
+    useEffect(() => {
+        if (!unresolvedKey) {
+            return;
+        }
+        const pending = unresolvedKey.split(',');
+        const controller = new AbortController();
+
+        void (async () => {
+            try {
+                const groups = await resolveAdminGroups(endpoint, pending, controller.signal);
+                if (controller.signal.aborted) {
+                    return;
+                }
+                learn(groups);
+                const found = new Set(groups.map((group) => group.id));
+                // Whatever the directory did not return no longer exists. Recording that
+                // is what lets a stale assignment be pointed out instead of silently
+                // rendering as a bare id.
+                setMissingIds((current) => {
+                    const next = new Set(current);
+                    for (const id of pending) {
+                        if (!found.has(id)) {
+                            next.add(id);
+                        }
+                    }
+                    return next;
+                });
+                setResolveError(null);
+            } catch (fetchError) {
+                if (!controller.signal.aborted) {
+                    // Deliberately not recorded as missing: a failed request is not a
+                    // deleted group, and mislabelling it would invite an administrator to
+                    // remove an assignment that is actually live.
+                    setResolveError(
+                        errorMessage(fetchError, 'Assigned groups could not be loaded.'),
+                    );
+                }
+            } finally {
+                if (!controller.signal.aborted) {
+                    // Marked attempted either way, so a failure does not retry forever.
+                    setAttemptedIds((current) => {
+                        const next = new Set(current);
+                        for (const id of pending) {
+                            next.add(id);
+                        }
+                        return next;
+                    });
+                }
+            }
+        })();
+
+        return () => controller.abort();
+    }, [unresolvedKey, endpoint, learn]);
+
+    useEffect(() => {
+        if (!browsing) {
+            return;
+        }
+
+        const controller = new AbortController();
+        const timer = window.setTimeout(() => {
+            setSearching(true);
+            void (async () => {
+                try {
+                    const page = await searchAdminGroups(endpoint, query, controller.signal);
+                    if (!controller.signal.aborted) {
+                        learn(page.groups);
+                        setResults(page.groups);
+                        setTruncated(page.truncated);
+                        setSearchError(null);
+                    }
+                } catch (fetchError) {
+                    if (!controller.signal.aborted) {
+                        setResults([]);
+                        setTruncated(false);
+                        setSearchError(errorMessage(fetchError, 'Groups could not be loaded.'));
+                    }
+                } finally {
+                    if (!controller.signal.aborted) {
+                        setSearching(false);
+                    }
+                }
+            })();
+        }, SEARCH_DEBOUNCE_MS);
+
+        return () => {
+            window.clearTimeout(timer);
+            controller.abort();
+        };
+    }, [browsing, query, endpoint, learn]);
+
+    const assign = (id: string) => {
+        if (assignedIds.includes(id)) {
+            return;
+        }
+        onChange([...assignedIds, id]);
+    };
+
+    const unassign = (id: string) => {
+        onChange(assignedIds.filter((assigned) => assigned !== id));
+    };
+
+    const describe = (id: string) => knownGroups[id];
+
+    return (
+        <div className="py-3">
+            <div className="mb-1.5 flex items-baseline justify-between gap-3">
+                <span className="text-sm font-medium text-text-1">{field.label}</span>
+                <span className="text-xs text-text-3">
+                    {assignedIds.length} group{assignedIds.length === 1 ? '' : 's'} assigned
+                </span>
+            </div>
+
+            {assignedIds.length === 0 ? (
+                <div className="flex items-center gap-2 rounded-lg border border-dashed border-edge px-3 py-4 text-sm text-text-3">
+                    <Users size={15} aria-hidden="true" />
+                    No groups assigned, so no group can use this capability yet.
+                </div>
+            ) : (
+                <ul className="flex flex-wrap gap-1.5">
+                    {assignedIds.map((id) => {
+                        const group = describe(id);
+                        // Not knowing a name yet and knowing there is no group are
+                        // different states, and only the second is a problem.
+                        const stale = missingIds.has(id);
+                        return (
+                            <li key={id}>
+                                <span
+                                    className={clsx(
+                                        'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs',
+                                        stale
+                                            ? 'border-warn/40 bg-warn-soft text-warn'
+                                            : 'border-edge bg-surface-2 text-text-1',
+                                    )}
+                                >
+                                    {stale ? (
+                                        <AlertCircle size={12} className="shrink-0" />
+                                    ) : null}
+                                    <span
+                                        className={clsx(!group && 'font-mono text-[11px]')}
+                                        title={group ? id : undefined}
+                                    >
+                                        {group?.name || id}
+                                    </span>
+                                    {stale ? (
+                                        <span className="text-[10px] tracking-wide uppercase">
+                                            Not found
+                                        </span>
+                                    ) : group ? (
+                                        <span className="text-text-3">
+                                            {group.member_count}
+                                        </span>
+                                    ) : null}
+                                    <button
+                                        type="button"
+                                        aria-label={`Remove ${group?.name || id}`}
+                                        title="Remove assignment"
+                                        disabled={disabled}
+                                        onClick={() => unassign(id)}
+                                        className="-mr-1 rounded-full p-0.5 text-text-3 transition-colors hover:bg-danger-soft hover:text-danger disabled:cursor-not-allowed disabled:opacity-40"
+                                    >
+                                        <X size={12} />
+                                    </button>
+                                </span>
+                            </li>
+                        );
+                    })}
+                </ul>
+            )}
+
+            {resolveError ? (
+                <p role="alert" className="mt-1.5 flex items-start gap-1.5 text-xs text-warn">
+                    <AlertCircle size={13} className="mt-0.5 shrink-0" />
+                    {resolveError} The assignment is shown by id and still saves correctly.
+                </p>
+            ) : null}
+
+            {browsing ? (
+                <div className="mt-2 rounded-lg border border-edge bg-surface-1 p-2">
+                    <div className="relative">
+                        <Search
+                            size={14}
+                            className="pointer-events-none absolute top-1/2 left-2.5 -translate-y-1/2 text-text-3"
+                        />
+                        <input
+                            type="search"
+                            autoFocus
+                            value={query}
+                            disabled={disabled}
+                            onChange={(event) => setQuery(event.target.value)}
+                            placeholder="Search by group name, description or id…"
+                            aria-label="Search groups to assign"
+                            className={clsx(
+                                'w-full rounded-lg border border-edge bg-surface-2 py-1.5 pr-2.5 pl-8',
+                                'text-sm text-text-1 placeholder:text-text-3',
+                                'focus:border-accent focus:outline-none',
+                                'disabled:cursor-not-allowed disabled:opacity-60',
+                            )}
+                        />
+                    </div>
+
+                    {searchError ? (
+                        <p
+                            role="alert"
+                            className="mt-2 flex items-start gap-1.5 text-xs text-danger"
+                        >
+                            <AlertCircle size={13} className="mt-0.5 shrink-0" />
+                            {searchError}
+                        </p>
+                    ) : null}
+
+                    {searching && results === null ? (
+                        <p className="mt-2 flex items-center gap-2 py-2 text-xs text-text-3">
+                            <Loader2 size={13} className="animate-spin" />
+                            Loading groups…
+                        </p>
+                    ) : null}
+
+                    {results !== null && results.length === 0 && !searchError ? (
+                        <p className="mt-2 py-2 text-xs text-text-3">
+                            {query.trim()
+                                ? `No groups match “${query.trim()}”.`
+                                : 'No groups exist yet.'}
+                        </p>
+                    ) : null}
+
+                    {results !== null && results.length > 0 ? (
+                        <ul className="mt-2 max-h-64 divide-y divide-edge overflow-y-auto">
+                            {results.map((group) => {
+                                const isAssigned = assignedIds.includes(group.id);
+                                return (
+                                    <li
+                                        key={group.id}
+                                        className="flex items-center gap-2 py-1.5"
+                                    >
+                                        <div className="min-w-0 flex-1">
+                                            <p className="truncate text-sm text-text-1">
+                                                {group.name || 'Unnamed group'}
+                                            </p>
+                                            <p className="truncate text-xs text-text-3">
+                                                {group.description ||
+                                                    `${group.member_count} member${
+                                                        group.member_count === 1 ? '' : 's'
+                                                    }`}
+                                            </p>
+                                        </div>
+                                        <GlassButton
+                                            type="button"
+                                            variant={isAssigned ? 'ghost' : 'subtle'}
+                                            size="sm"
+                                            disabled={disabled}
+                                            onClick={() =>
+                                                isAssigned
+                                                    ? unassign(group.id)
+                                                    : assign(group.id)
+                                            }
+                                        >
+                                            {isAssigned ? 'Remove' : 'Assign'}
+                                        </GlassButton>
+                                    </li>
+                                );
+                            })}
+                        </ul>
+                    ) : null}
+
+                    {truncated ? (
+                        <p className="mt-2 text-xs text-text-3">
+                            More groups matched than are shown. Narrow the search to reach
+                            the rest.
+                        </p>
+                    ) : null}
+                </div>
+            ) : null}
+
+            <GlassButton
+                type="button"
+                variant="subtle"
+                size="sm"
+                className="mt-2"
+                disabled={disabled}
+                onClick={() => setBrowsing((current) => !current)}
+            >
+                <Search size={14} />
+                {browsing ? 'Done' : 'Find groups'}
+            </GlassButton>
+
+            {field.help ? (
+                <p className="mt-1.5 text-xs leading-relaxed text-text-3">{field.help}</p>
+            ) : null}
+
+            <FieldNotice field={field} />
+
+            {error ? (
+                <p role="alert" className="mt-1.5 flex items-start gap-1.5 text-xs text-danger">
+                    <AlertCircle size={13} className="mt-0.5 shrink-0" />
+                    {error}
+                </p>
+            ) : null}
+        </div>
+    );
+}

--- a/application/v2_ui/src/components/admin/fields.tsx
+++ b/application/v2_ui/src/components/admin/fields.tsx
@@ -10,7 +10,7 @@
 // rejected save points at the control that caused it.
 
 import { clsx } from 'clsx';
-import { AlertCircle } from 'lucide-react';
+import { AlertCircle, Info } from 'lucide-react';
 import type { ReactNode } from 'react';
 import {
     asBoolean,
@@ -28,6 +28,36 @@ const inputClass = clsx(
     'focus:border-accent focus:outline-none',
     'disabled:cursor-not-allowed disabled:opacity-60',
 );
+
+/**
+ * Standing operational guidance a field carries, drawn beneath its control.
+ *
+ * Separate from `help`, which says what the setting does, and from the server's
+ * per-save warnings, which react to a value that was just submitted. A notice is true
+ * whenever the setting is on screen, so it renders regardless of the current value.
+ */
+export function FieldNotice({ field }: { field: AdminField }) {
+    if (!field.notice) {
+        return null;
+    }
+
+    const isWarning = field.notice_level === 'warning';
+    const Icon = isWarning ? AlertCircle : Info;
+
+    return (
+        <div
+            className={clsx(
+                'mt-2 flex items-start gap-2 rounded-lg border px-3 py-2 text-xs leading-relaxed',
+                isWarning
+                    ? 'border-warn/40 bg-warn-soft text-warn'
+                    : 'border-edge bg-surface-2 text-text-2',
+            )}
+        >
+            <Icon size={13} className="mt-0.5 shrink-0" />
+            <span>{field.notice}</span>
+        </div>
+    );
+}
 
 /** Label, help text, control and error, laid out consistently for every field type. */
 export function FieldShell({
@@ -62,6 +92,8 @@ export function FieldShell({
             {field.help ? (
                 <p className="mt-1.5 text-xs leading-relaxed text-text-3">{field.help}</p>
             ) : null}
+
+            <FieldNotice field={field} />
 
             {warning ? (
                 <p className="mt-1.5 flex items-start gap-1.5 text-xs text-warn">
@@ -184,6 +216,13 @@ function SwitchControl({ field, value, error, warning, disabled, onChange }: Fie
                 disabled={disabled}
                 onChange={(next) => onChange(next)}
             />
+            {/* Indented to the switch's text column so a notice reads as part of the row
+                rather than as a page-level banner. */}
+            {field.notice ? (
+                <div className="ml-14">
+                    <FieldNotice field={field} />
+                </div>
+            ) : null}
             {warning ? (
                 <p className="mt-1 ml-14 text-xs text-warn">{warning}</p>
             ) : null}

--- a/application/v2_ui/src/lib/adminFields.ts
+++ b/application/v2_ui/src/lib/adminFields.ts
@@ -20,6 +20,7 @@ export type AdminFieldType =
     | 'number'
     | 'image'
     | 'link_list'
+    | 'group_picker'
     | 'component';
 
 export interface AdminFieldOption {
@@ -71,6 +72,17 @@ export interface AdminField {
     version_key?: string;
     /** Component fields only: which bespoke widget to render. */
     component?: string;
+    /** Group picker fields only: the admin endpoint that searches and resolves groups. */
+    search_endpoint?: string;
+    /**
+     * Standing guidance shown as a callout beneath the control.
+     *
+     * Distinct from `help`, which describes what the setting does, and from the
+     * server's per-save `warnings`, which react to a submitted value. A notice is
+     * an operational caveat that is true whenever the setting is on screen.
+     */
+    notice?: string;
+    notice_level?: 'info' | 'warning';
     depends_on?: AdminFieldDependency;
     requires_acknowledgement?: AdminFieldAcknowledgement;
 }
@@ -196,7 +208,13 @@ export function countWords(text: string): number {
 
 /** Text a field contributes to the page search index. */
 export function fieldSearchText(field: AdminField): string {
-    return [field.key ?? '', field.label, field.help ?? '', field.component ?? '']
+    return [
+        field.key ?? '',
+        field.label,
+        field.help ?? '',
+        field.notice ?? '',
+        field.component ?? '',
+    ]
         .join(' ')
         .toLowerCase();
 }

--- a/application/v2_ui/src/lib/adminGroups.ts
+++ b/application/v2_ui/src/lib/adminGroups.ts
@@ -1,0 +1,117 @@
+// adminGroups.ts
+// Group directory lookups for administrator assignment pickers.
+//
+// Several admin settings scope a capability to a list of group ids. An id is not
+// something an administrator recognises, so a picker has to do two things the settings
+// document cannot: resolve the ids already saved into names, and search the directory
+// for more.
+//
+// Both go through `/api/v2/admin/groups`, which is admin-scoped. The endpoint is passed
+// in from the field definition rather than hard-coded, so the same control serves every
+// setting that stores a group assignment.
+
+import { api } from './apiClient';
+
+export interface AdminGroup {
+    id: string;
+    name: string;
+    description: string;
+    member_count: number;
+}
+
+interface AdminGroupResponse {
+    groups?: unknown[];
+    truncated?: boolean;
+}
+
+export interface AdminGroupPage {
+    groups: AdminGroup[];
+    /** True when more groups matched than the endpoint returned. */
+    truncated: boolean;
+}
+
+/** Read a directory row defensively; it is database content shaped by the server. */
+function toAdminGroup(value: unknown): AdminGroup | null {
+    if (!value || typeof value !== 'object') {
+        return null;
+    }
+    const row = value as Record<string, unknown>;
+    const id = typeof row.id === 'string' ? row.id : '';
+    if (!id) {
+        return null;
+    }
+    return {
+        id,
+        name: typeof row.name === 'string' ? row.name : '',
+        description: typeof row.description === 'string' ? row.description : '',
+        member_count: typeof row.member_count === 'number' ? row.member_count : 0,
+    };
+}
+
+function toAdminGroupPage(response: AdminGroupResponse): AdminGroupPage {
+    return {
+        groups: (response.groups ?? [])
+            .map(toAdminGroup)
+            .filter((group): group is AdminGroup => group !== null),
+        truncated: Boolean(response.truncated),
+    };
+}
+
+/** Search the directory. An empty term browses it. */
+export async function searchAdminGroups(
+    endpoint: string,
+    search: string,
+    signal?: AbortSignal,
+): Promise<AdminGroupPage> {
+    const query = new URLSearchParams();
+    if (search.trim()) {
+        query.set('search', search.trim());
+    }
+    const suffix = query.toString();
+    return toAdminGroupPage(
+        await api.get<AdminGroupResponse>(`${endpoint}${suffix ? `?${suffix}` : ''}`, signal),
+    );
+}
+
+/**
+ * Ids per resolve request.
+ *
+ * A group id is 36 characters, so 40 of them plus separators is roughly 1.5 KB of
+ * query string. IIS on Azure App Service rejects a query string over 2048 bytes by
+ * default, and an administrator with a large assignment would otherwise see every
+ * chip fall back to a raw id with no obvious reason.
+ */
+const RESOLVE_BATCH_SIZE = 40;
+
+/**
+ * Resolve specific ids to directory rows.
+ *
+ * An id that no longer exists is simply absent from the result rather than being an
+ * error, which is what lets the caller mark a stale assignment instead of either hiding
+ * it or failing the whole lookup because of one deleted group.
+ */
+export async function resolveAdminGroups(
+    endpoint: string,
+    ids: string[],
+    signal?: AbortSignal,
+): Promise<AdminGroup[]> {
+    if (!ids.length) {
+        return [];
+    }
+
+    const batches: string[][] = [];
+    for (let index = 0; index < ids.length; index += RESOLVE_BATCH_SIZE) {
+        batches.push(ids.slice(index, index + RESOLVE_BATCH_SIZE));
+    }
+
+    const pages = await Promise.all(
+        batches.map(async (batch) => {
+            const query = new URLSearchParams({ ids: batch.join(',') });
+            return toAdminGroupPage(
+                await api.get<AdminGroupResponse>(`${endpoint}?${query.toString()}`, signal),
+            );
+        }),
+    );
+
+    return pages.flatMap((page) => page.groups);
+}

--- a/application/v2_ui/src/pages/AdminSettingsPage.tsx
+++ b/application/v2_ui/src/pages/AdminSettingsPage.tsx
@@ -36,6 +36,7 @@ import { AdminMarkdown } from '../components/admin/AdminMarkdown';
 import { BrandingImageField } from '../components/admin/BrandingImageField';
 import { CustomPagesTable } from '../components/admin/CustomPagesTable';
 import { ExternalLinksEditor } from '../components/admin/ExternalLinksEditor';
+import { GroupAssignmentField } from '../components/admin/GroupAssignmentField';
 import { SaveBar } from '../components/admin/SaveBar';
 import { SettingField } from '../components/admin/fields';
 import {
@@ -527,6 +528,19 @@ export function AdminSettingsPage() {
                     field={field}
                     value={value}
                     error={error}
+                    onChange={(next) => field.key && setValue(field.key, next)}
+                />
+            );
+        }
+
+        if (field.type === 'group_picker') {
+            return (
+                <GroupAssignmentField
+                    key={key}
+                    field={field}
+                    value={value}
+                    error={error}
+                    disabled={saving}
                     onChange={(next) => field.key && setValue(field.key, next)}
                 />
             );

--- a/docs/admin/workflow.md
+++ b/docs/admin/workflow.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: "Workflow settings"
-description: "Workflow centralizes task sequence, assignment, and approval behavior used across SimpleChat surfaces."
+description: "Workflow controls who can build and run agent-driven task sequences, and how much work a single run may do."
 section: "Administration"
 audience: admin
 admin_tab: workflow
@@ -12,11 +12,16 @@ admin_tab: workflow
 
 ## What this group controls
 
-Workflow centralizes task sequence, assignment, and approval behavior used across SimpleChat surfaces.
+Who may build and run workflows — the ordered instruction sequences an agent or
+model executes against a workspace — separately for personal and group
+workspaces, and the ceilings that bound a single run.
 
 ## Why it matters
 
-Workflow settings affect handoffs between people and automated steps. Keep the path understandable so workspace owners can diagnose stalled approvals.
+A workflow run makes agent calls without a person watching each step, so the
+limits here are the difference between a long run and a runaway one. The access
+settings decide whether workflows are a pilot for one team or a capability every
+user has.
 
 {% include media.html src="admin/workflow-overview.png" alt="Screenshot placeholder for the Workflow group in Admin Settings." title="Workflow settings" capture="Capture the Workflow group in Admin Settings showing its tabs." %}
 
@@ -24,36 +29,60 @@ Workflow settings affect handoffs between people and automated steps. Keep the p
 
 ## Before you change anything
 
-- Document which teams own workflow templates.
-- Confirm assignment roles before enabling a workflow path.
+- Decide whether personal workflows, group workflows, or both are in scope.
+- If you plan to require the `WorkflowUser` app role, assign it in the Enterprise
+  App first. Turning the requirement on before assigning it removes access from
+  everyone at once.
+- If you plan to require group assignment, know which groups belong on the list.
 
 ## Workflow {#workflow}
 
 ### Workflow {#workflow-settings-section}
 
-The Workflow section belongs to the Workflow tab. Use it with the adjacent settings in this group so related rollout, access, and operational choices stay aligned.
+Workflows let a person hand a repeatable job to an agent or model: an ordered set
+of instruction tasks that runs on demand or on a schedule, against documents in a
+workspace. This section decides who may build and run them, and how much work a
+single run is allowed to do.
+
+The two capabilities are independent. Personal workflows belong to one user and
+run in their own workspace. Group workflows belong to a group workspace and are
+visible to its members. Turning one on does not turn on the other.
 
 #### Settings
 
 | Setting | What it does | Default | Notes |
 | --- | --- | --- | --- |
-| Enable Personal Workflows | Permits enable personal workflows when the related workspace or agent feature is enabled. | Off | `allow_user_workflows` |
-| Require WorkflowUser App Role | Requires the `WorkflowUser` app role before users can use this capability or view. | Off | `require_member_of_workflow_user` |
-| Workflow Agent Action Limit | Maximum automatic tool or action calls an agent can make during one workflow run. Default is 60; increase for large document sets. | 60 | `workflow_max_auto_invoke_attempts` |
-| Workflow Task Limit | Maximum ordered instruction tasks users can add to one workflow. Default is 50; supported range is 1-100. | 50 | `workflow_max_tasks` |
-| Enable Group Workflows | Permits enable group workflows when the related workspace or agent feature is enabled. | Off | `allow_group_workflows` |
-| Require Group Assignment to Use Workflow | Defines behavior for the related admin workflow; verify the affected feature after saving. | Off | `require_group_assignment_for_group_workflows` |
-| Group Workflow Allowed Group Ids | Lists the approved IDs, domains, groups, workspaces, or sources that may use this feature. | Empty list | `group_workflow_allowed_group_ids` |
+| Enable Personal Workflows | Lets users build workflows in their personal workspace and run them manually or on an interval schedule. | Off | `allow_user_workflows` |
+| Require WorkflowUser App Role | Restricts personal workflows to holders of the `WorkflowUser` Enterprise App role. Covers opening, creating, editing, running and inspecting them, so assign the role before turning this on or every user loses access at once. | Off | `require_member_of_workflow_user` |
+| Enable Group Workflows | Lets permitted members create, manage and run workflows from group workspaces. Owners and Admins may author them unless Workspaces restricts group agent, action and workflow management to Owners. | Off | `allow_group_workflows` |
+| Require Group Assignment to Use Workflow | Narrows group workflows to an explicit allow list instead of every group. Groups outside the list lose the capability. | Off | `require_group_assignment_for_group_workflows` |
+| Assigned Groups | The groups that may use group workflows while assignment is required. Ignored when it is not. | Empty list | `group_workflow_allowed_group_ids` |
+| Workflow Agent Action Limit | Caps the automatic tool and action calls an agent may make in one workflow run, which is what stops a run from looping. Large document sets need a higher cap. Values above 100 are capacity-sensitive: enable Cosmos DB throughput automation and watch Azure OpenAI throttling, App Service CPU and memory, and downstream latency. | 60 | `workflow_max_auto_invoke_attempts` |
+| Workflow Task Limit | Caps the ordered instruction tasks a single workflow may contain. Supported range is 1–100. | 50 | `workflow_max_tasks` |
+
+The action and task limits apply to personal and group runs alike, so they stay
+in effect whichever capability is enabled.
 
 ## Common tasks
 
-1. **Validate a workflow path.** Review the Workflow tab and run a simple test sequence. Outcome to verify: The sequence reaches the expected state and assignee.
+1. **Pilot group workflows with one team.** Enable Group Workflows, turn on
+   Require Group Assignment to Use Workflow, then assign only the pilot group.
+   Outcome to verify: members of the pilot group see the Workflows section in
+   their group workspace and no other group does.
+
+2. **Raise the action limit for a large document set.** Increase Workflow Agent
+   Action Limit and rerun the workflow that stopped early. Outcome to verify: the
+   run reaches the end of its task list instead of halting mid-way, and Cosmos RU
+   and Azure OpenAI throttling stay within headroom.
 
 ## Troubleshooting
 
 | Symptom | Likely cause | Fix |
 | --- | --- | --- |
-| A workflow does not advance | Assignment or approval state is not configured for the path. | Check workflow settings and rerun with a small item. |
+| A user cannot open personal workflows | Personal workflows are off, or Require WorkflowUser App Role is on and the user does not hold the role. | Check Enable Personal Workflows, then confirm the `WorkflowUser` role assignment in the Enterprise App. |
+| A group has no Workflows section | Group workflows are off, or assignment is required and the group is not assigned. | Check Enable Group Workflows, then add the group under Assigned Groups. |
+| A workflow run stops before its last task | The run hit the agent action limit. | Raise Workflow Agent Action Limit, and review capacity before going above 100. |
+| A workflow rejects a new task | The workflow already holds the maximum number of tasks. | Raise Workflow Task Limit, or split the work across two workflows. |
 
 ## Related
 

--- a/docs/explanation/fixes/V2_ADMIN_WORKFLOW_SETTINGS_PARITY_FIX.md
+++ b/docs/explanation/fixes/V2_ADMIN_WORKFLOW_SETTINGS_PARITY_FIX.md
@@ -1,0 +1,208 @@
+# V2 Admin Workflow Settings Parity Fix
+
+**Fixed in version: 0.261.059**
+
+## Issue
+
+The **Workflow** group in the V2 React admin interface was empty. Selecting it in
+the category rail showed no card, no controls and no explanation — the group
+simply had nothing under it.
+
+All seven workflow settings were unreachable from V2:
+
+| Setting | Key |
+| --- | --- |
+| Enable Personal Workflows | `allow_user_workflows` |
+| Require WorkflowUser App Role | `require_member_of_workflow_user` |
+| Enable Group Workflows | `allow_group_workflows` |
+| Require Group Assignment to Use Workflow | `require_group_assignment_for_group_workflows` |
+| Assigned Groups | `group_workflow_allowed_group_ids` |
+| Workflow Agent Action Limit | `workflow_max_auto_invoke_attempts` |
+| Workflow Task Limit | `workflow_max_tasks` |
+
+An administrator had to fall back to the classic `/admin/settings` page to enable
+workflows at all.
+
+## Root cause
+
+One cause, not seven.
+
+`admin_settings_nav.py` defines the group, its tab and its section
+(`workflow` > `workflow` > `workflow-settings-section`), which is why the rail
+entry existed. What lives *inside* a section comes from one of two sources:
+
+1. `admin_settings_fields.py`, which declares real controls; or
+2. the V2 surface's fallback, which scans the settings document for `enable_*`
+   booleans and matches each key to a section by shared word stems.
+
+The schema described the Appearance group and a handful of individual keys. It did
+not describe the workflow section. So the fallback was the only source — and
+**every workflow setting is named `allow_*`, `require_*`, `workflow_max_*` or
+`group_workflow_*`.** Not one of them starts with `enable_`, so the scan returned
+nothing.
+
+`AdminSettingsPage.tsx` then skips any section with neither declared fields nor
+fallback rows:
+
+```ts
+if (!fields.length && !capabilities.length) {
+    continue;
+}
+```
+
+The section was dropped, and with it the entire group.
+
+This is a worse failure mode than the misfiled toggles fixed in
+[V2_APPEARANCE_PARITY_FIX.md](V2_APPEARANCE_PARITY_FIX.md). A toggle in the wrong
+tab is at least visible somewhere. A group with no `enable_*` keys at all
+disappears silently, and nothing in the page hints that anything is missing.
+
+## Fix
+
+### Described the section
+
+`admin_settings_fields.py` gained a `workflow-settings-section` entry declaring
+all seven settings, with wording taken from the V1 pane so both interfaces
+describe a setting the same way.
+
+Dependent controls are hidden until the capability they belong to is on, matching
+how the Appearance group already behaves:
+
+```
+allow_user_workflows ─────► require_member_of_workflow_user
+
+allow_group_workflows ────► require_group_assignment_for_group_workflows
+                                    └──► group_workflow_allowed_group_ids
+```
+
+The two run limits are deliberately **not** gated. They bound personal *and* group
+runs, and `depends_on` names a single key, so gating either one on one capability
+would hide a live limit from an administrator who only uses the other.
+
+### Added a `group_picker` field type
+
+`group_workflow_allowed_group_ids` stores a list of group ids, which none of the
+existing control types can edit. `group_picker` was added to `FIELD_TYPES` and
+routed in `_normalize_field_value` to
+`normalize_group_workflow_allowed_group_ids` — the same normalizer the
+server-rendered form uses, so an assignment saved from V2 is byte-for-byte what V1
+would have stored, including which ids it drops.
+
+It is deliberately **not** in `NON_PATCHABLE_TYPES`. Requiring assignment and
+choosing the assigned groups is one decision; saving them through separate
+requests would lock every group out of group workflows in between.
+
+The field carries a `search_endpoint` rather than hard-coding one, so the File Sync
+and file download group pickers can reuse the type.
+
+### Added an admin-scoped group directory endpoint
+
+`GET /api/v2/admin/groups` (`login_required` + `admin_required`, in the existing
+`backend_v2_admin` blueprint) returns lightweight directory rows:
+
+- `?search=` matches name, description or id, capped and reporting `truncated` so
+  a large directory narrows the search rather than silently hiding groups;
+- `?ids=` resolves a saved assignment to names. Ids that no longer exist are
+  absent from the response, which is how the UI detects a stale entry.
+
+V1's `/api/groups/discover` was not reused. It answers a different question: it is
+member-facing, gated on the `User` role and on `enable_group_workspaces`, returns
+every group in one unbounded response, and cannot resolve a specific set of ids.
+An administrator managing an assignment may hold neither the `User` role nor
+membership in the groups being assigned.
+
+### Built the assignment control
+
+`GroupAssignmentField.tsx` replaces V1's modal, which could only report
+"3 groups assigned":
+
+- assigned groups render as removable chips showing the group **name**;
+- an id that no longer resolves is marked *Not found* and can still be removed,
+  instead of rotting invisibly in the list;
+- search is inline and debounced, with Assign/Remove per row;
+- a failed lookup falls back to showing raw ids and says so, rather than losing
+  the assignment.
+
+Edits flow into the page's draft, so the picker saves with the same save bar and
+dirty count as every other field.
+
+### Added a generic `notice` property
+
+V1 renders a warning block under the agent action limit about capacity. Rather
+than hard-code that text in React, fields may now carry `notice` and
+`notice_level`, rendered as a callout by `FieldShell` and `SwitchControl`. This is
+distinct from `help` (what the setting does) and from the server's per-save
+`warnings` (a reaction to a submitted value).
+
+### Moved the id normalizers to a leaf module
+
+`admin_settings_fields.py` must delegate to the same normalizer V1 uses, but it
+cannot import `functions_settings` — that module builds a Cosmos client at import
+time through `config.py`, and the functional-test harness replaces it with a stub.
+
+`GROUP_WORKFLOW_ALLOWED_GROUP_ID_PARSE_DEPTH_LIMIT`,
+`_iter_group_workflow_allowed_group_id_candidates`,
+`normalize_group_workflow_allowed_group_id` and
+`normalize_group_workflow_allowed_group_ids` moved verbatim into
+`functions_group_assignment_ids.py`. `functions_settings.py` re-exports all four,
+so every existing caller is unaffected.
+
+## Files modified
+
+| File | Change |
+| --- | --- |
+| `application/single_app/functions_group_assignment_ids.py` | New. The four pure group-id normalizers. |
+| `application/single_app/functions_settings.py` | Re-exports them from the leaf module. |
+| `application/single_app/admin_settings_fields.py` | Declares the workflow section; adds the `group_picker` type and its normalization. |
+| `application/single_app/functions_group.py` | Adds `find_groups_by_ids` and `list_groups_for_admin_directory`. |
+| `application/single_app/route_backend_v2.py` | Adds `GET /api/v2/admin/groups`. |
+| `application/v2_ui/src/lib/adminFields.ts` | Adds `group_picker`, `notice`, `notice_level`, `search_endpoint`. |
+| `application/v2_ui/src/lib/adminGroups.ts` | New. Directory search and id resolution. |
+| `application/v2_ui/src/components/admin/GroupAssignmentField.tsx` | New. The assignment control. |
+| `application/v2_ui/src/components/admin/fields.tsx` | Adds `FieldNotice`, wired into `FieldShell` and `SwitchControl`. |
+| `application/v2_ui/src/pages/AdminSettingsPage.tsx` | Adds the `group_picker` branch. |
+| `application/single_app/config.py` | Version bumped to `0.261.059`. |
+
+## Validation
+
+`functional_tests/test_v2_admin_workflow_parity.py` is new and holds the
+invariants that would have caught this:
+
+| Check | Guards against |
+| --- | --- |
+| The section declares at least one field | The original bug: an empty group |
+| Every V1 pane field name is claimed by the schema | A setting reachable in only one interface |
+| No schema field lacks a V1 counterpart | V2 writing a setting nothing reads |
+| Number `min`/`max`/`step` match the V1 markup | V2 saving a value V1 refuses to show |
+| The gating chain matches its capability | A control hidden while its feature is live |
+| The assignment is a patchable `group_picker` | The list saving apart from its gate |
+| Normalization matches V1 for duplicates, non-UUIDs and JSON strings | Storage-shape drift between interfaces |
+
+Also run and passing:
+
+- `test_v2_admin_settings_schema.py` (extended with `group_picker`)
+- `test_v2_admin_settings_normalization.py`
+- `test_v2_admin_field_renderer_coverage.py`
+- `test_v2_admin_capability_placement.py`
+- `test_v2_admin_appearance_parity.py`
+- `test_v2_bootstrap_branding_and_navigation.py`
+- `test_docs_app_surface_coverage.py`, `test_docs_site_quality.py`
+- `route_tests/` (all three; the new route needed no policy entry, since the
+  `backend_v2_admin` blueprint already carries `login_required` + `admin_required`)
+- `npm run build` in `application/v2_ui`
+
+## Before and after
+
+| | Before | After |
+| --- | --- | --- |
+| Workflow group in V2 | Empty | Seven settings in one card |
+| Reaching a workflow setting | Only via the classic admin page | Either interface |
+| Assigned groups | "3 groups assigned" | Named chips |
+| A deleted assigned group | Invisible | Marked *Not found*, removable |
+| Searching for a group | Modal, explicit Search button | Inline, debounced |
+
+## Out of scope
+
+Two workflow-adjacent settings live in other V1 panes and stay where V1 puts them:
+`url_access_max_workflow_urls_per_run` (Web Research) and
+`require_owner_for_group_agent_management` (Workspace Types).

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,25 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/features) and [Fixes by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/fixes).
 
+### **(v0.261.059)**
+
+#### Bug Fixes
+
+*   **Workflow Settings Are Reachable In The New Admin Interface**
+    *   The **Workflow** group in the new admin interface was empty. Selecting it showed no controls at all — not a missing toggle here or there, but the whole group. Enabling workflows meant going back to the classic admin page.
+    *   The cause was one thing, not seven. The new admin interface draws a section either from a description of its controls, or by scanning for settings whose names begin with `enable_`. Workflow had no description, and not one of its settings is named that way — they are `allow_user_workflows`, `allow_group_workflows`, `workflow_max_tasks` and so on — so the scan found nothing and the section was dropped for being empty.
+    *   All seven settings are now present: **Enable Personal Workflows**, **Require WorkflowUser App Role**, **Enable Group Workflows**, **Require Group Assignment to Use Workflow**, **Assigned Groups**, **Workflow Agent Action Limit** and **Workflow Task Limit**.
+    *   **Sub-settings stay out of the way until they apply.** The `WorkflowUser` role requirement appears once personal workflows are on, and the group allow list appears once group assignment is required. The two run limits are always shown, because they bound personal and group runs alike.
+    *   (Ref: `admin_settings_fields.py`, `AdminSettingsPage.tsx`, [V2 Admin Workflow Settings Parity](fixes/V2_ADMIN_WORKFLOW_SETTINGS_PARITY_FIX.md))
+
+#### User Interface Enhancements
+
+*   **Assigned Groups Are Shown By Name Instead Of Counted**
+    *   The classic admin page could only report "3 groups assigned". Finding out *which* three meant opening a modal and searching for them again, and a group that had since been deleted left an id in the list that nothing on screen ever mentioned.
+    *   In the new interface the assignment is visible: each assigned group appears as a named chip you can remove, search is inline and filters as you type rather than waiting behind a Search button, and an assignment pointing at a group that no longer exists is marked **Not found** so it can be cleared out.
+    *   The list saves with the toggle that gates it, so requiring assignment and choosing the groups is one save rather than two.
+    *   (Ref: `GroupAssignmentField.tsx`, `/api/v2/admin/groups`)
+
 ### **(v0.261.058)**
 
 #### New Features

--- a/functional_tests/test_group_workflow_assignment_cleanup_fix.py
+++ b/functional_tests/test_group_workflow_assignment_cleanup_fix.py
@@ -2,15 +2,22 @@
 # test_group_workflow_assignment_cleanup_fix.py
 """
 Functional test for group workflow assignment cleanup.
-Version: 0.241.201
+Version: 0.261.059
 Implemented in: 0.241.201
 
 This test ensures malformed nested JSON strings cannot be persisted as group
 workflow assignment IDs and that valid group UUIDs are preserved.
+
+The normalizers are extracted from source and executed in isolation rather than
+imported, because importing ``functions_settings`` reaches ``config.py`` and a
+live Cosmos client. As of 0.261.059 the pure ones live in
+``functions_group_assignment_ids.py`` and are re-exported, so the extraction spans
+both modules and the re-export itself is asserted.
 """
 
 import ast
 import json
+import re
 import sys
 import traceback
 import uuid
@@ -19,9 +26,31 @@ from test_support.versioning import assert_app_version_at_least
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-FUNCTIONS_SETTINGS_PATH = REPO_ROOT / "application" / "single_app" / "functions_settings.py"
-ADMIN_SETTINGS_JS_PATH = REPO_ROOT / "application" / "single_app" / "static" / "js" / "admin" / "admin_settings.js"
-CONFIG_PATH = REPO_ROOT / "application" / "single_app" / "config.py"
+APP_DIR = REPO_ROOT / "application" / "single_app"
+FUNCTIONS_SETTINGS_PATH = APP_DIR / "functions_settings.py"
+# The pure id normalizers were moved out of functions_settings.py so that
+# admin_settings_fields.py could reuse them: that module renders the V2 admin
+# surface and cannot import functions_settings, which builds a Cosmos client at
+# import time. functions_settings re-exports them, so callers are unchanged, but
+# the AST extraction below has to look in both files to find their definitions.
+GROUP_ASSIGNMENT_IDS_PATH = APP_DIR / "functions_group_assignment_ids.py"
+ADMIN_SETTINGS_JS_PATH = APP_DIR / "static" / "js" / "admin" / "admin_settings.js"
+CONFIG_PATH = APP_DIR / "config.py"
+
+# Where each symbol is defined. Pinning this rather than searching every module
+# keeps the test meaningful: a symbol that quietly moves again fails here with the
+# file it was expected in, instead of passing because some other copy was found.
+NORMALIZER_SYMBOL_SOURCES = {
+    GROUP_ASSIGNMENT_IDS_PATH: {
+        "GROUP_WORKFLOW_ALLOWED_GROUP_ID_PARSE_DEPTH_LIMIT",
+        "_iter_group_workflow_allowed_group_id_candidates",
+        "normalize_group_workflow_allowed_group_id",
+        "normalize_group_workflow_allowed_group_ids",
+    },
+    FUNCTIONS_SETTINGS_PATH: {
+        "normalize_group_workflow_assignment_settings",
+    },
+}
 
 
 def read_text(path):
@@ -29,17 +58,9 @@ def read_text(path):
     return path.read_text(encoding="utf-8")
 
 
-def load_settings_normalizer_symbols():
-    """Load the pure group workflow assignment normalizer symbols from functions_settings.py."""
-    source = read_text(FUNCTIONS_SETTINGS_PATH)
+def _select_symbol_nodes(source, path, required_names):
+    """Return the AST nodes defining ``required_names``, asserting none are missing."""
     module_tree = ast.parse(source)
-    required_names = {
-        "GROUP_WORKFLOW_ALLOWED_GROUP_ID_PARSE_DEPTH_LIMIT",
-        "_iter_group_workflow_allowed_group_id_candidates",
-        "normalize_group_workflow_allowed_group_id",
-        "normalize_group_workflow_allowed_group_ids",
-        "normalize_group_workflow_assignment_settings",
-    }
     selected_nodes = []
 
     for node in module_tree.body:
@@ -54,20 +75,40 @@ def load_settings_normalizer_symbols():
         elif isinstance(node, ast.FunctionDef) and node.name in required_names:
             selected_nodes.append(node)
 
-    missing_names = [
-        name for name in required_names
-        if name not in {
-            getattr(node, "name", None)
-            for node in selected_nodes
-        } and name not in {
-            target.id
-            for node in selected_nodes
-            if isinstance(node, ast.Assign)
-            for target in node.targets
-            if isinstance(target, ast.Name)
-        }
-    ]
-    assert not missing_names, f"Missing expected normalizer symbols: {missing_names}"
+    defined_names = {
+        getattr(node, "name", None) for node in selected_nodes
+    } | {
+        target.id
+        for node in selected_nodes
+        if isinstance(node, ast.Assign)
+        for target in node.targets
+        if isinstance(target, ast.Name)
+    }
+
+    missing_names = sorted(required_names - defined_names)
+    assert not missing_names, (
+        f"Missing expected normalizer symbols in {path.name}: {missing_names}. "
+        "An import does not count: this test executes the definitions in isolation "
+        "so the normalizers are exercised without standing up Azure clients."
+    )
+    return selected_nodes
+
+
+def load_settings_normalizer_symbols():
+    """Load the pure group workflow assignment normalizer symbols.
+
+    Returns ``(namespace, functions_settings_source)``. The namespace holds the
+    normalizers executed in isolation, which is how this test exercises them
+    without importing ``functions_settings`` and, through it, a live Cosmos client.
+    """
+    selected_nodes = []
+    settings_source = None
+
+    for path, required_names in NORMALIZER_SYMBOL_SOURCES.items():
+        source = read_text(path)
+        if path == FUNCTIONS_SETTINGS_PATH:
+            settings_source = source
+        selected_nodes.extend(_select_symbol_nodes(source, path, required_names))
 
     normalizer_module = ast.Module(body=selected_nodes, type_ignores=[])
     ast.fix_missing_locations(normalizer_module)
@@ -77,7 +118,34 @@ def load_settings_normalizer_symbols():
         "uuid": uuid,
     }
     exec(compile(normalizer_module, str(FUNCTIONS_SETTINGS_PATH), "exec"), namespace)
-    return namespace, source
+    return namespace, settings_source
+
+
+def test_normalizers_are_re_exported_by_functions_settings():
+    """Callers import these from functions_settings; the move must be invisible."""
+    print("Testing that functions_settings re-exports the moved normalizers...")
+
+    settings_source = read_text(FUNCTIONS_SETTINGS_PATH)
+    module_tree = ast.parse(settings_source)
+
+    imported_names = {
+        alias.asname or alias.name
+        for node in module_tree.body
+        if isinstance(node, ast.ImportFrom)
+        and node.module == GROUP_ASSIGNMENT_IDS_PATH.stem
+        for alias in node.names
+    }
+
+    expected = NORMALIZER_SYMBOL_SOURCES[GROUP_ASSIGNMENT_IDS_PATH]
+    missing = sorted(expected - imported_names)
+
+    assert not missing, (
+        "functions_settings.py no longer re-exports these normalizers from "
+        f"{GROUP_ASSIGNMENT_IDS_PATH.name}, so every existing caller that imports "
+        f"them from functions_settings breaks:\n  {missing}"
+    )
+
+    print(f"  All {len(expected)} moved normalizer(s) are re-exported.")
 
 
 def build_nested_json_list(value, depth):
@@ -167,11 +235,30 @@ def test_settings_and_admin_ui_wiring():
 
     required_settings_markers = [
         "assignment_settings_updated = normalize_group_workflow_assignment_settings(merged)",
-        "if merge_changed or migration_updated or assignment_settings_updated:",
         "normalize_group_workflow_assignment_settings(settings_item)",
     ]
     for marker in required_settings_markers:
         assert marker in settings_source, f"Missing settings cleanup marker: {marker}"
+
+    # The cleanup only reaches Cosmos if its result is one of the reasons
+    # get_settings decides to write the merged document back. Matched as a clause
+    # rather than as a whole line: the condition has grown to a dozen terms across
+    # as many lines, and pinning its exact text made this assertion fail for
+    # formatting reasons rather than behavioural ones.
+    persistence_condition = re.search(
+        r"# If merging added anything new.*?\n\s*if \((?P<clauses>.*?)\n\s*\):",
+        settings_source,
+        re.DOTALL,
+    )
+    assert persistence_condition, (
+        "Could not find the condition in get_settings that upserts the merged "
+        "settings document; the cleanup wiring can no longer be verified."
+    )
+    assert "assignment_settings_updated" in persistence_condition.group("clauses"), (
+        "normalize_group_workflow_assignment_settings runs, but its result is no "
+        "longer one of the reasons the merged settings document is written back, so "
+        "a malformed stored assignment would be cleaned in memory and never saved."
+    )
 
     required_admin_js_markers = [
         "const GROUP_WORKFLOW_ASSIGNMENT_PARSE_DEPTH_LIMIT = 5;",
@@ -192,6 +279,7 @@ def run_tests():
     tests = [
         test_normalizer_removes_junk_and_preserves_valid_group_ids,
         test_assignment_settings_cleanup_is_idempotent,
+        test_normalizers_are_re_exported_by_functions_settings,
         test_settings_and_admin_ui_wiring,
     ]
     results = []

--- a/functional_tests/test_v2_admin_settings_schema.py
+++ b/functional_tests/test_v2_admin_settings_schema.py
@@ -52,6 +52,7 @@ REQUIRED_PROPERTIES_BY_TYPE = {
     "textarea": ("default",),
     "switch": ("default",),
     "link_list": ("item_fields", "default"),
+    "group_picker": ("default", "search_endpoint"),
     "image": ("upload_target", "accept", "version_key"),
     "component": ("component",),
 }
@@ -66,6 +67,7 @@ EXPECTED_DEFAULT_TYPES = {
     "number": int,
     "checkbox_set": list,
     "link_list": list,
+    "group_picker": list,
 }
 
 

--- a/functional_tests/test_v2_admin_workflow_parity.py
+++ b/functional_tests/test_v2_admin_workflow_parity.py
@@ -1,0 +1,411 @@
+#!/usr/bin/env python3
+# test_v2_admin_workflow_parity.py
+"""
+Functional test pinning V1/V2 parity for the Admin Settings Workflow group.
+Version: 0.261.059
+Implemented in: 0.261.059
+
+The Workflow group rendered completely empty in the V2 React admin surface. The
+navigation defined the group, the tab and the section, but nothing described what
+the section contains, and the fallback that keeps undescribed groups usable only
+scans for ``enable_*`` booleans. Every workflow setting is named ``allow_*``,
+``require_*``, ``workflow_max_*`` or ``group_workflow_*``, so the scan had nothing
+to find and the section was skipped for having no fields at all.
+
+That is a worse failure than a misfiled toggle, because there is no partial
+rendering to notice. These checks make it a test failure:
+
+  - the panes and sections this test reads are the ones ADMIN_NAV defines;
+  - every form field the V1 pane submits is claimed by the schema;
+  - the schema invents no workflow field that V1 does not have;
+  - the section is not empty, which is the specific regression;
+  - the two numeric limits share identical bounds with the V1 inputs, since a V2
+    control offering a wider range would save a value V1 refuses to show; and
+  - the gating chain matches the capability each sub-setting belongs to.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent))
+
+from test_support.app_stubs import import_app_module
+from test_support.nav import ADMIN_NAV
+from test_support.versioning import assert_app_version_at_least
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PANES_DIR = REPO_ROOT / "application" / "single_app" / "templates" / "admin" / "_panes"
+
+WORKFLOW_GROUP_ID = "workflow"
+WORKFLOW_PANES = {
+    "workflow": ("workflow-settings-section",),
+}
+WORKFLOW_SECTION_ID = "workflow-settings-section"
+
+FIELD_NAME_RE = re.compile(r'\sname="([^"]+)"')
+JINJA_RE = re.compile(r"\{\{|\{%")
+NUMBER_BLOCK_RE = re.compile(r'<input[^>]*type="number"(?P<attrs>[^>]*)>', re.DOTALL)
+ATTR_RE = re.compile(r'(\w[\w-]*)="([^"]*)"')
+
+# Which capability each sub-setting belongs to. The two run limits are absent on
+# purpose: they bound personal *and* group runs, and `depends_on` names a single
+# key, so gating either one on a single capability would hide a live limit from
+# an administrator who only uses the other.
+EXPECTED_DEPENDENCIES = {
+    "require_member_of_workflow_user": "allow_user_workflows",
+    "require_group_assignment_for_group_workflows": "allow_group_workflows",
+    "group_workflow_allowed_group_ids": "require_group_assignment_for_group_workflows",
+}
+
+UNGATED_KEYS = ("workflow_max_auto_invoke_attempts", "workflow_max_tasks")
+
+fields_module = import_app_module("admin_settings_fields")
+
+
+def read_pane(pane_id):
+    """Return the raw markup for one Admin Settings pane."""
+    pane_path = PANES_DIR / f"{pane_id}.html"
+    assert pane_path.is_file(), f"Missing Admin Settings pane: {pane_path}"
+    return pane_path.read_text(encoding="utf-8")
+
+
+def collect_pane_field_names(markup):
+    """Return literal form field names submitted by a pane."""
+    return {
+        name
+        for name in FIELD_NAME_RE.findall(markup)
+        if not JINJA_RE.search(name)
+    }
+
+
+def workflow_fields():
+    """Return the schema entries filed under the workflow section."""
+    return fields_module.get_admin_settings_fields().get(WORKFLOW_SECTION_ID, [])
+
+
+def test_workflow_panes_match_navigation():
+    """The pane this test reads must be the one ADMIN_NAV puts in the group."""
+    print("Testing Workflow pane list against ADMIN_NAV...")
+
+    assert_app_version_at_least("0.261.059")
+
+    group = next((g for g in ADMIN_NAV if g["id"] == WORKFLOW_GROUP_ID), None)
+    assert group, "ADMIN_NAV no longer defines a 'workflow' group."
+
+    nav_tabs = {tab["id"]: tuple(s["id"] for s in tab["sections"]) for tab in group["tabs"]}
+
+    assert set(nav_tabs) == set(WORKFLOW_PANES), (
+        "The Workflow group's tabs changed. Update WORKFLOW_PANES and the schema "
+        f"together.\n  ADMIN_NAV: {sorted(nav_tabs)}\n  test: {sorted(WORKFLOW_PANES)}"
+    )
+
+    for tab_id, section_ids in nav_tabs.items():
+        assert section_ids == WORKFLOW_PANES[tab_id], (
+            f"Sections for the '{tab_id}' tab changed.\n"
+            f"  ADMIN_NAV: {section_ids}\n  test: {WORKFLOW_PANES[tab_id]}"
+        )
+
+    print(f"  {len(nav_tabs)} tab(s) and their sections match ADMIN_NAV.")
+    return True
+
+
+def test_workflow_section_is_described():
+    """An undescribed section renders as nothing, which is the original bug."""
+    print("\nTesting that the workflow section has declared fields...")
+
+    declared = workflow_fields()
+
+    assert declared, (
+        "admin_settings_fields.py declares no fields for "
+        f"{WORKFLOW_SECTION_ID!r}. None of the workflow settings are named enable_*, "
+        "so the V2 surface's fallback scan cannot find them either, and the whole "
+        "Workflow group renders empty."
+    )
+
+    print(f"  {len(declared)} workflow field(s) declared.")
+    return True
+
+
+def test_every_v1_field_is_claimed_by_the_schema():
+    """A V1 workflow field with no V2 equivalent is invisible in the new UI."""
+    print("\nTesting that every V1 Workflow field is claimed by the schema...")
+
+    claimed = fields_module.get_legacy_field_names()
+    documented = set(fields_module.LEGACY_FIELDS_WITHOUT_V2_EQUIVALENT)
+
+    unclaimed = {}
+    total = 0
+    for pane_id in WORKFLOW_PANES:
+        names = collect_pane_field_names(read_pane(pane_id))
+        total += len(names)
+        missing = sorted(names - claimed - documented)
+        if missing:
+            unclaimed[pane_id] = missing
+
+    assert not unclaimed, (
+        "These fields exist in the server-rendered Workflow pane but are not "
+        "described in admin_settings_fields.py, so they cannot appear in the V2 "
+        "admin UI. Add a field definition, record the name in LEGACY_FIELD_NAMES "
+        "if the shapes differ, or document the omission in "
+        "LEGACY_FIELDS_WITHOUT_V2_EQUIVALENT:\n"
+        + "\n".join(f"  {pane}: {', '.join(names)}" for pane, names in unclaimed.items())
+    )
+
+    print(f"  All {total} V1 Workflow field(s) are claimed by the schema.")
+    return True
+
+
+def test_schema_does_not_invent_workflow_fields():
+    """A schema key with no V1 counterpart would save a setting nothing reads."""
+    print("\nTesting that the schema does not invent Workflow fields...")
+
+    v1_names = set()
+    for pane_id in WORKFLOW_PANES:
+        v1_names |= collect_pane_field_names(read_pane(pane_id))
+
+    invented = []
+    for field in workflow_fields():
+        key = field.get("key")
+        if not key:
+            continue
+        legacy = fields_module.LEGACY_FIELD_NAMES.get(key, [key])
+        if not any(name in v1_names for name in legacy):
+            invented.append(f"{WORKFLOW_SECTION_ID}.{key}")
+
+    assert not invented, (
+        "These schema fields have no matching field in the V1 Workflow pane, so V2 "
+        "would write settings the rest of the application never reads:\n  "
+        + "\n  ".join(invented)
+    )
+
+    print("  Every Workflow schema field maps back to a V1 field.")
+    return True
+
+
+def test_number_bounds_match_v1():
+    """A wider range in V2 would save a value the V1 input refuses to show."""
+    print("\nTesting number bounds against V1...")
+
+    v1_numbers = {}
+    for pane_id in WORKFLOW_PANES:
+        for match in NUMBER_BLOCK_RE.finditer(read_pane(pane_id)):
+            attrs = dict(ATTR_RE.findall(match.group("attrs")))
+            name = attrs.get("name")
+            if not name or JINJA_RE.search(name):
+                continue
+            v1_numbers[name] = attrs
+
+    assert v1_numbers, "No number inputs were found in the Workflow pane."
+
+    mismatches = []
+    checked = 0
+    for field in workflow_fields():
+        if field.get("type") != "number":
+            continue
+        attrs = v1_numbers.get(field.get("key"))
+        if not attrs:
+            mismatches.append(f"{field.get('key')}: no number input in the V1 pane")
+            continue
+        for schema_prop, html_attr in (("min", "min"), ("max", "max"), ("step", "step")):
+            if str(field.get(schema_prop)) != attrs.get(html_attr):
+                mismatches.append(
+                    f"{field['key']}.{schema_prop}: schema {field.get(schema_prop)} "
+                    f"!= template {attrs.get(html_attr)}"
+                )
+        checked += 1
+
+    assert not mismatches, (
+        "These number controls differ between interfaces:\n  " + "\n  ".join(mismatches)
+    )
+    assert checked == len(v1_numbers), (
+        f"The V1 pane has {len(v1_numbers)} number input(s) but the schema declares "
+        f"{checked}. Every one must be described or it is unreachable in V2."
+    )
+
+    print(f"  {checked} number control(s) share identical bounds.")
+    return True
+
+
+def test_sub_settings_are_gated_by_their_capability():
+    """A sub-setting gated on the wrong capability hides while its feature is live."""
+    print("\nTesting the workflow gating chain...")
+
+    declared = {field["key"]: field for field in workflow_fields() if field.get("key")}
+
+    problems = []
+    for key, expected_gate in EXPECTED_DEPENDENCIES.items():
+        field = declared.get(key)
+        if field is None:
+            problems.append(f"{key}: not declared")
+            continue
+        depends_on = field.get("depends_on") or {}
+        if depends_on.get("key") != expected_gate:
+            problems.append(
+                f"{key}: gated on {depends_on.get('key')!r}, expected {expected_gate!r}"
+            )
+        if depends_on.get("equals") is not True:
+            problems.append(f"{key}: gate expects {depends_on.get('equals')!r}, not True")
+
+    for key in UNGATED_KEYS:
+        field = declared.get(key)
+        if field is None:
+            problems.append(f"{key}: not declared")
+            continue
+        if field.get("depends_on"):
+            problems.append(
+                f"{key}: gated on {field['depends_on'].get('key')!r}. It bounds both "
+                "personal and group runs, so gating it on one capability hides a live "
+                "limit from administrators who use the other."
+            )
+
+    assert not problems, (
+        "The workflow gating chain does not match the capabilities it belongs to:\n  "
+        + "\n  ".join(problems)
+    )
+
+    print(
+        f"  {len(EXPECTED_DEPENDENCIES)} gated and {len(UNGATED_KEYS)} ungated "
+        "field(s) are correct."
+    )
+    return True
+
+
+def test_group_assignment_uses_the_group_picker():
+    """Stored as a list of ids, so a text control would save unreadable state."""
+    print("\nTesting the group assignment control...")
+
+    declared = {field["key"]: field for field in workflow_fields() if field.get("key")}
+    field = declared.get("group_workflow_allowed_group_ids")
+
+    assert field, "group_workflow_allowed_group_ids is not declared."
+    assert field.get("type") == "group_picker", (
+        f"group_workflow_allowed_group_ids is declared as {field.get('type')!r}. It "
+        "stores a list of group ids, so it needs the group_picker control."
+    )
+    assert field.get("search_endpoint"), (
+        "The group picker has no search_endpoint, so it cannot resolve an assigned id "
+        "to a group name or search for another."
+    )
+    assert "group_picker" not in fields_module.NON_PATCHABLE_TYPES, (
+        "group_picker is marked non-patchable, so the assignment could not save with "
+        "the toggle that gates it. Requiring assignment and choosing the assigned "
+        "groups is one decision; saving them apart locks every group out in between."
+    )
+
+    print("  The assignment is a patchable group picker with a search endpoint.")
+    return True
+
+
+def test_group_picker_endpoint_exists_and_is_admin_only():
+    """A picker pointing at no route renders but can never resolve a group."""
+    print("\nTesting the group picker's search endpoint...")
+
+    source = (
+        REPO_ROOT / "application" / "single_app" / "route_backend_v2.py"
+    ).read_text(encoding="utf-8")
+
+    endpoints = {
+        field["search_endpoint"]
+        for field in workflow_fields()
+        if field.get("type") == "group_picker" and field.get("search_endpoint")
+    }
+    assert endpoints, "No group picker declares a search endpoint."
+
+    problems = []
+    for endpoint in sorted(endpoints):
+        # Capture everything between the route decorator and the handler, rather
+        # than modelling decorator syntax: the chain mixes bare decorators with
+        # ones taking nested calls, and a regex precise enough to parse that is
+        # easier to get wrong than the thing it checks.
+        route = re.search(
+            r'@bp\.route\(\s*"' + re.escape(endpoint) + r'".*?\n'
+            r'(?P<decorators>(?:[ \t]*@.*\n)*)'
+            r'[ \t]*def ',
+            source,
+        )
+        if not route:
+            problems.append(
+                f"{endpoint}: no matching @bp.route in route_backend_v2.py"
+            )
+            continue
+
+        decorators = route.group("decorators")
+        # An unauthenticated or merely signed-in group directory would let any user
+        # enumerate every group in the tenant, which the member-facing directory
+        # deliberately does not do.
+        for required in ("@login_required", "@admin_required", "@swagger_route"):
+            if required not in decorators:
+                problems.append(f"{endpoint}: missing {required}")
+
+    assert not problems, (
+        "The group picker's endpoint is missing or insufficiently guarded:\n  "
+        + "\n  ".join(problems)
+    )
+
+    print(f"  {len(endpoints)} picker endpoint(s) exist and are admin-only.")
+    return True
+
+
+def test_group_picker_normalizes_like_v1():
+    """V2 must store the shape V1 stores, including the ids it drops."""
+    print("\nTesting group picker normalization...")
+
+    group_id = "11111111-1111-1111-1111-111111111111"
+    other_id = "22222222-2222-2222-2222-222222222222"
+
+    cases = (
+        ([group_id, group_id], [group_id], "duplicates are collapsed"),
+        ([group_id, "not-a-uuid"], [group_id], "non-uuid ids are dropped"),
+        (f'["{group_id}", "{other_id}"]', [group_id, other_id], "a JSON string parses"),
+        ([], [], "an empty assignment stays empty"),
+    )
+
+    problems = []
+    for value, expected, description in cases:
+        normalized, errors, _warnings = fields_module.normalize_admin_settings_updates(
+            {"group_workflow_allowed_group_ids": value}, {}
+        )
+        if errors:
+            problems.append(f"{description}: rejected with {errors}")
+            continue
+        actual = normalized.get("group_workflow_allowed_group_ids")
+        if actual != expected:
+            problems.append(f"{description}: got {actual!r}, expected {expected!r}")
+
+    assert not problems, (
+        "The group picker does not normalize the way the server-rendered form does:\n  "
+        + "\n  ".join(problems)
+    )
+
+    print(f"  {len(cases)} normalization case(s) match V1.")
+    return True
+
+
+if __name__ == "__main__":
+    tests = [
+        test_workflow_panes_match_navigation,
+        test_workflow_section_is_described,
+        test_every_v1_field_is_claimed_by_the_schema,
+        test_schema_does_not_invent_workflow_fields,
+        test_number_bounds_match_v1,
+        test_sub_settings_are_gated_by_their_capability,
+        test_group_assignment_uses_the_group_picker,
+        test_group_picker_endpoint_exists_and_is_admin_only,
+        test_group_picker_normalizes_like_v1,
+    ]
+
+    results = []
+    for test in tests:
+        try:
+            results.append(bool(test()))
+        except Exception as exc:
+            print(f"FAILED {test.__name__}: {exc}")
+            import traceback
+
+            traceback.print_exc()
+            results.append(False)
+
+    print(f"\nResults: {sum(results)}/{len(results)} tests passed")
+    sys.exit(0 if all(results) else 1)


### PR DESCRIPTION
## The problem

The **Workflow** group in the V2 React admin interface was empty. Not partly — entirely. Selecting it in the category rail showed no card, no controls, and no explanation.

All seven workflow settings were unreachable from V2, so enabling workflows at all meant going back to the classic `/admin/settings` page.

## Root cause

One cause, not seven.

`admin_settings_nav.py` defines the group, its tab and its section, which is why the rail entry existed. What lives *inside* a section comes from one of two places: a description in `admin_settings_fields.py`, or the fallback that scans the settings document for `enable_*` booleans and matches each key to a section by shared word stems.

Workflow had no description. And **not one of its settings starts with `enable_`** — they are `allow_user_workflows`, `allow_group_workflows`, `require_member_of_workflow_user`, `workflow_max_tasks`, and so on. The scan had nothing to find, so the section had neither declared fields nor fallback rows, and `AdminSettingsPage` skipped it:

```ts
if (!fields.length && !capabilities.length) {
    continue;
}
```

This is a worse failure mode than the misfiled toggles fixed in `V2_APPEARANCE_PARITY_FIX`. A toggle in the wrong tab is at least visible somewhere; a group with no `enable_*` keys disappears silently, and nothing on the page hints that anything is missing.

## What this changes

### The section is described

All seven settings declared in `admin_settings_fields.py`, wording taken from the V1 pane so both interfaces say the same thing. Sub-settings are hidden until the capability they belong to is on, matching how Appearance already behaves:

```
allow_user_workflows ─────► require_member_of_workflow_user

allow_group_workflows ────► require_group_assignment_for_group_workflows
                                    └──► group_workflow_allowed_group_ids

workflow_max_auto_invoke_attempts   (ungated)
workflow_max_tasks                  (ungated)
```

The two run limits are ungated **on purpose**. They bound personal *and* group runs, and `depends_on` names a single key, so gating either on one capability would hide a live limit from an administrator who only uses the other kind.

### Assigned groups are visible

V1's modal could only report *"3 groups assigned"*. Finding out which three meant searching for them again, and a group that had since been deleted left an id in the list that nothing on screen ever mentioned.

The new `GroupAssignmentField`:

- shows each assignment as a **named**, removable chip;
- marks an id that no longer resolves as **Not found**, so it can be cleared instead of rotting invisibly;
- searches inline and debounced, rather than behind a modal and a Search button;
- falls back to raw ids and says so if the lookup fails, rather than losing the assignment.

Edits flow into the page draft, so it saves with the same save bar and dirty count as every other field.

### Supporting changes

| Change | Why |
|---|---|
| New `group_picker` field type | Nothing existing can edit a list of group ids. Normalized through the same function the server-rendered form uses, so the stored shape can't drift. Deliberately **patchable** — requiring assignment and choosing the groups is one decision, and saving them apart would lock every group out in between. |
| New `GET /api/v2/admin/groups` | `login_required` + `admin_required`. Searches the directory and resolves saved ids to names. |
| Generic `notice` / `notice_level` on fields | Carries V1's Cosmos capacity warning on the agent action limit from the schema instead of hard-coding it in React. Distinct from `help` (what a setting does) and from the server's per-save `warnings` (a reaction to a submitted value). |
| Normalizers moved to `functions_group_assignment_ids.py` | `admin_settings_fields.py` must delegate to them but cannot import `functions_settings`, which builds a Cosmos client at import time. Re-exported, so no caller changed. |

**Why not reuse `/api/groups/discover`?** It answers a different question: it's member-facing, gated on the `User` role and on `enable_group_workspaces`, returns every group in one unbounded response, and can't resolve a specific set of ids. An administrator managing an assignment may hold neither the `User` role nor membership in the groups being assigned.

## Notes for review

Three things worth a second pair of eyes:

1. **Only canonical UUIDs reach Cosmos.** The `ids` parameter goes through `normalize_group_workflow_allowed_group_ids` before the query, and `search` is parameterized — so neither can carry arbitrary text into `ARRAY_CONTAINS`.
2. **Id resolution is batched at 40 per request.** IIS on Azure App Service rejects a query string over 2048 bytes by default; a large assignment sent in one request would have silently fallen back to raw ids.
3. **`list_groups_for_admin_directory` has no `ORDER BY`.** Cosmos drops documents that lack the sorted property, which would hide legacy groups saved without a name. The page is sorted in Python instead, and asks for `limit + 1` rows so truncation is reported rather than silently hiding groups.

Two bugs caught during development, both fixed here:

- The first version of `GroupAssignmentField` read a ref during render, so `setResolving(true)` changed the effect's dependencies and **aborted its own in-flight fetch** — names would never have loaded. Rewritten to track resolution in state, separating "we asked and it's gone" from "the request failed", because those must not read the same on screen.
- The new endpoint-guard test initially passed for the wrong reason: its regex only matched decorators that take parentheses, so it never saw `@login_required`. Re-verified against a tampered source with `@admin_required` stripped to confirm it actually fails.

## Testing

`functional_tests/test_v2_admin_workflow_parity.py` is new and holds the invariants that would have caught this:

| Check | Guards against |
|---|---|
| The section declares at least one field | The original bug: an empty group |
| Every V1 pane field name is claimed by the schema | A setting reachable in only one interface |
| No schema field lacks a V1 counterpart | V2 writing a setting nothing reads |
| Number `min`/`max`/`step` match the V1 markup | V2 saving a value V1 refuses to show |
| The gating chain matches its capability | A control hidden while its feature is live |
| The picker's endpoint exists and is admin-only | An unguarded group directory |
| Normalization matches V1 for duplicates, non-UUIDs and JSON strings | Storage-shape drift between interfaces |

Also run and passing (13 files, 92 assertions):

- `test_v2_admin_settings_schema.py` (extended for `group_picker`), `test_v2_admin_settings_normalization.py`, `test_v2_admin_field_renderer_coverage.py`, `test_v2_admin_capability_placement.py`, `test_v2_admin_appearance_parity.py`, `test_v2_bootstrap_branding_and_navigation.py`
- `test_group_workflow_assignment_cleanup_fix.py`
- `test_docs_app_surface_coverage.py`, `test_docs_site_quality.py`
- All three `route_tests/` — the new route needed no policy entry, since `backend_v2_admin` already carries `login_required` + `admin_required`
- `npm run build` in `application/v2_ui`

**One test needed fixing.** `test_group_workflow_assignment_cleanup_fix.py` AST-extracts the normalizers from `functions_settings.py` source and executes them in isolation, so moving them broke it. Its loader now spans both modules and asserts the re-export itself. While there, it also carried a stale one-line marker for a condition the application had since split across a dozen lines — it was failing on formatting rather than behaviour — so it now checks that the clause participates in the condition.

**Five unrelated workflow tests fail, and they were already failing.** Verified by running them in a throwaway worktree at the base commit: `test_group_workflow_activity_view_gate.py`, `test_group_workflows_feature.py`, `test_workflow_access_controls.py`, `test_personal_workflows_feature.py` and `test_file_sync_workspace_assignment_gates.py` fail identically with and without this branch. None are touched here.

## Before and after

| | Before | After |
|---|---|---|
| Workflow group in V2 | Empty | Seven settings in one card |
| Reaching a workflow setting | Only via the classic admin page | Either interface |
| Assigned groups | "3 groups assigned" | Named chips |
| A deleted assigned group | Invisible | Marked *Not found*, removable |
| Searching for a group | Modal, explicit Search button | Inline, debounced |

## Documentation

- `docs/admin/workflow.md` — the settings table was generated filler (*"Permits enable personal workflows when the related workspace or agent feature is enabled"*), rewritten so each row says what the setting actually does, with real troubleshooting rows.
- `docs/explanation/fixes/V2_ADMIN_WORKFLOW_SETTINGS_PARITY_FIX.md` — new.
- `docs/explanation/release_notes.md` — entry under v0.261.059.
- `VERSION` bumped `0.261.058` → `0.261.059`.

## Out of scope

Two workflow-adjacent settings live in other V1 panes and stay where V1 puts them: `url_access_max_workflow_urls_per_run` (Web Research) and `require_owner_for_group_agent_management` (Workspace Types).

Separately, the filler wording found in `docs/admin/workflow.md` looks generated, so other admin doc pages likely have the same problem. Not touched here.
