### PR TITLE
Bring the Workspaces group into the V2 admin surface

### DIFF
--- a/application/single_app/admin_settings_fields.py
+++ b/application/single_app/admin_settings_fields.py
@@ -30,11 +30,13 @@ Two things keep this honest rather than becoming a third source of truth:
     to the same normalizers the server-rendered form uses. Both interfaces
     therefore agree on what a valid value is.
 
-Only the Appearance group is described in full so far. Sections with no entry
-here fall back to the V2 surface's ``enable_*`` scan, so undescribed groups keep
-working exactly as they did. A handful of individual fields outside Appearance
-are also declared: that scan places a key by guessing from shared word stems,
-and declaring a field is the only way to stop it guessing wrong.
+Only the Appearance and Workspaces groups are described in full so far. Sections
+with no entry here fall back to the V2 surface's ``enable_*`` scan, so undescribed
+groups keep working exactly as they did. A handful of individual fields outside
+those groups are also declared: that scan places a key by guessing from shared word
+stems and only ever sees ``enable_*`` booleans, so declaring a field is the only way
+to stop it guessing wrong, and the only way a ``require_member_of_*`` setting
+appears in V2 at all.
 """
 
 import re
@@ -71,6 +73,7 @@ FIELD_TYPES = (
     "number",
     "image",
     "link_list",
+    "id_list",
     "component",
 )
 
@@ -92,6 +95,12 @@ USER_AGREEMENT_WORD_LIMIT = 200
 
 CLASSIFICATION_BANNER_DEFAULT_COLOR = "#ffc107"
 CLASSIFICATION_BANNER_DEFAULT_TEXT_COLOR = "#ffffff"
+
+# Mirrors PUBLIC_WORKSPACE_DISPLAY_NAME_MAX_LENGTH in functions_settings.py, which
+# cannot be imported here: it reaches config.py and a live Cosmos client, and is one
+# of the modules the functional tests stub out. test_v2_admin_workspaces_parity.py
+# reads the value back out of that source and fails if the two drift apart.
+PUBLIC_WORKSPACE_DISPLAY_NAME_MAX_LENGTH = 32
 
 # Schemes permitted for administrator-configured navigation links. These render
 # into an anchor href, so allowing arbitrary schemes would let a saved link
@@ -614,10 +623,383 @@ ADMIN_SETTINGS_FIELDS = {
             "type": "switch",
             "label": "Enable Personal Workspaces",
             "help": (
-                "Users can create and manage their own private workspace for document "
-                "storage, knowledge bases and personal AI interactions."
+                "Gives every user a private space for their own documents, prompts, "
+                "agents and actions, which only they can reach. The new interface "
+                "presents it to end users as \"My Workspace\"; admin settings and "
+                "internal references call it the personal workspace. Turning this off "
+                "hides the destination and the personal scope in chat, and leaves "
+                "already-stored documents in place but unreachable."
             ),
             "default": True,
+        },
+    ],
+    "group-workspaces-section": [
+        {
+            "key": "enable_group_workspaces",
+            "type": "switch",
+            "label": "Enable Group Workspaces",
+            "help": (
+                "Lets users form groups that share one document library, prompt set "
+                "and agent catalogue, with membership managed per group. This is the "
+                "gate for everything else in this section."
+            ),
+            "default": True,
+        },
+        {
+            # V1 renders this inverted, as a "Disable Group Creation" checkbox, while
+            # the stored key is enable_group_creation. Declaring it positively means
+            # the switch and the value it writes finally agree, which is what makes
+            # the interaction with the role requirement below readable.
+            "key": "enable_group_creation",
+            "type": "switch",
+            "label": "Allow Users to Create Groups",
+            "help": (
+                "When off, nobody can create a new group regardless of app role, and "
+                "existing groups keep working. Use this to freeze the group list "
+                "while a migration or review is under way. Off here overrides the "
+                "CreateGroups role requirement entirely."
+            ),
+            "default": True,
+            "depends_on": {"key": "enable_group_workspaces", "equals": True},
+        },
+        {
+            "key": "require_member_of_create_group",
+            "type": "switch",
+            "label": "Require CreateGroups App Role",
+            "help": (
+                "Narrows group creation to users holding the CreateGroups app role. "
+                "Assign the role in the Enterprise App before switching this on, or "
+                "nobody will be able to create a group. Left off, any signed-in user "
+                "can create groups while the two settings above allow it."
+            ),
+            "default": False,
+            "depends_on": {"key": "enable_group_workspaces", "equals": True},
+        },
+        {
+            "key": "require_owner_for_group_agent_management",
+            "type": "switch",
+            "label": "Require Owner to Manage Group Agents, Actions and Workflows",
+            "help": (
+                "Restricts creating, editing and deleting a group's agents, actions "
+                "and workflows to the group Owner. Group Admins keep read access, so "
+                "they can still see what is configured without being able to change "
+                "what the group's agents are allowed to do."
+            ),
+            "default": False,
+            "depends_on": {"key": "enable_group_workspaces", "equals": True},
+        },
+    ],
+    "public-workspaces-section": [
+        {
+            "key": "enable_public_workspaces",
+            "type": "switch",
+            "label": "Enable Public Workspaces",
+            "help": (
+                "Adds a workspace type any user in the organisation can read without "
+                "being a member, for reference material meant to reach everyone. "
+                "Membership still controls who can add or change documents."
+            ),
+            "default": False,
+        },
+        {
+            "key": "public_workspace_display_name",
+            "type": "text",
+            "label": "End-user display name",
+            "help": (
+                "Renames the workspace type wherever end users meet it, so it can "
+                "match what your organisation already calls this material -- "
+                "\"Knowledge Base\" or \"Library\", for example. Admin settings and "
+                "internal references keep saying Public Workspace. Leave empty to use "
+                "the default name."
+            ),
+            "placeholder": "Public Workspace",
+            "default": "",
+            "max_length": PUBLIC_WORKSPACE_DISPLAY_NAME_MAX_LENGTH,
+            "depends_on": {"key": "enable_public_workspaces", "equals": True},
+        },
+        {
+            "key": "require_member_of_create_public_workspace",
+            "type": "switch",
+            "label": "Require CreatePublicWorkspaces App Role",
+            "help": (
+                "Narrows public workspace creation to users holding the "
+                "CreatePublicWorkspaces app role. Because anything published here is "
+                "readable organisation-wide, this is usually the setting to reach for "
+                "before enabling the workspace type broadly."
+            ),
+            "default": False,
+            "depends_on": {"key": "enable_public_workspaces", "equals": True},
+        },
+    ],
+    "file-download-settings-section": [
+        {
+            "key": "allow_personal_workspace_file_downloads",
+            "type": "switch",
+            "label": "Enable Personal Workspace Downloads",
+            "help": (
+                "Lets users retrieve the original uploaded file from their own "
+                "workspace, rather than only the extracted text the model reads. Off "
+                "by default because it turns the workspace into a way to move a file "
+                "back out of the tenant."
+            ),
+            "default": False,
+        },
+        {
+            "key": "allow_group_workspace_file_downloads",
+            "type": "switch",
+            "label": "Enable Group Workspace Downloads",
+            "help": (
+                "Permits downloads from group workspaces. A group Owner or Admin can "
+                "still switch downloads off for their own group, so this sets the "
+                "ceiling rather than the outcome."
+            ),
+            "default": False,
+        },
+        {
+            "key": "require_group_assignment_for_file_downloads",
+            "type": "switch",
+            "label": "Require Group Assignment for Downloads",
+            "help": (
+                "Limits downloads to the groups named below instead of every group. "
+                "Use this to pilot downloads with a few teams before opening them up."
+            ),
+            "default": False,
+            "depends_on": {"key": "allow_group_workspace_file_downloads", "equals": True},
+        },
+        {
+            "key": "file_download_allowed_group_ids",
+            "type": "id_list",
+            "label": "Groups allowed to download",
+            "help": (
+                "Only these groups can offer downloads while the requirement above is "
+                "on. A group left out of this list behaves as though downloads were "
+                "never enabled."
+            ),
+            "default": [],
+            "search_endpoint": "/api/groups/discover",
+            "search_param": "search",
+            "search_extra": {"showAll": "true"},
+            "results_key": "groups",
+            "item_noun": "group",
+            "item_noun_plural": "groups",
+            "depends_on": {
+                "key": "require_group_assignment_for_file_downloads",
+                "equals": True,
+            },
+        },
+        {
+            "key": "allow_public_workspace_file_downloads",
+            "type": "switch",
+            "label": "Enable Public Workspace Downloads",
+            "help": (
+                "Permits downloads from public workspaces. Because these are readable "
+                "organisation-wide, this makes every original file in them retrievable "
+                "by anyone who can see the workspace."
+            ),
+            "default": False,
+        },
+        {
+            "key": "require_public_workspace_assignment_for_file_downloads",
+            "type": "switch",
+            "label": "Require Public Workspace Assignment for Downloads",
+            "help": (
+                "Limits downloads to the public workspaces named below instead of all "
+                "of them."
+            ),
+            "default": False,
+            "depends_on": {
+                "key": "allow_public_workspace_file_downloads",
+                "equals": True,
+            },
+        },
+        {
+            "key": "file_download_allowed_public_workspace_ids",
+            "type": "id_list",
+            "label": "Public workspaces allowed to download",
+            "help": (
+                "Only these public workspaces can offer downloads while the "
+                "requirement above is on."
+            ),
+            "default": [],
+            "search_endpoint": "/api/admin/file-sync/public-workspaces/search",
+            "search_param": "q",
+            "results_key": "workspaces",
+            "item_noun": "public workspace",
+            "item_noun_plural": "public workspaces",
+            "depends_on": {
+                "key": "require_public_workspace_assignment_for_file_downloads",
+                "equals": True,
+            },
+        },
+    ],
+    "file-sharing-section": [
+        {
+            "key": "enable_file_sharing",
+            "type": "switch",
+            "label": "Enable File Sharing",
+            "help": (
+                "Lets a user hand a workspace file to another user or workspace from "
+                "inside the application, instead of downloading it and sending it on."
+            ),
+            "default": False,
+        },
+    ],
+    "shared-conversation-file-approvals-section": [
+        {
+            "key": "require_shared_conversation_file_approval",
+            "type": "switch",
+            "label": "Require approval for participant-generated files",
+            "help": (
+                "Files a participant generates in someone else's shared conversation "
+                "are saved into the owner's storage. With this on they are withheld "
+                "until the owner approves them -- in a group conversation any Owner, "
+                "Admin or Document Manager can. Anything left unapproved is declined "
+                "and deleted after three days. Covers CSV, XLSX, DOCX, PDF, JSON and "
+                "XML; generated images and charts are never held."
+            ),
+            "default": True,
+        },
+    ],
+    "file-size-limit-section": [
+        {
+            "key": "max_file_size_mb",
+            "type": "number",
+            "label": "Maximum File Size (MB)",
+            "help": (
+                "Rejects an upload larger than this before any extraction runs. It "
+                "applies to workspace documents and to files attached to a chat "
+                "message, so lowering it narrows both paths at once. Raise it only as "
+                "far as your extraction and storage tiers can actually handle."
+            ),
+            "default": 150,
+            "min": 1,
+            "suffix": " MB",
+        },
+    ],
+    "workspace-identities-section": [
+        {
+            "type": "component",
+            "component": "global-identities-list",
+            "label": "Global Identities",
+            "help": (
+                "Credentials saved once and reused by File Sync sources and Actions, "
+                "referenced by name so the secret itself never travels with a "
+                "configuration. Each one stores its secret in Key Vault when Key Vault "
+                "is configured."
+            ),
+        },
+    ],
+    "permissions-section": [
+        {
+            "key": "require_member_of_safety_violation_admin",
+            "type": "switch",
+            "label": "Require SafetyViolationAdmin App Role",
+            "help": (
+                "Narrows the Safety Violations report to holders of the "
+                "SafetyViolationAdmin app role. Left off, anyone with the general "
+                "Admin role can read it, including the flagged message text."
+            ),
+            "default": False,
+        },
+        {
+            "key": "require_member_of_feedback_admin",
+            "type": "switch",
+            "label": "Require FeedbackAdmin App Role",
+            "help": (
+                "Narrows the User Feedback report to holders of the FeedbackAdmin app "
+                "role. It only governs that report, so it has no effect until User "
+                "Feedback is enabled under Chat."
+            ),
+            "default": False,
+        },
+    ],
+    "app-role-requirements-section": [
+        {
+            "type": "component",
+            "component": "app-role-requirements-roster",
+            "label": "App Role Requirements",
+            "help": (
+                "Every setting that can demand an Entra app role, gathered so the "
+                "whole access policy reads in one place. Each switch is the same value "
+                "as the one on its own tab, so changing it here changes it there."
+            ),
+        },
+    ],
+    "chat-file-uploads-section": [
+        {
+            "key": "require_member_of_chat_file_upload_user",
+            "type": "switch",
+            "label": "Require ChatFileUploadUser App Role",
+            "help": (
+                "Narrows attaching files to a chat message to holders of the "
+                "ChatFileUploadUser app role. Attachments already in a conversation "
+                "stay readable; this governs new uploads only."
+            ),
+            "default": False,
+        },
+    ],
+    "control-center-overview-section": [
+        {
+            "key": "require_member_of_control_center_admin",
+            "type": "switch",
+            "label": "Require ControlCenterAdmin App Role",
+            "help": (
+                "Narrows the Control Center -- user management, group oversight, "
+                "public workspace control and activity logs -- to holders of the "
+                "ControlCenterAdmin app role. Note that this takes it away from "
+                "general Admins, so assign the role before switching it on."
+            ),
+            "default": False,
+        },
+        {
+            "key": "require_member_of_control_center_dashboard_reader",
+            "type": "switch",
+            "label": "Allow ControlCenterDashboardReader App Role",
+            "help": (
+                "Grants the Control Center dashboard, and nothing else, to holders of "
+                "the ControlCenterDashboardReader app role. Useful for giving someone "
+                "the usage picture without any management ability."
+            ),
+            "default": False,
+        },
+    ],
+    "url-access-section": [
+        {
+            "key": "require_member_of_url_access_user",
+            "type": "switch",
+            "label": "Require UrlAccessUser App Role",
+            "help": (
+                "Narrows fetching a URL in chat, and enabling it for a workflow, to "
+                "holders of the UrlAccessUser app role."
+            ),
+            "default": False,
+        },
+    ],
+    "source-review-section": [
+        {
+            "key": "require_member_of_deep_research_user",
+            "type": "switch",
+            "label": "Require DeepResearchUser App Role",
+            "help": (
+                "Narrows Deep Research to holders of the DeepResearchUser app role. "
+                "Worth using where the multi-step runs it performs are expensive "
+                "enough to want a named audience."
+            ),
+            "default": False,
+        },
+    ],
+    "workflow-settings-section": [
+        {
+            "key": "require_member_of_workflow_user",
+            "type": "switch",
+            "label": "Require WorkflowUser App Role",
+            "help": (
+                "Narrows opening, creating, editing, running and inspecting personal "
+                "workflows to holders of the WorkflowUser app role. Scheduled "
+                "workflows run unattended, so this is the control over who can leave "
+                "one running."
+            ),
+            "default": False,
         },
     ],
     "actions-config": [
@@ -656,6 +1038,9 @@ LEGACY_FIELD_NAMES = {
     "custom_favicon_base64": ["favicon_file"],
     # Collected as an acknowledgement on the toggle rather than a stored value.
     "enable_custom_pages": ["enable_custom_pages", "custom_pages_restart_acknowledged"],
+    # V1 renders this as an inverted "Disable Group Creation" checkbox and flips it
+    # server-side; V2 edits the stored key directly.
+    "enable_group_creation": ["disable_group_creation"],
 }
 
 # Field names present in the V1 Appearance panes that intentionally have no V2
@@ -778,6 +1163,29 @@ def _normalize_link_list(value):
     return links, None
 
 
+def _normalize_id_list(value):
+    """Return ``(ids, error)`` for a list of assigned group or workspace ids.
+
+    ``functions_settings`` already normalizes these keys for the server-rendered
+    form, but it is one of the modules ``test_support/app_stubs.py`` replaces, so
+    importing it here would stop every test that loads this schema. The V2 surface
+    only ever sends a real JSON array, which is the input shape where both
+    implementations agree: blanks dropped, duplicates removed, order preserved.
+    """
+    if not isinstance(value, list):
+        return None, "Expected a list of ids."
+
+    ids = []
+    seen = set()
+    for item in value:
+        candidate = str(item or "").strip()
+        if not candidate or candidate in seen:
+            continue
+        ids.append(candidate)
+        seen.add(candidate)
+    return ids, None
+
+
 def _normalize_checkbox_set(value, field):
     """Return ``(selection, error)`` for a multi-select checkbox group."""
     if isinstance(value, str):
@@ -872,6 +1280,10 @@ def _normalize_field_value(key, value, field):
     if field_type == "link_list":
         links, error = _normalize_link_list(value)
         return links, error, None
+
+    if field_type == "id_list":
+        ids, error = _normalize_id_list(value)
+        return ids, error, None
 
     if field_type == "textarea":
         text = str(value if value is not None else "")

--- a/application/single_app/admin_settings_nav.py
+++ b/application/single_app/admin_settings_nav.py
@@ -186,14 +186,7 @@ ADMIN_NAV = [
                     {"id": "file-download-settings-section", "label": "File Downloads", "icon": "bi-download"},
                     {"id": "file-sharing-section", "label": "File Sharing", "icon": "bi-share"},
                     {"id": "shared-conversation-file-approvals-section", "label": "Shared Conversation File Approvals", "icon": "bi-check2-square"},
-                    {"id": "file-size-limit-section", "label": "Maximum File Size", "icon": "bi-file-earmark-arrow-up"},
                 ],
-            },
-            {
-                "id": "workspace-identities",
-                "label": "Global Identities",
-                "icon": "bi-person-badge",
-                "sections": [],
             },
         ],
     },
@@ -246,6 +239,10 @@ ADMIN_NAV = [
                 "sections": [
                     {"id": "document-intelligence-section", "label": "Document Intelligence", "icon": "bi-file-earmark-text"},
                     {"id": "chunk-size-section", "label": "Chunk Sizes", "icon": "bi-collection"},
+                    # The upload ceiling belongs with the extraction pipeline it
+                    # feeds rather than with Workspaces, because it caps chat
+                    # attachments as well as workspace documents.
+                    {"id": "file-size-limit-section", "label": "Maximum File Size", "icon": "bi-file-earmark-arrow-up"},
                     {"id": "metadata-extraction-section", "label": "Metadata Extraction", "icon": "bi-file-earmark-code"},
                     {"id": "multimodal-vision-section", "label": "Multi-Modal Vision Analysis", "icon": "bi-eye"},
                 ],
@@ -297,6 +294,18 @@ ADMIN_NAV = [
                 "icon": "bi-safe",
                 "sections": [
                     {"id": "keyvault-section", "label": "Key Vault", "icon": "bi-safe"},
+                ],
+            },
+            {
+                # Stored credentials for the systems File Sync and Actions reach
+                # out to, not accounts for signing in. They sit with Secrets
+                # because each one keeps its secret in Key Vault; they used to sit
+                # under Workspaces, which owns neither of the things that use them.
+                "id": "workspace-identities",
+                "label": "Global Identities",
+                "icon": "bi-person-badge",
+                "sections": [
+                    {"id": "workspace-identities-section", "label": "Global Identities", "icon": "bi-person-badge"},
                 ],
             },
             {

--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -97,7 +97,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.261.058"
+VERSION = "0.261.059"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/templates/admin/_panes/extraction.html
+++ b/application/single_app/templates/admin/_panes/extraction.html
@@ -593,6 +593,20 @@
                     </div>
                 </div>
 
+                <div class="card p-3 mb-3" id="file-size-limit-section">
+                    <h5>
+                        <i class="bi bi-file-earmark-arrow-up me-2"></i>Maximum File Size
+                    </h5>
+                    <p class="text-muted">
+                        The largest file that may be uploaded, whether into a workspace or attached to a chat message.
+                    </p>
+                    <div class="mb-3">
+                        <label for="max_file_size_mb" class="form-label">Maximum File Size (MB)</label>
+                        <input type="number" class="form-control" id="max_file_size_mb" name="max_file_size_mb"
+                            value="{{ settings.max_file_size_mb }}">
+                    </div>
+                </div>
+
                 <!-- AI Video Intelligence Card -->
                 <div class="card mb-3 p-3" id="metadata-extraction-section">
                     <h5>

--- a/application/single_app/templates/admin/_panes/files-sharing.html
+++ b/application/single_app/templates/admin/_panes/files-sharing.html
@@ -200,7 +200,7 @@
 
 
 
-                <div class="card p-3 mb-4" id="shared-conversation-file-approvals-section">
+                <div class="card p-3 mb-3" id="shared-conversation-file-approvals-section">
                     <h5>
                         <i class="bi bi-file-earmark-lock me-2"></i>Shared Conversation File Approvals
                     </h5>
@@ -217,20 +217,6 @@
                             Require approval for participant-generated files
                         </label>
                         <i class="bi bi-info-circle ms-2" data-bs-toggle="tooltip" title="When a participant who does not own a shared conversation generates a downloadable file (CSV, XLSX, DOCX, PDF, JSON, XML), the file is created but withheld until the conversation owner approves it. In group conversations, any group Owner, Admin, or Document Manager can approve. Unapproved files are automatically declined and deleted after 3 days. Generated images and charts are never gated."></i>
-                    </div>
-                </div>
-
-                <div class="card p-3 mb-3" id="file-size-limit-section">
-                    <h5>
-                        <i class="bi bi-file-earmark-arrow-up me-2"></i>Maximum File Size
-                    </h5>
-                    <p class="text-muted">
-                        The largest file a user may upload into a workspace.
-                    </p>
-                    <div class="mb-3">
-                        <label for="max_file_size_mb" class="form-label">Maximum File Size (MB)</label>
-                        <input type="number" class="form-control" id="max_file_size_mb" name="max_file_size_mb"
-                            value="{{ settings.max_file_size_mb }}">
                     </div>
                 </div>
 

--- a/application/v2_ui/src/components/admin/AppRoleRoster.tsx
+++ b/application/v2_ui/src/components/admin/AppRoleRoster.tsx
@@ -1,0 +1,71 @@
+// AppRoleRoster.tsx
+// Every app role requirement in the deployment, gathered in one place.
+//
+// Each switch here is the same stored value as the one on the tab that owns the feature,
+// not a copy of it: both write the same key into the page draft, so flipping a role here
+// and flipping it there are the same edit. That is deliberate. Read individually, a role
+// requirement tells you little; read together they are the access policy, and deciding
+// whether it is coherent means seeing all of them at once.
+//
+// The roster is built from the field schema, so a role requirement that nobody has
+// declared is absent here for the same reason it is absent everywhere else in this UI:
+// the page's fallback scan only ever sees `enable_*` keys.
+
+import { clsx } from 'clsx';
+import { ShieldCheck } from 'lucide-react';
+import type { AppRoleEntry } from '../../lib/adminFields';
+import { Toggle } from '../ui/primitives';
+
+export function AppRoleRoster({
+    entries,
+    values,
+    help,
+    disabled,
+    onChange,
+}: {
+    entries: AppRoleEntry[];
+    values: Record<string, boolean>;
+    help?: string;
+    disabled?: boolean;
+    onChange: (key: string, next: boolean) => void;
+}) {
+    if (entries.length === 0) {
+        return (
+            <p className="py-3 text-xs leading-relaxed text-text-3">
+                No app role requirements are declared yet.
+            </p>
+        );
+    }
+
+    const enforced = entries.filter((entry) => values[entry.key]).length;
+
+    return (
+        <div className="py-3">
+            {help ? (
+                <p className="mb-3 text-xs leading-relaxed text-text-3">{help}</p>
+            ) : null}
+
+            <p className="mb-3 flex items-center gap-1.5 text-xs text-text-3">
+                <ShieldCheck size={13} className="shrink-0" />
+                {enforced} of {entries.length} requirements are being enforced.
+            </p>
+
+            <ul className="space-y-1">
+                {entries.map((entry) => (
+                    <li
+                        key={entry.key}
+                        className={clsx('rounded-lg border border-edge px-3 py-1.5')}
+                    >
+                        <Toggle
+                            label={entry.label}
+                            description={`${entry.groupLabel} › ${entry.tabLabel} › ${entry.sectionLabel}`}
+                            checked={Boolean(values[entry.key])}
+                            disabled={disabled}
+                            onChange={(next) => onChange(entry.key, next)}
+                        />
+                    </li>
+                ))}
+            </ul>
+        </div>
+    );
+}

--- a/application/v2_ui/src/components/admin/AssignmentPicker.tsx
+++ b/application/v2_ui/src/components/admin/AssignmentPicker.tsx
@@ -1,0 +1,285 @@
+// AssignmentPicker.tsx
+// Editor for an `id_list` field: the set of groups or public workspaces a policy applies to.
+//
+// The value is a list of opaque record ids, and there is no endpoint that turns an id back
+// into a name in bulk. The server-rendered admin page has the same constraint and answers
+// it by summarising the selection as a count and resolving names only through search; this
+// does the same rather than inventing a lookup the API cannot serve.
+//
+// Edits are reported upward into the page draft like any other field, so a change here is
+// saved by the same Save button and is discarded by the same Cancel.
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { clsx } from 'clsx';
+import { AlertCircle, Loader2, Search, Users } from 'lucide-react';
+import { ApiError, api } from '../../lib/apiClient';
+import { asStringArray, type AdminField } from '../../lib/adminFields';
+import { AdminModal } from './AdminModal';
+import { GlassButton } from '../ui/primitives';
+
+/** One record the search endpoint offered. Only these three fields are relied on. */
+interface AssignableRecord {
+    id: string;
+    name?: string;
+    description?: string;
+}
+
+/** Pull the result array out of a response whose property name the schema declares. */
+function readResults(payload: unknown, resultsKey: string): AssignableRecord[] {
+    if (!payload || typeof payload !== 'object') {
+        return [];
+    }
+    const candidate = (payload as Record<string, unknown>)[resultsKey];
+    if (!Array.isArray(candidate)) {
+        return [];
+    }
+    return candidate
+        .filter((item): item is Record<string, unknown> => Boolean(item) && typeof item === 'object')
+        .map((item) => ({
+            id: String(item.id ?? ''),
+            name: typeof item.name === 'string' ? item.name : undefined,
+            description: typeof item.description === 'string' ? item.description : undefined,
+        }))
+        .filter((item) => item.id);
+}
+
+function buildSearchUrl(field: AdminField, term: string): string {
+    const params = new URLSearchParams({ ...(field.search_extra ?? {}) });
+    params.set(field.search_param ?? 'q', term);
+    return `${field.search_endpoint}?${params.toString()}`;
+}
+
+function summarise(count: number, field: AdminField): string {
+    const singular = field.item_noun ?? 'item';
+    const plural = field.item_noun_plural ?? `${singular}s`;
+    if (count === 0) {
+        return `No ${plural} assigned.`;
+    }
+    return `${count} ${count === 1 ? singular : plural} assigned.`;
+}
+
+function PickerModal({
+    field,
+    selected,
+    onToggle,
+    onClose,
+}: {
+    field: AdminField;
+    selected: string[];
+    onToggle: (id: string, checked: boolean) => void;
+    onClose: () => void;
+}) {
+    const [term, setTerm] = useState('');
+    const [results, setResults] = useState<AssignableRecord[]>([]);
+    const [status, setStatus] = useState<string | null>(null);
+    const [error, setError] = useState<string | null>(null);
+    const [searching, setSearching] = useState(false);
+    const searchRef = useRef<HTMLInputElement>(null);
+
+    const runSearch = useCallback(
+        async (query: string) => {
+            if (!field.search_endpoint) {
+                return;
+            }
+            setSearching(true);
+            setError(null);
+            try {
+                const payload = await api.get<unknown>(buildSearchUrl(field, query));
+                const records = readResults(payload, field.results_key ?? 'results');
+                setResults(records);
+                setStatus(
+                    records.length
+                        ? null
+                        : `No ${field.item_noun_plural ?? 'records'} matched that search.`,
+                );
+            } catch (searchError) {
+                setResults([]);
+                setStatus(null);
+                setError(
+                    searchError instanceof ApiError && searchError.status === 403
+                        ? 'You do not have permission to search here, or the feature this search depends on is disabled.'
+                        : searchError instanceof Error
+                          ? searchError.message
+                          : 'The search failed.',
+                );
+            } finally {
+                setSearching(false);
+            }
+        },
+        [field],
+    );
+
+    // Open with the unfiltered list where the endpoint returns one. The public workspace
+    // search requires two characters and answers an empty term with nothing, so the status
+    // line below tells the reader to type rather than leaving a bare empty list.
+    useEffect(() => {
+        void runSearch('');
+        searchRef.current?.focus();
+    }, [runSearch]);
+
+    const plural = field.item_noun_plural ?? 'records';
+
+    return (
+        <AdminModal
+            title={field.label}
+            description={`Choose which ${plural} this policy applies to.`}
+            size="lg"
+            onClose={onClose}
+            footer={
+                <GlassButton variant="subtle" size="sm" onClick={onClose}>
+                    Done
+                </GlassButton>
+            }
+        >
+            <form
+                className="mb-3 flex items-center gap-2"
+                onSubmit={(event) => {
+                    event.preventDefault();
+                    void runSearch(term.trim());
+                }}
+            >
+                <div className="relative min-w-0 flex-1">
+                    <Search
+                        size={15}
+                        className="pointer-events-none absolute top-1/2 left-3 -translate-y-1/2 text-text-3"
+                    />
+                    <input
+                        ref={searchRef}
+                        type="search"
+                        value={term}
+                        onChange={(event) => setTerm(event.target.value)}
+                        placeholder={`Search ${plural} by name or description`}
+                        aria-label={`Search ${plural}`}
+                        className={clsx(
+                            'w-full rounded-lg border border-edge bg-surface-1 py-2 pr-3 pl-9',
+                            'text-sm text-text-1 placeholder:text-text-3',
+                            'focus:border-accent focus:outline-none',
+                        )}
+                    />
+                </div>
+                <GlassButton type="submit" variant="subtle" size="sm" disabled={searching}>
+                    {searching ? <Loader2 size={14} className="animate-spin" /> : 'Search'}
+                </GlassButton>
+            </form>
+
+            {error ? (
+                <p
+                    role="alert"
+                    className="mb-3 flex items-start gap-1.5 rounded-lg bg-danger-soft px-3 py-2 text-xs text-danger"
+                >
+                    <AlertCircle size={13} className="mt-0.5 shrink-0" />
+                    {error}
+                </p>
+            ) : null}
+
+            <p className="mb-2 text-xs text-text-3">
+                {summarise(selected.length, field)} Assignments are kept even while a record
+                is outside the current results, so searching never clears a selection.
+            </p>
+
+            {status ? <p className="py-6 text-center text-sm text-text-3">{status}</p> : null}
+
+            <ul className="space-y-1">
+                {results.map((record) => {
+                    const checked = selected.includes(record.id);
+                    const id = `assignment-${field.key}-${record.id}`;
+                    return (
+                        <li key={record.id}>
+                            <label
+                                htmlFor={id}
+                                className={clsx(
+                                    'flex cursor-pointer items-start gap-3 rounded-lg border border-edge px-3 py-2',
+                                    checked ? 'bg-accent-soft' : 'hover:bg-surface-2',
+                                )}
+                            >
+                                <input
+                                    id={id}
+                                    type="checkbox"
+                                    className="mt-0.5 accent-[var(--accent)]"
+                                    checked={checked}
+                                    onChange={(event) =>
+                                        onToggle(record.id, event.target.checked)
+                                    }
+                                />
+                                <span className="min-w-0">
+                                    <span className="block truncate text-sm text-text-1">
+                                        {record.name || 'Unnamed'}
+                                    </span>
+                                    {record.description ? (
+                                        <span className="block truncate text-xs text-text-3">
+                                            {record.description}
+                                        </span>
+                                    ) : null}
+                                </span>
+                            </label>
+                        </li>
+                    );
+                })}
+            </ul>
+        </AdminModal>
+    );
+}
+
+export function AssignmentPicker({
+    field,
+    value,
+    error,
+    disabled,
+    onChange,
+}: {
+    field: AdminField;
+    value: unknown;
+    error?: string;
+    disabled?: boolean;
+    onChange: (next: string[]) => void;
+}) {
+    const [open, setOpen] = useState(false);
+    const selected = asStringArray(value);
+
+    const onToggle = (id: string, checked: boolean) => {
+        onChange(checked ? [...selected, id] : selected.filter((item) => item !== id));
+    };
+
+    return (
+        <div className="py-3">
+            <p className="mb-1.5 text-sm font-medium text-text-1">{field.label}</p>
+
+            <div className="flex flex-wrap items-center gap-2">
+                <GlassButton
+                    type="button"
+                    variant="subtle"
+                    size="sm"
+                    disabled={disabled}
+                    onClick={() => setOpen(true)}
+                >
+                    <Users size={14} />
+                    Manage
+                </GlassButton>
+                <span className="text-xs text-text-3">{summarise(selected.length, field)}</span>
+            </div>
+
+            {field.help ? (
+                <p className="mt-1.5 text-xs leading-relaxed text-text-3">{field.help}</p>
+            ) : null}
+
+            {error ? (
+                <p
+                    role="alert"
+                    className="mt-1.5 flex items-start gap-1.5 text-xs text-danger"
+                >
+                    <AlertCircle size={13} className="mt-0.5 shrink-0" />
+                    {error}
+                </p>
+            ) : null}
+
+            {open ? (
+                <PickerModal
+                    field={field}
+                    selected={selected}
+                    onToggle={onToggle}
+                    onClose={() => setOpen(false)}
+                />
+            ) : null}
+        </div>
+    );
+}

--- a/application/v2_ui/src/components/admin/AssignmentPicker.tsx
+++ b/application/v2_ui/src/components/admin/AssignmentPicker.tsx
@@ -90,7 +90,13 @@ function PickerModal({
                 setStatus(
                     records.length
                         ? null
-                        : `No ${field.item_noun_plural ?? 'records'} matched that search.`,
+                        : query
+                          ? `No ${field.item_noun_plural ?? 'records'} matched that search.`
+                          : // Not every endpoint answers an empty term with a full list --
+                            // the public workspace search requires two characters -- so an
+                            // empty result for an empty term means "type something", not
+                            // "nothing exists".
+                            `Search to find ${field.item_noun_plural ?? 'records'} to assign.`,
                 );
             } catch (searchError) {
                 setResults([]);

--- a/application/v2_ui/src/components/admin/GlobalIdentitiesList.tsx
+++ b/application/v2_ui/src/components/admin/GlobalIdentitiesList.tsx
@@ -1,0 +1,116 @@
+// GlobalIdentitiesList.tsx
+// Read-only inventory of the deployment-wide saved credentials.
+//
+// "Identity" reliably reads as a user sign-in rather than as a stored credential, so the
+// copy here is explicit about what these are and what consumes them. Creating and editing
+// one is still done on the server-rendered admin page: the editor there handles Key Vault
+// round-tripping and per-auth-type field sets, and rebuilding it would be a large amount
+// of work for a surface almost nobody reaches. Listing what exists, and saying plainly
+// where to go to change it, is more useful than the blank tab this replaces.
+
+import { useEffect, useState } from 'react';
+import { clsx } from 'clsx';
+import { AlertCircle, KeyRound, Loader2 } from 'lucide-react';
+import { api } from '../../lib/apiClient';
+import { authTypeLabel } from '../../pages/workspace/IdentitiesSection';
+import type { WorkspaceIdentity } from '../../lib/types';
+
+const GLOBAL_IDENTITIES_ENDPOINT = '/api/admin/workspace-identities/global/identities';
+
+interface IdentitiesResponse {
+    identities: WorkspaceIdentity[];
+}
+
+export function GlobalIdentitiesList({ help }: { help?: string }) {
+    const [identities, setIdentities] = useState<WorkspaceIdentity[] | null>(null);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        let cancelled = false;
+        void (async () => {
+            try {
+                const response = await api.get<IdentitiesResponse>(GLOBAL_IDENTITIES_ENDPOINT);
+                if (!cancelled) {
+                    setIdentities(response.identities ?? []);
+                }
+            } catch (fetchError) {
+                if (!cancelled) {
+                    setError(
+                        fetchError instanceof Error
+                            ? fetchError.message
+                            : 'Failed to load global identities.',
+                    );
+                }
+            }
+        })();
+
+        return () => {
+            cancelled = true;
+        };
+    }, []);
+
+    return (
+        <div className="py-3">
+            {help ? (
+                <p className="mb-3 text-xs leading-relaxed text-text-3">{help}</p>
+            ) : null}
+
+            <p className="mb-3 text-xs leading-relaxed text-text-3">
+                Adding, editing and deleting an identity is done on the{' '}
+                <a
+                    href="/admin_settings#workspace-identities"
+                    className="text-accent hover:underline"
+                >
+                    classic admin settings page
+                </a>
+                .
+            </p>
+
+            {error ? (
+                <p
+                    role="alert"
+                    className="flex items-start gap-1.5 rounded-lg bg-danger-soft px-3 py-2 text-xs text-danger"
+                >
+                    <AlertCircle size={13} className="mt-0.5 shrink-0" />
+                    {error}
+                </p>
+            ) : identities === null ? (
+                <p className="flex items-center gap-2 py-4 text-sm text-text-3">
+                    <Loader2 size={15} className="animate-spin" />
+                    Loading identities…
+                </p>
+            ) : identities.length === 0 ? (
+                <p className="py-4 text-sm text-text-3">
+                    No global identities are saved. File Sync sources and actions that need
+                    credentials can define their own within a workspace instead.
+                </p>
+            ) : (
+                <ul className="space-y-1">
+                    {identities.map((identity, index) => (
+                        <li
+                            key={String(identity.id ?? index)}
+                            className={clsx(
+                                'flex items-start gap-3 rounded-lg border border-edge px-3 py-2',
+                            )}
+                        >
+                            <KeyRound size={16} className="mt-0.5 shrink-0 text-text-3" />
+                            <span className="min-w-0 flex-1">
+                                <span className="block truncate text-sm text-text-1">
+                                    {String(identity.name ?? 'Untitled identity')}
+                                </span>
+                                {identity.username || identity.description ? (
+                                    <span className="block truncate text-xs text-text-3">
+                                        {String(identity.username ?? identity.description ?? '')}
+                                    </span>
+                                ) : null}
+                            </span>
+                            <span className="shrink-0 rounded-full bg-surface-2 px-2 py-0.5 text-[11px] text-text-3">
+                                {authTypeLabel(identity.auth_type)}
+                            </span>
+                        </li>
+                    ))}
+                </ul>
+            )}
+        </div>
+    );
+}

--- a/application/v2_ui/src/lib/adminFields.ts
+++ b/application/v2_ui/src/lib/adminFields.ts
@@ -20,6 +20,7 @@ export type AdminFieldType =
     | 'number'
     | 'image'
     | 'link_list'
+    | 'id_list'
     | 'component';
 
 export interface AdminFieldOption {
@@ -65,6 +66,17 @@ export interface AdminField {
     min_selected?: number;
     fallback_when_empty?: boolean;
     item_fields?: AdminField[];
+    /** `id_list` only: the admin search endpoint that finds assignable records. */
+    search_endpoint?: string;
+    /** `id_list` only: query parameter the endpoint reads the search term from. */
+    search_param?: string;
+    /** `id_list` only: fixed query parameters sent with every search. */
+    search_extra?: Record<string, string>;
+    /** `id_list` only: property on the response holding the result array. */
+    results_key?: string;
+    /** `id_list` only: what one assignable record is called, for summaries. */
+    item_noun?: string;
+    item_noun_plural?: string;
     /** Image fields only: which branding slot the upload endpoint should write. */
     upload_target?: 'logo' | 'logo_dark' | 'favicon';
     accept?: string;
@@ -199,4 +211,59 @@ export function fieldSearchText(field: AdminField): string {
     return [field.key ?? '', field.label, field.help ?? '', field.component ?? '']
         .join(' ')
         .toLowerCase();
+}
+
+/** Settings that gate a capability behind an Entra app role. */
+export const APP_ROLE_KEY_PREFIX = 'require_member_of_';
+
+/** One app role requirement, with the section that owns its primary control. */
+export interface AppRoleEntry {
+    key: string;
+    label: string;
+    help?: string;
+    groupLabel: string;
+    tabLabel: string;
+    sectionLabel: string;
+}
+
+/**
+ * Collect every declared app role requirement, in navigation order.
+ *
+ * The roster in Security mirrors switches that live on other tabs, so it has to know
+ * where each one really belongs -- an administrator who flips a role here should be able
+ * to find the feature it governs. Walking the navigation rather than the schema dict is
+ * what puts the entries in the order the rest of the page uses, and it silently drops a
+ * field filed under a section navigation does not define, which could never be reached.
+ *
+ * Only declared fields are visible: the page's `enable_*` fallback scan cannot see a
+ * `require_member_of_*` key, so an undeclared role requirement appears nowhere at all and
+ * would be missing from the roster for the same reason.
+ */
+export function collectAppRoleEntries(
+    nav: import('./types').AdminNavGroup[],
+    schema: AdminFieldSchema,
+): AppRoleEntry[] {
+    const entries: AppRoleEntry[] = [];
+
+    for (const group of nav) {
+        for (const tab of group.tabs) {
+            for (const section of tab.sections) {
+                for (const field of schema[section.id] ?? []) {
+                    if (!field.key?.startsWith(APP_ROLE_KEY_PREFIX)) {
+                        continue;
+                    }
+                    entries.push({
+                        key: field.key,
+                        label: field.label,
+                        help: field.help,
+                        groupLabel: group.label,
+                        tabLabel: tab.label,
+                        sectionLabel: section.label,
+                    });
+                }
+            }
+        }
+    }
+
+    return entries;
 }

--- a/application/v2_ui/src/pages/AdminSettingsPage.tsx
+++ b/application/v2_ui/src/pages/AdminSettingsPage.tsx
@@ -33,9 +33,12 @@ import { PageHeader } from '../components/layout/PageHeader';
 import { GlassButton, GlassPanel, Skeleton, Toggle } from '../components/ui/primitives';
 import { AdminModal } from '../components/admin/AdminModal';
 import { AdminMarkdown } from '../components/admin/AdminMarkdown';
+import { AppRoleRoster } from '../components/admin/AppRoleRoster';
+import { AssignmentPicker } from '../components/admin/AssignmentPicker';
 import { BrandingImageField } from '../components/admin/BrandingImageField';
 import { CustomPagesTable } from '../components/admin/CustomPagesTable';
 import { ExternalLinksEditor } from '../components/admin/ExternalLinksEditor';
+import { GlobalIdentitiesList } from '../components/admin/GlobalIdentitiesList';
 import { SaveBar } from '../components/admin/SaveBar';
 import { SettingField } from '../components/admin/fields';
 import {
@@ -46,6 +49,7 @@ import {
     asBoolean,
     asNumber,
     asString,
+    collectAppRoleEntries,
     extractFieldErrors,
     fieldSearchText,
     humanizeKey,
@@ -347,6 +351,29 @@ export function AdminSettingsPage() {
     const settingCount = declaredKeys.size + capabilityRows.length;
 
     /**
+     * App role requirements, for the roster that mirrors them into Security.
+     *
+     * Built from the navigation and the schema together so each entry can say which tab
+     * really owns it, and so the order matches the rest of the page.
+     */
+    const appRoleEntries = useMemo(
+        () => (data ? collectAppRoleEntries(data.admin_nav, schema) : []),
+        [data, schema],
+    );
+
+    const appRoleValues = useMemo(() => {
+        const values: Record<string, boolean> = {};
+        for (const entry of appRoleEntries) {
+            values[entry.key] = asBoolean(
+                Object.prototype.hasOwnProperty.call(draft, entry.key)
+                    ? draft[entry.key]
+                    : settings[entry.key],
+            );
+        }
+        return values;
+    }, [appRoleEntries, draft, settings]);
+
+    /**
      * Keys that gate a save rather than being stored.
      *
      * They ride along in the draft so they reach the PATCH, but they are not changes an
@@ -532,10 +559,36 @@ export function AdminSettingsPage() {
             );
         }
 
+        if (field.type === 'id_list') {
+            return (
+                <AssignmentPicker
+                    key={key}
+                    field={field}
+                    value={value}
+                    error={error}
+                    disabled={saving}
+                    onChange={(next) => field.key && setValue(field.key, next)}
+                />
+            );
+        }
+
         if (field.type === 'component') {
             switch (field.component) {
                 case 'custom-pages-table':
                     return <CustomPagesTable key={key} help={field.help} />;
+                case 'global-identities-list':
+                    return <GlobalIdentitiesList key={key} help={field.help} />;
+                case 'app-role-requirements-roster':
+                    return (
+                        <AppRoleRoster
+                            key={key}
+                            entries={appRoleEntries}
+                            values={appRoleValues}
+                            help={field.help}
+                            disabled={saving}
+                            onChange={setValue}
+                        />
+                    );
                 case 'classification-banner-preview':
                     return (
                         <ClassificationBannerPreview

--- a/docs/_data/app_surface.yml
+++ b/docs/_data/app_surface.yml
@@ -4,7 +4,7 @@ counts:
   capabilities: 112
   admin_groups: 14
   admin_tabs: 46
-  admin_sections: 96
+  admin_sections: 97
   actions: 27
   chat_controls: 47
   sub_elements: 3
@@ -314,6 +314,7 @@ admin_groups:
   - rate-limiting
   - secrets
   - session
+  - workspace-identities
 - id: workflow
   label: Workflow
   tabs:
@@ -322,7 +323,6 @@ admin_groups:
   label: Workspaces
   tabs:
   - files-sharing
-  - workspace-identities
   - workspace-types
 admin_tabs:
 - id: access-roles
@@ -459,7 +459,7 @@ admin_tabs:
   group: workflow
 - id: workspace-identities
   label: Global Identities
-  group: workspaces
+  group: security
 - id: workspace-types
   label: Workspace Types
   group: workspaces
@@ -658,8 +658,8 @@ admin_sections:
   group: workspaces
 - id: file-size-limit-section
   label: Maximum File Size
-  tab: files-sharing
-  group: workspaces
+  tab: extraction
+  group: knowledge
 - id: file-sync-group-section
   label: Group Workspace Sync
   tab: file-sync
@@ -844,6 +844,10 @@ admin_sections:
   label: Workflow
   tab: workflow
   group: workflow
+- id: workspace-identities-section
+  label: Global Identities
+  tab: workspace-identities
+  group: security
 - id: workspace-scope-lock-section
   label: Workspace Scope Lock
   tab: chat-experience

--- a/docs/admin/knowledge.md
+++ b/docs/admin/knowledge.md
@@ -141,18 +141,47 @@ vector is trimmed, and the event is logged.
 Custom sizes apply to new uploads only. Existing documents keep the chunks they were indexed with
 until they are uploaded again.
 
+### Maximum File Size {#file-size-limit-section}
+
+The ceiling applies to every upload, whether a document going into a workspace or a file
+attached to a chat message, and it is checked before any extraction runs. That makes it the
+cheapest control available for protecting the extraction pipeline: an oversized file is
+refused outright rather than consuming Document Intelligence capacity and then failing.
+
+It sits with extraction rather than with Workspaces because both upload paths feed the same
+pipeline, and because the practical ceiling is whatever your extraction and storage tiers can
+absorb rather than a workspace policy decision.
+
 ### Metadata Extraction {#metadata-extraction-section}
 
-The Metadata Extraction section belongs to the Document Extraction tab. Use it with the adjacent settings in this group so related rollout, access, and operational choices stay aligned.
+After a document is chunked, a further model pass can read it and record structured metadata
+about it -- title, authors, subject, keywords -- which is what makes a citation readable as a
+source rather than as a filename. It runs on upload, so enabling it later does not backfill
+documents that are already indexed.
+
+It costs an extra model call per document, and it needs a deployment selected for it, so it
+is off by default.
 
 ### Multi-Modal Vision Analysis {#multimodal-vision-section}
 
-The Multi-Modal Vision Analysis section belongs to the Document Extraction tab. Use it with the adjacent settings in this group so related rollout, access, and operational choices stay aligned.
+Sends page images to a vision-capable model so the text inside diagrams, screenshots and
+scanned pages becomes searchable alongside the extracted text. Only vision-capable
+deployments are offered for selection, because a text-only model silently returns nothing
+useful here.
+
+This is the most expensive extraction path in the group. Reach for it when the material is
+genuinely visual; for text documents that happen to contain a chart, Document Intelligence
+already captures the surrounding structure.
 
 #### Settings
 
 | Setting | What it does | Default | Notes |
 | --- | --- | --- | --- |
+| Maximum File Size (MB) | Rejects an upload larger than this before extraction runs. Applies to workspace documents and chat attachments alike. | 150 | `max_file_size_mb` |
+| Enable Extract Meta Data | Runs a model pass on upload to record title, authors, subject and keywords for each document. | Off | `enable_extract_meta_data`; capability toggle |
+| Extraction Model | The deployment the metadata pass sends its requests to. | Empty | `metadata_extraction_model` |
+| Enable Multi-Modal Vision Analysis | Sends page images to a vision model so text inside diagrams and scans becomes searchable. | Off | `enable_multimodal_vision`; capability toggle |
+| Vision Model | A vision-capable deployment, such as gpt-4o or a supported GPT 5 or later model. Only vision-capable models are offered. | Empty | `multimodal_vision_model` |
 | Require DeepResearchUser App Role | Required app role value: DeepResearchUser. Assign this role to users or groups in the Enterprise App before enabling the requirement. When enabled, only assigned users can use Deep Research. | Off | `require_member_of_deep_research_user` |
 | Max User URLs per Turn | Direct URLs beyond this cap are recorded as omitted in the ledger. | 100 | `deep_research_max_user_urls_per_turn` |
 | Max Search Queries per Turn | Includes the original current-message query. | 8 | `deep_research_max_search_queries_per_turn` |

--- a/docs/admin/security.md
+++ b/docs/admin/security.md
@@ -7,6 +7,7 @@ audience: admin
 admin_tab: security
 redirect_from:
   - /admin/safety/
+  - /admin/workspace-identities/
 ---
 
 
@@ -36,11 +37,27 @@ This group protects who can enter the app, what secrets the app can use, what co
 
 ### Permissions {#permissions-section}
 
-The Permissions section belongs to the Access & Roles tab. Use it with the adjacent settings in this group so related rollout, access, and operational choices stay aligned.
+Two administrative reports can be narrowed beyond the general Admin role: Safety Violations,
+which shows flagged message text, and User Feedback. Both are readable by any Admin unless a
+dedicated role is required here, so these are the settings to reach for when "administrator"
+and "may read what users typed" should not be the same group of people.
+
+The FeedbackAdmin requirement only governs the User Feedback report, so it does nothing until
+User Feedback is enabled under Chat.
 
 ### App Role Requirements {#app-role-requirements-section}
 
-The App Role Requirements section belongs to the Access & Roles tab. Use it with the adjacent settings in this group so related rollout, access, and operational choices stay aligned.
+Every setting in the application that can demand an Entra app role, gathered in one place.
+Each switch is the same stored value as the one on the tab that owns the feature, not a copy
+of it, so changing it here changes it there.
+
+The reason for the duplication is that a role requirement read on its own tells you very
+little. Read together they are the deployment's access policy, and deciding whether that
+policy is coherent -- whether the same people can create groups, publish public workspaces,
+run workflows and read the Control Center -- means seeing all of them at once.
+
+Assign a role in the Enterprise App before requiring it. Switching a requirement on before
+anyone holds the role removes the capability from everybody.
 
 ### Access Denied Message {#access-denied-message-section}
 
@@ -51,7 +68,8 @@ The Access Denied Message section belongs to the Access & Roles tab. Use it with
 | Setting | What it does | Default | Notes |
 | --- | --- | --- | --- |
 | Access Denied Message | Shown to signed-in users who lack the required roles. Use Enter for line breaks. | You are logged in but do not have the required permissions to access this application. Please contact an administrator for access. | `access_denied_message` |
-| Require SafetyViolationAdmin App Role | Requires the `SafetyViolationAdmin` app role before users can use this capability or view. | Off | `require_member_of_safety_violation_admin` |
+| Require SafetyViolationAdmin App Role | Narrows the Safety Violations report, including the flagged message text, to holders of the `SafetyViolationAdmin` role. | Off | `require_member_of_safety_violation_admin` |
+| Require FeedbackAdmin App Role | Narrows the User Feedback report to holders of the `FeedbackAdmin` role. Has no effect until User Feedback is enabled under Chat. | Off | `require_member_of_feedback_admin` |
 
 ## Secrets {#secrets}
 
@@ -75,6 +93,26 @@ The Key Vault section belongs to the Secrets tab. Use it with the adjacent setti
 | Include reminder contact email in external telemetry | Default off. Enable only when Azure Monitor, Logic Apps, Functions, or webhook automation needs the email address to route notifications directly. | Off | `key_vault_secret_expiration_emit_contact_email_in_telemetry` |
 | Key Vault Reminders Search | Defines behavior for the related admin workflow; verify the affected feature after saving. | N/A (runtime control) | Runtime UI control |
 | Key Vault Reminders Status | Defines behavior for the related admin workflow; verify the affected feature after saving. | Empty | Runtime UI control |
+
+## Global Identities {#workspace-identities}
+
+### Global Identities {#workspace-identities-section}
+
+A global identity is a credential for a system SimpleChat connects out to -- a SharePoint
+site, an HTTP API behind a key, a database -- saved once and referenced by name everywhere it
+is used. It is not an account for signing in to SimpleChat. Two things consume them: File
+Sync sources, which authenticate when they pull documents, and actions, which authenticate
+when an agent calls out.
+
+Storing the credential once and referencing it by name means the secret itself never travels
+with a source or action configuration, never appears in an export, and can be rotated in one
+place. Where Key Vault is configured, the secret is held there rather than in the settings
+document, which is why this sits next to Secrets rather than with the features that use it.
+
+An identity that is still referenced by a File Sync source or an action cannot be deleted;
+remove the reference first.
+
+{% include media.html src="admin-settings/global-identity.png" alt="Screenshot of the Global Identities tab in Admin Settings." title="Global Identities" %}
 
 ## Content Safety {#content-safety}
 

--- a/docs/admin/workspaces.md
+++ b/docs/admin/workspaces.md
@@ -1,12 +1,10 @@
 ---
 layout: page
 title: "Workspaces settings"
-description: "Workspaces controls personal, group, and public workspace availability, file downloads, sharing policy, file-size limits, and global identities."
+description: "Workspaces controls which workspace types exist, who may create them, and how files move in and out of them through sharing, downloads, and approvals."
 section: "Administration"
 audience: admin
 admin_tab: workspaces
-redirect_from:
-  - /admin/workspace-identities/
 ---
 
 
@@ -14,109 +12,147 @@ redirect_from:
 
 ## What this group controls
 
-Workspaces controls personal, group, and public workspace availability, file downloads, sharing policy, file-size limits, and global identities.
+Workspaces decides which of the three workspace types exist in your deployment, who is
+allowed to create one, and how a file may leave a workspace once it is in there.
+
+Two things that used to be in this group now live elsewhere, because neither is really a
+workspace decision:
+
+- **Maximum File Size** is on [Knowledge > Document Extraction]({{ '/admin/knowledge/#file-size-limit-section' | relative_url }}). It caps chat attachments as well as workspace uploads, and it exists to protect the extraction pipeline.
+- **Global Identities** are on [Security > Global Identities]({{ '/admin/security/#workspace-identities' | relative_url }}). They are stored credentials that File Sync sources and actions reuse, and they keep their secrets in Key Vault.
 
 ## Why it matters
 
-Workspace settings define where documents live and how users can move them. Public workspaces, sharing, and downloads widen the audience for files, so configure them with approval expectations.
+Workspace types set the default audience for a document. Personal is one person, group is a
+named membership, and public is everyone in the organisation. Sharing and downloads then
+decide whether a file can leave that audience, which is the point at which a document
+management decision becomes a data movement decision.
 
 {% include media.html src="admin-settings/workspaces.png" alt="Screenshot of the Workspaces group in Admin Settings." title="Workspaces settings" %}
-
-{% include media.html src="admin-settings/global-identity.png" alt="Screenshot of the Workspaces group in Admin Settings." title="Workspaces settings" %}
 
 {% include media.html type="video" title="Workspaces settings walkthrough" poster="video-posters/admin-workspaces.png" capture="Recording planned. Walk through each tab in the Workspaces group and explain when to change each setting." %}
 
 ## Before you change anything
 
-- Define which workspace types policy supports.
-- Choose file-sharing and download rules before inviting broad groups.
-- Create shared identity mappings before connectors depend on them.
+- Decide which workspace types your policy supports before enabling them; a public workspace is readable organisation-wide.
+- Assign the `CreateGroups` and `CreatePublicWorkspaces` app roles in the Enterprise App before requiring them, or nobody will be able to create anything.
+- Decide the download policy before inviting a broad audience. Turning downloads on later is easier than retracting files that have already left.
 
 ## Workspace Types {#workspace-types}
 
 ### Personal Workspaces {#personal-workspaces-section}
 
-The Personal Workspaces section belongs to the Workspace Types tab. Use it with the adjacent settings in this group so related rollout, access, and operational choices stay aligned.
+Every user gets one private space for their own documents, prompts, agents and actions, which
+nobody else can reach. The new interface presents it to end users as **My Workspace**; admin
+settings and internal references call it the personal workspace.
+
+Turning this off hides the destination and removes the personal scope from chat. Documents
+already stored stay in place but become unreachable, so this retires the feature rather than
+clearing it.
 
 ### Group Workspaces {#group-workspaces-section}
 
-The Group Workspaces section belongs to the Workspace Types tab. Use it with the adjacent settings in this group so related rollout, access, and operational choices stay aligned.
+A group is a named membership sharing one document library, prompt set and agent catalogue.
+Three separate controls decide who can make one, and they stack:
+
+1. **Group workspaces** must be enabled at all.
+2. **Allow Users to Create Groups** can be switched off to freeze the group list without
+   disabling existing groups, which is useful during a migration or a review. Off here
+   overrides the role requirement entirely.
+3. **Require CreateGroups App Role** then narrows creation to holders of that role.
+
+Separately, group agent management can be restricted to the group Owner. Group Admins keep
+read access, so they can see what a group's agents are configured to do without being able to
+change it.
 
 ### Public Workspaces {#public-workspaces-section}
 
-The Public Workspaces section belongs to the Workspace Types tab. Use it with the adjacent settings in this group so related rollout, access, and operational choices stay aligned.
+A public workspace is readable by anyone in the organisation without being a member;
+membership still controls who can add or change documents. Because publishing here reaches
+everybody, requiring the `CreatePublicWorkspaces` role is usually the setting to reach for
+before enabling the type broadly.
+
+The end-user display name renames the type wherever users meet it, so it can match what your
+organisation already calls this material -- "Knowledge Base" or "Library", for example. Admin
+settings and internal references keep saying Public Workspace, so a support conversation
+about a setting still resolves to the same words.
 
 #### Settings
 
 | Setting | What it does | Default | Notes |
 | --- | --- | --- | --- |
-| Enable Personal Workspaces | Exposes the capability after required services, permissions, and rollout policy are ready. | On | `enable_user_workspace`; capability toggle |
-| Search Groups | Defines behavior for the related admin workflow; verify the affected feature after saving. | N/A (runtime control) | Runtime UI control |
-| Search Public Workspaces | Defines behavior for the related admin workflow; verify the affected feature after saving. | N/A (runtime control) | Runtime UI control |
-| Enable Group Workspaces | Exposes the capability after required services, permissions, and rollout policy are ready. | On | `enable_group_workspaces`; capability toggle |
-| Disable Group Creation | Exposes the capability after required services, permissions, and rollout policy are ready. | Off | Inverse of `enable_group_creation` |
-| Require CreateGroups App Role | Requires the `CreateGroups` app role before users can use this capability or view. | Off | `require_member_of_create_group` |
-| Require Owner to Manage Group Agents, Actions and Workflows | Defines behavior for the related admin workflow; verify the affected feature after saving. | Off | `require_owner_for_group_agent_management` |
-| Enable Public Workspaces | Exposes the capability after required services, permissions, and rollout policy are ready. | Off | `enable_public_workspaces`; capability toggle |
-| End-user display name | Optional. End users will see this label instead of Public Workspace. Admin settings and internal references continue to use Public Workspace. | Empty | `public_workspace_display_name` |
-| Require CreatePublicWorkspaces App Role | Requires the `CreatePublicWorkspaces` app role before users can use this capability or view. | Off | `require_member_of_create_public_workspace` |
-| Enable Extract Meta Data | Exposes the capability after required services, permissions, and rollout policy are ready. | Off | `enable_extract_meta_data`; capability toggle |
-| Extraction Model | Selects the deployment SimpleChat sends requests to for this capability. | Empty | `metadata_extraction_model` |
-| Enable Multi-Modal Vision Analysis | Exposes the capability after required services, permissions, and rollout policy are ready. | Off | `enable_multimodal_vision`; capability toggle |
-| Vision Model * | Select a GPT model with vision capabilities (for example, gpt-4o or supported GPT 5 and later models). Only vision-capable models are shown. | Empty | `multimodal_vision_model` |
+| Enable Personal Workspaces | Gives every user a private space, shown to end users as My Workspace. | On | `enable_user_workspace`; capability toggle |
+| Enable Group Workspaces | Lets users form groups that share a document library, prompts and agents. Gates everything else in the section. | On | `enable_group_workspaces`; capability toggle |
+| Allow Users to Create Groups | Off freezes the group list without disabling existing groups, and overrides the role requirement below. | On | `enable_group_creation`; the classic page renders this inverted, as "Disable Group Creation" |
+| Require CreateGroups App Role | Narrows group creation to holders of the `CreateGroups` role. | Off | `require_member_of_create_group` |
+| Require Owner to Manage Group Agents, Actions and Workflows | Restricts changing a group's agents, actions and workflows to the Owner; Admins keep read access. | Off | `require_owner_for_group_agent_management` |
+| Enable Public Workspaces | Adds a workspace type any user in the organisation can read without being a member. | Off | `enable_public_workspaces`; capability toggle |
+| End-user display name | Renames the type for end users only, up to 32 characters. Admin settings keep saying Public Workspace. | Empty | `public_workspace_display_name` |
+| Require CreatePublicWorkspaces App Role | Narrows public workspace creation to holders of the `CreatePublicWorkspaces` role. | Off | `require_member_of_create_public_workspace` |
 
 ## Files & Sharing {#files-sharing}
 
 ### File Downloads {#file-download-settings-section}
 
-The File Downloads section belongs to the Files & Sharing tab. Use it with the adjacent settings in this group so related rollout, access, and operational choices stay aligned.
+Downloads return the original uploaded file rather than the extracted text the model reads,
+so enabling them turns a workspace into a way to move a file back out of the tenant. That is
+why all three scopes default to off.
+
+Group and public downloads are a ceiling rather than an outcome: a group Owner or Admin, or a
+public workspace Owner, can still switch downloads off locally. Requiring an assignment
+narrows the ceiling further to a named list, which is the usual way to pilot downloads with a
+few teams before opening them up. A group or workspace left off that list behaves as though
+downloads were never enabled.
 
 ### File Sharing {#file-sharing-section}
 
-The File Sharing section belongs to the Files & Sharing tab. Use it with the adjacent settings in this group so related rollout, access, and operational choices stay aligned.
+Lets a user hand a workspace file to another user or workspace from inside the application,
+rather than downloading it and sending it on. It is a separate decision from downloads: you
+can allow movement within SimpleChat while still refusing to hand out the original file.
 
 ### Shared Conversation File Approvals {#shared-conversation-file-approvals-section}
 
-The Shared Conversation File Approvals section belongs to the Files & Sharing tab. Use it with the adjacent settings in this group so related rollout, access, and operational choices stay aligned.
+When a participant generates a downloadable file in a conversation they do not own, the file
+is written into the owner's storage. Left ungated, that means one participant can put content
+into another person's workspace.
 
-### Maximum File Size {#file-size-limit-section}
-
-The Maximum File Size section belongs to the Files & Sharing tab. Use it with the adjacent settings in this group so related rollout, access, and operational choices stay aligned.
+With approvals on, the file is created but withheld until an approver releases it: the
+conversation owner, or in a group conversation any Owner, Admin or Document Manager. Anything
+left unapproved is declined and deleted after three days, so the queue does not accumulate.
+It covers CSV, XLSX, DOCX, PDF, JSON and XML; generated images and charts are never held.
 
 #### Settings
 
 | Setting | What it does | Default | Notes |
 | --- | --- | --- | --- |
-| Maximum File Size (MB) | Defines a capacity or timing boundary that keeps the feature inside supported limits. | 150 | `max_file_size_mb` |
-| Enable Personal Workspace Downloads | Permits enable personal workspace downloads when the related workspace or agent feature is enabled. | Off | `allow_personal_workspace_file_downloads` |
-| Enable Group Workspace Downloads | Permits enable group workspace downloads when the related workspace or agent feature is enabled. | Off | `allow_group_workspace_file_downloads` |
-| Require Group Assignment for Downloads | Defines behavior for the related admin workflow; verify the affected feature after saving. | Off | `require_group_assignment_for_file_downloads` |
-| File Download Allowed Group Ids | Lists the approved IDs, domains, groups, workspaces, or sources that may use this feature. | Empty list | `file_download_allowed_group_ids` |
-| Enable Public Workspace Downloads | Permits enable public workspace downloads when the related workspace or agent feature is enabled. | Off | `allow_public_workspace_file_downloads` |
-| Require Public Workspace Assignment for Downloads | Defines behavior for the related admin workflow; verify the affected feature after saving. | Off | `require_public_workspace_assignment_for_file_downloads` |
-| File Download Allowed Public Workspace Ids | Lists the approved IDs, domains, groups, workspaces, or sources that may use this feature. | Empty list | `file_download_allowed_public_workspace_ids` |
-| Enable File Sharing | Exposes the capability after required services, permissions, and rollout policy are ready. | Off | `enable_file_sharing`; capability toggle |
-
-## Global Identities {#workspace-identities}
-
-Global Identities is rendered dynamically and does not declare static settings sections in `admin_settings_nav.py`.
-
-No retired-page setting rows mapped to Global Identities; use the live Admin Settings UI to review identity records.
+| Enable Personal Workspace Downloads | Lets users retrieve the original uploaded file from their own workspace. | Off | `allow_personal_workspace_file_downloads` |
+| Enable Group Workspace Downloads | Permits group downloads. A group Owner or Admin can still disable them locally. | Off | `allow_group_workspace_file_downloads` |
+| Require Group Assignment for Downloads | Limits downloads to the groups named below instead of every group. | Off | `require_group_assignment_for_file_downloads` |
+| Groups allowed to download | The named groups. A group left off this list cannot offer downloads. | Empty list | `file_download_allowed_group_ids` |
+| Enable Public Workspace Downloads | Permits public workspace downloads, which makes originals retrievable by anyone who can see the workspace. | Off | `allow_public_workspace_file_downloads` |
+| Require Public Workspace Assignment for Downloads | Limits downloads to the public workspaces named below. | Off | `require_public_workspace_assignment_for_file_downloads` |
+| Public workspaces allowed to download | The named public workspaces. | Empty list | `file_download_allowed_public_workspace_ids` |
+| Enable File Sharing | Lets a user hand a workspace file to another user or workspace inside the application. | Off | `enable_file_sharing`; capability toggle |
+| Require approval for participant-generated files | Holds files a participant generates in someone else's shared conversation until an approver releases them. | On | `require_shared_conversation_file_approval` |
 
 ## Common tasks
 
-1. **Enable a workspace type.** Enable the desired scope and create a small test workspace. Outcome to verify: The workspace type appears for the intended audience.
-2. **Constrain file movement.** Review download, sharing, approval, and size settings, then test a share. Outcome to verify: Files move only through the allowed path.
-3. **Review global identities.** Check identity ownership and test a dependent connector. Outcome to verify: Connector activity uses the expected shared identity.
+1. **Pilot downloads with one team.** Enable group workspace downloads, require group assignment, and add the pilot group. Outcome to verify: members of that group see a download option and members of another group do not.
+2. **Freeze the group list during a migration.** Turn off Allow Users to Create Groups. Outcome to verify: existing groups keep working and the create action is unavailable to everyone, including role holders.
+3. **Rename the public workspace for end users.** Set the end-user display name and reload a user session. Outcome to verify: the new name appears in navigation and chat scope while Admin Settings still reads Public Workspace.
 
 ## Troubleshooting
 
 | Symptom | Likely cause | Fix |
 | --- | --- | --- |
-| Users cannot create a group workspace | Group workspaces or group creation are disabled. | Enable the correct workspace controls and retry with an eligible user. |
+| Users cannot create a group workspace | Group workspaces are disabled, group creation is switched off, or the `CreateGroups` role is required and unassigned. | Work down the three controls in order; the first one that is off explains it. |
+| A group has downloads enabled but users still cannot download | Group assignment is required and the group is not on the list, or a group Owner disabled downloads locally. | Check the assignment list first, then the group's own setting. |
+| A generated file never appears for the recipient | Shared conversation file approvals are on and nobody released it. | Have the conversation owner, or a group Owner, Admin or Document Manager, approve it within three days. |
 
 ## Related
 
 - [Administration settings overview]({{ '/admin/' | relative_url }})
+- [Knowledge settings]({{ '/admin/knowledge/' | relative_url }})
+- [Security settings]({{ '/admin/security/' | relative_url }})
 - [Workflow settings]({{ '/admin/workflow/' | relative_url }})
 - [Agents & Actions settings]({{ '/admin/agents-actions/' | relative_url }})

--- a/docs/explanation/features/V2_WORKSPACES_ADMIN_SETTINGS.md
+++ b/docs/explanation/features/V2_WORKSPACES_ADMIN_SETTINGS.md
@@ -1,0 +1,195 @@
+# Workspaces Admin Settings in the V2 Interface
+
+**Implemented in version: 0.261.059**
+
+## Overview
+
+The V2 React admin surface renders from the declarative field schema in
+`admin_settings_fields.py`. A section with no entry there falls back to scanning the
+settings document for `enable_*` booleans and guessing a home for each one from shared
+word stems. That fallback keeps undescribed groups usable, but it can only ever draw
+switches: a text box, a number, a list of assigned record ids, or any `require_member_of_*`
+role gate is invisible to it.
+
+The Workspaces group was almost entirely undescribed, which left thirteen settings with no
+control anywhere in V2 and one tab that rendered nothing at all. This change describes the
+group, adds the field type and three widgets it needs, and takes two structural decisions
+about settings that were filed in the wrong place.
+
+## What was invisible
+
+| Setting | State before | State now |
+| --- | --- | --- |
+| `enable_user_workspace` | Declared | Declared, with copy naming the V2 "My Workspace" label |
+| `enable_group_workspaces` | Guessed toggle, no help | Declared |
+| `enable_group_creation` | Guessed toggle, no help | Declared positively, gated on group workspaces |
+| `enable_public_workspaces` | Guessed toggle, no help | Declared |
+| `enable_file_sharing` | Guessed toggle, no help | Declared |
+| `require_member_of_create_group` | Not rendered | Declared |
+| `require_owner_for_group_agent_management` | Not rendered | Declared |
+| `public_workspace_display_name` | Not rendered | Declared (`text`, 32 characters) |
+| `require_member_of_create_public_workspace` | Not rendered | Declared |
+| `allow_personal_workspace_file_downloads` | Not rendered | Declared |
+| `allow_group_workspace_file_downloads` | Not rendered | Declared |
+| `require_group_assignment_for_file_downloads` | Not rendered | Declared |
+| `file_download_allowed_group_ids` | Not rendered | Declared (`id_list`) |
+| `allow_public_workspace_file_downloads` | Not rendered | Declared |
+| `require_public_workspace_assignment_for_file_downloads` | Not rendered | Declared |
+| `file_download_allowed_public_workspace_ids` | Not rendered | Declared (`id_list`) |
+| `require_shared_conversation_file_approval` | Not rendered | Declared |
+| `max_file_size_mb` | Not rendered | Declared, and moved to Knowledge |
+| Global Identities | Empty tab | Read-only list, moved to Security |
+
+Separately, none of the ten `require_member_of_*` settings rendered anywhere in V2, for the
+same reason: the fallback scan only ever sees `enable_*` keys. All ten are now declared in
+the sections that own them, and Security gained a roster that mirrors them.
+
+## Architecture
+
+### The `id_list` field type
+
+Two file-download settings hold a list of record ids. `component` fields are non-patchable
+by design, and `link_list` is the wrong shape, so a new patchable type was added:
+
+```python
+{
+    "key": "file_download_allowed_group_ids",
+    "type": "id_list",
+    "label": "Groups allowed to download",
+    "default": [],
+    "search_endpoint": "/api/groups/discover",
+    "search_param": "search",
+    "search_extra": {"showAll": "true"},
+    "results_key": "groups",
+    "item_noun": "group",
+    "item_noun_plural": "groups",
+    "depends_on": {"key": "require_group_assignment_for_file_downloads", "equals": True},
+}
+```
+
+Normalization is `_normalize_id_list` in `admin_settings_fields.py`: blanks dropped,
+duplicates removed, order preserved, non-list input refused. It deliberately does not import
+`normalize_file_download_allowed_group_ids` from `functions_settings`, because that module
+reaches `config.py` and a live Cosmos client and is one of the modules the functional tests
+replace with a stub. The V2 surface always sends a real JSON array, which is the input shape
+where both implementations agree.
+
+The V2 renderer dispatches `id_list` from `AdminSettingsPage.tsx` the way `link_list` is
+already dispatched, to `components/admin/AssignmentPicker.tsx`.
+
+### Two structural moves
+
+**Maximum File Size moved to Knowledge > Document Extraction.** `max_file_size_mb` is read
+by `functions_documents.py` for workspace uploads and by `route_frontend_chats.py` for chat
+attachments, so Workspaces only ever owned half of what it does. It is checked before any
+extraction runs, which is what puts it next to Chunk Sizes.
+
+**Global Identities moved to Security, after Secrets.** They are credentials that File Sync
+sources and actions reuse, referenced by name so the secret never travels with a
+configuration, and stored in Key Vault where Key Vault is configured. Workspaces owns neither
+consumer. The tab id `workspace-identities` is unchanged so deep links and the documentation
+anchor still resolve, and the tab gained the `workspace-identities-section` entry it was
+missing -- without a section, the V2 surface, which builds its page from group > tab >
+section, had nowhere to render it.
+
+Both moves change the server-rendered interface too, because `admin_settings_nav.py` is the
+single definition both interfaces render from. The pane markup moved with each nav entry;
+`test_admin_settings_sidebar_card_parity.py` fails if only one of the two is done.
+
+### Group creation polarity
+
+The server-rendered page renders an inverted `disable_group_creation` checkbox and flips it
+before storing `enable_group_creation`. V2 declares the stored key directly, as "Allow Users
+to Create Groups", so the switch and the value it writes agree. `LEGACY_FIELD_NAMES` records
+the mapping so the parity test can resolve either name. The V1 pane is unchanged.
+
+### Gating chains
+
+The server-rendered File Downloads card shows every control unconditionally. V2 hides a
+setting whose parent makes it inert:
+
+```
+allow_group_workspace_file_downloads
+  └── require_group_assignment_for_file_downloads
+        └── file_download_allowed_group_ids
+```
+
+with the same shape for the public workspace trio, and the group and public role
+requirements gated on their workspace type.
+
+### The app role roster
+
+`collectAppRoleEntries` in `lib/adminFields.ts` walks the navigation and the field schema
+together, collecting every declared field whose key starts with `require_member_of_`, and
+records which group, tab and section owns each one. `components/admin/AppRoleRoster.tsx`
+renders that list in Security > App Role Requirements.
+
+Each roster switch binds to the same draft key as the control on the owning tab, so the two
+are one edit rather than two values that can disagree. This mirrors what
+`admin_access_roles_roster.js` does in the server-rendered page, except that it is built from
+the schema instead of from the DOM, which means it cannot pick up a control that is not
+really a settings key.
+
+## File structure
+
+| File | Change |
+| --- | --- |
+| `application/single_app/admin_settings_fields.py` | `id_list` type, `_normalize_id_list`, all Workspaces sections, `max_file_size_mb`, ten role gates, two component fields |
+| `application/single_app/admin_settings_nav.py` | File size section and Global Identities tab relocated; the tab gained a section |
+| `application/single_app/templates/admin/_panes/files-sharing.html` | File size card removed |
+| `application/single_app/templates/admin/_panes/extraction.html` | File size card added after Chunk Sizes |
+| `application/v2_ui/src/lib/adminFields.ts` | `id_list` type and properties, `collectAppRoleEntries` |
+| `application/v2_ui/src/components/admin/AssignmentPicker.tsx` | New |
+| `application/v2_ui/src/components/admin/GlobalIdentitiesList.tsx` | New |
+| `application/v2_ui/src/components/admin/AppRoleRoster.tsx` | New |
+| `application/v2_ui/src/pages/AdminSettingsPage.tsx` | Dispatch for the new type and two components |
+
+## Usage
+
+No configuration is required. Administrators open **Admin settings** in the V2 interface and
+find the Workspaces group fully populated, Maximum File Size under Knowledge, and Global
+Identities under Security.
+
+Creating and editing a global identity is still done on the server-rendered admin page. The
+V2 list links to it. The editor there handles Key Vault round-tripping and per-auth-type
+field sets, and rebuilding it was not worth doing for a surface with very few users; a list
+that says what exists and where to change it is more useful than the blank tab it replaces.
+
+## Testing
+
+`functional_tests/test_v2_admin_workspaces_parity.py` holds eleven checks:
+
+- The Workspaces panes match `ADMIN_NAV`.
+- Every form field the V1 Workspaces panes submit is claimed by the schema.
+- The schema invents no Workspaces field V1 does not have.
+- The group creation polarity mapping is recorded and defaults to on.
+- The public workspace name limit in the schema matches `functions_settings.py`.
+- Each relocated section moved in `ADMIN_NAV` **and** in the pane markup, and is not left behind in the pane it came from.
+- Each relocated tab is in its new group and declares at least one section.
+- All ten `require_member_of_*` keys the application seeds are declared, in the right section, as switches, and exist in their V1 pane.
+- Every `id_list` search endpoint is a route the application registers.
+- Every schema section id exists in `ADMIN_NAV`.
+- The V2 renderer has a branch for the new type and both new components.
+
+Also extended:
+
+- `test_v2_admin_settings_schema.py` — `id_list` required properties and default type.
+- `test_v2_admin_settings_normalization.py` — assignment lists are deduplicated and trimmed, and non-list input is refused.
+
+Run:
+
+```powershell
+python .\functional_tests\test_v2_admin_workspaces_parity.py
+python .\functional_tests\test_v2_admin_settings_schema.py
+python .\functional_tests\test_v2_admin_settings_normalization.py
+python .\functional_tests\test_v2_admin_field_renderer_coverage.py
+python .\functional_tests\test_v2_admin_capability_placement.py
+python .\functional_tests\test_docs_app_surface_coverage.py
+```
+
+## Known limitations
+
+- The assignment pickers summarise a selection as a count and resolve names only through search. There is no endpoint that turns a set of ids back into names in bulk, and the server-rendered page has the same constraint.
+- The group picker calls `/api/groups/discover`, which is gated on `enable_group_workspaces`. With group workspaces disabled the picker reports that the search is unavailable, which matches the server-rendered behaviour.
+- Global Identities are read-only in V2.
+- The roster shows only declared role requirements. All ten are declared today, so it is complete, but a new role gate added without a schema entry would be absent from it — and from the rest of V2 — until it is declared.

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,44 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/features) and [Fixes by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/fixes).
 
+### **(v0.261.059)**
+
+#### New Features
+
+*   **The Whole Workspaces Group Is Now Editable In The New Interface**
+    *   The new admin page draws real controls from a description of each settings section. Workspaces had almost no description, so it fell back to scanning for on/off flags — which meant it could show switches and nothing else. Thirteen Workspaces settings had no control anywhere in the new interface, and the Global Identities tab rendered as a blank page.
+    *   **Everything that was missing is now there**: personal, group and public workspace downloads, both "require assignment" rules and the group and public workspace pickers that go with them, the public workspace end-user display name, shared conversation file approvals, the CreateGroups and CreatePublicWorkspaces role requirements, and the owner-only restriction on group agents and actions.
+    *   **The four toggles that were already visible now explain themselves.** They were previously drawn from the flag name alone — "Group creation", with no help text and no indication that it does nothing while group workspaces are off. Each now carries a written explanation of what it does and when you would want it.
+    *   **Settings that do nothing are hidden rather than shown as inert.** Requiring a group assignment only appears once group downloads are enabled, and the group picker only appears once the assignment is required, so what is on screen is what currently has an effect.
+    *   (Ref: `admin_settings_fields.py`, `AssignmentPicker.tsx`, `AdminSettingsPage.tsx`, [V2 Workspaces Admin Settings](features/V2_WORKSPACES_ADMIN_SETTINGS.md))
+
+*   **Every App Role Requirement, Readable In One Place**
+    *   Ten settings in SimpleChat can demand an Entra app role, spread across six tabs. None of them appeared in the new interface at all, because the fallback scan that was drawing those pages could only see on/off capability flags.
+    *   All ten are now on the tab that owns them, and **Security > App Role Requirements** additionally gathers them into one list. Each switch there is the same value as the one on its own tab, not a copy, so changing it in either place is the same change.
+    *   Each entry names the group, tab and section the setting really lives on, and the list reports how many of the ten are currently being enforced — so the deployment's access policy can be read as a whole rather than reconstructed tab by tab.
+    *   (Ref: `collectAppRoleEntries`, `AppRoleRoster.tsx`, `admin_access_roles_roster.js`)
+
+*   **Global Identities Explain What They Are, And Sit Somewhere Sensible**
+    *   Global Identities are saved credentials for the systems SimpleChat connects out to, used by File Sync sources and actions. They were filed under Workspaces, which owns neither, and the tab in the new interface was empty.
+    *   The tab has moved to **Security**, next to Key Vault — which is where each identity's secret is actually stored — and now lists what exists with its sign-in type, alongside a link to the classic page for adding or editing one. Existing links to the tab still work.
+    *   (Ref: `admin_settings_nav.py`, `GlobalIdentitiesList.tsx`)
+
+#### User Interface Enhancements
+
+*   **Maximum File Size Moved To Knowledge**
+    *   The upload ceiling applies to chat attachments as well as workspace documents, and it is checked before extraction runs, so Workspaces only ever described half of what it does. It now sits in **Knowledge > Document Extraction** beside Chunk Sizes, and its description says plainly that it covers both upload paths.
+    *   (Ref: `max_file_size_mb`, `functions_documents.py`, `route_frontend_chats.py`)
+
+*   **Group Creation Reads The Right Way Round**
+    *   The classic page asks you to tick "Disable Group Creation" to prevent it — a double negative over a setting that is stored as *enable* group creation. The new interface presents it as **Allow Users to Create Groups**, where on means users can create groups.
+    *   The wording also now says what was previously undocumented: switching it off freezes the group list without disabling existing groups, and overrides the CreateGroups role requirement entirely.
+    *   The classic page is unchanged, so nothing about an existing deployment moves.
+    *   (Ref: `enable_group_creation`, `LEGACY_FIELD_NAMES`)
+
+*   **Workspaces, Knowledge And Security Documentation Rewritten**
+    *   The Workspaces admin page described its sections with a repeated sentence that said only which tab they belonged to. It now explains what each workspace type means for who can read a document, how the three group-creation controls stack, and why downloads default to off, with troubleshooting for the cases where a setting appears to have no effect.
+    *   (Ref: `docs/admin/workspaces.md`, `docs/admin/knowledge.md`, `docs/admin/security.md`)
+
 ### **(v0.261.058)**
 
 #### New Features

--- a/functional_tests/test_v2_admin_settings_normalization.py
+++ b/functional_tests/test_v2_admin_settings_normalization.py
@@ -138,6 +138,38 @@ def test_checkbox_sets_are_ordered_and_bounded():
     return True
 
 
+def test_assignment_lists_are_deduplicated_and_typed():
+    """A download policy keyed on a blank or repeated id would grant the wrong set."""
+    print("\nTesting assignment list handling...")
+
+    assert_app_version_at_least("0.261.059")
+
+    normalized, errors, _ = normalize(
+        {
+            "file_download_allowed_group_ids": [
+                " group-a ",
+                "group-b",
+                "group-a",
+                "",
+                None,
+            ]
+        }
+    )
+    assert not errors, errors
+    assert normalized["file_download_allowed_group_ids"] == ["group-a", "group-b"], (
+        normalized
+    )
+
+    # V1 round-trips this through a hidden textarea and accepts a JSON string. V2
+    # always sends a real array, and accepting a string here would mean two shapes
+    # to keep in step for no gain.
+    _, errors, _ = normalize({"file_download_allowed_public_workspace_ids": "ws-a,ws-b"})
+    assert "file_download_allowed_public_workspace_ids" in errors, errors
+
+    print("  Assignment lists are deduplicated, trimmed and reject non-list input.")
+    return True
+
+
 def test_selects_reject_unknown_values_but_reuse_shared_aliases():
     """Frequency fields must accept the same aliases the V1 form accepts."""
     print("\nTesting select handling...")
@@ -303,6 +335,7 @@ if __name__ == "__main__":
         test_colours_must_be_hex,
         test_external_links_reject_unsafe_urls,
         test_checkbox_sets_are_ordered_and_bounded,
+        test_assignment_lists_are_deduplicated_and_typed,
         test_selects_reject_unknown_values_but_reuse_shared_aliases,
         test_redirect_url_refuses_unsafe_targets,
         test_text_is_bounded_and_falls_back_when_empty,

--- a/functional_tests/test_v2_admin_settings_schema.py
+++ b/functional_tests/test_v2_admin_settings_schema.py
@@ -52,6 +52,9 @@ REQUIRED_PROPERTIES_BY_TYPE = {
     "textarea": ("default",),
     "switch": ("default",),
     "link_list": ("item_fields", "default"),
+    # An id_list resolves names through a search endpoint, so the renderer cannot
+    # draw its picker without knowing where to search and what the response holds.
+    "id_list": ("default", "search_endpoint", "results_key", "item_noun", "item_noun_plural"),
     "image": ("upload_target", "accept", "version_key"),
     "component": ("component",),
 }
@@ -66,6 +69,7 @@ EXPECTED_DEFAULT_TYPES = {
     "number": int,
     "checkbox_set": list,
     "link_list": list,
+    "id_list": list,
 }
 
 

--- a/functional_tests/test_v2_admin_workspaces_parity.py
+++ b/functional_tests/test_v2_admin_workspaces_parity.py
@@ -1,0 +1,549 @@
+#!/usr/bin/env python3
+# test_v2_admin_workspaces_parity.py
+"""
+Functional test pinning V1/V2 parity for the Admin Settings Workspaces group.
+Version: 0.261.059
+Implemented in: 0.261.059
+
+The V2 React admin surface renders from ``admin_settings_fields.py``. Sections with
+no entry there fall back to scanning the settings document for ``enable_*``
+booleans, which means a setting that is not a boolean capability toggle -- a text
+box, a number, a list of assigned ids, or any ``require_member_of_*`` role gate --
+is simply invisible in V2 and nothing fails.
+
+Before the Workspaces group was described, thirteen of its settings were in exactly
+that position. This test keeps them described, the same way
+``test_v2_admin_appearance_parity.py`` does for Appearance: every form field the
+server-rendered panes submit must be claimed by the schema, and the schema must not
+claim a field V1 does not have.
+
+It also pins the two structural moves made at the same time, because both split a
+setting away from the pane it used to live in and a half-applied move leaves either
+V1 or V2 with a section that renders nothing:
+
+  - Maximum File Size moved to Knowledge > Document Extraction. It caps chat
+    attachments as well as workspace documents, so Workspaces only ever owned half
+    of what it does.
+  - Global Identities moved to Security. They are credentials that File Sync sources
+    and Actions reuse, and Workspaces owns neither of those.
+
+Finally it covers the app role roster, which mirrors every declared
+``require_member_of_*`` switch into one place in Security. That roster is built from
+the schema, so an undeclared role requirement is missing from it for the same reason
+it is missing from the rest of V2.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent))
+
+from test_support.app_stubs import import_app_module
+from test_support.nav import ADMIN_NAV
+from test_support.versioning import assert_app_version_at_least
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+APP_ROOT = REPO_ROOT / "application" / "single_app"
+PANES_DIR = APP_ROOT / "templates" / "admin" / "_panes"
+SETTINGS_MODULE = APP_ROOT / "functions_settings.py"
+V2_SRC = REPO_ROOT / "application" / "v2_ui" / "src"
+
+WORKSPACES_GROUP_ID = "workspaces"
+
+# The tabs that make up the Workspaces group after the moves, and the sections each
+# one contributes. Verified against ADMIN_NAV below rather than trusted.
+WORKSPACES_PANES = {
+    "workspace-types": (
+        "personal-workspaces-section",
+        "group-workspaces-section",
+        "public-workspaces-section",
+    ),
+    "files-sharing": (
+        "file-download-settings-section",
+        "file-sharing-section",
+        "shared-conversation-file-approvals-section",
+    ),
+}
+
+# Where each relocated section now lives, and the pane whose markup must have moved
+# with it. Nav and markup are separate files, so only checking one would let the
+# other drift.
+RELOCATED_SECTIONS = {
+    "file-size-limit-section": {
+        "group": "knowledge",
+        "tab": "extraction",
+        "pane": "extraction",
+        "vacated_pane": "files-sharing",
+        "field": "max_file_size_mb",
+    },
+}
+
+# The tab that moved wholesale, rather than one section of a tab.
+RELOCATED_TABS = {
+    "workspace-identities": "security",
+}
+
+# Every app role requirement the application seeds, and the section that must own
+# its primary control. The roster in Security mirrors these; a key missing from the
+# schema is missing from V2 entirely, because the fallback scan only sees enable_*.
+APP_ROLE_SECTIONS = {
+    "require_member_of_create_group": ("group-workspaces-section", "workspace-types"),
+    "require_member_of_create_public_workspace": (
+        "public-workspaces-section",
+        "workspace-types",
+    ),
+    "require_member_of_safety_violation_admin": ("permissions-section", "access-roles"),
+    "require_member_of_feedback_admin": ("permissions-section", "access-roles"),
+    "require_member_of_chat_file_upload_user": (
+        "chat-file-uploads-section",
+        "chat-experience",
+    ),
+    "require_member_of_control_center_admin": (
+        "control-center-overview-section",
+        "control-center-config",
+    ),
+    "require_member_of_control_center_dashboard_reader": (
+        "control-center-overview-section",
+        "control-center-config",
+    ),
+    "require_member_of_url_access_user": ("url-access-section", "web-research"),
+    "require_member_of_deep_research_user": ("source-review-section", "web-research"),
+    "require_member_of_workflow_user": ("workflow-settings-section", "workflow"),
+}
+
+FIELD_NAME_RE = re.compile(r'\sname="([^"]+)"')
+JINJA_RE = re.compile(r"\{\{|\{%")
+CARD_ID_RE = re.compile(r'class="card[^"]*"\s+id="([a-z0-9-]+)"')
+APP_ROLE_DEFAULT_RE = re.compile(
+    r"^\s*'(require_member_of_[a-z0-9_]+)'\s*:\s*(?:True|False)\s*,", re.MULTILINE
+)
+PUBLIC_NAME_LIMIT_RE = re.compile(
+    r"^PUBLIC_WORKSPACE_DISPLAY_NAME_MAX_LENGTH\s*=\s*(\d+)\s*$", re.MULTILINE
+)
+
+fields_module = import_app_module("admin_settings_fields")
+
+
+def read_pane(pane_id):
+    """Return the raw markup for one Admin Settings pane."""
+    pane_path = PANES_DIR / f"{pane_id}.html"
+    assert pane_path.is_file(), f"Missing Admin Settings pane: {pane_path}"
+    return pane_path.read_text(encoding="utf-8")
+
+
+def collect_pane_field_names(markup):
+    """Return literal form field names submitted by a pane."""
+    return {name for name in FIELD_NAME_RE.findall(markup) if not JINJA_RE.search(name)}
+
+
+def declared_sections():
+    """Return ``key -> (section_id, field)`` for every declared field."""
+    return {
+        field["key"]: (section_id, field)
+        for section_id, field in fields_module.iter_fields()
+        if field.get("key")
+    }
+
+
+def nav_index():
+    """Return group id, tab id and section id lookups from ADMIN_NAV."""
+    section_home = {}
+    tab_home = {}
+    for group in ADMIN_NAV:
+        for tab in group["tabs"]:
+            tab_home[tab["id"]] = group["id"]
+            for section in tab["sections"]:
+                section_home[section["id"]] = (group["id"], tab["id"])
+    return section_home, tab_home
+
+
+def test_workspaces_panes_match_navigation():
+    """The panes this test reads must be the ones ADMIN_NAV puts in the group."""
+    print("Testing Workspaces pane list against ADMIN_NAV...")
+
+    assert_app_version_at_least("0.261.059")
+
+    group = next((g for g in ADMIN_NAV if g["id"] == WORKSPACES_GROUP_ID), None)
+    assert group, "ADMIN_NAV no longer defines a 'workspaces' group."
+
+    nav_tabs = {tab["id"]: tuple(s["id"] for s in tab["sections"]) for tab in group["tabs"]}
+
+    assert set(nav_tabs) == set(WORKSPACES_PANES), (
+        "The Workspaces group's tabs changed. Update WORKSPACES_PANES and the schema "
+        f"together.\n  ADMIN_NAV: {sorted(nav_tabs)}\n  test: {sorted(WORKSPACES_PANES)}"
+    )
+
+    for tab_id, section_ids in nav_tabs.items():
+        assert section_ids == WORKSPACES_PANES[tab_id], (
+            f"Sections for the '{tab_id}' tab changed.\n"
+            f"  ADMIN_NAV: {section_ids}\n  test: {WORKSPACES_PANES[tab_id]}"
+        )
+
+    print(f"  {len(nav_tabs)} tab(s) and their sections match ADMIN_NAV.")
+    return True
+
+
+def test_every_v1_field_is_claimed_by_the_schema():
+    """A V1 Workspaces field with no V2 equivalent is invisible in the new UI."""
+    print("\nTesting that every V1 Workspaces field is claimed by the schema...")
+
+    claimed = fields_module.get_legacy_field_names()
+    documented = set(fields_module.LEGACY_FIELDS_WITHOUT_V2_EQUIVALENT)
+
+    unclaimed = {}
+    total = 0
+    for pane_id in WORKSPACES_PANES:
+        names = collect_pane_field_names(read_pane(pane_id))
+        total += len(names)
+        missing = sorted(names - claimed - documented)
+        if missing:
+            unclaimed[pane_id] = missing
+
+    assert not unclaimed, (
+        "These fields exist in the server-rendered Workspaces panes but are not "
+        "described in admin_settings_fields.py, so they cannot appear in the V2 admin "
+        "UI. Add a field definition, record the name in LEGACY_FIELD_NAMES if the "
+        "shapes differ, or document the omission in "
+        "LEGACY_FIELDS_WITHOUT_V2_EQUIVALENT:\n"
+        + "\n".join(f"  {pane}: {', '.join(names)}" for pane, names in unclaimed.items())
+    )
+
+    print(f"  All {total} V1 Workspaces field(s) are claimed by the schema.")
+    return True
+
+
+def test_schema_does_not_invent_workspace_fields():
+    """A schema key with no V1 counterpart would save a setting nothing reads."""
+    print("\nTesting that the schema does not invent Workspaces fields...")
+
+    v1_names = set()
+    for pane_id in WORKSPACES_PANES:
+        v1_names |= collect_pane_field_names(read_pane(pane_id))
+
+    workspace_sections = {
+        section for sections in WORKSPACES_PANES.values() for section in sections
+    }
+
+    invented = []
+    for section_id, field in fields_module.iter_fields():
+        if section_id not in workspace_sections:
+            continue
+        key = field.get("key")
+        if not key:
+            continue
+        legacy = fields_module.LEGACY_FIELD_NAMES.get(key, [key])
+        if not any(name in v1_names for name in legacy):
+            invented.append(f"{section_id}.{key}")
+
+    assert not invented, (
+        "These schema fields have no matching field in the V1 Workspaces panes, so V2 "
+        "would write settings the rest of the application never reads:\n  "
+        + "\n  ".join(invented)
+    )
+
+    print("  Every Workspaces schema field maps back to a V1 field.")
+    return True
+
+
+def test_group_creation_polarity_is_recorded():
+    """V1 submits the inverse of the stored key, which only a mapping can reconcile."""
+    print("\nTesting the group creation polarity mapping...")
+
+    legacy = fields_module.LEGACY_FIELD_NAMES.get("enable_group_creation")
+    assert legacy == ["disable_group_creation"], (
+        "V1 renders group creation as an inverted 'Disable Group Creation' checkbox "
+        "and flips it server-side, while V2 edits enable_group_creation directly. "
+        "LEGACY_FIELD_NAMES is what records that difference; without it the parity "
+        f"check above cannot resolve either name. Found: {legacy!r}"
+    )
+
+    section_id, field = declared_sections()["enable_group_creation"]
+    assert section_id == "group-workspaces-section", (
+        f"enable_group_creation is declared under {section_id!r}, not the group "
+        "workspaces section it belongs to."
+    )
+    assert field.get("default") is True, (
+        "enable_group_creation must default to True. Declaring it positively while "
+        "defaulting it off would silently forbid group creation on a fresh deployment."
+    )
+
+    print("  Group creation is declared positively and its V1 inverse is recorded.")
+    return True
+
+
+def test_public_display_name_limit_matches_the_application():
+    """A longer value than the application allows would be truncated after saving."""
+    print("\nTesting the public workspace display name limit...")
+
+    match = PUBLIC_NAME_LIMIT_RE.search(SETTINGS_MODULE.read_text(encoding="utf-8"))
+    assert match, (
+        "PUBLIC_WORKSPACE_DISPLAY_NAME_MAX_LENGTH was not found in "
+        "functions_settings.py; the extraction likely broke."
+    )
+    application_limit = int(match.group(1))
+
+    assert fields_module.PUBLIC_WORKSPACE_DISPLAY_NAME_MAX_LENGTH == application_limit, (
+        "admin_settings_fields.py mirrors this constant because functions_settings "
+        "cannot be imported there. The two have drifted:\n"
+        f"  schema: {fields_module.PUBLIC_WORKSPACE_DISPLAY_NAME_MAX_LENGTH}\n"
+        f"  application: {application_limit}"
+    )
+
+    _section_id, field = declared_sections()["public_workspace_display_name"]
+    assert field.get("max_length") == application_limit, (
+        f"public_workspace_display_name declares max_length {field.get('max_length')}, "
+        f"but the application truncates at {application_limit}."
+    )
+
+    print(f"  Both interfaces limit the display name to {application_limit} characters.")
+    return True
+
+
+def test_relocated_sections_moved_in_both_places():
+    """A nav entry without its markup leaves one interface rendering nothing."""
+    print("\nTesting the relocated sections...")
+
+    section_home, _tab_home = nav_index()
+    declared = declared_sections()
+    problems = []
+
+    for section_id, expected in RELOCATED_SECTIONS.items():
+        home = section_home.get(section_id)
+        if home is None:
+            problems.append(f"{section_id}: no longer defined in ADMIN_NAV")
+            continue
+        if home != (expected["group"], expected["tab"]):
+            problems.append(
+                f"{section_id}: ADMIN_NAV places it in {home}, expected "
+                f"{(expected['group'], expected['tab'])}"
+            )
+
+        if section_id not in CARD_ID_RE.findall(read_pane(expected["pane"])):
+            problems.append(
+                f"{section_id}: no card with that id in {expected['pane']}.html"
+            )
+        if section_id in CARD_ID_RE.findall(read_pane(expected["vacated_pane"])):
+            problems.append(
+                f"{section_id}: card is still in {expected['vacated_pane']}.html, so "
+                "the same id would render twice"
+            )
+
+        field_key = expected["field"]
+        entry = declared.get(field_key)
+        if entry is None:
+            problems.append(f"{field_key}: not declared at all")
+        elif entry[0] != section_id:
+            problems.append(
+                f"{field_key}: declared under {entry[0]!r}, expected {section_id!r}"
+            )
+
+    assert not problems, (
+        "These sections were moved to a new tab. A move has to happen in "
+        "admin_settings_nav.py and in the pane markup together:\n  "
+        + "\n  ".join(problems)
+    )
+
+    print(f"  All {len(RELOCATED_SECTIONS)} relocated section(s) moved in both places.")
+    return True
+
+
+def test_relocated_tabs_have_a_renderable_section():
+    """A tab with no sections renders nothing at all in V2."""
+    print("\nTesting the relocated tabs...")
+
+    _section_home, tab_home = nav_index()
+    problems = []
+
+    for tab_id, expected_group in RELOCATED_TABS.items():
+        group_id = tab_home.get(tab_id)
+        if group_id is None:
+            problems.append(f"{tab_id}: no longer defined in ADMIN_NAV")
+            continue
+        if group_id != expected_group:
+            problems.append(
+                f"{tab_id}: in group {group_id!r}, expected {expected_group!r}"
+            )
+
+        tab = next(
+            (
+                tab
+                for group in ADMIN_NAV
+                for tab in group["tabs"]
+                if tab["id"] == tab_id
+            ),
+            None,
+        )
+        if tab is not None and not tab["sections"]:
+            problems.append(
+                f"{tab_id}: declares no sections, so the V2 surface -- which builds "
+                "its page from group > tab > section -- has nowhere to render it"
+            )
+
+    assert not problems, (
+        "These tabs were moved between groups:\n  " + "\n  ".join(problems)
+    )
+
+    print(f"  All {len(RELOCATED_TABS)} relocated tab(s) are where they belong.")
+    return True
+
+
+def test_every_app_role_requirement_is_declared():
+    """An undeclared role gate renders nowhere in V2 and is absent from the roster."""
+    print("\nTesting app role requirement declarations...")
+
+    application_keys = sorted(
+        {
+            match.group(1)
+            for match in APP_ROLE_DEFAULT_RE.finditer(
+                SETTINGS_MODULE.read_text(encoding="utf-8")
+            )
+        }
+    )
+    assert application_keys, "No require_member_of_* defaults found; extraction broke."
+
+    assert set(application_keys) == set(APP_ROLE_SECTIONS), (
+        "The set of app role requirements changed. Declare the new one in the section "
+        "that owns the feature it gates, and list it here so the roster stays "
+        "complete:\n"
+        f"  application: {application_keys}\n  test: {sorted(APP_ROLE_SECTIONS)}"
+    )
+
+    declared = declared_sections()
+    problems = []
+    for key, (expected_section, pane_id) in APP_ROLE_SECTIONS.items():
+        entry = declared.get(key)
+        if entry is None:
+            problems.append(f"{key}: not declared at all")
+            continue
+        section_id, field = entry
+        if section_id != expected_section:
+            problems.append(
+                f"{key}: declared under {section_id!r}, expected {expected_section!r}"
+            )
+        if field.get("type") != "switch":
+            problems.append(f"{key}: declared as {field.get('type')!r}, expected 'switch'")
+        if f'name="{key}"' not in read_pane(pane_id):
+            problems.append(f"{key}: no name=\"{key}\" field in {pane_id}.html")
+
+    assert not problems, (
+        "The Security roster is built from declared fields, so these gaps make a role "
+        "requirement unreachable in V2:\n  " + "\n  ".join(problems)
+    )
+
+    print(f"  All {len(APP_ROLE_SECTIONS)} app role requirement(s) are declared.")
+    return True
+
+
+def test_assignment_pickers_target_real_endpoints():
+    """An id_list pointing at a route that does not exist renders an empty picker."""
+    print("\nTesting id_list search endpoints against registered routes...")
+
+    routes = "\n".join(
+        path.read_text(encoding="utf-8")
+        for path in sorted(APP_ROOT.glob("route_*.py"))
+    )
+
+    problems = []
+    checked = 0
+    for section_id, field in fields_module.iter_fields():
+        if field.get("type") != "id_list":
+            continue
+        checked += 1
+        endpoint = field.get("search_endpoint", "")
+        if f"'{endpoint}'" not in routes and f'"{endpoint}"' not in routes:
+            problems.append(f"{section_id}.{field['key']}: no route registers {endpoint!r}")
+
+    assert not problems, (
+        "These assignment pickers search an endpoint the application does not "
+        "register:\n  " + "\n  ".join(problems)
+    )
+    assert checked, "No id_list fields were checked; the schema extraction likely broke."
+
+    print(f"  All {checked} assignment picker(s) target a registered route.")
+    return True
+
+
+def test_schema_sections_exist_in_navigation():
+    """A field filed under an unknown section id would never render."""
+    print("\nTesting schema section ids against ADMIN_NAV...")
+
+    nav_sections = {
+        section["id"]
+        for group in ADMIN_NAV
+        for tab in group["tabs"]
+        for section in tab["sections"]
+    }
+
+    unknown = sorted(set(fields_module.ADMIN_SETTINGS_FIELDS) - nav_sections)
+    assert not unknown, (
+        "These schema sections are not defined in admin_settings_nav.py, so the V2 UI "
+        "has nowhere to render them:\n  " + "\n  ".join(unknown)
+    )
+
+    print(
+        f"  All {len(fields_module.ADMIN_SETTINGS_FIELDS)} schema section(s) exist in "
+        "ADMIN_NAV."
+    )
+    return True
+
+
+def test_v2_renderer_handles_the_new_widgets():
+    """The schema can name a widget the renderer has no branch for, and nothing fails."""
+    print("\nTesting the V2 renderer branches for this group...")
+
+    page = (V2_SRC / "pages" / "AdminSettingsPage.tsx").read_text(encoding="utf-8")
+    helpers = (V2_SRC / "lib" / "adminFields.ts").read_text(encoding="utf-8")
+
+    required = (
+        ("the id_list assignment picker", "field.type === 'id_list'", page),
+        ("the global identities list", "case 'global-identities-list':", page),
+        ("the app role roster", "case 'app-role-requirements-roster':", page),
+        ("the roster's entry collector", "export function collectAppRoleEntries", helpers),
+        ("the role key prefix", "require_member_of_", helpers),
+    )
+
+    missing = [description for description, fragment, source in required if fragment not in source]
+
+    assert not missing, (
+        "The V2 admin surface has no branch for these, so the section would render an "
+        "empty space:\n  " + "\n  ".join(missing)
+    )
+
+    for component_dir_file in ("AssignmentPicker.tsx", "GlobalIdentitiesList.tsx", "AppRoleRoster.tsx"):
+        path = V2_SRC / "components" / "admin" / component_dir_file
+        assert path.is_file(), f"Missing V2 admin component: {path}"
+
+    print(f"  All {len(required)} renderer branch(es) and 3 component file(s) are present.")
+    return True
+
+
+if __name__ == "__main__":
+    tests = [
+        test_workspaces_panes_match_navigation,
+        test_every_v1_field_is_claimed_by_the_schema,
+        test_schema_does_not_invent_workspace_fields,
+        test_group_creation_polarity_is_recorded,
+        test_public_display_name_limit_matches_the_application,
+        test_relocated_sections_moved_in_both_places,
+        test_relocated_tabs_have_a_renderable_section,
+        test_every_app_role_requirement_is_declared,
+        test_assignment_pickers_target_real_endpoints,
+        test_schema_sections_exist_in_navigation,
+        test_v2_renderer_handles_the_new_widgets,
+    ]
+
+    results = []
+    for test in tests:
+        try:
+            results.append(bool(test()))
+        except Exception as exc:
+            print(f"FAILED {test.__name__}: {exc}")
+            import traceback
+
+            traceback.print_exc()
+            results.append(False)
+
+    print(f"\nResults: {sum(results)}/{len(results)} tests passed")
+    sys.exit(0 if all(results) else 1)


### PR DESCRIPTION
## The gap

The V2 admin page renders from `admin_settings_fields.py`. A section with no entry there falls back to scanning the settings document for `enable_*` booleans and guessing a home from shared word stems. That fallback keeps undescribed groups usable, but it can only ever draw switches — a text box, a number, a list of assigned ids, or any `require_member_of_*` role gate is invisible to it.

Workspaces was almost entirely undescribed:

- **13 settings had no control anywhere in V2** — every file-download setting, both assignment pickers, `max_file_size_mb`, `require_shared_conversation_file_approval`, `public_workspace_display_name`, and all three `require_*` role/owner settings.
- **4 more rendered as bare guessed toggles**, drawn from the flag name alone, with no help text and no gating.
- **Global Identities declared no sections at all** (`"sections": []`), so the tab rendered as a blank page.

Separately, and found while doing this: **none of the ten `require_member_of_*` app-role settings rendered anywhere in V2**, for the same reason. V1 has a Security roster mirroring them; V2 had no equivalent.

## What changed

### Workspaces is described

All 17 settings in the group are now declared with real controls, written help text, and gating chains V1 doesn't have:

```
allow_group_workspace_file_downloads
  └── require_group_assignment_for_file_downloads
        └── file_download_allowed_group_ids
```

with the same shape for the public-workspace trio. Each dependent setting has no effect while its parent is off, so hiding it removes a control that silently does nothing.

### Two settings moved

**Maximum File Size → Knowledge > Document Extraction.** `max_file_size_mb` is read by `functions_documents.py` for workspace uploads *and* `route_frontend_chats.py` for chat attachments, so Workspaces only ever owned half of what it does. It's checked before extraction runs, which puts it next to Chunk Sizes.

**Global Identities → Security, after Secrets.** These are credentials File Sync sources and actions reuse, referenced by name so the secret never travels with a configuration, and stored in Key Vault where configured. Workspaces owns neither consumer. The tab id is unchanged so deep links and the docs anchor still resolve, and the tab gained the section it was missing.

Both moves change the server-rendered page too, since `admin_settings_nav.py` is the one definition both interfaces render from. The pane markup moved with each nav entry — `test_admin_settings_sidebar_card_parity.py` fails if only one of the two is done.

### App role requirements

All ten are declared in the sections that own them, and Security > App Role Requirements gained a schema-driven roster. Each roster switch binds the **same draft key** as the control on the owning tab, so the two are one edit rather than two values that can disagree. Same behaviour as `admin_access_roles_roster.js` in V1, but built from the schema rather than scraped from the DOM.

### Group creation polarity

V1 renders an inverted "Disable Group Creation" checkbox and flips it server-side, while the stored key is `enable_group_creation`. V2 declares the stored key directly, as **"Allow Users to Create Groups"**. `LEGACY_FIELD_NAMES` records the mapping so parity resolves either name. **V1 is unchanged.**

## Merge note — and a bug it caught

The Workflow admin settings work (#1416) landed on this base branch mid-flight and touched six of the same files. Both branches independently added a patchable list-of-ids control: `group_picker` for the workflow group assignment, `id_list` for the two file-download pickers.

**Both are kept rather than converged.** Converging means rewriting three tests in `test_v2_admin_workflow_parity.py` that assert the type by name, and that's a deliberate call rather than something to make inside a merge. Flagged as a follow-up below.

Resolving the overlap did expose a **real bug in my `id_list`**. Its normalizer trimmed and deduplicated but accepted any non-blank string, while the application's `normalize_file_download_allowed_group_ids` delegates to `normalize_group_workflow_allowed_group_ids`, which requires a canonical group UUID and silently drops anything else. **A group assignment saved from V2 could have held an id the server-rendered form would have discarded.**

The Workflow work also supplied the fix, by splitting `functions_group_assignment_ids` out of `functions_settings` so `admin_settings_fields` can import it — the parent builds a Cosmos client at import time and is stubbed by the functional tests. `id_list` now delegates through it, selected per field by a new `id_kind`, because the two cases genuinely differ:

| `id_kind` | Behaviour | Why |
| --- | --- | --- |
| `group` | Canonical UUID required, others dropped | Matches `normalize_file_download_allowed_group_ids` |
| `opaque` | Trimmed and deduplicated only | Public workspace ids aren't UUID-constrained; a UUID check would reject valid assignments |

Both behaviours are pinned in `test_v2_admin_settings_normalization.py`.

Both branches also released as `0.261.059`, so this renumbers to **`0.261.060`** and leaves their section at `.059`.

## Testing

New `test_v2_admin_workspaces_parity.py` — 11 checks, modelled on the Appearance parity test:

- Every form field the V1 Workspaces panes submit is claimed by the schema, and the schema invents nothing V1 lacks
- Each relocated section moved in `ADMIN_NAV` **and** in the pane markup, and isn't left behind in the pane it came from
- Each relocated tab is in its new group and declares at least one section
- All ten `require_member_of_*` keys are declared, in the right section, as switches, and exist in their V1 pane
- Every `id_list` search endpoint is a route the application actually registers
- The group-creation polarity mapping is recorded and defaults to on
- The public workspace name limit matches `functions_settings.py`

**17/17 test files pass**, including the Workflow team's `test_v2_admin_workflow_parity.py` (9/9). TypeScript typechecks, vite builds, docs inventory regenerated.

Two pre-existing failures are untouched and confirmed unrelated by stashing these changes: `inbound-mcp-configuration` duplicate id in card parity, and a `class="tab-pane fade` check in tab preservation.

## Follow-up

`group_picker` and `id_list` do the same job — `id_list` is the generalized form. The next person adding an assignment list won't know which to reach for. Worth converging in a separate change, with the Workflow author's input, rather than silently during a merge.

## Not included

Global Identities are read-only in V2; creating and editing still goes to the classic page, which handles Key Vault round-tripping and per-auth-type field sets. The list links there. Rebuilding that editor wasn't worth it for a surface with very few users, and a list that says what exists beats the blank tab it replaces.
