### PR TITLE
Rebuild admin AI Models: Chat section (phase 2)

### DIFF
--- a/application/single_app/admin_settings_fields.py
+++ b/application/single_app/admin_settings_fields.py
@@ -82,6 +82,11 @@ FIELD_TYPES = (
 
 # Types that own their persistence outside the settings PATCH: image uploads go
 # through the multipart branding endpoint, and components talk to their own API.
+#
+# Declaring a key with one of these types is also how a value is kept *out* of the
+# PATCH. Undeclared keys pass through it unexamined, which is fine for a boolean
+# but not for something like ``default_model_selection``, whose meaning depends on
+# configuration the PATCH does not look at.
 NON_PATCHABLE_TYPES = ("image", "component")
 
 LANDING_PAGE_ALIGNMENTS = ("left", "center", "right")
@@ -693,6 +698,29 @@ ADMIN_SETTINGS_FIELDS = {
             "depends_on": {"key": "model_endpoint_identity_header_enabled", "equals": True},
         },
     ],
+    "gpt-config": [
+        {
+            "type": "component",
+            "component": "chat-mode-notice",
+            "label": "Which endpoint chat is using",
+            "help": (
+                "Connections and the classic single endpoint are two separate routes, and "
+                "only one of them is live at a time. This says which."
+            ),
+        },
+        {
+            "key": "default_model_selection",
+            "type": "component",
+            "component": "chat-default-model",
+            "label": "Default model",
+            "help": (
+                "Used when nothing else has chosen a model -- a new conversation, or work "
+                "started outside the chat window. Only models that are enabled on an "
+                "enabled connection can be picked, because anything else is cleared the "
+                "next time the connections are saved."
+            ),
+        },
+    ],
     "actions-config": [
         {
             "key": "enable_text_plugin",
@@ -722,6 +750,9 @@ LEGACY_FIELD_NAMES = {
     ],
     # V1 round-trips the list through a hidden JSON field maintained by script.
     "external_links": ["external_links_json"],
+    # Same pattern: V1 posts the default model reference as serialized JSON, while V2
+    # writes it through /api/v2/admin/default-model.
+    "default_model_selection": ["default_model_selection_json"],
     # V1 posts the images as part of the settings form; V2 uploads them
     # separately, so the stored keys are what the schema names.
     "custom_logo_base64": ["logo_file"],

--- a/application/single_app/admin_settings_fields.py
+++ b/application/single_app/admin_settings_fields.py
@@ -720,6 +720,20 @@ ADMIN_SETTINGS_FIELDS = {
                 "next time the connections are saved."
             ),
         },
+        {
+            "key": "enable_gpt_apim",
+            "type": "switch",
+            "label": "Send requests through API Management",
+            "help": (
+                "Routes GPT requests that use the classic endpoint through API Management "
+                "rather than straight to the Azure OpenAI resource, which is how a "
+                "deployment applies its own governance and monitoring to them. The APIM "
+                "endpoint, deployment and subscription key this needs are configured on "
+                "the classic admin page, so turning it on before those are set leaves "
+                "those requests with nowhere to go."
+            ),
+            "default": False,
+        },
     ],
     "actions-config": [
         {

--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -97,7 +97,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.261.073"
+VERSION = "0.261.081"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -97,7 +97,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.261.060"
+VERSION = "0.261.061"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/route_backend_v2.py
+++ b/application/single_app/route_backend_v2.py
@@ -76,6 +76,7 @@ from functions_settings import (
     is_chat_file_upload_enabled_for_user,
     is_user_workflows_enabled_for_user,
     merge_model_endpoint_payload,
+    normalize_default_model_selection,
     normalize_model_endpoints,
     resolve_default_model_selection,
     resolve_metadata_extraction_model_selection,
@@ -1166,3 +1167,132 @@ def register_route_backend_v2_admin(bp):
                 exceptionTraceback=True,
             )
             return jsonify({"error": "Failed to delete the model endpoint"}), 500
+
+    # ---------------------------------------------------------------------
+    # Default chat model
+    # ---------------------------------------------------------------------
+    #
+    # ``default_model_selection`` is a reference -- an endpoint id plus a model id --
+    # rather than a scalar, so it cannot travel through the settings PATCH: values there
+    # are coerced by type, and a reference has to be checked against what is actually
+    # configured before it means anything. It gets its own pair of routes instead, and
+    # the schema declares it as a ``component`` so the PATCH refuses it outright rather
+    # than storing an unchecked dict.
+
+    @bp.route("/api/v2/admin/default-model", methods=["GET"])
+    @swagger_route(security=get_auth_security())
+    @login_required
+    @admin_required
+    def v2_admin_get_default_model():
+        """Return the default chat model, resolved against the connections that exist.
+
+        The answer is what the selection currently means, not what is stored, because the
+        two diverge as soon as the connection or model it names is deleted or disabled.
+        ``reason`` carries that difference so the administrator is told why the field
+        looks empty instead of assuming it was never set.
+
+        The stored value is deliberately left alone: a read should not write.
+        """
+        try:
+            settings = get_settings()
+            multi_endpoint_enabled = bool(settings.get("enable_multi_model_endpoints", False))
+            selection, reason = resolve_default_model_selection(
+                settings.get("default_model_selection"),
+                _load_global_model_endpoints(settings),
+                multi_endpoint_enabled=multi_endpoint_enabled,
+            )
+            return (
+                jsonify(
+                    {
+                        "selection": selection,
+                        "multi_endpoint_enabled": multi_endpoint_enabled,
+                        "reason": reason,
+                    }
+                ),
+                200,
+            )
+        except Exception as exc:
+            log_event(
+                f"[V2_ADMIN_DEFAULT_MODEL] Failed to read the default model: {exc}",
+                level=logging.ERROR,
+                exceptionTraceback=True,
+            )
+            return jsonify({"error": "Failed to load the default model"}), 500
+
+    @bp.route("/api/v2/admin/default-model", methods=["PUT"])
+    @swagger_route(security=get_auth_security())
+    @login_required
+    @admin_required
+    def v2_admin_set_default_model():
+        """Store the default chat model, or clear it.
+
+        A selection that does not resolve is rejected rather than quietly stored or
+        quietly emptied. Both of those failure modes look identical to an administrator --
+        the field reads as "no default" afterwards -- and neither says which connection or
+        model went missing, which is the thing worth knowing.
+        """
+        payload = request.get_json(silent=True)
+        if not isinstance(payload, dict):
+            return jsonify({"error": "Default model payload must be an object."}), 400
+
+        candidate = payload.get("selection")
+        if not isinstance(candidate, dict):
+            return jsonify({"error": "Supply the selection as an object."}), 400
+
+        try:
+            settings = get_settings()
+            multi_endpoint_enabled = bool(settings.get("enable_multi_model_endpoints", False))
+            requested = normalize_default_model_selection(candidate)
+            clearing = not requested["endpoint_id"] and not requested["model_id"]
+
+            if not clearing and not multi_endpoint_enabled:
+                return (
+                    jsonify(
+                        {
+                            "error": (
+                                "Chat is running on the classic single endpoint, so a "
+                                "default chosen from the connections would not be used. "
+                                "Turn on \"Use connections for chat\" first."
+                            )
+                        }
+                    ),
+                    400,
+                )
+
+            resolved, reason = resolve_default_model_selection(
+                requested,
+                _load_global_model_endpoints(settings),
+                multi_endpoint_enabled=multi_endpoint_enabled,
+            )
+
+            if not clearing and not resolved["endpoint_id"]:
+                # ``reason`` is empty when only one half of the reference was supplied,
+                # which is a different mistake and deserves its own wording.
+                return (
+                    jsonify(
+                        {
+                            "error": reason
+                            or "Choose a connection and one of its enabled models."
+                        }
+                    ),
+                    400,
+                )
+
+            # ``update_settings`` catches its own exceptions and answers False, so an
+            # unchecked call would report a save that never reached storage.
+            if not update_settings({"default_model_selection": resolved}):
+                return jsonify({"error": "Failed to store the default model"}), 500
+
+            log_event(
+                "[V2_ADMIN_DEFAULT_MODEL] Default model set to "
+                f"{resolved['endpoint_id'] or 'none'}/{resolved['model_id'] or 'none'}",
+                level=logging.INFO,
+            )
+            return jsonify({"selection": resolved}), 200
+        except Exception as exc:
+            log_event(
+                f"[V2_ADMIN_DEFAULT_MODEL] Failed to store the default model: {exc}",
+                level=logging.ERROR,
+                exceptionTraceback=True,
+            )
+            return jsonify({"error": "Failed to store the default model"}), 500

--- a/application/v2_ui/src/components/admin/ChatDefaultModel.tsx
+++ b/application/v2_ui/src/components/admin/ChatDefaultModel.tsx
@@ -1,0 +1,241 @@
+// ChatDefaultModel.tsx
+// Picks the model chat falls back to when nothing else has chosen one.
+//
+// The stored value is a reference -- a connection id plus a model id -- so it is only
+// meaningful next to the connections that currently exist. Two consequences shape this
+// component:
+//
+//   - The list is built from /api/v2/admin/model-endpoints rather than the settings
+//     document the surrounding page already holds, because that document carries raw
+//     credentials and the sanitized route does not.
+//   - Only models that are enabled on an enabled connection are offered. Anything else
+//     is cleared by the server the next time connections are written, so offering it
+//     would let an administrator pick a value that silently reverts.
+//
+// The choice saves on its own rather than joining the page's draft, for the same reason
+// the connection list does: it is written through its own validating endpoint, not the
+// settings PATCH, which refuses this key outright.
+//
+// Connections are edited in the section directly above this one, so what may be offered
+// changes while this component is mounted. Whether chat uses connections at all is passed
+// in from the page rather than fetched here, and the connection list is re-read whenever
+// it is written -- otherwise the picker would keep describing the state the page was
+// opened in, and contradict the notice sitting next to it.
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { clsx } from 'clsx';
+import { AlertCircle, Loader2 } from 'lucide-react';
+import { ApiError } from '../../lib/apiClient';
+import {
+    buildDefaultModelChoices,
+    choiceToSelection,
+    fetchDefaultModel,
+    fetchModelConnections,
+    findChoiceIndex,
+    groupChoicesByConnection,
+    hasDefaultModel,
+    saveDefaultModel,
+    toDefaultModelSelection,
+    type DefaultModelChoice,
+    type DefaultModelSelection,
+} from '../../lib/modelConnections';
+import { useModelConnectionsStore } from '../../stores/modelConnectionsStore';
+import { toast } from '../../stores/toastStore';
+
+const selectClass = clsx(
+    'w-full rounded-lg border border-edge bg-surface-1 px-3 py-2',
+    'text-sm text-text-1',
+    'focus:border-accent focus:outline-none',
+    'disabled:cursor-not-allowed disabled:opacity-60',
+);
+
+const NO_DEFAULT = '';
+
+function errorMessage(error: unknown, fallback: string): string {
+    if (error instanceof ApiError || error instanceof Error) {
+        return error.message || fallback;
+    }
+    return fallback;
+}
+
+/** How a choice reads in the list: the model, then the deployment when they differ. */
+function choiceLabel(choice: DefaultModelChoice): string {
+    if (choice.deploymentName && choice.deploymentName !== choice.modelLabel) {
+        return `${choice.modelLabel} (${choice.deploymentName})`;
+    }
+    return choice.modelLabel;
+}
+
+interface ChatDefaultModelProps {
+    /**
+     * Whether chat is stored as using connections. Taken from the page's saved settings
+     * rather than this component's own fetch: the switch that controls it lives in the
+     * section above, so a value read once at mount would still say "off" after it had
+     * been turned on and the notice beside it had already said so.
+     */
+    multiEndpointEnabled: boolean;
+    help?: string;
+}
+
+export function ChatDefaultModel({ multiEndpointEnabled, help }: ChatDefaultModelProps) {
+    const [choices, setChoices] = useState<DefaultModelChoice[]>([]);
+    const [selection, setSelection] = useState<DefaultModelSelection | null>(null);
+    const [clearedReason, setClearedReason] = useState<string | null>(null);
+    const [error, setError] = useState<string | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [saving, setSaving] = useState(false);
+
+    // Bumped by every write to the connection list. Adding a connection or enabling a
+    // model changes what may be offered here, and deleting one makes the server clear a
+    // default that named it.
+    const connectionsRevision = useModelConnectionsStore((state) => state.revision);
+
+    const load = useCallback(async (signal?: AbortSignal) => {
+        try {
+            const [connections, current] = await Promise.all([
+                fetchModelConnections(signal),
+                fetchDefaultModel(signal),
+            ]);
+            setChoices(buildDefaultModelChoices(connections.endpoints ?? []));
+            setSelection(toDefaultModelSelection(current.selection));
+            setClearedReason(current.reason ?? null);
+            setError(null);
+        } catch (loadError) {
+            // An abort is this component going away, not a failure worth reporting.
+            if (signal?.aborted) {
+                return;
+            }
+            setError(errorMessage(loadError, 'The default model could not be loaded.'));
+        } finally {
+            setLoading(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        const controller = new AbortController();
+        void load(controller.signal);
+        return () => controller.abort();
+        // Enabling connections seeds the list server-side, so the reload is what surfaces
+        // the connection an administrator did not add by hand.
+    }, [load, connectionsRevision, multiEndpointEnabled]);
+
+    const groups = useMemo(() => groupChoicesByConnection(choices), [choices]);
+    const selectedIndex = useMemo(
+        () => (selection ? findChoiceIndex(choices, selection) : -1),
+        [choices, selection],
+    );
+
+    // A stored default whose model is no longer offered would otherwise show as "None",
+    // which reads as "never set" rather than "the thing it named went away".
+    const danglingSelection = Boolean(
+        selection && hasDefaultModel(selection) && selectedIndex < 0,
+    );
+
+    const onChange = async (raw: string) => {
+        const previous = selection;
+        const choice = raw === NO_DEFAULT ? null : (choices[Number(raw)] ?? null);
+        const next = choiceToSelection(choice);
+
+        setSelection(next);
+        setSaving(true);
+        setError(null);
+        try {
+            const response = await saveDefaultModel(next);
+            setSelection(toDefaultModelSelection(response.selection));
+            setClearedReason(null);
+            toast.success(choice ? `Default model set to ${choice.modelLabel}.` : 'Default model cleared.');
+        } catch (saveError) {
+            setSelection(previous);
+            setError(errorMessage(saveError, 'The default model could not be saved.'));
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    return (
+        <div className="py-3">
+            <label
+                htmlFor="chat-default-model"
+                className="mb-1.5 block text-sm font-medium text-text-1"
+            >
+                Default model
+            </label>
+
+            {loading ? (
+                <p className="flex items-center gap-2 py-2 text-xs text-text-3">
+                    <Loader2 size={14} className="animate-spin" />
+                    Loading models…
+                </p>
+            ) : (
+                <>
+                    <select
+                        id="chat-default-model"
+                        className={selectClass}
+                        value={selectedIndex >= 0 ? String(selectedIndex) : NO_DEFAULT}
+                        disabled={saving || !multiEndpointEnabled || choices.length === 0}
+                        onChange={(event) => void onChange(event.target.value)}
+                    >
+                        <option value={NO_DEFAULT}>No default model</option>
+                        {groups.map((group) => (
+                            <optgroup key={group.connectionName} label={group.connectionName}>
+                                {group.items.map(({ choice, index }) => (
+                                    <option
+                                        key={`${choice.endpointId}\u0000${choice.modelId}`}
+                                        value={String(index)}
+                                    >
+                                        {choiceLabel(choice)}
+                                    </option>
+                                ))}
+                            </optgroup>
+                        ))}
+                    </select>
+
+                    {saving ? (
+                        <p className="mt-1.5 flex items-center gap-1.5 text-xs text-text-3">
+                            <Loader2 size={12} className="animate-spin" />
+                            Saving…
+                        </p>
+                    ) : null}
+                </>
+            )}
+
+            {help ? <p className="mt-1.5 text-xs leading-relaxed text-text-3">{help}</p> : null}
+
+            {!loading && !multiEndpointEnabled ? (
+                <p className="mt-1.5 text-xs leading-relaxed text-text-3">
+                    Chat is on the classic single endpoint, so this has nothing to choose from.
+                    The default model applies to connections only.
+                </p>
+            ) : null}
+
+            {!loading && multiEndpointEnabled && choices.length === 0 ? (
+                <p className="mt-1.5 text-xs leading-relaxed text-text-3">
+                    No connection currently publishes an enabled model. Add a connection, or
+                    enable one of the models on an existing one.
+                </p>
+            ) : null}
+
+            {clearedReason ? (
+                <p className="mt-1.5 flex items-start gap-1.5 text-xs text-warn">
+                    <AlertCircle size={13} className="mt-0.5 shrink-0" />
+                    {clearedReason}
+                </p>
+            ) : null}
+
+            {danglingSelection && !clearedReason ? (
+                <p className="mt-1.5 flex items-start gap-1.5 text-xs text-warn">
+                    <AlertCircle size={13} className="mt-0.5 shrink-0" />
+                    The saved default is not in this list any more. Pick a replacement, or it
+                    will be cleared the next time a connection is saved.
+                </p>
+            ) : null}
+
+            {error ? (
+                <p role="alert" className="mt-1.5 flex items-start gap-1.5 text-xs text-danger">
+                    <AlertCircle size={13} className="mt-0.5 shrink-0" />
+                    {error}
+                </p>
+            ) : null}
+        </div>
+    );
+}

--- a/application/v2_ui/src/components/admin/ChatModeNotice.tsx
+++ b/application/v2_ui/src/components/admin/ChatModeNotice.tsx
@@ -1,0 +1,88 @@
+// ChatModeNotice.tsx
+// Says which of the two chat routes is live.
+//
+// SimpleChat has two ways to reach a chat model and only one is in force at a time:
+// the connections listed above, or a single classic endpoint whose fields exist solely
+// on the server-rendered admin page. Nothing on screen used to distinguish them, so an
+// administrator could add a connection here, watch it save, and still be served by the
+// classic endpoint -- with no error to explain the difference.
+//
+// V2 deliberately does not carry the classic endpoint's fields. Being explicit about
+// which route is live, and pointing at where the other one is configured, is what keeps
+// that omission honest rather than hidden.
+
+import { ExternalLink, Info, TriangleAlert } from 'lucide-react';
+import { clsx } from 'clsx';
+
+interface ChatModeNoticeProps {
+    /** Whether connections are in force, as currently stored. */
+    enabled: boolean;
+    /**
+     * The unsaved value of the same toggle, when it differs from `enabled`. The route
+     * does not change until the save lands, and saying so avoids reading the notice as
+     * a description of what is already happening.
+     */
+    pending?: boolean;
+    help?: string;
+}
+
+export function ChatModeNotice({ enabled, pending, help }: ChatModeNoticeProps) {
+    // Switching to connections is one-way: the settings write coerces the flag to
+    // "already on or newly on", so an attempt to turn it back off is refused rather
+    // than stored. Only the on-switch is worth announcing.
+    const switchingOn = !enabled && pending === true;
+
+    return (
+        <div className="py-3">
+            <div
+                role="note"
+                className={clsx(
+                    'flex items-start gap-2.5 rounded-lg border p-3 text-xs leading-relaxed',
+                    enabled
+                        ? 'border-edge bg-surface-1 text-text-2'
+                        : 'border-warn/40 bg-warn-soft text-text-1',
+                )}
+            >
+                <span className={clsx('mt-0.5 shrink-0', enabled ? 'text-text-3' : 'text-warn')}>
+                    {enabled ? <Info size={15} /> : <TriangleAlert size={15} />}
+                </span>
+                <div>
+                    <p className="font-medium text-text-1">
+                        {enabled
+                            ? 'Chat is using the connections above.'
+                            : 'Chat is using the classic single endpoint.'}
+                    </p>
+                    <p className="mt-1">
+                        {enabled ? (
+                            <>
+                                People can choose any model that is enabled on an enabled
+                                connection. The classic single endpoint is not consulted.
+                            </>
+                        ) : (
+                            <>
+                                Connections are configured but unused. Chat runs on one Azure
+                                OpenAI or API Management endpoint whose address, credentials and
+                                deployment are set on the{' '}
+                                <a
+                                    href="/admin/settings#model-endpoints"
+                                    className="inline-flex items-center gap-1 text-accent underline"
+                                >
+                                    classic admin page
+                                    <ExternalLink size={11} />
+                                </a>
+                                . Turn on <strong>Use connections for chat</strong> to switch.
+                            </>
+                        )}
+                    </p>
+                    {switchingOn ? (
+                        <p className="mt-1.5 font-medium text-text-1">
+                            Saving will switch chat to the connections above, and that cannot
+                            be reversed from here.
+                        </p>
+                    ) : null}
+                </div>
+            </div>
+            {help ? <p className="mt-1.5 text-xs leading-relaxed text-text-3">{help}</p> : null}
+        </div>
+    );
+}

--- a/application/v2_ui/src/components/admin/ModelConnectionsManager.tsx
+++ b/application/v2_ui/src/components/admin/ModelConnectionsManager.tsx
@@ -57,6 +57,7 @@ import {
 } from '../../lib/modelConnections';
 import { AdminModal } from './AdminModal';
 import { GlassButton } from '../ui/primitives';
+import { useModelConnectionsStore, modelConnectionsChanged } from '../../stores/modelConnectionsStore';
 import { toast } from '../../stores/toastStore';
 
 const inputClass = clsx(
@@ -899,12 +900,20 @@ export function ModelConnectionsManager({ help }: { help?: string }) {
     const [busyId, setBusyId] = useState<string | null>(null);
     const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
 
+    // Turning connections on seeds this list server-side with the classic chat endpoint,
+    // and that save happens in the section above rather than here. Without a reload the
+    // list would keep reading as empty at the exact moment it stopped being so.
+    const connectionsRevision = useModelConnectionsStore((state) => state.revision);
+
     const load = useCallback(async (signal?: AbortSignal) => {
         try {
             const response = await fetchModelConnections(signal);
             setConnections(Array.isArray(response.endpoints) ? response.endpoints : []);
             setError(null);
         } catch (loadError) {
+            if (signal?.aborted) {
+                return;
+            }
             setError(errorMessage(loadError, 'Model connections could not be loaded.'));
         } finally {
             setLoading(false);
@@ -915,7 +924,7 @@ export function ModelConnectionsManager({ help }: { help?: string }) {
         const controller = new AbortController();
         void load(controller.signal);
         return () => controller.abort();
-    }, [load]);
+    }, [load, connectionsRevision]);
 
     const visible = useMemo(() => {
         const needle = query.trim().toLowerCase();
@@ -942,6 +951,7 @@ export function ModelConnectionsManager({ help }: { help?: string }) {
             // A partial update, so the stripped secrets in the copy held here are never
             // sent back and cannot overwrite what is stored.
             await updateModelConnection(connection.id, { enabled: next });
+            modelConnectionsChanged();
         } catch (toggleError) {
             setConnections(previous);
             setError(errorMessage(toggleError, 'The connection could not be updated.'));
@@ -957,6 +967,7 @@ export function ModelConnectionsManager({ help }: { help?: string }) {
         setConnections(connections.filter((item) => item.id !== connection.id));
         try {
             await deleteModelConnection(connection.id);
+            modelConnectionsChanged();
             toast.success(`Deleted ${connection.name || 'connection'}.`);
         } catch (deleteError) {
             setConnections(previous);
@@ -969,6 +980,7 @@ export function ModelConnectionsManager({ help }: { help?: string }) {
     const onSaved = (saved: ModelConnection, created: boolean) => {
         setEditing(null);
         setError(null);
+        modelConnectionsChanged();
         if (created) {
             setConnections((current) => [...current, saved]);
             toast.success(`Created ${saved.name || 'connection'}.`);

--- a/application/v2_ui/src/lib/modelConnections.ts
+++ b/application/v2_ui/src/lib/modelConnections.ts
@@ -532,6 +532,166 @@ export function enabledModelCount(connection: ModelConnection): number {
 }
 
 /* -------------------------------------------------------------------------- */
+/* Default chat model                                                          */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * The stored reference to the model chat falls back to.
+ *
+ * It names an endpoint and a model by id rather than holding the model itself, which is
+ * why it outlives what it points at and has to be re-checked against the connections that
+ * currently exist.
+ */
+export interface DefaultModelSelection {
+    endpoint_id: string;
+    model_id: string;
+    provider: string;
+}
+
+/** One offerable model, already resolved to the labels a picker needs. */
+export interface DefaultModelChoice {
+    endpointId: string;
+    modelId: string;
+    provider: string;
+    connectionName: string;
+    modelLabel: string;
+    deploymentName: string;
+}
+
+export const EMPTY_DEFAULT_MODEL_SELECTION: DefaultModelSelection = {
+    endpoint_id: '',
+    model_id: '',
+    provider: '',
+};
+
+export function toDefaultModelSelection(value: unknown): DefaultModelSelection {
+    const source = (value ?? {}) as Record<string, unknown>;
+    return {
+        endpoint_id: text(source.endpoint_id),
+        model_id: text(source.model_id),
+        provider: text(source.provider).toLowerCase(),
+    };
+}
+
+export function hasDefaultModel(selection: DefaultModelSelection): boolean {
+    return Boolean(selection.endpoint_id && selection.model_id);
+}
+
+export function isSameSelection(a: DefaultModelSelection, b: DefaultModelSelection): boolean {
+    return a.endpoint_id === b.endpoint_id && a.model_id === b.model_id;
+}
+
+/**
+ * The models an administrator may actually pick as the default.
+ *
+ * A disabled connection or a disabled model is excluded rather than shown greyed out,
+ * because `resolve_default_model_selection` clears anything in that state on the next
+ * write -- offering it would let someone choose a value that silently reverts.
+ *
+ * Ordered by connection then model so the list is stable between renders; the stored
+ * order of connections is whatever the administrator added them in.
+ */
+export function buildDefaultModelChoices(connections: ModelConnection[]): DefaultModelChoice[] {
+    const choices: DefaultModelChoice[] = [];
+
+    for (const connection of connections ?? []) {
+        if (!connection || connection.enabled === false || !text(connection.id)) {
+            continue;
+        }
+        const connectionName =
+            text(connection.name) || text(connection.connection?.endpoint) || 'Connection';
+
+        for (const model of connection.models ?? []) {
+            if (!model || model.enabled === false) {
+                continue;
+            }
+            // `normalize_model_endpoints` fills a missing id from the deployment name, so
+            // a model with neither is not addressable and cannot be referenced.
+            const modelId = text(model.id) || text(model.deploymentName);
+            if (!modelId) {
+                continue;
+            }
+            choices.push({
+                endpointId: text(connection.id),
+                modelId,
+                provider: text(connection.provider).toLowerCase(),
+                connectionName,
+                modelLabel:
+                    text(model.displayName) ||
+                    text(model.deploymentName) ||
+                    text(model.modelName) ||
+                    modelId,
+                deploymentName: text(model.deploymentName),
+            });
+        }
+    }
+
+    return choices.sort(
+        (a, b) =>
+            a.connectionName.localeCompare(b.connectionName) ||
+            a.modelLabel.localeCompare(b.modelLabel),
+    );
+}
+
+/**
+ * Group choices by connection for `optgroup` rendering, carrying each one's index.
+ *
+ * The index is what the `select` uses as an option value, so it has to survive the
+ * grouping; recovering it afterwards would mean searching the flat list per option.
+ */
+export function groupChoicesByConnection(
+    choices: DefaultModelChoice[],
+): Array<{ connectionName: string; items: Array<{ choice: DefaultModelChoice; index: number }> }> {
+    const groups: Array<{
+        connectionName: string;
+        items: Array<{ choice: DefaultModelChoice; index: number }>;
+    }> = [];
+
+    choices.forEach((choice, index) => {
+        const last = groups[groups.length - 1];
+        if (last && last.connectionName === choice.connectionName) {
+            last.items.push({ choice, index });
+        } else {
+            groups.push({ connectionName: choice.connectionName, items: [{ choice, index }] });
+        }
+    });
+
+    return groups;
+}
+
+/**
+ * Where a stored selection sits in the offerable list, or -1.
+ *
+ * The index is what the `select` carries as its option value. Endpoint and model ids are
+ * administrator-supplied strings, so composing them into one value would need an escape
+ * rule that a deployment name could still break.
+ */
+export function findChoiceIndex(
+    choices: DefaultModelChoice[],
+    selection: DefaultModelSelection,
+): number {
+    if (!hasDefaultModel(selection)) {
+        return -1;
+    }
+    return choices.findIndex(
+        (choice) =>
+            choice.endpointId === selection.endpoint_id && choice.modelId === selection.model_id,
+    );
+}
+
+/** Turn a picked choice back into the shape the API stores. */
+export function choiceToSelection(choice: DefaultModelChoice | null): DefaultModelSelection {
+    if (!choice) {
+        return { ...EMPTY_DEFAULT_MODEL_SELECTION };
+    }
+    return {
+        endpoint_id: choice.endpointId,
+        model_id: choice.modelId,
+        provider: choice.provider,
+    };
+}
+
+/* -------------------------------------------------------------------------- */
 /* API                                                                         */
 /* -------------------------------------------------------------------------- */
 
@@ -568,3 +728,18 @@ export const testConnectionModel = (payload: Record<string, unknown>, deployment
         ...payload,
         model: { deploymentName },
     });
+
+const DEFAULT_MODEL_BASE = '/api/v2/admin/default-model';
+
+export interface DefaultModelResponse {
+    selection: DefaultModelSelection;
+    multi_endpoint_enabled: boolean;
+    /** Why the stored selection no longer resolves, when it does not. */
+    reason: string | null;
+}
+
+export const fetchDefaultModel = (signal?: AbortSignal) =>
+    api.get<DefaultModelResponse>(DEFAULT_MODEL_BASE, signal);
+
+export const saveDefaultModel = (selection: DefaultModelSelection) =>
+    api.put<{ selection: DefaultModelSelection }>(DEFAULT_MODEL_BASE, { selection });

--- a/application/v2_ui/src/pages/AdminSettingsPage.tsx
+++ b/application/v2_ui/src/pages/AdminSettingsPage.tsx
@@ -34,6 +34,8 @@ import { GlassButton, GlassPanel, Skeleton, Toggle } from '../components/ui/prim
 import { AdminModal } from '../components/admin/AdminModal';
 import { AdminMarkdown } from '../components/admin/AdminMarkdown';
 import { BrandingImageField } from '../components/admin/BrandingImageField';
+import { ChatDefaultModel } from '../components/admin/ChatDefaultModel';
+import { ChatModeNotice } from '../components/admin/ChatModeNotice';
 import { CustomPagesTable } from '../components/admin/CustomPagesTable';
 import { ExternalLinksEditor } from '../components/admin/ExternalLinksEditor';
 import { ModelConnectionsManager } from '../components/admin/ModelConnectionsManager';
@@ -59,6 +61,7 @@ import {
     type BrandingUploadResponse,
 } from '../lib/adminFields';
 import { toast } from '../stores/toastStore';
+import { modelConnectionsChanged } from '../stores/modelConnectionsStore';
 import type { AdminNavGroup, Json } from '../lib/types';
 
 /** One fallback row: an `enable_*` key with no declared field. */
@@ -447,6 +450,17 @@ export function AdminSettingsPage() {
             setDraft({});
             void refreshBootstrap();
 
+            // Enabling connections carries the classic chat endpoint into the connection
+            // list server-side. That write happens here rather than in the connections
+            // section, so nothing else would tell it, or the default model picker, that
+            // the list they are showing is no longer what is stored.
+            if (
+                response.updated_keys.includes('model_endpoints') ||
+                response.updated_keys.includes('enable_multi_model_endpoints')
+            ) {
+                modelConnectionsChanged();
+            }
+
             const warningCount = Object.keys(response.warnings ?? {}).length;
             toast.success(
                 warningCount
@@ -539,6 +553,37 @@ export function AdminSettingsPage() {
                     return <CustomPagesTable key={key} help={field.help} />;
                 case 'model-connections-manager':
                     return <ModelConnectionsManager key={key} help={field.help} />;
+                case 'chat-mode-notice': {
+                    // The saved value decides which route is live; the draft value only
+                    // says what a pending save would change it to, so the notice is given
+                    // both rather than the merged reading the other fields use.
+                    const savedEnabled = asBoolean(settings['enable_multi_model_endpoints']);
+                    return (
+                        <ChatModeNotice
+                            key={key}
+                            enabled={savedEnabled}
+                            pending={
+                                Object.prototype.hasOwnProperty.call(
+                                    draft,
+                                    'enable_multi_model_endpoints',
+                                )
+                                    ? asBoolean(draft['enable_multi_model_endpoints'])
+                                    : undefined
+                            }
+                            help={field.help}
+                        />
+                    );
+                }
+                case 'chat-default-model':
+                    return (
+                        <ChatDefaultModel
+                            key={key}
+                            multiEndpointEnabled={asBoolean(
+                                settings['enable_multi_model_endpoints'],
+                            )}
+                            help={field.help}
+                        />
+                    );
                 case 'classification-banner-preview':
                     return (
                         <ClassificationBannerPreview

--- a/application/v2_ui/src/stores/modelConnectionsStore.ts
+++ b/application/v2_ui/src/stores/modelConnectionsStore.ts
@@ -1,0 +1,28 @@
+// modelConnectionsStore.ts
+// A revision counter bumped whenever the global model connection list is written.
+//
+// Connections and the settings that depend on them are edited side by side in one Admin
+// Settings view, so a component that loads the connection list once goes stale as soon as
+// the list next to it changes: adding a connection, enabling a model, or deleting one all
+// alter what the default model picker may offer, and deleting one also makes the server
+// clear a default that named it.
+//
+// The two components are siblings rendered from a declarative field schema rather than
+// parent and child, so there is no prop to pass between them. A revision is enough --
+// readers refetch rather than being handed data, which keeps the sanitized fetch as the
+// single source of what a connection looks like.
+
+import { create } from 'zustand';
+
+interface ModelConnectionsState {
+    revision: number;
+    markChanged: () => void;
+}
+
+export const useModelConnectionsStore = create<ModelConnectionsState>((set) => ({
+    revision: 0,
+    markChanged: () => set((state) => ({ revision: state.revision + 1 })),
+}));
+
+/** Announce that the stored connection list has changed. Safe to call from any handler. */
+export const modelConnectionsChanged = () => useModelConnectionsStore.getState().markChanged();

--- a/docs/admin/ai-models.md
+++ b/docs/admin/ai-models.md
@@ -83,12 +83,12 @@ The default applies to connections only. With chat on the classic single endpoin
 
 #### Settings
 
-The classic single endpoint is configured on the server-rendered admin page. Its values are listed here because they are what chat uses while **Use connections for chat** is off.
+The classic single endpoint is configured on the server-rendered admin page. Its values are listed here because they are what chat uses while **Use connections for chat** is off, and because API Management applies to GPT requests that use the classic endpoint whichever mode chat is in.
 
 | Setting | What it does | Default | Notes |
 | --- | --- | --- | --- |
 | Default model | The model chat uses when nothing else has chosen one. Cleared automatically if the connection or model it names is deleted or disabled. | Not specified in defaults | `default_model_selection`; connections mode only |
-| Use APIM instead of direct to Azure OpenAI endpoint | Sends chat requests through API Management rather than straight to the Azure OpenAI resource. | Off | `enable_gpt_apim`; capability toggle |
+| Send requests through API Management | Routes GPT requests that use the classic endpoint through API Management rather than straight to the Azure OpenAI resource, so a deployment can apply its own governance and monitoring to them. | Off | `enable_gpt_apim`; needs the three APIM values below |
 | Azure OpenAI Endpoint | Provides the endpoint or route SimpleChat uses for this service. | Empty | `azure_openai_gpt_endpoint` |
 | Authentication Type | Chooses whether SimpleChat authenticates to this service with a key, managed identity, or another supported method. | key | `azure_openai_gpt_authentication_type` |
 | Subscription ID | Addresses the resource when listing its deployments. | Empty | `azure_openai_gpt_subscription_id` |

--- a/docs/admin/ai-models.md
+++ b/docs/admin/ai-models.md
@@ -34,7 +34,7 @@ Model endpoints are production dependencies for every generated answer, embeddin
 
 A connection is one Azure OpenAI or Azure AI Foundry resource: where it is, how SimpleChat authenticates to it, and which of its deployed models may be used. Several connections can serve models at once, so a deployment in one subscription and a Foundry project in another can both appear in the chat model picker.
 
-Connections are consulted only when **Use connections for chat** is on. With it off, chat runs on the single classic endpoint configured under Chat Model instead, and anything listed here is ignored.
+Connections are consulted only when **Use connections for chat** is on. With it off, chat runs on the single classic endpoint configured under Chat instead, and anything listed here is ignored.
 
 Each connection is stored on its own. Adding, editing or deleting one takes effect when you save that connection, rather than when the surrounding settings page is saved.
 
@@ -64,16 +64,30 @@ Individual connections can override the global choice, which is useful when only
 | Send an identity header with model requests | Adds a header identifying the signed-in user to every model request. | Off | `model_endpoint_identity_header_enabled` |
 | Header name | Rejected if it collides with a header the model call already sets, such as `authorization`. | x-simplechat-identity-key | `model_endpoint_identity_header_name` |
 | Identity sent in the header | Object id is stable across a rename; UPN is readable in gateway logs. Tenant variants qualify the value for a multi-tenant gateway. | Object id and tenant id | `model_endpoint_identity_header_value_type` |
-| Default model for fallbacks | The model used when no other choice applies. Cleared automatically if the connection or model it names is deleted or disabled. | Not specified in defaults | `default_model_selection` |
 
 ### Chat {#gpt-config}
 
-The classic single-endpoint chat configuration. It is what chat uses when **Use connections for chat** is off, and it remains available as a fallback route.
+SimpleChat has two ways to reach a chat model and only one of them is in force at a time. When **Use connections for chat** is on, chat draws from the connections above. When it is off, chat runs on a single classic endpoint — one Azure OpenAI resource, or API Management in front of one — whose address, credentials, API version and deployment are configured on the server-rendered admin page rather than here.
+
+That distinction is worth stating because the two are easy to confuse: connections can be fully configured and still be unused, with nothing failing to signal it. This section names the route that is actually live, and links to the classic page when that route is the classic one.
+
+Turning connections on is not reversible from the admin interface. The setting is stored as "already on or newly on", so an attempt to switch back is refused rather than silently discarded. The switch also carries the classic endpoint over as the first connection, so the change does not begin with an empty model list. Treat it as a migration.
+
+#### Default model
+
+The default model is the one chat uses when nothing else has chosen — a conversation started before the user has picked anything, or work that begins outside the chat window. It is stored as a reference to a connection and one of that connection's models, not as a copy of the model, so it outlives what it names: deleting a connection, disabling one, or switching off a single model all leave it pointing at nothing.
+
+Rather than let that reference decay into a silent fallback to some other model, SimpleChat clears it whenever the thing it names stops being available, and says so. Only models that are enabled on an enabled connection can be chosen, for the same reason — anything else would be cleared again on the next save.
+
+The default applies to connections only. With chat on the classic single endpoint there is nothing for it to select from, and a choice made in that state is refused rather than stored.
 
 #### Settings
 
+The classic single endpoint is configured on the server-rendered admin page. Its values are listed here because they are what chat uses while **Use connections for chat** is off.
+
 | Setting | What it does | Default | Notes |
 | --- | --- | --- | --- |
+| Default model | The model chat uses when nothing else has chosen one. Cleared automatically if the connection or model it names is deleted or disabled. | Not specified in defaults | `default_model_selection`; connections mode only |
 | Use APIM instead of direct to Azure OpenAI endpoint | Sends chat requests through API Management rather than straight to the Azure OpenAI resource. | Off | `enable_gpt_apim`; capability toggle |
 | Azure OpenAI Endpoint | Provides the endpoint or route SimpleChat uses for this service. | Empty | `azure_openai_gpt_endpoint` |
 | Authentication Type | Chooses whether SimpleChat authenticates to this service with a key, managed identity, or another supported method. | key | `azure_openai_gpt_authentication_type` |
@@ -135,20 +149,23 @@ The Image Generation section belongs to the Image Generation tab. Use it with th
 
 1. **Publish models from a new resource.** Add a connection, choose its provider and authentication, run **Test connection**, then **Discover models** and turn on the ones people may use. Save the connection. Outcome to verify: the enabled models appear in the chat model picker.
 2. **Rotate a stored key.** Edit the connection, type the new key over the empty field, and save. Outcome to verify: **Test connection** succeeds with the replacement.
-3. **Retire a connection.** Disable it first and confirm chat still works, then delete it. Outcome to verify: its models stop being offered, and a default model that named it is cleared.
-4. **Configure embeddings.** Set endpoint, authentication, API version, and deployment, then index a small document. Outcome to verify: Indexing succeeds with the configured embedding route.
-5. **Enable image generation.** Enable the capability, set endpoint values, and generate a low-risk test image. Outcome to verify: The image tool returns output from the configured deployment.
+3. **Choose the model chat starts from.** With connections in force, pick a default under Chat. Outcome to verify: a new conversation opens on that model without anyone selecting it.
+4. **Retire a connection.** Disable it first and confirm chat still works, then delete it. Outcome to verify: its models stop being offered, and a default model that named it is cleared.
+5. **Configure embeddings.** Set endpoint, authentication, API version, and deployment, then index a small document. Outcome to verify: Indexing succeeds with the configured embedding route.
+6. **Enable image generation.** Enable the capability, set endpoint values, and generate a low-risk test image. Outcome to verify: The image tool returns output from the configured deployment.
 
 ## Troubleshooting
 
 | Symptom | Likely cause | Fix |
 | --- | --- | --- |
-| A connection's models never appear in chat | **Use connections for chat** is off, so chat is running on the classic single endpoint. | Turn it on, or configure the classic endpoint under Chat instead. |
+| A connection's models never appear in chat | **Use connections for chat** is off, so chat is running on the classic single endpoint. | Turn it on, or configure the classic endpoint instead. Chat says which route is live. |
 | **Use connections for chat** will not turn off | Enabling connections is one-way, because chats, agents and workflows may already reference a model published from one. | Disable the individual connections instead, or point chat at the model you want by making it the default. |
 | **Discover models** is unavailable | The connection authenticates with an API key, which reaches inference but not Azure Resource Manager. | Switch to managed identity or a service principal, or add the deployment names by hand. |
 | Discovery returns nothing for an Azure OpenAI connection | The subscription id or resource group does not match the resource. | Correct them, then run **Test connection** before discovering again. |
 | Models are listed but nobody can choose them | Discovered models arrive switched off. | Turn on each model that should be available, then save the connection. |
 | The default model reverted to none | The connection or model it named was deleted or disabled, so the reference no longer resolved. | Choose a default that points at an enabled model on an enabled connection. |
+| The default model list is empty | Either chat is on the classic single endpoint, or no connection currently has an enabled model on an enabled connection. | Turn on **Use connections for chat**, then enable at least one model. |
+| A default model choice is refused | Chat is on the classic single endpoint, so the choice would be cleared on the next save rather than taking effect. | Turn on **Use connections for chat** first. |
 | Embeddings fail during indexing | Endpoint, deployment, API version, or authentication does not match the Azure resource. | Validate the embedding route with a small document before bulk indexing. |
 
 ## Related

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,7 +2,7 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/features) and [Fixes by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/fixes).
 
-### **(v0.261.073)**
+### **(v0.261.081)**
 
 #### New Features
 

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,27 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/features) and [Fixes by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/fixes).
 
+### **(v0.261.061)**
+
+#### New Features
+
+*   **The Default Chat Model Can Be Chosen In The New Admin Interface**
+    *   The Chat section of AI Models had nothing in it but a single switch. The default model — the one chat uses when nobody has picked anything, such as on a brand new conversation — could only be set on the classic admin page, even though the connections it selects from had just moved.
+    *   **Only models that can actually serve are offered.** The list is built from enabled models on enabled connections, because a reference to anything else is cleared the moment connections are next saved. Offering a disabled model would have let an administrator choose a value that quietly reverted, with nothing to explain why.
+    *   **A choice that no longer resolves is refused rather than accepted.** Naming a connection that has been deleted, or a model that has been switched off, now comes back with a message saying so. Previously the two failure modes — storing a dangling reference, and silently emptying it — both ended up looking identical: the field simply read as having no default.
+    *   **The saved default is shown for what it currently means.** If the connection or model it named has since gone, the interface says that rather than presenting an empty field as though nothing had ever been set. Opening the page does not rewrite the stored value, so the evidence of what went missing survives.
+    *   The reference is validated by the same rule the classic form uses, so the two interfaces cannot disagree about whether a default is still valid.
+    *   (Ref: `route_backend_v2.py`, `/api/v2/admin/default-model`, `ChatDefaultModel.tsx`, `modelConnections.ts`, `admin_settings_fields.py`, `resolve_default_model_selection`)
+
+#### User Interface Enhancements
+
+*   **Chat Now Says Which Endpoint Is Actually Serving It**
+    *   SimpleChat has two ways to reach a chat model — the connections list, or a single classic endpoint — and only one is in force at a time. Nothing on screen distinguished them. An administrator could add a connection, test it, watch it save, and still be served by the classic endpoint, with no error and nothing to suggest the two were different things.
+    *   The Chat section now names the live route. When it is the classic single endpoint, it links to the page where that endpoint is configured, since those fields are deliberately not duplicated in the new interface.
+    *   It also warns before the switch is thrown: turning connections on is one-way, because the setting is stored as "already on or newly on" and cannot be turned back off afterwards.
+    *   Connections and the settings that depend on them are edited side by side, so they now stay in step with each other. Enabling connections, adding one, or switching a model off is reflected immediately in the model list and in the notice, rather than leaving adjacent parts of one screen describing different states until the page is reloaded.
+    *   (Ref: `ChatModeNotice.tsx`, `ModelConnectionsManager.tsx`, `modelConnectionsStore.ts`, `enable_multi_model_endpoints`, `docs/admin/ai-models.md`)
+
 ### **(v0.261.060)**
 
 #### Bug Fixes

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -21,7 +21,8 @@ For feature-focused and fix-focused drill-downs by version, see [Features by Ver
     *   The Chat section now names the live route. When it is the classic single endpoint, it links to the page where that endpoint is configured, since those fields are deliberately not duplicated in the new interface.
     *   It also warns before the switch is thrown: turning connections on is one-way, because the setting is stored as "already on or newly on" and cannot be turned back off afterwards.
     *   Connections and the settings that depend on them are edited side by side, so they now stay in step with each other. Enabling connections, adding one, or switching a model off is reflected immediately in the model list and in the notice, rather than leaving adjacent parts of one screen describing different states until the page is reloaded.
-    *   (Ref: `ChatModeNotice.tsx`, `ModelConnectionsManager.tsx`, `modelConnectionsStore.ts`, `enable_multi_model_endpoints`, `docs/admin/ai-models.md`)
+    *   **The API Management switch is no longer anonymous.** Settings the new interface has not described are placed by matching their name against section names, and that guess had dropped this one into the Chat section as a bare switch reading "Gpt apim". Beneath a notice explaining which endpoint chat uses, it looked like part of the same explanation — while turning it on actually reaches for an APIM endpoint, deployment and subscription key that can only be set on the classic admin page, so requests would have had nowhere to go. It now says what it does and where the rest of it lives.
+    *   (Ref: `ChatModeNotice.tsx`, `ModelConnectionsManager.tsx`, `modelConnectionsStore.ts`, `enable_multi_model_endpoints`, `enable_gpt_apim`, `docs/admin/ai-models.md`)
 
 ### **(v0.261.060)**
 

--- a/functional_tests/test_v2_admin_default_model_api.py
+++ b/functional_tests/test_v2_admin_default_model_api.py
@@ -1,0 +1,508 @@
+#!/usr/bin/env python3
+# test_v2_admin_default_model_api.py
+"""
+Functional test for the V2 admin default chat model API.
+Version: 0.261.061
+Implemented in: 0.261.061
+
+``default_model_selection`` is a reference -- a connection id plus a model id -- not a
+value. That makes it the one Admin Settings key the JSON PATCH cannot carry safely:
+``normalize_admin_settings_updates`` passes undeclared keys through unexamined, so a
+dangling reference would be stored exactly as sent and only surface later, as chat
+quietly answering from a different model.
+
+These checks pin the replacement:
+
+  1. The key is declared as a ``component``, which is what makes the settings PATCH
+     refuse it instead of storing an unchecked dict.
+  2. It has its own read and write routes, both admin-gated.
+  3. The read does not write, so opening the page cannot mutate stored configuration.
+  4. The write stores only what ``resolve_default_model_selection`` returned, and
+     refuses a reference that does not resolve rather than storing or silently
+     emptying it.
+"""
+
+import ast
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent))
+
+from test_support.app_stubs import import_app_module
+from test_support.nav import ADMIN_NAV
+from test_support.versioning import assert_app_version_at_least
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+APP_DIR = REPO_ROOT / "application" / "single_app"
+ROUTES_FILE = APP_DIR / "route_backend_v2.py"
+SETTINGS_FILE = APP_DIR / "functions_settings.py"
+
+SECTION_ID = "gpt-config"
+
+EXPECTED_ROUTES = {
+    ("/api/v2/admin/default-model", "GET"): "v2_admin_get_default_model",
+    ("/api/v2/admin/default-model", "PUT"): "v2_admin_set_default_model",
+}
+
+REQUIRED_DECORATORS = ("swagger_route", "login_required", "admin_required")
+
+# The rules the ported decision procedure below depends on. If the route stops doing
+# any of these, the assertions about its behaviour no longer describe it.
+WRITE_ROUTE_INVARIANTS = (
+    ("normalizes the requested selection", "normalize_default_model_selection(candidate)"),
+    ("treats an empty reference as a deliberate clear", 'not requested["endpoint_id"] and not requested["model_id"]'),
+    ("refuses a selection while chat is on the classic endpoint", "not clearing and not multi_endpoint_enabled"),
+    ("resolves against the stored connections", "resolve_default_model_selection("),
+    ("refuses a reference that did not resolve", 'not clearing and not resolved["endpoint_id"]'),
+    ("checks that the settings write succeeded", "if not update_settings("),
+)
+
+fields_module = import_app_module("admin_settings_fields")
+
+
+def _parse(path):
+    return ast.parse(path.read_text(encoding="utf-8"))
+
+
+def _decorator_names(node):
+    """Return the bare names of a function's decorators."""
+    names = []
+    for decorator in node.decorator_list:
+        target = decorator.func if isinstance(decorator, ast.Call) else decorator
+        if isinstance(target, ast.Name):
+            names.append(target.id)
+        elif isinstance(target, ast.Attribute):
+            names.append(target.attr)
+    return names
+
+
+def _route_declarations(node):
+    """Return (path, method) pairs declared by ``@bp.route`` on a function."""
+    declared = []
+    for decorator in node.decorator_list:
+        if not isinstance(decorator, ast.Call):
+            continue
+        target = decorator.func
+        if not (isinstance(target, ast.Attribute) and target.attr == "route"):
+            continue
+        if not decorator.args or not isinstance(decorator.args[0], ast.Constant):
+            continue
+        path = decorator.args[0].value
+        methods = ["GET"]
+        for keyword in decorator.keywords:
+            if keyword.arg == "methods" and isinstance(keyword.value, ast.List):
+                methods = [
+                    element.value
+                    for element in keyword.value.elts
+                    if isinstance(element, ast.Constant)
+                ]
+        declared.extend((path, method) for method in methods)
+    return declared
+
+
+def _find_functions(tree):
+    """Return every function definition in the module, at any nesting depth."""
+    return {
+        node.name: node
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+
+
+def _called_names(node):
+    """Return the names of every function called inside a function body."""
+    called = set()
+    for child in ast.walk(node):
+        if not isinstance(child, ast.Call):
+            continue
+        target = child.func
+        if isinstance(target, ast.Name):
+            called.add(target.id)
+        elif isinstance(target, ast.Attribute):
+            called.add(target.attr)
+    return called
+
+
+def _load_selection_helpers():
+    """Exec the pure default-model helpers out of ``functions_settings.py``.
+
+    ``functions_settings`` builds Azure clients at import time and the shared test stub
+    replaces the whole module, so the real functions cannot simply be imported. They are
+    pure, so lifting their source keeps the test honest about which implementation it is
+    checking. ``resolve_default_model_selection`` delegates to a generic resolver, so
+    whichever helpers exist are collected rather than a fixed list being demanded.
+    """
+    tree = _parse(SETTINGS_FILE)
+    wanted_functions = {
+        "normalize_default_model_selection",
+        "resolve_default_model_selection",
+        "resolve_model_selection",
+    }
+    wanted_constants = {"EMPTY_DEFAULT_MODEL_SELECTION", "EMPTY_MODEL_SELECTION"}
+
+    selected = []
+    found_functions = set()
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name in wanted_functions:
+            selected.append(node)
+            found_functions.add(node.name)
+        elif isinstance(node, ast.Assign):
+            targets = {t.id for t in node.targets if isinstance(t, ast.Name)}
+            if targets & wanted_constants:
+                selected.append(node)
+
+    required = {"normalize_default_model_selection", "resolve_default_model_selection"}
+    missing = required - found_functions
+    assert not missing, (
+        "These default-model helpers were not found in functions_settings.py, so this "
+        f"test cannot exercise the real rule: {', '.join(sorted(missing))}"
+    )
+
+    namespace = {}
+    exec(
+        compile(ast.Module(body=selected, type_ignores=[]), str(SETTINGS_FILE), "exec"),
+        namespace,
+    )
+    return namespace
+
+
+HELPERS = _load_selection_helpers()
+
+
+def endpoints_fixture():
+    """Two connections: one usable, one disabled, plus a disabled model."""
+    return [
+        {
+            "id": "conn-live",
+            "name": "Primary",
+            "provider": "aoai",
+            "enabled": True,
+            "models": [
+                {"id": "gpt-4o", "deploymentName": "gpt-4o", "enabled": True},
+                {"id": "retired", "deploymentName": "retired", "enabled": False},
+            ],
+        },
+        {
+            "id": "conn-off",
+            "name": "Secondary",
+            "provider": "aifoundry",
+            "enabled": False,
+            "models": [{"id": "phi-4", "deploymentName": "phi-4", "enabled": True}],
+        },
+    ]
+
+
+def decide(selection, endpoints, multi_endpoint_enabled):
+    """Port of ``v2_admin_set_default_model``: what a write does with a selection.
+
+    Returns ``(status, stored_or_error)``. ``stored`` is what reaches
+    ``update_settings``; on a refusal nothing is stored at all.
+    """
+    requested = HELPERS["normalize_default_model_selection"](selection)
+    clearing = not requested["endpoint_id"] and not requested["model_id"]
+
+    if not clearing and not multi_endpoint_enabled:
+        return 400, "classic-endpoint"
+
+    resolved, reason = HELPERS["resolve_default_model_selection"](
+        requested, endpoints, multi_endpoint_enabled=multi_endpoint_enabled
+    )
+
+    if not clearing and not resolved["endpoint_id"]:
+        return 400, reason or "incomplete"
+
+    return 200, resolved
+
+
+def test_the_key_is_declared_so_the_settings_patch_refuses_it():
+    """An undeclared key would be written into settings exactly as sent."""
+    print("Testing that the settings PATCH refuses the default model...")
+
+    assert_app_version_at_least("0.261.061")
+
+    field = fields_module.get_field_definition("default_model_selection")
+    assert field is not None, (
+        "default_model_selection is not declared in admin_settings_fields.py. Without a "
+        "declaration the settings PATCH passes it through unexamined, which is how a "
+        "dangling reference gets stored."
+    )
+    assert field["type"] == "component", (
+        f"default_model_selection is declared as {field['type']!r}. It must be "
+        "'component' so NON_PATCHABLE_TYPES refuses it on the settings PATCH."
+    )
+
+    _normalized, errors, _warnings = fields_module.normalize_admin_settings_updates(
+        {"default_model_selection": {"endpoint_id": "anything", "model_id": "anything"}}
+    )
+    assert "default_model_selection" in errors, (
+        "The settings PATCH accepted a raw default_model_selection. It must be rejected "
+        f"so it can only be written through its own validating route. Got: {errors}"
+    )
+
+    print("  Declared as a component, and the settings PATCH refuses it.")
+    return True
+
+
+def test_the_chat_section_declares_its_components():
+    """An undeclared section falls back to the enable_* scan and shows only switches."""
+    print("\nTesting the Chat section declaration...")
+
+    section_ids = {
+        section["id"]
+        for group in ADMIN_NAV
+        for tab in group["tabs"]
+        for section in tab["sections"]
+    }
+    assert SECTION_ID in section_ids, (
+        f"ADMIN_NAV no longer defines a {SECTION_ID!r} section, so the schema entry "
+        "would render nowhere."
+    )
+
+    fields = fields_module.get_admin_settings_fields().get(SECTION_ID)
+    assert fields, f"No fields are declared for the {SECTION_ID!r} section."
+
+    components = [
+        field.get("component") for field in fields if field.get("type") == "component"
+    ]
+    for expected in ("chat-mode-notice", "chat-default-model"):
+        assert expected in components, (
+            f"The {SECTION_ID!r} section does not declare the {expected!r} component. "
+            f"Declared: {components}"
+        )
+
+    print(f"  {SECTION_ID} declares {len(fields)} field(s), including both components.")
+    return True
+
+
+def test_routes_exist_and_are_admin_gated():
+    """A missing admin guard would let any signed-in user repoint chat's default."""
+    print("\nTesting default model route declarations...")
+
+    functions = _find_functions(_parse(ROUTES_FILE))
+
+    declared = {}
+    for name, node in functions.items():
+        for route in _route_declarations(node):
+            declared[route] = name
+
+    for route, expected_name in EXPECTED_ROUTES.items():
+        assert route in declared, f"Route {route[1]} {route[0]} is not declared"
+        assert declared[route] == expected_name, (
+            f"Route {route[1]} {route[0]} is handled by {declared[route]}, "
+            f"expected {expected_name}"
+        )
+
+        decorators = _decorator_names(functions[expected_name])
+        for required in REQUIRED_DECORATORS:
+            assert required in decorators, (
+                f"{expected_name} is missing @{required}. Got: {decorators}"
+            )
+
+    print(f"  Both route(s) declared and carrying {len(REQUIRED_DECORATORS)} guard(s).")
+    return True
+
+
+def test_the_read_route_does_not_write():
+    """Re-resolving on read is a report, not a repair; writing there hides the cause."""
+    print("\nTesting that reading the default model does not store anything...")
+
+    functions = _find_functions(_parse(ROUTES_FILE))
+    reader = functions["v2_admin_get_default_model"]
+    called = _called_names(reader)
+
+    assert "update_settings" not in called, (
+        "v2_admin_get_default_model calls update_settings. Loading the admin page would "
+        "then rewrite stored configuration, which erases the evidence of why a default "
+        "stopped resolving."
+    )
+    assert "resolve_default_model_selection" in called, (
+        "v2_admin_get_default_model must resolve the stored selection before returning "
+        "it, otherwise the UI shows a reference that no longer means anything."
+    )
+
+    print("  The read route resolves for display and writes nothing.")
+    return True
+
+
+def test_the_write_route_stores_only_the_resolved_value():
+    """Storing the request's own dict is exactly the failure the route exists to stop."""
+    print("\nTesting what the write route hands to update_settings...")
+
+    functions = _find_functions(_parse(ROUTES_FILE))
+    writer = functions["v2_admin_set_default_model"]
+
+    resolved_names = set()
+    for node in ast.walk(writer):
+        if (
+            isinstance(node, ast.Assign)
+            and isinstance(node.value, ast.Call)
+            and isinstance(node.value.func, ast.Name)
+            and node.value.func.id == "resolve_default_model_selection"
+        ):
+            for target in node.targets:
+                if isinstance(target, ast.Tuple):
+                    resolved_names.update(
+                        element.id
+                        for element in target.elts
+                        if isinstance(element, ast.Name)
+                    )
+                elif isinstance(target, ast.Name):
+                    resolved_names.add(target.id)
+
+    assert resolved_names, (
+        "v2_admin_set_default_model does not bind the result of "
+        "resolve_default_model_selection, so it cannot be storing a validated value."
+    )
+
+    stored_values = []
+    for node in ast.walk(writer):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "update_settings"
+            and node.args
+            and isinstance(node.args[0], ast.Dict)
+        ):
+            for key, value in zip(node.args[0].keys, node.args[0].values):
+                if isinstance(key, ast.Constant) and key.value == "default_model_selection":
+                    stored_values.append(value)
+
+    assert stored_values, (
+        "v2_admin_set_default_model never writes default_model_selection."
+    )
+    for value in stored_values:
+        assert isinstance(value, ast.Name) and value.id in resolved_names, (
+            "default_model_selection is written from something other than the resolved "
+            f"selection: {ast.dump(value)[:120]}"
+        )
+
+    source = ast.get_source_segment(ROUTES_FILE.read_text(encoding="utf-8"), writer) or ""
+    missing = [
+        description
+        for description, fragment in WRITE_ROUTE_INVARIANTS
+        if fragment not in source
+    ]
+    assert not missing, (
+        "The write route no longer works the way this test models it, so the behaviour "
+        "assertions below are no longer meaningful. Re-read the route and update "
+        "decide() to match:\n  " + "\n  ".join(missing)
+    )
+
+    print("  Only the resolved selection is stored, and every guard is present.")
+    return True
+
+
+def test_a_reference_that_does_not_resolve_is_refused():
+    """Storing or silently emptying it both read as 'no default' afterwards."""
+    print("\nTesting refusals for references that do not resolve...")
+
+    endpoints = endpoints_fixture()
+
+    cases = {
+        "missing connection": {"endpoint_id": "conn-gone", "model_id": "gpt-4o"},
+        "disabled connection": {"endpoint_id": "conn-off", "model_id": "phi-4"},
+        "missing model": {"endpoint_id": "conn-live", "model_id": "gpt-9"},
+        "disabled model": {"endpoint_id": "conn-live", "model_id": "retired"},
+        "connection without a model": {"endpoint_id": "conn-live", "model_id": ""},
+        "model without a connection": {"endpoint_id": "", "model_id": "gpt-4o"},
+    }
+
+    for description, selection in cases.items():
+        status, detail = decide(selection, endpoints, multi_endpoint_enabled=True)
+        assert status == 400, (
+            f"A {description} was accepted and stored as {detail!r}. It must be refused "
+            "so the administrator is told what went missing."
+        )
+        assert isinstance(detail, str) and detail, (
+            f"A {description} was refused without a message."
+        )
+
+    print(f"  All {len(cases)} unresolvable reference(s) are refused.")
+    return True
+
+
+def test_a_resolvable_reference_is_stored_with_its_provider():
+    """The provider is taken from the connection, not from whatever the browser sent."""
+    print("\nTesting an accepted selection...")
+
+    status, stored = decide(
+        {"endpoint_id": "conn-live", "model_id": "gpt-4o", "provider": "WRONG"},
+        endpoints_fixture(),
+        multi_endpoint_enabled=True,
+    )
+
+    assert status == 200, f"A valid selection was refused: {stored!r}"
+    assert stored == {
+        "endpoint_id": "conn-live",
+        "model_id": "gpt-4o",
+        "provider": "aoai",
+    }, stored
+
+    print("  The stored selection carries the connection's own provider.")
+    return True
+
+
+def test_clearing_is_allowed_in_either_mode():
+    """Choosing 'no default' must work even when nothing else could be chosen."""
+    print("\nTesting that the default can be cleared...")
+
+    for multi_endpoint_enabled in (True, False):
+        status, stored = decide(
+            {"endpoint_id": "", "model_id": "", "provider": ""},
+            endpoints_fixture(),
+            multi_endpoint_enabled=multi_endpoint_enabled,
+        )
+        assert status == 200, f"Clearing was refused: {stored!r}"
+        assert stored == {"endpoint_id": "", "model_id": "", "provider": ""}, stored
+
+    print("  Clearing succeeds whether or not connections are in force.")
+    return True
+
+
+def test_a_selection_is_refused_while_chat_uses_the_classic_endpoint():
+    """Resolving would empty it silently, which looks identical to never setting it."""
+    print("\nTesting a selection made while connections are off...")
+
+    status, detail = decide(
+        {"endpoint_id": "conn-live", "model_id": "gpt-4o"},
+        endpoints_fixture(),
+        multi_endpoint_enabled=False,
+    )
+
+    assert status == 400, (
+        f"A default was accepted while chat runs on the classic single endpoint: {detail!r}. "
+        "It would be cleared on the next write, so accepting it reports a save that did "
+        "not survive."
+    )
+
+    print("  Refused, rather than accepted and quietly emptied.")
+    return True
+
+
+if __name__ == "__main__":
+    tests = [
+        test_the_key_is_declared_so_the_settings_patch_refuses_it,
+        test_the_chat_section_declares_its_components,
+        test_routes_exist_and_are_admin_gated,
+        test_the_read_route_does_not_write,
+        test_the_write_route_stores_only_the_resolved_value,
+        test_a_reference_that_does_not_resolve_is_refused,
+        test_a_resolvable_reference_is_stored_with_its_provider,
+        test_clearing_is_allowed_in_either_mode,
+        test_a_selection_is_refused_while_chat_uses_the_classic_endpoint,
+    ]
+
+    results = []
+    for test in tests:
+        try:
+            results.append(bool(test()))
+        except Exception as exc:
+            print(f"FAILED {test.__name__}: {exc}")
+            import traceback
+
+            traceback.print_exc()
+            results.append(False)
+
+    print(f"\nResults: {sum(results)}/{len(results)} tests passed")
+    sys.exit(0 if all(results) else 1)

--- a/functional_tests/test_v2_admin_default_model_api.py
+++ b/functional_tests/test_v2_admin_default_model_api.py
@@ -40,6 +40,10 @@ SETTINGS_FILE = APP_DIR / "functions_settings.py"
 
 SECTION_ID = "gpt-config"
 
+# Declared alongside the two components rather than left to the V2 fallback scan. See
+# test_the_apim_toggle_is_declared_rather_than_guessed for why that matters.
+APIM_TOGGLE_KEY = "enable_gpt_apim"
+
 EXPECTED_ROUTES = {
     ("/api/v2/admin/default-model", "GET"): "v2_admin_get_default_model",
     ("/api/v2/admin/default-model", "PUT"): "v2_admin_set_default_model",
@@ -275,6 +279,72 @@ def test_the_chat_section_declares_its_components():
     return True
 
 
+def test_the_apim_toggle_is_declared_rather_than_guessed():
+    """Left undeclared, this lands in the Chat card as an unlabelled switch.
+
+    ``buildCapabilityIndex`` files an undeclared ``enable_*`` key under the section
+    whose id shares the most word stems. ``enable_gpt_apim`` splits to ``{gpt, apim}``
+    and ``gpt-config`` to ``{gpt, config}``, so it scores and wins -- and renders as
+    "Gpt apim" with no help text, directly beneath a notice that speaks
+    authoritatively about which endpoint chat is using.
+
+    That is a trap rather than an inconvenience: the APIM endpoint, deployment and
+    subscription key it depends on are only settable on the classic admin page, so
+    the switch reaches for configuration the surrounding surface does not offer.
+    Declaring it is what both names it and takes it out of the guess.
+    """
+    print("\nTesting the APIM toggle declaration...")
+
+    declared_sections = {
+        field["key"]: (section_id, field)
+        for section_id, field in fields_module.iter_fields()
+        if field.get("key")
+    }
+
+    entry = declared_sections.get(APIM_TOGGLE_KEY)
+    assert entry is not None, (
+        f"{APIM_TOGGLE_KEY} is not declared, so the V2 admin surface guesses a home for "
+        f"it. Declare it in the {SECTION_ID!r} section."
+    )
+
+    section_id, field = entry
+    assert section_id == SECTION_ID, (
+        f"{APIM_TOGGLE_KEY} is declared under {section_id!r}, expected {SECTION_ID!r}."
+    )
+    assert field.get("type") == "switch", (
+        f"{APIM_TOGGLE_KEY} is declared as {field.get('type')!r}, expected 'switch'."
+    )
+    assert field.get("help"), (
+        f"{APIM_TOGGLE_KEY} is declared without help text, which leaves it as anonymous "
+        "as the fallback scan rendered it."
+    )
+
+    # This is the property the renderer actually reads: `!declaredKeys.has(key)` is what
+    # suppresses the guess.
+    assert APIM_TOGGLE_KEY in fields_module.get_declared_setting_keys(), (
+        f"{APIM_TOGGLE_KEY} is not reported as declared, so the fallback scan would "
+        "still place it."
+    )
+
+    print(f"  {APIM_TOGGLE_KEY} is declared in {SECTION_ID} with help text.")
+    return True
+
+
+def test_the_apim_toggle_exists_in_its_server_rendered_pane():
+    """A declared field with no V1 counterpart would write a setting nothing reads."""
+    print("\nTesting the APIM toggle against the server-rendered pane...")
+
+    pane = APP_DIR / "templates" / "admin" / "_panes" / "model-endpoints.html"
+    assert pane.is_file(), f"Missing the server-rendered pane: {pane}"
+    assert f'name="{APIM_TOGGLE_KEY}"' in pane.read_text(encoding="utf-8"), (
+        f"{APIM_TOGGLE_KEY} has no field in {pane.name}, so the two admin interfaces "
+        "would not be editing the same setting."
+    )
+
+    print(f"  {APIM_TOGGLE_KEY} exists in {pane.name}.")
+    return True
+
+
 def test_routes_exist_and_are_admin_gated():
     """A missing admin guard would let any signed-in user repoint chat's default."""
     print("\nTesting default model route declarations...")
@@ -484,6 +554,8 @@ if __name__ == "__main__":
     tests = [
         test_the_key_is_declared_so_the_settings_patch_refuses_it,
         test_the_chat_section_declares_its_components,
+        test_the_apim_toggle_is_declared_rather_than_guessed,
+        test_the_apim_toggle_exists_in_its_server_rendered_pane,
         test_routes_exist_and_are_admin_gated,
         test_the_read_route_does_not_write,
         test_the_write_route_stores_only_the_resolved_value,

--- a/functional_tests/test_v2_default_model_choices.mjs
+++ b/functional_tests/test_v2_default_model_choices.mjs
@@ -1,0 +1,330 @@
+// test_v2_default_model_choices.mjs
+//
+// Runtime test for the V2 default chat model picker logic.
+// Version: 0.261.061
+// Implemented in: 0.261.061
+//
+// The picker's whole job is to refuse to offer a model that the server will not accept.
+// `resolve_default_model_selection` clears a reference to a disabled connection or a
+// disabled model on the next write, so listing one would let an administrator choose a
+// value that reverts with no explanation -- the same silent-revert problem the phase 2
+// work exists to remove.
+//
+// The filtering, labelling and index bookkeeping are pure, so they are executed here
+// rather than inferred from the rendered DOM.
+//
+// Run directly with `node functional_tests/test_v2_default_model_choices.mjs`. Requires
+// Node 22.6 or newer, which strips the TypeScript types so the real module is imported.
+
+import assert from 'node:assert/strict';
+
+import './test_support/tsResolve.mjs';
+
+const {
+    buildDefaultModelChoices,
+    choiceToSelection,
+    findChoiceIndex,
+    groupChoicesByConnection,
+    hasDefaultModel,
+    isSameSelection,
+    toDefaultModelSelection,
+    EMPTY_DEFAULT_MODEL_SELECTION,
+} = await import('../application/v2_ui/src/lib/modelConnections.ts');
+
+const checks = [];
+function check(name, fn) {
+    checks.push([name, fn]);
+}
+
+/** Two connections shaped the way `sanitize_model_endpoints_for_frontend` returns them. */
+function connections() {
+    return [
+        {
+            id: 'conn-live',
+            name: 'Primary',
+            provider: 'aoai',
+            enabled: true,
+            connection: { endpoint: 'https://primary.openai.azure.com' },
+            models: [
+                { id: 'gpt-4o', deploymentName: 'gpt-4o-prod', displayName: 'GPT-4o', enabled: true },
+                { id: 'retired', deploymentName: 'retired', enabled: false },
+            ],
+        },
+        {
+            id: 'conn-off',
+            name: 'Secondary',
+            provider: 'aifoundry',
+            enabled: false,
+            connection: { endpoint: 'https://secondary.services.ai.azure.com' },
+            models: [{ id: 'phi-4', deploymentName: 'phi-4', enabled: true }],
+        },
+    ];
+}
+
+/* --------------------------- what may be offered --------------------------- */
+
+check('a disabled connection contributes nothing', () => {
+    const choices = buildDefaultModelChoices(connections());
+    assert.equal(
+        choices.some((choice) => choice.endpointId === 'conn-off'),
+        false,
+    );
+});
+
+check('a disabled model is left out of its enabled connection', () => {
+    const choices = buildDefaultModelChoices(connections());
+    assert.deepEqual(
+        choices.map((choice) => choice.modelId),
+        ['gpt-4o'],
+    );
+});
+
+check('a model with no id and no deployment name is not addressable', () => {
+    const choices = buildDefaultModelChoices([
+        {
+            id: 'conn-live',
+            name: 'Primary',
+            enabled: true,
+            models: [{ displayName: 'Nameless', enabled: true }],
+        },
+    ]);
+    assert.deepEqual(choices, []);
+});
+
+check('a model missing an id falls back to its deployment name, as the server does', () => {
+    const choices = buildDefaultModelChoices([
+        {
+            id: 'conn-live',
+            name: 'Primary',
+            enabled: true,
+            models: [{ deploymentName: 'gpt-4o-prod', enabled: true }],
+        },
+    ]);
+    assert.equal(choices[0].modelId, 'gpt-4o-prod');
+});
+
+check('an absent enabled flag means enabled, matching normalize_model_endpoints', () => {
+    const choices = buildDefaultModelChoices([
+        {
+            id: 'conn-live',
+            name: 'Primary',
+            models: [{ id: 'gpt-4o' }],
+        },
+    ]);
+    assert.equal(choices.length, 1);
+});
+
+check('a connection with no id cannot be referenced', () => {
+    const choices = buildDefaultModelChoices([
+        { id: '', name: 'Unsaved', enabled: true, models: [{ id: 'gpt-4o', enabled: true }] },
+    ]);
+    assert.deepEqual(choices, []);
+});
+
+/* ------------------------------- how it reads ------------------------------ */
+
+check('a choice carries the connection provider, not the model', () => {
+    const [choice] = buildDefaultModelChoices(connections());
+    assert.equal(choice.provider, 'aoai');
+    assert.equal(choice.connectionName, 'Primary');
+});
+
+check('an unnamed connection falls back to its endpoint so it is still identifiable', () => {
+    const [choice] = buildDefaultModelChoices([
+        {
+            id: 'conn-live',
+            enabled: true,
+            connection: { endpoint: 'https://primary.openai.azure.com' },
+            models: [{ id: 'gpt-4o', enabled: true }],
+        },
+    ]);
+    assert.equal(choice.connectionName, 'https://primary.openai.azure.com');
+});
+
+check('the model label prefers the display name over the deployment', () => {
+    const [choice] = buildDefaultModelChoices(connections());
+    assert.equal(choice.modelLabel, 'GPT-4o');
+    assert.equal(choice.deploymentName, 'gpt-4o-prod');
+});
+
+check('a model with only an id still gets a label rather than rendering blank', () => {
+    const [choice] = buildDefaultModelChoices([
+        { id: 'conn-live', name: 'Primary', enabled: true, models: [{ id: 'gpt-4o' }] },
+    ]);
+    assert.equal(choice.modelLabel, 'gpt-4o');
+});
+
+check('choices are ordered by connection then model, not by storage order', () => {
+    const choices = buildDefaultModelChoices([
+        {
+            id: 'z',
+            name: 'Zulu',
+            enabled: true,
+            models: [{ id: 'b', displayName: 'Beta' }, { id: 'a', displayName: 'Alpha' }],
+        },
+        { id: 'a', name: 'Alpha', enabled: true, models: [{ id: 'c', displayName: 'Gamma' }] },
+    ]);
+    assert.deepEqual(
+        choices.map((choice) => `${choice.connectionName}/${choice.modelLabel}`),
+        ['Alpha/Gamma', 'Zulu/Alpha', 'Zulu/Beta'],
+    );
+});
+
+/* ------------------------------- grouping ---------------------------------- */
+
+check('grouping keeps each choice next to the index the select uses', () => {
+    const choices = buildDefaultModelChoices([
+        {
+            id: 'a',
+            name: 'Alpha',
+            enabled: true,
+            models: [{ id: 'one', displayName: 'One' }, { id: 'two', displayName: 'Two' }],
+        },
+        { id: 'z', name: 'Zulu', enabled: true, models: [{ id: 'three', displayName: 'Three' }] },
+    ]);
+    const groups = groupChoicesByConnection(choices);
+
+    assert.deepEqual(
+        groups.map((group) => group.connectionName),
+        ['Alpha', 'Zulu'],
+    );
+    for (const group of groups) {
+        for (const { choice, index } of group.items) {
+            assert.equal(choices[index], choice);
+        }
+    }
+});
+
+check('two connections sharing a name are not merged into one group', () => {
+    // Names are free text, so duplicates happen. Merging them would put a model under
+    // a connection it does not belong to.
+    const choices = [
+        { endpointId: 'a', modelId: '1', provider: '', connectionName: 'Same', modelLabel: 'One', deploymentName: '' },
+        { endpointId: 'b', modelId: '2', provider: '', connectionName: 'Other', modelLabel: 'Two', deploymentName: '' },
+        { endpointId: 'c', modelId: '3', provider: '', connectionName: 'Same', modelLabel: 'Three', deploymentName: '' },
+    ];
+    assert.equal(groupChoicesByConnection(choices).length, 3);
+});
+
+/* --------------------------- selection round trip -------------------------- */
+
+check('a stored selection is found in the offered list', () => {
+    const choices = buildDefaultModelChoices(connections());
+    const index = findChoiceIndex(choices, {
+        endpoint_id: 'conn-live',
+        model_id: 'gpt-4o',
+        provider: 'aoai',
+    });
+    assert.equal(index, 0);
+});
+
+check('a selection naming something no longer offered reports -1, not a wrong match', () => {
+    const choices = buildDefaultModelChoices(connections());
+    assert.equal(
+        findChoiceIndex(choices, { endpoint_id: 'conn-off', model_id: 'phi-4', provider: '' }),
+        -1,
+    );
+    assert.equal(
+        findChoiceIndex(choices, { endpoint_id: 'conn-live', model_id: 'retired', provider: '' }),
+        -1,
+    );
+});
+
+check('the same model id on two connections does not cross-match', () => {
+    const choices = buildDefaultModelChoices([
+        { id: 'first', name: 'A', enabled: true, models: [{ id: 'gpt-4o' }] },
+        { id: 'second', name: 'B', enabled: true, models: [{ id: 'gpt-4o' }] },
+    ]);
+    assert.equal(
+        findChoiceIndex(choices, { endpoint_id: 'second', model_id: 'gpt-4o', provider: '' }),
+        1,
+    );
+});
+
+check('an empty selection matches nothing rather than the first option', () => {
+    const choices = buildDefaultModelChoices(connections());
+    assert.equal(findChoiceIndex(choices, EMPTY_DEFAULT_MODEL_SELECTION), -1);
+});
+
+check('a picked choice converts back to the shape the API stores', () => {
+    const [choice] = buildDefaultModelChoices(connections());
+    assert.deepEqual(choiceToSelection(choice), {
+        endpoint_id: 'conn-live',
+        model_id: 'gpt-4o',
+        provider: 'aoai',
+    });
+});
+
+check('clearing converts to the empty selection the server expects', () => {
+    assert.deepEqual(choiceToSelection(null), {
+        endpoint_id: '',
+        model_id: '',
+        provider: '',
+    });
+});
+
+/* ------------------------------ shape coercion ----------------------------- */
+
+check('a missing or malformed stored selection reads as empty', () => {
+    for (const value of [undefined, null, 'gpt-4o', 42, {}]) {
+        assert.deepEqual(toDefaultModelSelection(value), {
+            endpoint_id: '',
+            model_id: '',
+            provider: '',
+        });
+    }
+});
+
+check('the provider is lowercased, matching normalize_default_model_selection', () => {
+    assert.deepEqual(
+        toDefaultModelSelection({ endpoint_id: ' a ', model_id: ' b ', provider: 'AOAI' }),
+        { endpoint_id: 'a', model_id: 'b', provider: 'aoai' },
+    );
+});
+
+check('half a reference is not a default', () => {
+    assert.equal(hasDefaultModel({ endpoint_id: 'a', model_id: '', provider: '' }), false);
+    assert.equal(hasDefaultModel({ endpoint_id: '', model_id: 'b', provider: '' }), false);
+    assert.equal(hasDefaultModel({ endpoint_id: 'a', model_id: 'b', provider: '' }), true);
+});
+
+check('two selections match on the reference alone, ignoring the provider', () => {
+    // The provider is derived from the connection on every write, so a difference there
+    // is not a different selection.
+    assert.equal(
+        isSameSelection(
+            { endpoint_id: 'a', model_id: 'b', provider: 'aoai' },
+            { endpoint_id: 'a', model_id: 'b', provider: '' },
+        ),
+        true,
+    );
+    assert.equal(
+        isSameSelection(
+            { endpoint_id: 'a', model_id: 'b', provider: 'aoai' },
+            { endpoint_id: 'a', model_id: 'c', provider: 'aoai' },
+        ),
+        false,
+    );
+});
+
+/* ---------------------------------- run ------------------------------------ */
+
+let passed = 0;
+const failures = [];
+
+for (const [name, fn] of checks) {
+    try {
+        fn();
+        passed += 1;
+    } catch (error) {
+        failures.push(`${name}: ${error.message}`);
+    }
+}
+
+console.log(`Results: ${passed}/${checks.length} checks passed`);
+if (failures.length) {
+    for (const failure of failures) {
+        console.error(`FAILED ${failure}`);
+    }
+    process.exit(1);
+}


### PR DESCRIPTION
Phase 2 of 3 of the Admin Settings **AI Models** rebuild. Phase 1 (#1415) gave the group a Connections manager and has since merged; this gives it a Chat section.

Base is `paullizer-react-v2-ui`, currently synced past #1424. `VERSION = 0.261.081`, per the merge queue's numbering.

## The problem

`gpt-config` — the Chat section — had no entry in `ADMIN_SETTINGS_FIELDS`, so the V2 admin surface fell back to scanning the settings document for `enable_*` booleans and rendered a single unlabelled switch. The two things an administrator needs there were both missing: which endpoint chat is actually using, and which model it starts from.

## Default model

`default_model_selection` is a **reference**, not a value — it names a connection id and a model id, so it outlives the thing it points at.

That makes it the one settings key the JSON PATCH cannot carry safely. `normalize_admin_settings_updates` passes **undeclared keys straight through unexamined**, so had the picker simply PATCHed the dict, a dangling reference would have been stored exactly as sent and surfaced later as chat quietly answering from a different model.

### Why the save works the way it does

The key is declared with `type: "component"`. That puts it in `NON_PATCHABLE_TYPES`, so `_normalize_field_value` **refuses it on the settings PATCH** — declaring it is precisely what closes the pass-through hole. It then gets its own pair of routes:

| Route | Behaviour |
| --- | --- |
| `GET /api/v2/admin/default-model` | Returns the selection **resolved** against the connections that currently exist, plus the `reason` it stopped resolving. Deliberately does **not** write — a read that repaired the value would erase the evidence of what went missing. |
| `PUT /api/v2/admin/default-model` | Validates through `resolve_default_model_selection` and stores **only what came back**. |

The write refuses a reference that does not resolve rather than storing it, and rather than silently emptying it. Both of those failure modes read as "no default" afterwards and neither says which connection or model went away. Clearing the default is still allowed, in either mode.

A selection made while chat is on the classic endpoint is also refused: `resolve_default_model_selection` clears the selection outright when connections are off, so accepting one would report a save that did not survive.

### The picker

Reads connections from the sanitized `/api/v2/admin/model-endpoints` route, never from the settings blob, which carries raw credentials. It offers **only** models that are enabled on an enabled connection — anything else is cleared on the next write, so offering it would let an administrator choose a value that silently reverts.

## The active-mode notice

Connections and the classic single endpoint are two separate routes and only one is live at a time, and **nothing on screen said which**. An administrator could add a connection, test it, watch it save, and still be served by the classic endpoint, with no error.

Per the scope decision, V2 does **not** carry the legacy chat form — no `azure_openai_gpt_*`, no `azure_apim_gpt_*`. The notice is what keeps that omission honest: it names the live route, and when that route is the classic one it links to `/admin/settings#model-endpoints`, where those fields live.

It also warns before the switch is thrown. `update_settings` coerces `enable_multi_model_endpoints` to `existing or requested`, so enabling connections is one-way; the notice says so rather than implying a reversal that would be refused.

## Keeping one screen self-consistent

Connections and the settings that depend on them are sibling sections in a single view. Review caught that `ChatDefaultModel` loaded its state once and never re-read it, so *open with connections off → enable → save* left the notice saying "chat is using the connections above" while the picker directly beneath it said "chat is on the classic single endpoint" and stayed disabled — the feature unusable until a full page reload.

Fixed structurally rather than patched: whether chat uses connections is now read from the page's saved settings by **both** components, so they cannot disagree. A small `modelConnectionsStore` revision counter announces every write to the connection list, and the affected sections re-read on it — which also covers the connection `_seed_connections_on_first_enable` migrates in server-side, and the default the server clears when a connection is deleted.

## The API Management toggle

Initially I left `enable_gpt_apim` to the fallback scan, reasoning that declaring it would pull a piece of the legacy chat form into V2. Review pushed back, correctly: leaving it undeclared does not keep it out of V2, it only renders it badly.

`buildCapabilityIndex` splits the key to `{gpt, apim}` and `gpt-config` to `{gpt, config}`, so it scores and wins — landing **inside the new Chat card** as a bare switch reading "Gpt apim" with no help text, directly beneath a notice that speaks authoritatively about which endpoint chat is using. Turning it on reaches for an APIM endpoint, deployment and subscription key that are only settable on the classic page, so it is a control that appears complete and is not.

It is now declared as an ordinary `switch` with help text saying what it does and where the rest of it lives. Declaring it also removes it from the stem matcher, so it renders where it was put.

The wording says *"requests that use the classic endpoint"* rather than *"chat"* deliberately. Tracing the consumers first showed the flag is read by four subsystems with **no connections branch at all** — `functions_search_service.py`, `functions_block_revision_assist.py`, `functions_workflow_runner.py`, `functions_personal_workflows.py` — alongside four that resolve connections first. Scoping the text to chat would have understated it. That trace produced #1427, which is the durable record of the underlying gap; this PR deliberately does not chase it, and the added sentence in `docs/admin/ai-models.md` is the stopgap it references.

## How the base merges were resolved

This branch has been re-synced through #1418, #1421, #1415, #1422 and #1424 landing underneath it. Worth stating how, because the correctness is a checked property rather than a careful read.

In `admin_settings_fields.py` the conflict region has repeatedly **cut through an unterminated field dict on both sides**, so a keep-both resolution would not even have parsed. But the sharper hazard is **deletions**, not duplicates:

- #1422 removed two dead duplicate section declarations.
- #1424 removed `actions-config` entirely, relocating `enable_text_plugin` and `enable_default_embedding_model_plugin` into `core-plugin-toggles`.

In both cases this branch still carried the old declaration, so the conflict pits their deletion against our declaration. A marker splice keeping both sides **silently resurrects a section the base deliberately removed** — and that result parses, passes, and contains no duplicate key to find.

So each conflicted file is rebuilt from its merge-stage blobs (`git ls-files -u` → `git cat-file`): take the base side whole, then re-apply only this branch's deltas onto it. Anything the base removed stays removed, because the deltas are applied *onto* their file rather than the reverse. The re-insertion anchor is resolved against the sections the base actually has, rather than assuming a section that may have been deleted is still present.

The verification is anchored on the base for the same reason:

```
set(merged_sections) == set(base_sections) | {"gpt-config"}
```

Exactly the base plus this branch's one declared addition, with the base set re-derived at each merge rather than reused. An earlier version compared against the **union** of both sides, which is weaker than it looks: a resurrected section is present on this branch, so it sits inside the union and trips neither the "lost" nor the "invented" direction. Demonstrated rather than asserted:

```
duplicate-key check -> PASS  (missed the resurrection)
union assertion     -> PASS  (missed the resurrection)
base-anchored       -> CAUGHT: resurrected=['actions-config']
```

The technique and the assertion cover **different** failures — the rebuild prevents the resurrection, the base-anchored assertion detects it — so a mistake in either is still caught by the other. That is not true of the technique paired with a union check.

Result of the current sync, past #1424: base **55** + `gpt-config` = **56**, nothing lost, nothing resurrected, zero duplicate section keys, and `actions-config` absent from both sides of the comparison.

`route_backend_v2.py` and `AdminSettingsPage.tsx` auto-merged this time. In earlier syncs they were resolved by keeping every route function and component arm whole, verified by count.

## Verification

- 19/19 Python suites, including the base's `test_admin_settings_fields_registry_integrity.py`, `test_v2_admin_capability_placement.py` and `test_v2_admin_workflow_parity.py`, plus this PR's new `test_v2_admin_default_model_api.py` (11/11).
- `python -m compileall application/single_app` clean.
- `npm run build` in `application/v2_ui` clean.
- `node test_v2_default_model_choices.mjs` (new, 23/23) and `node test_v2_model_connections_logic.mjs` (28/28).

Pre-existing failures on a clean tree, untouched: `test_admin_settings_sidebar_card_parity.py`, `test_docs_release_notes_integrity.py`, `test_admin_settings_tab_preservation.py` (console encoding).

## Also in this change

- `docs/admin/ai-models.md` — Chat section rewritten, default model row moved into it, APIM row reworded to match the declaration, troubleshooting rows for the two new refusals.
- `docs/explanation/release_notes.md` — new `### **(v0.261.081)**` section, with #1424's incoming `0.261.074` intact below it.