### PR TITLE
Describe the Chat group for the V2 admin settings surface

### DIFF
--- a/application/single_app/admin_settings_fields.py
+++ b/application/single_app/admin_settings_fields.py
@@ -30,16 +30,23 @@ Two things keep this honest rather than becoming a third source of truth:
     to the same normalizers the server-rendered form uses. Both interfaces
     therefore agree on what a valid value is.
 
-Only the Appearance group is described in full so far. Sections with no entry
-here fall back to the V2 surface's ``enable_*`` scan, so undescribed groups keep
-working exactly as they did. A handful of individual fields outside Appearance
-are also declared: that scan places a key by guessing from shared word stems,
-and declaring a field is the only way to stop it guessing wrong.
+Only the Appearance and Chat groups are described in full so far. Sections with
+no entry here fall back to the V2 surface's ``enable_*`` scan, so undescribed
+groups keep working exactly as they did. A handful of individual fields outside
+those groups are also declared: that scan places a key by guessing from shared
+word stems, and declaring a field is the only way to stop it guessing wrong.
+
+``SUPPRESSED_CAPABILITY_KEYS`` covers the opposite case -- a boolean the scan
+would draw but which is not an editable setting at all.
 """
 
 import re
 from urllib.parse import urlparse
 
+from admin_settings_secret_utils import (
+    ADMIN_SETTINGS_SECRET_REDACTED_VALUE,
+    resolve_admin_settings_secret_value,
+)
 from functions_ai_notice import (
     AI_NOTICE_MAX_MESSAGE_LENGTH,
     normalize_ai_notice_frequency,
@@ -63,6 +70,7 @@ HEX_COLOR_PATTERN = re.compile(r"^#[0-9a-fA-F]{6}$")
 FIELD_TYPES = (
     "text",
     "textarea",
+    "secret",
     "select",
     "switch",
     "checkbox_set",
@@ -77,6 +85,20 @@ FIELD_TYPES = (
 # Types that own their persistence outside the settings PATCH: image uploads go
 # through the multipart branding endpoint, and components talk to their own API.
 NON_PATCHABLE_TYPES = ("image", "component")
+
+# Keys the settings PATCH must refuse outright.
+#
+# ``model_endpoints`` holds each endpoint's API key and client secret inside the
+# list, so the admin surface is served a sanitized copy with those stripped.
+# Writing that copy back would erase every credential it removed. The V2 surface
+# has no editor for it, so refusing is safe and keeps a malformed or hostile
+# payload from destroying the endpoint configuration.
+NON_PATCHABLE_KEYS = {
+    "model_endpoints": (
+        "Model endpoints hold credentials that are stripped before they reach "
+        "the browser, so they cannot be saved from here."
+    ),
+}
 
 LANDING_PAGE_ALIGNMENTS = ("left", "center", "right")
 USER_AGREEMENT_APPLY_TO_VALUES = ("personal", "group", "public", "chat")
@@ -535,6 +557,326 @@ ADMIN_SETTINGS_FIELDS = {
             "depends_on": {"key": "enable_external_links", "equals": True},
         },
     ],
+    # ------------------------------------------------------------------
+    # Chat group. Sections and order follow admin_settings_nav.py; wording
+    # follows the V1 panes (chat-experience, feedback-alerts, citation) so both
+    # interfaces describe the same setting the same way.
+    # ------------------------------------------------------------------
+    "processing-thoughts-section": [
+        {
+            "key": "enable_thoughts",
+            "type": "switch",
+            "label": "Enable Processing Thoughts",
+            "help": (
+                "Shows the steps taken while answering -- document searches, web "
+                "searches, agent calls -- as they happen, and stores them so a "
+                "message can be reviewed afterwards."
+            ),
+            "default": True,
+        },
+    ],
+    "chat-file-uploads-section": [
+        {
+            "key": "enable_chat_file_uploads",
+            "type": "switch",
+            "label": "Enable Chat File Uploads",
+            "help": (
+                "Lets users attach files directly to a conversation instead of "
+                "adding them to a workspace first."
+            ),
+            "default": True,
+        },
+        {
+            "key": "require_member_of_chat_file_upload_user",
+            "type": "switch",
+            "label": "Require ChatFileUploadUser App Role",
+            "help": (
+                "Restricts new uploads to users holding the ChatFileUploadUser "
+                "Enterprise App role. Files already attached stay visible."
+            ),
+            "default": False,
+            "depends_on": {"key": "enable_chat_file_uploads", "equals": True},
+        },
+    ],
+    "conversation-contents-drawer-section": [
+        {
+            "key": "enable_conversation_contents_drawer",
+            "type": "switch",
+            "label": "Enable Conversation Contents Drawer",
+            "help": (
+                "Adds a drawer listing a conversation's prompts so users can jump "
+                "back to an earlier turn. Users can turn it off for themselves in "
+                "their profile."
+            ),
+            "default": True,
+        },
+    ],
+    "workspace-scope-lock-section": [
+        {
+            "key": "enforce_workspace_scope_lock",
+            "type": "switch",
+            "label": "Enforce Workspace Scope Lock",
+            "help": (
+                "Keeps a conversation restricted to the workspaces that produced "
+                "its first search results. Turn this off to let users unlock the "
+                "scope and search elsewhere in the same conversation."
+            ),
+            "default": True,
+        },
+    ],
+    "conversation-history-section": [
+        {
+            "key": "conversation_history_limit",
+            "type": "number",
+            "label": "Conversation History Limit",
+            "help": (
+                "How many previous messages are carried into each new request. "
+                "Raising it preserves more context and costs more tokens per turn."
+            ),
+            "default": 10,
+            "min": 1,
+        },
+        {
+            "key": "enable_summarize_content_history_beyond_conversation_history_limit",
+            "type": "switch",
+            "label": "Summarize Messages Beyond the History Limit",
+            "help": (
+                "Replaces messages that fall outside the limit with a running "
+                "summary instead of dropping them, so older context survives a "
+                "long conversation."
+            ),
+            "default": False,
+        },
+        {
+            "key": "enable_summarize_content_history_for_search",
+            "type": "switch",
+            "label": "Summarize Conversation History for Search",
+            "help": (
+                "Summarizes recent turns into the query used for hybrid document "
+                "search, so a follow-up question that relies on earlier context "
+                "still retrieves the right sources."
+            ),
+            "default": False,
+        },
+        {
+            "key": "number_of_historical_messages_to_summarize",
+            "type": "number",
+            "label": "Historical Messages to Summarize",
+            "help": (
+                "How many recent messages are summarized into the search query. "
+                "Twice this many are read to build the summary."
+            ),
+            "default": 10,
+            "min": 1,
+            "max": 100,
+            "depends_on": {
+                "key": "enable_summarize_content_history_for_search",
+                "equals": True,
+            },
+        },
+    ],
+    "default-system-prompt-section": [
+        {
+            "key": "default_system_prompt",
+            "type": "textarea",
+            "label": "Default System Prompt",
+            "help": (
+                "Applied to conversations that do not set their own. Agents and "
+                "conversations with a custom prompt are unaffected."
+            ),
+            "default": "",
+            "rows": 5,
+        },
+    ],
+    "fact-memory-section": [
+        {
+            "key": "enable_fact_memory_plugin",
+            "type": "switch",
+            "label": "Enable Fact Memory",
+            "help": (
+                "Lets the assistant carry durable context between conversations. "
+                "Instruction memories apply to every prompt; fact memories are "
+                "recalled only when relevant. This is a chat capability and does "
+                "not require agents or actions. Users manage their own entries "
+                "under Profile > Fact Memory. Existing entries are preserved while "
+                "this is off, but stay inactive."
+            ),
+            "default": True,
+        },
+    ],
+    "user-feedback-section": [
+        {
+            "key": "enable_user_feedback",
+            "type": "switch",
+            "label": "Enable User Feedback (Thumbs Up/Down)",
+            "help": (
+                "Adds thumbs up and down controls to AI responses and routes the "
+                "ratings to the feedback review workflow."
+            ),
+            "default": True,
+        },
+    ],
+    "desktop-notifications-section": [
+        {
+            "key": "enable_desktop_notifications",
+            "type": "switch",
+            "label": "Enable Desktop Conversation Notifications",
+            "help": (
+                "Lets users receive an operating system notification when a "
+                "response finishes in a hidden or unfocused tab. Requires browser "
+                "permission, stops when the tab is closed, and users can turn it "
+                "off in their profile."
+            ),
+            "default": False,
+        },
+    ],
+    # Standard citations has no settings -- V1's card is explanatory only -- so it
+    # is deliberately absent. A section with nothing to render is skipped.
+    "enhanced-citations-section": [
+        {
+            "key": "enable_enhanced_citations",
+            "type": "switch",
+            "label": "Enable Enhanced Citations",
+            "help": (
+                "Stores original files in an Azure Storage account so citations can "
+                "link to and preview the source document rather than only quoting "
+                "extracted text."
+            ),
+            "default": False,
+        },
+        {
+            "type": "component",
+            "label": "Storage Connection",
+            "component": "enhanced-citations-storage-test",
+            "help": (
+                "Startup does not check storage, so an outage cannot block boot. "
+                "Test here to confirm the account is reachable and the expected "
+                "containers exist."
+            ),
+            "depends_on": {"key": "enable_enhanced_citations", "equals": True},
+        },
+        {
+            "key": "office_docs_authentication_type",
+            "type": "select",
+            "label": "Storage Account Authentication Type",
+            "help": "How SimpleChat authenticates to the storage account.",
+            "default": "key",
+            "options": [
+                {"value": "key", "label": "Connection String"},
+                {"value": "managed_identity", "label": "Managed Identity"},
+            ],
+            "depends_on": {"key": "enable_enhanced_citations", "equals": True},
+        },
+        {
+            "key": "office_docs_storage_account_url",
+            "type": "secret",
+            "label": "Storage Account Connection String",
+            "help": "Used when authenticating with a connection string.",
+            "default": "",
+            "depends_on": [
+                {"key": "enable_enhanced_citations", "equals": True},
+                {"key": "office_docs_authentication_type", "equals": "key"},
+            ],
+        },
+        {
+            "key": "office_docs_storage_account_blob_endpoint",
+            "type": "secret",
+            "label": "Storage Account Blob Service Endpoint",
+            "help": "Used when authenticating with a managed identity.",
+            "default": "",
+            "depends_on": [
+                {"key": "enable_enhanced_citations", "equals": True},
+                {
+                    "key": "office_docs_authentication_type",
+                    "equals": "managed_identity",
+                },
+            ],
+        },
+        {
+            "key": "tabular_preview_max_blob_size_mb",
+            "type": "number",
+            "label": "Maximum File Size for Tabular Preview (MB)",
+            "help": (
+                "CSV and XLSX files above this size are not previewed. Raise it for "
+                "larger files when the host has memory to spare; lower it to protect "
+                "smaller instances."
+            ),
+            "default": 200,
+            "min": 1,
+            "max": 1024,
+            "depends_on": {"key": "enable_enhanced_citations", "equals": True},
+        },
+        {
+            "key": "enable_tabular_durable_run_confirmation",
+            "type": "switch",
+            "label": "Confirm very large row-level runs before starting",
+            "help": (
+                "When a prompt names an explicitly large row count, the user is "
+                "asked to continue or narrow the scope before the run starts."
+            ),
+            "default": True,
+            "depends_on": {"key": "enable_enhanced_citations", "equals": True},
+        },
+        {
+            "key": "tabular_durable_run_confirmation_threshold_rows",
+            "type": "number",
+            "label": "Confirmation Row Threshold",
+            "help": "Row count at or above which the confirmation is shown.",
+            "default": 500,
+            "min": 1,
+            "max": 1000000,
+            "depends_on": [
+                {"key": "enable_enhanced_citations", "equals": True},
+                {"key": "enable_tabular_durable_run_confirmation", "equals": True},
+            ],
+        },
+        {
+            "key": "tabular_durable_run_confirmation_threshold_batches",
+            "type": "number",
+            "label": "Confirmation Batch Threshold",
+            "help": "Batch count at or above which the confirmation is shown.",
+            "default": 75,
+            "min": 1,
+            "max": 100000,
+            "depends_on": [
+                {"key": "enable_enhanced_citations", "equals": True},
+                {"key": "enable_tabular_durable_run_confirmation", "equals": True},
+            ],
+        },
+        {
+            "key": "tabular_generated_output_chunk_model_mode",
+            "type": "select",
+            "label": "Chunk Processing Model",
+            "help": (
+                "Whether per-chunk work reuses the model the user selected or a "
+                "deployment set aside for it."
+            ),
+            "default": "current",
+            "options": [
+                {"value": "current", "label": "Use the user's selected model"},
+                {
+                    "value": "configured",
+                    "label": "Use a configured deployment for chunk work",
+                },
+            ],
+            "depends_on": {"key": "enable_enhanced_citations", "equals": True},
+        },
+        {
+            "key": "tabular_generated_output_chunk_model_deployment",
+            "type": "text",
+            "label": "Configured Chunk Model Deployment",
+            "help": "Deployment name used when chunk work runs on its own model.",
+            "default": "",
+            "max_length": 120,
+            "depends_on": [
+                {"key": "enable_enhanced_citations", "equals": True},
+                {
+                    "key": "tabular_generated_output_chunk_model_mode",
+                    "equals": "configured",
+                },
+            ],
+        },
+    ],
     # The sections below are not part of the Appearance group. They are described
     # here because the V2 surface's `enable_*` fallback was filing their toggles
     # under Appearance: it matches a key to a section by shared leading word
@@ -580,8 +922,15 @@ ADMIN_SETTINGS_FIELDS = {
             ),
             "default": False,
             # V1 hides this control entirely while the Latest Features destination
-            # is off, because the cards it affects are not reachable then.
-            "depends_on": {"key": "enable_support_latest_features", "equals": True},
+            # is off, because the cards it affects are not reachable then. The
+            # Support Menu condition is repeated because visibility is evaluated
+            # per field rather than recursively: `enable_support_latest_features`
+            # defaults to True, so gating on it alone would leave this on screen
+            # while the whole Support menu is off.
+            "depends_on": [
+                {"key": "enable_support_menu", "equals": True},
+                {"key": "enable_support_latest_features", "equals": True},
+            ],
         },
     ],
     # Declared so the dependency above resolves to a control an administrator can
@@ -631,7 +980,99 @@ ADMIN_SETTINGS_FIELDS = {
             ),
             "default": True,
         },
+        {
+            "key": "enable_default_embedding_model_plugin",
+            "type": "switch",
+            "label": "Enable Default Embedding Model Action",
+            "help": (
+                "Registers the configured embedding deployment as an action agents "
+                "can call to embed text directly."
+            ),
+            "default": False,
+        },
     ],
+    # The four sections below belong to Knowledge, not Chat. They are declared for
+    # the same reason as Health Check above: the fallback scan matched their keys
+    # to a Chat section by shared word stems -- "audio" and "video" and "file"
+    # reaching chat-file-uploads-section, "enhanced" reaching
+    # enhanced-citations-section -- and put audio, video and extraction toggles on
+    # the Chat page. Declaring a key is what takes it out of that scan.
+    "ai-voice-chat-section": [
+        {
+            "key": "enable_audio_file_support",
+            "type": "switch",
+            "label": "Enable Audio File Support",
+            "help": (
+                "Allows audio files to be uploaded and transcribed so their spoken "
+                "content becomes searchable and citable."
+            ),
+            "default": False,
+        },
+        {
+            "key": "enable_chat_completion_audio_cues",
+            "type": "switch",
+            "label": "Enable Chat Completion Audio Cues",
+            "help": (
+                "Plays a short sound when a response finishes. Users choose their "
+                "own sound and volume, or mute it, in their profile."
+            ),
+            "default": False,
+        },
+    ],
+    "video-intelligence-section": [
+        {
+            "key": "enable_video_file_support",
+            "type": "switch",
+            "label": "Enable Video File Support",
+            "help": (
+                "Allows video files to be uploaded and indexed so their spoken and "
+                "on-screen content becomes searchable and citable."
+            ),
+            "default": False,
+        },
+    ],
+    "document-intelligence-section": [
+        {
+            "key": "enable_enhanced_extraction",
+            "type": "switch",
+            "label": "Enable Enhanced Extraction",
+            "help": (
+                "Uses richer Document Intelligence extraction for layout, tables and "
+                "structure, at a higher processing cost per document."
+            ),
+            "default": False,
+        },
+    ],
+}
+
+
+# Keys the V2 fallback scan must not draw a switch for.
+#
+# That scan renders every `enable_*` boolean it finds in the settings document.
+# Some of those booleans are not settings an administrator can change, so a
+# switch would appear to save and then silently revert, or save a value nothing
+# ever reads. Declaring them is not the answer either -- a declared field claims
+# there is something to edit. They are named here with the reason instead, and
+# the settings GET sends this list so the scan can skip them.
+SUPPRESSED_CAPABILITY_KEYS = {
+    "enable_tabular_processing_plugin": (
+        "Derived, not stored: is_tabular_processing_enabled() returns "
+        "enable_enhanced_citations, and get_settings() overwrites the stored value "
+        "on every read. A switch here would revert on the next page load."
+    ),
+    "enable_enhanced_citations_mount": (
+        "No control in either interface. The saved value is forced off unless "
+        "Enhanced Citations is enabled, and the mount path itself is not "
+        "administrator-editable."
+    ),
+    "enable_mixed_source_chat_search": (
+        "Staged rollout flag for mixed-source chat and search, with no control in "
+        "the server-rendered admin form."
+    ),
+    "enable_mixed_source_conversation_continuity": (
+        "Staged rollout flag gated behind enable_mixed_source_chat_search, with no "
+        "control in the server-rendered admin form."
+    ),
 }
 
 
@@ -691,6 +1132,28 @@ def get_declared_setting_keys():
     that already have a proper field, so a toggle is never rendered twice.
     """
     return {field["key"] for _section_id, field in iter_fields() if field.get("key")}
+
+
+def get_suppressed_capability_keys():
+    """Return the keys the V2 fallback scan must not render a switch for."""
+    return sorted(SUPPRESSED_CAPABILITY_KEYS)
+
+
+def iter_field_dependencies(field):
+    """Return a field's visibility conditions as a tuple.
+
+    ``depends_on`` is normally one condition. It may also be a list, and then every
+    condition must hold. That is needed wherever a control is gated on a sibling
+    whose own default would otherwise reveal it: the Enhanced Citations storage
+    credentials are chosen by authentication type, but must stay hidden entirely
+    while Enhanced Citations itself is off.
+    """
+    depends_on = field.get("depends_on")
+    if not depends_on:
+        return ()
+    if isinstance(depends_on, dict):
+        return (depends_on,)
+    return tuple(depends_on)
 
 
 def get_legacy_field_names():
@@ -835,7 +1298,7 @@ _DELEGATED_NORMALIZERS = {
 }
 
 
-def _normalize_field_value(key, value, field):
+def _normalize_field_value(key, value, field, current_settings=None):
     """Return ``(normalized, error, warning)`` for one declared field."""
     field_type = field.get("type")
 
@@ -847,6 +1310,16 @@ def _normalize_field_value(key, value, field):
 
     if field_type == "switch":
         return _coerce_bool(value), None, None
+
+    if field_type == "secret":
+        # A value still equal to the mask means the administrator did not touch
+        # the field, so the stored secret is kept. Storing the mask would
+        # overwrite a working credential with the literal "***REDACTED***".
+        resolved = resolve_admin_settings_secret_value(
+            key, value, current_settings or {}
+        )
+        max_length = field.get("max_length")
+        return (resolved[:max_length] if max_length else resolved), None, None
 
     if field_type == "select":
         allowed = [option["value"] for option in field.get("options", [])]
@@ -957,6 +1430,10 @@ def normalize_admin_settings_updates(updates, current_settings=None):
         if key in acknowledgement_keys:
             continue
 
+        if key in NON_PATCHABLE_KEYS:
+            errors[key] = NON_PATCHABLE_KEYS[key]
+            continue
+
         field = get_field_definition(key)
         if field is None:
             normalized[key] = value
@@ -970,7 +1447,7 @@ def normalize_admin_settings_updates(updates, current_settings=None):
                 normalized[key] = redirect_value
             continue
 
-        field_value, error, warning = _normalize_field_value(key, value, field)
+        field_value, error, warning = _normalize_field_value(key, value, field, current)
         if error:
             errors[key] = error
             continue
@@ -987,6 +1464,19 @@ def normalize_admin_settings_updates(updates, current_settings=None):
     return normalized, errors, warnings
 
 
+def _dependency_is_satisfied(depends_on, value):
+    """Whether a ``depends_on`` condition holds for a field's current value.
+
+    ``equals`` is usually a boolean, gating a field on a capability switch. It
+    may also be a string, which gates a field on a select -- the Enhanced
+    Citations storage credentials each apply to one authentication type only.
+    """
+    expected = depends_on.get("equals", True)
+    if isinstance(expected, str):
+        return str(value or "").strip() == expected
+    return _coerce_bool(value) == expected
+
+
 def _check_minimum_selections(normalized, current_settings, errors):
     """Enforce ``min_selected`` once the merged state of a save is known."""
     for _section_id, field in iter_fields():
@@ -997,12 +1487,17 @@ def _check_minimum_selections(normalized, current_settings, errors):
 
         depends_on = field.get("depends_on")
         if depends_on:
-            gate_key = depends_on["key"]
-            gate_value = (
-                normalized[gate_key] if gate_key in normalized
-                else current_settings.get(gate_key, False)
-            )
-            if _coerce_bool(gate_value) != depends_on.get("equals", True):
+            gated_off = False
+            for condition in iter_field_dependencies(field):
+                gate_key = condition["key"]
+                gate_value = (
+                    normalized[gate_key] if gate_key in normalized
+                    else current_settings.get(gate_key, False)
+                )
+                if not _dependency_is_satisfied(condition, gate_value):
+                    gated_off = True
+                    break
+            if gated_off:
                 continue
 
         selection = (

--- a/application/single_app/admin_settings_fields.py
+++ b/application/single_app/admin_settings_fields.py
@@ -1142,10 +1142,10 @@ ADMIN_SETTINGS_FIELDS = {
             "results_key": "groups",
             "item_noun": "group",
             "item_noun_plural": "groups",
-            "depends_on": {
-                "key": "require_group_assignment_for_file_downloads",
-                "equals": True,
-            },
+            "depends_on": [
+                {"key": "allow_group_workspace_file_downloads", "equals": True},
+                {"key": "require_group_assignment_for_file_downloads", "equals": True},
+            ],
         },
         {
             "key": "allow_public_workspace_file_downloads",
@@ -1187,10 +1187,13 @@ ADMIN_SETTINGS_FIELDS = {
             "results_key": "workspaces",
             "item_noun": "public workspace",
             "item_noun_plural": "public workspaces",
-            "depends_on": {
-                "key": "require_public_workspace_assignment_for_file_downloads",
-                "equals": True,
-            },
+            "depends_on": [
+                {"key": "allow_public_workspace_file_downloads", "equals": True},
+                {
+                    "key": "require_public_workspace_assignment_for_file_downloads",
+                    "equals": True,
+                },
+            ],
         },
     ],
     "file-sharing-section": [
@@ -1480,10 +1483,13 @@ ADMIN_SETTINGS_FIELDS = {
             ),
             "default": [],
             "search_endpoint": "/api/v2/admin/groups",
-            "depends_on": {
-                "key": "require_group_assignment_for_group_workflows",
-                "equals": True,
-            },
+            "depends_on": [
+                {"key": "allow_group_workflows", "equals": True},
+                {
+                    "key": "require_group_assignment_for_group_workflows",
+                    "equals": True,
+                },
+            ],
         },
         {
             "key": "workflow_max_auto_invoke_attempts",

--- a/application/single_app/admin_settings_secret_utils.py
+++ b/application/single_app/admin_settings_secret_utils.py
@@ -1,0 +1,120 @@
+# admin_settings_secret_utils.py
+"""Masking and restoring the secrets an administrator edits in Admin Settings.
+
+Admin Settings is the one surface that legitimately edits keys, connection
+strings and client secrets, so it cannot use ``sanitize_settings_for_user``,
+which removes those keys entirely. Instead it round-trips them: the stored value
+is replaced with a fixed sentinel on the way out, and a submitted value still
+equal to that sentinel resolves back to the stored value on the way in. An
+administrator can therefore see that a secret is configured, and replace or clear
+it, without the secret itself ever reaching the browser.
+
+These helpers live here rather than in ``functions_settings`` because
+``admin_settings_fields`` needs them to normalize a ``secret`` field, and
+``functions_settings`` builds a Cosmos client at import time.
+``functions_settings`` re-exports everything below, so existing callers are
+unaffected.
+"""
+
+import copy
+
+
+ADMIN_SETTINGS_SECRET_REDACTED_VALUE = "***REDACTED***"
+
+# Top-level settings keys holding a secret. Editing Admin Settings must never
+# send these to the browser, and must never overwrite one with the mask.
+ADMIN_SETTINGS_FORM_SECRET_FIELDS = (
+    "azure_openai_gpt_key",
+    "azure_apim_gpt_subscription_key",
+    "azure_openai_embedding_key",
+    "azure_apim_embedding_subscription_key",
+    "azure_openai_image_gen_key",
+    "azure_apim_image_gen_subscription_key",
+    "redis_key",
+    "office_docs_storage_account_url",
+    "office_docs_storage_account_blob_endpoint",
+    # Storage account keys used to sign SAS tokens for citation file access. No
+    # form submits these, so they are read-only from the interface's point of
+    # view, but they are live credentials and must not be sent to a browser.
+    "office_docs_key",
+    "video_files_key",
+    "audio_files_key",
+    "video_files_storage_account_url",
+    "audio_files_storage_account_url",
+    "content_safety_key",
+    "azure_apim_content_safety_subscription_key",
+    "azure_ai_search_key",
+    "azure_apim_ai_search_subscription_key",
+    "azure_document_intelligence_key",
+    "azure_apim_document_intelligence_subscription_key",
+    "azure_content_understanding_key",
+    "speech_service_key",
+    "model_endpoint_identity_header_hmac_secret",
+)
+
+# Secrets stored inside a nested object rather than at the top level, addressed
+# by a dotted path.
+ADMIN_SETTINGS_NESTED_SECRET_FIELDS = (
+    "web_search_agent.other_settings.azure_ai_foundry.client_secret",
+)
+
+
+def is_admin_settings_redacted_secret(value):
+    """Return True when a submitted value is the mask rather than a real secret."""
+    return str(value or '').strip() == ADMIN_SETTINGS_SECRET_REDACTED_VALUE
+
+
+def get_nested_setting_value(settings, field_path):
+    """Read a dotted path out of a settings document, or '' when absent."""
+    current = settings if isinstance(settings, dict) else {}
+    for part in str(field_path or '').split('.'):
+        if not isinstance(current, dict):
+            return ''
+        current = current.get(part)
+    return current if current is not None else ''
+
+
+def set_nested_setting_value(settings, field_path, value):
+    """Write a dotted path into a settings document, creating missing levels."""
+    current = settings
+    parts = str(field_path or '').split('.')
+    for part in parts[:-1]:
+        if not isinstance(current.get(part), dict):
+            current[part] = {}
+        current = current[part]
+    current[parts[-1]] = value
+
+
+def resolve_admin_settings_secret_value(field_name, submitted_value, existing_settings):
+    """Return the value to store for a secret an administrator submitted.
+
+    A submitted value equal to the mask means "leave it alone", so the stored
+    value is returned. Anything else is taken at face value, including an empty
+    string, which is how a secret is deliberately cleared.
+    """
+    submitted_text = str(submitted_value or '').strip()
+    if not is_admin_settings_redacted_secret(submitted_text):
+        return submitted_text
+    return str(get_nested_setting_value(existing_settings, field_name) or '').strip()
+
+
+def redact_admin_settings_secrets_for_form(settings):
+    """Return a copy of a settings document with every configured secret masked.
+
+    Only populated secrets are masked. An unset secret stays empty so the
+    interface can tell "not configured" from "configured but hidden".
+
+    Model endpoint credentials live inside the ``model_endpoints`` list rather
+    than at a fixed key, so they are not reachable from the lists above and must
+    be stripped separately by the caller.
+    """
+    redacted_settings = copy.deepcopy(settings or {})
+    for field_name in ADMIN_SETTINGS_FORM_SECRET_FIELDS:
+        if redacted_settings.get(field_name):
+            redacted_settings[field_name] = ADMIN_SETTINGS_SECRET_REDACTED_VALUE
+    for field_path in ADMIN_SETTINGS_NESTED_SECRET_FIELDS:
+        if get_nested_setting_value(redacted_settings, field_path):
+            set_nested_setting_value(
+                redacted_settings, field_path, ADMIN_SETTINGS_SECRET_REDACTED_VALUE
+            )
+    return redacted_settings

--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -97,7 +97,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.261.058"
+VERSION = "0.261.059"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/functions_settings.py
+++ b/application/single_app/functions_settings.py
@@ -27,6 +27,7 @@ from functions_rate_limit import (
     build_rate_limit_message,
 )
 from functions_service_health import get_default_service_health
+import admin_settings_secret_utils as _secret_utils
 import app_settings_cache
 import inspect
 import copy
@@ -83,32 +84,9 @@ USER_UI_SETTINGS_KEYS = (
     "chatCompletionAudioSound",
     "chatCompletionAudioVolume",
 )
-ADMIN_SETTINGS_SECRET_REDACTED_VALUE = "***REDACTED***"
-ADMIN_SETTINGS_FORM_SECRET_FIELDS = (
-    "azure_openai_gpt_key",
-    "azure_apim_gpt_subscription_key",
-    "azure_openai_embedding_key",
-    "azure_apim_embedding_subscription_key",
-    "azure_openai_image_gen_key",
-    "azure_apim_image_gen_subscription_key",
-    "redis_key",
-    "office_docs_storage_account_url",
-    "office_docs_storage_account_blob_endpoint",
-    "video_files_storage_account_url",
-    "audio_files_storage_account_url",
-    "content_safety_key",
-    "azure_apim_content_safety_subscription_key",
-    "azure_ai_search_key",
-    "azure_apim_ai_search_subscription_key",
-    "azure_document_intelligence_key",
-    "azure_apim_document_intelligence_subscription_key",
-    "azure_content_understanding_key",
-    "speech_service_key",
-    "model_endpoint_identity_header_hmac_secret",
-)
-ADMIN_SETTINGS_NESTED_SECRET_FIELDS = (
-    "web_search_agent.other_settings.azure_ai_foundry.client_secret",
-)
+ADMIN_SETTINGS_SECRET_REDACTED_VALUE = _secret_utils.ADMIN_SETTINGS_SECRET_REDACTED_VALUE
+ADMIN_SETTINGS_FORM_SECRET_FIELDS = _secret_utils.ADMIN_SETTINGS_FORM_SECRET_FIELDS
+ADMIN_SETTINGS_NESTED_SECRET_FIELDS = _secret_utils.ADMIN_SETTINGS_NESTED_SECRET_FIELDS
 TABULAR_GENERATION_BACKEND_SETTING_KEYS = {
     'enable_analysis_deliverable_contract_telemetry',
     'analysis_deliverable_contract_mode',
@@ -151,33 +129,21 @@ PUBLIC_WORKSPACE_DISPLAY_NAME_MAX_LENGTH = 32
 
 
 def is_admin_settings_redacted_secret(value):
-    return str(value or '').strip() == ADMIN_SETTINGS_SECRET_REDACTED_VALUE
+    return _secret_utils.is_admin_settings_redacted_secret(value)
 
 
 def _get_nested_setting_value(settings, field_path):
-    current = settings if isinstance(settings, dict) else {}
-    for part in str(field_path or '').split('.'):
-        if not isinstance(current, dict):
-            return ''
-        current = current.get(part)
-    return current if current is not None else ''
+    return _secret_utils.get_nested_setting_value(settings, field_path)
 
 
 def _set_nested_setting_value(settings, field_path, value):
-    current = settings
-    parts = str(field_path or '').split('.')
-    for part in parts[:-1]:
-        if not isinstance(current.get(part), dict):
-            current[part] = {}
-        current = current[part]
-    current[parts[-1]] = value
+    _secret_utils.set_nested_setting_value(settings, field_path, value)
 
 
 def resolve_admin_settings_secret_value(field_name, submitted_value, existing_settings):
-    submitted_text = str(submitted_value or '').strip()
-    if not is_admin_settings_redacted_secret(submitted_text):
-        return submitted_text
-    return str(_get_nested_setting_value(existing_settings, field_name) or '').strip()
+    return _secret_utils.resolve_admin_settings_secret_value(
+        field_name, submitted_value, existing_settings
+    )
 
 
 def normalize_public_workspace_display_name(value):
@@ -358,14 +324,7 @@ def normalize_model_endpoint_identity_header_settings(settings):
 
 
 def redact_admin_settings_secrets_for_form(settings):
-    redacted_settings = copy.deepcopy(settings or {})
-    for field_name in ADMIN_SETTINGS_FORM_SECRET_FIELDS:
-        if redacted_settings.get(field_name):
-            redacted_settings[field_name] = ADMIN_SETTINGS_SECRET_REDACTED_VALUE
-    for field_path in ADMIN_SETTINGS_NESTED_SECRET_FIELDS:
-        if _get_nested_setting_value(redacted_settings, field_path):
-            _set_nested_setting_value(redacted_settings, field_path, ADMIN_SETTINGS_SECRET_REDACTED_VALUE)
-    return redacted_settings
+    return _secret_utils.redact_admin_settings_secrets_for_form(settings)
 
 
 def _clone_user_settings_doc(doc):

--- a/application/single_app/route_backend_v2.py
+++ b/application/single_app/route_backend_v2.py
@@ -29,6 +29,7 @@ from admin_settings_fields import (
     LOGO_SCALE_MAX_PERCENT,
     LOGO_SCALE_MIN_PERCENT,
     get_admin_settings_fields,
+    get_suppressed_capability_keys,
     is_safe_external_link_url,
     normalize_admin_settings_updates,
 )
@@ -73,6 +74,8 @@ from functions_settings import (
     get_user_settings,
     is_chat_file_upload_enabled_for_user,
     is_user_workflows_enabled_for_user,
+    redact_admin_settings_secrets_for_form,
+    sanitize_model_endpoints_for_frontend,
     sanitize_settings_for_user,
     update_settings,
 )
@@ -612,25 +615,42 @@ def register_route_backend_v2_admin(bp):
     @login_required
     @admin_required
     def v2_admin_get_settings():
-        """Return the raw settings document, the admin navigation and the field schema.
+        """Return the settings document, the admin navigation and the field schema.
 
-        Admin settings are not sanitized. Sanitization removes keys, secrets and endpoint
-        configuration, which are exactly the values an administrator is here to manage.
-        Access is restricted to the Admin role by the blueprint guard and the decorator.
+        Admin settings are not run through ``sanitize_settings_for_user``. That removes
+        keys and endpoint configuration outright, which are exactly the values an
+        administrator is here to manage. Access is restricted to the Admin role by the
+        blueprint guard and the decorator.
+
+        Stored secrets are masked all the same, using the same helpers the
+        server-rendered form uses. An administrator needs to know a credential is
+        configured and be able to replace it, not to read it back, and the settings
+        PATCH resolves the mask to the stored value so an untouched field round-trips
+        intact. Model endpoint credentials are nested inside the ``model_endpoints``
+        list rather than at a fixed key, so they are stripped by
+        ``sanitize_model_endpoints_for_frontend`` first, matching what the
+        server-rendered page passes to its template.
 
         ``field_schema`` describes the concrete controls each section owns. Sections with
         no entry are rendered by the SPA's ``enable_*`` fallback scan, so groups that have
-        not been described yet keep working.
+        not been described yet keep working. ``suppressed_capabilities`` names the keys
+        that scan must skip because they are derived or are staged rollout flags with no
+        administrator control.
         """
         try:
             settings = get_settings()
+            safe_settings = redact_admin_settings_secrets_for_form(settings)
+            safe_settings["model_endpoints"] = sanitize_model_endpoints_for_frontend(
+                settings.get("model_endpoints")
+            )
             return (
                 jsonify(
                     {
-                        "settings": settings,
+                        "settings": safe_settings,
                         "admin_nav": ADMIN_NAV,
                         "field_schema": get_admin_settings_fields(),
                         "branding_assets": _build_branding_assets(settings),
+                        "suppressed_capabilities": get_suppressed_capability_keys(),
                         "version": VERSION,
                     }
                 ),
@@ -706,7 +726,10 @@ def register_route_backend_v2_admin(bp):
                     {
                         "success": True,
                         "updated_keys": sorted(normalized.keys()),
-                        "settings": normalized,
+                        # Re-mask before echoing. A secret field resolves the mask back to
+                        # the stored credential, so returning `normalized` unchanged would
+                        # hand the browser the very value the GET withholds.
+                        "settings": redact_admin_settings_secrets_for_form(normalized),
                         "warnings": warnings,
                     }
                 ),

--- a/application/single_app/route_frontend_admin_settings.py
+++ b/application/single_app/route_frontend_admin_settings.py
@@ -1069,7 +1069,12 @@ def register_route_frontend_admin_settings(bp):
                 )
             )
             max_file_size_mb = int(form_data.get('max_file_size_mb', 16))
-            conversation_history_limit = int(form_data.get('conversation_history_limit', 10))
+            conversation_history_limit = max(1, parse_admin_int(
+                form_data.get('conversation_history_limit'),
+                settings.get('conversation_history_limit', 10),
+                'conversation_history_limit',
+                10,
+            ))
             enable_idle_timeout = form_data.get('enable_idle_timeout') == 'on'
             idle_timeout_minutes = max(10, parse_admin_int(form_data.get('idle_timeout_minutes'), settings.get('idle_timeout_minutes', 30), 'idle_timeout_minutes', 30))
             idle_warning_minutes = max(0, parse_admin_int(form_data.get('idle_warning_minutes'), settings.get('idle_warning_minutes', 28), 'idle_warning_minutes', 28))
@@ -2576,7 +2581,12 @@ def register_route_frontend_admin_settings(bp):
                 'enable_extract_meta_data': enable_extract_meta_data,
                 'enable_summarize_content_history_for_search': form_data.get('enable_summarize_content_history_for_search') == 'on',
                 'enable_summarize_content_history_beyond_conversation_history_limit': form_data.get('enable_summarize_content_history_beyond_conversation_history_limit') == 'on',
-                'number_of_historical_messages_to_summarize': int(form_data.get('number_of_historical_messages_to_summarize', 10)),
+                'number_of_historical_messages_to_summarize': min(100, max(1, parse_admin_int(
+                    form_data.get('number_of_historical_messages_to_summarize'),
+                    settings.get('number_of_historical_messages_to_summarize', 10),
+                    'number_of_historical_messages_to_summarize',
+                    10,
+                ))),
                 
                 # *** Document Classification ***
                 'enable_document_classification': enable_document_classification,
@@ -2635,13 +2645,17 @@ def register_route_frontend_admin_settings(bp):
                 'office_docs_storage_account_blob_endpoint': admin_secret('office_docs_storage_account_blob_endpoint'),
                 'office_docs_storage_account_url': admin_secret('office_docs_storage_account_url'),
                 'office_docs_authentication_type': form_data.get('office_docs_authentication_type', 'key'),
-                'office_docs_key': form_data.get('office_docs_key', '').strip(),
+                # Storage account keys have no input anywhere in the form, so a bare
+                # '' default would overwrite the stored key on every save and break
+                # SAS signing for citation file access. Fall back to the stored value
+                # when the field is absent; an explicit empty submission still clears.
+                'office_docs_key': form_data.get('office_docs_key', settings.get('office_docs_key', '')).strip(),
                 'video_files_storage_account_url': admin_secret('video_files_storage_account_url'),
                 'video_files_authentication_type': form_data.get('video_files_authentication_type', 'key'),
-                'video_files_key': form_data.get('video_files_key', '').strip(),
+                'video_files_key': form_data.get('video_files_key', settings.get('video_files_key', '')).strip(),
                 'audio_files_storage_account_url': admin_secret('audio_files_storage_account_url'),
                 'audio_files_authentication_type': form_data.get('audio_files_authentication_type', 'key'),
-                'audio_files_key': form_data.get('audio_files_key', '').strip(),
+                'audio_files_key': form_data.get('audio_files_key', settings.get('audio_files_key', '')).strip(),
 
                 # Safety (Content Safety Direct & APIM)
                 'enable_content_safety': form_data.get('enable_content_safety') == 'on',

--- a/application/single_app/templates/admin/_panes/chat-experience.html
+++ b/application/single_app/templates/admin/_panes/chat-experience.html
@@ -110,6 +110,50 @@
                         </label>
                         <input type="number" class="form-control" id="conversation_history_limit"
                             name="conversation_history_limit" value="{{ settings.conversation_history_limit }}">
+                        <small class="form-text text-muted">
+                            Raising this preserves more context and costs more tokens per turn.
+                        </small>
+                    </div>
+
+                    <hr>
+                    <h6><strong>History Summarization</strong></h6>
+                    <div class="form-group form-check form-switch mb-3">
+                        <input
+                            type="checkbox"
+                            class="form-check-input"
+                            id="enable_summarize_content_history_beyond_conversation_history_limit"
+                            name="enable_summarize_content_history_beyond_conversation_history_limit"
+                            {% if settings.enable_summarize_content_history_beyond_conversation_history_limit %}checked{% endif %}
+                        >
+                        <label class="form-check-label ms-2" for="enable_summarize_content_history_beyond_conversation_history_limit">
+                            Summarize Messages Beyond the History Limit
+                        </label>
+                        <i class="bi bi-info-circle ms-2" data-bs-toggle="tooltip" title="Replaces messages that fall outside the limit with a running summary instead of dropping them, so older context survives a long conversation."></i>
+                    </div>
+                    <div class="form-group form-check form-switch mb-3">
+                        <input
+                            type="checkbox"
+                            class="form-check-input"
+                            id="enable_summarize_content_history_for_search"
+                            name="enable_summarize_content_history_for_search"
+                            {% if settings.enable_summarize_content_history_for_search %}checked{% endif %}
+                        >
+                        <label class="form-check-label ms-2" for="enable_summarize_content_history_for_search">
+                            Summarize Conversation History for Search
+                        </label>
+                        <i class="bi bi-info-circle ms-2" data-bs-toggle="tooltip" title="Summarizes recent turns into the query used for hybrid document search, so a follow-up question that relies on earlier context still retrieves the right sources."></i>
+                    </div>
+                    <div class="mb-0">
+                        <label for="number_of_historical_messages_to_summarize" class="form-label">
+                            Historical Messages to Summarize
+                        </label>
+                        <input type="number" class="form-control" id="number_of_historical_messages_to_summarize"
+                            name="number_of_historical_messages_to_summarize"
+                            min="1" max="100"
+                            value="{{ settings.number_of_historical_messages_to_summarize | default(10, true) }}">
+                        <small class="form-text text-muted">
+                            How many recent messages are summarized into the search query. Twice this many are read to build the summary.
+                        </small>
                     </div>
                 </div>
 

--- a/application/v2_ui/src/components/admin/EnhancedCitationsStorageTest.tsx
+++ b/application/v2_ui/src/components/admin/EnhancedCitationsStorageTest.tsx
@@ -1,0 +1,160 @@
+// EnhancedCitationsStorageTest.tsx
+// On-demand reachability check for the Enhanced Citations storage account.
+//
+// Startup deliberately skips live storage checks so a storage outage cannot stop the
+// application booting, which means a misconfigured account is otherwise only discovered
+// when a citation fails to open. This runs the same check the server-rendered admin page
+// runs, against the values currently on screen, so a connection string can be validated
+// before it is saved.
+//
+// The credentials are masked, so the draft usually holds the redaction placeholder rather
+// than a real secret. That is sent as-is: the test endpoint resolves the placeholder back
+// to the stored value, exactly as the settings save does.
+
+import { useState } from 'react';
+import { clsx } from 'clsx';
+import { CheckCircle2, Loader2, PlugZap, TriangleAlert, XCircle } from 'lucide-react';
+import { ApiError, api } from '../../lib/apiClient';
+import { GlassButton } from '../ui/primitives';
+
+interface StorageTestResponse {
+    success?: boolean;
+    status?: string;
+    message?: string;
+    error?: string;
+    details?: string[];
+    guidance?: string[];
+}
+
+type Outcome = 'success' | 'warning' | 'error';
+
+interface TestResult {
+    outcome: Outcome;
+    message: string;
+    details: string[];
+    guidance: string[];
+}
+
+const OUTCOME_STYLES: Record<Outcome, { icon: typeof CheckCircle2; className: string }> = {
+    success: { icon: CheckCircle2, className: 'text-ok' },
+    warning: { icon: TriangleAlert, className: 'text-warn' },
+    error: { icon: XCircle, className: 'text-danger' },
+};
+
+/** Coerce whatever the endpoint returned into something renderable. */
+function toStrings(value: unknown): string[] {
+    return Array.isArray(value) ? value.map((item) => String(item)) : [];
+}
+
+export function EnhancedCitationsStorageTest({
+    help,
+    authenticationType,
+    connectionString,
+    blobEndpoint,
+}: {
+    help?: string;
+    authenticationType: string;
+    connectionString: string;
+    blobEndpoint: string;
+}) {
+    const [testing, setTesting] = useState(false);
+    const [result, setResult] = useState<TestResult | null>(null);
+
+    const runTest = async () => {
+        setTesting(true);
+        setResult(null);
+
+        try {
+            const response = await api.post<StorageTestResponse>(
+                '/api/admin/settings/test_connection',
+                {
+                    test_type: 'enhanced_citations_storage',
+                    authentication_type: authenticationType || 'key',
+                    connection_string: connectionString,
+                    blob_endpoint: blobEndpoint,
+                },
+            );
+
+            setResult({
+                outcome: response.status === 'warning' ? 'warning' : 'success',
+                message: response.message ?? 'Enhanced Citations storage is reachable.',
+                details: toStrings(response.details),
+                guidance: toStrings(response.guidance),
+            });
+        } catch (testError) {
+            const payload =
+                testError instanceof ApiError
+                    ? (testError.payload as StorageTestResponse | undefined)
+                    : undefined;
+
+            setResult({
+                outcome: 'error',
+                message:
+                    payload?.error ??
+                    (testError instanceof Error
+                        ? testError.message
+                        : 'The storage test could not be completed.'),
+                details: toStrings(payload?.details),
+                guidance: toStrings(payload?.guidance),
+            });
+        } finally {
+            setTesting(false);
+        }
+    };
+
+    const styles = result ? OUTCOME_STYLES[result.outcome] : null;
+    const Icon = styles?.icon;
+
+    return (
+        <div className="py-3">
+            <span className="mb-1.5 block text-sm font-medium text-text-1">
+                Storage Connection
+            </span>
+
+            <GlassButton
+                type="button"
+                variant="subtle"
+                size="sm"
+                disabled={testing}
+                onClick={() => void runTest()}
+            >
+                {testing ? (
+                    <Loader2 size={14} className="animate-spin" />
+                ) : (
+                    <PlugZap size={14} />
+                )}
+                {testing ? 'Testing…' : 'Test storage connection'}
+            </GlassButton>
+
+            {help ? <p className="mt-1.5 text-xs leading-relaxed text-text-3">{help}</p> : null}
+
+            {result && Icon ? (
+                <div
+                    role="status"
+                    className="mt-2 rounded-lg border border-edge bg-surface-1 p-3"
+                >
+                    <p className={clsx('flex items-start gap-1.5 text-sm', styles.className)}>
+                        <Icon size={15} className="mt-0.5 shrink-0" />
+                        {result.message}
+                    </p>
+
+                    {result.details.length ? (
+                        <ul className="mt-1.5 ml-5 list-disc text-xs text-text-3">
+                            {result.details.map((detail) => (
+                                <li key={detail}>{detail}</li>
+                            ))}
+                        </ul>
+                    ) : null}
+
+                    {result.guidance.length ? (
+                        <ul className="mt-1.5 ml-5 list-disc text-xs text-text-2">
+                            {result.guidance.map((item) => (
+                                <li key={item}>{item}</li>
+                            ))}
+                        </ul>
+                    ) : null}
+                </div>
+            ) : null}
+        </div>
+    );
+}

--- a/application/v2_ui/src/components/admin/SecretField.tsx
+++ b/application/v2_ui/src/components/admin/SecretField.tsx
@@ -1,0 +1,132 @@
+// SecretField.tsx
+// A stored credential: masked, replaceable, and clearable, but never displayed.
+//
+// The server never sends the real value. It sends `REDACTED_SECRET` when one is stored,
+// and treats that same string coming back as "leave it alone", so an untouched field
+// round-trips without the credential reaching the browser.
+//
+// That leaves three states an administrator can be in, and the whole point of this
+// component is to keep them distinguishable. An empty input could otherwise mean "nothing
+// is configured", "something is configured and hidden", or "the configured value is about
+// to be deleted" -- and deleting a working connection string by backspacing, with no
+// visible difference from the untouched state, is the one outcome that must not happen
+// quietly. The stored value is passed in alongside the draft value so the component can
+// tell the difference and say which state it is in.
+
+import { clsx } from 'clsx';
+import { useState } from 'react';
+import { Eye, EyeOff, TriangleAlert } from 'lucide-react';
+import { asString, REDACTED_SECRET, type AdminField } from '../../lib/adminFields';
+import { FieldShell, inputClass } from './fields';
+
+export function SecretField({
+    field,
+    value,
+    storedValue,
+    error,
+    warning,
+    disabled,
+    onChange,
+}: {
+    field: AdminField;
+    value: unknown;
+    /** The value the server sent: the mask when a credential is stored, else empty. */
+    storedValue: unknown;
+    error?: string;
+    warning?: string;
+    disabled?: boolean;
+    onChange: (next: unknown) => void;
+}) {
+    const id = `admin-field-${field.key}`;
+    const [revealed, setRevealed] = useState(false);
+
+    const current = asString(value);
+    const isConfigured = asString(storedValue) === REDACTED_SECRET;
+    const isUntouched = current === REDACTED_SECRET;
+    // Configured, and the pending value is empty: saving now removes the credential.
+    // Reached by pressing Clear and also by simply erasing what was typed.
+    const willBeRemoved = isConfigured && !isUntouched && current === '';
+
+    // The mask is never put in the input. A keystroke would append to it and save
+    // `***REDACTED***newvalue` as the credential.
+    const inputValue = isUntouched ? '' : current;
+
+    const placeholder = isUntouched
+        ? 'Saved — type to replace'
+        : (field.placeholder ?? 'Not configured');
+
+    return (
+        <FieldShell
+            field={field}
+            error={error}
+            warning={warning}
+            htmlFor={id}
+            trailing={
+                isUntouched ? (
+                    <button
+                        type="button"
+                        className="text-xs text-text-3 hover:text-text-1 disabled:cursor-not-allowed disabled:opacity-60"
+                        disabled={disabled}
+                        onClick={() => onChange('')}
+                    >
+                        Clear
+                    </button>
+                ) : willBeRemoved ? (
+                    <button
+                        type="button"
+                        className="text-xs text-text-3 hover:text-text-1 disabled:cursor-not-allowed disabled:opacity-60"
+                        disabled={disabled}
+                        // Restoring the mask is what marks the field untouched again, so
+                        // the save leaves the stored credential alone.
+                        onClick={() => onChange(REDACTED_SECRET)}
+                    >
+                        Undo
+                    </button>
+                ) : null
+            }
+        >
+            <div className="flex items-center gap-2">
+                <input
+                    id={id}
+                    type={revealed ? 'text' : 'password'}
+                    className={clsx(inputClass, 'font-mono')}
+                    value={inputValue}
+                    placeholder={placeholder}
+                    disabled={disabled}
+                    spellCheck={false}
+                    autoComplete="off"
+                    onChange={(event) => onChange(event.target.value)}
+                />
+                <button
+                    type="button"
+                    className="shrink-0 rounded-lg border border-edge p-2 text-text-3 hover:text-text-1 disabled:cursor-not-allowed disabled:opacity-60"
+                    aria-label={revealed ? `Hide ${field.label}` : `Show ${field.label}`}
+                    aria-pressed={revealed}
+                    // Nothing to reveal until something has been typed: the stored value
+                    // is not here to show.
+                    disabled={disabled || !inputValue}
+                    onClick={() => setRevealed((previous) => !previous)}
+                >
+                    {revealed ? <EyeOff size={15} /> : <Eye size={15} />}
+                </button>
+            </div>
+
+            {isUntouched ? (
+                <p className="mt-1.5 text-xs text-text-3">
+                    A value is saved and hidden. Type a new one to replace it, or Clear to
+                    remove it.
+                </p>
+            ) : null}
+
+            {willBeRemoved ? (
+                <p
+                    role="alert"
+                    className="mt-1.5 flex items-start gap-1.5 text-xs text-warn"
+                >
+                    <TriangleAlert size={13} className="mt-0.5 shrink-0" />
+                    The saved value will be removed when you save.
+                </p>
+            ) : null}
+        </FieldShell>
+    );
+}

--- a/application/v2_ui/src/components/admin/fields.tsx
+++ b/application/v2_ui/src/components/admin/fields.tsx
@@ -29,6 +29,8 @@ const inputClass = clsx(
     'disabled:cursor-not-allowed disabled:opacity-60',
 );
 
+export { inputClass };
+
 /** Label, help text, control and error, laid out consistently for every field type. */
 export function FieldShell({
     field,
@@ -348,8 +350,9 @@ function CheckboxSetControl({
 /**
  * Render one declared field.
  *
- * `image`, `link_list` and `component` fields are handled by the page, which owns the
- * upload endpoint and the bespoke widgets, so they are not reached here.
+ * `image`, `link_list`, `secret` and `component` fields are handled by the page, which
+ * owns the upload endpoint, the bespoke widgets, and the stored value a secret needs to
+ * distinguish "not configured" from "configured but hidden".
  */
 export function SettingField(props: FieldControlProps) {
     switch (props.field.type) {

--- a/application/v2_ui/src/lib/adminFields.ts
+++ b/application/v2_ui/src/lib/adminFields.ts
@@ -12,6 +12,7 @@ import type { Json } from './types';
 export type AdminFieldType =
     | 'text'
     | 'textarea'
+    | 'secret'
     | 'select'
     | 'switch'
     | 'checkbox_set'
@@ -22,15 +23,30 @@ export type AdminFieldType =
     | 'link_list'
     | 'component';
 
+/**
+ * The placeholder the server sends in place of a stored secret.
+ *
+ * Mirrors `ADMIN_SETTINGS_SECRET_REDACTED_VALUE`. A secret field that still holds this
+ * has not been edited, and sending it back is what tells the server to keep the stored
+ * value rather than overwrite the credential with the mask.
+ */
+export const REDACTED_SECRET = '***REDACTED***';
+
 export interface AdminFieldOption {
     value: string;
     label: string;
 }
 
-/** Shows a field only while another field holds a given value. */
+/**
+ * Shows a field only while another field holds a given value.
+ *
+ * `equals` is usually a boolean, gating a field on a capability switch. A string gates
+ * it on a select instead: each Enhanced Citations storage credential applies to one
+ * authentication type only.
+ */
 export interface AdminFieldDependency {
     key: string;
-    equals: boolean;
+    equals: boolean | string;
 }
 
 /**
@@ -71,7 +87,7 @@ export interface AdminField {
     version_key?: string;
     /** Component fields only: which bespoke widget to render. */
     component?: string;
-    depends_on?: AdminFieldDependency;
+    depends_on?: AdminFieldDependency | AdminFieldDependency[];
     requires_acknowledgement?: AdminFieldAcknowledgement;
 }
 
@@ -91,6 +107,14 @@ export interface AdminSettingsResponse {
     admin_nav: import('./types').AdminNavGroup[];
     field_schema: AdminFieldSchema;
     branding_assets: BrandingAssets;
+    /**
+     * `enable_*` keys the fallback scan must not draw.
+     *
+     * Some booleans in the settings document are derived or are staged rollout flags
+     * with no administrator control. A switch for one would appear to save and then
+     * revert, so the server names them and the scan skips them.
+     */
+    suppressed_capabilities: string[];
     version: string;
 }
 
@@ -170,16 +194,33 @@ export function asStringArray(value: unknown): string[] {
     return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : [];
 }
 
-/** Whether a field's `depends_on` condition is currently satisfied. */
+/**
+ * Whether a field's `depends_on` condition is currently satisfied.
+ *
+ * `depends_on` is normally one condition, and may be a list, in which case every
+ * condition must hold. A list is needed wherever a control is gated on a sibling whose
+ * own default would otherwise reveal it -- the Enhanced Citations storage credentials are
+ * chosen by authentication type, but must stay hidden while the capability itself is off.
+ */
 export function isFieldVisible(field: AdminField, settings: Json, draft: Json): boolean {
-    const dependency = field.depends_on;
-    if (!dependency) {
+    if (!field.depends_on) {
         return true;
     }
-    const current = Object.prototype.hasOwnProperty.call(draft, dependency.key)
-        ? draft[dependency.key]
-        : settings[dependency.key];
-    return asBoolean(current) === dependency.equals;
+
+    const conditions = Array.isArray(field.depends_on)
+        ? field.depends_on
+        : [field.depends_on];
+
+    return conditions.every((dependency) => {
+        const current = Object.prototype.hasOwnProperty.call(draft, dependency.key)
+            ? draft[dependency.key]
+            : settings[dependency.key];
+
+        // A string condition compares the select's value; anything else is a switch.
+        return typeof dependency.equals === 'string'
+            ? asString(current) === dependency.equals
+            : asBoolean(current) === dependency.equals;
+    });
 }
 
 /** Turn `enable_document_classification` into `Document classification`. */

--- a/application/v2_ui/src/pages/AdminSettingsPage.tsx
+++ b/application/v2_ui/src/pages/AdminSettingsPage.tsx
@@ -35,8 +35,10 @@ import { AdminModal } from '../components/admin/AdminModal';
 import { AdminMarkdown } from '../components/admin/AdminMarkdown';
 import { BrandingImageField } from '../components/admin/BrandingImageField';
 import { CustomPagesTable } from '../components/admin/CustomPagesTable';
+import { EnhancedCitationsStorageTest } from '../components/admin/EnhancedCitationsStorageTest';
 import { ExternalLinksEditor } from '../components/admin/ExternalLinksEditor';
 import { SaveBar } from '../components/admin/SaveBar';
+import { SecretField } from '../components/admin/SecretField';
 import { SettingField } from '../components/admin/fields';
 import {
     ClassificationBannerPreview,
@@ -92,11 +94,15 @@ const READ_ONLY_REF = (key: string): AdminField => ({ key, type: 'text', label: 
  * belong to them, so keys are matched to the section whose id shares the most leading
  * word stems. Anything with no reasonable match is collected under "Other capabilities"
  * rather than being hidden, because a silently missing toggle is worse than a misfiled one.
+ *
+ * `suppressed` names keys that must not be drawn at all -- derived values and staged
+ * rollout flags, which would render a switch that appears to save and then reverts.
  */
 function buildCapabilityIndex(
     nav: AdminNavGroup[],
     settings: Json,
     declaredKeys: Set<string>,
+    suppressedKeys: Set<string>,
 ): CapabilityRow[] {
     const capabilityKeys = Object.keys(settings)
         .filter(
@@ -105,7 +111,8 @@ function buildCapabilityIndex(
                 typeof settings[key] === 'boolean' &&
                 // A key with a proper field is rendered by the schema path; rendering it
                 // here as well would put two controls on one value.
-                !declaredKeys.has(key),
+                !declaredKeys.has(key) &&
+                !suppressedKeys.has(key),
         )
         .sort();
 
@@ -254,9 +261,22 @@ export function AdminSettingsPage() {
         return keys;
     }, [schema]);
 
+    const suppressedKeys = useMemo(
+        () => new Set(data?.suppressed_capabilities ?? []),
+        [data],
+    );
+
     const capabilityRows = useMemo(
-        () => (data ? buildCapabilityIndex(data.admin_nav, data.settings, declaredKeys) : []),
-        [data, declaredKeys],
+        () =>
+            data
+                ? buildCapabilityIndex(
+                      data.admin_nav,
+                      data.settings,
+                      declaredKeys,
+                      suppressedKeys,
+                  )
+                : [],
+        [data, declaredKeys, suppressedKeys],
     );
 
     /** Every section that has something to show, in navigation order. */
@@ -532,6 +552,23 @@ export function AdminSettingsPage() {
             );
         }
 
+        if (field.type === 'secret') {
+            return (
+                <SecretField
+                    key={key}
+                    field={field}
+                    value={value}
+                    // The saved value, not the draft: only that says whether a credential
+                    // exists, which is what tells an empty box apart from a pending delete.
+                    storedValue={field.key ? settings[field.key] : undefined}
+                    error={error}
+                    warning={warning}
+                    disabled={saving}
+                    onChange={(next) => field.key && setValue(field.key, next)}
+                />
+            );
+        }
+
         if (field.type === 'component') {
             switch (field.component) {
                 case 'custom-pages-table':
@@ -553,6 +590,21 @@ export function AdminSettingsPage() {
                         <UserAgreementPreview
                             key={key}
                             text={readSibling('user_agreement_text')}
+                        />
+                    );
+                case 'enhanced-citations-storage-test':
+                    return (
+                        <EnhancedCitationsStorageTest
+                            key={key}
+                            help={field.help}
+                            authenticationType={readSibling(
+                                'office_docs_authentication_type',
+                                'key',
+                            )}
+                            connectionString={readSibling('office_docs_storage_account_url')}
+                            blobEndpoint={readSibling(
+                                'office_docs_storage_account_blob_endpoint',
+                            )}
                         />
                     );
                 default:

--- a/docs/admin/chat.md
+++ b/docs/admin/chat.md
@@ -34,61 +34,155 @@ These choices affect how users inspect answers and preserve context. Citations a
 
 ### Processing Thoughts {#processing-thoughts-section}
 
-The Processing Thoughts section belongs to the Chat Experience tab. Use it with the adjacent settings in this group so related rollout, access, and operational choices stay aligned.
+Answers that involve searching workspaces, calling an action, or running an agent
+can take a while, and without any indication of progress they look like the
+application has stalled. Processing thoughts shows the steps as they happen —
+which documents were searched, which web queries ran, which agent was called —
+and stores them alongside the message so the same trace can be reopened later
+from the stars icon on any response.
+
+The stored trace is what makes an answer auditable after the fact. Turn this on
+where reviewers need to see how an answer was reached, not just what it said.
+Turn it off where the extra detail is noise, or where the step list would expose
+source names to users who should only see the final answer.
 
 ### Chat File Uploads {#chat-file-uploads-section}
 
-The Chat File Uploads section belongs to the Chat Experience tab. Use it with the adjacent settings in this group so related rollout, access, and operational choices stay aligned.
+Workspaces are the governed path for documents: they are indexed, classified, and
+retained under policy. Chat file uploads are the ungoverned shortcut — a user
+attaches a file to one conversation and asks about it directly, without it
+entering a workspace at all.
+
+That is the right trade-off for a quick one-off question and the wrong one for
+anything that needs to be discoverable or retained. Where uploads should exist
+but not for everyone, the `ChatFileUploadUser` app role narrows them to assigned
+users without turning the capability off. Assign the role in the Enterprise App
+before requiring it, or every user loses the ability to upload at once. Files
+already attached to conversations stay visible either way; the requirement only
+governs new uploads.
 
 ### Conversation Contents Drawer {#conversation-contents-drawer-section}
 
-The Conversation Contents Drawer section belongs to the Chat Experience tab. Use it with the adjacent settings in this group so related rollout, access, and operational choices stay aligned.
+Long conversations are hard to navigate by scrolling, because the thing a user
+wants to return to is usually their own earlier question rather than a specific
+answer. The drawer lists the prompts in a conversation and jumps to the one
+selected.
+
+This is a navigation aid with no effect on what the model sees. Users who do not
+want it can turn it off for their own account in their profile, so enabling it
+sets the default rather than forcing it.
 
 ### Workspace Scope Lock {#workspace-scope-lock-section}
 
-The Workspace Scope Lock section belongs to the Chat Experience tab. Use it with the adjacent settings in this group so related rollout, access, and operational choices stay aligned.
+Once a conversation has searched a workspace, that workspace is where its context
+comes from. Scope lock keeps it there: after the first search, the conversation
+stays bound to the workspaces that produced results, so a later question cannot
+quietly pull in a different data source and mix it with what has already been
+discussed.
+
+Leave this enforced where cross-contamination between data sources is a
+compliance concern. Turn it off to let users deliberately unlock a conversation
+and widen it mid-thread, which is convenient for exploratory work and removes the
+guarantee that a conversation drew on one set of sources.
 
 ### Conversation History {#conversation-history-section}
 
-The Conversation History section belongs to the Chat Experience tab. Use it with the adjacent settings in this group so related rollout, access, and operational choices stay aligned.
+Every request carries some of the conversation back to the model, because the
+model has no memory between calls. The history limit decides how many previous
+messages travel with each request. A higher limit preserves more context and
+costs more tokens on every turn; a lower one is cheaper and starts losing the
+thread of long conversations.
+
+The two summarization options change what happens to the messages that fall
+outside that limit and what the search sees, rather than raising the limit
+itself:
+
+- **Summarizing beyond the limit** replaces dropped messages with a running
+  summary, so older context survives in compressed form instead of disappearing.
+  Use it for long working sessions where the early part of the conversation still
+  matters.
+- **Summarizing for search** rewrites the document-search query using recent
+  turns, so a follow-up like "what about the second one?" still retrieves the
+  right sources. Without it, a query that only makes sense in context retrieves
+  poorly. The message count controls how much recent conversation feeds that
+  summary; twice that many messages are read to produce it.
+
+Both cost an extra model call per affected turn, which is why they are off by
+default.
 
 ### Default System Prompt {#default-system-prompt-section}
 
-The Default System Prompt section belongs to the Chat Experience tab. Use it with the adjacent settings in this group so related rollout, access, and operational choices stay aligned.
+The default system prompt is the instruction applied to conversations that do not
+carry one of their own. It is where organisation-wide expectations belong — tone,
+formatting conventions, what to do when the answer is not known, and any standing
+constraint that should apply whether or not a user picked an agent.
+
+Agents and conversations with their own prompt are unaffected, so this sets the
+floor rather than the ceiling. Leaving it empty is a valid choice, and means
+conversations run on the model's own defaults.
 
 ### Fact Memory {#fact-memory-section}
 
-Fact memory lets the assistant carry durable context between conversations, so users do not have to restate their role, preferences, or working style every time they open a new chat. Two kinds of entries are stored. Instruction memories are durable rules about how to respond, and are applied to every prompt. Fact memories are details about the user, and are recalled only when they are relevant to the current request.
+Fact memory lets the assistant carry durable context between conversations, so
+users do not have to restate their role, preferences, or working style every time
+they open a new chat. Two kinds of entries are stored. Instruction memories are
+durable rules about how to respond, and are applied to every prompt. Fact
+memories are details about the user, and are recalled only when they are relevant
+to the current request.
 
-This is a chat capability. It does not require agents or actions, and it does not depend on the Agents & Actions tab. Once it is on, standard chat recalls memories, users manage their own entries from Profile > Fact Memory, and the assistant saves or removes memories when a user asks it to in conversation.
+This is a chat capability. It does not require agents or actions, and it does not
+depend on the Agents & Actions tab. Once it is on, standard chat recalls memories,
+users manage their own entries from Profile > Fact Memory, and the assistant saves
+or removes memories when a user asks it to in conversation.
 
-Enable it when users repeatedly restate the same context, or when you want response preferences such as tone, format, or naming to persist without a custom agent. Leave it off in environments where per-user retained context is not acceptable. Existing entries are preserved while the setting is off, but they stay inactive and are not used in chat.
+Enable it when users repeatedly restate the same context, or when you want
+response preferences such as tone, format, or naming to persist without a custom
+agent. Leave it off in environments where per-user retained context is not
+acceptable. Existing entries are preserved while the setting is off, but they stay
+inactive and are not used in chat.
 
-Memories are stored per user or per group and are only readable inside that scope. Because they persist, they are not an appropriate place for secrets or regulated data.
+Memories are stored per user or per group and are only readable inside that scope.
+Because they persist, they are not an appropriate place for secrets or regulated
+data.
 
 #### Settings
 
 | Setting | What it does | Default | Notes |
 | --- | --- | --- | --- |
-| Enable Processing Thoughts | Exposes the capability after required services, permissions, and rollout policy are ready. | On | `enable_thoughts`; capability toggle |
-| Conversation History Limit | Defines a capacity or timing boundary that keeps the feature inside supported limits. | 10 | `conversation_history_limit` |
-| Default System Prompt | Defines behavior for the related admin workflow; verify the affected feature after saving. | Empty | `default_system_prompt` |
-| Enable Chat File Uploads | Exposes the capability after required services, permissions, and rollout policy are ready. | On | `enable_chat_file_uploads`; capability toggle |
-| Enable Conversation Contents Drawer | Exposes the capability after required services, permissions, and rollout policy are ready. | On | `enable_conversation_contents_drawer`; capability toggle |
+| Enable Processing Thoughts | Shows the steps taken while answering and stores them for later review. | On | `enable_thoughts`; capability toggle |
+| Conversation History Limit | How many previous messages are carried into each new request. | 10 | `conversation_history_limit` |
+| Summarize Messages Beyond the History Limit | Replaces messages outside the limit with a running summary instead of dropping them. | Off | `enable_summarize_content_history_beyond_conversation_history_limit`; capability toggle |
+| Summarize Conversation History for Search | Summarizes recent turns into the document-search query so context-dependent follow-ups retrieve correctly. | Off | `enable_summarize_content_history_for_search`; capability toggle |
+| Historical Messages to Summarize | How many recent messages feed the search summary. Twice this many are read to build it. | 10 | `number_of_historical_messages_to_summarize` |
+| Default System Prompt | The instruction applied to conversations that do not set their own. | Empty | `default_system_prompt` |
+| Enable Chat File Uploads | Lets users attach files to a conversation without adding them to a workspace. | On | `enable_chat_file_uploads`; capability toggle |
+| Require ChatFileUploadUser App Role | Restricts new chat uploads to holders of the `ChatFileUploadUser` app role. | Off | `require_member_of_chat_file_upload_user` |
+| Enable Conversation Contents Drawer | Adds a drawer listing a conversation's prompts for navigation. | On | `enable_conversation_contents_drawer`; capability toggle |
 | Collaborative conversations | Enables shared conversation records and collaboration endpoints so permitted users can create and participate in collaborative conversations instead of only single-user conversation threads. | On | `enable_collaborative_conversations`; no visible field in `admin_settings.html` |
-| Require ChatFileUploadUser App Role | Requires the `ChatFileUploadUser` app role before users can use this capability or view. | Off | `require_member_of_chat_file_upload_user` |
-| Enforce Workspace Scope Lock | Defines behavior for the related admin workflow; verify the affected feature after saving. | On | `enforce_workspace_scope_lock` |
+| Enforce Workspace Scope Lock | Keeps a conversation bound to the workspaces that produced its first search results. | On | `enforce_workspace_scope_lock` |
 | Enable Fact Memory | Lets standard chat recall a user's saved instruction and fact memories, and lets the assistant save, change, or remove them when the user asks. Works without agents or actions. | Off | `enable_fact_memory_plugin`; capability toggle |
 
 ## Feedback & Alerts {#feedback-alerts}
 
 ### User Feedback {#user-feedback-section}
 
-The User Feedback section belongs to the Feedback & Alerts tab. Use it with the adjacent settings in this group so related rollout, access, and operational choices stay aligned.
+Thumbs up and down controls on AI responses are the cheapest signal available
+about answer quality, because they cost the user one click at the moment they
+have an opinion. Ratings are routed to the feedback review workflow, where
+reviewers can see the conversation that produced them.
+
+Enable this once someone is actually reviewing the results. Collecting ratings
+nobody reads trains users to stop giving them.
 
 ### Desktop Conversation Notifications {#desktop-notifications-section}
 
-The Desktop Conversation Notifications section belongs to the Feedback & Alerts tab. Use it with the adjacent settings in this group so related rollout, access, and operational choices stay aligned.
+Long answers encourage users to switch tabs while they wait, and then forget to
+come back. A desktop notification when a response finishes closes that gap.
+
+Notifications require browser permission, only fire when the SimpleChat tab is
+hidden or unfocused, and stop entirely once the tab is closed. Users can turn
+them off in their profile, so enabling this offers the capability rather than
+imposing it.
 
 #### Settings
 
@@ -102,27 +196,62 @@ The Desktop Conversation Notifications section belongs to the Feedback & Alerts 
 
 ### Standard {#standard-citations-section}
 
-The Standard section belongs to the Citations tab. Use it with the adjacent settings in this group so related rollout, access, and operational choices stay aligned.
+Standard citations are always on, for personal and group workspaces alike, and
+have nothing to configure. When an answer draws on an indexed document, the
+citation exposes the text of the chunk that was used, so a user can read the
+passage behind a claim without leaving the conversation.
+
+This is the baseline everything else builds on: it needs no storage account and
+no extra configuration, because the text is already in the search index.
 
 ### Enhanced {#enhanced-citations-section}
 
-The Enhanced section belongs to the Citations tab. Use it with the adjacent settings in this group so related rollout, access, and operational choices stay aligned.
+Standard citations can only show text that was extracted into the index. Enhanced
+citations keep the original file in an Azure Storage account as well, so a
+citation can open the source document itself — the actual spreadsheet, the actual
+page — rather than a paragraph lifted out of it. That is the difference between
+checking a number and checking it in context.
+
+The cost is an Azure Storage account that SimpleChat must reach, authenticated
+either with a connection string or with the application's managed identity.
+Startup deliberately does not verify that account, so a storage outage cannot
+prevent the application from booting, which also means a wrong credential is not
+reported until a citation fails to open. Use **Test storage connection** after
+changing these values: it confirms the account is reachable and reports any
+expected container that does not yet exist. Missing containers are usually
+harmless, because they are created on demand during upload when permissions
+allow it.
+
+Storage credentials are write-only in the admin interface. A configured value is
+shown as saved and hidden rather than displayed, and can be replaced or cleared
+but not read back.
+
+**Tabular preview and run limits.** Enhanced citations is also what makes CSV and
+XLSX sources previewable, so the limits governing that work live here. The preview
+size cap protects the host from loading a very large spreadsheet into memory to
+render a preview; raise it when the host has memory to spare and lower it on
+smaller instances. The large-run confirmation catches the other failure mode: a
+prompt that implies thousands of rows of work, which is better confirmed than
+started by accident. The row and batch thresholds decide when that confirmation
+appears. Chunk work normally reuses whichever model the user selected; pointing it
+at a dedicated deployment keeps bulk row processing off the interactive model's
+quota.
 
 #### Settings
 
 | Setting | What it does | Default | Notes |
 | --- | --- | --- | --- |
-| Enable Enhanced Citations | Preserves source files for richer citation preview and source-document access in chat answers. | Off | `enable_enhanced_citations`; capability toggle |
+| Enable Enhanced Citations | Stores original files in Azure Storage so citations can open the source document, not just quoted text. | Off | `enable_enhanced_citations`; capability toggle |
 | Enhanced Citations mount path | Enables use of the configured Enhanced Citations mount path for document-view routing when Enhanced Citations is on; the saved value is forced off unless Enhanced Citations is enabled. | Off | `enable_enhanced_citations_mount`; no visible field in `admin_settings.html` |
-| Storage Account Authentication Type | Chooses whether SimpleChat authenticates to this service with a key, managed identity, or another supported method. | key | `office_docs_authentication_type` |
-| Storage Account Connection String | Defines behavior for the related admin workflow; verify the affected feature after saving. | Empty | `office_docs_storage_account_url` |
-| Storage Account Blob Service Endpoint | Provides the endpoint or route SimpleChat uses for this service. | Empty | `office_docs_storage_account_blob_endpoint` |
-| Maximum File Size for Tabular Preview (MB) | Maximum blob size (in MB) allowed for tabular file previews (CSV, XLSX). Files larger than this will not be previewed. Increase for larger files if your compute has sufficient memory, or decrease to protect smaller insta | 200 | `tabular_preview_max_blob_size_mb` |
+| Storage Account Authentication Type | Whether SimpleChat authenticates to the storage account with a connection string or a managed identity. | key | `office_docs_authentication_type` |
+| Storage Account Connection String | Credential used for connection string authentication. Stored write-only. | Empty | `office_docs_storage_account_url` |
+| Storage Account Blob Service Endpoint | Blob endpoint used for managed identity authentication. Stored write-only. | Empty | `office_docs_storage_account_blob_endpoint` |
+| Maximum File Size for Tabular Preview (MB) | CSV and XLSX files above this size are not previewed, which protects the host from loading very large spreadsheets into memory. | 200 | `tabular_preview_max_blob_size_mb` |
 | Confirm very large row-level runs before starting | When a prompt includes an explicit large row count, users are asked to continue or narrow scope before the run starts. | On | `enable_tabular_durable_run_confirmation`; capability toggle |
-| Confirmation Row Threshold | Defines a capacity or timing boundary that keeps the feature inside supported limits. | 500 | `tabular_durable_run_confirmation_threshold_rows` |
-| Confirmation Batch Threshold | Defines a capacity or timing boundary that keeps the feature inside supported limits. | 75 | `tabular_durable_run_confirmation_threshold_batches` |
-| Chunk Processing Model | Selects the deployment SimpleChat sends requests to for this capability. | current | `tabular_generated_output_chunk_model_mode` |
-| Configured Chunk Model Deployment | Selects the deployment SimpleChat sends requests to for this capability. | Empty | `tabular_generated_output_chunk_model_deployment` |
+| Confirmation Row Threshold | Row count at or above which the confirmation is shown. | 500 | `tabular_durable_run_confirmation_threshold_rows` |
+| Confirmation Batch Threshold | Batch count at or above which the confirmation is shown. | 75 | `tabular_durable_run_confirmation_threshold_batches` |
+| Chunk Processing Model | Whether per-chunk work reuses the user's selected model or a deployment set aside for it. | current | `tabular_generated_output_chunk_model_mode` |
+| Configured Chunk Model Deployment | Deployment name used when chunk work runs on its own model. | Empty | `tabular_generated_output_chunk_model_deployment` |
 
 ## Common tasks
 

--- a/docs/explanation/features/V2_ADMIN_CHAT_SETTINGS.md
+++ b/docs/explanation/features/V2_ADMIN_CHAT_SETTINGS.md
@@ -1,0 +1,213 @@
+# V2 Admin Chat Settings
+
+**Implemented in version: 0.261.059**
+
+## Overview
+
+The V2 React admin surface renders its controls from a machine-readable field
+schema in `admin_settings_fields.py`. Sections with no entry fall back to
+scanning the settings document for `enable_*` booleans and guessing which section
+each belongs to. That fallback keeps undescribed groups usable, but it can only
+draw switches.
+
+This describes the **Chat** group in full — eleven sections across three tabs —
+so it renders the same controls the server-rendered admin page does, and moves
+six toggles that the fallback had been filing under Chat back to the groups they
+belong to.
+
+## Dependencies
+
+- `admin_settings_nav.py` — supplies the section ids the schema keys off
+- `admin_settings_secret_utils.py` — masking and resolution for credential fields
+- `route_backend_settings.py` — the connection test endpoint reused by the
+  storage test component
+
+## What the fallback could not render
+
+Before this change the Chat page had three distinct problems.
+
+**Every non-boolean chat setting was invisible.** The scan only sees `enable_*`
+booleans, so these had no control at all:
+
+| Section | Missing |
+| --- | --- |
+| Chat File Uploads | `require_member_of_chat_file_upload_user` — a switch, but not `enable_`-prefixed |
+| Workspace Scope Lock | `enforce_workspace_scope_lock` — same |
+| Conversation History | `conversation_history_limit` |
+| Default System Prompt | `default_system_prompt` |
+| Enhanced Citations | Authentication type, two storage credentials, four numeric limits, chunk model mode and deployment |
+
+**Six toggles from other groups were misfiled into Chat.** The scan matches a key
+to the section sharing the most leading word stems, and takes the first section
+that scores at all:
+
+| Key | Guessed into | Actually belongs to |
+| --- | --- | --- |
+| `enable_audio_file_support` | Chat File Uploads | Knowledge › Audio & Video |
+| `enable_chat_completion_audio_cues` | Chat File Uploads | Knowledge › Audio & Video |
+| `enable_video_file_support` | Chat File Uploads | Knowledge › Audio & Video |
+| `enable_enhanced_extraction` | Enhanced Citations | Knowledge › Document Extraction |
+| `enable_default_embedding_model_plugin` | Default System Prompt | Agents & Actions › Actions |
+| `enable_tabular_processing_plugin` | Processing Thoughts | Nowhere — it is derived |
+
+**Four switches were not editable settings.** `enable_tabular_processing_plugin`
+is the clearest: `is_tabular_processing_enabled()` returns
+`enable_enhanced_citations`, and `get_settings()` rewrites the stored value on
+every read, so toggling it appeared to save and then reverted on the next load.
+
+## Architecture
+
+### Declared sections
+
+| Tab | Section | Fields |
+| --- | --- | --- |
+| Chat Experience | `processing-thoughts-section` | 1 |
+| Chat Experience | `chat-file-uploads-section` | 2 |
+| Chat Experience | `conversation-contents-drawer-section` | 1 |
+| Chat Experience | `workspace-scope-lock-section` | 1 |
+| Chat Experience | `conversation-history-section` | 4 |
+| Chat Experience | `default-system-prompt-section` | 1 |
+| Chat Experience | `fact-memory-section` | 1 |
+| Feedback & Alerts | `user-feedback-section` | 1 |
+| Feedback & Alerts | `desktop-notifications-section` | 1 |
+| Citations | `standard-citations-section` | 0 — explanatory only |
+| Citations | `enhanced-citations-section` | 11 |
+
+Standard Citations is deliberately absent from the schema. Standard citations are
+always on and have nothing to configure, so declaring an empty section would
+imply otherwise. A section with no fields and no guessed rows is skipped.
+
+### The `secret` field type
+
+Enhanced Citations is the first V2 section to render a credential, which required
+a field type that never shows the stored value.
+
+A `secret` renders as a masked input with a reveal toggle and a Clear action, and
+receives the stored value alongside the pending one so it can tell "nothing is
+configured" from "configured but hidden" from "about to be deleted". The server
+sends `***REDACTED***` in place of a populated credential and resolves that same
+sentinel back to the stored value on save, so an untouched field round-trips
+without the secret reaching the browser. The mask is not rendered into the input
+itself — the field is left empty with a placeholder saying a value is saved —
+because putting it there would let a keystroke append to it, and clearing it on
+focus would turn an idle click into a deleted credential. Clearing submits an
+empty string, which is the only way to remove a credential rather than replace it,
+and the control warns and offers Undo before a save acts on it.
+
+Adding this type also closed a pre-existing gap in which the V2 admin API
+returned every stored credential in cleartext. See
+`V2_ADMIN_SETTINGS_SECRET_EXPOSURE_FIX.md`.
+
+### String-valued and multiple dependencies
+
+`depends_on.equals` accepted only a boolean, which is enough to gate a field on a
+capability switch. V1 gates each Enhanced Citations credential on the selected
+authentication type instead — the connection string appears for key
+authentication, the blob endpoint for managed identity. `equals` now also accepts
+a string, compared against the gate field's value.
+
+`depends_on` also accepts a **list** of conditions, all of which must hold. That
+is required because the renderer evaluates each field's conditions on its own
+rather than recursively: a field gated only on a sibling stays visible whenever
+that sibling's *value* matches, even when the sibling is itself hidden. Gating the
+connection string on the authentication type alone left it on screen while
+Enhanced Citations was off, because the authentication type defaults to `key`
+either way. Each field therefore repeats the conditions its gate carries:
+
+```python
+{
+    "key": "office_docs_storage_account_blob_endpoint",
+    "type": "secret",
+    "label": "Storage Account Blob Service Endpoint",
+    "default": "",
+    "depends_on": [
+        {"key": "enable_enhanced_citations", "equals": True},
+        {"key": "office_docs_authentication_type", "equals": "managed_identity"},
+    ],
+}
+```
+
+Two schema tests hold this: a string condition must name a value its gate actually
+offers, and a gated field must repeat every condition its gate carries. The second
+also caught a pre-existing instance of the same bug in the Appearance group, where
+the Latest Features documentation links toggle stayed visible with the Support
+menu switched off.
+
+### Suppressed capabilities
+
+`SUPPRESSED_CAPABILITY_KEYS` names keys the fallback scan must not draw, each
+with a written reason. Declaring them was not an option, because a declared field
+claims there is something to edit.
+
+| Key | Why |
+| --- | --- |
+| `enable_tabular_processing_plugin` | Derived from `enable_enhanced_citations` and rewritten on every read |
+| `enable_enhanced_citations_mount` | No control in either interface; forced off unless Enhanced Citations is on |
+| `enable_mixed_source_chat_search` | Staged rollout flag with no administrator control |
+| `enable_mixed_source_conversation_continuity` | Staged rollout flag gated behind the above |
+
+The list is served on the settings GET as `suppressed_capabilities` and honoured
+by `buildCapabilityIndex`.
+
+### Enhanced Citations storage test
+
+Startup deliberately skips live storage checks so a storage outage cannot block
+application boot, which means a wrong credential is otherwise only discovered
+when a citation fails to open.
+
+The `enhanced-citations-storage-test` component posts to
+`/api/admin/settings/test_connection` with `test_type: enhanced_citations_storage`
+and the values currently on screen. Because the credentials are masked, the draft
+usually holds the sentinel; the endpoint already resolves it through
+`_resolve_admin_settings_test_secrets`, so a stored credential can be validated
+without the browser holding it. The response's status, message, details and
+guidance are rendered inline.
+
+## File structure
+
+| File | Role |
+| --- | --- |
+| `application/single_app/admin_settings_fields.py` | Section declarations, the `secret` type, `SUPPRESSED_CAPABILITY_KEYS` |
+| `application/single_app/admin_settings_secret_utils.py` | Masking and resolution, importable without Azure clients |
+| `application/single_app/route_backend_v2.py` | Serves the schema and suppression list; masks secrets both ways |
+| `application/single_app/templates/admin/_panes/chat-experience.html` | V1 counterpart, including the new summarization controls |
+| `application/v2_ui/src/components/admin/fields.tsx` | Generic field controls |
+| `application/v2_ui/src/components/admin/SecretField.tsx` | Masked credential control |
+| `application/v2_ui/src/components/admin/EnhancedCitationsStorageTest.tsx` | Storage connection test |
+| `application/v2_ui/src/lib/adminFields.ts` | `secret` type, string dependencies, the sentinel |
+| `application/v2_ui/src/pages/AdminSettingsPage.tsx` | Component branch and capability suppression |
+
+## Usage
+
+No configuration is required. Administrators see the controls at
+**Admin Settings › Chat** in the V2 interface, matching the server-rendered page.
+
+To add a Chat setting, declare it in `admin_settings_fields.py` under its section
+id and add the matching control to the V1 pane. The parity test fails if either
+half is missing, so the two interfaces cannot drift apart.
+
+## Testing and validation
+
+| Test | Covers |
+| --- | --- |
+| `test_v2_admin_chat_parity.py` | Panes match navigation; every V1 field is claimed; no invented schema field; select options and number bounds agree; V1 password inputs are declared as secrets |
+| `test_v2_admin_secret_field_handling.py` | Masking, the sentinel round trip, replace, clear, nested secrets, and both endpoint responses |
+| `test_v2_admin_capability_placement.py` | Appearance and Chat receive no guessed rows; relocated keys stay declared; suppressed keys stay suppressed and carry a reason |
+| `test_v2_admin_settings_schema.py` | Field shape, defaults against the application, string dependencies reachable, gated fields inherit their gate's conditions |
+| `test_v2_admin_field_renderer_coverage.py` | Every declared type and component has a renderer branch |
+
+### Known limitations
+
+- The `enable_*` fallback still serves every group that is not yet described.
+  Around 22 rollout and telemetry flags remain under "Other capabilities".
+- Number bounds are compared only where V1 declares them. V1 leaves
+  `conversation_history_limit` unbounded; the schema gives it a floor of 1 so the
+  control cannot produce a negative, and V1's save now clamps to the same floor.
+- The storage test reports reachability and container existence. It does not
+  verify write permission, which is only exercised on a real upload.
+
+## Related
+
+- `docs/admin/chat.md` — administrator-facing settings reference
+- `docs/explanation/fixes/CHAT_HISTORY_SUMMARIZE_SETTINGS_RESET_FIX.md`
+- `docs/explanation/fixes/V2_ADMIN_SETTINGS_SECRET_EXPOSURE_FIX.md`

--- a/docs/explanation/fixes/CHAT_HISTORY_SUMMARIZE_SETTINGS_RESET_FIX.md
+++ b/docs/explanation/fixes/CHAT_HISTORY_SUMMARIZE_SETTINGS_RESET_FIX.md
@@ -1,0 +1,118 @@
+# Chat History Summarize Settings Reset Fix
+
+**Fixed in version: 0.261.059**
+
+## Issue
+
+Three conversation history settings were reset to their defaults every time an
+administrator saved Admin Settings, regardless of what they had been set to:
+
+| Setting | Reset to |
+| --- | --- |
+| `enable_summarize_content_history_for_search` | `False` |
+| `enable_summarize_content_history_beyond_conversation_history_limit` | `False` |
+| `number_of_historical_messages_to_summarize` | `10` |
+
+An administrator who had configured these — the only way to do so was writing
+them directly into the settings document in Cosmos DB — lost the values the next
+time anyone opened Admin Settings and pressed Save, for any unrelated reason.
+Nothing reported the change.
+
+## Root cause
+
+All three settings are read and acted on by `route_backend_chats.py`:
+
+```python
+enable_summarize_content_history_beyond_conversation_history_limit = settings.get(
+    'enable_summarize_content_history_beyond_conversation_history_limit', True)
+enable_summarize_content_history_for_search = settings.get(
+    'enable_summarize_content_history_for_search', False)
+number_of_historical_messages_to_summarize = settings.get(
+    'number_of_historical_messages_to_summarize', 10)
+```
+
+`route_frontend_admin_settings.py` wrote all three on every save:
+
+```python
+'enable_summarize_content_history_for_search': form_data.get('enable_summarize_content_history_for_search') == 'on',
+'enable_summarize_content_history_beyond_conversation_history_limit': form_data.get('enable_summarize_content_history_beyond_conversation_history_limit') == 'on',
+'number_of_historical_messages_to_summarize': int(form_data.get('number_of_historical_messages_to_summarize', 10)),
+```
+
+But no template rendered an input for any of them. An unchecked checkbox is
+simply absent from a form submission, and an absent checkbox is indistinguishable
+from one the user deliberately unticked — so both booleans evaluated to `False`
+on every save. The integer fell back to its literal default for the same reason.
+
+The write path existed; the read path never did. The settings could be stored but
+not kept.
+
+## Fix
+
+**Added the missing controls.** The Conversation History card in
+`templates/admin/_panes/chat-experience.html` gained a "History Summarization"
+group holding all three, so the form now submits what the save handler reads.
+
+**Made the integer parse defensively.** The bare `int()` call raised a
+`ValueError` on an empty submission and ignored the stored value. It now uses the
+same `parse_admin_int` helper the rest of the form uses, falling back to the
+stored setting rather than the literal default, and is clamped to the 1–100 range
+the new input declares:
+
+```python
+'number_of_historical_messages_to_summarize': min(100, max(1, parse_admin_int(
+    form_data.get('number_of_historical_messages_to_summarize'),
+    settings.get('number_of_historical_messages_to_summarize', 10),
+    'number_of_historical_messages_to_summarize',
+    10,
+))),
+```
+
+**Aligned the adjacent history limit.** `conversation_history_limit` in the same
+card used the same fragile `int(form_data.get(...))` pattern, which raised on an
+empty value and accepted zero or negative numbers. It now parses through
+`parse_admin_int` with a floor of 1, matching the bound the V2 schema declares.
+
+**Declared them for the V2 admin surface.** `admin_settings_fields.py` describes
+all four fields under `conversation-history-section`, so both interfaces offer
+the same controls with the same bounds. The message count is gated on the search
+summarization switch, because it has no effect while that is off.
+
+## Files modified
+
+| File | Change |
+| --- | --- |
+| `application/single_app/templates/admin/_panes/chat-experience.html` | Added the three summarization controls to the Conversation History card |
+| `application/single_app/route_frontend_admin_settings.py` | Defensive integer parsing for both history values |
+| `application/single_app/admin_settings_fields.py` | Declared the four Conversation History fields |
+| `application/single_app/config.py` | Version bump to 0.261.059 |
+
+## Validation
+
+`functional_tests/test_v2_admin_chat_parity.py` requires every field name the V1
+chat panes submit to be claimed by the schema, and every schema field in the Chat
+group to map back to a V1 field. Either half of this regression — a control
+removed from V1, or a setting written without a control — fails that test.
+
+`functional_tests/test_admin_settings_field_contract.py` confirms the three new
+field names are registered and that no existing name was lost.
+
+`functional_tests/test_admin_settings_absent_field_preservation.py` generalises
+the bug class: it requires every settings key the save handler reads from the
+form with a literal empty default to be backed by an input that actually exists.
+That check found a second instance in the same handler — see
+`ENHANCED_CITATIONS_STORAGE_KEY_RESET_FIX.md`.
+
+### Before and after
+
+| | Before | After |
+| --- | --- | --- |
+| Control in V1 | None | Conversation History card |
+| Control in V2 | None | Conversation History section |
+| Effect of an unrelated admin save | All three reset | Values preserved |
+| Empty history limit submitted | `ValueError` | Falls back to the stored value |
+
+## Related
+
+- `docs/admin/chat.md` — Conversation History settings reference
+- `docs/explanation/features/V2_ADMIN_CHAT_SETTINGS.md` — the described Chat group

--- a/docs/explanation/fixes/ENHANCED_CITATIONS_STORAGE_KEY_RESET_FIX.md
+++ b/docs/explanation/fixes/ENHANCED_CITATIONS_STORAGE_KEY_RESET_FIX.md
@@ -1,0 +1,115 @@
+# Enhanced Citations Storage Key Reset Fix
+
+**Fixed in version: 0.261.059**
+
+## Issue
+
+Every save of the server-rendered Admin Settings page overwrote three stored
+Azure Storage account keys with an empty string:
+
+- `office_docs_key`
+- `video_files_key`
+- `audio_files_key`
+
+`office_docs_key` is the key used to sign the SAS tokens that grant access to
+Enhanced Citations source files. Once it was blanked, citation file downloads
+returned `500 Internal server error: Storage access not configured` for every
+user, and the only recovery was writing the key back into the settings document
+directly.
+
+The trigger was any admin save, for any unrelated reason.
+
+## Root cause
+
+The save handler wrote all three from form data with a literal empty default:
+
+```python
+'office_docs_key': form_data.get('office_docs_key', '').strip(),
+'video_files_key': form_data.get('video_files_key', '').strip(),
+'audio_files_key': form_data.get('audio_files_key', '').strip(),
+```
+
+No template renders an input named `office_docs_key`, `video_files_key` or
+`audio_files_key`. A repository-wide search finds the names only in the settings
+defaults, these three save lines, the two consumers in `route_frontend_chats.py`,
+and some orphaned `getElementById` calls in `static/js/admin/admin_settings.js`
+whose elements no longer exist.
+
+With no field in the submission, `form_data.get(name, '')` returned `''` every
+time, so the save stored an empty key.
+
+The neighbouring fields in the same block escaped this. `office_docs_storage_account_url`
+and `office_docs_storage_account_blob_endpoint` go through `admin_secret(...)`,
+and `citation.html` does render inputs for them.
+
+Note that `admin_secret` would **not** have fixed these three. It maps the
+`***REDACTED***` sentinel back to the stored value, and an absent field yields
+`''`, not the sentinel — and `''` is a legitimate "clear this credential"
+signal. Preserving the stored value is what is needed when the field is absent.
+
+## Consumers of the blanked key
+
+| Location | Use |
+| --- | --- |
+| `route_frontend_chats.py:1711` | `generate_blob_sas(..., account_key=settings.get("office_docs_key"), ...)` |
+| `route_frontend_chats.py:1870-1874` | Returns HTTP 500 when the key is empty |
+
+## Fix
+
+All three now fall back to the stored setting when the form does not carry the
+field, matching the pattern already used by `tabular_generated_output_chunk_model_deployment`
+a few lines above:
+
+```python
+'office_docs_key': form_data.get('office_docs_key', settings.get('office_docs_key', '')).strip(),
+'video_files_key': form_data.get('video_files_key', settings.get('video_files_key', '')).strip(),
+'audio_files_key': form_data.get('audio_files_key', settings.get('audio_files_key', '')).strip(),
+```
+
+`form_data.get` returns the fallback only when the key is absent from the
+submission, so if an input is added later an explicit empty submission still
+clears the key, which is the expected behaviour for a credential field.
+
+The three keys were also added to `ADMIN_SETTINGS_FORM_SECRET_FIELDS` in the same
+change, so they are masked before any settings document reaches a browser. See
+`V2_ADMIN_SETTINGS_SECRET_EXPOSURE_FIX.md`.
+
+## Files modified
+
+| File | Change |
+| --- | --- |
+| `application/single_app/route_frontend_admin_settings.py` | Stored-value fallback for the three storage account keys |
+| `application/single_app/admin_settings_secret_utils.py` | The three keys added to the mask list |
+| `application/single_app/config.py` | Version bump to 0.261.059 |
+
+## Validation
+
+`functional_tests/test_admin_settings_absent_field_preservation.py` generalises
+the rule rather than pinning these three keys. It parses the save handler for
+every `'key': form_data.get('field', '')` read and requires each `field` to be
+submitted by the composed admin template, so the whole bug class fails the build:
+
+- 66 literal-default form reads are checked; all are backed by a real input.
+- The three storage keys are separately asserted to use the stored fallback.
+- One remaining unbacked read, `web_search_foundry_notes`, is recorded in
+  `KNOWN_UNBACKED_FORM_READS` with a written reason. It belongs to Web Search,
+  nothing renders or reads it, and there is no stored value to lose. The list is
+  itself checked for staleness, so the exemption cannot outlive the setting.
+
+This is the second instance of the same bug class found in this version; the
+first was the conversation history summarize settings. See
+`CHAT_HISTORY_SUMMARIZE_SETTINGS_RESET_FIX.md`.
+
+### Before and after
+
+| | Before | After |
+| --- | --- | --- |
+| `office_docs_key` after any admin save | `''` | Preserved |
+| Enhanced Citations file download after a save | HTTP 500 | Works |
+| Key visible in the settings sent to a browser | Yes | Masked |
+
+## Related
+
+- `docs/explanation/fixes/CHAT_HISTORY_SUMMARIZE_SETTINGS_RESET_FIX.md`
+- `docs/explanation/fixes/V2_ADMIN_SETTINGS_SECRET_EXPOSURE_FIX.md`
+- `docs/admin/chat.md` — Enhanced Citations settings reference

--- a/docs/explanation/fixes/V2_ADMIN_SETTINGS_SECRET_EXPOSURE_FIX.md
+++ b/docs/explanation/fixes/V2_ADMIN_SETTINGS_SECRET_EXPOSURE_FIX.md
@@ -1,0 +1,171 @@
+# V2 Admin Settings Secret Exposure Fix
+
+**Fixed in version: 0.261.059**
+
+## Issue
+
+`GET /api/v2/admin/settings` returned the settings document unchanged. Every
+stored credential in it — Azure OpenAI keys, APIM subscription keys, the Redis
+key, Azure AI Search and Document Intelligence keys, the Speech service key, the
+storage connection strings used by Enhanced Citations, and the Azure AI Foundry
+client secret — was serialized into the JSON response and delivered to the
+administrator's browser in cleartext.
+
+Once there, the values were readable in the network response, in memory, and in
+anything that captured either.
+
+## Root cause
+
+The endpoint documented a deliberate decision not to sanitize:
+
+> Admin settings are not sanitized. Sanitization removes keys, secrets and
+> endpoint configuration, which are exactly the values an administrator is here
+> to manage.
+
+That reasoning is correct, but it applies to `sanitize_settings_for_user()`,
+which strips the keys outright and would leave the admin page unable to show that
+a credential exists at all.
+
+It does not apply to `redact_admin_settings_secrets_for_form()`, which is a
+different mechanism built for exactly this situation. The server-rendered admin
+form has used it for some time:
+
+- On render, every populated secret is replaced with the sentinel
+  `***REDACTED***`. Unset secrets stay empty, so "not configured" remains
+  distinguishable from "configured but hidden".
+- On save, `resolve_admin_settings_secret_value()` turns a submitted sentinel
+  back into the stored value, so an untouched field round-trips without the
+  credential ever leaving the server.
+
+The V2 endpoint implemented neither half. The gap went unnoticed because no V2
+section had rendered a secret yet — describing Enhanced Citations for the Chat
+group is what first put one on the page.
+
+## Fix
+
+**Masked the read.** The GET now returns
+`redact_admin_settings_secrets_for_form(settings)`. The branding assets payload
+is still built from the unmasked document, because it reads image presence and
+version counters rather than secrets.
+
+**Stripped the model endpoint credentials.** Each entry in the `model_endpoints`
+list carries `auth.api_key` and `auth.client_secret`, nested inside a list rather
+than at a fixed settings key, so the key-based mask cannot reach them. The GET now
+runs the list through `sanitize_model_endpoints_for_frontend` first, which
+replaces the credentials with `has_api_key` and `has_client_secret` booleans —
+the same substitution the server-rendered page makes before rendering its
+template.
+
+**Refused writing them back.** Because the browser only ever holds the stripped
+copy, saving it would erase the credentials of every configured endpoint. The V2
+surface has no model endpoint editor, so `model_endpoints` is listed in
+`NON_PATCHABLE_KEYS` and the settings PATCH rejects it with an explanation rather
+than passing it through.
+
+**Masked the storage account keys.** `office_docs_key`, `video_files_key` and
+`audio_files_key` were absent from the mask list on both surfaces.
+`office_docs_key` is used directly as `account_key=` to sign the SAS tokens that
+grant citation file access, so it is a live credential. No form submits any of
+the three, so masking them affects only what is sent out.
+
+**Masked the echo.** The PATCH responds with the keys it saved, and the client
+merges that response into its state. Because a `secret` field resolves the
+sentinel back to the real credential before saving, echoing `normalized`
+unchanged would have handed the browser the exact value the GET now withholds.
+The response is re-masked:
+
+```python
+"settings": redact_admin_settings_secrets_for_form(normalized),
+```
+
+**Extracted the helpers so the schema could use them.** The masking helpers lived
+in `functions_settings.py`, which builds a Cosmos client at import time and
+therefore cannot be imported by `admin_settings_fields.py`. They are pure
+functions, so they moved to a new `admin_settings_secret_utils.py`.
+`functions_settings.py` re-exports all of them, leaving every existing caller
+unchanged.
+
+**Added the `secret` field type.** The schema can now declare a field as a
+credential rather than as text. Its normalizer resolves the sentinel against the
+current settings, so an unedited field keeps its stored value instead of
+overwriting a working credential with the literal string `***REDACTED***`.
+
+## Files modified
+
+| File | Change |
+| --- | --- |
+| `application/single_app/admin_settings_secret_utils.py` | New: the masking and resolution helpers, importable without Azure clients; adds the three storage account keys |
+| `application/single_app/functions_settings.py` | Delegates to the new module and re-exports it |
+| `application/single_app/admin_settings_fields.py` | `secret` field type and its normalizer; `NON_PATCHABLE_KEYS` |
+| `application/single_app/route_backend_v2.py` | Masks the GET response, strips model endpoint credentials, masks the PATCH echo |
+| `application/v2_ui/src/components/admin/SecretField.tsx` | New: masked input, reveal, clear, and the pending-removal warning |
+| `application/v2_ui/src/pages/AdminSettingsPage.tsx` | Passes the stored value to the secret control |
+| `application/single_app/config.py` | Version bump to 0.261.059 |
+
+## Interface behaviour
+
+The control shows a masked input, and its job is to keep three states apart. An
+empty box could otherwise mean "nothing is configured", "something is configured
+and hidden", or "the configured value is about to be deleted" — and deleting a
+working connection string by backspacing, with no visible difference from the
+untouched state, is the outcome that must not happen quietly. The component
+therefore receives the stored value alongside the pending one.
+
+When a credential is stored, the input is left empty and its placeholder says a
+value is saved. The mask itself is never rendered into the input: a keystroke
+would append to it and save `***REDACTED***newvalue` as the credential, and
+clearing it on focus instead would turn an idle click into a deleted secret.
+
+**Clear** submits an empty string, which is the only way to remove a credential
+rather than replace it. Whenever a stored credential has a pending empty value —
+whether from Clear or from erasing what was typed — the control says "The saved
+value will be removed when you save" and offers **Undo**, which restores the
+sentinel and returns the field to untouched.
+
+| State | Input | Says |
+| --- | --- | --- |
+| Not configured | Empty | "Not configured" |
+| Configured, untouched | Empty | "A value is saved and hidden" + Clear |
+| Being replaced | The typed value | — |
+| Pending removal | Empty | "The saved value will be removed when you save" + Undo |
+
+The Enhanced Citations connection test sends whatever the field currently holds,
+including the sentinel. The existing test endpoint already resolves it through
+`_resolve_admin_settings_test_secrets`, so a stored credential can be validated
+without the browser ever seeing it.
+
+## Validation
+
+`functional_tests/test_v2_admin_secret_field_handling.py` covers:
+
+- a populated secret is masked, an unset one is not, and the caller's document is
+  not mutated
+- every field declared as a `secret` is in the masked-key list, so a control that
+  promises to hide a value cannot be pointed at an unmasked key
+- an untouched secret survives a save — the destructive case, where failing to
+  resolve the sentinel would overwrite a working connection string
+- a submitted secret replaces the stored value
+- an empty submission clears it
+- both endpoints mask before responding, and the GET strips model endpoint
+  credentials
+- `model_endpoints` is refused by the PATCH
+- the three storage account keys are masked
+- nested secrets are masked on a deep copy
+- the control can tell untouched from pending removal, and the page supplies the
+  stored value it needs to do so
+
+### Before and after
+
+| | Before | After |
+| --- | --- | --- |
+| GET response | 20 top-level secrets, 1 nested secret, and every model endpoint's API key and client secret in cleartext | All masked or stripped |
+| Storage account keys | Unmasked on both surfaces | Masked |
+| PATCH echo | Resolved secret returned to the browser | Re-masked |
+| PATCH of `model_endpoints` | Would have written the stripped copy, erasing every key | Rejected |
+| Saving an untouched Enhanced Citations section | N/A — no control existed | Stored credential preserved |
+| Erasing a typed credential then saving | N/A | Warns and offers Undo before removing |
+
+## Related
+
+- `docs/admin/chat.md` — Enhanced Citations settings reference
+- `docs/explanation/features/V2_ADMIN_CHAT_SETTINGS.md` — the described Chat group

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -46,7 +46,13 @@ For feature-focused and fix-focused drill-downs by version, see [Features by Ver
 *   **Settings No Longer Linger After Their Feature Is Switched Off**
     *   A setting shown only under certain conditions was checked against one other setting, which was not always enough. The Latest Features documentation links toggle stayed on screen with the Support menu switched off, because the condition it was checked against remained satisfied on its own.
     *   Conditions can now be combined, so a setting disappears with the feature that owns it as well as with the option that selects it.
+    *   The same problem affected three group assignment pickers — group and public workspace file downloads, and group workflows. Turning the capability off left the picker on screen assigning access for a disabled feature.
     *   (Ref: `depends_on`, `isFieldVisible`, `admin_settings_fields.py`)
+
+*   **Workflow Settings Were Declared Twice**
+    *   The Workflow section was registered twice, and only the second registration took effect. The two were not identical, so the first was silently dead — and a reordering would have swapped which one applied, dropping six settings from the page.
+    *   The same duplication had begun to affect chat file uploads, where the second registration was overriding the first and hiding the **Enable Chat File Uploads** switch.
+    *   (Ref: `ADMIN_SETTINGS_FIELDS`, `workflow-settings-section`, `chat-file-uploads-section`)
 
 ### **(v0.261.061)**
 

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,52 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/features) and [Fixes by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/fixes).
 
+### **(v0.261.059)**
+
+#### New Features
+
+*   **Chat Settings Are Fully Editable In The New Admin Interface**
+    *   The new admin interface builds each settings section from a description of what it contains. Chat had no description, so it fell back to scanning for on/off flags — which meant it could draw switches and nothing else. Every chat setting that was not a switch was simply absent: the conversation history limit, the default system prompt, and the whole Enhanced Citations configuration.
+    *   All eleven Chat sections now render the same controls the classic interface does, across Chat Experience, Feedback & Alerts and Citations.
+    *   **Two switches were invisible even though they are switches**, because their setting names do not begin with `enable_`. Workspace Scope Lock and the ChatFileUploadUser role requirement are now both present.
+    *   **Enhanced Citations came across in full**, including the storage authentication type, the storage credentials, the tabular preview size cap, the large-run confirmation thresholds, and the chunk processing model — plus a **Test storage connection** button. Startup deliberately skips storage checks so an outage cannot stop the application booting, which previously meant a wrong credential was only discovered when a citation failed to open.
+    *   (Ref: `admin_settings_fields.py`, `EnhancedCitationsStorageTest.tsx`, `AdminSettingsPage.tsx`, [V2 Admin Chat Settings](features/V2_ADMIN_CHAT_SETTINGS.md))
+
+*   **Conversation History Summarization Can Be Configured**
+    *   Three settings that control what happens to conversation history — summarizing messages that fall outside the history limit, summarizing recent turns into the document-search query, and how many messages that summary reads — have always been acted on by the chat backend but have never had a control anywhere.
+    *   All three are now editable in both the classic and the new admin interface, under Conversation History.
+    *   (Ref: `chat-experience.html`, `conversation-history-section`, [Chat settings](../../admin/chat/))
+
+#### Bug Fixes
+
+*   **Admin Saves No Longer Reset The History Summarization Settings**
+    *   Because the three settings above had no input anywhere, every save of Admin Settings wrote them back as off and 10 — whatever they had been set to. An administrator who configured them directly in the database lost the values the next time anyone saved the page for any unrelated reason.
+    *   Adding the controls fixes this. The conversation history limit and the message count are also parsed defensively now, so an empty value keeps the current setting instead of raising an error or snapping to a default.
+    *   (Ref: `route_frontend_admin_settings.py`, [Chat History Summarize Settings Reset Fix](fixes/CHAT_HISTORY_SUMMARIZE_SETTINGS_RESET_FIX.md))
+
+*   **Enhanced Citations File Downloads No Longer Break After An Admin Save**
+    *   The storage account key used to sign Enhanced Citations file links has no input on the admin page, but the save handler wrote it from the form anyway — so every admin save, for any unrelated reason, replaced it with an empty value and citation downloads started returning a server error.
+    *   The key is now preserved when the form does not carry it, along with the equivalent video and audio storage keys.
+    *   (Ref: `route_frontend_admin_settings.py`, `office_docs_key`, [Enhanced Citations Storage Key Reset Fix](fixes/ENHANCED_CITATIONS_STORAGE_KEY_RESET_FIX.md))
+
+*   **Stored Credentials Are No Longer Sent To The Admin Browser**
+    *   The new admin interface's settings endpoint returned the settings document unchanged, so every stored credential in it — model keys, search and Document Intelligence keys, the Redis key, storage connection strings, and every configured model endpoint's API key and client secret — was delivered to the administrator's browser in cleartext. The classic admin page has always masked these.
+    *   Credentials are now masked the same way in the new interface. A configured value shows as saved and hidden, and can be replaced or cleared but not read back. An untouched field keeps its stored value on save rather than being overwritten by the mask, and erasing one warns before it is removed.
+    *   **Three storage account keys were unmasked on both interfaces.** The key used to sign citation file access links is a live credential and is now masked everywhere.
+    *   (Ref: `admin_settings_secret_utils.py`, `route_backend_v2.py`, `SecretField.tsx`, [V2 Admin Settings Secret Exposure Fix](fixes/V2_ADMIN_SETTINGS_SECRET_EXPOSURE_FIX.md))
+
+#### User Interface Enhancements
+
+*   **Settings From Other Areas No Longer Appear Under Chat**
+    *   Undescribed settings are placed by matching their name against section names, and six landed in the wrong group: audio and video file support and chat completion audio cues (Knowledge > Audio & Video), enhanced extraction (Knowledge > Document Extraction), and the embedding model and tabular processing actions (Agents & Actions). Each now appears where it belongs.
+    *   **Four switches that did nothing have been removed.** Tabular processing is derived from Enhanced Citations rather than stored, so toggling it appeared to save and then reverted; the Enhanced Citations mount and two mixed-source rollout flags have no administrator control at all.
+    *   (Ref: `SUPPRESSED_CAPABILITY_KEYS`, `buildCapabilityIndex`, `test_v2_admin_capability_placement.py`)
+
+*   **Settings No Longer Linger After Their Feature Is Switched Off**
+    *   A setting shown only under certain conditions was checked against one other setting, which was not always enough. The Latest Features documentation links toggle stayed on screen with the Support menu switched off, because the condition it was checked against remained satisfied on its own.
+    *   Conditions can now be combined, so a setting disappears with the feature that owns it as well as with the option that selects it.
+    *   (Ref: `depends_on`, `isFieldVisible`, `admin_settings_fields.py`)
+
 ### **(v0.261.058)**
 
 #### New Features

--- a/functional_tests/test_admin_settings_absent_field_preservation.py
+++ b/functional_tests/test_admin_settings_absent_field_preservation.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+# test_admin_settings_absent_field_preservation.py
+"""
+Functional test that the admin save cannot zero a setting nobody can edit.
+Version: 0.261.059
+Implemented in: 0.261.059
+
+The server-rendered admin page submits one big form and the save handler reads
+every value out of it by name. When a setting is written from ``form_data`` but
+no template renders an input for it, ``form_data.get(name, '')`` returns the
+literal default on every save -- so the stored value is silently overwritten,
+for any unrelated reason, with no error anywhere.
+
+This has bitten twice:
+
+``number_of_historical_messages_to_summarize`` and the two summarize switches
+    Read by ``route_backend_chats.py`` but never rendered, so every save reset
+    them to off and 10. Fixed by adding the controls.
+
+``office_docs_key``, ``video_files_key``, ``audio_files_key``
+    Azure Storage account keys. ``office_docs_key`` is passed straight to
+    ``generate_blob_sas`` as ``account_key=`` for Enhanced Citations file
+    access, and ``route_frontend_chats.py`` returns a 500 when it is empty, so
+    zeroing it breaks citation downloads after the first admin save. There is
+    still no input for these, so they are preserved from the stored settings
+    instead.
+
+The check below is the general one: any settings key the save handler reads from
+the form with a *literal* default must either have an input in the composed
+template, or fall back to the stored value.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent))
+
+from test_support.templates import read_admin_settings_template
+from test_support.versioning import assert_app_version_at_least
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SAVE_HANDLER = REPO_ROOT / "application" / "single_app" / "route_frontend_admin_settings.py"
+
+# `'some_key': form_data.get('some_key', <default>)` -- the shape that silently
+# resets. A default that is anything other than a literal '' or "" is reading a
+# fallback, which is the fix, so only the literal-empty form is matched.
+RESET_SHAPE_RE = re.compile(
+    r"""^\s*['"](?P<key>[a-z0-9_]+)['"]\s*:\s*form_data\.get\(\s*"""
+    r"""['"](?P<field>[a-z0-9_]+)['"]\s*,\s*(?P<default>''|"")\s*\)""",
+    re.MULTILINE,
+)
+
+FIELD_NAME_RE = re.compile(r'\sname="([^"]+)"')
+TEMPLATED = re.compile(r"\{\{|\{%")
+
+# Keys written with a literal '' default whose form field does not exist, with the
+# reason each is recorded rather than fixed. An entry here is a decision, not an
+# oversight, and the staleness check below stops one outliving its setting.
+KNOWN_UNBACKED_FORM_READS = {
+    "web_search_foundry_notes": (
+        "Free-text notes on the Azure AI Foundry web search config. No template or "
+        "script renders it and nothing reads it back, so there is no value to lose. "
+        "Recorded rather than fixed because it belongs to the Web Search settings, "
+        "not the Chat work that added this check."
+    ),
+}
+
+
+def submitted_field_names():
+    """Every literal form field name the composed admin template submits."""
+    markup = read_admin_settings_template()
+    return {
+        name for name in FIELD_NAME_RE.findall(markup) if not TEMPLATED.search(name)
+    }
+
+
+def test_no_setting_is_reset_by_a_form_it_cannot_be_edited_in():
+    """A key read from an input that does not exist is zeroed on every save."""
+    print("Testing that the admin save cannot zero an uneditable setting...")
+
+    assert_app_version_at_least("0.261.059")
+
+    assert SAVE_HANDLER.is_file(), f"Missing the admin save handler: {SAVE_HANDLER}"
+    source = SAVE_HANDLER.read_text(encoding="utf-8")
+
+    rendered = submitted_field_names()
+    assert rendered, "No form field names were found; the extraction likely broke."
+
+    offenders = []
+    checked = 0
+    for match in RESET_SHAPE_RE.finditer(source):
+        key = match.group("key")
+        field = match.group("field")
+        checked += 1
+
+        if field in rendered or field in KNOWN_UNBACKED_FORM_READS:
+            continue
+
+        offenders.append(
+            f"{key}: read from form field {field!r}, which no template renders"
+        )
+
+    assert not offenders, (
+        "These settings are written from a form field that does not exist, so "
+        "form_data.get returns the empty default and every admin save overwrites "
+        "the stored value. Either render an input, or fall back to the stored "
+        "setting as the neighbouring fields do:\n  " + "\n  ".join(sorted(offenders))
+    )
+
+    assert checked, "No form reads were inspected; the extraction likely broke."
+    print(f"  {checked} literal-default form read(s), all backed by a real input.")
+    return True
+
+
+def test_storage_account_keys_fall_back_to_the_stored_value():
+    """These have no input at all, so only a stored fallback preserves them."""
+    print("\nTesting the storage account key fallbacks...")
+
+    source = SAVE_HANDLER.read_text(encoding="utf-8")
+
+    missing = [
+        key
+        for key in ("office_docs_key", "video_files_key", "audio_files_key")
+        if not re.search(
+            rf"""['"]{key}['"]\s*:\s*form_data\.get\(\s*['"]{key}['"]\s*,\s*"""
+            rf"""settings\.get\(\s*['"]{key}['"]""",
+            source,
+        )
+    ]
+
+    assert not missing, (
+        "These storage account keys no longer fall back to the stored value, so "
+        "an admin save zeroes them. office_docs_key is passed to generate_blob_sas "
+        "as account_key= for Enhanced Citations, and an empty value returns a 500 "
+        "on every citation download:\n  " + "\n  ".join(missing)
+    )
+
+    print("  All 3 storage account key(s) preserve the stored value.")
+    return True
+
+
+def test_known_unbacked_reads_are_still_real():
+    """An exemption that outlives its setting hides the next instance of this bug."""
+    print("\nTesting the known unbacked form read list...")
+
+    source = SAVE_HANDLER.read_text(encoding="utf-8")
+    rendered = submitted_field_names()
+
+    problems = []
+    for field, reason in KNOWN_UNBACKED_FORM_READS.items():
+        if f"'{field}'" not in source:
+            problems.append(f"{field}: the save handler no longer reads it")
+        if field in rendered:
+            problems.append(
+                f"{field}: a template now renders it, so the exemption is obsolete"
+            )
+        if not str(reason or "").strip():
+            problems.append(f"{field}: recorded with no reason")
+
+    assert not problems, (
+        "The known unbacked form read list is stale:\n  " + "\n  ".join(problems)
+    )
+
+    print(f"  {len(KNOWN_UNBACKED_FORM_READS)} recorded read(s), all still real.")
+    return True
+
+
+if __name__ == "__main__":
+    tests = [
+        test_no_setting_is_reset_by_a_form_it_cannot_be_edited_in,
+        test_storage_account_keys_fall_back_to_the_stored_value,
+        test_known_unbacked_reads_are_still_real,
+    ]
+
+    results = []
+    for test in tests:
+        try:
+            results.append(bool(test()))
+        except Exception as exc:
+            print(f"FAILED {test.__name__}: {exc}")
+            import traceback
+
+            traceback.print_exc()
+            results.append(False)
+
+    print(f"\nResults: {sum(results)}/{len(results)} tests passed")
+    sys.exit(0 if all(results) else 1)

--- a/functional_tests/test_v2_admin_capability_placement.py
+++ b/functional_tests/test_v2_admin_capability_placement.py
@@ -24,13 +24,17 @@ without opening the page:
   - ``enable_text_plugin`` matched "text" in ``home-page-text-section`` and
     appeared under Appearance > Branding.
 
-Declaring a field is what takes a key out of that scan. This test holds two
+Declaring a field is what takes a key out of that scan. This test holds three
 invariants so the misfiling cannot come back:
 
-  1. The Appearance group is fully described by the schema, so it must receive
-     *no* guessed rows at all. A new undeclared key that lands there fails here,
-     and the fix is to declare it in its real section.
+  1. The Appearance and Chat groups are fully described by the schema, so they
+     must receive *no* guessed rows at all. A new undeclared key that lands in
+     either fails here, and the fix is to declare it in its real section.
   2. The keys that were moved stay declared where they were moved to.
+  3. Keys that are not editable settings at all stay suppressed rather than
+     declared. ``enable_tabular_processing_plugin`` is the clearest case: it is
+     derived from ``enable_enhanced_citations`` and rewritten by ``get_settings``
+     on every read, so a switch would appear to save and then revert.
 """
 
 import re
@@ -51,6 +55,11 @@ RENDERER = REPO_ROOT / "application" / "v2_ui" / "src" / "pages" / "AdminSetting
 
 APPEARANCE_GROUP_ID = "appearance"
 
+# Groups whose sections are described in full by the schema. A guessed row landing
+# in one of these is by definition misfiled, because everything that genuinely
+# belongs there is declared.
+FULLY_DESCRIBED_GROUP_IDS = ("appearance", "chat")
+
 # Where each relocated toggle now lives, and the V1 pane it is mirrored from. The
 # pane is checked too, because a schema field with no server-rendered counterpart
 # would write a setting the rest of the application never reads.
@@ -65,7 +74,24 @@ RELOCATED_CAPABILITIES = {
     "enable_support_menu": ("support-menu-section", "support-menu"),
     "enable_user_workspace": ("personal-workspaces-section", "workspace-types"),
     "enable_text_plugin": ("actions-config", "actions"),
+    # Guessed into the Chat group before the Chat work: "audio", "video" and
+    # "file" all reached chat-file-uploads-section, and "enhanced" reached
+    # enhanced-citations-section.
+    "enable_audio_file_support": ("ai-voice-chat-section", "audio-video"),
+    "enable_chat_completion_audio_cues": ("ai-voice-chat-section", "audio-video"),
+    "enable_video_file_support": ("video-intelligence-section", "audio-video"),
+    "enable_enhanced_extraction": ("document-intelligence-section", "extraction"),
+    "enable_default_embedding_model_plugin": ("actions-config", "actions"),
 }
+
+# Keys the scan must skip entirely, because they are not settings an
+# administrator can change. Declaring one would claim there is something to edit.
+EXPECTED_SUPPRESSED_CAPABILITIES = (
+    "enable_tabular_processing_plugin",
+    "enable_enhanced_citations_mount",
+    "enable_mixed_source_chat_search",
+    "enable_mixed_source_conversation_continuity",
+)
 
 # The rules the ported heuristic depends on. If the renderer stops doing any of
 # these, the port below no longer predicts what an administrator sees.
@@ -76,6 +102,7 @@ RENDERER_INVARIANTS = (
     ("ignores tokens of two characters or fewer", "token.length > 2"),
     ("keeps the first section that scores highest", "score > bestScore"),
     ("skips keys that have a declared field", "!declaredKeys.has(key)"),
+    ("skips keys the server suppresses", "!suppressedKeys.has(key)"),
 )
 
 DEFAULT_SETTING_RE = re.compile(
@@ -147,7 +174,7 @@ def test_ported_heuristic_still_matches_the_renderer():
     """A rewritten renderer would leave this test asserting the wrong thing."""
     print("Testing the ported heuristic against AdminSettingsPage.tsx...")
 
-    assert_app_version_at_least("0.261.047")
+    assert_app_version_at_least("0.261.059")
 
     assert RENDERER.is_file(), f"Missing the V2 admin renderer: {RENDERER}"
     source = RENDERER.read_text(encoding="utf-8")
@@ -169,26 +196,27 @@ def test_ported_heuristic_still_matches_the_renderer():
     return True
 
 
-def test_appearance_group_receives_no_guessed_capabilities():
-    """Appearance is fully described, so anything guessed into it is misfiled."""
-    print("\nTesting that no guessed capability lands in the Appearance group...")
+def test_described_groups_receive_no_guessed_capabilities():
+    """Appearance and Chat are fully described, so anything guessed in is misfiled."""
+    print("\nTesting that no guessed capability lands in a described group...")
 
     declared = fields_module.get_declared_setting_keys()
+    suppressed = set(fields_module.get_suppressed_capability_keys())
     sections = build_sections()
-    appearance_sections = {
-        section["section_id"]
+    described_sections = {
+        section["section_id"]: section["group_label"]
         for section in sections
-        if section["group_id"] == APPEARANCE_GROUP_ID
+        if section["group_id"] in FULLY_DESCRIBED_GROUP_IDS
     }
 
     misfiled = []
     guessed = 0
     for key in read_capability_keys():
-        if key in declared:
+        if key in declared or key in suppressed:
             continue
         guessed += 1
         placement = place_capability(key, sections)
-        if placement and placement["section_id"] in appearance_sections:
+        if placement and placement["section_id"] in described_sections:
             misfiled.append(
                 f"{key} -> {placement['group_label']} > {placement['tab_label']} "
                 f"> {placement['section_id']}"
@@ -196,12 +224,72 @@ def test_appearance_group_receives_no_guessed_capabilities():
 
     assert not misfiled, (
         "These settings have no declared field, so the V2 admin UI guessed a home "
-        "for them and put them in the Appearance group, where they do not belong. "
-        "Declare each one in admin_settings_fields.py under the section it really "
-        "lives in:\n  " + "\n  ".join(misfiled)
+        "for them and put them in a group that is described in full, where they do "
+        "not belong. Declare each one in admin_settings_fields.py under the section "
+        "it really lives in, or suppress it if it is not an editable setting:\n  "
+        + "\n  ".join(misfiled)
     )
 
-    print(f"  {guessed} guessed capability row(s), none of them in Appearance.")
+    print(
+        f"  {guessed} guessed capability row(s), none of them in "
+        f"{', '.join(FULLY_DESCRIBED_GROUP_IDS)}."
+    )
+    return True
+
+
+def test_non_editable_capabilities_are_suppressed_not_declared():
+    """A switch over a derived value appears to save and then reverts."""
+    print("\nTesting the suppressed capability declarations...")
+
+    suppressed = set(fields_module.get_suppressed_capability_keys())
+    declared = fields_module.get_declared_setting_keys()
+
+    problems = []
+    for key in EXPECTED_SUPPRESSED_CAPABILITIES:
+        if key not in suppressed:
+            problems.append(
+                f"{key}: not suppressed, so the fallback scan will draw a switch for it"
+            )
+        if key in declared:
+            problems.append(
+                f"{key}: declared as an editable field, but it is not an editable setting"
+            )
+
+    # Every suppression must carry a written reason, so a key cannot be hidden
+    # from administrators without saying why.
+    unexplained = sorted(
+        key
+        for key, reason in fields_module.SUPPRESSED_CAPABILITY_KEYS.items()
+        if not str(reason or "").strip()
+    )
+    problems.extend(f"{key}: suppressed with no reason recorded" for key in unexplained)
+
+    assert not problems, (
+        "The suppressed capability list is wrong:\n  " + "\n  ".join(problems)
+    )
+
+    print(f"  All {len(EXPECTED_SUPPRESSED_CAPABILITIES)} suppression(s) hold.")
+    return True
+
+
+def test_suppressed_capabilities_are_real_settings_keys():
+    """A suppression for a key that no longer exists hides nothing and misleads."""
+    print("\nTesting that suppressed keys still exist in the settings document...")
+
+    capability_keys = set(read_capability_keys())
+    stale = sorted(
+        key
+        for key in fields_module.SUPPRESSED_CAPABILITY_KEYS
+        if key not in capability_keys
+    )
+
+    assert not stale, (
+        "These keys are suppressed but no longer appear in the settings defaults. "
+        "Remove the suppression so it does not outlive the setting it describes:\n  "
+        + "\n  ".join(stale)
+    )
+
+    print(f"  All {len(fields_module.SUPPRESSED_CAPABILITY_KEYS)} suppressed key(s) exist.")
     return True
 
 
@@ -265,7 +353,9 @@ def test_relocated_capabilities_exist_in_their_v1_panes():
 if __name__ == "__main__":
     tests = [
         test_ported_heuristic_still_matches_the_renderer,
-        test_appearance_group_receives_no_guessed_capabilities,
+        test_described_groups_receive_no_guessed_capabilities,
+        test_non_editable_capabilities_are_suppressed_not_declared,
+        test_suppressed_capabilities_are_real_settings_keys,
         test_relocated_capabilities_are_declared_where_they_belong,
         test_relocated_capabilities_exist_in_their_v1_panes,
     ]

--- a/functional_tests/test_v2_admin_chat_parity.py
+++ b/functional_tests/test_v2_admin_chat_parity.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python3
+# test_v2_admin_chat_parity.py
+"""
+Functional test pinning V1/V2 parity for the Admin Settings Chat group.
+Version: 0.261.059
+Implemented in: 0.261.059
+
+The V2 React admin surface renders from ``admin_settings_fields.py`` rather than
+from the server-rendered panes, so the two descriptions of the same settings can
+drift apart silently: a field added to a V1 pane simply never appears in V2, and
+nothing fails.
+
+Before the Chat group was described, that gap was not hypothetical. The V2
+surface could only discover settings by scanning for ``enable_*`` booleans, so
+every non-boolean chat setting was invisible -- the conversation history limit,
+the default system prompt, and the nine Enhanced Citations controls -- along with
+the two switches whose keys do not start with ``enable_``
+(``enforce_workspace_scope_lock`` and
+``require_member_of_chat_file_upload_user``).
+
+This test closes that gap the way ``test_v2_admin_appearance_parity.py`` closes
+it for Appearance. It reads the three panes that make up the group, collects the
+form field names V1 submits, and requires each one to be claimed by the schema.
+
+It also checks the parts of a field a generic renderer must get right and a
+name-only comparison would miss: select option values and numeric bounds. Bounds
+are compared only where V1 declares them, because V1 leaves several number inputs
+unbounded and inventing a matching absence in the schema would mean shipping a
+control with no floor.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent))
+
+from test_support.app_stubs import import_app_module
+from test_support.nav import ADMIN_NAV
+from test_support.versioning import assert_app_version_at_least
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PANES_DIR = REPO_ROOT / "application" / "single_app" / "templates" / "admin" / "_panes"
+
+# The three tabs that make up the Chat group, and the sections each one
+# contributes. Sourced from ADMIN_NAV, verified against it below.
+CHAT_GROUP_ID = "chat"
+CHAT_PANES = {
+    "chat-experience": (
+        "processing-thoughts-section",
+        "chat-file-uploads-section",
+        "conversation-contents-drawer-section",
+        "workspace-scope-lock-section",
+        "conversation-history-section",
+        "default-system-prompt-section",
+        "fact-memory-section",
+    ),
+    "feedback-alerts": ("user-feedback-section", "desktop-notifications-section"),
+    "citation": ("standard-citations-section", "enhanced-citations-section"),
+}
+
+# Sections in the group that hold no settings at all. Standard Citations is a
+# card of explanatory prose in V1: standard citations are always on and have
+# nothing to configure. Declaring an empty section would imply otherwise.
+SECTIONS_WITHOUT_SETTINGS = {"standard-citations-section"}
+
+FIELD_NAME_RE = re.compile(r'\sname="([^"]+)"')
+JINJA_RE = re.compile(r"\{\{|\{%")
+
+OPTION_RE = re.compile(r'<option value="([^"]*)"')
+SELECT_BLOCK_RE = re.compile(
+    r'<select[^>]*\sname="(?P<name>[^"]+)"(?P<body>.*?)</select>',
+    re.DOTALL,
+)
+NUMBER_BLOCK_RE = re.compile(r'<input[^>]*type="number"(?P<attrs>[^>]*)>', re.DOTALL)
+ATTR_RE = re.compile(r'(\w[\w-]*)="([^"]*)"')
+
+# V1 renders a secret as a password input. The schema must agree, or the V2
+# surface would print a stored connection string in cleartext on the page.
+PASSWORD_BLOCK_RE = re.compile(r'<input[^>]*type="password"(?P<attrs>[^>]*)>', re.DOTALL)
+
+# Markup that V1 comments out is not a live field. The citation pane keeps the
+# video and audio storage cards commented out pending a presentation layer, and
+# treating those as unclaimed V1 fields would demand V2 controls for settings the
+# server-rendered page does not actually show either.
+HTML_COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
+
+fields_module = import_app_module("admin_settings_fields")
+
+
+def read_pane(pane_id):
+    """Return the live markup for one Admin Settings pane, comments removed."""
+    pane_path = PANES_DIR / f"{pane_id}.html"
+    assert pane_path.is_file(), f"Missing Admin Settings pane: {pane_path}"
+    return HTML_COMMENT_RE.sub("", pane_path.read_text(encoding="utf-8"))
+
+
+def collect_pane_field_names(markup):
+    """Return literal form field names submitted by a pane."""
+    return {
+        name
+        for name in FIELD_NAME_RE.findall(markup)
+        if not JINJA_RE.search(name)
+    }
+
+
+def chat_section_ids():
+    """Every section id in the Chat group."""
+    return {section for sections in CHAT_PANES.values() for section in sections}
+
+
+def test_chat_panes_match_navigation():
+    """The panes this test reads must be the ones ADMIN_NAV puts in the group."""
+    print("Testing Chat pane list against ADMIN_NAV...")
+
+    assert_app_version_at_least("0.261.059")
+
+    group = next((g for g in ADMIN_NAV if g["id"] == CHAT_GROUP_ID), None)
+    assert group, "ADMIN_NAV no longer defines a 'chat' group."
+
+    nav_tabs = {tab["id"]: tuple(s["id"] for s in tab["sections"]) for tab in group["tabs"]}
+
+    assert set(nav_tabs) == set(CHAT_PANES), (
+        "The Chat group's tabs changed. Update CHAT_PANES and the schema "
+        f"together.\n  ADMIN_NAV: {sorted(nav_tabs)}\n  test: {sorted(CHAT_PANES)}"
+    )
+
+    for tab_id, section_ids in nav_tabs.items():
+        assert section_ids == CHAT_PANES[tab_id], (
+            f"Sections for the '{tab_id}' tab changed.\n"
+            f"  ADMIN_NAV: {section_ids}\n  test: {CHAT_PANES[tab_id]}"
+        )
+
+    print(f"  {len(nav_tabs)} tab(s) and their sections match ADMIN_NAV.")
+    return True
+
+
+def test_every_v1_field_is_claimed_by_the_schema():
+    """A V1 Chat field with no V2 equivalent is invisible in the new UI."""
+    print("\nTesting that every V1 Chat field is claimed by the schema...")
+
+    claimed = fields_module.get_legacy_field_names()
+    documented = set(fields_module.LEGACY_FIELDS_WITHOUT_V2_EQUIVALENT)
+
+    unclaimed = {}
+    total = 0
+    for pane_id in CHAT_PANES:
+        names = collect_pane_field_names(read_pane(pane_id))
+        total += len(names)
+        missing = sorted(names - claimed - documented)
+        if missing:
+            unclaimed[pane_id] = missing
+
+    assert not unclaimed, (
+        "These fields exist in the server-rendered Chat panes but are not "
+        "described in admin_settings_fields.py, so they cannot appear in the V2 "
+        "admin UI. Add a field definition, record the name in LEGACY_FIELD_NAMES "
+        "if the shapes differ, or document the omission in "
+        "LEGACY_FIELDS_WITHOUT_V2_EQUIVALENT:\n"
+        + "\n".join(f"  {pane}: {', '.join(names)}" for pane, names in unclaimed.items())
+    )
+
+    print(f"  All {total} V1 Chat field(s) are claimed by the schema.")
+    return True
+
+
+def test_schema_does_not_invent_chat_fields():
+    """A schema key with no V1 counterpart would save a setting nothing reads."""
+    print("\nTesting that the schema does not invent Chat fields...")
+
+    v1_names = set()
+    for pane_id in CHAT_PANES:
+        v1_names |= collect_pane_field_names(read_pane(pane_id))
+
+    invented = []
+    for section_id, field in fields_module.iter_fields():
+        if section_id not in chat_section_ids():
+            continue
+        key = field.get("key")
+        if not key:
+            continue
+        legacy = fields_module.LEGACY_FIELD_NAMES.get(key, [key])
+        if not any(name in v1_names for name in legacy):
+            invented.append(f"{section_id}.{key}")
+
+    assert not invented, (
+        "These schema fields have no matching field in the V1 Chat panes, so V2 "
+        "would write settings the rest of the application never reads:\n  "
+        + "\n  ".join(invented)
+    )
+
+    print("  Every Chat schema field maps back to a V1 field.")
+    return True
+
+
+def test_every_chat_section_with_settings_is_described():
+    """An undescribed section falls back to switches, which is what this fixes."""
+    print("\nTesting that every Chat section with settings is described...")
+
+    described = set(fields_module.ADMIN_SETTINGS_FIELDS)
+
+    missing = []
+    for pane_id, section_ids in CHAT_PANES.items():
+        pane_has_fields = bool(collect_pane_field_names(read_pane(pane_id)))
+        for section_id in section_ids:
+            if section_id in SECTIONS_WITHOUT_SETTINGS or section_id in described:
+                continue
+            if pane_has_fields:
+                missing.append(f"{section_id} (from {pane_id}.html)")
+
+    assert not missing, (
+        "These Chat sections have no schema entry, so the V2 surface falls back "
+        "to guessing their settings from enable_* booleans:\n  "
+        + "\n  ".join(missing)
+    )
+
+    empty = sorted(
+        section_id
+        for section_id in SECTIONS_WITHOUT_SETTINGS
+        if section_id in described
+    )
+    assert not empty, (
+        "These sections are recorded as holding no settings but are declared "
+        "anyway. Either V1 gained a control and SECTIONS_WITHOUT_SETTINGS is "
+        "stale, or the declaration is empty and should be removed:\n  "
+        + "\n  ".join(empty)
+    )
+
+    print(f"  All {len(chat_section_ids())} Chat section(s) accounted for.")
+    return True
+
+
+def test_select_options_match_v1():
+    """A select offering different values than V1 would save unreadable state."""
+    print("\nTesting Chat select option values against V1...")
+
+    v1_options = {}
+    for pane_id in CHAT_PANES:
+        for match in SELECT_BLOCK_RE.finditer(read_pane(pane_id)):
+            name = match.group("name")
+            if JINJA_RE.search(name):
+                continue
+            v1_options[name] = OPTION_RE.findall(match.group("body"))
+
+    mismatches = []
+    checked = 0
+    for section_id, field in fields_module.iter_fields():
+        if section_id not in chat_section_ids() or field.get("type") != "select":
+            continue
+        key = field.get("key")
+        if key not in v1_options:
+            continue
+        schema_values = [option["value"] for option in field["options"]]
+        if schema_values != v1_options[key]:
+            mismatches.append(
+                f"{key}: schema {schema_values} != template {v1_options[key]}"
+            )
+        checked += 1
+
+    assert not mismatches, (
+        "These selects offer different values in each interface:\n  "
+        + "\n  ".join(mismatches)
+    )
+
+    assert checked, "No Chat select fields were compared; the extraction likely broke."
+    print(f"  {checked} select(s) offer identical values in both interfaces.")
+    return True
+
+
+def test_number_bounds_match_v1():
+    """A tighter bound in one interface rejects a value the other accepts."""
+    print("\nTesting Chat number bounds against V1...")
+
+    v1_numbers = {}
+    for pane_id in CHAT_PANES:
+        for match in NUMBER_BLOCK_RE.finditer(read_pane(pane_id)):
+            attrs = dict(ATTR_RE.findall(match.group("attrs")))
+            name = attrs.get("name")
+            if not name or JINJA_RE.search(name):
+                continue
+            v1_numbers[name] = attrs
+
+    mismatches = []
+    checked = 0
+    for section_id, field in fields_module.iter_fields():
+        if section_id not in chat_section_ids() or field.get("type") != "number":
+            continue
+        attrs = v1_numbers.get(field.get("key"))
+        if not attrs:
+            continue
+        checked += 1
+        for prop in ("min", "max"):
+            # Only compare a bound V1 actually declares. V1 leaves several number
+            # inputs unbounded; the schema still needs a floor so the control
+            # cannot produce a negative, and that is not a parity failure.
+            if prop not in attrs:
+                continue
+            if str(field.get(prop)) != attrs[prop]:
+                mismatches.append(
+                    f"{field['key']}.{prop}: schema {field.get(prop)} "
+                    f"!= template {attrs[prop]}"
+                )
+
+    assert not mismatches, (
+        "These number controls differ between interfaces:\n  " + "\n  ".join(mismatches)
+    )
+    assert checked, "No Chat number fields were compared; the extraction likely broke."
+    print(f"  {checked} number control(s) agree with the bounds V1 declares.")
+    return True
+
+
+def test_v1_password_fields_are_declared_as_secrets():
+    """A secret declared as text would print a credential onto the page."""
+    print("\nTesting that V1 password fields are declared as secrets...")
+
+    v1_passwords = set()
+    for pane_id in CHAT_PANES:
+        for match in PASSWORD_BLOCK_RE.finditer(read_pane(pane_id)):
+            attrs = dict(ATTR_RE.findall(match.group("attrs")))
+            name = attrs.get("name")
+            if name and not JINJA_RE.search(name):
+                v1_passwords.add(name)
+
+    assert v1_passwords, (
+        "No password inputs were found in the Chat panes; the extraction likely broke."
+    )
+
+    declared_types = {
+        field["key"]: field.get("type")
+        for section_id, field in fields_module.iter_fields()
+        if section_id in chat_section_ids() and field.get("key")
+    }
+
+    wrong = [
+        f"{name}: declared as {declared_types.get(name)!r}, expected 'secret'"
+        for name in sorted(v1_passwords)
+        if declared_types.get(name) != "secret"
+    ]
+
+    assert not wrong, (
+        "V1 masks these fields as password inputs, so the schema must declare "
+        "them as secrets. Any other type renders the stored value in cleartext:\n  "
+        + "\n  ".join(wrong)
+    )
+
+    print(f"  All {len(v1_passwords)} V1 password field(s) are declared as secrets.")
+    return True
+
+
+if __name__ == "__main__":
+    tests = [
+        test_chat_panes_match_navigation,
+        test_every_v1_field_is_claimed_by_the_schema,
+        test_schema_does_not_invent_chat_fields,
+        test_every_chat_section_with_settings_is_described,
+        test_select_options_match_v1,
+        test_number_bounds_match_v1,
+        test_v1_password_fields_are_declared_as_secrets,
+    ]
+
+    results = []
+    for test in tests:
+        try:
+            results.append(bool(test()))
+        except Exception as exc:
+            print(f"FAILED {test.__name__}: {exc}")
+            import traceback
+
+            traceback.print_exc()
+            results.append(False)
+
+    print(f"\nResults: {sum(results)}/{len(results)} tests passed")
+    sys.exit(0 if all(results) else 1)

--- a/functional_tests/test_v2_admin_secret_field_handling.py
+++ b/functional_tests/test_v2_admin_secret_field_handling.py
@@ -1,0 +1,362 @@
+#!/usr/bin/env python3
+# test_v2_admin_secret_field_handling.py
+"""
+Functional test for masking and restoring secrets on the V2 admin settings API.
+Version: 0.261.059
+Implemented in: 0.261.059
+
+Admin Settings is the one surface that edits credentials, so it cannot use
+``sanitize_settings_for_user``, which removes those keys entirely. The
+server-rendered form solved this years ago with a round trip: the stored value
+goes out as ``***REDACTED***``, and a submitted value still equal to that
+sentinel resolves back to the stored value on the way in.
+
+The V2 admin API did neither. ``GET /api/v2/admin/settings`` returned
+``get_settings()`` unchanged, so every stored API key and storage connection
+string was sent to the admin browser in cleartext. Enhanced Citations is the
+first section to put those credentials on the V2 page, which is what made the
+gap actionable.
+
+The round trip is also the part of this that fails destructively. If the sentinel
+is not resolved, saving an untouched Enhanced Citations section overwrites a
+working connection string with the literal string ``***REDACTED***`` and storage
+stops working. These checks cover the three cases that matter -- untouched,
+replaced, cleared -- plus the mask itself and the re-mask on the way back out.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent))
+
+from test_support.app_stubs import import_app_module
+from test_support.versioning import assert_app_version_at_least
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+APP_ROOT = REPO_ROOT / "application" / "single_app"
+ROUTE_MODULE = APP_ROOT / "route_backend_v2.py"
+V2_SRC = REPO_ROOT / "application" / "v2_ui" / "src"
+SECRET_FIELD = V2_SRC / "components" / "admin" / "SecretField.tsx"
+PAGE_MODULE = V2_SRC / "pages" / "AdminSettingsPage.tsx"
+
+secret_utils = import_app_module("admin_settings_secret_utils")
+fields_module = import_app_module("admin_settings_fields")
+
+SENTINEL = secret_utils.ADMIN_SETTINGS_SECRET_REDACTED_VALUE
+REAL_SECRET = "DefaultEndpointsProtocol=https;AccountKey=super-secret-value=="
+
+
+def test_the_mask_hides_configured_secrets_only():
+    """An unset secret must stay empty so "not configured" stays distinguishable."""
+    print("Testing the secret mask...")
+
+    assert_app_version_at_least("0.261.059")
+
+    settings = {
+        "office_docs_storage_account_url": REAL_SECRET,
+        "office_docs_storage_account_blob_endpoint": "",
+        "app_title": "Simple Chat",
+    }
+
+    masked = secret_utils.redact_admin_settings_secrets_for_form(settings)
+
+    assert masked["office_docs_storage_account_url"] == SENTINEL, (
+        "A configured secret was not masked, so the credential would be sent to "
+        f"the browser: {masked['office_docs_storage_account_url']!r}"
+    )
+    assert masked["office_docs_storage_account_blob_endpoint"] == "", (
+        "An unset secret was masked, which would show 'saved and hidden' for a "
+        "credential that was never configured."
+    )
+    assert masked["app_title"] == "Simple Chat", "A non-secret value was altered."
+    assert settings["office_docs_storage_account_url"] == REAL_SECRET, (
+        "Masking mutated the caller's settings document."
+    )
+
+    print(f"  {len(secret_utils.ADMIN_SETTINGS_FORM_SECRET_FIELDS)} secret field(s) declared; masking is value-dependent.")
+    return True
+
+
+def test_every_declared_secret_field_is_a_known_secret():
+    """A secret control over an unmasked key would show the real value."""
+    print("\nTesting declared secret fields against the mask list...")
+
+    declared_secrets = sorted(
+        field["key"]
+        for _section_id, field in fields_module.iter_fields()
+        if field.get("type") == "secret" and field.get("key")
+    )
+    assert declared_secrets, "No secret fields are declared; the extraction likely broke."
+
+    unmasked = [
+        key
+        for key in declared_secrets
+        if key not in secret_utils.ADMIN_SETTINGS_FORM_SECRET_FIELDS
+    ]
+
+    assert not unmasked, (
+        "These fields are declared as secrets but are not in "
+        "ADMIN_SETTINGS_FORM_SECRET_FIELDS, so the GET would send the real value "
+        "to a control that promises it is hidden:\n  " + "\n  ".join(unmasked)
+    )
+
+    print(f"  All {len(declared_secrets)} declared secret(s) are masked on read.")
+    return True
+
+
+def test_an_untouched_secret_keeps_its_stored_value():
+    """The destructive case: saving the mask would overwrite the credential."""
+    print("\nTesting that an untouched secret survives a save...")
+
+    current = {"office_docs_storage_account_url": REAL_SECRET}
+
+    normalized, errors, _warnings = fields_module.normalize_admin_settings_updates(
+        {"office_docs_storage_account_url": SENTINEL}, current
+    )
+
+    assert not errors, f"Unexpected validation errors: {errors}"
+    assert normalized["office_docs_storage_account_url"] == REAL_SECRET, (
+        "Submitting the mask did not resolve back to the stored secret. Saving an "
+        "untouched Enhanced Citations section would replace a working connection "
+        f"string with {normalized['office_docs_storage_account_url']!r}."
+    )
+
+    print("  The sentinel resolves back to the stored secret.")
+    return True
+
+
+def test_a_new_secret_replaces_the_stored_value():
+    """Replacing a credential is the normal case and must not be swallowed."""
+    print("\nTesting that a new secret replaces the stored value...")
+
+    current = {"office_docs_storage_account_url": REAL_SECRET}
+    replacement = "DefaultEndpointsProtocol=https;AccountKey=rotated-value=="
+
+    normalized, errors, _warnings = fields_module.normalize_admin_settings_updates(
+        {"office_docs_storage_account_url": replacement}, current
+    )
+
+    assert not errors, f"Unexpected validation errors: {errors}"
+    assert normalized["office_docs_storage_account_url"] == replacement, (
+        "A submitted secret did not replace the stored value: "
+        f"{normalized['office_docs_storage_account_url']!r}"
+    )
+
+    print("  A submitted secret replaces the stored value.")
+    return True
+
+
+def test_an_empty_secret_clears_the_stored_value():
+    """Clearing must be possible, or a secret could only ever be replaced."""
+    print("\nTesting that an empty secret clears the stored value...")
+
+    current = {"office_docs_storage_account_url": REAL_SECRET}
+
+    normalized, errors, _warnings = fields_module.normalize_admin_settings_updates(
+        {"office_docs_storage_account_url": ""}, current
+    )
+
+    assert not errors, f"Unexpected validation errors: {errors}"
+    assert normalized["office_docs_storage_account_url"] == "", (
+        "An empty submission did not clear the secret, so a credential could be "
+        f"replaced but never removed: {normalized['office_docs_storage_account_url']!r}"
+    )
+
+    print("  An empty submission clears the stored secret.")
+    return True
+
+
+def test_the_settings_endpoints_mask_before_responding():
+    """Both the read and the echo must mask, or the round trip leaks anyway."""
+    print("\nTesting that the V2 settings endpoints mask their responses...")
+
+    assert ROUTE_MODULE.is_file(), f"Missing the V2 route module: {ROUTE_MODULE}"
+    source = ROUTE_MODULE.read_text(encoding="utf-8")
+
+    # The GET must not hand the raw document straight to jsonify.
+    assert re.search(
+        r"safe_settings\s*=\s*redact_admin_settings_secrets_for_form\(settings\)", source
+    ), (
+        "GET /api/v2/admin/settings no longer masks its response. Returning "
+        "get_settings() unchanged sends every stored API key and connection "
+        "string to the admin browser."
+    )
+
+    # Model endpoint credentials are nested inside a list, so the key-based mask
+    # cannot reach them and they need stripping separately.
+    assert re.search(
+        r'safe_settings\["model_endpoints"\]\s*=\s*sanitize_model_endpoints_for_frontend',
+        source,
+    ), (
+        "GET /api/v2/admin/settings no longer strips model endpoint credentials. "
+        "Each entry in model_endpoints carries auth.api_key and auth.client_secret, "
+        "which the key-based mask does not reach."
+    )
+
+    # The PATCH echoes what it saved, and a secret field resolves the mask back
+    # to the real credential before saving, so the echo has to be re-masked.
+    assert re.search(
+        r'"settings":\s*redact_admin_settings_secrets_for_form\(normalized\)', source
+    ), (
+        "PATCH /api/v2/admin/settings no longer masks its echoed settings. A "
+        "resolved secret would be returned to the browser, defeating the mask on "
+        "the GET."
+    )
+
+    print("  Both endpoints mask before responding.")
+    return True
+
+
+def test_model_endpoints_cannot_be_written_through_the_patch():
+    """The browser only ever holds a stripped copy; saving it would erase the keys."""
+    print("\nTesting that model_endpoints is refused by the settings PATCH...")
+
+    stored = [{"id": "one", "auth": {"api_key": REAL_SECRET}}]
+    sanitized = [{"id": "one", "auth": {}, "has_api_key": True}]
+
+    normalized, errors, _warnings = fields_module.normalize_admin_settings_updates(
+        {"model_endpoints": sanitized}, {"model_endpoints": stored}
+    )
+
+    assert "model_endpoints" in errors, (
+        "The settings PATCH accepted model_endpoints. The admin surface is served a "
+        "copy with every api_key and client_secret stripped, so writing it back "
+        "would erase the credentials of every configured endpoint."
+    )
+    assert "model_endpoints" not in normalized, (
+        "model_endpoints was rejected but still made it into the normalized update."
+    )
+
+    print("  model_endpoints is refused with an explanation.")
+    return True
+
+
+def test_storage_account_keys_are_masked():
+    """These sign SAS tokens for citation access and must not reach a browser."""
+    print("\nTesting that storage account keys are masked...")
+
+    storage_keys = ("office_docs_key", "video_files_key", "audio_files_key")
+
+    missing = [
+        key
+        for key in storage_keys
+        if key not in secret_utils.ADMIN_SETTINGS_FORM_SECRET_FIELDS
+    ]
+    assert not missing, (
+        "These storage account keys are not masked, so they are sent to the admin "
+        "browser in cleartext. office_docs_key is used directly as account_key= to "
+        "sign citation SAS tokens:\n  " + "\n  ".join(missing)
+    )
+
+    masked = secret_utils.redact_admin_settings_secrets_for_form(
+        {key: REAL_SECRET for key in storage_keys}
+    )
+    still_visible = [key for key in storage_keys if masked[key] != SENTINEL]
+    assert not still_visible, f"Not masked in practice: {still_visible}"
+
+    print(f"  All {len(storage_keys)} storage account key(s) are masked.")
+    return True
+
+
+def test_nested_secrets_are_masked_too():
+    """The web search client secret lives inside a nested object, not at the top."""
+    print("\nTesting nested secret masking...")
+
+    settings = {
+        "web_search_agent": {
+            "other_settings": {"azure_ai_foundry": {"client_secret": REAL_SECRET}}
+        }
+    }
+
+    masked = secret_utils.redact_admin_settings_secrets_for_form(settings)
+    nested = masked["web_search_agent"]["other_settings"]["azure_ai_foundry"]
+
+    assert nested["client_secret"] == SENTINEL, (
+        f"A nested secret was not masked: {nested['client_secret']!r}"
+    )
+    assert (
+        settings["web_search_agent"]["other_settings"]["azure_ai_foundry"][
+            "client_secret"
+        ]
+        == REAL_SECRET
+    ), "Masking mutated the caller's nested settings."
+
+    print("  Nested secrets are masked on a deep copy.")
+    return True
+
+
+def test_the_control_distinguishes_untouched_from_pending_delete():
+    """An empty box must not mean both "hidden" and "about to be deleted"."""
+    print("\nTesting the secret control's pending-delete state...")
+
+    assert SECRET_FIELD.is_file(), f"Missing the secret control: {SECRET_FIELD}"
+    source = SECRET_FIELD.read_text(encoding="utf-8")
+
+    required = (
+        (
+            "reads the stored value, not just the draft",
+            "storedValue",
+        ),
+        (
+            "detects a pending removal",
+            "willBeRemoved",
+        ),
+        (
+            "warns before a save removes a credential",
+            "will be removed when you save",
+        ),
+        (
+            "offers a way back to the untouched state",
+            "onChange(REDACTED_SECRET)",
+        ),
+    )
+
+    missing = [description for description, fragment in required if fragment not in source]
+
+    assert not missing, (
+        "The secret control can no longer tell an untouched credential from one that "
+        "is about to be deleted. Erasing a typed value leaves an empty box identical "
+        "to the untouched state, and the next save silently destroys a working "
+        "credential:\n  " + "\n  ".join(missing)
+    )
+
+    # The page must supply the stored value, or the control cannot make the call.
+    page = PAGE_MODULE.read_text(encoding="utf-8")
+    assert re.search(r"storedValue=\{field\.key \? settings\[field\.key\]", page), (
+        "AdminSettingsPage no longer passes the stored value to SecretField, so the "
+        "control cannot tell a configured credential from an unconfigured one."
+    )
+
+    print("  Untouched, replacing and pending-delete are distinguishable.")
+    return True
+
+
+if __name__ == "__main__":
+    tests = [
+        test_the_mask_hides_configured_secrets_only,
+        test_every_declared_secret_field_is_a_known_secret,
+        test_an_untouched_secret_keeps_its_stored_value,
+        test_a_new_secret_replaces_the_stored_value,
+        test_an_empty_secret_clears_the_stored_value,
+        test_the_settings_endpoints_mask_before_responding,
+        test_model_endpoints_cannot_be_written_through_the_patch,
+        test_storage_account_keys_are_masked,
+        test_nested_secrets_are_masked_too,
+        test_the_control_distinguishes_untouched_from_pending_delete,
+    ]
+
+    results = []
+    for test in tests:
+        try:
+            results.append(bool(test()))
+        except Exception as exc:
+            print(f"FAILED {test.__name__}: {exc}")
+            import traceback
+
+            traceback.print_exc()
+            results.append(False)
+
+    print(f"\nResults: {sum(results)}/{len(results)} tests passed")
+    sys.exit(0 if all(results) else 1)

--- a/functional_tests/test_v2_admin_settings_schema.py
+++ b/functional_tests/test_v2_admin_settings_schema.py
@@ -50,6 +50,7 @@ REQUIRED_PROPERTIES_BY_TYPE = {
     "color": ("default",),
     "text": ("default",),
     "textarea": ("default",),
+    "secret": ("default",),
     "switch": ("default",),
     "link_list": ("item_fields", "default"),
     "image": ("upload_target", "accept", "version_key"),
@@ -60,6 +61,7 @@ EXPECTED_DEFAULT_TYPES = {
     "switch": bool,
     "text": str,
     "textarea": str,
+    "secret": str,
     "select": str,
     "color": str,
     "range": int,
@@ -200,25 +202,143 @@ def test_dependencies_reference_real_fields():
     checked = 0
 
     for section_id, field in fields_module.iter_fields():
-        depends_on = field.get("depends_on")
-        if not depends_on:
-            continue
-        checked += 1
         identity = f"{section_id}.{field.get('key') or field.get('component')}"
+        for depends_on in fields_module.iter_field_dependencies(field):
+            checked += 1
 
-        if "key" not in depends_on:
-            problems.append(f"{identity}: depends_on has no key")
-            continue
-        if depends_on["key"] not in declared:
-            problems.append(f"{identity}: depends on undeclared key {depends_on['key']!r}")
-        if field.get("key") == depends_on["key"]:
-            problems.append(f"{identity}: depends on itself")
+            if "key" not in depends_on:
+                problems.append(f"{identity}: depends_on has no key")
+                continue
+            if depends_on["key"] not in declared:
+                problems.append(
+                    f"{identity}: depends on undeclared key {depends_on['key']!r}"
+                )
+            if field.get("key") == depends_on["key"]:
+                problems.append(f"{identity}: depends on itself")
 
     assert not problems, (
         "These visibility dependencies are broken:\n  " + "\n  ".join(problems)
     )
 
     print(f"  All {checked} dependency reference(s) resolve to declared fields.")
+    return True
+
+
+def test_string_dependencies_name_an_offered_option():
+    """A string condition that no option produces would hide the field forever."""
+    print("\nTesting string visibility dependencies against their select options...")
+
+    fields_by_key = {
+        field["key"]: field
+        for _section_id, field in fields_module.iter_fields()
+        if field.get("key")
+    }
+
+    problems = []
+    checked = 0
+    for section_id, field in fields_module.iter_fields():
+        identity = f"{section_id}.{field.get('key') or field.get('component')}"
+        for depends_on in fields_module.iter_field_dependencies(field):
+            expected = depends_on.get("equals")
+            if not isinstance(expected, str):
+                continue
+
+            checked += 1
+            gate = fields_by_key.get(depends_on.get("key"))
+
+            if gate is None:
+                problems.append(f"{identity}: gate field is not declared")
+                continue
+            if gate.get("type") != "select":
+                problems.append(
+                    f"{identity}: gate {gate['key']!r} is a {gate.get('type')!r}, but a "
+                    "string condition only makes sense against a select"
+                )
+                continue
+
+            values = [option["value"] for option in gate.get("options", [])]
+            if expected not in values:
+                problems.append(
+                    f"{identity}: waits for {gate['key']}=={expected!r}, which is not "
+                    f"one of {values}"
+                )
+
+    assert not problems, (
+        "These string dependencies can never be satisfied, so the field would "
+        "never render:\n  " + "\n  ".join(problems)
+    )
+
+    assert checked, (
+        "No string dependencies were compared; the Enhanced Citations storage "
+        "credentials should each be gated on an authentication type."
+    )
+    print(f"  All {checked} string dependency condition(s) are reachable.")
+    return True
+
+
+def test_gated_fields_inherit_their_gate_s_own_conditions():
+    """The renderer evaluates each field's conditions alone, not recursively.
+
+    So a field gated on a sibling is visible whenever that sibling's *value* matches,
+    even when the sibling is itself hidden. Gating the Enhanced Citations connection
+    string on the authentication type alone left it on screen while Enhanced Citations
+    was off, because the authentication type defaults to ``key`` whether the capability
+    is on or not -- offering a credential field for a disabled feature.
+
+    A field must therefore repeat every condition its gate carries.
+    """
+    print("\nTesting that gated fields inherit their gate's conditions...")
+
+    fields_by_key = {
+        field["key"]: field
+        for _section_id, field in fields_module.iter_fields()
+        if field.get("key")
+    }
+
+    def condition_set(field, seen=None):
+        """Every (key, equals) a field declares, plus everything its gates declare."""
+        seen = seen if seen is not None else set()
+        for condition in fields_module.iter_field_dependencies(field):
+            key = condition.get("key")
+            entry = (key, condition.get("equals", True))
+            if entry in seen:
+                continue
+            seen.add(entry)
+            parent = fields_by_key.get(key)
+            if parent is not None:
+                condition_set(parent, seen)
+        return seen
+
+    problems = []
+    checked = 0
+    for section_id, field in fields_module.iter_fields():
+        own = {
+            (condition.get("key"), condition.get("equals", True))
+            for condition in fields_module.iter_field_dependencies(field)
+        }
+        if not own:
+            continue
+
+        checked += 1
+        inherited = condition_set(field)
+        missing = sorted(
+            f"{key}=={value!r}" for key, value in inherited - own
+        )
+        if missing:
+            problems.append(
+                f"{section_id}.{field.get('key') or field.get('component')}: also needs "
+                + ", ".join(missing)
+            )
+
+    assert not problems, (
+        "These fields are gated on another field that is itself gated, but do not "
+        "repeat its conditions. Because visibility is evaluated per field rather than "
+        "recursively, they stay on screen when their gate is hidden:\n  "
+        + "\n  ".join(problems)
+    )
+
+    assert checked, "No gated fields were compared; the extraction likely broke."
+    print(f"  All {checked} gated field(s) carry their gate's conditions.")
     return True
 
 
@@ -308,6 +428,8 @@ if __name__ == "__main__":
         test_select_defaults_are_offered_as_options,
         test_setting_keys_are_unique,
         test_dependencies_reference_real_fields,
+        test_string_dependencies_name_an_offered_option,
+        test_gated_fields_inherit_their_gate_s_own_conditions,
         test_option_values_are_unique_within_a_field,
         test_declared_defaults_match_the_application,
     ]


### PR DESCRIPTION
## Why

The V2 admin surface renders each section from `admin_settings_fields.py`. **Chat had no entry**, so it fell back to scanning the settings document for `enable_*` booleans and matching each to a nav section by shared word stems — which can only draw switches.

Three things followed from that:

**Every non-boolean chat setting was invisible.**

| Section | Missing |
|---|---|
| Chat File Uploads | `require_member_of_chat_file_upload_user` — a switch, but not `enable_`-prefixed |
| Workspace Scope Lock | `enforce_workspace_scope_lock` — same |
| Conversation History | `conversation_history_limit` |
| Default System Prompt | `default_system_prompt` |
| Enhanced Citations | all 9 controls |

**Six toggles from other groups were misfiled into Chat.** Measured by porting `buildCapabilityIndex` and running it against the real navigation:

| Key | Guessed into | Actually lives in |
|---|---|---|
| `enable_audio_file_support` | Chat File Uploads | Knowledge › Audio & Video |
| `enable_chat_completion_audio_cues` | Chat File Uploads | Knowledge › Audio & Video |
| `enable_video_file_support` | Chat File Uploads | Knowledge › Audio & Video |
| `enable_enhanced_extraction` | Enhanced Citations | Knowledge › Document Extraction |
| `enable_default_embedding_model_plugin` | Default System Prompt | Agents & Actions › Actions |
| `enable_tabular_processing_plugin` | Processing Thoughts | nowhere — it is derived |

**Four switches were not editable settings.** `is_tabular_processing_enabled()` returns `enable_enhanced_citations`, and `get_settings()` rewrites the stored value on every read, so toggling that switch appeared to save and then reverted on the next load.

## What changed

All eleven Chat sections are described and render the same controls the server-rendered page does. Standard Citations stays undeclared — its V1 card is explanatory prose and holds no settings.

Enhanced Citations came across in full, including the tabular preview and large-run sub-cards V1 nests inside it, plus a **Test storage connection** widget. Startup deliberately skips storage checks so an outage cannot block boot, which also meant a wrong credential was only discovered when a citation failed to open.

The six misfiled toggles are declared where they belong. The four non-editable ones are listed in `SUPPRESSED_CAPABILITY_KEYS` with a written reason each and skipped by the scan — declaring them would claim there is something to edit.

### Two schema capabilities this needed

**A `secret` field type.** Enhanced Citations is the first V2 section to render a credential. The server sends `***REDACTED***` and resolves that same sentinel back on save, so an untouched field round-trips without the credential reaching the browser.

**Combinable and string-valued `depends_on`.** V1 selects each storage credential by authentication type, which needs a string condition. Conditions also have to combine, because visibility is evaluated per field rather than recursively — gating the connection string on the authentication type alone left it on screen while Enhanced Citations was off, since that type defaults to `key` either way. The check added for this also caught a pre-existing instance in Appearance, where the Latest Features documentation links toggle stayed visible with the Support menu off.

## Three bugs fixed

**1 · Admin saves reset the conversation history summarize settings.** `route_backend_chats.py` reads all three, but no interface ever rendered an input, so `form_data.get(...)` returned its literal default and every save wrote them back as off and 10. An administrator who set them directly in Cosmos lost the values the next time anyone touched Admin Settings. Controls added to both interfaces; both history integers now parse through `parse_admin_int` with the stored value as fallback.

**2 · The V2 admin API sent stored credentials to the browser in cleartext.** `GET /api/v2/admin/settings` returned `get_settings()` unchanged. Now masked the way the server-rendered form already does. Model endpoint API keys and client secrets are nested inside a list where the key-based mask cannot reach them, so they are stripped separately; the PATCH echo is re-masked, since a secret field resolves the sentinel to the real credential just before saving; and `model_endpoints` is refused on the PATCH, because the browser only ever holds the stripped copy and writing it back would erase every key. Three storage account keys absent from the mask list on **both** interfaces were added.

**3 · Admin saves wiped the Enhanced Citations storage account key.** `office_docs_key` signs the SAS tokens for citation file access and has no input anywhere, so every save blanked it and downloads returned a 500. Preserved from stored settings, along with the video and audio keys.

## Notes for review

- The masking helpers moved to a new `admin_settings_secret_utils.py` because `admin_settings_fields.py` needs them and `functions_settings.py` builds a Cosmos client at import time. `functions_settings.py` re-exports everything, so no caller changes.
- `SecretField` deliberately never puts the mask in the input — a keystroke would append to it and save `***REDACTED***newvalue`. It also distinguishes *not configured* / *configured but hidden* / *about to be deleted*, so erasing a credential warns and offers Undo rather than deleting silently.
- The `enable_*` fallback still serves every group that is not yet described; this change describes Chat only.

## Validation

19/20 admin suites pass. The one failure (`test_admin_settings_safe_int_fallback_fix.py`) hardcodes `VERSION = "0.240.002"` and fails identically on the base commit, as do `test_admin_settings_sidebar_card_parity.py`, `test_admin_settings_group_shared_regions.py` and `test_admin_multi_endpoint_persistence_guard.py` — all verified pre-existing by stashing.

V2 typechecks (`tsc -b --noEmit`) and builds clean.

New tests:

| Test | Covers |
|---|---|
| `test_v2_admin_chat_parity.py` | Every V1 chat field is claimed; no invented schema field; select options, number bounds and password inputs agree |
| `test_v2_admin_secret_field_handling.py` | The mask; untouched / replace / clear round trips; both endpoint responses; the control's pending-delete state |
| `test_admin_settings_absent_field_preservation.py` | Generalises the reset bug class — every literal-default form read must be backed by an input that exists |

Extended: `test_v2_admin_capability_placement.py` now requires Chat, like Appearance, to receive **zero** guessed rows; `test_v2_admin_settings_schema.py` gains checks that string conditions are reachable and that a gated field repeats its gate's conditions.

Version bumped to `0.261.059`. Docs: `docs/admin/chat.md` rewritten (ten boilerplate section stubs replaced with real prose), one feature doc, three fix docs, release notes.