### PR TITLE
Declare the Agents & Actions group in the V2 admin settings schema

### DIFF
--- a/application/single_app/admin_settings_fields.py
+++ b/application/single_app/admin_settings_fields.py
@@ -30,11 +30,12 @@ Two things keep this honest rather than becoming a third source of truth:
     to the same normalizers the server-rendered form uses. Both interfaces
     therefore agree on what a valid value is.
 
-Only the Appearance group is described in full so far. Sections with no entry
-here fall back to the V2 surface's ``enable_*`` scan, so undescribed groups keep
-working exactly as they did. A handful of individual fields outside Appearance
-are also declared: that scan places a key by guessing from shared word stems,
-and declaring a field is the only way to stop it guessing wrong.
+Only the Appearance and Agents & Actions groups are described in full so far.
+Sections with no entry here fall back to the V2 surface's ``enable_*`` scan, so
+undescribed groups keep working exactly as they did. A handful of individual
+fields outside those groups are also declared: that scan places a key by guessing
+from shared word stems, and declaring a field is the only way to stop it guessing
+wrong.
 """
 
 import re
@@ -80,6 +81,10 @@ NON_PATCHABLE_TYPES = ("image", "component")
 
 LANDING_PAGE_ALIGNMENTS = ("left", "center", "right")
 USER_AGREEMENT_APPLY_TO_VALUES = ("personal", "group", "public", "chat")
+
+# Mirrors AGENTS_PAGE_PROMOTED_POPULAR_ORDER_OPTIONS in functions_settings.py.
+AGENTS_PAGE_PROMOTED_POPULAR_ORDERS = ("before", "after", "mixed")
+AGENTS_PAGE_HERO_COLOR_MODES = ("single", "two_tone")
 
 LOGO_SCALE_MIN_PERCENT = 50
 LOGO_SCALE_MAX_PERCENT = 500
@@ -620,6 +625,297 @@ ADMIN_SETTINGS_FIELDS = {
             "default": True,
         },
     ],
+    # --- Agents & Actions -------------------------------------------------
+    #
+    # The V1 pane renders the whole Agents tab as one card with several nested
+    # cards inside it. The fields below are filed under those nested card ids,
+    # which ``ADMIN_NAV`` now names as sections, so the V2 surface can separate
+    # the runtime gate from the workspace permissions and the Agents page copy
+    # without the server-rendered page changing at all.
+    "agents-config": [
+        {
+            "key": "enable_semantic_kernel",
+            "type": "switch",
+            "label": "Enable Agents",
+            "help": (
+                "Runs the Semantic Kernel agent runtime. Everything else in this "
+                "group depends on it: the Agents catalog page, the global agent "
+                "and action tables, and every workspace permission are all "
+                "unavailable while it is off."
+            ),
+            "default": False,
+        },
+        {
+            "key": "per_user_semantic_kernel",
+            "type": "switch",
+            "label": "Workspace Mode",
+            "help": (
+                "Decides where agents and actions come from. Off means everyone "
+                "shares one global set and an administrator picks the single agent "
+                "that answers. On means each user and group keeps their own "
+                "collection, and the workspace permissions become available."
+            ),
+            "default": False,
+            "depends_on": {"key": "enable_semantic_kernel", "equals": True},
+        },
+        {
+            "key": "merge_global_semantic_kernel_with_workspace",
+            "type": "switch",
+            "label": "Add Global Agents and Actions to Workspaces",
+            "help": (
+                "Folds the global set into every workspace collection, so people "
+                "see both what they built and what the organisation publishes. "
+                "Without this, turning on Workspace Mode hides the global set."
+            ),
+            "default": False,
+            "depends_on": [
+                {"key": "enable_semantic_kernel", "equals": True},
+                {"key": "per_user_semantic_kernel", "equals": True},
+            ],
+        },
+        {
+            # Reads and writes through /api/orchestration_settings rather than the
+            # settings PATCH, and draws nothing while the deployment offers a
+            # single orchestration type, which is the case today.
+            "type": "component",
+            "component": "agent-orchestration",
+            "label": "Agent Orchestration",
+            "help": (
+                "How a chat is routed across agents. Only appears when this "
+                "deployment offers more than one orchestration type."
+            ),
+            "depends_on": {"key": "enable_semantic_kernel", "equals": True},
+        },
+    ],
+    # Rendered by V1 only while Workspace Mode is on, which ``ADMIN_NAV`` now
+    # states as a section condition, so V2 hides the section on the same terms.
+    "agent-toggles-card": [
+        {
+            "key": "allow_user_agents",
+            "type": "switch",
+            "label": "Allow Personal Agents",
+            "help": (
+                "People can build and keep agents in their own workspace. Use a "
+                "personal agent governance policy when only some of them should."
+            ),
+            "default": False,
+        },
+        {
+            "key": "allow_group_agents",
+            "type": "switch",
+            "label": "Allow Group Agents",
+            "help": (
+                "Groups can own agents their members share. Group workspaces must "
+                "also be enabled under Workspaces, or the agents stay invisible."
+            ),
+            "default": False,
+        },
+        {
+            "key": "allow_user_custom_endpoints",
+            "type": "switch",
+            "label": "Allow Personal Custom Endpoints",
+            "help": (
+                "People can point their own agents at a model endpoint they "
+                "configure themselves instead of the deployment's shared models. "
+                "This lets model traffic leave the endpoints you administer."
+            ),
+            "default": False,
+        },
+        {
+            "key": "allow_group_custom_endpoints",
+            "type": "switch",
+            "label": "Allow Group Custom Endpoints",
+            "help": (
+                "The same for group-owned agents. Group workspaces must also be "
+                "enabled under Workspaces."
+            ),
+            "default": False,
+        },
+        {
+            "key": "enable_agent_template_gallery",
+            "type": "switch",
+            "label": "Enable Agent Template Gallery",
+            "help": (
+                "Gives workspace users a gallery of approved agents to start from "
+                "rather than a blank editor, and adds the Agent Template Approvals "
+                "section below."
+            ),
+            "default": True,
+        },
+    ],
+    # Customises the /agents catalog page. That page carries
+    # @enabled_required('enable_semantic_kernel'), so none of this copy is
+    # reachable while agents are off -- which is why every field depends on it.
+    "agents-page-customization-card": [
+        {
+            "key": "agents_page_title",
+            "type": "text",
+            "label": "Hero Title",
+            "help": "Headline at the top of the Agents catalog page.",
+            "default": "Find your next AI partner",
+            "max_length": 120,
+            "fallback_when_empty": True,
+            "group": "Hero",
+            "depends_on": {"key": "enable_semantic_kernel", "equals": True},
+        },
+        {
+            "key": "agents_page_subtitle",
+            "type": "text",
+            "label": "Hero Subtitle",
+            "help": "Supporting line under the headline.",
+            "default": "Explore specialized agents built to accelerate how you work.",
+            "max_length": 240,
+            "fallback_when_empty": True,
+            "group": "Hero",
+            "depends_on": {"key": "enable_semantic_kernel", "equals": True},
+        },
+        {
+            "key": "agents_page_hero_color_mode",
+            "type": "select",
+            "label": "Hero Color Mode",
+            "help": "A flat colour, or a gradient between the two colours below.",
+            "default": "single",
+            "options": [
+                {"value": "single", "label": "Single color"},
+                {"value": "two_tone", "label": "Two tone gradient"},
+            ],
+            "group": "Hero",
+            "depends_on": {"key": "enable_semantic_kernel", "equals": True},
+        },
+        {
+            "key": "agents_page_hero_primary_color",
+            "type": "color",
+            "label": "Primary Color",
+            "help": "Hero background, and the first stop of the gradient.",
+            "default": "#0f172a",
+            "group": "Hero",
+            "depends_on": {"key": "enable_semantic_kernel", "equals": True},
+        },
+        {
+            "key": "agents_page_hero_secondary_color",
+            "type": "color",
+            "label": "Secondary Color",
+            "help": "Second stop of the gradient.",
+            "default": "#1e293b",
+            "group": "Hero",
+            "depends_on": [
+                {"key": "enable_semantic_kernel", "equals": True},
+                {"key": "agents_page_hero_color_mode", "equals": "two_tone"},
+            ],
+        },
+        {
+            "key": "agents_page_disclaimer_markdown",
+            "type": "textarea",
+            "label": "Disclaimer or Guidance Text",
+            "help": (
+                "Shown under the hero. Use it for who to contact about a new agent, "
+                "or the governance reminder people need before picking one."
+            ),
+            "default": "",
+            "rows": 4,
+            "markdown": True,
+            "max_length": 3000,
+            "placeholder": "Need a new agent? Contact ai-support@example.com.",
+            "group": "Guidance",
+            "depends_on": {"key": "enable_semantic_kernel", "equals": True},
+        },
+        {
+            "key": "agents_page_show_instructions_in_details",
+            "type": "switch",
+            "label": "Show Agent Instructions in Details",
+            "help": (
+                "Reveals an agent's system prompt in its details popup and in the "
+                "catalog API response. Turn it off when instructions carry wording "
+                "or internal references you would rather not publish."
+            ),
+            "default": True,
+            "group": "Guidance",
+            "depends_on": {"key": "enable_semantic_kernel", "equals": True},
+        },
+        {
+            "key": "agents_page_promoted_popular_order",
+            "type": "select",
+            "label": "Promoted Placement",
+            "help": (
+                "Where promoted agents sit relative to the ones that earned their "
+                "place through usage."
+            ),
+            "default": "before",
+            "options": [
+                {"value": "before", "label": "Before actual popular agents"},
+                {"value": "after", "label": "After actual popular agents"},
+                {"value": "mixed", "label": "Mixed in by usage"},
+            ],
+            "group": "Promoted agents",
+            "collapsed": True,
+            "depends_on": {"key": "enable_semantic_kernel", "equals": True},
+        },
+        {
+            "key": "agents_page_promoted_popular_tag_enabled",
+            "type": "switch",
+            "label": "Show Promoted Tag",
+            "help": "Marks promoted agents so their placement is not mistaken for usage.",
+            "default": True,
+            "group": "Promoted agents",
+            "collapsed": True,
+            "depends_on": {"key": "enable_semantic_kernel", "equals": True},
+        },
+        {
+            "key": "agents_page_promoted_popular_tag_label",
+            "type": "text",
+            "label": "Promoted Tag Label",
+            "help": "Wording of that tag.",
+            "default": "Promoted",
+            "max_length": 40,
+            "fallback_when_empty": True,
+            "group": "Promoted agents",
+            "collapsed": True,
+            "depends_on": [
+                {"key": "enable_semantic_kernel", "equals": True},
+                {"key": "agents_page_promoted_popular_tag_enabled", "equals": True},
+            ],
+        },
+        {
+            # Writes agents_page_promoted_popular_agents into the draft. The list
+            # is normalized on save by the delegated normalizer below.
+            "type": "component",
+            "component": "promoted-popular-agents",
+            "key": "agents_page_promoted_popular_agents",
+            "label": "Promoted Agents",
+            "help": (
+                "Puts chosen agents in the Popular tab before they have any usage "
+                "behind them, which is how a brand new agent gets discovered. "
+                "People only ever see agents already visible to them."
+            ),
+            "group": "Promoted agents",
+            "collapsed": True,
+            "depends_on": {"key": "enable_semantic_kernel", "equals": True},
+        },
+    ],
+    "agent-template-approvals-section": [
+        {
+            "key": "agent_templates_allow_user_submission",
+            "type": "switch",
+            "label": "Allow User Template Submissions",
+            "help": (
+                "Workspace users can offer an agent they built as a template for "
+                "everyone else, which is how a gallery grows without an admin "
+                "authoring every entry."
+            ),
+            "default": True,
+        },
+        {
+            "key": "agent_templates_require_approval",
+            "type": "switch",
+            "label": "Require Admin Approval",
+            "help": (
+                "Holds submissions in the approvals queue instead of publishing "
+                "them straight into the gallery."
+            ),
+            "default": True,
+            "depends_on": {"key": "agent_templates_allow_user_submission", "equals": True},
+        },
+    ],
     "actions-config": [
         {
             "key": "enable_text_plugin",
@@ -656,12 +952,26 @@ LEGACY_FIELD_NAMES = {
     "custom_favicon_base64": ["favicon_file"],
     # Collected as an acknowledgement on the toggle rather than a stored value.
     "enable_custom_pages": ["enable_custom_pages", "custom_pages_restart_acknowledged"],
+    # V1 round-trips the promoted agent list through a hidden JSON field that its
+    # script maintains; V2 edits the stored list directly.
+    "agents_page_promoted_popular_agents": ["agents_page_promoted_popular_agents_json"],
 }
 
-# Field names present in the V1 Appearance panes that intentionally have no V2
-# equivalent, with the reason. The parity test reads this, so an unexplained
-# omission fails rather than passing silently.
-LEGACY_FIELDS_WITHOUT_V2_EQUIVALENT = {}
+# Field names present in the V1 panes that intentionally have no V2 equivalent,
+# with the reason. The parity tests read this, so an unexplained omission fails
+# rather than passing silently.
+LEGACY_FIELDS_WITHOUT_V2_EQUIVALENT = {
+    "orchestration_type": (
+        "Saved through POST /api/orchestration_settings, not the settings PATCH. "
+        "V2 renders it from the agent-orchestration component, which reads the "
+        "available types from the server rather than hard-coding them."
+    ),
+    "max_rounds_per_agent": (
+        "Saved through POST /api/orchestration_settings alongside "
+        "orchestration_type, and only meaningful for a multi-agent orchestration "
+        "type. Owned by the agent-orchestration component."
+    ),
+}
 
 
 def get_admin_settings_fields():
@@ -702,6 +1012,25 @@ def get_legacy_field_names():
             continue
         claimed.update(LEGACY_FIELD_NAMES.get(key, [key]))
     return claimed
+
+
+def iter_dependencies(field):
+    """Yield each ``depends_on`` condition a field declares.
+
+    ``depends_on`` started as a single condition and most fields still use one.
+    A chain such as Agents -> Workspace Mode -> merge behaviour needs every link
+    checked, otherwise a field reappears whenever an intermediate toggle is off
+    but its own gate happens to be on, so a list is accepted too.
+    """
+    dependency = field.get("depends_on")
+    if not dependency:
+        return
+    if isinstance(dependency, dict):
+        yield dependency
+        return
+    for entry in dependency:
+        if isinstance(entry, dict):
+            yield entry
 
 
 def _coerce_bool(value):
@@ -813,6 +1142,19 @@ def _normalize_number(value, field):
     return number, None
 
 
+def _normalize_promoted_popular_agents(value):
+    """Normalize the Agents page promotion list.
+
+    Imported lazily, and documented here as the exception to the imports-at-top
+    rule: ``functions_settings`` reaches ``config.py``, which builds a Cosmos
+    client at import time, so importing it at module scope would make this
+    schema module unimportable in a plain test process.
+    """
+    from functions_settings import normalize_agents_page_promoted_popular_agents
+
+    return normalize_agents_page_promoted_popular_agents(value)
+
+
 # Keys whose normalization already exists elsewhere. Reusing those functions is
 # what stops the two admin surfaces from disagreeing about, for example, which
 # frequency aliases are accepted or how a terms message is trimmed.
@@ -832,6 +1174,11 @@ _DELEGATED_NORMALIZERS = {
     "terms_of_use_decline_button_text": lambda value, field: normalize_terms_of_use_text(
         value, fallback="Cancel", max_length=TERMS_OF_USE_MAX_BUTTON_TEXT_LENGTH
     ),
+    # Declared as a component field, so it never reaches the type-driven
+    # normalization below and would otherwise be written through unvalidated.
+    "agents_page_promoted_popular_agents": lambda value, field: (
+        _normalize_promoted_popular_agents(value)
+    ),
 }
 
 
@@ -841,9 +1188,6 @@ def _normalize_field_value(key, value, field):
 
     if field_type in NON_PATCHABLE_TYPES:
         return None, f"{key} cannot be changed through this endpoint.", None
-
-    if key in _DELEGATED_NORMALIZERS:
-        return _DELEGATED_NORMALIZERS[key](value, field), None, None
 
     if field_type == "switch":
         return _coerce_bool(value), None, None
@@ -958,6 +1302,15 @@ def normalize_admin_settings_updates(updates, current_settings=None):
             continue
 
         field = get_field_definition(key)
+
+        # Delegated keys are normalized by the function that already owns them,
+        # whatever their field type. This runs before the field lookup so a
+        # component-backed key such as the Agents page promotion list is still
+        # validated rather than written straight through.
+        if key in _DELEGATED_NORMALIZERS:
+            normalized[key] = _DELEGATED_NORMALIZERS[key](value, field)
+            continue
+
         if field is None:
             normalized[key] = value
             continue
@@ -995,15 +1348,24 @@ def _check_minimum_selections(normalized, current_settings, errors):
         if not key or not minimum:
             continue
 
-        depends_on = field.get("depends_on")
-        if depends_on:
+        gated_off = False
+        for depends_on in iter_dependencies(field):
             gate_key = depends_on["key"]
             gate_value = (
                 normalized[gate_key] if gate_key in normalized
                 else current_settings.get(gate_key, False)
             )
-            if _coerce_bool(gate_value) != depends_on.get("equals", True):
-                continue
+            expected = depends_on.get("equals", True)
+            actual = (
+                _coerce_bool(gate_value)
+                if isinstance(expected, bool)
+                else str(gate_value or "")
+            )
+            if actual != expected:
+                gated_off = True
+                break
+        if gated_off:
+            continue
 
         selection = (
             normalized[key] if key in normalized else current_settings.get(key) or []

--- a/application/single_app/admin_settings_fields.py
+++ b/application/single_app/admin_settings_fields.py
@@ -73,6 +73,7 @@ FIELD_TYPES = (
     "number",
     "image",
     "link_list",
+    "entry_list",
     "component",
 )
 
@@ -1154,6 +1155,243 @@ ADMIN_SETTINGS_FIELDS = {
             "group": "Managed elsewhere",
         },
     ],
+    # --- Inbound MCP ------------------------------------------------------
+    #
+    # The whole card is gated by ENABLE_MCP_UI, an App Service application
+    # setting with no entry in the settings document, so the fields depend on a
+    # runtime flag rather than a settings key. When the flag is off the section
+    # still renders, showing only the notice that explains how to turn it on --
+    # which is why the notice depends on the same flag being false.
+    "inbound-mcp-configuration": [
+        {
+            "type": "component",
+            "component": "inbound-mcp-disabled-notice",
+            "label": "Inbound MCP preview",
+            "depends_on": {"flag": "mcp_ui_enabled", "equals": False},
+        },
+        {
+            "key": "enable_inbound_mcp_server",
+            "type": "switch",
+            "label": "Enable Inbound MCP Server",
+            "help": (
+                "Accepts requests from external MCP clients such as an editor. "
+                "Access stays deny-by-default afterwards: a request must also pass "
+                "the delegated scope, the Entra role, the client allowlist, the "
+                "source allowlist, and a governance policy. Turn this on last."
+            ),
+            "default": False,
+            "group": "Runtime gate",
+            "depends_on": {"flag": "mcp_ui_enabled", "equals": True},
+        },
+        {
+            "key": "inbound_mcp_required_scope",
+            "type": "text",
+            "label": "Required Delegated Scope",
+            "help": (
+                "The delegated scope a user's client must present. It has to match "
+                "the scope exposed on the Entra application registration, or every "
+                "request is refused."
+            ),
+            "default": "DelegatedMcpServerAccess",
+            "max_length": 128,
+            "fallback_when_empty": True,
+            "group": "Runtime gate",
+            "depends_on": {"flag": "mcp_ui_enabled", "equals": True},
+        },
+        {
+            "key": "inbound_mcp_required_user_role",
+            "type": "text",
+            "label": "Required Delegated User Role",
+            "help": (
+                "The Entra app role a signed-in user must hold. This decides who "
+                "may connect at all; which tools they then get is decided by "
+                "governance policy."
+            ),
+            "default": "InboundMCPUserAccess",
+            "max_length": 128,
+            "fallback_when_empty": True,
+            "group": "Runtime gate",
+            "depends_on": {"flag": "mcp_ui_enabled", "equals": True},
+        },
+        {
+            "key": "inbound_mcp_required_app_role",
+            "type": "text",
+            "label": "Required App-Only Role",
+            "help": (
+                "Reserved for future service-to-service tools. No tool uses it "
+                "today; personal tools require a delegated user token."
+            ),
+            "default": "InboundMCPAppAccess",
+            "max_length": 128,
+            "fallback_when_empty": True,
+            "group": "Runtime gate",
+            "depends_on": {"flag": "mcp_ui_enabled", "equals": True},
+        },
+        {
+            "key": "enable_inbound_mcp_rate_limits",
+            "type": "switch",
+            "label": "Enable Tool Throttles",
+            "help": (
+                "Caps how often one caller may invoke each category of tool. On by "
+                "default, and enforced across app instances, so a client stuck in a "
+                "loop cannot exhaust the deployment. It has no effect until the "
+                "server itself is enabled."
+            ),
+            "default": True,
+            "group": "Request limits",
+            "depends_on": {"flag": "mcp_ui_enabled", "equals": True},
+        },
+        {
+            "key": "inbound_mcp_max_request_bytes",
+            "type": "number",
+            "label": "Max Request Bytes",
+            "help": "Largest request body accepted. Anything bigger is refused unread.",
+            "default": 65536,
+            "min": 1024,
+            "max": 1048576,
+            "group": "Request limits",
+            "depends_on": {"flag": "mcp_ui_enabled", "equals": True},
+        },
+        {
+            "key": "inbound_mcp_rate_limit_window_seconds",
+            "type": "number",
+            "label": "Throttle Window (Seconds)",
+            "help": "The period each of the three limits below is counted over.",
+            "default": 60,
+            "min": 10,
+            "max": 3600,
+            "group": "Request limits",
+            "depends_on": [
+                {"flag": "mcp_ui_enabled", "equals": True},
+                {"key": "enable_inbound_mcp_rate_limits", "equals": True},
+            ],
+        },
+        {
+            "key": "inbound_mcp_rate_limit_read_per_window",
+            "type": "number",
+            "label": "Read Calls Per Window",
+            "help": "Reads are cheap, so this is the most permissive of the three.",
+            "default": 120,
+            "min": 1,
+            "max": 10000,
+            "group": "Request limits",
+            "depends_on": [
+                {"flag": "mcp_ui_enabled", "equals": True},
+                {"key": "enable_inbound_mcp_rate_limits", "equals": True},
+            ],
+        },
+        {
+            "key": "inbound_mcp_rate_limit_search_per_window",
+            "type": "number",
+            "label": "Search Calls Per Window",
+            "help": "Searches cost an index query each, so they are limited harder than reads.",
+            "default": 30,
+            "min": 1,
+            "max": 10000,
+            "group": "Request limits",
+            "depends_on": [
+                {"flag": "mcp_ui_enabled", "equals": True},
+                {"key": "enable_inbound_mcp_rate_limits", "equals": True},
+            ],
+        },
+        {
+            "key": "inbound_mcp_rate_limit_write_per_window",
+            "type": "number",
+            "label": "Write Calls Per Window",
+            "help": "Writes change stored data, so this is the tightest limit.",
+            "default": 10,
+            "min": 1,
+            "max": 10000,
+            "group": "Request limits",
+            "depends_on": [
+                {"flag": "mcp_ui_enabled", "equals": True},
+                {"key": "enable_inbound_mcp_rate_limits", "equals": True},
+            ],
+        },
+        {
+            "key": "inbound_mcp_allowed_client_app_entries",
+            "type": "entry_list",
+            "label": "Allowed Client App IDs",
+            "help": (
+                "The Entra application ids permitted to connect. This list is "
+                "required: while it is empty no MCP client can reach the endpoint, "
+                "whatever else is configured."
+            ),
+            "default": [],
+            "value_label": "Client app ID",
+            "placeholder": "00000000-0000-0000-0000-000000000000",
+            "empty_text": "No client apps allowed, so nothing can connect.",
+            "group": "Allowlists",
+            "depends_on": {"flag": "mcp_ui_enabled", "equals": True},
+        },
+        {
+            "key": "inbound_mcp_allow_external_tenants",
+            "type": "switch",
+            "label": "Allow Additional Tenant IDs",
+            "help": (
+                "Off restricts callers to this deployment's own tenant. Turn it on "
+                "only to admit a named partner tenant; the deployment's own tenant "
+                "is always included."
+            ),
+            "default": False,
+            "group": "Allowlists",
+            "depends_on": {"flag": "mcp_ui_enabled", "equals": True},
+        },
+        {
+            "key": "inbound_mcp_allowed_tenant_entries",
+            "type": "entry_list",
+            "label": "Allowed Tenant IDs",
+            "help": "Additional tenants whose users may connect.",
+            "default": [],
+            "value_label": "Tenant ID",
+            "placeholder": "00000000-0000-0000-0000-000000000000",
+            "empty_text": "Only this deployment's tenant is allowed.",
+            "group": "Allowlists",
+            "depends_on": [
+                {"flag": "mcp_ui_enabled", "equals": True},
+                {"key": "inbound_mcp_allow_external_tenants", "equals": True},
+            ],
+        },
+        {
+            "key": "inbound_mcp_allow_all_source_ids",
+            "type": "switch",
+            "label": "Allow All Source IDs",
+            "help": (
+                "The source is a client-supplied header, so it identifies rather "
+                "than authenticates. Leaving this on accepts any value at this "
+                "layer; a governance policy still decides who gets tools. Turn it "
+                "off only where a gateway sets and enforces the header."
+            ),
+            "default": True,
+            "group": "Allowlists",
+            "depends_on": {"flag": "mcp_ui_enabled", "equals": True},
+        },
+        {
+            "key": "inbound_mcp_source_header",
+            "type": "text",
+            "label": "Source Header Name",
+            "help": "The request header the source value is read from.",
+            "default": "X-SimpleChat-MCP-Source",
+            "max_length": 128,
+            "fallback_when_empty": True,
+            "group": "Allowlists",
+            "depends_on": {"flag": "mcp_ui_enabled", "equals": True},
+        },
+        {
+            "key": "inbound_mcp_allowed_source_entries",
+            "type": "entry_list",
+            "label": "Allowed Source IDs",
+            "help": "The source values accepted when not allowing all of them.",
+            "default": [],
+            "value_label": "Source value",
+            "empty_text": "No source values allowed, so no request passes this check.",
+            "group": "Allowlists",
+            "depends_on": [
+                {"flag": "mcp_ui_enabled", "equals": True},
+                {"key": "inbound_mcp_allow_all_source_ids", "equals": False},
+            ],
+        },
+    ],
     # Declared so the Actions surface keeps the editable Fact Memory control where
     # it belongs. Without it the mirror above would claim the key and remove the
     # real toggle from Chat.
@@ -1198,6 +1436,10 @@ LEGACY_FIELD_NAMES = {
     # V1 round-trips the promoted agent list through a hidden JSON field that its
     # script maintains; V2 edits the stored list directly.
     "agents_page_promoted_popular_agents": ["agents_page_promoted_popular_agents_json"],
+    # The inbound MCP allowlists take the same shape: a hidden JSON field in V1.
+    "inbound_mcp_allowed_client_app_entries": ["inbound_mcp_allowed_client_app_entries_json"],
+    "inbound_mcp_allowed_tenant_entries": ["inbound_mcp_allowed_tenant_entries_json"],
+    "inbound_mcp_allowed_source_entries": ["inbound_mcp_allowed_source_entries_json"],
 }
 
 # Field names present in the V1 panes that intentionally have no V2 equivalent,
@@ -1428,6 +1670,117 @@ _CONTAINER_NORMALIZERS = {
 }
 
 
+def _normalize_entry_list(value):
+    """Normalize a ``{value, description}`` allowlist.
+
+    Delegated to ``functions_mcp_server_config`` so both admin surfaces agree on
+    what a row is worth keeping. Imported lazily for the reason given above.
+    """
+    from functions_mcp_server_config import normalize_inbound_mcp_value_entries
+
+    return normalize_inbound_mcp_value_entries(value)
+
+
+def _apply_inbound_mcp_derivations(normalized, current_settings):
+    """Write the flat lists the inbound MCP runtime reads.
+
+    The runtime does not read the ``*_entries`` lists an administrator edits. It
+    reads ``*_ids`` lists, and single-role settings are mirrored into
+    ``*_roles`` arrays. The server-rendered form derives all of those on every
+    save; without the same derivation here, an allowlist edited in V2 would be
+    stored and then ignored.
+
+    The rules are not a straight mapping, which is why this reproduces the whole
+    block rather than a per-key transform: the tenant list only takes effect when
+    additional tenants are allowed and always gains the deployment's own tenant,
+    and the source list collapses to ``*`` when all sources are allowed.
+    """
+    if not any(key.startswith("inbound_mcp_") for key in normalized):
+        return
+
+    from functions_mcp_server_config import (
+        INBOUND_MCP_SETTINGS_DEFAULTS,
+        ensure_inbound_mcp_default_tenant_entry,
+        inbound_mcp_entry_values,
+        normalize_inbound_mcp_single_value,
+        normalize_inbound_mcp_value_entries,
+    )
+
+    def merged(key):
+        """The value this save will leave behind, edited or not."""
+        if key in normalized:
+            return normalized[key]
+        if key in current_settings:
+            return current_settings[key]
+        return INBOUND_MCP_SETTINGS_DEFAULTS.get(key)
+
+    for role_key, roles_key in (
+        ("inbound_mcp_required_user_role", "inbound_mcp_required_user_roles"),
+        ("inbound_mcp_required_app_role", "inbound_mcp_required_app_roles"),
+    ):
+        if role_key not in normalized:
+            continue
+        role = normalize_inbound_mcp_single_value(
+            normalized[role_key],
+            default_value=INBOUND_MCP_SETTINGS_DEFAULTS[role_key],
+            max_length=128,
+        )
+        normalized[role_key] = role
+        normalized[roles_key] = [role] if role else []
+
+    if "inbound_mcp_allowed_client_app_entries" in normalized:
+        entries = normalize_inbound_mcp_value_entries(
+            normalized["inbound_mcp_allowed_client_app_entries"], lowercase=True
+        )
+        normalized["inbound_mcp_allowed_client_app_entries"] = entries
+        normalized["inbound_mcp_allowed_client_app_ids"] = inbound_mcp_entry_values(
+            entries, lowercase=True
+        )
+
+    if (
+        "inbound_mcp_allowed_tenant_entries" in normalized
+        or "inbound_mcp_allow_external_tenants" in normalized
+    ):
+        entries = normalize_inbound_mcp_value_entries(
+            merged("inbound_mcp_allowed_tenant_entries"), lowercase=True
+        )
+        if _coerce_bool(merged("inbound_mcp_allow_external_tenants")):
+            entries = ensure_inbound_mcp_default_tenant_entry(entries)
+            tenant_ids = inbound_mcp_entry_values(entries, lowercase=True)
+        else:
+            # Restricting to the deployment's own tenant is expressed by the id
+            # list, not by clearing the entries, so a partner tenant an admin
+            # added is still there when they turn the switch back on.
+            from config import TENANT_ID
+
+            own_tenant = str(TENANT_ID or "").strip().lower()
+            tenant_ids = [own_tenant] if own_tenant else []
+        normalized["inbound_mcp_allowed_tenant_entries"] = entries
+        normalized["inbound_mcp_allowed_tenant_ids"] = tenant_ids
+
+    if (
+        "inbound_mcp_allowed_source_entries" in normalized
+        or "inbound_mcp_allow_all_source_ids" in normalized
+    ):
+        allow_all = _coerce_bool(merged("inbound_mcp_allow_all_source_ids"))
+        entries = normalize_inbound_mcp_value_entries(
+            merged("inbound_mcp_allowed_source_entries"),
+            default=(
+                INBOUND_MCP_SETTINGS_DEFAULTS["inbound_mcp_allowed_source_entries"]
+                if allow_all
+                else None
+            ),
+        )
+        if not allow_all:
+            # The wildcard row belongs to the allow-all mode. Leaving it in a
+            # controlled list would silently keep accepting every source.
+            entries = [entry for entry in entries if entry.get("value") != "*"]
+        normalized["inbound_mcp_allowed_source_entries"] = entries
+        normalized["inbound_mcp_allowed_source_ids"] = (
+            ["*"] if allow_all else inbound_mcp_entry_values(entries)
+        )
+
+
 def _apply_nested_paths(normalized, current_settings):
     """Fold ``settings_path`` values into the container key they belong to.
 
@@ -1538,6 +1891,9 @@ def _normalize_field_value(key, value, field):
     if field_type == "link_list":
         links, error = _normalize_link_list(value)
         return links, error, None
+
+    if field_type == "entry_list":
+        return _normalize_entry_list(value), None, None
 
     if field_type == "textarea":
         text = str(value if value is not None else "")
@@ -1663,6 +2019,7 @@ def normalize_admin_settings_updates(updates, current_settings=None):
     # against, and so a rejected save never assembles a container.
     if not errors:
         _apply_nested_paths(normalized, current)
+        _apply_inbound_mcp_derivations(normalized, current)
 
     return normalized, errors, warnings
 
@@ -1677,7 +2034,11 @@ def _check_minimum_selections(normalized, current_settings, errors):
 
         gated_off = False
         for depends_on in iter_dependencies(field):
-            gate_key = depends_on["key"]
+            gate_key = depends_on.get("key")
+            if not gate_key:
+                # A runtime-flag condition is resolved in the browser; the server
+                # cannot judge it here and does not need to.
+                continue
             gate_value = (
                 normalized[gate_key] if gate_key in normalized
                 else current_settings.get(gate_key, False)

--- a/application/single_app/admin_settings_fields.py
+++ b/application/single_app/admin_settings_fields.py
@@ -688,6 +688,23 @@ ADMIN_SETTINGS_FIELDS = {
             ],
         },
         {
+            # Derived by POST /api/orchestration_settings from the chosen
+            # orchestration mode. The fallback scan used to render it as a live
+            # switch under AI Models, where setting it did nothing.
+            "key": "enable_multi_agent_orchestration",
+            "type": "switch",
+            "label": "Multi-Agent Orchestration",
+            "help": (
+                "Whether the runtime coordinates several agents rather than "
+                "routing to one. Follows the orchestration mode; this deployment "
+                "offers only single-agent orchestration."
+            ),
+            "default": False,
+            "readonly": True,
+            "managed_by": "Agent Orchestration",
+            "depends_on": {"key": "enable_semantic_kernel", "equals": True},
+        },
+        {
             # Reads and writes through /api/orchestration_settings rather than the
             # settings PATCH, and draws nothing while the deployment offers a
             # single orchestration type, which is the case today.

--- a/application/single_app/admin_settings_fields.py
+++ b/application/single_app/admin_settings_fields.py
@@ -38,6 +38,7 @@ from shared word stems, and declaring a field is the only way to stop it guessin
 wrong.
 """
 
+import copy
 import re
 from urllib.parse import urlparse
 
@@ -97,6 +98,18 @@ USER_AGREEMENT_WORD_LIMIT = 200
 
 CLASSIFICATION_BANNER_DEFAULT_COLOR = "#ffc107"
 CLASSIFICATION_BANNER_DEFAULT_TEXT_COLOR = "#ffffff"
+
+# Document action limits, mirrored from DOCUMENT_ACTION_LIMIT_BOUNDS and
+# DEFAULT_DOCUMENT_ACTION_CAPABILITIES in functions_document_actions.py. That
+# module cannot be imported here -- it reaches config.py, which builds a Cosmos
+# client at import time -- so the values are restated and pinned by
+# test_v2_admin_actions_parity.py rather than left to drift.
+DOCUMENT_ACTION_CHAT_MIN_LIMIT = 2
+DOCUMENT_ACTION_CHAT_MAX_LIMIT = 300
+DOCUMENT_ACTION_CHAT_DEFAULT_LIMIT = 3
+DOCUMENT_ACTION_WORKFLOW_MIN_LIMIT = 2
+DOCUMENT_ACTION_WORKFLOW_MAX_LIMIT = 1000
+DOCUMENT_ACTION_WORKFLOW_DEFAULT_LIMIT = 10
 
 # Schemes permitted for administrator-configured navigation links. These render
 # into an anchor href, so allowing arbitrary schemes would let a saved link
@@ -916,14 +929,244 @@ ADMIN_SETTINGS_FIELDS = {
             "depends_on": {"key": "agent_templates_allow_user_submission", "equals": True},
         },
     ],
-    "actions-config": [
+    # --- Actions ----------------------------------------------------------
+    #
+    # Analyze and Comparison are stored as one nested object rather than as six
+    # top-level keys, so each field names the path it writes and the container is
+    # reassembled on save. Both limits are bounded by
+    # DOCUMENT_ACTION_LIMIT_BOUNDS, which the container normalizer enforces.
+    "document-action-capabilities-card": [
+        {
+            "key": "document_action_analyze_enabled",
+            "settings_path": ["document_action_capabilities", "analyze", "enabled"],
+            "type": "switch",
+            "label": "Enable Analyze",
+            "help": (
+                "Offers Analyze in the Action menu in chat and workflows. It reads "
+                "the selected documents in full rather than searching them, so an "
+                "answer covers every one instead of the passages a search returned."
+            ),
+            "default": True,
+            "group": "Analyze",
+        },
+        {
+            "key": "document_action_analyze_chat_max_documents",
+            "settings_path": ["document_action_capabilities", "analyze", "chat_max_documents"],
+            "type": "number",
+            "label": "Analyze: Chat Document Limit",
+            "help": (
+                "Most documents one chat message may analyze. Each one is read in "
+                "full, so this bounds how long a single message can take and how "
+                "much it costs."
+            ),
+            "default": DOCUMENT_ACTION_CHAT_DEFAULT_LIMIT,
+            "min": DOCUMENT_ACTION_CHAT_MIN_LIMIT,
+            "max": DOCUMENT_ACTION_CHAT_MAX_LIMIT,
+            "group": "Analyze",
+            "depends_on": {"key": "document_action_analyze_enabled", "equals": True},
+        },
+        {
+            "key": "document_action_analyze_workflow_max_documents",
+            "settings_path": [
+                "document_action_capabilities",
+                "analyze",
+                "workflow_max_documents",
+            ],
+            "type": "number",
+            "label": "Analyze: Workflow Document Limit",
+            "help": (
+                "The same limit for a workflow run, which is not waiting on someone "
+                "watching a chat and so can be allowed a far larger batch."
+            ),
+            "default": DOCUMENT_ACTION_WORKFLOW_DEFAULT_LIMIT,
+            "min": DOCUMENT_ACTION_WORKFLOW_MIN_LIMIT,
+            "max": DOCUMENT_ACTION_WORKFLOW_MAX_LIMIT,
+            "group": "Analyze",
+            "depends_on": {"key": "document_action_analyze_enabled", "equals": True},
+        },
+        {
+            "key": "document_action_comparison_enabled",
+            "settings_path": ["document_action_capabilities", "comparison", "enabled"],
+            "type": "switch",
+            "label": "Enable Document Comparison",
+            "help": (
+                "Offers Document Comparison in the Action menu. It reads one "
+                "baseline document against the others selected, which is what "
+                "answers questions about what changed between versions."
+            ),
+            "default": True,
+            "group": "Comparison",
+        },
+        {
+            "key": "document_action_comparison_chat_max_documents",
+            "settings_path": [
+                "document_action_capabilities",
+                "comparison",
+                "chat_max_documents",
+            ],
+            "type": "number",
+            "label": "Comparison: Chat Document Limit",
+            "help": "Most documents one chat message may compare, including the baseline.",
+            "default": DOCUMENT_ACTION_CHAT_DEFAULT_LIMIT,
+            "min": DOCUMENT_ACTION_CHAT_MIN_LIMIT,
+            "max": DOCUMENT_ACTION_CHAT_MAX_LIMIT,
+            "group": "Comparison",
+            "depends_on": {"key": "document_action_comparison_enabled", "equals": True},
+        },
+        {
+            "key": "document_action_comparison_workflow_max_documents",
+            "settings_path": [
+                "document_action_capabilities",
+                "comparison",
+                "workflow_max_documents",
+            ],
+            "type": "number",
+            "label": "Comparison: Workflow Document Limit",
+            "help": "The same limit for a workflow run.",
+            "default": DOCUMENT_ACTION_WORKFLOW_DEFAULT_LIMIT,
+            "min": DOCUMENT_ACTION_WORKFLOW_MIN_LIMIT,
+            "max": DOCUMENT_ACTION_WORKFLOW_MAX_LIMIT,
+            "group": "Comparison",
+            "depends_on": {"key": "document_action_comparison_enabled", "equals": True},
+        },
+    ],
+    # Rendered by V1 only while Workspace Mode is on, matching agent-toggles-card.
+    "plugin-feature-toggles": [
+        {
+            "key": "allow_user_plugins",
+            "type": "switch",
+            "label": "Allow Personal Actions",
+            "help": (
+                "People can create actions in their own workspace. This is a wider "
+                "grant than a personal agent: an action carries an endpoint and the "
+                "credentials to reach it, so the traffic an agent generates is no "
+                "longer limited to destinations you configured."
+            ),
+            "default": False,
+        },
+        {
+            "key": "allow_group_plugins",
+            "type": "switch",
+            "label": "Allow Group Actions",
+            "help": (
+                "The same for a group's shared actions. Group workspaces must also "
+                "be enabled under Workspaces."
+            ),
+            "default": False,
+        },
+    ],
+    "core-plugin-toggles": [
+        {
+            "key": "enable_time_plugin",
+            "type": "switch",
+            "label": "Time",
+            "help": (
+                "Lets an agent read the current date and time and calculate with "
+                "them. Without it a model answers date questions from its training "
+                "data, which is always out of date."
+            ),
+            "default": True,
+            "group": "Built-in actions",
+            "collapsed": True,
+        },
+        {
+            "key": "enable_http_plugin",
+            "type": "switch",
+            "label": "HTTP",
+            "help": (
+                "Lets an agent fetch a URL directly. This is the one built-in action "
+                "that reaches outside the deployment, so turn it off where agents "
+                "should only use the connectors you configured."
+            ),
+            "default": True,
+            "group": "Built-in actions",
+            "collapsed": True,
+        },
+        {
+            "key": "enable_wait_plugin",
+            "type": "switch",
+            "label": "Wait",
+            "help": "Lets an agent pause, which workflows use to space out repeated calls.",
+            "default": True,
+            "group": "Built-in actions",
+            "collapsed": True,
+        },
+        {
+            "key": "enable_math_plugin",
+            "type": "switch",
+            "label": "Math",
+            "help": (
+                "Lets an agent calculate rather than predict an answer, which is why "
+                "arithmetic in a reply can be relied on."
+            ),
+            "default": True,
+            "group": "Built-in actions",
+            "collapsed": True,
+        },
         {
             "key": "enable_text_plugin",
             "type": "switch",
-            "label": "Enable Text Action",
+            "label": "Text",
+            "help": "Lets an agent format, trim and reshape text deterministically.",
+            "default": True,
+            "group": "Built-in actions",
+            "collapsed": True,
+        },
+        {
+            "key": "enable_default_embedding_model_plugin",
+            "type": "switch",
+            "label": "Default Embedding Model",
             "help": (
-                "Agents can perform text processing operations such as formatting, "
-                "validation and manipulation of strings and text content."
+                "Exposes the embedding model to agents for similarity work outside "
+                "the normal document search path. Off by default; document search "
+                "already embeds without it."
+            ),
+            "default": False,
+            "group": "Built-in actions",
+            "collapsed": True,
+        },
+        {
+            "key": "enable_fact_memory_plugin",
+            "type": "switch",
+            "label": "Fact Memory",
+            "help": (
+                "Lets an agent store, update and remove durable facts and "
+                "instructions for the current user or group."
+            ),
+            "default": True,
+            "readonly": True,
+            "managed_by": "Chat \u203a Chat Experience \u203a Fact Memory",
+            "group": "Managed elsewhere",
+        },
+        {
+            "key": "enable_tabular_processing_plugin",
+            "type": "switch",
+            "label": "Tabular Processing",
+            "help": (
+                "Lets an agent analyse a CSV or XLSX file as a whole dataset rather "
+                "than as retrieved passages. The application recomputes this from "
+                "Enhanced Citations on every settings read, so it cannot be set "
+                "independently."
+            ),
+            "default": False,
+            "readonly": True,
+            "managed_by": "Chat \u203a Citations \u203a Enhanced",
+            "group": "Managed elsewhere",
+        },
+    ],
+    # Declared so the Actions surface keeps the editable Fact Memory control where
+    # it belongs. Without it the mirror above would claim the key and remove the
+    # real toggle from Chat.
+    "fact-memory-section": [
+        {
+            "key": "enable_fact_memory_plugin",
+            "type": "switch",
+            "label": "Enable Fact Memory",
+            "help": (
+                "Saved memories are recalled during chat, and can be created or "
+                "removed when a user asks. Instruction memories apply to every "
+                "prompt; fact memories are recalled only when relevant. This is a "
+                "chat capability and does not require agents."
             ),
             "default": True,
         },
@@ -987,11 +1230,23 @@ def iter_fields():
 
 
 def get_field_definition(key):
-    """Return the field definition for a settings key, or None."""
+    """Return the field definition for a settings key, or None.
+
+    A key may be declared twice: once where it is edited, and once as a read-only
+    mirror in a section that only needs to report its state. Fact memory is
+    edited under Chat but affects which actions an agent has, so it appears in
+    both. The writable declaration is the one that governs saving, so it wins
+    regardless of declaration order.
+    """
+    mirror = None
     for _section_id, field in iter_fields():
-        if field.get("key") == key:
-            return field
-    return None
+        if field.get("key") != key:
+            continue
+        if field.get("readonly"):
+            mirror = mirror or field
+            continue
+        return field
+    return mirror
 
 
 def get_declared_setting_keys():
@@ -1155,6 +1410,63 @@ def _normalize_promoted_popular_agents(value):
     return normalize_agents_page_promoted_popular_agents(value)
 
 
+def _normalize_document_action_capabilities(value):
+    """Normalize the assembled document action capabilities container.
+
+    Lazily imported for the same reason as above.
+    """
+    from functions_document_actions import normalize_document_action_capabilities
+
+    return normalize_document_action_capabilities({"document_action_capabilities": value})
+
+
+# Containers assembled from several ``settings_path`` fields, and the function
+# that already owns validating the whole object. Bounds live there, so a limit
+# typed into either admin surface is clamped the same way.
+_CONTAINER_NORMALIZERS = {
+    "document_action_capabilities": _normalize_document_action_capabilities,
+}
+
+
+def _apply_nested_paths(normalized, current_settings):
+    """Fold ``settings_path`` values into the container key they belong to.
+
+    A few settings are stored as one nested object rather than as top-level
+    keys. ``document_action_capabilities`` holds six values across two action
+    types, and nothing reads a flattened form of them, so writing the flat keys
+    through would save a setting the application never looks at.
+
+    The container is rebuilt from the stored object so that saving one limit does
+    not discard the other five, then handed to the function that owns it.
+    """
+    containers = {}
+
+    for key in list(normalized):
+        field = get_field_definition(key)
+        path = (field or {}).get("settings_path")
+        if not path:
+            continue
+
+        value = normalized.pop(key)
+        root = path[0]
+        if root not in containers:
+            stored = current_settings.get(root)
+            containers[root] = copy.deepcopy(stored) if isinstance(stored, dict) else {}
+
+        node = containers[root]
+        for segment in path[1:-1]:
+            child = node.get(segment)
+            if not isinstance(child, dict):
+                child = {}
+                node[segment] = child
+            node = child
+        node[path[-1]] = value
+
+    for root, value in containers.items():
+        container_normalizer = _CONTAINER_NORMALIZERS.get(root)
+        normalized[root] = container_normalizer(value) if container_normalizer else value
+
+
 # Keys whose normalization already exists elsewhere. Reusing those functions is
 # what stops the two admin surfaces from disagreeing about, for example, which
 # frequency aliases are accepted or how a terms message is trimmed.
@@ -1188,6 +1500,16 @@ def _normalize_field_value(key, value, field):
 
     if field_type in NON_PATCHABLE_TYPES:
         return None, f"{key} cannot be changed through this endpoint.", None
+
+    if field.get("readonly"):
+        # A mirror reports a value that something else owns. Accepting a write
+        # here would let the Actions surface set a Chat capability, or set a key
+        # the application recomputes on every read.
+        owner = field.get("managed_by")
+        return None, (
+            f"{key} is managed by {owner}." if owner
+            else f"{key} cannot be changed through this endpoint."
+        ), None
 
     if field_type == "switch":
         return _coerce_bool(value), None, None
@@ -1336,6 +1658,11 @@ def normalize_admin_settings_updates(updates, current_settings=None):
     # "At least one" style constraints can only be judged once the whole payload
     # is known, because the capability toggle and its selection may arrive apart.
     _check_minimum_selections(normalized, current, errors)
+
+    # Folded last so the checks above still see the flat keys they were written
+    # against, and so a rejected save never assembles a container.
+    if not errors:
+        _apply_nested_paths(normalized, current)
 
     return normalized, errors, warnings
 

--- a/application/single_app/admin_settings_nav.py
+++ b/application/single_app/admin_settings_nav.py
@@ -132,11 +132,18 @@ ADMIN_NAV = [
         "icon": "bi-robot",
         "tabs": [
             {
+                # The nested cards listed here already exist in the V1 pane, so
+                # naming them costs the server-rendered page nothing while giving
+                # the V2 surface -- which draws one section per entry -- somewhere
+                # to put the runtime gate, the workspace permissions and the
+                # Agents page copy instead of one undifferentiated block.
                 "id": "agents",
                 "label": "Agents",
                 "icon": "bi-robot",
                 "sections": [
-                    {"id": "agents-config", "label": "Agents Configuration", "icon": "bi-robot"},
+                    {"id": "agents-config", "label": "Agent Runtime", "icon": "bi-robot"},
+                    {"id": "agent-toggles-card", "label": "Workspace Agent Permissions", "icon": "bi-person-gear", "condition": "per_user_semantic_kernel"},
+                    {"id": "agents-page-customization-card", "label": "Agents Page", "icon": "bi-palette"},
                     {"id": "agent-template-approvals-section", "label": "Agent Template Approvals", "icon": "bi-layers", "condition": "enable_agent_template_gallery"},
                 ],
             },
@@ -145,8 +152,10 @@ ADMIN_NAV = [
                 "label": "Actions",
                 "icon": "bi-plugin",
                 "sections": [
-                    {"id": "document-action-capabilities-card", "label": "Document Action Capabilities", "icon": "bi-files"},
-                    {"id": "actions-config", "label": "Actions Configuration", "icon": "bi-plugin"},
+                    {"id": "document-action-capabilities-card", "label": "Document Actions", "icon": "bi-files"},
+                    {"id": "plugin-feature-toggles", "label": "Workspace Action Permissions", "icon": "bi-person-gear", "condition": "per_user_semantic_kernel"},
+                    {"id": "core-plugin-toggles", "label": "Built-in Actions", "icon": "bi-tools"},
+                    {"id": "actions-config", "label": "Global Actions", "icon": "bi-plugin"},
                 ],
             },
             {

--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -97,7 +97,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.261.059"
+VERSION = "0.261.060"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -97,7 +97,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.261.060"
+VERSION = "0.261.061"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -97,7 +97,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.261.061"
+VERSION = "0.261.062"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -97,7 +97,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.261.058"
+VERSION = "0.261.059"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/route_backend_v2.py
+++ b/application/single_app/route_backend_v2.py
@@ -33,6 +33,7 @@ from admin_settings_fields import (
     normalize_admin_settings_updates,
 )
 from admin_settings_nav import ADMIN_NAV
+from functions_mcp_server_config import is_mcp_ui_enabled
 from config import (
     ensure_custom_favicon_file_exists,
     ensure_custom_logo_file_exists,
@@ -631,6 +632,11 @@ def register_route_backend_v2_admin(bp):
                         "admin_nav": ADMIN_NAV,
                         "field_schema": get_admin_settings_fields(),
                         "branding_assets": _build_branding_assets(settings),
+                        # Navigation sections may be conditional on a runtime flag
+                        # rather than a stored setting. Inbound MCP is gated by an
+                        # App Service application setting, so its value cannot be
+                        # read out of the settings document the SPA already holds.
+                        "runtime_flags": {"mcp_ui_enabled": is_mcp_ui_enabled()},
                         "version": VERSION,
                     }
                 ),

--- a/application/v2_ui/src/components/admin/EntryListEditor.tsx
+++ b/application/v2_ui/src/components/admin/EntryListEditor.tsx
@@ -1,0 +1,157 @@
+// EntryListEditor.tsx
+// A repeatable allowlist of `{ value, description }` rows.
+//
+// The inbound MCP allowlists are not free text. Each row is an identifier the runtime
+// matches a request against -- a client application id, a tenant id, a source value -- and
+// a description saying who it belongs to. The description is there because an allowlist of
+// bare GUIDs becomes unauditable within weeks: nobody can say which entry may safely be
+// removed.
+//
+// The list flows into the page draft like any other field, so it is saved by the same save
+// bar. The server re-normalizes it and derives the flat id list the runtime actually reads.
+
+import { clsx } from 'clsx';
+import { AlertCircle, ListChecks, Plus, Trash2 } from 'lucide-react';
+import type { AdminField } from '../../lib/adminFields';
+import { readEntryList, type AllowlistEntry } from '../../lib/adminEntries';
+import { GlassButton } from '../ui/primitives';
+
+const inputClass = clsx(
+    'w-full rounded-lg border border-edge bg-surface-1 px-2.5 py-1.5',
+    'text-sm text-text-1 placeholder:text-text-3',
+    'focus:border-accent focus:outline-none',
+    'disabled:cursor-not-allowed disabled:opacity-60',
+);
+
+export function EntryListEditor({
+    field,
+    value,
+    error,
+    disabled,
+    onChange,
+}: {
+    field: AdminField;
+    value: unknown;
+    error?: string;
+    disabled?: boolean;
+    onChange: (next: AllowlistEntry[]) => void;
+}) {
+    const entries = readEntryList(value);
+    const valueLabel = field.value_label ?? 'Value';
+    const duplicates = new Set(
+        entries
+            .map((entry) => entry.value.trim().toLowerCase())
+            .filter((entry, index, all) => entry && all.indexOf(entry) !== index),
+    );
+
+    const replace = (index: number, patch: Partial<AllowlistEntry>) => {
+        onChange(entries.map((entry, i) => (i === index ? { ...entry, ...patch } : entry)));
+    };
+
+    return (
+        <div className="py-3">
+            <div className="mb-1.5 flex items-baseline justify-between gap-3">
+                <span className="text-sm font-medium text-text-1">{field.label}</span>
+                <span className="text-xs text-text-3">
+                    {entries.length} {entries.length === 1 ? 'entry' : 'entries'}
+                </span>
+            </div>
+
+            {entries.length === 0 ? (
+                <div className="flex items-center gap-2 rounded-lg border border-dashed border-edge px-3 py-4 text-sm text-text-3">
+                    <ListChecks size={15} aria-hidden="true" />
+                    {field.empty_text ?? 'No entries yet.'}
+                </div>
+            ) : (
+                <ul className="space-y-2">
+                    {entries.map((entry, index) => {
+                        const duplicated =
+                            entry.value.trim() !== '' &&
+                            duplicates.has(entry.value.trim().toLowerCase());
+                        return (
+                            <li
+                                key={index}
+                                className="rounded-lg border border-edge bg-surface-1 p-2"
+                            >
+                                <div className="flex items-start gap-2">
+                                    <div className="grid min-w-0 flex-1 gap-2 sm:grid-cols-2">
+                                        <input
+                                            type="text"
+                                            className={clsx(inputClass, 'font-mono text-xs')}
+                                            placeholder={field.placeholder ?? valueLabel}
+                                            aria-label={`${valueLabel} ${index + 1}`}
+                                            maxLength={256}
+                                            spellCheck={false}
+                                            disabled={disabled}
+                                            value={entry.value}
+                                            onChange={(event) =>
+                                                replace(index, { value: event.target.value })
+                                            }
+                                        />
+                                        <input
+                                            type="text"
+                                            className={inputClass}
+                                            placeholder="Who this belongs to"
+                                            aria-label={`Description for entry ${index + 1}`}
+                                            maxLength={256}
+                                            disabled={disabled}
+                                            value={entry.description}
+                                            onChange={(event) =>
+                                                replace(index, {
+                                                    description: event.target.value,
+                                                })
+                                            }
+                                        />
+                                    </div>
+
+                                    <button
+                                        type="button"
+                                        title="Remove"
+                                        aria-label={`Remove entry ${index + 1}`}
+                                        disabled={disabled}
+                                        onClick={() =>
+                                            onChange(entries.filter((_, i) => i !== index))
+                                        }
+                                        className="shrink-0 rounded-lg p-1.5 text-text-3 transition-colors hover:bg-danger-soft hover:text-danger disabled:cursor-not-allowed disabled:opacity-40"
+                                    >
+                                        <Trash2 size={14} />
+                                    </button>
+                                </div>
+
+                                {duplicated ? (
+                                    <p className="mt-1.5 flex items-center gap-1.5 text-xs text-warn">
+                                        <AlertCircle size={12} className="shrink-0" />
+                                        Repeated value. Only the first is kept on save.
+                                    </p>
+                                ) : null}
+                            </li>
+                        );
+                    })}
+                </ul>
+            )}
+
+            <GlassButton
+                type="button"
+                variant="subtle"
+                size="sm"
+                className="mt-2"
+                disabled={disabled}
+                onClick={() => onChange([...entries, { value: '', description: '' }])}
+            >
+                <Plus size={14} />
+                Add {valueLabel.toLowerCase()}
+            </GlassButton>
+
+            {field.help ? (
+                <p className="mt-1.5 text-xs leading-relaxed text-text-3">{field.help}</p>
+            ) : null}
+
+            {error ? (
+                <p role="alert" className="mt-1.5 flex items-start gap-1.5 text-xs text-danger">
+                    <AlertCircle size={13} className="mt-0.5 shrink-0" />
+                    {error}
+                </p>
+            ) : null}
+        </div>
+    );
+}

--- a/application/v2_ui/src/components/admin/InboundMcpNotice.tsx
+++ b/application/v2_ui/src/components/admin/InboundMcpNotice.tsx
@@ -1,0 +1,56 @@
+// InboundMcpNotice.tsx
+// What the Inbound MCP section shows while its preview gate is off.
+//
+// The gate is `ENABLE_MCP_UI`, an App Service application setting rather than a stored
+// setting, so there is nothing on this page that can turn it on. Hiding the section
+// entirely would leave an administrator with no way to discover that, which is why the
+// server-rendered page shows the same instructions.
+//
+// Turning the gate on only reveals the configuration. The runtime stays off until
+// "Enable Inbound MCP Server" is switched on, after the authentication, allowlist and
+// governance prerequisites are in place.
+
+import { Info } from 'lucide-react';
+
+export function InboundMcpNotice() {
+    return (
+        <div className="py-3">
+            <div className="rounded-lg border border-edge bg-surface-1 p-3">
+                <p className="flex items-center gap-2 text-sm font-medium text-text-1">
+                    <Info size={15} className="shrink-0 text-text-3" aria-hidden="true" />
+                    Inbound MCP configuration is not available on this deployment
+                </p>
+
+                <p className="mt-2 text-xs leading-relaxed text-text-3">
+                    Inbound MCP lets external MCP clients, such as an editor, call
+                    SimpleChat tools on a user&apos;s behalf. It is a preview capability
+                    and its settings stay hidden until the deployment opts in.
+                </p>
+
+                <ol className="mt-2 list-decimal space-y-1 pl-5 text-xs leading-relaxed text-text-3">
+                    <li>Open the Azure App Service that hosts SimpleChat.</li>
+                    <li>
+                        Add an application setting named{' '}
+                        <code className="rounded bg-surface-2 px-1 py-0.5 font-mono">
+                            ENABLE_MCP_UI
+                        </code>{' '}
+                        with the value{' '}
+                        <code className="rounded bg-surface-2 px-1 py-0.5 font-mono">
+                            true
+                        </code>
+                        .
+                    </li>
+                    <li>Save, and restart the app if your host does not restart it.</li>
+                    <li>Reload this page.</li>
+                </ol>
+
+                <p className="mt-2 text-xs leading-relaxed text-text-3">
+                    That only reveals the settings. The endpoint itself stays closed until
+                    it is enabled here, and every request is then still checked against the
+                    delegated scope, the Entra role, the client and source allowlists, and
+                    governance policy.
+                </p>
+            </div>
+        </div>
+    );
+}

--- a/application/v2_ui/src/components/admin/OrchestrationCard.tsx
+++ b/application/v2_ui/src/components/admin/OrchestrationCard.tsx
@@ -1,0 +1,194 @@
+// OrchestrationCard.tsx
+// Agent orchestration: how a chat is routed across agents.
+//
+// Two things make this different from every other Admin Settings control, and both are
+// why it is a component rather than a declared field.
+//
+// It does not save through the settings PATCH. `POST /api/orchestration_settings` also
+// derives `enable_multi_agent_orchestration` from the chosen type and forces
+// `max_rounds_per_agent` back to 1 for single-agent modes, so routing the value through
+// the settings document would drop those two rules on the floor.
+//
+// And the set of orchestration types is a server-side list, not a fixed enum. Today
+// `get_agent_orchestration_types()` returns a single entry, `default_agent`, because the
+// multi-agent modes are commented out. A select with one option is not a choice, so this
+// renders nothing at all until the deployment offers more than one type — and starts
+// rendering again by itself if the multi-agent modes come back.
+
+import { useCallback, useEffect, useState } from 'react';
+import { clsx } from 'clsx';
+import { Loader2, Workflow } from 'lucide-react';
+import { api } from '../../lib/apiClient';
+import {
+    orchestrationIsSelectable,
+    readOrchestrationTypes,
+    roundsApply,
+    type OrchestrationType,
+} from '../../lib/adminAgents';
+import { GlassButton } from '../ui/primitives';
+import { toast } from '../../stores/toastStore';
+
+interface OrchestrationSettings {
+    orchestration_type?: string | null;
+    max_rounds_per_agent?: number | null;
+}
+
+const inputClass = clsx(
+    'w-full rounded-lg border border-edge bg-surface-1 px-3 py-2',
+    'text-sm text-text-1 focus:border-accent focus:outline-none',
+    'disabled:cursor-not-allowed disabled:opacity-60',
+);
+
+export function OrchestrationCard({ help }: { help?: string }) {
+    const [types, setTypes] = useState<OrchestrationType[]>([]);
+    const [selected, setSelected] = useState('');
+    const [rounds, setRounds] = useState(1);
+    const [loading, setLoading] = useState(true);
+    const [saving, setSaving] = useState(false);
+    const [dirty, setDirty] = useState(false);
+
+    useEffect(() => {
+        let cancelled = false;
+        void (async () => {
+            try {
+                const [typePayload, current] = await Promise.all([
+                    api.get<unknown>('/api/orchestration_types'),
+                    api.get<OrchestrationSettings>('/api/orchestration_settings'),
+                ]);
+                if (cancelled) {
+                    return;
+                }
+                const available = readOrchestrationTypes(typePayload);
+                setTypes(available);
+                setSelected(
+                    current.orchestration_type || available[0]?.value || '',
+                );
+                setRounds(
+                    typeof current.max_rounds_per_agent === 'number'
+                        ? current.max_rounds_per_agent
+                        : 1,
+                );
+            } catch {
+                // A failure here means the card cannot be trusted to describe the
+                // runtime, so it stays hidden rather than showing a stale choice.
+                if (!cancelled) {
+                    setTypes([]);
+                }
+            } finally {
+                if (!cancelled) {
+                    setLoading(false);
+                }
+            }
+        })();
+        return () => {
+            cancelled = true;
+        };
+    }, []);
+
+    const save = useCallback(async () => {
+        setSaving(true);
+        try {
+            await api.post('/api/orchestration_settings', {
+                orchestration_type: selected,
+                max_rounds_per_agent: roundsApply(types, selected) ? rounds : 1,
+            });
+            setDirty(false);
+            toast.success('Orchestration settings saved.');
+        } catch (error) {
+            toast.error(
+                error instanceof Error
+                    ? error.message
+                    : 'Failed to save orchestration settings.',
+            );
+        } finally {
+            setSaving(false);
+        }
+    }, [selected, rounds, types]);
+
+    if (loading || !orchestrationIsSelectable(types)) {
+        return null;
+    }
+
+    const showRounds = roundsApply(types, selected);
+    const description = types.find((type) => type.value === selected)?.description;
+
+    return (
+        <div className="py-3">
+            <div className="mb-1.5 flex items-center gap-2">
+                <Workflow size={15} className="shrink-0 text-text-3" aria-hidden="true" />
+                <span className="text-sm font-medium text-text-1">Agent Orchestration</span>
+            </div>
+
+            <label
+                htmlFor="admin-orchestration-type"
+                className="mb-1 block text-xs text-text-3"
+            >
+                Orchestration type
+            </label>
+            <select
+                id="admin-orchestration-type"
+                className={clsx(inputClass, 'appearance-none pr-8')}
+                value={selected}
+                disabled={saving}
+                onChange={(event) => {
+                    setSelected(event.target.value);
+                    setDirty(true);
+                }}
+            >
+                {types.map((type) => (
+                    <option key={type.value} value={type.value}>
+                        {type.label}
+                    </option>
+                ))}
+            </select>
+
+            {description ? (
+                <p className="mt-1.5 text-xs leading-relaxed text-text-3">{description}</p>
+            ) : null}
+
+            {showRounds ? (
+                <div className="mt-3">
+                    <label
+                        htmlFor="admin-orchestration-rounds"
+                        className="mb-1 block text-xs text-text-3"
+                    >
+                        Max rounds per agent
+                    </label>
+                    <input
+                        id="admin-orchestration-rounds"
+                        type="number"
+                        min={1}
+                        className={inputClass}
+                        value={rounds}
+                        disabled={saving}
+                        onChange={(event) => {
+                            setRounds(Number(event.target.value));
+                            setDirty(true);
+                        }}
+                    />
+                    <p className="mt-1.5 text-xs leading-relaxed text-text-3">
+                        How many turns each agent may take before the conversation is
+                        handed back. Raising it costs proportionally more model calls.
+                    </p>
+                </div>
+            ) : null}
+
+            {help ? (
+                <p className="mt-1.5 text-xs leading-relaxed text-text-3">{help}</p>
+            ) : null}
+
+            {/* Saved separately from the page's save bar, so the button says so. */}
+            <GlassButton
+                type="button"
+                variant="subtle"
+                size="sm"
+                className="mt-2"
+                disabled={!dirty || saving}
+                onClick={() => void save()}
+            >
+                {saving ? <Loader2 size={14} className="animate-spin" /> : null}
+                Save orchestration
+            </GlassButton>
+        </div>
+    );
+}

--- a/application/v2_ui/src/components/admin/PromotedAgentsEditor.tsx
+++ b/application/v2_ui/src/components/admin/PromotedAgentsEditor.tsx
@@ -1,0 +1,221 @@
+// PromotedAgentsEditor.tsx
+// Agents promoted into the Popular tab before they have any usage behind them.
+//
+// The Popular tab ranks agents by how often people actually run them, which is a problem
+// for a brand new agent: nothing can become popular until it is already popular. A
+// promotion places a chosen agent there regardless, so it can be found at all.
+//
+// Candidates come from the agent catalog rather than being typed in, because the stored
+// entry has to carry the catalog key the Agents page ranks on, plus the display name and
+// scope used to describe it. `functions_settings.normalize_agents_page_promoted_popular_agents`
+// re-normalizes the list on save, so this only has to produce entries of the same shape.
+
+import { useEffect, useMemo, useState } from 'react';
+import { clsx } from 'clsx';
+import { AlertCircle, Plus, Star, Trash2 } from 'lucide-react';
+import { api } from '../../lib/apiClient';
+import {
+    PROMOTED_WINDOW_OPTIONS,
+    promotableAgents,
+    readPromotedAgents,
+    type CatalogAgent,
+    type PromotedAgent,
+} from '../../lib/adminAgents';
+import type { AdminField } from '../../lib/adminFields';
+import { GlassButton } from '../ui/primitives';
+
+const controlClass = clsx(
+    'rounded-lg border border-edge bg-surface-1 px-2.5 py-1.5',
+    'text-sm text-text-1 focus:border-accent focus:outline-none',
+    'disabled:cursor-not-allowed disabled:opacity-60',
+);
+
+export function PromotedAgentsEditor({
+    field,
+    value,
+    error,
+    disabled,
+    onChange,
+}: {
+    field: AdminField;
+    value: unknown;
+    error?: string;
+    disabled?: boolean;
+    onChange: (next: PromotedAgent[]) => void;
+}) {
+    const promoted = readPromotedAgents(value);
+
+    const [candidates, setCandidates] = useState<CatalogAgent[]>([]);
+    const [loadError, setLoadError] = useState<string | null>(null);
+    const [choice, setChoice] = useState('');
+
+    useEffect(() => {
+        let cancelled = false;
+        void (async () => {
+            try {
+                const payload = await api.get<{ agents?: unknown }>(
+                    '/api/agents/catalog?include_usage=true',
+                );
+                if (!cancelled) {
+                    setCandidates(Array.isArray(payload.agents) ? payload.agents : []);
+                    setLoadError(null);
+                }
+            } catch (fetchError) {
+                if (!cancelled) {
+                    setCandidates([]);
+                    setLoadError(
+                        fetchError instanceof Error
+                            ? fetchError.message
+                            : 'Failed to load available agents.',
+                    );
+                }
+            }
+        })();
+        return () => {
+            cancelled = true;
+        };
+    }, []);
+
+    // An agent already promoted is not offered again: the stored list is keyed by
+    // catalog key and the server drops duplicates, so a second entry would vanish
+    // on save with no explanation.
+    const available = useMemo(
+        () => promotableAgents(candidates, promoted),
+        [candidates, promoted],
+    );
+
+    const add = () => {
+        const agent = available.find((item) => item.catalog_key === choice);
+        if (agent) {
+            onChange([...promoted, agent]);
+            setChoice('');
+        }
+    };
+
+    return (
+        <div className="py-3">
+            <div className="mb-1.5 flex items-baseline justify-between gap-3">
+                <span className="text-sm font-medium text-text-1">{field.label}</span>
+                <span className="text-xs text-text-3">
+                    {promoted.length} promoted
+                </span>
+            </div>
+
+            <div className="flex items-center gap-2">
+                <select
+                    aria-label="Agent to promote"
+                    className={clsx(controlClass, 'min-w-0 flex-1 appearance-none pr-8')}
+                    value={choice}
+                    disabled={disabled || available.length === 0}
+                    onChange={(event) => setChoice(event.target.value)}
+                >
+                    <option value="">
+                        {available.length === 0
+                            ? 'No agents available to promote'
+                            : 'Choose an agent…'}
+                    </option>
+                    {available.map((agent) => (
+                        <option key={agent.catalog_key} value={agent.catalog_key}>
+                            {agent.display_name || agent.catalog_key}
+                            {agent.scope_label ? ` · ${agent.scope_label}` : ''}
+                        </option>
+                    ))}
+                </select>
+                <GlassButton
+                    type="button"
+                    variant="subtle"
+                    size="sm"
+                    disabled={disabled || !choice}
+                    onClick={add}
+                >
+                    <Plus size={14} />
+                    Promote
+                </GlassButton>
+            </div>
+
+            {promoted.length === 0 ? (
+                <div className="mt-2 flex items-center gap-2 rounded-lg border border-dashed border-edge px-3 py-4 text-sm text-text-3">
+                    <Star size={15} aria-hidden="true" />
+                    No agents are promoted yet.
+                </div>
+            ) : (
+                <ul className="mt-2 space-y-2">
+                    {promoted.map((agent, index) => (
+                        <li
+                            key={agent.catalog_key}
+                            className="flex items-center gap-2 rounded-lg border border-edge bg-surface-1 p-2"
+                        >
+                            <div className="min-w-0 flex-1">
+                                <p className="truncate text-sm text-text-1">
+                                    {agent.display_name || agent.catalog_key}
+                                </p>
+                                {agent.scope_label ? (
+                                    <p className="truncate text-xs text-text-3">
+                                        {agent.scope_label}
+                                    </p>
+                                ) : null}
+                            </div>
+
+                            <select
+                                aria-label={`Popular window for ${
+                                    agent.display_name || agent.catalog_key
+                                }`}
+                                className={clsx(controlClass, 'shrink-0 appearance-none pr-7 text-xs')}
+                                value={agent.window}
+                                disabled={disabled}
+                                onChange={(event) =>
+                                    onChange(
+                                        promoted.map((item, i) =>
+                                            i === index
+                                                ? { ...item, window: event.target.value }
+                                                : item,
+                                        ),
+                                    )
+                                }
+                            >
+                                {PROMOTED_WINDOW_OPTIONS.map((option) => (
+                                    <option key={option.value} value={option.value}>
+                                        {option.label}
+                                    </option>
+                                ))}
+                            </select>
+
+                            <button
+                                type="button"
+                                title="Remove"
+                                aria-label={`Stop promoting ${
+                                    agent.display_name || agent.catalog_key
+                                }`}
+                                disabled={disabled}
+                                onClick={() =>
+                                    onChange(promoted.filter((_, i) => i !== index))
+                                }
+                                className="shrink-0 rounded-lg p-1.5 text-text-3 transition-colors hover:bg-danger-soft hover:text-danger disabled:cursor-not-allowed disabled:opacity-40"
+                            >
+                                <Trash2 size={14} />
+                            </button>
+                        </li>
+                    ))}
+                </ul>
+            )}
+
+            {field.help ? (
+                <p className="mt-1.5 text-xs leading-relaxed text-text-3">{field.help}</p>
+            ) : null}
+
+            {loadError ? (
+                <p className="mt-1.5 flex items-start gap-1.5 text-xs text-warn">
+                    <AlertCircle size={13} className="mt-0.5 shrink-0" />
+                    {loadError}
+                </p>
+            ) : null}
+
+            {error ? (
+                <p role="alert" className="mt-1.5 flex items-start gap-1.5 text-xs text-danger">
+                    <AlertCircle size={13} className="mt-0.5 shrink-0" />
+                    {error}
+                </p>
+            ) : null}
+        </div>
+    );
+}

--- a/application/v2_ui/src/components/admin/fields.tsx
+++ b/application/v2_ui/src/components/admin/fields.tsx
@@ -10,7 +10,7 @@
 // rejected save points at the control that caused it.
 
 import { clsx } from 'clsx';
-import { AlertCircle } from 'lucide-react';
+import { AlertCircle, Lock } from 'lucide-react';
 import type { ReactNode } from 'react';
 import {
     asBoolean,
@@ -346,12 +346,53 @@ function CheckboxSetControl({
 }
 
 /**
+ * A setting shown here but owned somewhere else.
+ *
+ * Fact memory is a chat capability that decides whether agents get a memory action, and
+ * tabular processing is recomputed from Enhanced Citations on every settings read. Both
+ * belong in this list for an administrator working out what an agent can do, and neither
+ * can be set from here -- so they report their state and name their owner instead of
+ * offering a switch that would be rejected or silently overwritten.
+ */
+function MirrorControl({ field, value }: FieldControlProps) {
+    const on = asBoolean(value);
+    return (
+        <div className="flex items-start justify-between gap-3 py-3">
+            <div className="min-w-0">
+                <p className="text-sm font-medium text-text-1">{field.label}</p>
+                {field.help ? (
+                    <p className="mt-1 text-xs leading-relaxed text-text-3">{field.help}</p>
+                ) : null}
+                {field.managed_by ? (
+                    <p className="mt-1 flex items-center gap-1.5 text-xs text-text-3">
+                        <Lock size={12} className="shrink-0" aria-hidden="true" />
+                        Configured in {field.managed_by}
+                    </p>
+                ) : null}
+            </div>
+            <span
+                className={clsx(
+                    'shrink-0 rounded-full px-2 py-0.5 text-xs font-medium',
+                    on ? 'bg-accent-soft text-accent' : 'bg-surface-2 text-text-3',
+                )}
+            >
+                {on ? 'On' : 'Off'}
+            </span>
+        </div>
+    );
+}
+
+/**
  * Render one declared field.
  *
  * `image`, `link_list` and `component` fields are handled by the page, which owns the
  * upload endpoint and the bespoke widgets, so they are not reached here.
  */
 export function SettingField(props: FieldControlProps) {
+    if (props.field.readonly) {
+        return <MirrorControl {...props} />;
+    }
+
     switch (props.field.type) {
         case 'text':
             return <TextControl {...props} />;

--- a/application/v2_ui/src/lib/adminAgents.ts
+++ b/application/v2_ui/src/lib/adminAgents.ts
@@ -1,0 +1,170 @@
+// adminAgents.ts
+// Pure helpers behind the two bespoke Agents controls in Admin Settings.
+//
+// They live here rather than beside their components so they can be executed by a test
+// directly. Both encode a server-side rule that is easy to break and impossible to see
+// breaking: orchestration hides a control the server would discard, and a promotion has to
+// carry the exact fields `normalize_agents_page_promoted_popular_agents` keeps.
+
+/** One orchestration mode offered by `GET /api/orchestration_types`. */
+export interface OrchestrationType {
+    value: string;
+    label: string;
+    agent_mode?: string;
+    description?: string;
+}
+
+/** One promotion, matching the stored entry shape exactly. */
+export interface PromotedAgent {
+    catalog_key: string;
+    display_name: string;
+    scope_label: string;
+    scope_type: string;
+    window: string;
+}
+
+/** A catalog entry as it arrives from `GET /api/agents/catalog`. */
+export interface CatalogAgent {
+    catalog_key?: unknown;
+    display_name?: unknown;
+    name?: unknown;
+    scope_label?: unknown;
+    scope_name?: unknown;
+    scope_type?: unknown;
+    window?: unknown;
+    is_global?: unknown;
+    is_group?: unknown;
+}
+
+/**
+ * Which Popular views a promotion applies to.
+ *
+ * Mirrors `AGENTS_PAGE_PROMOTED_POPULAR_WINDOW_OPTIONS`; the server rewrites anything else
+ * to `both`, so offering a value outside this set would silently change on save.
+ */
+export const PROMOTED_WINDOW_OPTIONS = [
+    { value: 'both', label: 'Both windows' },
+    { value: '30_days', label: 'Last 30 days' },
+    { value: 'all_time', label: 'All time' },
+];
+
+function text(value: unknown): string {
+    return typeof value === 'string' ? value.trim() : '';
+}
+
+/** Types the server offers, filtered to the ones a select could actually use. */
+export function readOrchestrationTypes(payload: unknown): OrchestrationType[] {
+    if (!Array.isArray(payload)) {
+        return [];
+    }
+    return payload
+        .filter((item): item is Record<string, unknown> => Boolean(item) && typeof item === 'object')
+        .map((item) => ({
+            value: String(item.value ?? ''),
+            label: String(item.label ?? item.value ?? ''),
+            agent_mode: typeof item.agent_mode === 'string' ? item.agent_mode : undefined,
+            description: typeof item.description === 'string' ? item.description : undefined,
+        }))
+        .filter((item) => item.value.length > 0);
+}
+
+/**
+ * Whether the orchestration control is worth drawing at all.
+ *
+ * `get_agent_orchestration_types()` returns a single entry today, because the multi-agent
+ * modes are commented out. A select with one option is not a choice, so the card stays
+ * hidden until a deployment offers a real one -- and reappears by itself if it does.
+ */
+export function orchestrationIsSelectable(types: OrchestrationType[]): boolean {
+    return types.length > 1;
+}
+
+/**
+ * Whether Max Rounds Per Agent applies to the selected type.
+ *
+ * The server forces the stored value back to 1 for anything that is not multi-agent, so
+ * showing the control otherwise would offer an edit that is discarded on save.
+ */
+export function roundsApply(types: OrchestrationType[], selected: string): boolean {
+    return types.find((type) => type.value === selected)?.agent_mode === 'multi';
+}
+
+/** Port of `getAdminAgentScopeType`, so both surfaces classify a scope the same way. */
+export function agentScopeType(agent: CatalogAgent): string {
+    const declared = text(agent.scope_type).toLowerCase();
+    if (agent.is_group || declared === 'group') {
+        return 'group';
+    }
+    if (agent.is_global || declared === 'global' || declared === 'enterprise') {
+        return 'global';
+    }
+    return 'personal';
+}
+
+/** Port of `getAdminAgentScopeLabel`. */
+export function agentScopeLabel(agent: CatalogAgent): string {
+    const scope = agentScopeType(agent);
+    if (scope === 'group') {
+        return text(agent.scope_name) || 'Group';
+    }
+    return scope === 'global' ? 'Enterprise' : 'Personal';
+}
+
+/** Build a stored promotion from a catalog entry, or null when it has no catalog key. */
+export function toPromotedAgent(agent: CatalogAgent): PromotedAgent | null {
+    const catalogKey = text(agent.catalog_key);
+    if (!catalogKey) {
+        return null;
+    }
+    return {
+        catalog_key: catalogKey,
+        display_name: text(agent.display_name) || text(agent.name),
+        scope_label: text(agent.scope_label) || agentScopeLabel(agent),
+        scope_type: agentScopeType(agent),
+        window: 'both',
+    };
+}
+
+/** Read the stored value defensively; it is administrator data from the database. */
+export function readPromotedAgents(value: unknown): PromotedAgent[] {
+    if (!Array.isArray(value)) {
+        return [];
+    }
+    const seen = new Set<string>();
+    const promoted: PromotedAgent[] = [];
+
+    for (const item of value) {
+        if (!item || typeof item !== 'object') {
+            continue;
+        }
+        const entry = item as CatalogAgent;
+        const catalogKey = text(entry.catalog_key);
+        // The server keys the list by catalog key and drops repeats, so a duplicate
+        // shown here would disappear on save with no explanation.
+        if (!catalogKey || seen.has(catalogKey)) {
+            continue;
+        }
+        seen.add(catalogKey);
+        promoted.push({
+            catalog_key: catalogKey,
+            display_name: text(entry.display_name) || text(entry.name),
+            scope_label: text(entry.scope_label) || text(entry.scope_name),
+            scope_type: text(entry.scope_type).toLowerCase(),
+            window: text(entry.window) || 'both',
+        });
+    }
+
+    return promoted;
+}
+
+/** Catalog agents that may still be promoted, given what is already promoted. */
+export function promotableAgents(
+    candidates: CatalogAgent[],
+    promoted: PromotedAgent[],
+): PromotedAgent[] {
+    const taken = new Set(promoted.map((agent) => agent.catalog_key));
+    return candidates
+        .map(toPromotedAgent)
+        .filter((agent): agent is PromotedAgent => agent !== null)
+        .filter((agent) => !taken.has(agent.catalog_key));
+}

--- a/application/v2_ui/src/lib/adminEntries.ts
+++ b/application/v2_ui/src/lib/adminEntries.ts
@@ -1,0 +1,64 @@
+// adminEntries.ts
+// Pure helpers for the `{ value, description }` allowlists the inbound MCP settings use.
+//
+// Kept out of the component so a test can execute them. The shape has to match what
+// `normalize_inbound_mcp_value_entries` keeps, because a row that does not survive
+// normalization disappears on save with no explanation.
+
+/** One allowlist row: an identifier the runtime matches, and who it belongs to. */
+export interface AllowlistEntry {
+    value: string;
+    description: string;
+}
+
+/** Read the stored value defensively; it is administrator data from the database. */
+export function readEntryList(value: unknown): AllowlistEntry[] {
+    if (!Array.isArray(value)) {
+        return [];
+    }
+    return value.map((item) => {
+        // The server has always accepted a bare string as shorthand for a value with
+        // no description, so a list written before descriptions existed still reads.
+        if (typeof item === 'string') {
+            return { value: item, description: '' };
+        }
+        if (!item || typeof item !== 'object') {
+            return { value: '', description: '' };
+        }
+        const entry = item as Record<string, unknown>;
+        return {
+            value: typeof entry.value === 'string' ? entry.value : '',
+            description: typeof entry.description === 'string' ? entry.description : '',
+        };
+    });
+}
+
+/**
+ * The rows the server will keep, in order.
+ *
+ * Empty values are dropped and repeats collapse to the first occurrence, matching
+ * `normalize_inbound_mcp_value_entries`. Used to tell an administrator how many entries a
+ * save will actually produce, rather than how many rows are on screen.
+ */
+export function effectiveEntries(
+    entries: AllowlistEntry[],
+    lowercase = false,
+): AllowlistEntry[] {
+    const seen = new Set<string>();
+    const kept: AllowlistEntry[] = [];
+
+    for (const entry of entries) {
+        const raw = entry.value.trim();
+        if (!raw) {
+            continue;
+        }
+        const value = lowercase ? raw.toLowerCase() : raw;
+        if (seen.has(value)) {
+            continue;
+        }
+        seen.add(value);
+        kept.push({ value, description: entry.description.trim() });
+    }
+
+    return kept;
+}

--- a/application/v2_ui/src/lib/adminFields.ts
+++ b/application/v2_ui/src/lib/adminFields.ts
@@ -20,6 +20,7 @@ export type AdminFieldType =
     | 'number'
     | 'image'
     | 'link_list'
+    | 'entry_list'
     | 'component';
 
 export interface AdminFieldOption {
@@ -28,14 +29,20 @@ export interface AdminFieldOption {
 }
 
 /**
- * Shows a field only while another field holds a given value.
+ * Shows a field only while a condition holds.
+ *
+ * `key` names another settings field. `flag` names a server-resolved runtime
+ * flag instead, for a capability that is gated outside the settings document --
+ * Inbound MCP is gated by an App Service application setting, so there is no
+ * settings key to depend on.
  *
  * `equals` is usually a boolean, because most gates are switches. A string
  * compares against a select's value, which is how the Agents page hides its
  * gradient colour unless the two-tone mode is chosen.
  */
 export interface AdminFieldDependency {
-    key: string;
+    key?: string;
+    flag?: string;
     equals: boolean | string;
 }
 
@@ -91,6 +98,10 @@ export interface AdminField {
     managed_by?: string;
     /** Optional sub-heading grouping several fields inside one section. */
     group?: string;
+    /** Entry list fields only: what one row's identifier is called. */
+    value_label?: string;
+    /** Entry list fields only: what to say when the list is empty. */
+    empty_text?: string;
     /** Group fields only: start the group closed. Rarely-changed settings. */
     collapsed?: boolean;
     /** One condition, or a chain that must all hold. */
@@ -271,14 +282,23 @@ function readDependencyValue(
  *
  * Each condition is judged against the unsaved draft first, so a field appears
  * or disappears as soon as its gate is flipped rather than only after a save.
+ * A condition naming a `flag` is answered from the server's runtime flags, which
+ * an administrator cannot change from this page at all.
  */
 export function isFieldVisible(
     field: AdminField,
     settings: Json,
     draft: Json,
     fieldsByKey?: Map<string, AdminField>,
+    runtimeFlags?: Record<string, boolean>,
 ): boolean {
     return fieldDependencies(field).every((dependency) => {
+        if (dependency.flag) {
+            return Boolean(runtimeFlags?.[dependency.flag]) === dependency.equals;
+        }
+        if (!dependency.key) {
+            return true;
+        }
         const current = readDependencyValue(dependency.key, settings, draft, fieldsByKey);
         return typeof dependency.equals === 'string'
             ? asString(current) === dependency.equals

--- a/application/v2_ui/src/lib/adminFields.ts
+++ b/application/v2_ui/src/lib/adminFields.ts
@@ -77,6 +77,18 @@ export interface AdminField {
     version_key?: string;
     /** Component fields only: which bespoke widget to render. */
     component?: string;
+    /**
+     * Path into a nested settings object this field reads and writes.
+     *
+     * A few settings are stored as one object rather than as top-level keys.
+     * `key` stays the flat name used in the draft and in field errors; the
+     * server folds the value back into the container on save.
+     */
+    settings_path?: string[];
+    /** Reports a value that something else owns. Never editable here. */
+    readonly?: boolean;
+    /** Where a read-only mirror is actually configured. */
+    managed_by?: string;
     /** Optional sub-heading grouping several fields inside one section. */
     group?: string;
     /** Group fields only: start the group closed. Rarely-changed settings. */
@@ -144,12 +156,27 @@ export function extractFieldErrors(payload: unknown): Record<string, string> {
     );
 }
 
+/** Walk a dotted path into the settings document, or undefined if it is not there. */
+export function readNestedValue(settings: Json, path: string[]): unknown {
+    let node: unknown = settings;
+    for (const segment of path) {
+        if (!node || typeof node !== 'object' || Array.isArray(node)) {
+            return undefined;
+        }
+        node = (node as Record<string, unknown>)[segment];
+    }
+    return node;
+}
+
 /**
  * Read a field's current value, preferring an unsaved edit over the stored value.
  *
  * Falls back to the schema default rather than `undefined` so a control is never
  * uncontrolled on first render, which React would warn about and which would lose the
  * first keystroke.
+ *
+ * A field with a `settings_path` is stored inside a nested object, so only the draft is
+ * keyed by its flat name; the saved value has to be walked to.
  */
 export function readFieldValue(field: AdminField, settings: Json, draft: Json): unknown {
     if (!field.key) {
@@ -158,7 +185,9 @@ export function readFieldValue(field: AdminField, settings: Json, draft: Json): 
     if (Object.prototype.hasOwnProperty.call(draft, field.key)) {
         return draft[field.key];
     }
-    const stored = settings[field.key];
+    const stored = field.settings_path
+        ? readNestedValue(settings, field.settings_path)
+        : settings[field.key];
     return stored === undefined || stored === null ? field.default : stored;
 }
 
@@ -197,17 +226,60 @@ export function fieldDependencies(field: AdminField): AdminFieldDependency[] {
     return Array.isArray(dependency) ? dependency : [dependency];
 }
 
+/** Index every declared field by the settings key it edits. */
+export function buildFieldIndex(schema: AdminFieldSchema): Map<string, AdminField> {
+    const index = new Map<string, AdminField>();
+    for (const fields of Object.values(schema)) {
+        for (const field of fields) {
+            if (!field.key) {
+                continue;
+            }
+            const existing = index.get(field.key);
+            // A key declared twice is a read-only mirror of a field edited
+            // elsewhere. The writable declaration describes where the value really
+            // lives, so it wins regardless of declaration order.
+            if (!existing || (existing.readonly && !field.readonly)) {
+                index.set(field.key, field);
+            }
+        }
+    }
+    return index;
+}
+
+/**
+ * Read the current value of a key another field depends on.
+ *
+ * A gate may itself be stored inside a nested object -- the document action limits are
+ * gated by an `enabled` flag that lives in the same container -- so the key alone is not
+ * enough to find the saved value.
+ */
+function readDependencyValue(
+    key: string,
+    settings: Json,
+    draft: Json,
+    fieldsByKey?: Map<string, AdminField>,
+): unknown {
+    if (Object.prototype.hasOwnProperty.call(draft, key)) {
+        return draft[key];
+    }
+    const gate = fieldsByKey?.get(key);
+    return gate?.settings_path ? readNestedValue(settings, gate.settings_path) : settings[key];
+}
+
 /**
  * Whether every one of a field's `depends_on` conditions is currently satisfied.
  *
  * Each condition is judged against the unsaved draft first, so a field appears
  * or disappears as soon as its gate is flipped rather than only after a save.
  */
-export function isFieldVisible(field: AdminField, settings: Json, draft: Json): boolean {
+export function isFieldVisible(
+    field: AdminField,
+    settings: Json,
+    draft: Json,
+    fieldsByKey?: Map<string, AdminField>,
+): boolean {
     return fieldDependencies(field).every((dependency) => {
-        const current = Object.prototype.hasOwnProperty.call(draft, dependency.key)
-            ? draft[dependency.key]
-            : settings[dependency.key];
+        const current = readDependencyValue(dependency.key, settings, draft, fieldsByKey);
         return typeof dependency.equals === 'string'
             ? asString(current) === dependency.equals
             : asBoolean(current) === dependency.equals;
@@ -226,6 +298,7 @@ export function isSectionVisible(
     settings: Json,
     draft: Json,
     runtimeFlags: Record<string, boolean>,
+    fieldsByKey?: Map<string, AdminField>,
 ): boolean {
     if (!condition) {
         return true;
@@ -233,10 +306,7 @@ export function isSectionVisible(
     if (Object.prototype.hasOwnProperty.call(runtimeFlags, condition)) {
         return runtimeFlags[condition];
     }
-    const current = Object.prototype.hasOwnProperty.call(draft, condition)
-        ? draft[condition]
-        : settings[condition];
-    return asBoolean(current);
+    return asBoolean(readDependencyValue(condition, settings, draft, fieldsByKey));
 }
 
 /** Turn `enable_document_classification` into `Document classification`. */

--- a/application/v2_ui/src/lib/adminFields.ts
+++ b/application/v2_ui/src/lib/adminFields.ts
@@ -27,10 +27,16 @@ export interface AdminFieldOption {
     label: string;
 }
 
-/** Shows a field only while another field holds a given value. */
+/**
+ * Shows a field only while another field holds a given value.
+ *
+ * `equals` is usually a boolean, because most gates are switches. A string
+ * compares against a select's value, which is how the Agents page hides its
+ * gradient colour unless the two-tone mode is chosen.
+ */
 export interface AdminFieldDependency {
     key: string;
-    equals: boolean;
+    equals: boolean | string;
 }
 
 /**
@@ -71,7 +77,12 @@ export interface AdminField {
     version_key?: string;
     /** Component fields only: which bespoke widget to render. */
     component?: string;
-    depends_on?: AdminFieldDependency;
+    /** Optional sub-heading grouping several fields inside one section. */
+    group?: string;
+    /** Group fields only: start the group closed. Rarely-changed settings. */
+    collapsed?: boolean;
+    /** One condition, or a chain that must all hold. */
+    depends_on?: AdminFieldDependency | AdminFieldDependency[];
     requires_acknowledgement?: AdminFieldAcknowledgement;
 }
 
@@ -91,6 +102,13 @@ export interface AdminSettingsResponse {
     admin_nav: import('./types').AdminNavGroup[];
     field_schema: AdminFieldSchema;
     branding_assets: BrandingAssets;
+    /**
+     * Server-resolved flags a navigation section may be conditional on.
+     *
+     * `mcp_ui_enabled` comes from an App Service application setting rather than
+     * the settings document, so it cannot be read from `settings`.
+     */
+    runtime_flags?: Record<string, boolean>;
     version: string;
 }
 
@@ -170,16 +188,55 @@ export function asStringArray(value: unknown): string[] {
     return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : [];
 }
 
-/** Whether a field's `depends_on` condition is currently satisfied. */
-export function isFieldVisible(field: AdminField, settings: Json, draft: Json): boolean {
+/** Every `depends_on` condition a field declares, whether one or a chain. */
+export function fieldDependencies(field: AdminField): AdminFieldDependency[] {
     const dependency = field.depends_on;
     if (!dependency) {
+        return [];
+    }
+    return Array.isArray(dependency) ? dependency : [dependency];
+}
+
+/**
+ * Whether every one of a field's `depends_on` conditions is currently satisfied.
+ *
+ * Each condition is judged against the unsaved draft first, so a field appears
+ * or disappears as soon as its gate is flipped rather than only after a save.
+ */
+export function isFieldVisible(field: AdminField, settings: Json, draft: Json): boolean {
+    return fieldDependencies(field).every((dependency) => {
+        const current = Object.prototype.hasOwnProperty.call(draft, dependency.key)
+            ? draft[dependency.key]
+            : settings[dependency.key];
+        return typeof dependency.equals === 'string'
+            ? asString(current) === dependency.equals
+            : asBoolean(current) === dependency.equals;
+    });
+}
+
+/**
+ * Whether a navigation section's `condition` holds.
+ *
+ * A condition names either a settings key or a server-resolved runtime flag.
+ * Runtime flags win, because a flag such as `mcp_ui_enabled` deliberately has no
+ * entry in the settings document.
+ */
+export function isSectionVisible(
+    condition: string | undefined,
+    settings: Json,
+    draft: Json,
+    runtimeFlags: Record<string, boolean>,
+): boolean {
+    if (!condition) {
         return true;
     }
-    const current = Object.prototype.hasOwnProperty.call(draft, dependency.key)
-        ? draft[dependency.key]
-        : settings[dependency.key];
-    return asBoolean(current) === dependency.equals;
+    if (Object.prototype.hasOwnProperty.call(runtimeFlags, condition)) {
+        return runtimeFlags[condition];
+    }
+    const current = Object.prototype.hasOwnProperty.call(draft, condition)
+        ? draft[condition]
+        : settings[condition];
+    return asBoolean(current);
 }
 
 /** Turn `enable_document_classification` into `Document classification`. */
@@ -199,4 +256,46 @@ export function fieldSearchText(field: AdminField): string {
     return [field.key ?? '', field.label, field.help ?? '', field.component ?? '']
         .join(' ')
         .toLowerCase();
+}
+
+/** A run of fields sharing a `group`, or a single ungrouped field. */
+export type SectionBlock =
+    | { kind: 'field'; field: AdminField }
+    | { kind: 'group'; name: string; collapsed: boolean; fields: AdminField[] };
+
+/**
+ * Lay a section's fields out as ordered blocks.
+ *
+ * A group appears where its first field does, so declaration order still decides what an
+ * administrator reads first. Grouping exists because a section such as the Agents page
+ * holds three unrelated concerns -- the hero, the guidance text, and promotions -- and a
+ * flat list of eleven controls gives no clue which ones belong together.
+ */
+export function buildSectionBlocks(fields: AdminField[]): SectionBlock[] {
+    const blocks: SectionBlock[] = [];
+    const groups = new Map<string, Extract<SectionBlock, { kind: 'group' }>>();
+
+    for (const field of fields) {
+        if (!field.group) {
+            blocks.push({ kind: 'field', field });
+            continue;
+        }
+        const existing = groups.get(field.group);
+        if (existing) {
+            existing.fields.push(field);
+            continue;
+        }
+        const group: Extract<SectionBlock, { kind: 'group' }> = {
+            kind: 'group',
+            name: field.group,
+            // Only the first field of a group decides how it opens, so a group
+            // cannot end up half-collapsed depending on which field is read.
+            collapsed: Boolean(field.collapsed),
+            fields: [field],
+        };
+        groups.set(field.group, group);
+        blocks.push(group);
+    }
+
+    return blocks;
 }

--- a/application/v2_ui/src/lib/types.ts
+++ b/application/v2_ui/src/lib/types.ts
@@ -637,6 +637,12 @@ export interface AdminNavSection {
     id: string;
     label: string;
     icon?: string;
+    /**
+     * Names a settings key or runtime flag that must be true for the section to
+     * apply. Workspace agent permissions, for instance, only exist while
+     * Workspace Mode is on.
+     */
+    condition?: string;
 }
 
 export interface AdminNavTab {

--- a/application/v2_ui/src/pages/AdminSettingsPage.tsx
+++ b/application/v2_ui/src/pages/AdminSettingsPage.tsx
@@ -35,7 +35,9 @@ import { AdminModal } from '../components/admin/AdminModal';
 import { AdminMarkdown } from '../components/admin/AdminMarkdown';
 import { BrandingImageField } from '../components/admin/BrandingImageField';
 import { CustomPagesTable } from '../components/admin/CustomPagesTable';
+import { EntryListEditor } from '../components/admin/EntryListEditor';
 import { ExternalLinksEditor } from '../components/admin/ExternalLinksEditor';
+import { InboundMcpNotice } from '../components/admin/InboundMcpNotice';
 import { OrchestrationCard } from '../components/admin/OrchestrationCard';
 import { PromotedAgentsEditor } from '../components/admin/PromotedAgentsEditor';
 import { SaveBar } from '../components/admin/SaveBar';
@@ -305,7 +307,7 @@ export function AdminSettingsPage() {
                     // than at render time, so a section left with nothing to show
                     // disappears instead of leaving an empty titled panel behind.
                     const fields = (schema[section.id] ?? []).filter((field) =>
-                        isFieldVisible(field, settings, draft, fieldsByKey),
+                        isFieldVisible(field, settings, draft, fieldsByKey, runtimeFlags),
                     );
 
                     if (!fields.length && !capabilities.length) {
@@ -518,7 +520,7 @@ export function AdminSettingsPage() {
 
     /** Render one declared field, dispatching the types the page owns. */
     const renderField = (field: AdminField) => {
-        if (!isFieldVisible(field, settings, draft, fieldsByKey)) {
+        if (!isFieldVisible(field, settings, draft, fieldsByKey, runtimeFlags)) {
             return null;
         }
 
@@ -558,12 +560,27 @@ export function AdminSettingsPage() {
             );
         }
 
+        if (field.type === 'entry_list') {
+            return (
+                <EntryListEditor
+                    key={key}
+                    field={field}
+                    value={value}
+                    error={error}
+                    disabled={saving}
+                    onChange={(next) => field.key && setValue(field.key, next)}
+                />
+            );
+        }
+
         if (field.type === 'component') {
             switch (field.component) {
                 case 'custom-pages-table':
                     return <CustomPagesTable key={key} help={field.help} />;
                 case 'agent-orchestration':
                     return <OrchestrationCard key={key} help={field.help} />;
+                case 'inbound-mcp-disabled-notice':
+                    return <InboundMcpNotice key={key} />;
                 case 'promoted-popular-agents':
                     return (
                         <PromotedAgentsEditor

--- a/application/v2_ui/src/pages/AdminSettingsPage.tsx
+++ b/application/v2_ui/src/pages/AdminSettingsPage.tsx
@@ -48,6 +48,7 @@ import {
     asBoolean,
     asNumber,
     asString,
+    buildFieldIndex,
     buildSectionBlocks,
     extractFieldErrors,
     fieldSearchText,
@@ -259,6 +260,10 @@ export function AdminSettingsPage() {
         return keys;
     }, [schema]);
 
+    // A gate may live inside a nested settings object, so resolving a dependency
+    // needs the schema rather than the key alone.
+    const fieldsByKey = useMemo(() => buildFieldIndex(schema), [schema]);
+
     const capabilityRows = useMemo(
         () => (data ? buildCapabilityIndex(data.admin_nav, data.settings, declaredKeys) : []),
         [data, declaredKeys],
@@ -292,7 +297,7 @@ export function AdminSettingsPage() {
                     // Mode is on, and Inbound MCP only while its App Service setting
                     // is present. The server-rendered page already honours this; V2
                     // used to draw the section regardless.
-                    if (!isSectionVisible(section.condition, settings, draft, runtimeFlags)) {
+                    if (!isSectionVisible(section.condition, settings, draft, runtimeFlags, fieldsByKey)) {
                         continue;
                     }
 
@@ -300,7 +305,7 @@ export function AdminSettingsPage() {
                     // than at render time, so a section left with nothing to show
                     // disappears instead of leaving an empty titled panel behind.
                     const fields = (schema[section.id] ?? []).filter((field) =>
-                        isFieldVisible(field, settings, draft),
+                        isFieldVisible(field, settings, draft, fieldsByKey),
                     );
 
                     if (!fields.length && !capabilities.length) {
@@ -333,7 +338,7 @@ export function AdminSettingsPage() {
         }
 
         return rendered;
-    }, [data, schema, capabilityRows, settings, draft, runtimeFlags]);
+    }, [data, schema, capabilityRows, settings, draft, runtimeFlags, fieldsByKey]);
 
     const visibleSections = useMemo(() => {
         const needle = query.trim().toLowerCase();
@@ -513,7 +518,7 @@ export function AdminSettingsPage() {
 
     /** Render one declared field, dispatching the types the page owns. */
     const renderField = (field: AdminField) => {
-        if (!isFieldVisible(field, settings, draft)) {
+        if (!isFieldVisible(field, settings, draft, fieldsByKey)) {
             return null;
         }
 

--- a/application/v2_ui/src/pages/AdminSettingsPage.tsx
+++ b/application/v2_ui/src/pages/AdminSettingsPage.tsx
@@ -26,7 +26,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { clsx } from 'clsx';
-import { Loader2, Search, ShieldAlert, TriangleAlert } from 'lucide-react';
+import { ChevronRight, Loader2, Search, ShieldAlert, TriangleAlert } from 'lucide-react';
 import { ApiError, api } from '../lib/apiClient';
 import { useBootstrapStore } from '../stores/bootstrapStore';
 import { PageHeader } from '../components/layout/PageHeader';
@@ -36,6 +36,8 @@ import { AdminMarkdown } from '../components/admin/AdminMarkdown';
 import { BrandingImageField } from '../components/admin/BrandingImageField';
 import { CustomPagesTable } from '../components/admin/CustomPagesTable';
 import { ExternalLinksEditor } from '../components/admin/ExternalLinksEditor';
+import { OrchestrationCard } from '../components/admin/OrchestrationCard';
+import { PromotedAgentsEditor } from '../components/admin/PromotedAgentsEditor';
 import { SaveBar } from '../components/admin/SaveBar';
 import { SettingField } from '../components/admin/fields';
 import {
@@ -46,10 +48,12 @@ import {
     asBoolean,
     asNumber,
     asString,
+    buildSectionBlocks,
     extractFieldErrors,
     fieldSearchText,
     humanizeKey,
     isFieldVisible,
+    isSectionVisible,
     readFieldValue,
     type AdminField,
     type AdminSettingsPatchResponse,
@@ -241,6 +245,7 @@ export function AdminSettingsPage() {
 
     const settings = useMemo<Json>(() => data?.settings ?? {}, [data]);
     const schema = useMemo(() => data?.field_schema ?? {}, [data]);
+    const runtimeFlags = useMemo(() => data?.runtime_flags ?? {}, [data]);
 
     const declaredKeys = useMemo(() => {
         const keys = new Set<string>();
@@ -279,9 +284,25 @@ export function AdminSettingsPage() {
         for (const group of data.admin_nav) {
             for (const tab of group.tabs) {
                 for (const section of tab.sections) {
-                    const fields = schema[section.id] ?? [];
                     const capabilities = capabilitiesBySection.get(section.id) ?? [];
                     capabilitiesBySection.delete(section.id);
+
+                    // A section can be conditional on a settings key or a runtime
+                    // flag -- workspace agent permissions only exist while Workspace
+                    // Mode is on, and Inbound MCP only while its App Service setting
+                    // is present. The server-rendered page already honours this; V2
+                    // used to draw the section regardless.
+                    if (!isSectionVisible(section.condition, settings, draft, runtimeFlags)) {
+                        continue;
+                    }
+
+                    // Fields whose own dependencies are unmet are dropped here rather
+                    // than at render time, so a section left with nothing to show
+                    // disappears instead of leaving an empty titled panel behind.
+                    const fields = (schema[section.id] ?? []).filter((field) =>
+                        isFieldVisible(field, settings, draft),
+                    );
+
                     if (!fields.length && !capabilities.length) {
                         continue;
                     }
@@ -312,7 +333,7 @@ export function AdminSettingsPage() {
         }
 
         return rendered;
-    }, [data, schema, capabilityRows]);
+    }, [data, schema, capabilityRows, settings, draft, runtimeFlags]);
 
     const visibleSections = useMemo(() => {
         const needle = query.trim().toLowerCase();
@@ -536,6 +557,19 @@ export function AdminSettingsPage() {
             switch (field.component) {
                 case 'custom-pages-table':
                     return <CustomPagesTable key={key} help={field.help} />;
+                case 'agent-orchestration':
+                    return <OrchestrationCard key={key} help={field.help} />;
+                case 'promoted-popular-agents':
+                    return (
+                        <PromotedAgentsEditor
+                            key={key}
+                            field={field}
+                            value={value}
+                            error={error}
+                            disabled={saving}
+                            onChange={(next) => field.key && setValue(field.key, next)}
+                        />
+                    );
                 case 'classification-banner-preview':
                     return (
                         <ClassificationBannerPreview
@@ -601,6 +635,41 @@ export function AdminSettingsPage() {
         }
 
         return <div key={key}>{control}</div>;
+    };
+
+    /**
+     * Render a section's fields, wrapping any declared group in a disclosure.
+     *
+     * A collapsed group is opened while a search is running, because a match hidden
+     * behind a closed disclosure looks exactly like no match at all.
+     */
+    const renderBlocks = (fields: AdminField[]) => {
+        const searching = query.trim().length > 0;
+
+        return buildSectionBlocks(fields).map((block) => {
+            if (block.kind === 'field') {
+                return renderField(block.field);
+            }
+            return (
+                <details
+                    key={`group-${block.name}`}
+                    open={searching || !block.collapsed}
+                    className="group py-2"
+                >
+                    <summary className="flex cursor-pointer items-center gap-1.5 text-xs font-semibold tracking-wide text-text-2 uppercase [&::-webkit-details-marker]:hidden">
+                        <ChevronRight
+                            size={13}
+                            aria-hidden="true"
+                            className="shrink-0 transition-transform group-open:rotate-90"
+                        />
+                        {block.name}
+                    </summary>
+                    <div className="mt-1 divide-y divide-edge border-l border-edge pl-3">
+                        {block.fields.map(renderField)}
+                    </div>
+                </details>
+            );
+        });
     };
 
     if (!isAdmin) {
@@ -732,7 +801,7 @@ export function AdminSettingsPage() {
                                     </div>
 
                                     <div className="divide-y divide-edge">
-                                        {section.fields.map(renderField)}
+                                        {renderBlocks(section.fields)}
 
                                         {section.capabilities.map((row) => (
                                             <div key={row.key} className="py-1">

--- a/docs/_data/app_surface.yml
+++ b/docs/_data/app_surface.yml
@@ -4,7 +4,7 @@ counts:
   capabilities: 112
   admin_groups: 14
   admin_tabs: 46
-  admin_sections: 96
+  admin_sections: 100
   actions: 27
   chat_controls: 47
   sub_elements: 3
@@ -469,15 +469,23 @@ admin_sections:
   tab: access-roles
   group: security
 - id: actions-config
-  label: Actions Configuration
+  label: Global Actions
   tab: actions
   group: agents-actions
 - id: agent-template-approvals-section
   label: Agent Template Approvals
   tab: agents
   group: agents-actions
+- id: agent-toggles-card
+  label: Workspace Agent Permissions
+  tab: agents
+  group: agents-actions
 - id: agents-config
-  label: Agents Configuration
+  label: Agent Runtime
+  tab: agents
+  group: agents-actions
+- id: agents-page-customization-card
+  label: Agents Page
   tab: agents
   group: agents-actions
 - id: ai-notice-section
@@ -548,6 +556,10 @@ admin_sections:
   label: Conversation History
   tab: chat-experience
   group: chat
+- id: core-plugin-toggles
+  label: Built-in Actions
+  tab: actions
+  group: agents-actions
 - id: cosmos-maintenance-section
   label: Cosmos Maintenance
   tab: cosmos
@@ -617,7 +629,7 @@ admin_sections:
   tab: cosmos
   group: scale
 - id: document-action-capabilities-card
-  label: Document Action Capabilities
+  label: Document Actions
   tab: actions
   group: agents-actions
 - id: document-classification-section
@@ -756,6 +768,10 @@ admin_sections:
   label: Personal Workspaces
   tab: workspace-types
   group: workspaces
+- id: plugin-feature-toggles
+  label: Workspace Action Permissions
+  tab: actions
+  group: agents-actions
 - id: processing-thoughts-section
   label: Processing Thoughts
   tab: chat-experience

--- a/docs/admin/agents-actions.md
+++ b/docs/admin/agents-actions.md
@@ -26,64 +26,132 @@ Agents and actions can call tools, inspect documents, and automate work. Expose 
 
 ## Before you change anything
 
-- Decide whether personal, group, or global agents are allowed.
+- **Enable Agents** gates this entire group. Decide whether you want agents at all before configuring anything below it.
+- Decide whether agents come from one shared global set or from each user's own workspace, because that choice changes which other settings do anything.
 - Confirm action dependencies before enabling a plugin.
 - Configure App Service Authentication excluded paths before exposing inbound MCP.
 
 ## Agents {#agents}
 
-### Agents Configuration {#agents-config}
+### Agent Runtime {#agents-config}
 
-The Agents Configuration section belongs to the Agents tab. Use it with the adjacent settings in this group so related rollout, access, and operational choices stay aligned.
+This is where you decide whether agents run at all, and where they come from.
 
-### Agent Template Approvals {#agent-template-approvals-section}
+**Enable Agents** starts the Semantic Kernel runtime. It is the gate for
+everything else in this group. While it is off, the Agents catalog page is not
+served, no global agent or action is loaded, and the workspace permissions have
+nothing to apply to.
 
-The Agent Template Approvals section belongs to the Agents tab. Use it with the adjacent settings in this group so related rollout, access, and operational choices stay aligned.
+**Workspace Mode** answers a question that determines most of the rest of your
+configuration: does everyone share one set of agents, or does each user and group
+keep their own?
+
+- **Off** — one global set, curated by administrators. You choose the single
+  agent that answers, and users pick from what you publish. Use this when agent
+  behaviour has to be reviewable and consistent.
+- **On** — each user and each group owns a collection. The workspace permissions
+  section appears, and the global set is no longer used on its own. Use this when
+  people need to build agents for their own work.
+
+**Add Global Agents and Actions to Workspaces** matters only in Workspace Mode.
+Turning Workspace Mode on otherwise hides the global set entirely, which is
+rarely what an administrator intends; this setting folds the shared agents back
+in alongside each person's own.
+
+**Agent Orchestration** appears only when the deployment offers more than one
+orchestration mode. This build ships a single mode, single-agent, so the control
+is not shown. Orchestration settings save through their own endpoint rather than
+with the rest of the page.
 
 #### Settings
 
 | Setting | What it does | Default | Notes |
 | --- | --- | --- | --- |
-| Hero Title | Provides displayed text that users see in the affected interface. | Find your next AI partner | `agents_page_title` |
-| Hero Subtitle | Provides displayed text that users see in the affected interface. | Explore specialized agents built to accelerate how you work. | `agents_page_subtitle` |
-| Hero Color Mode | Defines behavior for the related admin workflow; verify the affected feature after saving. | single | `agents_page_hero_color_mode` |
-| Primary Color | Defines behavior for the related admin workflow; verify the affected feature after saving. | #0f172a | `agents_page_hero_primary_color` |
-| Secondary Color | Defines behavior for the related admin workflow; verify the affected feature after saving. | #1e293b | `agents_page_hero_secondary_color` |
-| Disclaimer / Guidance Text (Markdown supported) | Shown below the Agents page hero. Use this for contact details, request guidance, or governance reminders. | Empty | `agents_page_disclaimer_markdown` |
-| Show agent instructions in Agents page details | Defines behavior for the related admin workflow; verify the affected feature after saving. | On | `agents_page_show_instructions_in_details` |
-| Agents Page Promoted Popular Agents Json | Defines behavior for the related admin workflow; verify the affected feature after saving. | Not specified in defaults | `agents_page_promoted_popular_agents_json` |
-| Placement | Defines behavior for the related admin workflow; verify the affected feature after saving. | before | `agents_page_promoted_popular_order` |
-| Promoted Tag Label | Defines behavior for the related admin workflow; verify the affected feature after saving. | Not specified in defaults | `agents_page_promoted_popular_tag_label` |
-| Show promoted tag | Defines behavior for the related admin workflow; verify the affected feature after saving. | On | `agents_page_promoted_popular_tag_enabled` |
-| Add Agent | Defines behavior for the related admin workflow; verify the affected feature after saving. | Not specified in defaults | Runtime UI control |
-| Enable Agents | Enables the agent and action runtime so users can work with configured agents instead of only the base chat experience. | Off | `enable_semantic_kernel`; capability toggle |
-| Workspace Mode (workspace-specific agents/plugins and disables global configuration) | Defines behavior for the related admin workflow; verify the affected feature after saving. | Off | `per_user_semantic_kernel` |
-| Allow User Agents | Permits user agents when the related workspace or agent feature is enabled. | Off | `allow_user_agents` |
-| Allow Group Agents | Permits group agents when the related workspace or agent feature is enabled. | Off | `allow_group_agents` |
-| Allow User Custom Endpoints | Permits user custom endpoints when the related workspace or agent feature is enabled. | Off | `allow_user_custom_endpoints` |
-| Allow Group Custom Endpoints | Permits group custom endpoints when the related workspace or agent feature is enabled. | Off | `allow_group_custom_endpoints` |
-| Merge Global Agents/Plugins into Workspace | Defines behavior for the related admin workflow; verify the affected feature after saving. | Off | `merge_global_semantic_kernel_with_workspace` |
-| Enable Agent Template Gallery | Exposes the capability after required services, permissions, and rollout policy are ready. | On | `enable_agent_template_gallery`; capability toggle |
-| Orchestration Type | Defines behavior for the related admin workflow; verify the affected feature after saving. | default_agent | `orchestration_type` |
-| Multi-agent orchestration | Derived from **Orchestration Type**; enables group-chat orchestration paths when the selected orchestration mode is multi-agent, so the runtime can coordinate multiple configured agents instead of routing to a single default agent. | Off | `enable_multi_agent_orchestration`; saved by orchestration settings API |
-| Max Rounds Per Agent (Group Chat) | Defines a capacity or timing boundary that keeps the feature inside supported limits. | 1 | `max_rounds_per_agent` |
-| Selected Agent: | Defines behavior for the related admin workflow; verify the affected feature after saving. | Not specified in defaults | Runtime UI control |
-| Allow User Template Submissions | Defines behavior for the related admin workflow; verify the affected feature after saving. | On | `agent_templates_allow_user_submission` |
-| Require Admin Approval | Defines behavior for the related admin workflow; verify the affected feature after saving. | On | `agent_templates_require_approval` |
-| Enable tool throttles | Exposes the capability after required services, permissions, and rollout policy are ready. | On | `enable_inbound_mcp_rate_limits`; capability toggle |
-| Value | Defines behavior for the related admin workflow; verify the affected feature after saving. | Not specified in defaults | Runtime UI control |
-| Description | Use descriptions to explain who owns this app, tenant, or source value without making the value easy to guess. | Not specified in defaults | Runtime UI control |
-| I have added the required App Service Authentication excluded paths for this SimpleChat App Service. | Defines behavior for the related admin workflow; verify the affected feature after saving. | Not specified in defaults | Runtime UI control |
+| Enable Agents | Starts the agent runtime. Gates the Agents catalog page, the global agent and action tables, and every workspace permission in this group. | Off | `enable_semantic_kernel`; capability toggle |
+| Workspace Mode | Chooses between one shared global set of agents and actions, and a separate collection per user and group. | Off | `per_user_semantic_kernel` |
+| Add Global Agents and Actions to Workspaces | Includes the global set in every workspace collection, so people see both what they built and what you publish. | Off | `merge_global_semantic_kernel_with_workspace`; only applies in Workspace Mode |
+| Orchestration Type | Selects how a chat is routed across agents. Hidden while only one mode is available. | default_agent | `orchestration_type`; saved by the orchestration settings API |
+| Max Rounds Per Agent | Caps how many turns each agent takes in a multi-agent conversation, which bounds the model calls one message can trigger. | 1 | `max_rounds_per_agent`; forced to 1 outside multi-agent modes |
+
+### Workspace Agent Permissions {#agent-toggles-card}
+
+Shown only in Workspace Mode, because outside it nothing reads these.
+
+Custom endpoints deserve particular attention: they let an agent send prompts to
+a model endpoint that the agent's owner configured, rather than one you
+administer. Enable them when teams genuinely need their own models, and pair them
+with an endpoint governance policy when only some of them should.
+
+#### Settings
+
+| Setting | What it does | Default | Notes |
+| --- | --- | --- | --- |
+| Allow Personal Agents | Lets people build and keep agents in their own workspace. | Off | `allow_user_agents`; pair with a personal agent governance policy |
+| Allow Group Agents | Lets a group own agents its members share. | Off | `allow_group_agents`; group workspaces must also be enabled |
+| Allow Personal Custom Endpoints | Lets people point their own agents at a model endpoint they configure, instead of the deployment's shared models. | Off | `allow_user_custom_endpoints` |
+| Allow Group Custom Endpoints | The same for group-owned agents. | Off | `allow_group_custom_endpoints`; group workspaces must also be enabled |
+| Enable Agent Template Gallery | Gives workspace users approved agents to start from rather than a blank editor, and adds the Agent Template Approvals section. | On | `enable_agent_template_gallery`; capability toggle |
+
+### Agents Page {#agents-page-customization-card}
+
+Controls how the Agents catalog page presents itself. That page is served behind
+**Enable Agents**, so none of this applies while agents are off.
+
+The promotion controls exist because the Popular tab ranks agents by how often
+people run them, which leaves a newly published agent unable to be found: nothing
+becomes popular until it is already popular. Promoting an agent places it in that
+tab regardless of usage. People only ever see promoted agents that are already
+visible to them, so a promotion cannot leak an agent someone has no access to.
+
+#### Settings
+
+| Setting | What it does | Default | Notes |
+| --- | --- | --- | --- |
+| Hero Title | Headline at the top of the Agents catalog page. Reverts to the default when left empty. | Find your next AI partner | `agents_page_title` |
+| Hero Subtitle | Supporting line under the headline. Reverts to the default when left empty. | Explore specialized agents built to accelerate how you work. | `agents_page_subtitle` |
+| Hero Color Mode | Draws the hero as a flat colour or as a gradient between the two colours below. | single | `agents_page_hero_color_mode` |
+| Primary Color | Hero background, and the first stop of the gradient. | #0f172a | `agents_page_hero_primary_color` |
+| Secondary Color | Second stop of the gradient. Only used in two-tone mode. | #1e293b | `agents_page_hero_secondary_color` |
+| Disclaimer or Guidance Text | Markdown shown under the hero. Use it for who to contact about a new agent, or the governance reminder people need before choosing one. | Empty | `agents_page_disclaimer_markdown` |
+| Show Agent Instructions in Details | Reveals an agent's system prompt in its details popup and in the catalog API response. Turn it off when instructions carry wording or internal references you would rather not publish. | On | `agents_page_show_instructions_in_details` |
+| Promoted Placement | Positions promoted agents before, after, or mixed in with the agents that earned their place through usage. | before | `agents_page_promoted_popular_order` |
+| Show Promoted Tag | Marks promoted agents so their placement is not mistaken for genuine usage. | On | `agents_page_promoted_popular_tag_enabled` |
+| Promoted Tag Label | Wording of that tag. | Promoted | `agents_page_promoted_popular_tag_label` |
+| Promoted Agents | The agents placed in the Popular tab regardless of usage, and which time window each promotion applies to. | None | `agents_page_promoted_popular_agents` |
+
+### Agent Template Approvals {#agent-template-approvals-section}
+
+Shown only while the Agent Template Gallery is enabled. Submissions are reviewed
+on the shared [approvals queue]({{ '/admin/governance/' | relative_url }}) rather
+than here.
+
+#### Settings
+
+| Setting | What it does | Default | Notes |
+| --- | --- | --- | --- |
+| Allow User Template Submissions | Lets workspace users offer an agent they built as a template for everyone else, which is how a gallery grows without an administrator authoring every entry. | On | `agent_templates_allow_user_submission` |
+| Require Admin Approval | Holds submissions in the approvals queue instead of publishing them straight into the gallery. | On | `agent_templates_require_approval` |
 
 ## Actions {#actions}
 
-### Document Action Capabilities {#document-action-capabilities-card}
+### Document Actions {#document-action-capabilities-card}
 
 The Document Action Capabilities section belongs to the Actions tab. Use it with the adjacent settings in this group so related rollout, access, and operational choices stay aligned.
 
-### Actions Configuration {#actions-config}
+### Workspace Action Permissions {#plugin-feature-toggles}
 
-The Actions Configuration section belongs to the Actions tab. Use it with the adjacent settings in this group so related rollout, access, and operational choices stay aligned.
+Shown only in Workspace Mode. Whether people may build their own actions, which
+is a larger grant than building their own agents: an action carries an endpoint
+and its credentials.
+
+### Built-in Actions {#core-plugin-toggles}
+
+The small set of general-purpose actions that ship with the runtime.
+
+### Global Actions {#actions-config}
+
+The actions published to everyone, and the workspace action permissions that sit
+alongside them.
 
 #### Settings
 

--- a/docs/admin/agents-actions.md
+++ b/docs/admin/agents-actions.md
@@ -136,47 +136,87 @@ than here.
 
 ### Document Actions {#document-action-capabilities-card}
 
-The Document Action Capabilities section belongs to the Actions tab. Use it with the adjacent settings in this group so related rollout, access, and operational choices stay aligned.
+**Analyze** and **Document Comparison** appear in the **Action** menu in chat and
+in workflows. They are not searches. Analyze reads every selected document in
+full, so an answer covers all of them rather than only the passages a search
+returned; Comparison reads one baseline document against the others, which is
+what answers questions about what changed between versions.
+
+Because each document is read in full, the limits are the control that matters.
+They bound how long a single message can take and how much it costs. Chat and
+workflow are limited separately: a chat message has someone waiting on it, while
+a workflow run does not and can be allowed a much larger batch.
+
+These six values are stored as one object, `document_action_capabilities`, rather
+than as separate settings.
+
+#### Settings
+
+| Setting | What it does | Default | Range | Notes |
+| --- | --- | --- | --- | --- |
+| Enable Analyze | Offers Analyze in the Action menu. | On | — | `document_action_capabilities.analyze.enabled` |
+| Analyze: Chat Document Limit | Most documents one chat message may analyze. | 3 | 2–300 | `analyze.chat_max_documents` |
+| Analyze: Workflow Document Limit | The same limit for a workflow run. | 10 | 2–1000 | `analyze.workflow_max_documents` |
+| Enable Document Comparison | Offers Document Comparison in the Action menu. | On | — | `document_action_capabilities.comparison.enabled` |
+| Comparison: Chat Document Limit | Most documents one chat message may compare, including the baseline. | 3 | 2–300 | `comparison.chat_max_documents` |
+| Comparison: Workflow Document Limit | The same limit for a workflow run. | 10 | 2–1000 | `comparison.workflow_max_documents` |
+
+Values outside the range are clamped on save rather than rejected.
 
 ### Workspace Action Permissions {#plugin-feature-toggles}
 
-Shown only in Workspace Mode. Whether people may build their own actions, which
-is a larger grant than building their own agents: an action carries an endpoint
-and its credentials.
+Shown only in Workspace Mode.
 
-### Built-in Actions {#core-plugin-toggles}
-
-The small set of general-purpose actions that ship with the runtime.
-
-### Global Actions {#actions-config}
-
-The actions published to everyone, and the workspace action permissions that sit
-alongside them.
+Letting someone build an action is a wider grant than letting them build an
+agent. An action carries an endpoint and the credentials to reach it, so once
+these are on, the traffic an agent can generate is no longer limited to the
+destinations you configured. Pair them with an action governance policy when only
+some people should have that.
 
 #### Settings
 
 | Setting | What it does | Default | Notes |
 | --- | --- | --- | --- |
-| Enable Analyze | Defines behavior for the related admin workflow; verify the affected feature after saving. | On | `document_action_analyze_enabled` |
-| Document Action Analyze Chat Max Documents Range | Defines a capacity or timing boundary that keeps the feature inside supported limits. | 3 | `document_action_analyze_chat_max_documents_range` |
-| Chat max documents | Defines a capacity or timing boundary that keeps the feature inside supported limits. | 3 | `document_action_analyze_chat_max_documents` |
-| Document Action Analyze Workflow Max Documents Range | Defines a capacity or timing boundary that keeps the feature inside supported limits. | 10 | `document_action_analyze_workflow_max_documents_range` |
-| Workflow max documents | Defines a capacity or timing boundary that keeps the feature inside supported limits. | 10 | `document_action_analyze_workflow_max_documents` |
-| Enable Document Comparison | Defines behavior for the related admin workflow; verify the affected feature after saving. | On | `document_action_comparison_enabled` |
-| Document Action Comparison Chat Max Documents Range | Defines a capacity or timing boundary that keeps the feature inside supported limits. | 3 | `document_action_comparison_chat_max_documents_range` |
-| Chat max documents | Defines a capacity or timing boundary that keeps the feature inside supported limits. | 3 | `document_action_comparison_chat_max_documents` |
-| Document Action Comparison Workflow Max Documents Range | Defines a capacity or timing boundary that keeps the feature inside supported limits. | 10 | `document_action_comparison_workflow_max_documents_range` |
-| Workflow max documents | Defines a capacity or timing boundary that keeps the feature inside supported limits. | 10 | `document_action_comparison_workflow_max_documents` |
-| Allow Personal Actions | Permits personal actions when the related workspace or agent feature is enabled. | Off | `allow_user_plugins` |
-| Allow Group Actions | Permits group actions when the related workspace or agent feature is enabled. | Off | `allow_group_plugins` |
-| Enable Time Action | Exposes the capability after required services, permissions, and rollout policy are ready. | On | `enable_time_plugin`; capability toggle |
-| Enable HTTP Action | Exposes the capability after required services, permissions, and rollout policy are ready. | On | `enable_http_plugin`; capability toggle |
-| Enable Wait Action | Exposes the capability after required services, permissions, and rollout policy are ready. | On | `enable_wait_plugin`; capability toggle |
-| Enable Math Action | Exposes the capability after required services, permissions, and rollout policy are ready. | On | `enable_math_plugin`; capability toggle |
-| Enable Text Action | Exposes the capability after required services, permissions, and rollout policy are ready. | On | `enable_text_plugin`; capability toggle |
-| Enable Default Embedding Model Action | Exposes the capability after required services, permissions, and rollout policy are ready. | Off | `enable_default_embedding_model_plugin`; capability toggle |
-| Fact Memory Action | Lets agents store, update, and remove durable facts and instructions for the current user or group. Fact memory is a chat capability, so its availability follows the Chat setting rather than being edited here. | On | `enable_fact_memory_plugin`; configured in [Chat settings]({{ '/admin/chat/#fact-memory-section' | relative_url }}) |
-| Tabular Processing Action | Makes the tabular-processing action available to agents for CSV and XLSX analysis when Enhanced Citations is enabled; the setting is normalized from Enhanced Citations rather than edited directly in the UI. | Off | `enable_tabular_processing_plugin`; effective value follows `enable_enhanced_citations` |
+| Allow Personal Actions | Lets people create actions in their own workspace. | Off | `allow_user_plugins` |
+| Allow Group Actions | The same for a group's shared actions. | Off | `allow_group_plugins`; group workspaces must also be enabled |
+
+### Built-in Actions {#core-plugin-toggles}
+
+The small set of general-purpose actions that ship with the runtime. They are on
+by default and are rarely changed, so they are collapsed.
+
+The one worth a decision is **HTTP**: it is the only built-in action that reaches
+outside the deployment. Turn it off where agents should only be able to use the
+connectors you configured.
+
+Each is loaded independently, so turning one off removes that capability and
+affects nothing else.
+
+#### Settings
+
+| Setting | What it does | Default | Notes |
+| --- | --- | --- | --- |
+| Time | Lets an agent read the current date and time and calculate with them, instead of answering date questions from training data. | On | `enable_time_plugin` |
+| HTTP | Lets an agent fetch a URL directly. The only built-in action that leaves the deployment. | On | `enable_http_plugin` |
+| Wait | Lets an agent pause, which workflows use to space out repeated calls. | On | `enable_wait_plugin` |
+| Math | Lets an agent calculate rather than predict an answer. | On | `enable_math_plugin` |
+| Text | Lets an agent format, trim and reshape text deterministically. | On | `enable_text_plugin` |
+| Default Embedding Model | Exposes the embedding model for similarity work outside the normal document search path. Document search already embeds without it. | Off | `enable_default_embedding_model_plugin` |
+
+#### Managed elsewhere
+
+Two actions are listed here because they change what an agent can do, but neither
+is set from this page.
+
+| Action | Where it comes from | Notes |
+| --- | --- | --- |
+| Fact Memory | [Chat › Chat Experience › Fact Memory]({{ '/admin/chat/#fact-memory-section' | relative_url }}) | `enable_fact_memory_plugin`; a chat capability that also gives agents a memory action |
+| Tabular Processing | [Chat › Citations › Enhanced]({{ '/admin/chat/#enhanced-citations-section' | relative_url }}) | `enable_tabular_processing_plugin`; recomputed from `enable_enhanced_citations` on every settings read, so it cannot be set independently |
+
+### Global Actions {#actions-config}
+
+The actions published to everyone. Authoring them stays in the classic admin
+interface for now.
 
 ## Inbound MCP {#inbound-mcp}
 

--- a/docs/admin/agents-actions.md
+++ b/docs/admin/agents-actions.md
@@ -222,26 +222,90 @@ interface for now.
 
 ### Inbound MCP {#inbound-mcp-configuration}
 
-The Inbound MCP section belongs to the Inbound MCP tab. Use it with the adjacent settings in this group so related rollout, access, and operational choices stay aligned.
+Inbound MCP lets an external MCP client — an editor, for example — call
+SimpleChat tools on a signed-in user's behalf. It is the one part of SimpleChat
+that accepts requests from software you do not control, so it is deny-by-default
+at five separate layers, and turning it on is the last step rather than the first.
 
-If the tab shows that the Inbound MCP admin UI is disabled, add the Azure App Service application setting `ENABLE_MCP_UI=true`, save the configuration, and restart the app if your host does not restart it automatically. This only exposes the preview configuration UI; the inbound MCP runtime remains off until **Enable inbound MCP server** is turned on after authentication, client allowlist, source, and governance prerequisites are ready.
+A request is served only if **all** of these hold:
 
-#### Settings
+1. the caller presents the required delegated scope;
+2. the signed-in user holds the required Entra app role;
+3. the caller's application id is on the client allowlist;
+4. the caller's tenant is allowed;
+5. the source value is allowed, **and** a governance policy grants that user or
+   group access to the tool.
+
+Today the tool surface is personal tools only, and every one of them needs a
+delegated user token. The app-only role is reserved for future service tools and
+grants nothing.
+
+#### If the settings are not shown
+
+The configuration is a preview and stays hidden until the deployment opts in. Add
+the Azure App Service application setting `ENABLE_MCP_UI=true`, save, and restart
+the app if your host does not restart it for you.
+
+That reveals the settings and nothing else. The endpoint stays closed until
+**Enable Inbound MCP Server** is switched on.
+
+#### Runtime gate
 
 | Setting | What it does | Default | Notes |
 | --- | --- | --- | --- |
-| Enable inbound MCP server | Exposes the capability after required services, permissions, and rollout policy are ready. | Off | `enable_inbound_mcp_server`; capability toggle |
-| Required delegated scope | Default: DelegatedMcpServerAccess. VS Code and other user clients must present this delegated scope. | DelegatedMcpServerAccess | `inbound_mcp_required_scope` |
-| Required delegated user role | Default: InboundMCPUserAccess. Governance determines which users/groups can use tools after this Entra role and delegated scope pass. | InboundMCPUserAccess | `inbound_mcp_required_user_role` |
-| Required app-only role | Default: InboundMCPAppAccess. Reserved for future app-only MCP tools and still governed separately. | InboundMCPAppAccess | `inbound_mcp_required_app_role` |
-| Max request bytes | Default: 65536. Range: 1 KB to 1 MB. | 65536 | `inbound_mcp_max_request_bytes` |
-| Rate window seconds | Default: 60. Applies to each throttle category. | 60 | `inbound_mcp_rate_limit_window_seconds` |
-| Read limit | Default: 120. | 120 | `inbound_mcp_rate_limit_read_per_window` |
-| Search limit | Default: 30. | 30 | `inbound_mcp_rate_limit_search_per_window` |
-| Write limit | Default: 10. | 10 | `inbound_mcp_rate_limit_write_per_window` |
-| Allow additional tenant IDs | Defines behavior for the related admin workflow; verify the affected feature after saving. | Off | `inbound_mcp_allow_external_tenants` |
-| Allow all source IDs | Defines behavior for the related admin workflow; verify the affected feature after saving. | On | `inbound_mcp_allow_all_source_ids` |
-| Source header name | Default: X-SimpleChat-MCP-Source. | X-SimpleChat-MCP-Source | `inbound_mcp_source_header` |
+| Enable Inbound MCP Server | Accepts requests from external MCP clients. Every check above still applies afterwards. | Off | `enable_inbound_mcp_server`; capability toggle |
+| Required Delegated Scope | The delegated scope a client must present. Must match the scope exposed on the Entra application registration, or every request is refused. | DelegatedMcpServerAccess | `inbound_mcp_required_scope` |
+| Required Delegated User Role | The Entra app role a signed-in user must hold to connect at all. Which tools they then get is decided by governance policy. | InboundMCPUserAccess | `inbound_mcp_required_user_role` |
+| Required App-Only Role | Reserved for future service-to-service tools. No tool uses it today. | InboundMCPAppAccess | `inbound_mcp_required_app_role` |
+
+#### Request limits
+
+Throttles are **on by default** while the server itself is off, so seeing them
+enabled does not mean the endpoint is reachable. They take effect only once the
+server is enabled, and are counted per caller and per tool category across app
+instances.
+
+| Setting | What it does | Default | Range |
+| --- | --- | --- | --- |
+| Enable Tool Throttles | Caps how often one caller may invoke each category of tool, so a client stuck in a loop cannot exhaust the deployment. | On | — |
+| Max Request Bytes | Largest request body accepted. Anything bigger is refused unread. | 65536 | 1 KB – 1 MB |
+| Throttle Window (Seconds) | The period each limit below is counted over. | 60 | 10 – 3600 |
+| Read Calls Per Window | Reads are cheap, so this is the most permissive limit. | 120 | 1 – 10000 |
+| Search Calls Per Window | Each search costs an index query, so it is limited harder than reads. | 30 | 1 – 10000 |
+| Write Calls Per Window | Writes change stored data, so this is the tightest limit. | 10 | 1 – 10000 |
+
+#### Allowlists
+
+Each allowlist row pairs the identifier the runtime matches with a description of
+who it belongs to. Fill the description in: a list of bare GUIDs becomes
+impossible to audit within weeks, and nobody can then say which entry is safe to
+remove.
+
+**Client app IDs are required.** While that list is empty no client can connect,
+whatever else is configured.
+
+**Source IDs are weaker than they look.** The source arrives in a request header
+the client sets, so it identifies rather than authenticates, and it can be
+spoofed unless a gateway or APIM policy sets and enforces it. Leaving **Allow all
+source IDs** on accepts any value at this layer; a governance policy still
+decides who gets tools. Turn it off only where something upstream controls the
+header.
+
+| Setting | What it does | Default | Notes |
+| --- | --- | --- | --- |
+| Allowed Client App IDs | The Entra application ids permitted to connect. | Empty, so nothing can connect | `inbound_mcp_allowed_client_app_entries` |
+| Allow Additional Tenant IDs | Off restricts callers to this deployment's own tenant. | Off | `inbound_mcp_allow_external_tenants` |
+| Allowed Tenant IDs | Additional tenants whose users may connect. The deployment's own tenant is always included. | Empty | `inbound_mcp_allowed_tenant_entries` |
+| Allow All Source IDs | Accepts any source value at the allowlist layer. | On | `inbound_mcp_allow_all_source_ids` |
+| Source Header Name | The request header the source value is read from. | X-SimpleChat-MCP-Source | `inbound_mcp_source_header` |
+| Allowed Source IDs | The source values accepted when not allowing all of them. | Empty | `inbound_mcp_allowed_source_entries` |
+
+Turning **Allow Additional Tenant IDs** off does not delete the tenants you
+listed; it stops admitting them. Turning it back on restores them.
+
+Application Insights records `mcp_request_id`, the calling app, the delegated
+user, the source, the tool, duration, result and rate-limit category for each
+request — and never prompts, document content, bearer tokens or secrets.
 
 ## Common tasks
 
@@ -254,6 +318,10 @@ If the tab shows that the Inbound MCP admin UI is disabled, add the Azure App Se
 | Symptom | Likely cause | Fix |
 | --- | --- | --- |
 | An action is missing from an agent | The built-in action toggle or workspace action permission is disabled. | Enable the action and confirm the agent scope allows it. |
+| The Agents page returns an error instead of the catalog | **Enable Agents** is off. That page is served behind it. | Turn on Enable Agents, or remove the link from navigation. |
+| An agent setting has no effect | Workspace Mode changes where agents come from, so a global agent is unused in Workspace Mode unless the merge setting is on. | Check Workspace Mode first, then the merge setting. |
+| A document action ignores the limit you set | The value was outside the supported range and was clamped on save. | Re-open the setting to see the stored value. |
+| An MCP client is refused after the allowlist was updated | Every layer must pass, and a governance policy is still required after the allowlists. | Check the client app id, the tenant, the source, and the governance policy in that order. |
 
 ## Related
 

--- a/docs/admin/agents-actions.md
+++ b/docs/admin/agents-actions.md
@@ -71,6 +71,7 @@ with the rest of the page.
 | Workspace Mode | Chooses between one shared global set of agents and actions, and a separate collection per user and group. | Off | `per_user_semantic_kernel` |
 | Add Global Agents and Actions to Workspaces | Includes the global set in every workspace collection, so people see both what they built and what you publish. | Off | `merge_global_semantic_kernel_with_workspace`; only applies in Workspace Mode |
 | Orchestration Type | Selects how a chat is routed across agents. Hidden while only one mode is available. | default_agent | `orchestration_type`; saved by the orchestration settings API |
+| Multi-Agent Orchestration | Reports whether the runtime coordinates several agents. Follows the orchestration mode rather than being set directly. | Off | `enable_multi_agent_orchestration`; derived |
 | Max Rounds Per Agent | Caps how many turns each agent takes in a multi-agent conversation, which bounds the model calls one message can trigger. | 1 | `max_rounds_per_agent`; forced to 1 outside multi-agent modes |
 
 ### Workspace Agent Permissions {#agent-toggles-card}

--- a/docs/explanation/features/V2_ADMIN_AGENTS_ACTIONS.md
+++ b/docs/explanation/features/V2_ADMIN_AGENTS_ACTIONS.md
@@ -1,0 +1,180 @@
+# V2 Admin Settings: Agents & Actions
+
+## Overview
+
+The V2 React admin surface renders its controls from a server-declared field
+schema. Groups with no entry in that schema fall back to scanning the settings
+document for `enable_*` booleans and matching each key to a navigation section by
+shared word stems.
+
+Agents and actions are not configured with booleans, so that fallback produced an
+almost empty tab. This feature declares the Agents & Actions group properly, and
+adds the small number of schema and renderer capabilities the group needs that
+the Appearance group never exercised.
+
+**Implemented in version:** 0.261.059 (phase 1 of 5)
+
+**Dependencies:** `admin_settings_fields.py`, `admin_settings_nav.py`,
+`route_backend_v2.py`, `application/v2_ui`.
+
+## What the fallback produced
+
+Tracing `buildCapabilityIndex` against `ADMIN_NAV` and the settings defaults, the
+V2 Agents & Actions group rendered:
+
+| Navigation section | Rendered |
+|---|---|
+| `agents-config` | nothing; the section was skipped |
+| `agent-template-approvals-section` | `enable_agent_template_gallery` |
+| `document-action-capabilities-card` | nothing; the section was skipped |
+| `actions-config` | `enable_text_plugin` |
+| `inbound-mcp-configuration` | `enable_inbound_mcp_server`, `enable_inbound_mcp_rate_limits` |
+| "Other capabilities" | `enable_semantic_kernel` and four `enable_*_plugin` keys |
+| Chat › Processing Thoughts | `enable_tabular_processing_plugin`, misfiled by stem match |
+
+Everything else in the group — `per_user_semantic_kernel`, the six `allow_*` and
+`merge_*` toggles, `orchestration_type`, `max_rounds_per_agent`, the eleven
+`agents_page_*` keys, `document_action_capabilities`, and nineteen
+`inbound_mcp_*` keys — was invisible, because the fallback only scans `enable_*`
+booleans.
+
+## Technical specifications
+
+### Navigation
+
+`ADMIN_NAV` now names the nested cards the V1 panes already carry, so the V2
+surface can render one section per concern without any change to the
+server-rendered page. Every id below already exists in `templates/admin/_panes/`.
+
+| Tab | Section id | Label | Condition |
+|---|---|---|---|
+| Agents | `agents-config` | Agent Runtime | — |
+| Agents | `agent-toggles-card` | Workspace Agent Permissions | `per_user_semantic_kernel` |
+| Agents | `agents-page-customization-card` | Agents Page | — |
+| Agents | `agent-template-approvals-section` | Agent Template Approvals | `enable_agent_template_gallery` |
+| Actions | `document-action-capabilities-card` | Document Actions | — |
+| Actions | `plugin-feature-toggles` | Workspace Action Permissions | `per_user_semantic_kernel` |
+| Actions | `core-plugin-toggles` | Built-in Actions | — |
+| Actions | `actions-config` | Global Actions | — |
+
+`agents-config` and `actions-config` resolve to the V1 card ids
+`agents-configuration` and `actions-configuration` through the existing
+`sectionMap` alias in `admin_sidebar_nav.js`.
+
+### Schema additions
+
+| Property | Purpose |
+|---|---|
+| `depends_on` as a list | A chain of conditions that must all hold. Agents → Workspace Mode → merge behaviour is three links, and judging one link alone puts a control back on screen while an intermediate gate is off. |
+| `equals` as a string | Compares against a select value rather than a boolean, so the Agents page hides its gradient colour outside two-tone mode. |
+| `group` | A sub-heading collecting related fields inside one section. |
+| `collapsed` | Starts a group closed. Only the first field of a group decides this. |
+
+`iter_dependencies(field)` yields each condition regardless of which shape was
+declared, so no caller re-derives it.
+
+### Section conditions
+
+`ADMIN_NAV` has always supported a section `condition`, and the server-rendered
+sidebar evaluates it. V2 ignored it. `isSectionVisible` now resolves a condition
+against, in order:
+
+1. `runtime_flags` from the settings API — currently `mcp_ui_enabled`, which
+   comes from an App Service application setting and is never stored in the
+   settings document;
+2. the unsaved draft, so a section appears the moment its gate is switched
+   rather than only after a save;
+3. the stored settings.
+
+A section whose declared fields are all hidden by their own dependencies is
+dropped too, so no empty titled panel is left behind.
+
+### API
+
+`GET /api/v2/admin/settings` gained a `runtime_flags` object:
+
+```json
+{
+  "settings": { },
+  "admin_nav": [],
+  "field_schema": { },
+  "branding_assets": { },
+  "runtime_flags": { "mcp_ui_enabled": false },
+  "version": "0.261.059"
+}
+```
+
+### Normalization
+
+`normalize_admin_settings_updates` now consults `_DELEGATED_NORMALIZERS` before
+looking up a field definition. Previously a key with no declared field passed
+straight through unvalidated, which would have applied to
+`agents_page_promoted_popular_agents`: it is edited by a component rather than a
+typed field, so it has no type-driven normalization of its own. It is now
+normalized by `normalize_agents_page_promoted_popular_agents`, the same function
+the server-rendered form uses.
+
+### Components
+
+**`agent-orchestration`** reads `GET /api/orchestration_types` and
+`GET /api/orchestration_settings`, and saves through
+`POST /api/orchestration_settings` rather than the settings PATCH, because that
+endpoint also derives `enable_multi_agent_orchestration` from the chosen mode and
+forces `max_rounds_per_agent` back to 1 outside multi-agent modes.
+
+It renders nothing while fewer than two types are offered.
+`get_agent_orchestration_types()` currently returns one entry, `default_agent`;
+`group_chat` and `magnetic` are inside a string literal in
+`semantic_kernel_loader.py` and are not built. The card therefore stays hidden,
+and reappears by itself if those modes return.
+
+**`promoted-popular-agents`** loads candidates from
+`GET /api/agents/catalog?include_usage=true` and writes
+`agents_page_promoted_popular_agents` into the page draft. It produces entries of
+exactly the shape the server keeps — `catalog_key`, `display_name`,
+`scope_label`, `scope_type`, `window` — and never offers an agent that is already
+promoted, because the server drops duplicate catalog keys on save.
+
+## Usage
+
+Admin Settings → Agents & Actions → Agents in the V2 interface (`/v2`).
+
+The dependency chain an administrator now sees:
+
+```
+Enable Agents  (enable_semantic_kernel, default off)
+├─ Workspace Mode  (per_user_semantic_kernel)
+│   ├─ Add Global Agents and Actions to Workspaces
+│   └─ Workspace Agent Permissions section
+│       ├─ Allow Personal / Group Agents
+│       ├─ Allow Personal / Group Custom Endpoints
+│       └─ Enable Agent Template Gallery
+│            └─ Agent Template Approvals section
+├─ Agents Page section  (hero, guidance, promotions)
+└─ Agent Orchestration  (hidden: one mode available)
+```
+
+## Testing and validation
+
+| Test | Covers |
+|---|---|
+| `functional_tests/test_v2_admin_agents_parity.py` | Every V1 field name in the Agents pane is claimed by the schema; the gate chain is declared; conditional sections name their gate; tracks which panes remain undeclared |
+| `functional_tests/test_v2_admin_agents_logic.mjs` | Executes group layout, dependency chains, string dependencies, section conditions, orchestration visibility, and promotion normalization |
+| `functional_tests/test_v2_admin_settings_schema.py` | Field shape, defaults matching the application, dependency references including string comparisons |
+| `functional_tests/test_v2_admin_field_renderer_coverage.py` | Both new components have a renderer branch |
+
+## Known limitations
+
+- The Actions and Inbound MCP tabs still use the `enable_*` fallback. Phases 2
+  and 3 declare them; `PANES_PENDING_DECLARATION` in the parity test tracks this.
+- Global agent and global action authoring stays in the classic interface until
+  phases 4 and 5.
+- The V1 sidebar cannot render a section whose `condition` is not one of the two
+  names hard-coded in its template, so the two Workspace Mode sections do not
+  appear as sidebar links there. The V1 cards themselves are unaffected, and V2
+  honours the condition correctly.
+
+## Related
+
+- `docs/admin/agents-actions.md` — administrator-facing reference
+- `docs/explanation/features/ADMIN_SETTINGS_IA_REWORK_STATUS.md` — the wider rework

--- a/docs/explanation/features/V2_ADMIN_AGENTS_ACTIONS.md
+++ b/docs/explanation/features/V2_ADMIN_AGENTS_ACTIONS.md
@@ -12,7 +12,7 @@ almost empty tab. This feature declares the Agents & Actions group properly, and
 adds the small number of schema and renderer capabilities the group needs that
 the Appearance group never exercised.
 
-**Implemented in version:** 0.261.059 (phase 1 of 5)
+**Implemented in version:** 0.261.059 (phase 1, Agents), 0.261.060 (phase 2, Actions)
 
 **Dependencies:** `admin_settings_fields.py`, `admin_settings_nav.py`,
 `route_backend_v2.py`, `application/v2_ui`.
@@ -69,9 +69,48 @@ server-rendered page. Every id below already exists in `templates/admin/_panes/`
 | `equals` as a string | Compares against a select value rather than a boolean, so the Agents page hides its gradient colour outside two-tone mode. |
 | `group` | A sub-heading collecting related fields inside one section. |
 | `collapsed` | Starts a group closed. Only the first field of a group decides this. |
+| `settings_path` | Reads and writes a value stored inside a nested object. `document_action_capabilities` holds six values across two action types, and nothing reads a flattened form of them. |
+| `readonly` + `managed_by` | Reports a value another surface owns, and names where it is set. |
 
 `iter_dependencies(field)` yields each condition regardless of which shape was
 declared, so no caller re-derives it.
+
+### Nested settings values
+
+A field with a `settings_path` keeps its flat `key` for the draft, the PATCH
+payload and field errors, and names the path its value really occupies.
+
+On save, `_apply_nested_paths` removes those flat keys from the normalized
+payload and rebuilds each container from the stored object, so editing one limit
+does not discard the other five. The assembled container is then handed to
+`_CONTAINER_NORMALIZERS`, which delegates to
+`normalize_document_action_capabilities` — the same function the server-rendered
+form uses, so both surfaces clamp to `DOCUMENT_ACTION_LIMIT_BOUNDS` identically.
+
+In the browser, `readFieldValue` walks the path for the saved value while still
+preferring a draft entry keyed by the flat name. A gate can itself be nested —
+the limits are gated by an `enabled` flag in the same container — so
+`isFieldVisible` takes a field index built by `buildFieldIndex` rather than
+looking the gate up by key alone.
+
+### Read-only mirrors
+
+Two actions change what an agent can do but are not set from the Actions tab:
+
+| Key | Owner | Why it is mirrored |
+|---|---|---|
+| `enable_fact_memory_plugin` | Chat › Chat Experience › Fact Memory | A chat capability that also gives agents a memory action |
+| `enable_tabular_processing_plugin` | Derived from `enable_enhanced_citations` | Recomputed on every settings read, so it can never be set directly |
+
+A mirror renders its state and its owner instead of a control, and the server
+refuses a write to it. Because fact memory is declared twice — editable under
+Chat, mirrored under Actions — `get_field_definition` returns the writable
+declaration regardless of order, so mirroring a key never removes the control
+that actually sets it.
+
+Before this, `enable_tabular_processing_plugin` was rendered by the fallback scan
+as a live switch under Chat › Processing Thoughts, purely because "processing"
+matched that section id. Flipping it did nothing.
 
 ### Section conditions
 
@@ -159,16 +198,20 @@ Enable Agents  (enable_semantic_kernel, default off)
 | Test | Covers |
 |---|---|
 | `functional_tests/test_v2_admin_agents_parity.py` | Every V1 field name in the Agents pane is claimed by the schema; the gate chain is declared; conditional sections name their gate; tracks which panes remain undeclared |
-| `functional_tests/test_v2_admin_agents_logic.mjs` | Executes group layout, dependency chains, string dependencies, section conditions, orchestration visibility, and promotion normalization |
-| `functional_tests/test_v2_admin_settings_schema.py` | Field shape, defaults matching the application, dependency references including string comparisons |
+| `functional_tests/test_v2_admin_actions_parity.py` | Every V1 field name in the Actions pane is claimed; document action paths, bounds and defaults match the application; the container is rebuilt without losing siblings; mirrors name their owner and the derived one refuses writes |
+| `functional_tests/test_v2_admin_agents_logic.mjs` | Executes group layout, dependency chains, string dependencies, section conditions, nested value reads, field-index ownership, orchestration visibility, and promotion normalization |
+| `functional_tests/test_v2_admin_settings_schema.py` | Field shape, defaults matching the application, key ownership, dependency references including string comparisons |
 | `functional_tests/test_v2_admin_field_renderer_coverage.py` | Both new components have a renderer branch |
 
 ## Known limitations
 
-- The Actions and Inbound MCP tabs still use the `enable_*` fallback. Phases 2
-  and 3 declare them; `PANES_PENDING_DECLARATION` in the parity test tracks this.
+- The Inbound MCP tab still uses the `enable_*` fallback. Phase 3 declares it;
+  `PANES_PENDING_DECLARATION` in the agents parity test tracks this.
 - Global agent and global action authoring stays in the classic interface until
-  phases 4 and 5.
+  phases 4 and 5, so the Global Actions section currently declares no fields.
+- `functions_document_actions` reaches `config.py` and a live Cosmos client, so
+  its normalizer is imported lazily and cannot be exercised in a test process.
+  The tests read its bounds from source and pin the delegation instead.
 - The V1 sidebar cannot render a section whose `condition` is not one of the two
   names hard-coded in its template, so the two Workspace Mode sections do not
   appear as sidebar links there. The V1 cards themselves are unaffected, and V2

--- a/docs/explanation/features/V2_ADMIN_AGENTS_ACTIONS.md
+++ b/docs/explanation/features/V2_ADMIN_AGENTS_ACTIONS.md
@@ -12,8 +12,7 @@ almost empty tab. This feature declares the Agents & Actions group properly, and
 adds the small number of schema and renderer capabilities the group needs that
 the Appearance group never exercised.
 
-**Implemented in version:** 0.261.062 (phase 1, Agents), 0.261.063 (phase 2,
-Actions), 0.261.064 (phase 3, Inbound MCP)
+**Implemented in version:** 0.261.065
 
 **Dependencies:** `admin_settings_fields.py`, `admin_settings_nav.py`,
 `route_backend_v2.py`, `application/v2_ui`.
@@ -169,7 +168,7 @@ dropped too, so no empty titled panel is left behind.
   "field_schema": { },
   "branding_assets": { },
   "runtime_flags": { "mcp_ui_enabled": false },
-  "version": "0.261.062"
+  "version": "0.261.065"
 }
 ```
 

--- a/docs/explanation/features/V2_ADMIN_AGENTS_ACTIONS.md
+++ b/docs/explanation/features/V2_ADMIN_AGENTS_ACTIONS.md
@@ -12,7 +12,8 @@ almost empty tab. This feature declares the Agents & Actions group properly, and
 adds the small number of schema and renderer capabilities the group needs that
 the Appearance group never exercised.
 
-**Implemented in version:** 0.261.059 (phase 1, Agents), 0.261.060 (phase 2, Actions)
+**Implemented in version:** 0.261.059 (phase 1, Agents), 0.261.060 (phase 2,
+Actions), 0.261.061 (phase 3, Inbound MCP)
 
 **Dependencies:** `admin_settings_fields.py`, `admin_settings_nav.py`,
 `route_backend_v2.py`, `application/v2_ui`.
@@ -71,6 +72,8 @@ server-rendered page. Every id below already exists in `templates/admin/_panes/`
 | `collapsed` | Starts a group closed. Only the first field of a group decides this. |
 | `settings_path` | Reads and writes a value stored inside a nested object. `document_action_capabilities` holds six values across two action types, and nothing reads a flattened form of them. |
 | `readonly` + `managed_by` | Reports a value another surface owns, and names where it is set. |
+| `depends_on` naming a `flag` | Gates a field on a server-resolved runtime flag rather than a settings key, for a capability gated outside the settings document. |
+| `entry_list` | A repeatable `{value, description}` allowlist. |
 
 `iter_dependencies(field)` yields each condition regardless of which shape was
 declared, so no caller re-derives it.
@@ -111,6 +114,33 @@ that actually sets it.
 Before this, `enable_tabular_processing_plugin` was rendered by the fallback scan
 as a live switch under Chat › Processing Thoughts, purely because "processing"
 matched that section id. Flipping it did nothing.
+
+### Runtime-flag gates and derived keys
+
+Inbound MCP is gated by `ENABLE_MCP_UI`, an App Service application setting. It
+has no entry in the settings document, so a `depends_on` may name a `flag`
+instead of a `key`; the flag is answered from `runtime_flags` and cannot be
+changed from the page at all. The section itself stays unconditional so the
+`inbound-mcp-disabled-notice` component can explain how to turn the gate on —
+that notice is simply the one field gated on the flag being *false*.
+
+The inbound MCP settings are also the first where one edit has to produce several
+stored keys. The runtime does not read the `*_entries` lists an administrator
+edits; it reads `*_ids` lists, and single-role settings are mirrored into
+`*_roles` arrays. `_apply_inbound_mcp_derivations` reproduces the block the
+server-rendered form runs on save, reusing
+`normalize_inbound_mcp_value_entries`, `inbound_mcp_entry_values`,
+`ensure_inbound_mcp_default_tenant_entry` and
+`normalize_inbound_mcp_single_value` rather than restating the rules, because
+those rules are not a straight mapping:
+
+- the tenant id list only reflects the entries while additional tenants are
+  allowed, and always includes the deployment's own tenant. Restricting tenants
+  changes the id list and keeps the entries, so a partner tenant survives the
+  switch being turned off and on again;
+- the source id list collapses to `["*"]` when all sources are allowed, and the
+  wildcard row is stripped when they are not — otherwise a controlled list would
+  keep accepting every source while the screen showed a restriction.
 
 ### Section conditions
 
@@ -199,19 +229,20 @@ Enable Agents  (enable_semantic_kernel, default off)
 |---|---|
 | `functional_tests/test_v2_admin_agents_parity.py` | Every V1 field name in the Agents pane is claimed by the schema; the gate chain is declared; conditional sections name their gate; tracks which panes remain undeclared |
 | `functional_tests/test_v2_admin_actions_parity.py` | Every V1 field name in the Actions pane is claimed; document action paths, bounds and defaults match the application; the container is rebuilt without losing siblings; mirrors name their owner and the derived one refuses writes |
-| `functional_tests/test_v2_admin_agents_logic.mjs` | Executes group layout, dependency chains, string dependencies, section conditions, nested value reads, field-index ownership, orchestration visibility, and promotion normalization |
-| `functional_tests/test_v2_admin_settings_schema.py` | Field shape, defaults matching the application, key ownership, dependency references including string comparisons |
-| `functional_tests/test_v2_admin_field_renderer_coverage.py` | Both new components have a renderer branch |
+| `functional_tests/test_v2_admin_inbound_mcp_parity.py` | Every V1 field name in the Inbound MCP pane is claimed; every setting is gated on the runtime flag and the notice covers the disabled state; the derivations are executed against the real helpers, loaded through `stubbed_config` |
+| `functional_tests/test_v2_admin_agents_logic.mjs` | Executes group layout, dependency chains, string and flag dependencies, section conditions, nested value reads, field-index ownership, allowlist normalization, orchestration visibility, and promotion normalization |
+| `functional_tests/test_v2_admin_settings_schema.py` | Field shape, defaults matching the application, key ownership, dependency references including string comparisons and runtime flags |
+| `functional_tests/test_v2_admin_field_renderer_coverage.py` | Every field type and every named component has a renderer branch |
 
 ## Known limitations
 
-- The Inbound MCP tab still uses the `enable_*` fallback. Phase 3 declares it;
-  `PANES_PENDING_DECLARATION` in the agents parity test tracks this.
 - Global agent and global action authoring stays in the classic interface until
   phases 4 and 5, so the Global Actions section currently declares no fields.
 - `functions_document_actions` reaches `config.py` and a live Cosmos client, so
   its normalizer is imported lazily and cannot be exercised in a test process.
   The tests read its bounds from source and pin the delegation instead.
+  `functions_mcp_server_config` needs only five constants from `config`, so its
+  real behaviour is exercised through `stubbed_config`.
 - The V1 sidebar cannot render a section whose `condition` is not one of the two
   names hard-coded in its template, so the two Workspace Mode sections do not
   appear as sidebar links there. The V1 cards themselves are unaffected, and V2

--- a/docs/explanation/fixes/ADMIN_SETTINGS_REGISTRY_MERGE_FIXES.md
+++ b/docs/explanation/fixes/ADMIN_SETTINGS_REGISTRY_MERGE_FIXES.md
@@ -1,0 +1,141 @@
+# Admin Settings Registry Merge Fixes
+
+## Issue
+
+Six branches described different groups of the V2 admin settings surface at the
+same time, all writing into the same three registries: `ADMIN_SETTINGS_FIELDS`
+in `admin_settings_fields.py`, the field type union in `adminFields.ts`, and the
+component switch in `AdminSettingsPage.tsx`.
+
+Merging them surfaced four defects that a passing build would not have caught.
+Every one of them produced code that parsed, imported and ran; three of them
+would have shipped silently.
+
+**Fixed in version:** 0.261.074
+
+## Root cause
+
+Each branch inserts its entries at the same anchor in a large dict literal, so
+git resolves the two sides by line similarity rather than by structure. The
+resulting conflict regions cut through unterminated dict literals, and a
+"keep both" resolution that happens to parse is not the same as a correct one.
+
+Merging these files by text is the underlying mistake. The reliable approach is
+to parse both sides with `ast`, diff the section and field key sets, and rebuild
+the union — then assert the result is exactly that union.
+
+## Defects and fixes
+
+### 1. Nine sections declared twice
+
+The Agents & Actions sections were added to the merged file twice: once by
+splicing the section sources, and again by applying a patch that also contained
+them. Python keeps the last definition of a duplicate dict key, so the file
+parsed, imported and behaved correctly. Nothing failed.
+
+`functional_tests/test_admin_settings_fields_registry_integrity.py`, added by
+the Chat work, caught it on its first run.
+
+**Fix:** rebuild the file from the incoming branch and apply this branch's diff
+exactly once, rather than combining two mechanisms that each carry the same
+additions.
+
+### 2. An emptied section can orphan a setting that arrived later
+
+`actions-config` was emptied when `enable_text_plugin` moved into
+`core-plugin-toggles` with the other built-in actions. That was safe at the
+time. It stopped being obviously safe when the Chat work moved a second toggle,
+`enable_default_embedding_model_plugin`, into the same section afterwards —
+by the time the branches met, removing the section would have dropped a setting
+that had arrived while nobody was looking.
+
+Both keys are declared in `core-plugin-toggles`, so nothing was lost, but that
+was verified rather than assumed.
+
+**Fix:** `test_removing_a_section_did_not_orphan_its_settings` in
+`test_v2_admin_actions_parity.py` asserts every key that section used to hold is
+declared somewhere. The general form — *a removed section must not take a
+setting with it* — is the reusable part.
+
+Restoring `actions-config` now fails the registry integrity test instead, because
+its fields would be declared twice.
+
+### 3. One key, two writable declarations
+
+Both this branch and the Chat work declared `fact-memory-section`, identically,
+with one writable field. Fact memory is a chat capability that also decides
+whether agents get a memory action, so it appears in both surfaces: editable
+under Chat, and as a read-only mirror under Built-in Actions.
+
+Two writable declarations give the key two owners. `get_field_definition` prefers
+a writable declaration over a mirror, but cannot choose between two writable
+ones, so which declaration governed saving would have depended on dict order.
+
+**Fix:** the Chat group owns the section, so its declaration is kept and this
+branch's dropped. `test_fact_memory_stays_editable_where_it_is_owned` now asserts
+there is exactly one writable declaration and that it is the one Chat owns.
+
+### 4. A resolved duplicate exposed a latent crash
+
+`test_v2_admin_workflow_parity.py` read `depends_on` as a single dict and raised
+`'list' object has no attribute 'get'`.
+
+The chained dependency it choked on was not new: `group_workflow_allowed_group_ids`
+had carried a two-link chain for some time. It was invisible because
+`workflow-settings-section` was declared **twice**, and Python keeps the later
+definition — which was not the chained one. Resolving that duplicate made the
+chained field live and the assumption failed immediately.
+
+**Fix:** the test reads gates through `fields_module.iter_field_dependencies`,
+the schema's own iterator, like every other caller.
+
+This is the most transferable of the four: **fixing a duplicate declaration can
+expose a bug in code that only ever saw the other copy.** The duplicate was known
+and considered harmless.
+
+## Test changed rather than code
+
+`test_v2_admin_capability_placement.py` asserted that a suppressed capability is
+not *declared*. It was narrowed to assert it is not *editable*.
+
+A read-only mirror is not an editable declaration, and cannot be saved — the
+schema rejects a write to a `readonly` field and returns an error naming its
+owner. Suppression and mirroring solve the same problem differently: suppression
+removes the key from the surface, while a mirror reports the derived value and
+names what computes it. For `enable_tabular_processing_plugin` the mirror is more
+use, because an administrator looking at what an agent can do should see that
+tabular processing is on and that Enhanced Citations is what turns it on.
+
+Both mechanisms remain: the key is still suppressed from the fallback scan, so it
+is never drawn as a switch.
+
+## Semantic collisions
+
+Three collisions produced no conflict markers at all, because each side added an
+equivalently-named-but-different helper that compiled fine alongside the other:
+
+| Collision | Resolution |
+|---|---|
+| `iter_dependencies` vs `iter_field_dependencies` / `_dependency_is_satisfied` | Kept the Security work's pair; taught `_dependency_is_satisfied` to return `True` for a condition naming a runtime flag, which has no settings key and would otherwise raise `KeyError` |
+| `groupFields` vs `buildSectionBlocks` | Kept `buildSectionBlocks`; it groups identically and also supports a collapsed group |
+| `AdminFieldDependency` renamed to `AdminFieldCondition` | Kept both names: `AdminFieldCondition` for one condition, `AdminFieldDependency` for the one-or-many alias |
+
+A duplicated helper is worse than a conflict. Two functions answering the same
+question drift, and nothing reports it.
+
+## Validation
+
+| Check | Result |
+|---|---|
+| `test_admin_settings_fields_registry_integrity.py` | 55 sections, no duplicate sections or fields |
+| `test_v2_admin_actions_parity.py` | Emptied section orphans nothing; one writable owner per key |
+| `test_v2_admin_workflow_parity.py` | Chained dependencies read correctly |
+| `test_v2_admin_capability_placement.py` | Read-only mirrors survive; suppression still enforced |
+| All admin parity suites | 132 tests passing across every group |
+| `python -m compileall application/single_app` | Clean |
+| `npm run typecheck` / `npm run build` | Clean |
+
+## Related
+
+- `docs/explanation/features/V2_ADMIN_AGENTS_ACTIONS.md`
+- `functional_tests/test_admin_settings_fields_registry_integrity.py`

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,15 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/features) and [Fixes by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/fixes).
 
+### **(v0.261.062)**
+
+#### Bug Fixes
+
+*   **Multi-Agent Orchestration Is No Longer Shown As A Switch Under AI Models**
+    *   **Multi-agent orchestration** appeared in the new Admin Settings surface as a live toggle in the AI Models group, which it has nothing to do with. It is written by the orchestration settings API from the chosen orchestration mode, so setting it there did nothing and the value reverted.
+    *   It now sits with the agent runtime settings as a read-only entry that reports the current mode.
+    *   (Ref: `enable_multi_agent_orchestration`, `admin_settings_fields.py`)
+
 ### **(v0.261.061)**
 
 #### New Features

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -48,6 +48,14 @@ For feature-focused and fix-focused drill-downs by version, see [Features by Ver
     *   It now sits with the agent runtime settings as a read-only entry that reports the current mode.
     *   (Ref: `enable_multi_agent_orchestration`, `admin_settings_fields.py`)
 
+*   **Defects Found While Combining The Admin Settings Groups**
+    *   Six efforts described different admin settings groups at the same time, all writing into the same registries. Combining them surfaced four faults that produced code which parsed, imported and ran — three would have shipped silently.
+    *   **Nine settings sections were declared twice.** Python keeps the last definition of a duplicate key, so nothing failed; the new registry integrity test caught it on its first run.
+    *   **A section emptied earlier had quietly gained a new setting.** The Actions Configuration section was emptied when the Text action moved in with the other built-in actions, and the Default Embedding Model action was moved into it afterwards. A check now confirms that emptying a section never takes a setting with it.
+    *   **Fact Memory was declared as editable in two places at once.** It is a chat capability that also decides whether agents get a memory action, so it appears in both surfaces; only the Chat declaration may be the editable one, or which control governs saving depends on declaration order.
+    *   **A test crashed once a duplicate was resolved.** A workflow check read a setting's dependency as a single condition rather than a chain. The chained setting had existed for some time but was masked by a duplicate section declaration; fixing the duplicate made it visible.
+    *   (Ref: [Admin Settings Registry Merge Fixes](fixes/ADMIN_SETTINGS_REGISTRY_MERGE_FIXES.md))
+
 #### User Interface Enhancements
 
 *   **Agent Orchestration No Longer Shows A Choice That Does Not Exist**

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,28 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/features) and [Fixes by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/fixes).
 
+### **(v0.261.060)**
+
+#### New Features
+
+*   **Action Settings Are Now Present In The New Admin Interface**
+    *   The Actions tab in the new Admin Settings surface showed a single toggle. The Analyze and Document Comparison limits were invisible because they are stored as one nested object rather than as separate settings, and the built-in action toggles had been scattered by the same guesswork that emptied the Agents tab — **Enable Text Action** had ended up under Appearance › Branding because its name contains "text".
+    *   The Actions tab now renders as four sections: **Document Actions**, **Workspace Action Permissions**, **Built-in Actions**, and **Global Actions**.
+    *   **Document action limits are editable again**, with the ranges the application actually enforces (2–300 for chat, 2–1000 for a workflow run) and the workflow limit separated from the chat one. Saving one limit no longer risks the other five, and out-of-range values are clamped by the same code the classic interface uses.
+    *   **Built-in actions are collapsed rather than laid out flat.** They default on and are rarely changed, so they no longer take up the tab; the documentation now says which one is worth a decision — HTTP, the only built-in action that reaches outside the deployment.
+
+#### Bug Fixes
+
+*   **Tabular Processing Is No Longer Shown As A Toggle That Does Nothing**
+    *   The new interface showed **Tabular Processing** as a live switch under Chat › Processing Thoughts, purely because the word "processing" matched that section. The application recomputes this setting from **Enhanced Citations** on every settings read, so switching it had no effect and the value silently reverted.
+    *   It now appears where it belongs, under Built-in Actions, as a read-only entry that reports its state and names Enhanced Citations as its source. Attempting to set it directly is refused rather than accepted and discarded.
+    *   (Ref: `enable_tabular_processing_plugin`, `is_tabular_processing_enabled`, `admin_settings_fields.py`)
+
+*   **Fact Memory Is Listed With The Actions It Affects Without Moving Its Control**
+    *   Fact memory is a chat capability, but it also decides whether agents get a memory action, so it was missing from any list an administrator would consult when working out what an agent can do.
+    *   It is now mirrored under Built-in Actions as a read-only entry that links to where it is set, while the control that actually sets it stays in Chat.
+    *   (Ref: `enable_fact_memory_plugin`, `fields.tsx`)
+
 ### **(v0.261.059)**
 
 #### New Features

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -4,16 +4,23 @@ For feature-focused and fix-focused drill-downs by version, see [Features by Ver
 
 ### **(v0.261.065)**
 
-#### Bug Fixes
-
-*   **Multi-Agent Orchestration Is No Longer Shown As A Switch Under AI Models**
-    *   **Multi-agent orchestration** appeared in the new Admin Settings surface as a live toggle in the AI Models group, which it has nothing to do with. It is written by the orchestration settings API from the chosen orchestration mode, so setting it there did nothing and the value reverted.
-    *   It now sits with the agent runtime settings as a read-only entry that reports the current mode.
-    *   (Ref: `enable_multi_agent_orchestration`, `admin_settings_fields.py`)
-
-### **(v0.261.064)**
-
 #### New Features
+
+*   **Agent Settings Are Now Actually Present In The New Admin Interface**
+    *   The new Admin Settings surface built its Agents tab by scanning the settings document for on/off switches and guessing where each one belonged. Agents are configured with far more than switches, so the result was close to empty: the Agents Configuration section rendered nothing at all, **Enable Agents** was filed under "Other capabilities" because nothing in its name matched the section, and not one of Workspace Mode, the workspace permissions, or the eleven Agents page settings appeared anywhere.
+    *   The Agents tab is now described properly and renders every one of those settings, split into four sections instead of a single crowded card: **Agent Runtime**, **Workspace Agent Permissions**, **Agents Page**, and **Agent Template Approvals**.
+    *   **The settings now say what depends on what.** Enable Agents gates the whole tab. Workspace Mode only appears once agents are on, and the merge behaviour only once Workspace Mode is on — a chain, so a control cannot reappear because an intermediate gate happens to be off. Workspace Agent Permissions is hidden entirely outside Workspace Mode, matching the classic interface.
+    *   **Workspace Mode explains itself.** It reads as a choice between one shared set of agents that administrators curate, and a separate collection for each user and group, rather than as an unexplained switch.
+    *   **The Agents page settings now follow the page they customise.** That page is served behind Enable Agents, so its hero, guidance text and promotion settings are hidden while agents are off instead of offering edits that could not take effect.
+    *   **Promoted agents are chosen from a list rather than edited as JSON.** Agents already promoted are not offered again, and each promotion's time window is set per row.
+    *   Rarely-changed settings are grouped and collapsed rather than laid out flat, and a search opens any collapsed group so a match is never hidden behind it.
+    *   (Ref: `admin_settings_fields.py`, `admin_settings_nav.py`, `adminAgents.ts`, `PromotedAgentsEditor.tsx`, `AdminSettingsPage.tsx`)
+
+*   **Action Settings Are Now Present In The New Admin Interface**
+    *   The Actions tab in the new Admin Settings surface showed a single toggle. The Analyze and Document Comparison limits were invisible because they are stored as one nested object rather than as separate settings, and the built-in action toggles had been scattered by the same guesswork that emptied the Agents tab — **Enable Text Action** had ended up under Appearance › Branding because its name contains "text".
+    *   The Actions tab now renders as four sections: **Document Actions**, **Workspace Action Permissions**, **Built-in Actions**, and **Global Actions**.
+    *   **Document action limits are editable again**, with the ranges the application actually enforces (2–300 for chat, 2–1000 for a workflow run) and the workflow limit separated from the chat one. Saving one limit no longer risks the other five, and out-of-range values are clamped by the same code the classic interface uses.
+    *   **Built-in actions are collapsed rather than laid out flat.** They default on and are rarely changed, so they no longer take up the tab; the documentation now says which one is worth a decision — HTTP, the only built-in action that reaches outside the deployment.
 
 *   **Inbound MCP Is Fully Configurable In The New Admin Interface**
     *   The Inbound MCP tab in the new Admin Settings surface showed exactly two switches — **Enable inbound MCP server** and **Enable tool throttles** — and nothing else. The delegated scope, the required Entra roles, the request and throttle limits, and all three allowlists were invisible, which read as "disabled, but throttles are on" with no explanation for either.
@@ -22,27 +29,6 @@ For feature-focused and fix-focused drill-downs by version, see [Features by Ver
     *   **The lists the runtime actually reads are derived on save**, exactly as the classic interface derives them. Editing an allowlist in the new interface now takes effect; previously the schema had no way to express that one setting produces several, which for an access control list is the worst kind of failure — the screen would show the new restriction while the runtime applied the old one.
     *   **Turning off "Allow additional tenant IDs" no longer discards the tenants you listed.** It stops admitting them, and turning it back on restores them.
     *   (Ref: `admin_settings_fields.py`, `functions_mcp_server_config.py`, `EntryListEditor.tsx`, `adminEntries.ts`)
-
-#### User Interface Enhancements
-
-*   **The Inbound MCP Tab Explains Why It Is Empty**
-    *   Inbound MCP is a preview whose settings stay hidden until an App Service application setting is added. Because that flag is not part of the settings document, the new interface could not see it, and simply rendered two unexplained switches.
-    *   The settings API now reports it, and the tab shows what Inbound MCP is, the `ENABLE_MCP_UI` setting that reveals it, and that revealing it does not open the endpoint.
-    *   (Ref: `runtime_flags`, `is_mcp_ui_enabled`, `InboundMcpNotice.tsx`)
-
-*   **Inbound MCP Documentation Describes The Access Model**
-    *   The administration page now states the five checks a request passes before it is served, explains that a source id is a client-supplied header that identifies rather than authenticates, and notes that throttles being on does not mean the endpoint is reachable.
-    *   (Ref: `docs/admin/agents-actions.md`)
-
-### **(v0.261.063)**
-
-#### New Features
-
-*   **Action Settings Are Now Present In The New Admin Interface**
-    *   The Actions tab in the new Admin Settings surface showed a single toggle. The Analyze and Document Comparison limits were invisible because they are stored as one nested object rather than as separate settings, and the built-in action toggles had been scattered by the same guesswork that emptied the Agents tab — **Enable Text Action** had ended up under Appearance › Branding because its name contains "text".
-    *   The Actions tab now renders as four sections: **Document Actions**, **Workspace Action Permissions**, **Built-in Actions**, and **Global Actions**.
-    *   **Document action limits are editable again**, with the ranges the application actually enforces (2–300 for chat, 2–1000 for a workflow run) and the workflow limit separated from the chat one. Saving one limit no longer risks the other five, and out-of-range values are clamped by the same code the classic interface uses.
-    *   **Built-in actions are collapsed rather than laid out flat.** They default on and are rarely changed, so they no longer take up the tab; the documentation now says which one is worth a decision — HTTP, the only built-in action that reaches outside the deployment.
 
 #### Bug Fixes
 
@@ -56,19 +42,10 @@ For feature-focused and fix-focused drill-downs by version, see [Features by Ver
     *   It is now mirrored under Built-in Actions as a read-only entry that links to where it is set, while the control that actually sets it stays in Chat.
     *   (Ref: `enable_fact_memory_plugin`, `fields.tsx`)
 
-### **(v0.261.062)**
-
-#### New Features
-
-*   **Agent Settings Are Now Actually Present In The New Admin Interface**
-    *   The new Admin Settings surface built its Agents tab by scanning the settings document for on/off switches and guessing where each one belonged. Agents are configured with far more than switches, so the result was close to empty: the Agents Configuration section rendered nothing at all, **Enable Agents** was filed under "Other capabilities" because nothing in its name matched the section, and not one of Workspace Mode, the workspace permissions, or the eleven Agents page settings appeared anywhere.
-    *   The Agents tab is now described properly and renders every one of those settings, split into four sections instead of a single crowded card: **Agent Runtime**, **Workspace Agent Permissions**, **Agents Page**, and **Agent Template Approvals**.
-    *   **The settings now say what depends on what.** Enable Agents gates the whole tab. Workspace Mode only appears once agents are on, and the merge behaviour only once Workspace Mode is on — a chain, so a control cannot reappear because an intermediate gate happens to be off. Workspace Agent Permissions is hidden entirely outside Workspace Mode, matching the classic interface.
-    *   **Workspace Mode explains itself.** It reads as a choice between one shared set of agents that administrators curate, and a separate collection for each user and group, rather than as an unexplained switch.
-    *   **The Agents page settings now follow the page they customise.** That page is served behind Enable Agents, so its hero, guidance text and promotion settings are hidden while agents are off instead of offering edits that could not take effect.
-    *   **Promoted agents are chosen from a list rather than edited as JSON.** Agents already promoted are not offered again, and each promotion's time window is set per row.
-    *   Rarely-changed settings are grouped and collapsed rather than laid out flat, and a search opens any collapsed group so a match is never hidden behind it.
-    *   (Ref: `admin_settings_fields.py`, `admin_settings_nav.py`, `adminAgents.ts`, `PromotedAgentsEditor.tsx`, `AdminSettingsPage.tsx`)
+*   **Multi-Agent Orchestration Is No Longer Shown As A Switch Under AI Models**
+    *   **Multi-agent orchestration** appeared in the new Admin Settings surface as a live toggle in the AI Models group, which it has nothing to do with. It is written by the orchestration settings API from the chosen orchestration mode, so setting it there did nothing and the value reverted.
+    *   It now sits with the agent runtime settings as a read-only entry that reports the current mode.
+    *   (Ref: `enable_multi_agent_orchestration`, `admin_settings_fields.py`)
 
 #### User Interface Enhancements
 
@@ -79,6 +56,15 @@ For feature-focused and fix-focused drill-downs by version, see [Features by Ver
 
 *   **Agents & Actions Documentation Describes Behaviour Instead Of Restating Labels**
     *   The Agents entries in the Agents & Actions administration page mostly read "Defines behavior for the related admin workflow", which told an administrator nothing. They now describe what each setting does, what it depends on, and why you would change it — including that the Agents catalog page is unavailable while agents are off, and why promoting an agent exists at all.
+    *   (Ref: `docs/admin/agents-actions.md`)
+
+*   **The Inbound MCP Tab Explains Why It Is Empty**
+    *   Inbound MCP is a preview whose settings stay hidden until an App Service application setting is added. Because that flag is not part of the settings document, the new interface could not see it, and simply rendered two unexplained switches.
+    *   The settings API now reports it, and the tab shows what Inbound MCP is, the `ENABLE_MCP_UI` setting that reveals it, and that revealing it does not open the endpoint.
+    *   (Ref: `runtime_flags`, `is_mcp_ui_enabled`, `InboundMcpNotice.tsx`)
+
+*   **Inbound MCP Documentation Describes The Access Model**
+    *   The administration page now states the five checks a request passes before it is served, explains that a source id is a client-supplied header that identifies rather than authenticates, and notes that throttles being on does not mean the endpoint is reachable.
     *   (Ref: `docs/admin/agents-actions.md`)
 
 ### **(v0.261.061)**

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,31 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/features) and [Fixes by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/fixes).
 
+### **(v0.261.059)**
+
+#### New Features
+
+*   **Agent Settings Are Now Actually Present In The New Admin Interface**
+    *   The new Admin Settings surface built its Agents tab by scanning the settings document for on/off switches and guessing where each one belonged. Agents are configured with far more than switches, so the result was close to empty: the Agents Configuration section rendered nothing at all, **Enable Agents** was filed under "Other capabilities" because nothing in its name matched the section, and not one of Workspace Mode, the workspace permissions, or the eleven Agents page settings appeared anywhere.
+    *   The Agents tab is now described properly and renders every one of those settings, split into four sections instead of a single crowded card: **Agent Runtime**, **Workspace Agent Permissions**, **Agents Page**, and **Agent Template Approvals**.
+    *   **The settings now say what depends on what.** Enable Agents gates the whole tab. Workspace Mode only appears once agents are on, and the merge behaviour only once Workspace Mode is on — a chain, so a control cannot reappear because an intermediate gate happens to be off. Workspace Agent Permissions is hidden entirely outside Workspace Mode, matching the classic interface.
+    *   **Workspace Mode explains itself.** It reads as a choice between one shared set of agents that administrators curate, and a separate collection for each user and group, rather than as an unexplained switch.
+    *   **The Agents page settings now follow the page they customise.** That page is served behind Enable Agents, so its hero, guidance text and promotion settings are hidden while agents are off instead of offering edits that could not take effect.
+    *   **Promoted agents are chosen from a list rather than edited as JSON.** Agents already promoted are not offered again, and each promotion's time window is set per row.
+    *   Rarely-changed settings are grouped and collapsed rather than laid out flat, and a search opens any collapsed group so a match is never hidden behind it.
+    *   (Ref: `admin_settings_fields.py`, `admin_settings_nav.py`, `adminAgents.ts`, `PromotedAgentsEditor.tsx`, `AdminSettingsPage.tsx`)
+
+#### User Interface Enhancements
+
+*   **Agent Orchestration No Longer Shows A Choice That Does Not Exist**
+    *   Agent Orchestration offered an Orchestration Type dropdown and a Max Rounds Per Agent field, but the application ships a single orchestration mode; the multi-agent modes are not built into this release. The dropdown therefore had exactly one option and Max Rounds could never be reached.
+    *   The new interface asks the server which modes exist and shows the card only when there is a genuine choice. It will reappear on its own if multi-agent orchestration ships, without another change here.
+    *   (Ref: `OrchestrationCard.tsx`, `/api/orchestration_types`, `get_agent_orchestration_types`)
+
+*   **Agents & Actions Documentation Describes Behaviour Instead Of Restating Labels**
+    *   The Agents entries in the Agents & Actions administration page mostly read "Defines behavior for the related admin workflow", which told an administrator nothing. They now describe what each setting does, what it depends on, and why you would change it — including that the Agents catalog page is unavailable while agents are off, and why promoting an agent exists at all.
+    *   (Ref: `docs/admin/agents-actions.md`)
+
 ### **(v0.261.058)**
 
 #### New Features

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,29 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/features) and [Fixes by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/fixes).
 
+### **(v0.261.061)**
+
+#### New Features
+
+*   **Inbound MCP Is Fully Configurable In The New Admin Interface**
+    *   The Inbound MCP tab in the new Admin Settings surface showed exactly two switches — **Enable inbound MCP server** and **Enable tool throttles** — and nothing else. The delegated scope, the required Entra roles, the request and throttle limits, and all three allowlists were invisible, which read as "disabled, but throttles are on" with no explanation for either.
+    *   The tab now renders the whole configuration, grouped as **Runtime gate**, **Request limits** and **Allowlists**.
+    *   **Allowlists are edited as rows rather than raw JSON.** Each row pairs the identifier the runtime matches with a description of who it belongs to, and a repeated value is flagged as you type rather than disappearing on save.
+    *   **The lists the runtime actually reads are derived on save**, exactly as the classic interface derives them. Editing an allowlist in the new interface now takes effect; previously the schema had no way to express that one setting produces several, which for an access control list is the worst kind of failure — the screen would show the new restriction while the runtime applied the old one.
+    *   **Turning off "Allow additional tenant IDs" no longer discards the tenants you listed.** It stops admitting them, and turning it back on restores them.
+    *   (Ref: `admin_settings_fields.py`, `functions_mcp_server_config.py`, `EntryListEditor.tsx`, `adminEntries.ts`)
+
+#### User Interface Enhancements
+
+*   **The Inbound MCP Tab Explains Why It Is Empty**
+    *   Inbound MCP is a preview whose settings stay hidden until an App Service application setting is added. Because that flag is not part of the settings document, the new interface could not see it, and simply rendered two unexplained switches.
+    *   The settings API now reports it, and the tab shows what Inbound MCP is, the `ENABLE_MCP_UI` setting that reveals it, and that revealing it does not open the endpoint.
+    *   (Ref: `runtime_flags`, `is_mcp_ui_enabled`, `InboundMcpNotice.tsx`)
+
+*   **Inbound MCP Documentation Describes The Access Model**
+    *   The administration page now states the five checks a request passes before it is served, explains that a source id is a client-supplied header that identifies rather than authenticates, and notes that throttles being on does not mean the endpoint is reachable.
+    *   (Ref: `docs/admin/agents-actions.md`)
+
 ### **(v0.261.060)**
 
 #### New Features

--- a/functional_tests/test_support/app_stubs.py
+++ b/functional_tests/test_support/app_stubs.py
@@ -90,3 +90,34 @@ def import_app_module(module_name):
         if not previously_loaded:
             sys.modules.pop(module_name, None)
         return module
+
+
+@contextmanager
+def stubbed_config(**values):
+    """Stand in for ``config`` so a module that reads a few constants can import.
+
+    ``config.py`` builds a Cosmos client at module scope, which is why nothing
+    that imports it can be loaded in a test process. A module that only needs a
+    handful of constants from it -- ``functions_mcp_server_config`` needs five --
+    can be imported for real against a stub carrying exactly those, which is
+    worth doing when the point of the test is to exercise that module's actual
+    behaviour rather than to read its source.
+
+    Every name the module asks for must be supplied. A missing one raises at
+    import, rather than silently producing a module that behaves differently
+    from the deployed one.
+    """
+    config = types.ModuleType("config")
+    for name, value in values.items():
+        setattr(config, name, value)
+
+    original = sys.modules.get("config", _MISSING)
+    sys.modules["config"] = config
+    try:
+        with stubbed_app_imports():
+            yield
+    finally:
+        if original is _MISSING:
+            sys.modules.pop("config", None)
+        else:
+            sys.modules["config"] = original

--- a/functional_tests/test_v2_admin_actions_parity.py
+++ b/functional_tests/test_v2_admin_actions_parity.py
@@ -47,6 +47,22 @@ ACTIONS_SECTIONS = (
     "actions-config",
 )
 
+# Built-in action toggles that used to be declared under `actions-config` and now
+# live with the rest of them in `core-plugin-toggles`. `actions-config` therefore
+# declares no fields at all, which is deliberate -- what belongs there is the
+# global actions table, still authored in the classic interface.
+#
+# The pairing matters during a merge. `enable_text_plugin` moved in 0.261.061 and
+# `enable_default_embedding_model_plugin` was moved into `actions-config` by the
+# Chat work afterwards, so by the time the two branches met, dropping the section
+# would have silently orphaned a key that had arrived while nobody was looking.
+# The check below is the general form: a removed section must not take a setting
+# with it.
+RELOCATED_FROM_ACTIONS_CONFIG = (
+    "enable_text_plugin",
+    "enable_default_embedding_model_plugin",
+)
+
 FIELD_NAME_RE = re.compile(r'\sname="([^"]+)"')
 JINJA_RE = re.compile(r"\{\{|\{%")
 
@@ -121,6 +137,46 @@ def document_action_default_limits():
         "chat": literal_assignment(source, "CHAT_DOCUMENT_ANALYSIS_MAX_DOCUMENTS"),
         "workflow": literal_assignment(source, "WORKFLOW_DOCUMENT_ANALYSIS_MAX_DOCUMENTS"),
     }
+
+
+def test_removing_a_section_did_not_orphan_its_settings():
+    """A section can be emptied, but not at the cost of losing a setting.
+
+    `actions-config` is declared by ``ADMIN_NAV`` and by the V1 pane, but the
+    schema deliberately gives it no fields. That is only safe while everything it
+    used to hold is declared somewhere else, and "everything it used to hold" is
+    not fixed: the Chat work moved a second toggle into it after this branch had
+    already emptied it.
+
+    So the invariant is checked rather than remembered. If a later merge restores
+    the section, the registry integrity test catches the resulting duplicate; if
+    one of these keys is dropped instead, this catches that.
+    """
+    print("\nTesting that the emptied section orphaned nothing...")
+
+    schema = fields_module.get_admin_settings_fields()
+    assert not schema.get("actions-config"), (
+        "actions-config declares fields again. If that is intended, the built-in "
+        "action toggles must not also be declared in core-plugin-toggles, or the "
+        "same key ends up with two controls."
+    )
+
+    declared = fields_module.get_declared_setting_keys()
+    orphaned = sorted(key for key in RELOCATED_FROM_ACTIONS_CONFIG if key not in declared)
+
+    assert not orphaned, (
+        "These settings were declared under actions-config before it was emptied "
+        "and are now declared nowhere, so they are invisible in V2:\n  "
+        + "\n  ".join(orphaned)
+    )
+
+    home = {
+        key: section_id
+        for section_id, field in fields_module.iter_fields()
+        if (key := field.get("key")) in RELOCATED_FROM_ACTIONS_CONFIG
+    }
+    print(f"  {len(RELOCATED_FROM_ACTIONS_CONFIG)} relocated key(s) accounted for: {home}")
+    return True
 
 
 def test_actions_sections_match_navigation():
@@ -382,7 +438,14 @@ def test_read_only_mirrors_name_their_owner_and_cannot_invent_a_value():
 
 
 def test_fact_memory_stays_editable_where_it_is_owned():
-    """Mirroring a key must not remove the control that actually sets it."""
+    """Mirroring a key must not remove the control that actually sets it.
+
+    Both this branch and the Chat work declared `fact-memory-section`, with the
+    same single writable field. Only one may survive a merge: two writable
+    declarations of one key give it two owners, and `get_field_definition` would
+    then return whichever came first rather than the one that governs saving.
+    The Chat group owns the section, so its declaration is the one kept.
+    """
     print("\nTesting that fact memory is still editable under Chat...")
 
     owner = fields_module.get_field_definition("enable_fact_memory_plugin")
@@ -400,6 +463,16 @@ def test_fact_memory_stays_editable_where_it_is_owned():
 
     assert 'name="enable_fact_memory_plugin"' in read_pane("chat-experience"), (
         "The V1 owner control moved; the schema still points at Chat."
+    )
+
+    writable = [
+        section_id
+        for section_id, field in fields_module.iter_fields()
+        if field.get("key") == "enable_fact_memory_plugin" and not field.get("readonly")
+    ]
+    assert writable == ["fact-memory-section"], (
+        "enable_fact_memory_plugin must have exactly one writable declaration, in "
+        f"the section Chat owns. Found: {writable}"
     )
 
     print("  Fact memory remains editable under Chat and mirrored under Actions.")
@@ -437,6 +510,7 @@ def test_tabular_processing_is_no_longer_an_editable_toggle():
 if __name__ == "__main__":
     tests = [
         test_actions_sections_match_navigation,
+        test_removing_a_section_did_not_orphan_its_settings,
         test_every_actions_pane_field_is_claimed_by_the_schema,
         test_document_action_fields_write_into_the_nested_container,
         test_document_action_bounds_match_the_application,

--- a/functional_tests/test_v2_admin_actions_parity.py
+++ b/functional_tests/test_v2_admin_actions_parity.py
@@ -2,8 +2,8 @@
 # test_v2_admin_actions_parity.py
 """
 Functional test pinning V1/V2 parity for the Admin Settings Actions tab.
-Version: 0.261.063
-Implemented in: 0.261.063
+Version: 0.261.065
+Implemented in: 0.261.065
 
 Two things in this tab are not ordinary settings, and both fail silently.
 
@@ -127,7 +127,7 @@ def test_actions_sections_match_navigation():
     """The sections this test asserts on must be the ones ADMIN_NAV declares."""
     print("Testing the Actions tab sections against ADMIN_NAV...")
 
-    assert_app_version_at_least("0.261.063")
+    assert_app_version_at_least("0.261.065")
 
     tab = next(
         (

--- a/functional_tests/test_v2_admin_actions_parity.py
+++ b/functional_tests/test_v2_admin_actions_parity.py
@@ -1,0 +1,451 @@
+#!/usr/bin/env python3
+# test_v2_admin_actions_parity.py
+"""
+Functional test pinning V1/V2 parity for the Admin Settings Actions tab.
+Version: 0.261.060
+Implemented in: 0.261.060
+
+Two things in this tab are not ordinary settings, and both fail silently.
+
+``document_action_capabilities`` is stored as one nested object holding six
+values across two action types. Nothing reads a flattened form of them, so a
+schema that declared six top-level keys would save settings the application never
+looks at, and the Analyze and Comparison limits would appear to have no effect.
+The schema therefore declares a ``settings_path`` per field and the container is
+reassembled on save.
+
+Fact memory and tabular processing are owned elsewhere: fact memory is a chat
+capability edited under Chat, and tabular processing is recomputed from Enhanced
+Citations on every settings read. Both belong in an actions list for an
+administrator working out what an agent can do, but neither may be written from
+here -- tabular processing in particular used to render as an editable toggle
+under Chat > Processing Thoughts, where flipping it did nothing at all.
+"""
+
+import ast
+import re
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent))
+
+from test_support.app_stubs import import_app_module
+from test_support.nav import ADMIN_NAV
+from test_support.versioning import assert_app_version_at_least
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+APP_ROOT = REPO_ROOT / "application" / "single_app"
+PANES_DIR = APP_ROOT / "templates" / "admin" / "_panes"
+DOCUMENT_ACTIONS_MODULE = APP_ROOT / "functions_document_actions.py"
+DOCUMENT_ANALYSIS_MODULE = APP_ROOT / "functions_document_analysis.py"
+
+ACTIONS_SECTIONS = (
+    "document-action-capabilities-card",
+    "plugin-feature-toggles",
+    "core-plugin-toggles",
+    "actions-config",
+)
+
+FIELD_NAME_RE = re.compile(r'\sname="([^"]+)"')
+JINJA_RE = re.compile(r"\{\{|\{%")
+
+fields_module = import_app_module("admin_settings_fields")
+
+
+def read_pane(pane_id):
+    pane_path = PANES_DIR / f"{pane_id}.html"
+    assert pane_path.is_file(), f"Missing Admin Settings pane: {pane_path}"
+    return pane_path.read_text(encoding="utf-8")
+
+
+def literal_assignment(source, name):
+    """Return a module-level literal assignment, without importing the module.
+
+    ``functions_document_actions`` reaches ``config.py``, which builds a Cosmos
+    client at import time, so it cannot be imported in a plain test process. The
+    values are read out of the source the same way the other schema tests read
+    the settings defaults.
+    """
+    tree = ast.parse(source)
+    namespace = {}
+    wanted = None
+
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if not isinstance(target, ast.Name):
+                continue
+            try:
+                namespace[target.id] = _resolve(node.value, namespace)
+            except AssertionError:
+                # Values built from imported names or calls are not needed here.
+                continue
+            if target.id == name:
+                wanted = namespace[target.id]
+
+    assert wanted is not None, f"{name} was not found; the extraction likely broke."
+    return wanted
+
+
+def _resolve(node, namespace):
+    """Evaluate a literal expression, resolving names already seen in the module."""
+    if isinstance(node, ast.Constant):
+        return node.value
+    if isinstance(node, ast.Name):
+        assert node.id in namespace, f"unresolved name {node.id}"
+        return namespace[node.id]
+    if isinstance(node, ast.Dict):
+        return {
+            _resolve(key, namespace): _resolve(value, namespace)
+            for key, value in zip(node.keys, node.values)
+        }
+    if isinstance(node, (ast.List, ast.Tuple)):
+        return [_resolve(element, namespace) for element in node.elts]
+    if isinstance(node, ast.Set):
+        return {_resolve(element, namespace) for element in node.elts}
+    raise AssertionError(f"unsupported expression: {type(node).__name__}")
+
+
+def document_action_bounds():
+    """Return the min/max bounds the application enforces per execution context."""
+    source = DOCUMENT_ACTIONS_MODULE.read_text(encoding="utf-8")
+    return literal_assignment(source, "DOCUMENT_ACTION_LIMIT_BOUNDS")
+
+
+def document_action_default_limits():
+    """Return the default chat and workflow limits."""
+    source = DOCUMENT_ANALYSIS_MODULE.read_text(encoding="utf-8")
+    return {
+        "chat": literal_assignment(source, "CHAT_DOCUMENT_ANALYSIS_MAX_DOCUMENTS"),
+        "workflow": literal_assignment(source, "WORKFLOW_DOCUMENT_ANALYSIS_MAX_DOCUMENTS"),
+    }
+
+
+def test_actions_sections_match_navigation():
+    """The sections this test asserts on must be the ones ADMIN_NAV declares."""
+    print("Testing the Actions tab sections against ADMIN_NAV...")
+
+    assert_app_version_at_least("0.261.060")
+
+    tab = next(
+        (
+            tab
+            for group in ADMIN_NAV
+            if group["id"] == "agents-actions"
+            for tab in group["tabs"]
+            if tab["id"] == "actions"
+        ),
+        None,
+    )
+    assert tab, "ADMIN_NAV no longer defines an 'actions' tab."
+
+    actual = tuple(section["id"] for section in tab["sections"])
+    assert actual == ACTIONS_SECTIONS, (
+        f"The Actions sections changed.\n  ADMIN_NAV: {actual}\n  test: {ACTIONS_SECTIONS}"
+    )
+
+    conditions = {section["id"]: section.get("condition") for section in tab["sections"]}
+    assert conditions["plugin-feature-toggles"] == "per_user_semantic_kernel", (
+        "Workspace Action Permissions must be conditional on Workspace Mode, "
+        "because nothing reads those permissions outside it."
+    )
+
+    print(f"  {len(actual)} section(s) match ADMIN_NAV.")
+    return True
+
+
+def test_every_actions_pane_field_is_claimed_by_the_schema():
+    """A V1 field with no V2 equivalent is invisible in the new UI."""
+    print("\nTesting that every V1 Actions field is claimed by the schema...")
+
+    claimed = fields_module.get_legacy_field_names()
+    documented = set(fields_module.LEGACY_FIELDS_WITHOUT_V2_EQUIVALENT)
+
+    names = {
+        name
+        for name in FIELD_NAME_RE.findall(read_pane("actions"))
+        if not JINJA_RE.search(name)
+    }
+    missing = sorted(names - claimed - documented)
+
+    assert not missing, (
+        "These V1 Actions fields have no V2 equivalent and no recorded reason:\n  "
+        + "\n  ".join(missing)
+    )
+
+    print(f"  All {len(names)} V1 Actions field name(s) are claimed.")
+    return True
+
+
+def test_document_action_fields_write_into_the_nested_container():
+    """A flat key here would save a setting the application never reads."""
+    print("\nTesting document action settings paths...")
+
+    schema = fields_module.get_admin_settings_fields()
+    fields = schema["document-action-capabilities-card"]
+
+    expected = {
+        "document_action_analyze_enabled": ["document_action_capabilities", "analyze", "enabled"],
+        "document_action_analyze_chat_max_documents": [
+            "document_action_capabilities",
+            "analyze",
+            "chat_max_documents",
+        ],
+        "document_action_analyze_workflow_max_documents": [
+            "document_action_capabilities",
+            "analyze",
+            "workflow_max_documents",
+        ],
+        "document_action_comparison_enabled": [
+            "document_action_capabilities",
+            "comparison",
+            "enabled",
+        ],
+        "document_action_comparison_chat_max_documents": [
+            "document_action_capabilities",
+            "comparison",
+            "chat_max_documents",
+        ],
+        "document_action_comparison_workflow_max_documents": [
+            "document_action_capabilities",
+            "comparison",
+            "workflow_max_documents",
+        ],
+    }
+
+    actual = {field["key"]: field.get("settings_path") for field in fields}
+    assert actual == expected, (
+        f"Document action settings paths drifted.\n  schema: {actual}\n  expected: {expected}"
+    )
+
+    print(f"  All {len(expected)} document action field(s) name their container path.")
+    return True
+
+
+def test_document_action_bounds_match_the_application():
+    """A wider bound in the UI accepts a value the server silently clamps."""
+    print("\nTesting document action bounds against functions_document_actions...")
+
+    bounds = document_action_bounds()
+    defaults = document_action_default_limits()
+    schema = fields_module.get_admin_settings_fields()
+
+    problems = []
+    for field in schema["document-action-capabilities-card"]:
+        path = field["settings_path"]
+        leaf = path[-1]
+        if leaf == "enabled":
+            if field.get("default") is not True:
+                problems.append(f"{field['key']}: default {field.get('default')!r}, expected True")
+            continue
+
+        context = "chat" if leaf == "chat_max_documents" else "workflow"
+        if field.get("min") != bounds[context]["min"]:
+            problems.append(
+                f"{field['key']}: min {field.get('min')!r} != {bounds[context]['min']!r}"
+            )
+        if field.get("max") != bounds[context]["max"]:
+            problems.append(
+                f"{field['key']}: max {field.get('max')!r} != {bounds[context]['max']!r}"
+            )
+        if field.get("default") != defaults[context]:
+            problems.append(
+                f"{field['key']}: default {field.get('default')!r} != {defaults[context]!r}"
+            )
+
+    assert not problems, (
+        "These document action bounds disagree with the application, which clamps "
+        "to DOCUMENT_ACTION_LIMIT_BOUNDS on save:\n  " + "\n  ".join(problems)
+    )
+
+    print(f"  Bounds and defaults match: chat {bounds['chat']}, workflow {bounds['workflow']}.")
+    return True
+
+
+def test_nested_values_are_folded_into_their_container_on_save():
+    """Saving one limit must not discard the other five.
+
+    The container normalizer is replaced with an identity function for this
+    check. It lives in ``functions_document_actions``, which reaches
+    ``config.py`` and a live Cosmos client and so cannot be imported in a test
+    process; the delegation itself is asserted separately below, and the bounds
+    it enforces are pinned against its source above.
+    """
+    print("\nTesting the nested container fold...")
+
+    current = {
+        "document_action_capabilities": {
+            "analyze": {
+                "enabled": True,
+                "chat_max_documents": 5,
+                "workflow_max_documents": 50,
+            },
+            "comparison": {
+                "enabled": False,
+                "chat_max_documents": 7,
+                "workflow_max_documents": 70,
+            },
+        }
+    }
+
+    original = fields_module._CONTAINER_NORMALIZERS
+    fields_module._CONTAINER_NORMALIZERS = {"document_action_capabilities": lambda value: value}
+    try:
+        normalized, errors, _warnings = fields_module.normalize_admin_settings_updates(
+            {"document_action_analyze_chat_max_documents": 9}, current
+        )
+    finally:
+        fields_module._CONTAINER_NORMALIZERS = original
+
+    assert not errors, f"Unexpected errors: {errors}"
+    assert "document_action_analyze_chat_max_documents" not in normalized, (
+        "The flat key must not reach update_settings; nothing reads it."
+    )
+
+    capabilities = normalized["document_action_capabilities"]
+    assert capabilities["analyze"]["chat_max_documents"] == 9
+    assert capabilities["analyze"]["workflow_max_documents"] == 50, (
+        "Rebuilding the container dropped a sibling value."
+    )
+    assert capabilities["comparison"] == {
+        "enabled": False,
+        "chat_max_documents": 7,
+        "workflow_max_documents": 70,
+    }, "Rebuilding the container disturbed the other action type."
+
+    assert current["document_action_capabilities"]["analyze"]["chat_max_documents"] == 5, (
+        "The stored settings were mutated in place rather than copied."
+    )
+
+    print("  One edit rebuilds the container without losing its siblings.")
+    return True
+
+
+def test_the_container_is_normalized_by_the_module_that_owns_it():
+    """Reimplementing the clamp here would let the two surfaces disagree."""
+    print("\nTesting that container validation is delegated...")
+
+    assert "document_action_capabilities" in fields_module._CONTAINER_NORMALIZERS, (
+        "The container has no normalizer, so out-of-range limits would be stored."
+    )
+
+    source = (APP_ROOT / "admin_settings_fields.py").read_text(encoding="utf-8")
+    assert (
+        "from functions_document_actions import normalize_document_action_capabilities"
+        in source
+    ), (
+        "Document action bounds must be enforced by the function the classic "
+        "admin form already uses, not reimplemented here."
+    )
+
+    print("  Clamping is delegated to functions_document_actions.")
+    return True
+
+
+def test_read_only_mirrors_name_their_owner_and_cannot_invent_a_value():
+    """A mirror must report a value, never set one it does not own."""
+    print("\nTesting read-only action mirrors...")
+
+    schema = fields_module.get_admin_settings_fields()
+    mirrors = {
+        field["key"]: field
+        for field in schema["core-plugin-toggles"]
+        if field.get("readonly")
+    }
+
+    assert set(mirrors) == {
+        "enable_fact_memory_plugin",
+        "enable_tabular_processing_plugin",
+    }, f"Unexpected read-only mirrors: {sorted(mirrors)}"
+
+    for key, field in mirrors.items():
+        assert field.get("managed_by"), f"{key}: read-only without naming its owner"
+
+    # Tabular processing has no editable declaration anywhere, because the
+    # application recomputes it from Enhanced Citations on every settings read.
+    # A write must therefore be refused rather than stored and then overwritten.
+    _normalized, errors, _warnings = fields_module.normalize_admin_settings_updates(
+        {"enable_tabular_processing_plugin": True}, {}
+    )
+    assert "enable_tabular_processing_plugin" in errors, (
+        "A derived setting accepted a write, which would store a value the next "
+        "settings read discards."
+    )
+    assert mirrors["enable_tabular_processing_plugin"]["managed_by"] in (
+        errors["enable_tabular_processing_plugin"]
+    ), "The rejection must point at where the value really comes from."
+
+    print(f"  {len(mirrors)} mirror(s) name their owner; the derived one refuses writes.")
+    return True
+
+
+def test_fact_memory_stays_editable_where_it_is_owned():
+    """Mirroring a key must not remove the control that actually sets it."""
+    print("\nTesting that fact memory is still editable under Chat...")
+
+    owner = fields_module.get_field_definition("enable_fact_memory_plugin")
+    assert owner is not None, "enable_fact_memory_plugin is not declared."
+    assert not owner.get("readonly"), (
+        "The read-only mirror claimed the key, so the Chat control that really "
+        "sets it would be rejected on save."
+    )
+
+    normalized, errors, _warnings = fields_module.normalize_admin_settings_updates(
+        {"enable_fact_memory_plugin": False}, {}
+    )
+    assert not errors, f"Editing fact memory was rejected: {errors}"
+    assert normalized["enable_fact_memory_plugin"] is False
+
+    assert 'name="enable_fact_memory_plugin"' in read_pane("chat-experience"), (
+        "The V1 owner control moved; the schema still points at Chat."
+    )
+
+    print("  Fact memory remains editable under Chat and mirrored under Actions.")
+    return True
+
+
+def test_tabular_processing_is_no_longer_an_editable_toggle():
+    """It is recomputed from Enhanced Citations, so editing it never did anything.
+
+    The fallback scan used to file it under Chat > Processing Thoughts as a live
+    switch, purely because "processing" matched. Declaring it as a mirror is what
+    takes it out of that scan.
+    """
+    print("\nTesting that tabular processing is declared as derived...")
+
+    field = fields_module.get_field_definition("enable_tabular_processing_plugin")
+    assert field is not None, "enable_tabular_processing_plugin is not declared."
+    assert field.get("readonly"), "It is derived, so it must not be editable."
+    assert "Enhanced Citations" in field.get("help", ""), (
+        "The mirror must say what recomputes it, or an administrator has no way "
+        "of knowing where to change it."
+    )
+
+    assert "is_tabular_processing_enabled" in (
+        APP_ROOT / "route_frontend_admin_settings.py"
+    ).read_text(encoding="utf-8"), (
+        "The application no longer recomputes it, so it may now be settable and "
+        "the mirror would be wrong."
+    )
+
+    print("  Tabular processing is declared derived and names its source.")
+    return True
+
+
+if __name__ == "__main__":
+    tests = [
+        test_actions_sections_match_navigation,
+        test_every_actions_pane_field_is_claimed_by_the_schema,
+        test_document_action_fields_write_into_the_nested_container,
+        test_document_action_bounds_match_the_application,
+        test_nested_values_are_folded_into_their_container_on_save,
+        test_the_container_is_normalized_by_the_module_that_owns_it,
+        test_read_only_mirrors_name_their_owner_and_cannot_invent_a_value,
+        test_fact_memory_stays_editable_where_it_is_owned,
+        test_tabular_processing_is_no_longer_an_editable_toggle,
+    ]
+    results = [test() for test in tests]
+    print(f"\nResults: {sum(bool(r) for r in results)}/{len(results)} passed")
+    sys.exit(0 if all(results) else 1)

--- a/functional_tests/test_v2_admin_agents_logic.mjs
+++ b/functional_tests/test_v2_admin_agents_logic.mjs
@@ -1,8 +1,8 @@
 // test_v2_admin_agents_logic.mjs
 //
 // Runtime test for the Admin Settings logic the Agents & Actions rework depends on.
-// Version: 0.261.059
-// Implemented in: 0.261.059
+// Version: 0.261.060
+// Implemented in: 0.261.059 (agents), 0.261.060 (nested values and mirrored fields)
 //
 // The companion test, test_v2_admin_agents_parity.py, proves the schema describes the same
 // settings the V1 pane submits. That is a source assertion; it says nothing about whether
@@ -26,9 +26,12 @@
 
 import assert from 'node:assert/strict';
 import {
+    buildFieldIndex,
     buildSectionBlocks,
     isFieldVisible,
     isSectionVisible,
+    readFieldValue,
+    readNestedValue,
 } from '../application/v2_ui/src/lib/adminFields.ts';
 import {
     agentScopeLabel,
@@ -144,7 +147,6 @@ check('a string dependency is not satisfied by a truthy non-match', () => {
 });
 
 /* ---------------------------- section conditions ----------------------------- */
-
 check('a section with no condition always applies', () => {
     assert.equal(isSectionVisible(undefined, {}, {}, {}), true);
 });
@@ -173,8 +175,103 @@ check('a section reveals itself from the draft before the save lands', () => {
     );
 });
 
-/* ------------------------------- orchestration -------------------------------- */
+/* --------------------------- nested settings values --------------------------- */
 
+const ANALYZE_ENABLED = field('document_action_analyze_enabled', {
+    settings_path: ['document_action_capabilities', 'analyze', 'enabled'],
+});
+const ANALYZE_CHAT_LIMIT = {
+    key: 'document_action_analyze_chat_max_documents',
+    type: 'number',
+    label: 'limit',
+    default: 3,
+    settings_path: ['document_action_capabilities', 'analyze', 'chat_max_documents'],
+    depends_on: { key: 'document_action_analyze_enabled', equals: true },
+};
+
+const CAPABILITIES = {
+    document_action_capabilities: {
+        analyze: { enabled: true, chat_max_documents: 25 },
+        comparison: { enabled: false },
+    },
+};
+
+check('a nested path is walked, and a missing branch reads as undefined', () => {
+    assert.equal(
+        readNestedValue(CAPABILITIES, ['document_action_capabilities', 'analyze', 'chat_max_documents']),
+        25,
+    );
+    assert.equal(readNestedValue(CAPABILITIES, ['document_action_capabilities', 'missing', 'x']), undefined);
+    assert.equal(readNestedValue({ a: 'text' }, ['a', 'b']), undefined);
+    assert.equal(readNestedValue({ a: [1] }, ['a', 'b']), undefined);
+});
+
+check('a settings_path field reads its stored value, not its flat key', () => {
+    assert.equal(readFieldValue(ANALYZE_CHAT_LIMIT, CAPABILITIES, {}), 25);
+});
+
+check('a settings_path field falls back to its declared default', () => {
+    assert.equal(readFieldValue(ANALYZE_CHAT_LIMIT, {}, {}), 3);
+});
+
+check('an unsaved edit is keyed by the flat name even for a nested field', () => {
+    assert.equal(
+        readFieldValue(ANALYZE_CHAT_LIMIT, CAPABILITIES, {
+            document_action_analyze_chat_max_documents: 9,
+        }),
+        9,
+    );
+});
+
+check('a gate stored inside a container is resolved through the field index', () => {
+    const index = buildFieldIndex({ 'document-action-capabilities-card': [ANALYZE_ENABLED] });
+
+    assert.equal(
+        isFieldVisible(ANALYZE_CHAT_LIMIT, CAPABILITIES, {}, index),
+        true,
+        'the limit must be visible while its container flag is on',
+    );
+    assert.equal(
+        isFieldVisible(
+            ANALYZE_CHAT_LIMIT,
+            { document_action_capabilities: { analyze: { enabled: false } } },
+            {},
+            index,
+        ),
+        false,
+    );
+});
+
+check('without the index a nested gate cannot be found, which is why it is passed', () => {
+    assert.equal(
+        isFieldVisible(ANALYZE_CHAT_LIMIT, CAPABILITIES, {}),
+        false,
+        'this is the failure the field index exists to prevent',
+    );
+});
+
+/* ------------------------------ mirrored fields ------------------------------- */
+
+const MIRROR = field('enable_fact_memory_plugin', {
+    readonly: true,
+    managed_by: 'Chat',
+});
+const OWNER = field('enable_fact_memory_plugin');
+
+check('the writable declaration owns a key however the sections are ordered', () => {
+    const mirrorFirst = buildFieldIndex({ actions: [MIRROR], chat: [OWNER] });
+    const ownerFirst = buildFieldIndex({ chat: [OWNER], actions: [MIRROR] });
+
+    assert.equal(mirrorFirst.get('enable_fact_memory_plugin').readonly, undefined);
+    assert.equal(ownerFirst.get('enable_fact_memory_plugin').readonly, undefined);
+});
+
+check('a key that is only ever mirrored still resolves to the mirror', () => {
+    const index = buildFieldIndex({ actions: [field('enable_tabular_processing_plugin', { readonly: true })] });
+    assert.equal(index.get('enable_tabular_processing_plugin').readonly, true);
+});
+
+/* ------------------------------- orchestration -------------------------------- */
 const SINGLE = [{ value: 'default_agent', label: 'Selected Agent', agent_mode: 'single' }];
 const MULTI = [...SINGLE, { value: 'group_chat', label: 'Group Chat', agent_mode: 'multi' }];
 

--- a/functional_tests/test_v2_admin_agents_logic.mjs
+++ b/functional_tests/test_v2_admin_agents_logic.mjs
@@ -1,9 +1,8 @@
 // test_v2_admin_agents_logic.mjs
 //
 // Runtime test for the Admin Settings logic the Agents & Actions rework depends on.
-// Version: 0.261.064
-// Implemented in: 0.261.062 (agents), 0.261.063 (nested values and mirrored fields),
-//                 0.261.064 (runtime flag gates and allowlists)
+// Version: 0.261.065
+// Implemented in: 0.261.065
 //
 // The companion test, test_v2_admin_agents_parity.py, proves the schema describes the same
 // settings the V1 pane submits. That is a source assertion; it says nothing about whether

--- a/functional_tests/test_v2_admin_agents_logic.mjs
+++ b/functional_tests/test_v2_admin_agents_logic.mjs
@@ -1,0 +1,309 @@
+// test_v2_admin_agents_logic.mjs
+//
+// Runtime test for the Admin Settings logic the Agents & Actions rework depends on.
+// Version: 0.261.059
+// Implemented in: 0.261.059
+//
+// The companion test, test_v2_admin_agents_parity.py, proves the schema describes the same
+// settings the V1 pane submits. That is a source assertion; it says nothing about whether
+// the browser then draws them correctly.
+//
+// These checks execute the decisions that determine what an administrator actually sees,
+// each of which fails silently in a way that looks like the feature simply not existing:
+//
+//   - A dependency chain judged one link at a time puts a control back on screen when an
+//     intermediate gate is off. The merge toggle only means something in Workspace Mode,
+//     which itself only means something when agents are on.
+//   - A section condition read from the settings document alone cannot see mcp_ui_enabled,
+//     because that flag comes from an App Service application setting and is never stored.
+//   - Orchestration must draw nothing while the server offers a single type. Getting that
+//     backwards shows a select with one option and a Max Rounds field the server discards.
+//   - A promotion has to carry the exact fields the server keeps, or it is silently
+//     rewritten on save.
+//
+// Run directly with `node functional_tests/test_v2_admin_agents_logic.mjs`. Requires Node
+// 22.6 or newer, which strips the TypeScript types so the real modules are imported.
+
+import assert from 'node:assert/strict';
+import {
+    buildSectionBlocks,
+    isFieldVisible,
+    isSectionVisible,
+} from '../application/v2_ui/src/lib/adminFields.ts';
+import {
+    agentScopeLabel,
+    agentScopeType,
+    orchestrationIsSelectable,
+    promotableAgents,
+    readOrchestrationTypes,
+    readPromotedAgents,
+    roundsApply,
+    toPromotedAgent,
+} from '../application/v2_ui/src/lib/adminAgents.ts';
+
+const checks = [];
+function check(name, fn) {
+    checks.push([name, fn]);
+}
+
+const field = (key, extra = {}) => ({ key, type: 'switch', label: key, ...extra });
+
+/* ------------------------------ section layout ------------------------------- */
+
+check('ungrouped fields keep their declared order', () => {
+    const blocks = buildSectionBlocks([field('a'), field('b')]);
+    assert.deepEqual(
+        blocks.map((block) => block.field.key),
+        ['a', 'b'],
+    );
+});
+
+check('a group is collected at the position of its first field', () => {
+    const blocks = buildSectionBlocks([
+        field('gate'),
+        field('title', { group: 'Hero' }),
+        field('promoted', { group: 'Promoted agents' }),
+        field('subtitle', { group: 'Hero' }),
+    ]);
+
+    assert.deepEqual(
+        blocks.map((block) => (block.kind === 'group' ? block.name : block.field.key)),
+        ['gate', 'Hero', 'Promoted agents'],
+    );
+    assert.deepEqual(
+        blocks[1].fields.map((item) => item.key),
+        ['title', 'subtitle'],
+    );
+});
+
+check('only the first field of a group decides whether it starts closed', () => {
+    const blocks = buildSectionBlocks([
+        field('one', { group: 'Promoted agents', collapsed: true }),
+        field('two', { group: 'Promoted agents' }),
+    ]);
+    assert.equal(blocks[0].collapsed, true);
+});
+
+check('a group with no collapsed marker starts open', () => {
+    const blocks = buildSectionBlocks([field('one', { group: 'Hero' })]);
+    assert.equal(blocks[0].collapsed, false);
+});
+
+/* -------------------------------- visibility --------------------------------- */
+
+const AGENTS_ON = { enable_semantic_kernel: true, per_user_semantic_kernel: true };
+
+check('a field with no dependency is always visible', () => {
+    assert.equal(isFieldVisible(field('a'), {}, {}), true);
+});
+
+check('a chain hides the field when any link is unmet', () => {
+    const merge = field('merge', {
+        depends_on: [
+            { key: 'enable_semantic_kernel', equals: true },
+            { key: 'per_user_semantic_kernel', equals: true },
+        ],
+    });
+
+    assert.equal(isFieldVisible(merge, AGENTS_ON, {}), true);
+    assert.equal(
+        isFieldVisible(merge, { ...AGENTS_ON, per_user_semantic_kernel: false }, {}),
+        false,
+        'workspace mode off must hide the merge toggle',
+    );
+    assert.equal(
+        isFieldVisible(merge, { ...AGENTS_ON, enable_semantic_kernel: false }, {}),
+        false,
+        'agents off must hide it even while workspace mode is on',
+    );
+});
+
+check('an unsaved edit decides visibility before the stored value does', () => {
+    const dependent = field('child', {
+        depends_on: { key: 'enable_semantic_kernel', equals: true },
+    });
+    assert.equal(
+        isFieldVisible(dependent, { enable_semantic_kernel: false }, { enable_semantic_kernel: true }),
+        true,
+    );
+});
+
+check('a string dependency compares against a select value', () => {
+    const secondary = field('secondary', {
+        depends_on: { key: 'agents_page_hero_color_mode', equals: 'two_tone' },
+    });
+    assert.equal(isFieldVisible(secondary, { agents_page_hero_color_mode: 'two_tone' }, {}), true);
+    assert.equal(isFieldVisible(secondary, { agents_page_hero_color_mode: 'single' }, {}), false);
+});
+
+check('a string dependency is not satisfied by a truthy non-match', () => {
+    const secondary = field('secondary', {
+        depends_on: { key: 'mode', equals: 'two_tone' },
+    });
+    assert.equal(isFieldVisible(secondary, { mode: 'anything' }, {}), false);
+});
+
+/* ---------------------------- section conditions ----------------------------- */
+
+check('a section with no condition always applies', () => {
+    assert.equal(isSectionVisible(undefined, {}, {}, {}), true);
+});
+
+check('a settings-key condition follows the setting', () => {
+    assert.equal(isSectionVisible('per_user_semantic_kernel', AGENTS_ON, {}, {}), true);
+    assert.equal(isSectionVisible('per_user_semantic_kernel', {}, {}, {}), false);
+});
+
+check('a runtime flag is used even though it is absent from settings', () => {
+    assert.equal(isSectionVisible('mcp_ui_enabled', {}, {}, { mcp_ui_enabled: true }), true);
+    assert.equal(isSectionVisible('mcp_ui_enabled', {}, {}, { mcp_ui_enabled: false }), false);
+});
+
+check('a runtime flag wins over a settings key of the same name', () => {
+    assert.equal(
+        isSectionVisible('mcp_ui_enabled', { mcp_ui_enabled: true }, {}, { mcp_ui_enabled: false }),
+        false,
+    );
+});
+
+check('a section reveals itself from the draft before the save lands', () => {
+    assert.equal(
+        isSectionVisible('per_user_semantic_kernel', {}, { per_user_semantic_kernel: true }, {}),
+        true,
+    );
+});
+
+/* ------------------------------- orchestration -------------------------------- */
+
+const SINGLE = [{ value: 'default_agent', label: 'Selected Agent', agent_mode: 'single' }];
+const MULTI = [...SINGLE, { value: 'group_chat', label: 'Group Chat', agent_mode: 'multi' }];
+
+check('orchestration types drop entries with no value', () => {
+    const parsed = readOrchestrationTypes([
+        { value: 'default_agent', label: 'Selected Agent' },
+        { label: 'nameless' },
+        null,
+        'not an object',
+    ]);
+    assert.deepEqual(
+        parsed.map((type) => type.value),
+        ['default_agent'],
+    );
+});
+
+check('a non-array orchestration payload yields no types', () => {
+    assert.deepEqual(readOrchestrationTypes(undefined), []);
+    assert.deepEqual(readOrchestrationTypes({ value: 'default_agent' }), []);
+});
+
+check('a label falls back to the value so an option is never blank', () => {
+    assert.equal(readOrchestrationTypes([{ value: 'default_agent' }])[0].label, 'default_agent');
+});
+
+check('one orchestration type is not a choice, so nothing is drawn', () => {
+    assert.equal(orchestrationIsSelectable([]), false);
+    assert.equal(
+        orchestrationIsSelectable(SINGLE),
+        false,
+        'today the server returns exactly one type and the card must stay hidden',
+    );
+    assert.equal(orchestrationIsSelectable(MULTI), true);
+});
+
+check('max rounds applies only to a multi-agent type', () => {
+    assert.equal(roundsApply(MULTI, 'group_chat'), true);
+    assert.equal(roundsApply(MULTI, 'default_agent'), false);
+    assert.equal(roundsApply(MULTI, 'unknown'), false);
+});
+
+/* --------------------------------- promotions --------------------------------- */
+
+check('scope is classified the same way the classic admin classifies it', () => {
+    assert.equal(agentScopeType({ is_group: true }), 'group');
+    assert.equal(agentScopeType({ is_global: true }), 'global');
+    assert.equal(agentScopeType({ scope_type: 'enterprise' }), 'global');
+    assert.equal(agentScopeType({}), 'personal');
+
+    assert.equal(agentScopeLabel({ is_global: true }), 'Enterprise');
+    assert.equal(agentScopeLabel({ is_group: true, scope_name: 'Finance' }), 'Finance');
+    assert.equal(agentScopeLabel({ is_group: true }), 'Group');
+    assert.equal(agentScopeLabel({}), 'Personal');
+});
+
+check('a catalog entry without a catalog key cannot be promoted', () => {
+    assert.equal(toPromotedAgent({ display_name: 'Nameless' }), null);
+});
+
+check('a promotion carries every field the server keeps', () => {
+    const promoted = toPromotedAgent({
+        catalog_key: 'global:researcher',
+        name: 'researcher',
+        is_global: true,
+    });
+    assert.deepEqual(promoted, {
+        catalog_key: 'global:researcher',
+        display_name: 'researcher',
+        scope_label: 'Enterprise',
+        scope_type: 'global',
+        window: 'both',
+    });
+});
+
+check('stored promotions drop junk and duplicates and default the window', () => {
+    const promoted = readPromotedAgents([
+        { catalog_key: 'a', display_name: 'A' },
+        { catalog_key: 'a', display_name: 'A again' },
+        { display_name: 'no key' },
+        null,
+        { catalog_key: 'b', display_name: 'B', window: '30_days' },
+    ]);
+
+    assert.deepEqual(
+        promoted.map((agent) => [agent.catalog_key, agent.window]),
+        [
+            ['a', 'both'],
+            ['b', '30_days'],
+        ],
+    );
+});
+
+check('a non-array stored value reads as no promotions', () => {
+    assert.deepEqual(readPromotedAgents(null), []);
+    assert.deepEqual(readPromotedAgents('[]'), []);
+});
+
+check('an already promoted agent is not offered a second time', () => {
+    const candidates = [
+        { catalog_key: 'a', display_name: 'A' },
+        { catalog_key: 'b', display_name: 'B' },
+        { display_name: 'unusable' },
+    ];
+    const available = promotableAgents(candidates, readPromotedAgents([{ catalog_key: 'a' }]));
+    assert.deepEqual(
+        available.map((agent) => agent.catalog_key),
+        ['b'],
+    );
+});
+
+/* ----------------------------------- runner ---------------------------------- */
+
+let passed = 0;
+let failed = 0;
+
+for (const [name, fn] of checks) {
+    try {
+        await fn();
+        console.log(`ok   ${name}`);
+        passed += 1;
+    } catch (error) {
+        console.log(`FAIL ${name}`);
+        console.log(`     ${error.message}`);
+        failed += 1;
+    }
+}
+
+console.log(`\n${passed}/${passed + failed} runtime checks passed`);
+
+// Set the code rather than calling process.exit, which can truncate piped stdout
+// on Windows and abort the process before this summary is flushed.
+process.exitCode = failed > 0 ? 1 : 0;

--- a/functional_tests/test_v2_admin_agents_logic.mjs
+++ b/functional_tests/test_v2_admin_agents_logic.mjs
@@ -1,8 +1,9 @@
 // test_v2_admin_agents_logic.mjs
 //
 // Runtime test for the Admin Settings logic the Agents & Actions rework depends on.
-// Version: 0.261.060
-// Implemented in: 0.261.059 (agents), 0.261.060 (nested values and mirrored fields)
+// Version: 0.261.061
+// Implemented in: 0.261.059 (agents), 0.261.060 (nested values and mirrored fields),
+//                 0.261.061 (runtime flag gates and allowlists)
 //
 // The companion test, test_v2_admin_agents_parity.py, proves the schema describes the same
 // settings the V1 pane submits. That is a source assertion; it says nothing about whether
@@ -43,6 +44,10 @@ import {
     roundsApply,
     toPromotedAgent,
 } from '../application/v2_ui/src/lib/adminAgents.ts';
+import {
+    effectiveEntries,
+    readEntryList,
+} from '../application/v2_ui/src/lib/adminEntries.ts';
 
 const checks = [];
 function check(name, fn) {
@@ -250,8 +255,100 @@ check('without the index a nested gate cannot be found, which is why it is passe
     );
 });
 
-/* ------------------------------ mirrored fields ------------------------------- */
+/* ------------------------------ runtime flag gates ---------------------------- */
 
+const MCP_FIELD = field('enable_inbound_mcp_server', {
+    depends_on: { flag: 'mcp_ui_enabled', equals: true },
+});
+const MCP_NOTICE = field('notice', {
+    depends_on: { flag: 'mcp_ui_enabled', equals: false },
+});
+
+check('a runtime flag gate cannot be satisfied from the settings document', () => {
+    assert.equal(
+        isFieldVisible(MCP_FIELD, { mcp_ui_enabled: true }, {}, undefined, {}),
+        false,
+        'the flag comes from the App Service, so a settings key of the same name must not count',
+    );
+    assert.equal(isFieldVisible(MCP_FIELD, {}, {}, undefined, { mcp_ui_enabled: true }), true);
+});
+
+check('the disabled notice is the complement of the gated fields', () => {
+    const off = { mcp_ui_enabled: false };
+    const on = { mcp_ui_enabled: true };
+
+    assert.equal(isFieldVisible(MCP_FIELD, {}, {}, undefined, off), false);
+    assert.equal(isFieldVisible(MCP_NOTICE, {}, {}, undefined, off), true);
+    assert.equal(isFieldVisible(MCP_FIELD, {}, {}, undefined, on), true);
+    assert.equal(isFieldVisible(MCP_NOTICE, {}, {}, undefined, on), false);
+});
+
+check('a missing flag reads as off rather than as satisfied', () => {
+    assert.equal(isFieldVisible(MCP_FIELD, {}, {}, undefined, undefined), false);
+    assert.equal(isFieldVisible(MCP_NOTICE, {}, {}, undefined, undefined), true);
+});
+
+check('a flag gate combines with an ordinary key gate', () => {
+    const throttle = field('inbound_mcp_rate_limit_window_seconds', {
+        depends_on: [
+            { flag: 'mcp_ui_enabled', equals: true },
+            { key: 'enable_inbound_mcp_rate_limits', equals: true },
+        ],
+    });
+    const flags = { mcp_ui_enabled: true };
+
+    assert.equal(
+        isFieldVisible(throttle, { enable_inbound_mcp_rate_limits: true }, {}, undefined, flags),
+        true,
+    );
+    assert.equal(
+        isFieldVisible(throttle, { enable_inbound_mcp_rate_limits: false }, {}, undefined, flags),
+        false,
+    );
+    assert.equal(
+        isFieldVisible(
+            throttle,
+            { enable_inbound_mcp_rate_limits: true },
+            {},
+            undefined,
+            { mcp_ui_enabled: false },
+        ),
+        false,
+    );
+});
+
+/* -------------------------------- allowlists ---------------------------------- */
+
+check('a stored allowlist reads rows, and a bare string is still accepted', () => {
+    assert.deepEqual(readEntryList([{ value: 'a', description: 'A' }, 'b', null]), [
+        { value: 'a', description: 'A' },
+        { value: 'b', description: '' },
+        { value: '', description: '' },
+    ]);
+    assert.deepEqual(readEntryList(undefined), []);
+});
+
+check('the effective allowlist drops blanks and repeats, keeping the first', () => {
+    const entries = [
+        { value: '  ABC  ', description: ' VS Code ' },
+        { value: '', description: 'blank' },
+        { value: 'abc', description: 'duplicate' },
+        { value: 'def', description: '' },
+    ];
+
+    assert.deepEqual(effectiveEntries(entries, true), [
+        { value: 'abc', description: 'VS Code' },
+        { value: 'def', description: '' },
+    ]);
+});
+
+check('case is only folded where the server folds it', () => {
+    const entries = [{ value: 'VSCode', description: '' }];
+    assert.equal(effectiveEntries(entries, false)[0].value, 'VSCode');
+    assert.equal(effectiveEntries(entries, true)[0].value, 'vscode');
+});
+
+/* ------------------------------ mirrored fields ------------------------------- */
 const MIRROR = field('enable_fact_memory_plugin', {
     readonly: true,
     managed_by: 'Chat',

--- a/functional_tests/test_v2_admin_agents_parity.py
+++ b/functional_tests/test_v2_admin_agents_parity.py
@@ -55,14 +55,13 @@ DECLARED_PANES = {
         "core-plugin-toggles",
         "actions-config",
     ),
+    "inbound-mcp": ("inbound-mcp-configuration",),
 }
 
 # Tabs still served by the fallback scan, with the phase that declares them. The
 # test asserts this is exactly the remainder, so declaring one of them fails here
 # until it is moved into DECLARED_PANES with its sections.
-PANES_PENDING_DECLARATION = {
-    "inbound-mcp": "Phase 3 -- inbound MCP runtime, throttles and allowlists",
-}
+PANES_PENDING_DECLARATION = {}
 
 # Declared sections that hold no settings, because what belongs in them is a
 # table rather than a field. The V2 surface skips a section with nothing in it,

--- a/functional_tests/test_v2_admin_agents_parity.py
+++ b/functional_tests/test_v2_admin_agents_parity.py
@@ -49,14 +49,27 @@ DECLARED_PANES = {
         "agents-page-customization-card",
         "agent-template-approvals-section",
     ),
+    "actions": (
+        "document-action-capabilities-card",
+        "plugin-feature-toggles",
+        "core-plugin-toggles",
+        "actions-config",
+    ),
 }
 
 # Tabs still served by the fallback scan, with the phase that declares them. The
 # test asserts this is exactly the remainder, so declaring one of them fails here
 # until it is moved into DECLARED_PANES with its sections.
 PANES_PENDING_DECLARATION = {
-    "actions": "Phase 2 -- document action capabilities and built-in actions",
     "inbound-mcp": "Phase 3 -- inbound MCP runtime, throttles and allowlists",
+}
+
+# Declared sections that hold no settings, because what belongs in them is a
+# table rather than a field. The V2 surface skips a section with nothing in it,
+# so this is not a broken heading; the entry records why and is checked for
+# staleness once the section is filled.
+SECTIONS_AWAITING_A_COMPONENT = {
+    "actions-config": "Phase 5 -- the global actions table",
 }
 
 FIELD_NAME_RE = re.compile(r'\sname="([^"]+)"')
@@ -177,7 +190,7 @@ def test_declared_agent_sections_are_not_empty():
         section_id
         for section_ids in DECLARED_PANES.values()
         for section_id in section_ids
-        if not schema.get(section_id)
+        if not schema.get(section_id) and section_id not in SECTIONS_AWAITING_A_COMPONENT
     ]
 
     assert not empty, (
@@ -185,8 +198,19 @@ def test_declared_agent_sections_are_not_empty():
         "them:\n  " + "\n  ".join(empty)
     )
 
+    stale = sorted(
+        section_id
+        for section_id in SECTIONS_AWAITING_A_COMPONENT
+        if schema.get(section_id)
+    )
+    assert not stale, (
+        "These sections now have fields, so their entry in "
+        "SECTIONS_AWAITING_A_COMPONENT is stale and should be removed:\n  "
+        + "\n  ".join(stale)
+    )
+
     declared = sum(
-        len(schema[section_id])
+        len(schema.get(section_id, ()))
         for section_ids in DECLARED_PANES.values()
         for section_id in section_ids
     )

--- a/functional_tests/test_v2_admin_agents_parity.py
+++ b/functional_tests/test_v2_admin_agents_parity.py
@@ -262,7 +262,21 @@ def test_the_agents_gate_chain_is_declared():
         "settings must be too. These are not:\n  " + "\n  ".join(map(str, ungated))
     )
 
-    print("  Gate chain and Agents page dependencies are declared.")
+    derived = next(
+        (
+            field
+            for field in schema["agents-config"]
+            if field.get("key") == "enable_multi_agent_orchestration"
+        ),
+        None,
+    )
+    assert derived is not None and derived.get("readonly"), (
+        "enable_multi_agent_orchestration is written by the orchestration API "
+        "from the chosen mode. Left undeclared it is guessed into AI Models and "
+        "rendered as a switch that does nothing."
+    )
+
+    print("  Gate chain, Agents page dependencies and the derived key are declared.")
     return True
 
 

--- a/functional_tests/test_v2_admin_agents_parity.py
+++ b/functional_tests/test_v2_admin_agents_parity.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+# test_v2_admin_agents_parity.py
+"""
+Functional test pinning V1/V2 parity for the Admin Settings Agents & Actions group.
+Version: 0.261.059
+Implemented in: 0.261.059
+
+The V2 React admin surface renders from ``admin_settings_fields.py``. A setting
+present in a V1 pane but absent from that schema does not fail anything: it
+simply never appears in V2, and an administrator has no way of knowing a control
+they used to have is gone.
+
+Before this group was declared, the V2 surface fell back to scanning the settings
+document for ``enable_*`` booleans, which meant the Agents tab rendered nothing
+at all -- not one of ``per_user_semantic_kernel``, the ``allow_*`` toggles, or
+the eleven ``agents_page_*`` keys is an ``enable_*`` boolean.
+
+This test requires each V1 field name in the panes that have been declared to be
+claimed by the schema, either because the schema declares the same key, because
+``LEGACY_FIELD_NAMES`` records a shape difference, or because
+``LEGACY_FIELDS_WITHOUT_V2_EQUIVALENT`` documents why there is none. It also
+tracks which panes in the group are still undeclared, so finishing one without
+extending this test fails rather than passing quietly.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent))
+
+from test_support.app_stubs import import_app_module
+from test_support.nav import ADMIN_NAV
+from test_support.versioning import assert_app_version_at_least
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PANES_DIR = REPO_ROOT / "application" / "single_app" / "templates" / "admin" / "_panes"
+
+GROUP_ID = "agents-actions"
+
+# Tabs of the group whose fields the schema describes, and the sections each one
+# contributes. Verified against ADMIN_NAV below so a navigation change cannot
+# leave this list quietly stale.
+DECLARED_PANES = {
+    "agents": (
+        "agents-config",
+        "agent-toggles-card",
+        "agents-page-customization-card",
+        "agent-template-approvals-section",
+    ),
+}
+
+# Tabs still served by the fallback scan, with the phase that declares them. The
+# test asserts this is exactly the remainder, so declaring one of them fails here
+# until it is moved into DECLARED_PANES with its sections.
+PANES_PENDING_DECLARATION = {
+    "actions": "Phase 2 -- document action capabilities and built-in actions",
+    "inbound-mcp": "Phase 3 -- inbound MCP runtime, throttles and allowlists",
+}
+
+FIELD_NAME_RE = re.compile(r'\sname="([^"]+)"')
+JINJA_RE = re.compile(r"\{\{|\{%")
+
+fields_module = import_app_module("admin_settings_fields")
+
+
+def read_pane(pane_id):
+    """Return the raw markup for one Admin Settings pane."""
+    pane_path = PANES_DIR / f"{pane_id}.html"
+    assert pane_path.is_file(), f"Missing Admin Settings pane: {pane_path}"
+    return pane_path.read_text(encoding="utf-8")
+
+
+def collect_pane_field_names(markup):
+    """Return literal form field names submitted by a pane."""
+    return {
+        name
+        for name in FIELD_NAME_RE.findall(markup)
+        if not JINJA_RE.search(name)
+    }
+
+
+def group_tabs():
+    """Return the group's tabs keyed by id, straight from ADMIN_NAV."""
+    group = next((g for g in ADMIN_NAV if g["id"] == GROUP_ID), None)
+    assert group, f"ADMIN_NAV no longer defines an '{GROUP_ID}' group."
+    return {tab["id"]: tab for tab in group["tabs"]}
+
+
+def test_declared_panes_match_navigation():
+    """The panes this test reads must be the ones ADMIN_NAV puts in the group."""
+    print("Testing Agents & Actions pane list against ADMIN_NAV...")
+
+    assert_app_version_at_least("0.261.059")
+
+    tabs = group_tabs()
+
+    covered = set(DECLARED_PANES) | set(PANES_PENDING_DECLARATION)
+    assert covered == set(tabs), (
+        "The Agents & Actions tabs changed. Update DECLARED_PANES and "
+        "PANES_PENDING_DECLARATION together.\n"
+        f"  ADMIN_NAV: {sorted(tabs)}\n  test: {sorted(covered)}"
+    )
+
+    for tab_id, section_ids in DECLARED_PANES.items():
+        actual = tuple(section["id"] for section in tabs[tab_id]["sections"])
+        assert actual == section_ids, (
+            f"Sections for the '{tab_id}' tab changed.\n"
+            f"  ADMIN_NAV: {actual}\n  test: {section_ids}"
+        )
+
+    print(f"  {len(tabs)} tab(s) accounted for, {len(DECLARED_PANES)} declared.")
+    return True
+
+
+def test_every_declared_pane_field_is_claimed_by_the_schema():
+    """A V1 field with no V2 equivalent is invisible in the new UI."""
+    print("\nTesting that every declared V1 field is claimed by the schema...")
+
+    claimed = fields_module.get_legacy_field_names()
+    documented = set(fields_module.LEGACY_FIELDS_WITHOUT_V2_EQUIVALENT)
+
+    unclaimed = {}
+    total = 0
+    for pane_id in DECLARED_PANES:
+        names = collect_pane_field_names(read_pane(pane_id))
+        total += len(names)
+        missing = sorted(names - claimed - documented)
+        if missing:
+            unclaimed[pane_id] = missing
+
+    assert not unclaimed, (
+        "These V1 fields have no V2 equivalent and no recorded reason. Declare "
+        "them in admin_settings_fields.py, map them through LEGACY_FIELD_NAMES, "
+        "or record why in LEGACY_FIELDS_WITHOUT_V2_EQUIVALENT:\n  "
+        + "\n  ".join(f"{pane}: {', '.join(names)}" for pane, names in unclaimed.items())
+    )
+
+    print(f"  All {total} V1 field name(s) across {len(DECLARED_PANES)} pane(s) are claimed.")
+    return True
+
+
+def test_documented_omissions_are_still_real():
+    """A recorded omission for a field that no longer exists is stale."""
+    print("\nTesting that documented omissions still appear in a pane...")
+
+    pane_names = set()
+    for pane_id in list(DECLARED_PANES) + list(PANES_PENDING_DECLARATION):
+        pane_names |= collect_pane_field_names(read_pane(pane_id))
+
+    # Only omissions this group is responsible for are checked here, so the
+    # Appearance group can record its own without this test failing.
+    group_omissions = {"orchestration_type", "max_rounds_per_agent"}
+    stale = sorted(
+        name
+        for name in fields_module.LEGACY_FIELDS_WITHOUT_V2_EQUIVALENT
+        if name in group_omissions and name not in pane_names
+    )
+
+    assert not stale, (
+        "These fields are recorded as having no V2 equivalent but no longer "
+        "appear in any Agents & Actions pane. Remove the entry:\n  "
+        + "\n  ".join(stale)
+    )
+
+    print(f"  {len(group_omissions)} documented omission(s) still exist in V1.")
+    return True
+
+
+def test_declared_agent_sections_are_not_empty():
+    """A named section with no fields renders as a heading over nothing."""
+    print("\nTesting that every declared section owns at least one field...")
+
+    schema = fields_module.get_admin_settings_fields()
+    empty = [
+        section_id
+        for section_ids in DECLARED_PANES.values()
+        for section_id in section_ids
+        if not schema.get(section_id)
+    ]
+
+    assert not empty, (
+        "These sections are listed as declared but the schema has no fields for "
+        "them:\n  " + "\n  ".join(empty)
+    )
+
+    declared = sum(
+        len(schema[section_id])
+        for section_ids in DECLARED_PANES.values()
+        for section_id in section_ids
+    )
+    print(f"  {declared} field(s) across {sum(map(len, DECLARED_PANES.values()))} section(s).")
+    return True
+
+
+def test_the_agents_gate_chain_is_declared():
+    """The dependency chain is the point of the rework, so it is pinned.
+
+    ``/agents`` carries ``@enabled_required('enable_semantic_kernel')``, and the
+    Agents page copy customises that page, so every one of those fields has to
+    depend on the gate. Losing a link in the chain puts a control back on screen
+    that cannot affect anything.
+    """
+    print("\nTesting the Agents dependency chain...")
+
+    schema = fields_module.get_admin_settings_fields()
+
+    def dependency_keys(field):
+        return {
+            dependency["key"]
+            for dependency in fields_module.iter_dependencies(field)
+        }
+
+    runtime = {field["key"]: field for field in schema["agents-config"] if field.get("key")}
+
+    assert "enable_semantic_kernel" in runtime, "The master gate is not declared."
+    assert not runtime["enable_semantic_kernel"].get("depends_on"), (
+        "The master gate must not itself be gated, or it could become unreachable."
+    )
+    assert dependency_keys(runtime["per_user_semantic_kernel"]) == {
+        "enable_semantic_kernel"
+    }, "Workspace Mode must depend on Enable Agents."
+    assert dependency_keys(runtime["merge_global_semantic_kernel_with_workspace"]) == {
+        "enable_semantic_kernel",
+        "per_user_semantic_kernel",
+    }, (
+        "The merge toggle only means anything in Workspace Mode, so it must "
+        "depend on both links of the chain rather than the outer one alone."
+    )
+
+    ungated = [
+        field.get("key") or field.get("component")
+        for field in schema["agents-page-customization-card"]
+        if "enable_semantic_kernel" not in dependency_keys(field)
+    ]
+    assert not ungated, (
+        "The Agents page is served behind enable_semantic_kernel, so its "
+        "settings must be too. These are not:\n  " + "\n  ".join(map(str, ungated))
+    )
+
+    print("  Gate chain and Agents page dependencies are declared.")
+    return True
+
+
+def test_workspace_permission_sections_are_conditional():
+    """V1 only renders these cards in Workspace Mode; V2 must agree.
+
+    Without the condition the section would render a set of permissions that the
+    runtime ignores, because nothing reads them outside Workspace Mode.
+    """
+    print("\nTesting workspace permission section conditions...")
+
+    conditions = {
+        section["id"]: section.get("condition")
+        for group in ADMIN_NAV
+        if group["id"] == GROUP_ID
+        for tab in group["tabs"]
+        for section in tab["sections"]
+    }
+
+    assert conditions.get("agent-toggles-card") == "per_user_semantic_kernel", (
+        "Workspace Agent Permissions must be conditional on Workspace Mode."
+    )
+    assert conditions.get("agent-template-approvals-section") == (
+        "enable_agent_template_gallery"
+    ), "Agent Template Approvals must stay conditional on the gallery toggle."
+
+    print("  Conditional sections declare the gate they belong to.")
+    return True
+
+
+if __name__ == "__main__":
+    tests = [
+        test_declared_panes_match_navigation,
+        test_every_declared_pane_field_is_claimed_by_the_schema,
+        test_documented_omissions_are_still_real,
+        test_declared_agent_sections_are_not_empty,
+        test_the_agents_gate_chain_is_declared,
+        test_workspace_permission_sections_are_conditional,
+    ]
+    results = [test() for test in tests]
+    print(f"\nResults: {sum(bool(r) for r in results)}/{len(results)} passed")
+    sys.exit(0 if all(results) else 1)

--- a/functional_tests/test_v2_admin_agents_parity.py
+++ b/functional_tests/test_v2_admin_agents_parity.py
@@ -2,8 +2,8 @@
 # test_v2_admin_agents_parity.py
 """
 Functional test pinning V1/V2 parity for the Admin Settings Agents & Actions group.
-Version: 0.261.062
-Implemented in: 0.261.062
+Version: 0.261.065
+Implemented in: 0.261.065
 
 The V2 React admin surface renders from ``admin_settings_fields.py``. A setting
 present in a V1 pane but absent from that schema does not fail anything: it
@@ -104,7 +104,7 @@ def test_declared_panes_match_navigation():
     """The panes this test reads must be the ones ADMIN_NAV puts in the group."""
     print("Testing Agents & Actions pane list against ADMIN_NAV...")
 
-    assert_app_version_at_least("0.261.062")
+    assert_app_version_at_least("0.261.065")
 
     tabs = group_tabs()
 

--- a/functional_tests/test_v2_admin_capability_placement.py
+++ b/functional_tests/test_v2_admin_capability_placement.py
@@ -64,7 +64,21 @@ RELOCATED_CAPABILITIES = {
     "enable_support_latest_features": ("support-menu-section", "support-menu"),
     "enable_support_menu": ("support-menu-section", "support-menu"),
     "enable_user_workspace": ("personal-workspaces-section", "workspace-types"),
-    "enable_text_plugin": ("actions-config", "actions"),
+    # Agents & Actions. Before these were declared, enable_semantic_kernel matched
+    # no section at all and was filed under "Other capabilities", and the plugin
+    # toggles were scattered: enable_text_plugin matched "text" in
+    # home-page-text-section, and the rest matched nothing.
+    "enable_semantic_kernel": ("agents-config", "agents"),
+    "enable_agent_template_gallery": ("agent-toggles-card", "agents"),
+    "enable_time_plugin": ("core-plugin-toggles", "actions"),
+    "enable_http_plugin": ("core-plugin-toggles", "actions"),
+    "enable_wait_plugin": ("core-plugin-toggles", "actions"),
+    "enable_math_plugin": ("core-plugin-toggles", "actions"),
+    "enable_text_plugin": ("core-plugin-toggles", "actions"),
+    "enable_default_embedding_model_plugin": ("core-plugin-toggles", "actions"),
+    # Declared under Chat, where it is edited. The Actions surface carries a
+    # read-only mirror of it, which must not claim the key.
+    "enable_fact_memory_plugin": ("fact-memory-section", "chat-experience"),
 }
 
 # The rules the ported heuristic depends on. If the renderer stops doing any of
@@ -212,8 +226,15 @@ def test_relocated_capabilities_are_declared_where_they_belong():
     declared_sections = {}
     for section_id, field in fields_module.iter_fields():
         key = field.get("key")
-        if key:
-            declared_sections[key] = (section_id, field)
+        if not key:
+            continue
+        # A key may also be declared as a read-only mirror in another section.
+        # The writable declaration is the one that owns the setting, so a mirror
+        # never displaces it here.
+        existing = declared_sections.get(key)
+        if existing and existing[1].get("readonly") is not True and field.get("readonly"):
+            continue
+        declared_sections[key] = (section_id, field)
 
     problems = []
     for key, (expected_section, _pane) in RELOCATED_CAPABILITIES.items():

--- a/functional_tests/test_v2_admin_inbound_mcp_parity.py
+++ b/functional_tests/test_v2_admin_inbound_mcp_parity.py
@@ -2,8 +2,8 @@
 # test_v2_admin_inbound_mcp_parity.py
 """
 Functional test pinning V1/V2 parity for the Admin Settings Inbound MCP tab.
-Version: 0.261.064
-Implemented in: 0.261.064
+Version: 0.261.065
+Implemented in: 0.261.065
 
 Two things about this tab are unusual, and both fail silently.
 
@@ -91,7 +91,7 @@ def test_inbound_mcp_section_is_declared():
     """An undeclared section falls back to rendering two bare switches."""
     print("Testing the Inbound MCP section declaration...")
 
-    assert_app_version_at_least("0.261.064")
+    assert_app_version_at_least("0.261.065")
 
     tab = next(
         (

--- a/functional_tests/test_v2_admin_inbound_mcp_parity.py
+++ b/functional_tests/test_v2_admin_inbound_mcp_parity.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+# test_v2_admin_inbound_mcp_parity.py
+"""
+Functional test pinning V1/V2 parity for the Admin Settings Inbound MCP tab.
+Version: 0.261.061
+Implemented in: 0.261.061
+
+Two things about this tab are unusual, and both fail silently.
+
+It is gated by ``ENABLE_MCP_UI``, an App Service application setting with no
+entry in the settings document. A condition read from settings alone can never
+see it, so the fields depend on a runtime flag the settings API sends, and the
+section still renders when the flag is off so an administrator can find out how
+to turn it on.
+
+Its allowlists are edited as ``{value, description}`` entries but the runtime
+reads flat id lists derived from them, and single roles are mirrored into arrays.
+The server-rendered form derives all of that on save. Without the same
+derivation, an allowlist edited in the new interface would be stored and then
+ignored -- the worst possible failure for an access control list, because the
+screen would show the restriction while the runtime applied the old one.
+"""
+
+import re
+import sys
+from contextlib import contextmanager
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent))
+
+from test_support.app_stubs import import_app_module, stubbed_config
+from test_support.nav import ADMIN_NAV
+from test_support.versioning import assert_app_version_at_least
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+APP_ROOT = REPO_ROOT / "application" / "single_app"
+PANES_DIR = APP_ROOT / "templates" / "admin" / "_panes"
+V2_SRC = REPO_ROOT / "application" / "v2_ui" / "src"
+
+SECTION_ID = "inbound-mcp-configuration"
+
+# The tenant this stubbed deployment belongs to. Restricting tenants is expressed
+# by admitting only this one, so the derivation is checked against a known value.
+HOME_TENANT_ID = "home-tenant-id"
+
+# The five constants functions_mcp_server_config reads from config. Paths are not
+# exercised here; only TENANT_ID affects the derivations under test.
+CONFIG_CONSTANTS = {
+    "INBOUND_MCP_AUTHORIZATION_SERVER_METADATA_PATH": "/.well-known/oauth-authorization-server",
+    "INBOUND_MCP_PRM_PATH": "/.well-known/oauth-protected-resource",
+    "INBOUND_MCP_PRM_PATHS": ("/.well-known/oauth-protected-resource",),
+    "INBOUND_MCP_RESOURCE_PATH": "/external/mcp",
+    "TENANT_ID": HOME_TENANT_ID,
+}
+
+FIELD_NAME_RE = re.compile(r'\sname="([^"]+)"')
+JINJA_RE = re.compile(r"\{\{|\{%")
+
+fields_module = import_app_module("admin_settings_fields")
+
+
+@contextmanager
+def real_mcp_config():
+    """Run a normalization with the real inbound MCP helpers available.
+
+    The derivations delegate to ``functions_mcp_server_config``, which is
+    imported lazily precisely because it cannot be loaded in a plain test
+    process. Loading it against a config stub is what lets these checks exercise
+    the real rules rather than assert on source text.
+    """
+    with stubbed_config(**CONFIG_CONSTANTS):
+        yield
+
+
+def normalize(updates, current=None):
+    with real_mcp_config():
+        return fields_module.normalize_admin_settings_updates(updates, current or {})
+
+
+def read(path):
+    assert path.is_file(), f"Missing expected file: {path}"
+    return path.read_text(encoding="utf-8")
+
+
+def mcp_fields():
+    return fields_module.get_admin_settings_fields()[SECTION_ID]
+
+
+def test_inbound_mcp_section_is_declared():
+    """An undeclared section falls back to rendering two bare switches."""
+    print("Testing the Inbound MCP section declaration...")
+
+    assert_app_version_at_least("0.261.061")
+
+    tab = next(
+        (
+            tab
+            for group in ADMIN_NAV
+            if group["id"] == "agents-actions"
+            for tab in group["tabs"]
+            if tab["id"] == "inbound-mcp"
+        ),
+        None,
+    )
+    assert tab, "ADMIN_NAV no longer defines an 'inbound-mcp' tab."
+    assert [section["id"] for section in tab["sections"]] == [SECTION_ID]
+
+    assert not tab["sections"][0].get("condition"), (
+        "The section must stay unconditional. Hiding it when the preview flag is "
+        "off would leave an administrator no way to learn the flag exists."
+    )
+
+    print(f"  {len(mcp_fields())} field(s) declared for {SECTION_ID}.")
+    return True
+
+
+def test_every_inbound_mcp_pane_field_is_claimed_by_the_schema():
+    """A V1 field with no V2 equivalent is invisible in the new UI."""
+    print("\nTesting that every V1 Inbound MCP field is claimed...")
+
+    claimed = fields_module.get_legacy_field_names()
+    documented = set(fields_module.LEGACY_FIELDS_WITHOUT_V2_EQUIVALENT)
+
+    names = {
+        name
+        for name in FIELD_NAME_RE.findall(read(PANES_DIR / "inbound-mcp.html"))
+        if not JINJA_RE.search(name)
+    }
+    missing = sorted(names - claimed - documented)
+
+    assert not missing, (
+        "These V1 Inbound MCP fields have no V2 equivalent and no recorded "
+        "reason:\n  " + "\n  ".join(missing)
+    )
+
+    print(f"  All {len(names)} V1 Inbound MCP field name(s) are claimed.")
+    return True
+
+
+def test_configuration_is_gated_on_the_runtime_flag():
+    """A settings-only condition can never see an App Service setting."""
+    print("\nTesting the preview flag gate...")
+
+    ungated = []
+    notice = None
+    for field in mcp_fields():
+        flags = {
+            (dependency.get("flag"), dependency.get("equals"))
+            for dependency in fields_module.iter_dependencies(field)
+            if dependency.get("flag")
+        }
+        if ("mcp_ui_enabled", False) in flags:
+            notice = field
+            continue
+        if ("mcp_ui_enabled", True) not in flags:
+            ungated.append(field.get("key") or field.get("component"))
+
+    assert not ungated, (
+        "These Inbound MCP fields would render even where the preview UI is "
+        "switched off for the deployment:\n  " + "\n  ".join(map(str, ungated))
+    )
+
+    assert notice is not None, (
+        "Nothing explains how to enable the tab, so an administrator would see "
+        "an empty section and no reason for it."
+    )
+    assert notice["type"] == "component", "The notice must be a component field."
+
+    print("  Every setting is gated, and a notice covers the disabled state.")
+    return True
+
+
+def test_the_settings_api_sends_the_runtime_flag():
+    """The gate is unusable if the flag never reaches the browser."""
+    print("\nTesting that mcp_ui_enabled is sent to the SPA...")
+
+    route = read(APP_ROOT / "route_backend_v2.py")
+    assert "runtime_flags" in route and "is_mcp_ui_enabled()" in route, (
+        "route_backend_v2.py no longer sends the runtime flags the schema "
+        "depends on, so every Inbound MCP field would stay hidden."
+    )
+
+    page = read(V2_SRC / "pages" / "AdminSettingsPage.tsx")
+    assert "runtime_flags" in page, "The SPA no longer reads runtime_flags."
+
+    print("  The flag is sent by the API and read by the page.")
+    return True
+
+
+def test_allowlist_edits_derive_the_lists_the_runtime_reads():
+    """Storing entries without their id list would apply the old allowlist."""
+    print("\nTesting inbound MCP derivations...")
+
+    normalized, errors, _warnings = normalize(
+        {
+            "inbound_mcp_allowed_client_app_entries": [
+                {"value": "  ABC-123  ", "description": "VS Code"},
+                {"value": "abc-123", "description": "duplicate"},
+                {"value": "", "description": "blank"},
+            ]
+        },
+        {},
+    )
+
+    assert not errors, f"Unexpected errors: {errors}"
+    assert normalized["inbound_mcp_allowed_client_app_ids"] == ["abc-123"], (
+        "The runtime reads the id list, so it must be derived, trimmed, "
+        "lowercased and de-duplicated alongside the entries."
+    )
+    assert [entry["value"] for entry in normalized["inbound_mcp_allowed_client_app_entries"]] == [
+        "abc-123"
+    ]
+
+    print("  Client app entries derive their id list.")
+    return True
+
+
+def test_a_single_role_is_mirrored_into_the_array_the_runtime_reads():
+    """Both shapes are stored, and V1 keeps them in step."""
+    print("\nTesting role mirroring...")
+
+    normalized, errors, _warnings = normalize(
+        {"inbound_mcp_required_user_role": "  CustomRole  "}, {}
+    )
+
+    assert not errors, f"Unexpected errors: {errors}"
+    assert normalized["inbound_mcp_required_user_role"] == "CustomRole"
+    assert normalized["inbound_mcp_required_user_roles"] == ["CustomRole"], (
+        "The array form was not updated, so the runtime would keep checking the "
+        "previous role."
+    )
+
+    print("  A role edit updates both stored shapes.")
+    return True
+
+
+def test_allowing_all_sources_collapses_the_source_list():
+    """The two modes are expressed differently, and mixing them is dangerous."""
+    print("\nTesting source allowlist modes...")
+
+    allow_all, errors, _warnings = normalize(
+        {"inbound_mcp_allow_all_source_ids": True}, {}
+    )
+    assert not errors, f"Unexpected errors: {errors}"
+    assert allow_all["inbound_mcp_allowed_source_ids"] == ["*"], (
+        "Allowing every source is expressed as the wildcard id list."
+    )
+
+    controlled, errors, _warnings = normalize(
+        {"inbound_mcp_allow_all_source_ids": False},
+        {
+            "inbound_mcp_allowed_source_entries": [
+                {"value": "*", "description": "Allow all inbound MCP source IDs"},
+                {"value": "vscode", "description": "Editor"},
+            ]
+        },
+    )
+    assert not errors, f"Unexpected errors: {errors}"
+    assert controlled["inbound_mcp_allowed_source_ids"] == ["vscode"], (
+        "Turning off allow-all must drop the wildcard row, or every source would "
+        "still be accepted while the screen showed a restricted list."
+    )
+    assert all(
+        entry["value"] != "*"
+        for entry in controlled["inbound_mcp_allowed_source_entries"]
+    )
+
+    print("  Each mode produces the id list the runtime expects.")
+    return True
+
+
+def test_restricting_tenants_keeps_the_entries_an_admin_typed():
+    """Switching the tenant gate off must not silently delete configuration."""
+    print("\nTesting tenant allowlist behaviour...")
+
+    current = {
+        "inbound_mcp_allowed_tenant_entries": [
+            {"value": "partner-tenant", "description": "Partner"}
+        ]
+    }
+
+    restricted, errors, _warnings = normalize(
+        {"inbound_mcp_allow_external_tenants": False}, current
+    )
+    assert not errors, f"Unexpected errors: {errors}"
+    assert [
+        entry["value"] for entry in restricted["inbound_mcp_allowed_tenant_entries"]
+    ] == ["partner-tenant"], "The partner tenant an admin configured was discarded."
+    assert restricted["inbound_mcp_allowed_tenant_ids"] == [HOME_TENANT_ID], (
+        "A restricted deployment must admit its own tenant and nothing else."
+    )
+
+    reopened, errors, _warnings = normalize(
+        {"inbound_mcp_allow_external_tenants": True}, current
+    )
+    assert not errors, f"Unexpected errors: {errors}"
+    assert "partner-tenant" in reopened["inbound_mcp_allowed_tenant_ids"]
+    assert HOME_TENANT_ID in reopened["inbound_mcp_allowed_tenant_ids"], (
+        "Admitting other tenants must not lock out the deployment's own."
+    )
+
+    print("  Entries survive the gate; only the effective id list changes.")
+    return True
+
+
+def test_derivations_reuse_the_functions_that_already_own_them():
+    """Reimplementing these rules would let the two admin surfaces disagree."""
+    print("\nTesting that derivations are delegated...")
+
+    source = read(APP_ROOT / "admin_settings_fields.py")
+    for helper in (
+        "normalize_inbound_mcp_value_entries",
+        "inbound_mcp_entry_values",
+        "ensure_inbound_mcp_default_tenant_entry",
+        "normalize_inbound_mcp_single_value",
+    ):
+        assert helper in source, (
+            f"{helper} is no longer used, so the V2 surface has its own idea of "
+            "what a valid inbound MCP allowlist is."
+        )
+
+    print("  All four allowlist helpers are reused.")
+    return True
+
+
+if __name__ == "__main__":
+    tests = [
+        test_inbound_mcp_section_is_declared,
+        test_every_inbound_mcp_pane_field_is_claimed_by_the_schema,
+        test_configuration_is_gated_on_the_runtime_flag,
+        test_the_settings_api_sends_the_runtime_flag,
+        test_allowlist_edits_derive_the_lists_the_runtime_reads,
+        test_a_single_role_is_mirrored_into_the_array_the_runtime_reads,
+        test_allowing_all_sources_collapses_the_source_list,
+        test_restricting_tenants_keeps_the_entries_an_admin_typed,
+        test_derivations_reuse_the_functions_that_already_own_them,
+    ]
+    results = [test() for test in tests]
+    print(f"\nResults: {sum(bool(r) for r in results)}/{len(results)} passed")
+    sys.exit(0 if all(results) else 1)
+

--- a/functional_tests/test_v2_admin_settings_schema.py
+++ b/functional_tests/test_v2_admin_settings_schema.py
@@ -40,6 +40,11 @@ APP_DEFAULT_RE = re.compile(
 
 fields_module = import_app_module("admin_settings_fields")
 
+# Runtime flags the settings API sends alongside the schema. A field may depend on
+# one of these instead of on another field, for a capability gated outside the
+# settings document.
+RUNTIME_FLAGS = {"mcp_ui_enabled"}
+
 # Properties every field type must carry beyond the common ones, because the
 # renderer cannot draw the control without them.
 REQUIRED_PROPERTIES_BY_TYPE = {
@@ -52,6 +57,7 @@ REQUIRED_PROPERTIES_BY_TYPE = {
     "textarea": ("default",),
     "switch": ("default",),
     "link_list": ("item_fields", "default"),
+    "entry_list": ("default", "value_label"),
     "image": ("upload_target", "accept", "version_key"),
     "component": ("component",),
 }
@@ -66,6 +72,7 @@ EXPECTED_DEFAULT_TYPES = {
     "number": int,
     "checkbox_set": list,
     "link_list": list,
+    "entry_list": list,
 }
 
 
@@ -237,8 +244,21 @@ def test_dependencies_reference_real_fields():
         for depends_on in fields_module.iter_dependencies(field):
             checked += 1
 
+            if depends_on.get("flag"):
+                # A runtime flag is resolved by the server, not by another field,
+                # so there is no declaration to point at. It must still be a flag
+                # the settings API actually sends.
+                if depends_on["flag"] not in RUNTIME_FLAGS:
+                    problems.append(
+                        f"{identity}: depends on unknown runtime flag "
+                        f"{depends_on['flag']!r}"
+                    )
+                if not isinstance(depends_on.get("equals"), bool):
+                    problems.append(f"{identity}: a flag condition must compare to a bool")
+                continue
+
             if "key" not in depends_on:
-                problems.append(f"{identity}: depends_on has no key")
+                problems.append(f"{identity}: depends_on names neither a key nor a flag")
                 continue
             if depends_on["key"] not in declared:
                 problems.append(f"{identity}: depends on undeclared key {depends_on['key']!r}")

--- a/functional_tests/test_v2_admin_settings_schema.py
+++ b/functional_tests/test_v2_admin_settings_schema.py
@@ -200,19 +200,33 @@ def test_dependencies_reference_real_fields():
     checked = 0
 
     for section_id, field in fields_module.iter_fields():
-        depends_on = field.get("depends_on")
-        if not depends_on:
-            continue
-        checked += 1
         identity = f"{section_id}.{field.get('key') or field.get('component')}"
 
-        if "key" not in depends_on:
-            problems.append(f"{identity}: depends_on has no key")
-            continue
-        if depends_on["key"] not in declared:
-            problems.append(f"{identity}: depends on undeclared key {depends_on['key']!r}")
-        if field.get("key") == depends_on["key"]:
-            problems.append(f"{identity}: depends on itself")
+        # ``depends_on`` may be one condition or a chain of them, so the schema
+        # exposes an iterator rather than each caller re-deriving the shape.
+        for depends_on in fields_module.iter_dependencies(field):
+            checked += 1
+
+            if "key" not in depends_on:
+                problems.append(f"{identity}: depends_on has no key")
+                continue
+            if depends_on["key"] not in declared:
+                problems.append(f"{identity}: depends on undeclared key {depends_on['key']!r}")
+            if field.get("key") == depends_on["key"]:
+                problems.append(f"{identity}: depends on itself")
+
+            # A string comparison only makes sense against a value the gating
+            # field can actually hold, and a typo there hides the dependent
+            # field for good.
+            expected = depends_on.get("equals", True)
+            if isinstance(expected, str):
+                gate = fields_module.get_field_definition(depends_on["key"]) or {}
+                allowed = {option["value"] for option in gate.get("options", [])}
+                if allowed and expected not in allowed:
+                    problems.append(
+                        f"{identity}: depends on {depends_on['key']!r} == {expected!r}, "
+                        f"which is not one of {sorted(allowed)}"
+                    )
 
     assert not problems, (
         "These visibility dependencies are broken:\n  " + "\n  ".join(problems)

--- a/functional_tests/test_v2_admin_settings_schema.py
+++ b/functional_tests/test_v2_admin_settings_schema.py
@@ -214,9 +214,10 @@ def test_setting_keys_have_one_owner():
             field["key"]
             for _section_id, field in fields_module.iter_fields()
             if field.get("readonly") and field.get("key") and field["key"] not in writable
-            # A derived key has no editable declaration anywhere, because the
-            # application recomputes it. Those are named in the mirror's help.
-            and field["key"] not in {"enable_tabular_processing_plugin"}
+            # A derived key has no editable declaration anywhere, because
+            # something else computes it. Those are named in the mirror's help.
+            and field["key"]
+            not in {"enable_tabular_processing_plugin", "enable_multi_agent_orchestration"}
         }
     )
     assert not orphaned, (

--- a/functional_tests/test_v2_admin_settings_schema.py
+++ b/functional_tests/test_v2_admin_settings_schema.py
@@ -169,25 +169,55 @@ def test_select_defaults_are_offered_as_options():
     return True
 
 
-def test_setting_keys_are_unique():
-    """The same key in two sections would render two controls fighting over one value."""
-    print("\nTesting settings key uniqueness...")
+def test_setting_keys_have_one_owner():
+    """Two editable controls on one value would fight over it.
 
-    seen = {}
+    A key may appear more than once, but only as one writable declaration plus
+    read-only mirrors. Fact memory is edited under Chat and mirrored under
+    Actions, because it decides whether agents get a memory action; a second
+    editable control would let one surface silently overwrite the other.
+    """
+    print("\nTesting settings key ownership...")
+
+    writable = {}
+    mirrors = 0
     duplicates = []
+
     for section_id, field in fields_module.iter_fields():
         key = field.get("key")
         if not key:
             continue
-        if key in seen:
-            duplicates.append(f"{key}: {seen[key]} and {section_id}")
-        seen[key] = section_id
+        if field.get("readonly"):
+            mirrors += 1
+            if not field.get("managed_by"):
+                duplicates.append(
+                    f"{key}: read-only in {section_id} without naming its owner"
+                )
+            continue
+        if key in writable:
+            duplicates.append(f"{key}: editable in both {writable[key]} and {section_id}")
+        writable[key] = section_id
 
     assert not duplicates, (
-        "These keys are declared in more than one section:\n  " + "\n  ".join(duplicates)
+        "These keys do not have exactly one owner:\n  " + "\n  ".join(duplicates)
     )
 
-    print(f"  All {len(seen)} declared key(s) are unique.")
+    orphaned = sorted(
+        {
+            field["key"]
+            for _section_id, field in fields_module.iter_fields()
+            if field.get("readonly") and field.get("key") and field["key"] not in writable
+            # A derived key has no editable declaration anywhere, because the
+            # application recomputes it. Those are named in the mirror's help.
+            and field["key"] not in {"enable_tabular_processing_plugin"}
+        }
+    )
+    assert not orphaned, (
+        "These keys are only ever mirrored, so nothing can set them:\n  "
+        + "\n  ".join(orphaned)
+    )
+
+    print(f"  {len(writable)} owned key(s) and {mirrors} read-only mirror(s).")
     return True
 
 
@@ -320,7 +350,7 @@ if __name__ == "__main__":
         test_fields_carry_required_properties,
         test_defaults_match_their_field_type,
         test_select_defaults_are_offered_as_options,
-        test_setting_keys_are_unique,
+        test_setting_keys_have_one_owner,
         test_dependencies_reference_real_fields,
         test_option_values_are_unique_within_a_field,
         test_declared_defaults_match_the_application,

--- a/functional_tests/test_v2_admin_workflow_parity.py
+++ b/functional_tests/test_v2_admin_workflow_parity.py
@@ -229,7 +229,19 @@ def test_number_bounds_match_v1():
 
 
 def test_sub_settings_are_gated_by_their_capability():
-    """A sub-setting gated on the wrong capability hides while its feature is live."""
+    """A sub-setting gated on the wrong capability hides while its feature is live.
+
+    This read ``depends_on`` as a single dict until 0.261.074, and raised
+    ``'list' object has no attribute 'get'`` the moment it met a chain. The crash
+    was latent rather than new: ``group_workflow_allowed_group_ids`` has carried a
+    two-link chain for some time, but ``workflow-settings-section`` was declared
+    twice and the later declaration won, so the chained field was never the one
+    this test read. Resolving that duplicate made it live and the assumption
+    failed immediately.
+
+    Worth remembering as a shape: fixing a duplicate declaration can expose a bug
+    in code that only ever saw the other copy.
+    """
     print("\nTesting the workflow gating chain...")
 
     declared = {field["key"]: field for field in workflow_fields() if field.get("key")}


### PR DESCRIPTION
Brings the Agents & Actions group into the V2 admin surface. Targets `paullizer-react-v2-ui`, matching the other V2 admin settings branches. Ships as **`0.261.074`**.

## Why

The V2 admin surface renders from `admin_settings_fields.py` and falls back to scanning the settings document for `enable_*` booleans where a group is not declared. Agents and actions are not configured with booleans, so the group rendered **7 switches out of 55 settings**:

| Navigation section | What V2 actually rendered |
|---|---|
| `agents-config` | nothing — the section was skipped |
| `agent-template-approvals-section` | `enable_agent_template_gallery` |
| `document-action-capabilities-card` | nothing — the section was skipped |
| `actions-config` | `enable_text_plugin` |
| `inbound-mcp-configuration` | `enable_inbound_mcp_server`, `enable_inbound_mcp_rate_limits` |
| "Other capabilities" | `enable_semantic_kernel` and four `enable_*_plugin` keys |
| Chat › Processing Thoughts | `enable_tabular_processing_plugin`, misfiled by stem match |

Everything else — `per_user_semantic_kernel`, the `allow_*` toggles, the eleven `agents_page_*` keys, `document_action_capabilities`, and nineteen `inbound_mcp_*` keys — was invisible.

Three findings from reading the runtime shaped the result:

- **The Agents page is gated.** `/agents` carries `@enabled_required('enable_semantic_kernel')`, but the customization card rendered outside that gate.
- **Agent Orchestration is dead UI.** `orchestration_types` has one entry; `group_chat` and `magnetic` sit inside a string literal in `semantic_kernel_loader.py`. The dropdown had one option and Max Rounds could never be reached.
- **Inbound MCP allowlists derive extra keys on save.** The runtime reads `*_ids`, not the `*_entries` an administrator edits. A 1:1 PATCH would have stored an allowlist and then ignored it — the screen showing the new restriction while the runtime applied the old one.

## What changed

**Agents** — 4 sections, 22 fields. Agents → Workspace Mode → merge is a real dependency chain, so a control cannot reappear because an intermediate gate is off. Workspace Mode now reads as a choice between one shared curated set and per-user collections. The Agents page copy follows the page it customizes. Promoted agents are picked from the catalog instead of edited as JSON.

**Actions** — 4 sections, 16 fields. Document action limits are editable again, written into the nested `document_action_capabilities` container and clamped by the same function the classic form uses. Built-in actions are collapsed.

**Inbound MCP** — 17 fields grouped Runtime gate / Request limits / Allowlists, gated on a runtime flag with a notice explaining `ENABLE_MCP_UI`. Allowlists are `{value, description}` rows; the derived keys reuse the four helpers in `functions_mcp_server_config`.

Also corrected three settings that were misrepresented:

- **Tabular processing** was a switch under Chat › Processing Thoughts that did nothing, because the application recomputes it from Enhanced Citations. Now a read-only entry naming its source.
- **Multi-agent orchestration** was a live switch under AI Models, written by the orchestration API from the chosen mode. Now read-only beside the agent runtime settings.
- **Fact memory** is listed with the actions it affects while its control stays in Chat.

### Schema and renderer additions

| Addition | Why |
|---|---|
| `depends_on` as a chain, `equals` as a string | Multi-link gates, and gating on a select value |
| `group` / `collapsed` | Sub-sections; a search opens a collapsed group so a match is never hidden |
| Section `condition` support | `ADMIN_NAV` already carried it and V1 honoured it; V2 ignored it |
| `settings_path` | Reads and writes a value inside a nested container |
| `readonly` / `managed_by` | Reports a value another surface owns |
| `depends_on` naming a `flag` | Gates on a server runtime flag, for a capability gated outside the settings document |
| `entry_list` | Repeatable allowlist rows |

Navigation names nested cards that already exist in the V1 panes, so **no server-rendered markup changed**.

## Testing

- **116 tests pass**, including this branch's three new parity suites, a 40-check runtime logic test, and the Security, Workflow, Workspaces and Appearance suites from the base branch.
- The Inbound MCP derivations are executed against the real `functions_mcp_server_config` helpers via a new `stubbed_config` seam, not asserted on source text.
- The `admin_settings.html` regression set is unchanged at **32 failed / 329 passed / 4 errors**, measured against `56ebe9ec` in a separate worktree before the work and again after merging.
- `compileall` clean, V2 UI typechecks and builds, docs inventory regenerated, docs coverage and quality tests pass.

## Merge notes

The base moved five times during this work, picking up Workflow/Workspaces (#1417), chart editing (#1418), Security (#1421) and AI Models phase 1 (#1415). After merging, all groups were confirmed present — 44 sections / 175 fields.

`ADMIN_SETTINGS_FIELDS` was resolved **by dict key, not by line**. Every branch inserts entries at the same anchor, so git interleaves them and the conflict regions cut through unterminated dict literals. Each side was parsed with `ast`, the section sources extracted, and the union spliced — then verified to be the exact union with no duplicate keys.

One section is deliberately absent from that union: **`actions-config`**, whose only field `enable_text_plugin` now sits with the other built-in actions in `core-plugin-toggles`. Restoring it would declare that key twice.

Three collisions were semantic rather than textual — both sides parsed fine, so git flagged nothing:

1. Security added `iter_field_dependencies` / `_dependency_is_satisfied`; this branch had `iter_dependencies`. Security's is kept, taught to return `True` for a runtime-flag condition, which it would otherwise have `KeyError`'d on.
2. Security added `groupFields`; this branch had `buildSectionBlocks`. The latter is kept — same grouping, plus collapse — and `groupFields` removed.
3. Security renamed `AdminFieldDependency` → `AdminFieldCondition`, keeping the old name as the one-or-many alias. Both names are needed.

## Not in this PR

The global agent editor (1,573 lines, 7-step wizard, ~59 fields) and the global action editor (3,037 lines, 5-step wizard, ~18 connector types, 8 test-connection integrations) are follow-on work. `PANES_PENDING_DECLARATION` and `SECTIONS_AWAITING_A_COMPONENT` in the parity tests track what is outstanding, so filling one in without updating the test fails rather than passing quietly.

Two pre-existing issues noticed and left alone: `/agents` returns a JSON 400 body to a browser when agents are disabled, because `enabled_required` is written for API routes; and `workflow-settings-section` is declared twice in `ADMIN_SETTINGS_FIELDS` on the base branch (it predates this work — later wins, so it is latent rather than broken).
