### PR TITLE
Rebuild admin AI Models: Embeddings and Image generation (phase 3)

### DIFF
--- a/application/single_app/admin_settings_fields.py
+++ b/application/single_app/admin_settings_fields.py
@@ -75,6 +75,7 @@ FIELD_TYPES = (
     "color",
     "range",
     "number",
+    "password",
     "image",
     "link_list",
     "component",
@@ -103,6 +104,14 @@ USER_AGREEMENT_WORD_LIMIT = 200
 
 CLASSIFICATION_BANNER_DEFAULT_COLOR = "#ffc107"
 CLASSIFICATION_BANNER_DEFAULT_TEXT_COLOR = "#ffffff"
+
+# The two ways SimpleChat authenticates to an Azure OpenAI resource on the classic
+# single-endpoint routes. Shared by the embedding and image generation sections so the
+# two cannot offer different values for the same question.
+AZURE_OPENAI_AUTH_OPTIONS = [
+    {"value": "key", "label": "Key"},
+    {"value": "managed_identity", "label": "Managed Identity"},
+]
 
 # Schemes permitted for administrator-configured navigation links. These render
 # into an anchor href, so allowing arbitrary schemes would let a saved link
@@ -735,6 +744,297 @@ ADMIN_SETTINGS_FIELDS = {
             "default": False,
         },
     ],
+    "document-intelligence-section": [
+        # Declared here to take it out of the V2 fallback scan, which matched the token
+        # "image" and filed it under Image Generation -- next to settings about producing
+        # pictures, when it is about reading them out of documents. The scan cannot tell
+        # those apart from the key alone; declaring the field is what stops it guessing.
+        {
+            "key": "enable_office_embedded_image_analysis",
+            "type": "switch",
+            "label": "Analyze images embedded in DOCX and PPTX files",
+            "help": (
+                "Neither extraction engine describes figures inside Word and PowerPoint "
+                "files. With this on, embedded images are pulled out of the file, analyzed "
+                "with whichever engine backs the selected extraction mode, and indexed as "
+                "their own citable chunks. It works with Standard extraction too, using "
+                "Document Intelligence. The minimum image size and the per-document cap "
+                "are on the classic admin page."
+            ),
+            "default": True,
+        },
+    ],
+    "embeddings-config": [
+        {
+            "key": "enable_embedding_apim",
+            "type": "switch",
+            "label": "Use APIM instead of direct to Azure OpenAI endpoint",
+            "help": (
+                "Sends embedding requests to API Management rather than straight to the "
+                "Azure OpenAI resource, so a gateway can apply its own governance and "
+                "monitoring. The two routes are configured separately and only the "
+                "selected one is used."
+            ),
+            "default": False,
+        },
+        {
+            "key": "azure_openai_embedding_endpoint",
+            "type": "text",
+            "label": "Azure OpenAI Embedding Endpoint",
+            "help": (
+                "The Azure OpenAI resource that turns document and query text into "
+                "vectors. Embeddings are not shared with chat: indexing and search use "
+                "this route even when chat is pointed somewhere else entirely."
+            ),
+            "default": "",
+            "placeholder": "https://your-resource.openai.azure.com",
+            "depends_on": {"key": "enable_embedding_apim", "equals": False},
+        },
+        {
+            "key": "azure_openai_embedding_authentication_type",
+            "type": "select",
+            "label": "Authentication Type",
+            "help": (
+                "Managed identity avoids storing a credential and is what lets SimpleChat "
+                "list the resource's deployments for you. A key authenticates to inference "
+                "only."
+            ),
+            "default": "key",
+            "options": AZURE_OPENAI_AUTH_OPTIONS,
+            "depends_on": {"key": "enable_embedding_apim", "equals": False},
+        },
+        {
+            "key": "azure_openai_embedding_subscription_id",
+            "type": "text",
+            "label": "Subscription ID",
+            "help": (
+                "Used to address the resource when listing its deployments. Inference does "
+                "not need it, so an embedding route can work while the model list stays "
+                "empty."
+            ),
+            "default": "",
+            "depends_on": {"key": "enable_embedding_apim", "equals": False},
+        },
+        {
+            "key": "azure_openai_embedding_resource_group",
+            "type": "text",
+            "label": "Resource Group",
+            "help": "The other half of the address the deployment list is fetched from.",
+            "default": "",
+            "depends_on": {"key": "enable_embedding_apim", "equals": False},
+        },
+        {
+            "key": "azure_openai_embedding_key",
+            "type": "password",
+            "label": "Azure OpenAI Embedding Key",
+            "help": (
+                "Only used with key authentication. Leave it blank to keep the stored key."
+            ),
+            "default": "",
+            "depends_on": {"key": "azure_openai_embedding_authentication_type", "equals": "key"},
+        },
+        {
+            "key": "embedding_model",
+            "type": "component",
+            "component": "embedding-model-selection",
+            "label": "Embedding model",
+            "help": (
+                "One deployment serves every embedding SimpleChat stores. Changing it does "
+                "not re-embed what is already indexed, so existing chunks keep the "
+                "dimensions of the model that wrote them."
+            ),
+            "depends_on": {"key": "enable_embedding_apim", "equals": False},
+        },
+        {
+            "key": "azure_openai_embedding_api_version",
+            "type": "text",
+            "label": "Azure OpenAI Embedding API Version",
+            "help": (
+                "Pin this only when a deployment needs a version other than the default; "
+                "an unsupported value fails every embedding call rather than degrading."
+            ),
+            "default": "2024-05-01-preview",
+            "depends_on": {"key": "enable_embedding_apim", "equals": False},
+        },
+        {
+            "key": "azure_apim_embedding_endpoint",
+            "type": "text",
+            "label": "Azure APIM Endpoint",
+            "help": "The API Management address that fronts the embedding deployment.",
+            "default": "",
+            "depends_on": {"key": "enable_embedding_apim", "equals": True},
+        },
+        {
+            "key": "azure_apim_embedding_api_version",
+            "type": "text",
+            "label": "Azure APIM API Version",
+            "help": (
+                "Whatever version the API Management operation expects. There is no "
+                "default here, because a gateway can publish any version it likes."
+            ),
+            "default": "",
+            "depends_on": {"key": "enable_embedding_apim", "equals": True},
+        },
+        {
+            "key": "azure_apim_embedding_deployment",
+            "type": "text",
+            "label": "Azure APIM Deployment",
+            "help": (
+                "The deployment name to send embedding requests to. Discovery does not "
+                "reach through a gateway, so this is typed rather than picked."
+            ),
+            "default": "",
+            "depends_on": {"key": "enable_embedding_apim", "equals": True},
+        },
+        {
+            "key": "azure_apim_embedding_subscription_key",
+            "type": "password",
+            "label": "Azure APIM Subscription Key",
+            "help": "Leave it blank to keep the stored key.",
+            "default": "",
+            "depends_on": {"key": "enable_embedding_apim", "equals": True},
+        },
+    ],
+    "image-config": [
+        {
+            "key": "enable_image_generation",
+            "type": "switch",
+            "label": "Enable Image Generation",
+            "help": (
+                "Offers image generation in chat. With it off nothing below is consulted, "
+                "and the rest of this section stays out of the way."
+            ),
+            "default": False,
+        },
+        {
+            "key": "enable_image_gen_apim",
+            "type": "switch",
+            "label": "Use APIM instead of direct to Azure OpenAI endpoint",
+            "help": (
+                "Sends image requests to API Management rather than straight to the Azure "
+                "OpenAI resource. The two routes are configured separately and only the "
+                "selected one is used."
+            ),
+            "default": False,
+            "depends_on": {"key": "enable_image_generation", "equals": True},
+        },
+        {
+            "key": "azure_openai_image_gen_endpoint",
+            "type": "text",
+            "label": "Azure OpenAI Image Generation Endpoint",
+            "help": (
+                "Image models are deployed separately from chat models and are often in a "
+                "different region, so this rarely matches the chat endpoint."
+            ),
+            "default": "",
+            "placeholder": "https://your-resource.openai.azure.com",
+            "depends_on": {"key": "enable_image_gen_apim", "equals": False},
+        },
+        {
+            "key": "azure_openai_image_gen_authentication_type",
+            "type": "select",
+            "label": "Authentication Type",
+            "help": (
+                "Managed identity avoids storing a credential and is what lets SimpleChat "
+                "list the resource's deployments for you. A key authenticates to inference "
+                "only."
+            ),
+            "default": "key",
+            "options": AZURE_OPENAI_AUTH_OPTIONS,
+            "depends_on": {"key": "enable_image_gen_apim", "equals": False},
+        },
+        {
+            "key": "azure_openai_image_gen_subscription_id",
+            "type": "text",
+            "label": "Subscription ID",
+            "help": (
+                "Used to address the resource when listing its deployments. Inference does "
+                "not need it, so generation can work while the model list stays empty."
+            ),
+            "default": "",
+            "depends_on": {"key": "enable_image_gen_apim", "equals": False},
+        },
+        {
+            "key": "azure_openai_image_gen_resource_group",
+            "type": "text",
+            "label": "Resource Group",
+            "help": "The other half of the address the deployment list is fetched from.",
+            "default": "",
+            "depends_on": {"key": "enable_image_gen_apim", "equals": False},
+        },
+        {
+            "key": "azure_openai_image_gen_key",
+            "type": "password",
+            "label": "Azure OpenAI Image Generation Key",
+            "help": (
+                "Only used with key authentication. Leave it blank to keep the stored key."
+            ),
+            "default": "",
+            "depends_on": {"key": "azure_openai_image_gen_authentication_type", "equals": "key"},
+        },
+        {
+            "key": "image_gen_model",
+            "type": "component",
+            "component": "image-model-selection",
+            "label": "Image model",
+            "help": (
+                "The deployment every generated image comes from. Image deployments differ "
+                "in the sizes and quality settings they accept, so a change here can alter "
+                "what the image tool is able to produce."
+            ),
+            "depends_on": {"key": "enable_image_gen_apim", "equals": False},
+        },
+        {
+            "key": "azure_openai_image_gen_api_version",
+            "type": "text",
+            "label": "Azure OpenAI Image Gen API Version",
+            "help": (
+                "Image generation moves on its own API schedule, which is why this defaults "
+                "later than the chat and embedding versions. Change it only for a "
+                "deployment that needs a different one."
+            ),
+            "default": "2024-12-01-preview",
+            "depends_on": {"key": "enable_image_gen_apim", "equals": False},
+        },
+        {
+            "key": "azure_apim_image_gen_endpoint",
+            "type": "text",
+            "label": "Azure APIM Endpoint",
+            "help": "The API Management address that fronts the image deployment.",
+            "default": "",
+            "depends_on": {"key": "enable_image_gen_apim", "equals": True},
+        },
+        {
+            "key": "azure_apim_image_gen_api_version",
+            "type": "text",
+            "label": "Azure APIM API Version",
+            "help": (
+                "Whatever version the API Management operation expects. There is no "
+                "default here, because a gateway can publish any version it likes."
+            ),
+            "default": "",
+            "depends_on": {"key": "enable_image_gen_apim", "equals": True},
+        },
+        {
+            "key": "azure_apim_image_gen_deployment",
+            "type": "text",
+            "label": "Azure APIM Deployment",
+            "help": (
+                "The deployment name to send image requests to. Discovery does not reach "
+                "through a gateway, so this is typed rather than picked."
+            ),
+            "default": "",
+            "depends_on": {"key": "enable_image_gen_apim", "equals": True},
+        },
+        {
+            "key": "azure_apim_image_gen_subscription_key",
+            "type": "password",
+            "label": "Azure APIM Subscription Key",
+            "help": "Leave it blank to keep the stored key.",
+            "default": "",
+            "depends_on": {"key": "enable_image_gen_apim", "equals": True},
+        },
+    ],
     "actions-config": [
         {
             "key": "enable_text_plugin",
@@ -767,6 +1067,10 @@ LEGACY_FIELD_NAMES = {
     # Same pattern: V1 posts the default model reference as serialized JSON, while V2
     # writes it through /api/v2/admin/default-model.
     "default_model_selection": ["default_model_selection_json"],
+    # And the same again for the embedding and image catalogs, which V1 round-trips
+    # through hidden JSON inputs maintained by script.
+    "embedding_model": ["embedding_model_json"],
+    "image_gen_model": ["image_gen_model_json"],
     # V1 posts the images as part of the settings form; V2 uploads them
     # separately, so the stored keys are what the schema names.
     "custom_logo_base64": ["logo_file"],
@@ -840,6 +1144,31 @@ def _normalize_text(value, field):
     if max_length:
         text = text[:max_length]
     return text
+
+
+def _normalize_password(value):
+    """Return ``(secret, keep_stored)`` for a secret arriving from the browser.
+
+    The V2 password control is write-only: it never renders the stored secret, so an
+    empty box does not mean "the secret is empty", it means "nothing was typed here".
+    Treating that as a value would let saving an unrelated field in the same section
+    wipe a working credential, and the failure would only surface the next time the
+    service was called.
+
+    So an empty submission keeps what is stored, and ``None`` -- which the control only
+    sends when an administrator explicitly removes the secret -- clears it. That leaves
+    both intentions expressible and neither one available by accident.
+
+    Surrounding whitespace is dropped. A key pasted from a portal or a terminal
+    routinely carries a trailing newline, and a credential that fails only because of
+    an invisible character is close to undiagnosable from the outside.
+    """
+    if value is None:
+        return "", False
+    secret = str(value).strip()
+    if not secret:
+        return "", True
+    return secret, False
 
 
 def _validate_external_link_url(url):
@@ -1148,6 +1477,14 @@ def normalize_admin_settings_updates(updates, current_settings=None):
                 normalized[key] = enablement
             continue
 
+        if field.get("type") == "password":
+            secret, keep_stored = _normalize_password(value)
+            # Dropped rather than stored, so an untouched secret field cannot reach
+            # ``update_settings`` at all.
+            if not keep_stored:
+                normalized[key] = secret
+            continue
+
         field_value, error, warning = _normalize_field_value(key, value, field)
         if error:
             errors[key] = error
@@ -1165,6 +1502,31 @@ def normalize_admin_settings_updates(updates, current_settings=None):
     return normalized, errors, warnings
 
 
+def _dependency_is_satisfied(depends_on, normalized, current_settings):
+    """Whether a field's ``depends_on`` condition holds for a given save.
+
+    ``equals`` is a boolean for a capability toggle and a string for a choice, such as
+    an authentication type. The comparison follows the declared value's type so a
+    string condition is not collapsed to truthiness, which would make every non-empty
+    choice satisfy every condition.
+    """
+    gate_key = depends_on["key"]
+    if gate_key in normalized:
+        gate_value = normalized[gate_key]
+    elif gate_key in current_settings:
+        gate_value = current_settings[gate_key]
+    else:
+        # A settings document that predates the gate key has no value for it, so the
+        # declared default is what the application would be applying.
+        gate_field = get_field_definition(gate_key) or {}
+        gate_value = gate_field.get("default")
+
+    expected = depends_on.get("equals", True)
+    if isinstance(expected, str):
+        return str(gate_value or "") == expected
+    return _coerce_bool(gate_value) == expected
+
+
 def _check_minimum_selections(normalized, current_settings, errors):
     """Enforce ``min_selected`` once the merged state of a save is known."""
     for _section_id, field in iter_fields():
@@ -1174,14 +1536,10 @@ def _check_minimum_selections(normalized, current_settings, errors):
             continue
 
         depends_on = field.get("depends_on")
-        if depends_on:
-            gate_key = depends_on["key"]
-            gate_value = (
-                normalized[gate_key] if gate_key in normalized
-                else current_settings.get(gate_key, False)
-            )
-            if _coerce_bool(gate_value) != depends_on.get("equals", True):
-                continue
+        if depends_on and not _dependency_is_satisfied(
+            depends_on, normalized, current_settings
+        ):
+            continue
 
         selection = (
             normalized[key] if key in normalized else current_settings.get(key) or []

--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -97,7 +97,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.261.061"
+VERSION = "0.261.075"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -97,7 +97,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.261.075"
+VERSION = "0.261.082"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/route_backend_v2.py
+++ b/application/single_app/route_backend_v2.py
@@ -626,6 +626,115 @@ def _load_global_model_endpoints(settings=None):
     return endpoints if isinstance(endpoints, list) else []
 
 
+# The classic single-endpoint model catalogs. Each is stored as
+# ``{"selected": [...], "all": [...]}`` -- the deployments last discovered, plus the one
+# in use. The shape is a dict, so it cannot travel through the settings PATCH, which
+# coerces by declared scalar type.
+MODEL_CATALOG_KINDS = {
+    "embedding": {
+        "settings_key": "embedding_model",
+        "discovery_path": "/api/models/embedding",
+        "label": "embedding",
+    },
+    "image": {
+        "settings_key": "image_gen_model",
+        "discovery_path": "/api/models/image",
+        "label": "image generation",
+    },
+}
+
+
+def _read_model_catalog(settings, settings_key):
+    """Return a stored catalog as ``(selected, all)``, tolerating an absent key."""
+    stored = settings.get(settings_key)
+    if not isinstance(stored, dict):
+        return [], []
+
+    selected = stored.get("selected")
+    available = stored.get("all")
+    return (
+        [item for item in selected if isinstance(item, dict)] if isinstance(selected, list) else [],
+        [item for item in available if isinstance(item, dict)] if isinstance(available, list) else [],
+    )
+
+
+def _normalize_model_deployment(entry):
+    """Return one catalog entry reduced to the two fields the application reads."""
+    deployment_name = str(entry.get("deploymentName") or "").strip()
+    if not deployment_name:
+        return None
+
+    model_name = entry.get("modelName")
+    return {
+        "deploymentName": deployment_name,
+        "modelName": str(model_name).strip() if model_name else "",
+    }
+
+
+def normalize_model_catalog(payload, stored_available):
+    """Return ``(catalog, error)`` for a requested classic model catalog.
+
+    ``catalog`` is the ``{"selected": [...], "all": [...]}`` value to store. Both admin
+    interfaces treat these catalogs as single-select, so ``selected`` holds at most one
+    deployment; storing more would offer a choice the rest of the application ignores.
+
+    A selection is required to name a deployment that is in the catalog. The alternative
+    -- accepting it and letting it fail at call time -- produces an admin page that looks
+    correctly configured while every embedding or image request returns a deployment-not
+    -found error, which reads like an outage rather than a settings mistake.
+
+    ``all`` is omitted rather than emptied when the caller has not re-run discovery, so
+    saving a selection from an already-loaded list cannot erase the list it came from.
+    """
+    if not isinstance(payload, dict):
+        return None, "Supply the model selection as an object."
+
+    raw_available = payload.get("models")
+    if raw_available is None:
+        available = list(stored_available)
+    elif isinstance(raw_available, list):
+        available = []
+        seen = set()
+        for entry in raw_available:
+            if not isinstance(entry, dict):
+                return None, "Each model must be an object."
+            deployment = _normalize_model_deployment(entry)
+            if deployment is None:
+                return None, "Each model must name a deployment."
+            if deployment["deploymentName"] in seen:
+                continue
+            seen.add(deployment["deploymentName"])
+            available.append(deployment)
+    else:
+        return None, "Expected a list of models."
+
+    raw_selected = payload.get("selected")
+    if raw_selected is None:
+        return {"selected": [], "all": available}, None
+    if not isinstance(raw_selected, dict):
+        return None, "Supply the selected model as an object, or null to clear it."
+
+    selected = _normalize_model_deployment(raw_selected)
+    if selected is None:
+        return None, "The selected model must name a deployment."
+
+    match = next(
+        (
+            entry
+            for entry in available
+            if entry["deploymentName"] == selected["deploymentName"]
+        ),
+        None,
+    )
+    if match is None:
+        return None, (
+            f"{selected['deploymentName']} is not in the fetched deployment list. "
+            "Fetch the deployments again and choose one of them."
+        )
+
+    return {"selected": [match], "all": available}, None
+
+
 def _find_model_endpoint(endpoints, endpoint_id):
     """Return the endpoint with the given id, or None."""
     reference = str(endpoint_id or "")
@@ -1296,3 +1405,105 @@ def register_route_backend_v2_admin(bp):
                 exceptionTraceback=True,
             )
             return jsonify({"error": "Failed to store the default model"}), 500
+
+    # ``embedding_model`` and ``image_gen_model`` are catalogs -- a list of discovered
+    # deployments plus the one in use -- rather than scalars, so like
+    # ``default_model_selection`` they are declared as ``component`` fields and the
+    # settings PATCH refuses them. These are the routes that write them, and they
+    # enforce the one rule the shape does not: the selection has to be a deployment
+    # that is actually in the catalog.
+    #
+    # Discovery is left where it already is, on ``/api/models/embedding`` and
+    # ``/api/models/image``. Both are admin-gated, both read the same stored endpoint
+    # configuration, and both are what the classic page calls, so re-implementing them
+    # would create a second answer to the same question.
+
+    @bp.route("/api/v2/admin/model-selection/<kind>", methods=["GET"])
+    @swagger_route(security=get_auth_security())
+    @login_required
+    @admin_required
+    def v2_admin_get_model_selection(kind):
+        """Return the stored deployment catalog for embeddings or image generation.
+
+        The stored list is returned rather than a fresh discovery call, so opening the
+        admin page never depends on Azure Resource Manager being reachable. Refreshing
+        the list is a deliberate action, exactly as it is on the classic page.
+        """
+        catalog_kind = MODEL_CATALOG_KINDS.get(str(kind or "").strip().lower())
+        if catalog_kind is None:
+            return jsonify({"error": "Unknown model selection."}), 404
+
+        try:
+            settings = get_settings()
+            selected, available = _read_model_catalog(
+                settings, catalog_kind["settings_key"]
+            )
+            return (
+                jsonify(
+                    {
+                        "kind": kind,
+                        "selected": selected[0] if selected else None,
+                        "models": available,
+                        "discovery_path": catalog_kind["discovery_path"],
+                    }
+                ),
+                200,
+            )
+        except Exception as exc:
+            log_event(
+                f"[V2_ADMIN_MODEL_SELECTION] Failed to read the {kind} catalog: {exc}",
+                level=logging.ERROR,
+                exceptionTraceback=True,
+            )
+            return jsonify({"error": "Failed to load the model selection"}), 500
+
+    @bp.route("/api/v2/admin/model-selection/<kind>", methods=["PUT"])
+    @swagger_route(security=get_auth_security())
+    @login_required
+    @admin_required
+    def v2_admin_set_model_selection(kind):
+        """Store the deployment catalog and the single deployment in use."""
+        catalog_kind = MODEL_CATALOG_KINDS.get(str(kind or "").strip().lower())
+        if catalog_kind is None:
+            return jsonify({"error": "Unknown model selection."}), 404
+
+        payload = request.get_json(silent=True)
+        if not isinstance(payload, dict):
+            return jsonify({"error": "Model selection payload must be an object."}), 400
+
+        settings_key = catalog_kind["settings_key"]
+        try:
+            settings = get_settings()
+            _selected, stored_available = _read_model_catalog(settings, settings_key)
+            catalog, error = normalize_model_catalog(payload, stored_available)
+            if error:
+                return jsonify({"error": error}), 400
+
+            # ``update_settings`` catches its own exceptions and answers False, so an
+            # unchecked call would report a save that never reached storage.
+            if not update_settings({settings_key: catalog}):
+                return jsonify({"error": "Failed to store the model selection"}), 500
+
+            chosen = catalog["selected"][0]["deploymentName"] if catalog["selected"] else "none"
+            log_event(
+                f"[V2_ADMIN_MODEL_SELECTION] {catalog_kind['label']} deployment set to "
+                f"{chosen} from {len(catalog['all'])} discovered deployment(s)",
+                level=logging.INFO,
+            )
+            return (
+                jsonify(
+                    {
+                        "kind": kind,
+                        "selected": catalog["selected"][0] if catalog["selected"] else None,
+                        "models": catalog["all"],
+                    }
+                ),
+                200,
+            )
+        except Exception as exc:
+            log_event(
+                f"[V2_ADMIN_MODEL_SELECTION] Failed to store the {kind} catalog: {exc}",
+                level=logging.ERROR,
+                exceptionTraceback=True,
+            )
+            return jsonify({"error": "Failed to store the model selection"}), 500

--- a/application/single_app/route_backend_v2.py
+++ b/application/single_app/route_backend_v2.py
@@ -69,15 +69,19 @@ from functions_public_workspaces import (
     get_user_visible_public_workspace_ids_from_settings,
 )
 from functions_settings import (
+    ADMIN_SETTINGS_FORM_SECRET_FIELDS,
     WEB_SEARCH_USER_NOTICE_DEFAULT_TEXT,
     build_migrated_model_endpoints_from_legacy,
     get_settings,
     get_user_settings,
+    is_admin_settings_redacted_secret,
     is_chat_file_upload_enabled_for_user,
     is_user_workflows_enabled_for_user,
     merge_model_endpoint_payload,
     normalize_default_model_selection,
     normalize_model_endpoints,
+    redact_admin_settings_secrets_for_form,
+    resolve_admin_settings_secret_value,
     resolve_default_model_selection,
     resolve_metadata_extraction_model_selection,
     sanitize_settings_for_user,
@@ -735,6 +739,25 @@ def normalize_model_catalog(payload, stored_available):
     return {"selected": [match], "all": available}, None
 
 
+def _resolve_redacted_secrets(updates, current_settings):
+    """Return ``updates`` with any redacted secret marker replaced by the stored value.
+
+    The GET redacts credentials, so a client that round-trips a whole section could hand
+    ``***REDACTED***`` back. Storing that literally would replace a working key with a
+    placeholder, and the failure would surface at the next call to the service rather
+    than at save time.
+
+    Only the marker is rewritten. A real value is a deliberate replacement, and ``None``
+    is the explicit clear a password control sends -- coercing either would defeat the
+    write rules the field schema applies immediately afterwards.
+    """
+    resolved = dict(updates)
+    for key, value in updates.items():
+        if key in ADMIN_SETTINGS_FORM_SECRET_FIELDS and is_admin_settings_redacted_secret(value):
+            resolved[key] = resolve_admin_settings_secret_value(key, value, current_settings)
+    return resolved
+
+
 def _find_model_endpoint(endpoints, endpoint_id):
     """Return the endpoint with the given id, or None."""
     reference = str(endpoint_id or "")
@@ -879,11 +902,19 @@ def register_route_backend_v2_admin(bp):
     @login_required
     @admin_required
     def v2_admin_get_settings():
-        """Return the raw settings document, the admin navigation and the field schema.
+        """Return the settings document, the admin navigation and the field schema.
 
-        Admin settings are not sanitized. Sanitization removes keys, secrets and endpoint
-        configuration, which are exactly the values an administrator is here to manage.
-        Access is restricted to the Admin role by the blueprint guard and the decorator.
+        Admin settings are otherwise unsanitized, and deliberately so: sanitization
+        removes endpoints and configuration, which are exactly the values an
+        administrator is here to manage. Access is restricted to the Admin role by the
+        blueprint guard and the decorator.
+
+        Stored credentials are the one exception. They are replaced with
+        ``ADMIN_SETTINGS_SECRET_REDACTED_VALUE`` by the same helper and the same field
+        list the server-rendered admin form uses, so a key is not readable in a browser
+        devtools payload, a proxy log or a HAR capture merely because the page that asked
+        for it was admin-only. Nothing in the V2 surface needs the real value: the
+        password control is write-only, and presence alone is what it renders.
 
         ``field_schema`` describes the concrete controls each section owns. Sections with
         no entry are rendered by the SPA's ``enable_*`` fallback scan, so groups that have
@@ -891,13 +922,16 @@ def register_route_backend_v2_admin(bp):
         """
         try:
             settings = get_settings()
+            # Branding assets are read before redaction because they are derived from
+            # non-secret keys, and redaction returns a deep copy either way.
+            branding_assets = _build_branding_assets(settings)
             return (
                 jsonify(
                     {
-                        "settings": settings,
+                        "settings": redact_admin_settings_secrets_for_form(settings),
                         "admin_nav": ADMIN_NAV,
                         "field_schema": get_admin_settings_fields(),
-                        "branding_assets": _build_branding_assets(settings),
+                        "branding_assets": branding_assets,
                         "version": VERSION,
                     }
                 ),
@@ -924,6 +958,10 @@ def register_route_backend_v2_admin(bp):
         Values are normalized against the field schema first, which is what keeps the two
         admin interfaces agreeing on what a valid value is. The update is applied only if
         every supplied key validates, so a save never lands half-applied.
+
+        Because the GET redacts credentials, a client round-tripping a whole section can
+        hand a redaction marker back; it is resolved to the stored value before
+        normalization rather than being stored as a literal.
         """
         payload = request.get_json(silent=True) or {}
         updates = payload.get("settings")
@@ -934,7 +972,7 @@ def register_route_backend_v2_admin(bp):
         try:
             current_settings = get_settings()
             normalized, errors, warnings = normalize_admin_settings_updates(
-                updates, current_settings
+                _resolve_redacted_secrets(updates, current_settings), current_settings
             )
 
             if errors:
@@ -975,7 +1013,10 @@ def register_route_backend_v2_admin(bp):
                     {
                         "success": True,
                         "updated_keys": sorted(normalized.keys()),
-                        "settings": normalized,
+                        # The client merges this into its copy of the settings document,
+                        # so it goes out redacted like the GET. Echoing a just-saved key
+                        # back would undo the redaction for whoever typed it.
+                        "settings": redact_admin_settings_secrets_for_form(normalized),
                         "warnings": warnings,
                     }
                 ),

--- a/application/v2_ui/src/components/admin/ModelSelectionPicker.tsx
+++ b/application/v2_ui/src/components/admin/ModelSelectionPicker.tsx
@@ -1,0 +1,281 @@
+// ModelSelectionPicker.tsx
+// Chooses the single deployment an embedding or image-generation route uses.
+//
+// Unlike the chat connections, these routes have no list to draw from: there is one Azure
+// OpenAI resource, and the only way to learn what it has deployed is to ask it. So the
+// list here is a cache of the last answer, and it is refreshed on demand rather than on
+// every page load — asking Azure Resource Manager each time would make opening Admin
+// Settings fail whenever discovery is slow or the credentials are mid-rotation.
+//
+// Two consequences the component has to make visible, because neither is an error:
+//
+//   - The list can be empty simply because nobody has fetched yet. That reads exactly
+//     like "the resource has nothing deployed" unless it is said out loud.
+//   - Discovery reads the *saved* endpoint, subscription id and resource group, so
+//     fetching before saving asks the old resource. The classic page carries the same
+//     caveat in fine print; here it is stated next to the button that trips over it.
+//
+// The choice saves on its own, like the connection list and the default chat model,
+// because its stored shape is a dict that the settings PATCH refuses.
+
+import { useCallback, useEffect, useState } from 'react';
+import { clsx } from 'clsx';
+import { AlertCircle, Loader2, RefreshCw } from 'lucide-react';
+import { ApiError } from '../../lib/apiClient';
+import {
+    applyDiscoveredModels,
+    deploymentLabel,
+    discoverCatalogModels,
+    fetchModelCatalog,
+    findDeploymentIndex,
+    isDanglingSelection,
+    saveModelCatalog,
+    toModelDeployment,
+    toModelDeployments,
+    type ModelCatalogKind,
+    type ModelDeployment,
+} from '../../lib/modelSelection';
+import { GlassButton } from '../ui/primitives';
+import { toast } from '../../stores/toastStore';
+
+const selectClass = clsx(
+    'w-full rounded-lg border border-edge bg-surface-1 px-3 py-2',
+    'text-sm text-text-1',
+    'focus:border-accent focus:outline-none',
+    'disabled:cursor-not-allowed disabled:opacity-60',
+);
+
+const NO_SELECTION = '';
+
+const KIND_COPY: Record<ModelCatalogKind, { noun: string; empty: string }> = {
+    embedding: {
+        noun: 'embedding deployment',
+        empty: 'No embedding deployments have been fetched yet.',
+    },
+    image: {
+        noun: 'image deployment',
+        empty: 'No image deployments have been fetched yet.',
+    },
+};
+
+function errorMessage(error: unknown, fallback: string): string {
+    if (error instanceof ApiError || error instanceof Error) {
+        return error.message || fallback;
+    }
+    return fallback;
+}
+
+export function ModelSelectionPicker({
+    kind,
+    label,
+    help,
+    unsavedConnectionEdits = false,
+}: {
+    kind: ModelCatalogKind;
+    label: string;
+    help?: string;
+    /** True while an unsaved edit to the endpoint, subscription or resource group exists. */
+    unsavedConnectionEdits?: boolean;
+}) {
+    const [models, setModels] = useState<ModelDeployment[]>([]);
+    const [selected, setSelected] = useState<ModelDeployment | null>(null);
+    const [error, setError] = useState<string | null>(null);
+    const [notice, setNotice] = useState<string | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [saving, setSaving] = useState(false);
+    const [discovering, setDiscovering] = useState(false);
+
+    const copy = KIND_COPY[kind];
+    const id = `admin-model-selection-${kind}`;
+
+    const load = useCallback(
+        async (signal?: AbortSignal) => {
+            try {
+                const catalog = await fetchModelCatalog(kind, signal);
+                setModels(toModelDeployments(catalog.models));
+                setSelected(toModelDeployment(catalog.selected));
+                setError(null);
+            } catch (loadError) {
+                setError(errorMessage(loadError, 'The deployment list could not be loaded.'));
+            } finally {
+                setLoading(false);
+            }
+        },
+        [kind],
+    );
+
+    useEffect(() => {
+        const controller = new AbortController();
+        void load(controller.signal);
+        return () => controller.abort();
+    }, [load]);
+
+    const persist = async (
+        nextModels: ModelDeployment[],
+        nextSelected: ModelDeployment | null,
+    ) => {
+        const previous = { models, selected };
+        setModels(nextModels);
+        setSelected(nextSelected);
+        setSaving(true);
+        setError(null);
+        try {
+            const saved = await saveModelCatalog(kind, {
+                models: nextModels,
+                selected: nextSelected,
+            });
+            setModels(toModelDeployments(saved.models));
+            setSelected(toModelDeployment(saved.selected));
+            return true;
+        } catch (saveError) {
+            setModels(previous.models);
+            setSelected(previous.selected);
+            setError(errorMessage(saveError, 'The deployment could not be saved.'));
+            return false;
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    const onChange = async (raw: string) => {
+        const choice = raw === NO_SELECTION ? null : (models[Number(raw)] ?? null);
+        setNotice(null);
+        if (await persist(models, choice)) {
+            toast.success(
+                choice
+                    ? `${label} set to ${choice.deploymentName}.`
+                    : `${label} cleared.`,
+            );
+        }
+    };
+
+    const onDiscover = async () => {
+        setDiscovering(true);
+        setError(null);
+        setNotice(null);
+        try {
+            const response = await discoverCatalogModels(kind);
+            const discovered = toModelDeployments(response.models);
+            if (discovered.length === 0) {
+                setNotice(
+                    `The resource reported no ${copy.noun}s. Check that the endpoint, ` +
+                        'subscription id and resource group name the resource the deployment ' +
+                        'lives in, and that they have been saved.',
+                );
+                return;
+            }
+
+            const result = applyDiscoveredModels(discovered, selected);
+            if (await persist(result.models, result.selected)) {
+                setNotice(
+                    result.droppedSelection
+                        ? `${selected?.deploymentName} is no longer deployed, so the ` +
+                              'selection was cleared. Choose a replacement.'
+                        : `${discovered.length} ${copy.noun}${discovered.length === 1 ? '' : 's'} found.`,
+                );
+            }
+        } catch (discoveryError) {
+            setError(
+                errorMessage(discoveryError, 'The deployment list could not be fetched.'),
+            );
+        } finally {
+            setDiscovering(false);
+        }
+    };
+
+    const selectedIndex = findDeploymentIndex(models, selected);
+    const dangling = isDanglingSelection(models, selected);
+    const busy = saving || discovering;
+
+    return (
+        <div className="py-3">
+            <label htmlFor={id} className="mb-1.5 block text-sm font-medium text-text-1">
+                {label}
+            </label>
+
+            {loading ? (
+                <p className="flex items-center gap-2 py-2 text-xs text-text-3">
+                    <Loader2 size={14} className="animate-spin" />
+                    Loading deployments…
+                </p>
+            ) : (
+                <>
+                    <select
+                        id={id}
+                        className={selectClass}
+                        value={selectedIndex >= 0 ? String(selectedIndex) : NO_SELECTION}
+                        disabled={busy || models.length === 0}
+                        onChange={(event) => void onChange(event.target.value)}
+                    >
+                        <option value={NO_SELECTION}>No deployment selected</option>
+                        {models.map((deployment, index) => (
+                            <option key={deployment.deploymentName} value={String(index)}>
+                                {deploymentLabel(deployment)}
+                            </option>
+                        ))}
+                    </select>
+
+                    <div className="mt-2 flex items-center gap-2">
+                        <GlassButton
+                            type="button"
+                            variant="subtle"
+                            size="sm"
+                            disabled={busy || unsavedConnectionEdits}
+                            onClick={() => void onDiscover()}
+                        >
+                            {discovering ? (
+                                <Loader2 size={14} className="animate-spin" />
+                            ) : (
+                                <RefreshCw size={14} />
+                            )}
+                            Fetch deployments
+                        </GlassButton>
+                        {saving ? (
+                            <span className="flex items-center gap-1.5 text-xs text-text-3">
+                                <Loader2 size={12} className="animate-spin" />
+                                Saving…
+                            </span>
+                        ) : null}
+                    </div>
+                </>
+            )}
+
+            {help ? <p className="mt-1.5 text-xs leading-relaxed text-text-3">{help}</p> : null}
+
+            {unsavedConnectionEdits ? (
+                <p className="mt-1.5 flex items-start gap-1.5 text-xs text-warn">
+                    <AlertCircle size={13} className="mt-0.5 shrink-0" />
+                    Fetching reads the saved endpoint, subscription id and resource group,
+                    so it would list the previous resource. Save this section first.
+                </p>
+            ) : (
+                <p className="mt-1.5 text-xs leading-relaxed text-text-3">
+                    Fetching reads the saved endpoint, subscription id and resource group.
+                </p>
+            )}
+
+            {!loading && models.length === 0 ? (
+                <p className="mt-1.5 text-xs leading-relaxed text-text-3">{copy.empty}</p>
+            ) : null}
+
+            {dangling ? (
+                <p className="mt-1.5 flex items-start gap-1.5 text-xs text-warn">
+                    <AlertCircle size={13} className="mt-0.5 shrink-0" />
+                    The saved deployment {selected?.deploymentName} is not in this list. Fetch
+                    the deployments again, or choose a replacement.
+                </p>
+            ) : null}
+
+            {notice ? (
+                <p className="mt-1.5 text-xs leading-relaxed text-text-2">{notice}</p>
+            ) : null}
+
+            {error ? (
+                <p role="alert" className="mt-1.5 flex items-start gap-1.5 text-xs text-danger">
+                    <AlertCircle size={13} className="mt-0.5 shrink-0" />
+                    {error}
+                </p>
+            ) : null}
+        </div>
+    );
+}

--- a/application/v2_ui/src/components/admin/fields.tsx
+++ b/application/v2_ui/src/components/admin/fields.tsx
@@ -10,8 +10,8 @@
 // rejected save points at the control that caused it.
 
 import { clsx } from 'clsx';
-import { AlertCircle } from 'lucide-react';
-import type { ReactNode } from 'react';
+import { AlertCircle, Eye, EyeOff } from 'lucide-react';
+import { useState, type ReactNode } from 'react';
 import {
     asBoolean,
     asNumber,
@@ -89,6 +89,8 @@ export interface FieldControlProps {
     error?: string;
     warning?: string;
     disabled?: boolean;
+    /** Password fields only: whether a secret is already stored under this key. */
+    hasStoredValue?: boolean;
     onChange: (next: unknown) => void;
 }
 
@@ -346,6 +348,105 @@ function CheckboxSetControl({
 }
 
 /**
+ * A secret, entered but never displayed.
+ *
+ * The control is write-only: it starts empty whatever is stored, so a live credential is
+ * never placed in a form control where autofill, browser form restore, a password
+ * manager or a screen recording can pick it up. An empty box therefore means "nothing
+ * typed here", and the server keeps the stored secret rather than overwriting it with
+ * nothing.
+ *
+ * That leaves removal with no natural gesture, so it gets an explicit one. The button
+ * sends `null`, which is the only value the server reads as "clear this".
+ *
+ * Reveal shows what has been typed this session, which is the difference between
+ * trusting a paste and re-doing it.
+ */
+function PasswordControl({
+    field,
+    value,
+    error,
+    warning,
+    disabled,
+    hasStoredValue,
+    onChange,
+}: FieldControlProps) {
+    const id = `admin-field-${field.key}`;
+    const [revealed, setRevealed] = useState(false);
+    const pendingRemoval = value === null;
+    const typed = asString(value);
+
+    return (
+        <FieldShell
+            field={field}
+            error={error}
+            warning={warning}
+            htmlFor={id}
+            trailing={
+                hasStoredValue && !pendingRemoval ? (
+                    <button
+                        type="button"
+                        className="text-xs text-text-3 underline hover:text-danger disabled:cursor-not-allowed"
+                        disabled={disabled}
+                        onClick={() => onChange(null)}
+                    >
+                        Remove stored value
+                    </button>
+                ) : null
+            }
+        >
+            <div className="flex items-center gap-2">
+                <input
+                    id={id}
+                    type={revealed ? 'text' : 'password'}
+                    autoComplete="new-password"
+                    spellCheck={false}
+                    className={inputClass}
+                    value={typed}
+                    maxLength={field.max_length}
+                    placeholder={
+                        pendingRemoval
+                            ? 'Will be removed on save'
+                            : hasStoredValue
+                              ? '••••••••  (stored)'
+                              : field.placeholder
+                    }
+                    disabled={disabled}
+                    onChange={(event) => onChange(event.target.value)}
+                />
+                <button
+                    type="button"
+                    aria-label={revealed ? 'Hide value' : 'Show value'}
+                    aria-pressed={revealed}
+                    className={clsx(
+                        'shrink-0 rounded-lg border border-edge bg-surface-1 p-2 text-text-3',
+                        'hover:text-text-1 disabled:cursor-not-allowed disabled:opacity-60',
+                    )}
+                    disabled={disabled}
+                    onClick={() => setRevealed((current) => !current)}
+                >
+                    {revealed ? <EyeOff size={16} /> : <Eye size={16} />}
+                </button>
+            </div>
+
+            {pendingRemoval ? (
+                <p className="mt-1.5 flex items-center gap-2 text-xs text-warn">
+                    The stored value is removed when you save.
+                    <button
+                        type="button"
+                        className="underline hover:text-text-1"
+                        disabled={disabled}
+                        onClick={() => onChange('')}
+                    >
+                        Keep it
+                    </button>
+                </p>
+            ) : null}
+        </FieldShell>
+    );
+}
+
+/**
  * Render one declared field.
  *
  * `image`, `link_list` and `component` fields are handled by the page, which owns the
@@ -367,6 +468,8 @@ export function SettingField(props: FieldControlProps) {
             return <RangeControl {...props} />;
         case 'number':
             return <NumberControl {...props} />;
+        case 'password':
+            return <PasswordControl {...props} />;
         case 'checkbox_set':
             return <CheckboxSetControl {...props} />;
         default:

--- a/application/v2_ui/src/lib/adminFields.ts
+++ b/application/v2_ui/src/lib/adminFields.ts
@@ -18,6 +18,7 @@ export type AdminFieldType =
     | 'color'
     | 'range'
     | 'number'
+    | 'password'
     | 'image'
     | 'link_list'
     | 'component';
@@ -27,10 +28,16 @@ export interface AdminFieldOption {
     label: string;
 }
 
-/** Shows a field only while another field holds a given value. */
+/**
+ * Shows a field only while another field holds a given value.
+ *
+ * `equals` is a boolean for a capability toggle and a string for a choice, such as an
+ * authentication type. A string is compared as a string rather than for truthiness,
+ * because every non-empty choice is truthy and so would satisfy every condition.
+ */
 export interface AdminFieldDependency {
     key: string;
-    equals: boolean;
+    equals: boolean | string;
 }
 
 /**
@@ -170,16 +177,86 @@ export function asStringArray(value: unknown): string[] {
     return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : [];
 }
 
-/** Whether a field's `depends_on` condition is currently satisfied. */
-export function isFieldVisible(field: AdminField, settings: Json, draft: Json): boolean {
+/**
+ * Whether a field's `depends_on` condition is currently satisfied.
+ *
+ * Two behaviours beyond the plain comparison, both of which exist because the server
+ * schema is flat while the panes it mirrors are nested:
+ *
+ *   - A field whose dependency is itself hidden is hidden too. The Azure OpenAI key sits
+ *     inside the direct-connection block *and* inside the key-authentication block on the
+ *     server-rendered page; a single `depends_on` can only express one of those, so the
+ *     other is inherited from the field it depends on. Without this, switching a section
+ *     to APIM would leave the direct connection's key on screen.
+ *   - A dependency with no stored value falls back to the declared default of the field
+ *     it names, because that is what the application would be applying. Reading an absent
+ *     value as empty would permanently hide anything conditional on a non-empty default.
+ *
+ * `siblings` supplies the fields the dependency may name; pass the section's own list.
+ */
+export function isFieldVisible(
+    field: AdminField,
+    settings: Json,
+    draft: Json,
+    siblings: AdminField[] = [],
+    seen: Set<string> = new Set(),
+): boolean {
     const dependency = field.depends_on;
     if (!dependency) {
         return true;
     }
-    const current = Object.prototype.hasOwnProperty.call(draft, dependency.key)
+
+    const stored = Object.prototype.hasOwnProperty.call(draft, dependency.key)
         ? draft[dependency.key]
         : settings[dependency.key];
-    return asBoolean(current) === dependency.equals;
+
+    const parent = siblings.find((candidate) => candidate.key === dependency.key);
+    const current = stored === undefined || stored === null ? parent?.default : stored;
+
+    const satisfied =
+        typeof dependency.equals === 'string'
+            ? asString(current) === dependency.equals
+            : asBoolean(current) === dependency.equals;
+
+    if (!satisfied) {
+        return false;
+    }
+
+    // A malformed schema could describe a cycle, and the schema test only rejects a
+    // field depending on itself. Stopping at a repeat keeps a bad declaration from
+    // hanging the page.
+    if (!parent || !field.key || seen.has(field.key)) {
+        return true;
+    }
+    return isFieldVisible(parent, settings, draft, siblings, new Set(seen).add(field.key));
+}
+
+/**
+ * Whether a secret is already stored for a password field.
+ *
+ * Only presence is reported, never the value. The password control is write-only, so
+ * the page has to be able to say "a key is stored" without putting that key into a
+ * form control to find out.
+ */
+export function hasStoredSecret(settings: Json, key: string | undefined): boolean {
+    if (!key) {
+        return false;
+    }
+    const stored = settings[key];
+    return typeof stored === 'string' && stored.trim().length > 0;
+}
+
+/**
+ * What a password control shows: what has been typed this session, and nothing else.
+ *
+ * `null` is an explicit removal held in the draft. It renders as an empty box with a
+ * pending-removal note rather than as the word "null".
+ */
+export function readSecretValue(field: AdminField, draft: Json): unknown {
+    if (!field.key || !Object.prototype.hasOwnProperty.call(draft, field.key)) {
+        return '';
+    }
+    return draft[field.key];
 }
 
 /** Turn `enable_document_classification` into `Document classification`. */

--- a/application/v2_ui/src/lib/modelSelection.ts
+++ b/application/v2_ui/src/lib/modelSelection.ts
@@ -1,0 +1,196 @@
+// modelSelection.ts
+// Types, API wrappers and pure logic for the classic embedding and image-generation
+// deployment catalogs.
+//
+// These predate connections and work nothing like them. A connection publishes several
+// models and is picked per conversation; an embedding or image route has exactly one
+// deployment in force for the whole application, and it is stored as
+// `{selected: [...], all: [...]}` -- the deployments discovery last returned, plus the
+// one in use.
+//
+// The list is not authoritative. It is a cache of what Azure answered the last time
+// someone pressed Fetch, so it can name a deployment that has since been removed, and it
+// is empty until someone presses Fetch at all. Both cases are ordinary rather than
+// errors, and the helpers here exist so the component can say which one it is in.
+//
+// Discovery reuses `/api/models/embedding` and `/api/models/image`, the admin-gated
+// routes the classic page already calls. Persistence goes through
+// `/api/v2/admin/model-selection/<kind>`, because the stored value is a dict and the
+// settings PATCH refuses it.
+
+import { api } from './apiClient';
+
+/* -------------------------------------------------------------------------- */
+/* Types                                                                       */
+/* -------------------------------------------------------------------------- */
+
+/** Which catalog is being edited. Matches `MODEL_CATALOG_KINDS` on the server. */
+export type ModelCatalogKind = 'embedding' | 'image';
+
+/** One deployment, in the shape both admin interfaces store. */
+export interface ModelDeployment {
+    deploymentName: string;
+    modelName?: string;
+}
+
+export interface ModelCatalog {
+    kind: ModelCatalogKind;
+    selected: ModelDeployment | null;
+    models: ModelDeployment[];
+    /** The admin-gated discovery route for this catalog, named by the server. */
+    discovery_path?: string;
+}
+
+export interface ModelDiscoveryResponse {
+    models?: Array<Record<string, unknown>>;
+    error?: string;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Pure logic                                                                  */
+/* -------------------------------------------------------------------------- */
+
+/** Read one deployment from an API response, or null when it is not addressable. */
+export function toModelDeployment(value: unknown): ModelDeployment | null {
+    if (!value || typeof value !== 'object') {
+        return null;
+    }
+    const source = value as Record<string, unknown>;
+    const deploymentName = String(source.deploymentName ?? '').trim();
+    if (!deploymentName) {
+        return null;
+    }
+    const modelName = String(source.modelName ?? '').trim();
+    return modelName ? { deploymentName, modelName } : { deploymentName };
+}
+
+/**
+ * Read a discovered list, dropping anything that cannot be sent as a deployment name.
+ *
+ * A duplicate deployment name is collapsed rather than listed twice: the name is the
+ * whole identity here, so two rows carrying it would be two ways to choose one thing.
+ */
+export function toModelDeployments(value: unknown): ModelDeployment[] {
+    if (!Array.isArray(value)) {
+        return [];
+    }
+    const seen = new Set<string>();
+    const deployments: ModelDeployment[] = [];
+    for (const entry of value) {
+        const deployment = toModelDeployment(entry);
+        if (!deployment || seen.has(deployment.deploymentName)) {
+            continue;
+        }
+        seen.add(deployment.deploymentName);
+        deployments.push(deployment);
+    }
+    return deployments;
+}
+
+/** How a deployment reads in the list: the deployment, then the model when they differ. */
+export function deploymentLabel(deployment: ModelDeployment): string {
+    if (deployment.modelName && deployment.modelName !== deployment.deploymentName) {
+        return `${deployment.deploymentName} (${deployment.modelName})`;
+    }
+    return deployment.deploymentName;
+}
+
+/** Where a deployment sits in the list, or -1. Deployment name is the identity. */
+export function findDeploymentIndex(
+    deployments: ModelDeployment[],
+    selected: ModelDeployment | null,
+): number {
+    if (!selected) {
+        return -1;
+    }
+    return deployments.findIndex(
+        (deployment) => deployment.deploymentName === selected.deploymentName,
+    );
+}
+
+/**
+ * Merge a fresh discovery over the stored catalog.
+ *
+ * The selection survives only if the deployment is still there. Keeping one that Azure
+ * no longer reports would leave the page showing a deployment in use that every request
+ * is about to fail on, and the server refuses it anyway, so it is dropped here where the
+ * reason can still be explained.
+ */
+export function applyDiscoveredModels(
+    discovered: ModelDeployment[],
+    selected: ModelDeployment | null,
+): { models: ModelDeployment[]; selected: ModelDeployment | null; droppedSelection: boolean } {
+    const index = findDeploymentIndex(discovered, selected);
+    return {
+        models: discovered,
+        selected: index >= 0 ? discovered[index] : null,
+        droppedSelection: Boolean(selected) && index < 0,
+    };
+}
+
+/**
+ * Whether the stored selection names something no longer in the list.
+ *
+ * Worth stating separately from "nothing selected": one means nobody has chosen yet, the
+ * other means the choice stopped resolving, and only the second needs acting on.
+ */
+export function isDanglingSelection(
+    deployments: ModelDeployment[],
+    selected: ModelDeployment | null,
+): boolean {
+    return Boolean(selected) && findDeploymentIndex(deployments, selected) < 0;
+}
+
+/**
+ * The saved settings each catalog's discovery reads.
+ *
+ * Discovery addresses the resource through Azure Resource Manager using the *stored*
+ * endpoint, subscription id and resource group, not whatever is on screen. Fetching
+ * after editing one of these but before saving therefore lists the previous resource's
+ * deployments, which reads as a wrong answer rather than as a stale question. The
+ * classic page carries this as fine print under the button; here it is checkable.
+ */
+export const DISCOVERY_SETTING_KEYS: Record<ModelCatalogKind, string[]> = {
+    embedding: [
+        'azure_openai_embedding_endpoint',
+        'azure_openai_embedding_subscription_id',
+        'azure_openai_embedding_resource_group',
+    ],
+    image: [
+        'azure_openai_image_gen_endpoint',
+        'azure_openai_image_gen_subscription_id',
+        'azure_openai_image_gen_resource_group',
+    ],
+};
+
+/** Whether an unsaved edit would make a fetch ask about the wrong resource. */
+export function hasUnsavedDiscoveryEdits(
+    kind: ModelCatalogKind,
+    draftKeys: string[],
+): boolean {
+    return DISCOVERY_SETTING_KEYS[kind].some((key) => draftKeys.includes(key));
+}
+
+/* -------------------------------------------------------------------------- */
+/* API                                                                         */
+/* -------------------------------------------------------------------------- */
+
+const BASE = '/api/v2/admin/model-selection';
+
+/** The admin-gated discovery route for each catalog, shared with the classic page. */
+export const DISCOVERY_PATHS: Record<ModelCatalogKind, string> = {
+    embedding: '/api/models/embedding',
+    image: '/api/models/image',
+};
+
+export const fetchModelCatalog = (kind: ModelCatalogKind, signal?: AbortSignal) =>
+    api.get<ModelCatalog>(`${BASE}/${kind}`, signal);
+
+export const saveModelCatalog = (
+    kind: ModelCatalogKind,
+    payload: { selected: ModelDeployment | null; models: ModelDeployment[] },
+) => api.put<ModelCatalog>(`${BASE}/${kind}`, payload);
+
+/** List the deployments the configured resource currently exposes. */
+export const discoverCatalogModels = (kind: ModelCatalogKind, signal?: AbortSignal) =>
+    api.get<ModelDiscoveryResponse>(DISCOVERY_PATHS[kind], signal);

--- a/application/v2_ui/src/pages/AdminSettingsPage.tsx
+++ b/application/v2_ui/src/pages/AdminSettingsPage.tsx
@@ -39,6 +39,7 @@ import { ChatModeNotice } from '../components/admin/ChatModeNotice';
 import { CustomPagesTable } from '../components/admin/CustomPagesTable';
 import { ExternalLinksEditor } from '../components/admin/ExternalLinksEditor';
 import { ModelConnectionsManager } from '../components/admin/ModelConnectionsManager';
+import { ModelSelectionPicker } from '../components/admin/ModelSelectionPicker';
 import { SaveBar } from '../components/admin/SaveBar';
 import { SettingField } from '../components/admin/fields';
 import {
@@ -51,9 +52,11 @@ import {
     asString,
     extractFieldErrors,
     fieldSearchText,
+    hasStoredSecret,
     humanizeKey,
     isFieldVisible,
     readFieldValue,
+    readSecretValue,
     type AdminField,
     type AdminSettingsPatchResponse,
     type AdminSettingsResponse,
@@ -61,6 +64,7 @@ import {
     type BrandingUploadResponse,
 } from '../lib/adminFields';
 import { toast } from '../stores/toastStore';
+import { hasUnsavedDiscoveryEdits } from '../lib/modelSelection';
 import { modelConnectionsChanged } from '../stores/modelConnectionsStore';
 import type { AdminNavGroup, Json } from '../lib/types';
 
@@ -386,6 +390,32 @@ export function AdminSettingsPage() {
     }, []);
 
     /**
+     * Drop a key from the draft entirely, so there is nothing left to save.
+     *
+     * Used when a control returns to the state it started in and that state is not a
+     * value: emptying a password box means "nothing typed", which must not be counted as
+     * a pending change or sent to the server.
+     */
+    const unsetValue = useCallback((key: string) => {
+        setDraft((current) => {
+            if (!Object.prototype.hasOwnProperty.call(current, key)) {
+                return current;
+            }
+            const next = { ...current };
+            delete next[key];
+            return next;
+        });
+        setFieldErrors((current) => {
+            if (!(key in current)) {
+                return current;
+            }
+            const next = { ...current };
+            delete next[key];
+            return next;
+        });
+    }, []);
+
+    /**
      * Apply a switch change, intercepting capabilities that require an acknowledgement.
      *
      * Custom Pages does not take full effect until the App Service restarts, so an
@@ -506,13 +536,19 @@ export function AdminSettingsPage() {
         asString(readFieldValue(READ_ONLY_REF(key), settings, draft), fallback);
 
     /** Render one declared field, dispatching the types the page owns. */
-    const renderField = (field: AdminField) => {
-        if (!isFieldVisible(field, settings, draft)) {
+    const renderField = (field: AdminField, siblings: AdminField[]) => {
+        if (!isFieldVisible(field, settings, draft, siblings)) {
             return null;
         }
 
         const key = field.key ?? field.component ?? field.label;
-        const value = readFieldValue(field, settings, draft);
+        // A password field is write-only: seeding it from the settings document would put
+        // a live credential into a form control, where autofill, browser form restore and
+        // a screen recording can all reach it. It shows only what has been typed.
+        const isSecret = field.type === 'password';
+        const value = isSecret
+            ? readSecretValue(field, draft)
+            : readFieldValue(field, settings, draft);
         const error = field.key ? fieldErrors[field.key] : undefined;
         const warning = field.key ? fieldWarnings[field.key] : undefined;
 
@@ -584,6 +620,32 @@ export function AdminSettingsPage() {
                             help={field.help}
                         />
                     );
+                case 'embedding-model-selection':
+                    return (
+                        <ModelSelectionPicker
+                            key={key}
+                            kind="embedding"
+                            label={field.label}
+                            help={field.help}
+                            unsavedConnectionEdits={hasUnsavedDiscoveryEdits(
+                                'embedding',
+                                Object.keys(draft),
+                            )}
+                        />
+                    );
+                case 'image-model-selection':
+                    return (
+                        <ModelSelectionPicker
+                            key={key}
+                            kind="image"
+                            label={field.label}
+                            help={field.help}
+                            unsavedConnectionEdits={hasUnsavedDiscoveryEdits(
+                                'image',
+                                Object.keys(draft),
+                            )}
+                        />
+                    );
                 case 'classification-banner-preview':
                     return (
                         <ClassificationBannerPreview
@@ -615,10 +677,18 @@ export function AdminSettingsPage() {
                 error={error}
                 warning={warning}
                 disabled={saving}
+                hasStoredValue={isSecret ? hasStoredSecret(settings, field.key) : undefined}
                 onChange={(next) => {
                     if (field.type === 'switch') {
                         onSwitchChange(field, asBoolean(next));
-                    } else if (field.key) {
+                    } else if (!field.key) {
+                        // Nothing to record against.
+                    } else if (isSecret && next === '') {
+                        // An empty secret box is "nothing typed", not "clear it", so it
+                        // leaves no pending change behind. Removal is its own action and
+                        // sends null.
+                        unsetValue(field.key);
+                    } else {
                         setValue(field.key, next);
                     }
                 }}
@@ -780,7 +850,16 @@ export function AdminSettingsPage() {
                                     </div>
 
                                     <div className="divide-y divide-edge">
-                                        {section.fields.map(renderField)}
+                                        {/* The section's full declared list, not the
+                                            search-narrowed one: visibility is judged
+                                            against sibling fields, and a filtered list
+                                            would drop the field a condition names. */}
+                                        {section.fields.map((field) =>
+                                            renderField(
+                                                field,
+                                                schema[section.sectionId] ?? section.fields,
+                                            ),
+                                        )}
 
                                         {section.capabilities.map((row) => (
                                             <div key={row.key} className="py-1">

--- a/docs/admin/ai-models.md
+++ b/docs/admin/ai-models.md
@@ -104,46 +104,85 @@ The classic single endpoint is configured on the server-rendered admin page. Its
 
 ### Embeddings {#embeddings-config}
 
-The Embeddings section belongs to the Embeddings tab. Use it with the adjacent settings in this group so related rollout, access, and operational choices stay aligned.
+Embeddings turn text into vectors so a document can be found by meaning rather than by exact words. Every workspace document is embedded when it is indexed, and every question is embedded when it is asked, which makes this route a dependency of search itself rather than of chat: with it misconfigured, indexing fails and citations stop being found, while chat continues to answer from whatever it is given.
+
+Unlike chat, embeddings have no connections list. There is one Azure OpenAI resource, or API Management in front of one, and it is configured here.
+
+#### Direct or through API Management
+
+The two routes are alternatives, and only the selected one is used. Switching to APIM does not carry the direct settings over — the gateway has its own address, version, deployment name and subscription key — so the fields for the route you are not using stay out of the way rather than sitting there looking configured.
+
+#### Authentication and deployment discovery
+
+Managed identity avoids storing a credential at all, and it is also what allows SimpleChat to list the resource's deployments for you. That listing goes through Azure Resource Manager, which is why it needs the subscription id and resource group as well as the endpoint: inference is addressed by URL, but a deployment list is addressed by resource. A key authenticates to inference only.
+
+**Fetch deployments** reads the *saved* endpoint, subscription id and resource group, not what is currently on screen, so save changes to those before fetching. The list it returns is a cache of that answer: it can name a deployment that has since been removed, and a deployment the resource no longer reports is dropped from the selection rather than left to fail on the next embedding call.
+
+The stored key is never shown. Its field stays empty whatever is stored, and leaving it empty keeps the stored key rather than clearing it, so saving an API version cannot wipe a working credential. Typing a value replaces it, and **Remove stored value** clears it.
+
+#### Changing the embedding model
+
+An embedding is only comparable with other embeddings from the same model. Changing the deployment does not re-embed what is already indexed, so existing chunks keep the dimensions and the semantics of the model that wrote them, and search quality across the two sets degrades quietly rather than failing. Treat a model change as a re-index.
 
 #### Settings
 
 | Setting | What it does | Default | Notes |
 | --- | --- | --- | --- |
-| Use APIM instead of direct to Azure OpenAI endpoint | Exposes the capability after required services, permissions, and rollout policy are ready. | Off | `enable_embedding_apim`; capability toggle |
-| Azure OpenAI Embedding Endpoint | Provides the endpoint or route SimpleChat uses for this service. | Empty | `azure_openai_embedding_endpoint` |
-| Authentication Type | Chooses whether SimpleChat authenticates to this service with a key, managed identity, or another supported method. | key | `azure_openai_embedding_authentication_type` |
-| Subscription ID | Defines behavior for the related admin workflow; verify the affected feature after saving. | Empty | `azure_openai_embedding_subscription_id` |
-| Resource Group | Defines behavior for the related admin workflow; verify the affected feature after saving. | Empty | `azure_openai_embedding_resource_group` |
-| Azure OpenAI Embedding Key | Provides the secret credential used when the selected authentication mode requires one. | Empty | `azure_openai_embedding_key` |
-| Azure OpenAI Embedding API Version | Pins the service API version SimpleChat sends with requests for this feature. | 2024-05-01-preview | `azure_openai_embedding_api_version` |
-| Azure APIM Endpoint | Provides the endpoint or route SimpleChat uses for this service. | Empty | `azure_apim_embedding_endpoint` |
-| Azure APIM API Version | Pins the service API version SimpleChat sends with requests for this feature. | Empty | `azure_apim_embedding_api_version` |
-| Azure APIM Deployment | Selects the deployment SimpleChat sends requests to for this capability. | Empty | `azure_apim_embedding_deployment` |
-| Azure APIM Subscription Key | Provides the secret credential used when the selected authentication mode requires one. | Empty | `azure_apim_embedding_subscription_key` |
+| Use APIM instead of direct to Azure OpenAI endpoint | Sends embedding requests through API Management rather than straight to the Azure OpenAI resource. Only the selected route is used. | Off | `enable_embedding_apim`; capability toggle |
+| Azure OpenAI Embedding Endpoint | The Azure OpenAI resource that produces vectors. Independent of the chat endpoint. | Empty | `azure_openai_embedding_endpoint` |
+| Authentication Type | Managed identity stores no credential and enables deployment discovery; a key authenticates to inference only. | key | `azure_openai_embedding_authentication_type` |
+| Subscription ID | Addresses the resource when listing its deployments. Inference does not need it. | Empty | `azure_openai_embedding_subscription_id` |
+| Resource Group | The other half of the address the deployment list is fetched from. | Empty | `azure_openai_embedding_resource_group` |
+| Azure OpenAI Embedding Key | Used only with key authentication. Leaving it blank keeps the stored key. | Empty | `azure_openai_embedding_key` |
+| Embedding model | The single deployment every stored embedding comes from. Changing it does not re-embed existing documents. | None selected | `embedding_model`; written through its own API |
+| Azure OpenAI Embedding API Version | Pin only when a deployment needs a version other than the default; an unsupported value fails every embedding call. | 2024-05-01-preview | `azure_openai_embedding_api_version` |
+| Azure APIM Endpoint | The API Management address that fronts the embedding deployment. | Empty | `azure_apim_embedding_endpoint` |
+| Azure APIM API Version | Whatever version the API Management operation publishes; there is no default, because a gateway can publish any. | Empty | `azure_apim_embedding_api_version` |
+| Azure APIM Deployment | The deployment name to send embedding requests to. Discovery does not reach through a gateway, so this is typed. | Empty | `azure_apim_embedding_deployment` |
+| Azure APIM Subscription Key | Leaving it blank keeps the stored key. | Empty | `azure_apim_embedding_subscription_key` |
 
 ## Image Generation {#image-generation}
 
 ### Image Generation {#image-config}
 
-The Image Generation section belongs to the Image Generation tab. Use it with the adjacent settings in this group so related rollout, access, and operational choices stay aligned.
+Image generation gives chat a tool that produces pictures from a prompt. It is off by default and configured entirely separately from chat and embeddings, because image models are deployed on their own and are frequently in a different region from the chat deployment.
+
+With **Enable Image Generation** off, nothing else in this section is consulted, and the rest of it stays out of the way rather than inviting configuration that would have no effect.
+
+#### Direct or through API Management
+
+As with embeddings, the direct and gateway routes are alternatives and only the selected one is used. The gateway has its own address, version, deployment name and subscription key.
+
+#### Authentication and deployment discovery
+
+Managed identity stores no credential and is what allows SimpleChat to list the resource's deployments, using the subscription id and resource group. A key authenticates to inference only.
+
+**Fetch deployments** reads the saved endpoint, subscription id and resource group, so save changes to those first. A deployment the resource no longer reports is dropped from the selection rather than left to fail on the next request.
+
+The stored key is never shown, and leaving its field empty keeps what is stored. **Remove stored value** clears it.
+
+#### Changing the image model
+
+Image deployments differ in the sizes, quality settings and response formats they accept, so a change here can alter what the image tool is able to produce, not only how the results look. Generate one test image after changing it.
 
 #### Settings
 
 | Setting | What it does | Default | Notes |
 | --- | --- | --- | --- |
-| Enable Image Generation | Exposes the capability after required services, permissions, and rollout policy are ready. | Off | `enable_image_generation`; capability toggle |
-| Use APIM instead of direct to Azure OpenAI endpoint. | Exposes the capability after required services, permissions, and rollout policy are ready. | Off | `enable_image_gen_apim`; capability toggle |
-| Azure OpenAI Image Generation Endpoint | Provides the endpoint or route SimpleChat uses for this service. | Empty | `azure_openai_image_gen_endpoint` |
-| Authentication Type | Chooses whether SimpleChat authenticates to this service with a key, managed identity, or another supported method. | key | `azure_openai_image_gen_authentication_type` |
-| Subscription ID | Defines behavior for the related admin workflow; verify the affected feature after saving. | Empty | `azure_openai_image_gen_subscription_id` |
-| Resource Group | Defines behavior for the related admin workflow; verify the affected feature after saving. | Empty | `azure_openai_image_gen_resource_group` |
-| Azure OpenAI Image Generation Key | Provides the secret credential used when the selected authentication mode requires one. | Empty | `azure_openai_image_gen_key` |
-| Azure OpenAI Image Gen API Version | Pins the service API version SimpleChat sends with requests for this feature. | 2024-12-01-preview | `azure_openai_image_gen_api_version` |
-| Azure APIM Endpoint | Provides the endpoint or route SimpleChat uses for this service. | Empty | `azure_apim_image_gen_endpoint` |
-| Azure APIM API Version | Pins the service API version SimpleChat sends with requests for this feature. | Empty | `azure_apim_image_gen_api_version` |
-| Azure APIM Deployment | Selects the deployment SimpleChat sends requests to for this capability. | Empty | `azure_apim_image_gen_deployment` |
-| Azure APIM Subscription Key | Provides the secret credential used when the selected authentication mode requires one. | Empty | `azure_apim_image_gen_subscription_key` |
+| Enable Image Generation | Offers image generation in chat. With it off, nothing else here is consulted. | Off | `enable_image_generation`; capability toggle |
+| Use APIM instead of direct to Azure OpenAI endpoint | Sends image requests through API Management rather than straight to the Azure OpenAI resource. Only the selected route is used. | Off | `enable_image_gen_apim`; capability toggle |
+| Azure OpenAI Image Generation Endpoint | The resource holding the image deployment. Rarely the same as the chat endpoint. | Empty | `azure_openai_image_gen_endpoint` |
+| Authentication Type | Managed identity stores no credential and enables deployment discovery; a key authenticates to inference only. | key | `azure_openai_image_gen_authentication_type` |
+| Subscription ID | Addresses the resource when listing its deployments. Inference does not need it. | Empty | `azure_openai_image_gen_subscription_id` |
+| Resource Group | The other half of the address the deployment list is fetched from. | Empty | `azure_openai_image_gen_resource_group` |
+| Azure OpenAI Image Generation Key | Used only with key authentication. Leaving it blank keeps the stored key. | Empty | `azure_openai_image_gen_key` |
+| Image model | The single deployment every generated image comes from. | None selected | `image_gen_model`; written through its own API |
+| Azure OpenAI Image Gen API Version | Image generation moves on its own API schedule, which is why this defaults later than the chat and embedding versions. | 2024-12-01-preview | `azure_openai_image_gen_api_version` |
+| Azure APIM Endpoint | The API Management address that fronts the image deployment. | Empty | `azure_apim_image_gen_endpoint` |
+| Azure APIM API Version | Whatever version the API Management operation publishes; there is no default, because a gateway can publish any. | Empty | `azure_apim_image_gen_api_version` |
+| Azure APIM Deployment | The deployment name to send image requests to. Discovery does not reach through a gateway, so this is typed. | Empty | `azure_apim_image_gen_deployment` |
+| Azure APIM Subscription Key | Leaving it blank keeps the stored key. | Empty | `azure_apim_image_gen_subscription_key` |
+
 
 ## Common tasks
 
@@ -151,8 +190,10 @@ The Image Generation section belongs to the Image Generation tab. Use it with th
 2. **Rotate a stored key.** Edit the connection, type the new key over the empty field, and save. Outcome to verify: **Test connection** succeeds with the replacement.
 3. **Choose the model chat starts from.** With connections in force, pick a default under Chat. Outcome to verify: a new conversation opens on that model without anyone selecting it.
 4. **Retire a connection.** Disable it first and confirm chat still works, then delete it. Outcome to verify: its models stop being offered, and a default model that named it is cleared.
-5. **Configure embeddings.** Set endpoint, authentication, API version, and deployment, then index a small document. Outcome to verify: Indexing succeeds with the configured embedding route.
-6. **Enable image generation.** Enable the capability, set endpoint values, and generate a low-risk test image. Outcome to verify: The image tool returns output from the configured deployment.
+5. **Configure embeddings.** Set the endpoint, authentication and — with managed identity — the subscription id and resource group, then save. Fetch the deployments, choose one, and index a small document. Outcome to verify: indexing completes and the document's citations are found by a question that does not repeat its wording.
+6. **Enable image generation.** Turn the capability on, set the endpoint and authentication, save, fetch the deployments and choose one. Outcome to verify: the image tool returns a picture from the deployment you chose.
+7. **Rotate an embedding or image key.** Type the new key over the empty field and save. Outcome to verify: **Test connection** on the classic admin page succeeds, and indexing or generation still works.
+8. **Move a route behind API Management.** Turn on **Use APIM**, then fill in the gateway address, version, deployment name and subscription key. Outcome to verify: requests appear in the gateway's logs, and the direct settings are left untouched in case you switch back.
 
 ## Troubleshooting
 
@@ -167,6 +208,12 @@ The Image Generation section belongs to the Image Generation tab. Use it with th
 | The default model list is empty | Either chat is on the classic single endpoint, or no connection currently has an enabled model on an enabled connection. | Turn on **Use connections for chat**, then enable at least one model. |
 | A default model choice is refused | Chat is on the classic single endpoint, so the choice would be cleared on the next save rather than taking effect. | Turn on **Use connections for chat** first. |
 | Embeddings fail during indexing | Endpoint, deployment, API version, or authentication does not match the Azure resource. | Validate the embedding route with a small document before bulk indexing. |
+| **Fetch deployments** returns nothing | Either the endpoint, subscription id and resource group do not name the resource the deployment lives in, or those changes have not been saved yet — fetching reads the saved values. | Save the connection details first, then fetch again. |
+| **Fetch deployments** is refused | The route authenticates with a key, which reaches inference but not Azure Resource Manager. | Switch to managed identity, and grant it read access to the resource. |
+| An embedding or image deployment disappeared from the list | The deployment was removed or renamed in Azure, so discovery no longer reports it. The selection is cleared rather than kept, because a request naming it would fail. | Choose a replacement from the refreshed list. |
+| Search quality dropped after changing the embedding model | Embeddings are only comparable with others from the same model, and existing chunks were not rewritten. | Re-index the affected workspaces so every chunk comes from one model. |
+| A key was cleared without anyone changing it | Nothing in the V2 admin surface clears a secret by saving an empty field, so check the classic admin page, where a blank key field does store a blank. | Re-enter the key. Use the V2 surface's **Remove stored value** when removal is what you want. |
+| Image generation is configured but never offered | **Enable Image Generation** is off, so the rest of the section is not consulted. | Turn it on, then confirm a deployment is selected. |
 
 ## Related
 

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,7 +2,7 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/features) and [Fixes by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/fixes).
 
-### **(v0.261.075)**
+### **(v0.261.082)**
 
 #### New Features
 

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,36 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/features) and [Fixes by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/fixes).
 
+### **(v0.261.075)**
+
+#### New Features
+
+*   **Embeddings And Image Generation Can Be Configured In The New Admin Interface**
+    *   These were the last two sections of AI Models with nothing behind them. Both fell back to scanning the settings document for `enable_*` booleans, so each showed a switch or two and hid everything that actually makes the route work: the endpoint, the authentication method, the subscription and resource group, the API version, the gateway alternative and the deployment in use.
+    *   **Neither has connections, and the interface no longer pretends otherwise.** Chat can draw from several resources at once; embeddings and image generation each have exactly one, or one API Management gateway in front of one. Both are now configured directly, with the direct and gateway routes presented as the alternatives they are — only the selected one is used, so the fields for the other stay out of the way instead of sitting there looking configured.
+    *   **The deployment in use is chosen from a list rather than typed.** **Fetch deployments** asks the resource what it has, and the choice is saved on its own. A deployment the resource no longer reports is dropped from the selection rather than kept, because a request naming it would fail on the next embedding or image call rather than at save time. The list is a cache of the last answer, which is why fetching is a deliberate action and why the interface says so.
+    *   **Fetching reads the saved endpoint, not the one on screen**, since that is how the underlying discovery has always worked. That caveat is now stated next to the button that trips over it.
+    *   (Ref: `admin_settings_fields.py`, `route_backend_v2.py`, `/api/v2/admin/model-selection`, `ModelSelectionPicker.tsx`, `modelSelection.ts`, `embedding_model`, `image_gen_model`)
+
+*   **Stored Credentials Are No Longer Placed In The Page**
+    *   The new admin interface had no way to describe a secret, so a credential declared in a section would have been drawn by the ordinary text control — a live Azure OpenAI key sitting in a readable box, offered to every password manager and form-restore cache on the machine. Secrets are now a field type of their own: masked, excluded from browser autofill, and revealed only on request.
+    *   **The box starts empty whatever is stored, and leaving it empty keeps the stored value.** The new interface saves a section at a time, so an untouched credential still travels with whatever else was edited. Had an empty box meant "empty string", saving an API version would have wiped a working key, and the damage would only have surfaced the next time the service was called. Removal is now its own action, which is the only thing that clears a stored secret.
+    *   (Ref: `admin_settings_fields.py`, `fields.tsx`, `AdminSettingsPage.tsx`, `azure_openai_embedding_key`, `azure_openai_image_gen_key`)
+
+#### Bug Fixes
+
+*   **A Document Extraction Setting Was Appearing Under Image Generation**
+    *   Settings the new admin interface has no description for are placed by matching words in their name against section names. **Analyze images embedded in DOCX and PPTX files** shares the word "image" with Image Generation, so it was filed there — as a bare switch, with no explanation, among settings about producing pictures rather than reading them out of Word and PowerPoint files.
+    *   It now appears under Knowledge, in Document Extraction, alongside the rest of Document Intelligence, and carries the explanation the classic page has always had.
+    *   (Ref: `admin_settings_fields.py`, `enable_office_embedded_image_analysis`, `document-intelligence-section`)
+
+#### User Interface Enhancements
+
+*   **Conditional Settings Follow The Choice They Depend On**
+    *   A setting could previously be shown or hidden by a switch, but not by a choice — the condition was read as true or false, and every non-empty option is true. The API key field, which belongs to key authentication, would therefore have stayed on screen after switching a route to managed identity, next to a note saying it was not being used.
+    *   Conditions now compare the actual value, and a setting whose condition depends on something already hidden is hidden with it. Switching an embedding or image route to API Management now takes the whole direct connection with it, including its key, rather than leaving parts of it behind.
+    *   (Ref: `adminFields.ts`, `isFieldVisible`, `admin_settings_fields.py`, `docs/admin/ai-models.md`)
+
 ### **(v0.261.061)**
 
 #### New Features

--- a/functional_tests/test_v2_admin_capability_placement.py
+++ b/functional_tests/test_v2_admin_capability_placement.py
@@ -65,6 +65,9 @@ RELOCATED_CAPABILITIES = {
     "enable_support_menu": ("support-menu-section", "support-menu"),
     "enable_user_workspace": ("personal-workspaces-section", "workspace-types"),
     "enable_text_plugin": ("actions-config", "actions"),
+    # Matched the token "image" and landed in Image Generation, which is about producing
+    # pictures rather than reading them out of Word and PowerPoint files.
+    "enable_office_embedded_image_analysis": ("document-intelligence-section", "extraction"),
 }
 
 # The rules the ported heuristic depends on. If the renderer stops doing any of

--- a/functional_tests/test_v2_admin_field_visibility.mjs
+++ b/functional_tests/test_v2_admin_field_visibility.mjs
@@ -1,0 +1,334 @@
+// test_v2_admin_field_visibility.mjs
+//
+// Runtime test for V2 admin field visibility and the deployment picker's pure logic.
+// Version: 0.261.075
+// Implemented in: 0.261.075
+//
+// Two rules are exercised here because both are invisible until a specific combination
+// of settings is on screen, and both fail silently when wrong.
+//
+// Visibility. The server field schema is flat, but the panes it mirrors are nested: the
+// Azure OpenAI key sits inside the direct-connection block *and* inside the
+// key-authentication block. A single `depends_on` expresses one of those, so the other
+// has to be inherited from the field it depends on. Get that wrong and switching a
+// section to APIM leaves a direct-connection credential on screen, next to fields that
+// are not being used -- which reads as though the direct connection is still live.
+//
+// Selection. The deployment list is a cache of the last discovery, so it can name a
+// deployment that has since been removed. The server refuses a selection outside the
+// list, so the picker has to drop one that discovery no longer reports rather than
+// submit it and surface a rejection the administrator did not cause.
+//
+// Run directly with `node functional_tests/test_v2_admin_field_visibility.mjs`. Requires
+// Node 22.6 or newer, which strips the TypeScript types so the real module is imported.
+
+import assert from 'node:assert/strict';
+
+import './test_support/tsResolve.mjs';
+
+const { hasStoredSecret, isFieldVisible, readSecretValue } = await import(
+    '../application/v2_ui/src/lib/adminFields.ts'
+);
+
+const {
+    applyDiscoveredModels,
+    deploymentLabel,
+    findDeploymentIndex,
+    hasUnsavedDiscoveryEdits,
+    isDanglingSelection,
+    toModelDeployment,
+    toModelDeployments,
+} = await import('../application/v2_ui/src/lib/modelSelection.ts');
+
+const checks = [];
+function check(name, fn) {
+    checks.push([name, fn]);
+}
+
+/** The embeddings section, shaped the way `admin_settings_fields.py` declares it. */
+function embeddingFields() {
+    return [
+        { key: 'enable_embedding_apim', type: 'switch', label: 'APIM', default: false },
+        {
+            key: 'azure_openai_embedding_endpoint',
+            type: 'text',
+            label: 'Endpoint',
+            default: '',
+            depends_on: { key: 'enable_embedding_apim', equals: false },
+        },
+        {
+            key: 'azure_openai_embedding_authentication_type',
+            type: 'select',
+            label: 'Authentication Type',
+            default: 'key',
+            options: [
+                { value: 'key', label: 'Key' },
+                { value: 'managed_identity', label: 'Managed Identity' },
+            ],
+            depends_on: { key: 'enable_embedding_apim', equals: false },
+        },
+        {
+            key: 'azure_openai_embedding_key',
+            type: 'password',
+            label: 'Key',
+            default: '',
+            depends_on: {
+                key: 'azure_openai_embedding_authentication_type',
+                equals: 'key',
+            },
+        },
+        {
+            key: 'azure_apim_embedding_endpoint',
+            type: 'text',
+            label: 'APIM endpoint',
+            default: '',
+            depends_on: { key: 'enable_embedding_apim', equals: true },
+        },
+    ];
+}
+
+const fieldsByKey = Object.fromEntries(embeddingFields().map((field) => [field.key, field]));
+
+function visible(key, settings, draft = {}) {
+    return isFieldVisible(fieldsByKey[key], settings, draft, embeddingFields());
+}
+
+/* ------------------------------- visibility -------------------------------- */
+
+check('a boolean dependency still decides visibility', () => {
+    const direct = { enable_embedding_apim: false };
+    assert.equal(visible('azure_openai_embedding_endpoint', direct), true);
+    assert.equal(visible('azure_apim_embedding_endpoint', direct), false);
+
+    const apim = { enable_embedding_apim: true };
+    assert.equal(visible('azure_openai_embedding_endpoint', apim), false);
+    assert.equal(visible('azure_apim_embedding_endpoint', apim), true);
+});
+
+check('a string dependency compares the value, not its truthiness', () => {
+    const withKey = {
+        enable_embedding_apim: false,
+        azure_openai_embedding_authentication_type: 'key',
+    };
+    assert.equal(visible('azure_openai_embedding_key', withKey), true);
+
+    // 'managed_identity' is truthy, so a boolean comparison would show the key field.
+    const withIdentity = {
+        enable_embedding_apim: false,
+        azure_openai_embedding_authentication_type: 'managed_identity',
+    };
+    assert.equal(visible('azure_openai_embedding_key', withIdentity), false);
+});
+
+check('a field whose dependency is hidden is hidden too', () => {
+    // Authentication type is still 'key', but the whole direct-connection block is gone.
+    const apim = {
+        enable_embedding_apim: true,
+        azure_openai_embedding_authentication_type: 'key',
+    };
+    assert.equal(visible('azure_openai_embedding_key', apim), false);
+});
+
+check('an unsaved edit decides visibility before the save lands', () => {
+    const settings = {
+        enable_embedding_apim: false,
+        azure_openai_embedding_authentication_type: 'key',
+    };
+    assert.equal(
+        visible('azure_openai_embedding_key', settings, {
+            azure_openai_embedding_authentication_type: 'managed_identity',
+        }),
+        false,
+    );
+    assert.equal(
+        visible('azure_openai_embedding_key', settings, { enable_embedding_apim: true }),
+        false,
+    );
+});
+
+check('an absent value falls back to the declared default', () => {
+    // A settings document that predates a key has no value for it. Reading that as empty
+    // would hide the API key permanently, because the default authentication is 'key'.
+    assert.equal(visible('azure_openai_embedding_key', {}), true);
+    assert.equal(visible('azure_apim_embedding_endpoint', {}), false);
+});
+
+check('a field with no dependency is always visible', () => {
+    assert.equal(visible('enable_embedding_apim', {}), true);
+});
+
+check('a dependency cycle terminates instead of hanging the page', () => {
+    const a = { key: 'a', type: 'switch', label: 'A', default: true, depends_on: { key: 'b', equals: true } };
+    const b = { key: 'b', type: 'switch', label: 'B', default: true, depends_on: { key: 'a', equals: true } };
+    assert.equal(isFieldVisible(a, { a: true, b: true }, {}, [a, b]), true);
+});
+
+check('visibility works without siblings, using the stored value alone', () => {
+    // The page passes the section's declared list, but the helper must not require it.
+    const field = fieldsByKey.azure_openai_embedding_key;
+    assert.equal(
+        isFieldVisible(field, { azure_openai_embedding_authentication_type: 'key' }, {}),
+        true,
+    );
+    assert.equal(
+        isFieldVisible(
+            field,
+            { azure_openai_embedding_authentication_type: 'managed_identity' },
+            {},
+        ),
+        false,
+    );
+});
+
+/* --------------------------------- secrets --------------------------------- */
+
+check('a stored secret is reported as present, never as its value', () => {
+    assert.equal(hasStoredSecret({ azure_openai_embedding_key: 'sk-live' }, 'azure_openai_embedding_key'), true);
+    assert.equal(hasStoredSecret({ azure_openai_embedding_key: '' }, 'azure_openai_embedding_key'), false);
+    assert.equal(hasStoredSecret({ azure_openai_embedding_key: '   ' }, 'azure_openai_embedding_key'), false);
+    assert.equal(hasStoredSecret({}, 'azure_openai_embedding_key'), false);
+    assert.equal(hasStoredSecret({ azure_openai_embedding_key: 'sk-live' }, undefined), false);
+});
+
+check('a password control shows only what was typed this session', () => {
+    const field = fieldsByKey.azure_openai_embedding_key;
+    const settings = { azure_openai_embedding_key: 'sk-live' };
+
+    // The stored secret must not reach the control, even though the admin settings
+    // payload carries it.
+    assert.equal(readSecretValue(field, {}), '');
+    assert.notEqual(readSecretValue(field, {}), settings.azure_openai_embedding_key);
+
+    assert.equal(readSecretValue(field, { azure_openai_embedding_key: 'typed' }), 'typed');
+    // An explicit removal is held as null so the control can say what will happen.
+    assert.equal(readSecretValue(field, { azure_openai_embedding_key: null }), null);
+});
+
+/* ---------------------------- deployment picker ---------------------------- */
+
+function discovered() {
+    return [
+        { deploymentName: 'text-embedding-3-large', modelName: 'text-embedding-3-large' },
+        { deploymentName: 'ada-002', modelName: 'text-embedding-ada-002' },
+    ];
+}
+
+check('a deployment with no name is not addressable', () => {
+    assert.equal(toModelDeployment({ modelName: 'nameless' }), null);
+    assert.equal(toModelDeployment(null), null);
+    assert.deepEqual(toModelDeployment({ deploymentName: '  ada-002 ' }), {
+        deploymentName: 'ada-002',
+    });
+});
+
+check('a duplicated deployment name is listed once', () => {
+    const models = toModelDeployments([
+        { deploymentName: 'ada-002' },
+        { deploymentName: 'ada-002', modelName: 'again' },
+        { modelName: 'dropped' },
+    ]);
+    assert.deepEqual(models, [{ deploymentName: 'ada-002' }]);
+});
+
+check('a non-array discovery response yields no deployments', () => {
+    assert.deepEqual(toModelDeployments(undefined), []);
+    assert.deepEqual(toModelDeployments({ models: [] }), []);
+});
+
+check('the label names the model only when it differs from the deployment', () => {
+    assert.equal(
+        deploymentLabel({ deploymentName: 'ada-002', modelName: 'text-embedding-ada-002' }),
+        'ada-002 (text-embedding-ada-002)',
+    );
+    assert.equal(deploymentLabel({ deploymentName: 'ada-002', modelName: 'ada-002' }), 'ada-002');
+    assert.equal(deploymentLabel({ deploymentName: 'ada-002' }), 'ada-002');
+});
+
+check('a selection survives a rediscovery that still lists it', () => {
+    const result = applyDiscoveredModels(discovered(), { deploymentName: 'ada-002' });
+    assert.equal(result.selected.deploymentName, 'ada-002');
+    assert.equal(result.droppedSelection, false);
+    // Refreshed from the discovered entry, so the model name follows the resource.
+    assert.equal(result.selected.modelName, 'text-embedding-ada-002');
+});
+
+check('a selection discovery no longer reports is dropped, and said so', () => {
+    const result = applyDiscoveredModels(discovered(), { deploymentName: 'retired' });
+    assert.equal(result.selected, null);
+    assert.equal(result.droppedSelection, true);
+});
+
+check('discovering with nothing selected drops nothing', () => {
+    const result = applyDiscoveredModels(discovered(), null);
+    assert.equal(result.selected, null);
+    assert.equal(result.droppedSelection, false);
+});
+
+check('a stored selection outside the list is dangling, an empty one is not', () => {
+    assert.equal(isDanglingSelection(discovered(), { deploymentName: 'retired' }), true);
+    assert.equal(isDanglingSelection(discovered(), { deploymentName: 'ada-002' }), false);
+    assert.equal(isDanglingSelection(discovered(), null), false);
+    // Nothing fetched yet is also dangling: the selection cannot be shown in the list.
+    assert.equal(isDanglingSelection([], { deploymentName: 'ada-002' }), true);
+});
+
+check('the index is the position in the list the select renders', () => {
+    assert.equal(findDeploymentIndex(discovered(), { deploymentName: 'ada-002' }), 1);
+    assert.equal(findDeploymentIndex(discovered(), { deploymentName: 'retired' }), -1);
+    assert.equal(findDeploymentIndex(discovered(), null), -1);
+});
+
+check('an unsaved endpoint edit blocks a fetch that would ask the wrong resource', () => {
+    // Discovery reads the stored endpoint, subscription and resource group, so fetching
+    // mid-edit lists the previous resource -- which reads as a wrong answer, not a stale
+    // question.
+    assert.equal(
+        hasUnsavedDiscoveryEdits('embedding', ['azure_openai_embedding_endpoint']),
+        true,
+    );
+    assert.equal(
+        hasUnsavedDiscoveryEdits('embedding', ['azure_openai_embedding_subscription_id']),
+        true,
+    );
+    assert.equal(
+        hasUnsavedDiscoveryEdits('image', ['azure_openai_image_gen_resource_group']),
+        true,
+    );
+});
+
+check('an unrelated edit does not block a fetch', () => {
+    // The API version and the key are sent with the request rather than used to address
+    // the resource, so editing them cannot make discovery answer about the wrong one.
+    assert.equal(
+        hasUnsavedDiscoveryEdits('embedding', ['azure_openai_embedding_api_version']),
+        false,
+    );
+    assert.equal(hasUnsavedDiscoveryEdits('embedding', []), false);
+    // And the two catalogs do not gate each other.
+    assert.equal(
+        hasUnsavedDiscoveryEdits('embedding', ['azure_openai_image_gen_endpoint']),
+        false,
+    );
+});
+
+/* ---------------------------------- run ------------------------------------ */
+
+let passed = 0;
+const failures = [];
+
+for (const [name, fn] of checks) {
+    try {
+        fn();
+        passed += 1;
+    } catch (error) {
+        failures.push(`${name}: ${error.message}`);
+    }
+}
+
+console.log(`Results: ${passed}/${checks.length} checks passed`);
+if (failures.length) {
+    for (const failure of failures) {
+        console.error(`FAILED ${failure}`);
+    }
+    process.exit(1);
+}

--- a/functional_tests/test_v2_admin_field_visibility.mjs
+++ b/functional_tests/test_v2_admin_field_visibility.mjs
@@ -1,8 +1,8 @@
 // test_v2_admin_field_visibility.mjs
 //
 // Runtime test for V2 admin field visibility and the deployment picker's pure logic.
-// Version: 0.261.075
-// Implemented in: 0.261.075
+// Version: 0.261.082
+// Implemented in: 0.261.082
 //
 // Two rules are exercised here because both are invisible until a specific combination
 // of settings is on screen, and both fail silently when wrong.

--- a/functional_tests/test_v2_admin_field_visibility.mjs
+++ b/functional_tests/test_v2_admin_field_visibility.mjs
@@ -272,6 +272,61 @@ check('a stored selection outside the list is dangling, an empty one is not', ()
     assert.equal(isDanglingSelection([], { deploymentName: 'ada-002' }), true);
 });
 
+check('a null or missing dependency value does not accidentally match', () => {
+    // `asString(null)` is '' and `asString(undefined)` is '', neither of which is 'key'.
+    // The risk is a comparison that coerces both sides and lets a nullish value through.
+    const field = fieldsByKey.azure_openai_embedding_key;
+    assert.equal(
+        isFieldVisible(field, { azure_openai_embedding_authentication_type: null }, {}, []),
+        false,
+    );
+    assert.equal(
+        isFieldVisible(field, { azure_openai_embedding_authentication_type: '' }, {}, []),
+        false,
+    );
+    // With no siblings there is no declared default to fall back to, so an absent value
+    // must not match either.
+    assert.equal(isFieldVisible(field, {}, {}, []), false);
+});
+
+check('a string dependency is case sensitive and not a prefix match', () => {
+    const field = fieldsByKey.azure_openai_embedding_key;
+    for (const nearMiss of ['KEY', 'Key', 'keys', 'ke', ' key', 'key ']) {
+        assert.equal(
+            isFieldVisible(
+                field,
+                {
+                    enable_embedding_apim: false,
+                    azure_openai_embedding_authentication_type: nearMiss,
+                },
+                {},
+                embeddingFields(),
+            ),
+            false,
+            `${nearMiss} matched a condition on 'key'`,
+        );
+    }
+});
+
+check('a boolean dependency is unaffected by the string branch', () => {
+    // Regression guard: widening `equals` must not change how booleans are read.
+    const apimField = fieldsByKey.azure_apim_embedding_endpoint;
+    for (const [stored, expected] of [
+        [true, true],
+        [false, false],
+        ['on', true],
+        ['', false],
+        [null, false],
+        [undefined, false],
+    ]) {
+        assert.equal(
+            isFieldVisible(apimField, { enable_embedding_apim: stored }, {}, []),
+            expected,
+            `enable_embedding_apim=${JSON.stringify(stored)}`,
+        );
+    }
+});
+
 check('the index is the position in the list the select renders', () => {
     assert.equal(findDeploymentIndex(discovered(), { deploymentName: 'ada-002' }), 1);
     assert.equal(findDeploymentIndex(discovered(), { deploymentName: 'retired' }), -1);

--- a/functional_tests/test_v2_admin_model_selection_api.py
+++ b/functional_tests/test_v2_admin_model_selection_api.py
@@ -2,8 +2,8 @@
 # test_v2_admin_model_selection_api.py
 """
 Functional test for the V2 admin embedding and image deployment selection API.
-Version: 0.261.075
-Implemented in: 0.261.075
+Version: 0.261.082
+Implemented in: 0.261.082
 
 ``embedding_model`` and ``image_gen_model`` are stored as
 ``{"selected": [...], "all": [...]}`` -- the deployments discovery last returned, plus
@@ -153,7 +153,7 @@ def test_routes_exist_and_are_admin_gated():
     """These routes read and write stored endpoint configuration."""
     print("Testing model selection route declarations...")
 
-    assert_app_version_at_least("0.261.075")
+    assert_app_version_at_least("0.261.082")
 
     functions = _find_functions(_parse(ROUTES_FILE))
 

--- a/functional_tests/test_v2_admin_model_selection_api.py
+++ b/functional_tests/test_v2_admin_model_selection_api.py
@@ -1,0 +1,410 @@
+#!/usr/bin/env python3
+# test_v2_admin_model_selection_api.py
+"""
+Functional test for the V2 admin embedding and image deployment selection API.
+Version: 0.261.075
+Implemented in: 0.261.075
+
+``embedding_model`` and ``image_gen_model`` are stored as
+``{"selected": [...], "all": [...]}`` -- the deployments discovery last returned, plus
+the one in use. That is a dict, and ``normalize_admin_settings_updates`` coerces declared
+values by scalar type and passes undeclared keys through untouched, so neither route the
+settings PATCH offers is safe for them: one would mangle the shape, the other would store
+whatever arrived.
+
+They are therefore declared as ``component`` fields, which puts them in
+``NON_PATCHABLE_TYPES`` and makes the PATCH refuse them, and given their own routes. The
+rule those routes exist to enforce is that the selection names a deployment that is
+actually in the catalog. Accepting one that is not produces an admin page that looks
+correctly configured while every embedding or image call fails with a deployment-not-found
+error, which reads like an outage rather than a settings mistake.
+
+Discovery is deliberately *not* reimplemented here: ``/api/models/embedding`` and
+``/api/models/image`` already exist, are already admin-gated, and are what the classic
+page calls.
+"""
+
+import ast
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent))
+
+from test_support.app_stubs import import_app_module
+from test_support.nav import ADMIN_NAV
+from test_support.versioning import assert_app_version_at_least
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+APP_DIR = REPO_ROOT / "application" / "single_app"
+ROUTES_FILE = APP_DIR / "route_backend_v2.py"
+MODELS_ROUTES_FILE = APP_DIR / "route_backend_models.py"
+V2_SRC = REPO_ROOT / "application" / "v2_ui" / "src"
+
+EXPECTED_ROUTES = {
+    ("/api/v2/admin/model-selection/<kind>", "GET"): "v2_admin_get_model_selection",
+    ("/api/v2/admin/model-selection/<kind>", "PUT"): "v2_admin_set_model_selection",
+}
+
+REQUIRED_DECORATORS = {"swagger_route", "login_required", "admin_required"}
+
+# The catalogs, the section that owns each one, and the component that renders it.
+EXPECTED_CATALOGS = {
+    "embedding_model": ("embeddings-config", "embedding-model-selection"),
+    "image_gen_model": ("image-config", "image-model-selection"),
+}
+
+# The discovery routes reused rather than reimplemented, and the guard each must keep.
+REUSED_DISCOVERY_ROUTES = {
+    "/api/models/embedding": "get_embedding_models",
+    "/api/models/image": "get_image_models",
+}
+
+fields_module = import_app_module("admin_settings_fields")
+
+
+def _parse(path):
+    return ast.parse(path.read_text(encoding="utf-8"))
+
+
+def _decorator_names(node):
+    """Return the bare names of a function's decorators."""
+    names = []
+    for decorator in node.decorator_list:
+        target = decorator.func if isinstance(decorator, ast.Call) else decorator
+        if isinstance(target, ast.Name):
+            names.append(target.id)
+        elif isinstance(target, ast.Attribute):
+            names.append(target.attr)
+    return names
+
+
+def _route_declarations(node):
+    """Return (path, method) pairs declared by ``@bp.route`` on a function."""
+    declared = []
+    for decorator in node.decorator_list:
+        if not isinstance(decorator, ast.Call):
+            continue
+        target = decorator.func
+        if not (isinstance(target, ast.Attribute) and target.attr == "route"):
+            continue
+        if not decorator.args or not isinstance(decorator.args[0], ast.Constant):
+            continue
+        path = decorator.args[0].value
+        methods = ["GET"]
+        for keyword in decorator.keywords:
+            if keyword.arg == "methods" and isinstance(keyword.value, ast.List):
+                methods = [
+                    element.value
+                    for element in keyword.value.elts
+                    if isinstance(element, ast.Constant)
+                ]
+        declared.extend((path, method) for method in methods)
+    return declared
+
+
+def _find_functions(tree):
+    """Return every function definition in the module, at any nesting depth."""
+    return {
+        node.name: node
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+
+
+def _load_catalog_normalizer():
+    """Exec ``normalize_model_catalog`` out of ``route_backend_v2.py``.
+
+    The route module builds Azure clients transitively and cannot be imported in a test.
+    The normalizer is ordinary Python over lists and dicts, so lifting its source runs
+    the real rule rather than a copy of it.
+    """
+    tree = _parse(ROUTES_FILE)
+    wanted = {"normalize_model_catalog", "_normalize_model_deployment"}
+
+    selected = [
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name in wanted
+    ]
+    found = {node.name for node in selected}
+    missing = wanted - found
+    assert not missing, (
+        "These catalog helpers were not found in route_backend_v2.py, so this test "
+        f"cannot exercise the real rule: {', '.join(sorted(missing))}"
+    )
+
+    namespace = {}
+    exec(compile(ast.Module(body=selected, type_ignores=[]), str(ROUTES_FILE), "exec"), namespace)
+    return namespace["normalize_model_catalog"]
+
+
+normalize_model_catalog = _load_catalog_normalizer()
+
+
+def deployments():
+    return [
+        {"deploymentName": "text-embedding-3-large", "modelName": "text-embedding-3-large"},
+        {"deploymentName": "ada-002", "modelName": "text-embedding-ada-002"},
+    ]
+
+
+def test_routes_exist_and_are_admin_gated():
+    """These routes read and write stored endpoint configuration."""
+    print("Testing model selection route declarations...")
+
+    assert_app_version_at_least("0.261.075")
+
+    functions = _find_functions(_parse(ROUTES_FILE))
+
+    declared = {}
+    for name, node in functions.items():
+        for route in _route_declarations(node):
+            declared[route] = name
+
+    for route, expected_name in EXPECTED_ROUTES.items():
+        assert route in declared, f"Route {route[1]} {route[0]} is not declared"
+        assert declared[route] == expected_name, (
+            f"Route {route[1]} {route[0]} is handled by {declared[route]}, "
+            f"expected {expected_name}"
+        )
+
+        decorators = set(_decorator_names(functions[expected_name]))
+        missing = REQUIRED_DECORATORS - decorators
+        assert not missing, f"{expected_name} is missing decorators: {sorted(missing)}"
+
+    print("  Both routes are declared and admin-gated.")
+    return True
+
+
+def test_the_read_route_does_not_write():
+    """Opening the admin page must not mutate stored configuration."""
+    print("\nTesting that the read route is read-only...")
+
+    functions = _find_functions(_parse(ROUTES_FILE))
+    source = ast.dump(functions["v2_admin_get_model_selection"])
+
+    assert "update_settings" not in source, (
+        "v2_admin_get_model_selection writes settings. A read that also writes turns "
+        "opening the page into a change, and hides what the stored value was."
+    )
+
+    # And it must not call Azure. The list is a cache precisely so that opening Admin
+    # Settings does not depend on Resource Manager being reachable.
+    for forbidden in ("build_cognitive_services_client", "deployments"):
+        assert forbidden not in source, (
+            f"v2_admin_get_model_selection references {forbidden}; discovery belongs on "
+            "the existing /api/models routes, run on demand."
+        )
+
+    print("  The read returns stored state and nothing else.")
+    return True
+
+
+def test_discovery_is_reused_rather_than_reimplemented():
+    """Two answers to 'what is deployed here' would eventually disagree."""
+    print("\nTesting discovery reuse...")
+
+    functions = _find_functions(_parse(MODELS_ROUTES_FILE))
+
+    declared = {}
+    for name, node in functions.items():
+        for path, method in _route_declarations(node):
+            if method == "GET":
+                declared[path] = name
+
+    for path, expected_name in REUSED_DISCOVERY_ROUTES.items():
+        assert declared.get(path) == expected_name, (
+            f"{path} is no longer served by {expected_name}; the V2 picker calls it "
+            f"directly, so a rename breaks the Fetch button. Found: {declared.get(path)}"
+        )
+        decorators = set(_decorator_names(functions[expected_name]))
+        assert "admin_required" in decorators, (
+            f"{expected_name} exposes deployment names and must stay admin-gated"
+        )
+
+    # The V2 library must point at exactly those paths.
+    library = (V2_SRC / "lib" / "modelSelection.ts").read_text(encoding="utf-8")
+    for path in REUSED_DISCOVERY_ROUTES:
+        assert f"'{path}'" in library, f"modelSelection.ts does not call {path}"
+
+    print("  Both discovery routes are reused and admin-gated.")
+    return True
+
+
+def test_catalogs_are_components_so_the_patch_refuses_them():
+    """A dict through the settings PATCH would be stored unexamined."""
+    print("\nTesting the catalog field declarations...")
+
+    declared_sections = {}
+    for section_id, field in fields_module.iter_fields():
+        key = field.get("key")
+        if key:
+            declared_sections[key] = (section_id, field)
+
+    problems = []
+    for key, (expected_section, expected_component) in EXPECTED_CATALOGS.items():
+        entry = declared_sections.get(key)
+        if entry is None:
+            problems.append(f"{key}: not declared at all")
+            continue
+        section_id, field = entry
+        if section_id != expected_section:
+            problems.append(
+                f"{key}: declared under {section_id!r}, expected {expected_section!r}"
+            )
+        if field.get("type") != "component":
+            problems.append(f"{key}: declared as {field.get('type')!r}, expected 'component'")
+        if field.get("component") != expected_component:
+            problems.append(
+                f"{key}: renders {field.get('component')!r}, expected {expected_component!r}"
+            )
+
+    assert not problems, (
+        "These catalogs are not declared as components, so the settings PATCH would "
+        "accept them:\n  " + "\n  ".join(problems)
+    )
+
+    assert "component" in fields_module.NON_PATCHABLE_TYPES, (
+        "Components are no longer refused by the PATCH, so declaring these as "
+        "components no longer protects them."
+    )
+
+    # And the refusal has to be real, not merely implied by the type list.
+    _normalized, errors, _warnings = fields_module.normalize_admin_settings_updates(
+        {"embedding_model": {"selected": [], "all": []}}, {}
+    )
+    assert "embedding_model" in errors, (
+        f"The settings PATCH accepted a catalog dict: {errors}"
+    )
+
+    print("  Both catalogs are components and the PATCH refuses them.")
+    return True
+
+
+def test_the_sections_exist_in_navigation():
+    """A schema section with no navigation entry never renders."""
+    print("\nTesting the owning navigation sections...")
+
+    section_ids = {
+        section["id"]
+        for group in ADMIN_NAV
+        for tab in group["tabs"]
+        for section in tab["sections"]
+    }
+
+    for _key, (section_id, _component) in EXPECTED_CATALOGS.items():
+        assert section_id in section_ids, (
+            f"{section_id} is not a navigation section, so nothing declared in it renders"
+        )
+
+    print("  Both sections exist in ADMIN_NAV.")
+    return True
+
+
+def test_a_selection_must_be_in_the_catalog():
+    """A deployment that is not deployed fails at call time, not at save time."""
+    print("\nTesting selection validation...")
+
+    catalog, error = normalize_model_catalog(
+        {"models": deployments(), "selected": {"deploymentName": "gone"}}, []
+    )
+    assert catalog is None, catalog
+    assert "gone" in error, error
+
+    catalog, error = normalize_model_catalog(
+        {"models": deployments(), "selected": {"deploymentName": "ada-002"}}, []
+    )
+    assert error is None, error
+    assert catalog["selected"] == [
+        {"deploymentName": "ada-002", "modelName": "text-embedding-ada-002"}
+    ], catalog
+    # Single-select: the rest of the application reads selected[0] and nothing else.
+    assert len(catalog["selected"]) == 1, catalog
+
+    print("  A selection outside the catalog is refused.")
+    return True
+
+
+def test_an_omitted_list_keeps_the_stored_one():
+    """Choosing from an already-loaded list must not erase the list."""
+    print("\nTesting the omitted-list case...")
+
+    stored = deployments()
+    catalog, error = normalize_model_catalog(
+        {"selected": {"deploymentName": "ada-002"}}, stored
+    )
+
+    assert error is None, error
+    assert catalog["all"] == stored, catalog
+    assert catalog["selected"][0]["deploymentName"] == "ada-002", catalog
+
+    print("  An omitted list falls back to what is stored.")
+    return True
+
+
+def test_clearing_and_malformed_input():
+    """Null clears; anything unusable is refused rather than half-stored."""
+    print("\nTesting clears and malformed payloads...")
+
+    catalog, error = normalize_model_catalog(
+        {"models": deployments(), "selected": None}, []
+    )
+    assert error is None, error
+    assert catalog["selected"] == [], catalog
+    assert len(catalog["all"]) == 2, catalog
+
+    for payload, why in (
+        ("not-a-dict", "a non-object payload"),
+        ({"models": "not-a-list"}, "a non-list model list"),
+        ({"models": ["not-a-dict"]}, "a non-object model"),
+        ({"models": [{"modelName": "no-deployment"}]}, "a model with no deployment name"),
+        ({"models": [], "selected": "not-a-dict"}, "a non-object selection"),
+        ({"models": [], "selected": {"modelName": "x"}}, "a selection with no deployment"),
+    ):
+        catalog, error = normalize_model_catalog(payload, [])
+        assert catalog is None and error, f"{why} was accepted"
+
+    # A duplicated deployment name is collapsed: the name is the whole identity, so two
+    # rows carrying it would be two ways to choose one thing.
+    catalog, error = normalize_model_catalog(
+        {
+            "models": [
+                {"deploymentName": "ada-002"},
+                {"deploymentName": "ada-002", "modelName": "again"},
+            ]
+        },
+        [],
+    )
+    assert error is None, error
+    assert len(catalog["all"]) == 1, catalog
+
+    print("  Clears work and malformed payloads are refused.")
+    return True
+
+
+if __name__ == "__main__":
+    tests = [
+        test_routes_exist_and_are_admin_gated,
+        test_the_read_route_does_not_write,
+        test_discovery_is_reused_rather_than_reimplemented,
+        test_catalogs_are_components_so_the_patch_refuses_them,
+        test_the_sections_exist_in_navigation,
+        test_a_selection_must_be_in_the_catalog,
+        test_an_omitted_list_keeps_the_stored_one,
+        test_clearing_and_malformed_input,
+    ]
+
+    results = []
+    for test in tests:
+        try:
+            results.append(bool(test()))
+        except Exception as exc:
+            print(f"FAILED {test.__name__}: {exc}")
+            import traceback
+
+            traceback.print_exc()
+            results.append(False)
+
+    print(f"\nResults: {sum(results)}/{len(results)} tests passed")
+    sys.exit(0 if all(results) else 1)

--- a/functional_tests/test_v2_admin_secret_fields.py
+++ b/functional_tests/test_v2_admin_secret_fields.py
@@ -22,6 +22,7 @@ update entirely, while ``None`` -- which the control sends only from an explicit
 declare them as secrets rather than as text.
 """
 
+import ast
 import sys
 from pathlib import Path
 
@@ -30,6 +31,11 @@ sys.path.append(str(Path(__file__).resolve().parent))
 from test_support.app_stubs import import_app_module
 from test_support.versioning import assert_app_version_at_least
 
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+APP_DIR = REPO_ROOT / "application" / "single_app"
+SETTINGS_FILE = APP_DIR / "functions_settings.py"
+ROUTES_FILE = APP_DIR / "route_backend_v2.py"
 
 fields_module = import_app_module("admin_settings_fields")
 
@@ -42,6 +48,68 @@ EXPECTED_SECRET_KEYS = {
     "azure_openai_image_gen_key",
     "azure_apim_image_gen_subscription_key",
 }
+
+
+def _parse(path):
+    return ast.parse(path.read_text(encoding="utf-8"))
+
+
+def _lift(path, function_names, constant_names=(), namespace=None):
+    """Exec named module-level functions and constants out of a source file.
+
+    ``functions_settings`` builds Azure clients at import time and the shared test stub
+    replaces the whole module, and ``route_backend_v2`` imports it transitively, so
+    neither can be imported here. The secret helpers are pure, so lifting their source
+    runs the real implementation rather than a copy of it.
+    """
+    tree = _parse(path)
+    selected = []
+    found = set()
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name in function_names:
+            selected.append(node)
+            found.add(node.name)
+        elif isinstance(node, ast.Assign):
+            targets = {t.id for t in node.targets if isinstance(t, ast.Name)}
+            if targets & set(constant_names):
+                selected.append(node)
+                found |= targets & set(constant_names)
+
+    missing = (set(function_names) | set(constant_names)) - found
+    assert not missing, (
+        f"These names were not found in {path.name}, so this test cannot exercise the "
+        f"real behaviour: {', '.join(sorted(missing))}"
+    )
+
+    scope = namespace if namespace is not None else {}
+    scope.setdefault("copy", __import__("copy"))
+    exec(compile(ast.Module(body=selected, type_ignores=[]), str(path), "exec"), scope)
+    return scope
+
+
+def load_secret_helpers():
+    """Return the real redaction and resolution helpers from both modules."""
+    scope = _lift(
+        SETTINGS_FILE,
+        function_names=(
+            "is_admin_settings_redacted_secret",
+            "_get_nested_setting_value",
+            "_set_nested_setting_value",
+            "resolve_admin_settings_secret_value",
+            "redact_admin_settings_secrets_for_form",
+        ),
+        constant_names=(
+            "ADMIN_SETTINGS_SECRET_REDACTED_VALUE",
+            "ADMIN_SETTINGS_FORM_SECRET_FIELDS",
+            "ADMIN_SETTINGS_NESTED_SECRET_FIELDS",
+        ),
+    )
+    # The route helper closes over the two names above, so it is exec'd into the same
+    # namespace rather than a fresh one.
+    return _lift(ROUTES_FILE, function_names=("_resolve_redacted_secrets",), namespace=scope)
+
+
+HELPERS = load_secret_helpers()
 
 
 def declared_fields_by_key():
@@ -167,6 +235,169 @@ def test_null_clears_the_stored_secret():
     return True
 
 
+def test_the_api_redacts_stored_secrets():
+    """The V2 read must not hand a working credential to the browser."""
+    print("\nTesting that the settings API redacts secrets...")
+
+    redact = HELPERS["redact_admin_settings_secrets_for_form"]
+    marker = HELPERS["ADMIN_SETTINGS_SECRET_REDACTED_VALUE"]
+
+    stored = {
+        "azure_openai_embedding_key": "sk-live-embedding",
+        "azure_openai_image_gen_key": "sk-live-image",
+        "azure_apim_embedding_subscription_key": "",
+        "azure_openai_embedding_endpoint": "https://example.openai.azure.com",
+    }
+    redacted = redact(stored)
+
+    for key in ("azure_openai_embedding_key", "azure_openai_image_gen_key"):
+        assert redacted[key] == marker, f"{key} was not redacted: {redacted[key]!r}"
+
+    serialized = repr(redacted)
+    for secret in ("sk-live-embedding", "sk-live-image"):
+        assert secret not in serialized, f"{secret} survived redaction"
+
+    # A key that is not set must stay empty rather than gaining a marker, or the UI
+    # would claim a credential exists where none does.
+    assert redacted["azure_apim_embedding_subscription_key"] == "", redacted
+
+    # Non-secret configuration is exactly what an administrator is here to manage.
+    assert redacted["azure_openai_embedding_endpoint"] == stored["azure_openai_embedding_endpoint"]
+
+    # And redaction must not mutate the document the application goes on using.
+    assert stored["azure_openai_embedding_key"] == "sk-live-embedding", stored
+
+    print("  Stored credentials are replaced with the shared redaction marker.")
+    return True
+
+
+def test_the_v2_routes_use_the_shared_secret_mechanism():
+    """A second, parallel secret mechanism would drift from the classic form's."""
+    print("\nTesting that the V2 routes reuse the shared helpers...")
+
+    source = ROUTES_FILE.read_text(encoding="utf-8")
+
+    for fragment, why in (
+        (
+            'redact_admin_settings_secrets_for_form(settings)',
+            "the settings read redacts before responding",
+        ),
+        (
+            "_resolve_redacted_secrets(updates, current_settings)",
+            "the settings write resolves a returned marker",
+        ),
+        (
+            "ADMIN_SETTINGS_FORM_SECRET_FIELDS",
+            "the field list is the shared one, not a second copy",
+        ),
+        (
+            "resolve_admin_settings_secret_value",
+            "resolution reuses the classic form's helper",
+        ),
+    ):
+        assert fragment in source, f"route_backend_v2.py no longer ensures that {why}"
+
+    # The four keys this PR declares must be covered by that shared list rather than
+    # relying on the schema alone, so a key is redacted whether or not it is declared.
+    covered = set(HELPERS["ADMIN_SETTINGS_FORM_SECRET_FIELDS"])
+    missing = EXPECTED_SECRET_KEYS - covered
+    assert not missing, (
+        "These credentials are not in ADMIN_SETTINGS_FORM_SECRET_FIELDS, so the read "
+        f"would return them in the clear: {', '.join(sorted(missing))}"
+    )
+
+    print(f"  Both routes use the shared mechanism; all {len(EXPECTED_SECRET_KEYS)} keys covered.")
+    return True
+
+
+def test_the_save_reload_save_round_trip_preserves_the_key():
+    """The case that actually breaks: save, reload, save again without retyping."""
+    print("\nTesting the save/reload/save round trip...")
+
+    redact = HELPERS["redact_admin_settings_secrets_for_form"]
+    resolve_updates = HELPERS["_resolve_redacted_secrets"]
+    marker = HELPERS["ADMIN_SETTINGS_SECRET_REDACTED_VALUE"]
+
+    # 1. A key is stored.
+    stored = {
+        "azure_openai_embedding_key": "sk-original",
+        "azure_openai_embedding_api_version": "2024-05-01-preview",
+    }
+
+    # 2. The page reloads. This is what the browser now holds.
+    from_api = redact(stored)
+    assert from_api["azure_openai_embedding_key"] == marker
+
+    # 3. The administrator edits only the API version, and the client returns the whole
+    #    section -- including the redacted marker it was given.
+    submitted = {
+        "azure_openai_embedding_api_version": "2025-01-01-preview",
+        "azure_openai_embedding_key": from_api["azure_openai_embedding_key"],
+    }
+
+    resolved = resolve_updates(submitted, stored)
+    normalized, errors, _warnings = fields_module.normalize_admin_settings_updates(
+        resolved, stored
+    )
+    assert not errors, errors
+
+    merged = {**stored, **normalized}
+    assert merged["azure_openai_embedding_key"] == "sk-original", (
+        "The round trip overwrote the stored key with "
+        f"{merged['azure_openai_embedding_key']!r}. The marker must never be stored, and "
+        "an untouched key must survive a save of the field next to it."
+    )
+    assert merged["azure_openai_embedding_api_version"] == "2025-01-01-preview", merged
+
+    # 4. The same round trip, but the client sends the untouched field as blank rather
+    #    than echoing the marker -- which is what the V2 password control actually does.
+    blank_submitted = {
+        "azure_openai_embedding_api_version": "2025-06-01-preview",
+        "azure_openai_embedding_key": "",
+    }
+    resolved = resolve_updates(blank_submitted, stored)
+    normalized, errors, _warnings = fields_module.normalize_admin_settings_updates(
+        resolved, stored
+    )
+    assert not errors, errors
+    merged = {**stored, **normalized}
+    assert merged["azure_openai_embedding_key"] == "sk-original", merged
+
+    print("  A key survives a reload and a save of the field beside it.")
+    return True
+
+
+def test_an_explicit_clear_survives_the_resolution_pass():
+    """The clear must not be swallowed by the marker-resolution step in front of it."""
+    print("\nTesting that the clear survives resolution...")
+
+    resolve_updates = HELPERS["_resolve_redacted_secrets"]
+    stored = {"azure_openai_image_gen_key": "sk-original"}
+
+    # `resolve_admin_settings_secret_value` coerces its input with `str(value or '')`,
+    # so passing None straight through it would turn an explicit clear into "keep".
+    # The pass therefore has to rewrite the marker only.
+    resolved = resolve_updates({"azure_openai_image_gen_key": None}, stored)
+    assert resolved["azure_openai_image_gen_key"] is None, (
+        "The resolution pass turned an explicit clear into "
+        f"{resolved['azure_openai_image_gen_key']!r}, so a key could never be removed."
+    )
+
+    normalized, errors, _warnings = fields_module.normalize_admin_settings_updates(
+        resolved, stored
+    )
+    assert not errors, errors
+    merged = {**stored, **normalized}
+    assert merged["azure_openai_image_gen_key"] == "", merged
+
+    # A real replacement must also pass through untouched.
+    resolved = resolve_updates({"azure_openai_image_gen_key": "sk-replacement"}, stored)
+    assert resolved["azure_openai_image_gen_key"] == "sk-replacement", resolved
+
+    print("  None still clears, and a typed replacement is untouched.")
+    return True
+
+
 def test_the_renderer_implements_the_control():
     """A declared type with no branch renders an empty space where a field should be."""
     print("\nTesting the V2 password control...")
@@ -204,9 +435,13 @@ if __name__ == "__main__":
     tests = [
         test_password_is_a_known_field_type,
         test_credentials_are_declared_as_secrets,
+        test_the_api_redacts_stored_secrets,
+        test_the_v2_routes_use_the_shared_secret_mechanism,
         test_an_empty_secret_keeps_what_is_stored,
         test_a_typed_secret_replaces_the_stored_one,
         test_null_clears_the_stored_secret,
+        test_the_save_reload_save_round_trip_preserves_the_key,
+        test_an_explicit_clear_survives_the_resolution_pass,
         test_the_renderer_implements_the_control,
     ]
 

--- a/functional_tests/test_v2_admin_secret_fields.py
+++ b/functional_tests/test_v2_admin_secret_fields.py
@@ -2,8 +2,8 @@
 # test_v2_admin_secret_fields.py
 """
 Functional test for the Admin Settings ``password`` field type.
-Version: 0.261.075
-Implemented in: 0.261.075
+Version: 0.261.082
+Implemented in: 0.261.082
 
 Before this type existed, a secret declared in the field schema would have been drawn by
 the generic text control: a live Azure OpenAI key in a plain ``<input type="text">``,
@@ -124,7 +124,7 @@ def test_password_is_a_known_field_type():
     """Without the type registered, a declared secret would render as nothing."""
     print("Testing that 'password' is a declared field type...")
 
-    assert_app_version_at_least("0.261.075")
+    assert_app_version_at_least("0.261.082")
 
     assert "password" in fields_module.FIELD_TYPES, (
         "'password' is not in FIELD_TYPES, so the schema test would reject any field "

--- a/functional_tests/test_v2_admin_secret_fields.py
+++ b/functional_tests/test_v2_admin_secret_fields.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+# test_v2_admin_secret_fields.py
+"""
+Functional test for the Admin Settings ``password`` field type.
+Version: 0.261.075
+Implemented in: 0.261.075
+
+Before this type existed, a secret declared in the field schema would have been drawn by
+the generic text control: a live Azure OpenAI key in a plain ``<input type="text">``,
+readable over a shoulder and offered to every password manager and form-restore cache on
+the machine.
+
+The type also carries a write rule that cannot be expressed by the control alone. The V2
+surface saves a section at a time, so a secret field that is left alone still travels
+with whatever else was edited. If an empty box meant "empty string", saving an API
+version would clear a working credential, and the damage would only appear the next time
+the service was called.
+
+So the server treats an empty secret as "nothing was typed" and drops the key from the
+update entirely, while ``None`` -- which the control sends only from an explicit remove
+-- clears it. These checks pin both halves, and that the sections carrying credentials
+declare them as secrets rather than as text.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent))
+
+from test_support.app_stubs import import_app_module
+from test_support.versioning import assert_app_version_at_least
+
+
+fields_module = import_app_module("admin_settings_fields")
+
+# Every settings key in the schema that carries a credential. Named explicitly rather
+# than matched on the word "key", because ``model_endpoint_identity_header_name`` and
+# several other keys contain it without being secret.
+EXPECTED_SECRET_KEYS = {
+    "azure_openai_embedding_key",
+    "azure_apim_embedding_subscription_key",
+    "azure_openai_image_gen_key",
+    "azure_apim_image_gen_subscription_key",
+}
+
+
+def declared_fields_by_key():
+    return {
+        field["key"]: field
+        for _section_id, field in fields_module.iter_fields()
+        if field.get("key")
+    }
+
+
+def test_password_is_a_known_field_type():
+    """Without the type registered, a declared secret would render as nothing."""
+    print("Testing that 'password' is a declared field type...")
+
+    assert_app_version_at_least("0.261.075")
+
+    assert "password" in fields_module.FIELD_TYPES, (
+        "'password' is not in FIELD_TYPES, so the schema test would reject any field "
+        "declaring it and the renderer would draw nothing."
+    )
+
+    # A secret still has to be savable. Putting it in NON_PATCHABLE_TYPES would make the
+    # settings PATCH refuse every credential in the AI Models group.
+    assert "password" not in fields_module.NON_PATCHABLE_TYPES, (
+        "'password' must stay patchable; it has no endpoint of its own."
+    )
+
+    print("  'password' is a known, patchable field type.")
+    return True
+
+
+def test_credentials_are_declared_as_secrets():
+    """A credential declared as text renders into a readable input."""
+    print("\nTesting that credential fields declare the password type...")
+
+    by_key = declared_fields_by_key()
+
+    problems = []
+    for key in sorted(EXPECTED_SECRET_KEYS):
+        field = by_key.get(key)
+        if field is None:
+            problems.append(f"{key}: not declared at all")
+            continue
+        if field.get("type") != "password":
+            problems.append(f"{key}: declared as {field.get('type')!r}, expected 'password'")
+
+    assert not problems, (
+        "These credentials are not declared as secrets, so the V2 admin surface would "
+        "render them in plain text:\n  " + "\n  ".join(problems)
+    )
+
+    print(f"  All {len(EXPECTED_SECRET_KEYS)} credential field(s) declare 'password'.")
+    return True
+
+
+def test_an_empty_secret_keeps_what_is_stored():
+    """Saving a neighbouring field must not wipe a credential nobody touched."""
+    print("\nTesting the empty-means-unchanged rule...")
+
+    current = {"azure_openai_embedding_key": "stored-secret"}
+
+    normalized, errors, _warnings = fields_module.normalize_admin_settings_updates(
+        {
+            "azure_openai_embedding_key": "",
+            "azure_openai_embedding_api_version": "2024-05-01-preview",
+        },
+        current,
+    )
+
+    assert not errors, errors
+    assert "azure_openai_embedding_key" not in normalized, (
+        "An empty secret reached update_settings, which would overwrite the stored "
+        f"credential with nothing: {normalized}"
+    )
+    assert normalized["azure_openai_embedding_api_version"] == "2024-05-01-preview", (
+        "The rest of the update must still be applied."
+    )
+
+    # Whitespace alone is still nothing typed, which is what a stray paste produces.
+    whitespace_only, _errors, _warnings = fields_module.normalize_admin_settings_updates(
+        {"azure_openai_embedding_key": "   \n"}, current
+    )
+    assert "azure_openai_embedding_key" not in whitespace_only, whitespace_only
+
+    print("  An empty or whitespace-only secret is dropped from the update.")
+    return True
+
+
+def test_a_typed_secret_replaces_the_stored_one():
+    """The ordinary case: a new credential is stored, trimmed."""
+    print("\nTesting that a typed secret is stored...")
+
+    normalized, errors, _warnings = fields_module.normalize_admin_settings_updates(
+        {"azure_apim_image_gen_subscription_key": "  new-secret\n"},
+        {"azure_apim_image_gen_subscription_key": "old-secret"},
+    )
+
+    assert not errors, errors
+    # A key pasted from a portal or terminal routinely carries a trailing newline, and a
+    # credential that fails only because of an invisible character is undiagnosable.
+    assert normalized["azure_apim_image_gen_subscription_key"] == "new-secret", normalized
+
+    print("  A typed secret replaces the stored one and is trimmed.")
+    return True
+
+
+def test_null_clears_the_stored_secret():
+    """Removal has to remain expressible, or a pasted mistake is permanent."""
+    print("\nTesting the explicit clear...")
+
+    normalized, errors, _warnings = fields_module.normalize_admin_settings_updates(
+        {"azure_openai_image_gen_key": None},
+        {"azure_openai_image_gen_key": "stored-secret"},
+    )
+
+    assert not errors, errors
+    assert "azure_openai_image_gen_key" in normalized, (
+        "An explicit clear must reach update_settings, or the secret cannot be removed."
+    )
+    assert normalized["azure_openai_image_gen_key"] == "", normalized
+
+    print("  None clears the stored secret.")
+    return True
+
+
+def test_the_renderer_implements_the_control():
+    """A declared type with no branch renders an empty space where a field should be."""
+    print("\nTesting the V2 password control...")
+
+    repo_root = Path(__file__).resolve().parents[1]
+    controls = (
+        repo_root / "application" / "v2_ui" / "src" / "components" / "admin" / "fields.tsx"
+    ).read_text(encoding="utf-8")
+
+    assert "case 'password':" in controls, "fields.tsx has no branch for the password type"
+
+    # The three properties that make it a secret control rather than a text box.
+    for fragment, why in (
+        ("type={revealed ? 'text' : 'password'}", "the input is masked by default"),
+        ('autoComplete="new-password"', "the browser is told not to autofill a stored login"),
+        ("onChange(null)", "removal sends the explicit clear the server reads"),
+    ):
+        assert fragment in controls, f"The password control no longer ensures that {why}"
+
+    page = (
+        repo_root / "application" / "v2_ui" / "src" / "pages" / "AdminSettingsPage.tsx"
+    ).read_text(encoding="utf-8")
+
+    assert "readSecretValue(field, draft)" in page, (
+        "The page must read a password field from the draft alone. Reading it through "
+        "readFieldValue would seed the control from the settings document, putting the "
+        "stored credential into a form control."
+    )
+
+    print("  The control is masked, non-autofilling and write-only.")
+    return True
+
+
+if __name__ == "__main__":
+    tests = [
+        test_password_is_a_known_field_type,
+        test_credentials_are_declared_as_secrets,
+        test_an_empty_secret_keeps_what_is_stored,
+        test_a_typed_secret_replaces_the_stored_one,
+        test_null_clears_the_stored_secret,
+        test_the_renderer_implements_the_control,
+    ]
+
+    results = []
+    for test in tests:
+        try:
+            results.append(bool(test()))
+        except Exception as exc:
+            print(f"FAILED {test.__name__}: {exc}")
+            import traceback
+
+            traceback.print_exc()
+            results.append(False)
+
+    print(f"\nResults: {sum(results)}/{len(results)} tests passed")
+    sys.exit(0 if all(results) else 1)

--- a/functional_tests/test_v2_admin_settings_normalization.py
+++ b/functional_tests/test_v2_admin_settings_normalization.py
@@ -29,7 +29,7 @@ def test_dependency_conditions_compare_by_declared_type():
     """A string condition compared for truthiness would match every non-empty choice."""
     print("Testing depends_on comparison semantics...")
 
-    assert_app_version_at_least("0.261.075")
+    assert_app_version_at_least("0.261.082")
 
     satisfied = fields_module._dependency_is_satisfied
 

--- a/functional_tests/test_v2_admin_settings_normalization.py
+++ b/functional_tests/test_v2_admin_settings_normalization.py
@@ -439,7 +439,7 @@ def test_switches_coerce_form_shaped_truthiness():
 if __name__ == "__main__":
     tests = [
         test_dependency_conditions_compare_by_declared_type,
-        test_dependency_reads_the_pending_save_before_stored_state,
+        test_every_condition_must_hold_for_a_multi_gated_field,
         test_numeric_values_are_clamped_to_declared_bounds,
         test_colours_must_be_hex,
         test_external_links_reject_unsafe_urls,

--- a/functional_tests/test_v2_admin_settings_normalization.py
+++ b/functional_tests/test_v2_admin_settings_normalization.py
@@ -25,6 +25,80 @@ fields_module = import_app_module("admin_settings_fields")
 normalize = fields_module.normalize_admin_settings_updates
 
 
+def test_dependency_conditions_compare_by_declared_type():
+    """A string condition compared for truthiness would match every non-empty choice."""
+    print("Testing depends_on comparison semantics...")
+
+    assert_app_version_at_least("0.261.075")
+
+    satisfied = fields_module._dependency_is_satisfied
+
+    # Boolean dependencies keep working exactly as they did.
+    assert satisfied({"key": "flag", "equals": True}, {"flag": True}, {}) is True
+    assert satisfied({"key": "flag", "equals": True}, {"flag": False}, {}) is False
+    assert satisfied({"key": "flag", "equals": False}, {"flag": False}, {}) is True
+    # Including the form-shaped truthiness the PATCH accepts elsewhere.
+    assert satisfied({"key": "flag", "equals": True}, {"flag": "on"}, {}) is True
+
+    # An omitted ``equals`` still means True, which is the historical default.
+    assert satisfied({"key": "flag"}, {"flag": True}, {}) is True
+
+    auth = {"key": "azure_openai_embedding_authentication_type", "equals": "key"}
+
+    # Exact equality only. "managed_identity" is truthy, so a boolean comparison here
+    # would show an API key field for a route that stores no key.
+    assert satisfied(auth, {"azure_openai_embedding_authentication_type": "key"}, {}) is True
+    assert (
+        satisfied(auth, {"azure_openai_embedding_authentication_type": "managed_identity"}, {})
+        is False
+    )
+
+    # A near miss must not match: no prefix, substring or case folding.
+    for near_miss in ("keys", "ke", "KEY", "Key", " key", "key "):
+        assert satisfied(auth, {"azure_openai_embedding_authentication_type": near_miss}, {}) is False, (
+            f"{near_miss!r} matched a condition on 'key'"
+        )
+
+    # A missing or null value must not match a string condition by accident.
+    for absent in ({}, {"azure_openai_embedding_authentication_type": None},
+                   {"azure_openai_embedding_authentication_type": ""}):
+        assert satisfied({"key": "some_undeclared_choice", "equals": "key"}, absent, {}) is False
+
+    print("  Boolean conditions unchanged; string conditions match on exact equality.")
+    return True
+
+
+def test_dependency_reads_the_pending_save_before_stored_state():
+    """A gate edited in the same PATCH decides the fields it gates."""
+    print("Testing depends_on value precedence...")
+
+    satisfied = fields_module._dependency_is_satisfied
+    dependency = {"key": "azure_openai_embedding_authentication_type", "equals": "key"}
+
+    # The value being written wins over the value on disk.
+    assert satisfied(
+        dependency,
+        {"azure_openai_embedding_authentication_type": "managed_identity"},
+        {"azure_openai_embedding_authentication_type": "key"},
+    ) is False
+
+    # Falling back to stored state when the gate is not part of this save.
+    assert satisfied(
+        dependency, {}, {"azure_openai_embedding_authentication_type": "key"}
+    ) is True
+
+    # And to the declared default when the document predates the key, because that is
+    # what the application would be applying.
+    declared_default = fields_module.get_field_definition(
+        "azure_openai_embedding_authentication_type"
+    )["default"]
+    assert declared_default == "key", declared_default
+    assert satisfied(dependency, {}, {}) is True
+
+    print("  Pending value beats stored value beats declared default.")
+    return True
+
+
 def test_numeric_values_are_clamped_to_declared_bounds():
     """An out-of-range logo scale would render an unusable home page."""
     print("Testing numeric clamping...")
@@ -299,6 +373,8 @@ def test_switches_coerce_form_shaped_truthiness():
 
 if __name__ == "__main__":
     tests = [
+        test_dependency_conditions_compare_by_declared_type,
+        test_dependency_reads_the_pending_save_before_stored_state,
         test_numeric_values_are_clamped_to_declared_bounds,
         test_colours_must_be_hex,
         test_external_links_reject_unsafe_urls,

--- a/functional_tests/test_v2_admin_settings_schema.py
+++ b/functional_tests/test_v2_admin_settings_schema.py
@@ -51,6 +51,7 @@ REQUIRED_PROPERTIES_BY_TYPE = {
     "text": ("default",),
     "textarea": ("default",),
     "switch": ("default",),
+    "password": ("default",),
     "link_list": ("item_fields", "default"),
     "image": ("upload_target", "accept", "version_key"),
     "component": ("component",),
@@ -64,6 +65,7 @@ EXPECTED_DEFAULT_TYPES = {
     "color": str,
     "range": int,
     "number": int,
+    "password": str,
     "checkbox_set": list,
     "link_list": list,
 }
@@ -196,6 +198,11 @@ def test_dependencies_reference_real_fields():
     print("\nTesting visibility dependencies...")
 
     declared = fields_module.get_declared_setting_keys()
+    by_key = {
+        field["key"]: field
+        for _section_id, field in fields_module.iter_fields()
+        if field.get("key")
+    }
     problems = []
     checked = 0
 
@@ -213,6 +220,24 @@ def test_dependencies_reference_real_fields():
             problems.append(f"{identity}: depends on undeclared key {depends_on['key']!r}")
         if field.get("key") == depends_on["key"]:
             problems.append(f"{identity}: depends on itself")
+
+        expected = depends_on.get("equals", True)
+        if not isinstance(expected, (bool, str)):
+            problems.append(
+                f"{identity}: equals {expected!r} is neither a boolean nor a string"
+            )
+            continue
+
+        # A string condition has to name a value the depended-on control can actually
+        # produce, or the field is unreachable however the page is used.
+        parent = by_key.get(depends_on["key"])
+        if isinstance(expected, str) and parent:
+            offered = [option["value"] for option in parent.get("options", [])]
+            if offered and expected not in offered:
+                problems.append(
+                    f"{identity}: depends on {depends_on['key']} == {expected!r}, "
+                    f"which is not one of {offered}"
+                )
 
     assert not problems, (
         "These visibility dependencies are broken:\n  " + "\n  ".join(problems)


### PR DESCRIPTION
Phase 3 of 3 of the Admin Settings **AI Models** rebuild.

> ## ⛔ Do not merge — the head branch is frozen, not the work
>
> **`CONFLICTING` here is an artifact of a stale head, not of stale work.** Push access to `microsoft/simplechat` was revoked mid-run (`push: false`; 403 on git, 404 on the refs API), confirmed independently from three worktrees, so this PR's head branch has been stuck ever since:
>
> | | This PR points at | Reality |
> | --- | --- | --- |
> | head | `9d100b4f` — **31 commits behind** | **`c38a5319`** (fork) |
> | base | `paullizer-react-v2-ui` @ `05eb3c35` | same — correctly retargeted |
>
> **The real work is already current with this base.** `origin/paullizer-react-v2-ui` is an ancestor of `c38a5319`: nothing on the base is missing from it, and `VERSION` is `0.261.083` against the base's `0.261.071`. Once the head is pushed, this should go green without a merge.
>
> Merging the frozen head instead would land `VERSION = "0.261.075"` — a regression *below* this base — plus none of the phase 2 merge, a duplicate `password` secret mechanism, and a transitive-gating defect in `image-config`.
>
> One command from anyone with write access fixes it. The fork shares object storage with upstream, so no fetch is needed:
>
> ```
> git push origin c38a5319:refs/heads/paullizer-admin-ai-models-embeddings-images
> ```
>
> Everything below describes `c38a5319`.

Embeddings and Image Generation were the last two sections of the group with no field schema, so both fell back to scanning the settings document for `enable_*` booleans and rendered a switch or two. Everything that makes either route work — endpoint, authentication, subscription and resource group, API version, the APIM alternative, and the deployment in use — was invisible.

Unlike chat, neither has multi-endpoint support. Each is one Azure OpenAI resource, or one API Management gateway in front of one, so this brings the real forms into V2 rather than pointing at the classic page.

## Credentials

**No security fix is claimed here.** An earlier revision of this branch added redaction to `GET /api/v2/admin/settings` and described it as closing an exposure. That was measured against a stale base: #1421/#1422 had already landed `admin_settings_secret_utils.py`, and the merged base already redacts on read and resolves the placeholder on write. The apparent gap existed only in this branch's `0.261.061`-era view of the tree.

What actually happens on the merged base, for `azure_openai_embedding_key` and `azure_openai_image_gen_key` (and the two APIM subscription keys):

- **`GET /api/v2/admin/settings` returns `***REDACTED***`** — not the real value, not empty. All four keys were already in `ADMIN_SETTINGS_FORM_SECRET_FIELDS`, and being in that list is what redacts them.
- **A save that round-trips the placeholder cannot overwrite the stored key.** The PATCH resolves it back through `resolve_admin_settings_secret_value` before writing.

This branch's contribution is to **register these four keys with that mechanism rather than build a second one**, and to delete what it had built independently.

### What was deleted rather than merged

The branch had arrived at the same design under the name `password`. The merge removes all of it:

| Removed | Superseded by |
| --- | --- |
| `password` field type | the base's `secret` type |
| `PasswordControl` | the base's `SecretControl` |
| `_normalize_password` | the base's `secret` normalizer |
| `_resolve_redacted_secrets` | the base's wider resolution pass |
| `hasStoredSecret`, `readSecretValue` | the base's `SECRET_PLACEHOLDER` |

The base's control is better than the one it replaces. Instead of a masked box that always accepts input, it shows **Stored** with an explicit **Replace**, and stages nothing until Replace is pressed — because the control can unmount when a search, a group change or a dependency switch drops it, and a queued empty value would take the escape hatch with it while leaving the deletion behind.

**The two designs disagree about the empty string, and the base's is self-consistent.** On the base, blank means *clear* — safe precisely because the control cannot emit blank by accident. The removed design needed blank to mean *keep*, because its box was always editable, and therefore needed a separate **Remove stored value** action. Adopting half of either would have produced a credential that could not be deleted. `test_removal_stays_possible` pins that removal still works.

## Conditional visibility

The base generalized `depends_on` to accept a list of conditions, all of which must hold, and its comparison already handles strings by value. That supersedes this branch's string comparison and its transitive parent-walk, and the declarative form is the better answer to the same problem: the schema is flat where the panes are nested, so a control inside two blocks now **names both gates** rather than inheriting one.

The Azure OpenAI keys declare the direct-connection route *and* the authentication type. The image fields additionally declare the capability toggle above them.

**That last part was a real defect the merge surfaced, and it is worth recording how.** Every field in `image-config` was gated only on `enable_image_gen_apim`, which is itself gated on `enable_image_generation`. Because visibility is judged per field rather than recursively, turning image generation off would have left the entire section on screen.

It was caught by `test_gated_fields_inherit_their_gate_s_own_conditions`, which arrived from #1422 (`bdc7bdd8`, "Describe the Chat group for the V2 admin settings surface") — written by someone who hit the same class of problem in a different group and encoded the invariant rather than fixing their instance of it. A transitive-gating bug caught by a transitive-gating test, in a section its author never saw. That is the schema's invariants doing real work rather than restating the code.

## Model selection

`embedding_model` and `image_gen_model` are `{"selected": [...], "all": [...]}` dicts, so they follow phase 2's `default_model_selection` pattern: declared as `component` *with* a `key`, which puts them in `NON_PATCHABLE_TYPES` so the settings PATCH refuses them, plus dedicated routes that validate server-side.

```
GET  /api/v2/admin/model-selection/<kind>   embedding | image
PUT  /api/v2/admin/model-selection/<kind>
```

- The **read returns stored state only** — no Azure call — so opening Admin Settings never depends on Resource Manager being reachable, and a read never writes.
- The **write requires the selection to name a deployment that is in the catalog.** Accepting one that is not there produces a page that looks correctly configured while every call returns deployment-not-found, which reads as an outage rather than a settings mistake.
- An **omitted `models` list keeps the stored one**, so choosing from an already-loaded list cannot erase the list it came from.
- Both catalogs are **single-select**, confirmed against `selectEmbeddingModel` / `selectImageModel`, which assign `[{...}]` rather than pushing.

Discovery reuses the existing admin-gated `GET /api/models/embedding` and `GET /api/models/image` rather than being reimplemented. Both read the *saved* endpoint, subscription id and resource group, which the classic page carries as fine print; here an unsaved edit to any of those disables **Fetch deployments** and says why.

## Misfiling corrected

`enable_office_embedded_image_analysis` was being guessed into `image-config` by the fallback scan, on the shared token "image". It governs analysing images *embedded in DOCX and PPTX files* during extraction — reading pictures, not generating them — and rendered as a bare, unexplained switch in the Image Generation card. It is now declared under `document-intelligence-section`, which is what removes it from the scan, and added to `RELOCATED_CAPABILITIES`.

**Its default is `True`, not `False`** as the relocation request assumed.

Because that section exists on both sides of the merge, the field is folded into the base's existing block rather than added as a second key — a duplicate would have silently discarded whichever block came first.

`enable_multi_agent_orchestration` also misfiles and is deliberately left alone: it is derived from `orchestration_type` with no independent V1 control, so it needs suppressing rather than declaring.

## Not taken on

- **Connection testing stays on the classic page.** `POST /api/admin/test-embedding-connection` and `/api/admin/test-image-connection` do not exist; testing is one dispatching route fed *ephemeral* form values including the raw credential. Wiring V2 into it would mean reconstructing that payload with a secret in it. Recorded as a decision in #1428.
- **The PATCH echo's `model_endpoints` gap** — the echo redacts by flat key match, so credentials inside that list are not reached. #1425 fixes it.

## Verification

`VERSION` → `0.261.083`. Release notes: `0.261.083` on top, then `081`, `071`, `070` and below intact. Docs inventory regenerates unchanged.

Registry checked base-anchored rather than by count, since a count cannot distinguish a resurrected section from an added one:

```
set(merged) == set(base) | {embeddings-config, image-config}   -> holds
51 sections, zero duplicates, none lost, none invented
```

19/19 required Python suites, 3/3 `.mjs` suites (19 + 23 + 28 checks), `python -m compileall application/single_app` clean, `npm run build` clean.

#1424 has not landed yet, so this base will move once more before merge.