### PR TITLE
Fix the model call that made every orchestration reasoning step fail

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -97,7 +97,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.261.085"
+VERSION = "0.261.086"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/route_backend_orchestration.py
+++ b/application/single_app/route_backend_orchestration.py
@@ -133,12 +133,26 @@ def _orchestration_enabled(settings):
     return bool((settings or {}).get('enable_chat_orchestration'))
 
 
-def _build_invoke_prompt(settings):
+def _build_invoke_prompt(settings, token_usage=None):
     """A closure the adapters call to ask the model something.
 
-    Shares the planner's client resolution, which already handles APIM, managed identity and
-    key auth, but deliberately not its deployment: planning may be pointed at a small model,
-    while the answer should come from the deployment the administrator chose for chat.
+    The signature is not ours to choose. ``run_document_analysis``,
+    ``run_document_comparison`` and the respond adapter all call this as
+    ``invoke_prompt(prompt_text, stage=..., metadata={...})``, which is the convention
+    ``functions_workflow_runner.invoke_model_prompt`` established and every existing caller
+    follows. Getting it wrong does not fail at import or in a unit test with fake adapters
+    -- it fails at the moment a real step runs, with a TypeError that reads as a mystery,
+    which is exactly how it was found.
+
+    ``stage`` and ``metadata`` are accepted and deliberately unused beyond logging: they
+    describe which phase of a multi-pass analysis is asking, and the answer is the same
+    model call either way. They are named rather than swallowed by ``**kwargs`` so this
+    file states the contract it is honouring.
+
+    Shares the planner's client resolution, which already handles APIM, managed identity
+    and key auth, but deliberately not its deployment: planning may be pointed at a small
+    model, while the answer should come from the deployment the administrator chose for
+    chat.
     """
     client, planner_deployment = resolve_planner_client(settings)
 
@@ -148,16 +162,34 @@ def _build_invoke_prompt(settings):
         deployment = (gpt_model['selected'][0] or {}).get('deploymentName')
     deployment = deployment or planner_deployment
 
-    def invoke_prompt(messages, max_tokens=ANSWER_MAX_TOKENS, temperature=ANSWER_TEMPERATURE):
-        if isinstance(messages, str):
-            messages = [{'role': 'user', 'content': messages}]
+    def invoke_prompt(prompt_text, stage='window_analysis', metadata=None):
+        messages = (
+            prompt_text
+            if isinstance(prompt_text, list)
+            else [{'role': 'user', 'content': str(prompt_text or '')}]
+        )
         response = client.chat.completions.create(
             model=deployment,
             messages=messages,
-            temperature=temperature,
-            max_tokens=max_tokens,
+            temperature=ANSWER_TEMPERATURE,
+            max_tokens=ANSWER_MAX_TOKENS,
         )
+
+        # Accumulated here because this is the only place every model call an orchestration
+        # run makes passes through. A run's cost was previously reported as zero for that
+        # reason, not because it was free.
+        usage = getattr(response, 'usage', None)
+        if usage is not None and isinstance(token_usage, dict):
+            for field in ('prompt_tokens', 'completion_tokens', 'total_tokens'):
+                value = getattr(usage, field, None)
+                if isinstance(value, int):
+                    token_usage[field] = token_usage.get(field, 0) + value
+
         if not response or not response.choices:
+            log_event(
+                f"[ORCHESTRATION] The model returned no choices at stage '{stage}'.",
+                level=logging.WARNING,
+            )
             return ''
         return response.choices[0].message.content or ''
 
@@ -560,8 +592,10 @@ def register_route_backend_orchestration(bp):
 
         conversation_id = conversation_id or _text(record.get('conversation_id'))
 
+        # One accumulator for the whole run, filled by every model call the closure makes.
+        run_token_usage = {}
         try:
-            invoke_prompt = _build_invoke_prompt(settings)
+            invoke_prompt = _build_invoke_prompt(settings, token_usage=run_token_usage)
         except Exception as exc:
             log_event(f"[ORCHESTRATION] No usable chat model: {exc}", level=logging.ERROR)
             return jsonify({'error': 'No chat model is configured.'}), 503
@@ -721,7 +755,7 @@ def register_route_backend_orchestration(bp):
                         'run_id': run_id,
                         'plan_summary': summary,
                     },
-                    'token_usage': result.get('token_usage') or {},
+                    'token_usage': run_token_usage or result.get('token_usage') or {},
                 },
             ) if answer else None
 
@@ -732,6 +766,7 @@ def register_route_backend_orchestration(bp):
             try:
                 update_orchestration_run(run_id, user_id, {
                     'assistant_message_id': message_id,
+                    'token_usage': run_token_usage,
                 }, conversation_id=conversation_id)
             except Exception:
                 # The answer is already saved and streamed; failing to cross-reference it

--- a/docs/explanation/features/CHAT_ORCHESTRATION.md
+++ b/docs/explanation/features/CHAT_ORCHESTRATION.md
@@ -1,6 +1,6 @@
 # Chat Orchestration
 
-**Implemented in version: 0.261.085**
+**Implemented in version: 0.261.086**
 
 ## Overview
 
@@ -197,6 +197,7 @@ to the front.
 | `functional_tests/test_orchestration_plan_schema.py` | Unknown and disabled capabilities, document authorization, argument coercion and bounds, cycles, step caps, narrowing-only edits, approval states |
 | `functional_tests/test_orchestration_elicitation_schema.py` | The MCP flat-object restriction, paging staying outside the schema, response validation |
 | `functional_tests/test_orchestration_run_ledger.py` | Run and byte bounds, oldest-first compaction, honest truncation, answered questions carrying forward |
+| `functional_tests/test_orchestration_invoke_prompt_contract.py` | The model-call convention: the route's closure must accept what the adapters and the document functions actually pass, and must count token usage |
 | `functional_tests/test_orchestration_executor.py` | Step ordering, dependency skipping, cancellation, budget caps, re-authorization |
 
 ## Known limitations

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,16 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/features) and [Fixes by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/fixes).
 
+### **(v0.261.086)**
+
+#### Bug Fixes
+
+*   **Orchestrated Answers Failed At The Last Step**
+    *   A plan would research correctly and then fail while writing the answer, reporting only "The answer could not be written". The same fault would have stopped document analysis and document comparison, which is every capability that reasons over what was gathered — web search and document search completed because they never call a model.
+    *   The step that writes the answer asks the model through a small function the request supplies, and SimpleChat has a long-standing convention for how that function is called. The orchestration request was supplying one with a different shape, so the call failed the moment a real step reached it.
+    *   Token usage is now also counted for orchestrated runs. It was previously reported as zero — not because the run was free, but because nothing was adding it up.
+    *   (Ref: `route_backend_orchestration._build_invoke_prompt`, `functions_orchestration_adapters.run_respond`, `functions_workflow_runner.invoke_model_prompt`)
+
 ### **(v0.261.085)**
 
 #### New Features

--- a/functional_tests/test_orchestration_invoke_prompt_contract.py
+++ b/functional_tests/test_orchestration_invoke_prompt_contract.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""
+Functional test for the orchestration invoke_prompt calling convention.
+Version: 0.261.086
+Implemented in: 0.261.086
+
+A run failed in production with:
+
+    invoke_prompt() got an unexpected keyword argument 'stage'
+
+The adapters call the model through a closure the route supplies, and the shape of that
+call is not the route's to choose: ``run_document_analysis``, ``run_document_comparison``
+and the respond adapter all invoke it as ``invoke_prompt(prompt, stage=..., metadata=...)``,
+the convention ``functions_workflow_runner.invoke_model_prompt`` established. The route
+built a closure taking ``(messages, max_tokens, temperature)`` instead.
+
+Nothing caught it. The executor tests drive fake adapters, so they never cross that seam,
+and every real adapter needs Azure to run. The mismatch therefore survived import,
+type-checking and the whole suite, and failed only when a real step ran -- taking respond,
+document_analyze and document_compare with it, which is every capability that reasons.
+
+This test closes that hole by checking the contract itself rather than the behaviour behind
+it: the route's closure must accept what the callers actually pass.
+"""
+
+import ast
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+
+from test_support.app_stubs import APP_ROOT  # noqa: E402
+from test_support.versioning import assert_app_version_at_least  # noqa: E402
+
+# The convention every existing caller follows.
+REQUIRED_PARAMETERS = ('stage', 'metadata')
+
+
+def _read(module):
+    with open(os.path.join(APP_ROOT, module), encoding='utf-8') as handle:
+        return handle.read()
+
+
+def _call_keywords(source, function_name):
+    """Every keyword argument any call to ``function_name`` passes, across a module."""
+    keywords = set()
+    for node in ast.walk(ast.parse(source)):
+        if not isinstance(node, ast.Call):
+            continue
+        target = node.func
+        name = getattr(target, 'id', None) or getattr(target, 'attr', None)
+        if name != function_name:
+            continue
+        for keyword in node.keywords:
+            if keyword.arg:
+                keywords.add(keyword.arg)
+    return keywords
+
+
+def _find_function(source, name, within=None):
+    """Locate a function definition, optionally nested inside another."""
+    tree = ast.parse(source)
+    scope = tree
+    if within:
+        scope = next(
+            (
+                node for node in ast.walk(tree)
+                if isinstance(node, ast.FunctionDef) and node.name == within
+            ),
+            None,
+        )
+        assert scope is not None, f"{within} not found"
+    for node in ast.walk(scope):
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    return None
+
+
+def _accepted_parameters(function_node):
+    """Parameter names a definition accepts, including **kwargs if it takes one."""
+    args = function_node.args
+    names = {arg.arg for arg in args.args}
+    names |= {arg.arg for arg in args.kwonlyargs}
+    if args.vararg:
+        names.add('*')
+    if args.kwarg:
+        names.add('**')
+    return names
+
+
+def test_route_closure_accepts_what_callers_pass():
+    """The route's invoke_prompt must accept `stage` and `metadata`.
+
+    Checked statically rather than by calling it. The route imports the Cosmos containers
+    at module scope, so importing it needs Azure -- which is precisely why nothing caught
+    this the first time. A source-level check has no such dependency and cannot be skipped
+    on a developer machine.
+    """
+    print("Testing the orchestration invoke_prompt signature...")
+    try:
+        source = _read('route_backend_orchestration.py')
+        closure = _find_function(source, 'invoke_prompt', within='_build_invoke_prompt')
+        assert closure is not None, (
+            "_build_invoke_prompt must define an invoke_prompt closure"
+        )
+
+        accepted = _accepted_parameters(closure)
+        for name in REQUIRED_PARAMETERS:
+            assert name in accepted or '**' in accepted, (
+                f"invoke_prompt must accept '{name}': run_document_analysis, "
+                f"run_document_comparison and the respond adapter all pass it, following "
+                f"functions_workflow_runner.invoke_model_prompt. Accepted: {sorted(accepted)}"
+            )
+
+        # The prompt itself is positional, because the document functions pass it that way.
+        positional = [arg.arg for arg in closure.args.args]
+        assert positional and positional[0] not in REQUIRED_PARAMETERS, (
+            f"the prompt must be the first positional parameter, saw {positional}"
+        )
+
+        print(f"  ok  invoke_prompt accepts {sorted(accepted)}")
+        return True
+    except Exception as e:
+        print(f"Test failed: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+
+def test_adapters_only_pass_supported_keywords():
+    """No adapter may invent a keyword the route's closure does not declare."""
+    print("Testing the adapter call sites against the closure...")
+    try:
+        passed = _call_keywords(_read('functions_orchestration_adapters.py'), 'invoke_prompt')
+
+        closure = _find_function(
+            _read('route_backend_orchestration.py'),
+            'invoke_prompt',
+            within='_build_invoke_prompt',
+        )
+        accepted = _accepted_parameters(closure)
+
+        if '**' not in accepted:
+            unsupported = sorted(passed - accepted)
+            assert not unsupported, (
+                f"adapters pass keyword(s) the route's closure does not accept: "
+                f"{unsupported}. This fails only when a real step runs, so it has to be "
+                f"caught here."
+            )
+        print(f"  ok  adapters pass {sorted(passed) or 'no keywords'}, all accepted")
+        return True
+    except Exception as e:
+        print(f"Test failed: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+
+def test_token_usage_is_accumulated():
+    """A run's cost must be counted, since every model call passes through one closure."""
+    print("Testing that the closure accumulates token usage...")
+    try:
+        source = _read('route_backend_orchestration.py')
+        builder = _find_function(source, '_build_invoke_prompt')
+        assert builder is not None
+
+        accepted = _accepted_parameters(builder)
+        assert 'token_usage' in accepted, (
+            "_build_invoke_prompt must take a token_usage accumulator; without one a run "
+            "reports zero cost because nothing counted it, not because it was free"
+        )
+
+        body = ast.dump(builder)
+        for field in ('prompt_tokens', 'completion_tokens', 'total_tokens'):
+            assert field in body, f"the closure should accumulate {field}"
+
+        print("  ok  the closure accumulates prompt, completion and total tokens")
+        return True
+    except Exception as e:
+        print(f"Test failed: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+
+def test_document_functions_agree_on_the_convention():
+    """The convention is repo-wide, so confirm the document functions still use it."""
+    print("Testing the document analysis and comparison call sites...")
+    try:
+        for module in ('functions_document_analysis.py', 'functions_document_comparison.py'):
+            keywords = _call_keywords(_read(module), 'invoke_prompt')
+            if not keywords:
+                # Comparison delegates to analysis on some paths; an absence of direct
+                # calls is fine, a contradictory call is not.
+                continue
+            for name in REQUIRED_PARAMETERS:
+                assert name in keywords, (
+                    f"{module} calls invoke_prompt without '{name}'; the orchestration "
+                    f"closure is built to this convention and would drift from it"
+                )
+        print("  ok  the document functions still call with stage and metadata")
+        return True
+    except Exception as e:
+        print(f"Test failed: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+
+if __name__ == "__main__":
+    assert_app_version_at_least("0.261.086")
+
+    tests = [
+        test_route_closure_accepts_what_callers_pass,
+        test_adapters_only_pass_supported_keywords,
+        test_token_usage_is_accumulated,
+        test_document_functions_agree_on_the_convention,
+    ]
+    results = []
+    for test in tests:
+        print(f"\nRunning {test.__name__}...")
+        results.append(test())
+
+    print(f"\nResults: {sum(results)}/{len(results)} tests passed")
+    sys.exit(0 if all(results) else 1)


### PR DESCRIPTION
A run researched correctly and then failed while writing the answer, reporting only "The answer could not be written". The step record carried the real cause:

```
invoke_prompt() got an unexpected keyword argument 'stage'
```

## What was wrong

Adapters reach the model through a closure the request supplies, and the shape of that call is not the request's to choose. `run_document_analysis`, `run_document_comparison` and the respond adapter all call it as `invoke_prompt(prompt, stage=..., metadata=...)` — the convention `functions_workflow_runner.invoke_model_prompt` established and every existing caller follows. The orchestration route built one taking `(messages, max_tokens, temperature)` instead.

So this was not a respond bug. It would have failed document analysis and document comparison identically — **every capability that reasons over what was gathered.** Web search and document search survived only because neither calls a model.

## Why nothing caught it

The more useful finding. The executor tests drive fake adapters, so they never cross this seam, and every real adapter needs Azure to run. The mismatch therefore passed import, type-checking and the entire suite, and failed only once a real step reached it in production.

`test_orchestration_invoke_prompt_contract.py` closes that hole by checking the contract at the source level, which needs no credentials and so cannot be quietly skipped on a developer machine:

- the route's closure must accept what the callers actually pass
- no adapter may invent a keyword the closure does not declare
- the document functions must still agree on the convention

Reverting the fix turns it red (2/4), which is the only evidence worth having.

## Also

Token usage is now accumulated. Every model call a run makes passes through this one closure, so a run reporting zero cost was reporting that nothing had counted it rather than that it was free.

## Verification

27 orchestration functional tests, 13 docs tests, pyflakes and swagger validation all clean.
