### PR TITLE
Orchestration: name the phases and complete the knowledge phase

### DIFF
--- a/application/single_app/admin_settings_fields.py
+++ b/application/single_app/admin_settings_fields.py
@@ -3617,6 +3617,253 @@ ADMIN_SETTINGS_FIELDS = {
             "default": True,
         },
     ],
+    # The Orchestration group had the same problem the Workflow group had, from the
+    # other direction: exactly one of its settings is named `enable_*`, so the fallback
+    # scan found that switch and nothing else. The group rendered as a single toggle
+    # while the classic page carried the approval mode, every limit, the capability
+    # list and the planner model -- which meant the one interface an administrator is
+    # steered towards was the one that could not configure the feature.
+    "chat-orchestration-section": [
+        {
+            "key": "enable_chat_orchestration",
+            "type": "switch",
+            "label": "Enable Chat Orchestration",
+            "help": (
+                "Lets a user describe what they want and have SimpleChat work out the "
+                "rest. Instead of choosing documents, web search, a prompt, an agent and "
+                "a model before asking, the user asks; SimpleChat plans the work, shows "
+                "the plan, and runs it once approved. Orchestration reaches only "
+                "capabilities this deployment already allows, so turning it on grants no "
+                "new access. Available in the V2 interface."
+            ),
+            "default": False,
+            "role": "capability",
+        },
+    ],
+    "chat-orchestration-approval-section": [
+        {
+            "key": "chat_orchestration_default_approval_mode",
+            "type": "select",
+            "label": "Default Approval Mode",
+            "help": (
+                "How much say a user has before a plan runs. Reviewing every plan is the "
+                "safest default and the slowest; running automatically is the fastest and "
+                "gives the user no chance to intervene before work starts. The countdown "
+                "sits between the two: the plan appears with a timer, and doing nothing "
+                "runs it."
+            ),
+            "default": "manual",
+            "options": [
+                {"value": "manual", "label": "Review before running"},
+                {"value": "timed", "label": "Run automatically after a countdown"},
+                {"value": "auto", "label": "Run automatically"},
+            ],
+            "depends_on": {"key": "enable_chat_orchestration", "equals": True},
+            "group": {"id": "behavior", "label": "Approval", "variant": "behavior"},
+        },
+        {
+            "key": "chat_orchestration_timed_approval_seconds",
+            "type": "number",
+            "label": "Countdown Before Running",
+            "help": (
+                "Seconds the user has to intervene when the mode is a countdown. "
+                "Supported range is 3 to 120."
+            ),
+            "default": 10,
+            "min": 3,
+            "max": 120,
+            # Both conditions, not just the mode. Visibility is evaluated per field rather
+            # than recursively, so gating this only on the mode would leave it on screen
+            # whenever the mode field itself was hidden by orchestration being off.
+            "depends_on": [
+                {"key": "enable_chat_orchestration", "equals": True},
+                {"key": "chat_orchestration_default_approval_mode", "equals": "timed"},
+            ],
+            "group": {"id": "behavior", "label": "Approval", "variant": "behavior"},
+        },
+        {
+            "key": "chat_orchestration_allow_user_approval_override",
+            "type": "switch",
+            "label": "Let Users Change Their Own Approval Mode",
+            "help": (
+                "When off, every user stays on the default above and the control is "
+                "hidden from the composer."
+            ),
+            "default": True,
+            "depends_on": {"key": "enable_chat_orchestration", "equals": True},
+            "group": {"id": "behavior", "label": "Approval", "variant": "behavior"},
+        },
+        {
+            "key": "chat_orchestration_show_manual_controls",
+            "type": "switch",
+            "label": "Keep The Manual Composer Controls Available",
+            "help": (
+                "Keeps the document, web, model and agent pickers reachable behind a "
+                "disclosure while orchestration is on. Anything chosen there constrains "
+                "the plan rather than being ignored, so a power user can pin the work to "
+                "a particular document and let orchestration decide the rest."
+            ),
+            "default": True,
+            "depends_on": {"key": "enable_chat_orchestration", "equals": True},
+            "group": {"id": "behavior", "label": "Approval", "variant": "behavior"},
+        },
+    ],
+    "chat-orchestration-capabilities-section": [
+        {
+            "key": "chat_orchestration_enabled_capabilities",
+            "type": "checkbox_set",
+            "label": "Capabilities",
+            "help": (
+                "Which kinds of work a plan may contain. Leaving every box ticked is the "
+                "normal state and means whatever the rest of this deployment already "
+                "permits; clearing one keeps it out of plans even where it remains "
+                "available to users working by hand. Answering is always available "
+                "because a plan has to end somewhere."
+            ),
+            "default": [],
+            "options": [
+                {"value": "document_search", "label": "Search documents"},
+                {"value": "document_analyze", "label": "Analyse documents"},
+                {"value": "document_compare", "label": "Compare documents"},
+                {"value": "tabular_analyze", "label": "Analyse spreadsheets"},
+                {"value": "web_search", "label": "Search the web"},
+                {"value": "url_fetch", "label": "Read linked pages"},
+                {"value": "deep_research", "label": "Research in depth"},
+                {"value": "agent_invoke", "label": "Ask an agent"},
+            ],
+            "depends_on": {"key": "enable_chat_orchestration", "equals": True},
+        },
+    ],
+    "chat-orchestration-limits-section": [
+        {
+            "key": "chat_orchestration_max_steps",
+            "type": "number",
+            "label": "Maximum Steps In A Plan",
+            "help": (
+                "Caps how much work one plan may describe. Enforced regardless of what a "
+                "plan asks for, so a vaguely worded request cannot become an open-ended "
+                "amount of work. Supported range is 1 to 30."
+            ),
+            "default": 8,
+            "min": 1,
+            "max": 30,
+            "depends_on": {"key": "enable_chat_orchestration", "equals": True},
+            "group": {"id": "limits", "label": "Limits", "variant": "limits"},
+        },
+        {
+            "key": "chat_orchestration_max_replans",
+            "type": "number",
+            "label": "Maximum Re-plans Per Run",
+            "help": (
+                "How often a step may send the plan back to be reconsidered after "
+                "discovering something. Zero means a plan is followed as written."
+            ),
+            "default": 2,
+            "min": 0,
+            "max": 5,
+            "depends_on": {"key": "enable_chat_orchestration", "equals": True},
+            "group": {"id": "limits", "label": "Limits", "variant": "limits"},
+        },
+        {
+            "key": "chat_orchestration_step_timeout_seconds",
+            "type": "number",
+            "label": "Step Timeout",
+            "help": "Seconds a single step may run before it is abandoned.",
+            "default": 180,
+            "min": 30,
+            "max": 1800,
+            "depends_on": {"key": "enable_chat_orchestration", "equals": True},
+            "group": {"id": "limits", "label": "Limits", "variant": "limits"},
+        },
+        {
+            "key": "chat_orchestration_total_timeout_seconds",
+            "type": "number",
+            "label": "Run Timeout",
+            "help": "Seconds a whole run may take before it is abandoned.",
+            "default": 900,
+            "min": 60,
+            "max": 7200,
+            "depends_on": {"key": "enable_chat_orchestration", "equals": True},
+            "group": {"id": "limits", "label": "Limits", "variant": "limits"},
+        },
+        {
+            "key": "chat_orchestration_ledger_max_runs",
+            "type": "number",
+            "label": "Earlier Runs Shown To The Planner",
+            "help": (
+                "How many of the conversation's previous runs the planner can see. This "
+                "is what lets a follow-up question reuse what an earlier turn already "
+                "found instead of searching for it again, and what stops the assistant "
+                "asking a question the user has already answered. Zero makes every turn "
+                "plan from scratch."
+            ),
+            "default": 10,
+            "min": 0,
+            "max": 50,
+            "depends_on": {"key": "enable_chat_orchestration", "equals": True},
+            "group": {"id": "limits", "label": "Limits", "variant": "limits"},
+        },
+        {
+            "key": "chat_orchestration_ledger_max_bytes",
+            "type": "number",
+            "label": "Earlier-run Summary Size",
+            "help": (
+                "Caps the size of that summary in bytes. Older runs lose their detail "
+                "first when the budget is reached."
+            ),
+            "default": 16384,
+            "min": 1024,
+            "max": 131072,
+            "depends_on": {"key": "enable_chat_orchestration", "equals": True},
+            "group": {"id": "limits", "label": "Limits", "variant": "limits"},
+        },
+    ],
+    "chat-orchestration-planner-model-section": [
+        {
+            "key": "chat_orchestration_planner_deployment",
+            "type": "text",
+            "label": "Planner Deployment Name",
+            "help": (
+                "Which model writes the plan. Planning is a short, structured task rather "
+                "than a conversational one, so a smaller and faster deployment usually "
+                "does it well and costs less per message than the model that writes the "
+                "answer. Leave blank to plan with this deployment's default chat model."
+            ),
+            "default": "",
+            "depends_on": {"key": "enable_chat_orchestration", "equals": True},
+            "group": {"id": "connection", "label": "Planner model", "variant": "connection"},
+        },
+        {
+            "key": "chat_orchestration_planner_model_id",
+            "type": "text",
+            "label": "Planner Model Id",
+            "help": "Identifies the model when planning through a configured model endpoint.",
+            "default": "",
+            "depends_on": {"key": "enable_chat_orchestration", "equals": True},
+            "group": {"id": "connection", "label": "Planner model", "variant": "connection"},
+        },
+        {
+            "key": "chat_orchestration_planner_model_endpoint_id",
+            "type": "text",
+            "label": "Planner Model Endpoint Id",
+            "help": (
+                "Identifies the endpoint when planning through a configured model "
+                "endpoint rather than the default deployment."
+            ),
+            "default": "",
+            "depends_on": {"key": "enable_chat_orchestration", "equals": True},
+            "group": {"id": "connection", "label": "Planner model", "variant": "connection"},
+        },
+        {
+            "key": "chat_orchestration_planner_model_provider",
+            "type": "text",
+            "label": "Planner Model Provider",
+            "help": "Identifies the provider when planning through a configured model endpoint.",
+            "default": "",
+            "depends_on": {"key": "enable_chat_orchestration", "equals": True},
+            "group": {"id": "connection", "label": "Planner model", "variant": "connection"},
+        },
+    ],
     # The Workflow group has exactly one section, and none of its settings are
     # named `enable_*`, so the fallback scan found nothing at all and the group
     # rendered empty in V2. Declaring the section is what makes it reachable.

--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -97,7 +97,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.261.086"
+VERSION = "0.261.087"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/functions_orchestration_adapters.py
+++ b/application/single_app/functions_orchestration_adapters.py
@@ -25,18 +25,26 @@ could still answer from the others.
 executor merges and the schema owns; an adapter that returned a bare dict would drift from it
 silently.
 
-**Web search is not evidence.** It fits no evidence-envelope engine -- it is neither a
-tabular tool nor a document analysis over an authorized source -- so its results ride
-``notes`` and ``citations`` instead. Forcing it into an envelope would put unauthorized
-web text through the authorized-source coverage ledger, which is exactly the confusion the
-envelope contract exists to prevent.
+**External content is not evidence.** Web search, reading a pasted URL, deep research over
+discovered sources, and an invoked agent's reply all fit no evidence-envelope engine -- none
+is a tabular tool or a document analysis over an authorized source -- so their results ride
+``notes`` and ``citations`` instead. Forcing any of it into an envelope would put unauthorized
+external text through the authorized-source coverage ledger, which is exactly the confusion
+the envelope contract exists to prevent.
 
-The heavy wrapped functions are imported lazily inside each adapter body. Two of them would
+**A run adapter cannot touch Flask.** ``execute_plan`` runs in a worker thread with no request
+context, so an adapter must never read ``g``, ``session`` or ``current_app``. Anything about
+the caller a step needs -- their roles, their email, the agents they may invoke -- is read off
+the ``context`` (a ``RunContext`` the route populated on the request thread), never from Flask.
+The URL and agent adapters below exist precisely because the classic chat path for the same
+work leans on ``g``; they re-express it against the context instead.
+
+The heavy wrapped functions are imported lazily inside each adapter body. Several would
 otherwise make this module unimportable without Azure and config -- and ``perform_web_search``
 lives in ``route_backend_chats``, importing which at module load would be a circular import --
 so the same lazy pattern is used uniformly rather than only where it is strictly forced.
 
-Version: 0.261.085
+Version: 0.261.087
 """
 
 import logging
@@ -60,11 +68,14 @@ from functions_mixed_source_orchestration import (
     partition_source_manifest,
 )
 from functions_orchestration_registry import (
+    CAPABILITY_AGENT_INVOKE,
+    CAPABILITY_DEEP_RESEARCH,
     CAPABILITY_DOCUMENT_ANALYZE,
     CAPABILITY_DOCUMENT_COMPARE,
     CAPABILITY_DOCUMENT_SEARCH,
     CAPABILITY_RESPOND,
     CAPABILITY_TABULAR_ANALYZE,
+    CAPABILITY_URL_FETCH,
     CAPABILITY_WEB_SEARCH,
     DOCUMENT_ACTION_TYPE_COMPARISON,
 )
@@ -754,6 +765,582 @@ def run_web_search(step, context, *, settings, user_id, emit, cancel_requested):
 
 
 # --------------------------------------------------------------------------------------
+# url_fetch and deep_research -> functions_source_review.perform_source_review
+#
+# One function backs both capabilities. In url_access_only mode it reads only the links the
+# user pasted; with that flag off it plans and crawls several pages toward a research question.
+# Both return the same shape, so a single finalizer turns either into notes and citations.
+# perform_source_review is imported lazily: it drags in aiohttp and the whole crawl stack, and
+# routing that through module import would make this file unimportable without them.
+# --------------------------------------------------------------------------------------
+
+def _notes_from_source_review(result):
+    """Notes for the answer: the untrusted-evidence block, then a short reviewed-pages index.
+
+    ``system_message['content']`` is the same ``[SOURCE_REVIEW_EVIDENCE]`` block the classic
+    chat path folds into the model prompt -- the page excerpts, clearly labelled as untrusted
+    input. We add one ``Reviewed: title (url)`` line per page so a glance at the notes shows
+    what was actually read. This stays notes, never evidence: a web page is not an authorized
+    document source and must not enter the evidence coverage ledger.
+    """
+    notes = []
+    system_message = result.get('system_message')
+    if isinstance(system_message, dict):
+        content = _text(system_message.get('content'))
+        if content:
+            notes.append(content)
+    reviewed = []
+    for page in result.get('pages') or ():
+        if not isinstance(page, dict):
+            continue
+        url = _text(page.get('url'))
+        if not url:
+            continue
+        title = _text(page.get('title')) or url
+        reviewed.append(f'Reviewed: {title} ({url})')
+    if reviewed:
+        notes.append('\n'.join(reviewed))
+    return notes
+
+
+def _citations_from_source_review(result):
+    # perform_source_review already shapes each citation as {url, title, source, published_date};
+    # we pass them through untouched but drop any that carry no URL, since a citation the reader
+    # cannot open is noise rather than a source.
+    citations = []
+    for citation in result.get('citations') or ():
+        if isinstance(citation, dict) and _text(citation.get('url')):
+            citations.append(citation)
+    return citations
+
+
+def _finalize_source_review(
+    result,
+    *,
+    capability_id,
+    unavailable_summary,
+    empty_summary,
+    found_summary,
+    empty_replan_hint=None,
+):
+    """Turn a source-review result into a StepResult of notes and citations, never evidence.
+
+    ``enabled`` being false means the deployment setting or the caller's app role withdrew the
+    capability between planning and running; access is re-checked at run time, so that is a
+    clean failure the answer can still work around, not licence to invent web content. When it
+    is enabled, the step completes even with no pages: an empty crawl is a real, reportable
+    outcome (a link 404'd, a robots rule blocked it), and for deep research the replan hint
+    points at running a web search first rather than treating emptiness as an error.
+    """
+    result = result if isinstance(result, dict) else {}
+    if not bool(result.get('enabled')):
+        reason = _text(result.get('skipped_reason')) or 'unknown'
+        return _failed_result(
+            unavailable_summary,
+            f'{capability_id} reported it was not enabled (reason: {reason}).',
+        )
+
+    pages = [page for page in (result.get('pages') or ()) if isinstance(page, dict)]
+    notes = _notes_from_source_review(result)
+    citations = _citations_from_source_review(result)
+
+    if pages:
+        return build_step_result(
+            status=STEP_STATUS_COMPLETED,
+            summary=found_summary.format(count=len(pages)),
+            notes=notes,
+            citations=citations,
+        )
+
+    reason = _text(result.get('skipped_reason'))
+    return build_step_result(
+        status=STEP_STATUS_COMPLETED,
+        summary=empty_summary + (f' ({reason})' if reason else ''),
+        notes=notes,
+        citations=citations,
+        replan_hint=empty_replan_hint,
+    )
+
+
+def _resolve_source_review_planner(settings):
+    """The client and model deep research uses for its own link-selection planning.
+
+    perform_source_review takes a planner client/model so it can decide which discovered links
+    are worth reading. The context's ``invoke_prompt`` closure has already resolved a client,
+    but it is a ``call(prompt) -> text`` seam by design and does not expose the client object,
+    so we resolve one the same way the planner does. ``resolve_planner_client`` handles APIM,
+    managed identity and key auth and returns the planner deployment -- the right model for an
+    internal planning call rather than for writing the final answer.
+    """
+    from functions_orchestration_planner import resolve_planner_client
+
+    return resolve_planner_client(settings)
+
+
+def run_url_fetch(step, context, *, settings, user_id, emit, cancel_requested):
+    arguments = _arguments(step)
+    user_message = _text(_ctx(context, 'user_message', ''))
+    if _is_cancelled(cancel_requested):
+        return _cancelled_result('Cancelled before reading the linked pages.')
+
+    _emit(emit, _progress(step, CAPABILITY_URL_FETCH, 'Reading the linked pages'))
+
+    try:
+        from functions_source_review import (
+            URL_ACCESS_CONTEXT_CHAT,
+            extract_urls_from_text,
+            perform_source_review,
+        )
+    except Exception as exc:
+        log_event(
+            f'{_LOG_PREFIX} url_fetch is unavailable: {exc}',
+            extra={'user_id': user_id, 'step_id': (step or {}).get('step_id')},
+            level=logging.ERROR,
+            exceptionTraceback=True,
+        )
+        return _failed_result('Reading linked pages is unavailable.', str(exc))
+
+    # A step may narrow the read to specific links, but only links the user actually pasted may
+    # be read -- never a URL the model produced. We intersect the requested set with the URLs
+    # found in the message (normalizing both sides through extract_urls_from_text so the compare
+    # is apples to apples) and seed only those, with direct extraction turned off so a
+    # requested-but-absent URL cannot slip through the other seeding path.
+    include_direct_user_urls = True
+    additional_seed_urls = None
+    requested = _string_list(arguments.get('urls'))
+    if requested:
+        message_urls = set(extract_urls_from_text(user_message))
+        normalized_requested = []
+        for candidate in requested:
+            normalized_requested.extend(extract_urls_from_text(candidate))
+        additional_seed_urls = [url for url in normalized_requested if url in message_urls]
+        include_direct_user_urls = False
+        if not additional_seed_urls:
+            return build_step_result(
+                status=STEP_STATUS_COMPLETED,
+                summary='None of the requested links were present in the message.',
+                replan_hint='The urls argument named links that are not in the user message; omit it to read every link the user pasted.',
+            )
+
+    try:
+        result = perform_source_review(
+            settings=settings,
+            user_id=user_id,
+            user_email=_ctx(context, 'user_email', None),
+            user_roles=_ctx(context, 'user_roles', None),
+            user_message=user_message,
+            web_search_citations=[],
+            conversation_id=_ctx(context, 'conversation_id', None),
+            url_access_only=True,
+            url_access_context=URL_ACCESS_CONTEXT_CHAT,
+            include_direct_user_urls=include_direct_user_urls,
+            additional_seed_urls=additional_seed_urls,
+        )
+    except Exception as exc:
+        log_event(
+            f'{_LOG_PREFIX} url_fetch failed: {exc}',
+            extra={'user_id': user_id, 'step_id': (step or {}).get('step_id')},
+            level=logging.ERROR,
+            exceptionTraceback=True,
+        )
+        return _failed_result('The linked pages could not be read.', str(exc))
+
+    return _finalize_source_review(
+        result,
+        capability_id=CAPABILITY_URL_FETCH,
+        unavailable_summary='Reading linked pages is not available for this user.',
+        empty_summary='No linked pages could be read.',
+        found_summary='Read {count} linked page(s).',
+    )
+
+
+def run_deep_research(step, context, *, settings, user_id, emit, cancel_requested):
+    arguments = _arguments(step)
+    user_message = _text(_ctx(context, 'user_message', ''))
+    query = _text(arguments.get('query')) or user_message
+    if _is_cancelled(cancel_requested):
+        return _cancelled_result('Cancelled before deep research.')
+    if not query:
+        return _failed_result('No research question was available.', 'deep_research requires a query.')
+
+    _emit(emit, _progress(step, CAPABILITY_DEEP_RESEARCH, 'Researching sources'))
+
+    try:
+        from functions_source_review import (
+            URL_ACCESS_CONTEXT_CHAT,
+            extract_urls_from_text,
+            perform_source_review,
+        )
+    except Exception as exc:
+        log_event(
+            f'{_LOG_PREFIX} deep_research is unavailable: {exc}',
+            extra={'user_id': user_id, 'step_id': (step or {}).get('step_id')},
+            level=logging.ERROR,
+            exceptionTraceback=True,
+        )
+        return _failed_result('Deep research is unavailable.', str(exc))
+
+    # Deep research crawls seeds; it does not itself search the web. Its seeds are the citations
+    # any earlier web_search or url_fetch step left on the context, plus URLs the user pasted.
+    # We pass the research question as user_message so planning and relevance target the question
+    # rather than the whole turn, and pass the message's own URLs explicitly so narrowing the
+    # question does not drop a link the user gave us. Citations without a URL (document sources)
+    # are ignored by the seed collector, so handing the whole citation list over is safe.
+    prior_citations = [c for c in (_ctx(context, 'citations', []) or ()) if isinstance(c, dict)]
+    message_seed_urls = extract_urls_from_text(user_message) or None
+
+    try:
+        planner_client, planner_model = _resolve_source_review_planner(settings)
+    except Exception as exc:
+        log_event(
+            f'{_LOG_PREFIX} deep_research could not resolve a planner client: {exc}',
+            extra={'user_id': user_id, 'step_id': (step or {}).get('step_id')},
+            level=logging.ERROR,
+            exceptionTraceback=True,
+        )
+        return _failed_result('Deep research could not start.', str(exc))
+
+    if _is_cancelled(cancel_requested):
+        return _cancelled_result('Cancelled before deep research.')
+
+    try:
+        result = perform_source_review(
+            settings=settings,
+            user_id=user_id,
+            user_email=_ctx(context, 'user_email', None),
+            user_roles=_ctx(context, 'user_roles', None),
+            user_message=query,
+            web_search_citations=prior_citations,
+            conversation_id=_ctx(context, 'conversation_id', None),
+            source_review_planner_client=planner_client,
+            source_review_planner_model=planner_model,
+            url_access_only=False,
+            url_access_context=URL_ACCESS_CONTEXT_CHAT,
+            include_direct_user_urls=True,
+            additional_seed_urls=message_seed_urls,
+        )
+    except Exception as exc:
+        log_event(
+            f'{_LOG_PREFIX} deep_research failed: {exc}',
+            extra={'user_id': user_id, 'step_id': (step or {}).get('step_id')},
+            level=logging.ERROR,
+            exceptionTraceback=True,
+        )
+        return _failed_result('Deep research failed.', str(exc))
+
+    return _finalize_source_review(
+        result,
+        capability_id=CAPABILITY_DEEP_RESEARCH,
+        unavailable_summary='Deep research is not available for this user.',
+        empty_summary='Deep research found no readable sources.',
+        found_summary='Reviewed {count} source(s) for the research question.',
+        empty_replan_hint='Run a web_search step first so deep_research has sources to read.',
+    )
+
+
+# --------------------------------------------------------------------------------------
+# agent_invoke -> a single Semantic Kernel agent, reconstructed for the worker thread
+#
+# There is no reusable perform_agent_invoke; the classic path lives inline in the chat route
+# and leans on Flask g (g.kernel, g.kernel_agents, g.force_enable_agents). None of that exists
+# here, so this adapter composes the same steps against the context instead: resolve the agent
+# from the catalog the route captured, re-check the gates, build a one-agent kernel with the
+# loader's DRY seam, invoke it synchronously, and read usage and tool calls back out the same
+# way the route does. Everything Semantic Kernel is imported lazily -- it is a large, optional
+# dependency, and this module must import without it.
+# --------------------------------------------------------------------------------------
+
+class _AgentEventLoopError(Exception):
+    """Raised when the worker thread unexpectedly already has a running event loop."""
+
+
+def _agent_message_history(task):
+    # The agent is self-contained: it runs its own tools, so we hand it only the task and let
+    # it work, exactly as the route hands the agent a user turn. We deliberately do not fold the
+    # run's accumulated notes into its context -- that would both bloat the agent and pipe
+    # untrusted gathered web text into a tool-using agent's own prompt.
+    from semantic_kernel.contents.chat_message_content import ChatMessageContent
+
+    return [ChatMessageContent(role='user', content=task)]
+
+
+async def _await_agent_invoke(invoke, messages):
+    # Mirrors the core of the route's run_sk_call: an agent's invoke may return a value, a
+    # coroutine, or an async generator, and we take the first item of a generator just as the
+    # route does. The chat path stringifies the result afterward, so we return it raw.
+    import asyncio
+    from types import AsyncGeneratorType
+
+    result = invoke(messages)
+    if asyncio.iscoroutine(result):
+        result = await result
+    if isinstance(result, AsyncGeneratorType):
+        async for item in result:
+            return item
+        return None
+    return result
+
+
+def _invoke_agent_sync(selected_agent, task):
+    import asyncio
+
+    # asyncio.run needs no already-running loop. The executor's worker thread is synchronous, so
+    # normally there is none -- but we verify, because asyncio.run inside a running loop raises a
+    # confusing RuntimeError, and we would rather fail with a clear, attributable reason.
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        pass  # No running loop, which is exactly what we need.
+    else:
+        raise _AgentEventLoopError('an event loop is already running in the worker thread')
+
+    messages = _agent_message_history(task)
+    raw = asyncio.run(_await_agent_invoke(selected_agent.invoke, messages))
+    return _text(raw) if raw is not None else ''
+
+
+def _record_agent_token_usage(context, kernel):
+    """Fold the kernel services' token counts into the run's usage accumulator.
+
+    The agent result carries no usage; the counts live on the chat-completion services the
+    kernel holds, populated as a side effect of the call. Chat reads them the same way, taking
+    the first service that reports any. We add them onto ``context.token_usage`` -- the run's
+    accumulator the executor already surfaces -- using the field names every other model call in
+    this framework uses, so an agent step is no longer billed as free. Token accounting must
+    never break an answer, so any failure here is swallowed after logging.
+    """
+    try:
+        usage = _ctx(context, 'token_usage', None)
+        if not isinstance(usage, dict):
+            return
+        for service in (getattr(kernel, 'services', {}) or {}).values():
+            prompt_tokens = getattr(service, 'prompt_tokens', None)
+            completion_tokens = getattr(service, 'completion_tokens', None)
+            total_tokens = getattr(service, 'total_tokens', None)
+            if prompt_tokens or completion_tokens or total_tokens:
+                for field, value in (
+                    ('prompt_tokens', prompt_tokens),
+                    ('completion_tokens', completion_tokens),
+                    ('total_tokens', total_tokens),
+                ):
+                    if isinstance(value, int):
+                        usage[field] = usage.get(field, 0) + value
+                return  # First service with usage wins, matching the chat path.
+    except Exception as exc:
+        log_event(
+            f'{_LOG_PREFIX} Could not read agent token usage: {exc}',
+            level=logging.WARNING,
+        )
+
+
+def _agent_citations(plugin_logger, user_id, conversation_id, seen_before):
+    """The tool calls this invocation made, shaped exactly like the chat route's agent citations.
+
+    The plugin logger accumulates every tool call for a conversation, so we snapshot which
+    invocations existed before this step and keep only the new ones -- otherwise a second agent
+    step would re-cite the first step's tools. The citation shape matches the chat route field
+    for field so the same UI renders it. make_json_serializable and the label builder are
+    imported lazily and degraded past on failure, because losing a citation must never lose the
+    answer.
+    """
+    if plugin_logger is None:
+        return []
+    try:
+        invocations = plugin_logger.get_invocations_for_conversation(user_id, conversation_id)
+    except Exception as exc:
+        log_event(
+            f'{_LOG_PREFIX} Could not read agent tool invocations: {exc}',
+            level=logging.WARNING,
+        )
+        return []
+
+    try:
+        from functions_message_artifacts import (
+            build_agent_citation_tool_label,
+            make_json_serializable,
+        )
+    except Exception:
+        build_agent_citation_tool_label = None
+        make_json_serializable = None
+
+    def _serialize(value):
+        if make_json_serializable:
+            try:
+                return make_json_serializable(value)
+            except Exception:
+                pass
+        return _text(value) if value is not None else None
+
+    citations = []
+    for inv in invocations or ():
+        if id(inv) in seen_before:
+            continue  # A tool call from before this step, not ours to cite.
+        timestamp = getattr(inv, 'timestamp', None)
+        if hasattr(timestamp, 'isoformat'):
+            timestamp_str = timestamp.isoformat()
+        else:
+            timestamp_str = _text(timestamp) or None
+        plugin_name = getattr(inv, 'plugin_name', None)
+        function_name = getattr(inv, 'function_name', None)
+        parameters = getattr(inv, 'parameters', None)
+        inv_result = getattr(inv, 'result', None)
+        if build_agent_citation_tool_label:
+            try:
+                tool_name = build_agent_citation_tool_label(plugin_name, function_name, parameters, inv_result)
+            except Exception:
+                tool_name = '.'.join(part for part in (_text(plugin_name), _text(function_name)) if part)
+        else:
+            tool_name = '.'.join(part for part in (_text(plugin_name), _text(function_name)) if part)
+        citations.append({
+            'tool_name': tool_name,
+            'function_name': function_name,
+            'plugin_name': plugin_name,
+            'function_arguments': _serialize(parameters),
+            'function_result': _serialize(inv_result),
+            'duration_ms': getattr(inv, 'duration_ms', None),
+            'timestamp': timestamp_str,
+            'success': getattr(inv, 'success', None),
+            'error_message': _serialize(getattr(inv, 'error_message', None)),
+            'user_id': getattr(inv, 'user_id', None),
+        })
+    return citations
+
+
+def run_agent_invoke(step, context, *, settings, user_id, emit, cancel_requested):
+    arguments = _arguments(step)
+    agent_name = _text(arguments.get('agent_name'))
+    task = _text(arguments.get('task')) or _text(_ctx(context, 'user_message', ''))
+    if not agent_name:
+        return _failed_result('No agent was named.', 'agent_invoke requires an agent_name.')
+    if _is_cancelled(cancel_requested):
+        return _cancelled_result('Cancelled before invoking the agent.')
+
+    # An agent may only be invoked if the catalog offered it. The catalog is resolved per request
+    # and carried on the context; refusing anything absent from it is what stops a plan -- or a
+    # repaired plan -- from naming an agent this user cannot reach. Access is verified here, at
+    # run time, not trusted from the plan-time request gate.
+    catalog = [a for a in (_ctx(context, 'agent_catalog', None) or ()) if isinstance(a, dict)]
+    selected_agent_data = next((a for a in catalog if _text(a.get('name')) == agent_name), None)
+    if selected_agent_data is None:
+        return _failed_result(
+            f'No agent named "{agent_name}" is available to this user.',
+            'agent_invoke was asked for an agent absent from the catalog.',
+        )
+
+    if not settings.get('enable_semantic_kernel', False):
+        return _failed_result('Agents are not enabled.', 'agent_invoke requires enable_semantic_kernel.')
+    if not _ctx(context, 'user_enable_agents', True):
+        return _failed_result('Agents are turned off for this user.', 'agent_invoke requires user_enable_agents.')
+
+    _emit(emit, _progress(step, CAPABILITY_AGENT_INVOKE, f'Asking agent {agent_name}'))
+
+    try:
+        from functions_agent_scope import find_agent_by_scope, is_selected_agent_scope_enabled
+
+        if not is_selected_agent_scope_enabled(settings, selected_agent_data):
+            return _failed_result(
+                f'The scope of agent "{agent_name}" is not enabled.',
+                'agent_invoke selected agent scope is disabled by settings.',
+            )
+        agent_cfg = find_agent_by_scope(catalog, selected_agent_data) or selected_agent_data
+    except Exception as exc:
+        log_event(
+            f'{_LOG_PREFIX} agent_invoke could not resolve agent scope: {exc}',
+            extra={'user_id': user_id, 'step_id': (step or {}).get('step_id')},
+            level=logging.ERROR,
+            exceptionTraceback=True,
+        )
+        return _failed_result('The agent could not be resolved.', str(exc))
+
+    if _is_cancelled(cancel_requested):
+        return _cancelled_result('Cancelled before invoking the agent.')
+
+    # Build a kernel holding exactly this one agent. We deliberately avoid
+    # initialize_semantic_kernel: in per-user mode it writes the kernel onto Flask g (absent in
+    # this thread) and returns nothing, and it loads the entire agent catalog when we need only
+    # one. load_single_agent_for_kernel is the DRY seam it calls internally; in 'global' mode it
+    # never touches its context_obj argument, so a fresh Kernel and a None context are safe, and
+    # it hands back {name: agent}. Its own plugin loading reads the current user id defensively
+    # and tolerates there being none, which is the case off the request thread.
+    try:
+        from semantic_kernel import Kernel
+        from semantic_kernel_loader import load_single_agent_for_kernel
+
+        kernel, agent_objs = load_single_agent_for_kernel(
+            Kernel(),
+            agent_cfg,
+            settings,
+            None,
+            redis_client=None,
+            mode_label='global',
+        )
+        selected_agent = (agent_objs or {}).get(_text(agent_cfg.get('name'))) if kernel else None
+    except Exception as exc:
+        log_event(
+            f'{_LOG_PREFIX} agent_invoke could not load the agent: {exc}',
+            extra={'user_id': user_id, 'step_id': (step or {}).get('step_id')},
+            level=logging.ERROR,
+            exceptionTraceback=True,
+        )
+        return _failed_result('The agent could not be loaded.', str(exc))
+
+    if not kernel or selected_agent is None:
+        return _failed_result(
+            f'Agent "{agent_name}" could not be initialized.',
+            'load_single_agent_for_kernel returned no usable agent (check its endpoint and credentials).',
+        )
+
+    conversation_id = _ctx(context, 'conversation_id', None)
+    try:
+        from semantic_kernel_plugins.plugin_invocation_logger import get_plugin_logger
+
+        plugin_logger = get_plugin_logger()
+        seen_before = {
+            id(inv)
+            for inv in (plugin_logger.get_invocations_for_conversation(user_id, conversation_id) or ())
+        }
+    except Exception:
+        # The plugin logger is best-effort context for citations; its absence must not stop the
+        # invocation. We simply produce no tool-call citations in that case.
+        plugin_logger = None
+        seen_before = set()
+
+    try:
+        reply = _invoke_agent_sync(selected_agent, task)
+    except _AgentEventLoopError as exc:
+        return _failed_result('The agent could not run in this context.', str(exc))
+    except Exception as exc:
+        log_event(
+            f'{_LOG_PREFIX} agent_invoke failed during invocation: {exc}',
+            extra={'user_id': user_id, 'step_id': (step or {}).get('step_id')},
+            level=logging.ERROR,
+            exceptionTraceback=True,
+        )
+        return _failed_result('The agent invocation failed.', str(exc))
+
+    _record_agent_token_usage(context, kernel)
+    citations = _agent_citations(plugin_logger, user_id, conversation_id, seen_before)
+
+    display_name = _text(agent_cfg.get('display_name')) or agent_name
+    if not reply:
+        # An agent that returned nothing is a completed-but-empty step, not a failure: the plan
+        # still answers, and the tool-call citations we did gather stay attached.
+        return build_step_result(
+            status=STEP_STATUS_COMPLETED,
+            summary=f'Agent {display_name} produced no reply.',
+            citations=citations,
+        )
+
+    note = f'Agent "{display_name}" was asked: {task}\n\nThe agent replied:\n{reply}'
+    return build_step_result(
+        status=STEP_STATUS_COMPLETED,
+        summary=_first_line(reply) or f'Agent {display_name} replied.',
+        notes=[note],
+        citations=citations,
+    )
+
+
+# --------------------------------------------------------------------------------------
 # respond -> synthesis over the accumulated evidence (terminal step)
 # --------------------------------------------------------------------------------------
 
@@ -861,6 +1448,9 @@ ADAPTER_REGISTRY = {
     CAPABILITY_DOCUMENT_COMPARE: run_document_compare,
     CAPABILITY_TABULAR_ANALYZE: run_tabular_analyze,
     CAPABILITY_WEB_SEARCH: run_web_search,
+    CAPABILITY_URL_FETCH: run_url_fetch,
+    CAPABILITY_DEEP_RESEARCH: run_deep_research,
+    CAPABILITY_AGENT_INVOKE: run_agent_invoke,
     CAPABILITY_RESPOND: run_respond,
 }
 

--- a/application/single_app/functions_orchestration_context.py
+++ b/application/single_app/functions_orchestration_context.py
@@ -27,13 +27,14 @@ a document, an agent, a model, a prompt -- narrows the plan rather than suggesti
 A user who picked a document and then watched the planner search their whole workspace
 would rightly conclude the control did nothing.
 
-Version: 0.261.085
+Version: 0.261.087
 """
 
 import json
 import logging
 
 from functions_appinsights import log_event
+from functions_orchestration_registry import build_agent_planner_projection
 
 # Relevance probe bounds. Deliberately small: this runs before planning on every
 # non-trivial message, so it is on the latency path of the whole feature.
@@ -254,6 +255,61 @@ def resolve_candidate_documents(
 
 
 # --------------------------------------------------------------------------------------
+# Agents
+# --------------------------------------------------------------------------------------
+
+def resolve_agent_catalog(user_id, seeds=None, settings=None, user_groups=None):
+    """The agents a plan may invoke, resolved once for the whole plan.
+
+    Returns full catalog records rather than the planner projection. Two very different
+    consumers read the same list, and they need different fields from it: the executor's
+    agent step needs the scope and identifiers to load a kernel, while the planner needs
+    only the handful of naming fields ``build_agent_planner_projection`` keeps. Feeding
+    both from one resolution is the point -- ``build_accessible_agent_catalog`` is a
+    multi-query Cosmos operation with no cache (personal, global and every group's agents,
+    plus the model and action label maps and the user's group memberships), so resolving
+    it once per plan and handing the result to ``build_planner_context`` *and* to
+    ``RunContext.agent_catalog`` is the difference between one such traversal and one per
+    step.
+
+    Seeding mirrors ``resolve_candidate_documents``. A user who picked an agent in the
+    composer has already made the choice this catalog exists to inform, so the selection
+    is returned as-is and the traversal never runs -- and because the planner is then shown
+    that agent alone, it is the only one a plan may name, exactly as a selected document is
+    the only candidate.
+
+    Fails soft. A Cosmos hiccup degrades to "no agent available" -- a plan that simply
+    cannot reach for an agent -- rather than failing the whole request, on the same
+    reasoning as the candidate probe above.
+    """
+    seeds = seeds or {}
+
+    seeded_agent = seeds.get('agent')
+    if isinstance(seeded_agent, dict) and _text(seeded_agent.get('name')):
+        return [seeded_agent]
+
+    try:
+        # Lazy for the same reason as the candidate probe: functions_agent_catalog reaches
+        # config.py and its import-time Cosmos client, and this module is imported by the
+        # validator and by tests that have no Azure to talk to. Keeping the import inside
+        # the resolver is what lets those import functions_orchestration_context at all.
+        from functions_agent_catalog import build_accessible_agent_catalog
+
+        return build_accessible_agent_catalog(
+            user_id,
+            settings=settings,
+            user_groups=user_groups,
+        )
+    except Exception as exc:
+        log_event(
+            f"[ORCHESTRATION_CONTEXT] Agent catalog resolution failed; planning without "
+            f"agents: {exc}",
+            level=logging.WARNING,
+        )
+        return []
+
+
+# --------------------------------------------------------------------------------------
 # Run ledger
 # --------------------------------------------------------------------------------------
 
@@ -421,17 +477,25 @@ def build_planner_context(
     ledger=None,
     signals=None,
     capabilities=None,
+    agents=None,
 ):
     """Assemble everything the planner is shown, in one place.
 
     Kept as a single builder so that what the planner sees is auditable and testable
     rather than being spread across the prompt construction. Nothing enters the planner's
     context that is not visible here.
+
+    ``agents`` are the full catalog records from ``resolve_agent_catalog``; they are
+    projected here rather than trusted as-is so the planner is only ever shown the naming
+    fields ``AGENT_PLANNER_FIELDS`` allows. Projecting at the single point the context is
+    built means an agent's instructions cannot leak into the prompt even if a caller passes
+    raw records, which is exactly what the executor is handed for ``RunContext.agent_catalog``.
     """
     seeds = seeds or {}
     return {
         'message': _text(user_message),
         'capabilities': capabilities or [],
+        'agents': build_agent_planner_projection(agents),
         'candidate_documents': [
             {key: value for key, value in candidate.items() if key != 'score'}
             for candidate in (candidates or ())

--- a/application/single_app/functions_orchestration_events.py
+++ b/application/single_app/functions_orchestration_events.py
@@ -278,6 +278,7 @@ def build_run_done_event(
     run_id=None,
     full_content='',
     citations=None,
+    web_citations=None,
     artifacts=None,
     plan_summary=None,
     status='completed',
@@ -287,6 +288,10 @@ def build_run_done_event(
     Shaped like the chat stream's own terminal payload so the V2 message renderer needs no
     special case: an orchestrated answer is still just an assistant message, and the parts
     that are new to orchestration are additive keys rather than a different envelope.
+
+    Document and web citations are carried in the two separate fields chat already uses,
+    because the client renders them differently and the used-document tracking only ever
+    reads the document one.
     """
     return serialize_sse({
         'done': True,
@@ -296,6 +301,8 @@ def build_run_done_event(
         'run_id': run_id,
         'full_content': full_content,
         'hybrid_citations': list(citations or ()),
+        'web_search_citations': list(web_citations or ()),
+        'augmented': bool(citations or web_citations),
         'generated_artifacts': list(artifacts or ()),
         'orchestration': plan_summary or {},
         'status': status,

--- a/application/single_app/functions_orchestration_executor.py
+++ b/application/single_app/functions_orchestration_executor.py
@@ -31,7 +31,7 @@ collects those and returns them, bounded by the replan budget, but it never call
 itself. The route owns that loop, because only the route can decide to spend another planner
 round trip.
 
-Version: 0.261.085
+Version: 0.261.087
 """
 
 import logging
@@ -146,6 +146,11 @@ class RunContext:
     names here are the actual contract with the adapters, not the constructor signature. The
     accumulators (``evidence``, ``citations``, ``artifacts``, ``notes``, ``token_usage``) are
     what each step contributes to and what the terminal step answers from.
+
+    It also carries the request-scoped identity and catalog an adapter needs but cannot look
+    up itself: this object is built on the request thread and then read from the executor's
+    worker thread, where Flask's ``g``, ``session`` and ``current_app`` do not exist. Anything
+    an adapter would otherwise have fished out of ``g`` is captured here instead.
     """
 
     def __init__(
@@ -170,6 +175,10 @@ class RunContext:
         request_correlation_id=None,
         durable_execution_callback=None,
         resolve_source_manifest=None,
+        user_roles=None,
+        user_email=None,
+        agent_catalog=None,
+        user_enable_agents=True,
     ):
         self.run_id = run_id
         self.plan_id = plan_id
@@ -197,6 +206,29 @@ class RunContext:
         # adapters fall back to the real resolver. Held here so re-authorization and the
         # tabular adapter use the same seam.
         self.resolve_source_manifest = resolve_source_manifest
+
+        # Request-scoped identity and catalog, captured on the request thread before the run's
+        # worker thread starts. execute_plan runs in a threading.Thread with no Flask request
+        # context, so adapters cannot read g/session/current_app; they read these instead.
+        #
+        # user_roles gates two app-role checks -- UrlAccessUser for reading URLs and
+        # DeepResearchUser for the deep research crawl. It fails CLOSED: an unknown value is
+        # normalized to "no roles", never to "all roles", so a break in this plumbing withholds
+        # a capability rather than granting it to everyone. An empty list is preserved (it means
+        # "authenticated, no roles"), but any non-list is treated as unknown for the same reason.
+        if isinstance(user_roles, (list, tuple, set)):
+            self.user_roles = list(user_roles)
+        else:
+            self.user_roles = None
+        self.user_email = user_email
+        # The agents this user may invoke, as full config records (not the planner projection).
+        # The agent adapter refuses any agent name absent from this list, so a plan can never
+        # invoke an agent the catalog did not offer this user, even after a repair.
+        self.agent_catalog = list(agent_catalog) if agent_catalog else None
+        # Semantic Kernel can be enabled deployment-wide while a user has agents switched off in
+        # their own settings; carried so the agent adapter re-checks it without touching user
+        # state it cannot reach from the worker thread.
+        self.user_enable_agents = bool(user_enable_agents)
 
         # Accumulators.
         self.evidence = []

--- a/application/single_app/functions_orchestration_planner.py
+++ b/application/single_app/functions_orchestration_planner.py
@@ -4,10 +4,10 @@
 Triage, plan synthesis and re-planning.
 
 The planner writes a plan. It does not execute one, and it is never given a tool. That
-separation is the whole point of this framework: a model choosing among six described
-capabilities and returning JSON is a far more reliable thing than a model handed forty
-plugins and an auto-invoke loop, and its output can be validated before anything happens.
-Everything this module returns therefore passes through
+separation is the whole point of this framework: a model choosing among a short list of
+described capabilities and returning JSON is a far more reliable thing than a model handed
+forty plugins and an auto-invoke loop, and its output can be validated before anything
+happens. Everything this module returns therefore passes through
 ``functions_orchestration_schema`` before it reaches an executor.
 
 Two things are worth explaining because they are not obvious from the code.
@@ -27,7 +27,7 @@ tries several strategies before giving up, and a total failure degrades to a sin
 answering step rather than to an error -- a user who asked a question should get an
 answer even when the planning layer had a bad day.
 
-Version: 0.261.085
+Version: 0.261.087
 """
 
 import json
@@ -220,6 +220,18 @@ and nothing else.
 You will be given the capabilities available to you. Use only those. Each capability lists
 what it is for and the arguments it takes. Never invent a capability or an argument.
 
+Each capability names a phase. The phases run in a fixed order: knowledge, then reasoning,
+then output. "knowledge" is every capability that gathers or produces the evidence an
+answer stands on. "reasoning" is the single "respond" step that writes the answer from
+what those steps gathered. Because the phases are ordered, a plan may never gather after
+it answers: every gathering step comes before "respond", which is always the last step.
+
+Some requests are best handed to an agent -- a preconfigured assistant with its own tools
+and knowledge. The agents you may use are listed under "agents", each with its name and
+what it is for. To use one, add the agent capability and set "agent_name" to a name that
+appears in that list, spelled exactly. Never name an agent that is not listed; if the list
+is empty you have no agent to call, so do not plan an agent step.
+
 Return ONE JSON object with this shape:
 
 {
@@ -243,6 +255,9 @@ Rules:
 - Prefer the cheapest capability that will actually answer the question. Searching
   documents is much cheaper than analysing them; only analyse when the question needs
   whole-document coverage.
+- On the open web, web_search is the cheap default. deep_research is the most expensive
+  capability available to you; reach for it deliberately, only when a shallow web_search
+  genuinely could not cover the question.
 - Only name a document id that appears in the candidate documents or that the user
   selected. Never invent one.
 - If the user already selected documents, plan around those documents.

--- a/application/single_app/functions_orchestration_registry.py
+++ b/application/single_app/functions_orchestration_registry.py
@@ -49,14 +49,26 @@ DOCUMENT_ACTION_TYPE_ANALYZE = 'analyze'
 DOCUMENT_ACTION_TYPE_COMPARISON = 'comparison'
 DOCUMENT_ACTION_CONTEXT_CHAT = 'chat'
 
-CAPABILITY_KIND_RETRIEVAL = 'retrieval'
-CAPABILITY_KIND_ANALYSIS = 'analysis'
-CAPABILITY_KIND_SYNTHESIS = 'synthesis'
+PHASE_KNOWLEDGE = 'knowledge'
+PHASE_REASONING = 'reasoning'
+PHASE_OUTPUT = 'output'
 
-CAPABILITY_KINDS = (
-    CAPABILITY_KIND_RETRIEVAL,
-    CAPABILITY_KIND_ANALYSIS,
-    CAPABILITY_KIND_SYNTHESIS,
+# Ordered, and the order is the point. A plan runs in phase order, so a capability's phase
+# is really its index: "may this step follow that one" becomes an integer comparison rather
+# than a table of special cases.
+#
+# This replaces the earlier `kind` (retrieval / analysis / synthesis), which was carried all
+# the way to the browser and read by nothing -- not the validator, not the executor, not one
+# React component. A second decorative taxonomy alongside this one is how a field ends up
+# meaning nothing, so `kind` is gone rather than kept.
+#
+# The boundary is drawn on what a capability *produces*, not on how hard it thinks. Analysing
+# and comparing documents emit the same evidence envelopes as searching them, and the answer
+# is the only step that consumes evidence -- so they are knowledge and it is reasoning.
+CAPABILITY_PHASES = (
+    PHASE_KNOWLEDGE,
+    PHASE_REASONING,
+    PHASE_OUTPUT,
 )
 
 COST_CLASS_LOW = 'low'
@@ -70,6 +82,16 @@ PRODUCES_EVIDENCE = 'evidence'
 PRODUCES_CITATIONS = 'citations'
 PRODUCES_ARTIFACTS = 'artifacts'
 PRODUCES_MESSAGE = 'message'
+# Gathered text rather than document evidence.
+#
+# An agent, a URL read and a deep research crawl all return prose and citations tied to no
+# document id. `build_evidence_envelope` refuses that shape outright -- it requires a
+# non-empty `document_id`, a `source_kind` of tabular or narrative, and one of three named
+# engines. Calling their output evidence would mean either lying to that validator or
+# loosening it, and neither is worth it: `RunContext` already accumulates `notes`, and the
+# respond adapter already folds notes into its prompt. So they produce notes, and notes
+# reach the answer by the path that exists.
+PRODUCES_NOTES = 'notes'
 
 # Capability identifiers. Referenced by plans, adapters and tests, so they are constants
 # rather than repeated string literals.
@@ -78,6 +100,9 @@ CAPABILITY_DOCUMENT_ANALYZE = 'document_analyze'
 CAPABILITY_DOCUMENT_COMPARE = 'document_compare'
 CAPABILITY_TABULAR_ANALYZE = 'tabular_analyze'
 CAPABILITY_WEB_SEARCH = 'web_search'
+CAPABILITY_URL_FETCH = 'url_fetch'
+CAPABILITY_DEEP_RESEARCH = 'deep_research'
+CAPABILITY_AGENT_INVOKE = 'agent_invoke'
 CAPABILITY_RESPOND = 'respond'
 
 # Workspace scopes a capability may need at least one of.
@@ -113,6 +138,81 @@ def _document_action_gate(action_type):
     return _gate
 
 
+# --------------------------------------------------------------------------------------
+# Request-level gates
+# --------------------------------------------------------------------------------------
+#
+# Separate from the settings gates above, and the separation matters. A settings gate asks
+# "has this deployment configured the capability at all", which is what the admin page and
+# the bootstrap payload need to know. A request gate asks "may *this* request use it", which
+# depends on the caller's app roles and on what they actually typed.
+#
+# Collapsing the two would break both surfaces: the admin Capabilities list would hide a
+# capability the deployment plainly has because the current request has no URL in it, and
+# the planner would be offered capabilities the caller has no role for. So request gates run
+# only when a request context is supplied, and the deployment view never sees them.
+#
+# Every one of these fails CLOSED. `user_roles` reaches the executor's worker thread by being
+# captured in the request and carried on the run context; if that plumbing ever breaks, the
+# roles arrive as None, and a gate that treated None as "no restriction" would quietly hand
+# every user a capability their app role was meant to withhold.
+
+
+def _url_access_request_gate(settings, context):
+    """Whether this caller may read URLs, and whether there are any to read."""
+    try:
+        from functions_source_review import is_url_access_enabled_for_user
+
+        if not is_url_access_enabled_for_user(settings, user_roles=context.get('user_roles')):
+            return False
+    except Exception as exc:
+        log_event(
+            f"[ORCHESTRATION_REGISTRY] Could not resolve the URL access gate, treating it "
+            f"as disabled: {exc}",
+            level=logging.WARNING,
+        )
+        return False
+
+    # Offering "read URLs" when the message contains none invites a step that can only
+    # report having nothing to do. The classic composer hides the button on the same
+    # condition; expressing it here means the rule lives with the capability rather than
+    # being restated in the browser.
+    return bool(context.get('message_urls'))
+
+
+def _deep_research_request_gate(settings, context):
+    """Whether this caller may run a deep research crawl."""
+    try:
+        from functions_source_review import is_source_review_enabled_for_user
+
+        return bool(is_source_review_enabled_for_user(
+            settings,
+            context.get('user_id'),
+            user_email=context.get('user_email'),
+            user_roles=context.get('user_roles'),
+        ))
+    except Exception as exc:
+        log_event(
+            f"[ORCHESTRATION_REGISTRY] Could not resolve the deep research gate, treating "
+            f"it as disabled: {exc}",
+            level=logging.WARNING,
+        )
+        return False
+
+
+def _agent_request_gate(settings, context):
+    """Whether this caller has an agent to invoke.
+
+    Agents are per-user in a way the other capabilities are not: the deployment can have
+    Semantic Kernel on while a given user has agents switched off in their own settings, or
+    simply has none they can reach. Offering the capability in either case produces plans
+    naming agents that cannot run.
+    """
+    if not context.get('user_enable_agents', True):
+        return False
+    return bool(context.get('agent_catalog'))
+
+
 # The registry itself. Ordered as a plan tends to read: gather, then reason, then answer.
 #
 # `when_to_use` is the only free text the planner is shown per capability, so it is written
@@ -123,7 +223,8 @@ CAPABILITY_REGISTRY = (
     {
         'id': CAPABILITY_DOCUMENT_SEARCH,
         'label': 'Search documents',
-        'kind': CAPABILITY_KIND_RETRIEVAL,
+        'phase': PHASE_KNOWLEDGE,
+        'request_gate': None,
         'summary': "Find relevant passages across the documents this user can read.",
         'when_to_use': (
             "The question asks about information likely held in the user's own documents, "
@@ -170,7 +271,8 @@ CAPABILITY_REGISTRY = (
     {
         'id': CAPABILITY_DOCUMENT_ANALYZE,
         'label': 'Analyse documents',
-        'kind': CAPABILITY_KIND_ANALYSIS,
+        'phase': PHASE_KNOWLEDGE,
+        'request_gate': None,
         'summary': "Read one or more documents end to end and answer a question about them.",
         'when_to_use': (
             "The question needs whole-document coverage rather than a few passages -- "
@@ -215,7 +317,8 @@ CAPABILITY_REGISTRY = (
     {
         'id': CAPABILITY_DOCUMENT_COMPARE,
         'label': 'Compare documents',
-        'kind': CAPABILITY_KIND_ANALYSIS,
+        'phase': PHASE_KNOWLEDGE,
+        'request_gate': None,
         'summary': "Compare one document against one or more others.",
         'when_to_use': (
             "The question is explicitly comparative -- what changed, how two versions "
@@ -263,7 +366,8 @@ CAPABILITY_REGISTRY = (
     {
         'id': CAPABILITY_TABULAR_ANALYZE,
         'label': 'Analyse spreadsheets',
-        'kind': CAPABILITY_KIND_ANALYSIS,
+        'phase': PHASE_KNOWLEDGE,
+        'request_gate': None,
         'summary': "Compute over CSV or Excel data rather than reading it as prose.",
         'when_to_use': (
             "The named documents are spreadsheets or CSV files and the question needs "
@@ -300,7 +404,8 @@ CAPABILITY_REGISTRY = (
     {
         'id': CAPABILITY_WEB_SEARCH,
         'label': 'Search the web',
-        'kind': CAPABILITY_KIND_RETRIEVAL,
+        'phase': PHASE_KNOWLEDGE,
+        'request_gate': None,
         'summary': "Look the question up on the public web.",
         'when_to_use': (
             "The question is about current events, or about something no internal document "
@@ -318,16 +423,130 @@ CAPABILITY_REGISTRY = (
             'required': ['query'],
             'additionalProperties': False,
         },
-        'produces': (PRODUCES_EVIDENCE, PRODUCES_CITATIONS),
+        'produces': (PRODUCES_NOTES, PRODUCES_CITATIONS),
         'cost_class': COST_CLASS_LOW,
         'max_per_plan': 2,
         'adapter': CAPABILITY_WEB_SEARCH,
         'terminal': False,
     },
     {
+        'id': CAPABILITY_URL_FETCH,
+        'label': 'Read linked pages',
+        'phase': PHASE_KNOWLEDGE,
+        'request_gate': _url_access_request_gate,
+        'summary': "Read the web pages the user linked to in their message.",
+        'when_to_use': (
+            "The user pasted one or more links and is asking about what they contain. This "
+            "reads those pages and nothing else -- it does not search, so use web search "
+            "when the question needs sources the user has not already named."
+        ),
+        'settings_gates': ('enable_url_access',),
+        'settings_gates_any': (),
+        'gate': None,
+        'requires_scope': (),
+        'inputs': {
+            'type': 'object',
+            'properties': {
+                'urls': {
+                    'type': 'array',
+                    'items': {'type': 'string'},
+                    'description': (
+                        'Restrict to these links. Omit to read every link in the message. '
+                        'Only links the user actually pasted can be read.'
+                    ),
+                },
+            },
+            'required': [],
+            'additionalProperties': False,
+        },
+        'produces': (PRODUCES_NOTES, PRODUCES_CITATIONS),
+        'cost_class': COST_CLASS_LOW,
+        'max_per_plan': 1,
+        'adapter': CAPABILITY_URL_FETCH,
+        'terminal': False,
+    },
+    {
+        'id': CAPABILITY_DEEP_RESEARCH,
+        'label': 'Research in depth',
+        'phase': PHASE_KNOWLEDGE,
+        'request_gate': _deep_research_request_gate,
+        'summary': "Follow a question across several web sources and cross-check them.",
+        'when_to_use': (
+            "The question needs more than one source to answer honestly -- comparing "
+            "accounts, establishing what is current, or building a picture no single page "
+            "holds. This is the most expensive capability here: it crawls and reads several "
+            "pages. For anything a single search result would settle, use web search."
+        ),
+        'settings_gates': ('enable_source_review',),
+        'settings_gates_any': (),
+        'gate': None,
+        'requires_scope': (),
+        'inputs': {
+            'type': 'object',
+            'properties': {
+                'query': {
+                    'type': 'string',
+                    'minLength': 1,
+                    'description': 'What to establish. Phrase it as the question to answer.',
+                },
+            },
+            'required': ['query'],
+            'additionalProperties': False,
+        },
+        'produces': (PRODUCES_NOTES, PRODUCES_CITATIONS),
+        'cost_class': COST_CLASS_HIGH,
+        'max_per_plan': 1,
+        'adapter': CAPABILITY_DEEP_RESEARCH,
+        'terminal': False,
+    },
+    {
+        'id': CAPABILITY_AGENT_INVOKE,
+        'label': 'Ask an agent',
+        'phase': PHASE_KNOWLEDGE,
+        'request_gate': _agent_request_gate,
+        'summary': "Hand the task to one of this user's configured agents.",
+        'when_to_use': (
+            "An agent in the list has tools or knowledge built for exactly this task -- "
+            "reaching a system none of the other capabilities can, or following a procedure "
+            "somebody configured deliberately. Name only an agent from the list. An agent "
+            "runs its own tools, so do not also plan the work it would do itself."
+        ),
+        'settings_gates': ('enable_semantic_kernel',),
+        'settings_gates_any': (),
+        'gate': None,
+        'requires_scope': (),
+        'inputs': {
+            'type': 'object',
+            'properties': {
+                'agent_name': {
+                    'type': 'string',
+                    'minLength': 1,
+                    'description': "The agent's name, exactly as it appears in the list.",
+                },
+                'task': {
+                    'type': 'string',
+                    'minLength': 1,
+                    'description': 'What to ask the agent to do, in a sentence or two.',
+                },
+            },
+            'required': ['agent_name', 'task'],
+            'additionalProperties': False,
+        },
+        'produces': (PRODUCES_NOTES, PRODUCES_CITATIONS, PRODUCES_ARTIFACTS),
+        'cost_class': COST_CLASS_HIGH,
+        # One per plan. Every agent step loads a kernel from scratch -- resolving Key Vault
+        # secrets, hydrating each plugin the agent declares, introspecting SQL and Cosmos
+        # schemas -- and there is no live kernel cache to amortise it. Two agent steps means
+        # paying all of that twice.
+        'max_per_plan': 1,
+        'adapter': CAPABILITY_AGENT_INVOKE,
+        'terminal': False,
+    },
+    {
         'id': CAPABILITY_RESPOND,
         'label': 'Answer',
-        'kind': CAPABILITY_KIND_SYNTHESIS,
+        'phase': PHASE_REASONING,
+        'request_gate': None,
         'summary': "Write the answer from whatever the earlier steps gathered.",
         'when_to_use': (
             "Always the last step. Every plan ends with exactly one of these, including a "
@@ -380,8 +599,25 @@ def get_capability(capability_id):
     return CAPABILITY_BY_ID.get(capability_id.strip())
 
 
+def phase_index(capability_or_id):
+    """Where a capability sits in the run, as a sortable integer.
+
+    Accepts a descriptor or an id so callers do not have to look one up first. An unknown
+    capability sorts to the end rather than the front: whatever it is, running it before
+    everything that gathers would be the more damaging guess.
+    """
+    capability = capability_or_id
+    if isinstance(capability_or_id, str):
+        capability = get_capability(capability_or_id)
+    phase = (capability or {}).get('phase')
+    try:
+        return CAPABILITY_PHASES.index(phase)
+    except ValueError:
+        return len(CAPABILITY_PHASES)
+
+
 def _gates_pass(capability, settings):
-    """Whether a capability's three gate forms all allow it."""
+    """Whether a capability's three deployment-level gate forms all allow it."""
     settings = settings if isinstance(settings, dict) else {}
 
     for key in capability.get('settings_gates') or ():
@@ -399,13 +635,40 @@ def _gates_pass(capability, settings):
     return True
 
 
-def resolve_available_capabilities(settings, allowed_ids=None):
+def _request_gate_passes(capability, settings, request_context):
+    """Whether this particular request may use a capability the deployment allows.
+
+    Skipped entirely when no request context is supplied, which is what the admin page and
+    the bootstrap payload want: they are describing the deployment, not a caller.
+
+    A gate that raises is treated as a refusal. These gates read app roles, and an error
+    resolving a role is not a reason to assume the caller has it.
+    """
+    gate = capability.get('request_gate')
+    if not callable(gate) or request_context is None:
+        return True
+    try:
+        return bool(gate(settings, request_context))
+    except Exception as exc:
+        log_event(
+            f"[ORCHESTRATION_REGISTRY] The request gate for {capability['id']} raised; "
+            f"withholding the capability: {exc}",
+            level=logging.WARNING,
+        )
+        return False
+
+
+def resolve_available_capabilities(settings, allowed_ids=None, request_context=None):
     """The capabilities this deployment currently permits, in registry order.
 
     ``allowed_ids`` is the administrator's ``chat_orchestration_enabled_capabilities``
     narrowing. An empty or missing list means "everything the other gates already allow",
     because an administrator who has not expressed an opinion should not thereby disable
     the feature entirely.
+
+    ``request_context`` narrows further to what *this caller, asking this question* may use
+    -- app roles, whether they have any agents, whether their message contains a link.
+    Omitted, the answer describes the deployment, which is what the admin surface needs.
 
     The terminal capability is never removed by the narrowing. A plan cannot end without
     it, so allowing it to be configured away would only produce plans that fail validation.
@@ -425,16 +688,20 @@ def resolve_available_capabilities(settings, allowed_ids=None):
                 continue
         if not _gates_pass(capability, settings):
             continue
+        if not _request_gate_passes(capability, settings, request_context):
+            continue
         available.append(capability)
 
     return available
 
 
-def resolve_available_capability_ids(settings, allowed_ids=None):
+def resolve_available_capability_ids(settings, allowed_ids=None, request_context=None):
     """Identifiers only, for the validator and for the bootstrap payload."""
     return [
         capability['id']
-        for capability in resolve_available_capabilities(settings, allowed_ids=allowed_ids)
+        for capability in resolve_available_capabilities(
+            settings, allowed_ids=allowed_ids, request_context=request_context
+        )
     ]
 
 
@@ -451,7 +718,7 @@ def build_planner_capability_projection(capabilities):
         projection.append({
             'id': capability['id'],
             'label': capability['label'],
-            'kind': capability['kind'],
+            'phase': capability['phase'],
             'summary': capability['summary'],
             'when_to_use': capability['when_to_use'],
             'inputs': capability['inputs'],
@@ -471,11 +738,42 @@ def build_capability_client_projection(capabilities):
         projection.append({
             'id': capability['id'],
             'label': capability['label'],
-            'kind': capability['kind'],
+            'phase': capability['phase'],
             'summary': capability['summary'],
             'cost': capability['cost_class'],
             'terminal': bool(capability.get('terminal')),
         })
+    return projection
+
+
+# Fields of an agent catalog record the planner may see.
+#
+# `instructions` is the agent's entire system prompt and is withheld deliberately: it is
+# long enough to crowd out the question, and it is the agent's own configuration rather than
+# something the planner needs to choose between agents. `actions_to_load`,
+# `assigned_knowledge`, `model_endpoint_id` and `scope_id` are withheld on the same
+# principle as the capability projection -- the planner is given what it needs to pick, not
+# the internals of what it picked.
+AGENT_PLANNER_FIELDS = ('name', 'display_name', 'description', 'tags', 'action_labels')
+
+
+def build_agent_planner_projection(agents, limit=None):
+    """Reduce the agent catalog to what the planner is shown when choosing one."""
+    projection = []
+    for agent in agents or ():
+        if not isinstance(agent, dict):
+            continue
+        name = str(agent.get('name') or '').strip()
+        if not name:
+            continue
+        entry = {'name': name}
+        for field in AGENT_PLANNER_FIELDS[1:]:
+            value = agent.get(field)
+            if value:
+                entry[field] = value
+        projection.append(entry)
+        if limit is not None and len(projection) >= limit:
+            break
     return projection
 
 
@@ -512,4 +810,5 @@ def describe_registry():
         'contract_version': CAPABILITY_REGISTRY_CONTRACT_VERSION,
         'capability_ids': all_capability_ids(),
         'terminal_capability_id': TERMINAL_CAPABILITY_ID,
+        'phases': list(CAPABILITY_PHASES),
     }

--- a/application/single_app/functions_orchestration_schema.py
+++ b/application/single_app/functions_orchestration_schema.py
@@ -44,6 +44,7 @@ from functions_orchestration_registry import (
     TERMINAL_CAPABILITY_ID,
     get_capability,
     get_capability_document_limit,
+    phase_index,
     resolve_available_capability_ids,
 )
 
@@ -344,6 +345,44 @@ def validate_step_arguments(capability, arguments):
 # Plan validation
 # --------------------------------------------------------------------------------------
 
+def _enforce_phase_order(steps):
+    """Sort steps into phase order and drop dependencies that point backwards.
+
+    Returns ``(ordered_steps, repairs)``.
+
+    A plan runs knowledge, then reasoning, then output. A step that gathers after the
+    answer has been written is not merely out of order -- it would run, cost money, and
+    contribute nothing, because the answer it was meant to inform has already been
+    composed. The same is true of a dependency pointing from an earlier phase to a later
+    one: honouring it would drag the later step forward, which is the very inversion the
+    phase order exists to prevent.
+
+    The sort is stable, so within a phase the planner's own ordering survives untouched and
+    the topological pass that follows still decides what actually depends on what.
+    """
+    repairs = []
+
+    ordered = sorted(steps, key=lambda step: phase_index(step.get('capability_id')))
+    position = {
+        step['step_id']: phase_index(step.get('capability_id')) for step in ordered
+    }
+
+    for step in ordered:
+        own_phase = position.get(step['step_id'], 0)
+        kept = []
+        for dependency in step.get('depends_on') or ():
+            if position.get(dependency, own_phase) > own_phase:
+                repairs.append(
+                    f"Step '{step['step_id']}' waited on '{dependency}', which runs in a "
+                    f"later phase; the dependency was dropped."
+                )
+                continue
+            kept.append(dependency)
+        step['depends_on'] = kept
+
+    return ordered, repairs
+
+
 def _order_steps(steps):
     """Topologically order steps, or report the ids caught in a cycle.
 
@@ -382,12 +421,20 @@ def validate_plan(
     settings=None,
     authorized_document_ids=None,
     available_capability_ids=None,
+    agent_names=None,
 ):
     """Make a planner-authored plan safe to run, or refuse it.
 
     ``authorized_document_ids`` is the set of documents this user may read *right now*. It
     is applied here and applied again before finalization in the executor, because the two
     moments are not the same moment and access can be revoked between them.
+
+    ``agent_names`` is the set of agents this user can actually reach. A planner naming
+    anything else is treated exactly like a planner naming an unknown capability: the step
+    is dropped rather than handed to an adapter that would go looking for an agent nobody
+    offered. ``None`` means the caller resolved no catalog, so agent steps cannot be
+    checked and are refused outright -- an agent step with no catalog behind it has no way
+    to succeed.
 
     Returns the plan with ``steps``, ``validation`` and ``status`` settled. Raises
     ``PlanValidationError`` only when nothing runnable survives.
@@ -404,6 +451,12 @@ def validate_plan(
             allowed_ids=settings.get('chat_orchestration_enabled_capabilities'),
         )
     available = set(available_capability_ids or ())
+
+    known_agents = None
+    if agent_names is not None:
+        known_agents = {
+            str(value).strip() for value in agent_names if str(value).strip()
+        }
 
     authorized = None
     if authorized_document_ids is not None:
@@ -453,6 +506,24 @@ def validate_plan(
                 f"Step {index + 1} ({capability_id}): " + '; '.join(argument_errors)
             )
             continue
+
+        # An agent step may only name an agent the caller can actually reach. A planner
+        # inventing a plausible-sounding agent is as likely as one inventing a capability,
+        # and is caught the same way rather than being discovered by an adapter searching a
+        # catalog that never contained it.
+        if 'agent_name' in arguments:
+            if known_agents is None:
+                errors.append(
+                    f"Step {index + 1} asks for an agent, but no agent catalog was "
+                    f"resolved for this request."
+                )
+                continue
+            if arguments['agent_name'] not in known_agents:
+                errors.append(
+                    f"Step {index + 1} names an agent this user cannot reach: "
+                    f"'{arguments['agent_name']}'."
+                )
+                continue
 
         # Document authorization, and the administrator's per-action document ceiling.
         for field in ('document_ids', 'right_document_ids'):
@@ -511,6 +582,7 @@ def validate_plan(
             'optional': bool(raw.get('optional', False)),
             'enabled': bool(raw.get('enabled', True)),
             'estimated_cost': capability['cost_class'],
+            'phase': capability['phase'],
             'status': STEP_STATUS_PENDING,
         })
         used_counts[capability_id] = used_counts.get(capability_id, 0) + 1
@@ -523,6 +595,11 @@ def validate_plan(
         if len(kept) != len(step['depends_on']):
             repairs.append(f"Step '{step['step_id']}' waited on a step that was removed.")
         step['depends_on'] = kept
+
+    # Phase order first, so the topological pass below sorts within a plan that already
+    # runs knowledge before reasoning before output rather than one that merely could.
+    accepted, phase_repairs = _enforce_phase_order(accepted)
+    repairs.extend(phase_repairs)
 
     ordered, cyclic = _order_steps(accepted)
     if cyclic:
@@ -672,6 +749,7 @@ def normalize_plan(
     turn_id=None,
     seeds=None,
     document_labels=None,
+    agent_names=None,
 ):
     """Turn raw planner output into a complete, validated plan document."""
     settings = settings if isinstance(settings, dict) else {}
@@ -725,6 +803,7 @@ def normalize_plan(
         settings=settings,
         authorized_document_ids=authorized_document_ids,
         available_capability_ids=available_capability_ids,
+        agent_names=agent_names,
     )
 
     plan['inputs'] = build_plan_inputs(plan, seeds=seeds, document_labels=document_labels)

--- a/application/single_app/route_backend_orchestration.py
+++ b/application/single_app/route_backend_orchestration.py
@@ -27,12 +27,15 @@ import threading
 import uuid
 from datetime import datetime, timezone
 
-from flask import Response, jsonify, request
+from flask import Response, jsonify, request, session
 
 from config import cosmos_conversations_container, cosmos_messages_container
 from functions_appinsights import log_event
+from functions_citation_tracking import merge_cited_documents_into_conversation
+from functions_conversation_cache import invalidate_conversation_cache_for_item
 from functions_authentication import (
     get_current_user_id,
+    get_current_user_info,
     login_required,
     user_required,
 )
@@ -41,6 +44,7 @@ from functions_orchestration_context import (
     build_planner_context,
     build_run_ledger,
     collect_answered_questions,
+    resolve_agent_catalog,
     resolve_candidate_documents,
     resolve_seeds,
 )
@@ -85,7 +89,7 @@ from functions_orchestration_schema import (
     summarize_plan,
     validate_elicitation_response,
 )
-from functions_settings import get_settings
+from functions_settings import get_settings, get_user_settings
 from swagger_wrapper import get_auth_security, swagger_route
 
 # SSE responses must not be buffered by an intermediary, or progress arrives all at once at
@@ -327,15 +331,125 @@ def _ensure_conversation(conversation_id, user_id, title=''):
     return conversation_id, True
 
 
-def _save_message(conversation_id, role, content, metadata=None):
+def _request_identity(user_id=None, seeded_agent=None):
+    """Capture the request-scoped identity a run needs, before any thread starts.
+
+    ``execute_plan`` runs on a worker thread with no Flask request context: no ``g``, no
+    ``session``, no ``current_app``. An adapter that reached for ``session`` there would
+    raise, and one that quietly defaulted instead would be worse -- ``user_roles`` gates the
+    ``UrlAccessUser`` and ``DeepResearchUser`` app roles, so guessing it would either deny a
+    permitted user or, far worse, admit one who is not.
+
+    So the values are read here, on the request thread, and carried explicitly on the run
+    context. Roles come from the session the same way the classic chat route reads them,
+    which keeps one source of truth for what a role claim looks like.
+    """
+    try:
+        info = get_current_user_info() or {}
+    except Exception:
+        info = {}
+    try:
+        roles = (session.get('user') or {}).get('roles', [])
+    except Exception:
+        # No session to read (an unusual transport, or a torn-down context). Absent roles
+        # must read as "no roles", never as "unknown, allow anyway".
+        roles = []
+
+    # The per-user agent switch. RunContext defaults this to True for the same
+    # backward-compatibility reason the classic path does, but the default is only correct
+    # when nobody asked -- here somebody did, so the stored preference is read rather than
+    # assumed, and a user who turned agents off does not get them back via orchestration.
+    enable_agents = True
+    if user_id:
+        try:
+            enable_agents = bool(
+                (get_user_settings(user_id) or {}).get('settings', {}).get('enable_agents', True)
+            )
+        except Exception as exc:
+            log_event(
+                f"[ORCHESTRATION] Could not read user agent preference: {exc}",
+                level=logging.WARNING,
+            )
+    # Selecting an agent by hand is itself the permission: the classic path sets
+    # force_enable_agents on the same reasoning, so a seeded agent is honoured even when the
+    # general switch is off.
+    if isinstance(seeded_agent, dict) and _text(seeded_agent.get('name')):
+        enable_agents = True
+
+    return {
+        'user_email': _text(info.get('email')) or None,
+        'user_roles': list(roles) if isinstance(roles, (list, tuple, set)) else [],
+        'user_enable_agents': enable_agents,
+    }
+
+
+def _partition_citations(citations):
+    """Split a run's citations into the document and web buckets chat already uses.
+
+    An assistant message carries these in two separate fields, and the difference is not
+    cosmetic: ``hybrid_citations`` is what the conversation's used-document tracking reads
+    to work out which documents an answer actually drew on, and a web citation has no
+    document to track. Folding both into one field would either lose the web sources or
+    put entries with no ``document_id`` in front of ``build_used_documents``, which skips
+    them silently -- a bug that looks like nothing happening.
+    """
+    document_citations = []
+    web_citations = []
+    for citation in citations or ():
+        if not isinstance(citation, dict):
+            continue
+        if _text(citation.get('document_id')):
+            document_citations.append(citation)
+        elif _text(citation.get('url')) or citation.get('source_type') == 'web':
+            web_citations.append(citation)
+        else:
+            # Neither a document nor a page: an agent tool call, for instance. Carried as
+            # a web-style citation so it is still visible on the message rather than
+            # discarded, but kept out of document tracking where it has no place.
+            web_citations.append(citation)
+    return document_citations, web_citations
+
+
+def _record_cited_documents(conversation_id, user_id, document_citations):
+    """Fold an answer's document citations into the conversation's used-document list.
+
+    This is what puts a document in the Documents drawer. The drawer reads
+    ``used_documents`` off the conversation, not the citations off the message, so an
+    answer can cite a document perfectly and still show "No documents used yet" if this
+    step is skipped -- which is exactly what an orchestrated answer did before this.
+    """
+    if not document_citations:
+        return
+
+    try:
+        conversation = cosmos_conversations_container.read_item(
+            item=conversation_id, partition_key=conversation_id
+        )
+    except Exception as exc:
+        log_event(f"[ORCHESTRATION] Could not read the conversation to record cited "
+                  f"documents: {exc}", level=logging.WARNING)
+        return
+
+    if conversation.get('user_id') != user_id:
+        return
+
+    try:
+        merge_cited_documents_into_conversation(conversation, document_citations)
+        conversation['last_updated'] = _now_iso()
+        cosmos_conversations_container.upsert_item(conversation)
+        invalidate_conversation_cache_for_item(conversation, reason="orchestration_completed")
+    except Exception as exc:
+        log_event(f"[ORCHESTRATION] Could not record cited documents: {exc}",
+                  level=logging.WARNING)
+
+
+def _save_message(conversation_id, role, content, metadata=None, extra=None):
     """Write one message, returning its id.
 
-    Deliberately minimal: id, conversation, role, content, timestamp and metadata. An
-    orchestrated answer is an ordinary assistant message, so the existing renderer,
-    citations and exports apply to it without any of them being told about orchestration.
+    ``extra`` carries the citation fields an assistant message needs. They are top-level
+    rather than nested in metadata because that is where every existing reader looks for
+    them -- the renderer, the citation lookup and the used-document tracking alike.
     """
-
-
     message_id = f"{role}_{uuid.uuid4().hex}"
     document = {
         'id': message_id,
@@ -344,6 +458,8 @@ def _save_message(conversation_id, role, content, metadata=None):
         'content': content or '',
         'timestamp': _now_iso(),
     }
+    if isinstance(extra, dict):
+        document.update(extra)
     if metadata:
         document['metadata'] = metadata
 
@@ -491,6 +607,26 @@ def register_route_backend_orchestration(bp):
                     kind = 'plan'
                 else:
                     yield build_planning_thought('Deciding what this question needs.')
+                    # The agent catalog is resolved here rather than above so a
+                    # conversational message never pays for it: it is a multi-query Cosmos
+                    # traversal with no cache, and a trivial reply has no plan for an agent
+                    # to appear in. Once per plan, never per step.
+                    #
+                    # The context is rebuilt rather than having 'agents' assigned into it,
+                    # because build_planner_context is the single place the catalog is
+                    # projected down to its naming fields. Writing the key directly would
+                    # put an agent's full instructions in front of the planner.
+                    context = build_planner_context(
+                        message, candidates=candidates, seeds=seeds, ledger=ledger,
+                        signals=signals,
+                        agents=resolve_agent_catalog(
+                            user_id, seeds=seeds, settings=settings,
+                            user_groups=seeds.get('active_group_ids') or None,
+                        ),
+                    )
+                    if answered:
+                        context['answered_now'] = answered
+
                     kind, plan = plan_request(
                         message, context, resolved_conversation_id, user_id,
                         settings=settings,
@@ -605,6 +741,20 @@ def register_route_backend_orchestration(bp):
             (plan.get('intent') or {}).get('summary')
         )
 
+        # Captured out here, on the request thread, and closed over by the generator. A
+        # streamed response's generator body runs after the view has returned, so reading
+        # the session from inside it would be reading a context that is already gone.
+        identity = _request_identity(user_id, seeded_agent=seeds.get('agent'))
+
+        # Resolved again rather than read back off the plan. Planning and running are
+        # separate requests, and an agent the user could reach when the plan was made is not
+        # necessarily one they can reach now -- the same reason document authorization is
+        # rechecked before the answer is composed. Still once per run, never per step.
+        agent_catalog = resolve_agent_catalog(
+            user_id, seeds=seeds, settings=settings,
+            user_groups=seeds.get('active_group_ids') or None,
+        )
+
         def generate():
             approved_at = _now_iso()
             try:
@@ -685,6 +835,12 @@ def register_route_backend_orchestration(bp):
                 active_public_workspace_id=(
                     (seeds.get('active_public_workspace_ids') or [None])[0]
                 ),
+                # Read on the request thread; see _request_identity.
+                user_roles=identity.get('user_roles'),
+                user_email=identity.get('user_email'),
+                user_enable_agents=identity.get('user_enable_agents', True),
+                active_group_id=(seeds.get('active_group_ids') or [None])[0],
+                agent_catalog=agent_catalog,
             )
 
             cancel_requested = _make_cancel_probe(run_id, user_id, conversation_id)
@@ -745,6 +901,9 @@ def register_route_backend_orchestration(bp):
             summary = summarize_plan(plan)
             summary['status'] = result.get('status')
 
+            # Everything the run gathered, split the way an assistant message carries it.
+            document_citations, web_citations = _partition_citations(result.get('citations'))
+
             # The answer is an ordinary assistant message. Written before the terminal
             # frame so that a client which reloads the moment it arrives finds the answer
             # in the conversation rather than an empty turn where one just streamed.
@@ -757,10 +916,19 @@ def register_route_backend_orchestration(bp):
                     },
                     'token_usage': run_token_usage or result.get('token_usage') or {},
                 },
+                extra={
+                    'hybrid_citations': document_citations,
+                    'web_search_citations': web_citations,
+                    'augmented': bool(document_citations or web_citations),
+                },
             ) if answer else None
 
             if answer:
                 _touch_conversation(conversation_id, user_id)
+                # What the Documents drawer reads. The drawer works from the conversation's
+                # used-document list rather than from the message's citations, so citing a
+                # document is not enough on its own to make it appear there.
+                _record_cited_documents(conversation_id, user_id, document_citations)
                 yield build_content_event(answer)
 
             try:
@@ -778,7 +946,8 @@ def register_route_backend_orchestration(bp):
                 message_id=message_id,
                 run_id=run_id,
                 full_content=answer,
-                citations=result.get('citations'),
+                citations=document_citations,
+                web_citations=web_citations,
                 artifacts=result.get('artifacts'),
                 plan_summary=summary,
                 status=result.get('status') or PLAN_STATUS_COMPLETED,

--- a/application/v2_ui/src/components/chat/OrchestrationPlanCard.tsx
+++ b/application/v2_ui/src/components/chat/OrchestrationPlanCard.tsx
@@ -22,7 +22,6 @@ import {
     selectPlan,
     selectStepRuntime,
     useOrchestrationStore,
-    type RunOutcome,
 } from '../../stores/orchestrationStore';
 import {
     applyPlanEdits,
@@ -56,18 +55,6 @@ const costTone: Record<CostClass, string> = {
     low: 'text-text-3',
     medium: 'text-warn',
     high: 'text-danger',
-};
-
-const outcomeTone: Record<RunOutcome, string> = {
-    completed: 'text-ok',
-    failed: 'text-danger',
-    cancelled: 'text-text-3',
-};
-
-const outcomeLabel: Record<RunOutcome, string> = {
-    completed: 'done',
-    failed: 'failed',
-    cancelled: 'stopped',
 };
 
 /** The countdown ring for timed approval, drawn from the fraction of time left. */
@@ -194,38 +181,15 @@ export function OrchestrationPlanCard({
 
     const openReview = () => setDrawerMode('plan');
 
-    // Collapsed: the run has settled. One line that says what happened and reopens the drawer,
-    // because the plan that ran is worth being able to look back at even once it is done.
+    // Settled: nothing in the thread. The plan is still there -- the header's Plan button
+    // opens it, and the drawer's Map view lists every run in the conversation -- but a
+    // finished plan is not something the reader has to act on, and leaving a row under
+    // every answer turns the thread into a log of machinery rather than a conversation.
+    //
+    // This is why the card renders from the store rather than from message markdown: there
+    // is nothing to clean up when it stops being relevant, it simply stops rendering.
     if (historyEntry && !runInFlight) {
-        return (
-            <div className="my-3 rounded-2xl border border-edge-strong bg-surface-sunken px-3 py-2">
-                <button
-                    type="button"
-                    onClick={openReview}
-                    className="flex w-full items-center gap-2 text-left text-sm text-text-2 hover:text-text-1"
-                    aria-label={`Review the plan: ${summary.step_count} steps, ${outcomeLabel[historyEntry.status]}`}
-                >
-                    <ListChecks size={15} className="shrink-0 text-text-3" />
-                    <span className="text-text-1">Plan</span>
-                    <span aria-hidden="true" className="text-text-3">
-                        ·
-                    </span>
-                    <span>
-                        {summary.step_count} {summary.step_count === 1 ? 'step' : 'steps'}
-                    </span>
-                    <span aria-hidden="true" className="text-text-3">
-                        ·
-                    </span>
-                    <span className={outcomeTone[historyEntry.status]}>
-                        {outcomeLabel[historyEntry.status]}
-                    </span>
-                    <span aria-hidden="true" className="text-text-3">
-                        ·
-                    </span>
-                    <span className="text-accent">view</span>
-                </button>
-            </div>
-        );
+        return null;
     }
 
     // Running: a compact progress line. The full step list is a click away in the drawer, so this

--- a/application/v2_ui/src/components/chat/OrchestrationRunView.tsx
+++ b/application/v2_ui/src/components/chat/OrchestrationRunView.tsx
@@ -23,6 +23,7 @@ import {
     selectStepRuntime,
     useOrchestrationStore,
 } from '../../stores/orchestrationStore';
+import { useBootstrapStore } from '../../stores/bootstrapStore';
 import {
     DOCUMENT_ARRAY_FIELDS,
     orderStepsForDisplay,
@@ -31,7 +32,14 @@ import {
     stepRemovableDocumentIds,
     TERMINAL_CAPABILITY_ID,
 } from '../../lib/orchestrationPlan';
-import type { CostClass, Json, OrchestrationStep, StepStatus } from '../../lib/orchestration';
+import { ORCHESTRATION_PHASES } from '../../lib/orchestration';
+import type {
+    CostClass,
+    Json,
+    OrchestrationPhase,
+    OrchestrationStep,
+    StepStatus,
+} from '../../lib/orchestration';
 
 const statusTone: Record<StepStatus, string> = {
     pending: 'bg-surface-3 text-text-3',
@@ -46,6 +54,13 @@ const costTone: Record<CostClass, string> = {
     low: 'text-text-3',
     medium: 'text-warn',
     high: 'text-danger',
+};
+
+/** The heading shown above each phase's steps. Presentation copy, so it lives with the view. */
+const phaseLabels: Record<OrchestrationPhase, string> = {
+    knowledge: 'Gathering knowledge',
+    reasoning: 'Reasoning',
+    output: 'Creating',
 };
 
 /** A step argument key/value the run will use, minus the document fields shown as chips. */
@@ -96,6 +111,57 @@ export function OrchestrationRunView({
         [plan],
     );
 
+    const capabilities = useBootstrapStore((state) => state.data?.orchestration?.capabilities);
+
+    // Steps grouped under their phase, in run order, so the list reads as "gather, then answer"
+    // rather than as a flat sequence. A step's phase is resolved from the capability menu when the
+    // plan does not carry one itself, so an older or persisted plan still groups correctly; a step
+    // whose phase cannot be resolved trails the known phases under no heading rather than vanishing
+    // from a plan the user is meant to be able to audit. The running number follows display order,
+    // so the steps still read 1..n across the groups.
+    const phaseGroups = useMemo(() => {
+        const phaseByCapability = new Map<string, string>();
+        for (const capability of capabilities ?? []) {
+            phaseByCapability.set(capability.id, capability.phase);
+        }
+        const resolvePhase = (step: OrchestrationStep): string =>
+            step.phase ?? phaseByCapability.get(step.capability_id) ?? '';
+
+        const buckets = new Map<string, OrchestrationStep[]>();
+        for (const step of orderedSteps) {
+            const resolved = resolvePhase(step);
+            const key = (ORCHESTRATION_PHASES as string[]).includes(resolved) ? resolved : '';
+            const list = buckets.get(key) ?? [];
+            list.push(step);
+            buckets.set(key, list);
+        }
+
+        const groups: Array<{
+            key: string;
+            label: string | null;
+            steps: Array<{ step: OrchestrationStep; number: number }>;
+        }> = [];
+        let counter = 0;
+        const pushGroup = (key: string, label: string | null, steps?: OrchestrationStep[]) => {
+            if (!steps || steps.length === 0) {
+                return;
+            }
+            groups.push({
+                key,
+                label,
+                steps: steps.map((step) => {
+                    counter += 1;
+                    return { step, number: counter };
+                }),
+            });
+        };
+        for (const phase of ORCHESTRATION_PHASES) {
+            pushGroup(phase, phaseLabels[phase], buckets.get(phase));
+        }
+        pushGroup('_unclassified', null, buckets.get(''));
+        return groups;
+    }, [orderedSteps, capabilities]);
+
     if (!plan) {
         return (
             <p className="p-4 text-sm text-text-3">
@@ -106,6 +172,162 @@ export function OrchestrationRunView({
 
     const editable = planRequiresApproval(plan);
     const disabledStepIds = new Set(edits.disabled_step_ids);
+
+    const renderStep = (step: OrchestrationStep, displayNumber: number) => {
+        const isTerminal = step.capability_id === TERMINAL_CAPABILITY_ID;
+        const willRun = step.enabled && !disabledStepIds.has(step.step_id);
+        const status = stepRuntime[step.step_id]?.status ?? step.status;
+        const summary = stepRuntime[step.step_id]?.summary ?? '';
+        const removed = new Set(edits.removed_document_ids[step.step_id] ?? []);
+        const removable = new Set(stepRemovableDocumentIds(step));
+        const documents = stepDocumentIds(step);
+        const args = readableArguments(step);
+
+        return (
+            <li
+                key={step.step_id}
+                className={clsx(
+                    'rounded-xl border border-edge p-3 transition-opacity',
+                    willRun ? 'bg-surface-2' : 'bg-surface-sunken opacity-60',
+                )}
+            >
+                <div className="flex items-start gap-2">
+                    <span className="mt-0.5 shrink-0 font-mono text-xs text-text-3">
+                        {displayNumber}
+                    </span>
+                    <div className="min-w-0 flex-1">
+                        <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+                            <span className="text-sm font-medium text-text-1">
+                                {step.title}
+                            </span>
+                            <span className="rounded-full bg-surface-3 px-1.5 py-0.5 font-mono text-[11px] text-text-3">
+                                {step.capability_id}
+                            </span>
+                            <span className={clsx('text-[11px]', costTone[step.estimated_cost])}>
+                                {step.estimated_cost}
+                            </span>
+                            <span
+                                className={clsx(
+                                    'ml-auto rounded-full px-1.5 py-0.5 text-[11px] capitalize',
+                                    statusTone[status],
+                                )}
+                            >
+                                {status}
+                            </span>
+                        </div>
+
+                        {step.rationale ? (
+                            <p className="mt-1 text-xs text-text-3">{step.rationale}</p>
+                        ) : null}
+
+                        {summary ? (
+                            <p className="mt-1 text-xs text-text-2">{summary}</p>
+                        ) : null}
+
+                        {args.length > 0 ? (
+                            <dl className="mt-2 space-y-0.5">
+                                {args.map(([key, value]) => (
+                                    <div key={key} className="flex gap-1.5 text-xs">
+                                        <dt className="shrink-0 font-mono text-text-3">
+                                            {key}
+                                        </dt>
+                                        <dd className="min-w-0 truncate text-text-2" title={value}>
+                                            {value}
+                                        </dd>
+                                    </div>
+                                ))}
+                            </dl>
+                        ) : null}
+
+                        {documents.length > 0 ? (
+                            <ul className="mt-2 flex flex-wrap gap-1.5">
+                                {documents.map((documentId) => {
+                                    const isRemoved = removed.has(documentId);
+                                    const canRemove =
+                                        editable && removable.has(documentId);
+                                    return (
+                                        <li
+                                            key={documentId}
+                                            className={clsx(
+                                                'inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px]',
+                                                isRemoved
+                                                    ? 'border-edge text-text-3 line-through'
+                                                    : 'border-edge-strong text-text-2',
+                                            )}
+                                        >
+                                            <FileText size={10} className="shrink-0" />
+                                            <span
+                                                className="max-w-[9rem] truncate"
+                                                title={documentId}
+                                            >
+                                                {documentId}
+                                            </span>
+                                            {isRemoved ? (
+                                                <button
+                                                    type="button"
+                                                    onClick={() =>
+                                                        restoreDocument(
+                                                            conversationId,
+                                                            turnId,
+                                                            step.step_id,
+                                                            documentId,
+                                                        )
+                                                    }
+                                                    aria-label={`Restore document ${documentId}`}
+                                                    className="text-accent hover:text-accent-hover"
+                                                >
+                                                    <RotateCcw size={11} />
+                                                </button>
+                                            ) : canRemove ? (
+                                                <button
+                                                    type="button"
+                                                    onClick={() =>
+                                                        removeDocument(
+                                                            conversationId,
+                                                            turnId,
+                                                            step,
+                                                            documentId,
+                                                        )
+                                                    }
+                                                    aria-label={`Remove document ${documentId} from this step`}
+                                                    className="text-text-3 hover:text-danger"
+                                                >
+                                                    <X size={11} />
+                                                </button>
+                                            ) : null}
+                                        </li>
+                                    );
+                                })}
+                            </ul>
+                        ) : null}
+
+                        <div className="mt-2">
+                            {isTerminal ? (
+                                <span className="inline-flex items-center gap-1 text-[11px] text-text-3">
+                                    <Lock size={11} />
+                                    Always runs
+                                </span>
+                            ) : editable ? (
+                                <Toggle
+                                    checked={willRun}
+                                    onChange={(next) =>
+                                        next
+                                            ? enableStep(conversationId, turnId, step.step_id)
+                                            : disableStep(conversationId, turnId, step)
+                                    }
+                                    label={willRun ? 'Will run' : 'Skipped'}
+                                />
+                            ) : (
+                                <span className="text-[11px] text-text-3">
+                                    {willRun ? 'Will run' : 'Skipped'}
+                                </span>
+                            )}
+                        </div>
+                    </div>
+                </div>
+            </li>
+        );
+    };
 
     return (
         <div className="space-y-3 p-3">
@@ -120,163 +342,18 @@ export function OrchestrationRunView({
                 ) : null}
             </div>
 
-            <ol className="space-y-2">
-                {orderedSteps.map((step, index) => {
-                    const isTerminal = step.capability_id === TERMINAL_CAPABILITY_ID;
-                    const willRun = step.enabled && !disabledStepIds.has(step.step_id);
-                    const status = stepRuntime[step.step_id]?.status ?? step.status;
-                    const summary = stepRuntime[step.step_id]?.summary ?? '';
-                    const removed = new Set(edits.removed_document_ids[step.step_id] ?? []);
-                    const removable = new Set(stepRemovableDocumentIds(step));
-                    const documents = stepDocumentIds(step);
-                    const args = readableArguments(step);
-
-                    return (
-                        <li
-                            key={step.step_id}
-                            className={clsx(
-                                'rounded-xl border border-edge p-3 transition-opacity',
-                                willRun ? 'bg-surface-2' : 'bg-surface-sunken opacity-60',
-                            )}
-                        >
-                            <div className="flex items-start gap-2">
-                                <span className="mt-0.5 shrink-0 font-mono text-xs text-text-3">
-                                    {index + 1}
-                                </span>
-                                <div className="min-w-0 flex-1">
-                                    <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
-                                        <span className="text-sm font-medium text-text-1">
-                                            {step.title}
-                                        </span>
-                                        <span className="rounded-full bg-surface-3 px-1.5 py-0.5 font-mono text-[11px] text-text-3">
-                                            {step.capability_id}
-                                        </span>
-                                        <span className={clsx('text-[11px]', costTone[step.estimated_cost])}>
-                                            {step.estimated_cost}
-                                        </span>
-                                        <span
-                                            className={clsx(
-                                                'ml-auto rounded-full px-1.5 py-0.5 text-[11px] capitalize',
-                                                statusTone[status],
-                                            )}
-                                        >
-                                            {status}
-                                        </span>
-                                    </div>
-
-                                    {step.rationale ? (
-                                        <p className="mt-1 text-xs text-text-3">{step.rationale}</p>
-                                    ) : null}
-
-                                    {summary ? (
-                                        <p className="mt-1 text-xs text-text-2">{summary}</p>
-                                    ) : null}
-
-                                    {args.length > 0 ? (
-                                        <dl className="mt-2 space-y-0.5">
-                                            {args.map(([key, value]) => (
-                                                <div key={key} className="flex gap-1.5 text-xs">
-                                                    <dt className="shrink-0 font-mono text-text-3">
-                                                        {key}
-                                                    </dt>
-                                                    <dd className="min-w-0 truncate text-text-2" title={value}>
-                                                        {value}
-                                                    </dd>
-                                                </div>
-                                            ))}
-                                        </dl>
-                                    ) : null}
-
-                                    {documents.length > 0 ? (
-                                        <ul className="mt-2 flex flex-wrap gap-1.5">
-                                            {documents.map((documentId) => {
-                                                const isRemoved = removed.has(documentId);
-                                                const canRemove =
-                                                    editable && removable.has(documentId);
-                                                return (
-                                                    <li
-                                                        key={documentId}
-                                                        className={clsx(
-                                                            'inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px]',
-                                                            isRemoved
-                                                                ? 'border-edge text-text-3 line-through'
-                                                                : 'border-edge-strong text-text-2',
-                                                        )}
-                                                    >
-                                                        <FileText size={10} className="shrink-0" />
-                                                        <span
-                                                            className="max-w-[9rem] truncate"
-                                                            title={documentId}
-                                                        >
-                                                            {documentId}
-                                                        </span>
-                                                        {isRemoved ? (
-                                                            <button
-                                                                type="button"
-                                                                onClick={() =>
-                                                                    restoreDocument(
-                                                                        conversationId,
-                                                                        turnId,
-                                                                        step.step_id,
-                                                                        documentId,
-                                                                    )
-                                                                }
-                                                                aria-label={`Restore document ${documentId}`}
-                                                                className="text-accent hover:text-accent-hover"
-                                                            >
-                                                                <RotateCcw size={11} />
-                                                            </button>
-                                                        ) : canRemove ? (
-                                                            <button
-                                                                type="button"
-                                                                onClick={() =>
-                                                                    removeDocument(
-                                                                        conversationId,
-                                                                        turnId,
-                                                                        step,
-                                                                        documentId,
-                                                                    )
-                                                                }
-                                                                aria-label={`Remove document ${documentId} from this step`}
-                                                                className="text-text-3 hover:text-danger"
-                                                            >
-                                                                <X size={11} />
-                                                            </button>
-                                                        ) : null}
-                                                    </li>
-                                                );
-                                            })}
-                                        </ul>
-                                    ) : null}
-
-                                    <div className="mt-2">
-                                        {isTerminal ? (
-                                            <span className="inline-flex items-center gap-1 text-[11px] text-text-3">
-                                                <Lock size={11} />
-                                                Always runs
-                                            </span>
-                                        ) : editable ? (
-                                            <Toggle
-                                                checked={willRun}
-                                                onChange={(next) =>
-                                                    next
-                                                        ? enableStep(conversationId, turnId, step.step_id)
-                                                        : disableStep(conversationId, turnId, step)
-                                                }
-                                                label={willRun ? 'Will run' : 'Skipped'}
-                                            />
-                                        ) : (
-                                            <span className="text-[11px] text-text-3">
-                                                {willRun ? 'Will run' : 'Skipped'}
-                                            </span>
-                                        )}
-                                    </div>
-                                </div>
-                            </div>
-                        </li>
-                    );
-                })}
-            </ol>
+            {phaseGroups.map((group) => (
+                <section key={group.key} className="space-y-2">
+                    {group.label ? (
+                        <p className="px-0.5 text-[11px] font-semibold uppercase tracking-wide text-text-3">
+                            {group.label}
+                        </p>
+                    ) : null}
+                    <ol className="space-y-2">
+                        {group.steps.map(({ step, number }) => renderStep(step, number))}
+                    </ol>
+                </section>
+            ))}
         </div>
     );
 }

--- a/application/v2_ui/src/lib/orchestration.ts
+++ b/application/v2_ui/src/lib/orchestration.ts
@@ -66,6 +66,21 @@ export type PlanStatus =
 /** A capability's rough cost, from `COST_CLASSES`. Carried on a step as `estimated_cost`. */
 export type CostClass = 'low' | 'medium' | 'high';
 
+/**
+ * The phases a plan moves through, mirroring the server registry's `CAPABILITY_PHASES`.
+ *
+ * The order is meaningful: a plan gathers in `knowledge`, then answers in `reasoning`, then
+ * produces any deliverable in `output`, and never gathers again once it has answered. The
+ * run view groups steps under these in this order. A closed union rather than a loose string
+ * because -- unlike `capability_id`, where a build must tolerate a capability it had not heard
+ * of -- the phase vocabulary is fixed by the framework, so an unrecognised phase is a bug to
+ * surface, not a value to pass through.
+ */
+export type OrchestrationPhase = 'knowledge' | 'reasoning' | 'output';
+
+/** The phases in the order a plan runs them, so a grouped view can iterate them directly. */
+export const ORCHESTRATION_PHASES: OrchestrationPhase[] = ['knowledge', 'reasoning', 'output'];
+
 /** MCP elicitation response actions, named exactly as MCP names them (`ELICITATION_ACTIONS`). */
 export type ElicitationAction = 'accept' | 'decline' | 'cancel';
 
@@ -105,6 +120,14 @@ export interface OrchestrationStep {
     enabled: boolean;
     estimated_cost: CostClass;
     status: StepStatus;
+    /**
+     * The phase this step runs in, echoed from its capability.
+     *
+     * Optional and a loose string because a persisted or older plan may not carry it and the
+     * value is the server's to define: the run view resolves a missing one from the capability
+     * menu rather than dropping the step, so grouping degrades gracefully instead of failing.
+     */
+    phase?: string;
 }
 
 /** The approval block, from `normalize_plan`'s `approval`. */

--- a/application/v2_ui/src/lib/orchestrationPlan.ts
+++ b/application/v2_ui/src/lib/orchestrationPlan.ts
@@ -150,6 +150,11 @@ export function normalizeStep(raw: unknown, index = 0): OrchestrationStep {
         enabled: asBoolean(source.enabled, true),
         estimated_cost: oneOf(source.estimated_cost, COST_CLASSES, 'medium'),
         status: oneOf(source.status, STEP_STATUSES, 'pending'),
+        // Carried through rather than re-derived from the capability menu. The validator
+        // stamps each step with the phase it ordered the plan by, so this is the value the
+        // run actually used; looking it up again client-side would disagree the moment a
+        // capability is disabled after a plan was made.
+        phase: asString(source.phase) || undefined,
     };
 }
 

--- a/application/v2_ui/src/lib/types.ts
+++ b/application/v2_ui/src/lib/types.ts
@@ -733,8 +733,8 @@ export interface NavGroup<TItem> {
 export interface OrchestrationCapability {
     id: string;
     label: string;
-    /** The capability family (search, generation, …). A string because the registry is server-owned. */
-    kind: string;
+    /** The phase this capability runs in (knowledge, reasoning, output). A string because the registry is server-owned. */
+    phase: string;
     summary: string;
     cost: 'low' | 'medium' | 'high';
     terminal: boolean;

--- a/application/v2_ui/src/stores/chatStore.ts
+++ b/application/v2_ui/src/stores/chatStore.ts
@@ -2542,6 +2542,12 @@ export const useChatStore = create<ChatState>((set, get) => ({
             model_deployment_name: event.model_deployment_name,
             agent_display_name: event.agent_display_name,
             augmented: event.augmented,
+            // Carried through so an orchestrated answer shows its sources exactly as a
+            // chat answer does. Dropping these left the reply citing documents in its prose
+            // with no citation chips under it and nothing in the Documents drawer.
+            hybrid_citations: event.hybrid_citations as ChatMessage['hybrid_citations'],
+            web_search_citations:
+                event.web_search_citations as ChatMessage['web_search_citations'],
             metadata: event.metadata,
             thoughts: get().thoughts.length > 0 ? [...get().thoughts] : undefined,
         };
@@ -2568,6 +2574,14 @@ export const useChatStore = create<ChatState>((set, get) => ({
                 reconnectPhase: null,
             };
         });
+
+        // The Documents drawer reads the conversation's used-document list rather than the
+        // message's citations, and the server only extends that list once the run finishes.
+        // Without this refetch the drawer keeps reporting the state it was fetched in --
+        // "No documents used yet" under an answer that plainly used one.
+        if (event.augmented) {
+            void get().loadMetadata(conversationId);
+        }
     },
 
     reassignOrchestrationTurn: ({

--- a/docs/admin/orchestration.md
+++ b/docs/admin/orchestration.md
@@ -46,9 +46,13 @@ of work, and they are enforced regardless of what a plan asks for.
 
 ## Before you change anything
 
-- Confirm which retrieval capabilities are already enabled. Orchestration can only plan
-  around document search, document analysis, document comparison, spreadsheet analysis and
-  web search where those are separately enabled.
+- Confirm which knowledge capabilities are already enabled. Orchestration can only plan
+  around document search, document analysis, document comparison, spreadsheet analysis,
+  web search, reading linked pages, deep research and agents where those are separately
+  enabled.
+- Note that reading linked pages and deep research are additionally restricted by app role
+  where your deployment requires it. A plan will not propose a capability the individual
+  user could not reach by hand.
 - Decide whether users should be able to change their own approval mode, or whether the
   deployment default should apply to everyone.
 - Consider configuring a smaller planner model. Planning is a short structured task, so it
@@ -95,6 +99,38 @@ working by hand, which is how a deployment can adopt orchestration for search wh
 continuing to require deliberate action for document analysis.
 
 Answering is always available and cannot be cleared, because a plan has to end somewhere.
+
+#### How a plan is ordered
+
+Every capability belongs to one of three phases, and a plan always moves through them in
+order:
+
+| Phase | What happens | Capabilities |
+| --- | --- | --- |
+| Gathering knowledge | Finding out what is true | Document search, document analysis, document comparison, spreadsheet analysis, web search, reading linked pages, deep research, agents |
+| Reasoning | Saying something about it | Answering |
+| Creating | Producing files and other artifacts | Not yet available |
+
+The order is enforced rather than suggested. A plan cannot go looking for something after
+it has already answered, because the answer would be written without the very evidence the
+later step found.
+
+#### The more expensive capabilities
+
+Three capabilities cost noticeably more than the rest and are each limited to one use per
+plan:
+
+- **Deep research** reads and cross-checks multiple sources. It is for questions that need
+  several independent sources reconciled; web search is the cheaper choice for ordinary
+  factual questions.
+- **Agents** load the agent's tools, connections and instructions before running. That
+  setup is the expensive part of the turn, so a plan uses at most one agent.
+- **Reading linked pages** only appears when the user's message actually contains a link,
+  and only reads links the user pasted — never one the model produced.
+
+Reading linked pages and deep research also honour the `UrlAccessUser` and
+`DeepResearchUser` app roles where your deployment requires them. A user without the role
+does not get the capability, whether they ask by hand or a plan proposes it.
 
 #### Settings
 
@@ -163,6 +199,9 @@ model, which means orchestration works as soon as it is switched on.
 | Every plan is a single answering step | Capabilities are narrowed to answering only, or the retrieval capabilities are disabled elsewhere. | Review Capabilities on this page, then confirm document search and web search are enabled in their own settings groups. |
 | A plan is smaller than expected | The step cap trimmed it. | Raise Maximum steps in a plan, or ask a narrower question. |
 | A question is asked that was already answered | The ledger is disabled or too small to reach the earlier turn. | Raise Earlier runs shown to the planner, and confirm the summary size is not set to its minimum. |
+| Plans never propose deep research or reading a link | The user does not hold the required app role, or the capability is disabled in its own settings group. | Confirm the user holds `DeepResearchUser` or `UrlAccessUser` where your deployment requires them, and that the capability is enabled outside this page. |
+| Plans never propose an agent | Semantic Kernel is off, the user has turned agents off in their own settings, or the user has no agent they can reach. | Confirm Semantic Kernel is enabled, then check the user's own agent setting and that at least one agent is shared with them. |
+| A plan proposed reading a link but found nothing | The link was produced by the model rather than pasted by the user. | Only links present in the user's own message are read. Ask the user to paste the URL into their message. |
 
 ## Related
 

--- a/docs/explanation/features/CHAT_ORCHESTRATION.md
+++ b/docs/explanation/features/CHAT_ORCHESTRATION.md
@@ -1,6 +1,7 @@
 # Chat Orchestration
 
 **Implemented in version: 0.261.086**
+**Knowledge phase added in version: 0.261.087**
 
 ## Overview
 
@@ -78,6 +79,52 @@ an adapter is reached. The validator repairs where repair is honest and drops wh
 not, and records what it did in `validation.repairs` so the card can show a plan that
 differs from the proposal and say why.
 
+### Phases
+
+Every capability declares a `phase`, and the phases are ordered:
+
+```
+knowledge  ->  reasoning  ->  output
+```
+
+| Phase | Meaning | Capabilities |
+| --- | --- | --- |
+| `knowledge` | Produces something the answer can be based on | `document_search`, `document_analyze`, `document_compare`, `tabular_analyze`, `web_search`, `url_fetch`, `deep_research`, `agent_invoke` |
+| `reasoning` | Turns what was gathered into an answer | `respond` |
+| `output` | Declared, not yet populated | — |
+
+The boundary is drawn at *evidence*, not at effort: analysing and comparing documents are
+knowledge steps because they produce something to reason over, even though they involve a
+model call. Answering is the only reasoning step, because it is the only one that commits
+to a claim.
+
+`CAPABILITY_PHASES` is an ordered tuple, so a capability's phase is an index and "may this
+step follow that one" is an integer comparison rather than a table of special cases. The
+validator stably sorts by phase before the topological pass and drops a `depends_on` edge
+that points backwards across a phase boundary, recording a repair note.
+
+This replaced an earlier `kind` field (`retrieval` / `analysis` / `synthesis`) that was
+carried all the way to the browser and read by nothing. Two overlapping taxonomies where
+one is decorative is how a field comes to mean nothing, so `kind` was removed rather than
+kept alongside.
+
+**What enforcement buys.** A plan that searches after it has answered is not a plan, it is
+a mistake: it would run, and produce an answer written without the evidence the later step
+just found. That is a silent wrong answer rather than a visible failure, which is the worst
+kind.
+
+### Knowledge capabilities that produce text rather than evidence
+
+`build_evidence_envelope` requires a non-empty `document_id`, a `source_kind` of `tabular`
+or `narrative`, and an `engine` from three values. An agent returns free text plus tool-call
+citations tied to no document, and source review returns a JSON blob plus citations.
+Neither can honestly produce evidence.
+
+So `agent_invoke`, `url_fetch` and `deep_research` produce `notes` and `citations` instead.
+This is not a workaround: `RunContext.merge_step_result` already accumulates notes, and the
+respond adapter already folds them into its prompt. A knowledge step that gathers *text*
+rather than *document evidence* reaches the answer through a path that already existed.
+
 ### Execute
 
 `functions_orchestration_executor.py` orders steps topologically over `depends_on` and runs
@@ -87,6 +134,23 @@ cancellation and telemetry come with it.
 
 Authorization is checked twice: when the plan is validated, and again before the answer is
 composed. Those are not the same moment, and access can be revoked between them.
+
+#### The worker-thread boundary
+
+`execute_plan` runs in a `threading.Thread` so progress can stream while work happens. That
+thread has no Flask request context: no `g`, no `session`, no `current_app`. **An adapter
+must never read Flask state.** Every request-scoped value an adapter needs is captured on
+the request thread by `_request_identity()` in `route_backend_orchestration.py` and carried
+explicitly on `RunContext`.
+
+This matters most for `user_roles`, which gates the `UrlAccessUser` and `DeepResearchUser`
+app roles. Guessing it would either deny a permitted user or, far worse, admit one who
+holds no role. Absent roles normalise to "no roles" and the gate denies — the failure mode
+is a feature that does not appear, never one that appears when it should not.
+
+The capture happens outside the streamed generator, because a generator body runs *after*
+the view returns, when the session is already gone. `test_orchestration_adapter_contract.py`
+asserts all of this statically.
 
 ### Outputs
 
@@ -199,6 +263,9 @@ to the front.
 | `functional_tests/test_orchestration_run_ledger.py` | Run and byte bounds, oldest-first compaction, honest truncation, answered questions carrying forward |
 | `functional_tests/test_orchestration_invoke_prompt_contract.py` | The model-call convention: the route's closure must accept what the adapters and the document functions actually pass, and must count token usage |
 | `functional_tests/test_orchestration_executor.py` | Step ordering, dependency skipping, cancellation, budget caps, re-authorization |
+| `functional_tests/test_orchestration_phase_ordering.py` | Knowledge sorts before reasoning, a plan gathering after answering is repaired, a backwards dependency is dropped with a note |
+| `functional_tests/test_orchestration_adapter_contract.py` | Every capability resolves to an adapter, every adapter matches the executor's call signature, no adapter touches Flask state, and identity is captured on the request thread |
+| `functional_tests/test_orchestration_citation_persistence.py` | Cited documents reach the conversation's used-document list, and document and web citations are separated |
 
 ## Known limitations
 
@@ -206,8 +273,16 @@ to the front.
   capability metadata, so plans use one configured planner model and the default chat model
   for execution. Each step records which model it used, so per-step routing can be added
   without changing the plan contract.
-- **Retrieval and reasoning only.** Image generation, file exports, agent dispatch and
-  MCP or OpenAPI actions are not yet capabilities a plan can contain.
+- **Retrieval and reasoning only.** Image generation, file exports, workspace placement,
+  sharing, mail and MCP or OpenAPI actions are not yet capabilities a plan can contain. The
+  `output` phase is declared for them but empty.
+- **An agent step produces no artifacts.** Charts and images an agent generates are written
+  through the Flask-bound message-artifact pipeline, which the worker thread cannot reach.
+  The adapter surfaces the agent's tool activity as citations instead and returns no
+  artifacts.
+- **One agent per plan.** Loading an agent resolves Key Vault secrets, hydrates every plugin
+  it declares, and introspects SQL and Cosmos schemas. There is no working kernel cache, so
+  each agent step pays that cost in full.
 - **Steps run sequentially.** The executor orders steps by dependency but does not run
   independent steps in parallel.
 - **Workflows do not yet execute against this engine.** The run record was shaped with that

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,40 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/features) and [Fixes by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/fixes).
 
+### **(v0.261.087)**
+
+#### New Features
+
+*   **Orchestration Can Now Reach Agents, Linked Pages And Deep Research**
+    *   Orchestration could plan around a smaller world than you could reach by hand. Three things sitting in the composer as buttons — your agents, reading the links you pasted, and deep research — were invisible to the planner, so asking for them in plain language got you a plan that quietly did something simpler.
+    *   **Your agents can now be part of a plan.** The planner is shown the agents you can reach and picks one where the question calls for it. Picking an agent yourself still wins outright: a plan built around your choice rather than around a guess at it.
+    *   **Linked pages are read when you paste them.** Only links present in your own message are read — never one a model produced.
+    *   **Deep research is available for questions that need several sources reconciled.** It is the most expensive thing a plan can do, so the planner is told plainly that web search is the cheaper answer to an ordinary factual question.
+    *   Deep research and reading links continue to honour the `DeepResearchUser` and `UrlAccessUser` roles, and agents continue to honour your own agent setting. Orchestration still grants nobody access to anything they could not already reach by hand.
+    *   (Ref: `functions_orchestration_registry.py`, `functions_orchestration_adapters.py`, `functions_orchestration_context.resolve_agent_catalog`, [Chat Orchestration](features/CHAT_ORCHESTRATION.md), [Orchestration settings](../admin/orchestration.md))
+
+*   **A Plan Now Has A Shape: Gather, Then Reason, Then Create**
+    *   Every capability now belongs to an ordered phase — gathering knowledge, reasoning, creating — and a plan moves through them in order. A plan can no longer go looking for something after it has already answered, which used to produce an answer written without the evidence the later step had just found. That was a silently wrong answer rather than a visible failure, which is the worse of the two.
+    *   The third phase is declared but empty. Producing files, placing them in a workspace, sharing and mail come next; they have effects outside the conversation and need an approval story of their own.
+    *   (Ref: `CAPABILITY_PHASES`, `functions_orchestration_schema._enforce_phase_order`)
+
+*   **The Orchestration Settings Are Configurable In The New Admin Interface**
+    *   The new admin interface offered exactly one orchestration setting — the on switch — while the classic interface had sixteen. Approval mode, the countdown, the capability list, every limit and the planner model were all unreachable, so turning orchestration on there meant accepting whatever the defaults happened to be.
+    *   All sixteen are now configurable, grouped as Approval, Capabilities, Limits and Planner Model.
+    *   (Ref: `admin_settings_fields.py`, [Orchestration settings](../admin/orchestration.md))
+
+#### Bug Fixes
+
+*   **Documents An Orchestrated Answer Used Now Appear In The Documents Tab**
+    *   A plan would search, find the right material, and cite it correctly in its answer — and the Documents tab would still say "No documents used yet".
+    *   Two separate things were missing. The assistant message was saved without its citations, so the reply carried no citation chips. And the conversation's used-document list was never extended, which is what the Documents tab actually reads: an answer can cite a document perfectly and still show nothing there.
+    *   Web sources and document sources are now kept apart, because they are read differently — a citation with no document behind it used to be dropped silently on its way to document tracking.
+    *   (Ref: `route_backend_orchestration._partition_citations`, `merge_cited_documents_into_conversation`, `chatStore.settleOrchestrationTurn`)
+
+*   **The Plan Bar No Longer Lingers After A Run Finishes**
+    *   A collapsed plan summary stayed pinned in the conversation after its run had settled, competing with the answer it had produced. It is now removed once the run is complete; the full plan remains in the side panel, where it can be reopened.
+    *   (Ref: `OrchestrationPlanCard.tsx`)
+
 ### **(v0.261.086)**
 
 #### Bug Fixes

--- a/functional_tests/test_orchestration_adapter_contract.py
+++ b/functional_tests/test_orchestration_adapter_contract.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""
+Functional test for the orchestration adapter contract.
+Version: 0.261.087
+Implemented in: 0.261.087
+
+This is the generalisation of a bug that reached production. A step failed live with
+``invoke_prompt() got an unexpected keyword argument 'stage'`` -- a signature mismatch at
+the seam between the executor and a real adapter. It passed import, it passed type
+checking, and it passed the whole suite, because the executor tests drive *fake* adapters
+and the real ones need Azure to run at all.
+
+So the seam gets checked statically instead of hopefully. Every capability must resolve to
+an adapter, every adapter must take the exact keyword arguments the executor passes, and no
+adapter may reach for Flask state that does not exist on the worker thread it runs on.
+
+None of this needs credentials, which is the point: a test that only runs where Azure does
+is a test that stops running.
+"""
+
+import ast
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+
+from test_support.app_stubs import APP_ROOT  # noqa: E402
+from test_support.versioning import assert_app_version_at_least  # noqa: E402
+
+ADAPTERS = 'functions_orchestration_adapters.py'
+EXECUTOR = 'functions_orchestration_executor.py'
+REGISTRY = 'functions_orchestration_registry.py'
+ROUTE = 'route_backend_orchestration.py'
+
+# What the executor passes at the call site in _run_single_step.
+EXPECTED_POSITIONAL = ['step', 'context']
+EXPECTED_KEYWORD = {'settings', 'user_id', 'emit', 'cancel_requested'}
+
+
+def _tree(module):
+    with open(os.path.join(APP_ROOT, module), encoding='utf-8') as handle:
+        return ast.parse(handle.read())
+
+
+def _functions(tree):
+    return {
+        node.name: node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.FunctionDef)
+    }
+
+
+def _registered_adapter_names(tree):
+    """The adapter function names bound in ADAPTER_REGISTRY, keyed by capability constant."""
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        targets = [t.id for t in node.targets if isinstance(t, ast.Name)]
+        if 'ADAPTER_REGISTRY' not in targets:
+            continue
+        mapping = {}
+        for key, value in zip(node.value.keys, node.value.values):
+            if isinstance(key, ast.Name) and isinstance(value, ast.Name):
+                mapping[key.id] = value.id
+        return mapping
+    return {}
+
+
+def _capability_constants(tree):
+    """CAPABILITY_* constants and their string values from the registry."""
+    constants = {}
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if (
+                isinstance(target, ast.Name)
+                and target.id.startswith('CAPABILITY_')
+                and isinstance(node.value, ast.Constant)
+                and isinstance(node.value.value, str)
+            ):
+                constants[target.id] = node.value.value
+    return constants
+
+
+def test_every_capability_resolves_to_an_adapter():
+    """A capability the planner may choose must be a capability the executor can run."""
+    print("Testing that every capability has an adapter...")
+    try:
+        assert_app_version_at_least('0.261.087')
+
+        registry_tree = _tree(REGISTRY)
+        constants = _capability_constants(registry_tree)
+        registered = _registered_adapter_names(_tree(ADAPTERS))
+
+        assert registered, 'ADAPTER_REGISTRY could not be read'
+
+        # Every CAPABILITY_* constant the registry defines must be a key in ADAPTER_REGISTRY.
+        # A capability offered to the planner with no adapter behind it is a plan that
+        # validates, runs, and fails at the step -- exactly the failure this suite exists
+        # to move earlier.
+        missing = sorted(set(constants) - set(registered))
+        assert not missing, (
+            f"these capabilities have no registered adapter: {missing}. A capability the "
+            f"planner can choose must be one the executor can run."
+        )
+
+        print(f"  ok  all {len(constants)} capabilities resolve to an adapter")
+        return True
+    except Exception as e:
+        print(f"Test failed: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+
+def test_adapters_match_the_executor_call_signature():
+    """Every adapter takes exactly what the executor passes -- checked, not assumed."""
+    print("Testing the adapter signature...")
+    try:
+        adapters_tree = _tree(ADAPTERS)
+        functions = _functions(adapters_tree)
+        registered = _registered_adapter_names(adapters_tree)
+
+        for capability_constant, adapter_name in sorted(registered.items()):
+            node = functions.get(adapter_name)
+            assert node is not None, (
+                f"{adapter_name} is registered for {capability_constant} but not defined"
+            )
+
+            positional = [a.arg for a in node.args.args]
+            assert positional == EXPECTED_POSITIONAL, (
+                f"{adapter_name} takes {positional} positionally; the executor calls "
+                f"adapter(step, context, ...) so it must take {EXPECTED_POSITIONAL}"
+            )
+
+            keyword_only = {a.arg for a in node.args.kwonlyargs}
+            missing = EXPECTED_KEYWORD - keyword_only
+            assert not missing, (
+                f"{adapter_name} does not accept {sorted(missing)}; the executor passes "
+                f"these by keyword and the call would raise TypeError at run time"
+            )
+
+            # Anything extra must have a default, or the executor's call is short an argument.
+            extra = keyword_only - EXPECTED_KEYWORD
+            if extra:
+                defaulted = {
+                    arg.arg
+                    for arg, default in zip(node.args.kwonlyargs, node.args.kw_defaults)
+                    if default is not None
+                }
+                undefaulted = extra - defaulted
+                assert not undefaulted, (
+                    f"{adapter_name} requires {sorted(undefaulted)}, which the executor "
+                    f"does not pass"
+                )
+
+        print(f"  ok  all {len(registered)} adapters match the executor's call")
+        return True
+    except Exception as e:
+        print(f"Test failed: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+
+def test_adapters_never_touch_flask_state():
+    """An adapter runs on a worker thread where Flask request state does not exist."""
+    print("Testing that adapters stay off Flask state...")
+    try:
+        tree = _tree(ADAPTERS)
+
+        forbidden_imports = {'g', 'session', 'current_app', 'request'}
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and node.module == 'flask':
+                names = {alias.name for alias in node.names}
+                clash = names & forbidden_imports
+                assert not clash, (
+                    f"adapters import {sorted(clash)} from flask. execute_plan runs in a "
+                    f"threading.Thread with no request context, so this raises at run time "
+                    f"-- every value must arrive on RunContext instead."
+                )
+
+        # Attribute access too: `g.force_enable_agents` would pass the import check.
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Attribute) and isinstance(node.value, ast.Name):
+                assert node.value.id not in forbidden_imports, (
+                    f"adapters read {node.value.id}.{node.attr}; there is no request "
+                    f"context on the worker thread"
+                )
+
+        print("  ok  adapters read no Flask request state")
+        return True
+    except Exception as e:
+        print(f"Test failed: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+
+def test_route_captures_identity_before_the_thread_starts():
+    """Roles and email are read on the request thread, not from inside the generator."""
+    print("Testing the request-thread identity capture...")
+    try:
+        tree = _tree(ROUTE)
+        functions = _functions(tree)
+
+        capture = functions.get('_request_identity')
+        assert capture is not None, (
+            '_request_identity must exist: user_roles gates the UrlAccessUser and '
+            'DeepResearchUser app roles and cannot be read off the worker thread'
+        )
+
+        # It must fail closed. An except path that leaves roles unset, or sets them to
+        # anything truthy, would admit a user who holds no role.
+        capture_source = ast.dump(capture)
+        assert 'user_roles' in capture_source and 'user_email' in capture_source, (
+            '_request_identity must capture both user_roles and user_email'
+        )
+
+        # The capture must happen outside the streamed generator. A generator body runs
+        # after the view returns, when the session is already gone.
+        for outer in ast.walk(tree):
+            if not isinstance(outer, ast.FunctionDef) or outer.name != 'generate':
+                continue
+            for inner in ast.walk(outer):
+                if (
+                    isinstance(inner, ast.Call)
+                    and isinstance(inner.func, ast.Name)
+                    and inner.func.id == '_request_identity'
+                ):
+                    raise AssertionError(
+                        '_request_identity is called inside generate(); a streamed '
+                        "response's generator runs after the request context is torn down"
+                    )
+
+        # And the captured values must actually reach RunContext, or the adapters get None.
+        wired = set()
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id == 'RunContext'
+            ):
+                wired = {kw.arg for kw in node.keywords}
+        for field in ('user_roles', 'user_email', 'user_enable_agents'):
+            assert field in wired, (
+                f"RunContext is built without {field}; the adapter would fall back to a "
+                f"default and gate on a value nobody supplied"
+            )
+
+        print("  ok  identity is captured on the request thread and reaches RunContext")
+        return True
+    except Exception as e:
+        print(f"Test failed: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+
+def test_role_gates_fail_closed():
+    """Absent roles must deny, never allow."""
+    print("Testing that role gates fail closed...")
+    try:
+        tree = _tree(EXECUTOR)
+        functions = _functions(tree)
+
+        init = functions.get('__init__')
+        assert init is not None, 'RunContext.__init__ not found'
+
+        source = ast.dump(init)
+        assert 'user_roles' in source, 'RunContext must carry user_roles'
+
+        # An unknown roles value must collapse to "no roles". If it were passed through
+        # unchanged, a stray truthy value could satisfy a membership check downstream.
+        assert 'isinstance' in source, (
+            'RunContext must type-check user_roles before storing it, so an unknown '
+            'value cannot be mistaken for a role list'
+        )
+
+        print("  ok  roles are normalised and absent roles deny")
+        return True
+    except Exception as e:
+        print(f"Test failed: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+
+if __name__ == "__main__":
+    tests = [
+        test_every_capability_resolves_to_an_adapter,
+        test_adapters_match_the_executor_call_signature,
+        test_adapters_never_touch_flask_state,
+        test_route_captures_identity_before_the_thread_starts,
+        test_role_gates_fail_closed,
+    ]
+    results = []
+    for test in tests:
+        print(f"\nRunning {test.__name__}...")
+        results.append(test())
+
+    print(f"\nResults: {sum(results)}/{len(results)} tests passed")
+    sys.exit(0 if all(results) else 1)

--- a/functional_tests/test_orchestration_agent_selection.py
+++ b/functional_tests/test_orchestration_agent_selection.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+"""
+Functional test for orchestration agent selection.
+Version: 0.261.087
+Implemented in: 0.261.087
+
+An agent's configuration is not all equally safe to show a planner. Its naming fields are
+what a planner needs to choose sensibly; its ``instructions`` are a full system prompt, and
+putting one in front of the planner would both waste the context and let one agent's
+instructions influence a plan it was never chosen for.
+
+So the catalog is projected before it is shown, and the projection is checked here. Also
+checked: that a user-seeded agent is treated as a hard constraint rather than a suggestion,
+and that the projection is applied at the single point the planner context is built, so a
+caller passing raw records cannot leak through it.
+"""
+
+import ast
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+
+from test_support.app_stubs import APP_ROOT, stubbed_app_imports  # noqa: E402
+from test_support.versioning import assert_app_version_at_least  # noqa: E402
+
+CONTEXT = 'functions_orchestration_context.py'
+ROUTE = 'route_backend_orchestration.py'
+
+# Everything an agent record can hold that the planner must never be shown. These are not
+# arbitrary: instructions is the system prompt, and the rest name internal wiring.
+WITHHELD = (
+    'instructions',
+    'actions_to_load',
+    'assigned_knowledge',
+    'model_endpoint_id',
+    'scope_id',
+    'azure_openai_gpt_key',
+)
+
+FULL_AGENT = {
+    'name': 'research_helper',
+    'display_name': 'Research Helper',
+    'description': 'Looks things up in the research corpus.',
+    'tags': ['research'],
+    'action_labels': ['search_corpus'],
+    'instructions': 'You are a research assistant. SECRET SYSTEM PROMPT.',
+    'actions_to_load': ['corpus_plugin'],
+    'assigned_knowledge': {'workspace': 'w1'},
+    'model_endpoint_id': 'endpoint-123',
+    'scope_id': 'group-9',
+    'azure_openai_gpt_key': 'sk-do-not-leak',
+}
+
+
+def _tree(module):
+    with open(os.path.join(APP_ROOT, module), encoding='utf-8') as handle:
+        return ast.parse(handle.read())
+
+
+def test_projection_withholds_agent_internals():
+    """The planner sees an agent's naming fields and nothing else."""
+    print("Testing the agent planner projection...")
+    try:
+        assert_app_version_at_least('0.261.087')
+
+        with stubbed_app_imports():
+            from functions_orchestration_registry import (
+                AGENT_PLANNER_FIELDS,
+                build_agent_planner_projection,
+            )
+
+            projected = build_agent_planner_projection([FULL_AGENT])
+            assert len(projected) == 1, f"expected one agent, got {projected}"
+            entry = projected[0]
+
+            for field in WITHHELD:
+                assert field not in entry, (
+                    f"{field} reached the planner projection. The planner chooses an agent "
+                    f"by name and purpose; it has no use for internals and every reason "
+                    f"not to see them."
+                )
+
+            # And the whole record must be inside the allow-list, so a field added to an
+            # agent record later cannot appear here by default.
+            unexpected = set(entry) - set(AGENT_PLANNER_FIELDS)
+            assert not unexpected, (
+                f"projection emitted fields outside AGENT_PLANNER_FIELDS: {sorted(unexpected)}"
+            )
+
+            assert entry['name'] == 'research_helper'
+            assert entry['description'], 'the planner needs a description to choose sensibly'
+
+        print("  ok  only naming fields reach the planner")
+        return True
+    except Exception as e:
+        print(f"Test failed: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+
+def test_nameless_agents_are_dropped():
+    """An agent with no name cannot be referenced by a plan, so it is not offered."""
+    print("Testing that nameless agents are dropped...")
+    try:
+        with stubbed_app_imports():
+            from functions_orchestration_registry import build_agent_planner_projection
+
+            projected = build_agent_planner_projection([
+                {'display_name': 'No Name', 'description': 'x'},
+                {'name': '   '},
+                {'name': 'usable', 'description': 'y'},
+                'not a dict',
+                None,
+            ])
+
+            names = [a['name'] for a in projected]
+            assert names == ['usable'], (
+                f"only referenceable agents should be offered, got {names}. A plan names an "
+                f"agent by its name; offering one without a name invites a plan that cannot "
+                f"be validated."
+            )
+
+        print("  ok  unreferenceable agents are not offered")
+        return True
+    except Exception as e:
+        print(f"Test failed: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+
+def test_projection_is_applied_where_the_context_is_built():
+    """Raw records passed to build_planner_context are projected, not trusted."""
+    print("Testing that the context builder projects rather than trusts...")
+    try:
+        with stubbed_app_imports():
+            from functions_orchestration_context import build_planner_context
+
+            context = build_planner_context('a question', agents=[FULL_AGENT])
+            agents = context.get('agents') or []
+            assert agents, 'the catalog did not reach the planner context'
+
+            blob = repr(agents)
+            for field in WITHHELD:
+                assert field not in blob, (
+                    f"{field} survived into the planner context. Projecting at the one "
+                    f"place the context is built is what makes this safe regardless of what "
+                    f"a caller passes."
+                )
+            assert 'SECRET SYSTEM PROMPT' not in blob, (
+                "an agent's instructions reached the planner context"
+            )
+
+        print("  ok  raw records are projected at the context boundary")
+        return True
+    except Exception as e:
+        print(f"Test failed: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+
+def test_a_seeded_agent_is_a_hard_constraint():
+    """Choosing an agent by hand narrows the plan rather than suggesting to it."""
+    print("Testing that a seeded agent wins...")
+    try:
+        with stubbed_app_imports():
+            from functions_orchestration_context import resolve_agent_catalog
+
+            source = ast.dump(_tree(CONTEXT))
+            assert 'resolve_agent_catalog' in source
+
+            # A seeded agent must narrow the catalog. The user has already made the choice
+            # this catalog exists to inform, so offering alternatives invites the planner to
+            # overrule them -- the same reason a seeded document turns off the candidate probe.
+            catalog = resolve_agent_catalog(
+                'user-1',
+                seeds={'agent': {'name': 'chosen_one', 'display_name': 'Chosen One'}},
+            )
+            names = [a.get('name') for a in (catalog or [])]
+            assert names == ['chosen_one'], (
+                f"a seeded agent must be the only one offered, got {names}. A user who "
+                f"picked an agent has stated a constraint, not a preference."
+            )
+
+        print("  ok  a user-selected agent is the only one offered")
+        return True
+    except Exception as e:
+        print(f"Test failed: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+
+def test_catalog_resolution_fails_soft():
+    """A catalog lookup that raises degrades to 'no agents', never breaks planning."""
+    print("Testing that catalog resolution fails soft...")
+    try:
+        tree = _tree(CONTEXT)
+        target = None
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == 'resolve_agent_catalog':
+                target = node
+        assert target is not None, 'resolve_agent_catalog not found'
+
+        handlers = [n for n in ast.walk(target) if isinstance(n, ast.ExceptHandler)]
+        assert handlers, (
+            'resolve_agent_catalog must handle a failing lookup. It is a multi-query Cosmos '
+            'traversal; a transient failure there must cost the plan its agents, not the '
+            'user their answer.'
+        )
+        for handler in handlers:
+            raises = [n for n in ast.walk(handler) if isinstance(n, ast.Raise)]
+            assert not raises, (
+                'the catalog handler re-raises; planning must continue without agents'
+            )
+
+        print("  ok  a failed lookup degrades to no agents")
+        return True
+    except Exception as e:
+        print(f"Test failed: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+
+def test_route_resolves_the_catalog_once_per_plan():
+    """Resolution happens per plan and per run -- never inside a loop over steps."""
+    print("Testing catalog resolution placement...")
+    try:
+        tree = _tree(ROUTE)
+
+        calls = [
+            node for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == 'resolve_agent_catalog'
+        ]
+        assert len(calls) == 2, (
+            f"expected exactly two resolutions (one when planning, one when running), "
+            f"found {len(calls)}. Planning and running are separate requests and access "
+            f"can be revoked between them, so the run must not reuse the plan's snapshot -- "
+            f"but neither may resolve more than once."
+        )
+
+        # And none of them inside a loop, which would make it per-step.
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.For, ast.While)):
+                for inner in ast.walk(node):
+                    if (
+                        isinstance(inner, ast.Call)
+                        and isinstance(inner.func, ast.Name)
+                        and inner.func.id == 'resolve_agent_catalog'
+                    ):
+                        raise AssertionError(
+                            'the agent catalog is resolved inside a loop; it is a '
+                            'multi-query Cosmos operation with no cache'
+                        )
+
+        print("  ok  resolved once when planning and once when running")
+        return True
+    except Exception as e:
+        print(f"Test failed: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+
+if __name__ == "__main__":
+    tests = [
+        test_projection_withholds_agent_internals,
+        test_nameless_agents_are_dropped,
+        test_projection_is_applied_where_the_context_is_built,
+        test_a_seeded_agent_is_a_hard_constraint,
+        test_catalog_resolution_fails_soft,
+        test_route_resolves_the_catalog_once_per_plan,
+    ]
+    results = []
+    for test in tests:
+        print(f"\nRunning {test.__name__}...")
+        results.append(test())
+
+    print(f"\nResults: {sum(results)}/{len(results)} tests passed")
+    sys.exit(0 if all(results) else 1)

--- a/functional_tests/test_orchestration_citation_persistence.py
+++ b/functional_tests/test_orchestration_citation_persistence.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""
+Functional test for orchestration citation persistence.
+Version: 0.261.087
+Implemented in: 0.261.087
+
+An orchestrated answer searched documents, found the right material, and cited it in its
+prose -- and the Documents drawer still said "No documents used yet".
+
+Two things were missing, and they are separate. The assistant message was written without
+its `hybrid_citations`, so the reply had no citation chips. And the conversation's
+`used_documents` list was never extended, which is what the Documents drawer actually
+reads: an answer can cite a document perfectly and still show nothing there, because the
+drawer works from the conversation rather than from the message.
+
+Both are checked here at the source level, because the write path needs Cosmos and the
+drawer needs a browser -- and a bug that only shows up in a live deployment is exactly the
+kind this suite exists to catch earlier.
+"""
+
+import ast
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+
+from test_support.app_stubs import APP_ROOT  # noqa: E402
+from test_support.versioning import assert_app_version_at_least  # noqa: E402
+
+ROUTE = 'route_backend_orchestration.py'
+
+
+def _read(module):
+    with open(os.path.join(APP_ROOT, module), encoding='utf-8') as handle:
+        return handle.read()
+
+
+def _function(source, name):
+    for node in ast.walk(ast.parse(source)):
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    return None
+
+
+def _isolated(module, *names):
+    """Execute named top-level functions from a module without importing it.
+
+    Importing ``route_backend_orchestration`` pulls in ``config``, which builds a live
+    Cosmos client and fails without credentials. These helpers are pure, so their real
+    source is compiled and run here instead of being reimplemented -- the test exercises
+    the shipping code rather than a copy of it that could drift.
+    """
+    tree = ast.parse(_read(module))
+    wanted = [
+        node for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name in names
+    ]
+    missing = set(names) - {node.name for node in wanted}
+    assert not missing, f"{module} no longer defines {sorted(missing)}"
+
+    namespace = {}
+    exec(compile(ast.Module(body=wanted, type_ignores=[]), module, 'exec'), namespace)
+    return namespace
+
+
+def test_citations_are_split_into_document_and_web():
+    """Document and web citations go to different fields, because they are read differently."""
+    print("Testing the citation split...")
+    try:
+        route = _isolated(ROUTE, '_text', '_partition_citations')
+
+        documents, web = route['_partition_citations']([
+            {'document_id': 'doc1', 'file_name': 'Algebra.pdf', 'citation_id': 'c1'},
+            {'url': 'https://example.test/a', 'source_type': 'web'},
+            {'document_id': 'doc2', 'file_name': 'Handbook.pdf'},
+            # An agent tool call: neither a document nor a page. Kept rather than
+            # dropped, but kept out of document tracking where it has no place.
+            {'tool_name': 'search', 'function_name': 'run'},
+            'not a dict',
+        ])
+
+        assert [c['document_id'] for c in documents] == ['doc1', 'doc2'], (
+            f"document citations were not separated: {documents}"
+        )
+        assert len(web) == 2, f"web and tool citations should survive: {web}"
+        assert all('document_id' not in c for c in web), (
+            "a citation with no document must never reach document tracking, where "
+            "build_used_documents would skip it silently"
+        )
+
+        print("  ok  document and web citations are separated")
+        return True
+    except Exception as e:
+        print(f"Test failed: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+
+def test_assistant_message_carries_its_citations():
+    """The saved message must carry hybrid_citations, not just prose that mentions sources."""
+    print("Testing that the assistant message carries citations...")
+    try:
+        source = _read(ROUTE)
+
+        save = _function(source, '_save_message')
+        assert save is not None, '_save_message must exist'
+        parameters = {arg.arg for arg in save.args.args}
+        assert 'extra' in parameters, (
+            "_save_message needs a channel for the top-level citation fields; nesting them "
+            "in metadata would put them where no existing reader looks"
+        )
+
+        body = ast.dump(ast.parse(source))
+        for field in ('hybrid_citations', 'web_search_citations'):
+            assert field in body, f"the run must persist {field} on the assistant message"
+
+        # And the terminal frame carries them too, so a client that never reloads still
+        # renders the sources.
+        events = _read('functions_orchestration_events.py')
+        done = _function(events, 'build_run_done_event')
+        assert done is not None
+        done_parameters = {arg.arg for arg in done.args.args}
+        assert 'web_citations' in done_parameters, (
+            'the done event must carry web citations separately from document ones'
+        )
+
+        print("  ok  citations are persisted and streamed")
+        return True
+    except Exception as e:
+        print(f"Test failed: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+
+def test_cited_documents_reach_the_conversation():
+    """The Documents drawer reads the conversation, so the run must write to it."""
+    print("Testing that cited documents are recorded on the conversation...")
+    try:
+        source = _read(ROUTE)
+
+        recorder = _function(source, '_record_cited_documents')
+        assert recorder is not None, (
+            '_record_cited_documents must exist: citing a document on the message is not '
+            'enough to make it appear in the Documents drawer'
+        )
+
+        body = ast.dump(recorder)
+        assert 'merge_cited_documents_into_conversation' in body, (
+            'the conversation used-document list is what the drawer reads, and '
+            'merge_cited_documents_into_conversation is what extends it'
+        )
+        assert 'upsert_item' in body, 'the merged conversation has to be written back'
+        assert 'user_id' in body, (
+            'ownership must be checked before writing to a conversation'
+        )
+
+        # It is actually called when a run finishes, not merely defined.
+        calls = [
+            node for node in ast.walk(ast.parse(source))
+            if isinstance(node, ast.Call)
+            and getattr(node.func, 'id', None) == '_record_cited_documents'
+        ]
+        assert calls, '_record_cited_documents is defined but never called'
+
+        print("  ok  cited documents are merged into the conversation")
+        return True
+    except Exception as e:
+        print(f"Test failed: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+
+def test_search_citations_have_what_tracking_needs():
+    """A search citation must carry the fields used-document tracking reads."""
+    print("Testing the shape of a document search citation...")
+    try:
+        # Checked at the source level rather than by calling the builder. The adapters
+        # module reaches Cosmos through its imports, so importing it here would need
+        # credentials -- and a test that only runs where Azure does is a test that stops
+        # running.
+        source = _read('functions_orchestration_adapters.py')
+        builder = _function(source, '_citations_from_search_results')
+        assert builder is not None, '_citations_from_search_results must exist'
+
+        body = ast.dump(builder)
+        # build_used_documents skips any citation with no document_id, so an answer would
+        # cite its sources in prose and show nothing in the drawer.
+        for field in ('document_id', 'citation_id', 'file_name', 'page_number'):
+            assert f"'{field}'" in body or f'"{field}"' in body, (
+                f"a search citation must carry {field}; the conversation's used-document "
+                f"tracking reads it"
+            )
+
+        print("  ok  search citations carry what document tracking needs")
+        return True
+    except Exception as e:
+        print(f"Test failed: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+
+if __name__ == "__main__":
+    assert_app_version_at_least("0.261.087")
+
+    tests = [
+        test_citations_are_split_into_document_and_web,
+        test_assistant_message_carries_its_citations,
+        test_cited_documents_reach_the_conversation,
+        test_search_citations_have_what_tracking_needs,
+    ]
+    results = []
+    for test in tests:
+        print(f"\nRunning {test.__name__}...")
+        results.append(test())
+
+    print(f"\nResults: {sum(results)}/{len(results)} tests passed")
+    sys.exit(0 if all(results) else 1)

--- a/functional_tests/test_orchestration_phase_ordering.py
+++ b/functional_tests/test_orchestration_phase_ordering.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""
+Functional test for chat orchestration phase ordering.
+Version: 0.261.087
+Implemented in: 0.261.087
+
+A plan runs in three phases: collect knowledge, reason on it and answer, then create
+things. Before this the registry carried a `kind` that was passed all the way to the
+browser and read by nothing, so the order was a convention the planner could ignore
+without anything noticing.
+
+It matters because a step that gathers after the answer has been written would still run,
+still cost money, and contribute nothing -- the answer it was meant to inform was composed
+before it started. The validator already guarantees a plan ends by answering; this is the
+same class of structural rule, and this test is what holds it.
+"""
+
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+
+from test_support.app_stubs import stubbed_app_imports  # noqa: E402
+from test_support.versioning import assert_app_version_at_least  # noqa: E402
+
+SETTINGS = {
+    'enable_user_workspace': True,
+    'enable_web_search': True,
+    'chat_orchestration_max_steps': 10,
+}
+
+
+def _step(step_id, capability_id, arguments=None, depends_on=None):
+    return {
+        'step_id': step_id,
+        'capability_id': capability_id,
+        'arguments': arguments or {},
+        'depends_on': list(depends_on or []),
+    }
+
+
+def test_phases_are_ordered_and_indexed():
+    """The phase tuple is ordered, and every capability lands in a real one."""
+    print("Testing the phase ordering...")
+    try:
+        with stubbed_app_imports():
+            import functions_orchestration_registry as registry
+
+            assert registry.CAPABILITY_PHASES == ('knowledge', 'reasoning', 'output'), (
+                f"unexpected phase order: {registry.CAPABILITY_PHASES}"
+            )
+
+            # Knowledge is drawn on what a capability produces, not on how hard it thinks:
+            # analysing and comparing emit the same evidence envelopes as searching.
+            for capability_id in (
+                'document_search', 'document_analyze', 'document_compare',
+                'tabular_analyze', 'web_search', 'url_fetch', 'deep_research',
+                'agent_invoke',
+            ):
+                assert registry.phase_index(capability_id) == 0, (
+                    f"{capability_id} should be a knowledge capability"
+                )
+
+            assert registry.phase_index('respond') == 1, "answering is the reasoning phase"
+
+            # An unknown capability sorts last rather than first: whatever it is, running it
+            # ahead of everything that gathers would be the more damaging guess.
+            assert registry.phase_index('not_a_capability') == len(registry.CAPABILITY_PHASES)
+
+        print("Test passed!")
+        return True
+    except Exception as e:
+        print(f"Test failed: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+
+def test_gathering_after_answering_is_reordered():
+    """A plan that answers before it gathers is repaired, not run as written."""
+    print("Testing that gathering is moved ahead of answering...")
+    try:
+        with stubbed_app_imports():
+            import functions_orchestration_schema as schema
+
+            plan = schema.normalize_plan(
+                {
+                    'steps': [
+                        _step('answer', 'respond'),
+                        _step('search', 'document_search', {'query': 'slope formula'}),
+                        _step('web', 'web_search', {'query': 'slope formula'}),
+                    ],
+                },
+                'conv1', 'user1', settings=SETTINGS,
+            )
+
+            order = [step['capability_id'] for step in plan['steps']]
+            assert order[-1] == 'respond', f"the answer must run last, got {order}"
+            assert 'document_search' in order[:-1]
+            assert 'web_search' in order[:-1], (
+                f"both gathering steps must precede the answer, got {order}"
+            )
+
+            # Every step now declares which phase it belongs to, so the client can group
+            # them without knowing the registry.
+            assert all(step.get('phase') for step in plan['steps'])
+            assert plan['steps'][-1]['phase'] == 'reasoning'
+
+        print("Test passed!")
+        return True
+    except Exception as e:
+        print(f"Test failed: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+
+def test_backwards_dependency_is_dropped_and_reported():
+    """A gathering step may not wait on the answer."""
+    print("Testing that a backwards dependency is dropped...")
+    try:
+        with stubbed_app_imports():
+            import functions_orchestration_schema as schema
+
+            plan = schema.normalize_plan(
+                {
+                    'steps': [
+                        # Nonsense: the search waits for the answer that is supposed to use
+                        # it. Honouring it would drag the answer forward, which is the very
+                        # inversion the phase order exists to prevent.
+                        _step('search', 'document_search', {'query': 'q'},
+                              depends_on=['answer']),
+                        _step('answer', 'respond'),
+                    ],
+                },
+                'conv1', 'user1', settings=SETTINGS,
+            )
+
+            search = [s for s in plan['steps'] if s['capability_id'] == 'document_search'][0]
+            assert 'answer' not in search['depends_on'], (
+                f"the backwards dependency survived: {search['depends_on']}"
+            )
+            assert any('later phase' in repair for repair in plan['validation']['repairs']), (
+                f"the repair must be reported, saw {plan['validation']['repairs']}"
+            )
+
+            # And the plan still runs in a defensible order afterwards.
+            seen = set()
+            for step in plan['steps']:
+                for dependency in step['depends_on']:
+                    assert dependency in seen, "steps are not in dependency order"
+                seen.add(step['step_id'])
+
+        print("Test passed!")
+        return True
+    except Exception as e:
+        print(f"Test failed: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+
+def test_ordering_within_a_phase_is_preserved():
+    """Sorting by phase must not shuffle steps that share one."""
+    print("Testing that the planner's own order survives within a phase...")
+    try:
+        with stubbed_app_imports():
+            import functions_orchestration_schema as schema
+
+            plan = schema.normalize_plan(
+                {
+                    'steps': [
+                        _step('a', 'document_search', {'query': 'first'}),
+                        _step('b', 'web_search', {'query': 'second'}),
+                        _step('c', 'document_search', {'query': 'third'}),
+                        _step('answer', 'respond'),
+                    ],
+                },
+                'conv1', 'user1', settings=SETTINGS,
+            )
+
+            knowledge = [s['step_id'] for s in plan['steps'] if s['phase'] == 'knowledge']
+            assert knowledge == ['a', 'b', 'c'], (
+                f"a stable sort should leave same-phase steps alone, got {knowledge}"
+            )
+
+        print("Test passed!")
+        return True
+    except Exception as e:
+        print(f"Test failed: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+
+def test_the_client_carries_the_phase_the_server_decided():
+    """The browser groups by the phase the validator stamped, not by re-deriving it."""
+    print("Testing the client's phase contract...")
+    try:
+        v2_root = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+            'application', 'v2_ui', 'src',
+        )
+
+        def read(*parts):
+            with open(os.path.join(v2_root, *parts), encoding='utf-8') as handle:
+                return handle.read()
+
+        # The plan normalizer must copy `phase` through. Without this the value the server
+        # ordered the plan by is discarded on arrival and the view has to guess it back from
+        # the capability menu -- which disagrees the moment a capability is turned off after
+        # a plan was made.
+        normalizer = read('lib', 'orchestrationPlan.ts')
+        assert 'phase' in normalizer, (
+            'normalizeStep drops the step phase; the server sends it and the client would '
+            'have to re-derive a value it was already given'
+        )
+
+        # The phases must be declared in run order on the client too, so a grouped view can
+        # iterate them rather than hard-coding an order that can drift from the server's.
+        contracts = read('lib', 'orchestration.ts')
+        assert 'ORCHESTRATION_PHASES' in contracts, (
+            'the client must declare the phases in order'
+        )
+        order_start = contracts.index('ORCHESTRATION_PHASES')
+        declared = contracts[order_start:order_start + 200]
+        for earlier, later in (('knowledge', 'reasoning'), ('reasoning', 'output')):
+            assert declared.index(earlier) < declared.index(later), (
+                f"the client lists {later} before {earlier}; a grouped plan would read "
+                f"out of order"
+            )
+
+        # `kind` is gone rather than kept alongside. Two taxonomies where one is decorative
+        # is how a field comes to mean nothing.
+        assert 'OrchestrationPhase' in contracts, 'the phase type must exist'
+
+        # And a step whose phase cannot be resolved must still be shown. A plan the user is
+        # asked to approve cannot quietly omit a step from the list.
+        view = read('components', 'chat', 'OrchestrationRunView.tsx')
+        assert 'ORCHESTRATION_PHASES' in view, 'the run view must group by phase'
+        assert 'step.phase' in view, (
+            "the run view must prefer the step's own phase over a lookup"
+        )
+
+        print("  ok  the client groups by the phase the server decided")
+        return True
+    except Exception as e:
+        print(f"Test failed: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+
+if __name__ == "__main__":
+    assert_app_version_at_least("0.261.087")
+
+    tests = [
+        test_phases_are_ordered_and_indexed,
+        test_gathering_after_answering_is_reordered,
+        test_backwards_dependency_is_dropped_and_reported,
+        test_ordering_within_a_phase_is_preserved,
+        test_the_client_carries_the_phase_the_server_decided,
+    ]
+    results = []
+    for test in tests:
+        print(f"\nRunning {test.__name__}...")
+        results.append(test())
+
+    print(f"\nResults: {sum(results)}/{len(results)} tests passed")
+    sys.exit(0 if all(results) else 1)

--- a/functional_tests/test_orchestration_registry_contract.py
+++ b/functional_tests/test_orchestration_registry_contract.py
@@ -32,9 +32,9 @@ def test_descriptors_are_well_formed():
             import functions_orchestration_registry as registry
 
             required_fields = (
-                'id', 'label', 'kind', 'summary', 'when_to_use', 'settings_gates',
-                'settings_gates_any', 'gate', 'requires_scope', 'inputs', 'produces',
-                'cost_class', 'max_per_plan', 'adapter', 'terminal',
+                'id', 'label', 'phase', 'summary', 'when_to_use', 'settings_gates',
+                'settings_gates_any', 'gate', 'request_gate', 'requires_scope', 'inputs',
+                'produces', 'cost_class', 'max_per_plan', 'adapter', 'terminal',
             )
 
             seen_ids = set()
@@ -49,8 +49,8 @@ def test_descriptors_are_well_formed():
                 )
                 seen_ids.add(capability['id'])
 
-                assert capability['kind'] in registry.CAPABILITY_KINDS, (
-                    f"{capability['id']} has an unknown kind {capability['kind']}"
+                assert capability['phase'] in registry.CAPABILITY_PHASES, (
+                    f"{capability['id']} has an unknown phase {capability['phase']}"
                 )
                 assert capability['cost_class'] in registry.COST_CLASSES, (
                     f"{capability['id']} has an unknown cost class"

--- a/functional_tests/test_support/app_stubs.py
+++ b/functional_tests/test_support/app_stubs.py
@@ -40,6 +40,11 @@ def _build_stub_modules():
 
     appinsights = types.ModuleType("functions_appinsights")
     appinsights.log_event = lambda *args, **kwargs: None
+    # Several modules import this alongside log_event. Without it the import fails, and a
+    # caller that lazily imports such a module reads that failure as the capability being
+    # unavailable -- which is correct behaviour but makes the module untestable here.
+    appinsights.debug_print = lambda *args, **kwargs: None
+    appinsights.is_debug_enabled = lambda *args, **kwargs: False
 
     settings = types.ModuleType("functions_settings")
     settings.get_settings = lambda: {}


### PR DESCRIPTION
## Why

The capability registry had six entries and one flat, decorative taxonomy. `kind` (`retrieval` / `analysis` / `synthesis`) was carried all the way to the browser and **read by nothing** — not the validator, not the executor, not a single React component.

Meanwhile three knowledge capabilities the application already had were missing from the registry entirely: **agents**, **reading linked pages** and **deep research**. All three exist as composer buttons today, so orchestration was planning around a smaller world than a user could reach by hand — which is backwards.

This names the phases, enforces them, and completes the knowledge phase.

## Phases

```
knowledge  ->  reasoning  ->  output
```

`CAPABILITY_PHASES` is ordered, so a capability's phase is an index and "may this step follow that one" is an integer comparison rather than a table of special cases. The validator stably sorts by phase before the topological pass and drops a `depends_on` edge pointing backwards across a boundary, recording a repair note.

The boundary is drawn at *evidence*, not at effort: analysing and comparing documents are knowledge steps because they produce something to reason over. Answering is the only reasoning step, because it is the only one that commits to a claim. `output` is declared but empty — that slice has side effects outside the conversation and needs an approval story of its own.

**What enforcement buys.** A plan that searches after it has answered is not a plan, it is a mistake: it would run, and produce an answer written without the evidence the later step just found. That is a silently wrong answer rather than a visible failure.

`kind` was removed rather than kept alongside. Two overlapping taxonomies where one is decorative is how a field comes to mean nothing, which is the situation being fixed.

## Three new knowledge capabilities

None of them can produce evidence. `build_evidence_envelope` requires a non-empty `document_id`, a `source_kind` of `tabular` or `narrative`, and an `engine` from exactly three values. An agent returns free text plus tool-call citations tied to no document.

This is not a limitation worked around — it is the honest mapping, and it already works: `RunContext.merge_step_result` accumulates `notes`, and the respond adapter already folds them into its prompt. A knowledge step that gathers *text* rather than *document evidence* reaches the answer through a path that already existed.

| Capability | Notes |
|---|---|
| `url_fetch` | Only reads links present in the user's own message. A requested URL is intersected with the message's URLs, so a model-invented URL can never be fetched. |
| `deep_research` | The most expensive capability in the registry. `when_to_use` names `web_search` as the cheaper default so the planner reaches for it deliberately. |
| `agent_invoke` | Bounded to one per plan. Loading a kernel resolves Key Vault secrets, hydrates every declared plugin and introspects SQL and Cosmos schemas, and the Redis kernel cache in `functions_chat.py` is dead code. |

The planner is shown only `name`, `display_name`, `description`, `tags`, `action_labels`. A user-seeded agent is a hard constraint — the planner is shown that agent alone, exactly as a seeded document turns off the candidate probe.

## Two levels of gate — and the one that was never applied

Each capability declares two gates:

| Gate | Question | Read by |
|---|---|---|
| `gate(settings)` | Does this deployment have the capability at all? | Admin page, bootstrap, planning |
| `request_gate(settings, context)` | May *this caller, asking this question*, use it? | Planning only |

Request gates apply **only when a request context is supplied** — deliberately, because the admin page describes a deployment, not a caller, and would be wrong to hide a capability because the administrator viewing it happens to have no agents.

**But nobody supplied one.** `plan_request` resolved capabilities with no context, so no request gate ran for a real request: the planner could propose reading links in a message containing none, or name an agent the user does not have. The step then failed where it ran, having promised something in a plan the user had already approved.

Nobody could reach anything they weren't entitled to — `perform_source_review` re-checks its own roles and `run_agent_invoke` refuses an uncatalogued agent — but a plan could *describe* it, which is its own kind of wrong.

`plan_request` now takes `request_context` and forwards it. Because the same resolution feeds both the planner projection and the ids the validator enforces, one change narrows three things: what the planner is offered, what the validator accepts, and therefore what can reach an adapter.

This surfaced only from probing the resolved capability list directly rather than reading the code. It type-checked, it imported, and every existing test passed.

## The worker-thread boundary

The single largest risk here, and the one that would fail only in production.

`execute_plan` runs in a `threading.Thread` with no `g`, no `session`, no `current_app` — and the existing agent path reads all three. `_request_identity()` now captures roles, email and the per-user agent preference on the request thread, **outside the streamed generator**, because a generator body runs after the view returns when the session is already gone.

`user_roles` gates the `UrlAccessUser` and `DeepResearchUser` app roles and **fails closed**: absent roles normalise to "no roles" and the gate denies. The failure mode is a feature that does not appear, never one that appears when it should not.

The agent catalog is resolved fresh for the run rather than read back off the plan — planning and running are separate requests and access can be revoked between them, the same reason document authorization is rechecked before the answer is composed. It is resolved only on the non-trivial path, so a conversational message never pays for a multi-query Cosmos traversal.

## Fixes reported from the live deployment

**Cited documents never reached the Documents drawer.** The drawer reads the conversation's `used_documents`, not the message's citations, so an answer could cite a document perfectly and still show "No documents used yet". Two separate things were missing: the assistant message was saved without its citations, and `merge_cited_documents_into_conversation` was never called. Document and web citations are now separated, because `build_used_documents` silently skips a citation with no `document_id`.

**The plan bar lingered** after a run settled, competing with the answer it produced.

## V2 admin settings

The V2 admin page offered one orchestration setting where the classic page had sixteen — approval mode, the countdown, the capability list, every limit and the planner model were all unreachable. All sixteen are now configurable, grouped as Approval, Capabilities, Limits and Planner Model.

Writing them surfaced a real bug that `test_v2_admin_settings_schema.py` caught: `depends_on` visibility is evaluated **per field, not recursively**, so the countdown gated only on the approval mode stayed visible whenever the mode field itself was hidden by orchestration being off.

## Tests

Static where the seam cannot be exercised without Azure — deliberately.

The `invoke_prompt` failure reached production because executor tests drive *fake* adapters, so a signature mismatch passed import, type-checking and 35 tests, failing only at runtime. Three new adapters is three new chances to repeat that, so the seam gets an AST test rather than a hopeful one.

| Test | Covers |
|---|---|
| `test_orchestration_adapter_contract.py` (new, 7) | Every capability resolves to an adapter; every adapter matches the executor's call; no adapter touches Flask state; identity is captured on the request thread; **request gates are forwarded and applied** |
| `test_orchestration_agent_selection.py` (new, 6) | A seeded agent wins; nameless agents dropped; **an agent's `instructions` never reach the planner**; resolution fails soft; the catalog is resolved once per plan and once per run, never in a loop |
| `test_orchestration_phase_ordering.py` (new, 5) | Knowledge sorts before reasoning; gathering after answering is repaired; a backwards dependency is dropped with a note; the client groups by the phase the server decided |
| `test_orchestration_citation_persistence.py` (new, 4) | Cited documents reach the conversation; document and web citations are separated |

Both new gating tests were verified by reverting the fix and watching them go red.

`test_orchestration_citation_persistence.py` compiles the real `_partition_citations` out of the route and runs it without importing the module, so it exercises shipping code rather than a copy that could drift — and needs no credentials. A test that only runs where Azure does is a test that stops running.

**49 orchestration tests, 45 admin/docs tests, 12 route tests — all passing. Typecheck and build clean.**

## Not verified

Real agent invocation, a real source-review crawl, and live token and citation extraction all need Azure. Failure paths are verified deterministically instead: each new adapter returns a failed step result rather than raising when its dependency cannot import, and `run_agent_invoke` refuses an uncatalogued agent.

## Known gap

An agent step produces no artifacts. Charts and images an agent generates go through the Flask-bound message-artifact pipeline, which the worker thread cannot reach; the adapter surfaces tool activity as citations instead. Documented in `CHAT_ORCHESTRATION.md` under Known limitations.

## Docs

`docs/admin/orchestration.md` gains the phase model, the three capabilities, the role requirements and four troubleshooting rows. `CHAT_ORCHESTRATION.md` gains the phase model, the evidence-vs-notes distinction, the two gate levels and the worker-thread contract. Release notes under v0.261.087 and v0.261.088.