### PR TITLE
Hide the classic APIM switch and let a chat model generate images

### DIFF
--- a/application/single_app/admin_settings_fields.py
+++ b/application/single_app/admin_settings_fields.py
@@ -4178,20 +4178,11 @@ ADMIN_SETTINGS_FIELDS = {
                 "next time the connections are saved."
             ),
         },
-        {
-            "key": "enable_gpt_apim",
-            "type": "switch",
-            "label": "Send requests through API Management",
-            "help": (
-                "Routes GPT requests that use the classic endpoint through API Management "
-                "rather than straight to the Azure OpenAI resource, which is how a "
-                "deployment applies its own governance and monitoring to them. The APIM "
-                "endpoint, deployment and subscription key this needs are configured on "
-                "the classic admin page, so turning it on before those are set leaves "
-                "those requests with nowhere to go."
-            ),
-            "default": False,
-        },
+        # `enable_gpt_apim` deliberately has no field here. It belongs to the classic
+        # single endpoint, and a connection now carries its own API Management
+        # configuration, so a switch in this section would be a second control for a
+        # route connections do not use. It is named in SUPPRESSED_CAPABILITY_KEYS so the
+        # fallback scan does not draw one anyway.
     ],
     "core-plugin-toggles": [
         {
@@ -5289,9 +5280,13 @@ ADMIN_SETTINGS_FIELDS = {
             "component": "image-model-selection",
             "label": "Image model",
             "help": (
-                "The deployment every generated image comes from. Image deployments differ "
-                "in the sizes and quality settings they accept, so a change here can alter "
-                "what the image tool is able to produce."
+                "The deployment every generated image comes from. A gpt-image or DALL-E "
+                "deployment is asked for an image directly; a chat deployment such as "
+                "gpt-5.6 has no image endpoint and is asked through the Responses image "
+                "tool instead, which is worth choosing where no image model is available "
+                "but cannot change part of an existing image. Image deployments also "
+                "differ in the sizes and quality settings they accept, so a change here "
+                "can alter what the image tool is able to produce."
             ),
             "depends_on": [
                 {"key": "enable_image_generation", "equals": True},
@@ -5305,7 +5300,9 @@ ADMIN_SETTINGS_FIELDS = {
             "help": (
                 "Image generation moves on its own API schedule, which is why this defaults "
                 "later than the chat and embedding versions. Change it only for a "
-                "deployment that needs a different one."
+                "deployment that needs a different one. It governs the image endpoints "
+                "only; a chat deployment reached through the Responses image tool uses a "
+                "version new enough for that route regardless of what is set here."
             ),
             "default": "2024-12-01-preview",
             "depends_on": [
@@ -5506,6 +5503,13 @@ ADMIN_SECTION_STATUS = {
 # there is something to edit. They are named here with the reason instead, and
 # the settings GET sends this list so the scan can skip them.
 SUPPRESSED_CAPABILITY_KEYS = {
+    "enable_gpt_apim": (
+        "Belongs to the classic single endpoint and is edited on the "
+        "server-rendered model-endpoints pane. A connection carries its own API "
+        "Management configuration, so a switch here would be a second control "
+        "for a route connections never take, and turning it on would silently "
+        "repoint only the classic path."
+    ),
     "enable_tabular_processing_plugin": (
         "Derived, not stored: is_tabular_processing_enabled() returns "
         "enable_enhanced_citations, and get_settings() overwrites the stored value "

--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -97,7 +97,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.261.086"
+VERSION = "0.261.087"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/functions_image_api_route.py
+++ b/application/single_app/functions_image_api_route.py
@@ -1,0 +1,247 @@
+# functions_image_api_route.py
+
+"""Which API an image deployment is reached through, and how to read its answer.
+
+Azure OpenAI produces images two different ways, and the difference is not a detail that
+can be hidden behind one call.
+
+``gpt-image-*`` and the legacy ``dall-e-*`` models serve ``/images/generations``: a
+deployment is asked for an image and answers with one. That is the route SimpleChat has
+always used, and it remains the route for every deployment that can take it.
+
+A general chat model -- ``gpt-5.6-*``, ``gpt-4o`` and their relations -- serves no such
+endpoint. It can still produce an image, but only through the Responses API's hosted
+``image_generation`` tool, which is a different request, a different response shape and a
+different API version. That route exists here because a deployment of one of those models
+is sometimes the only thing a tenant has: where ``gpt-image-*`` is unavailable, a chat
+deployment is the difference between image generation working and not being offered.
+
+The route is derived from the model name already stored alongside the selected
+deployment rather than asked of the administrator, because it is not a preference. A
+deployment serves one of these APIs and not the other, and a wrong answer is a failed
+request rather than a degraded one.
+
+Two cases deliberately keep the images endpoint rather than being guessed at:
+
+- A deployment whose model name was never recorded. Settings saved before ``modelName``
+  was stored have none, and treating "unknown" as "chat model" would move a working
+  deployment onto a route it cannot serve.
+- The API Management route, which records a deployment name and nothing else. There is
+  no model name to classify on, and a gateway's published operation is what decides the
+  shape of the call in any case.
+
+Nothing here imports application configuration or an Azure client, so the classification
+and the response reading can be exercised directly.
+"""
+
+import json
+import re
+
+
+# The two ways an image is produced. Named rather than expressed as a boolean because
+# "not the images endpoint" is not a description of anything.
+IMAGE_API_ROUTE_IMAGES = 'images'
+IMAGE_API_ROUTE_RESPONSES = 'responses'
+
+# Models that serve /images/generations. Matched as substrings because a deployment
+# reports a model name like ``gpt-image-1.5`` or ``dall-e-3`` and the family is what
+# decides the route, not the version. ``image`` is deliberately the broad form rather than
+# ``gpt-image``: it is what the discovery filter has always matched on, so narrowing it
+# here would drop a deployment that was previously selectable and send it to a route it
+# cannot serve.
+IMAGES_ENDPOINT_MODEL_MARKERS = ('image', 'dall-e', 'dalle')
+
+# Deployments that produce vectors and nothing else. Named so discovery can rule them out
+# before the general chat-model test below, which they would otherwise pass on the strength
+# of an unrelated substring.
+EMBEDDING_MODEL_MARKERS = ('embedding', 'ada')
+
+# A chat model recognisable to Azure OpenAI. The same shape the chat-model discovery filter
+# uses, so a deployment cannot be a chat model for one list and not the other.
+_CHAT_MODEL_SERIES_PATTERN = re.compile(r'o\d+')
+
+# The earliest Azure preview that routes /responses with hosted tools. The image
+# section's own API version governs /images/generations and /images/edits, and defaults
+# to a version predating the Responses API entirely, so it cannot be used here. An
+# administrator who has pinned something newer is honoured; anything older is replaced
+# rather than reported, because the setting was never about this route.
+RESPONSES_IMAGE_API_VERSION = '2025-04-01-preview'
+
+# What the image_generation tool call answers with when no format is stated.
+DEFAULT_RESPONSES_IMAGE_FORMAT = 'png'
+
+_IMAGE_FORMAT_MIME_TYPES = {
+    'png': 'image/png',
+    'webp': 'image/webp',
+    'jpeg': 'image/jpeg',
+    'jpg': 'image/jpeg',
+}
+
+
+def resolve_selected_image_model_name(settings):
+    """Return the model behind the selected image deployment, or '' when it is not recorded.
+
+    Admin settings persist ``{deploymentName, modelName}`` for the chosen deployment, but an
+    APIM route records only a deployment name and settings saved before ``modelName`` was added
+    have none either. An empty answer therefore means "unknown", not "none".
+    """
+    if not isinstance(settings, dict):
+        return ''
+
+    if settings.get('enable_image_gen_apim', False):
+        return ''
+
+    selected = (settings.get('image_gen_model') or {}).get('selected') or []
+    if not selected or not isinstance(selected[0], dict):
+        return ''
+    return str(selected[0].get('modelName') or '').strip()
+
+
+def resolve_selected_image_deployment_name(settings):
+    """Return the deployment name image requests are addressed to, or '' when none is set.
+
+    The APIM route names its deployment directly; the direct route names it inside the
+    stored catalog entry. Both are the same fact, and callers that only need to say which
+    deployment answered should not have to know which route produced it.
+    """
+    if not isinstance(settings, dict):
+        return ''
+
+    if settings.get('enable_image_gen_apim', False):
+        return str(settings.get('azure_apim_image_gen_deployment') or '').strip()
+
+    selected = (settings.get('image_gen_model') or {}).get('selected') or []
+    if not selected or not isinstance(selected[0], dict):
+        return ''
+    return str(selected[0].get('deploymentName') or '').strip()
+
+
+def resolve_image_api_route(settings):
+    """Return which API the selected image deployment is reached through.
+
+    Defaults to the images endpoint. Every deployment selectable before the Responses
+    route existed answers to it, so an unrecognised or unrecorded model name leaves an
+    existing configuration exactly where it was.
+    """
+    model_name = resolve_selected_image_model_name(settings).lower()
+    if not model_name:
+        return IMAGE_API_ROUTE_IMAGES
+
+    if any(marker in model_name for marker in IMAGES_ENDPOINT_MODEL_MARKERS):
+        return IMAGE_API_ROUTE_IMAGES
+
+    return IMAGE_API_ROUTE_RESPONSES
+
+
+def is_image_capable_model_name(model_name):
+    """Return whether a deployment of this model could produce an image at all.
+
+    Used by discovery, so it answers the question an administrator is actually asking
+    when they press Fetch: is this deployment worth offering as the image model. A
+    gpt-image or DALL-E model qualifies through the images endpoint; a chat model
+    qualifies through the Responses image tool. An embedding deployment qualifies through
+    neither, and is ruled out before the chat test rather than after, because its name can
+    otherwise satisfy it.
+    """
+    normalized_model = str(model_name or '').strip().lower()
+    if not normalized_model:
+        return False
+
+    if any(marker in normalized_model for marker in IMAGES_ENDPOINT_MODEL_MARKERS):
+        return True
+
+    if any(marker in normalized_model for marker in EMBEDDING_MODEL_MARKERS):
+        return False
+
+    return 'gpt' in normalized_model or bool(_CHAT_MODEL_SERIES_PATTERN.search(normalized_model))
+
+
+def _parse_preview_api_version(api_version):
+    """Return an Azure API version as a comparable date tuple, or None."""
+    parts = str(api_version or '').strip().split('-')
+    if len(parts) < 3:
+        return None
+    try:
+        return tuple(int(part) for part in parts[:3])
+    except (TypeError, ValueError):
+        return None
+
+
+def resolve_responses_image_api_version(settings):
+    """Return the API version the Responses image route should be called with.
+
+    The stored image API version wins only when it is newer, which keeps a deliberate pin
+    -- a tenant on a later preview, or one whose gateway publishes a specific version --
+    from being overridden by a constant that will age.
+    """
+    settings = settings if isinstance(settings, dict) else {}
+    stored = _parse_preview_api_version(settings.get('azure_openai_image_gen_api_version'))
+    minimum = _parse_preview_api_version(RESPONSES_IMAGE_API_VERSION)
+
+    if stored and minimum and stored > minimum:
+        return str(settings.get('azure_openai_image_gen_api_version')).strip()
+    return RESPONSES_IMAGE_API_VERSION
+
+
+def build_image_generation_tool(size='', quality='', background=''):
+    """Describe the hosted image_generation tool for a Responses request.
+
+    Only stated options are sent. The tool defaults each of these itself, and naming a
+    value the deployment does not accept fails the request, so an unset control is left
+    unset rather than filled in with a guess.
+    """
+    tool = {'type': 'image_generation'}
+    if size:
+        tool['size'] = size
+    if quality:
+        tool['quality'] = quality
+    if background:
+        tool['background'] = background
+    return tool
+
+
+def _as_response_dict(response):
+    """Return a Responses result as a plain dict, whether it arrived as one or as a model."""
+    if isinstance(response, dict):
+        return response
+    if hasattr(response, 'model_dump_json'):
+        return json.loads(response.model_dump_json())
+    if hasattr(response, 'model_dump'):
+        return response.model_dump()
+    raise ValueError('Image response could not be read')
+
+
+def extract_responses_image_source(response):
+    """Return a data URL for the image a Responses result carries, or '' when it has none.
+
+    The image arrives as an ``image_generation_call`` item in ``output``, alongside the
+    reasoning and message items the model also produced, and carries base64 rather than a
+    URL. Returning the same data-URL string the images endpoint path produces is what lets
+    everything downstream -- blob storage, proposals, revisions, the lightbox -- stay
+    unaware of which route was taken.
+
+    An empty answer is returned rather than raised because "the model replied without
+    calling the tool" is a distinct outcome from "the call failed", and only the caller
+    knows which message suits.
+    """
+    response_dict = _as_response_dict(response)
+    output_items = response_dict.get('output')
+    if not isinstance(output_items, list):
+        return ''
+
+    for item in output_items:
+        if not isinstance(item, dict) or item.get('type') != 'image_generation_call':
+            continue
+
+        encoded_image = item.get('result')
+        if not encoded_image:
+            continue
+
+        image_format = str(item.get('output_format') or DEFAULT_RESPONSES_IMAGE_FORMAT).lower()
+        mime_type = _IMAGE_FORMAT_MIME_TYPES.get(
+            image_format,
+            _IMAGE_FORMAT_MIME_TYPES[DEFAULT_RESPONSES_IMAGE_FORMAT],
+        )
+        return f'data:{mime_type};base64,{encoded_image}'
+
+    return ''

--- a/application/single_app/functions_image_edit.py
+++ b/application/single_app/functions_image_edit.py
@@ -31,6 +31,12 @@ import re
 
 from PIL import Image
 
+from functions_image_api_route import (
+    IMAGE_API_ROUTE_RESPONSES,
+    resolve_image_api_route,
+    resolve_selected_image_deployment_name,
+    resolve_selected_image_model_name,
+)
 from functions_image_messages import decode_image_content, is_external_image_url
 
 # Config, the Azure clients and the generation helpers are imported inside the functions that
@@ -95,25 +101,6 @@ EDIT_CAPABLE_MODEL_MARKERS = ('gpt-image', 'dall-e-2', 'dalle-2')
 MIN_IMAGE_EDIT_API_VERSION = '2025-04-01-preview'
 
 
-def resolve_selected_image_model_name(settings):
-    """Return the model behind the selected image deployment, or '' when it is not recorded.
-
-    Admin settings persist ``{deploymentName, modelName}`` for the chosen deployment, but an
-    APIM route records only a deployment name and settings saved before ``modelName`` was added
-    have none either. An empty answer therefore means "unknown", not "none".
-    """
-    if not isinstance(settings, dict):
-        return ''
-
-    if settings.get('enable_image_gen_apim', False):
-        return ''
-
-    selected = (settings.get('image_gen_model') or {}).get('selected') or []
-    if not selected or not isinstance(selected[0], dict):
-        return ''
-    return str(selected[0].get('modelName') or '').strip()
-
-
 def image_api_version_supports_edit(api_version):
     """Return whether an Azure OpenAI API version can route /images/edits.
 
@@ -167,14 +154,21 @@ def resolve_image_edit_capability(settings):
         }
 
     if not any(marker in normalized_model for marker in EDIT_CAPABLE_MODEL_MARKERS):
+        if resolve_image_api_route(settings) == IMAGE_API_ROUTE_RESPONSES:
+            reason = (
+                f'{model_name} produces images through the Responses image tool, which has '
+                'no way to change part of one, so a change replaces the whole image.'
+            )
+        else:
+            reason = (
+                f'{model_name} can generate images but cannot edit them, so a change replaces '
+                'the whole image.'
+            )
         return {
             'mode': IMAGE_EDIT_MODE_REGENERATE,
             'enabled': True,
             'model_name': model_name,
-            'reason': (
-                f'{model_name} can generate images but cannot edit them, so a change replaces '
-                'the whole image.'
-            ),
+            'reason': reason,
         }
 
     api_version = settings.get('azure_openai_image_gen_api_version')
@@ -681,14 +675,46 @@ def request_image_edit(
     from functions_appinsights import log_event
     from functions_image_generation import (
         extract_generated_image_source,
+        request_generated_image_source,
         resolve_image_generation_client,
-        resolve_generated_image_bytes,
     )
 
     capability = resolve_image_edit_capability(settings)
+    normalized_size = size if size in SUPPORTED_IMAGE_SIZES else ''
+
+    if (
+        capability['mode'] != IMAGE_EDIT_MODE_MASKED
+        and resolve_image_api_route(settings) == IMAGE_API_ROUTE_RESPONSES
+    ):
+        # This deployment answers on the Responses API and nowhere else, so the images
+        # endpoint below is not a fallback for it -- it is a request it cannot serve.
+        deployment = resolve_selected_image_deployment_name(settings)
+        try:
+            generated_source = request_generated_image_source(
+                settings,
+                prompt,
+                size=normalized_size,
+                quality=quality,
+                background=background,
+            )
+        except Exception as exc:
+            log_event(
+                f'[IMAGE_EDIT] Regeneration request failed: {exc}',
+                extra={'deployment': deployment},
+            )
+            raise ImageEditError('The image could not be regenerated') from exc
+
+        return _finish_image_edit(
+            generated_source,
+            deployment=deployment,
+            method='regenerate',
+            normalized_size=normalized_size,
+            quality=quality,
+            background=background,
+        )
+
     client, deployment = resolve_image_generation_client(settings)
 
-    normalized_size = size if size in SUPPORTED_IMAGE_SIZES else ''
     optional = _optional_parameters(
         quality=quality,
         background=background,
@@ -750,6 +776,33 @@ def request_image_edit(
         generated_source = extract_generated_image_source(response)
     except ValueError as exc:
         raise ImageEditError('The model returned no image') from exc
+
+    return _finish_image_edit(
+        generated_source,
+        deployment=deployment,
+        method=method,
+        normalized_size=normalized_size,
+        quality=quality,
+        background=background,
+    )
+
+
+def _finish_image_edit(
+    generated_source,
+    *,
+    deployment,
+    method,
+    normalized_size,
+    quality,
+    background,
+):
+    """Turn a produced image into the result shape both routes return.
+
+    Shared so the Responses route reports its outcome identically to the images endpoint:
+    the caller records ``method`` in the revision history, and a difference here would show
+    up as two kinds of regeneration rather than one.
+    """
+    from functions_image_generation import resolve_generated_image_bytes
 
     if is_external_image_url(generated_source) or generated_source.startswith('data:image/'):
         mime_type, image_bytes = resolve_generated_image_bytes(generated_source)

--- a/application/single_app/functions_image_generation.py
+++ b/application/single_app/functions_image_generation.py
@@ -14,6 +14,13 @@ from azure.identity import DefaultAzureCredential, get_bearer_token_provider
 
 from config import AzureOpenAI, cognitive_services_scope, cosmos_messages_container
 from functions_appinsights import log_event
+from functions_image_api_route import (
+    IMAGE_API_ROUTE_RESPONSES,
+    build_image_generation_tool,
+    extract_responses_image_source,
+    resolve_image_api_route,
+    resolve_responses_image_api_version,
+)
 from functions_image_messages import build_image_message_documents, decode_image_content
 
 
@@ -135,15 +142,21 @@ def normalize_image_proposal(raw_proposal):
     return normalized_proposal
 
 
-def resolve_image_generation_client(settings):
-    """Create the Azure OpenAI image generation client and return it with the deployment name."""
+def resolve_image_generation_client(settings, api_version=None):
+    """Create the Azure OpenAI image generation client and return it with the deployment name.
+
+    ``api_version`` overrides the stored image API version. The Responses route passes one
+    because that setting defaults to a version predating the Responses API, and honouring
+    it there would fail every request against a deployment that is otherwise configured
+    correctly.
+    """
     if not image_generation_is_enabled(settings):
         raise PermissionError('Image generation is not enabled')
 
     if settings.get('enable_image_gen_apim', False):
         image_gen_model = settings.get('azure_apim_image_gen_deployment')
         image_gen_client = AzureOpenAI(
-            api_version=settings.get('azure_apim_image_gen_api_version'),
+            api_version=api_version or settings.get('azure_apim_image_gen_api_version'),
             azure_endpoint=settings.get('azure_apim_image_gen_endpoint'),
             api_key=settings.get('azure_apim_image_gen_subscription_key'),
         )
@@ -155,16 +168,18 @@ def resolve_image_generation_client(settings):
         selected_image_gen_model = image_gen_model_obj['selected'][0]
         image_gen_model = selected_image_gen_model.get('deploymentName')
 
+    resolved_api_version = api_version or settings.get('azure_openai_image_gen_api_version')
+
     if settings.get('azure_openai_image_gen_authentication_type') == 'managed_identity':
         token_provider = get_bearer_token_provider(DefaultAzureCredential(), cognitive_services_scope)
         image_gen_client = AzureOpenAI(
-            api_version=settings.get('azure_openai_image_gen_api_version'),
+            api_version=resolved_api_version,
             azure_endpoint=settings.get('azure_openai_image_gen_endpoint'),
             azure_ad_token_provider=token_provider,
         )
     else:
         image_gen_client = AzureOpenAI(
-            api_version=settings.get('azure_openai_image_gen_api_version'),
+            api_version=resolved_api_version,
             azure_endpoint=settings.get('azure_openai_image_gen_endpoint'),
             api_key=settings.get('azure_openai_image_gen_key'),
         )
@@ -173,6 +188,43 @@ def resolve_image_generation_client(settings):
         raise ValueError('No image generation deployment is selected')
 
     return image_gen_client, image_gen_model
+
+
+def request_generated_image_source(settings, prompt, size='', quality='', background=''):
+    """Ask the configured deployment for an image and return its URL or data URL.
+
+    The single place that decides between the images endpoint and the Responses image
+    tool. Every caller goes through it, including the admin connection test, because a
+    test that exercised a different route from the real call would certify a path nobody
+    uses.
+    """
+    if resolve_image_api_route(settings) != IMAGE_API_ROUTE_RESPONSES:
+        client, deployment = resolve_image_generation_client(settings)
+        arguments = {'model': deployment, 'prompt': prompt, 'n': 1}
+        if size:
+            arguments['size'] = size
+        return extract_generated_image_source(client.images.generate(**arguments))
+
+    client, deployment = resolve_image_generation_client(
+        settings,
+        api_version=resolve_responses_image_api_version(settings),
+    )
+    response = client.responses.create(
+        model=deployment,
+        input=prompt,
+        tools=[build_image_generation_tool(size=size, quality=quality, background=background)],
+        # Without this the model is free to answer with prose about the image it would
+        # have drawn, which reads as an empty result rather than as a refusal.
+        tool_choice={'type': 'image_generation'},
+    )
+
+    generated_image_url = extract_responses_image_source(response)
+    if not generated_image_url:
+        raise ValueError(
+            f'{deployment} answered without generating an image. Its deployment may not '
+            'support the image generation tool.'
+        )
+    return generated_image_url
 
 
 def extract_generated_image_source(image_response):
@@ -257,13 +309,7 @@ def generate_chat_image_message(
     if not normalized_prompt:
         raise ValueError('Image generation prompt is required')
 
-    image_gen_client, image_gen_model = resolve_image_generation_client(settings)
-    image_response = image_gen_client.images.generate(
-        prompt=normalized_prompt,
-        n=1,
-        model=image_gen_model,
-    )
-    generated_image_url = extract_generated_image_source(image_response)
+    generated_image_url = request_generated_image_source(settings, normalized_prompt)
     if not generated_image_url or generated_image_url == 'null':
         raise ValueError('Generated image URL is null or empty')
 

--- a/application/single_app/route_backend_chats.py
+++ b/application/single_app/route_backend_chats.py
@@ -204,11 +204,13 @@ from functions_conversation_metadata import collect_conversation_metadata, updat
 from functions_conversation_unread import mark_conversation_unread
 from functions_image_messages import build_image_message_documents, decode_image_content, get_complete_image_content
 from functions_icon_utils import normalize_icon_payload
+from functions_image_api_route import resolve_selected_image_deployment_name
 from functions_image_generation import (
     build_image_proposal_guidance_message,
     generate_chat_image_message,
     image_generation_is_enabled,
     normalize_image_proposal,
+    request_generated_image_source,
     user_request_supports_image_proposals,
 )
 from functions_appinsights import log_event
@@ -16729,7 +16731,6 @@ def register_route_backend_chats(bp):
             gpt_response_length_parameter = None
             tabular_model_context = None
             enable_gpt_apim = settings.get('enable_gpt_apim', False)
-            enable_image_gen_apim = settings.get('enable_image_gen_apim', False)
             should_use_default_model = (
                 _has_chat_agent_selection(request_agent_info)
                 and settings.get('enable_multi_model_endpoints', False)
@@ -18359,83 +18360,16 @@ def register_route_backend_chats(bp):
 
             # Image Generation
             if image_gen_enabled:
-                if enable_image_gen_apim:
-                    image_gen_model = settings.get('azure_apim_image_gen_deployment')
-                    image_gen_client = AzureOpenAI(
-                        api_version=settings.get('azure_apim_image_gen_api_version'),
-                        azure_endpoint=settings.get('azure_apim_image_gen_endpoint'),
-                        api_key=settings.get('azure_apim_image_gen_subscription_key')
-                    )
-                else:
-                    if (settings.get('azure_openai_image_gen_authentication_type') == 'managed_identity'):
-                        token_provider = get_bearer_token_provider(DefaultAzureCredential(), cognitive_services_scope)
-                        image_gen_client = AzureOpenAI(
-                            api_version=settings.get('azure_openai_image_gen_api_version'),
-                            azure_endpoint=settings.get('azure_openai_image_gen_endpoint'),
-                            azure_ad_token_provider=token_provider
-                        )
-                        image_gen_model_obj = settings.get('image_gen_model', {})
-
-                        if image_gen_model_obj and image_gen_model_obj.get('selected'):
-                            selected_image_gen_model = image_gen_model_obj['selected'][0]
-                            image_gen_model = selected_image_gen_model['deploymentName']
-                    else:
-                        image_gen_client = AzureOpenAI(
-                            api_version=settings.get('azure_openai_image_gen_api_version'),
-                            azure_endpoint=settings.get('azure_openai_image_gen_endpoint'),
-                            api_key=settings.get('azure_openai_image_gen_key')
-                        )
-                        image_gen_obj = settings.get('image_gen_model', {})
-                        if image_gen_obj and image_gen_obj.get('selected'):
-                            selected_image_gen_model = image_gen_obj['selected'][0]
-                            image_gen_model = selected_image_gen_model['deploymentName']
+                image_gen_model = resolve_selected_image_deployment_name(settings)
 
                 try:
                     debug_print(f"Generating image with model: {image_gen_model}")
                     debug_print(f"Using prompt: {user_message}")
 
-                    # Azure OpenAI doesn't support response_format parameter
-                    # Different models return different formats automatically
-                    image_response = image_gen_client.images.generate(
-                        prompt=user_message,
-                        n=1,
-                        model=image_gen_model
-                    )
-
-                    debug_print(f"Image response received: {type(image_response)}")
-                    response_dict = json.loads(image_response.model_dump_json())
-                    debug_print(f"Response dict: {response_dict}")
-
-                    # Extract image URL or base64 data with validation
-                    if 'data' not in response_dict or not response_dict['data']:
-                        raise ValueError("No image data in response")
-
-                    image_data = response_dict['data'][0]
-                    debug_print(f"Image data keys: {list(image_data.keys())}")
-
-                    generated_image_url = None
-
-                    # Handle different response formats
-                    if 'url' in image_data and image_data['url']:
-                        # dall-e-3 format: returns URL
-                        generated_image_url = image_data['url']
-                        debug_print(f"Using URL format: {generated_image_url}")
-                    elif 'b64_json' in image_data and image_data['b64_json']:
-                        # gpt-image-1 format: returns base64 data
-                        b64_data = image_data['b64_json']
-                        # Create data URL for frontend
-                        generated_image_url = f"data:image/png;base64,{b64_data}"
-
-                        # Redacted logging for large base64 content
-                        if len(b64_data) > 100:
-                            redacted_content = f"{b64_data[:50]}...{b64_data[-50:]}"
-                            debug_print(f"Using base64 format, length: {len(b64_data)}")
-                            debug_print(f"Base64 content (redacted): {redacted_content}")
-                        else:
-                            debug_print(f"Using base64 format, full content: {b64_data}")
-                    else:
-                        available_keys = list(image_data.keys())
-                        raise ValueError(f"No URL or base64 data in image data. Available keys: {available_keys}")
+                    # Route selection, the request itself and the response shape all
+                    # differ between the images endpoint and the Responses image tool,
+                    # so they live in one helper rather than being repeated here.
+                    generated_image_url = request_generated_image_source(settings, user_message)
 
                     # Validate we have a valid image source
                     if not generated_image_url or generated_image_url == 'null':

--- a/application/single_app/route_backend_models.py
+++ b/application/single_app/route_backend_models.py
@@ -10,6 +10,7 @@ from functions_keyvault import SecretReturnType, keyvault_model_endpoint_cleanup
 from functions_settings import *
 from foundry_agent_runtime import FoundryAgentUserAuthenticationRequired, list_foundry_agents_from_endpoint, list_foundry_workflows_from_endpoint, list_new_foundry_agents_from_endpoint, resolve_foundry_project_base, resolve_foundry_project_api_version, build_project_credential, resolve_authority
 from functions_appinsights import log_event
+from functions_image_api_route import is_image_capable_model_name
 from functions_model_capabilities import resolve_model_vision_support
 from model_endpoint_clients import (
     MODEL_ENDPOINT_PROTOCOL_ANTHROPIC,
@@ -683,8 +684,13 @@ def register_route_backend_models(bp):
     @admin_required
     def get_image_models():
         """
-        Fetch available DALL-E image generation Azure OpenAI deployments using Azure Management API.
-        Returns a list of image generation models with deployment names and model information.
+        Fetch available image-capable Azure OpenAI deployments using Azure Management API.
+
+        Two kinds qualify. A gpt-image or DALL-E deployment serves /images/generations
+        directly. A chat model serves no image endpoint at all, but can still produce an
+        image through the Responses API's image_generation tool, and where gpt-image is
+        unavailable it is the only deployment that can. Both are listed; which route a
+        selection takes is decided from its model name at call time.
         """
         settings = get_settings()
 
@@ -711,10 +717,7 @@ def register_route_backend_models(bp):
                 if not is_deployment_enabled(d):
                     continue
                 model_name = d.properties.model.name
-                if model_name and (
-                    "dall-e" in model_name.lower() or
-                    "image" in model_name.lower()
-                ):
+                if model_name and is_image_capable_model_name(model_name):
                     models.append({
                         "deploymentName": d.name,
                         "modelName": model_name

--- a/application/single_app/route_backend_settings.py
+++ b/application/single_app/route_backend_settings.py
@@ -5,6 +5,13 @@ from functions_documents import *
 from functions_authentication import *
 from functions_settings import *
 from functions_web_search_test import run_web_search_connection_test
+from functions_image_api_route import (
+    IMAGE_API_ROUTE_RESPONSES,
+    build_image_generation_tool,
+    extract_responses_image_source,
+    resolve_image_api_route,
+    resolve_responses_image_api_version,
+)
 from functions_url_access_policy_test import run_url_access_policy_test
 from functions_model_endpoint_runtime import (
     build_model_endpoint_sync_chat_client,
@@ -1771,6 +1778,19 @@ def _test_image_gen_connection(payload):
         api_version = direct_data.get('api_version')
         image_gen_model = selected_model.get('deploymentName')
 
+        # The route is decided by the model behind the deployment, and a test that took a
+        # different route from the real call would report success for a path chat never
+        # uses. The ephemeral payload is reshaped into what the classifier reads rather
+        # than the answer being guessed here.
+        image_api_route = resolve_image_api_route({
+            'enable_image_gen_apim': False,
+            'image_gen_model': {'selected': [selected_model]},
+        })
+        if image_api_route == IMAGE_API_ROUTE_RESPONSES:
+            api_version = resolve_responses_image_api_version(
+                {'azure_openai_image_gen_api_version': api_version}
+            )
+
         if direct_data.get('auth_type') == 'managed_identity':
             token_provider = get_bearer_token_provider(DefaultAzureCredential(), cognitive_services_scope)
             
@@ -1787,6 +1807,27 @@ def _test_image_gen_connection(payload):
                 azure_endpoint=endpoint,
                 api_key=key
             )
+
+        if image_api_route == IMAGE_API_ROUTE_RESPONSES:
+            try:
+                response = image_gen_client.responses.create(
+                    model=image_gen_model,
+                    input=prompt,
+                    tools=[build_image_generation_tool()],
+                    tool_choice={'type': 'image_generation'},
+                )
+                if extract_responses_image_source(response):
+                    return jsonify({'message': 'Image generation connection successful'}), 200
+                return jsonify({
+                    'error': (
+                        f'{image_gen_model} answered without generating an image. Its '
+                        'deployment may not support the image generation tool.'
+                    )
+                }), 500
+            except Exception as e:
+                print(str(e))
+                return jsonify({'error': f'Error generating model response: {str(e)}'}), 500
+
     try:
         response = image_gen_client.images.generate(
             prompt=prompt,

--- a/docs/admin/ai-models.md
+++ b/docs/admin/ai-models.md
@@ -109,7 +109,7 @@ The classic single endpoint is configured on the server-rendered admin page. Its
 | Setting | What it does | Default | Notes |
 | --- | --- | --- | --- |
 | Default model | The model chat uses when nothing else has chosen one. Cleared automatically if the connection or model it names is deleted or disabled. | Not specified in defaults | `default_model_selection`; connections mode only |
-| Send requests through API Management | Routes GPT requests that use the classic endpoint through API Management rather than straight to the Azure OpenAI resource, so a deployment can apply its own governance and monitoring to them. | Off | `enable_gpt_apim`; needs the three APIM values below |
+| Send requests through API Management | Routes GPT requests that use the classic endpoint through API Management rather than straight to the Azure OpenAI resource, so a deployment can apply its own governance and monitoring to them. Set on the classic page only — a connection carries its own API Management configuration, so this tab does not offer it. | Off | `enable_gpt_apim`; needs the three APIM values below |
 | Azure OpenAI Endpoint | Provides the endpoint or route SimpleChat uses for this service. | Empty | `azure_openai_gpt_endpoint` |
 | Authentication Type | Chooses whether SimpleChat authenticates to this service with a key, managed identity, or another supported method. | key | `azure_openai_gpt_authentication_type` |
 | Subscription ID | Addresses the resource when listing its deployments. | Empty | `azure_openai_gpt_subscription_id` |
@@ -174,17 +174,34 @@ With **Enable Image Generation** off, nothing else in this section is consulted,
 
 As with embeddings, the direct and gateway routes are alternatives and only the selected one is used. The gateway has its own address, version, deployment name and subscription key.
 
+#### Which API produces the image
+
+Azure OpenAI produces images two different ways, and which one applies is decided by the model behind the deployment you select rather than by a setting.
+
+A `gpt-image-*` or DALL-E deployment serves the images endpoint and is asked for a picture directly. That is the route SimpleChat has always used, and it remains the route for every deployment that can take it.
+
+A chat deployment — `gpt-5.6-*`, `gpt-4o` and their relations — serves no image endpoint at all. It can still produce an image, through the Responses API's hosted `image_generation` tool, and SimpleChat sends it that way instead. This matters where an image model is not available to a subscription or region: a chat deployment is then the difference between image generation working and not being offered. It is not the better route where both exist, because it cannot change part of an existing image and puts the orchestrating model in front of every picture.
+
+Two things follow from selecting a chat deployment:
+
+- The image editor offers whole-image regeneration only. Changing part of an image needs `/images/edits`, which the Responses tool has no equivalent for, and the editor says so before you paint a region rather than after.
+- **Azure OpenAI Image Gen API Version** does not apply to it. That setting governs the image endpoints, and its default predates the Responses API entirely, so this route uses a version new enough for it regardless of what is set. A value newer than that is honoured.
+
+A deployment reached through API Management always uses the images endpoint. The gateway records a deployment name and no model name, so there is nothing to decide from, and the operation the gateway publishes determines the shape of the call in any case.
+
+A deployment saved before SimpleChat began recording model names also stays on the images endpoint, because an unknown model is not the same as a chat model. Re-running **Fetch deployments** and re-selecting it records the name and lets it be classified.
+
 #### Authentication and deployment discovery
 
 Managed identity stores no credential and is what allows SimpleChat to list the resource's deployments, using the subscription id and resource group. A key authenticates to inference only.
 
-**Fetch deployments** reads the saved endpoint, subscription id and resource group, so save changes to those first. A deployment the resource no longer reports is dropped from the selection rather than left to fail on the next request.
+**Fetch deployments** reads the saved endpoint, subscription id and resource group, so save changes to those first. It lists both the image models and the chat models the resource exposes, since either can produce an image, and excludes embedding deployments, which can produce neither. A deployment the resource no longer reports is dropped from the selection rather than left to fail on the next request.
 
 The stored key is never shown, and leaving its field empty keeps what is stored. **Remove stored value** clears it.
 
 #### Changing the image model
 
-Image deployments differ in the sizes, quality settings and response formats they accept, so a change here can alter what the image tool is able to produce, not only how the results look. Generate one test image after changing it.
+Image deployments differ in the sizes, quality settings and response formats they accept, so a change here can alter what the image tool is able to produce, not only how the results look. Moving between an image model and a chat model changes the API the request takes as well, and with it whether the editor can change part of an image. Generate one test image after changing it.
 
 #### Settings
 
@@ -197,8 +214,8 @@ Image deployments differ in the sizes, quality settings and response formats the
 | Subscription ID | Addresses the resource when listing its deployments. Inference does not need it. | Empty | `azure_openai_image_gen_subscription_id` |
 | Resource Group | The other half of the address the deployment list is fetched from. | Empty | `azure_openai_image_gen_resource_group` |
 | Azure OpenAI Image Generation Key | Used only with key authentication. Leaving it blank keeps the stored key. | Empty | `azure_openai_image_gen_key` |
-| Image model | The single deployment every generated image comes from. | None selected | `image_gen_model`; written through its own API |
-| Azure OpenAI Image Gen API Version | Image generation moves on its own API schedule, which is why this defaults later than the chat and embedding versions. | 2024-12-01-preview | `azure_openai_image_gen_api_version` |
+| Image model | The single deployment every generated image comes from. An image model is asked through the images endpoint; a chat model through the Responses image tool. | None selected | `image_gen_model`; written through its own API |
+| Azure OpenAI Image Gen API Version | Image generation moves on its own API schedule, which is why this defaults later than the chat and embedding versions. Governs the image endpoints only. | 2024-12-01-preview | `azure_openai_image_gen_api_version` |
 | Azure APIM Endpoint | The API Management address that fronts the image deployment. | Empty | `azure_apim_image_gen_endpoint` |
 | Azure APIM API Version | Whatever version the API Management operation publishes; there is no default, because a gateway can publish any. | Empty | `azure_apim_image_gen_api_version` |
 | Azure APIM Deployment | The deployment name to send image requests to. Discovery does not reach through a gateway, so this is typed. | Empty | `azure_apim_image_gen_deployment` |

--- a/docs/explanation/features/IMAGE_GENERATION_RESPONSES_MODELS.md
+++ b/docs/explanation/features/IMAGE_GENERATION_RESPONSES_MODELS.md
@@ -1,0 +1,140 @@
+# Image Generation Through Responses-Capable Chat Models
+
+## Overview
+
+SimpleChat can now produce images from a chat deployment such as `gpt-5.6-sol`, not only
+from a dedicated `gpt-image-*` or DALL-E deployment.
+
+The reason is availability rather than quality. An image model is a separate deployment,
+often gated by approval and not offered in every subscription or region, while a chat
+deployment is generally already there. Before this change, a tenant without an image model
+could not switch image generation on at all: the deployment list was filtered to names
+containing `dall-e` or `image`, so nothing appeared to select.
+
+**Implemented in version:** `0.261.087`
+
+**Dependencies:** `openai==1.109.1` (the `responses` client surface and the
+`image_generation` hosted tool), an Azure OpenAI resource in a region where the Responses
+API is available.
+
+## Architecture
+
+### Two routes, chosen from the model name
+
+Azure OpenAI serves images two ways, and a deployment answers on one of them and not the
+other:
+
+| Route | Endpoint | Models |
+| --- | --- | --- |
+| `images` | `/images/generations`, `/images/edits` | `gpt-image-*`, `dall-e-*` |
+| `responses` | `/responses` with the hosted `image_generation` tool | chat models — `gpt-5.6-*`, `gpt-5*`, `gpt-4o`, `o*` |
+
+The route is derived from the `modelName` already stored alongside the selected
+deployment, not asked of the administrator. It is not a preference: a wrong answer is a
+failed request rather than a degraded one, and an administrator would be guessing at
+something the deployment already states.
+
+Two cases keep the images endpoint rather than being classified, because in both of them
+"unknown" would otherwise be read as "chat model" and move a working deployment onto a
+route it cannot serve:
+
+- A deployment whose `modelName` was never recorded. Settings saved before that field
+  existed have none.
+- The API Management route, which records a deployment name only. What the gateway
+  publishes decides the shape of the call in any case.
+
+### API version
+
+`azure_openai_image_gen_api_version` defaults to `2024-12-01-preview`, which predates the
+Responses API. Honouring it on the Responses route would fail every request against a
+deployment that is otherwise configured correctly, so that route substitutes
+`RESPONSES_IMAGE_API_VERSION` (`2025-04-01-preview`) instead. A stored version *newer*
+than the constant is honoured, so a deliberate pin is not overridden by a constant that
+will age.
+
+The stored setting continues to govern `/images/generations` and `/images/edits`
+unchanged.
+
+### Response shape
+
+The images endpoint answers with `data[0].url` or `data[0].b64_json`. The Responses route
+answers with an `image_generation_call` item in `output`, alongside the reasoning and
+message items the model also produced, carrying base64 in `result` and an optional
+`output_format`.
+
+Both are normalised to the same data-URL or HTTP-URL string before returning, which is
+what lets blob storage, the image proposal pipeline, revision history and the lightbox
+stay unaware of which route was taken.
+
+A reply that carries no `image_generation_call` is reported as an empty result rather than
+raised, because "the model answered without calling the tool" and "the call failed" are
+different outcomes with different messages. The generation helper turns the first into a
+message naming the deployment.
+
+## File structure
+
+| File | Role |
+| --- | --- |
+| `application/single_app/functions_image_api_route.py` | New. Route classification, API version selection, tool spec, and Responses output reading. Imports no application configuration, so all of it is directly testable. |
+| `application/single_app/functions_image_generation.py` | `request_generated_image_source` — the single entry point every caller uses. `resolve_image_generation_client` gained an API version override. |
+| `application/single_app/functions_image_edit.py` | Regeneration takes the Responses route when that is the deployment's route. `resolve_selected_image_model_name` moved to the new module. |
+| `application/single_app/route_backend_chats.py` | The inline client construction and response parsing in the chat path were replaced by the shared helper. |
+| `application/single_app/route_backend_settings.py` | Admin **Test connection** exercises whichever route the real call will take. |
+| `application/single_app/route_backend_models.py` | `/api/models/image` lists chat deployments as well as image deployments. |
+
+### Callers
+
+Every path that produces an image goes through
+`functions_image_generation.request_generated_image_source`:
+
+- `generate_chat_image_message` — the image proposal pipeline and inline approvals.
+- `route_backend_chats` — the chat image generation toggle.
+- `functions_image_edit.request_image_edit` — the regenerate branch of the image editor.
+- `route_backend_settings._test_image_gen_connection` — admin **Test connection**.
+
+The connection test is included deliberately. A test that took a different route from the
+real call would report success for a path chat never uses.
+
+## Configuration
+
+No new setting. Selecting a different deployment under **Admin Settings → AI Models →
+Image Generation → Image model** is the whole of it.
+
+**Fetch deployments** now returns image models and chat models, and excludes embedding
+deployments, which can produce an image on neither route.
+
+## Behaviour with a chat deployment
+
+- **Generation** works as it does for an image model. Size, quality and background are
+  carried onto the tool spec; unset controls are left unset rather than filled with a
+  guess, since a value the deployment does not accept fails the whole request.
+- **Editing** offers whole-image regeneration only. `resolve_image_edit_capability`
+  already degrades any non-`gpt-image` model to regenerate-only, and now explains that the
+  Responses tool has no way to change part of an image. The editor states this before a
+  region is painted.
+- **Tool choice** is forced. Without it the model is free to answer with prose about the
+  image it would have drawn, which reads as an empty result rather than as a refusal.
+
+## Testing and validation
+
+`functional_tests/test_image_generation_responses_route.py` covers the classification in
+both directions, the two cases that must stay on the images endpoint, the API version
+substitution, the tool spec, and the response reading including replies that carry no
+image.
+
+The emphasis is on what must *not* change. Every deployment selectable before this feature
+existed answers on the images endpoint, and the classifier is tested against the full set
+of image model names to prove none of them moved.
+
+## Known limitations
+
+- **The Responses `image_generation` tool is served by an image model behind the scenes.**
+  Where a subscription has no image capability at all rather than no image *deployment*,
+  this route may fail for the same underlying reason. It is the only way a chat deployment
+  can produce an image, so it is worth having either way, but it is not a guaranteed
+  substitute for an image model and should be confirmed with one test generation.
+- **Masked editing is unavailable** on this route, as described above.
+- **API Management cannot use it.** The gateway route records no model name to classify
+  on.
+- **Cost and latency are higher** than an equivalent image deployment, because an
+  orchestrating model sits in front of every generation.

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,26 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/features) and [Fixes by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/fixes).
 
+### **(v0.261.087)**
+
+#### New Features
+
+*   **Image Generation Can Now Use A Chat Model Where No Image Model Is Available**
+    *   Image generation previously required a dedicated `gpt-image` or DALL-E deployment. A deployment like that is separately approved and is not offered in every subscription or region, so a tenant without one could not switch image generation on at all — the deployment list was filtered to image models, and nothing appeared to select.
+    *   A chat deployment such as `gpt-5.6` can now be selected instead. It has no image endpoint, so SimpleChat asks it through the Responses API's image generation tool rather than the images endpoint, and works out which of the two applies from the model behind the deployment you chose. There is no new setting to configure.
+    *   **Fetch deployments** now lists chat models alongside image models, and excludes embedding deployments, which can produce an image either way.
+    *   A chat deployment offers whole-image regeneration only. Changing part of an image needs the images API, and the editor says so before you paint a region rather than after.
+    *   Existing configurations are untouched. Every deployment that could be selected before still takes the route it always did, including one whose model name was never recorded and one reached through API Management.
+    *   Worth one test generation after selecting a chat deployment: the tool is served by an image model behind the scenes, so a subscription with no image capability at all may still be refused.
+    *   (Ref: `functions_image_api_route.py`, `functions_image_generation.request_generated_image_source`, `/api/models/image`, [Image generation through Responses-capable chat models](features/IMAGE_GENERATION_RESPONSES_MODELS.md))
+
+#### User Interface Enhancements
+
+*   **The Redundant API Management Switch Is Gone From AI Models**
+    *   **Send requests through API Management** has been removed from the AI Models tab. It belongs to the classic single endpoint, and a connection now carries its own API Management configuration, so the switch was a second control for a route connections never take — and the endpoint, deployment and subscription key it depends on were only settable on the classic admin page anyway.
+    *   The setting itself is unchanged and still applies to the classic endpoint. It is edited on the server-rendered admin page.
+    *   (Ref: `admin_settings_fields.ADMIN_SETTINGS_FIELDS['gpt-config']`, `SUPPRESSED_CAPABILITY_KEYS`, [AI Models](../admin/ai-models.md))
+
 ### **(v0.261.086)**
 
 #### Bug Fixes

--- a/functional_tests/test_image_generation_responses_route.py
+++ b/functional_tests/test_image_generation_responses_route.py
@@ -1,0 +1,302 @@
+#!/usr/bin/env python3
+# test_image_generation_responses_route.py
+"""
+Functional test for image generation through the Responses image tool.
+Version: 0.261.087
+Implemented in: 0.261.087
+
+Azure OpenAI produces images two different ways. ``gpt-image-*`` and the legacy
+``dall-e-*`` models serve ``/images/generations``; a chat model such as ``gpt-5.6-*``
+serves no image endpoint at all and can only produce one through the Responses API's
+hosted ``image_generation`` tool. SimpleChat now selects between the two from the model
+name already stored alongside the chosen deployment.
+
+The risk this test covers is not that the new route fails -- that surfaces immediately --
+but that it captures deployments it should have left alone. Everything selectable before
+the Responses route existed answers on the images endpoint, and moving one of those onto
+a route it cannot serve would break image generation for an installation that changed
+nothing.
+
+So these checks pin the classification in both directions, the two cases that must stay on
+the images endpoint despite carrying no usable model name, the API version substitution
+that makes the Responses call routable at all, and the response reading that lets
+everything downstream stay unaware of which route was taken.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent))
+
+from test_support.versioning import assert_app_version_at_least
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "application" / "single_app"))
+
+from functions_image_api_route import (  # noqa: E402  - path set above
+    DEFAULT_RESPONSES_IMAGE_FORMAT,
+    IMAGE_API_ROUTE_IMAGES,
+    IMAGE_API_ROUTE_RESPONSES,
+    RESPONSES_IMAGE_API_VERSION,
+    build_image_generation_tool,
+    extract_responses_image_source,
+    is_image_capable_model_name,
+    resolve_image_api_route,
+    resolve_responses_image_api_version,
+    resolve_selected_image_deployment_name,
+    resolve_selected_image_model_name,
+)
+
+
+def settings_for(model_name, deployment_name="image-deployment", **extra):
+    """Build the settings shape admin saves for a selected image deployment."""
+    selected = {"deploymentName": deployment_name}
+    if model_name is not None:
+        selected["modelName"] = model_name
+    return {
+        "enable_image_generation": True,
+        "image_gen_model": {"selected": [selected]},
+        **extra,
+    }
+
+
+def test_image_models_keep_the_images_endpoint():
+    """Every deployment selectable before this change must route exactly as it did."""
+    print("\nTesting that image models keep the images endpoint...")
+
+    for model_name in (
+        "gpt-image-1",
+        "gpt-image-1-mini",
+        "gpt-image-1.5",
+        "gpt-image-2",
+        "GPT-Image-2",
+        "dall-e-3",
+        "dall-e-2",
+        "dalle-2",
+        # Anything the old discovery filter matched on has to keep working, or this
+        # change would take a selectable deployment and route it somewhere it cannot go.
+        "some-other-image-model",
+    ):
+        route = resolve_image_api_route(settings_for(model_name))
+        assert route == IMAGE_API_ROUTE_IMAGES, (
+            f"{model_name} was routed to {route!r}. It serves /images/generations, and "
+            "the Responses route would fail every request against it."
+        )
+
+    print("  All 9 image models route to the images endpoint.")
+    return True
+
+
+def test_chat_models_route_to_the_responses_tool():
+    """A chat deployment is the only thing some tenants have, and has no image endpoint."""
+    print("\nTesting that chat models route to the Responses image tool...")
+
+    for model_name in ("gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5", "gpt-4o", "o3"):
+        route = resolve_image_api_route(settings_for(model_name))
+        assert route == IMAGE_API_ROUTE_RESPONSES, (
+            f"{model_name} was routed to {route!r}. It serves no image endpoint, so the "
+            "images route would fail rather than degrade."
+        )
+
+    print("  All 6 chat models route to the Responses image tool.")
+    return True
+
+
+def test_an_unknown_model_stays_on_the_images_endpoint():
+    """Settings saved before modelName was stored must not be re-routed on a guess."""
+    print("\nTesting the two cases with no model name to classify on...")
+
+    unrecorded = settings_for(None)
+    assert resolve_selected_image_model_name(unrecorded) == "", (
+        "A deployment saved without modelName should read as unknown."
+    )
+    assert resolve_image_api_route(unrecorded) == IMAGE_API_ROUTE_IMAGES, (
+        "A deployment with no recorded model name was moved off the images endpoint. "
+        "Unknown is not the same as 'chat model', and this is what an installation that "
+        "has not re-selected its deployment looks like."
+    )
+
+    apim = {
+        "enable_image_generation": True,
+        "enable_image_gen_apim": True,
+        "azure_apim_image_gen_deployment": "gateway-images",
+    }
+    assert resolve_image_api_route(apim) == IMAGE_API_ROUTE_IMAGES, (
+        "The APIM route was classified. It records no model name, and what a gateway "
+        "publishes decides the shape of the call in any case."
+    )
+    assert resolve_selected_image_deployment_name(apim) == "gateway-images", (
+        "The APIM deployment name should still be readable for reporting."
+    )
+    assert resolve_selected_image_deployment_name(unrecorded) == "image-deployment", (
+        "The direct deployment name should be readable without a model name."
+    )
+
+    print("  An unrecorded model name and the APIM route both stay on the images endpoint.")
+    return True
+
+
+def test_the_responses_route_does_not_inherit_an_unusable_api_version():
+    """The stored default predates the Responses API, so honouring it would fail every call."""
+    print("\nTesting the Responses API version substitution...")
+
+    stored_default = {"azure_openai_image_gen_api_version": "2024-12-01-preview"}
+    assert resolve_responses_image_api_version(stored_default) == RESPONSES_IMAGE_API_VERSION, (
+        "The image section's default API version was used for a Responses call. It "
+        "predates the Responses API entirely."
+    )
+
+    for unusable in ({}, {"azure_openai_image_gen_api_version": ""}, {"azure_openai_image_gen_api_version": "latest"}):
+        assert resolve_responses_image_api_version(unusable) == RESPONSES_IMAGE_API_VERSION, (
+            f"An unreadable API version {unusable!r} should fall back to the constant."
+        )
+
+    newer = {"azure_openai_image_gen_api_version": "2026-01-01-preview"}
+    assert resolve_responses_image_api_version(newer) == "2026-01-01-preview", (
+        "A deliberately pinned newer version was overridden by a constant that will age."
+    )
+
+    print(f"  Older and unreadable versions become {RESPONSES_IMAGE_API_VERSION}; newer ones survive.")
+    return True
+
+
+def test_only_stated_image_options_are_sent():
+    """The tool defaults each option itself; a guessed value fails the whole request."""
+    print("\nTesting the image_generation tool spec...")
+
+    assert build_image_generation_tool() == {"type": "image_generation"}, (
+        "An unset control was filled in with a guess."
+    )
+
+    tool = build_image_generation_tool(size="1024x1536", quality="high", background="transparent")
+    assert tool == {
+        "type": "image_generation",
+        "size": "1024x1536",
+        "quality": "high",
+        "background": "transparent",
+    }, f"Stated options were not carried onto the tool: {tool!r}"
+
+    partial = build_image_generation_tool(size="1024x1024", quality="", background="")
+    assert partial == {"type": "image_generation", "size": "1024x1024"}, (
+        f"Empty options were sent as values: {partial!r}"
+    )
+
+    print("  Only stated options reach the tool.")
+    return True
+
+
+def test_a_generated_image_is_read_out_of_the_responses_output():
+    """Returning the same data URL is what keeps every downstream consumer route-agnostic."""
+    print("\nTesting extraction from a Responses result...")
+
+    response = {
+        "output": [
+            {"type": "reasoning", "id": "rs_1", "summary": []},
+            {"type": "image_generation_call", "id": "ig_1", "status": "completed", "result": "QUJD"},
+            {"type": "message", "id": "msg_1", "content": []},
+        ]
+    }
+    source = extract_responses_image_source(response)
+    assert source == "data:image/png;base64,QUJD", (
+        f"The image was not read out of the output items: {source!r}"
+    )
+
+    webp = {
+        "output": [
+            {
+                "type": "image_generation_call",
+                "id": "ig_2",
+                "status": "completed",
+                "result": "QUJD",
+                "output_format": "webp",
+            }
+        ]
+    }
+    assert extract_responses_image_source(webp) == "data:image/webp;base64,QUJD", (
+        "A stated output format was ignored, so the stored image would claim the wrong type."
+    )
+
+    unknown_format = {
+        "output": [
+            {"type": "image_generation_call", "id": "ig_3", "result": "QUJD", "output_format": "tiff"}
+        ]
+    }
+    assert extract_responses_image_source(unknown_format) == "data:image/png;base64,QUJD", (
+        f"An unrecognised format should fall back to {DEFAULT_RESPONSES_IMAGE_FORMAT}."
+    )
+
+    print("  The image is read as a data URL, honouring the stated format.")
+    return True
+
+
+def test_a_reply_without_an_image_is_reported_as_empty():
+    """'Answered without calling the tool' is a different outcome from 'the call failed'."""
+    print("\nTesting a Responses result that carries no image...")
+
+    for barren in (
+        {"output": []},
+        {"output": [{"type": "message", "id": "msg_1", "content": []}]},
+        {"output": [{"type": "image_generation_call", "id": "ig_1", "status": "failed", "result": None}]},
+        {},
+        {"output": "not a list"},
+    ):
+        assert extract_responses_image_source(barren) == "", (
+            f"A result with no usable image returned something: {barren!r}"
+        )
+
+    print("  All 5 imageless results read as empty rather than raising.")
+    return True
+
+
+def test_discovery_offers_what_could_actually_produce_an_image():
+    """Discovery answers 'is this worth offering', which both routes now widen."""
+    print("\nTesting image deployment discovery...")
+
+    for model_name in ("gpt-image-1", "gpt-image-2", "dall-e-3", "gpt-5.6-sol", "gpt-4o", "o3", "gpt-5"):
+        assert is_image_capable_model_name(model_name), (
+            f"{model_name} was excluded from discovery, so it could never be selected."
+        )
+
+    # The old filter matched any name containing "image". Discovery must stay a superset
+    # of what it offered, or this change would remove a working configuration's model
+    # from the list it was chosen from.
+    assert is_image_capable_model_name("some-other-image-model"), (
+        "A deployment the previous filter offered is no longer discoverable."
+    )
+
+    for model_name in ("text-embedding-3-large", "text-embedding-ada-002", "", None, "whisper"):
+        assert not is_image_capable_model_name(model_name), (
+            f"{model_name!r} was offered as an image model. It can produce no image on "
+            "either route, so selecting it would fail at the point of use."
+        )
+
+    print("  Image and chat models are offered; embedding and audio models are not.")
+    return True
+
+
+if __name__ == "__main__":
+    assert_app_version_at_least("0.261.087")
+
+    tests = [
+        test_image_models_keep_the_images_endpoint,
+        test_chat_models_route_to_the_responses_tool,
+        test_an_unknown_model_stays_on_the_images_endpoint,
+        test_the_responses_route_does_not_inherit_an_unusable_api_version,
+        test_only_stated_image_options_are_sent,
+        test_a_generated_image_is_read_out_of_the_responses_output,
+        test_a_reply_without_an_image_is_reported_as_empty,
+        test_discovery_offers_what_could_actually_produce_an_image,
+    ]
+
+    results = []
+    for test in tests:
+        try:
+            results.append(bool(test()))
+        except Exception as exc:
+            print(f"FAILED {test.__name__}: {exc}")
+            import traceback
+
+            traceback.print_exc()
+            results.append(False)
+
+    print(f"\nResults: {sum(results)}/{len(results)} tests passed")
+    sys.exit(0 if all(results) else 1)

--- a/functional_tests/test_v2_admin_default_model_api.py
+++ b/functional_tests/test_v2_admin_default_model_api.py
@@ -40,8 +40,10 @@ SETTINGS_FILE = APP_DIR / "functions_settings.py"
 
 SECTION_ID = "gpt-config"
 
-# Declared alongside the two components rather than left to the V2 fallback scan. See
-# test_the_apim_toggle_is_declared_rather_than_guessed for why that matters.
+# Suppressed rather than declared: the switch was removed from the V2 section once
+# connections began carrying their own APIM configuration. See
+# test_the_apim_toggle_is_suppressed_rather_than_guessed for why removing it is not
+# enough on its own.
 APIM_TOGGLE_KEY = "enable_gpt_apim"
 
 EXPECTED_ROUTES = {
@@ -279,66 +281,64 @@ def test_the_chat_section_declares_its_components():
     return True
 
 
-def test_the_apim_toggle_is_declared_rather_than_guessed():
-    """Left undeclared, this lands in the Chat card as an unlabelled switch.
+def test_the_apim_toggle_is_suppressed_rather_than_guessed():
+    """Removing the field is not enough: the fallback scan would put it straight back.
 
     ``buildCapabilityIndex`` files an undeclared ``enable_*`` key under the section
     whose id shares the most word stems. ``enable_gpt_apim`` splits to ``{gpt, apim}``
     and ``gpt-config`` to ``{gpt, config}``, so it scores and wins -- and renders as
     "Gpt apim" with no help text, directly beneath a notice that speaks
-    authoritatively about which endpoint chat is using.
+    authoritatively about which endpoint chat is using. Deleting the field alone would
+    therefore trade a labelled switch for an anonymous one in the same place.
 
-    That is a trap rather than an inconvenience: the APIM endpoint, deployment and
-    subscription key it depends on are only settable on the classic admin page, so
-    the switch reaches for configuration the surrounding surface does not offer.
-    Declaring it is what both names it and takes it out of the guess.
+    Suppression is what actually removes it. The setting itself still exists and is
+    still read for the classic single endpoint; it is edited on the server-rendered
+    pane, and a connection carries its own APIM configuration, so there is nothing for
+    this section to offer.
     """
-    print("\nTesting the APIM toggle declaration...")
+    print("\nTesting the APIM toggle suppression...")
 
     declared_sections = {
-        field["key"]: (section_id, field)
+        field["key"]: section_id
         for section_id, field in fields_module.iter_fields()
         if field.get("key")
     }
 
-    entry = declared_sections.get(APIM_TOGGLE_KEY)
-    assert entry is not None, (
-        f"{APIM_TOGGLE_KEY} is not declared, so the V2 admin surface guesses a home for "
-        f"it. Declare it in the {SECTION_ID!r} section."
+    assert APIM_TOGGLE_KEY not in declared_sections, (
+        f"{APIM_TOGGLE_KEY} is declared under "
+        f"{declared_sections[APIM_TOGGLE_KEY]!r}, but connections carry their own APIM "
+        "configuration and the setting is edited on the server-rendered pane. Remove "
+        "the field and suppress the key instead."
+    )
+    assert APIM_TOGGLE_KEY not in fields_module.get_declared_setting_keys(), (
+        f"{APIM_TOGGLE_KEY} is still reported as declared."
     )
 
-    section_id, field = entry
-    assert section_id == SECTION_ID, (
-        f"{APIM_TOGGLE_KEY} is declared under {section_id!r}, expected {SECTION_ID!r}."
+    # This is the property the renderer actually reads. Without it the fallback scan
+    # draws the switch the field removal was meant to take away.
+    assert APIM_TOGGLE_KEY in fields_module.get_suppressed_capability_keys(), (
+        f"{APIM_TOGGLE_KEY} is neither declared nor suppressed, so the fallback scan "
+        f"guesses it into {SECTION_ID!r} as an unlabelled switch."
     )
-    assert field.get("type") == "switch", (
-        f"{APIM_TOGGLE_KEY} is declared as {field.get('type')!r}, expected 'switch'."
-    )
-    assert field.get("help"), (
-        f"{APIM_TOGGLE_KEY} is declared without help text, which leaves it as anonymous "
-        "as the fallback scan rendered it."
-    )
-
-    # This is the property the renderer actually reads: `!declaredKeys.has(key)` is what
-    # suppresses the guess.
-    assert APIM_TOGGLE_KEY in fields_module.get_declared_setting_keys(), (
-        f"{APIM_TOGGLE_KEY} is not reported as declared, so the fallback scan would "
-        "still place it."
+    assert fields_module.SUPPRESSED_CAPABILITY_KEYS[APIM_TOGGLE_KEY].strip(), (
+        f"{APIM_TOGGLE_KEY} is suppressed without a stated reason, which is the one "
+        "thing that list requires of an entry."
     )
 
-    print(f"  {APIM_TOGGLE_KEY} is declared in {SECTION_ID} with help text.")
+    print(f"  {APIM_TOGGLE_KEY} is suppressed with a stated reason.")
     return True
 
 
-def test_the_apim_toggle_exists_in_its_server_rendered_pane():
-    """A declared field with no V1 counterpart would write a setting nothing reads."""
+def test_the_apim_toggle_is_still_editable_on_its_server_rendered_pane():
+    """The setting is still read; losing its only remaining control would strand it."""
     print("\nTesting the APIM toggle against the server-rendered pane...")
 
     pane = APP_DIR / "templates" / "admin" / "_panes" / "model-endpoints.html"
     assert pane.is_file(), f"Missing the server-rendered pane: {pane}"
     assert f'name="{APIM_TOGGLE_KEY}"' in pane.read_text(encoding="utf-8"), (
-        f"{APIM_TOGGLE_KEY} has no field in {pane.name}, so the two admin interfaces "
-        "would not be editing the same setting."
+        f"{APIM_TOGGLE_KEY} has no field in {pane.name}. Now that V2 does not offer it, "
+        "this pane is the only place it can be changed, while the classic endpoint path "
+        "still reads it."
     )
 
     print(f"  {APIM_TOGGLE_KEY} exists in {pane.name}.")
@@ -554,8 +554,8 @@ if __name__ == "__main__":
     tests = [
         test_the_key_is_declared_so_the_settings_patch_refuses_it,
         test_the_chat_section_declares_its_components,
-        test_the_apim_toggle_is_declared_rather_than_guessed,
-        test_the_apim_toggle_exists_in_its_server_rendered_pane,
+        test_the_apim_toggle_is_suppressed_rather_than_guessed,
+        test_the_apim_toggle_is_still_editable_on_its_server_rendered_pane,
         test_routes_exist_and_are_admin_gated,
         test_the_read_route_does_not_write,
         test_the_write_route_stores_only_the_resolved_value,


### PR DESCRIPTION
Two unrelated items in the v2 Admin Settings **AI Models** tab.

## 1. The GPT "Send requests through API Management" switch is removed

`enable_gpt_apim` belongs to the classic single endpoint, and a connection now carries its own API Management configuration, so the switch was a second control for a route connections never take — and the endpoint, deployment and subscription key it depends on were only settable on the classic admin page anyway.

**Deleting the field alone would not have removed it.** The SPA runs an `enable_*` fallback scan that files an undeclared capability key under the section sharing the most word stems; `enable_gpt_apim` splits to `{gpt, apim}` and `gpt-config` to `{gpt, config}`, so it would have been guessed straight back into the same section — this time as an unlabelled "Gpt apim" switch with no help text, directly beneath a notice that speaks authoritatively about which endpoint chat is using. The key is therefore **suppressed**, not merely undeclared.

The setting itself is unchanged. All ~20 backend readers, the server-rendered `model-endpoints.html` pane and its form handler are untouched, and it still governs the classic endpoint.

## 2. Image generation can use a Responses-capable chat deployment

Image generation previously required a `gpt-image-*` or DALL-E deployment. One of those is separately approved and unavailable in some subscriptions and regions, and `/api/models/image` filtered the deployment list to image models — so a tenant without one could not switch image generation on at all, because nothing appeared to select.

A chat deployment such as `gpt-5.6-*` serves no image endpoint, but can produce an image through the Responses API's hosted `image_generation` tool. SimpleChat now derives which of the two routes applies from the `modelName` already stored alongside the selected deployment. There is no new setting.

| Route | Endpoint | Models |
| --- | --- | --- |
| `images` | `/images/generations`, `/images/edits` | `*image*`, `dall-e-*` |
| `responses` | `/responses` + `image_generation` tool | `gpt-5.6-*`, `gpt-5*`, `gpt-4o`, `o*` |

Notable details:

- **Nothing existing moves.** An unrecorded model name and the APIM route both stay on the images endpoint, because "unknown" is not the same as "chat model" and re-routing a working deployment would break an installation that changed nothing.
- **`tool_choice` is forced.** Without it the model is free to answer with prose about the image it would have drawn, which reads as an empty result rather than as a refusal.
- **The stored API version is not inherited.** `azure_openai_image_gen_api_version` defaults to `2024-12-01-preview`, which predates the Responses API, so that route substitutes `2025-04-01-preview`. A version pinned *newer* than the constant is honoured.
- **One helper, four callers.** Chat, the proposal pipeline, the editor's regenerate branch and the admin **Test connection** all go through `request_generated_image_source`. The connection test is included deliberately — a test taking a different route from the real call would certify a path nobody uses.
- **Editing degrades honestly.** A chat deployment offers whole-image regeneration only, and the editor says so before a region is painted rather than after.
- **Discovery stays a superset.** The images marker is the broad `image` rather than `gpt-image`; narrowing it would have dropped any `*-image-*` deployment the previous filter offered and then routed it somewhere it cannot go. Covered by a test.

### Known limitation, stated rather than claimed away

On Azure the `image_generation` tool is served by an image model behind the scenes. Where a subscription has no image *capability* at all rather than no image *deployment*, this route may be refused for the same underlying reason. It remains the only way a chat deployment can produce an image, so it is worth having either way, but it is not a guaranteed substitute — **worth one test generation against a `gpt-5.6`-only resource to confirm.** This is documented in both the admin page and the release notes.

## Validation

10/10 touched tests pass, including a new `functional_tests/test_image_generation_responses_route.py` (8 cases) that pins the classification in both directions, the two cases that must stay on the images endpoint, the API version substitution, the tool spec, and replies carrying no image. The emphasis is on what must *not* change.

`functions_image_api_route.py` imports no application configuration, so all of it is directly testable.

Two failures were confirmed **pre-existing** against a stashed baseline and left alone: `test_admin_settings_sidebar_card_parity.py` (a duplicated `inbound-mcp-configuration` entry, 3/4 before and after) and `test_image_proposal_pipeline.py` (imports `config`, which needs real Cosmos credentials).

`docs/_data/app_surface.yml` is unchanged — the inventory reads `enable_*` from the settings defaults, not the admin field schema, so suppressing a field leaves it alone.

Version bumped to `0.261.088`. (Originally `0.261.087`, but #1439 landed on the base branch claiming that number first, so this moved up when the base was merged in. The release notes carry both sections, in order.)
