### PR TITLE
Apply the capability request gates when a plan is built

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -97,7 +97,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.261.087"
+VERSION = "0.261.088"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/functions_orchestration_adapters.py
+++ b/application/single_app/functions_orchestration_adapters.py
@@ -295,6 +295,12 @@ def _citations_from_search_results(results):
             'page_number': result.get('page_number'),
             'chunk_sequence': result.get('chunk_sequence'),
             'score': result.get('score'),
+            # Which workspace the hit came from. The search index selects these per scope
+            # and they were being dropped here, which left a found document with no home:
+            # the composer groups its context chips by workspace, so a document the run
+            # discovered could not be offered back to the user without one.
+            'group_id': result.get('group_id'),
+            'public_workspace_id': result.get('public_workspace_id'),
         })
     return citations
 
@@ -320,6 +326,10 @@ def run_document_search(step, context, *, settings, user_id, emit, cancel_reques
             doc_scope=_text(arguments.get('doc_scope')) or _ctx(context, 'doc_scope', 'all'),
             active_group_ids=_ctx(context, 'active_group_ids', None) or None,
             active_public_workspace_id=_ctx(context, 'active_public_workspace_id', None),
+            # The tags the user picked, applied to every search in the run. A step is free
+            # to choose its own query, but not to widen the shelf the user narrowed to.
+            tags_filter=_ctx(context, 'tags', None) or None,
+            document_filter_mode=_ctx(context, 'document_filter_mode', 'intersection'),
         )
     except Exception as exc:
         log_event(

--- a/application/single_app/functions_orchestration_context.py
+++ b/application/single_app/functions_orchestration_context.py
@@ -121,9 +121,31 @@ def resolve_seeds(request_data):
     prompt = request_data.get('prompt_info')
     prompt = prompt if isinstance(prompt, dict) else None
 
+    # Display names for the picked documents, sent by the composer because it already knows
+    # them. Used for labels only -- what the user may actually read is decided from the ids
+    # against Cosmos, never from anything the browser asserts about them.
+    document_labels = {}
+    for entry in request_data.get('context_documents') or ():
+        if not isinstance(entry, dict):
+            continue
+        document_id = _text(entry.get('id') or entry.get('document_id'))
+        label = _text(entry.get('label') or entry.get('file_name'), 200)
+        if document_id and label:
+            document_labels[document_id] = label
+
     return {
         'document_ids': document_ids,
+        'document_labels': document_labels,
         'doc_scope': _text(request_data.get('doc_scope')) or 'all',
+        # Tags narrow a search rather than naming documents, so they are a separate seed
+        # from document_ids and are treated differently: a picked document replaces the
+        # candidate probe, a picked tag scopes it.
+        'tags': _string_list(request_data.get('tags')),
+        'document_filter_mode': (
+            'union'
+            if _text(request_data.get('document_filter_mode')).lower() in ('union', 'or', 'additive')
+            else ''
+        ),
         'agent': agent,
         'model': model or None,
         'prompt': prompt,
@@ -141,7 +163,13 @@ def resolve_seeds(request_data):
 
 
 def seeds_are_explicit(seeds):
-    """Whether the user named documents, which turns the candidate probe off."""
+    """Whether the user named documents, which turns the candidate probe off.
+
+    Naming a tag deliberately does not count. A document is an answer to "which documents";
+    a tag is an answer to "which shelf", and the probe is still the thing that decides which
+    documents on that shelf are worth naming. Treating a tag as explicit would hand the
+    planner every document carrying it, which is the opposite of narrowing.
+    """
     return bool((seeds or {}).get('document_ids'))
 
 
@@ -212,11 +240,18 @@ def resolve_candidate_documents(
     if seeds_are_explicit(seeds):
         # The user already answered this question. Probing would only offer alternatives
         # to a choice that has been made.
+        #
+        # The names come from the composer, which had them on screen when the user picked.
+        # Without them the planner reasons about bare uuids -- it cannot write "compare the
+        # Q3 and Q4 contracts" if it has never been told which document is which, and the
+        # approval card, whose whole purpose is letting someone check the planner picked the
+        # right document, would show a row of identifiers.
+        labels = seeds.get('document_labels') or {}
         return [
             {
                 'document_id': document_id,
-                'file_name': '',
-                'title': '',
+                'file_name': labels.get(document_id, ''),
+                'title': labels.get(document_id, ''),
                 'scope': seeds.get('doc_scope') or 'all',
                 'classification': '',
                 'tags': [],
@@ -242,6 +277,11 @@ def resolve_candidate_documents(
             active_public_workspace_id=(
                 (seeds.get('active_public_workspace_ids') or [None])[0]
             ),
+            # A picked tag is part of the question. Probing without it would offer the
+            # planner documents the user has already excluded, and the plan would then be
+            # built around a candidate they did not want considered.
+            tags_filter=seeds.get('tags') or None,
+            document_filter_mode=seeds.get('document_filter_mode') or 'intersection',
         )
     except Exception as exc:
         log_event(

--- a/application/single_app/functions_orchestration_executor.py
+++ b/application/single_app/functions_orchestration_executor.py
@@ -167,6 +167,8 @@ class RunContext:
         chat_type='personal',
         selection_mode=None,
         doc_scope='all',
+        tags=None,
+        document_filter_mode=None,
         active_group_ids=None,
         active_group_id=None,
         active_public_workspace_id=None,
@@ -193,6 +195,11 @@ class RunContext:
 
         self.selection_mode = selection_mode
         self.doc_scope = doc_scope
+        # The tags the user picked in the composer. Carried for the whole run rather than
+        # per step: a tag is a standing narrowing of what this turn is about, so a step that
+        # searched without it would look more widely than the user asked.
+        self.tags = list(tags or [])
+        self.document_filter_mode = document_filter_mode or 'intersection'
         self.active_group_ids = list(active_group_ids or [])
         self.active_group_id = active_group_id
         self.active_public_workspace_id = active_public_workspace_id

--- a/application/single_app/functions_orchestration_planner.py
+++ b/application/single_app/functions_orchestration_planner.py
@@ -407,10 +407,19 @@ def plan_request(
     turn_id=None,
     seeds=None,
     document_labels=None,
+    request_context=None,
 ):
     """Produce a validated plan, or a question set, for one request.
 
     Returns ``(kind, document)`` where ``kind`` is ``'plan'`` or ``'elicitation'``.
+
+    ``request_context`` describes *this caller*, as opposed to the deployment: their app
+    roles, whether their message contains a URL, whether they have an agent to invoke. It
+    is what the capability request gates read. Passing it here narrows one resolution and
+    thereby three things at once -- what the planner is shown, what the validator will
+    accept, and so what can reach an adapter. Omitting it describes the deployment instead,
+    which is what the admin page and the bootstrap payload want but never what a real
+    request wants.
 
     A planner that fails -- unreachable, unparseable, or producing something that cannot
     be validated -- degrades to a single answering step rather than raising. The user
@@ -422,6 +431,7 @@ def plan_request(
     capabilities = resolve_available_capabilities(
         settings,
         allowed_ids=settings.get('chat_orchestration_enabled_capabilities'),
+        request_context=request_context,
     )
     available_ids = [capability['id'] for capability in capabilities]
 

--- a/application/single_app/route_backend_orchestration.py
+++ b/application/single_app/route_backend_orchestration.py
@@ -383,6 +383,43 @@ def _request_identity(user_id=None, seeded_agent=None):
     }
 
 
+def _capability_request_context(user_id, identity, user_message, agent_catalog):
+    """Describe this caller, so the capability request gates can answer for them.
+
+    Distinct from the deployment-level gates: those answer "does this installation have
+    URL access at all", these answer "may this person read a URL, and is there one to
+    read". Without it the planner would be offered capabilities the caller cannot use --
+    reading links in a message containing none, or an agent they have none of -- and
+    produce plans whose steps could only fail.
+
+    Built in the route because that is where the request is. The registry stays free of
+    Flask, and the gates stay next to the capabilities they belong to.
+    """
+    identity = identity or {}
+    urls = []
+    try:
+        from functions_source_review import extract_urls_from_text
+
+        urls = extract_urls_from_text(user_message or '') or []
+    except Exception as exc:
+        # No URLs found is the safe reading: url_fetch is withheld rather than offered for
+        # a message we could not scan.
+        log_event(
+            f"[ORCHESTRATION] Could not scan the message for URLs: {exc}",
+            level=logging.WARNING,
+        )
+
+    return {
+        'user_id': user_id,
+        'user_message': user_message or '',
+        'message_urls': urls,
+        'user_roles': identity.get('user_roles') or [],
+        'user_email': identity.get('user_email'),
+        'user_enable_agents': identity.get('user_enable_agents', True),
+        'agent_catalog': list(agent_catalog or ()),
+    }
+
+
 def _partition_citations(citations):
     """Split a run's citations into the document and web buckets chat already uses.
 
@@ -560,6 +597,11 @@ def register_route_backend_orchestration(bp):
             # of asking again. Either way this is a new attempt at the same turn.
             revision += 1
 
+        # Captured on the request thread, before the streamed generator body runs. See
+        # _request_identity: a generator runs after the view returns, when the session is
+        # already gone.
+        identity = _request_identity(user_id, seeded_agent=seeds.get('agent'))
+
         def generate():
             try:
                 resolved_conversation_id, created = _ensure_conversation(
@@ -611,18 +653,18 @@ def register_route_backend_orchestration(bp):
                     # conversational message never pays for it: it is a multi-query Cosmos
                     # traversal with no cache, and a trivial reply has no plan for an agent
                     # to appear in. Once per plan, never per step.
-                    #
+                    agent_catalog = resolve_agent_catalog(
+                        user_id, seeds=seeds, settings=settings,
+                        user_groups=seeds.get('active_group_ids') or None,
+                    )
+
                     # The context is rebuilt rather than having 'agents' assigned into it,
                     # because build_planner_context is the single place the catalog is
                     # projected down to its naming fields. Writing the key directly would
                     # put an agent's full instructions in front of the planner.
                     context = build_planner_context(
                         message, candidates=candidates, seeds=seeds, ledger=ledger,
-                        signals=signals,
-                        agents=resolve_agent_catalog(
-                            user_id, seeds=seeds, settings=settings,
-                            user_groups=seeds.get('active_group_ids') or None,
-                        ),
+                        signals=signals, agents=agent_catalog,
                     )
                     if answered:
                         context['answered_now'] = answered
@@ -635,6 +677,13 @@ def register_route_backend_orchestration(bp):
                         replan_hint=replan_hint or None,
                         revision=revision,
                         turn_id=turn_id, seeds=seeds, document_labels=labels,
+                        # Narrows one resolution and thereby three things: what the planner
+                        # is offered, what the validator will accept, and so what can reach
+                        # an adapter. Without it a plan could propose reading links in a
+                        # message that has none, or an agent this user does not have.
+                        request_context=_capability_request_context(
+                            user_id, identity, message, agent_catalog,
+                        ),
                     )
 
                 if kind == 'elicitation':

--- a/application/single_app/route_backend_orchestration.py
+++ b/application/single_app/route_backend_orchestration.py
@@ -880,6 +880,8 @@ def register_route_backend_orchestration(bp):
                 invoke_prompt=invoke_prompt,
                 user_message=user_message,
                 doc_scope=seeds.get('doc_scope') or 'all',
+                tags=seeds.get('tags') or None,
+                document_filter_mode=seeds.get('document_filter_mode') or None,
                 active_group_ids=seeds.get('active_group_ids') or None,
                 active_public_workspace_id=(
                     (seeds.get('active_public_workspace_ids') or [None])[0]

--- a/application/v2_ui/src/components/chat/Composer.tsx
+++ b/application/v2_ui/src/components/chat/Composer.tsx
@@ -38,7 +38,9 @@ import { resolveGating } from '../../lib/composerGating';
 import { resolveDocumentScope } from '../../lib/documentScope';
 import {
     addContextItem,
+    contextDocumentDescriptors,
     contextDocumentIds,
+    contextFilterMode,
     contextScopes,
     contextTags,
     hasContextItem,
@@ -800,6 +802,9 @@ export function Composer() {
         const seeds: Record<string, unknown> = {
             web_search_enabled: options.webSearch,
             selected_document_ids: contextDocumentIds(options.contextItems),
+            // Names for those ids, so the planner can reason about "the Q3 contract" and the
+            // approval card can be read. Display only -- the server authorizes from the ids.
+            context_documents: contextDocumentDescriptors(options.contextItems),
             // `resolve_seeds` reads doc_scope and the workspace ids alongside the document
             // ids, and `seeds_are_explicit` turns the planner's candidate probe off once
             // documents are named. Sending the ids without the scope that reaches them would
@@ -809,6 +814,12 @@ export function Composer() {
         const tags = contextTags(options.contextItems);
         if (tags.length > 0) {
             seeds.tags = tags;
+        }
+        // Without this a picked document beside an unrelated tag chip intersects to nothing,
+        // exactly as it did on the chat path before the same field was sent there.
+        const filterMode = contextFilterMode(options.contextItems);
+        if (filterMode) {
+            seeds.document_filter_mode = filterMode;
         }
         Object.assign(
             seeds,

--- a/application/v2_ui/src/components/chat/OrchestrationRunView.tsx
+++ b/application/v2_ui/src/components/chat/OrchestrationRunView.tsx
@@ -113,14 +113,38 @@ export function OrchestrationRunView({
     );
 
     /**
-     * Names for every document the plan touches.
+     * Names for every document the plan touches, and which of them the user chose.
      *
-     * Resolved across the whole plan rather than per step so a document used by two steps is
-     * looked up once, and so the lookup does not restart as steps re-render.
+     * The plan describes its own documents in `inputs`, resolved server-side from the composer's
+     * selection and the relevance probe. Preferring that to a second lookup means a picked
+     * document is named immediately rather than after three fetches, and it is the only source
+     * for `selected_by_user` -- which is the distinction actually worth showing on a card whose
+     * purpose is confirming the planner picked the right thing.
+     */
+    const planInputDocuments = useMemo(() => {
+        const byId = new Map<string, { name: string; selectedByUser: boolean }>();
+        for (const entry of plan?.inputs?.documents ?? []) {
+            byId.set(entry.document_id, {
+                name: entry.display_name,
+                selectedByUser: entry.selected_by_user,
+            });
+        }
+        return byId;
+    }, [plan]);
+
+    /**
+     * Names for anything the plan did not describe.
+     *
+     * Only ids the plan left unnamed are looked up, so the common case costs no request at all.
+     * A step edited after planning, or a plan persisted before the server named its inputs, still
+     * resolves rather than showing a uuid.
      */
     const planDocumentIds = useMemo(
-        () => [...new Set(orderedSteps.flatMap((step) => stepDocumentIds(step)))],
-        [orderedSteps],
+        () =>
+            [...new Set(orderedSteps.flatMap((step) => stepDocumentIds(step)))].filter(
+                (id) => !(planInputDocuments.get(id)?.name),
+            ),
+        [orderedSteps, planInputDocuments],
     );
     const documentTitles = useDocumentTitles(planDocumentIds);
 
@@ -258,10 +282,17 @@ export function OrchestrationRunView({
                                     const isRemoved = removed.has(documentId);
                                     const canRemove =
                                         editable && removable.has(documentId);
-                                    // Falls back to the id while the lookup is in flight, or
-                                    // when the document cannot be read any more, so a chip is
-                                    // never blank.
-                                    const title = documentTitles.get(documentId) ?? documentId;
+                                    const planned = planInputDocuments.get(documentId);
+                                    // The plan's own name first, then a lookup, then the id, so
+                                    // a chip is never blank.
+                                    const title =
+                                        planned?.name ??
+                                        documentTitles.get(documentId) ??
+                                        documentId;
+                                    // Worth distinguishing: a document the user picked is not a
+                                    // decision the planner made, so it is not one they are being
+                                    // asked to check.
+                                    const chosenByUser = planned?.selectedByUser ?? false;
                                     return (
                                         <li
                                             key={documentId}
@@ -269,20 +300,33 @@ export function OrchestrationRunView({
                                                 'inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px]',
                                                 isRemoved
                                                     ? 'border-edge text-text-3 line-through'
-                                                    : 'border-edge-strong text-text-2',
+                                                    : chosenByUser
+                                                      ? 'border-accent/50 bg-accent/5 text-text-2'
+                                                      : 'border-edge-strong text-text-2',
                                             )}
                                         >
                                             <FileText size={10} className="shrink-0" />
                                             <span
                                                 className="max-w-[12rem] truncate"
                                                 title={
-                                                    title === documentId
-                                                        ? documentId
-                                                        : `${title} · ${documentId}`
+                                                    [
+                                                        title === documentId ? null : title,
+                                                        documentId,
+                                                        chosenByUser
+                                                            ? 'You chose this document'
+                                                            : 'Chosen by the planner',
+                                                    ]
+                                                        .filter(Boolean)
+                                                        .join(' · ')
                                                 }
                                             >
                                                 {title}
                                             </span>
+                                            {chosenByUser && !isRemoved ? (
+                                                <span className="text-[10px] text-text-3">
+                                                    yours
+                                                </span>
+                                            ) : null}
                                             {isRemoved ? (
                                                 <button
                                                     type="button"

--- a/application/v2_ui/src/lib/chatContext.ts
+++ b/application/v2_ui/src/lib/chatContext.ts
@@ -227,6 +227,44 @@ export function contextDocumentIds(items: readonly ContextItem[]): string[] {
     return items.filter((item) => item.kind === 'document').map((item) => item.id);
 }
 
+/** A picked document, described well enough for a plan to be read by a person. */
+export interface ContextDocumentDescriptor {
+    id: string;
+    label: string;
+    file_name?: string;
+    scope_kind: ContextScopeKind;
+    workspace_id?: string;
+}
+
+/**
+ * The picked documents with their names, for `resolve_seeds`.
+ *
+ * The ids alone are enough to *run* a plan and are the only thing authorization uses. They are
+ * not enough to *review* one: `resolve_candidate_documents` returns seeded documents with an
+ * empty `file_name`, so the planner is asked to choose between identifiers and the approval
+ * card -- whose entire purpose is letting someone confirm the right document was picked --
+ * shows `8f14e45f-ceea-467a-…`.
+ *
+ * The composer had these names on screen when the user clicked them, so it sends them rather
+ * than making the server resolve across three containers to recover what was just discarded.
+ *
+ * Display only. The server labels with these and authorizes from the ids, so a tampered label
+ * mislabels the sender's own plan card and reaches nothing new.
+ */
+export function contextDocumentDescriptors(
+    items: readonly ContextItem[],
+): ContextDocumentDescriptor[] {
+    return items
+        .filter((item) => item.kind === 'document')
+        .map((item) => ({
+            id: item.id,
+            label: item.label,
+            file_name: item.meta?.fileName,
+            scope_kind: item.scope.kind,
+            workspace_id: item.scope.id ?? undefined,
+        }));
+}
+
 /**
  * The tag names to filter on.
  *

--- a/application/v2_ui/src/lib/orchestration.ts
+++ b/application/v2_ui/src/lib/orchestration.ts
@@ -158,12 +158,38 @@ export interface OrchestrationValidation {
 }
 
 /**
+ * A document the plan will act on, as the server described it.
+ *
+ * `build_plan_inputs` derives this from the *validated* steps rather than from what the planner
+ * proposed, so it reflects what will actually run after unauthorized documents were dropped.
+ *
+ * `selected_by_user` is the distinction worth showing: a document the user picked in the
+ * composer and one the planner chose from a relevance probe are both "documents this plan
+ * reads", but only the second is a decision the user is being asked to check.
+ */
+export interface OrchestrationPlanDocument {
+    document_id: string;
+    /** Falls back to the id server-side when no name could be resolved. */
+    display_name: string;
+    selected_by_user: boolean;
+}
+
+/** What the plan will act on, for the approval card. */
+export interface OrchestrationPlanInputs {
+    documents: OrchestrationPlanDocument[];
+    web: boolean;
+    agent?: Json;
+    model?: Json;
+    prompt?: Json;
+}
+
+/**
  * A validated, runnable plan.
  *
- * `inputs` and `outputs` are carried opaquely: the prompt's contract lists them, but the schema
- * module (`normalize_plan`) does not populate them, so their shape is owned by the planner /
- * executor work being built in parallel. They are typed loosely rather than guessed at, so this
- * client neither drops them nor claims a structure the server has not committed to.
+ * `outputs` is carried opaquely: its shape is owned by the executor work being built in
+ * parallel, so it is typed loosely rather than guessed at. `inputs` is not -- `build_plan_inputs`
+ * commits to a shape, and reading it is what lets the card name a document rather than resolve
+ * the name a second time from the browser.
  */
 export interface OrchestrationPlan {
     plan_id: string;
@@ -183,7 +209,7 @@ export interface OrchestrationPlan {
     planner_contract_version: number;
     intent: OrchestrationIntent;
     assumptions: string[];
-    inputs?: Json;
+    inputs?: OrchestrationPlanInputs;
     steps: OrchestrationStep[];
     outputs?: Json[];
     approval: OrchestrationApproval;

--- a/application/v2_ui/src/lib/orchestrationPlan.ts
+++ b/application/v2_ui/src/lib/orchestrationPlan.ts
@@ -21,6 +21,8 @@ import type {
     OrchestrationApproval,
     OrchestrationIntent,
     OrchestrationPlan,
+    OrchestrationPlanDocument,
+    OrchestrationPlanInputs,
     OrchestrationStep,
     OrchestrationValidation,
     PlanComplexity,
@@ -195,9 +197,9 @@ function normalizeValidation(raw: unknown): OrchestrationValidation {
  *
  * Null rather than a throw, because a plan can arrive from an untrusted place -- a persisted
  * blob, a stream frame the server truncated -- and a caller adopting one wants to test the
- * result, not guard a try/catch. `inputs` and `outputs` pass through as-is: their shape is not
- * fixed by the schema module, so re-coercing them would risk discarding a structure the planner
- * work being built in parallel does commit to.
+ * result, not guard a try/catch. `outputs` passes through as-is: its shape is not fixed by the
+ * schema module, so re-coercing it would risk discarding a structure the executor work being
+ * built in parallel does commit to.
  */
 export function normalizePlan(raw: unknown): OrchestrationPlan | null {
     if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
@@ -221,12 +223,48 @@ export function normalizePlan(raw: unknown): OrchestrationPlan | null {
                 : 1,
         intent: normalizeIntent(source.intent),
         assumptions: asStringList(source.assumptions),
-        inputs: source.inputs !== undefined ? asRecord(source.inputs) : undefined,
+        inputs: source.inputs !== undefined ? normalizeInputs(source.inputs) : undefined,
         steps,
         outputs: Array.isArray(source.outputs) ? (source.outputs as Json[]) : undefined,
         approval: normalizeApproval(source.approval),
         validation: normalizeValidation(source.validation),
         status: oneOf(source.status, PLAN_STATUSES, 'awaiting_approval'),
+    };
+}
+
+/**
+ * What the plan will act on.
+ *
+ * A document with no id is dropped rather than kept with an empty one: it could not be shown,
+ * removed or acted on, so carrying it would only put a blank row on the approval card.
+ */
+function normalizeInputs(raw: unknown): OrchestrationPlanInputs {
+    const source = asRecord(raw);
+    const rawDocuments: unknown[] = Array.isArray(source.documents) ? source.documents : [];
+
+    const documents: OrchestrationPlanDocument[] = [];
+    for (const entry of rawDocuments) {
+        const record = asRecord(entry);
+        const documentId = asString(record.document_id);
+        if (!documentId) {
+            continue;
+        }
+        documents.push({
+            document_id: documentId,
+            // The server already falls back to the id when it cannot name a document, but a
+            // truncated frame could still arrive without one, and a blank chip is worse than
+            // an ugly one.
+            display_name: asString(record.display_name) || documentId,
+            selected_by_user: asBoolean(record.selected_by_user, false),
+        });
+    }
+
+    return {
+        documents,
+        web: asBoolean(source.web, false),
+        agent: source.agent !== undefined ? asRecord(source.agent) : undefined,
+        model: source.model !== undefined ? asRecord(source.model) : undefined,
+        prompt: source.prompt !== undefined ? asRecord(source.prompt) : undefined,
     };
 }
 

--- a/docs/explanation/features/CHAT_CONTEXT_PICKER.md
+++ b/docs/explanation/features/CHAT_CONTEXT_PICKER.md
@@ -113,17 +113,31 @@ happened to be off would otherwise be collected, sent, and ignored.
 
 ## Orchestration
 
-Chips travel to the planner as seeds. Naming documents explicitly also suppresses
-the planner's candidate probe, so it works from your choice rather than guessing
-at one.
+Chips travel to the planner as seeds, and each kind lands differently:
 
-In the other direction, documents the planner chose are listed on each step of
-the plan **by name** rather than by id — deciding whether it picked the right
-contract is the reason the plan is shown before it runs, and a bare uuid does not
-support that decision. Documents can be removed from a step, which narrows the
-plan. Adding one is deliberately not offered inline: widening a plan goes back
-through planning, so a request never skips the reasoning and permission check
-that produced it.
+| Chip kind | Effect on a plan |
+| --- | --- |
+| Document | Replaces the planner's candidate probe. You answered "which documents", so it works from your choice rather than guessing at one. |
+| Tag | **Scopes** the probe rather than replacing it. A tag says which shelf; the probe still decides which documents on that shelf are worth naming. |
+| Workspace | Bounds where the probe and every search step in the run may look. |
+
+Your tags stay in force for the whole run, not just the first step. A step is free
+to choose its own search query, but not to widen the shelf you narrowed to.
+
+In the other direction, documents are listed on each step of the plan **by name**
+rather than by id — deciding whether it picked the right contract is the reason
+the plan is shown before it runs, and a bare uuid does not support that decision.
+Documents you chose are marked as yours, so the ones actually worth checking are
+the ones the planner introduced. Documents can be removed from a step, which
+narrows the plan. Adding one is deliberately not offered inline: widening a plan
+goes back through planning, so a request never skips the reasoning and permission
+check that produced it.
+
+Names are display only. The server labels a plan with the names the composer sends
+and decides what you may read from the ids, so a renamed document is still exactly
+the document it was.
+
+See [Chat Orchestration](CHAT_ORCHESTRATION.md) for the planner side.
 
 ## Files
 

--- a/docs/explanation/features/CHAT_ORCHESTRATION.md
+++ b/docs/explanation/features/CHAT_ORCHESTRATION.md
@@ -61,6 +61,41 @@ enablement lives in a nested capability record rather than a flag.
   question reuse earlier findings instead of repeating them, and what stops an elicitation
   asking the same question twice.
 
+#### What the context picker contributes
+
+The composer's context picker lets a user name documents, tags and whole workspaces before
+asking. Each reaches the plan differently, and the difference is the point.
+
+| Picked | Seed | Effect on planning |
+|---|---|---|
+| A document | `document_ids` | Replaces the candidate probe. The user answered "which documents", so probing would only offer alternatives to a decision already made. |
+| A tag | `tags` | **Scopes** the probe. A tag answers "which shelf", not "which document" — the probe still decides which documents on that shelf are worth naming. |
+| A workspace | `doc_scope`, `active_group_ids`, `active_public_workspace_ids` | Bounds where the probe and every search step may look. |
+
+Treating a tag as an explicit choice would hand the planner every document carrying it,
+which is the opposite of narrowing. `seeds_are_explicit` therefore tests documents alone.
+
+Tags are carried on `RunContext` for the whole run rather than per step, because a tag is a
+standing narrowing of what the turn is about: a step is free to choose its own query, but
+not to widen the shelf the user narrowed to. `document_filter_mode` travels with them —
+without it a picked document beside an unrelated tag intersects to nothing.
+
+#### Document names
+
+`resolve_candidate_documents` used to return seeded documents with an empty `file_name`,
+so a picked document reached the planner as a bare uuid. That breaks two things: the
+planner cannot write "compare the Q3 and Q4 contracts" if it was never told which document
+is which, and the approval card — whose entire purpose is letting someone confirm the
+planner picked the right document — showed a row of identifiers.
+
+The composer had those names on screen when the user clicked them, so it sends them as
+`context_documents` rather than making the server resolve across three containers to
+recover what was just discarded.
+
+**Names are display; authorization is by id.** `_authorized_document_ids` reads
+`document_ids` and nothing else, so a client that renamed a document mislabels its own plan
+card and reaches nothing new. `test_orchestration_context_picker.py` asserts this directly.
+
 ### Plan
 
 `functions_orchestration_planner.py` triages first. The point of triage is to stop a
@@ -289,6 +324,7 @@ to the front.
 | `functional_tests/test_orchestration_phase_ordering.py` | Knowledge sorts before reasoning, a plan gathering after answering is repaired, a backwards dependency is dropped with a note |
 | `functional_tests/test_orchestration_adapter_contract.py` | Every capability resolves to an adapter, every adapter matches the executor's call signature, no adapter touches Flask state, and identity is captured on the request thread |
 | `functional_tests/test_orchestration_citation_persistence.py` | Cited documents reach the conversation's used-document list, and document and web citations are separated |
+| `functional_tests/test_orchestration_context_picker.py` | Picked tags reach the seeds and both search paths under the parameter `hybrid_search` really takes; a tag scopes the probe rather than replacing it; a picked document reaches the planner and the approval card by name; a browser-supplied name cannot widen access; search citations carry the workspace a document came from |
 
 ## Known limitations
 

--- a/docs/explanation/features/CHAT_ORCHESTRATION.md
+++ b/docs/explanation/features/CHAT_ORCHESTRATION.md
@@ -1,7 +1,7 @@
 # Chat Orchestration
 
 **Implemented in version: 0.261.086**
-**Knowledge phase added in version: 0.261.087**
+**Knowledge phase added in version: 0.261.088**
 
 ## Overview
 
@@ -124,6 +124,29 @@ So `agent_invoke`, `url_fetch` and `deep_research` produce `notes` and `citation
 This is not a workaround: `RunContext.merge_step_result` already accumulates notes, and the
 respond adapter already folds them into its prompt. A knowledge step that gathers *text*
 rather than *document evidence* reaches the answer through a path that already existed.
+
+### Two levels of gate
+
+A capability is gated twice, and the two answer different questions.
+
+| Gate | Question | Read by |
+|---|---|---|
+| `gate(settings)` | Does this deployment have the capability at all? | The admin page, the bootstrap payload, and planning |
+| `request_gate(settings, context)` | May *this caller, asking this question* use it? | Planning only |
+
+`resolve_available_capabilities` applies request gates **only when a request context is
+given**. That is deliberate: the admin page and the bootstrap payload describe a
+deployment, not a caller, and would be wrong to hide a capability because the administrator
+viewing the page happens to have no agents.
+
+But it means a caller that forgets to pass a context silently gets the deployment answer.
+`plan_request` takes `request_context` and forwards it, so one resolution narrows three
+things at once: what the planner is offered, what the validator accepts, and therefore what
+can reach an adapter. `test_orchestration_adapter_contract.py` asserts that the parameter
+exists, that it is forwarded, and that the route supplies one.
+
+Every request gate **fails closed** — a gate that raises withholds the capability. These
+read app roles, and an error resolving a role is not a reason to assume the caller holds it.
 
 ### Execute
 

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -4,6 +4,16 @@ For feature-focused and fix-focused drill-downs by version, see [Features by Ver
 
 ### **(v0.261.090)**
 
+#### New Features
+
+*   **Orchestration Uses The Documents And Tags You Picked**
+    *   The context picker's chips reached a plan only as document ids. A tag chip narrowed a normal chat message and did nothing at all in orchestration, so a plan searched more widely than you had asked it to — the one thing a chip is for.
+    *   **Tags now narrow a plan too, and stay in force for the whole run.** A later step can choose its own search query but cannot widen the shelf you narrowed to. Documents and tags picked together are combined additively, matching the chat path.
+    *   **A document you picked now reaches the planner by name.** It previously arrived as a bare identifier, so the planner could not write "compare the Q3 and Q4 contracts" without being told which document was which, and the plan you were asked to approve listed a row of uuids. The composer sends the names it already had on screen.
+    *   **The plan marks which documents were your choice.** A document you picked and one the planner found are both documents the plan will read, but only the second is a decision worth checking — so the two now look different on the card.
+    *   Names are display only. What a plan may read is still decided from the document ids, so a renamed document is exactly the document it was.
+    *   (Ref: `resolve_seeds`, `resolve_candidate_documents`, `RunContext.tags`, `contextDocumentDescriptors`, [Chat Orchestration](features/CHAT_ORCHESTRATION.md), [Chat Context Picker](features/CHAT_CONTEXT_PICKER.md))
+
 #### Bug Fixes
 
 *   **Plans No Longer Propose Work The User Cannot Do**
@@ -11,6 +21,10 @@ For feature-focused and fix-focused drill-downs by version, see [Features by Ver
     *   The per-caller checks now run when a plan is built. Because the same resolution feeds the planner and the validator, this narrows what is offered, what is accepted, and what can reach execution.
     *   Nobody could reach anything they were not entitled to — each capability re-checks its own permission before doing any work — but a plan could describe it, which is its own kind of wrong.
     *   (Ref: `plan_request(request_context=...)`, `route_backend_orchestration._capability_request_context`, `functions_orchestration_registry` request gates)
+
+*   **Documents Found During A Run Had No Workspace**
+    *   A document discovered by a search step lost the workspace it came from, because the citation dropped `group_id` and `public_workspace_id` even though the search index returns them. Since context chips are grouped by workspace, a found document had no home to be offered back into.
+    *   (Ref: `_citations_from_search_results`)
 
 ### **(v0.261.089)**
 

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,16 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/features) and [Fixes by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/fixes).
 
+### **(v0.261.088)**
+
+#### Bug Fixes
+
+*   **Plans No Longer Propose Work The User Cannot Do**
+    *   Whether a capability suits *this person, asking this question* — do they hold the app role, does their message actually contain a link, do they have an agent at all — was described for each capability but never consulted when a plan was made. The planner was shown every capability the deployment allowed, so it could propose reading links in a message containing none, or name an agent the user does not have. The step then failed at the point it ran, having promised something in a plan the user had already approved.
+    *   The per-caller checks now run when a plan is built. Because the same resolution feeds the planner and the validator, this narrows what is offered, what is accepted, and what can reach execution.
+    *   Nobody could reach anything they were not entitled to — each capability re-checks its own permission before doing any work — but a plan could describe it, which is its own kind of wrong.
+    *   (Ref: `plan_request(request_context=...)`, `route_backend_orchestration._capability_request_context`, `functions_orchestration_registry` request gates)
+
 ### **(v0.261.087)**
 
 #### New Features

--- a/functional_tests/test_orchestration_adapter_contract.py
+++ b/functional_tests/test_orchestration_adapter_contract.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
 Functional test for the orchestration adapter contract.
-Version: 0.261.087
+Version: 0.261.088
 Implemented in: 0.261.087
 
 This is the generalisation of a bug that reached production. A step failed live with
@@ -24,11 +24,12 @@ import sys
 
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
-from test_support.app_stubs import APP_ROOT  # noqa: E402
+from test_support.app_stubs import APP_ROOT, stubbed_app_imports  # noqa: E402
 from test_support.versioning import assert_app_version_at_least  # noqa: E402
 
 ADAPTERS = 'functions_orchestration_adapters.py'
 EXECUTOR = 'functions_orchestration_executor.py'
+PLANNER = 'functions_orchestration_planner.py'
 REGISTRY = 'functions_orchestration_registry.py'
 ROUTE = 'route_backend_orchestration.py'
 
@@ -287,6 +288,142 @@ def test_role_gates_fail_closed():
         return False
 
 
+def test_request_gates_are_actually_applied_by_the_planner():
+    """A capability gate nobody invokes is decoration."""
+    print("Testing that the planner applies request gates...")
+    try:
+        tree = _tree(PLANNER)
+        functions = _functions(tree)
+
+        plan_request = functions.get('plan_request')
+        assert plan_request is not None, 'plan_request not found'
+
+        # The signature must accept a request context...
+        accepted = (
+            {a.arg for a in plan_request.args.args}
+            | {a.arg for a in plan_request.args.kwonlyargs}
+        )
+        assert 'request_context' in accepted, (
+            'plan_request does not accept a request_context. Without one, '
+            'resolve_available_capabilities skips every request gate -- which is right for '
+            'the admin page describing a deployment, and wrong for a real caller. The '
+            'planner would be offered URL reading for a message with no URL, and agents a '
+            'user does not have.'
+        )
+
+        # ...and must actually forward it. Accepting an argument and dropping it is the
+        # same bug wearing a signature that looks correct.
+        forwarded = False
+        for node in ast.walk(plan_request):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id == 'resolve_available_capabilities'
+            ):
+                for keyword in node.keywords:
+                    if keyword.arg == 'request_context':
+                        forwarded = True
+        assert forwarded, (
+            'plan_request accepts a request_context but does not pass it to '
+            'resolve_available_capabilities'
+        )
+
+        # And the route must supply one when it plans.
+        route_tree = _tree(ROUTE)
+        supplied = False
+        for node in ast.walk(route_tree):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id == 'plan_request'
+            ):
+                supplied = any(kw.arg == 'request_context' for kw in node.keywords)
+        assert supplied, (
+            'the route calls plan_request without a request_context, so no request gate '
+            'runs for a real request'
+        )
+
+        print("  ok  request gates reach the planner and the validator")
+        return True
+    except Exception as e:
+        print(f"Test failed: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+
+def test_request_gates_withhold_what_the_caller_cannot_use():
+    """The gates themselves, exercised rather than inspected."""
+    print("Testing request gate behaviour...")
+    try:
+        with stubbed_app_imports():
+            from functions_orchestration_registry import resolve_available_capabilities
+
+            settings = {
+                'enable_chat_orchestration': True,
+                'enable_user_workspace': True,
+                'enable_web_search': True,
+                'enable_url_access': True,
+                'enable_source_review': True,
+                'enable_semantic_kernel': True,
+            }
+
+            def ids(context, override=None):
+                return [
+                    c['id'] for c in resolve_available_capabilities(
+                        override or settings, request_context=context,
+                    )
+                ]
+
+            plain = {
+                'user_id': 'u1',
+                'user_message': 'what is in my handbook?',
+                'message_urls': [],
+                'user_roles': [],
+                'user_enable_agents': True,
+                'agent_catalog': [],
+            }
+
+            # Offering "read the links" for a message with no links produces a step whose
+            # only possible outcome is reporting that it had nothing to do.
+            assert 'url_fetch' not in ids(plain), 'url_fetch offered with no URL'
+            assert 'url_fetch' in ids(dict(
+                plain,
+                user_message='summarise https://example.com/a',
+                message_urls=['https://example.com/a'],
+            )), 'url_fetch withheld despite a URL in the message'
+
+            # An agent the user does not have produces a plan naming something that cannot run.
+            assert 'agent_invoke' not in ids(plain), 'agent_invoke offered with no agents'
+            with_agent = dict(plain, agent_catalog=[{'name': 'research_helper'}])
+            assert 'agent_invoke' in ids(with_agent), 'agent_invoke withheld despite an agent'
+            assert 'agent_invoke' not in ids(dict(with_agent, user_enable_agents=False)), (
+                'agent_invoke offered to a user who turned agents off; orchestration must '
+                'not hand back a capability the user switched off for themselves'
+            )
+
+            # And the app role must be enforced where the deployment requires it.
+            strict = dict(
+                settings,
+                require_member_of_deep_research_user=True,
+                source_review_settings={'require_member_of_deep_research_user': True},
+            )
+            assert 'deep_research' not in ids(plain, strict), (
+                'deep_research offered to a user holding no DeepResearchUser role'
+            )
+            assert 'deep_research' in ids(dict(plain, user_roles=['DeepResearchUser']), strict), (
+                'deep_research withheld from a user who holds the role'
+            )
+
+        print("  ok  each gate withholds what its caller cannot use")
+        return True
+    except Exception as e:
+        print(f"Test failed: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+
 if __name__ == "__main__":
     tests = [
         test_every_capability_resolves_to_an_adapter,
@@ -294,6 +431,8 @@ if __name__ == "__main__":
         test_adapters_never_touch_flask_state,
         test_route_captures_identity_before_the_thread_starts,
         test_role_gates_fail_closed,
+        test_request_gates_are_actually_applied_by_the_planner,
+        test_request_gates_withhold_what_the_caller_cannot_use,
     ]
     results = []
     for test in tests:

--- a/functional_tests/test_orchestration_agent_selection.py
+++ b/functional_tests/test_orchestration_agent_selection.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
 Functional test for orchestration agent selection.
-Version: 0.261.087
+Version: 0.261.088
 Implemented in: 0.261.087
 
 An agent's configuration is not all equally safe to show a planner. Its naming fields are

--- a/functional_tests/test_orchestration_citation_persistence.py
+++ b/functional_tests/test_orchestration_citation_persistence.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
 Functional test for orchestration citation persistence.
-Version: 0.261.087
+Version: 0.261.088
 Implemented in: 0.261.087
 
 An orchestrated answer searched documents, found the right material, and cited it in its

--- a/functional_tests/test_orchestration_context_picker.py
+++ b/functional_tests/test_orchestration_context_picker.py
@@ -1,0 +1,338 @@
+#!/usr/bin/env python3
+"""
+Functional test for the document context picker reaching orchestration.
+Version: 0.261.090
+Implemented in: 0.261.090
+
+The composer's context picker lets a user name documents, tags and whole workspaces before
+asking. Orchestration read the document ids and ignored everything else: a tag chip worked
+in classic chat and silently did nothing in a plan, and a picked document reached the
+planner as a bare uuid because the seeded-candidate path filled its name in as ''.
+
+Both matter for different reasons. The tag is a correctness bug -- the run searched more
+widely than the user asked. The name is a reviewability bug -- the approval card exists so
+someone can confirm the planner picked the right document, and `8f14e45f-ceea-467a-...`
+cannot support that.
+
+The security-relevant assertion here is the last one: names come from the browser, and a
+browser must not be able to widen what it can read by claiming a document is called
+something. Labels are display; authorization is by id.
+"""
+
+import ast
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+
+from test_support.app_stubs import APP_ROOT, stubbed_app_imports  # noqa: E402
+from test_support.versioning import assert_app_version_at_least  # noqa: E402
+
+ADAPTERS = 'functions_orchestration_adapters.py'
+CONTEXT = 'functions_orchestration_context.py'
+SEARCH = 'functions_search.py'
+
+
+def _tree(module):
+    with open(os.path.join(APP_ROOT, module), encoding='utf-8') as handle:
+        return ast.parse(handle.read())
+
+
+def _function(tree, name):
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    return None
+
+
+def test_picked_tags_reach_the_plan():
+    """A tag chip must narrow a plan the way it narrows a chat message."""
+    print("Testing that picked tags reach the seeds...")
+    try:
+        assert_app_version_at_least('0.261.090')
+
+        with stubbed_app_imports():
+            from functions_orchestration_context import resolve_seeds
+
+            seeds = resolve_seeds({
+                'selected_document_ids': ['doc1'],
+                'tags': ['Contracts', 'Q3'],
+                'document_filter_mode': 'union',
+            })
+
+            assert seeds['tags'] == ['Contracts', 'Q3'], (
+                f"tags were dropped from the seeds: {seeds.get('tags')}. The composer sends "
+                f"them on both the chat and the orchestration path; ignoring them here means "
+                f"the run searches more widely than the user asked."
+            )
+            assert seeds['document_filter_mode'] == 'union', (
+                'the filter mode was dropped; a picked document beside an unrelated tag '
+                'intersects to nothing without it'
+            )
+
+            # Anything unrecognised must fall back to the server default rather than being
+            # passed through to the query builder.
+            assert resolve_seeds({'document_filter_mode': 'nonsense'})['document_filter_mode'] == ''
+            assert resolve_seeds({})['tags'] == []
+
+        print("  ok  tags and filter mode reach the seeds")
+        return True
+    except Exception as e:
+        print(f"Test failed: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+
+def test_a_tag_scopes_the_probe_rather_than_replacing_it():
+    """Naming a shelf is not naming a document."""
+    print("Testing that a tag does not suppress the candidate probe...")
+    try:
+        with stubbed_app_imports():
+            from functions_orchestration_context import resolve_seeds, seeds_are_explicit
+
+            tag_only = resolve_seeds({'tags': ['Contracts']})
+            assert not seeds_are_explicit(tag_only), (
+                "a tag was treated as an explicit document choice. A document answers "
+                "'which documents'; a tag answers 'which shelf', and the probe is still what "
+                "decides which documents on that shelf are worth naming. Treating a tag as "
+                "explicit would hand the planner every document carrying it."
+            )
+
+            picked = resolve_seeds({'selected_document_ids': ['doc1']})
+            assert seeds_are_explicit(picked), (
+                'a picked document must still turn the probe off'
+            )
+
+        print("  ok  a tag scopes the probe; a document replaces it")
+        return True
+    except Exception as e:
+        print(f"Test failed: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+
+def test_the_probe_and_the_run_filter_by_the_same_tags():
+    """Both search paths must pass the tags, under the name hybrid_search actually uses."""
+    print("Testing that both search paths pass the tags...")
+    try:
+        # hybrid_search takes `tags_filter`, not `tags`. Passing `tags=` type-checks, imports
+        # and passes every test that drives a fake search -- and raises TypeError the first
+        # time a real step runs. That exact class of mismatch has already reached production
+        # once in this feature, so the parameter name is asserted against the real signature.
+        search_fn = _function(_tree(SEARCH), 'hybrid_search')
+        assert search_fn is not None, 'hybrid_search not found'
+        accepted = {a.arg for a in search_fn.args.args} | {
+            a.arg for a in search_fn.args.kwonlyargs
+        }
+        assert 'tags_filter' in accepted, (
+            'hybrid_search no longer takes tags_filter; the callers below need updating'
+        )
+
+        for module, function_name in (
+            (CONTEXT, 'resolve_candidate_documents'),
+            (ADAPTERS, 'run_document_search'),
+        ):
+            node = _function(_tree(module), function_name)
+            assert node is not None, f'{function_name} not found in {module}'
+
+            passed = set()
+            for call in ast.walk(node):
+                if (
+                    isinstance(call, ast.Call)
+                    and isinstance(call.func, ast.Name)
+                    and call.func.id == 'hybrid_search'
+                ):
+                    passed = {kw.arg for kw in call.keywords}
+
+            assert passed, f'{function_name} does not call hybrid_search'
+            missing = {'tags_filter', 'document_filter_mode'} - passed
+            assert not missing, (
+                f"{function_name} calls hybrid_search without {sorted(missing)}. The planner "
+                f"would be offered, or the run would return, documents the user's tag "
+                f"selection had already excluded."
+            )
+            unknown = passed - accepted
+            assert not unknown, (
+                f"{function_name} passes {sorted(unknown)} to hybrid_search, which does not "
+                f"accept it -- this raises TypeError at run time only"
+            )
+
+        print("  ok  both paths filter by tag, under the real parameter name")
+        return True
+    except Exception as e:
+        print(f"Test failed: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+
+def test_a_picked_document_reaches_the_planner_by_name():
+    """The approval card cannot do its job with a uuid."""
+    print("Testing that picked documents carry their names...")
+    try:
+        with stubbed_app_imports():
+            from functions_orchestration_context import (
+                resolve_candidate_documents,
+                resolve_seeds,
+            )
+
+            seeds = resolve_seeds({
+                'selected_document_ids': ['doc1', 'doc2'],
+                'context_documents': [
+                    {'id': 'doc1', 'label': 'Q3 Contract.pdf', 'scope_kind': 'personal'},
+                    {'id': 'doc2', 'label': 'Q4 Contract.pdf', 'scope_kind': 'group'},
+                ],
+            })
+            assert seeds['document_labels'] == {
+                'doc1': 'Q3 Contract.pdf',
+                'doc2': 'Q4 Contract.pdf',
+            }, f"labels were not read off the request: {seeds.get('document_labels')}"
+
+            candidates, probed = resolve_candidate_documents('anything', 'user-1', seeds=seeds)
+            assert not probed, 'a picked document must still suppress the probe'
+
+            names = {c['document_id']: c['file_name'] for c in candidates}
+            assert names == {
+                'doc1': 'Q3 Contract.pdf',
+                'doc2': 'Q4 Contract.pdf',
+            }, (
+                f"seeded candidates reached the planner unnamed: {names}. The planner cannot "
+                f"write 'compare the Q3 and Q4 contracts' if it was never told which document "
+                f"is which."
+            )
+            assert all(c['selected_by_user'] for c in candidates), (
+                'a picked document must be marked as the user\'s choice'
+            )
+
+        print("  ok  picked documents reach the planner by name")
+        return True
+    except Exception as e:
+        print(f"Test failed: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+
+def test_the_name_reaches_the_approval_card():
+    """The whole chain, end to end: composer -> seeds -> candidates -> plan inputs."""
+    print("Testing the label chain to the plan card...")
+    try:
+        with stubbed_app_imports():
+            from functions_orchestration_context import (
+                resolve_candidate_documents,
+                resolve_seeds,
+            )
+            from functions_orchestration_schema import build_plan_inputs
+
+            seeds = resolve_seeds({
+                'selected_document_ids': ['doc1'],
+                'context_documents': [{'id': 'doc1', 'label': 'Q3 Contract.pdf'}],
+            })
+            candidates, _ = resolve_candidate_documents('anything', 'user-1', seeds=seeds)
+
+            # The route derives its label map from the candidates, exactly like this.
+            labels = {
+                c['document_id']: (c.get('title') or c.get('file_name'))
+                for c in candidates
+            }
+
+            plan = {
+                'steps': [{
+                    'step_id': 's1',
+                    'capability_id': 'document_analyze',
+                    'enabled': True,
+                    'arguments': {'document_ids': ['doc1', 'doc9']},
+                }],
+            }
+            inputs = build_plan_inputs(plan, seeds=seeds, document_labels=labels)
+
+            by_id = {d['document_id']: d for d in inputs['documents']}
+            assert by_id['doc1']['display_name'] == 'Q3 Contract.pdf', (
+                f"the name did not survive to the card: {by_id['doc1']}"
+            )
+            assert by_id['doc1']['selected_by_user'] is True
+
+            # A document the planner introduced has no label and no claim to being the
+            # user's choice. Falling back to the id is honest; claiming a name is not.
+            assert by_id['doc9']['display_name'] == 'doc9'
+            assert by_id['doc9']['selected_by_user'] is False
+
+        print("  ok  the name reaches the approval card, and only where it is real")
+        return True
+    except Exception as e:
+        print(f"Test failed: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+
+def test_a_supplied_label_cannot_widen_access():
+    """Names come from the browser. Access must not."""
+    print("Testing that labels grant nothing...")
+    try:
+        tree = _tree('route_backend_orchestration.py')
+        node = _function(tree, '_authorized_document_ids')
+        assert node is not None, '_authorized_document_ids not found'
+
+        body = ast.dump(node)
+        for label_field in ('document_labels', 'context_documents', 'label', 'file_name'):
+            assert label_field not in body, (
+                f"_authorized_document_ids reads {label_field}. Names are supplied by the "
+                f"browser; authorization must be decided from the ids alone, or a client "
+                f"could widen its own access by describing a document differently."
+            )
+        assert 'document_ids' in body, 'authorization must still be decided from the ids'
+
+        print("  ok  authorization ignores anything the browser named")
+        return True
+    except Exception as e:
+        print(f"Test failed: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+
+def test_found_documents_carry_their_workspace():
+    """A discovered document with no workspace cannot be offered back to the user."""
+    print("Testing that search citations carry scope...")
+    try:
+        source = _tree(ADAPTERS)
+        node = _function(source, '_citations_from_search_results')
+        assert node is not None, '_citations_from_search_results not found'
+
+        body = ast.dump(node)
+        for field in ('group_id', 'public_workspace_id'):
+            assert f"'{field}'" in body, (
+                f"search citations drop {field}, which the index does select. The composer "
+                f"groups context chips by workspace, so a document the run found has no home "
+                f"without it."
+            )
+
+        print("  ok  citations carry the workspace a document came from")
+        return True
+    except Exception as e:
+        print(f"Test failed: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+
+if __name__ == "__main__":
+    tests = [
+        test_picked_tags_reach_the_plan,
+        test_a_tag_scopes_the_probe_rather_than_replacing_it,
+        test_the_probe_and_the_run_filter_by_the_same_tags,
+        test_a_picked_document_reaches_the_planner_by_name,
+        test_the_name_reaches_the_approval_card,
+        test_a_supplied_label_cannot_widen_access,
+        test_found_documents_carry_their_workspace,
+    ]
+    results = []
+    for test in tests:
+        print(f"\nRunning {test.__name__}...")
+        results.append(test())
+
+    print(f"\nResults: {sum(results)}/{len(results)} tests passed")
+    sys.exit(0 if all(results) else 1)

--- a/functional_tests/test_orchestration_phase_ordering.py
+++ b/functional_tests/test_orchestration_phase_ordering.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
 Functional test for chat orchestration phase ordering.
-Version: 0.261.087
+Version: 0.261.088
 Implemented in: 0.261.087
 
 A plan runs in three phases: collect knowledge, reason on it and answer, then create


### PR DESCRIPTION
Follow-up to #1439, which merged before this commit landed.

## The bug

Each capability in the orchestration registry declares **two** gates:

| Gate | Question | Read by |
|---|---|---|
| `gate(settings)` | Does this deployment have the capability at all? | Admin page, bootstrap, planning |
| `request_gate(settings, context)` | May *this caller, asking this question*, use it? | Planning only |

`resolve_available_capabilities` applies request gates **only when a request context is supplied**. That is deliberate and right for the admin page and the bootstrap payload: they describe a deployment, not a caller, and would be wrong to hide a capability because the administrator viewing the page happens to have no agents.

**But nobody supplied one.** `plan_request` resolved capabilities with no context, so no request gate ran for any real request. The planner was shown every capability the deployment allowed, and could therefore propose:

- reading the links in a message containing no links
- invoking an agent the user does not have, or has switched off for themselves
- deep research for a user holding no `DeepResearchUser` role

The step then failed at the point it ran, having promised something in a plan the user had already approved.

## Severity

No access breach. Every capability re-checks its own permission before doing any work — `perform_source_review` re-runs `is_url_access_enabled_for_user` / `is_source_review_enabled_for_user`, and `run_agent_invoke` refuses an agent absent from the catalog. Nobody could reach anything they were not entitled to.

But a plan could *describe* it, which is its own kind of wrong: the user approves a plan and then watches a step fail for a reason that was knowable before it was ever proposed.

## The fix

`plan_request` takes `request_context` and forwards it to `resolve_available_capabilities`.

Because that single resolution feeds both the planner projection **and** the `available_capability_ids` the validator enforces, one change narrows three things at once: what the planner is offered, what the validator will accept, and therefore what can reach an adapter.

The route builds the context from what it already has — the identity captured on the request thread, the URLs in the message, and the agent catalog it already resolves once per plan. `_capability_request_context()` lives in the route because that is where the request is; the registry stays free of Flask and the gates stay next to the capabilities they belong to.

## How it was found

By probing the resolved capability list directly rather than by reading the code — which is the only reason it surfaced. It type-checks, it imports, and all 46 existing tests passed. A gate nobody invokes is indistinguishable from a gate that always returns true, unless you actually ask what came back.

## Verification

Behaviour, exercised rather than inspected:

| Case | Before | After |
|---|---|---|
| No URL in the message | `url_fetch` offered | withheld |
| URL present | offered | offered |
| User has no agents | `agent_invoke` offered | withheld |
| User turned agents off | offered | withheld |
| `DeepResearchUser` required, not held | `deep_research` offered | withheld |
| Role required and held | offered | offered |

Two new tests in `test_orchestration_adapter_contract.py`:

- `test_request_gates_are_actually_applied_by_the_planner` — asserts the parameter exists, that it is **forwarded** (accepting an argument and dropping it is the same bug wearing a correct-looking signature), and that the route supplies one.
- `test_request_gates_withhold_what_the_caller_cannot_use` — drives the gates through every case in the table above.

Both verified by reverting the fix and watching them go red:

```
Test failed: plan_request accepts a request_context but does not pass it to
             resolve_available_capabilities
Results: 6/7 tests passed
```

**49 orchestration tests, 45 admin/docs tests, 12 route tests — all passing. Typecheck and build clean.**

## Merge

The base moved while #1439 was in flight and claimed `v0.261.088`, so this renumbers to `v0.261.089`. One conflict in `release_notes.md`, both sides real content, resolved by keeping both under their own version headings.

`docs/explanation/features/CHAT_ORCHESTRATION.md` gains a "Two levels of gate" section explaining why the skip-when-no-context behaviour is correct and what it therefore requires of every caller.