### PR TITLE
Add a document context picker to the V2 chat composer

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -97,7 +97,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.261.086"
+VERSION = "0.261.087"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/route_backend_chats.py
+++ b/application/single_app/route_backend_chats.py
@@ -21670,6 +21670,13 @@ def register_route_backend_chats(bp):
                             'requested_document_ids': requested_selected_document_ids,
                             'active_group_ids': effective_active_group_ids,
                             'active_public_workspace_ids': effective_active_public_workspace_ids,
+                            # Recorded here for the same reason the non-streaming path records
+                            # it: without the tags, a retry or edit of this message replays a
+                            # narrower search than the one that produced the answer, because
+                            # _build_replayed_document_context has no tag filter to restore.
+                            # Streaming is the path the V2 client uses, so omitting it here
+                            # meant every tag-filtered message in that client replayed wrong.
+                            'tags': tags_filter,
                             'classification': classifications_to_send
                         }
                         if prior_grounded_source_merge:

--- a/application/single_app/route_backend_conversations.py
+++ b/application/single_app/route_backend_conversations.py
@@ -231,6 +231,14 @@ def _build_replayed_document_context(original_metadata):
             workspace_search.get('classification')
             or workspace_search.get('classifications')
         ),
+        # Restored alongside the document ids so a retry or edit reproduces the same search.
+        # A tag filter dropped here silently widens the replay, which reads as the assistant
+        # answering a different question the second time it is asked.
+        'tags': (
+            workspace_search.get('tags')
+            or workspace_search.get('tags_filter')
+            or []
+        ),
         'active_group_ids': workspace_search.get('active_group_ids') or [],
         'active_public_workspace_ids': workspace_search.get('active_public_workspace_ids') or [],
     }

--- a/application/v2_ui/src/components/chat/Composer.tsx
+++ b/application/v2_ui/src/components/chat/Composer.tsx
@@ -3,7 +3,7 @@
 // and the capability toggles that map onto the /api/chat/stream request fields.
 
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useLocation, useSearchParams } from 'react-router-dom';
 import { clsx } from 'clsx';
 import {
     ArrowUp,
@@ -35,6 +35,48 @@ import { agentSelectionKey } from '../../lib/agents';
 import { buildSelectionFields, hasResolvableAgent } from '../../lib/chatRequestSelection';
 import { modelSelectionKey, findModel, type ModelCatalogEntry } from '../../lib/models';
 import { resolveGating } from '../../lib/composerGating';
+import { resolveDocumentScope } from '../../lib/documentScope';
+import {
+    addContextItem,
+    contextDocumentIds,
+    contextScopes,
+    contextTags,
+    hasContextItem,
+    removeContextItem,
+    type ContextItem,
+    type ContextOrigin,
+} from '../../lib/chatContext';
+import {
+    appendContextToken,
+    insertContextToken,
+    readContextQuery,
+    reconcileContextItems,
+    removeContextToken,
+    type ContextQuery,
+} from '../../lib/chatContextTokens';
+import {
+    candidateToContextItem,
+    type ContextCandidate,
+} from '../../lib/contextMentions';
+import { ContextChips } from './ContextChips';
+import {
+    COMPOSER_TEXT_CLASS,
+    COMPOSER_TRANSPARENT_TEXT_STYLE,
+    ComposerHighlight,
+    useHighlightScrollSync,
+} from './ComposerHighlight';
+import {
+    ContextMenu,
+    useContextSuggestions,
+    type ContextSearchScope,
+} from './ContextMenu';
+import { DocumentPickerPopover } from './DocumentPickerPopover';
+import {
+    CONTEXT_HANDOFF_PARAMS,
+    readContextHandoff,
+    resolveContextHandoff,
+    type ContextHandoffState,
+} from '../../lib/chatContextHandoff';
 import type { ApprovalMode } from '../../lib/orchestration';
 import {
     cancelOrchestration,
@@ -76,7 +118,7 @@ import { promptNeedsFilling } from '../../lib/promptVariables';
 import { readPromptParam } from '../../lib/conversationUrl';
 import { createPrompt } from '../../lib/workspaceApi';
 import { messageToPlainText } from '../../lib/messageText';
-import type { PromptOption } from '../../lib/types';
+import type { PromptOption, WorkspaceRef } from '../../lib/types';
 import {
     EMPTY_PROMPT_DRAFT,
     PromptEditorDialog,
@@ -206,6 +248,13 @@ export function Composer() {
     const [slash, setSlash] = useState<SlashQuery | null>(null);
     const [slashIndex, setSlashIndex] = useState(0);
 
+    /** The `#` token under the caret, when the menu should be offering references for it. */
+    const [contextQuery, setContextQuery] = useState<ContextQuery | null>(null);
+    const [contextIndex, setContextIndex] = useState(0);
+    /** Whether the Documents button's picker is open. */
+    const [pickerOpen, setPickerOpen] = useState(false);
+    const backdropRef = useRef<HTMLDivElement>(null);
+
     /** The prompt whose variables are being filled in, if any. */
     const [fillingPrompt, setFillingPrompt] = useState<PromptOption | null>(null);
     /** A prompt being saved from what is currently written, if any. */
@@ -219,7 +268,7 @@ export function Composer() {
         imageGeneration: false,
         deepResearch: false,
         urlAccess: false,
-        selectedDocumentIds: [],
+        contextItems: [],
     });
 
     /**
@@ -368,6 +417,7 @@ export function Composer() {
     };
 
     useEffect(autoGrow, [text]);
+    useHighlightScrollSync(textareaRef, backdropRef, text);
 
     /**
      * Tell the other participants that this person is writing.
@@ -447,7 +497,8 @@ export function Composer() {
      * The ref guards against StrictMode running effects twice on mount: a state flag is still
      * false in the second invocation's closure, so the prompt would be inserted twice.
      */
-    const [searchParams] = useSearchParams();
+    const [searchParams, setSearchParams] = useSearchParams();
+    const location = useLocation();
     const [linkedPromptId] = useState(() => readPromptParam(searchParams));
     const promptLinkConsumed = useRef(false);
     useEffect(() => {
@@ -699,10 +750,30 @@ export function Composer() {
         dispatch(text);
     };
 
-    const dispatch = (message: string) => {
-        void sendMessage(message, options);
+    /**
+     * Clear the draft once it has been sent.
+     *
+     * The chips go with the text, because they are two views of one thing. The references are
+     * not lost: they are in the message that was just sent, both in its wording and in its
+     * stored `requested_document_ids`. Keeping them here instead would leave a row of chips
+     * whose tokens are no longer in the box -- which the next keystroke would reconcile away,
+     * so the references would appear to survive the send and then vanish one character into
+     * the following message.
+     */
+    const clearDraft = () => {
         setText('');
         setMention(null);
+        setContextQuery(null);
+        setOptions((current) =>
+            current.contextItems.length === 0 ? current : { ...current, contextItems: [] },
+        );
+    };
+
+    const dispatch = (message: string) => {
+        // `options` is read before the clear below replaces it, so the request carries the
+        // references this message was written with.
+        void sendMessage(message, options);
+        clearDraft();
         // Sent, so the indicator other people can see must stop now rather than when the
         // idle timer happens to fire.
         stopTyping();
@@ -718,10 +789,27 @@ export function Composer() {
      * keeps the agent-XOR-model exclusivity the chat request already relies on.
      */
     const buildOrchestrationSeeds = (): Record<string, unknown> => {
+        const workspaces = contextScopes(options.contextItems);
+        const scope = resolveDocumentScope({
+            activeGroupId: bootstrap?.scope?.active_group_id,
+            activePublicWorkspaceId: bootstrap?.scope?.active_public_workspace_id,
+            contextGroupIds: workspaces.groupIds,
+            contextPublicWorkspaceIds: workspaces.publicWorkspaceIds,
+        });
+
         const seeds: Record<string, unknown> = {
             web_search_enabled: options.webSearch,
-            selected_document_ids: options.selectedDocumentIds,
+            selected_document_ids: contextDocumentIds(options.contextItems),
+            // `resolve_seeds` reads doc_scope and the workspace ids alongside the document
+            // ids, and `seeds_are_explicit` turns the planner's candidate probe off once
+            // documents are named. Sending the ids without the scope that reaches them would
+            // suppress the probe and then find nothing.
+            ...scope,
         };
+        const tags = contextTags(options.contextItems);
+        if (tags.length > 0) {
+            seeds.tags = tags;
+        }
         Object.assign(
             seeds,
             buildSelectionFields({
@@ -755,8 +843,7 @@ export function Composer() {
             approvalMode: effectiveApprovalMode,
             seeds: buildOrchestrationSeeds(),
         });
-        setText('');
-        setMention(null);
+        clearDraft();
         stopTyping();
     };
 
@@ -791,6 +878,230 @@ export function Composer() {
         setMention(found);
         setMentionIndex(0);
     };
+
+    /* ---------------------------------------------------------------------- */
+    /* Context references                                                      */
+    /* ---------------------------------------------------------------------- */
+
+    const contextItems = options.contextItems;
+    const contextKeys = useMemo(
+        () => new Set(contextItems.map((item) => item.key)),
+        [contextItems],
+    );
+    const contextTokens = useMemo(
+        () => new Set(contextItems.map((item) => item.token)),
+        [contextItems],
+    );
+
+    /** Which workspaces the picker and the `#` menu may search. */
+    const searchScope: ContextSearchScope = useMemo(
+        () => ({
+            groups: (bootstrap?.scope?.groups ?? []) as WorkspaceRef[],
+            publicWorkspaces: (bootstrap?.scope?.public_workspaces ?? []) as WorkspaceRef[],
+            groupsEnabled: Boolean(features.enable_group_workspaces),
+            publicEnabled: Boolean(features.enable_public_workspaces),
+        }),
+        [bootstrap?.scope, features.enable_group_workspaces, features.enable_public_workspaces],
+    );
+
+    const { candidates: contextCandidates, loading: contextLoading } = useContextSuggestions(
+        canPost ? (contextQuery?.query ?? null) : null,
+        searchScope,
+    );
+
+    const syncContext = (element: HTMLTextAreaElement) => {
+        if (!canPost) {
+            return;
+        }
+        const found = readContextQuery(element.value, element.selectionStart ?? 0);
+        setContextQuery(found);
+        setContextIndex(0);
+    };
+
+    /**
+     * Write new text and retire any reference it no longer names.
+     *
+     * Every path that changes the message goes through here, because the reconciliation is the
+     * thing that keeps a chip from outliving the token it belongs to -- and a chip that
+     * outlives its token still puts its document into the request.
+     */
+    const applyText = (value: string) => {
+        setText(value);
+        setOptions((current) => {
+            const kept = reconcileContextItems(value, current.contextItems);
+            return kept.length === current.contextItems.length
+                ? current
+                : { ...current, contextItems: kept };
+        });
+    };
+
+    const addContextCandidate = (candidate: ContextCandidate, origin: ContextOrigin = 'user') => {
+        if (hasContextItem(contextItems, candidate.key)) {
+            return;
+        }
+        // Built against the current row so the label collision check sees the tokens already
+        // in play. Nothing is mutated here; both updates below are plain state writes.
+        const item = candidateToContextItem(candidate, contextItems, origin);
+        // The token is appended rather than spliced at the caret: the picker has no caret
+        // position to speak of, and the reference still ends up in the sentence.
+        setText((value) => appendContextToken(value, item.token));
+        setOptions((current) => ({
+            ...current,
+            contextItems: addContextItem(current.contextItems, item),
+        }));
+    };
+
+    /** Pick from the `#` menu: the token replaces the query it was typed for. */
+    const applyContextCandidate = (candidate: ContextCandidate) => {
+        const element = textareaRef.current;
+        if (!element || !contextQuery) {
+            return;
+        }
+
+        const { start, end } = contextQuery;
+        setContextQuery(null);
+
+        const focusAt = (caret: number) => {
+            window.requestAnimationFrame(() => {
+                element.focus();
+                element.setSelectionRange(caret, caret);
+            });
+        };
+
+        if (hasContextItem(contextItems, candidate.key)) {
+            // Already referenced. The half-typed `#doc` is still cleared, so it does not stay
+            // behind looking like a reference that failed to resolve.
+            setText(`${text.slice(0, start)}${text.slice(end)}`);
+            focusAt(start);
+            return;
+        }
+
+        const item = candidateToContextItem(candidate, contextItems);
+        const next = insertContextToken(text, start, end, item.token);
+        setText(next.text);
+        setOptions((current) => ({
+            ...current,
+            contextItems: addContextItem(current.contextItems, item),
+        }));
+        focusAt(next.caret);
+    };
+
+    /**
+     * Take a reference off the row, and its text with it.
+     *
+     * The token is only stripped when no *other* remaining chip still uses it. Two chips can
+     * share one token when two documents share a title, and blanking the text while a second
+     * chip still points at it would orphan that chip: reconciliation drops it on the next
+     * keystroke, but a message sent before that keystroke would still carry its document id --
+     * grounding the answer in something the user had already removed.
+     */
+    const removeContextChip = (item: ContextItem) => {
+        const remaining = removeContextItem(contextItems, item.key);
+        if (!remaining.some((entry) => entry.token === item.token)) {
+            setText((value) => removeContextToken(value, item.token));
+        }
+        setOptions((current) => ({
+            ...current,
+            contextItems: removeContextItem(current.contextItems, item.key),
+        }));
+    };
+
+    const removeContextChips = (items: ContextItem[]) => {
+        const dropped = new Set(items.map((item) => item.key));
+        const remaining = contextItems.filter((entry) => !dropped.has(entry.key));
+        const stillReferenced = new Set(remaining.map((entry) => entry.token));
+        const strip = [...new Set(items.map((item) => item.token))].filter(
+            (token) => !stillReferenced.has(token),
+        );
+
+        setText((value) =>
+            strip.reduce((carry, token) => removeContextToken(carry, token), value),
+        );
+        setOptions((current) => ({
+            ...current,
+            contextItems: current.contextItems.filter((entry) => !dropped.has(entry.key)),
+        }));
+    };
+
+    /** Used by the picker, where clicking a ticked row unticks it. */
+    const toggleContextCandidate = (candidate: ContextCandidate) => {
+        const existing = contextItems.find((item) => item.key === candidate.key);
+        if (existing) {
+            removeContextChip(existing);
+            return;
+        }
+        addContextCandidate(candidate);
+    };
+
+    const clearContextChips = () => removeContextChips(contextItems);
+
+    /**
+     * Adopt a selection handed over from the workspace.
+     *
+     * The hand-off is captured during the first render rather than read inside the effect, for
+     * the same reason the prompt link above is: effects that rewrite the query string also run
+     * on mount, and whichever ran first would decide whether the selection survived.
+     *
+     * The ref guards against StrictMode running effects twice, which would otherwise seed the
+     * chips -- and append their tokens -- a second time.
+     */
+    const [linkedHandoff] = useState(() => readContextHandoff(searchParams));
+    const [linkedHandoffState] = useState(
+        () => (location.state ?? null) as ContextHandoffState | null,
+    );
+    const handoffApplied = useRef(false);
+
+    useEffect(() => {
+        if (handoffApplied.current || !linkedHandoff || !canPost) {
+            return;
+        }
+        handoffApplied.current = true;
+
+        const controller = new AbortController();
+        void resolveContextHandoff(linkedHandoff, {
+            groups: (bootstrap?.scope?.groups ?? []) as WorkspaceRef[],
+            publicWorkspaces: (bootstrap?.scope?.public_workspaces ?? []) as WorkspaceRef[],
+            state: linkedHandoffState,
+            signal: controller.signal,
+        })
+            .then((items) => {
+                if (controller.signal.aborted || items.length === 0) {
+                    return;
+                }
+                setOptions((current) => ({
+                    ...current,
+                    // Arriving with documents named is a request to search them, so the
+                    // toggle is not left off underneath a full chip row.
+                    documentSearch: true,
+                    contextItems: items.reduce(
+                        (carry, item) => addContextItem(carry, item),
+                        current.contextItems,
+                    ),
+                }));
+                setText((value) =>
+                    items.reduce((carry, item) => appendContextToken(carry, item.token), value),
+                );
+                textareaRef.current?.focus();
+            })
+            .catch(() => {
+                // The composer is still usable; the references simply have to be re-picked.
+            });
+
+        // Stripped so reloading or re-sharing the link does not silently re-apply a selection
+        // the user may since have cleared.
+        setSearchParams(
+            (current) => {
+                const next = new URLSearchParams(current);
+                for (const key of CONTEXT_HANDOFF_PARAMS) {
+                    next.delete(key);
+                }
+                return next;
+            },
+            { replace: true },
+        );
+
+        return () => controller.abort();
+    }, [canPost, linkedHandoff, linkedHandoffState, setSearchParams, bootstrap?.scope]);
 
     const applySuggestion = (suggestion: MentionSuggestion) => {
         const element = textareaRef.current;
@@ -851,7 +1162,9 @@ export function Composer() {
         const end = range?.end ?? element?.selectionEnd ?? start;
 
         const result = insertPromptText(text, start, end, addition);
-        setText(result.text);
+        // Through applyText because a prompt inserted over a selection can overwrite a
+        // reference, and the chip for it has to go with the text it replaced.
+        applyText(result.text);
         setSlash(null);
         setMention(null);
 
@@ -995,6 +1308,35 @@ export function Composer() {
     };
 
     const onKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+        // The context menu owns these keys first. A `#` token and a `/` or `@` token cannot
+        // both be under the caret, so the order between the three is arbitrary — but all
+        // three must be tested before the send, or Enter posts a message containing a
+        // half-typed reference instead of completing it.
+        if (contextQuery && contextCandidates.length > 0) {
+            if (event.key === 'ArrowDown') {
+                event.preventDefault();
+                setContextIndex((index) => (index + 1) % contextCandidates.length);
+                return;
+            }
+            if (event.key === 'ArrowUp') {
+                event.preventDefault();
+                setContextIndex(
+                    (index) => (index - 1 + contextCandidates.length) % contextCandidates.length,
+                );
+                return;
+            }
+            if (event.key === 'Enter' || event.key === 'Tab') {
+                event.preventDefault();
+                applyContextCandidate(contextCandidates[contextIndex]);
+                return;
+            }
+            if (event.key === 'Escape') {
+                event.preventDefault();
+                setContextQuery(null);
+                return;
+            }
+        }
+
         // The slash menu owns these keys while it has something to offer, and is tested before
         // the mention menu because a `/` token and an `@` token cannot both be under the caret.
         if (slashResults.length > 0) {
@@ -1136,6 +1478,33 @@ export function Composer() {
                         />
                     )}
 
+                    {contextQuery && !pickerOpen && (
+                        <ContextMenu
+                            candidates={contextCandidates}
+                            loading={contextLoading}
+                            activeIndex={contextIndex}
+                            selectedKeys={contextKeys}
+                            onSelect={applyContextCandidate}
+                        />
+                    )}
+
+                    {pickerOpen && (
+                        <DocumentPickerPopover
+                            scope={searchScope}
+                            searchAll={options.documentSearch}
+                            selectedKeys={contextKeys}
+                            onToggleSearchAll={() =>
+                                setOptions((current) => ({
+                                    ...current,
+                                    documentSearch: !current.documentSearch,
+                                }))
+                            }
+                            onToggle={toggleContextCandidate}
+                            onClear={clearContextChips}
+                            onClose={() => setPickerOpen(false)}
+                        />
+                    )}
+
                     {replyTo && (
                         <div className="mb-1 flex items-start gap-2 rounded-xl bg-surface-2 px-3 py-2">
                             <Reply size={13} className="mt-0.5 shrink-0 text-text-3" />
@@ -1159,43 +1528,67 @@ export function Composer() {
                     <label htmlFor="composer-input" className="sr-only">
                         Message
                     </label>
-                    <textarea
-                        id="composer-input"
-                        ref={textareaRef}
-                        rows={1}
-                        value={text}
-                        disabled={!canPost}
-                        onChange={(event) => {
-                            setText(event.target.value);
-                            syncMention(event.target);
-                            syncSlash(event.target);
-                            noteTyping(event.target.value);
-                        }}
-                        // The caret can move without the value changing — clicking, or an
-                        // arrow key — and the token under it changes with it.
-                        onSelect={(event) => {
-                            syncMention(event.currentTarget);
-                            syncSlash(event.currentTarget);
-                        }}
-                        onBlur={stopTyping}
-                        onKeyDown={onKeyDown}
-                        placeholder={
-                            checkingAccess
-                                ? 'Checking your access to this conversation…'
-                                : awaitingInvite
-                                  ? 'Join this conversation to reply'
-                                  : !canPost
-                                    ? 'You do not have permission to write in this conversation'
-                                    : shared
-                                      ? 'Message the group, or @mention a model or agent to ask the assistant…'
-                                      : 'Send a message…'
-                        }
-                        className={clsx(
-                            'w-full resize-none bg-transparent px-3 py-2.5 text-[15px] leading-relaxed',
-                            'text-text-1 placeholder:text-text-3 focus:outline-none',
-                            'disabled:cursor-not-allowed',
-                        )}
+
+                    <ContextChips
+                        items={contextItems}
+                        onRemove={removeContextChip}
+                        onRemoveAll={removeContextChips}
+                        onClear={clearContextChips}
                     />
+
+                    {/* The backdrop is positioned against this wrapper rather than the whole
+                        composer, so it lines up with the textarea and not with the toolbar
+                        below it. */}
+                    <div className="relative">
+                        <ComposerHighlight
+                            text={text}
+                            tokens={contextTokens}
+                            backdropRef={backdropRef}
+                        />
+                        <textarea
+                            id="composer-input"
+                            ref={textareaRef}
+                            rows={1}
+                            value={text}
+                            disabled={!canPost}
+                            onChange={(event) => {
+                                applyText(event.target.value);
+                                syncMention(event.target);
+                                syncSlash(event.target);
+                                syncContext(event.target);
+                                noteTyping(event.target.value);
+                            }}
+                            // The caret can move without the value changing — clicking, or an
+                            // arrow key — and the token under it changes with it.
+                            onSelect={(event) => {
+                                syncMention(event.currentTarget);
+                                syncSlash(event.currentTarget);
+                                syncContext(event.currentTarget);
+                            }}
+                            onBlur={stopTyping}
+                            onKeyDown={onKeyDown}
+                            placeholder={
+                                checkingAccess
+                                    ? 'Checking your access to this conversation…'
+                                    : awaitingInvite
+                                      ? 'Join this conversation to reply'
+                                      : !canPost
+                                        ? 'You do not have permission to write in this conversation'
+                                        : shared
+                                          ? 'Message the group, or @mention a model or agent to ask the assistant…'
+                                          : 'Send a message, or type # to add a document…'
+                            }
+                            // Metrics come from the shared constant so the backdrop cannot
+                            // drift out of step with the text it is drawing behind.
+                            className={clsx(
+                                COMPOSER_TEXT_CLASS,
+                                'relative resize-none bg-transparent',
+                                'placeholder:text-text-3 focus:outline-none',
+                                'selection:bg-accent-soft disabled:cursor-not-allowed',
+                            )}
+                            style={COMPOSER_TRANSPARENT_TEXT_STYLE}
+                        />
+                    </div>
 
                     <div className="flex flex-wrap items-center gap-1.5 px-1 pt-1">
                         {orchestrationAvailable && (
@@ -1324,16 +1717,15 @@ export function Composer() {
                                 <span className="mx-0.5 h-6 w-px bg-edge-strong" aria-hidden="true" />
 
                                 <ToolToggle
-                                    active={options.documentSearch}
+                                    active={options.documentSearch || contextItems.length > 0}
                                     disabled={gating.disabledByImageGeneration}
-                                    onClick={() =>
-                                        setOptions((current) => ({
-                                            ...current,
-                                            documentSearch: !current.documentSearch,
-                                        }))
-                                    }
+                                    onClick={() => setPickerOpen((open) => !open)}
                                     icon={<Search size={15} />}
-                                    label="Documents"
+                                    label={
+                                        contextItems.length > 0
+                                            ? `Documents · ${contextItems.length}`
+                                            : 'Documents'
+                                    }
                                 />
 
                                 {gating.showWeb && (

--- a/application/v2_ui/src/components/chat/ComposerHighlight.tsx
+++ b/application/v2_ui/src/components/chat/ComposerHighlight.tsx
@@ -1,0 +1,143 @@
+// ComposerHighlight.tsx
+// Drawing `#[…]` references as chips inside the message box.
+//
+// A reference lives in two places: as a chip above the input, and as literal text within it,
+// so it stays part of the sentence the user actually sends. Left unstyled that text reads as
+// punctuation noise -- `compare #[Q3 Contract.pdf] against #[Q2 Contract.pdf]` is a lot of
+// brackets -- and the reference stops looking like the resolved thing it is.
+//
+// A textarea cannot style its own content, so this is the standard backdrop arrangement: an
+// element behind the textarea holding the same text with the same metrics, and a textarea
+// whose glyphs are transparent while its caret and selection stay visible.
+//
+// THE ONE RULE: the backdrop and the textarea must lay text out identically. Any difference in
+// font, size, spacing, padding or wrapping shows up as chips drifting away from the words they
+// belong to. That is why both read their box metrics from COMPOSER_TEXT_CLASS below rather
+// than each carrying its own copy, and why the backdrop is not merely `whitespace-pre-wrap`
+// but matched on word breaking too.
+
+import { useEffect, type CSSProperties, type RefObject } from 'react';
+import { parseContextTokens } from '../../lib/chatContextTokens';
+
+/**
+ * The typography and box metrics the textarea and its backdrop share.
+ *
+ * Exported so the textarea uses this exact string. Two hand-kept copies of these values is the
+ * defect this constant exists to prevent.
+ */
+export const COMPOSER_TEXT_CLASS =
+    'w-full px-3 py-2.5 text-[15px] leading-relaxed whitespace-pre-wrap break-words';
+
+/**
+ * Caret and selection have to be set explicitly once the text is transparent.
+ *
+ * `caret-color` is independent of `color`, so the caret survives; without naming it the
+ * browser would draw it in the transparent text colour and the user would be typing into what
+ * looks like a dead box.
+ */
+export const COMPOSER_TRANSPARENT_TEXT_STYLE: CSSProperties = {
+    color: 'transparent',
+    caretColor: 'var(--text-1)',
+    WebkitTextFillColor: 'transparent',
+};
+
+/**
+ * Keep the backdrop's scroll position tied to the textarea's.
+ *
+ * The composer grows to 224px and then scrolls. Without this the chips stay put while the
+ * words move, which is worse than not styling them at all.
+ */
+export function useHighlightScrollSync(
+    textareaRef: RefObject<HTMLTextAreaElement>,
+    backdropRef: RefObject<HTMLDivElement>,
+    text: string,
+) {
+    useEffect(() => {
+        const textarea = textareaRef.current;
+        const backdrop = backdropRef.current;
+        if (!textarea || !backdrop) {
+            return;
+        }
+
+        const sync = () => {
+            backdrop.scrollTop = textarea.scrollTop;
+            backdrop.scrollLeft = textarea.scrollLeft;
+        };
+
+        sync();
+        textarea.addEventListener('scroll', sync);
+        return () => textarea.removeEventListener('scroll', sync);
+        // `text` is a dependency because growing the box changes the scroll offset without
+        // ever firing a scroll event.
+    }, [textareaRef, backdropRef, text]);
+}
+
+/**
+ * The message text with its resolved references drawn as chips.
+ *
+ * Only tokens that a chip still backs are styled. A hand-typed `#[Something]` that resolves to
+ * nothing stays plain, so the styling means "this is a real reference" rather than "this looks
+ * like one" -- the same distinction `reconcileContextItems` makes on the data side.
+ *
+ * A trailing newline gets a zero-width space so the backdrop keeps the height the textarea
+ * gives that line; without it the last line's chips sit one row too high.
+ */
+export function ComposerHighlight({
+    text,
+    tokens,
+    backdropRef,
+}: {
+    text: string;
+    /** The tokens currently backed by a chip. */
+    tokens: ReadonlySet<string>;
+    backdropRef: RefObject<HTMLDivElement>;
+}) {
+    const parsed = parseContextTokens(text);
+    const pieces: Array<{ key: string; value: string; chip: boolean }> = [];
+
+    let cursor = 0;
+    parsed.forEach((token, index) => {
+        if (token.start > cursor) {
+            pieces.push({
+                key: `text-${cursor}`,
+                value: text.slice(cursor, token.start),
+                chip: false,
+            });
+        }
+        pieces.push({
+            key: `token-${index}-${token.start}`,
+            value: token.token,
+            chip: tokens.has(token.token),
+        });
+        cursor = token.end;
+    });
+    if (cursor < text.length) {
+        pieces.push({ key: `text-${cursor}`, value: text.slice(cursor), chip: false });
+    }
+
+    return (
+        <div
+            ref={backdropRef}
+            aria-hidden="true"
+            className={`pointer-events-none absolute inset-0 overflow-hidden text-text-1 ${COMPOSER_TEXT_CLASS}`}
+        >
+            {pieces.map((piece) =>
+                piece.chip ? (
+                    <span
+                        key={piece.key}
+                        className="rounded bg-accent-soft text-accent"
+                        // Padding is horizontal only and applied as a negative-free inline box:
+                        // vertical padding would change the line box and push the backdrop's
+                        // wrapping out of step with the textarea's.
+                        style={{ paddingLeft: '2px', paddingRight: '2px' }}
+                    >
+                        {piece.value}
+                    </span>
+                ) : (
+                    <span key={piece.key}>{piece.value}</span>
+                ),
+            )}
+            {text.endsWith('\n') && <span>{'\u200b'}</span>}
+        </div>
+    );
+}

--- a/application/v2_ui/src/components/chat/ContextChips.tsx
+++ b/application/v2_ui/src/components/chat/ContextChips.tsx
@@ -1,0 +1,255 @@
+// ContextChips.tsx
+// What the next message is pointed at, shown above the composer.
+//
+// The row answers one question before the message is sent: which documents is the assistant
+// actually going to look at? V2 previously had no answer to that -- the Documents button was
+// on or off, and what it searched was whatever the deployment's scope happened to resolve to.
+//
+// It condenses as it fills, because the two failure modes pull in opposite directions. A
+// handful of references shown only as "4 documents" is useless: the whole point is to see that
+// the wrong contract is not in the list. Forty of them shown individually is a wall that
+// pushes the message box off the screen. So few items render by name, and past a threshold
+// each workspace collapses to a count that opens on click.
+//
+// Grouping appears only when more than one workspace is involved. A single group container
+// wrapped around a single personal document is a box drawn for no reason.
+
+import { useEffect, useRef, useState } from 'react';
+import { clsx } from 'clsx';
+import { FileText, FolderOpen, Sparkles, Tag as TagIcon, X } from 'lucide-react';
+import {
+    describeContextGroup,
+    describeContextItem,
+    groupContextItems,
+    type ContextItem,
+    type ContextKind,
+} from '../../lib/chatContext';
+
+/**
+ * How many references render by name before a workspace collapses to a count.
+ *
+ * Chosen so the common cases stay legible: picking two documents to compare, or a document
+ * and the tag it belongs to, are what this control is mostly used for.
+ */
+const EXPANDED_LIMIT = 5;
+
+const KIND_ICON: Record<ContextKind, typeof FileText> = {
+    document: FileText,
+    tag: TagIcon,
+    scope: FolderOpen,
+};
+
+function ContextChip({
+    item,
+    onRemove,
+}: {
+    item: ContextItem;
+    onRemove: (item: ContextItem) => void;
+}) {
+    const Icon = item.origin === 'planner' ? Sparkles : KIND_ICON[item.kind];
+
+    return (
+        <span
+            title={describeContextItem(item)}
+            className={clsx(
+                'inline-flex max-w-[16rem] items-center gap-1.5 rounded-lg py-0.5 pl-2 pr-1',
+                'text-xs text-accent',
+                // The planner's own choices are drawn as provisional, because they are: they
+                // arrived from a proposal the reader has not accepted yet.
+                item.origin === 'planner'
+                    ? 'border border-dashed border-accent-ring bg-accent-soft/60'
+                    : 'bg-accent-soft',
+            )}
+        >
+            <Icon size={12} className="shrink-0" aria-hidden="true" />
+            <span className="truncate">{item.label}</span>
+            <button
+                type="button"
+                onClick={() => onRemove(item)}
+                aria-label={`Remove ${item.label}`}
+                className="shrink-0 rounded p-0.5 text-accent/70 hover:bg-accent-soft hover:text-accent"
+            >
+                <X size={11} />
+            </button>
+        </span>
+    );
+}
+
+/**
+ * A workspace's references, collapsed to a count until asked for.
+ *
+ * The popover is anchored above rather than below: the row sits directly on top of the
+ * message box, and opening downwards would cover the thing being written.
+ */
+function CollapsedGroup({
+    label,
+    items,
+    onRemove,
+    onRemoveAll,
+}: {
+    label: string;
+    items: ContextItem[];
+    onRemove: (item: ContextItem) => void;
+    onRemoveAll: (items: ContextItem[]) => void;
+}) {
+    const [open, setOpen] = useState(false);
+    const holder = useRef<HTMLSpanElement>(null);
+
+    useEffect(() => {
+        if (!open) {
+            return;
+        }
+        const onPointerDown = (event: MouseEvent) => {
+            if (!holder.current?.contains(event.target as Node)) {
+                setOpen(false);
+            }
+        };
+        const onEscape = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') {
+                setOpen(false);
+            }
+        };
+        document.addEventListener('mousedown', onPointerDown);
+        document.addEventListener('keydown', onEscape);
+        return () => {
+            document.removeEventListener('mousedown', onPointerDown);
+            document.removeEventListener('keydown', onEscape);
+        };
+    }, [open]);
+
+    return (
+        <span ref={holder} className="relative inline-flex">
+            <button
+                type="button"
+                onClick={() => setOpen((current) => !current)}
+                aria-expanded={open}
+                className={clsx(
+                    'inline-flex items-center gap-1.5 rounded-lg bg-accent-soft py-0.5 pl-2 pr-2',
+                    'text-xs text-accent hover:bg-accent-soft/80',
+                )}
+            >
+                <FolderOpen size={12} className="shrink-0" aria-hidden="true" />
+                <span className="font-medium">{label}</span>
+                <span className="text-accent/75">{describeContextGroup(items)}</span>
+            </button>
+
+            {open && (
+                <div className="glass-modal absolute bottom-full left-0 z-50 mb-1.5 max-h-64 w-72 overflow-y-auto rounded-xl p-1.5">
+                    <div className="flex items-center justify-between gap-2 px-1.5 pb-1.5">
+                        <span className="text-[11px] font-medium text-text-2">{label}</span>
+                        <button
+                            type="button"
+                            onClick={() => {
+                                onRemoveAll(items);
+                                setOpen(false);
+                            }}
+                            className="rounded px-1 text-[11px] text-text-3 hover:text-text-1"
+                        >
+                            Remove all
+                        </button>
+                    </div>
+                    <ul className="space-y-0.5">
+                        {items.map((item) => {
+                            const Icon =
+                                item.origin === 'planner' ? Sparkles : KIND_ICON[item.kind];
+                            return (
+                                <li key={item.key}>
+                                    <div className="flex items-center gap-2 rounded-lg px-1.5 py-1 hover:bg-surface-2">
+                                        <Icon
+                                            size={12}
+                                            className="shrink-0 text-text-3"
+                                            aria-hidden="true"
+                                        />
+                                        <span className="min-w-0 flex-1">
+                                            <span className="block truncate text-xs text-text-1">
+                                                {item.label}
+                                            </span>
+                                            {item.meta?.fileName && (
+                                                <span className="block truncate text-[10px] text-text-3">
+                                                    {item.meta.fileName}
+                                                </span>
+                                            )}
+                                        </span>
+                                        <button
+                                            type="button"
+                                            onClick={() => onRemove(item)}
+                                            aria-label={`Remove ${item.label}`}
+                                            className="shrink-0 rounded p-0.5 text-text-3 hover:bg-surface-3 hover:text-text-1"
+                                        >
+                                            <X size={11} />
+                                        </button>
+                                    </div>
+                                </li>
+                            );
+                        })}
+                    </ul>
+                </div>
+            )}
+        </span>
+    );
+}
+
+export function ContextChips({
+    items,
+    onRemove,
+    onRemoveAll,
+    onClear,
+}: {
+    items: ContextItem[];
+    onRemove: (item: ContextItem) => void;
+    onRemoveAll: (items: ContextItem[]) => void;
+    onClear: () => void;
+}) {
+    if (items.length === 0) {
+        return null;
+    }
+
+    const groups = groupContextItems(items);
+    // Condensing is decided on the whole row, not per workspace, so two workspaces holding
+    // three references each do not render one expanded and one collapsed.
+    const collapse = items.length > EXPANDED_LIMIT;
+    const showGroupLabels = groups.length > 1;
+
+    return (
+        <div className="mb-1.5 flex flex-wrap items-center gap-1.5 px-1">
+            {groups.map((group) =>
+                collapse ? (
+                    <CollapsedGroup
+                        key={group.key}
+                        label={group.scope.name}
+                        items={group.items}
+                        onRemove={onRemove}
+                        onRemoveAll={onRemoveAll}
+                    />
+                ) : (
+                    <span
+                        key={group.key}
+                        className={clsx(
+                            'inline-flex flex-wrap items-center gap-1.5',
+                            showGroupLabels && 'rounded-xl border border-edge bg-surface-1 px-1.5 py-1',
+                        )}
+                    >
+                        {showGroupLabels && (
+                            <span className="pl-0.5 text-[10px] font-medium uppercase tracking-wide text-text-3">
+                                {group.scope.name}
+                            </span>
+                        )}
+                        {group.items.map((item) => (
+                            <ContextChip key={item.key} item={item} onRemove={onRemove} />
+                        ))}
+                    </span>
+                ),
+            )}
+
+            {items.length > 1 && (
+                <button
+                    type="button"
+                    onClick={onClear}
+                    className="rounded-lg px-1.5 py-0.5 text-[11px] text-text-3 hover:bg-surface-2 hover:text-text-1"
+                >
+                    Clear all
+                </button>
+            )}
+        </div>
+    );
+}

--- a/application/v2_ui/src/components/chat/ContextMenu.tsx
+++ b/application/v2_ui/src/components/chat/ContextMenu.tsx
@@ -1,0 +1,196 @@
+// ContextMenu.tsx
+// The `#` autocomplete for choosing documents, tags and workspaces.
+//
+// Third of the composer's three token menus, after `@` (people and models) and `/` (saved
+// prompts), and deliberately built to the same shape: a debounced search behind a keyboard-
+// navigable list that opens upward over the message box.
+//
+// The rows are typed rather than uniform because the three kinds mean genuinely different
+// things to the request that follows -- a document is an id, a tag is a filter, a workspace is
+// a scope -- and a list that hid that distinction would make "everything in Marketing" look
+// like just another file.
+
+import { useEffect, useRef, useState } from 'react';
+import { clsx } from 'clsx';
+import { FileText, FolderOpen, Loader2, Tag as TagIcon } from 'lucide-react';
+import {
+    searchContextCandidates,
+    type ContextCandidate,
+} from '../../lib/contextMentions';
+import type { ContextKind } from '../../lib/chatContext';
+import type { WorkspaceRef } from '../../lib/types';
+
+/** How long to wait after a keystroke before asking the server for candidates. */
+const SEARCH_DEBOUNCE_MS = 250;
+
+const ROW_ICON: Record<ContextKind, typeof FileText> = {
+    document: FileText,
+    tag: TagIcon,
+    scope: FolderOpen,
+};
+
+const GROUP_LABEL: Record<ContextKind, string> = {
+    document: 'Documents',
+    tag: 'Tags',
+    scope: 'Workspaces',
+};
+
+export interface ContextSearchScope {
+    groups: WorkspaceRef[];
+    publicWorkspaces: WorkspaceRef[];
+    groupsEnabled: boolean;
+    publicEnabled: boolean;
+}
+
+/**
+ * Candidates for the query under the caret.
+ *
+ * Returns `loading` separately from an empty list so the menu can tell "still looking" from
+ * "nothing matches". Collapsing the two makes a slow group workspace look like an empty one.
+ */
+export function useContextSuggestions(
+    query: string | null,
+    scope: ContextSearchScope,
+): { candidates: ContextCandidate[]; loading: boolean } {
+    const [candidates, setCandidates] = useState<ContextCandidate[]>([]);
+    const [loading, setLoading] = useState(false);
+
+    const groupIds = scope.groups.map((group) => group.id).join(',');
+    const publicIds = scope.publicWorkspaces.map((workspace) => workspace.id).join(',');
+
+    // The scope arrays are rebuilt on every bootstrap read, so the effect keys on their ids
+    // rather than the arrays themselves; keying on identity would restart the search on every
+    // unrelated render and the menu would never settle.
+    const scopeRef = useRef(scope);
+    scopeRef.current = scope;
+
+    useEffect(() => {
+        if (query === null) {
+            setCandidates([]);
+            setLoading(false);
+            return;
+        }
+
+        const controller = new AbortController();
+        setLoading(true);
+
+        const timer = window.setTimeout(() => {
+            searchContextCandidates({
+                query,
+                groups: scopeRef.current.groups,
+                publicWorkspaces: scopeRef.current.publicWorkspaces,
+                groupsEnabled: scopeRef.current.groupsEnabled,
+                publicEnabled: scopeRef.current.publicEnabled,
+                signal: controller.signal,
+            })
+                .then((found) => {
+                    if (!controller.signal.aborted) {
+                        setCandidates(found);
+                        setLoading(false);
+                    }
+                })
+                .catch(() => {
+                    if (!controller.signal.aborted) {
+                        // Every individual request is already settled independently, so
+                        // reaching here means the fan-out itself failed. Offering nothing is
+                        // better than an error banner over the message box.
+                        setCandidates([]);
+                        setLoading(false);
+                    }
+                });
+        }, SEARCH_DEBOUNCE_MS);
+
+        return () => {
+            window.clearTimeout(timer);
+            controller.abort();
+        };
+    }, [query, groupIds, publicIds, scope.groupsEnabled, scope.publicEnabled]);
+
+    return { candidates, loading };
+}
+
+export function ContextMenu({
+    candidates,
+    loading,
+    activeIndex,
+    selectedKeys,
+    onSelect,
+}: {
+    candidates: ContextCandidate[];
+    loading: boolean;
+    activeIndex: number;
+    /** Keys already on the chip row, so a second pick reads as already-added. */
+    selectedKeys: ReadonlySet<string>;
+    onSelect: (candidate: ContextCandidate) => void;
+}) {
+    if (!loading && candidates.length === 0) {
+        return null;
+    }
+
+    let lastKind: ContextKind | null = null;
+
+    return (
+        <div
+            role="listbox"
+            aria-label="Context suggestions"
+            className="glass-modal absolute bottom-full left-2 z-50 mb-2 max-h-72 w-80 overflow-y-auto rounded-xl p-1"
+        >
+            {loading && candidates.length === 0 && (
+                <div className="flex items-center gap-2 px-2.5 py-2 text-xs text-text-3">
+                    <Loader2 size={13} className="animate-spin" />
+                    Searching your workspaces…
+                </div>
+            )}
+
+            {candidates.map((candidate, index) => {
+                const Icon = ROW_ICON[candidate.kind];
+                const heading = candidate.kind !== lastKind ? GROUP_LABEL[candidate.kind] : null;
+                lastKind = candidate.kind;
+                const already = selectedKeys.has(candidate.key);
+
+                return (
+                    <div key={candidate.key}>
+                        {heading && (
+                            <div className="px-2.5 pb-0.5 pt-1.5 text-[10px] font-medium uppercase tracking-wide text-text-3">
+                                {heading}
+                            </div>
+                        )}
+                        <button
+                            type="button"
+                            role="option"
+                            aria-selected={index === activeIndex}
+                            // Pointer-down rather than click: the textarea loses focus on
+                            // mouse-up, and the blur handler that closes the menu would remove
+                            // the button before the click ever landed.
+                            onMouseDown={(event) => {
+                                event.preventDefault();
+                                onSelect(candidate);
+                            }}
+                            className={clsx(
+                                'flex w-full items-center gap-2 rounded-lg px-2.5 py-1.5 text-left text-sm',
+                                index === activeIndex
+                                    ? 'bg-accent-soft text-accent'
+                                    : 'text-text-1 hover:bg-surface-2',
+                            )}
+                        >
+                            <span className="shrink-0 text-text-3">
+                                <Icon size={14} />
+                            </span>
+                            <span className="min-w-0 flex-1">
+                                <span className="block truncate">{candidate.label}</span>
+                                {candidate.subtitle && (
+                                    <span className="block truncate text-[11px] text-text-3">
+                                        {candidate.subtitle}
+                                    </span>
+                                )}
+                            </span>
+                            {already && (
+                                <span className="shrink-0 text-[10px] text-text-3">Added</span>
+                            )}
+                        </button>
+                    </div>
+                );
+            })}
+        </div>
+    );
+}

--- a/application/v2_ui/src/components/chat/DocumentPickerPopover.tsx
+++ b/application/v2_ui/src/components/chat/DocumentPickerPopover.tsx
@@ -1,0 +1,269 @@
+// DocumentPickerPopover.tsx
+// The Documents button's menu.
+//
+// V2 shipped Documents as a plain on/off mapped to `hybrid_search`, with no way to say which
+// documents. This replaces it with a picker, and keeps the original switch inside as the
+// "search everything" case it always was -- the two are the server's `relevance` and
+// `selected` selection modes, which is why they belong in one control rather than two.
+//
+// It opens upward. The composer sits at the bottom of the window, so a menu dropping downward
+// is either clipped or covers the message being written. The classic interface drops its
+// document dropdown down for the same reason V1's toolbar is above the input; V2's is below.
+//
+// It has a search box, which the classic dropdowns have and V2's do not. A workspace of any
+// size is unusable without one.
+
+import { useEffect, useRef, useState } from 'react';
+import { clsx } from 'clsx';
+import { Check, FileText, FolderOpen, Loader2, Search, Tag as TagIcon } from 'lucide-react';
+import {
+    searchContextCandidates,
+    type ContextCandidate,
+} from '../../lib/contextMentions';
+import type { ContextSearchScope } from './ContextMenu';
+
+const SEARCH_DEBOUNCE_MS = 250;
+
+export function DocumentPickerPopover({
+    scope,
+    searchAll,
+    selectedKeys,
+    onToggleSearchAll,
+    onToggle,
+    onClear,
+    onClose,
+}: {
+    scope: ContextSearchScope;
+    /** The original Documents boolean: search everything by relevance. */
+    searchAll: boolean;
+    selectedKeys: ReadonlySet<string>;
+    onToggleSearchAll: () => void;
+    onToggle: (candidate: ContextCandidate) => void;
+    onClear: () => void;
+    onClose: () => void;
+}) {
+    const [query, setQuery] = useState('');
+    const [candidates, setCandidates] = useState<ContextCandidate[]>([]);
+    const [loading, setLoading] = useState(true);
+    const holder = useRef<HTMLDivElement>(null);
+    const searchRef = useRef<HTMLInputElement>(null);
+
+    useEffect(() => {
+        searchRef.current?.focus();
+    }, []);
+
+    useEffect(() => {
+        const onPointerDown = (event: MouseEvent) => {
+            if (!holder.current?.contains(event.target as Node)) {
+                onClose();
+            }
+        };
+        const onEscape = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') {
+                event.stopPropagation();
+                onClose();
+            }
+        };
+        document.addEventListener('mousedown', onPointerDown);
+        document.addEventListener('keydown', onEscape);
+        return () => {
+            document.removeEventListener('mousedown', onPointerDown);
+            document.removeEventListener('keydown', onEscape);
+        };
+    }, [onClose]);
+
+    useEffect(() => {
+        const controller = new AbortController();
+        setLoading(true);
+
+        const timer = window.setTimeout(() => {
+            searchContextCandidates({
+                query,
+                groups: scope.groups,
+                publicWorkspaces: scope.publicWorkspaces,
+                groupsEnabled: scope.groupsEnabled,
+                publicEnabled: scope.publicEnabled,
+                signal: controller.signal,
+            })
+                .then((found) => {
+                    if (!controller.signal.aborted) {
+                        setCandidates(found);
+                        setLoading(false);
+                    }
+                })
+                .catch(() => {
+                    if (!controller.signal.aborted) {
+                        setCandidates([]);
+                        setLoading(false);
+                    }
+                });
+        }, SEARCH_DEBOUNCE_MS);
+
+        return () => {
+            window.clearTimeout(timer);
+            controller.abort();
+        };
+        // The scope arrays are rebuilt on every bootstrap read, so this keys on the flags and
+        // the query rather than on array identity.
+    }, [query, scope.groupsEnabled, scope.publicEnabled]);
+
+    // Grouped by workspace, which is how the chip row groups them too: a reader scanning for
+    // "the contract in Marketing" is looking for the workspace first.
+    const byScope = new Map<string, { name: string; items: ContextCandidate[] }>();
+    for (const candidate of candidates) {
+        const key = `${candidate.scope.kind}:${candidate.scope.id ?? ''}`;
+        const bucket = byScope.get(key);
+        if (bucket) {
+            bucket.items.push(candidate);
+        } else {
+            byScope.set(key, { name: candidate.scope.name, items: [candidate] });
+        }
+    }
+
+    return (
+        <div
+            ref={holder}
+            className="glass-modal absolute bottom-full left-2 z-50 mb-2 flex max-h-[26rem] w-96 flex-col rounded-xl p-1.5"
+        >
+            <div className="relative shrink-0 px-0.5 pb-1.5">
+                <Search
+                    size={13}
+                    className="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-text-3"
+                    aria-hidden="true"
+                />
+                <input
+                    ref={searchRef}
+                    type="search"
+                    value={query}
+                    onChange={(event) => setQuery(event.target.value)}
+                    placeholder="Search documents, tags and workspaces…"
+                    aria-label="Search documents"
+                    className={clsx(
+                        'w-full rounded-lg border border-edge bg-surface-1 py-1.5 pl-7 pr-2',
+                        'text-sm text-text-1 placeholder:text-text-3',
+                        'focus:border-accent-ring focus:outline-none',
+                    )}
+                />
+            </div>
+
+            <button
+                type="button"
+                onClick={onToggleSearchAll}
+                className={clsx(
+                    'flex shrink-0 items-center gap-2 rounded-lg px-2 py-1.5 text-left text-sm',
+                    searchAll ? 'bg-accent-soft text-accent' : 'text-text-1 hover:bg-surface-2',
+                )}
+            >
+                <span
+                    className={clsx(
+                        'flex h-4 w-4 shrink-0 items-center justify-center rounded border',
+                        searchAll ? 'border-accent bg-accent text-white' : 'border-edge-strong',
+                    )}
+                >
+                    {searchAll && <Check size={11} />}
+                </span>
+                <span className="min-w-0 flex-1">
+                    <span className="block">Search all my documents</span>
+                    <span className="block text-[11px] text-text-3">
+                        Finds whatever is most relevant, rather than a fixed list
+                    </span>
+                </span>
+            </button>
+
+            <div className="my-1 h-px shrink-0 bg-edge-strong" aria-hidden="true" />
+
+            <div className="min-h-0 flex-1 overflow-y-auto">
+                {loading && candidates.length === 0 && (
+                    <div className="flex items-center gap-2 px-2 py-3 text-xs text-text-3">
+                        <Loader2 size={13} className="animate-spin" />
+                        Searching your workspaces…
+                    </div>
+                )}
+
+                {!loading && candidates.length === 0 && (
+                    <p className="px-2 py-3 text-xs text-text-3">
+                        {query.trim()
+                            ? 'Nothing matches that.'
+                            : 'No documents in your workspaces yet.'}
+                    </p>
+                )}
+
+                {[...byScope.entries()].map(([key, bucket]) => (
+                    <div key={key}>
+                        <div className="px-2 pb-0.5 pt-1.5 text-[10px] font-medium uppercase tracking-wide text-text-3">
+                            {bucket.name}
+                        </div>
+                        {bucket.items.map((candidate) => {
+                            const picked = selectedKeys.has(candidate.key);
+                            const Icon =
+                                candidate.kind === 'tag'
+                                    ? TagIcon
+                                    : candidate.kind === 'scope'
+                                      ? FolderOpen
+                                      : FileText;
+
+                            return (
+                                <button
+                                    key={candidate.key}
+                                    type="button"
+                                    onClick={() => onToggle(candidate)}
+                                    aria-pressed={picked}
+                                    className={clsx(
+                                        'flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left text-sm',
+                                        picked
+                                            ? 'bg-accent-soft text-accent'
+                                            : 'text-text-1 hover:bg-surface-2',
+                                    )}
+                                >
+                                    <span
+                                        className={clsx(
+                                            'flex h-4 w-4 shrink-0 items-center justify-center rounded border',
+                                            picked
+                                                ? 'border-accent bg-accent text-white'
+                                                : 'border-edge-strong',
+                                        )}
+                                    >
+                                        {picked && <Check size={11} />}
+                                    </span>
+                                    <Icon size={13} className="shrink-0 text-text-3" />
+                                    <span className="min-w-0 flex-1">
+                                        <span className="block truncate">{candidate.label}</span>
+                                        {candidate.subtitle && (
+                                            <span className="block truncate text-[11px] text-text-3">
+                                                {candidate.subtitle}
+                                            </span>
+                                        )}
+                                    </span>
+                                </button>
+                            );
+                        })}
+                    </div>
+                ))}
+            </div>
+
+            <div className="mt-1 flex shrink-0 items-center justify-between gap-2 border-t border-edge-strong px-1.5 pt-1.5">
+                <span className="text-[11px] text-text-3">
+                    Tip: type <span className="font-medium text-text-2">#</span> in your message
+                </span>
+                <div className="flex items-center gap-1">
+                    {selectedKeys.size > 0 && (
+                        <button
+                            type="button"
+                            onClick={onClear}
+                            className="rounded-lg px-1.5 py-0.5 text-[11px] text-text-3 hover:bg-surface-2 hover:text-text-1"
+                        >
+                            Clear
+                        </button>
+                    )}
+                    <button
+                        type="button"
+                        onClick={onClose}
+                        className="rounded-lg px-2 py-0.5 text-[11px] font-medium text-accent hover:bg-accent-soft"
+                    >
+                        Done
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/application/v2_ui/src/components/chat/OrchestrationRunView.tsx
+++ b/application/v2_ui/src/components/chat/OrchestrationRunView.tsx
@@ -32,6 +32,7 @@ import {
     TERMINAL_CAPABILITY_ID,
 } from '../../lib/orchestrationPlan';
 import type { CostClass, Json, OrchestrationStep, StepStatus } from '../../lib/orchestration';
+import { useDocumentTitles } from '../../lib/documentTitles';
 
 const statusTone: Record<StepStatus, string> = {
     pending: 'bg-surface-3 text-text-3',
@@ -95,6 +96,18 @@ export function OrchestrationRunView({
         () => (plan ? orderStepsForDisplay(plan.steps) : []),
         [plan],
     );
+
+    /**
+     * Names for every document the plan touches.
+     *
+     * Resolved across the whole plan rather than per step so a document used by two steps is
+     * looked up once, and so the lookup does not restart as steps re-render.
+     */
+    const planDocumentIds = useMemo(
+        () => [...new Set(orderedSteps.flatMap((step) => stepDocumentIds(step)))],
+        [orderedSteps],
+    );
+    const documentTitles = useDocumentTitles(planDocumentIds);
 
     if (!plan) {
         return (
@@ -193,6 +206,11 @@ export function OrchestrationRunView({
                                                 const isRemoved = removed.has(documentId);
                                                 const canRemove =
                                                     editable && removable.has(documentId);
+                                                // Falls back to the id while the lookup is in
+                                                // flight, or when the document cannot be read
+                                                // any more, so a chip is never blank.
+                                                const title =
+                                                    documentTitles.get(documentId) ?? documentId;
                                                 return (
                                                     <li
                                                         key={documentId}
@@ -205,10 +223,14 @@ export function OrchestrationRunView({
                                                     >
                                                         <FileText size={10} className="shrink-0" />
                                                         <span
-                                                            className="max-w-[9rem] truncate"
-                                                            title={documentId}
+                                                            className="max-w-[12rem] truncate"
+                                                            title={
+                                                                title === documentId
+                                                                    ? documentId
+                                                                    : `${title} · ${documentId}`
+                                                            }
                                                         >
-                                                            {documentId}
+                                                            {title}
                                                         </span>
                                                         {isRemoved ? (
                                                             <button

--- a/application/v2_ui/src/components/documents/DocumentExplorer.tsx
+++ b/application/v2_ui/src/components/documents/DocumentExplorer.tsx
@@ -12,7 +12,13 @@
 // without a renderer.
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { FileText, Upload } from 'lucide-react';
+import {
+    buildContextHandoffParams,
+    type ContextHandoffState,
+} from '../../lib/chatContextHandoff';
+import { PERSONAL_SCOPE } from '../../lib/chatContext';
 import type {
     DocumentExplorerPrefs,
     DocumentQuery,
@@ -137,6 +143,7 @@ function saveBlob(blob: Blob, fileName: string) {
 }
 
 export function DocumentExplorer() {
+    const navigate = useNavigate();
     const features = useBootstrapStore((state) => state.data?.features);
     const settings = useBootstrapStore((state) => state.data?.settings);
     const userSettings = useUserSettingsStore((state) => state.settings);
@@ -630,18 +637,37 @@ export function DocumentExplorer() {
         }
     }, []);
 
-    const onChat = useCallback((targets: WorkspaceDocument[]) => {
-        const ids = targets.map(documentId).filter(Boolean);
-        if (ids.length === 0) {
-            return;
-        }
-        const params = new URLSearchParams({
-            search_documents: 'true',
-            doc_scope: 'personal',
-            document_ids: ids.join(','),
-        });
-        window.location.href = `/chats?${params.toString()}`;
-    }, []);
+    /**
+     * Hand the selection to the composer.
+     *
+     * This used to be `window.location.href = '/chats?…'`, which is a full page load into the
+     * *classic* interface: the one action most likely to follow choosing a document quietly
+     * moved the user out of V2. Navigating within the router keeps them here, and the document
+     * records ride along in router state so the composer does not have to fetch back what this
+     * page already has in hand.
+     */
+    const onChat = useCallback(
+        (targets: WorkspaceDocument[]) => {
+            const documents = targets.filter((target) => documentId(target));
+            if (documents.length === 0) {
+                return;
+            }
+
+            const query = buildContextHandoffParams({
+                documentIds: documents.map(documentId),
+                docScope: 'personal',
+            });
+            const state: ContextHandoffState = {
+                contextDocuments: documents.map((document) => ({
+                    document,
+                    scope: PERSONAL_SCOPE,
+                })),
+            };
+
+            navigate(`/chat?${query}`, { state });
+        },
+        [navigate],
+    );
 
     const onExtractMetadata = useCallback(
         async (targets: WorkspaceDocument[]) => {

--- a/application/v2_ui/src/lib/chatContext.ts
+++ b/application/v2_ui/src/lib/chatContext.ts
@@ -1,0 +1,385 @@
+// chatContext.ts
+// What the composer is pointed at: the documents, tags and workspaces a message is grounded in.
+//
+// V2 shipped the Documents button as a bare on/off mapped to `hybrid_search`, with
+// `selectedDocumentIds` present in `ComposerOptions`, forwarded to both the chat request and
+// the orchestration seeds, and never populated by anything. This module is the missing middle:
+// one list of context items that the `#` menu, the picker popover, the workspace hand-off and
+// the orchestration planner all write into, and that the request builders read out of.
+//
+// Three kinds share the list because they answer the same question -- "what should this look
+// at?" -- and the server already takes all three in one request:
+//
+//   document  -> selected_document_ids
+//   tag       -> tags        (becomes tags_filter)
+//   scope     -> doc_scope + active_group_ids / active_public_workspace_ids
+//
+// Identity is the `key`, not the label. Two documents may share a title, and a tag name may
+// exist in more than one workspace, so nothing here de-duplicates on what the user sees.
+
+import { documentDisplayName, documentId, normalizeStringList } from './documentExplorer';
+import {
+    buildContextToken,
+    sanitizeContextLabel,
+    uniqueContextLabel,
+} from './chatContextTokens';
+import type { WorkspaceDocument, WorkspaceRef } from './types';
+
+export type ContextKind = 'document' | 'tag' | 'scope';
+
+/**
+ * Where an item came from.
+ *
+ * Only `planner` changes behaviour -- those chips are drawn differently and their removal is
+ * recorded as a plan edit rather than a plain deselection -- but knowing that a chip arrived
+ * from the workspace hand-off rather than being chosen in the composer is worth keeping for
+ * the same reason: it is the difference between something the user did and something that was
+ * done for them.
+ */
+export type ContextOrigin = 'user' | 'handoff' | 'planner';
+
+export type ContextScopeKind = 'personal' | 'group' | 'public';
+
+export interface ContextScopeRef {
+    kind: ContextScopeKind;
+    /** Null for personal, which has no workspace id: the server derives it from the caller. */
+    id: string | null;
+    name: string;
+}
+
+export interface ContextItem {
+    /** Dedupe identity. Never the label. */
+    key: string;
+    kind: ContextKind;
+    /** Document id, tag name, or workspace id. */
+    id: string;
+    /** The full display name. May be longer than the token's label. */
+    label: string;
+    /** The literal `#[…]` text this item owns in the message. */
+    token: string;
+    scope: ContextScopeRef;
+    origin: ContextOrigin;
+    meta?: {
+        fileName?: string;
+        classification?: string;
+        version?: number;
+        tags?: string[];
+        /** Set on planner items so a removal can be attributed to the step that asked for it. */
+        stepId?: string;
+    };
+}
+
+export const PERSONAL_SCOPE: ContextScopeRef = {
+    kind: 'personal',
+    id: null,
+    name: 'My workspace',
+};
+
+export function groupScope(ref: WorkspaceRef): ContextScopeRef {
+    return { kind: 'group', id: String(ref.id ?? ''), name: String(ref.name ?? 'Group') };
+}
+
+export function publicScope(ref: WorkspaceRef): ContextScopeRef {
+    return {
+        kind: 'public',
+        id: String(ref.id ?? ''),
+        name: String(ref.name ?? 'Public workspace'),
+    };
+}
+
+/** Stable identity for a scope, used in keys and to group the chip row. */
+export function scopeKey(scope: ContextScopeRef): string {
+    return `${scope.kind}:${scope.id ?? ''}`;
+}
+
+export function contextKey(kind: ContextKind, id: string, scope: ContextScopeRef): string {
+    // Documents carry globally unique ids, so their scope is display information rather than
+    // part of their identity. Tags and scopes are only unique within a workspace.
+    if (kind === 'document') {
+        return `document:${id}`;
+    }
+    return `${kind}:${scopeKey(scope)}:${id.toLowerCase()}`;
+}
+
+/** The labels currently spoken for, so a new token can avoid colliding with them. */
+function takenLabels(items: readonly ContextItem[]): string[] {
+    return items.map((item) => item.token.slice(2, -1));
+}
+
+function finish(
+    partial: Omit<ContextItem, 'token'>,
+    existing: readonly ContextItem[],
+): ContextItem {
+    const label = uniqueContextLabel(partial.label, takenLabels(existing));
+    return { ...partial, token: buildContextToken(label) };
+}
+
+/**
+ * Turn a workspace document into a context item.
+ *
+ * The token uses the display title, which is what the reader recognises; the id travels
+ * separately in `id`. `documentDisplayName` already decides between an extracted title and a
+ * file name, so a document whose title is `MSA_v2_FINAL(3).docx` reads the same here as it
+ * does in the explorer.
+ */
+export function documentContextItem(
+    document: WorkspaceDocument,
+    scope: ContextScopeRef,
+    existing: readonly ContextItem[] = [],
+    origin: ContextOrigin = 'user',
+): ContextItem {
+    const id = documentId(document);
+    const { primary, secondary } = documentDisplayName(document);
+    const classification = String(document.document_classification ?? '').trim();
+
+    return finish(
+        {
+            key: contextKey('document', id, scope),
+            kind: 'document',
+            id,
+            label: primary,
+            scope,
+            origin,
+            meta: {
+                fileName: secondary ?? (String(document.file_name ?? '').trim() || undefined),
+                classification: classification || undefined,
+                version:
+                    typeof document.version === 'number' ? document.version : undefined,
+                tags: normalizeStringList(document.tags),
+            },
+        },
+        existing,
+    );
+}
+
+export function tagContextItem(
+    name: string,
+    scope: ContextScopeRef,
+    existing: readonly ContextItem[] = [],
+    origin: ContextOrigin = 'user',
+): ContextItem {
+    const tag = String(name ?? '').trim();
+    return finish(
+        {
+            key: contextKey('tag', tag, scope),
+            kind: 'tag',
+            id: tag,
+            label: tag,
+            scope,
+            origin,
+        },
+        existing,
+    );
+}
+
+/**
+ * A whole workspace as context.
+ *
+ * Selecting one does not enumerate its documents -- that would pin a snapshot of the workspace
+ * as it was when the chip was added. It widens `doc_scope` instead, so the search covers
+ * whatever the workspace holds at the time the message is sent.
+ */
+export function scopeContextItem(
+    scope: ContextScopeRef,
+    existing: readonly ContextItem[] = [],
+    origin: ContextOrigin = 'user',
+): ContextItem {
+    return finish(
+        {
+            key: contextKey('scope', scope.id ?? 'personal', scope),
+            kind: 'scope',
+            id: scope.id ?? '',
+            label: scope.name,
+            scope,
+            origin,
+        },
+        existing,
+    );
+}
+
+/** Add an item unless its key is already present. */
+export function addContextItem(
+    items: readonly ContextItem[],
+    item: ContextItem,
+): ContextItem[] {
+    if (items.some((entry) => entry.key === item.key)) {
+        return items.slice();
+    }
+    return [...items, item];
+}
+
+export function removeContextItem(
+    items: readonly ContextItem[],
+    key: string,
+): ContextItem[] {
+    return items.filter((entry) => entry.key !== key);
+}
+
+export function hasContextItem(items: readonly ContextItem[], key: string): boolean {
+    return items.some((entry) => entry.key === key);
+}
+
+/* -------------------------------------------------------------------------- */
+/* Derived request fields                                                      */
+/* -------------------------------------------------------------------------- */
+
+export function contextDocumentIds(items: readonly ContextItem[]): string[] {
+    return items.filter((item) => item.kind === 'document').map((item) => item.id);
+}
+
+/**
+ * The tag names to filter on.
+ *
+ * De-duplicated case-insensitively: the same tag picked from two workspaces is one filter, and
+ * `build_tags_filter` in functions_search.py joins these with `and`, so sending it twice would
+ * narrow the search rather than widen it.
+ */
+export function contextTags(items: readonly ContextItem[]): string[] {
+    const seen = new Set<string>();
+    const tags: string[] = [];
+    for (const item of items) {
+        if (item.kind !== 'tag') {
+            continue;
+        }
+        const key = item.id.toLowerCase();
+        if (!seen.has(key)) {
+            seen.add(key);
+            tags.push(item.id);
+        }
+    }
+    return tags;
+}
+
+/**
+ * Whether documents and tags should be additive.
+ *
+ * `_build_document_content_filter` in functions_search.py defaults to `intersection`, which
+ * emits `doc_ids and tags` -- so a picked document that does not carry a picked tag matches
+ * nothing, and a chip row holding one of each returns no results at all. Assigned Knowledge
+ * already passes `union` for this reason (functions_search.py:418).
+ *
+ * Only sent when both kinds are present, because with one kind the mode has no effect and a
+ * needless field in the request is one more thing to explain.
+ */
+export function contextFilterMode(
+    items: readonly ContextItem[],
+): 'union' | undefined {
+    const hasDocuments = items.some((item) => item.kind === 'document');
+    const hasTags = items.some((item) => item.kind === 'tag');
+    return hasDocuments && hasTags ? 'union' : undefined;
+}
+
+/** The workspaces the chips imply, for `resolveDocumentScope`. */
+export function contextScopes(items: readonly ContextItem[]): {
+    includesPersonal: boolean;
+    groupIds: string[];
+    publicWorkspaceIds: string[];
+} {
+    const groupIds = new Set<string>();
+    const publicWorkspaceIds = new Set<string>();
+    let includesPersonal = false;
+
+    for (const item of items) {
+        if (item.scope.kind === 'personal') {
+            includesPersonal = true;
+        } else if (item.scope.kind === 'group' && item.scope.id) {
+            groupIds.add(item.scope.id);
+        } else if (item.scope.kind === 'public' && item.scope.id) {
+            publicWorkspaceIds.add(item.scope.id);
+        }
+    }
+
+    return {
+        includesPersonal,
+        groupIds: [...groupIds],
+        publicWorkspaceIds: [...publicWorkspaceIds],
+    };
+}
+
+/* -------------------------------------------------------------------------- */
+/* Presentation                                                                */
+/* -------------------------------------------------------------------------- */
+
+export interface ContextGroup {
+    scope: ContextScopeRef;
+    key: string;
+    items: ContextItem[];
+}
+
+const SCOPE_ORDER: Record<ContextScopeKind, number> = {
+    personal: 0,
+    group: 1,
+    public: 2,
+};
+
+/**
+ * The chip row's grouping.
+ *
+ * Personal first, then groups, then public workspaces, each holding its items in the order
+ * they were added. Ordering is fixed rather than by size so a chip does not migrate across
+ * the row when another one is added beside it.
+ */
+export function groupContextItems(items: readonly ContextItem[]): ContextGroup[] {
+    const groups = new Map<string, ContextGroup>();
+
+    for (const item of items) {
+        const key = scopeKey(item.scope);
+        const existing = groups.get(key);
+        if (existing) {
+            existing.items.push(item);
+        } else {
+            groups.set(key, { scope: item.scope, key, items: [item] });
+        }
+    }
+
+    return [...groups.values()].sort((left, right) => {
+        const order = SCOPE_ORDER[left.scope.kind] - SCOPE_ORDER[right.scope.kind];
+        return order !== 0 ? order : left.scope.name.localeCompare(right.scope.name);
+    });
+}
+
+/** `3 documents and 1 tag`, for a collapsed group's summary chip. */
+export function describeContextGroup(items: readonly ContextItem[]): string {
+    const counts: Array<[number, string, string]> = [
+        [items.filter((item) => item.kind === 'document').length, 'document', 'documents'],
+        [items.filter((item) => item.kind === 'tag').length, 'tag', 'tags'],
+        [items.filter((item) => item.kind === 'scope').length, 'workspace', 'workspaces'],
+    ];
+
+    const parts = counts
+        .filter(([count]) => count > 0)
+        .map(([count, one, many]) => `${count} ${count === 1 ? one : many}`);
+
+    if (parts.length === 0) {
+        return 'Nothing selected';
+    }
+    if (parts.length === 1) {
+        return parts[0];
+    }
+    return `${parts.slice(0, -1).join(', ')} and ${parts[parts.length - 1]}`;
+}
+
+/** A one-line explanation for a chip's tooltip. */
+export function describeContextItem(item: ContextItem): string {
+    const lines: string[] = [sanitizeContextLabel(item.label) || item.label];
+
+    if (item.kind === 'tag') {
+        lines.push(`Tag in ${item.scope.name}`);
+    } else if (item.kind === 'scope') {
+        lines.push('Every document in this workspace');
+    } else {
+        lines.push(item.scope.name);
+        if (item.meta?.fileName) {
+            lines.push(item.meta.fileName);
+        }
+        if (item.meta?.classification) {
+            lines.push(item.meta.classification);
+        }
+    }
+
+    if (item.origin === 'planner') {
+        lines.push('Chosen by the planner');
+    }
+
+    return lines.join(' · ');
+}

--- a/application/v2_ui/src/lib/chatContextHandoff.ts
+++ b/application/v2_ui/src/lib/chatContextHandoff.ts
@@ -1,0 +1,234 @@
+// chatContextHandoff.ts
+// Carrying a workspace selection into the chat composer.
+//
+// Selecting documents in the workspace and pressing Chat used to do this:
+//
+//     window.location.href = `/chats?search_documents=true&doc_scope=personal&document_ids=…`
+//
+// which is a full page load into the *classic* interface. A user working in V2 was quietly
+// moved to V1 by the one action most likely to follow choosing a document. This module is the
+// V2 replacement, and it keeps the classic query vocabulary so a link built by either
+// interface is readable by both.
+//
+// Two routes in, by preference:
+//
+//   1. Router state. The page that raised the hand-off already holds the document records, so
+//      passing them through avoids re-fetching what is in memory and works for every scope --
+//      including public workspaces, which have no single-document endpoint to fetch from.
+//   2. Query parameters. What a bookmarked, copied or hand-written link has. Ids have to be
+//      resolved back into names, which is best-effort per scope.
+
+import {
+    fetchGroupDocument,
+    fetchPersonalDocument,
+    fetchPublicWorkspaceDocuments,
+} from './endpoints';
+import { documentId as readDocumentId } from './documentExplorer';
+import {
+    PERSONAL_SCOPE,
+    documentContextItem,
+    groupScope,
+    publicScope,
+    tagContextItem,
+    type ContextItem,
+    type ContextScopeRef,
+} from './chatContext';
+import type { WorkspaceDocument, WorkspaceRef } from './types';
+
+/**
+ * The parameters a hand-off uses, named as the classic client names them.
+ *
+ * Listed so the composer can strip exactly these after consuming them: leaving them behind
+ * would re-apply the same selection every time the page was reloaded or the link re-shared.
+ */
+export const CONTEXT_HANDOFF_PARAMS = [
+    'search_documents',
+    'doc_scope',
+    'document_id',
+    'document_ids',
+    'tags',
+    'group_id',
+    'workspace_id',
+] as const;
+
+export interface ContextHandoff {
+    documentIds: string[];
+    tags: string[];
+    docScope: string;
+    groupId: string;
+    workspaceId: string;
+}
+
+/** Items passed directly through router state, skipping id resolution entirely. */
+export interface ContextHandoffState {
+    contextDocuments?: Array<{ document: WorkspaceDocument; scope: ContextScopeRef }>;
+    contextTags?: Array<{ name: string; scope: ContextScopeRef }>;
+}
+
+function list(value: string | null): string[] {
+    return String(value ?? '')
+        .split(',')
+        .map((entry) => entry.trim())
+        .filter(Boolean);
+}
+
+/** Read a hand-off out of the URL, or null when there is not one. */
+export function readContextHandoff(params: URLSearchParams): ContextHandoff | null {
+    const documentIds = [...list(params.get('document_ids')), ...list(params.get('document_id'))];
+    const tags = list(params.get('tags'));
+
+    if (documentIds.length === 0 && tags.length === 0) {
+        return null;
+    }
+
+    return {
+        documentIds: [...new Set(documentIds)],
+        tags: [...new Set(tags)],
+        docScope: String(params.get('doc_scope') ?? '').trim().toLowerCase(),
+        groupId: String(params.get('group_id') ?? '').trim(),
+        workspaceId: String(params.get('workspace_id') ?? '').trim(),
+    };
+}
+
+/** Build the query a workspace page navigates with. */
+export function buildContextHandoffParams(options: {
+    documentIds?: readonly string[];
+    tags?: readonly string[];
+    docScope?: string;
+    groupId?: string;
+    workspaceId?: string;
+}): string {
+    const params = new URLSearchParams({ search_documents: 'true' });
+
+    if (options.docScope) {
+        params.set('doc_scope', options.docScope);
+    }
+    if (options.documentIds?.length) {
+        params.set('document_ids', options.documentIds.join(','));
+    }
+    if (options.tags?.length) {
+        params.set('tags', options.tags.join(','));
+    }
+    if (options.groupId) {
+        params.set('group_id', options.groupId);
+    }
+    if (options.workspaceId) {
+        params.set('workspace_id', options.workspaceId);
+    }
+
+    return params.toString();
+}
+
+/** Which workspace a hand-off's ids belong to, from the scope it names. */
+function handoffScope(
+    handoff: ContextHandoff,
+    groups: readonly WorkspaceRef[],
+    publicWorkspaces: readonly WorkspaceRef[],
+): ContextScopeRef {
+    if (handoff.docScope === 'group' && handoff.groupId) {
+        const match = groups.find((group) => String(group.id) === handoff.groupId);
+        return groupScope(match ?? { id: handoff.groupId, name: 'Group workspace' });
+    }
+    if (handoff.docScope === 'public' && handoff.workspaceId) {
+        const match = publicWorkspaces.find(
+            (workspace) => String(workspace.id) === handoff.workspaceId,
+        );
+        return publicScope(match ?? { id: handoff.workspaceId, name: 'Public workspace' });
+    }
+    return PERSONAL_SCOPE;
+}
+
+/**
+ * Look a document up so its chip can carry a name rather than an id.
+ *
+ * Personal and group documents have single-document endpoints. Public workspace documents do
+ * not -- only `/versions` exists -- so those are found by scanning the visible list, which is
+ * bounded by what the user has made visible in their directory and is therefore small. A
+ * document that still cannot be resolved is skipped rather than shown as a bare id: a chip
+ * reading `a3f1b2…` tells the reader nothing about what their message is pointed at.
+ */
+async function resolveDocument(
+    id: string,
+    scope: ContextScopeRef,
+    publicIndex: Map<string, WorkspaceDocument> | null,
+    signal?: AbortSignal,
+): Promise<WorkspaceDocument | null> {
+    try {
+        if (scope.kind === 'group') {
+            return await fetchGroupDocument(id, signal);
+        }
+        if (scope.kind === 'public') {
+            return publicIndex?.get(id) ?? null;
+        }
+        return await fetchPersonalDocument(id, signal);
+    } catch {
+        // A document that was deleted between choosing it and arriving here, or one the
+        // caller may not read. Dropping it is the honest outcome; the rest still arrive.
+        return null;
+    }
+}
+
+/**
+ * Turn a hand-off into the chips the composer starts with.
+ *
+ * Router state wins when it is present, because it is both faster and more complete than
+ * anything that can be recovered from ids alone.
+ */
+export async function resolveContextHandoff(
+    handoff: ContextHandoff,
+    options: {
+        groups?: readonly WorkspaceRef[];
+        publicWorkspaces?: readonly WorkspaceRef[];
+        state?: ContextHandoffState | null;
+        signal?: AbortSignal;
+    } = {},
+): Promise<ContextItem[]> {
+    const groups = options.groups ?? [];
+    const publicWorkspaces = options.publicWorkspaces ?? [];
+    const items: ContextItem[] = [];
+
+    const passed = options.state;
+    if (passed?.contextDocuments?.length || passed?.contextTags?.length) {
+        for (const entry of passed.contextDocuments ?? []) {
+            items.push(documentContextItem(entry.document, entry.scope, items, 'handoff'));
+        }
+        for (const entry of passed.contextTags ?? []) {
+            items.push(tagContextItem(entry.name, entry.scope, items, 'handoff'));
+        }
+        return items;
+    }
+
+    const scope = handoffScope(handoff, groups, publicWorkspaces);
+
+    let publicIndex: Map<string, WorkspaceDocument> | null = null;
+    if (scope.kind === 'public' && handoff.documentIds.length > 0) {
+        try {
+            const listed = await fetchPublicWorkspaceDocuments(
+                { page: 1, pageSize: 250 },
+                options.signal,
+            );
+            publicIndex = new Map(
+                (listed.documents ?? []).map((document) => [readDocumentId(document), document]),
+            );
+        } catch {
+            publicIndex = null;
+        }
+    }
+
+    const documents = await Promise.all(
+        handoff.documentIds.map((id) =>
+            resolveDocument(id, scope, publicIndex, options.signal),
+        ),
+    );
+
+    for (const document of documents) {
+        if (document) {
+            items.push(documentContextItem(document, scope, items, 'handoff'));
+        }
+    }
+    for (const tag of handoff.tags) {
+        items.push(tagContextItem(tag, scope, items, 'handoff'));
+    }
+
+    return items;
+}

--- a/application/v2_ui/src/lib/chatContextTokens.ts
+++ b/application/v2_ui/src/lib/chatContextTokens.ts
@@ -1,0 +1,274 @@
+// chatContextTokens.ts
+// The `#[…]` grammar that keeps the composer's context chips and its message text in step.
+//
+// A context reference exists in two places at once: as a chip above the input, and as literal
+// text inside it. That is deliberate -- the reference stays in the message the user actually
+// sends, so "compare #[Q3 Contract.pdf] against #[Q2 Contract.pdf]" still reads as a sentence
+// after it has been sent, and still reads as one to the model. Only the message text survives
+// into every downstream view; per-message metadata keeps `requested_document_ids` but nothing
+// renders it in prose.
+//
+// Holding the same fact twice means they can disagree, so the rules below are written around a
+// single principle: THE TEXT IS AUTHORITATIVE FOR REMOVAL, THE CHIP LIST IS AUTHORITATIVE FOR
+// IDENTITY. A token that has been edited or deleted drops its chip (`reconcileContextItems`),
+// but a token typed by hand never creates one -- there is no id behind it, and inventing a
+// document from a string the user typed is exactly the kind of guess that produces a request
+// citing something they never chose.
+//
+// Shaped after lib/promptSlash.ts and lib/mentions.ts, which do the equivalent job for `/` and
+// `@`. Nothing here touches the DOM: the caller reads `selectionStart` and writes the result
+// back, so every rule is testable without a textarea.
+
+/** Longest query the menu stays open for, past which this is prose rather than a search. */
+export const MAX_CONTEXT_QUERY_LENGTH = 60;
+
+/**
+ * Longest label carried inside a token.
+ *
+ * Document titles run to sentence length, and an untruncated one turns the message box into a
+ * wall of brackets. The chip keeps the full title; only the token is shortened.
+ */
+export const MAX_CONTEXT_LABEL_LENGTH = 80;
+
+/**
+ * Matches one complete token.
+ *
+ * `[^\]\n]+` rather than `.+?` so a token can never span a line or swallow the next one: an
+ * unclosed `#[` stays inert text instead of eating the rest of the paragraph the moment a
+ * later token closes it.
+ */
+const CONTEXT_TOKEN_PATTERN = /#\[([^\]\n]+)\]/g;
+
+export interface ContextQuery {
+    /** What has been typed after the `#`. */
+    query: string;
+    /** Index of the `#`. */
+    start: number;
+    /** Index just past the query, which is the caret. */
+    end: number;
+}
+
+export interface ParsedContextToken {
+    /** The text between the brackets. */
+    label: string;
+    /** The whole token including `#[` and `]`. */
+    token: string;
+    start: number;
+    end: number;
+}
+
+/**
+ * Make a label safe to carry inside a token.
+ *
+ * Brackets are the delimiters, so a title containing one would truncate its own token and
+ * leave the remainder as loose text. They are replaced rather than escaped because the token
+ * is read by people as much as by `parseContextTokens`, and `#[Report (final)]` reads better
+ * than `#[Report \]final\[]`.
+ */
+export function sanitizeContextLabel(label: string): string {
+    const collapsed = String(label ?? '')
+        .replace(/[\r\n\t]+/g, ' ')
+        .replace(/\[/g, '(')
+        .replace(/\]/g, ')')
+        .replace(/\s{2,}/g, ' ')
+        .trim();
+
+    if (collapsed.length <= MAX_CONTEXT_LABEL_LENGTH) {
+        return collapsed;
+    }
+    return `${collapsed.slice(0, MAX_CONTEXT_LABEL_LENGTH).trimEnd()}…`;
+}
+
+/**
+ * A label that no existing token is already using.
+ *
+ * Two documents may share a title, and two identical tokens could not be told apart when one
+ * of them is removed. The suffix is applied to the sanitized label so the cap above is not
+ * quietly exceeded by the disambiguator.
+ */
+export function uniqueContextLabel(label: string, taken: Iterable<string>): string {
+    const base = sanitizeContextLabel(label) || 'Untitled';
+    const used = new Set(taken);
+    if (!used.has(base)) {
+        return base;
+    }
+
+    for (let suffix = 2; suffix < 1000; suffix += 1) {
+        const candidate = sanitizeContextLabel(`${base} (${suffix})`);
+        if (!used.has(candidate)) {
+            return candidate;
+        }
+    }
+    return base;
+}
+
+/** Wrap a label that has already been sanitized and de-duplicated. */
+export function buildContextToken(label: string): string {
+    return `#[${label}]`;
+}
+
+/** Every complete token in the text, in the order they appear. */
+export function parseContextTokens(text: string): ParsedContextToken[] {
+    const value = String(text ?? '');
+    const found: ParsedContextToken[] = [];
+
+    // A fresh regex per call: CONTEXT_TOKEN_PATTERN is global, and sharing `lastIndex` across
+    // calls makes results depend on who parsed last.
+    const pattern = new RegExp(CONTEXT_TOKEN_PATTERN.source, 'g');
+    let match = pattern.exec(value);
+    while (match !== null) {
+        found.push({
+            label: match[1],
+            token: match[0],
+            start: match.index,
+            end: match.index + match[0].length,
+        });
+        match = pattern.exec(value);
+    }
+    return found;
+}
+
+/**
+ * The `#` query the caret is currently inside, if any.
+ *
+ * The `#` must open a word -- at the very start, or straight after whitespace -- so a markdown
+ * heading is unaffected and `C#` mid-sentence does not open the menu.
+ *
+ * A `#` immediately followed by `[` is a token, not a query. Without that rule, clicking just
+ * after the hash of an existing `#[Contract.pdf]` reopens the menu over a reference that has
+ * already been resolved.
+ */
+export function readContextQuery(text: string, caret: number): ContextQuery | null {
+    const value = String(text ?? '');
+    const position = Math.max(0, Math.min(caret, value.length));
+
+    const hashIndex = value.lastIndexOf('#', position - 1);
+    if (hashIndex === -1) {
+        return null;
+    }
+
+    const preceding = hashIndex === 0 ? '' : value[hashIndex - 1];
+    if (preceding && !/\s/.test(preceding)) {
+        return null;
+    }
+
+    if (value[hashIndex + 1] === '[') {
+        return null;
+    }
+
+    const query = value.slice(hashIndex + 1, position);
+    if (query.includes('\n') || query.length > MAX_CONTEXT_QUERY_LENGTH) {
+        return null;
+    }
+    // `# ` is a hash in prose. Left alone it trims to empty, which the suggestion builder
+    // reads as "offer everything", holding the menu open over an ordinary sentence and
+    // swallowing the Enter meant to send it. `]` and `[` end it for the same reason.
+    if (/^\s/.test(query) || /[[\]]/.test(query)) {
+        return null;
+    }
+
+    return { query, start: hashIndex, end: position };
+}
+
+/**
+ * Replace the `#` query under the caret with a finished token.
+ *
+ * A trailing space is added so the next word does not run into the closing bracket, but only
+ * when the following text does not already begin with whitespace -- otherwise picking two
+ * references in a row leaves a widening gap between them.
+ */
+export function insertContextToken(
+    text: string,
+    start: number,
+    end: number,
+    token: string,
+): { text: string; caret: number } {
+    const value = String(text ?? '');
+    const from = Math.max(0, Math.min(start, value.length));
+    const to = Math.max(from, Math.min(end, value.length));
+
+    const before = value.slice(0, from);
+    const after = value.slice(to);
+
+    const lead = before && !/\s$/.test(before) ? ' ' : '';
+    const trail = /^\s/.test(after) ? '' : ' ';
+
+    return {
+        text: `${before}${lead}${token}${trail}${after}`,
+        caret: before.length + lead.length + token.length + trail.length,
+    };
+}
+
+/**
+ * Append a token to the end of the text.
+ *
+ * Used by the picker popover and by the workspace hand-off, neither of which has a `#` query
+ * to replace. The hand-off arrives with an empty composer, so the leading separator rule keeps
+ * it from opening on a stray space.
+ */
+export function appendContextToken(text: string, token: string): string {
+    const value = String(text ?? '');
+    const lead = value && !/\s$/.test(value) ? ' ' : '';
+    return `${value}${lead}${token} `;
+}
+
+/**
+ * Remove every occurrence of a token.
+ *
+ * Removal has to tidy after itself: deleting the token from `compare #[A] with #[B]` by simple
+ * excision leaves a double space, and doing that a few times leaves a line of them. When the
+ * token had whitespace on both sides, one space is kept.
+ */
+export function removeContextToken(text: string, token: string): string {
+    const value = String(text ?? '');
+    if (!token || !value.includes(token)) {
+        return value;
+    }
+
+    let result = '';
+    let cursor = 0;
+    for (;;) {
+        const at = value.indexOf(token, cursor);
+        if (at === -1) {
+            result += value.slice(cursor);
+            break;
+        }
+
+        const before = value.slice(cursor, at);
+        const afterIndex = at + token.length;
+        const followedBySpace = /^[^\S\n]/.test(value.slice(afterIndex));
+        const precededBySpace = /[^\S\n]$/.test(before);
+        // End of the text, or end of the line, is a seam too: a token removed from there
+        // would otherwise leave the space that used to separate it dangling.
+        const atEdge = afterIndex >= value.length || value[afterIndex] === '\n';
+
+        // Drop one side of the gap the token used to sit in, so the join reads as a single
+        // space rather than the two that surrounded it.
+        result += precededBySpace && (followedBySpace || atEdge) ? before.slice(0, -1) : before;
+        cursor = followedBySpace && !precededBySpace ? afterIndex + 1 : afterIndex;
+    }
+
+    return result;
+}
+
+/**
+ * Drop the items whose token is no longer in the text.
+ *
+ * This is what makes editing the sentence a supported way of removing a reference: backspacing
+ * through `#[Q3 Contract.pdf]` retires the chip, rather than leaving a chip that still puts the
+ * document in the request while the message no longer mentions it.
+ *
+ * Order follows the chip list, not the text, so removing one reference does not reshuffle the
+ * row underneath the pointer.
+ */
+export function reconcileContextItems<T extends { token: string }>(
+    text: string,
+    items: readonly T[],
+): T[] {
+    if (items.length === 0) {
+        return [];
+    }
+
+    const present = new Set(parseContextTokens(text).map((entry) => entry.token));
+    return items.filter((item) => present.has(item.token));
+}

--- a/application/v2_ui/src/lib/contextMentions.ts
+++ b/application/v2_ui/src/lib/contextMentions.ts
@@ -1,0 +1,331 @@
+// contextMentions.ts
+// Finding the documents, tags and workspaces the `#` menu and the picker popover offer.
+//
+// The composer can point at three kinds of thing living in three different places, and the
+// server has no single endpoint that spans them: personal documents, group documents and
+// public workspace documents are three routes with three permission models. So the search is
+// a fan-out, and the rules that matter are about what happens when part of it fails.
+//
+// Every request is settled independently. A user who belongs to a group whose document index
+// is briefly unavailable still gets their personal documents, because the alternative -- one
+// rejected promise emptying the whole menu -- reads to them as "none of my documents exist".
+//
+// Tags are cached briefly. They are a small, slow-changing vocabulary fetched whole rather
+// than searched server-side, and re-fetching three tag lists on every debounced keystroke is
+// work that buys nothing.
+
+import {
+    fetchGroupDocumentTags,
+    fetchGroupDocuments,
+    fetchPersonalDocumentTags,
+    fetchPersonalDocuments,
+    fetchPublicWorkspaceDocumentTags,
+    fetchPublicWorkspaceDocuments,
+} from './endpoints';
+import { documentId } from './documentExplorer';
+import {
+    PERSONAL_SCOPE,
+    contextKey,
+    documentContextItem,
+    groupScope,
+    publicScope,
+    scopeContextItem,
+    tagContextItem,
+    type ContextItem,
+    type ContextKind,
+    type ContextOrigin,
+    type ContextScopeRef,
+} from './chatContext';
+import type { WorkspaceDocument, WorkspaceRef, WorkspaceTag } from './types';
+
+/** How many rows of each kind a query offers before the menu starts to feel like a list. */
+const DOCUMENTS_PER_SCOPE = 6;
+const TAG_LIMIT = 5;
+const SCOPE_LIMIT = 3;
+
+/** How long a fetched tag vocabulary stays good for. */
+const TAG_CACHE_MS = 60_000;
+
+export interface ContextCandidate {
+    /** Matches the `key` of the item this becomes, so membership can be tested before building. */
+    key: string;
+    kind: ContextKind;
+    label: string;
+    subtitle?: string;
+    scope: ContextScopeRef;
+    /** Present for documents, so the item keeps the metadata its tooltip shows. */
+    document?: WorkspaceDocument;
+}
+
+export interface ContextSearchOptions {
+    query: string;
+    groups?: readonly WorkspaceRef[];
+    publicWorkspaces?: readonly WorkspaceRef[];
+    /** Whether the deployment offers these at all; both routes are `@enabled_required`. */
+    groupsEnabled?: boolean;
+    publicEnabled?: boolean;
+    signal?: AbortSignal;
+}
+
+/** Build the item a chosen candidate becomes. */
+export function candidateToContextItem(
+    candidate: ContextCandidate,
+    existing: readonly ContextItem[],
+    origin: ContextOrigin = 'user',
+): ContextItem {
+    if (candidate.kind === 'document' && candidate.document) {
+        return documentContextItem(candidate.document, candidate.scope, existing, origin);
+    }
+    if (candidate.kind === 'tag') {
+        return tagContextItem(candidate.label, candidate.scope, existing, origin);
+    }
+    return scopeContextItem(candidate.scope, existing, origin);
+}
+
+function documentCandidate(
+    document: WorkspaceDocument,
+    scope: ContextScopeRef,
+): ContextCandidate | null {
+    const id = documentId(document);
+    if (!id) {
+        return null;
+    }
+
+    const title = String(document.title ?? '').trim();
+    const fileName = String(document.file_name ?? '').trim();
+
+    return {
+        key: contextKey('document', id, scope),
+        kind: 'document',
+        label: title || fileName || 'Untitled',
+        // The scope leads: which workspace a document is in is the thing a reader cannot
+        // infer from its name, and it is what makes two similarly named files tellable apart.
+        subtitle: title && fileName && title !== fileName
+            ? `${scope.name} · ${fileName}`
+            : scope.name,
+        scope,
+        document,
+    };
+}
+
+/**
+ * Which workspace a returned document belongs to.
+ *
+ * The group and public routes can each return documents from several workspaces in one
+ * response, so the scope is read off the document rather than assumed from the request.
+ */
+function scopeForDocument(
+    document: WorkspaceDocument,
+    fallback: ContextScopeRef,
+    byGroupId: Map<string, ContextScopeRef>,
+    byWorkspaceId: Map<string, ContextScopeRef>,
+): ContextScopeRef {
+    const groupId = String(document.group_id ?? '').trim();
+    if (groupId) {
+        return byGroupId.get(groupId) ?? fallback;
+    }
+    const workspaceId = String(document.public_workspace_id ?? '').trim();
+    if (workspaceId) {
+        return byWorkspaceId.get(workspaceId) ?? fallback;
+    }
+    return fallback;
+}
+
+/** Run a request that must not be able to empty the whole menu when it fails. */
+async function settled<T>(work: Promise<T>, fallback: T): Promise<T> {
+    try {
+        return await work;
+    } catch {
+        // Advisory: the other scopes are unaffected, and a partial menu is more useful than
+        // an empty one with no explanation.
+        return fallback;
+    }
+}
+
+/* -------------------------------------------------------------------------- */
+/* Tag vocabulary                                                              */
+/* -------------------------------------------------------------------------- */
+
+interface ScopedTag {
+    name: string;
+    scope: ContextScopeRef;
+}
+
+let tagCache: { at: number; tags: ScopedTag[] } | null = null;
+let tagCacheKey = '';
+
+/** Drop the memoized tag vocabulary, for when one has just been created or renamed. */
+export function clearContextTagCache(): void {
+    tagCache = null;
+}
+
+function readTags(payload: { tags?: WorkspaceTag[] } | null, scope: ContextScopeRef): ScopedTag[] {
+    return (payload?.tags ?? [])
+        .map((tag) => String(tag?.name ?? '').trim())
+        .filter(Boolean)
+        .map((name) => ({ name, scope }));
+}
+
+async function loadTags(options: ContextSearchOptions): Promise<ScopedTag[]> {
+    // Keyed on which scopes are in play, so enabling a group does not keep serving a
+    // vocabulary gathered before it was reachable.
+    const key = [
+        options.groupsEnabled ? 'g' : '',
+        options.publicEnabled ? 'p' : '',
+        (options.groups ?? []).map((group) => group.id).join(','),
+    ].join('|');
+
+    if (tagCache && tagCacheKey === key && Date.now() - tagCache.at < TAG_CACHE_MS) {
+        return tagCache.tags;
+    }
+
+    const [personal, group, publicTags] = await Promise.all([
+        settled(fetchPersonalDocumentTags(options.signal), { tags: [] }),
+        options.groupsEnabled
+            ? settled(fetchGroupDocumentTags(options.signal), { tags: [] })
+            : Promise.resolve({ tags: [] as WorkspaceTag[] }),
+        options.publicEnabled
+            ? settled(fetchPublicWorkspaceDocumentTags(options.signal), { tags: [] })
+            : Promise.resolve({ tags: [] as WorkspaceTag[] }),
+    ]);
+
+    const firstGroup = (options.groups ?? [])[0];
+    const firstPublic = (options.publicWorkspaces ?? [])[0];
+
+    const tags = [
+        ...readTags(personal, PERSONAL_SCOPE),
+        // The tag routes return a vocabulary rather than per-workspace lists, so a group tag
+        // is attributed to the group the user is working in. Getting this wrong only affects
+        // which workspace the chip widens the search to, never whether the tag itself matches.
+        ...(firstGroup ? readTags(group, groupScope(firstGroup)) : []),
+        ...(firstPublic ? readTags(publicTags, publicScope(firstPublic)) : []),
+    ];
+
+    // A superseded keystroke aborts these requests, and `settled` reports an abort as an
+    // empty vocabulary. Caching that would answer every `#` for the next minute with no tags
+    // at all -- and typing is exactly what aborts them, so it would be the common case.
+    if (!options.signal?.aborted) {
+        tagCache = { at: Date.now(), tags };
+        tagCacheKey = key;
+    }
+    return tags;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Search                                                                      */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * The candidates a `#` query offers.
+ *
+ * Documents lead because they are the specific thing; tags and whole workspaces are broader
+ * and sit below. An empty query is not treated as "match nothing" -- it offers the most
+ * recently touched documents, which is what makes a bare `#` useful rather than a dead end.
+ */
+export async function searchContextCandidates(
+    options: ContextSearchOptions,
+): Promise<ContextCandidate[]> {
+    const needle = String(options.query ?? '').trim();
+    const lowered = needle.toLowerCase();
+
+    const groups = options.groups ?? [];
+    const publicWorkspaces = options.publicWorkspaces ?? [];
+    const groupIds = groups.map((group) => String(group.id ?? '')).filter(Boolean);
+
+    const byGroupId = new Map(groupIds.map((id, index) => [id, groupScope(groups[index])]));
+    const byWorkspaceId = new Map(
+        publicWorkspaces
+            .map((workspace) => [String(workspace.id ?? ''), publicScope(workspace)] as const)
+            .filter(([id]) => Boolean(id)),
+    );
+
+    const listQuery = { search: needle, page: 1, pageSize: DOCUMENTS_PER_SCOPE };
+
+    const [personal, groupDocs, publicDocs, tags] = await Promise.all([
+        settled(fetchPersonalDocuments(listQuery, options.signal), { documents: [] }),
+        options.groupsEnabled && groupIds.length > 0
+            ? settled(fetchGroupDocuments(groupIds, listQuery, options.signal), {
+                  documents: [],
+              })
+            : Promise.resolve({ documents: [] as WorkspaceDocument[] }),
+        options.publicEnabled
+            ? settled(fetchPublicWorkspaceDocuments(listQuery, options.signal), {
+                  documents: [],
+              })
+            : Promise.resolve({ documents: [] as WorkspaceDocument[] }),
+        settled(loadTags(options), [] as ScopedTag[]),
+    ]);
+
+    const candidates: ContextCandidate[] = [];
+    const seen = new Set<string>();
+
+    const push = (candidate: ContextCandidate | null) => {
+        if (candidate && !seen.has(candidate.key)) {
+            seen.add(candidate.key);
+            candidates.push(candidate);
+        }
+    };
+
+    for (const document of personal.documents ?? []) {
+        push(documentCandidate(document, PERSONAL_SCOPE));
+    }
+
+    // A response can mix workspaces, so each document names its own; these only cover the
+    // case where the id is missing from the record entirely.
+    const groupFallback = groups[0] ? groupScope(groups[0]) : PERSONAL_SCOPE;
+    const publicFallback = publicWorkspaces[0]
+        ? publicScope(publicWorkspaces[0])
+        : PERSONAL_SCOPE;
+
+    for (const document of groupDocs.documents ?? []) {
+        push(
+            documentCandidate(
+                document,
+                scopeForDocument(document, groupFallback, byGroupId, byWorkspaceId),
+            ),
+        );
+    }
+    for (const document of publicDocs.documents ?? []) {
+        push(
+            documentCandidate(
+                document,
+                scopeForDocument(document, publicFallback, byGroupId, byWorkspaceId),
+            ),
+        );
+    }
+
+    // Tags and workspaces are filtered here rather than server-side: both are short lists
+    // already in hand, and a round trip per keystroke to narrow a dozen names is not worth it.
+    const matchedTags = tags
+        .filter((tag) => !lowered || tag.name.toLowerCase().includes(lowered))
+        .slice(0, TAG_LIMIT);
+    for (const tag of matchedTags) {
+        push({
+            key: contextKey('tag', tag.name, tag.scope),
+            kind: 'tag',
+            label: tag.name,
+            subtitle: `Tag · ${tag.scope.name}`,
+            scope: tag.scope,
+        });
+    }
+
+    const allScopes: ContextScopeRef[] = [
+        PERSONAL_SCOPE,
+        ...(options.groupsEnabled ? groups.map(groupScope) : []),
+        ...(options.publicEnabled ? publicWorkspaces.map(publicScope) : []),
+    ];
+    const matchedScopes = allScopes
+        .filter((scope) => !lowered || scope.name.toLowerCase().includes(lowered))
+        .slice(0, SCOPE_LIMIT);
+    for (const scope of matchedScopes) {
+        push({
+            key: contextKey('scope', scope.id ?? 'personal', scope),
+            kind: 'scope',
+            label: scope.name,
+            subtitle: 'Everything in this workspace',
+            scope,
+        });
+    }
+
+    return candidates;
+}

--- a/application/v2_ui/src/lib/documentScope.ts
+++ b/application/v2_ui/src/lib/documentScope.ts
@@ -19,6 +19,17 @@ export interface ScopeState {
     activeGroupId?: string | null;
     /** The public workspace the user is currently working in, if any. */
     activePublicWorkspaceId?: string | null;
+    /**
+     * Groups named by the composer's context chips.
+     *
+     * Without these a chip pointing at a group document is unreachable: the server filters the
+     * requested ids down to what the caller may see, and a group whose id was never sent is not
+     * in that set. The document would simply be missing from the answer, with nothing to say
+     * why -- which is the same failure this file was written about, arriving by a new route.
+     */
+    contextGroupIds?: readonly string[];
+    /** Public workspaces named by the composer's context chips, for the same reason. */
+    contextPublicWorkspaceIds?: readonly string[];
 }
 
 export interface DocumentScopeRequest {
@@ -33,18 +44,37 @@ function id(value: unknown): string {
     return typeof value === 'string' ? value.trim() : '';
 }
 
+/** Union of the workspace currently in play and any the chips name, in that order. */
+function mergeIds(active: unknown, fromContext: readonly string[] | undefined): string[] {
+    const merged: string[] = [];
+    const seen = new Set<string>();
+
+    for (const candidate of [id(active), ...(fromContext ?? [])]) {
+        const value = id(candidate);
+        if (value && !seen.has(value)) {
+            seen.add(value);
+            merged.push(value);
+        }
+    }
+    return merged;
+}
+
 /**
  * Resolve the scope for a document search.
  *
- * Personal documents are always in scope: the interface has no control for excluding them,
- * so treating them as always selected matches what the user sees.
+ * Personal documents are always in scope. That was originally because the interface had no
+ * control for excluding them, and it stays true now that the chip row does: narrowing the
+ * scope to the kinds the chips happen to mention would drop personal results that the caller
+ * never asked to exclude, and a search that silently covers less is the harder failure to
+ * notice. The real narrowing is done by `selected_document_ids` and `tags_filter`, which
+ * constrain the result set directly rather than by omission.
  */
 export function resolveDocumentScope(scope: ScopeState | undefined): DocumentScopeRequest {
-    const groupId = id(scope?.activeGroupId);
-    const publicId = id(scope?.activePublicWorkspaceId);
-
-    const groupIds = groupId ? [groupId] : [];
-    const publicIds = publicId ? [publicId] : [];
+    const groupIds = mergeIds(scope?.activeGroupId, scope?.contextGroupIds);
+    const publicIds = mergeIds(
+        scope?.activePublicWorkspaceId,
+        scope?.contextPublicWorkspaceIds,
+    );
 
     // Personal is always in play, so any additional workspace widens the search to 'all'
     // rather than replacing it.

--- a/application/v2_ui/src/lib/documentTitles.ts
+++ b/application/v2_ui/src/lib/documentTitles.ts
@@ -1,0 +1,173 @@
+// documentTitles.ts
+// Turning document ids into something a reader recognises.
+//
+// The orchestration plan names its documents by id, because that is what the planner works in
+// and what `apply_plan_edits` matches on. Shown to a person unchanged, a step reads:
+//
+//     document_ids: 8f14e45f-ceea-467a-9f47-2c7a1d0b3e55
+//
+// which tells them nothing about whether the planner picked the right contract -- and deciding
+// exactly that is the entire purpose of showing them the plan before it runs.
+//
+// Resolution is best-effort and cached, including its failures. A document may have been
+// deleted, or belong to a workspace the caller can no longer read; re-asking for it on every
+// render would turn one unresolvable id into a stream of requests.
+
+import { useEffect, useState } from 'react';
+import {
+    fetchGroupDocument,
+    fetchPersonalDocument,
+    fetchPublicWorkspaceDocuments,
+} from './endpoints';
+import { documentDisplayName, documentId as readDocumentId } from './documentExplorer';
+
+/** id -> title, or null for "asked, and it could not be resolved". */
+const titles = new Map<string, string | null>();
+/** In-flight lookups, so ten chips for one id make one request. */
+const pending = new Map<string, Promise<string | null>>();
+
+let publicIndex: Map<string, string> | null = null;
+let publicIndexLoading: Promise<void> | null = null;
+
+/**
+ * Index the public workspace documents once.
+ *
+ * There is no single-document route for these -- only `/versions` -- so the visible list is
+ * the only way to name one. It is bounded by what the user has surfaced in their directory.
+ */
+async function ensurePublicIndex(signal?: AbortSignal): Promise<void> {
+    if (publicIndex || publicIndexLoading) {
+        await publicIndexLoading;
+        return;
+    }
+
+    publicIndexLoading = (async () => {
+        try {
+            const listed = await fetchPublicWorkspaceDocuments({ page: 1, pageSize: 250 }, signal);
+            publicIndex = new Map(
+                (listed.documents ?? []).map((document) => [
+                    readDocumentId(document),
+                    documentDisplayName(document).primary,
+                ]),
+            );
+        } catch {
+            // An abort is not an answer. Caching an empty index for one would leave every
+            // public document shown by id for the rest of the session, and StrictMode aborts
+            // the first run of every effect on mount.
+            if (!signal?.aborted) {
+                publicIndex = new Map();
+            }
+        } finally {
+            publicIndexLoading = null;
+        }
+    })();
+
+    await publicIndexLoading;
+}
+
+async function lookup(id: string, signal?: AbortSignal): Promise<string | null> {
+    // Personal first: it is both the most common case and the only one with a cheap exact
+    // route. Group second. Public last, because it costs a list.
+    try {
+        return documentDisplayName(await fetchPersonalDocument(id, signal)).primary;
+    } catch {
+        // Not personal, or not readable as personal. Fall through.
+    }
+
+    try {
+        return documentDisplayName(await fetchGroupDocument(id, signal)).primary;
+    } catch {
+        // Not a group document either.
+    }
+
+    try {
+        await ensurePublicIndex(signal);
+        return publicIndex?.get(id) ?? null;
+    } catch {
+        return null;
+    }
+}
+
+/** Resolve ids, reusing anything already known or already being fetched. */
+export async function resolveDocumentTitles(
+    ids: readonly string[],
+    signal?: AbortSignal,
+): Promise<Map<string, string>> {
+    await Promise.all(
+        ids
+            .filter((id) => id && !titles.has(id))
+            .map((id) => {
+                const existing = pending.get(id);
+                if (existing) {
+                    return existing;
+                }
+                const work = lookup(id, signal)
+                    .then((title) => {
+                        // A cancelled lookup has not established that the document is
+                        // unnameable, so it must not be remembered as one -- `titles.has(id)`
+                        // would then skip it forever and the chip would show a bare uuid for
+                        // the rest of the session. StrictMode aborts the first run of every
+                        // effect on mount, so this is the ordinary path, not the rare one.
+                        if (!signal?.aborted) {
+                            titles.set(id, title);
+                        }
+                        return title;
+                    })
+                    .finally(() => pending.delete(id));
+                pending.set(id, work);
+                return work;
+            }),
+    );
+
+    const resolved = new Map<string, string>();
+    for (const id of ids) {
+        const title = titles.get(id);
+        if (title) {
+            resolved.set(id, title);
+        }
+    }
+    return resolved;
+}
+
+/**
+ * Titles for a set of ids, filled in as they arrive.
+ *
+ * Returns a map rather than a list so a caller can render the id immediately and swap in the
+ * name when it lands, instead of holding the whole plan back on a lookup.
+ */
+export function useDocumentTitles(ids: readonly string[]): Map<string, string> {
+    const key = ids.join(',');
+    const [resolved, setResolved] = useState<Map<string, string>>(() => {
+        const known = new Map<string, string>();
+        for (const id of ids) {
+            const title = titles.get(id);
+            if (title) {
+                known.set(id, title);
+            }
+        }
+        return known;
+    });
+
+    useEffect(() => {
+        if (ids.length === 0) {
+            return;
+        }
+        const controller = new AbortController();
+        let cancelled = false;
+
+        void resolveDocumentTitles(ids, controller.signal).then((found) => {
+            if (!cancelled) {
+                setResolved(found);
+            }
+        });
+
+        return () => {
+            cancelled = true;
+            controller.abort();
+        };
+        // Keyed on the joined ids: the array is rebuilt on every render, and depending on its
+        // identity would restart the lookup forever.
+    }, [key]);
+
+    return resolved;
+}

--- a/application/v2_ui/src/lib/endpoints.ts
+++ b/application/v2_ui/src/lib/endpoints.ts
@@ -1387,6 +1387,59 @@ export const reprocessPersonalDocumentExtraction = (
         { document_ids: documentIds, extraction_mode: extractionMode },
     );
 
+/* --- Group and public workspace documents -------------------------------- */
+
+/**
+ * List documents in one or more groups.
+ *
+ * `group_ids` is honoured by `/api/group_documents` as a comma-separated multi-group mode,
+ * with each group validated against the caller's membership and non-members silently dropped.
+ * Passing them explicitly rather than relying on the active group is what lets the composer's
+ * picker search every group the user belongs to at once, instead of only the one the classic
+ * workspace happens to have selected.
+ */
+export function fetchGroupDocuments(
+    groupIds: readonly string[],
+    query: Partial<DocumentQuery> = {},
+    signal?: AbortSignal,
+) {
+    const params = buildDocumentListParams(query);
+    const ids = groupIds.filter(Boolean).join(',');
+    return api.get<DocumentListResponse>(
+        `/api/group_documents?${params}${ids ? `&group_ids=${encodeURIComponent(ids)}` : ''}`,
+        signal,
+    );
+}
+
+/**
+ * List documents across every public workspace the user has made visible.
+ *
+ * The route derives the set from `publicDirectorySettings` rather than taking ids, so a
+ * workspace the user has not surfaced in their directory is not searchable here — which
+ * matches what the rest of the interface shows them.
+ */
+export function fetchPublicWorkspaceDocuments(
+    query: Partial<DocumentQuery> = {},
+    signal?: AbortSignal,
+) {
+    return api.get<DocumentListResponse>(
+        `/api/public_workspace_documents?${buildDocumentListParams(query)}`,
+        signal,
+    );
+}
+
+export const fetchGroupDocumentTags = (signal?: AbortSignal) =>
+    api.get<{ tags?: WorkspaceTag[] }>('/api/group_documents/tags', signal);
+
+export const fetchGroupDocument = (documentId: string, signal?: AbortSignal) =>
+    api.get<WorkspaceDocument>(
+        `/api/group_documents/${encodeURIComponent(documentId)}`,
+        signal,
+    );
+
+export const fetchPublicWorkspaceDocumentTags = (signal?: AbortSignal) =>
+    api.get<{ tags?: WorkspaceTag[] }>('/api/public_workspace_documents/tags', signal);
+
 /* --- Tags ---------------------------------------------------------------- */
 
 export const fetchPersonalDocumentTags = (signal?: AbortSignal) =>

--- a/application/v2_ui/src/lib/types.ts
+++ b/application/v2_ui/src/lib/types.ts
@@ -942,6 +942,20 @@ export interface ChatStreamRequest {
     doc_scope?: string;
     selected_document_id?: string | null;
     selected_document_ids?: string[];
+    /**
+     * Tag names to filter on, read as `tags_filter` by `hybrid_search`.
+     *
+     * Joined with `and` by `build_tags_filter`, so a document must carry every tag sent here.
+     */
+    tags?: string[];
+    /**
+     * How `selected_document_ids` and `tags` combine.
+     *
+     * `_build_document_content_filter` defaults to `intersection`, which requires a picked
+     * document to also carry every picked tag. The composer sends `union` when it has both,
+     * so its chips add context instead of cancelling each other out.
+     */
+    document_filter_mode?: 'union' | 'intersection';
     active_group_id?: string | null;
     active_group_ids?: string[];
     active_public_workspace_id?: string | null;

--- a/application/v2_ui/src/pages/workspace/TagsSection.tsx
+++ b/application/v2_ui/src/pages/workspace/TagsSection.tsx
@@ -12,9 +12,15 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import { clsx } from 'clsx';
-import { Loader2, Merge, Plus, Tag as TagIcon, Trash2 } from 'lucide-react';
-import { Link } from 'react-router-dom';
+import { Loader2, Merge, MessageSquare, Plus, Tag as TagIcon, Trash2 } from 'lucide-react';
+import { Link, useNavigate } from 'react-router-dom';
 import type { WorkspaceTag } from '../../lib/types';
+import {
+    buildContextHandoffParams,
+    type ContextHandoffState,
+} from '../../lib/chatContextHandoff';
+import { PERSONAL_SCOPE } from '../../lib/chatContext';
+import { clearContextTagCache } from '../../lib/contextMentions';
 import {
     createPersonalDocumentTag,
     deletePersonalDocumentTag,
@@ -46,6 +52,7 @@ function TagRow({
     onRename,
     onRecolour,
     onDelete,
+    onChat,
 }: {
     tag: WorkspaceTag;
     busy: boolean;
@@ -53,6 +60,7 @@ function TagRow({
     onRename: (name: string) => void;
     onRecolour: (color: string) => void;
     onDelete: () => void;
+    onChat: () => void;
 }) {
     const [editing, setEditing] = useState(false);
     const [draftName, setDraftName] = useState(tag.name);
@@ -149,6 +157,23 @@ function TagRow({
                 {tag.count ?? 0} {tag.count === 1 ? 'document' : 'documents'}
             </span>
 
+            {/* Chatting against a tag is the reason most of them exist: it is how a grouping
+                becomes a body of material to ask questions of, rather than a filing label. */}
+            <button
+                type="button"
+                onClick={onChat}
+                disabled={!tag.count}
+                aria-label={`Chat with documents tagged ${tag.name}`}
+                title={
+                    tag.count
+                        ? `Chat with documents tagged ${tag.name}`
+                        : 'No documents carry this tag yet'
+                }
+                className="shrink-0 rounded-lg p-1.5 text-text-3 transition-colors hover:bg-accent-soft hover:text-accent disabled:opacity-40"
+            >
+                <MessageSquare size={15} />
+            </button>
+
             <button
                 type="button"
                 onClick={onDelete}
@@ -164,6 +189,7 @@ function TagRow({
 }
 
 export function TagsSection({ documentsEnabled }: { documentsEnabled: boolean }) {
+    const navigate = useNavigate();
     const [tags, setTags] = useState<WorkspaceTag[]>([]);
     const [loading, setLoading] = useState(true);
     const [busy, setBusy] = useState(false);
@@ -185,9 +211,38 @@ export function TagsSection({ documentsEnabled }: { documentsEnabled: boolean })
         }
     };
 
+    /**
+     * Reload after a change, and drop the composer's memoized vocabulary with it.
+     *
+     * The `#` menu caches the tag list for a minute so it is not re-fetched on every
+     * keystroke. Without this, a tag created or renamed here would be missing from that menu
+     * -- or offered under its old name -- for up to that long afterwards.
+     */
+    const reload = async () => {
+        clearContextTagCache();
+        await load();
+    };
+
     useEffect(() => {
         void load();
     }, []);
+
+    /**
+     * Take a tag to the composer as a context chip.
+     *
+     * The tag travels as a filter rather than as the documents carrying it, so the message
+     * searches whatever holds the tag when it is sent rather than a list captured here.
+     */
+    const onChat = (tag: WorkspaceTag) => {
+        const query = buildContextHandoffParams({
+            tags: [tag.name],
+            docScope: 'personal',
+        });
+        const state: ContextHandoffState = {
+            contextTags: [{ name: tag.name, scope: PERSONAL_SCOPE }],
+        };
+        navigate(`/chat?${query}`, { state });
+    };
 
     const visible = useMemo(() => {
         const needle = query.trim().toLowerCase();
@@ -209,7 +264,7 @@ export function TagsSection({ documentsEnabled }: { documentsEnabled: boolean })
         try {
             await createPersonalDocumentTag(name, newColor);
             setNewName('');
-            await load();
+            await reload();
             toast.success(`Created "${name}".`);
         } catch (createError) {
             toast.error(errorMessage(createError, 'Could not create the tag.'));
@@ -225,7 +280,7 @@ export function TagsSection({ documentsEnabled }: { documentsEnabled: boolean })
         setBusy(true);
         try {
             const response = await updatePersonalDocumentTag(tag.name, { new_name: name });
-            await load();
+            await reload();
             const updated = response.documents_updated ?? 0;
             toast.success(
                 updated > 0
@@ -249,7 +304,7 @@ export function TagsSection({ documentsEnabled }: { documentsEnabled: boolean })
             await updatePersonalDocumentTag(tag.name, { color });
         } catch (colourError) {
             toast.error(errorMessage(colourError, 'Could not save the colour.'));
-            await load();
+            await reload();
         }
     };
 
@@ -265,7 +320,7 @@ export function TagsSection({ documentsEnabled }: { documentsEnabled: boolean })
         setBusy(true);
         try {
             await deletePersonalDocumentTag(tag.name);
-            await load();
+            await reload();
             toast.success(`Deleted "${tag.name}".`);
         } catch (deleteError) {
             toast.error(errorMessage(deleteError, 'Could not delete the tag.'));
@@ -375,6 +430,7 @@ export function TagsSection({ documentsEnabled }: { documentsEnabled: boolean })
                                 onRename={(name) => void onRename(tag, name)}
                                 onRecolour={(color) => void onRecolour(tag, color)}
                                 onDelete={() => void onDelete(tag)}
+                                onChat={() => onChat(tag)}
                             />
                         ))}
                     </ul>

--- a/application/v2_ui/src/stores/chatStore.ts
+++ b/application/v2_ui/src/stores/chatStore.ts
@@ -86,6 +86,13 @@ import {
 } from '../lib/conversationSelection';
 import type { ModelCatalogEntry } from '../lib/models';
 import { resolveDocumentScope } from '../lib/documentScope';
+import {
+    contextDocumentIds,
+    contextFilterMode,
+    contextScopes,
+    contextTags,
+    type ContextItem,
+} from '../lib/chatContext';
 import { messageThreadId } from '../lib/threads';
 import { proposalSourceMessageId, type ImageProposalSpec } from '../lib/imageProposalSpec';
 import { toast } from './toastStore';
@@ -176,7 +183,15 @@ export interface ComposerOptions {
     /** Deep research sets both source_review_enabled and deep_research_enabled. */
     deepResearch: boolean;
     urlAccess: boolean;
-    selectedDocumentIds: string[];
+    /**
+     * What this message is grounded in: documents, tags and workspaces chosen in the composer.
+     *
+     * Replaces the write-only `selectedDocumentIds` this interface shipped with, which was
+     * declared, forwarded to both the chat request and the orchestration seeds, and never
+     * populated by anything. The document ids are now derived from here at send time, so
+     * everything downstream that already reads `selected_document_ids` is unchanged.
+     */
+    contextItems: ContextItem[];
 }
 
 interface ChatState {
@@ -2283,9 +2298,19 @@ export const useChatStore = create<ChatState>((set, get) => ({
             return;
         }
 
+        // Derived once here rather than at each field: the chip row is the single source of
+        // truth for what this message is pointed at, and the request is three views of it.
+        const contextItems = options.contextItems ?? [];
+        const contextDocuments = contextDocumentIds(contextItems);
+        const contextTagNames = contextTags(contextItems);
+        const contextWorkspaces = contextScopes(contextItems);
+        const filterMode = contextFilterMode(contextItems);
+
         const scope = resolveDocumentScope({
             activeGroupId: bootstrap?.scope?.active_group_id,
             activePublicWorkspaceId: bootstrap?.scope?.active_public_workspace_id,
+            contextGroupIds: contextWorkspaces.groupIds,
+            contextPublicWorkspaceIds: contextWorkspaces.publicWorkspaceIds,
         });
 
         const requestBody: ChatStreamRequest = {
@@ -2298,10 +2323,12 @@ export const useChatStore = create<ChatState>((set, get) => ({
             // `window.activeChatTabType` is read in two places and assigned in none — so
             // 'user' is what it actually sends, and matching that is the real parity.
             chat_type: 'user',
-            hybrid_search: options.documentSearch,
+            // Naming a document is itself a request to search: a chip the user added while
+            // the toggle happened to be off would otherwise be collected, sent, and ignored.
+            hybrid_search: options.documentSearch || contextDocuments.length > 0,
             web_search_enabled: options.webSearch,
             image_generation: options.imageGeneration,
-            selected_document_ids: options.selectedDocumentIds,
+            selected_document_ids: contextDocuments,
             // The scope and its workspace ids travel together: the server filters the ids
             // down to what the caller may see, so a scope without them covers nothing.
             // Document search is widened to the group this way, without re-scoping the
@@ -2313,6 +2340,15 @@ export const useChatStore = create<ChatState>((set, get) => ({
             deep_research_enabled: options.deepResearch,
             url_access_enabled: options.urlAccess,
         };
+
+        if (contextTagNames.length > 0) {
+            requestBody.tags = contextTagNames;
+        }
+        // Only when both kinds are present. With one kind the mode has no effect, and an
+        // unnecessary field in the request is one more thing to account for later.
+        if (filterMode) {
+            requestBody.document_filter_mode = filterMode;
+        }
 
         // Model identity, agent and reasoning level are mutually exclusive halves of the same
         // decision, resolved in one place. An agent answers with its own deployment, and a

--- a/docs/explanation/features/CHAT_CONTEXT_PICKER.md
+++ b/docs/explanation/features/CHAT_CONTEXT_PICKER.md
@@ -1,0 +1,158 @@
+# Chat Context Picker
+
+Choosing which documents a message is grounded in, and seeing that choice before
+you send it.
+
+**Implemented in version:** 0.261.087
+**Interface:** V2 only. The classic interface is unchanged.
+**Dependencies:** `enable_user_workspace` for personal documents,
+`enable_group_workspaces` and `enable_public_workspaces` to reach those scopes.
+
+## Overview
+
+The V2 composer's **Documents** button used to be a plain on/off switch. Turning
+it on meant "search my documents"; there was no way to say *which* documents,
+and nothing on screen said what a message would actually look at. Choosing
+documents in the workspace and pressing **Chat** navigated to the classic
+interface.
+
+This release replaces that with a context picker built around three ways of
+naming something, all feeding one visible list:
+
+- Type `#` in the message box and search.
+- Open the **Documents** button's picker and tick items.
+- Select documents or a tag in the workspace and press **Chat**.
+
+## What a reference looks like
+
+A chosen reference appears in two places at once, and this is deliberate.
+
+It becomes a **chip above the message box**, grouped by workspace, each with an
+`×` to remove it. And it stays **inside the message text** as `#[Q3 Contract.pdf]`,
+rendered as a highlighted chip rather than raw brackets. Keeping it in the text
+means the sentence still reads as a sentence — "compare `#[Q3 Contract.pdf]`
+against `#[Q2 Contract.pdf]`" — and the reference survives into the sent message
+rather than existing only as invisible request metadata.
+
+The two stay in step:
+
+- Removing a chip removes its `#[…]` text.
+- Editing or deleting the `#[…]` text retires its chip.
+- Typing `#[Something]` by hand does **not** create a chip. There is no document
+  behind it, and adopting one would ground the message in something nobody chose.
+
+### Condensing
+
+Chips render individually while there are five or fewer, showing the document
+name with the rest of its detail on hover. Past that, each workspace collapses to
+a single chip reading, for example, `Marketing · 7 documents`, which opens on
+click for per-item removal. Workspace grouping containers only appear when more
+than one workspace is involved.
+
+## The `#` menu
+
+Typing `#` at the start of a word opens a search over:
+
+- **Documents**, across your personal workspace, every group you belong to, and
+  every public workspace you have made visible — searched in parallel.
+- **Tags**, from each scope's tag vocabulary.
+- **Workspaces**, which add the whole workspace as context rather than pinning
+  the documents in it at the moment you chose it.
+
+The search is debounced, and each scope is requested independently: a group whose
+index is briefly unavailable does not empty the menu of your personal documents.
+
+`#` mid-word does not open the menu, so `C#` and `issue#42` are left alone, and a
+`#` followed by a space is treated as prose.
+
+## The Documents picker
+
+Clicking **Documents** opens a panel upward over the composer containing:
+
+- A search box, focused on open.
+- **Search all my documents**, which is the original on/off behaviour: find
+  whatever is most relevant rather than a fixed list.
+- Checkbox lists grouped by workspace.
+
+Ticking specific documents moves the request from relevance search to an explicit
+selection. The button shows a count once anything is chosen.
+
+## Handing off from the workspace
+
+Selecting documents in **My workspace → Documents** and pressing **Chat** now
+opens the V2 composer with those documents already referenced. Tags have a chat
+action of their own, which carries the tag as a filter rather than as the list of
+documents that happened to carry it when you clicked.
+
+The link uses the same query vocabulary as the classic interface
+(`search_documents`, `doc_scope`, `document_ids`, `tags`), so a link built by
+either interface is readable by both. The parameters are cleared once applied, so
+reloading does not silently re-apply a selection you have since cleared.
+
+## How it reaches the server
+
+| Chip kind | Request field |
+| --- | --- |
+| Document | `selected_document_ids` |
+| Tag | `tags`, which becomes `tags_filter` |
+| Workspace | `doc_scope` plus `active_group_ids` / `active_public_workspace_ids` |
+
+Two behaviours are worth knowing about:
+
+**Documents and tags are additive.** When a message carries both, the request
+sends `document_filter_mode: "union"`. The server's default is `intersection`,
+which requires a chosen document to *also* carry every chosen tag — so a document
+chip beside an unrelated tag chip would match nothing at all.
+
+**Multiple tags are combined with AND.** A document must carry every tag you
+select. This is the server's existing behaviour (`build_tags_filter`) and is
+unchanged here.
+
+Naming a document also switches document search on. A chip added while the toggle
+happened to be off would otherwise be collected, sent, and ignored.
+
+## Orchestration
+
+Chips travel to the planner as seeds. Naming documents explicitly also suppresses
+the planner's candidate probe, so it works from your choice rather than guessing
+at one.
+
+In the other direction, documents the planner chose are listed on each step of
+the plan **by name** rather than by id — deciding whether it picked the right
+contract is the reason the plan is shown before it runs, and a bare uuid does not
+support that decision. Documents can be removed from a step, which narrows the
+plan. Adding one is deliberately not offered inline: widening a plan goes back
+through planning, so a request never skips the reasoning and permission check
+that produced it.
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| `lib/chatContext.ts` | The context item model and the derived request fields |
+| `lib/chatContextTokens.ts` | The `#[…]` grammar, and chip/text reconciliation |
+| `lib/contextMentions.ts` | Cross-scope search for documents, tags and workspaces |
+| `lib/chatContextHandoff.ts` | Reading and building the workspace hand-off |
+| `lib/documentTitles.ts` | Cached id-to-title resolution for plan steps |
+| `components/chat/ContextChips.tsx` | The chip row and its condensing |
+| `components/chat/ComposerHighlight.tsx` | Inline rendering of `#[…]` in the message box |
+| `components/chat/ContextMenu.tsx` | The `#` menu |
+| `components/chat/DocumentPickerPopover.tsx` | The Documents button's picker |
+
+## Testing
+
+| Test | Covers |
+| --- | --- |
+| `functional_tests/test_v2_chat_context_tokens.mjs` | Token grammar: parsing, insertion, removal, reconciliation, collisions |
+| `functional_tests/test_v2_chat_context_request.ts` | Chip-to-request mapping, filter mode, scope resolution |
+| `functional_tests/test_v2_chat_context_picker.py` | Hand-off destination, composer wiring, chat metadata parity; bundles and runs the TypeScript checks |
+
+## Known limitations
+
+- Public workspace documents have no single-document endpoint, so resolving one
+  by id alone falls back to scanning the visible list. References arriving from
+  within the app carry their records directly and are unaffected.
+- V2's group and public workspace *pages* are still placeholders. The picker
+  reaches documents in those workspaces regardless, through their APIs.
+- The inline rendering relies on a backdrop matching the message box's text
+  metrics. If it cannot be drawn the box remains fully usable, just unstyled.

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,34 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/features) and [Fixes by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/fixes).
 
+### **(v0.261.087)**
+
+#### New Features
+
+*   **Choose Which Documents A Message Uses, And See The Choice**
+    *   The **Documents** button was previously a plain on/off: it meant "search my documents", with no way to say *which* ones and nothing on screen describing what a message would actually look at.
+    *   **You can now name them three ways.** Type `#` in the message box and search; open the Documents picker and tick them; or select documents in your workspace and press **Chat**. Tags have a chat action of their own now too.
+    *   **A reference shows up in two places on purpose.** It becomes a removable chip above the message box, grouped by workspace, and it stays inside your message as `#[Q3 Contract.pdf]` — rendered as a chip rather than raw brackets — so "compare `#[Q3 Contract.pdf]` against `#[Q2 Contract.pdf]`" still reads as a sentence after it is sent. Removing the chip removes the text, and editing the text retires the chip.
+    *   **The row condenses as it fills.** Up to five references show by name; beyond that each workspace collapses to a count you can open, so a long selection does not push the message box off the screen.
+    *   **The `#` menu searches everywhere at once** — your personal workspace, every group you belong to, and every visible public workspace — plus tags and whole workspaces. A scope that is briefly unavailable no longer empties the menu of everything else.
+    *   **The Documents picker opens upward and has a search box**, which the V2 dropdowns did not, and groups results by workspace. The original "search all my documents" behaviour is still there as the first row.
+    *   Documents and tags chosen together are now combined additively, so a document chip beside an unrelated tag chip no longer matches nothing. Selecting several tags still requires a document to carry all of them.
+    *   (Ref: `lib/chatContext.ts`, `lib/chatContextTokens.ts`, `lib/contextMentions.ts`, `components/chat/ContextChips.tsx`, `components/chat/DocumentPickerPopover.tsx`, [Chat Context Picker](features/CHAT_CONTEXT_PICKER.md))
+
+#### Bug Fixes
+
+*   **Chat From The Workspace Left The V2 Interface**
+    *   Selecting documents in the V2 workspace and pressing **Chat** performed a full page load into the *classic* chat page, quietly moving the user out of V2 by the action most likely to follow choosing a document. It now opens the V2 composer with those documents already referenced.
+    *   (Ref: `DocumentExplorer.onChat`, `lib/chatContextHandoff.ts`)
+
+*   **Retrying A Tag-Filtered Message Searched More Widely Than The Original**
+    *   The streaming chat path — the one the V2 interface uses — recorded which documents a message searched but not which tags, while the non-streaming path recorded both. Retrying or editing such a message therefore replayed a broader search than the one that produced the original answer, which reads as the assistant answering a different question the second time it is asked.
+    *   (Ref: `route_backend_chats.py` `workspace_search` metadata, `route_backend_conversations._build_replayed_document_context`)
+
+*   **Planned Documents Were Listed As Raw Identifiers**
+    *   Each step of an orchestration plan listed the documents it would read as bare uuids. Deciding whether the planner picked the right document is the entire purpose of showing the plan before it runs, and `8f14e45f-ceea-467a-…` does not support that decision. Steps now list documents by name, falling back to the id only when the document can no longer be read.
+    *   (Ref: `lib/documentTitles.ts`, `components/chat/OrchestrationRunView.tsx`)
+
 ### **(v0.261.086)**
 
 #### Bug Fixes

--- a/docs/reference/chat-controls.md
+++ b/docs/reference/chat-controls.md
@@ -119,3 +119,14 @@ Use this page when you can see a control in Chat but are not sure what it does o
 | `speech-input-btn` | Starts voice input capture for speech-to-text in chat. | Use it to dictate longer prompts, work hands-free, or reduce typing. | [`enable_speech_to_text_input`]({{ '/admin/knowledge/' | relative_url }}) |
 | `send-recording-btn` | Submits the captured recording for transcription and chat input. | Use it after recording a prompt you want SimpleChat to process. | Always available |
 | `cancel-recording-btn` | Stops and discards the current voice recording. | Use it when you misspoke, captured background noise, or no longer want to send the dictated prompt. | Always available |
+
+## Context references (V2 interface)
+
+These controls exist only in the V2 interface, so they are not part of the generated inventory above, which is taken from the classic chat page. They replace the classic scope, tags, and documents dropdowns with one list of what the next message is pointed at. See [Chat Context Picker]({{ '/explanation/features/CHAT_CONTEXT_PICKER/' | relative_url }}) for the full description.
+
+| Control | What it does | Why you would use it | Enabled by |
+| --- | --- | --- | --- |
+| Documents button | Opens a search panel above the composer listing your documents, tags, and workspaces grouped by workspace, with checkboxes. Its first row, **Search all my documents**, is the original on/off relevance search. | Use it to pick the specific documents an answer should come from, rather than hoping a relevance search surfaces them. | [`enable_user_workspace`]({{ '/admin/workspaces/' | relative_url }}) |
+| `#` in the message box | Searches documents, tags, and workspaces across your personal workspace, your groups, and visible public workspaces, and inserts the chosen one as `#[Name]`. | Use it to name a document while writing, without leaving the sentence to open a menu. | [`enable_user_workspace`]({{ '/admin/workspaces/' | relative_url }}) |
+| Context chips | Sit above the message box showing every reference the next message carries, grouped by workspace, each removable. Collapse to a per-workspace count once there are more than five. | Use them to confirm what an answer will be grounded in before you send, and to drop anything that should not be. | [`enable_user_workspace`]({{ '/admin/workspaces/' | relative_url }}) |
+| Chat action on a tag | Opens the composer with that tag carried as a filter, so the message searches whatever holds the tag when it is sent. | Use it to ask questions of a whole grouping rather than of documents chosen one at a time. | [`enable_user_workspace`]({{ '/admin/workspaces/' | relative_url }}) |

--- a/functional_tests/test_v2_chat_context_picker.py
+++ b/functional_tests/test_v2_chat_context_picker.py
@@ -1,0 +1,361 @@
+#!/usr/bin/env python3
+# test_v2_chat_context_picker.py
+"""
+Functional test for the V2 chat context picker.
+Version: 0.261.087
+Implemented in: 0.261.087
+
+The V2 composer shipped with a Documents button that was a plain on/off, and a
+``selectedDocumentIds`` field that was declared, forwarded to both the chat
+request and the orchestration seeds, and never populated by anything. Choosing
+a document in the workspace and pressing Chat navigated to ``/chats``, which is
+a full page load into the *classic* interface.
+
+Three groups of checks arrive together here, because each covers a failure the
+others cannot see:
+
+* Structural, in Python. That the workspace hand-off stays inside V2, and that
+  the composer no longer carries the write-only field.
+* Metadata parity, in Python. The streaming path -- the one the V2 client uses
+  -- did not record the tag filter it searched with, while the non-streaming
+  path did. A retry or edit of a tag-filtered message therefore replayed a
+  wider search than the one that produced the answer.
+* Behavioural, in TypeScript. The chip-to-request mapping, bundled and executed
+  by the companion ``test_v2_chat_context_request.ts``.
+"""
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent))
+
+from test_support.versioning import assert_app_version_at_least
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+APP_ROOT = REPO_ROOT / "application" / "single_app"
+V2_DIR = REPO_ROOT / "application" / "v2_ui"
+
+CHATS_ROUTE_PY = APP_ROOT / "route_backend_chats.py"
+CONVERSATIONS_ROUTE_PY = APP_ROOT / "route_backend_conversations.py"
+COMPOSER_TSX = V2_DIR / "src" / "components" / "chat" / "Composer.tsx"
+EXPLORER_TSX = V2_DIR / "src" / "components" / "documents" / "DocumentExplorer.tsx"
+TAGS_TSX = V2_DIR / "src" / "pages" / "workspace" / "TagsSection.tsx"
+RUN_VIEW_TSX = V2_DIR / "src" / "components" / "chat" / "OrchestrationRunView.tsx"
+LOGIC_CHECK_TS = Path(__file__).resolve().parent / "test_v2_chat_context_request.ts"
+
+
+def test_the_version_carries_the_feature():
+    """The picker is present from the version it was implemented in."""
+    print("\nTesting version...")
+    assert_app_version_at_least("0.261.087")
+    print("  The application version covers the context picker.")
+    return True
+
+
+def test_the_workspace_hand_off_stays_in_v2():
+    """Choosing Chat in the workspace must not drop the user into the classic UI."""
+    print("\nTesting the workspace hand-off...")
+
+    explorer = EXPLORER_TSX.read_text(encoding="utf-8")
+
+    assert "window.location.href = `/chats" not in explorer, (
+        "DocumentExplorer still hands off to the classic chat page. That is a full "
+        "page load out of V2, triggered by the action most likely to follow "
+        "choosing a document."
+    )
+    assert "navigate(`/chat?" in explorer, (
+        "DocumentExplorer should navigate within the router so the selection "
+        "arrives in the V2 composer."
+    )
+    assert "buildContextHandoffParams" in explorer, (
+        "The hand-off should be built through the shared helper so the classic "
+        "query vocabulary stays in one place."
+    )
+
+    tags = TAGS_TSX.read_text(encoding="utf-8")
+    assert "navigate(`/chat?" in tags and "contextTags" in tags, (
+        "The tags section should be able to hand a tag to the composer; chatting "
+        "against a tag is the reason most tags exist."
+    )
+
+    print("  Documents and tags hand off into the V2 composer.")
+    return True
+
+
+def test_the_composer_no_longer_carries_a_write_only_selection():
+    """`selectedDocumentIds` was never populated; the chip row replaces it."""
+    print("\nTesting the composer's context state...")
+
+    composer = COMPOSER_TSX.read_text(encoding="utf-8")
+
+    assert "selectedDocumentIds" not in composer, (
+        "The composer still references selectedDocumentIds, which nothing ever "
+        "filled in."
+    )
+    assert "contextItems" in composer, (
+        "The composer should hold its context references in contextItems."
+    )
+    assert "readContextQuery" in composer, (
+        "The composer should offer the `#` menu."
+    )
+    assert "DocumentPickerPopover" in composer, (
+        "The Documents button should open the picker rather than toggling."
+    )
+
+    print("  The composer drives the request from its chip row.")
+    return True
+
+
+def test_sending_clears_the_chips_with_the_text():
+    """Chips and their `#[...]` text are two views of one thing and must clear together.
+
+    Left behind on send, the chips would sit over an empty box holding tokens that
+    are no longer in it -- and the next keystroke reconciles those away, so the
+    references appear to survive the send and then vanish one character into the
+    following message.
+    """
+    print("\nTesting draft clearing...")
+
+    composer = COMPOSER_TSX.read_text(encoding="utf-8")
+
+    assert "const clearDraft = () => {" in composer, (
+        "The composer should clear its draft through one helper, so the plain and "
+        "orchestrated send paths cannot drift apart."
+    )
+
+    # Both send paths, and no stragglers still clearing only the text: the draft is
+    # emptied in exactly one place, which is what keeps them from drifting apart.
+    assert composer.count("clearDraft();") >= 2, (
+        "Both the plain and the orchestrated send should clear the draft."
+    )
+    assert composer.count("setText('')") == 1, (
+        "The composer empties its text in more than one place, so a send path can "
+        "clear the box while leaving the chip row behind."
+    )
+    assert "setContextQuery(null)" in composer, (
+        "Clearing the draft should also close any open `#` query."
+    )
+
+    print("  Both send paths clear the chips with the text.")
+    return True
+
+
+def test_caches_are_not_poisoned_by_cancelled_requests():
+    """An aborted fetch is not an answer, and must not be remembered as one.
+
+    StrictMode aborts the first run of every effect on mount, and each debounced
+    keystroke aborts the request before it. Caching those as "no result" would make
+    the empty answer the common one: documents shown as bare uuids for the rest of
+    the session, and `#` offering no tags for a minute at a time.
+    """
+    print("\nTesting cache behaviour on cancellation...")
+
+    titles = (V2_DIR / "src" / "lib" / "documentTitles.ts").read_text(encoding="utf-8")
+    assert titles.count("signal?.aborted") >= 2, (
+        "documentTitles caches lookup results without checking whether the request "
+        "was cancelled, so an aborted lookup is remembered as an unnameable "
+        "document and never retried."
+    )
+
+    mentions = (V2_DIR / "src" / "lib" / "contextMentions.ts").read_text(encoding="utf-8")
+    assert "options.signal?.aborted" in mentions, (
+        "The tag vocabulary is cached without checking for cancellation, so a "
+        "superseded keystroke caches an empty vocabulary for the whole TTL."
+    )
+
+    print("  Cancelled requests are not cached.")
+    return True
+
+
+def test_removing_a_chip_cannot_orphan_a_shared_reference():
+    """Two documents can share a title, and so two chips can share one token.
+
+    Stripping the text while a second chip still points at it leaves that chip
+    with no token. Reconciliation drops it on the next keystroke, but a message
+    sent before that keystroke still carries its document id -- grounding the
+    answer in something the user had already removed.
+    """
+    print("\nTesting chip removal with shared tokens...")
+
+    composer = COMPOSER_TSX.read_text(encoding="utf-8")
+
+    assert "remaining.some((entry) => entry.token === item.token)" in composer, (
+        "Removing a chip strips its token unconditionally, which orphans any other "
+        "chip sharing that token."
+    )
+    assert "stillReferenced" in composer, (
+        "Bulk removal should also keep tokens that remaining chips still use."
+    )
+
+    print("  A shared token survives until its last chip is removed.")
+    return True
+
+
+def test_the_plan_names_its_documents():
+    """A plan that lists raw ids cannot be reviewed."""
+    print("\nTesting orchestration plan legibility...")
+
+    run_view = RUN_VIEW_TSX.read_text(encoding="utf-8")
+    assert "useDocumentTitles" in run_view, (
+        "The plan view should resolve document ids to titles. Deciding whether "
+        "the planner picked the right contract is the entire purpose of showing "
+        "the plan before it runs, and a bare uuid does not support that."
+    )
+
+    print("  Planned documents are shown by name.")
+    return True
+
+
+def _workspace_search_metadata_blocks(source: str):
+    """The ``user_metadata['workspace_search'] = { ... }`` literals that record a search.
+
+    Four of these exist. Two are the ``{'search_enabled': False}`` placeholder written
+    when a turn used no document context at all, which has nothing to record and is
+    deliberately excluded here; the other two are the streaming and non-streaming
+    paths that actually searched.
+    """
+    blocks = []
+    marker = "user_metadata['workspace_search'] = {"
+    start = source.find(marker)
+    while start != -1:
+        end = source.find("}", start)
+        block = source[start:end]
+        if "'search_enabled': True" in block:
+            blocks.append(block)
+        start = source.find(marker, end)
+    return blocks
+
+
+def test_both_chat_paths_record_the_tag_filter():
+    """The streaming path dropped tags, so V2 retries replayed a wider search."""
+    print("\nTesting workspace_search metadata parity...")
+
+    source = CHATS_ROUTE_PY.read_text(encoding="utf-8")
+    blocks = _workspace_search_metadata_blocks(source)
+
+    assert len(blocks) >= 2, (
+        "Expected both the streaming and non-streaming chat paths to record "
+        f"workspace_search metadata for a real search; found {len(blocks)}."
+    )
+
+    for index, block in enumerate(blocks):
+        assert "'tags'" in block, (
+            f"workspace_search block {index + 1} does not record the tag filter. "
+            "Without it, _build_replayed_document_context has no tags to restore "
+            "and a retry silently searches more widely than the original."
+        )
+        # The document ids were already recorded on both paths; asserted here so a
+        # future edit cannot quietly drop one while adding the other.
+        assert "'requested_document_ids'" in block, (
+            f"workspace_search block {index + 1} stopped recording the requested "
+            "document ids."
+        )
+
+    print(f"  All {len(blocks)} workspace_search blocks record tags and document ids.")
+    return True
+
+
+def test_replay_restores_the_tag_filter():
+    """Recording tags is only useful if the replay reads them back."""
+    print("\nTesting retry and edit replay...")
+
+    source = CONVERSATIONS_ROUTE_PY.read_text(encoding="utf-8")
+    match = re.search(
+        r"def _build_replayed_document_context\(.*?\n(?=\n\ndef )",
+        source,
+        re.DOTALL,
+    )
+    assert match, "_build_replayed_document_context could not be located"
+
+    body = match.group(0)
+    assert "'tags'" in body, (
+        "The replayed document context does not restore the tag filter, so a "
+        "retried or edited message answers a different question than the one it "
+        "originally answered."
+    )
+
+    print("  Retry and edit restore the tag filter.")
+    return True
+
+
+def test_the_typescript_logic_checks_pass():
+    """Execute the behavioural half, skipping when the front-end toolchain is absent."""
+    print("\nTesting chip-to-request mapping (TypeScript)...")
+
+    if not (V2_DIR / "node_modules").exists():
+        print("  skip  application/v2_ui/node_modules is absent; run npm install to include")
+        return True
+
+    assert LOGIC_CHECK_TS.exists(), "The TypeScript logic checks are missing"
+
+    # functional_tests/ has no node_modules of its own, so the bundle is written where
+    # node can resolve bare imports from.
+    bundle = V2_DIR / "node_modules" / ".cache-chat-context-check.mjs"
+    try:
+        subprocess.run(
+            [
+                "npx",
+                "esbuild",
+                str(LOGIC_CHECK_TS),
+                "--bundle",
+                "--platform=node",
+                "--format=esm",
+                "--packages=external",
+                # chatContext reaches nothing Vite-specific, but the define keeps this
+                # identical to the other logic-check runners.
+                "--define:import.meta.env={}",
+                f"--outfile={bundle}",
+                "--log-level=error",
+            ],
+            cwd=str(V2_DIR),
+            check=True,
+            shell=(sys.platform == "win32"),
+        )
+        result = subprocess.run(
+            ["node", str(bundle)],
+            cwd=str(V2_DIR),
+            capture_output=True,
+            text=True,
+            shell=(sys.platform == "win32"),
+        )
+    finally:
+        if bundle.exists():
+            bundle.unlink()
+
+    if result.returncode != 0:
+        print(result.stdout)
+        print(result.stderr)
+        raise AssertionError("the TypeScript logic checks failed")
+
+    passed = result.stdout.count("  ok  ")
+    print(f"  ok  {passed} TypeScript logic checks passed")
+    return True
+
+
+if __name__ == "__main__":
+    tests = [
+        test_the_version_carries_the_feature,
+        test_the_workspace_hand_off_stays_in_v2,
+        test_the_composer_no_longer_carries_a_write_only_selection,
+        test_sending_clears_the_chips_with_the_text,
+        test_caches_are_not_poisoned_by_cancelled_requests,
+        test_removing_a_chip_cannot_orphan_a_shared_reference,
+        test_the_plan_names_its_documents,
+        test_both_chat_paths_record_the_tag_filter,
+        test_replay_restores_the_tag_filter,
+        test_the_typescript_logic_checks_pass,
+    ]
+
+    results = []
+    for test in tests:
+        try:
+            results.append(test())
+        except Exception as error:  # noqa: BLE001 - report and continue
+            print(f"  FAILED  {test.__name__}: {error}")
+            results.append(False)
+
+    print(f"\n{sum(1 for r in results if r)}/{len(results)} tests passed")
+    sys.exit(0 if all(results) else 1)

--- a/functional_tests/test_v2_chat_context_request.ts
+++ b/functional_tests/test_v2_chat_context_request.ts
@@ -1,0 +1,244 @@
+// test_v2_chat_context_request.ts
+//
+// Runtime test for how the V2 composer's context chips become a chat request.
+// Version: 0.261.087
+// Implemented in: 0.261.087
+//
+// These are the decisions that turn "the user picked a document" into fields the server acts
+// on, and each one fails as a wrong answer rather than an error:
+//
+//   - `_build_document_content_filter` defaults to `intersection`, so a picked document AND a
+//     picked tag must both match. A chip row holding one of each would return nothing at all
+//     unless the composer asks for `union`.
+//   - `hybrid_search` off while documents are named collects a selection, sends it, and has
+//     the server ignore it.
+//   - A group document whose group id is not in `active_group_ids` is filtered out server-side
+//     by `_get_authorized_chat_scope_context`. The document is simply absent from the answer,
+//     with nothing to say why.
+//   - `build_tags_filter` joins tags with `and`, so sending one twice narrows the search.
+//
+// Run by test_v2_chat_context_picker.py, which bundles this with the esbuild Vite already
+// brings in and executes it under node, skipping when the front-end toolchain is absent.
+// Bundling rather than running directly is what resolves the extensionless imports between
+// chatContext, chatContextTokens and documentExplorer.
+
+import assert from 'node:assert/strict';
+import {
+    PERSONAL_SCOPE,
+    addContextItem,
+    contextDocumentIds,
+    contextFilterMode,
+    contextScopes,
+    contextTags,
+    describeContextGroup,
+    documentContextItem,
+    groupContextItems,
+    groupScope,
+    publicScope,
+    removeContextItem,
+    scopeContextItem,
+    tagContextItem,
+} from '../application/v2_ui/src/lib/chatContext';
+import { resolveDocumentScope } from '../application/v2_ui/src/lib/documentScope';
+
+const MARKETING = groupScope({ id: 'grp-1', name: 'Marketing' });
+const LEGAL = groupScope({ id: 'grp-2', name: 'Legal' });
+const HANDBOOK = publicScope({ id: 'pub-1', name: 'Handbook' });
+
+const checks: Array<[string, () => void]> = [];
+function check(name: string, run: () => void) {
+    checks.push([name, run]);
+}
+
+function doc(id: string, title: string, scope = PERSONAL_SCOPE, existing: never[] | ReturnType<typeof documentContextItem>[] = []) {
+    return documentContextItem({ id, title, file_name: `${title}.pdf` }, scope, existing);
+}
+
+/* -------------------------------------------------------------------------- */
+/* Identity                                                                    */
+/* -------------------------------------------------------------------------- */
+
+check('a document is identified by its id, not its title', () => {
+    // Two files can share a title. Keying on the label would silently collapse them into one.
+    const first = doc('a', 'Contract');
+    const second = doc('b', 'Contract', PERSONAL_SCOPE, [first]);
+
+    assert.notEqual(first.key, second.key);
+    assert.notEqual(first.token, second.token);
+
+    const items = addContextItem(addContextItem([], first), second);
+    assert.deepEqual(contextDocumentIds(items), ['a', 'b']);
+});
+
+check('the same document is not added twice', () => {
+    const item = doc('a', 'Contract');
+    const items = addContextItem(addContextItem([], item), item);
+    assert.equal(items.length, 1);
+});
+
+check('the same tag in two workspaces is two chips but one filter', () => {
+    // Each chip widens the scope to its own workspace, but `build_tags_filter` joins names
+    // with `and`, so sending "urgent" twice would require a document to carry it twice.
+    const personal = tagContextItem('urgent', PERSONAL_SCOPE);
+    const marketing = tagContextItem('urgent', MARKETING, [personal]);
+    const items = [personal, marketing];
+
+    assert.equal(items.length, 2);
+    assert.deepEqual(contextTags(items), ['urgent']);
+    assert.deepEqual(contextScopes(items).groupIds, ['grp-1']);
+});
+
+check('tag de-duplication ignores case', () => {
+    const items = [tagContextItem('Urgent', PERSONAL_SCOPE), tagContextItem('urgent', MARKETING)];
+    assert.deepEqual(contextTags(items), ['Urgent']);
+});
+
+check('removing a chip removes only that one', () => {
+    const first = doc('a', 'A');
+    const second = doc('b', 'B', PERSONAL_SCOPE, [first]);
+    assert.deepEqual(
+        contextDocumentIds(removeContextItem([first, second], first.key)),
+        ['b'],
+    );
+});
+
+/* -------------------------------------------------------------------------- */
+/* Filter mode                                                                 */
+/* -------------------------------------------------------------------------- */
+
+check('documents and tags together are sent as additive', () => {
+    // Without this the server ANDs them and a document that does not carry the tag is
+    // excluded -- so the row shows two chips and the search returns nothing.
+    const items = [doc('a', 'Contract'), tagContextItem('urgent', PERSONAL_SCOPE)];
+    assert.equal(contextFilterMode(items), 'union');
+});
+
+check('one kind alone sends no mode at all', () => {
+    // With a single kind the mode has no effect, and an unnecessary field is one more thing
+    // to account for later.
+    assert.equal(contextFilterMode([doc('a', 'A')]), undefined);
+    assert.equal(contextFilterMode([tagContextItem('urgent', PERSONAL_SCOPE)]), undefined);
+    assert.equal(contextFilterMode([]), undefined);
+});
+
+/* -------------------------------------------------------------------------- */
+/* Scope                                                                       */
+/* -------------------------------------------------------------------------- */
+
+check('no chips leaves the deployment scope untouched', () => {
+    assert.deepEqual(resolveDocumentScope(undefined), {
+        doc_scope: 'personal',
+        active_group_ids: [],
+        active_group_id: null,
+        active_public_workspace_ids: [],
+        active_public_workspace_id: null,
+    });
+});
+
+check('a group chip makes its group reachable', () => {
+    // The whole point: without the id in active_group_ids the server filters the document out
+    // and the answer is missing it with no explanation.
+    const items = [doc('a', 'Brief', MARKETING)];
+    const scope = resolveDocumentScope({
+        contextGroupIds: contextScopes(items).groupIds,
+    });
+
+    assert.equal(scope.doc_scope, 'all');
+    assert.deepEqual(scope.active_group_ids, ['grp-1']);
+    assert.equal(scope.active_group_id, 'grp-1');
+});
+
+check('chips from several workspaces all travel', () => {
+    const items = [
+        doc('a', 'Brief', MARKETING),
+        doc('b', 'Policy', LEGAL),
+        doc('c', 'Handbook', HANDBOOK),
+        doc('d', 'Notes'),
+    ];
+    const workspaces = contextScopes(items);
+    const scope = resolveDocumentScope({
+        contextGroupIds: workspaces.groupIds,
+        contextPublicWorkspaceIds: workspaces.publicWorkspaceIds,
+    });
+
+    assert.equal(workspaces.includesPersonal, true);
+    assert.deepEqual(scope.active_group_ids, ['grp-1', 'grp-2']);
+    assert.deepEqual(scope.active_public_workspace_ids, ['pub-1']);
+    assert.equal(scope.doc_scope, 'all');
+});
+
+check('the active workspace is kept alongside the chips', () => {
+    // Someone working inside a group who pins a personal document must not lose the group.
+    const scope = resolveDocumentScope({
+        activeGroupId: 'grp-active',
+        contextGroupIds: ['grp-1'],
+    });
+    assert.deepEqual(scope.active_group_ids, ['grp-active', 'grp-1']);
+});
+
+check('a workspace named twice is sent once', () => {
+    const scope = resolveDocumentScope({
+        activeGroupId: 'grp-1',
+        contextGroupIds: ['grp-1', 'grp-1'],
+    });
+    assert.deepEqual(scope.active_group_ids, ['grp-1']);
+});
+
+check('a whole-workspace chip widens the scope without pinning documents', () => {
+    // Enumerating the workspace here would freeze it as it was when the chip was added.
+    const items = [scopeContextItem(MARKETING)];
+    assert.deepEqual(contextDocumentIds(items), []);
+    assert.deepEqual(contextScopes(items).groupIds, ['grp-1']);
+});
+
+/* -------------------------------------------------------------------------- */
+/* Presentation                                                                */
+/* -------------------------------------------------------------------------- */
+
+check('chips group by workspace, personal first', () => {
+    const items = [
+        doc('a', 'Brief', HANDBOOK),
+        doc('b', 'Policy', MARKETING),
+        doc('c', 'Notes'),
+    ];
+    assert.deepEqual(
+        groupContextItems(items).map((group) => group.scope.name),
+        ['My workspace', 'Marketing', 'Handbook'],
+    );
+});
+
+check('a collapsed group counts each kind', () => {
+    const items = [
+        doc('a', 'A', MARKETING),
+        doc('b', 'B', MARKETING),
+        tagContextItem('urgent', MARKETING),
+    ];
+    assert.equal(describeContextGroup(items), '2 documents and 1 tag');
+    assert.equal(describeContextGroup([items[2]]), '1 tag');
+});
+
+check('a document with no extracted title falls back to its file name', () => {
+    const item = documentContextItem(
+        { id: 'a', file_name: 'MSA_v2_FINAL(3).docx' },
+        PERSONAL_SCOPE,
+    );
+    assert.equal(item.label, 'MSA_v2_FINAL(3).docx');
+    assert.equal(item.token, '#[MSA_v2_FINAL(3).docx]');
+});
+
+/* -------------------------------------------------------------------------- */
+
+let failed = 0;
+for (const [name, run] of checks) {
+    try {
+        run();
+        console.log(`  ok  ${name}`);
+    } catch (error) {
+        failed += 1;
+        console.error(`  FAIL  ${name}`);
+        console.error(`        ${(error as Error).message}`);
+    }
+}
+
+console.log(`\n${checks.length - failed}/${checks.length} checks passed`);
+process.exit(failed === 0 ? 0 : 1);

--- a/functional_tests/test_v2_chat_context_tokens.mjs
+++ b/functional_tests/test_v2_chat_context_tokens.mjs
@@ -1,0 +1,267 @@
+// test_v2_chat_context_tokens.mjs
+//
+// Runtime test for the `#[…]` grammar behind the V2 chat context picker.
+// Version: 0.261.087
+// Implemented in: 0.261.087
+//
+// The composer holds each context reference twice: as a chip above the input and as literal
+// text inside it. Everything that can go wrong with that arrangement is a silent wrong answer
+// rather than a visible failure, which is why these are worth pinning:
+//
+//   - A token that survives an edit it should not have survived leaves a chip that keeps
+//     putting a document into the request after the message stopped naming it.
+//   - A `#` that opens the menu mid-word, inside an existing token, or over prose swallows the
+//     Enter meant to send the message.
+//   - Two documents sharing a title produce two identical tokens, and removing one then
+//     removes both.
+//   - Careless excision leaves a run of double spaces in the sentence the user is writing.
+//
+// Run directly with `node functional_tests/test_v2_chat_context_tokens.mjs`. Requires Node
+// 22.6 or newer, which strips the TypeScript types so the real module is imported.
+
+import assert from 'node:assert/strict';
+import {
+    MAX_CONTEXT_LABEL_LENGTH,
+    appendContextToken,
+    buildContextToken,
+    insertContextToken,
+    parseContextTokens,
+    readContextQuery,
+    reconcileContextItems,
+    removeContextToken,
+    sanitizeContextLabel,
+    uniqueContextLabel,
+} from '../application/v2_ui/src/lib/chatContextTokens.ts';
+
+const checks = [];
+function check(name, run) {
+    checks.push([name, run]);
+}
+
+/* -------------------------------------------------------------------------- */
+/* Label sanitisation                                                          */
+/* -------------------------------------------------------------------------- */
+
+check('brackets in a title cannot truncate their own token', () => {
+    // `Report [final].pdf` would close the token early and leave `.pdf]` as loose text.
+    const label = sanitizeContextLabel('Report [final].pdf');
+    assert.equal(label, 'Report (final).pdf');
+    assert.equal(parseContextTokens(buildContextToken(label)).length, 1);
+});
+
+check('newlines and runs of whitespace collapse', () => {
+    assert.equal(sanitizeContextLabel('Q3\n\nContract   final.pdf'), 'Q3 Contract final.pdf');
+});
+
+check('an over-long title is capped so the message box stays readable', () => {
+    const label = sanitizeContextLabel('x'.repeat(200));
+    assert.ok(label.length <= MAX_CONTEXT_LABEL_LENGTH + 1, label.length);
+    assert.ok(label.endsWith('…'));
+});
+
+check('colliding labels are disambiguated rather than duplicated', () => {
+    const first = uniqueContextLabel('Contract.pdf', []);
+    const second = uniqueContextLabel('Contract.pdf', [first]);
+    const third = uniqueContextLabel('Contract.pdf', [first, second]);
+
+    assert.equal(first, 'Contract.pdf');
+    assert.equal(second, 'Contract.pdf (2)');
+    assert.equal(third, 'Contract.pdf (3)');
+    assert.equal(new Set([first, second, third]).size, 3);
+});
+
+/* -------------------------------------------------------------------------- */
+/* Parsing                                                                     */
+/* -------------------------------------------------------------------------- */
+
+check('multi-word labels round-trip', () => {
+    const text = 'compare #[Q3 Contract.pdf] against #[Q2 Contract.pdf] please';
+    assert.deepEqual(
+        parseContextTokens(text).map((entry) => entry.label),
+        ['Q3 Contract.pdf', 'Q2 Contract.pdf'],
+    );
+});
+
+check('an unclosed bracket does not swallow the next token', () => {
+    // Without the `[^\]\n]+` bound, `#[oops` would run on and consume `#[Real.pdf]`.
+    const found = parseContextTokens('#[oops\nand #[Real.pdf]');
+    assert.deepEqual(found.map((entry) => entry.label), ['Real.pdf']);
+});
+
+check('parsing does not depend on who parsed last', () => {
+    // A shared global regex keeps `lastIndex` between calls, so the second call would start
+    // mid-string and silently return fewer tokens.
+    const text = '#[A] #[B]';
+    assert.equal(parseContextTokens(text).length, 2);
+    assert.equal(parseContextTokens(text).length, 2);
+});
+
+check('an empty token is not a token', () => {
+    assert.deepEqual(parseContextTokens('#[]'), []);
+});
+
+/* -------------------------------------------------------------------------- */
+/* Query detection                                                             */
+/* -------------------------------------------------------------------------- */
+
+check('a hash opening a word starts a query', () => {
+    const query = readContextQuery('look at #contr', 14);
+    assert.deepEqual(query, { query: 'contr', start: 8, end: 14 });
+});
+
+check('a hash mid-word does not', () => {
+    assert.equal(readContextQuery('C#', 2), null);
+    assert.equal(readContextQuery('issue#42', 8), null);
+});
+
+check('a caret inside a finished token does not reopen the menu', () => {
+    const text = '#[Contract.pdf]';
+    // Just past the `#`, which is where a click lands when correcting the start of a token.
+    assert.equal(readContextQuery(text, 1), null);
+    assert.equal(readContextQuery(text, text.length), null);
+});
+
+check('a hash followed by a space is prose, not a search', () => {
+    // `# ` trims to an empty query, which the suggestion builder reads as "offer everything",
+    // holding the menu open over an ordinary sentence and swallowing the Enter meant to send it.
+    assert.equal(readContextQuery('# heading', 2), null);
+    assert.equal(readContextQuery('a # b', 4), null);
+});
+
+check('a bare hash opens the menu on its defaults', () => {
+    // The caret sits immediately after the `#` and nothing has been typed yet, which is when
+    // the menu should offer recent documents rather than wait for a character.
+    assert.deepEqual(readContextQuery('a #', 3), { query: '', start: 2, end: 3 });
+});
+
+check('a numeric query is still a query', () => {
+    // `#1` reads as prose in "rank #1", but it is also how `#1099-form.pdf` starts. Excluding
+    // digits would make that document unreachable; an unmatched query simply draws no menu,
+    // which is the same outcome without the cost.
+    assert.deepEqual(readContextQuery('rank #1', 7), { query: '1', start: 5, end: 7 });
+});
+
+check('a newline ends the query', () => {
+    assert.equal(readContextQuery('#contract\nnext', 14), null);
+});
+
+check('an over-long query is prose, not a search', () => {
+    assert.equal(readContextQuery(`#${'x'.repeat(80)}`, 81), null);
+});
+
+/* -------------------------------------------------------------------------- */
+/* Insertion                                                                   */
+/* -------------------------------------------------------------------------- */
+
+check('picking a suggestion replaces the query it was typed for', () => {
+    const text = 'compare #contr';
+    const query = readContextQuery(text, text.length);
+    const result = insertContextToken(text, query.start, query.end, '#[Q3 Contract.pdf]');
+
+    assert.equal(result.text, 'compare #[Q3 Contract.pdf] ');
+    assert.equal(result.caret, result.text.length);
+});
+
+check('two references in a row do not accumulate spaces', () => {
+    const first = insertContextToken('compare ', 8, 8, '#[A.pdf]');
+    const second = insertContextToken(first.text, first.caret, first.caret, '#[B.pdf]');
+
+    assert.equal(second.text, 'compare #[A.pdf] #[B.pdf] ');
+    assert.ok(!/ {2}/.test(second.text));
+});
+
+check('inserting before existing text keeps a single separator', () => {
+    const result = insertContextToken('a  b', 2, 2, '#[X]');
+    assert.equal(result.text, 'a #[X] b');
+});
+
+check('the hand-off appends onto an empty composer without a leading space', () => {
+    assert.equal(appendContextToken('', '#[A]'), '#[A] ');
+    assert.equal(appendContextToken('note', '#[A]'), 'note #[A] ');
+    assert.equal(appendContextToken('note ', '#[A]'), 'note #[A] ');
+});
+
+/* -------------------------------------------------------------------------- */
+/* Removal                                                                     */
+/* -------------------------------------------------------------------------- */
+
+check('removing a mid-sentence reference leaves one space', () => {
+    assert.equal(removeContextToken('compare #[A] with #[B]', '#[A]'), 'compare with #[B]');
+});
+
+check('removing every reference in turn never doubles a space', () => {
+    let text = 'compare #[A] with #[B] and #[C] too';
+    for (const token of ['#[A]', '#[B]', '#[C]']) {
+        text = removeContextToken(text, token);
+    }
+    assert.equal(text, 'compare with and too');
+    assert.ok(!/ {2}/.test(text));
+});
+
+check('removing a repeated reference removes all of it', () => {
+    assert.equal(removeContextToken('#[A] then #[A]', '#[A]'), 'then');
+});
+
+check('removing a token that is not there changes nothing', () => {
+    assert.equal(removeContextToken('compare #[A]', '#[Z]'), 'compare #[A]');
+});
+
+check('a token at the very start is removed cleanly', () => {
+    assert.equal(removeContextToken('#[A] summarise this', '#[A]'), 'summarise this');
+});
+
+/* -------------------------------------------------------------------------- */
+/* Reconciliation                                                              */
+/* -------------------------------------------------------------------------- */
+
+const items = [
+    { key: 'document:a', token: '#[A.pdf]' },
+    { key: 'document:b', token: '#[B.pdf]' },
+];
+
+check('editing a token out of the text retires its chip', () => {
+    assert.deepEqual(
+        reconcileContextItems('compare #[B.pdf]', items).map((item) => item.key),
+        ['document:b'],
+    );
+});
+
+check('backspacing through a token retires its chip', () => {
+    // Mid-delete the token is malformed, which must already count as gone -- otherwise the
+    // chip lingers over a message that no longer names the document.
+    assert.deepEqual(reconcileContextItems('compare #[A.pd', items), []);
+});
+
+check('a hand-typed token never invents a chip', () => {
+    // There is no id behind it, so adopting it would put a document into the request that the
+    // user never chose from the menu.
+    assert.deepEqual(reconcileContextItems('#[A.pdf] #[Invented.pdf]', items), [items[0]]);
+});
+
+check('chip order follows the row, not the sentence', () => {
+    assert.deepEqual(
+        reconcileContextItems('#[B.pdf] then #[A.pdf]', items).map((item) => item.key),
+        ['document:a', 'document:b'],
+    );
+});
+
+check('reconciling an empty row is a no-op', () => {
+    assert.deepEqual(reconcileContextItems('#[A.pdf]', []), []);
+});
+
+/* -------------------------------------------------------------------------- */
+
+let failed = 0;
+for (const [name, run] of checks) {
+    try {
+        run();
+        console.log(`  PASS  ${name}`);
+    } catch (error) {
+        failed += 1;
+        console.error(`  FAIL  ${name}`);
+        console.error(`        ${error.message}`);
+    }
+}
+
+console.log(`\n${checks.length - failed}/${checks.length} checks passed`);
+process.exit(failed === 0 ? 0 : 1);


### PR DESCRIPTION
## Why

V2 shipped **Documents** as a bare on/off toggle. `ComposerOptions.selectedDocumentIds` was declared, forwarded to both the chat request and the orchestration seeds, and **never populated by anything** (`Composer.tsx:222` hardcoded `[]`). There was no way to say *which* documents a message should use, and nothing on screen said what it would actually look at.

Choosing documents in the workspace and pressing **Chat** did `window.location.href = '/chats?…'` — a full page load into the *classic* interface, triggered by the action most likely to follow choosing a document.

## What this adds

A reference now lives in **two places at once**, deliberately: a removable chip above the message box, and `#[Q3 Contract.pdf]` inside the message text, drawn as a citation-style pill by a backdrop behind a transparent-text textarea. Keeping it in the text is what lets the sent message still read as a sentence — "compare `#[Q3 Contract.pdf]` against `#[Q2 Contract.pdf]`" — and survives into history, where per-message metadata only keeps a count.

The two are kept in step:

- Removing a chip removes its `#[…]` text.
- Editing or deleting the `#[…]` text retires its chip.
- A hand-typed `#[Something]` **never** creates a chip — there is no id behind it, and adopting one would ground the message in something nobody chose.
- Sending clears both, through a single `clearDraft()` so the plain and orchestrated send paths cannot drift.

**Three ways to name something:**

| | |
|---|---|
| `#` in the message box | Searches documents, tags and workspaces across personal, every group, and every visible public workspace — in parallel, each scope settled independently so one unavailable group cannot empty the menu |
| **Documents** button | Now opens *upward*, with the search box V2's dropdowns never had, workspace-grouped checkboxes, and the original on/off preserved as its first row ("Search all my documents" = the server's `relevance` mode) |
| Workspace → **Chat** | Stays inside V2 via the router, carrying the document records in router state. Tags got their own Chat action |

**Chips condense as they fill:** individual names up to five, then each workspace collapses to `Marketing · 7 documents` that opens on click. Workspace grouping containers appear only when more than one workspace is involved.

## Bugs fixed along the way

- **`document_filter_mode` defaults to `intersection`** (`_build_document_content_filter`), so a picked document had to *also* carry every picked tag — a document chip beside an unrelated tag chip matched **nothing**. Now sends `union`, as Assigned Knowledge already does.
- **The streaming chat path dropped `tags` from `workspace_search` metadata** while the non-streaming path stored it. Streaming is the path V2 uses, so retrying or editing a tag-filtered message replayed a *wider* search than the one that produced the answer.
- **Orchestration plan steps listed documents as bare uuids.** Deciding whether the planner picked the right contract is the entire purpose of showing a plan before it runs, and `8f14e45f-ceea-467a-…` does not support that decision.

A review pass caught three more, two of which were live on **every** StrictMode mount:

- Aborted fetches were cached as "no result" in the document-title cache — a cancelled lookup meant that document showed as a bare uuid for the rest of the session.
- Same in the tag cache: a superseded keystroke cached an empty vocabulary, so `#` offered no tags for up to a minute. Typing is exactly what aborts it, so this was the common path.
- Two documents sharing a title share a token; removing one chip stripped the text from under the other, orphaning it. Reconciliation would drop it on the next keystroke — but a message sent before that keystroke still carried its document id, grounding the answer in something the user had already removed.

## Request mapping

| Chip kind | Field |
|---|---|
| Document | `selected_document_ids` |
| Tag | `tags` → `tags_filter` |
| Workspace | `doc_scope` + `active_group_ids` / `active_public_workspace_ids` |

Naming a document also switches `hybrid_search` on — a chip added while the toggle happened to be off would otherwise be collected, sent, and ignored. `resolveDocumentScope` now unions in the workspaces the chips imply, because the server filters requested ids down to what the caller may see and a group whose id was never sent is silently absent from the answer.

Orchestration is unchanged in shape: chips travel as seeds (`resolve_seeds` already read them, and `seeds_are_explicit` suppresses the candidate probe), and planner-chosen documents remain **narrowing-only** via the existing `removed_document_ids` — adding one still goes back through planning, per the rule in `orchestration.ts`.

## Deliberately not changed

Multiple tags are still AND'ed (`build_tags_filter` joins with `and`), so a document must carry every selected tag. That is existing server behaviour shared with workflows, agents and Assigned Knowledge; this states it in the UI and docs rather than touching shared search code.

## Verification

- `tsc -b` and `vite build` clean
- `functional_tests/test_v2_chat_context_picker.py` — 10/10 (bundles and runs the TS logic checks)
- `functional_tests/test_v2_chat_context_tokens.mjs` — 30/30 token-grammar checks
- `test_v2_chat_context_request.ts` — 16 chip-to-request checks
- Docs coverage 7/7, site quality 6/6, route policy tests pass
- The four `test_orchestration_*` suites that arrived with the base merge all pass
- `test_conversation_context_grounding`, `test_conversation_export` and `test_assigned_knowledge_agent_policy` fail **identically on the clean base commit** (confirmed by stashing); untouched here

## Notes

- Version → `0.261.089`. The base moved to `0.261.088` while this was in progress, so this branch merged it in and renumbered past it. `deployers/` untouched, so `deployers/version.txt` is unchanged.
- The merge also picked up the base's phase-grouped plan view; the document-title rendering was ported into its new `renderStep` helper rather than kept as the old inline block.
- Docs: new feature page `docs/explanation/features/CHAT_CONTEXT_PICKER.md`, a `v0.261.089` release-notes section above the base's `088`/`087`, and a V2 section in `docs/reference/chat-controls.md`. The generated `app_surface.yml` only scans V1 templates and is correctly unchanged.
- No new npm dependency — the highlight overlay is hand-rolled, keeping the repo's local-browser-assets rule intact.
- No new Flask routes; the two backend edits are inside existing handlers.
