### PR TITLE
Integrate the document context picker with orchestration

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -97,7 +97,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.261.090"
+VERSION = "0.261.091"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/functions_orchestration_adapters.py
+++ b/application/single_app/functions_orchestration_adapters.py
@@ -418,6 +418,53 @@ def _analysis_envelopes(result, requested_document_ids):
     return envelopes
 
 
+def _resolve_step_document_ids(step, context, *, settings=None, capability_id=None):
+    """The documents this step should read.
+
+    Either the ones the plan named, or -- when it named an earlier step instead -- the ones
+    that step actually found. The second is what lets a plan say "search for the relevant
+    contracts, then analyse them" without having to know at planning time which contracts
+    those turn out to be.
+
+    Documents arriving this way were returned by an earlier search, which only ever returns
+    what this user can read, and the document functions resolve access again from the user
+    id and scope they are given. The reference widens nothing.
+
+    The administrator's per-action document ceiling is applied here as well. The validator
+    trims what a plan *names*, but it cannot trim what a search has not run yet -- so a
+    reference would otherwise be a way around a configured limit.
+    """
+    arguments = _arguments(step)
+    explicit = _string_list(arguments.get('document_ids'))
+
+    reference = _text(arguments.get('documents_from_step'))
+    if not reference:
+        return explicit
+
+    found = (_ctx(context, 'step_documents', None) or {}).get(reference) or []
+    merged = list(explicit)
+    for document_id in found:
+        if document_id not in merged:
+            merged.append(document_id)
+
+    try:
+        from functions_orchestration_registry import (
+            get_capability,
+            get_capability_document_limit,
+        )
+
+        limit = get_capability_document_limit(get_capability(capability_id), settings=settings)
+        if limit and len(merged) > limit:
+            merged = merged[:limit]
+    except Exception as exc:
+        log_event(
+            f'{_LOG_PREFIX} Could not resolve the document ceiling: {exc}',
+            level=logging.WARNING,
+        )
+
+    return merged
+
+
 def run_document_analyze(step, context, *, settings, user_id, emit, cancel_requested):
     arguments = _arguments(step)
     invoke_prompt = _ctx(context, 'invoke_prompt', None)
@@ -427,7 +474,9 @@ def run_document_analyze(step, context, *, settings, user_id, emit, cancel_reque
             'document_analyze requires a callable invoke_prompt on the context.',
         )
 
-    document_ids = _string_list(arguments.get('document_ids'))
+    document_ids = _resolve_step_document_ids(
+        step, context, settings=settings, capability_id=CAPABILITY_DOCUMENT_ANALYZE,
+    )
     analysis_prompt = (
         _text(arguments.get('analysis_prompt'))
         or _text(arguments.get('prompt'))
@@ -435,6 +484,18 @@ def run_document_analyze(step, context, *, settings, user_id, emit, cancel_reque
         or _text(_ctx(context, 'user_message', ''))
     )
     if not document_ids:
+        # Either the plan named none, or it deferred to a step that found none. The second
+        # is worth a replan hint rather than a bare failure: nothing was wrong with the
+        # plan's shape, the search simply came back empty.
+        if _text(arguments.get('documents_from_step')):
+            return build_step_result(
+                status=STEP_STATUS_COMPLETED,
+                summary='The earlier search found no documents to analyse.',
+                replan_hint=(
+                    'The step this analysis reads from returned no documents; broaden the '
+                    'search or answer from what was already gathered.'
+                ),
+            )
         return _failed_result('No documents were provided to analyze.', 'document_analyze requires document_ids.')
     if not analysis_prompt:
         return _failed_result('No analysis prompt was provided.', 'document_analyze requires an analysis prompt.')

--- a/application/single_app/functions_orchestration_executor.py
+++ b/application/single_app/functions_orchestration_executor.py
@@ -246,17 +246,26 @@ class RunContext:
 
         # Documents any step produced evidence for, in first-seen order.
         self.documents_touched = []
+        # Which documents each step reached, keyed by step id. A later step can name an
+        # earlier one instead of naming documents, which is how a plan expresses "search,
+        # then analyse what you found" -- something it could not say while every step's
+        # documents had to be known when the plan was written.
+        self.step_documents = {}
 
         # The manifest captured when execution began, and the authorized manifest resolved
         # again before finalization; the second is what the handoff is built from.
         self.execution_manifest = []
         self.source_manifest = []
 
-    def merge_step_result(self, result):
+    def merge_step_result(self, result, step_id=None):
         """Fold one step's accumulables into the run.
 
         Failed steps return empty lists, so merging them is harmless; that is deliberate, so
         the caller never has to branch on status before merging.
+
+        ``step_id`` records which documents *this* step reached, which is what lets a later
+        step act on what an earlier one found rather than on what the planner guessed at
+        plan time.
         """
         if not isinstance(result, dict):
             return
@@ -264,10 +273,16 @@ class RunContext:
         self.citations.extend(result.get('citations') or [])
         self.artifacts.extend(result.get('artifacts') or [])
         self.notes.extend(result.get('notes') or [])
+
+        found_here = []
         for envelope in result.get('evidence') or []:
             document_id = _text((envelope or {}).get('document_id'))
             if document_id and document_id not in self.documents_touched:
                 self.documents_touched.append(document_id)
+            if document_id and document_id not in found_here:
+                found_here.append(document_id)
+        if step_id:
+            self.step_documents[step_id] = found_here
 
 
 # --------------------------------------------------------------------------------------
@@ -720,7 +735,7 @@ def execute_plan(
         else:
             # The terminal step's citations echo what the run already accumulated; merging
             # them would double every citation, so only non-terminal results are merged.
-            context.merge_step_result(result)
+            context.merge_step_result(result, step_id=step_id)
             executed_non_terminal += 1
 
         replan_hint = _text(result.get('replan_hint'))

--- a/application/single_app/functions_orchestration_planner.py
+++ b/application/single_app/functions_orchestration_planner.py
@@ -232,6 +232,14 @@ what it is for. To use one, add the agent capability and set "agent_name" to a n
 appears in that list, spelled exactly. Never name an agent that is not listed; if the list
 is empty you have no agent to call, so do not plan an agent step.
 
+You do not always know which documents matter before the run starts. Where a capability
+accepts "documents_from_step", you may give it the step_id of an earlier searching step
+instead of naming documents, and it will read whichever documents that step finds. Use this
+when the right documents depend on a search that has not run yet. When the documents are
+already known -- the user selected them, or they appear in "candidate_documents" -- name
+them directly, because a named document can be shown to the user for approval and a
+deferred one cannot.
+
 Return ONE JSON object with this shape:
 
 {

--- a/application/single_app/functions_orchestration_registry.py
+++ b/application/single_app/functions_orchestration_registry.py
@@ -297,13 +297,22 @@ CAPABILITY_REGISTRY = (
                     'minItems': 1,
                     'description': 'The documents to read. Must be named explicitly.',
                 },
+                'documents_from_step': {
+                    'type': 'string',
+                    'description': (
+                        'Instead of naming documents, read whichever ones an earlier '
+                        'step found. Give that step\'s step_id. Use this when the '
+                        'documents worth reading are not known until a search has run; '
+                        'name documents directly whenever they are already known.'
+                    ),
+                },
                 'doc_scope': {
                     'type': 'string',
                     'enum': ['all', 'personal', 'group', 'public'],
                     'default': 'all',
                 },
             },
-            'required': ['analysis_prompt', 'document_ids'],
+            'required': ['analysis_prompt'],
             'additionalProperties': False,
         },
         'produces': (PRODUCES_EVIDENCE, PRODUCES_CITATIONS),

--- a/application/single_app/functions_orchestration_schema.py
+++ b/application/single_app/functions_orchestration_schema.py
@@ -41,6 +41,7 @@ import uuid
 
 from functions_appinsights import log_event
 from functions_orchestration_registry import (
+    PRODUCES_EVIDENCE,
     TERMINAL_CAPABILITY_ID,
     get_capability,
     get_capability_document_limit,
@@ -50,6 +51,11 @@ from functions_orchestration_registry import (
 
 ORCHESTRATION_PLAN_CONTRACT_VERSION = 1
 ORCHESTRATION_ELICITATION_CONTRACT_VERSION = 1
+
+# Document fields a step cannot simply lose. These are not in their capability's `required`
+# list, because a step may supply `documents_from_step` instead -- but once neither is
+# present the step has nothing to read and cannot run.
+DOCUMENT_FIELDS_REQUIRED_UNLESS_REFERENCED = ('document_ids',)
 
 # Plan lifecycle.
 PLAN_STATUS_DRAFT = 'draft'
@@ -345,6 +351,71 @@ def validate_step_arguments(capability, arguments):
 # Plan validation
 # --------------------------------------------------------------------------------------
 
+def _resolve_document_references(steps):
+    """Resolve a step that reads whichever documents an earlier step found.
+
+    A plan could previously only act on documents whose ids were known when it was written,
+    which meant it could not express the most natural shape of all: search for the relevant
+    material, then analyse what turned up. ``documents_from_step`` says that instead.
+
+    Three things are checked:
+
+    - The named step must exist. A reference to a step that was dropped goes with it.
+    - It must not be the step itself, which could never resolve.
+    - It must produce documents. Only evidence-producing capabilities do, so pointing at a
+      web search or at ``respond`` would resolve to nothing every time.
+
+    Ordering is deliberately *not* checked here. A resolved reference is added to
+    ``depends_on``, and the topological pass that follows is what guarantees the referenced
+    step runs first -- with the existing cycle detection catching a plan that points two
+    steps at each other. Checking positions here as well would duplicate that and disagree
+    with it as soon as phase ordering moved a step.
+
+    A failure is a repair where the step still means something without the reference, and an
+    error where it does not: a step with no documents and no way to find any cannot run.
+    """
+    repairs = []
+    errors = []
+    failed = set()
+    by_id = {step['step_id']: step for step in steps}
+
+    for step in steps:
+        arguments = step.get('arguments') or {}
+        reference = _text(arguments.get('documents_from_step'))
+        if not reference:
+            continue
+
+        source = by_id.get(reference)
+        if source is None:
+            problem = 'names a step that is not in the plan'
+        elif reference == step['step_id']:
+            problem = 'refers to itself'
+        elif PRODUCES_EVIDENCE not in (
+            (get_capability(source['capability_id']) or {}).get('produces') or ()
+        ):
+            problem = 'reads from a step that does not produce documents'
+        else:
+            problem = None
+
+        if problem is None:
+            if reference not in step['depends_on']:
+                step['depends_on'] = [*step['depends_on'], reference]
+            continue
+
+        arguments.pop('documents_from_step', None)
+        if arguments.get('document_ids'):
+            repairs.append(
+                f"Step '{step['step_id']}' {problem}; its own documents were kept."
+            )
+        else:
+            errors.append(
+                f"Step '{step['step_id']}' {problem} and names no documents of its own."
+            )
+            failed.add(step['step_id'])
+
+    return [step for step in steps if step['step_id'] not in failed], repairs, errors
+
+
 def _enforce_phase_order(steps):
     """Sort steps into phase order and drop dependencies that point backwards.
 
@@ -552,13 +623,19 @@ def validate_plan(
                 )
                 continue
 
-        # A step whose documents have all been removed has nothing left to do.
+        # A step whose documents have all been removed has nothing left to do -- unless it
+        # is reading whatever an earlier step finds, in which case having no documents of
+        # its own is the entire point.
         emptied = [
             field
             for field in ('document_ids', 'right_document_ids')
             if field in arguments
             and not arguments[field]
-            and field in set((capability.get('inputs') or {}).get('required') or ())
+            and not _text(arguments.get('documents_from_step'))
+            and (
+                field in set((capability.get('inputs') or {}).get('required') or ())
+                or field in DOCUMENT_FIELDS_REQUIRED_UNLESS_REFERENCED
+            )
         ]
         if emptied:
             errors.append(
@@ -595,6 +672,14 @@ def validate_plan(
         if len(kept) != len(step['depends_on']):
             repairs.append(f"Step '{step['step_id']}' waited on a step that was removed.")
         step['depends_on'] = kept
+
+    # A step may read the documents an earlier step found rather than naming its own. The
+    # reference is resolved here, once every surviving step id is known, because ids can be
+    # renamed above and a reference validated earlier could point at a name that no longer
+    # exists.
+    accepted, reference_repairs, reference_errors = _resolve_document_references(accepted)
+    repairs.extend(reference_repairs)
+    errors.extend(reference_errors)
 
     # Phase order first, so the topological pass below sorts within a plan that already
     # runs knowledge before reasoning before output rather than one that merely could.

--- a/application/v2_ui/src/components/chat/OrchestrationRunView.tsx
+++ b/application/v2_ui/src/components/chat/OrchestrationRunView.tsx
@@ -66,7 +66,12 @@ const phaseLabels: Record<OrchestrationPhase, string> = {
 
 /** A step argument key/value the run will use, minus the document fields shown as chips. */
 function readableArguments(step: OrchestrationStep): Array<[string, string]> {
-    const hidden = new Set<string>([...DOCUMENT_ARRAY_FIELDS, 'left_document_id']);
+    const hidden = new Set<string>([
+        ...DOCUMENT_ARRAY_FIELDS,
+        'left_document_id',
+        // Shown as its own chip, naming the step rather than repeating its id.
+        'documents_from_step',
+    ]);
     const entries: Array<[string, string]> = [];
     const args = step.arguments as Json;
     for (const [key, value] of Object.entries(args)) {
@@ -150,6 +155,12 @@ export function OrchestrationRunView({
 
     const capabilities = useBootstrapStore((state) => state.data?.orchestration?.capabilities);
 
+    /** Step titles by id, so a reference to another step can name it rather than show its id. */
+    const stepTitles = useMemo(
+        () => new Map(orderedSteps.map((step) => [step.step_id, step.title])),
+        [orderedSteps],
+    );
+
     // Steps grouped under their phase, in run order, so the list reads as "gather, then answer"
     // rather than as a flat sequence. A step's phase is resolved from the capability menu when the
     // plan does not carry one itself, so an older or persisted plan still groups correctly; a step
@@ -219,6 +230,13 @@ export function OrchestrationRunView({
         const removable = new Set(stepRemovableDocumentIds(step));
         const documents = stepDocumentIds(step);
         const args = readableArguments(step);
+        // A step can defer its documents to whatever an earlier step finds, so it may have
+        // none of its own to show.
+        const documentsFromStep = String(
+            (step.arguments as Record<string, unknown>).documents_from_step ?? '',
+        ).trim();
+        const documentsFromStepLabel =
+            stepTitles.get(documentsFromStep) ?? 'the earlier step';
 
         return (
             <li
@@ -364,6 +382,16 @@ export function OrchestrationRunView({
                                     );
                                 })}
                             </ul>
+                        ) : null}
+
+                        {documentsFromStep ? (
+                            // A step reading whatever an earlier one finds has no documents
+                            // to list yet. Saying so is more honest than showing nothing,
+                            // which reads as "this step touches no documents at all".
+                            <p className="mt-2 inline-flex items-center gap-1 rounded-full border border-dashed border-edge-strong px-2 py-0.5 text-[11px] text-text-3">
+                                <FileText size={10} className="shrink-0" />
+                                Whatever {documentsFromStepLabel} finds
+                            </p>
                         ) : null}
 
                         <div className="mt-2">

--- a/docs/explanation/features/CHAT_ORCHESTRATION.md
+++ b/docs/explanation/features/CHAT_ORCHESTRATION.md
@@ -96,6 +96,39 @@ recover what was just discarded.
 `document_ids` and nothing else, so a client that renamed a document mislabels its own plan
 card and reaches nothing new. `test_orchestration_context_picker.py` asserts this directly.
 
+#### Reading what an earlier step found
+
+Every step's documents used to be fixed when the plan was written, which meant a plan could
+not express the most natural shape of all: search for the relevant material, then analyse
+what turned up. The planner had to guess document ids from the candidate probe, or the plan
+simply could not say it.
+
+A step may now set `documents_from_step` to an earlier step's `step_id` instead of naming
+documents. At run time the adapter resolves it from `RunContext.step_documents`, which
+records which documents each step reached.
+
+The reference is validated where the surviving step ids are known, because ids can be
+renamed during validation. It must name a step that exists, must not name the step itself,
+and must name a capability that *produces evidence* — pointing at a web search or at
+`respond` would resolve to nothing every time. A resolved reference is added to
+`depends_on`, and the topological pass is what guarantees ordering; positions are
+deliberately not checked here as well, since that would duplicate the cycle detection and
+disagree with it as soon as phase ordering moved a step.
+
+Two constraints are worth stating plainly:
+
+- **It widens nothing.** Documents arriving this way came from a search, which only returns
+  what the user can read, and the document functions resolve access again from the user id
+  and scope they are given.
+- **It does not dodge the administrator's ceiling.** The validator trims the documents a
+  plan *names*, but it cannot trim what a search has not run yet, so the limit is applied
+  again when the reference resolves.
+
+The cost is real and is the reason this is not the default: a plan that defers its
+documents cannot show the user which ones it will read. The approval card says "whatever
+the earlier step finds" rather than pretending to a list, and the planner is told to name
+documents directly whenever they are already known.
+
 ### Plan
 
 `functions_orchestration_planner.py` triages first. The point of triage is to stop a
@@ -324,7 +357,7 @@ to the front.
 | `functional_tests/test_orchestration_phase_ordering.py` | Knowledge sorts before reasoning, a plan gathering after answering is repaired, a backwards dependency is dropped with a note |
 | `functional_tests/test_orchestration_adapter_contract.py` | Every capability resolves to an adapter, every adapter matches the executor's call signature, no adapter touches Flask state, and identity is captured on the request thread |
 | `functional_tests/test_orchestration_citation_persistence.py` | Cited documents reach the conversation's used-document list, and document and web citations are separated |
-| `functional_tests/test_orchestration_context_picker.py` | Picked tags reach the seeds and both search paths under the parameter `hybrid_search` really takes; a tag scopes the probe rather than replacing it; a picked document reaches the planner and the approval card by name; a browser-supplied name cannot widen access; search citations carry the workspace a document came from |
+| `functional_tests/test_orchestration_context_picker.py` | Picked tags reach the seeds and both search paths under the parameter `hybrid_search` really takes; a tag scopes the probe rather than replacing it; a picked document reaches the planner and the approval card by name; a browser-supplied name cannot widen access; search citations carry the workspace a document came from; a step can read what an earlier step found, an unusable reference is repaired or dropped, and a run-time document still respects the configured ceiling |
 
 ## Known limitations
 

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,7 +2,7 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/features) and [Fixes by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/fixes).
 
-### **(v0.261.090)**
+### **(v0.261.091)**
 
 #### New Features
 
@@ -11,8 +11,9 @@ For feature-focused and fix-focused drill-downs by version, see [Features by Ver
     *   **Tags now narrow a plan too, and stay in force for the whole run.** A later step can choose its own search query but cannot widen the shelf you narrowed to. Documents and tags picked together are combined additively, matching the chat path.
     *   **A document you picked now reaches the planner by name.** It previously arrived as a bare identifier, so the planner could not write "compare the Q3 and Q4 contracts" without being told which document was which, and the plan you were asked to approve listed a row of uuids. The composer sends the names it already had on screen.
     *   **The plan marks which documents were your choice.** A document you picked and one the planner found are both documents the plan will read, but only the second is a decision worth checking — so the two now look different on the card.
-    *   Names are display only. What a plan may read is still decided from the document ids, so a renamed document is exactly the document it was.
-    *   (Ref: `resolve_seeds`, `resolve_candidate_documents`, `RunContext.tags`, `contextDocumentDescriptors`, [Chat Orchestration](features/CHAT_ORCHESTRATION.md), [Chat Context Picker](features/CHAT_CONTEXT_PICKER.md))
+    *   **A step can act on what an earlier step finds.** A plan could previously only use documents whose ids were known when it was written, so it could not express "search for the relevant contracts, then analyse them" — the planner had to guess which contracts, or not plan it at all. A step can now defer to an earlier searching step instead. The plan says so plainly rather than showing an empty list, and the planner still names documents directly whenever they are already known, because a named document can be approved and a deferred one cannot.
+    *   Names are display only. What a plan may read is still decided from the document ids, so a renamed document is exactly the document it was. Documents that arrive mid-run are re-checked the same way, and still respect the administrator's per-action limit.
+    *   (Ref: `resolve_seeds`, `resolve_candidate_documents`, `RunContext.tags`, `RunContext.step_documents`, `documents_from_step`, `contextDocumentDescriptors`, [Chat Orchestration](features/CHAT_ORCHESTRATION.md), [Chat Context Picker](features/CHAT_CONTEXT_PICKER.md))
 
 #### Bug Fixes
 

--- a/functional_tests/test_orchestration_context_picker.py
+++ b/functional_tests/test_orchestration_context_picker.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """
 Functional test for the document context picker reaching orchestration.
-Version: 0.261.090
-Implemented in: 0.261.090
+Version: 0.261.091
+Implemented in: 0.261.091
 
 The composer's context picker lets a user name documents, tags and whole workspaces before
 asking. Orchestration read the document ids and ignored everything else: a tag chip worked
@@ -32,10 +32,31 @@ ADAPTERS = 'functions_orchestration_adapters.py'
 CONTEXT = 'functions_orchestration_context.py'
 SEARCH = 'functions_search.py'
 
+# A deployment with everything on, so a validation test fails on the thing it is testing
+# rather than on a gate.
+_PERMISSIVE = {
+    'enable_chat_orchestration': True,
+    'enable_user_workspace': True,
+    'enable_group_workspaces': True,
+    'enable_web_search': True,
+}
+_CAPABILITIES = [
+    'document_search',
+    'document_analyze',
+    'document_compare',
+    'tabular_analyze',
+    'web_search',
+    'respond',
+]
+
+
+def _read(module):
+    with open(os.path.join(APP_ROOT, module), encoding='utf-8') as handle:
+        return handle.read()
+
 
 def _tree(module):
-    with open(os.path.join(APP_ROOT, module), encoding='utf-8') as handle:
-        return ast.parse(handle.read())
+    return ast.parse(_read(module))
 
 
 def _function(tree, name):
@@ -49,7 +70,7 @@ def test_picked_tags_reach_the_plan():
     """A tag chip must narrow a plan the way it narrows a chat message."""
     print("Testing that picked tags reach the seeds...")
     try:
-        assert_app_version_at_least('0.261.090')
+        assert_app_version_at_least('0.261.091')
 
         with stubbed_app_imports():
             from functions_orchestration_context import resolve_seeds
@@ -319,6 +340,203 @@ def test_found_documents_carry_their_workspace():
         return False
 
 
+def test_a_step_can_read_what_an_earlier_step_found():
+    """A plan can say "search, then analyse what you found"."""
+    print("Testing the cross-step document reference...")
+    try:
+        with stubbed_app_imports():
+            from functions_orchestration_schema import validate_plan
+
+            plan = validate_plan({
+                'intent': {'summary': 'Analyse the relevant contracts'},
+                'steps': [
+                    {
+                        'step_id': 'find',
+                        'capability_id': 'document_search',
+                        'arguments': {'query': 'contracts'},
+                    },
+                    {
+                        'step_id': 'read',
+                        'capability_id': 'document_analyze',
+                        'arguments': {
+                            'analysis_prompt': 'Summarise the payment terms.',
+                            'documents_from_step': 'find',
+                        },
+                    },
+                    {'step_id': 'answer', 'capability_id': 'respond', 'arguments': {}},
+                ],
+            }, settings=_PERMISSIVE, available_capability_ids=_CAPABILITIES)
+
+            validation = plan['validation']
+            assert validation['ok'], f"a valid reference was rejected: {validation['errors']}"
+
+            by_id = {s['step_id']: s for s in plan['steps']}
+            assert 'read' in by_id, 'the analysing step was dropped'
+            assert by_id['read']['arguments']['documents_from_step'] == 'find'
+
+            # The reference must imply the dependency. Without it the topological pass is
+            # free to run the analysis first, and it would resolve to nothing.
+            assert 'find' in by_id['read']['depends_on'], (
+                f"the reference did not create a dependency: {by_id['read']['depends_on']}. "
+                f"The executor would be free to analyse before searching."
+            )
+
+            order = [s['step_id'] for s in plan['steps']]
+            assert order.index('find') < order.index('read'), (
+                f"the referenced step must run first: {order}"
+            )
+
+        print("  ok  a step can read what an earlier step found")
+        return True
+    except Exception as e:
+        print(f"Test failed: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+
+def test_a_bad_document_reference_is_caught():
+    """A reference that could never resolve must not reach an adapter."""
+    print("Testing bad document references...")
+    try:
+        with stubbed_app_imports():
+            from functions_orchestration_schema import validate_plan
+
+            def analyse(reference, extra=None):
+                arguments = {
+                    'analysis_prompt': 'Summarise.',
+                    'documents_from_step': reference,
+                }
+                arguments.update(extra or {})
+                return validate_plan({
+                    'intent': {'summary': 'x'},
+                    'steps': [
+                        {'step_id': 'search', 'capability_id': 'web_search',
+                         'arguments': {'query': 'x'}},
+                        {'step_id': 'read', 'capability_id': 'document_analyze',
+                         'arguments': arguments},
+                        {'step_id': 'answer', 'capability_id': 'respond', 'arguments': {}},
+                    ],
+                }, settings=_PERMISSIVE, available_capability_ids=_CAPABILITIES)
+
+            # A web search produces notes, not documents. Reading documents from it would
+            # resolve to nothing every single time.
+            plan = analyse('search')
+            assert 'read' not in {s['step_id'] for s in plan['steps']}, (
+                'a step reading documents from a web search should not have survived'
+            )
+
+            # Unless it has documents of its own, in which case the reference is dropped and
+            # the step still means something.
+            plan = analyse('search', {'document_ids': ['doc1']})
+            by_id = {s['step_id']: s for s in plan['steps']}
+            assert 'read' in by_id, 'a step with its own documents should survive'
+            assert 'documents_from_step' not in by_id['read']['arguments'], (
+                'the unusable reference should have been removed'
+            )
+            assert by_id['read']['arguments']['document_ids'] == ['doc1']
+            assert plan['validation']['repairs'], 'dropping a reference should be reported'
+
+            # A step naming itself could never resolve.
+            plan = analyse('read')
+            assert 'read' not in {s['step_id'] for s in plan['steps']}
+
+            # A step that is not in the plan at all.
+            plan = analyse('nonexistent')
+            assert 'read' not in {s['step_id'] for s in plan['steps']}
+
+        print("  ok  unusable references are repaired or dropped")
+        return True
+    except Exception as e:
+        print(f"Test failed: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+
+def test_a_reference_cannot_dodge_the_document_ceiling():
+    """The administrator's limit must apply to documents that arrive at run time."""
+    print("Testing the document ceiling on a reference...")
+    try:
+        source = _read(ADAPTERS)
+        resolver = _function(ast.parse(source), '_resolve_step_document_ids')
+        assert resolver is not None, '_resolve_step_document_ids must exist'
+
+        body = ast.dump(resolver)
+        # The validator trims what a plan *names*. It cannot trim what a search has not run
+        # yet, so without this the reference is a way around a configured maximum.
+        assert 'get_capability_document_limit' in body, (
+            "_resolve_step_document_ids does not apply the administrator's document "
+            "ceiling. The validator caps the documents a plan names, but documents "
+            "arriving through documents_from_step never pass through it."
+        )
+
+        # And the caller must actually tell it which capability's limit applies.
+        analyze = _function(ast.parse(source), 'run_document_analyze')
+        called = False
+        for node in ast.walk(analyze):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id == '_resolve_step_document_ids'
+            ):
+                passed = {kw.arg for kw in node.keywords}
+                assert {'settings', 'capability_id'} <= passed, (
+                    f"run_document_analyze resolves documents without {sorted({'settings', 'capability_id'} - passed)}, "
+                    f"so no ceiling can be applied"
+                )
+                called = True
+        assert called, 'run_document_analyze must resolve its documents through the helper'
+
+        print("  ok  a run-time document still respects the configured ceiling")
+        return True
+    except Exception as e:
+        print(f"Test failed: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+
+def test_the_executor_records_what_each_step_found():
+    """A reference resolves from per-step documents, so they must be recorded per step."""
+    print("Testing per-step document recording...")
+    try:
+        with stubbed_app_imports():
+            from functions_orchestration_executor import RunContext
+
+            context = RunContext(run_id='r1', plan_id='p1', conversation_id='c1', user_id='u1')
+            assert hasattr(context, 'step_documents'), (
+                'RunContext must record which documents each step found, or a reference '
+                'has nothing to resolve against'
+            )
+
+            context.merge_step_result({
+                'evidence': [
+                    {'document_id': 'doc1', 'source_kind': 'narrative'},
+                    {'document_id': 'doc2', 'source_kind': 'narrative'},
+                ],
+            }, step_id='find')
+
+            assert context.step_documents['find'] == ['doc1', 'doc2'], (
+                f"per-step documents were not recorded: {context.step_documents}"
+            )
+            # And the run-level list still works, since the ledger reads it.
+            assert context.documents_touched == ['doc1', 'doc2']
+
+            # A step that found nothing records an empty list rather than nothing at all,
+            # so a reference to it resolves to "none" rather than to "unknown".
+            context.merge_step_result({'evidence': []}, step_id='empty')
+            assert context.step_documents['empty'] == []
+
+        print("  ok  each step's documents are recorded against its id")
+        return True
+    except Exception as e:
+        print(f"Test failed: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+
 if __name__ == "__main__":
     tests = [
         test_picked_tags_reach_the_plan,
@@ -328,6 +546,10 @@ if __name__ == "__main__":
         test_the_name_reaches_the_approval_card,
         test_a_supplied_label_cannot_widen_access,
         test_found_documents_carry_their_workspace,
+        test_a_step_can_read_what_an_earlier_step_found,
+        test_a_bad_document_reference_is_caught,
+        test_a_reference_cannot_dodge_the_document_ceiling,
+        test_the_executor_records_what_each_step_found,
     ]
     results = []
     for test in tests:


### PR DESCRIPTION
Integrates the document context picker (#1442) with the orchestration layer, and closes the gap it exposed.

## What the picker sent that orchestration ignored

`resolve_seeds` read `selected_document_ids` and nothing else, so two of the three chip kinds fell on the floor:

**Tags were a correctness bug.** The composer sends them on both the chat and the orchestration path. Classic chat honoured them; a plan did not — so a run searched a wider corpus than the user had just narrowed to. They now reach the seeds, the candidate probe, and every search step in the run via `RunContext`.

A tag deliberately does **not** count as an explicit selection. A document answers "which documents" and replaces the probe; a tag answers "which shelf" and scopes it. Treating a tag as explicit would hand the planner every document carrying it — the opposite of narrowing.

`document_filter_mode` travels with them, or a picked document beside an unrelated tag intersects to nothing, exactly as it did on the chat path before the same field was sent there.

**Names were a reviewability bug.** `resolve_candidate_documents` returned seeded documents with `file_name: ''`, so a picked document reached the planner as a bare uuid. That breaks two things at once: the planner cannot write "compare the Q3 and Q4 contracts" if it was never told which document is which, and the approval card — whose entire purpose is confirming the planner picked the right document — listed identifiers. The composer had those names on screen when the user clicked them, so it sends them.

## Chosen vs found

`build_plan_inputs` already computed `selected_by_user`, and the client was carrying `inputs` as an opaque blob that **nothing read**. It is now typed and rendered: a document you picked and one the planner found are both documents the plan will read, but only the second is a decision anyone needs to check.

Preferring the plan's own names to a second lookup also means a picked document is named immediately rather than after three fetches; the existing `useDocumentTitles` resolver now only runs for ids the plan left unnamed.

## Reading what an earlier step found

The gap the picker exposed: every step's documents had to be known when the plan was *written*. `document_ids` was required and documented as "must be named explicitly", so a plan could not express the most natural shape of all — search for the relevant material, then analyse what turned up.

A step may now set `documents_from_step` to an earlier step's id. The executor records per-step documents on `RunContext.step_documents`; the adapter resolves the reference at run time.

Validated where the surviving step ids are known, because ids can be renamed during validation and a reference checked earlier could point at a name that no longer exists. It must name a step that exists, must not name itself, and must name a capability that **produces evidence** — pointing at a web search or at `respond` would resolve to nothing every time.

Ordering is deliberately *not* checked there. A resolved reference is added to `depends_on`, and the topological pass guarantees it runs first, with the existing cycle detection catching two steps pointing at each other. Checking positions as well would duplicate that and disagree with it as soon as phase ordering moved a step.

### Two things it must not do

| | |
|---|---|
| **Widen access** | Documents arriving this way came from a search, which only returns what the user can read, and the document functions resolve access again from the user id and scope they are given. |
| **Dodge the ceiling** | The validator trims the documents a plan *names*. It cannot trim what a search has not run yet — so the administrator's per-action limit is applied again when the reference resolves. |

Both are asserted, not assumed.

### A bug this surfaced

Removing `document_ids` from `required` also disarmed the emptied-step check, which keyed off that list. A step whose documents were all stripped as unauthorized would have passed validation and failed at the adapter. The check now tests for a reference instead.

### The cost, stated plainly

A plan that defers its documents cannot show which ones it will read — in tension with the whole point of showing a plan before it runs. So the card says "whatever the earlier step finds" rather than pretending to a list, and the planner prompt says to name documents directly whenever they are already known, because a named document can be approved and a deferred one cannot.

## Also fixed

Search citations were dropping `group_id` and `public_workspace_id`, which the index does select. Context chips are grouped by workspace, so a document the run discovered had no home to be offered back into.

## Security

Names come from the browser. `_authorized_document_ids` reads `document_ids` and nothing else, so a client that renames a document mislabels its own plan card and reaches nothing new. Asserted directly rather than argued.

## Tests

`test_orchestration_context_picker.py`, 11 checks: tags reach the seeds and both search paths; a tag scopes the probe rather than replacing it; a picked document reaches the planner and the card by name; a supplied name cannot widen access; citations carry workspace; a step can read what an earlier step found; an unusable reference is repaired or dropped; a run-time document still respects the ceiling; the executor records documents per step.

One assertion is worth calling out: the tag test checks the parameter name **against `hybrid_search`'s real signature**. It takes `tags_filter`, not `tags` — and `tags=` type-checks, imports, and passes every test that drives a fake search. I made exactly that mistake writing this, caught it only by reading the signature, and the same class of mismatch has already reached production once in this feature. Verified by reverting to the wrong name and watching it go red.

**48 orchestration tests, the picker's own 10, plus admin/docs/route suites — all passing. Typecheck and build clean.**

## Not verified

Real Cosmos resolution, a live search and a real analysis all need Azure. Behaviour is exercised through the stub harness and AST contracts.