### PR TITLE
Improve visual hierarchy in V2 Agents settings

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -97,7 +97,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.261.092"
+VERSION = "0.261.093"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/v2_ui/src/components/admin/PromotedAgentsEditor.tsx
+++ b/application/v2_ui/src/components/admin/PromotedAgentsEditor.tsx
@@ -94,14 +94,14 @@ export function PromotedAgentsEditor({
 
     return (
         <div className="py-3">
-            <div className="mb-1.5 flex items-baseline justify-between gap-3">
+            <div className="admin-field-heading mb-1.5 flex items-baseline justify-between gap-3">
                 <span className="text-sm font-medium text-text-1">{field.label}</span>
                 <span className="text-xs text-text-3">
                     {promoted.length} promoted
                 </span>
             </div>
 
-            <div className="flex items-center gap-2">
+            <div className="admin-promoted-agents-picker flex items-center gap-2">
                 <select
                     aria-label="Agent to promote"
                     className={clsx(controlClass, 'min-w-0 flex-1 appearance-none pr-8')}
@@ -143,7 +143,7 @@ export function PromotedAgentsEditor({
                     {promoted.map((agent, index) => (
                         <li
                             key={agent.catalog_key}
-                            className="flex items-center gap-2 rounded-lg border border-edge bg-surface-1 p-2"
+                            className="admin-promoted-agent-row flex items-center gap-2 rounded-lg border border-edge bg-surface-1 p-2"
                         >
                             <div className="min-w-0 flex-1">
                                 <p className="truncate text-sm text-text-1">

--- a/application/v2_ui/src/components/admin/SettingsSection.tsx
+++ b/application/v2_ui/src/components/admin/SettingsSection.tsx
@@ -21,7 +21,14 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import { clsx } from 'clsx';
-import { AlertTriangle, ChevronRight, CircleDashed, CircleCheck, CircleSlash } from 'lucide-react';
+import {
+    AlertTriangle,
+    ChevronRight,
+    CircleDashed,
+    CircleCheck,
+    CircleSlash,
+    type LucideIcon,
+} from 'lucide-react';
 import {
     asBoolean,
     groupFields,
@@ -74,6 +81,14 @@ const DECLARED_STATUS_MAP: Record<'off' | 'unconfigured' | 'on', SectionStatus> 
     on: 'ready',
 };
 
+export interface SettingsSectionAppearance {
+    Icon: LucideIcon;
+    fields?: Readonly<Partial<Record<string, {
+        emphasis?: 'primary' | 'dependent';
+        Icon?: LucideIcon;
+    }>>>;
+}
+
 export interface SettingsSectionProps {
     sectionId: string;
     label: string;
@@ -96,6 +111,8 @@ export interface SettingsSectionProps {
     statusRule?: AdminSectionStatusRule;
     /** Force every group open, used while a search is filtering the page. */
     forceExpanded?: boolean;
+    /** Opt-in visual hierarchy; does not change the schema's behavior. */
+    appearance?: SettingsSectionAppearance;
     children?: React.ReactNode;
 }
 
@@ -153,11 +170,13 @@ function FieldGroup({
     startOpen,
     forceExpanded,
     renderField,
+    distinct = false,
 }: {
     group: RenderedFieldGroup;
     startOpen: boolean;
     forceExpanded?: boolean;
     renderField: (field: AdminField) => React.ReactNode;
+    distinct?: boolean;
 }) {
     const [open, setOpen] = useState(startOpen);
 
@@ -170,29 +189,51 @@ function FieldGroup({
     }, [forceExpanded]);
 
     if (!group.id) {
-        return <div className="divide-y divide-edge">{group.fields.map(renderField)}</div>;
+        return (
+            <div className={clsx('divide-y', distinct ? 'divide-edge-strong' : 'divide-edge')}>
+                {group.fields.map(renderField)}
+            </div>
+        );
     }
 
     return (
-        <div className="mt-2 rounded-lg border border-edge">
+        <div
+            className={clsx(
+                'border',
+                distinct
+                    ? 'mt-3 rounded-xl border-edge-strong bg-surface-solid'
+                    : 'mt-2 rounded-lg border-edge',
+            )}
+        >
             <button
                 type="button"
                 aria-expanded={open}
-                className="flex w-full items-center gap-2 px-3 py-2 text-left hover:bg-surface-2"
+                className={clsx(
+                    'flex w-full items-center gap-2 px-3 py-2 text-left',
+                    distinct
+                        ? 'min-h-11 rounded-xl hover:bg-surface-sunken'
+                        : 'hover:bg-surface-2',
+                    distinct && open && 'rounded-b-none bg-surface-sunken',
+                )}
                 onClick={() => setOpen((previous) => !previous)}
             >
                 <ChevronRight
                     size={14}
                     className={clsx(
-                        'shrink-0 text-text-3 transition-transform',
+                        'shrink-0 transition-transform',
+                        distinct ? 'text-text-2' : 'text-text-3',
                         open && 'rotate-90',
                     )}
                 />
-                <span className="text-xs font-medium text-text-2">
+                <span
+                    className={distinct
+                        ? 'min-w-0 text-sm font-semibold text-text-1'
+                        : 'text-xs font-medium text-text-2'}
+                >
                     {group.label ?? group.id}
                 </span>
                 {!open ? (
-                    <span className="ml-auto text-xs text-text-3">
+                    <span className={clsx('ml-auto text-xs text-text-3', distinct && 'shrink-0')}>
                         {group.fields.length}{' '}
                         {group.fields.length === 1 ? 'setting' : 'settings'}
                     </span>
@@ -200,11 +241,18 @@ function FieldGroup({
             </button>
 
             {open ? (
-                <div className="border-t border-edge px-3 pb-1">
+                <div
+                    className={clsx(
+                        'border-t px-3 pb-1',
+                        distinct ? 'border-edge-strong' : 'border-edge',
+                    )}
+                >
                     {group.help ? (
                         <p className="pt-2 text-xs leading-relaxed text-text-3">{group.help}</p>
                     ) : null}
-                    <div className="divide-y divide-edge">{group.fields.map(renderField)}</div>
+                    <div className={clsx('divide-y', distinct ? 'divide-edge-strong' : 'divide-edge')}>
+                        {group.fields.map(renderField)}
+                    </div>
                 </div>
             ) : null}
         </div>
@@ -223,6 +271,7 @@ export function SettingsSection({
     renderField,
     renderCapability,
     forceExpanded,
+    appearance,
     children,
 }: SettingsSectionProps) {
     const capability = useMemo(() => findCapabilityField(fields), [fields]);
@@ -257,15 +306,111 @@ export function SettingsSection({
 
     const presentation = status === 'none' ? null : STATUS_PRESENTATION[status];
 
+    const decorateField = (
+        field: AdminField,
+        renderer: SettingsSectionProps['renderField'],
+    ) => {
+        const fieldAppearance = appearance?.fields?.[field.key ?? ''];
+        const control = renderer(field);
+        if (!fieldAppearance || control == null) {
+            return control;
+        }
+        return (
+            <div
+                key={field.key}
+                data-setting-emphasis={fieldAppearance.emphasis}
+                className={clsx(
+                    'flex min-w-0 items-start gap-2.5',
+                    fieldAppearance.emphasis === 'primary' &&
+                        'mb-3 rounded-xl border border-accent/40 bg-accent-soft px-3 py-1',
+                    fieldAppearance.emphasis === 'dependent' &&
+                        'ms-3 border-s-2 border-edge-strong ps-3',
+                )}
+            >
+                {fieldAppearance.Icon ? (
+                    <span
+                        aria-hidden="true"
+                        className="mt-3 shrink-0 rounded-lg bg-surface-sunken p-1.5 text-text-2"
+                    >
+                        <fieldAppearance.Icon size={16} />
+                    </span>
+                ) : null}
+                <div className="min-w-0 flex-1">{control}</div>
+            </div>
+        );
+    };
+
+    const body = (
+        <>
+            {requirements.map((requirement) => (
+                <RequirementNotice
+                    key={requirement.key}
+                    requirement={requirement}
+                    satisfied={asBoolean(readSectionValue(settings, draft, requirement.key))}
+                />
+            ))}
+
+            {capability ? (
+                <div className="mb-1 border-b border-edge pb-2">
+                    {decorateField(capability, renderCapability)}
+                </div>
+            ) : null}
+
+            {groups.map((group) => (
+                <FieldGroup
+                    key={group.id || '__ungrouped'}
+                    group={group}
+                    startOpen={shouldGroupStartOpen(group, status, capabilityOn)}
+                    forceExpanded={forceExpanded}
+                    renderField={(field) => decorateField(field, renderField)}
+                    distinct={Boolean(appearance)}
+                />
+            ))}
+
+            {children}
+        </>
+    );
+
     return (
-        <GlassPanel id={sectionId} edge className="p-4">
-            <div className="mb-2 flex items-start justify-between gap-3">
-                <div className="min-w-0">
-                    <h2 className="text-sm font-semibold text-text-1">{label}</h2>
-                    <p className="text-xs text-text-3">
-                        {groupLabel}
-                        {tabLabel ? ` · ${tabLabel}` : ''}
-                    </p>
+        <GlassPanel
+            id={sectionId}
+            edge
+            role={appearance ? 'region' : undefined}
+            aria-labelledby={appearance ? `${sectionId}-title` : undefined}
+            className={appearance ? 'admin-settings-distinct border-edge-strong' : 'p-4'}
+        >
+            <div
+                className={clsx(
+                    'flex items-start justify-between gap-3',
+                    appearance
+                        ? 'flex-wrap rounded-t-2xl border-b border-edge-strong bg-surface-2 p-4 sm:px-5'
+                        : 'mb-2',
+                )}
+            >
+                <div className={clsx('min-w-0', appearance && 'flex flex-1 flex-wrap items-start gap-3')}>
+                    {appearance ? (
+                        <span
+                            aria-hidden="true"
+                            className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl border border-edge-strong bg-surface-solid text-text-2"
+                        >
+                            <appearance.Icon size={20} />
+                        </span>
+                    ) : null}
+                    <div className={clsx('min-w-0', appearance && 'flex-1 basis-40')}>
+                        <h2
+                            id={appearance ? `${sectionId}-title` : undefined}
+                            className={clsx(
+                                'font-semibold text-text-1',
+                                appearance ? 'text-lg leading-snug' : 'text-sm',
+                            )}
+                        >
+                            {label}
+                        </h2>
+                        <p className={clsx('text-xs text-text-3', appearance && 'mt-1')}>
+                            {groupLabel}
+                            {tabLabel ? ` · ${tabLabel}` : ''}
+                        </p>
+                    </div>
                 </div>
 
                 {presentation ? (
@@ -281,31 +426,7 @@ export function SettingsSection({
                 ) : null}
             </div>
 
-            {requirements.map((requirement) => (
-                <RequirementNotice
-                    key={requirement.key}
-                    requirement={requirement}
-                    satisfied={asBoolean(readSectionValue(settings, draft, requirement.key))}
-                />
-            ))}
-
-            {capability ? (
-                <div className="mb-1 border-b border-edge pb-2">
-                    {renderCapability(capability)}
-                </div>
-            ) : null}
-
-            {groups.map((group) => (
-                <FieldGroup
-                    key={group.id || '__ungrouped'}
-                    group={group}
-                    startOpen={shouldGroupStartOpen(group, status, capabilityOn)}
-                    forceExpanded={forceExpanded}
-                    renderField={renderField}
-                />
-            ))}
-
-            {children}
+            {appearance ? <div className="admin-section-body p-4 sm:p-5">{body}</div> : body}
         </GlassPanel>
     );
 }

--- a/application/v2_ui/src/components/admin/agentSectionAppearance.ts
+++ b/application/v2_ui/src/components/admin/agentSectionAppearance.ts
@@ -1,0 +1,29 @@
+// agentSectionAppearance.ts
+
+import { Bot, Layers, Palette, UserRound, UsersRound } from 'lucide-react';
+import type { SettingsSectionAppearance } from './SettingsSection';
+
+// Presentation only: field order, visibility, and status still come from the schema.
+export const agentSectionAppearances: Readonly<
+    Partial<Record<string, SettingsSectionAppearance>>
+> = {
+    'agents-config': {
+        Icon: Bot,
+        fields: {
+            enable_semantic_kernel: { emphasis: 'primary' },
+            per_user_semantic_kernel: { emphasis: 'dependent' },
+            merge_global_semantic_kernel_with_workspace: { emphasis: 'dependent' },
+        },
+    },
+    'agent-toggles-card': {
+        Icon: UsersRound,
+        fields: {
+            allow_user_agents: { Icon: UserRound },
+            allow_group_agents: { Icon: UsersRound },
+            allow_user_custom_endpoints: { Icon: UserRound },
+            allow_group_custom_endpoints: { Icon: UsersRound },
+        },
+    },
+    'agents-page-customization-card': { Icon: Palette },
+    'agent-template-approvals-section': { Icon: Layers },
+};

--- a/application/v2_ui/src/components/admin/fields.tsx
+++ b/application/v2_ui/src/components/admin/fields.tsx
@@ -80,7 +80,7 @@ export function FieldShell({
 }) {
     return (
         <div className="py-3">
-            <div className="mb-1.5 flex items-baseline justify-between gap-3">
+            <div className="admin-field-heading mb-1.5 flex items-baseline justify-between gap-3">
                 <label
                     htmlFor={htmlFor}
                     className="text-sm font-medium text-text-1"
@@ -426,7 +426,7 @@ function ColorControl({ field, value, error, warning, disabled, onChange }: Fiel
 
     return (
         <FieldShell field={field} error={error} warning={warning} htmlFor={id}>
-            <div className="flex items-center gap-2">
+            <div className="admin-color-controls flex items-center gap-2">
                 <input
                     id={id}
                     type="color"

--- a/application/v2_ui/src/pages/AdminSettingsPage.tsx
+++ b/application/v2_ui/src/pages/AdminSettingsPage.tsx
@@ -57,6 +57,7 @@ import { PromotedAgentsEditor } from '../components/admin/PromotedAgentsEditor';
 import { SaveBar } from '../components/admin/SaveBar';
 import { SecretField } from '../components/admin/SecretField';
 import { SettingsSection } from '../components/admin/SettingsSection';
+import { agentSectionAppearances } from '../components/admin/agentSectionAppearance';
 import { SettingField } from '../components/admin/fields';
 import {
     ClassificationBannerPreview,
@@ -1080,6 +1081,7 @@ export function AdminSettingsPage() {
                                     statusRule={sectionStatus[section.sectionId]}
                                     renderField={renderField}
                                     renderCapability={renderField}
+                                    appearance={agentSectionAppearances[section.sectionId]}
                                     // While a search is filtering, a match inside a
                                     // collapsed group has to be shown or the card would
                                     // appear empty.

--- a/application/v2_ui/src/styles/theme.css
+++ b/application/v2_ui/src/styles/theme.css
@@ -315,6 +315,63 @@ html[data-font-size='xl'] {
 }
 
 @layer utilities {
+    .admin-settings-distinct {
+        container-type: inline-size;
+        overflow-wrap: anywhere;
+    }
+
+    /* Same layer as field borders; focus utilities retain their higher specificity. */
+    .admin-settings-distinct :where(input:not([type='checkbox']), select, textarea) {
+        border-color: color-mix(in srgb, var(--text-3) 85%, transparent);
+    }
+
+    /* Relative to the card, not the viewport, so text scaling also triggers wrapping. */
+    @container (max-width: 16rem) {
+        .admin-settings-distinct .admin-section-body {
+            padding: 0.75rem;
+        }
+
+        .admin-settings-distinct :where(
+            label:has(input[type='checkbox']),
+            .admin-field-heading,
+            .admin-color-controls,
+            .admin-promoted-agents-picker,
+            .admin-promoted-agent-row
+        ) {
+            flex-wrap: wrap;
+        }
+
+        .admin-settings-distinct label:has(input[type='checkbox']) > span:last-child,
+        .admin-settings-distinct .admin-promoted-agents-picker > select,
+        .admin-settings-distinct .admin-promoted-agent-row > div {
+            flex-basis: 100%;
+        }
+
+        .admin-settings-distinct .admin-promoted-agent-row > select {
+            min-width: 0;
+            max-width: 100%;
+            flex-shrink: 1;
+        }
+
+        .admin-settings-distinct .admin-promoted-agents-picker > button {
+            height: auto;
+            min-height: 2rem;
+            max-width: 100%;
+            flex-wrap: wrap;
+            padding: 0.25rem 0.5rem;
+        }
+
+        .admin-settings-distinct button[aria-expanded] {
+            display: grid;
+            grid-template-columns: auto minmax(0, 1fr);
+        }
+
+        .admin-settings-distinct button[aria-expanded] > span:last-child:not(:first-of-type) {
+            grid-column: 2;
+            margin-inline-start: 0;
+        }
+    }
+
     /*
      * Respect users who have asked for less motion or less transparency. The second is
      * important for readability: transparency is dropped for solid surfaces rather than

--- a/docs/admin/agents-actions.md
+++ b/docs/admin/agents-actions.md
@@ -5,6 +5,7 @@ description: "Agents & Actions controls the Semantic Kernel runtime, agent marke
 section: "Administration"
 audience: admin
 admin_tab: agents-actions
+version: "0.261.093"
 redirect_from:
   - /admin/agents/
 ---
@@ -32,6 +33,22 @@ Agents and actions can call tools, inspect documents, and automate work. Expose 
 - Configure App Service Authentication excluded paths before exposing inbound MCP.
 
 ## Agents {#agents}
+
+### Reading the V2 settings cards
+
+In V2, neutral header bands and larger titles separate the runtime, workspace
+permissions, catalog presentation, and template approval settings. Person and
+group icons help distinguish the similarly named permission controls, while the
+accent-backed **Enable Agents** row identifies the runtime's main switch.
+
+**Hero**, **Guidance**, and **Promoted agents** remain independently expandable.
+Their headers show setting counts while collapsed, and search reveals matching
+fields inside them. At narrow widths or larger text sizes, controls wrap within
+their card. Use the existing save bar to save or discard edits; the visual
+treatment does not change defaults, permissions, or when settings take effect.
+
+This presentation was implemented in **0.261.093**, tracked in
+`application/single_app/config.py`.
 
 ### Agent Runtime {#agents-config}
 

--- a/docs/explanation/features/V2_ADMIN_AGENTS_ACTIONS.md
+++ b/docs/explanation/features/V2_ADMIN_AGENTS_ACTIONS.md
@@ -14,6 +14,8 @@ the Appearance group never exercised.
 
 **Implemented in version:** 0.261.074
 
+**Current documentation version:** 0.261.093
+
 **Dependencies:** `admin_settings_fields.py`, `admin_settings_nav.py`,
 `route_backend_v2.py`, `application/v2_ui`.
 
@@ -39,6 +41,18 @@ Everything else in the group — `per_user_semantic_kernel`, the six `allow_*` a
 booleans.
 
 ## Technical specifications
+
+### Visual hierarchy
+
+In version **0.261.093**, the four Agents sections gained neutral header bands,
+distinct icons, larger titles, and clearer field and disclosure boundaries.
+Runtime emphasis and personal/group cues are presentation-only; they do not
+change the schema, defaults, section status, or save behavior. Other admin
+sections retain their existing appearance.
+
+See [V2 Admin Agents Visual Hierarchy](V2_ADMIN_AGENTS_VISUAL_HIERARCHY.md) for
+the scoped implementation and browser coverage. The release version remains
+tracked in `application/single_app/config.py`.
 
 ### Navigation
 

--- a/docs/explanation/features/V2_ADMIN_AGENTS_VISUAL_HIERARCHY.md
+++ b/docs/explanation/features/V2_ADMIN_AGENTS_VISUAL_HIERARCHY.md
@@ -1,0 +1,89 @@
+# V2 Admin Agents Visual Hierarchy
+
+## Overview
+
+The Agents cards in V2 Admin Settings distinguish runtime controls, workspace
+permissions, catalog presentation, and template approvals without changing their
+order or behavior. Neutral header bands, section icons, larger titles, and stronger
+inset boundaries make those different responsibilities easier to recognize.
+
+## Implemented in version: **0.261.093**
+
+The application version is maintained in `application/single_app/config.py`.
+This change increments its third segment from `0.261.092` to `0.261.093`.
+
+**Dependencies:** the existing React/TypeScript V2 UI, local Lucide icons,
+`SettingsSection`, and the server-declared admin field schema. No new packages,
+settings, routes, or browser asset sources are required.
+
+## Technical specifications
+
+`AdminSettingsPage` supplies an optional appearance configuration to the existing
+section renderer. The configuration is limited to these section IDs:
+
+| Section | Presentation |
+| --- | --- |
+| `agents-config` | Robot icon, an accent-backed Enable Agents row, and subordinate styling for Workspace Mode and its global-agent option. |
+| `agent-toggles-card` | People icon with separate person/group cues alongside the existing permission labels. |
+| `agents-page-customization-card` | Palette icon and stronger Hero, Guidance, and Promoted agents disclosure headers. |
+| `agent-template-approvals-section` | Layers icon and the same neutral section-header treatment. |
+
+The appearance map contains no values or dependency rules. Field order,
+conditional visibility, section status, acknowledgement handling, and saving
+continue to use the existing schema and callbacks. In particular, emphasizing
+Enable Agents does not turn it into a new readiness indicator.
+
+The opt-in CSS uses existing semantic theme tokens. Each card is an inline-size
+container: when it is narrow relative to the selected text size, labels, color
+inputs, promotion controls, and setting counts wrap instead of extending past
+the card. Normal-width layouts and all non-Agents sections keep their previous
+presentation.
+
+### File structure
+
+| File | Responsibility |
+| --- | --- |
+| `application/v2_ui/src/components/admin/agentSectionAppearance.ts` | The four-section appearance map. |
+| `application/v2_ui/src/components/admin/SettingsSection.tsx` | Opt-in headers, decorative field cues, and disclosure styling. |
+| `application/v2_ui/src/components/admin/fields.tsx` | Inert CSS hooks for field headings and color controls. |
+| `application/v2_ui/src/components/admin/PromotedAgentsEditor.tsx` | Inert CSS hooks for promotion controls and rows. |
+| `application/v2_ui/src/pages/AdminSettingsPage.tsx` | Applies the map while retaining the shared renderer. |
+| `application/v2_ui/src/styles/theme.css` | Scoped contrast and container-based wrapping rules. |
+
+There are no API or persistence changes. The main save bar still buffers settings,
+and orchestration retains its existing separate save endpoint.
+
+## Usage
+
+In V2 Admin Settings, choose **Agents & Actions**. Use **Agent Runtime** for the
+runtime and workspace-source controls; use **Workspace Agent Permissions** to
+distinguish personal and group permissions. Their full labels and endpoint
+guidance remain visible.
+
+Expand **Hero**, **Guidance**, or **Promoted agents** in **Agents Page** to work on
+catalog presentation. The disclosure headers still show setting counts when
+collapsed. Search continues to reveal matching fields inside collapsed groups.
+
+Use the existing save bar to save or discard a draft. The new header bands and
+icons do not indicate that a change has already been saved.
+
+## Testing and validation
+
+- `functional_tests/test_v2_admin_section_logic.ts`, run by
+  `test_v2_admin_section_shell.py`, covers the four-section boundary, retained
+  rendering callbacks and order, unchanged status semantics, and collapse defaults.
+- `functional_tests/test_v2_admin_agents_parity.py` retains schema and visibility
+  parity coverage.
+- `ui_tests/test_v2_admin_agents_visual_hierarchy.py` exercises the built SPA with
+  real schema metadata and intercepted APIs: light/dark contrast, heading sizes,
+  keyboard disclosure, search, permission visibility, save/discard, rejected
+  saves, promotions, narrow viewports, and 200% text scaling.
+
+Browser fixtures never write to a live settings document. Local Chromium is the
+default; the fixture can connect to a configured Azure Playwright workspace using
+`PLAYWRIGHT_SERVICE_URL`, `PLAYWRIGHT_WORKSPACE_RESOURCE_ID`, and
+`DefaultAzureCredential`. Azure execution requires an existing workspace and
+appropriate access; no resource provisioning is performed by these tests.
+
+The enhancement adds no API requests or per-field state. The classic interface,
+Actions, Inbound MCP, and other admin categories are outside its scope.

--- a/functional_tests/test_v2_admin_section_logic.ts
+++ b/functional_tests/test_v2_admin_section_logic.ts
@@ -1,8 +1,9 @@
 // test_v2_admin_section_logic.ts
 //
 // Runtime test for the Admin Settings section shell's presentation decisions.
-// Version: 0.261.084
+// Version: 0.261.093
 // Implemented in: 0.261.084
+// Agents-only visual hierarchy coverage added in: 0.261.093
 //
 // The V2 admin surface used to render a section as a flat run of controls in declaration
 // order. That is fine for Appearance. It is not fine for Knowledge, where Document
@@ -20,6 +21,13 @@
 // adminSections and adminFields.
 
 import assert from 'node:assert/strict';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import {
+    SettingsSection,
+    type SettingsSectionProps,
+} from '../application/v2_ui/src/components/admin/SettingsSection';
+import { agentSectionAppearances } from '../application/v2_ui/src/components/admin/agentSectionAppearance';
 import {
     collectRequirements,
     deriveSectionStatus,
@@ -328,6 +336,102 @@ check('dependency evaluation agrees with the server rules', () => {
     };
     assert.equal(evaluateDependency(allOf, read), false);
     assert.equal(evaluateDependency({ key: 'missing', equals: false }, read), true);
+});
+
+check('distinct presentation is limited to the four Agents sections', () => {
+    assert.deepEqual(Object.keys(agentSectionAppearances), [
+        'agents-config',
+        'agent-toggles-card',
+        'agents-page-customization-card',
+        'agent-template-approvals-section',
+    ]);
+    for (const id of ['core-plugin-toggles', 'inbound-mcp-configuration', 'unknown-section']) {
+        assert.equal(agentSectionAppearances[id], undefined);
+    }
+});
+
+function renderSection(
+    appearance: SettingsSectionProps['appearance'],
+    fields: AdminField[],
+    settings: Record<string, unknown>,
+    calls: string[],
+) {
+    return renderToStaticMarkup(createElement(SettingsSection, {
+        sectionId: 'agents-config',
+        label: 'Agent Runtime',
+        groupLabel: 'Agents & Actions',
+        tabLabel: 'Agents',
+        fields,
+        settings,
+        draft: {},
+        appearance,
+        renderField: (field) => {
+            calls.push(`field:${field.key}`);
+            return createElement('span', { key: field.key }, field.label);
+        },
+        renderCapability: (field) => {
+            calls.push(`capability:${field.key}`);
+            return createElement('span', { key: field.key }, field.label);
+        },
+    }));
+}
+
+check('presentation keeps rendering order, capability callbacks, and visibility intact', () => {
+    const fields: AdminField[] = [
+        capability('enable_semantic_kernel'),
+        { key: 'per_user_semantic_kernel', type: 'switch', label: 'Workspace Mode' },
+        {
+            key: 'merge_global_semantic_kernel_with_workspace',
+            type: 'switch',
+            label: 'Include global agents',
+            depends_on: { key: 'per_user_semantic_kernel', equals: true },
+        },
+    ];
+    const values = { enable_semantic_kernel: true, per_user_semantic_kernel: false };
+    const plainCalls: string[] = [];
+    const distinctCalls: string[] = [];
+    const plain = renderSection(undefined, fields, values, plainCalls);
+    const distinct = renderSection(
+        agentSectionAppearances['agents-config'], fields, values, distinctCalls,
+    );
+
+    assert.deepEqual(distinctCalls, plainCalls);
+    assert.deepEqual(distinctCalls, [
+        'capability:enable_semantic_kernel',
+        'field:per_user_semantic_kernel',
+    ]);
+    assert.doesNotMatch(plain, /admin-settings-distinct|role="region"/);
+    assert.match(distinct, /role="region" aria-labelledby="agents-config-title"/);
+    assert.match(distinct, /data-setting-emphasis="primary"/);
+    assert.match(distinct, /data-setting-emphasis="dependent"/);
+    assert.equal(distinct.includes('Configured'), plain.includes('Configured'));
+    assert.doesNotMatch(distinct, /Include global agents/);
+});
+
+check('runtime emphasis does not turn an ordinary switch into a capability status', () => {
+    const fields = [{ key: 'enable_semantic_kernel', type: 'switch', label: 'Enable Agents' }];
+    const calls: string[] = [];
+    const markup = renderSection(
+        agentSectionAppearances['agents-config'], fields, { enable_semantic_kernel: true }, calls,
+    );
+    assert.deepEqual(calls, ['field:enable_semantic_kernel']);
+    assert.match(markup, /data-setting-emphasis="primary"/);
+    assert.doesNotMatch(markup, /Configured|Needs configuration/);
+});
+
+check('distinct subsection presentation preserves collapsed defaults and counts', () => {
+    const fields = [
+        { key: 'agents_page_title', type: 'text', label: 'Hero Title', group: 'Hero' },
+        { key: 'agents_page_subtitle', type: 'text', label: 'Hero Subtitle', group: 'Hero' },
+    ];
+    const calls: string[] = [];
+    const markup = renderSection(
+        agentSectionAppearances['agents-page-customization-card'], fields, {}, calls,
+    );
+    assert.match(markup, /aria-expanded="false"/);
+    assert.match(markup, /2 settings/);
+    assert.doesNotMatch(markup, /Hero Title|Hero Subtitle/);
+    assert.deepEqual(calls, []);
 });
 
 let passed = 0;

--- a/functional_tests/test_v2_admin_section_shell.py
+++ b/functional_tests/test_v2_admin_section_shell.py
@@ -2,8 +2,9 @@
 # test_v2_admin_section_shell.py
 """
 Functional test for the Admin Settings section shell and connection tests.
-Version: 0.261.084
+Version: 0.261.093
 Implemented in: 0.261.084
+Agents-only visual hierarchy coverage added in: 0.261.093
 
 Two things arrive together here, because neither is useful without the other.
 

--- a/ui_tests/fixtures/v2_admin_settings.py
+++ b/ui_tests/fixtures/v2_admin_settings.py
@@ -1,0 +1,251 @@
+# v2_admin_settings.py
+"""
+Schema-backed browser fixtures for V2 Admin Settings.
+Version: 0.261.093
+Implemented in: 0.261.093
+
+Serve the real built SPA through Playwright request interception, using the real
+Agents field schema and synthetic settings. No application server, signed-in
+account, or live settings writes are needed. Unexpected requests fail the test.
+
+The default browser is local. To use Azure Playwright, set PLAYWRIGHT_SERVICE_URL
+and PLAYWRIGHT_WORKSPACE_RESOURCE_ID. The workspace is read with
+azure-mgmt-playwright and authenticated with DefaultAzureCredential; no resources
+are created and no access tokens are stored.
+"""
+
+import copy
+import os
+import sys
+from pathlib import Path
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+from uuid import uuid4
+
+import pytest
+from azure.identity import DefaultAzureCredential
+from azure.mgmt.playwright import PlaywrightMgmtClient
+from playwright.sync_api import Page, Route, expect
+
+# Reuse the existing isolated application imports rather than initializing Azure clients.
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "functional_tests"))
+
+from test_support.app_stubs import import_app_module
+from test_support.nav import ADMIN_NAV
+
+
+STATIC_ROOT = REPO_ROOT / "application" / "single_app" / "static"
+SPA_INDEX = STATIC_ROOT / "v2" / "index.html"
+ORIGIN = "http://simplechat.test"
+AGENT_SECTION_IDS = (
+    "agents-config",
+    "agent-toggles-card",
+    "agents-page-customization-card",
+    "agent-template-approvals-section",
+)
+
+
+@pytest.fixture(scope="session")
+def connect_options():
+    """Let pytest-playwright use the configured Azure workspace, or a local browser."""
+    service_url = os.getenv("PLAYWRIGHT_SERVICE_URL", "")
+    if not service_url:
+        return {}
+
+    resource_id = os.getenv("PLAYWRIGHT_WORKSPACE_RESOURCE_ID", "")
+    parts = resource_id.strip("/").split("/")
+    if (
+        len(parts) != 8
+        or parts[0].lower() != "subscriptions"
+        or parts[2].lower() != "resourcegroups"
+        or parts[4].lower() != "providers"
+        or parts[5].lower() != "microsoft.loadtestservice"
+        or parts[6].lower() != "playwrightworkspaces"
+    ):
+        raise ValueError("Set PLAYWRIGHT_WORKSPACE_RESOURCE_ID to the workspace's ARM resource ID.")
+
+    endpoint = urlsplit(service_url)
+    with DefaultAzureCredential() as credential:
+        with PlaywrightMgmtClient(credential, parts[1]) as client:
+            workspace = client.playwright_workspaces.get(parts[3], parts[7])
+        dataplane_uri = workspace.properties.dataplane_uri if workspace.properties else None
+        if (
+            endpoint.scheme != "wss"
+            or not dataplane_uri
+            or endpoint.hostname != urlsplit(dataplane_uri).hostname
+        ):
+            raise ValueError("PLAYWRIGHT_SERVICE_URL must target the configured Azure workspace.")
+        token = credential.get_token("https://management.azure.com/.default").token
+
+    query = dict(parse_qsl(endpoint.query))
+    query.update({
+        "os": "linux",
+        "runId": os.getenv("PLAYWRIGHT_SERVICE_RUN_ID") or str(uuid4()),
+        "api-version": "2025-09-01",
+    })
+    return {
+        "ws_endpoint": urlunsplit(endpoint._replace(query=urlencode(query))),
+        "headers": {"Authorization": f"Bearer {token}"},
+        "timeout": 180000,
+    }
+
+
+class AdminSettingsFixture:
+    """Load the production admin page with a closed, in-memory API boundary."""
+
+    def __init__(self, page: Page):
+        self.page = page
+        fields_module = import_app_module("admin_settings_fields")
+        schema = fields_module.get_admin_settings_fields()
+        group = copy.deepcopy(next(item for item in ADMIN_NAV if item["id"] == "agents-actions"))
+        agents_tab = next(tab for tab in group["tabs"] if tab["id"] == "agents")
+        actions_tab = next(tab for tab in group["tabs"] if tab["id"] == "actions")
+        actions_tab["sections"] = [
+            section for section in actions_tab["sections"] if section["id"] == "core-plugin-toggles"
+        ]
+        group["tabs"] = [agents_tab, actions_tab]
+        section_ids = (*AGENT_SECTION_IDS, "core-plugin-toggles")
+        self.schema = {section_id: copy.deepcopy(schema[section_id]) for section_id in section_ids}
+        self.settings = {
+            field["key"]: copy.deepcopy(field["default"])
+            for fields in self.schema.values()
+            for field in fields
+            if field.get("key") and "default" in field
+        }
+        self.settings.update({
+            "enable_semantic_kernel": True,
+            "per_user_semantic_kernel": True,
+            "allow_user_agents": True,
+        })
+        self.payload = {
+            "settings": self.settings,
+            "admin_nav": [group],
+            "field_schema": self.schema,
+            "section_status": {},
+            "runtime_flags": {},
+            "suppressed_capabilities": fields_module.get_suppressed_capability_keys(),
+        }
+        self.preferences = {}
+        self.catalog_agents = [
+            {
+                "catalog_key": "global:research",
+                "display_name": "Quarterly Research Assistant",
+                "scope_label": "Enterprise",
+                "scope_type": "global",
+                "window": "both",
+            },
+            {
+                "catalog_key": "global:roadmap",
+                "display_name": "Roadmap Advisor",
+                "scope_label": "Enterprise",
+                "scope_type": "global",
+                "window": "both",
+            },
+        ]
+        self.patches = []
+        self.reject_next_save = False
+        self.errors = []
+        self.unexpected_requests = []
+        page.on("pageerror", lambda error: self.errors.append(str(error)))
+        page.on(
+            "console",
+            lambda message: self.errors.append(message.text) if message.type == "error" else None,
+        )
+        page.route("**/*", self._route)
+
+    def _bootstrap(self):
+        return {
+            "version": "0.261.093",
+            "user": {"id": "test-admin", "display_name": "Test Admin", "is_admin": True, "roles": ["Admin"]},
+            "branding": {"app_title": "SimpleChat", "show_logo": False, "hide_app_title": False},
+            "features": {},
+            "catalogs": {"models": [], "agents": [], "prompts": [], "initial_model_selection": None},
+            "scope": {"groups": [], "public_workspaces": []},
+            "navigation": {
+                "custom_pages": {"enabled": False, "items": []},
+                "external_links": {"enabled": False, "items": []},
+            },
+            "workspace": {"sections": {}},
+            "admin_nav": self.payload["admin_nav"],
+            "settings": {},
+        }
+
+    def _route(self, route: Route):
+        request = route.request
+        parsed = urlsplit(request.url)
+        path = parsed.path
+        if f"{parsed.scheme}://{parsed.netloc}" != ORIGIN:
+            self.unexpected_requests.append(request.url)
+            route.abort()
+            return
+
+        if request.method == "GET" and path == "/v2/admin":
+            route.fulfill(path=str(SPA_INDEX), content_type="text/html")
+        elif request.method == "GET" and path.startswith("/static/"):
+            asset = (STATIC_ROOT / path.removeprefix("/static/")).resolve()
+            if asset.is_relative_to(STATIC_ROOT.resolve()) and asset.is_file():
+                route.fulfill(path=str(asset))
+            else:
+                self.unexpected_requests.append(path)
+                route.fulfill(status=404, body="Fixture asset not found")
+        elif path == "/api/v2/bootstrap" and request.method == "GET":
+            route.fulfill(json=self._bootstrap())
+        elif path == "/api/user/settings" and request.method == "GET":
+            route.fulfill(json={"settings": self.preferences})
+        elif path == "/api/user/settings" and request.method == "POST":
+            self.preferences.update(request.post_data_json["settings"])
+            route.fulfill(json={"message": "Saved fixture preferences."})
+        elif path == "/api/v2/admin/settings" and request.method == "GET":
+            route.fulfill(json=self.payload)
+        elif path == "/api/v2/admin/settings" and request.method == "PATCH":
+            updates = request.post_data_json["settings"]
+            self.patches.append(copy.deepcopy(updates))
+            if self.reject_next_save:
+                self.reject_next_save = False
+                route.fulfill(status=400, json={
+                    "error": "Invalid settings.",
+                    "field_errors": {key: "Fixture validation error." for key in updates},
+                })
+            else:
+                self.settings.update(updates)
+                route.fulfill(json={"settings": updates, "updated_keys": list(updates)})
+        elif path == "/api/orchestration_types" and request.method == "GET":
+            route.fulfill(json=[{"value": "default_agent", "label": "Single agent"}])
+        elif path == "/api/orchestration_settings" and request.method == "GET":
+            route.fulfill(json={"orchestration_type": "default_agent", "max_rounds_per_agent": 1})
+        elif path == "/api/agents/catalog" and request.method == "GET":
+            route.fulfill(json={"agents": self.catalog_agents})
+        else:
+            self.unexpected_requests.append(f"{request.method} {path}")
+            route.fulfill(status=404, json={"error": "Unexpected fixture request."})
+
+    def open(self, theme="light", width=1440, font_size="m"):
+        if not SPA_INDEX.is_file():
+            pytest.fail("Build the V2 SPA first: npm --prefix application/v2_ui run build")
+        source_root = REPO_ROOT / "application" / "v2_ui" / "src"
+        if any(
+            path.stat().st_mtime > SPA_INDEX.stat().st_mtime
+            for path in source_root.rglob("*")
+            if path.is_file()
+        ):
+            pytest.fail("The V2 bundle is stale. Run npm --prefix application/v2_ui run build")
+        self.preferences = {
+            "darkModeEnabled": theme == "dark",
+            "v2RailCollapsed": width < 1024,
+            "fontSizePreference": font_size,
+        }
+        self.page.set_viewport_size({"width": width, "height": 1000})
+        self.page.goto(f"{ORIGIN}/v2/admin", wait_until="networkidle")
+        expect(self.page.get_by_role("region", name="Agent Runtime", exact=True)).to_be_visible()
+        expect(self.page.locator("html")).to_have_attribute("data-font-size", font_size)
+
+    def capture(self, name):
+        artifacts = REPO_ROOT / "ui_tests" / "artifacts" / "v2_admin_agents"
+        artifacts.mkdir(parents=True, exist_ok=True)
+        self.page.screenshot(
+            path=str(artifacts / f"{name}.png"), full_page=True, animations="disabled"
+        )
+
+    def assert_clean(self):
+        assert not self.unexpected_requests, self.unexpected_requests
+        assert not self.errors, self.errors

--- a/ui_tests/test_v2_admin_agents_visual_hierarchy.py
+++ b/ui_tests/test_v2_admin_agents_visual_hierarchy.py
@@ -1,0 +1,252 @@
+# test_v2_admin_agents_visual_hierarchy.py
+"""
+Browser coverage for the scoped V2 Agents settings presentation.
+Version: 0.261.093
+Implemented in: 0.261.093
+
+Exercise the built application and real field schema with intercepted APIs. Check
+visual hierarchy, contrast, keyboard disclosure, responsiveness, dependency
+visibility, and draft/save behavior without modifying live settings.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+from playwright.sync_api import expect
+
+# Fixtures stay under ui_tests; the import also registers Azure connect_options.
+sys.path.insert(0, str(Path(__file__).resolve().parent / "fixtures"))
+
+from v2_admin_settings import AGENT_SECTION_IDS, AdminSettingsFixture, connect_options
+
+
+pytestmark = pytest.mark.ui
+
+
+@pytest.fixture
+def agents_ui(page):
+    fixture = AdminSettingsFixture(page)
+    yield fixture
+    fixture.assert_clean()
+
+
+def _checkbox(page, label):
+    return page.get_by_role("checkbox", name=re.compile(f"^{re.escape(label)}"))
+
+
+def _set_checkbox(page, label, checked):
+    checkbox = _checkbox(page, label)
+    if checkbox.is_checked() != checked:
+        page.get_by_text(label, exact=True).click()
+    expect(checkbox).to_be_checked(checked=checked)
+
+
+def _catalog_group(page, label):
+    return page.get_by_role("region", name="Agents Page", exact=True).get_by_role(
+        "button", name=re.compile(f"^{re.escape(label)}")
+    )
+
+
+# Resolve alpha against actual ancestor surfaces. Only used inside the opaque
+# catalog groups, so the ambient page gradients cannot invalidate the result.
+_CONTRAST = """
+(element, property) => {
+    const canvas = document.createElement('canvas');
+    canvas.width = canvas.height = 1;
+    const context = canvas.getContext('2d', {willReadFrequently: true});
+    const rgba = (color) => {
+        context.clearRect(0, 0, 1, 1);
+        context.fillStyle = color;
+        context.fillRect(0, 0, 1, 1);
+        const pixel = context.getImageData(0, 0, 1, 1).data;
+        return [pixel[0], pixel[1], pixel[2], pixel[3] / 255];
+    };
+    const over = (top, bottom) => {
+        const alpha = top[3] + bottom[3] * (1 - top[3]);
+        return [0, 1, 2].map((index) =>
+            (top[index] * top[3] + bottom[index] * bottom[3] * (1 - top[3])) / alpha
+        ).concat(alpha);
+    };
+    let background = [0, 0, 0, 0];
+    for (let parent = element; parent; parent = parent.parentElement) {
+        const color = rgba(getComputedStyle(parent).backgroundColor);
+        if (color[3]) {
+            background = over(background, color);
+        }
+        if (background[3] === 1) break;
+    }
+    if (background[3] !== 1) throw new Error('Contrast requires an opaque ancestor');
+    const foreground = over(rgba(getComputedStyle(element)[property]), background);
+    const luminance = (color) => color.slice(0, 3).reduce((sum, value, index) => {
+        const channel = value / 255;
+        const linear = channel <= 0.04045 ? channel / 12.92 : ((channel + 0.055) / 1.055) ** 2.4;
+        return sum + linear * [0.2126, 0.7152, 0.0722][index];
+    }, 0);
+    const light = Math.max(luminance(background), luminance(foreground));
+    const dark = Math.min(luminance(background), luminance(foreground));
+    return (light + 0.05) / (dark + 0.05);
+}
+"""
+
+
+@pytest.mark.parametrize("theme", ["light", "dark"])
+def test_agent_sections_have_distinct_headers_and_readable_controls(agents_ui, theme):
+    agents_ui.open(theme=theme)
+    page = agents_ui.page
+    expect(page.locator(".admin-settings-distinct")).to_have_count(4)
+    field_size = page.get_by_text("Enable Agents", exact=True).evaluate(
+        "element => parseFloat(getComputedStyle(element).fontSize)"
+    )
+    for section_id in AGENT_SECTION_IDS:
+        section = page.locator(f"#{section_id}")
+        expect(section).to_have_attribute("role", "region")
+        heading = section.get_by_role("heading", level=2)
+        assert heading.evaluate("element => parseFloat(getComputedStyle(element).fontSize)") > field_size
+        expect(section.locator(":scope > div").first.locator('[aria-hidden="true"] svg')).to_have_count(1)
+
+    other = page.locator("#core-plugin-toggles")
+    expect(other).not_to_have_class(re.compile("admin-settings-distinct"))
+    assert other.get_by_role("heading", level=2).evaluate(
+        "element => parseFloat(getComputedStyle(element).fontSize)"
+    ) == field_size
+
+    runtime = page.get_by_role("region", name="Agent Runtime", exact=True)
+    expect(runtime.locator('[data-setting-emphasis="primary"]')).to_contain_text("Enable Agents")
+    expect(runtime.locator('[data-setting-emphasis="dependent"]')).to_have_count(2)
+    expect(runtime.get_by_text("Configured", exact=True)).to_have_count(0)
+    agents_ui.capture(f"overview-{theme}")
+
+    _catalog_group(page, "Hero").click()
+    title = page.get_by_label("Hero Title", exact=True)
+    help_text = page.get_by_text("Headline at the top of the Agents catalog page.", exact=True)
+    assert title.evaluate(_CONTRAST, "color") >= 4.5
+    assert help_text.evaluate(_CONTRAST, "color") >= 4.5
+    assert title.evaluate(_CONTRAST, "borderTopColor") >= 3
+    border_before = title.evaluate("element => getComputedStyle(element).borderTopColor")
+    title.focus()
+    assert title.evaluate("element => getComputedStyle(element).borderTopColor") != border_before
+    assert title.evaluate(_CONTRAST, "borderTopColor") >= 3
+    agents_ui.capture(f"headers-{theme}")
+
+
+def test_disclosure_keyboard_and_search_keep_the_current_workflow(agents_ui):
+    agents_ui.open()
+    page = agents_ui.page
+    hero = _catalog_group(page, "Hero")
+    guidance = _catalog_group(page, "Guidance")
+    promoted = _catalog_group(page, "Promoted agents")
+    for group in (hero, guidance, promoted):
+        expect(group).to_have_attribute("aria-expanded", "false")
+    expect(hero).to_contain_text("settings")
+
+    hero.focus()
+    page.keyboard.press("Space")
+    expect(hero).to_have_attribute("aria-expanded", "true")
+    assert hero.evaluate("element => getComputedStyle(element).outlineStyle") == "solid"
+    assert hero.evaluate("element => parseFloat(getComputedStyle(element).outlineWidth)") >= 2
+    expect(page.get_by_label("Hero Title", exact=True)).to_be_visible()
+    expect(guidance).to_have_attribute("aria-expanded", "false")
+    page.keyboard.press("Space")
+    expect(hero).to_have_attribute("aria-expanded", "false")
+    expect(page.get_by_label("Hero Title", exact=True)).to_have_count(0)
+
+    page.get_by_role("searchbox", name="Search settings").fill("Promoted Tag Label")
+    expect(_catalog_group(page, "Promoted agents")).to_have_attribute("aria-expanded", "true")
+    expect(page.get_by_label("Promoted Tag Label", exact=True)).to_be_visible()
+    page.get_by_role("searchbox", name="Search settings").fill("")
+    expect(page.get_by_role("region", name="Agent Runtime", exact=True)).to_be_visible()
+
+
+def test_permissions_visibility_and_save_discard_remain_schema_driven(agents_ui):
+    agents_ui.open()
+    page = agents_ui.page
+    permissions = page.get_by_role("region", name="Workspace Agent Permissions", exact=True)
+    expect(permissions.locator('[aria-hidden="true"] svg.lucide-user-round')).to_have_count(2)
+    # Two group field icons and the section header icon.
+    expect(permissions.locator('[aria-hidden="true"] svg.lucide-users-round')).to_have_count(3)
+    expect(_checkbox(page, "Allow Personal Agents")).to_be_checked()
+    expect(_checkbox(page, "Allow Group Agents")).not_to_be_checked()
+    expect(page.get_by_text(
+        re.compile("This lets model traffic leave the endpoints you administer")
+    )).to_be_visible()
+
+    _set_checkbox(page, "Enable Agents", False)
+    expect(_checkbox(page, "Workspace Mode")).to_have_count(0)
+    expect(page.get_by_role("region", name="Agents Page", exact=True)).to_have_count(0)
+    _set_checkbox(page, "Enable Agents", True)
+    _set_checkbox(page, "Workspace Mode", False)
+    expect(permissions).to_have_count(0)
+    page.get_by_role("button", name="Discard", exact=True).click()
+    expect(permissions).to_be_visible()
+    expect(_checkbox(page, "Workspace Mode")).to_be_checked()
+    assert agents_ui.patches == []
+
+    _set_checkbox(page, "Enable Agent Template Gallery", False)
+    expect(page.get_by_role("region", name="Agent Template Approvals", exact=True)).to_have_count(0)
+    page.get_by_role("button", name="Discard", exact=True).click()
+    expect(page.get_by_role("region", name="Agent Template Approvals", exact=True)).to_be_visible()
+
+    _set_checkbox(page, "Allow Group Agents", True)
+    page.get_by_role("button", name="Save changes", exact=True).click()
+    expect(page.get_by_role("button", name="Save changes", exact=True)).to_have_count(0)
+    assert agents_ui.patches == [{"allow_group_agents": True}]
+    assert agents_ui.settings["allow_group_agents"] is True
+    page.reload(wait_until="networkidle")
+    expect(_checkbox(page, "Allow Group Agents")).to_be_checked()
+
+
+def test_promoted_agent_controls_still_save_the_catalog_entry_and_window(agents_ui):
+    agents_ui.settings["agents_page_promoted_popular_agents"] = [agents_ui.catalog_agents[0]]
+    agents_ui.open()
+    page = agents_ui.page
+    _catalog_group(page, "Promoted agents").click()
+    page.get_by_role("combobox", name="Agent to promote", exact=True).select_option("global:roadmap")
+    page.get_by_role("button", name="Promote", exact=True).click()
+    window = page.get_by_role("combobox", name="Popular window for Roadmap Advisor", exact=True)
+    expect(window).to_have_value("both")
+    window.select_option("30_days")
+    remove = page.get_by_role("button", name="Stop promoting Quarterly Research Assistant", exact=True)
+    remove.click()
+    expect(remove).to_have_count(0)
+    page.get_by_role("button", name="Save changes", exact=True).click()
+    expect(page.get_by_role("button", name="Save changes", exact=True)).to_have_count(0)
+    assert agents_ui.patches == [{
+        "agents_page_promoted_popular_agents": [
+            {**agents_ui.catalog_agents[1], "window": "30_days"}
+        ]
+    }]
+
+
+def test_rejected_save_keeps_the_draft_and_error_visible(agents_ui):
+    agents_ui.open()
+    page = agents_ui.page
+    _catalog_group(page, "Hero").click()
+    title = page.get_by_label("Hero Title", exact=True)
+    original = title.input_value()
+    title.fill("Updated catalog")
+    agents_ui.reject_next_save = True
+    page.get_by_role("button", name="Save changes", exact=True).click()
+    expect(title).to_have_value("Updated catalog")
+    expect(page.get_by_role("alert").filter(has_text="Fixture validation error.")).to_be_visible()
+    assert agents_ui.settings["agents_page_title"] == original
+    page.get_by_role("button", name="Discard", exact=True).click()
+    expect(title).to_have_value(original)
+    # The intercepted 400 is expected; all other console errors remain failures.
+    agents_ui.errors = [error for error in agents_ui.errors if "400 (Bad Request)" not in error]
+
+
+@pytest.mark.parametrize("theme", ["light", "dark"])
+@pytest.mark.parametrize("width,font_size", [(390, "m"), (1440, "xl"), (390, "xl")])
+def test_agent_cards_wrap_at_narrow_widths_and_large_text(agents_ui, theme, width, font_size):
+    agents_ui.settings["agents_page_promoted_popular_agents"] = [agents_ui.catalog_agents[0]]
+    agents_ui.open(theme=theme, width=width, font_size=font_size)
+    page = agents_ui.page
+    for label in ("Hero", "Guidance", "Promoted agents"):
+        _catalog_group(page, label).click()
+    agents_ui.capture(f"responsive-{theme}-{width}-{font_size}")
+    for section_id in AGENT_SECTION_IDS:
+        section = page.locator(f"#{section_id}")
+        overflow = section.evaluate("element => element.scrollWidth - element.clientWidth")
+        assert overflow <= 1, f"{section_id} overflows by {overflow}px at {width}px/{font_size}"


### PR DESCRIPTION
<!-- Thanks for contributing to SimpleChat! Keep this practical and delete sections that truly do not apply. -->

## Summary

<!-- What changed and why? Include the user/admin impact in 2-4 bullets. -->

- Give the four V2 Agents settings sections stronger neutral headers, larger titles, local icons, and clearer card boundaries.
- Emphasize Enable Agents, distinguish personal/group permissions, and improve Hero, Guidance, and Promoted agents disclosure headers without changing settings behavior.
- Add scoped wrapping for narrow cards and larger text, while preserving other admin sections, existing dependency rules, search, and save/discard behavior.
- Document the enhancement and bump the application version to **0.261.093**. No API, settings-schema, authentication, or deployment changes.

**Base:** `paullizer-react-v2-ui`. This change depends on the existing V2 integration branch, which is not yet in `Development`. Keeping that base limits this PR to the Agents polish rather than including the V2 integration history.

## Linked issue

<!-- Use one when applicable: Fixes #123, Closes #123, Refs #123. -->

No associated issue; the user requested this improvement directly and chose not to create an issue.

## Release Notes & Latest Features

<!-- Check the most relevant category. Release notes go under the current VERSION from application/single_app/config.py in docs/explanation/release_notes.md. -->

- [ ] New Feature
- [ ] Bug Fix
- [x] UI Enhancement
- [ ] Breaking Change
- [ ] Internal only

Is this visible to end users?

- [ ] Yes
- [x] No — this is limited to Admin Settings.

Is this admin-facing (Admin Settings, governance, deployment, config)?

- [x] Yes
- [ ] No

Should this become a Latest Feature card?

- [ ] Yes
- [x] No
- [ ] Already added

Screenshot needed for the card?

- [ ] Yes
- [x] No
- [ ] Attached

## Version bump

<!-- Confirm application/single_app/config.py VERSION patch segment was bumped for code changes. If deployers/ changed, also bump deployers/version.txt. -->

- [x] `application/single_app/config.py` `VERSION` third segment bumped: `0.261.092` → `0.261.093`.
- [x] `deployers/version.txt` bump not needed because `deployers/` was not changed.

## Testing / validation

<!-- List commands run and any manual validation. -->

- `npm --prefix .\application\v2_ui run typecheck`
- `npm --prefix .\application\v2_ui run build`
- `python -m pytest .\ui_tests\test_v2_admin_agents_visual_hierarchy.py -q` — 12 passed.
- `python .\functional_tests\test_v2_admin_agents_parity.py` — 6 passed.
- `python .\functional_tests\test_v2_admin_section_shell.py` — 5 passed, including 21 TypeScript rendering/logic checks.
- `python .\functional_tests\test_docs_app_surface_coverage.py` and `python .\functional_tests\test_docs_site_quality.py` — passed; generated inventory remains current.

Browser coverage uses the built SPA, real field metadata, and intercepted APIs in local Chromium. It covers light/dark themes, 390px layouts, 200% text scaling, contrast, keyboard disclosure, search, visibility, save/discard, rejected saves, and promotion controls. No live settings were modified. Screenshots were reviewed locally; generated artifacts are excluded from this commit.

## Documentation

<!-- Feature docs: docs/explanation/features/. Fix docs: docs/explanation/fixes/. -->

- [ ] Release notes updated — left unchanged because the offered update was not approved.
- [x] Feature documentation updated: `V2_ADMIN_AGENTS_VISUAL_HIERARCHY.md`, `V2_ADMIN_AGENTS_ACTIONS.md`, and the Agents & Actions admin guide.
- [x] Separate fix documentation not needed; this is documented as a UI enhancement.

## Security checklist

<!-- These are common SimpleChat review requirements. -->

- [x] New Flask route requirements are not applicable; no Flask routes were added or changed.
- [x] Production settings sanitization is unchanged; no new settings payloads are sent to the frontend.
- [x] Browser JavaScript is served from local SimpleChat static assets only; no CDN-hosted JS.
- [x] No secrets, keys, connection strings, or local-only artifacts are included.