### PR TITLE
Build native V2 workspace agent and action editors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ local_storage_state.json
 .pytest_cache
 .playwright-mcp
 .impeccable
+
+# UI automation screenshots, traces, and recordings
+/ui_tests/artifacts/

--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -97,7 +97,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.261.095"
+VERSION = "0.261.096"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/functions_personal_agents.py
+++ b/application/single_app/functions_personal_agents.py
@@ -1,4 +1,3 @@
-
 # functions_personal_agents.py
 
 """
@@ -17,19 +16,20 @@ from flask import current_app
 import logging
 from config import cosmos_personal_agents_container
 from functions_settings import get_settings, get_user_settings, update_user_settings
-from functions_keyvault import keyvault_agent_save_helper, keyvault_agent_get_helper, keyvault_agent_delete_helper
+from functions_keyvault import keyvault_agent_save_helper, keyvault_agent_get_helper, keyvault_agent_delete_helper, SecretReturnType
 from functions_agent_payload import sanitize_agent_payload
 from functions_agent_delegation import validate_agent_delegation_bindings
 from functions_debug import debug_print
 from functions_governance import ensure_governance_access
 from functions_chat_bootstrap_cache import bump_chat_bootstrap_user_cache_version
 
-def get_personal_agents(user_id):
+def get_personal_agents(user_id, return_type=SecretReturnType.TRIGGER):
     """
     Fetch all personal agents for a user.
     
     Args:
         user_id (str): The user's unique identifier
+        return_type (SecretReturnType): Use placeholders for UI reads or actual stored references for backend cleanup.
         
     Returns:
         list: List of agent dictionaries
@@ -48,7 +48,7 @@ def get_personal_agents(user_id):
         cleaned_agents = []
         for agent in agents:
             cleaned_agent = {k: v for k, v in agent.items() if not k.startswith('_')}
-            cleaned_agent = keyvault_agent_get_helper(cleaned_agent, cleaned_agent.get('id', ''), scope="user")
+            cleaned_agent = keyvault_agent_get_helper(cleaned_agent, cleaned_agent.get('id', ''), scope="user", return_type=return_type)
             if cleaned_agent.get('max_completion_tokens') is None:
                 cleaned_agent['max_completion_tokens'] = -1
             cleaned_agent.setdefault('is_global', False)
@@ -71,13 +71,14 @@ def get_personal_agents(user_id):
         debug_print(f"Error fetching personal agents for user {user_id}: {e}")
         return []
 
-def get_personal_agent(user_id, agent_id):
+def get_personal_agent(user_id, agent_id, return_type=SecretReturnType.TRIGGER):
     """
     Fetch a specific personal agent.
     
     Args:
         user_id (str): The user's unique identifier
         agent_id (str): The agent's unique identifier
+        return_type (SecretReturnType): Use placeholders for UI reads or actual stored references for backend cleanup.
         
     Returns:
         dict: Agent dictionary or None if not found
@@ -90,7 +91,7 @@ def get_personal_agent(user_id, agent_id):
         
         # Remove Cosmos metadata and retrieve secrets from Key Vault
         cleaned_agent = {k: v for k, v in agent.items() if not k.startswith('_')}
-        cleaned_agent = keyvault_agent_get_helper(cleaned_agent, cleaned_agent.get('id', agent_id), scope="user")
+        cleaned_agent = keyvault_agent_get_helper(cleaned_agent, cleaned_agent.get('id', agent_id), scope="user", return_type=return_type)
         # Ensure max_completion_tokens field exists
         if cleaned_agent.get('max_completion_tokens') is None:
             cleaned_agent['max_completion_tokens'] = -1
@@ -244,10 +245,11 @@ def delete_personal_agent(user_id, agent_id):
     try:
         # Try to find the agent first to get the correct ID
         # Check if agent_id is actually a name and we need to find the real ID
-        agent = get_personal_agent(user_id, agent_id)
+        # UI placeholders cannot reconstruct the fresh secret names used by editor saves.
+        agent = get_personal_agent(user_id, agent_id, return_type=SecretReturnType.NAME)
         if not agent:
             # Try to find by name if direct ID lookup failed
-            agents = get_personal_agents(user_id)
+            agents = get_personal_agents(user_id, return_type=SecretReturnType.NAME)
             agent = next((a for a in agents if a['name'] == agent_id), None)
         if not agent:
             return False

--- a/application/single_app/functions_workspace_authoring.py
+++ b/application/single_app/functions_workspace_authoring.py
@@ -1,0 +1,1044 @@
+# functions_workspace_authoring.py
+"""Opt-in personal editor projections, patch intent, and conditional persistence.
+
+Service imports stay at operation boundaries, as in functions_agent_delegation,
+to avoid initializing Azure clients during schema discovery and pure draft tests.
+"""
+
+import builtins
+import json
+import logging
+import re
+import uuid
+from copy import deepcopy
+from datetime import datetime, timezone
+from importlib import import_module
+from pathlib import Path
+
+from flask import jsonify, request
+
+
+EDITOR_SECRET_MASK = "***REDACTED***"
+EDITOR_SECRET_PLACEHOLDERS = frozenset({
+    EDITOR_SECRET_MASK, "Stored_In_KeyVault", "[REDACTED]", "********", "**********",
+})
+_MISSING = object()
+_MANAGED_FIELDS = frozenset({
+    "id", "user_id", "owner_id", "owner_user_id", "group_id", "scope", "scope_type",
+    "scope_id", "is_global", "is_group", "created_at", "created_by", "modified_at",
+    "modified_by", "updated_at", "updated_by", "last_updated",
+})
+_SECRET_NAMES = frozenset({
+    "key", "apikey", "clientsecret", "password", "connectionstring", "accesstoken",
+    "refreshtoken", "token", "bearertoken", "subscriptionkey", "privatekey",
+    "privatekeypem", "privatekeypassphrase", "accountkey", "sas", "sastoken",
+    "authorization", "cookie", "setcookie", "secret",
+})
+_AGENT_CUSTOM_CONNECTION_FIELDS = frozenset({
+    "azure_openai_gpt_endpoint", "azure_openai_gpt_key", "azure_openai_gpt_api_revision",
+    "azure_agent_apim_gpt_endpoint", "azure_agent_apim_gpt_subscription_key",
+    "azure_agent_apim_gpt_api_revision",
+})
+_AGENT_TYPES = (
+    ("local", "Local agent", None),
+    ("aifoundry", "Azure AI Foundry", "allow_personal_ai_foundry_agents"),
+    ("new_foundry", "New Foundry", "allow_personal_new_foundry_agents"),
+    ("foundry_workflow", "Foundry Workflow", "allow_personal_new_foundry_agents"),
+)
+_BUILTIN_ACTIONS = (
+    ("time", "Time", "enable_time_plugin"),
+    ("fact_memory", "Fact memory", "enable_fact_memory_plugin"),
+    ("math", "Math", "enable_math_plugin"),
+    ("text", "Text", "enable_text_plugin"),
+    ("http", "HTTP", "enable_http_plugin"),
+    ("wait", "Wait", "enable_wait_plugin"),
+    ("embedding_model", "Embedding model", "enable_default_embedding_model_plugin"),
+)
+_OPTION_DEFAULTS = {
+    "enable_semantic_kernel": False,
+    "allow_user_agents": False,
+    "allow_user_plugins": False,
+    "per_user_semantic_kernel": False,
+    "merge_global_semantic_kernel_with_workspace": False,
+    "allow_user_custom_endpoints": False,
+    "allow_personal_ai_foundry_agents": False,
+    "allow_personal_new_foundry_agents": False,
+    "allow_ai_foundry_agents": False,
+    "allow_new_foundry_agents": False,
+    "enable_multi_model_endpoints": False,
+    "default_model_selection": {},
+    "gpt_model": {},
+    "enable_gpt_apim": False,
+    "azure_apim_gpt_deployment": "",
+    "enable_agent_template_gallery": False,
+    "agent_templates_allow_user_submission": True,
+    "enable_user_workspace": True,
+    "enable_public_workspaces": False,
+    "enable_web_search": False,
+    "enable_url_access": False,
+    **{flag: False for _, _, flag in _BUILTIN_ACTIONS},
+}
+
+
+class WorkspaceAuthoringConflict(ValueError):
+    """The stored revision no longer matches the editor's revision."""
+
+
+class WorkspaceAuthoringValidation(ValueError):
+    """An editor request is invalid; only fixed, developer-authored messages are public."""
+
+    def __init__(self, public_message):
+        super().__init__(public_message)
+        self.public_message = public_message
+
+
+def _pointer(path):
+    return "/" + "/".join(str(part).replace("~", "~0").replace("/", "~1") for part in path)
+
+
+def _parse_pointer(pointer):
+    if not isinstance(pointer, str) or not pointer.startswith("/") or re.search(r"~(?![01])", pointer):
+        raise WorkspaceAuthoringValidation("Use valid JSON pointers for removed and cleared fields.")
+    parts = tuple(part.replace("~1", "/").replace("~0", "~") for part in pointer[1:].split("/"))
+    if not parts[0] or parts[0] in _MANAGED_FIELDS or parts[0].startswith("_"):
+        raise WorkspaceAuthoringValidation("Ownership, scope, IDs, and audit fields cannot be changed.")
+    return parts
+
+
+def _get(data, path, default=_MISSING):
+    current = data
+    for part in path:
+        if isinstance(current, dict) and part in current:
+            current = current[part]
+        elif isinstance(current, list) and str(part).isdigit() and str(int(part)) == str(part) and int(part) < len(current):
+            current = current[int(part)]
+        else:
+            return default
+    return current
+
+
+def _set(data, path, value):
+    parent = _get(data, path[:-1])
+    if isinstance(parent, dict):
+        parent[path[-1]] = value
+    elif isinstance(parent, list) and str(path[-1]).isdigit() and int(path[-1]) < len(parent):
+        parent[int(path[-1])] = value
+    else:
+        raise WorkspaceAuthoringValidation("The requested field no longer exists.")
+
+
+def _walk(value, path=()):
+    if isinstance(value, dict):
+        for key, child in value.items():
+            yield from _walk(child, (*path, key))
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            yield from _walk(child, (*path, str(index)))
+    else:
+        yield path, value
+
+
+def _is_placeholder(value):
+    return isinstance(value, str) and value in EDITOR_SECRET_PLACEHOLDERS
+
+
+def _is_reference(value):
+    if not isinstance(value, str):
+        return False
+    keyvault = import_module("functions_keyvault")
+    return keyvault.validate_secret_name_dynamic(value) or bool(
+        re.match(r"^https://[^/]+/secrets/", value, re.IGNORECASE)
+    )
+
+
+def editor_secret_paths(record, kind):
+    """Include canonical secrets and nested custom/legacy credentials, with KV on or off."""
+    paths = set()
+    if kind == "actions":
+        redacted = import_module("functions_keyvault").redact_plugin_secret_values(record)
+        paths.update(path for path, value in _walk(redacted) if value == EDITOR_SECRET_MASK)
+    else:
+        paths.update({("azure_openai_gpt_key",), ("azure_agent_apim_gpt_subscription_key",)})
+    for path, value in _walk(record):
+        if not path:
+            continue
+        name = re.sub(r"[_-]", "", path[-1]).lower()
+        if (
+            name in _SECRET_NAMES
+            or path[-1].endswith("__Secret")
+            or _is_reference(value)
+            or _is_placeholder(value)
+        ):
+            paths.add(path)
+    return {path for path in paths if _get(record, path, None) not in (None, "")}
+
+
+def project_editor_record(record, kind, *, global_scope=False):
+    """Project stored configuration without hydrating credentials or leaking Cosmos metadata."""
+    result = {key: deepcopy(value) for key, value in record.items() if not key.startswith("_")}
+    paths = editor_secret_paths(result, kind)
+    for path in paths:
+        _set(result, path, EDITOR_SECRET_MASK)
+    metadata = result.get("metadata")
+    if isinstance(metadata, dict) and isinstance(metadata.get("key_vault_secret_reminder_sync"), dict):
+        metadata["key_vault_secret_reminder_sync"] = {
+            path: {
+                "status": status.get("status", ""),
+                "updated_at": status.get("updated_at", ""),
+            }
+            for path, status in metadata["key_vault_secret_reminder_sync"].items()
+            if isinstance(status, dict)
+        }
+    result["is_global"] = global_scope
+    result["is_group"] = False
+    if kind == "agents":
+        result.setdefault("agent_type", "local")
+        result.setdefault("actions_to_load", [])
+        result.setdefault("other_settings", {})
+        if result.get("max_completion_tokens") is None:
+            result["max_completion_tokens"] = -1
+    else:
+        result.setdefault("metadata", {})
+        result.setdefault("additionalFields", {})
+    return result
+
+
+def editor_resource(record, kind, *, global_scope=False):
+    projected = project_editor_record(record, kind, global_scope=global_scope)
+    return {
+        "record": projected,
+        "revision": record.get("_etag") or "",
+        "secret_paths": sorted(_pointer(path) for path in editor_secret_paths(projected, kind)),
+        "read_only": global_scope,
+    }
+
+
+def clear_editor_test_secrets(record, clear_secret_paths):
+    """Remove explicit clears from authorized, transient test/discovery fallback state."""
+    if not isinstance(record, dict):
+        raise WorkspaceAuthoringValidation("A saved action is required to clear stored test credentials.")
+    if not isinstance(clear_secret_paths, list) or len(clear_secret_paths) > 1000:
+        raise WorkspaceAuthoringValidation("Cleared fields must be an array of JSON pointers.")
+    configured = editor_secret_paths(record, "actions")
+    result = deepcopy(record)
+    for pointer in clear_secret_paths:
+        path = _parse_pointer(pointer)
+        if path not in configured:
+            raise WorkspaceAuthoringValidation("Only an existing secret can be cleared.")
+        parent = _get(result, path[:-1])
+        if isinstance(parent, dict):
+            parent.pop(path[-1], None)
+        else:
+            _set(result, path, "")
+    return result
+
+
+def _container(kind, scope="personal"):
+    if kind not in {"agents", "actions"} or scope not in {"personal", "global"}:
+        raise WorkspaceAuthoringValidation("Invalid workspace resource.")
+    return getattr(import_module("config"), f"cosmos_{scope}_{kind}_container")
+
+
+def ensure_editor_access(kind, user_id, settings, *, operation="write"):
+    if not isinstance(user_id, str) or not user_id.strip():
+        raise PermissionError("An authenticated user is required.")
+    if kind == "actions" and operation in {"read", "delete"}:
+        # Classic action reads and cleanup are independent of authoring flags.
+        # Per-item governance is checked before exposing or deleting each record.
+        return
+    flag = "allow_user_agents" if kind == "agents" else "allow_user_plugins"
+    if (
+        not settings.get("enable_semantic_kernel", False)
+        or not settings.get("enable_user_workspace", True)
+        or not settings.get(flag, False)
+    ):
+        raise PermissionError("This workspace capability is disabled.")
+    governance = import_module("functions_governance")
+    if kind == "agents":
+        governance.ensure_governance_access("governance_user_agents", user_id)
+    elif not governance.is_action_scope_access_allowed("governance_user_actions", user_id, "personal"):
+        raise PermissionError("This workspace capability is unavailable.")
+
+
+def ensure_editor_options_access(user_id, settings):
+    """Action-only authors may read reminder defaults, but not an agent model catalogue."""
+    try:
+        ensure_editor_access("agents", user_id, settings)
+        return True
+    except PermissionError:
+        ensure_editor_access("actions", user_id, settings)
+        return False
+
+
+def _assert_record_access(kind, user_id, record, settings, *, global_scope=False):
+    governance = import_module("functions_governance")
+    if global_scope:
+        if not settings.get("merge_global_semantic_kernel_with_workspace", False):
+            raise LookupError("This resource is unavailable.")
+        if kind == "agents" and not settings.get("per_user_semantic_kernel", False):
+            raise LookupError("This resource is unavailable.")
+        if not record.get("is_enabled", True):
+            raise LookupError("This resource is unavailable.")
+        if kind == "agents":
+            governance.ensure_governance_access(
+                "governance_global_agents_usage", user_id, item_entity_type="global_agent",
+                item_id=record["id"],
+            )
+        else:
+            governance.ensure_global_action_access(user_id, record)
+        return
+    if (
+        record.get("user_id") != user_id
+        or record.get("is_global")
+        or record.get("is_group")
+        or record.get("group_id")
+        or record.get("scope") not in (None, "", "personal", "user")
+    ):
+        raise LookupError("This resource is unavailable.")
+    if kind == "actions":
+        governance.ensure_action_type_access("governance_user_actions", user_id, record.get("type"), "personal")
+
+
+def read_editor_record(kind, user_id, record_id, settings, *, scope="personal"):
+    ensure_editor_access(kind, user_id, settings, operation="read")
+    if scope not in {"personal", "global"}:
+        raise WorkspaceAuthoringValidation("Invalid workspace scope.")
+    if not isinstance(record_id, str) or not record_id or any(char in record_id for char in "/\\?#"):
+        raise LookupError("This resource is unavailable.")
+    exceptions = import_module("azure.cosmos.exceptions")
+    try:
+        record = _container(kind, scope).read_item(
+            item=record_id, partition_key=record_id if scope == "global" else user_id,
+        )
+    except exceptions.CosmosResourceNotFoundError as exc:
+        raise LookupError("This resource is unavailable.") from exc
+    if record.get("id") != record_id:
+        raise LookupError("This resource is unavailable.")
+    _assert_record_access(kind, user_id, record, settings, global_scope=scope == "global")
+    return deepcopy(record)
+
+
+def list_editor_records(kind, user_id, settings):
+    ensure_editor_access(kind, user_id, settings, operation="read")
+    personal = []
+    if kind != "actions" or import_module("functions_governance").is_action_scope_access_allowed(
+        "governance_user_actions", user_id, "personal",
+    ):
+        personal = _container(kind).query_items(
+            query="SELECT * FROM c WHERE c.user_id = @user_id",
+            parameters=[{"name": "@user_id", "value": user_id}], partition_key=user_id,
+        )
+    records = []
+    sources = [(False, personal)]
+    if settings.get("merge_global_semantic_kernel_with_workspace", False) and (
+        kind == "actions" or settings.get("per_user_semantic_kernel", False)
+    ):
+        sources.append((True, _container(kind, "global").query_items(
+            query="SELECT * FROM c", enable_cross_partition_query=True,
+        )))
+    for global_scope, source in sources:
+        for record in source:
+            try:
+                _assert_record_access(kind, user_id, record, settings, global_scope=global_scope)
+            except (LookupError, PermissionError):
+                continue
+            records.append(project_editor_record(record, kind, global_scope=global_scope))
+    return records
+
+
+def merge_editor_write(existing, payload, kind, *, creating=False, resolve_stored_placeholder=None):
+    """Apply changed leaves; removals and clearing configured secrets require explicit intent."""
+    if not isinstance(payload, dict) or set(payload) - {
+        "updates", "expected_revision", "clear_secret_paths", "removed_paths",
+    }:
+        raise WorkspaceAuthoringValidation("Invalid editor request.")
+    updates = payload.get("updates")
+    if not isinstance(updates, dict):
+        raise WorkspaceAuthoringValidation("Updates must be an object.")
+    if not creating:
+        expected = payload.get("expected_revision")
+        if not isinstance(expected, str) or not expected:
+            raise WorkspaceAuthoringValidation("Reload this resource before saving; its revision is required.")
+        if not existing.get("_etag") or expected != existing["_etag"]:
+            raise WorkspaceAuthoringConflict("This resource changed. Reload it before saving.")
+    for key in updates:
+        if (key in _MANAGED_FIELDS or key.startswith("_")) and not (
+            key == "id" and creating and kind == "agents"
+        ):
+            raise WorkspaceAuthoringValidation("Ownership, scope, IDs, and audit fields cannot be changed.")
+    paths = {}
+    for field in ("clear_secret_paths", "removed_paths"):
+        values = payload.get(field, [])
+        if not isinstance(values, list) or len(values) > 1000:
+            raise WorkspaceAuthoringValidation("Cleared and removed fields must be arrays of JSON pointers.")
+        paths[field] = {_parse_pointer(value) for value in values}
+    if paths["clear_secret_paths"] & paths["removed_paths"]:
+        raise WorkspaceAuthoringValidation("A field cannot be both removed and cleared.")
+    existing = deepcopy(existing)
+    existing_secrets = editor_secret_paths(existing, kind)
+    if resolve_stored_placeholder:
+        for path in existing_secrets - paths["clear_secret_paths"]:
+            submitted = _get(updates, path)
+            if _is_placeholder(_get(existing, path)) and (
+                submitted is _MISSING or _is_placeholder(submitted)
+            ):
+                _set(existing, path, resolve_stored_placeholder(existing, path))
+    result = deepcopy(existing)
+
+    def merge(before, changes, path=(), *, replace_objects=False):
+        if isinstance(changes, dict):
+            previous = before if isinstance(before, dict) else {}
+            merged = {} if replace_objects else deepcopy(previous)
+            for key, value in changes.items():
+                merged[key] = merge(
+                    previous.get(key, _MISSING), value, (*path, key),
+                    replace_objects=replace_objects,
+                )
+            return merged
+        if isinstance(changes, list):
+            # Array objects are replacements; only masks reuse the same stored JSON pointer.
+            return [
+                merge(
+                    before[index] if isinstance(before, list) and index < len(before) else _MISSING,
+                    value, (*path, str(index)), replace_objects=True,
+                )
+                for index, value in enumerate(changes)
+            ]
+        if _is_placeholder(changes):
+            if path not in existing_secrets or before is _MISSING or _is_placeholder(before):
+                raise WorkspaceAuthoringValidation("A stored secret is unavailable. Re-enter its value.")
+            return deepcopy(before)
+        if _is_reference(changes):
+            if path not in existing_secrets or before != changes:
+                raise WorkspaceAuthoringValidation("Secret references cannot be supplied by an editor.")
+        if path in existing_secrets and changes in (None, "") and path not in paths["clear_secret_paths"]:
+            raise WorkspaceAuthoringValidation("Use clear_secret_paths to clear a stored credential.")
+        return deepcopy(changes)
+
+    result = merge(result, updates)
+    for path in paths["clear_secret_paths"]:
+        if path not in existing_secrets:
+            raise WorkspaceAuthoringValidation("Only an existing secret can be cleared.")
+        if _get(result, path) is _MISSING:
+            continue
+        parent = _get(result, path[:-1])
+        if isinstance(parent, dict):
+            parent.pop(path[-1])
+        else:
+            _set(result, path, "")
+    for path in paths["removed_paths"]:
+        if any(secret[:len(path)] == path and secret not in paths["clear_secret_paths"] for secret in existing_secrets):
+            raise WorkspaceAuthoringValidation("Clear stored credentials explicitly before removing their configuration.")
+        parent = _get(result, path[:-1])
+        if isinstance(parent, dict):
+            parent.pop(path[-1], None)
+        else:
+            raise WorkspaceAuthoringValidation("Replace arrays explicitly rather than removing their elements.")
+    for path in existing_secrets - paths["clear_secret_paths"]:
+        if _get(result, path, None) in (None, ""):
+            raise WorkspaceAuthoringValidation("Clear stored credentials explicitly before replacing their configuration.")
+    if any(_is_placeholder(value) for _, value in _walk(result)):
+        raise WorkspaceAuthoringValidation("A stored secret is unavailable. Re-enter its value.")
+    return result
+
+
+def _secret_scope(kind, user_id, record, path):
+    return (record["id"], "agent") if kind == "agents" else (
+        user_id, "action" if path[0] == "auth" else "action-addset",
+    )
+
+
+def _legacy_editor_secret_reference(record, path, kind, user_id, settings):
+    """Recover a legacy stored trigger only from its owned, conventional Key Vault name."""
+    unavailable = "A stored secret is unavailable. Re-enter its value."
+    if not settings.get("enable_key_vault_secret_storage") or not settings.get("key_vault_name"):
+        raise WorkspaceAuthoringValidation(unavailable)
+    keyvault = import_module("functions_keyvault")
+    name = record.get("name", "")
+    secret_name = None
+    if kind == "agents":
+        for field in keyvault.AGENT_SENSITIVE_SECRET_FIELDS:
+            if path == field["path"]:
+                secret_name = field["secret_name"](name)
+                break
+    elif path == ("auth", "key"):
+        secret_name = name
+    elif len(path) == 2 and path[0] == "auth" and path[1] in keyvault.SQL_PLUGIN_SENSITIVE_AUTH_FIELDS:
+        secret_name = f"{name}-{path[1]}"
+    elif path in _supported_storage_paths(record, kind):
+        if len(path) == 2 and path[0] == "additionalFields":
+            field = path[1][:-8] if path[1].endswith("__Secret") else path[1]
+            secret_name = keyvault._build_plugin_additional_field_secret_name(name, field)
+        elif len(path) == 3 and path[:2] == ("additionalFields", keyvault.MCP_CUSTOM_HEADERS_FIELD):
+            secret_name = keyvault._build_plugin_additional_field_secret_name(name, f"mcp-custom-header-{path[2]}")
+    if not secret_name:
+        raise WorkspaceAuthoringValidation(unavailable)
+    scope_value, source = _secret_scope(kind, user_id, record, path)
+    try:
+        reference = keyvault.build_full_secret_name(secret_name, scope_value, source, "user")
+        value = keyvault.resolve_secret_reference_for_context(
+            reference, scope_value=scope_value, scope="user", allowed_sources={source},
+            context_label="owned personal editor credential",
+        )
+        if not value or _is_placeholder(value) or _is_reference(value):
+            raise ValueError("The credential is unavailable.")
+    except (ValueError, RuntimeError) as exc:
+        raise WorkspaceAuthoringValidation(unavailable) from exc
+    return reference
+
+
+def _supported_storage_paths(record, kind):
+    keyvault = import_module("functions_keyvault")
+    if kind == "actions":
+        redacted = keyvault.redact_plugin_secret_values(record)
+        return {path for path, value in _walk(redacted) if value == EDITOR_SECRET_MASK}
+    return {
+        ("azure_openai_gpt_key",), ("azure_agent_apim_gpt_subscription_key",),
+        *(("other_settings", section, "client_secret") for section in (
+            "azure_ai_foundry", "new_foundry", "foundry_workflow",
+        )),
+    }
+
+
+def _check_stored_references(record, kind, user_id):
+    keyvault = import_module("functions_keyvault")
+    for path in editor_secret_paths(record, kind):
+        value = _get(record, path)
+        if _is_reference(value):
+            scope_value, source = _secret_scope(kind, user_id, record, path)
+            if not keyvault.secret_reference_matches_context(
+                value, scope_value=scope_value, scope="user", allowed_sources={source},
+            ):
+                raise WorkspaceAuthoringValidation("A stored credential does not belong to this resource.")
+
+
+def _cleanup_staged_secrets(references):
+    if not references:
+        return
+    keyvault = import_module("functions_keyvault")
+    settings = import_module("functions_settings").get_settings()
+    try:
+        client = keyvault.SecretClient(
+            vault_url=f"https://{settings['key_vault_name']}{keyvault.KEY_VAULT_DOMAIN}",
+            credential=keyvault.get_keyvault_credential(),
+        )
+        for reference in references:
+            client.begin_delete_secret(reference)
+    except Exception as exc:
+        import_module("functions_appinsights").log_event(
+            "[KEY_VAULT] Unable to clean up unused editor secrets.",
+            level=logging.WARNING, extra={"error_type": type(exc).__name__},
+        )
+
+
+def _stage_editor_secrets(record, kind, user_id, settings, staged):
+    """Fresh names isolate failed CAS writes from every credential in a stored manifest."""
+    keyvault = import_module("functions_keyvault")
+    _check_stored_references(record, kind, user_id)
+    if not settings.get("enable_key_vault_secret_storage", False):
+        return
+    if not settings.get("key_vault_name"):
+        raise RuntimeError("Key Vault is unavailable.")
+    for path in _supported_storage_paths(record, kind):
+        value = _get(record, path, None)
+        if value in (None, "") or _is_reference(value):
+            continue
+        if not isinstance(value, str):
+            raise WorkspaceAuthoringValidation("Credentials must be text values.")
+        scope_value, source = _secret_scope(kind, user_id, record, path)
+        secret_name = f"editor-{uuid.uuid4().hex}"
+        reference = keyvault.store_secret_in_key_vault(
+            secret_name, value, scope_value, source=source, scope="user",
+        )
+        if not keyvault.secret_reference_matches_context(
+            reference, scope_value=scope_value, scope="user", allowed_sources={source},
+        ):
+            raise RuntimeError("Key Vault did not store the credential.")
+        staged.append(reference)
+        _set(record, path, reference)
+
+
+def _cleanup_replaced_secrets(record, kind, user_id, settings):
+    if not record or not settings.get("enable_key_vault_secret_storage") or not settings.get("key_vault_name"):
+        return
+    keyvault = import_module("functions_keyvault")
+    references = set()
+    for path in _supported_storage_paths(record, kind):
+        value = _get(record, path, None)
+        scope_value, source = _secret_scope(kind, user_id, record, path)
+        if isinstance(value, str) and keyvault.secret_reference_matches_context(
+            value, scope_value=scope_value, scope="user", allowed_sources={source},
+        ):
+            references.add(value)
+    if not references:
+        return
+    try:
+        # Legacy names may be shared after a classic rename. Never delete a reference
+        # still used by another owned manifest (including the just-committed one).
+        for stored in _container(kind).query_items(
+            query="SELECT * FROM c WHERE c.user_id = @user_id",
+            parameters=[{"name": "@user_id", "value": user_id}], partition_key=user_id,
+        ):
+            references.difference_update(value for _, value in _walk(stored) if isinstance(value, str))
+        _cleanup_staged_secrets(references)
+        if (record.get("metadata") or {}).get("key_vault_secret_reminders"):
+            reminders = import_module("functions_keyvault_reminders")
+            for reference in references:
+                reminders.mark_key_vault_secret_reminder_disabled(reference)
+    except Exception as exc:
+        import_module("functions_appinsights").log_event(
+            "[KEY_VAULT] Unable to check superseded editor secrets for cleanup.",
+            level=logging.WARNING, extra={"error_type": type(exc).__name__},
+        )
+
+
+def _sync_editor_reminders(saved, kind, user_id, settings):
+    if kind != "actions" or not settings.get("enable_key_vault_secret_storage"):
+        return saved
+    metadata = saved.get("metadata") or {}
+    if not isinstance(metadata.get("key_vault_secret_reminders"), dict):
+        return saved
+    keyvault = import_module("functions_keyvault")
+    updated = deepcopy(saved)
+    try:
+        # The main CAS already succeeded. In particular, a stale request cannot
+        # update expiration on a previously stored credential or reminder inventory.
+        for path in _supported_storage_paths(updated, kind):
+            reference = _get(updated, path, None)
+            if isinstance(reference, str) and keyvault.validate_secret_name_dynamic(reference):
+                scope_value, source = _secret_scope(kind, user_id, updated, path)
+                keyvault._sync_plugin_secret_reminder(updated, path, reference, scope_value, source, "user")
+        sync_status = (updated.get("metadata") or {}).get("key_vault_secret_reminder_sync")
+        if sync_status is not None and sync_status != metadata.get("key_vault_secret_reminder_sync"):
+            return _container(kind).patch_item(
+                item=saved["id"], partition_key=user_id,
+                patch_operations=[{"op": "set", "path": "/metadata/key_vault_secret_reminder_sync", "value": sync_status}],
+                etag=saved["_etag"], match_condition=import_module("azure.core").MatchConditions.IfNotModified,
+            )
+    except Exception as exc:
+        # A failure to record reminder status must not report a committed action as
+        # unsaved, or retry the manifest with an unconditional write.
+        import_module("functions_appinsights").log_event(
+            "[KEY_VAULT] Unable to finish editor reminder synchronization.",
+            level=logging.WARNING, extra={"error_type": type(exc).__name__},
+        )
+    return saved
+
+
+def _invalidate_editor_catalog(kind, user_id, operation):
+    builtins.kernel_reload_needed = True
+    try:
+        import_module("functions_chat_bootstrap_cache").bump_chat_bootstrap_user_cache_version(
+            user_id, reason=f"personal_{'agent' if kind == 'agents' else 'action'}_{operation}",
+        )
+    except Exception as exc:
+        import_module("functions_appinsights").log_event(
+            "[CHAT_BOOTSTRAP_CACHE] Unable to invalidate a committed editor change.",
+            level=logging.WARNING, extra={"error_type": type(exc).__name__},
+        )
+
+
+def save_editor_record(kind, user_id, record, existing, settings):
+    """Save one prepared manifest using a mandatory conditional Cosmos write."""
+    ensure_editor_access(kind, user_id, settings)
+    if existing:
+        try:
+            current = read_editor_record(kind, user_id, existing["id"], settings)
+        except LookupError as exc:
+            raise WorkspaceAuthoringConflict("This resource changed. Reload it before saving.") from exc
+        if not existing.get("_etag") or existing["_etag"] != current.get("_etag"):
+            raise WorkspaceAuthoringConflict("This resource changed. Reload it before saving.")
+    delegation = import_module("functions_agent_delegation")
+    if kind == "agents":
+        delegation.validate_agent_delegation_bindings(
+            record, user_id=user_id, scope_type="personal", scope_id=user_id,
+            settings=settings, existing_agent=existing,
+        )
+    else:
+        import_module("functions_governance").ensure_action_type_access(
+            "governance_user_actions", user_id, record.get("type"), "personal",
+        )
+        record = delegation.validate_agent_action_for_scope(
+            record, user_id=user_id, scope_type="personal", scope_id=user_id, settings=settings,
+        )
+        import_module("functions_workspace_identities").validate_action_identity_reference(record, "personal", user_id)
+    result = {key: deepcopy(value) for key, value in record.items() if not key.startswith("_") and key not in _MANAGED_FIELDS}
+    now = datetime.now(timezone.utc).isoformat()
+    result.update({
+        "id": existing["id"] if existing else record["id"], "user_id": user_id,
+        "created_at": (existing or {}).get("created_at", now),
+        "created_by": (existing or {}).get("created_by", user_id),
+        "modified_at": now, "modified_by": user_id, "last_updated": now,
+    })
+    if kind == "agents":
+        result.update({"is_global": False, "is_group": False})
+    staged = []
+    write_started = False
+    exceptions = import_module("azure.cosmos.exceptions")
+    try:
+        _stage_editor_secrets(result, kind, user_id, settings, staged)
+        container = _container(kind)
+        write_started = True
+        if existing:
+            saved = container.replace_item(
+                item=existing["id"], body=result, etag=existing["_etag"],
+                match_condition=import_module("azure.core").MatchConditions.IfNotModified,
+            )
+        else:
+            saved = container.create_item(body=result)
+    except Exception as exc:
+        conflict_response = isinstance(exc, exceptions.CosmosHttpResponseError) and (
+            exc.status_code in (409, 412) or (existing is not None and exc.status_code == 404)
+        )
+        # SDK retries can turn a committed write with a lost response into 409/412.
+        # Once a write starts, even a conflict cannot prove its fresh secrets are unused.
+        if not write_started:
+            _cleanup_staged_secrets(staged)
+        if conflict_response:
+            raise WorkspaceAuthoringConflict("This resource changed. Reload it before saving.") from exc
+        raise
+    saved = _sync_editor_reminders(saved, kind, user_id, settings)
+    _cleanup_replaced_secrets(existing, kind, user_id, settings)
+    _invalidate_editor_catalog(kind, user_id, "saved")
+    return saved
+
+
+def delete_editor_record(kind, user_id, record, settings):
+    ensure_editor_access(kind, user_id, settings, operation="delete")
+    _assert_record_access(kind, user_id, record, settings)
+    if not record.get("_etag"):
+        raise WorkspaceAuthoringConflict("Reload this resource before deleting it.")
+    if kind == "agents" and (settings.get("global_selected_agent") or {}).get("name") == record.get("name"):
+        raise WorkspaceAuthoringValidation("Choose another default agent before deleting this agent.")
+    exceptions = import_module("azure.cosmos.exceptions")
+    try:
+        _container(kind).delete_item(
+            item=record["id"], partition_key=user_id, etag=record["_etag"],
+            match_condition=import_module("azure.core").MatchConditions.IfNotModified,
+        )
+    except exceptions.CosmosHttpResponseError as exc:
+        if exc.status_code in (404, 412):
+            raise WorkspaceAuthoringConflict("This resource changed. Reload it before deleting.") from exc
+        raise
+    _cleanup_replaced_secrets(record, kind, user_id, settings)
+    _invalidate_editor_catalog(kind, user_id, "deleted")
+
+
+def _validate_agent_editor_changes(record, existing, settings, user_id):
+    kind = record.get("agent_type", "local")
+    flag = next((flag for value, _, flag in _AGENT_TYPES if value == kind), _MISSING)
+    if flag is _MISSING:
+        raise WorkspaceAuthoringValidation("Select a supported agent type.")
+    if flag and not settings.get(flag, False):
+        raise PermissionError("This agent type is disabled for personal workspaces.")
+    if kind != "local" and record.get("actions_to_load"):
+        raise WorkspaceAuthoringValidation("Remove local actions explicitly before selecting a Foundry agent type.")
+    if kind == "local":
+        configured_connection = any(
+            record.get(field) not in (None, "")
+            and record.get(field) != (existing or {}).get(field)
+            and not (_is_placeholder((existing or {}).get(field)) and _is_reference(record.get(field)))
+            for field in _AGENT_CUSTOM_CONNECTION_FIELDS
+        )
+        if configured_connection and not settings.get("allow_user_custom_endpoints", False):
+            raise PermissionError("Custom model connections are disabled for personal workspaces.")
+        if configured_connection:
+            import_module("functions_governance").ensure_governance_access("governance_user_endpoints", user_id)
+
+
+def _preserve_unedited_values(original, merged, prepared, *, root=True):
+    """Normalization of an edited leaf must not discard untouched legacy siblings."""
+    result = deepcopy(prepared)
+    for key, previous in original.items():
+        if key not in merged or (root and (key in _MANAGED_FIELDS or key.startswith("_"))):
+            continue
+        if merged[key] == previous:
+            result[key] = deepcopy(previous)
+        elif isinstance(previous, dict) and isinstance(merged[key], dict) and isinstance(result.get(key), dict):
+            result[key] = _preserve_unedited_values(previous, merged[key], result[key], root=False)
+    return result
+
+
+def validate_editor_action_manifest(plugin):
+    """Validate personal editor fields that the existing embedding runtime reads at root."""
+    validation_copy = dict(plugin)
+    if str(plugin.get("type") or "").strip().lower() == "embedding_model":
+        for field in ("api_version", "deployment"):
+            if field in validation_copy:
+                value = validation_copy.pop(field)
+                if not isinstance(value, str) or not value.strip():
+                    return f"Embedding {field} must be a non-empty string."
+    return import_module("json_schema_validation").validate_plugin(validation_copy)
+
+
+def _editor_validation_input(kind, merged, existing):
+    """Retain old extension fields without allowing new unsupported manifest properties."""
+    result = deepcopy(merged)
+    for field in ("other_settings",) if kind == "agents" else ("auth", "additionalFields", "metadata"):
+        if field in result and not isinstance(result[field], dict):
+            raise WorkspaceAuthoringValidation("Configuration sections must be JSON objects.")
+    if not existing:
+        return result
+    validation = import_module("json_schema_validation")
+    schema = validation.load_schema("agent.schema.json" if kind == "agents" else "plugin.schema.json")
+    definition = schema.get("definitions", {}).get("Agent" if kind == "agents" else "Plugin", schema)
+
+    def retain_for_validation(value, previous, field_schema):
+        if not isinstance(value, dict) or not isinstance(previous, dict):
+            return
+        properties = field_schema.get("properties", {})
+        if field_schema.get("additionalProperties") is False:
+            for key in list(value):
+                if key not in properties and key in previous and value[key] == previous[key]:
+                    value.pop(key)
+        for key in value.keys() & properties.keys():
+            retain_for_validation(value[key], previous.get(key), properties[key])
+
+    retain_for_validation(result, existing, definition)
+    return result
+
+
+def _assert_available_name(kind, user_id, record, existing):
+    name = record.get("name")
+    if not isinstance(name, str) or not name.strip():
+        raise WorkspaceAuthoringValidation("A name is required.")
+    if existing and name == existing.get("name"):
+        return
+    matches = _container(kind).query_items(
+        query="SELECT c.id FROM c WHERE c.user_id = @user_id AND c.name = @name",
+        parameters=[{"name": "@user_id", "value": user_id}, {"name": "@name", "value": name}],
+        partition_key=user_id,
+    )
+    if any(match.get("id") != (existing or {}).get("id") for match in matches):
+        raise WorkspaceAuthoringConflict("An item with this name already exists.")
+    if kind == "actions":
+        matches = _container(kind, "global").query_items(
+            query="SELECT c.id FROM c WHERE STRINGEQUALS(c.name, @name, true)",
+            parameters=[{"name": "@name", "value": name}], enable_cross_partition_query=True,
+        )
+        if next(iter(matches), None):
+            raise WorkspaceAuthoringConflict("An item with this name already exists.")
+
+
+def editor_error_response(exc):
+    if isinstance(exc, WorkspaceAuthoringConflict):
+        status, message = 409, "This resource changed. Reload it before saving."
+    elif isinstance(exc, PermissionError):
+        status, message = 403, "You are not authorized to manage this workspace resource."
+    elif isinstance(exc, LookupError):
+        status, message = 404, "This workspace resource is unavailable."
+    elif isinstance(exc, WorkspaceAuthoringValidation):
+        status, message = 400, exc.public_message
+    elif isinstance(exc, ValueError):
+        status, message = 400, "Invalid workspace configuration."
+    else:
+        status, message = 503, "Unable to complete this workspace request. Try again."
+    import_module("functions_appinsights").log_event(
+        "[WORKSPACE_ROUTE] Personal editor request could not be completed.",
+        level=logging.ERROR if status >= 500 else logging.WARNING,
+        extra={"error_type": type(exc).__name__, "status_code": status},
+        debug_only=status < 500,
+    )
+    response = jsonify({"error": message})
+    response.headers["Cache-Control"] = "no-store"
+    return response, status
+
+
+def personal_editor_response(kind, user_id, prepare, record_id=None, *, migrate=None):
+    """Serve only the explicitly opted-in representation on existing personal routes."""
+    try:
+        settings = import_module("functions_settings").get_settings()
+        operation = "read" if request.method == "GET" else "delete" if request.method == "DELETE" else "write"
+        ensure_editor_access(kind, user_id, settings, operation=operation)
+        scope = request.args.get("scope", "personal")
+        if scope not in {"personal", "global"}:
+            raise WorkspaceAuthoringValidation("Invalid workspace scope.")
+        if scope == "global" and (request.method != "GET" or not record_id):
+            raise PermissionError("Provided resources are read-only.")
+        if request.method == "GET":
+            if not record_id and migrate and (
+                kind != "actions" or import_module("functions_governance").is_action_scope_access_allowed(
+                    "governance_user_actions", user_id, "personal",
+                )
+            ):
+                migrate(user_id)
+            result = editor_resource(
+                read_editor_record(kind, user_id, record_id, settings, scope=scope), kind,
+                global_scope=scope == "global",
+            ) if record_id else list_editor_records(kind, user_id, settings)
+            status = 200
+        else:
+            existing = read_editor_record(kind, user_id, record_id, settings) if record_id else None
+            if request.method == "DELETE":
+                delete_editor_record(kind, user_id, existing, settings)
+                result, status = {"success": True}, 200
+            else:
+                merged = merge_editor_write(
+                    existing or {}, request.get_json(silent=True), kind, creating=existing is None,
+                    resolve_stored_placeholder=lambda record, path: _legacy_editor_secret_reference(
+                        record, path, kind, user_id, settings,
+                    ),
+                )
+                if not existing:
+                    if kind == "agents":
+                        try:
+                            merged["id"] = str(uuid.UUID(merged.get("id", "")))
+                        except (ValueError, TypeError, AttributeError) as exc:
+                            raise WorkspaceAuthoringValidation("Allocate an agent ID before saving.") from exc
+                    else:
+                        merged["id"] = str(uuid.uuid4())
+                    display_key = "display_name" if kind == "agents" else "displayName"
+                    merged.setdefault(display_key, merged.get("name", ""))
+                    merged.setdefault("description", "")
+                    if kind == "agents":
+                        merged.setdefault("instructions", "")
+                if kind == "agents":
+                    _validate_agent_editor_changes(merged, existing, settings, user_id)
+                proposed = deepcopy(merged)
+                prepared, error = prepare(
+                    user_id, _editor_validation_input(kind, merged, existing), settings, existing,
+                )
+                if error:
+                    status = error[1] if isinstance(error, tuple) else 400
+                    if status == 403:
+                        raise PermissionError("This configuration is unavailable.")
+                    raise WorkspaceAuthoringValidation("Invalid agent configuration." if kind == "agents" else "Invalid action configuration.")
+                if existing:
+                    prepared = _preserve_unedited_values(existing, proposed, prepared)
+                _assert_available_name(kind, user_id, prepared, existing)
+                saved = save_editor_record(kind, user_id, prepared, existing, settings)
+                result, status = editor_resource(saved, kind), 200 if existing else 201
+            activity = import_module("functions_activity_logging")
+            operation = "deletion" if request.method == "DELETE" else "update" if existing else "creation"
+            stored = existing if request.method == "DELETE" else saved
+            prefix = "agent" if kind == "agents" else "action"
+            event = getattr(activity, f"log_{prefix}_{operation}")
+            try:
+                event(
+                    user_id=user_id, scope="personal",
+                    **{f"{prefix}_id": stored["id"], f"{prefix}_name": stored.get("name", "")},
+                    **({"agent_display_name": stored.get("display_name", "")} if prefix == "agent" and operation != "deletion" else {}),
+                    **({"action_type": stored.get("type", "")} if prefix == "action" and operation != "deletion" else {}),
+                )
+            except Exception as exc:
+                import_module("functions_appinsights").log_event(
+                    "[WORKSPACE_ACTIVITY] Unable to record a committed editor change.",
+                    level=logging.WARNING, extra={"error_type": type(exc).__name__},
+                )
+        response = jsonify(result)
+        response.headers["Cache-Control"] = "no-store"
+        return response, status
+    except Exception as exc:
+        return editor_error_response(exc)
+
+
+def build_agent_editor_options(user_id, settings, model_endpoints):
+    can_manage_agents = ensure_editor_options_access(user_id, settings)
+    settings_module = import_module("functions_settings")
+    sanitized = settings_module.sanitize_settings_for_user({
+        key: deepcopy(settings.get(key, default)) for key, default in _OPTION_DEFAULTS.items()
+    })
+    safe = {key: sanitized[key] for key in _OPTION_DEFAULTS if key in sanitized}
+    safe["allow_user_agents"] = can_manage_agents
+    try:
+        ensure_editor_access("actions", user_id, settings)
+        safe["allow_user_plugins"] = True
+    except PermissionError:
+        safe["allow_user_plugins"] = False
+    if not can_manage_agents:
+        model_endpoints = []
+        safe["gpt_model"] = {}
+        safe["default_model_selection"] = {}
+    model_endpoints = settings_module.sanitize_settings_for_user(
+        {"model_endpoints": model_endpoints},
+    ).get("model_endpoints", [])
+    # These names contain "key"/"secret", but their values are strictly UI flags/defaults.
+    try:
+        reminder_lead_days = min(3650, max(1, int(settings.get("key_vault_secret_expiration_default_lead_days", 30))))
+    except (ValueError, TypeError):
+        reminder_lead_days = 30
+    reminder_contact = settings.get("key_vault_secret_expiration_default_contact_email", "")
+    reminder_options = settings_module.sanitize_settings_for_user({
+        "storage_enabled": bool(settings.get("enable_key_vault_secret_storage", False)),
+        "reminders_enabled": bool(settings.get("enable_key_vault_secret_expiration_reminders", False)),
+        "lead_days": reminder_lead_days,
+        "contact_email": reminder_contact[:254] if isinstance(reminder_contact, str) else "",
+        "require_expiration": bool(settings.get("key_vault_secret_expiration_require_expiration", False)),
+    })
+    safe.update({
+        "enable_key_vault_secret_storage": reminder_options["storage_enabled"],
+        "enable_key_vault_secret_expiration_reminders": reminder_options["reminders_enabled"],
+        "key_vault_secret_expiration_default_lead_days": reminder_options["lead_days"],
+        "key_vault_secret_expiration_default_contact_email": reminder_options["contact_email"],
+        "key_vault_secret_expiration_require_expiration": reminder_options["require_expiration"],
+    })
+    governance = import_module("functions_governance")
+    if safe.get("allow_user_custom_endpoints"):
+        try:
+            governance.ensure_governance_access("governance_user_endpoints", user_id)
+        except PermissionError:
+            safe["allow_user_custom_endpoints"] = False
+    globals_allowed = governance.filter_governed_model_endpoints(
+        user_id, [endpoint for endpoint in model_endpoints if endpoint.get("scope") == "global"],
+        "governance_global_endpoints",
+    )
+    allowed_ids = {endpoint.get("id") for endpoint in globals_allowed}
+    endpoints = [
+        deepcopy(endpoint) for endpoint in model_endpoints
+        if (
+            endpoint.get("scope") == "global" and endpoint.get("id") in allowed_ids
+        ) or (
+            endpoint.get("scope") in {"user", "personal"} and safe.get("allow_user_custom_endpoints")
+        )
+    ]
+    for endpoint in endpoints:
+        for path in editor_secret_paths(endpoint, "agents"):
+            _set(endpoint, path, EDITOR_SECRET_MASK)
+    safe["enable_multi_model_endpoints"] = bool(safe.get("enable_multi_model_endpoints") or endpoints)
+    return {
+        "agent_types": [
+            {
+                "value": value, "label": label,
+                "enabled": can_manage_agents and (not flag or bool(settings.get(flag, False))),
+                **({"reason": "Agent authoring is unavailable for this personal workspace."} if not can_manage_agents else (
+                    {"reason": "Disabled for personal workspaces by your administrator."} if flag and not settings.get(flag, False) else {}
+                )),
+            }
+            for value, label, flag in _AGENT_TYPES
+        ],
+        "settings": safe,
+        "model_endpoints": endpoints,
+        "builtin_actions": [
+            {"id": value, "label": label}
+            for value, label, flag in _BUILTIN_ACTIONS if can_manage_agents and safe.get(flag)
+        ],
+    }
+
+
+def build_action_editor_types(discovered_types):
+    """Enrich governed discovery with canonical local schemas, without example defaults."""
+    validation = import_module("json_schema_validation")
+    schema_root = Path(validation.SCHEMA_DIR)
+    results = []
+    for definition in discovered_types:
+        action_type = definition["type"]
+        schema_type = validation.normalize_plugin_definition_type(action_type)
+        record = {
+            "type": action_type,
+            "display": definition.get("display") or action_type,
+            "description": (
+                "Connect to an API using OpenAPI JSON/YAML content and configurable authentication. "
+                "Download hosted specifications before uploading them."
+                if schema_type == "openapi" else definition.get("description") or ""
+            ),
+            "allowed_auth_types": sorted(validation.get_allowed_auth_types_for_plugin_type(action_type)),
+        }
+        for field, suffix in (
+            ("additional_fields_schema", "additional_settings"), ("metadata_schema", "metadata"),
+        ):
+            path = schema_root / f"{schema_type}_plugin.{suffix}.schema.json"
+            record[field] = json.loads(path.read_text(encoding="utf-8")) if path.is_file() else {
+                "type": "object", "additionalProperties": True, "properties": {},
+            }
+        results.append(record)
+    return results

--- a/application/single_app/route_backend_agents.py
+++ b/application/single_app/route_backend_agents.py
@@ -68,6 +68,12 @@ from functions_agent_delegation import (
     update_agent_delegation_bindings,
     validate_agent_delegation_bindings,
 )
+from functions_workspace_authoring import (
+    build_agent_editor_options,
+    editor_error_response,
+    ensure_editor_options_access,
+    personal_editor_response,
+)
 
 bpa = Blueprint('admin_agents', __name__)
 bpa.before_request(login_required_blueprint())
@@ -1076,6 +1082,11 @@ def draft_agent_instructions():
 @login_required
 @user_required
 def get_user_agents():
+    if request.args.get('view') == 'editor':
+        return personal_editor_response(
+            'agents', get_current_user_id(), _prepare_personal_agent_for_editor,
+            migrate=ensure_migration_complete,
+        )
     settings = get_settings()
     if not settings.get('allow_user_agents', False):
         return jsonify([])
@@ -1189,14 +1200,18 @@ def _find_personal_agent(user_id, agent_ref):
     return None
 
 
-def _prepare_personal_agent_payload(user_id, agent, settings):
+def _prepare_personal_agent_for_editor(user_id, agent, settings, existing):
+    return _prepare_personal_agent_payload(user_id, agent, settings, editor_existing=existing)
+
+
+def _prepare_personal_agent_payload(user_id, agent, settings, *, editor_existing=None):
     """Clean, enrich and validate a single personal agent.
 
     This is the per-agent half of the bulk save, factored out so the per-item create and
     update routes cannot drift from it. Returns ``(cleaned_agent, error_response)`` where
     exactly one of the two is None.
     """
-    if not settings.get('allow_user_custom_endpoints', False):
+    if not settings.get('allow_user_custom_endpoints', False) and editor_existing is None:
         _strip_disallowed_local_custom_connection_fields(agent)
 
     try:
@@ -1208,12 +1223,16 @@ def _prepare_personal_agent_payload(user_id, agent, settings):
     cleaned_agent['is_group'] = False
 
     try:
-        cleaned_agent = apply_assigned_knowledge_to_agent_payload(
-            cleaned_agent,
-            user_id=user_id,
-            agent_scope='personal',
-            is_admin=False,
-        )
+        if editor_existing is None or (
+            cleaned_agent.get('other_settings', {}).get('assigned_knowledge')
+            != (editor_existing.get('other_settings') or {}).get('assigned_knowledge')
+        ):
+            cleaned_agent = apply_assigned_knowledge_to_agent_payload(
+                cleaned_agent,
+                user_id=user_id,
+                agent_scope='personal',
+                is_admin=False,
+            )
     except AssignedKnowledgeError as exc:
         return None, (jsonify({'error': str(exc)}), 400)
 
@@ -1226,8 +1245,10 @@ def _prepare_personal_agent_payload(user_id, agent, settings):
             cleaned_agent, user_id=user_id, scope_type='personal', scope_id=user_id,
             settings=settings,
             existing_agent=(
-                _find_personal_agent(user_id, cleaned_agent.get('id'))
-                if cleaned_agent.get('actions_to_load') else None
+                editor_existing if editor_existing is not None else (
+                    _find_personal_agent(user_id, cleaned_agent.get('id'))
+                    if cleaned_agent.get('actions_to_load') else None
+                )
             ),
         )
     except PermissionError:
@@ -1286,6 +1307,8 @@ def set_user_agents():
     PATCH for edits and DELETE for removals.
     """
     user_id = get_current_user_id()
+    if request.args.get('view') == 'editor':
+        return personal_editor_response('agents', user_id, _prepare_personal_agent_for_editor)
     payload = request.get_json(silent=True)
 
     if isinstance(payload, dict):
@@ -1358,6 +1381,8 @@ def set_user_agents():
 def get_user_agent(agent_id):
     """Return one personal agent, addressed by id or by name."""
     user_id = get_current_user_id()
+    if request.args.get('view') == 'editor':
+        return personal_editor_response('agents', user_id, _prepare_personal_agent_for_editor, agent_id)
     try:
         ensure_governance_access('governance_user_agents', user_id)
     except PermissionError as exc:
@@ -1388,6 +1413,8 @@ def update_user_agent(agent_id):
     client round-trips a stale copy.
     """
     user_id = get_current_user_id()
+    if request.args.get('view') == 'editor':
+        return personal_editor_response('agents', user_id, _prepare_personal_agent_for_editor, agent_id)
     try:
         ensure_governance_access('governance_user_agents', user_id)
     except PermissionError as exc:
@@ -1435,6 +1462,8 @@ def update_user_agent(agent_id):
 def delete_user_agent(agent_id):
     """Delete one personal agent, addressed by id or by name."""
     user_id = get_current_user_id()
+    if request.args.get('view') == 'editor':
+        return personal_editor_response('agents', user_id, _prepare_personal_agent_for_editor, agent_id)
     # The collection save enforces governance; deleting is just as destructive, so it is
     # enforced here too rather than left to the container helper, which does not check.
     try:
@@ -1767,6 +1796,19 @@ def set_user_selected_agent():
 @user_required
 def get_global_agent_settings_for_users():
     user_id = get_current_user_id()
+    if request.args.get('view') == 'editor':
+        try:
+            settings = get_settings()
+            can_manage_agents = ensure_editor_options_access(user_id, settings)
+            result = build_agent_editor_options(
+                user_id, settings,
+                build_combined_model_endpoints(settings, user_id=user_id) if can_manage_agents else [],
+            )
+            response = jsonify(result)
+            response.headers['Cache-Control'] = 'no-store'
+            return response
+        except Exception as exc:
+            return editor_error_response(exc)
     return get_global_agent_settings(include_admin_extras=False, user_id=user_id)
 
 @bpa.route('/api/group/agent/settings', methods=['GET'])

--- a/application/single_app/route_backend_plugins.py
+++ b/application/single_app/route_backend_plugins.py
@@ -164,6 +164,15 @@ from functions_governance import (
     is_action_type_access_allowed,
     upsert_item_policy,
 )
+from functions_workspace_authoring import (
+    WorkspaceAuthoringValidation,
+    build_action_editor_types,
+    clear_editor_test_secrets,
+    editor_error_response,
+    ensure_editor_access,
+    personal_editor_response,
+    validate_editor_action_manifest,
+)
 
 
 ACTION_VALIDATION_ERROR_MESSAGE = "Invalid action configuration."
@@ -396,7 +405,7 @@ def get_plugin_types(allowed_type_filter=None):
                     # Special handling for OpenAPI plugin that requires spec path
                     if 'openapi' in module_name.lower():
                         display_name = "OpenAPI"
-                        description = "Plugin for integrating with external APIs using OpenAPI specifications. Supports file upload, URL download, and various authentication methods."
+                        description = "Connect to an API using OpenAPI JSON/YAML content and configurable authentication. Download hosted specifications before uploading them."
                         types.append({
                             'type': module_type,
                             'class': attr,
@@ -828,6 +837,154 @@ def _hydrate_sql_test_identity(data, existing_plugin, user_id):
     )
 
 
+def _flatten_editor_test_fields(data, field_names):
+    """Bridge complete editor manifests to the existing flat connector test inputs."""
+    additional_fields = data.get('additionalFields', {})
+    if not isinstance(additional_fields, dict):
+        raise ValueError('Additional fields must be an object.')
+    result = dict(data)
+    result.update({field: additional_fields[field] for field in field_names if field in additional_fields})
+    return result
+
+
+def _is_personal_editor_test_request(data):
+    scope = str(data.get('action_scope') or 'personal').strip().lower()
+    context = data.get('existing_plugin') or {}
+    context_scope = str(context.get('scope') or 'user').strip().lower() if isinstance(context, dict) else ''
+    return scope in {'personal', 'user'} and context_scope in {'personal', 'user'}
+
+
+def _assert_personal_editor_test_access(data, existing_plugin, user_id, action_type):
+    ensure_editor_access('actions', user_id, get_settings())
+    if not _is_personal_editor_test_request(data):
+        raise PermissionError('This editor test is available only in My Workspace.')
+    if existing_plugin:
+        if (
+            existing_plugin.get('user_id') != user_id or existing_plugin.get('is_global')
+            or existing_plugin.get('is_group') or existing_plugin.get('group_id')
+            or existing_plugin.get('scope') not in (None, '', 'personal', 'user')
+        ):
+            raise PermissionError('This action does not belong to the personal workspace.')
+        ensure_action_type_access('governance_user_actions', user_id, existing_plugin.get('type'), 'personal')
+    ensure_action_type_access('governance_user_actions', user_id, action_type, 'personal')
+
+
+def _prepare_editor_sql_test_data(data, existing_plugin, user_id):
+    action_type = data.get('type') or (existing_plugin or {}).get('type')
+    if action_type not in {'sql_query', 'sql_schema'}:
+        action_type = 'sql_query' if is_action_type_access_allowed(
+            'governance_user_actions', user_id, 'sql_query', 'personal',
+        ) else 'sql_schema'
+    _assert_personal_editor_test_access(data, existing_plugin, user_id, action_type)
+    result = _flatten_editor_test_fields(data, (
+        'database_type', 'connection_method', 'connection_string', 'server', 'database',
+        'port', 'driver', 'username', 'password', 'auth_type', 'timeout',
+    ))
+    auth = result.get('auth', {})
+    if not isinstance(auth, dict):
+        raise ValueError('Authentication must be an object.')
+    identity_manifest = _hydrate_sql_test_identity(result, existing_plugin, user_id)
+    if identity_manifest:
+        auth = identity_manifest.get('auth') or {}
+        fields = identity_manifest.get('additionalFields') or {}
+        for field in ('connection_string', 'username', 'password', 'auth_type', 'identity_auth_type'):
+            if field in fields:
+                result[field] = fields[field]
+
+    auth_type = str(auth.get('type') or result.get('auth_type') or '').strip()
+    declared_mode = '' if identity_manifest else str(result.get('auth_type') or result.get('identity_auth_type') or '').strip()
+    if auth_type.lower() in {'serviceprincipal', 'service_principal', 'client_secret'} or declared_mode.lower() in {
+        'serviceprincipal', 'service_principal', 'client_secret',
+    }:
+        # The shared SQL runtime has no SP credential path. A test-only token
+        # implementation would misleadingly validate an action the runtime cannot use.
+        raise WorkspaceAuthoringValidation(
+            'SQL service-principal fields are not supported by the SQL action runtime. '
+            'Use a supported SQL authentication mode or a complete connection string.'
+        )
+
+    stored_auth = (existing_plugin or {}).get('auth') or {}
+    scope_value, scope = _resolve_plugin_secret_context(existing_plugin, user_id)
+    auth_key = None
+    target_field = 'connection_string' if auth_type == 'connection_string' else 'password'
+    if 'key' in auth and target_field not in result:
+        auth_key = auth['key'] if identity_manifest else _rehydrate_action_test_secret(
+            auth['key'], stored_auth.get('key'), 'SQL', 'auth.key',
+        )
+        if not identity_manifest:
+            auth_key = _resolve_secret_value_for_action_test(
+                auth_key, 'auth.key', 'SQL', scope_value, scope, ACTION_AUTH_SECRET_SOURCES,
+            )
+    if auth_type == 'connection_string':
+        if auth_key is not None:
+            result['connection_string'] = auth_key
+        result['connection_method'] = 'connection_string'
+        result['auth_type'] = 'connection_string_only'
+        if not result.get('connection_string'):
+            raise ValueError('A connection string is required.')
+    elif auth_type == 'identity' and auth.get('identity') == 'managed_identity':
+        result['auth_type'] = 'managed_identity'
+    elif auth_type in {'user', 'username_password', 'basic'}:
+        if identity_manifest or declared_mode not in {'integrated', 'none'}:
+            result['auth_type'] = 'username_password'
+        if auth.get('identity') and 'username' not in result:
+            result['username'] = auth['identity']
+        if auth_key is not None:
+            result['password'] = auth_key
+    return result
+
+
+def _prepare_editor_yamcs_test_data(data, existing_plugin, user_id):
+    _assert_personal_editor_test_access(data, existing_plugin, user_id, YAMCS_PLUGIN_TYPE)
+    result = _flatten_editor_test_fields(data, (
+        'server_url', 'instance', 'auth_method', 'username', 'tls_verify', 'timeout',
+    ))
+    auth = result.get('auth', {})
+    if not isinstance(auth, dict):
+        raise ValueError('Authentication must be an object.')
+    identity_id = str(result.get('identity_id') or '').strip()
+    fields = dict(result.get('additionalFields') or {})
+    fields.update({
+        field: result[field] for field in ('server_url', 'instance', 'auth_method', 'tls_verify', 'timeout')
+        if field in result
+    })
+    if not auth:
+        method = result.get('auth_method')
+        auth = {
+            'type': 'NoAuth' if method == YAMCS_AUTH_METHOD_NONE else (
+                'key' if method in {YAMCS_AUTH_METHOD_API_KEY, YAMCS_AUTH_METHOD_BEARER_TOKEN} else 'username_password'
+            ),
+            'key': result.get('auth_key', ''),
+            'identity': result.get('username', ''),
+        }
+    manifest = {
+        'name': 'yamcs_connection_test', 'type': YAMCS_PLUGIN_TYPE,
+        'endpoint': result.get('endpoint') or result.get('server_url', ''),
+        'auth': dict(auth), 'additionalFields': fields,
+    }
+    if identity_id:
+        scope_type, scope_id = _resolve_action_identity_context(result, existing_plugin, user_id)
+        manifest['identity_id'] = identity_id
+        manifest['auth'] = {'type': 'identity', 'identity': identity_id}
+        manifest = hydrate_action_identity_reference(
+            manifest, scope_type, scope_id, return_type=SecretReturnType.VALUE,
+        )
+        auth = manifest['auth']
+        if not auth.get('key'):
+            raise ValueError('The selected identity does not provide a Yamcs credential.')
+        if auth.get('type') == 'username_password' and not auth.get('identity'):
+            raise ValueError('The selected identity does not provide a Yamcs username.')
+    _apply_plugin_runtime_defaults(manifest)
+    auth = manifest['auth']
+    result['auth_method'] = manifest['additionalFields']['auth_method']
+    result['server_url'] = manifest['endpoint']
+    if 'key' in auth:
+        result['auth_key'] = auth['key']
+    if 'identity' in auth:
+        result['username'] = auth['identity']
+    return result
+
+
 ACTION_CONNECTION_TEST_AUTH_SECRET_FIELDS = ('key', 'identity', 'tenantId')
 ACTION_CONNECTION_TEST_ADDITIONAL_SECRET_FIELDS = ('private_key_passphrase',)
 # Secret reference sources must match how keyvault_plugin_get_helper stored each field.
@@ -849,6 +1006,8 @@ def _resolve_secret_value_for_action_test(value, field_name, plugin_label, scope
     """
     if not isinstance(value, str) or not value:
         return value
+    if value == "***REDACTED***":
+        raise ValueError("A stored credential could not be resolved for testing. Re-enter its value.")
     if not validate_secret_name_dynamic(value):
         return value
 
@@ -881,9 +1040,9 @@ def _hydrate_mcp_custom_headers_for_test(discovery_manifest, existing_plugin, sc
     hydrated_headers = {}
     for header_name, header_value in custom_headers.items():
         resolved_header_value = header_value
-        if resolved_header_value in ('', None, ui_trigger_word):
+        if resolved_header_value in ('', None, ui_trigger_word, "***REDACTED***"):
             resolved_header_value = existing_headers.get(header_name)
-        if resolved_header_value == ui_trigger_word:
+        if resolved_header_value in (ui_trigger_word, "***REDACTED***"):
             raise ValueError(f"Stored MCP custom header '{header_name}' could not be resolved. Re-enter the header value.")
         if not resolved_header_value:
             continue
@@ -957,6 +1116,11 @@ def _load_existing_plugin_for_sql_test(plugin_context, user_id):
 @user_required
 def get_user_plugins():
     user_id = get_current_user_id()
+    if request.args.get('view') == 'editor':
+        return personal_editor_response(
+            'actions', user_id, _prepare_personal_action_for_editor,
+            migrate=ensure_migration_complete,
+        )
     # Ensure migration is complete (will migrate any remaining legacy data)
     ensure_migration_complete(user_id)
     
@@ -996,7 +1160,11 @@ def get_user_plugins():
     else:
         return jsonify(plugins)
 
-def _prepare_personal_action_payload(user_id, plugin):
+def _prepare_personal_action_for_editor(user_id, plugin, settings, existing):
+    return _prepare_personal_action_payload(user_id, plugin, editor=True)
+
+
+def _prepare_personal_action_payload(user_id, plugin, *, editor=False):
     """Clean, default and validate a single personal action.
 
     This is the per-action half of the bulk save, factored out so the per-item create and
@@ -1055,7 +1223,7 @@ def _prepare_personal_action_payload(user_id, plugin):
             plugin_to_save['type'] = 'unknown'  # Default type
 
     debug_print(f"Plugin build: {_redact_plugin_for_logging(plugin_to_save)}")
-    validation_error = validate_plugin(plugin_to_save)
+    validation_error = validate_editor_action_manifest(plugin_to_save) if editor else validate_plugin(plugin_to_save)
     if validation_error:
         return None, (jsonify({'error': f'Plugin validation failed: {validation_error}'}), 400)
     is_valid, validation_errors = PluginHealthChecker.validate_plugin_manifest(plugin_to_save, plugin_type)
@@ -1138,6 +1306,8 @@ def _create_personal_action(user_id, payload):
 def get_user_plugin(action_id):
     """Return one personal action, addressed by id or by name."""
     user_id = get_current_user_id()
+    if request.args.get('view') == 'editor':
+        return personal_editor_response('actions', user_id, _prepare_personal_action_for_editor, action_id)
     try:
         action = get_personal_action(user_id, action_id, return_type=SecretReturnType.NAME)
     except PermissionError:
@@ -1160,6 +1330,8 @@ def update_user_plugin(action_id):
     that does not know about a field has to send it back verbatim or lose it.
     """
     user_id = get_current_user_id()
+    if request.args.get('view') == 'editor':
+        return personal_editor_response('actions', user_id, _prepare_personal_action_for_editor, action_id)
     updates = request.get_json(silent=True)
     if not isinstance(updates, dict):
         return jsonify({'error': 'Action payload must be an object.'}), 400
@@ -1211,6 +1383,8 @@ def set_user_plugins():
     and an omitted element is an unintended delete.
     """
     user_id = get_current_user_id()
+    if request.args.get('view') == 'editor':
+        return personal_editor_response('actions', user_id, _prepare_personal_action_for_editor)
     payload = request.get_json(silent=True)
 
     if isinstance(payload, dict):
@@ -1305,6 +1479,8 @@ def delete_user_plugin(action_id):
     Governance is still enforced, inside ``delete_personal_action``.
     """
     user_id = get_current_user_id()
+    if request.args.get('view') == 'editor':
+        return personal_editor_response('actions', user_id, _prepare_personal_action_for_editor, action_id)
 
     # Try to delete from personal_actions container
     try:
@@ -1622,6 +1798,19 @@ def delete_group_action_route(action_id):
 @user_required
 def get_user_plugin_types():
     user_id = get_current_user_id()
+    if request.args.get('view') == 'editor':
+        try:
+            ensure_editor_access('actions', user_id, get_settings(), operation='read')
+            discovered = get_plugin_types(
+                allowed_type_filter=lambda action_type: is_action_type_access_allowed(
+                    'governance_user_actions', user_id, action_type, 'personal',
+                ),
+            )
+            response = jsonify(build_action_editor_types(discovered.get_json()))
+            response.headers['Cache-Control'] = 'no-store'
+            return response
+        except Exception as exc:
+            return editor_error_response(exc)
     return get_plugin_types(
         allowed_type_filter=lambda action_type: is_action_type_access_allowed(
             'governance_user_actions',
@@ -2150,6 +2339,8 @@ def discover_mcp_tools():
 
     try:
         existing_plugin = _load_existing_plugin_for_test(payload.get('plugin_context'), user_id)
+        if payload.get('clear_secret_paths'):
+            existing_plugin = clear_editor_test_secrets(existing_plugin, payload['clear_secret_paths'])
         scope_type, scope_id = _resolve_action_identity_context(payload, existing_plugin, user_id)
         plugin_scope_value, plugin_scope = _resolve_plugin_secret_context(existing_plugin, user_id)
 
@@ -2188,7 +2379,7 @@ def discover_mcp_tools():
 
         auth = discovery_manifest.get('auth') if isinstance(discovery_manifest.get('auth'), dict) else {}
         existing_auth = existing_plugin.get('auth') if isinstance(existing_plugin, dict) and isinstance(existing_plugin.get('auth'), dict) else {}
-        if auth.get('key') in ('', None, ui_trigger_word) and existing_auth.get('key'):
+        if auth.get('key') in ('', None, ui_trigger_word, "***REDACTED***") and existing_auth.get('key'):
             auth['key'] = existing_auth.get('key')
         if auth.get('identity') in ('', None) and existing_auth.get('identity'):
             auth['identity'] = existing_auth.get('identity')
@@ -2439,7 +2630,31 @@ def _merge_group_and_global_actions(group_actions, global_actions):
 def test_sql_connection():
     """Test a SQL database connection using provided configuration."""
     data = request.get_json(silent=True) or {}
+    if not isinstance(data, dict):
+        return jsonify({'success': False, 'error': 'SQL test configuration must be an object.'}), 400
+    editor_call = _is_personal_editor_test_request(data) and ('auth' in data or 'additionalFields' in data)
     user_id = get_current_user_id()
+
+    try:
+        existing_plugin = _load_existing_plugin_for_sql_test(data.get('existing_plugin'), user_id)
+        if data.get('clear_secret_paths'):
+            existing_plugin = clear_editor_test_secrets(existing_plugin, data['clear_secret_paths'])
+        if editor_call:
+            data = _prepare_editor_sql_test_data(data, existing_plugin, user_id)
+    except PermissionError as exc:
+        if editor_call:
+            return jsonify({'success': False, 'error': 'You cannot use the selected SQL action or identity.'}), 403
+        return jsonify({'success': False, 'error': str(exc)}), 403
+    except LookupError as exc:
+        if editor_call:
+            return jsonify({'success': False, 'error': 'The selected SQL action or identity is unavailable.'}), 404
+        return jsonify({'success': False, 'error': str(exc)}), 404
+    except ValueError as exc:
+        if editor_call:
+            message = exc.public_message if isinstance(exc, WorkspaceAuthoringValidation) else 'Invalid SQL connection configuration or identity.'
+            return jsonify({'success': False, 'error': message}), 400
+        return jsonify({'success': False, 'error': str(exc)}), 400
+
     database_type = (data.get('database_type') or 'sqlserver').lower()
     connection_method = data.get('connection_method', 'parameters')
     connection_string = data.get('connection_string', '')
@@ -2450,33 +2665,29 @@ def test_sql_connection():
     username = data.get('username', '')
     password = data.get('password', '')
     auth_type = data.get('auth_type', 'username_password')
-    timeout = min(int(data.get('timeout', 10)), 15)  # Cap at 15 seconds for test
-
     try:
-        existing_plugin = _load_existing_plugin_for_sql_test(data.get('existing_plugin'), user_id)
-    except PermissionError as exc:
-        return jsonify({'success': False, 'error': str(exc)}), 403
-    except LookupError as exc:
-        return jsonify({'success': False, 'error': str(exc)}), 404
-    except ValueError as exc:
-        return jsonify({'success': False, 'error': str(exc)}), 400
+        timeout = min(int(data.get('timeout', 10)), 15)  # Cap at 15 seconds for test
+    except (TypeError, ValueError):
+        return jsonify({'success': False, 'error': 'SQL timeout must be an integer.'}), 400
 
     existing_additional_fields = {}
     if isinstance(existing_plugin, dict) and isinstance(existing_plugin.get('additionalFields'), dict):
         existing_additional_fields = existing_plugin['additionalFields']
 
-    if connection_string == ui_trigger_word:
+    if connection_string in (ui_trigger_word, "***REDACTED***"):
         connection_string = existing_additional_fields.get('connection_string', '')
-    if password == ui_trigger_word:
+    if password in (ui_trigger_word, "***REDACTED***"):
         password = existing_additional_fields.get('password', '')
 
     try:
-        identity_manifest = _hydrate_sql_test_identity(data, existing_plugin, user_id)
+        identity_manifest = None if editor_call else _hydrate_sql_test_identity(data, existing_plugin, user_id)
     except PermissionError as exc:
         return jsonify({'success': False, 'error': str(exc)}), 403
     except LookupError as exc:
         return jsonify({'success': False, 'error': str(exc)}), 404
     except ValueError as exc:
+        if editor_call:
+            return jsonify({'success': False, 'error': 'A stored SQL credential could not be resolved.'}), 400
         return jsonify({'success': False, 'error': str(exc)}), 400
 
     if identity_manifest:
@@ -2495,9 +2706,9 @@ def test_sql_connection():
             auth_type = 'username_password'
 
     unresolved_fields = []
-    if connection_string == ui_trigger_word:
+    if connection_string in (ui_trigger_word, "***REDACTED***"):
         unresolved_fields.append('connection string')
-    if password == ui_trigger_word:
+    if password in (ui_trigger_word, "***REDACTED***"):
         unresolved_fields.append('password')
     if unresolved_fields:
         field_list = ', '.join(unresolved_fields)
@@ -2519,7 +2730,16 @@ def test_sql_connection():
             scope=plugin_scope,
         )
     except ValueError as exc:
+        if editor_call:
+            return jsonify({'success': False, 'error': 'A stored SQL credential could not be resolved.'}), 400
         return jsonify({'success': False, 'error': str(exc)}), 400
+
+    if (
+        editor_call and auth_type == 'username_password' and database_type != 'sqlite'
+        and not (connection_method == 'connection_string' and connection_string)
+        and (not username or not password)
+    ):
+        return jsonify({'success': False, 'error': 'SQL username and password are required for this authentication mode.'}), 400
 
     # Map azure_sql to sqlserver
     if database_type in ('azure_sql', 'azuresql'):
@@ -2617,6 +2837,8 @@ def test_sql_connection():
             return jsonify({'success': False, 'error': f'Unsupported database type: {database_type}'}), 400
 
     except ImportError as e:
+        if editor_call:
+            return jsonify({'success': False, 'error': 'The required database driver is not available on the server.'}), 400
         if database_type == 'sqlserver' and 'libodbc' in str(e):
             return jsonify({
                 'success': False,
@@ -2624,6 +2846,13 @@ def test_sql_connection():
             }), 400
         return jsonify({'success': False, 'error': f'Database driver not installed: {str(e)}'}), 400
     except Exception as e:
+        if editor_call:
+            log_event(
+                '[PLUGINS] SQL editor connection test failed.',
+                level=logging.WARNING,
+                extra={'database_type': database_type, 'error_type': type(e).__name__},
+            )
+            return jsonify({'success': False, 'error': 'SQL connection failed. Verify the connection and authentication settings.'}), 400
         error_msg = str(e)
         if database_type == 'sqlserver' and "Can't open lib 'ODBC Driver 17 for SQL Server'" in error_msg:
             error_msg = 'The selected ODBC Driver 17 is not installed in this container image. Select ODBC Driver 18 for SQL Server or rebuild the image with Driver 17.'
@@ -2666,6 +2895,8 @@ def test_cosmos_connection():
 
     try:
         existing_plugin = _load_existing_plugin_for_test(data.get('existing_plugin'), user_id)
+        if data.get('clear_secret_paths'):
+            existing_plugin = clear_editor_test_secrets(existing_plugin, data['clear_secret_paths'])
     except PermissionError as exc:
         return jsonify({'success': False, 'error': str(exc)}), 403
     except LookupError as exc:
@@ -2678,10 +2909,10 @@ def test_cosmos_connection():
         existing_auth = existing_plugin['auth']
 
     if auth_type == 'key':
-        if auth_key == ui_trigger_word:
+        if auth_key in (ui_trigger_word, "***REDACTED***"):
             auth_key = existing_auth.get('key', '')
 
-        if auth_key == ui_trigger_word:
+        if auth_key in (ui_trigger_word, "***REDACTED***"):
             return jsonify({'success': False, 'error': 'Stored Cosmos DB account key could not be resolved for testing. Re-enter the account key.'}), 400
 
         try:
@@ -2799,7 +3030,25 @@ def test_cosmos_connection():
 def test_yamcs_connection():
     """Test a Yamcs mission control server connection using the configured credentials."""
     data = request.get_json(silent=True) or {}
+    if not isinstance(data, dict):
+        return jsonify({'success': False, 'error': 'Yamcs test configuration must be an object.'}), 400
     user_id = get_current_user_id()
+    editor_call = _is_personal_editor_test_request(data) and (
+        'auth' in data or 'additionalFields' in data or bool(data.get('identity_id'))
+    )
+    existing_plugin = None
+    if editor_call:
+        try:
+            existing_plugin = _load_existing_plugin_for_test(data.get('existing_plugin'), user_id)
+            if data.get('clear_secret_paths'):
+                existing_plugin = clear_editor_test_secrets(existing_plugin, data['clear_secret_paths'])
+            data = _prepare_editor_yamcs_test_data(data, existing_plugin, user_id)
+        except PermissionError:
+            return jsonify({'success': False, 'error': 'You cannot use the selected Yamcs action or identity.'}), 403
+        except LookupError:
+            return jsonify({'success': False, 'error': 'The selected Yamcs action or identity is unavailable.'}), 404
+        except ValueError:
+            return jsonify({'success': False, 'error': 'Invalid Yamcs connection configuration or identity.'}), 400
     server_url = normalize_yamcs_server_url(data.get('server_url') or data.get('endpoint') or '')
     instance = (data.get('instance') or '').strip()
     auth_method = (data.get('auth_method') or YAMCS_AUTH_METHOD_USERNAME_PASSWORD).strip().lower()
@@ -2825,23 +3074,26 @@ def test_yamcs_connection():
             'error': "Yamcs auth_method must be 'username_password', 'api_key', 'bearer_token', or 'none'."
         }), 400
 
-    try:
-        existing_plugin = _load_existing_plugin_for_test(data.get('existing_plugin'), user_id)
-    except PermissionError as exc:
-        return jsonify({'success': False, 'error': str(exc)}), 403
-    except LookupError as exc:
-        return jsonify({'success': False, 'error': str(exc)}), 404
-    except ValueError as exc:
-        return jsonify({'success': False, 'error': str(exc)}), 400
+    if not editor_call:
+        try:
+            existing_plugin = _load_existing_plugin_for_test(data.get('existing_plugin'), user_id)
+            if data.get('clear_secret_paths'):
+                existing_plugin = clear_editor_test_secrets(existing_plugin, data['clear_secret_paths'])
+        except PermissionError as exc:
+            return jsonify({'success': False, 'error': str(exc)}), 403
+        except LookupError as exc:
+            return jsonify({'success': False, 'error': str(exc)}), 404
+        except ValueError as exc:
+            return jsonify({'success': False, 'error': str(exc)}), 400
 
     existing_auth = {}
     if isinstance(existing_plugin, dict) and isinstance(existing_plugin.get('auth'), dict):
         existing_auth = existing_plugin['auth']
 
     if auth_method != YAMCS_AUTH_METHOD_NONE:
-        if auth_key in ('', ui_trigger_word):
+        if auth_key in ('', ui_trigger_word, "***REDACTED***"):
             auth_key = existing_auth.get('key', '')
-        if auth_key == ui_trigger_word:
+        if auth_key in (ui_trigger_word, "***REDACTED***"):
             return jsonify({
                 'success': False,
                 'error': 'Stored Yamcs credential could not be resolved for testing. Re-enter the credential.'
@@ -2858,6 +3110,8 @@ def test_yamcs_connection():
                 ACTION_AUTH_SECRET_SOURCES,
             )
         except ValueError as exc:
+            if editor_call:
+                return jsonify({'success': False, 'error': 'The stored Yamcs credential could not be resolved.'}), 400
             return jsonify({'success': False, 'error': str(exc)}), 400
 
         if not auth_key:
@@ -3003,6 +3257,8 @@ def test_rocksdb_connection():
 
     try:
         existing_plugin = _load_existing_plugin_for_test(data.get('existing_plugin'), user_id)
+        if data.get('clear_secret_paths'):
+            existing_plugin = clear_editor_test_secrets(existing_plugin, data['clear_secret_paths'])
     except PermissionError:
         return jsonify({'success': False, 'error': 'You do not have access to the selected action.'}), 403
     except LookupError:
@@ -3015,9 +3271,9 @@ def test_rocksdb_connection():
         if isinstance(existing_plugin, dict) and isinstance(existing_plugin.get('auth'), dict):
             existing_auth = existing_plugin['auth']
 
-        if auth_key == ui_trigger_word:
+        if auth_key in (ui_trigger_word, "***REDACTED***"):
             auth_key = existing_auth.get('key', '')
-        if auth_key == ui_trigger_word:
+        if auth_key in (ui_trigger_word, "***REDACTED***"):
             return jsonify({
                 'success': False,
                 'error': 'The stored RocksDB service token could not be resolved for testing. Re-enter the token.'
@@ -3126,9 +3382,9 @@ def test_rocksdb_connection():
 def _rehydrate_action_test_secret(current_value, stored_value, plugin_label, field_label):
     """Restore a masked action secret from the stored manifest for a transient test."""
     resolved_value = current_value
-    if resolved_value in ('', None, ui_trigger_word) and stored_value:
+    if resolved_value in ('', None, ui_trigger_word, "***REDACTED***") and stored_value:
         resolved_value = stored_value
-    if resolved_value == ui_trigger_word:
+    if resolved_value in (ui_trigger_word, "***REDACTED***"):
         raise ValueError(
             f"The stored {plugin_label} value for '{field_label}' could not be resolved for testing. Re-enter the credential."
         )
@@ -3142,6 +3398,8 @@ def _prepare_action_test_manifest(data, plugin_type, plugin_label):
 
     user_id = get_current_user_id()
     existing_plugin = _load_existing_plugin_for_test(data.get('plugin_context'), user_id)
+    if data.get('clear_secret_paths'):
+        existing_plugin = clear_editor_test_secrets(existing_plugin, data['clear_secret_paths'])
     scope_type, scope_id = _resolve_action_identity_context(data, existing_plugin, user_id)
     # Secret references are resolved against the loaded action's own Key Vault scope, never
     # against a scope derived from the request body.

--- a/application/v2_ui/src/App.tsx
+++ b/application/v2_ui/src/App.tsx
@@ -18,6 +18,7 @@ import { SettingsPage } from './pages/SettingsPage';
 import { WorkspacePage } from './pages/workspace/WorkspacePage';
 import { PlaceholderPage } from './pages/PlaceholderPage';
 import { GroupAgentDelegationPage } from './pages/GroupAgentDelegationPage';
+import { clearWorkspaceEditorDrafts } from './lib/workspaceEditorDrafts';
 
 function BootScreen() {
     return (
@@ -72,6 +73,10 @@ export function App() {
         (state) => (state.settings.fontSizePreference as string) || 'm',
     );
     const location = useLocation();
+
+    useEffect(() => {
+        clearWorkspaceEditorDrafts();
+    }, [data?.user?.id, authExpired]);
 
     useEffect(() => {
         initializeTheme();
@@ -172,6 +177,7 @@ export function App() {
                 {/* Sections are real paths rather than a query parameter, so a link to one
                     reads as what it is and survives being shared. */}
                 <Route path="/workspace/:section" element={<WorkspacePage />} />
+                <Route path="/workspace/:section/:resourceId" element={<WorkspacePage />} />
                 <Route path="/settings" element={<SettingsPage />} />
                 <Route path="/admin" element={<AdminSettingsPage />} />
                 <Route

--- a/application/v2_ui/src/components/chat/Composer.tsx
+++ b/application/v2_ui/src/components/chat/Composer.tsx
@@ -174,7 +174,7 @@ function ToolToggle({
     );
 }
 
-export function Composer() {
+export function Composer({ initialAgentSelection }: { initialAgentSelection?: string } = {}) {
     const { streaming, sendMessage, stopStreaming, activeConversationId } = useChatStore();
     // Read for the built-in prompt variables ({{last_response}} and friends) and for the name
     // suggested when saving what is written as a prompt.
@@ -283,6 +283,7 @@ export function Composer() {
         deepResearch: false,
         urlAccess: false,
         contextItems: [],
+        agentSelection: initialAgentSelection,
     });
 
     /**
@@ -306,12 +307,12 @@ export function Composer() {
     const orchestrationAvailable = Boolean(
         features.enable_chat_orchestration && orchestrationConfig?.enabled,
     );
-    const [orchestrationOn, setOrchestrationOn] = useState(orchestrationAvailable);
+    const [orchestrationOn, setOrchestrationOn] = useState(orchestrationAvailable && !initialAgentSelection);
     // Whether the user has expressed an opinion. The bootstrap resolves after the first
     // render, so the deployment's answer has to be adopted when it lands -- but adopting it
     // unconditionally would switch orchestration back on every time the payload refreshed,
     // overriding somebody who had just turned it off.
-    const orchestrationChosen = useRef(false);
+    const orchestrationChosen = useRef(Boolean(initialAgentSelection));
     useEffect(() => {
         if (!orchestrationChosen.current) {
             setOrchestrationOn(orchestrationAvailable);

--- a/application/v2_ui/src/components/chat/ConversationBadges.tsx
+++ b/application/v2_ui/src/components/chat/ConversationBadges.tsx
@@ -39,7 +39,7 @@ export function ConversationBadges({
     );
     const categories = useBootstrapStore(
         (state) =>
-            (state.data?.settings?.document_classification_categories ?? []) as
+            state.data?.settings?.document_classification_categories as
                 | ClassificationCategory[]
                 | undefined,
     );

--- a/application/v2_ui/src/components/workspace/WorkspaceEditorFrame.tsx
+++ b/application/v2_ui/src/components/workspace/WorkspaceEditorFrame.tsx
@@ -1,0 +1,197 @@
+// WorkspaceEditorFrame.tsx
+
+import { useEffect, useId, useRef, type ReactNode } from 'react';
+import { useBlocker, useNavigate } from 'react-router-dom';
+import { ArrowLeft, Loader2, Lock, Save } from 'lucide-react';
+import { GlassButton, GlassPanel } from '../ui/primitives';
+import { agentEditorReturnPath, isRecord } from '../../lib/workspaceAuthoring';
+
+export interface WorkspaceEditorSection {
+    id: string;
+    label: string;
+    description?: string;
+    content: ReactNode;
+}
+
+function LeavePrompt({
+    saving, onStay, onDiscard,
+}: { saving: boolean; onStay: () => void; onDiscard: () => void }) {
+    const dialog = useRef<HTMLDialogElement>(null);
+    const titleId = useId();
+    useEffect(() => {
+        const element = dialog.current;
+        if (!element) return;
+        element.showModal();
+        return () => element.close();
+    }, []);
+
+    return (
+        <dialog ref={dialog} aria-labelledby={titleId}
+            onCancel={(event) => { event.preventDefault(); onStay(); }}
+            className="glass-modal m-auto w-[calc(100%_-_2rem)] max-w-md rounded-2xl border border-edge p-5 text-text-1 backdrop:bg-surface-sunken/75">
+            <h2 id={titleId} className="text-lg font-semibold">
+                {saving ? 'Your changes are still being saved' : 'Discard unsaved changes?'}
+            </h2>
+            <p className="mt-2 text-sm text-text-2">
+                {saving ? 'Stay here until the save finishes.' : 'Your changes have not been saved. Stay to keep editing, or discard them before leaving.'}
+            </p>
+            <div className="mt-5 flex flex-wrap justify-end gap-2">
+                <GlassButton type="button" autoFocus onClick={onStay}>Keep editing</GlassButton>
+                <GlassButton type="button" variant="danger" disabled={saving} onClick={onDiscard}>Discard changes</GlassButton>
+            </div>
+        </dialog>
+    );
+}
+
+export function WorkspaceEditorFrame({
+    title, description, backTo, sections, dirty, saving, readOnly = false, error,
+    onSave, onDiscard, saveLabel = 'Save changes', actions, saveDisabled = false,
+}: {
+    title: string;
+    description?: string;
+    backTo: string;
+    sections: WorkspaceEditorSection[];
+    dirty: boolean;
+    saving: boolean;
+    readOnly?: boolean;
+    error?: string | null;
+    onSave: () => void;
+    onDiscard: () => void;
+    saveLabel?: string;
+    actions?: ReactNode;
+    saveDisabled?: boolean;
+}) {
+    const navigate = useNavigate();
+    const form = useRef<HTMLFormElement>(null);
+    const errorSummary = useRef<HTMLDivElement>(null);
+    const prefix = useId();
+    const blocker = useBlocker(({ currentLocation, nextLocation, historyAction }) => {
+        if (readOnly || (!dirty && !saving)) return false;
+        const state = isRecord(nextLocation.state) ? nextLocation.state : {};
+        const currentEditorTransition = historyAction !== 'POP' &&
+            state.workspaceEditorFrom === currentLocation.key;
+        if (currentEditorTransition && state.workspaceEditorSaved === true && /^\/workspace\/(?:agents|actions)(?:\/|$)/.test(nextLocation.pathname)) return false;
+        if (currentEditorTransition && state.preserveWorkspaceDraft === true) {
+            const goingToAction = nextLocation.pathname === '/workspace/actions/new' &&
+                agentEditorReturnPath(currentLocation.pathname) &&
+                new URLSearchParams(nextLocation.search).get('returnTo') === currentLocation.pathname;
+            const returningToAgent = currentLocation.pathname === '/workspace/actions/new' &&
+                agentEditorReturnPath(nextLocation.pathname) &&
+                new URLSearchParams(currentLocation.search).get('returnTo') === nextLocation.pathname;
+            if (goingToAction || returningToAgent) return false;
+        }
+        return currentLocation.pathname !== nextLocation.pathname || currentLocation.search !== nextLocation.search;
+    });
+
+    useEffect(() => {
+        if (readOnly || (!dirty && !saving)) return;
+        const beforeUnload = (event: BeforeUnloadEvent) => {
+            event.preventDefault();
+            event.returnValue = '';
+        };
+        window.addEventListener('beforeunload', beforeUnload);
+        return () => window.removeEventListener('beforeunload', beforeUnload);
+    }, [dirty, saving, readOnly]);
+
+    useEffect(() => {
+        if (error) errorSummary.current?.focus();
+    }, [error]);
+
+    const goToSection = (id: string) => {
+        const target = document.getElementById(`${prefix}-${id}`);
+        if (target instanceof HTMLDetailsElement) target.open = true;
+        target?.scrollIntoView({ block: 'start', behavior: 'smooth' });
+        target?.focus({ preventScroll: true });
+    };
+
+    return (
+        <form ref={form} className="flex h-full min-h-0 flex-col"
+            onSubmit={(event) => { event.preventDefault(); if (!readOnly && !saving && !saveDisabled) onSave(); }}
+            onInvalidCapture={(event) => {
+                const input = event.target;
+                if (input instanceof HTMLElement) {
+                    const details = input.closest('details');
+                    if (details) details.open = true;
+                }
+            }}
+            onKeyDown={(event) => {
+                if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 's' && !readOnly) {
+                    event.preventDefault();
+                    form.current?.requestSubmit();
+                }
+            }}>
+            <header className="shrink-0 space-y-3 border-b border-edge pb-3">
+                <GlassButton type="button" size="sm" onClick={() => navigate(backTo)}>
+                    <ArrowLeft size={15} /> Back
+                </GlassButton>
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div className="min-w-0">
+                        <h2 className="break-words text-xl font-semibold text-text-1">{title}</h2>
+                        {description ? <p className="mt-1 max-w-2xl text-sm text-text-3">{description}</p> : null}
+                    </div>
+                    <div className="flex flex-wrap items-center gap-2">
+                        {actions}
+                        {readOnly ? (
+                            <span className="flex items-center gap-1.5 text-sm text-text-3"><Lock size={14} /> Provided - read only</span>
+                        ) : (
+                            <>
+                                <GlassButton type="button" disabled={saving} onClick={() => navigate(backTo)}>Cancel</GlassButton>
+                                <GlassButton type="submit" variant="primary" disabled={saving || saveDisabled}>
+                                    {saving ? <Loader2 size={15} className="animate-spin" /> : <Save size={15} />}
+                                    {saving ? 'Saving...' : saveLabel}
+                                </GlassButton>
+                            </>
+                        )}
+                    </div>
+                </div>
+                {!readOnly ? <p role="status" className="text-xs text-text-3">{saving ? 'Saving your changes.' : dirty ? 'Unsaved changes' : 'No unsaved changes'}</p> : null}
+            </header>
+
+            <div className="flex min-h-0 flex-1 flex-col gap-3 pt-3 lg:flex-row lg:gap-5">
+                <nav aria-label="Editor sections" className="hidden w-40 shrink-0 space-y-1 overflow-y-auto lg:block">
+                    {sections.map((section) => (
+                        <button key={section.id} type="button" onClick={() => goToSection(section.id)}
+                            className="block w-full rounded-lg px-3 py-2 text-left text-sm text-text-2 hover:bg-surface-2 hover:text-text-1">
+                            {section.label}
+                        </button>
+                    ))}
+                </nav>
+                <label className="shrink-0 text-xs text-text-3 lg:hidden">
+                    Jump to section
+                    <select aria-label="Jump to section" defaultValue="" onChange={(event) => { if (event.target.value) goToSection(event.target.value); }}
+                        className="mt-1 block w-full rounded-lg border border-edge bg-surface-1 px-3 py-2 text-sm text-text-1">
+                        <option value="">Choose a section</option>
+                        {sections.map((section) => <option key={section.id} value={section.id}>{section.label}</option>)}
+                    </select>
+                </label>
+                <div className="min-h-0 min-w-0 flex-1 space-y-4 overflow-y-auto pb-6 pr-1">
+                    {error ? <GlassPanel elevation="flat" className="border border-danger/30 p-4">
+                        <div ref={errorSummary} role="alert" tabIndex={-1} className="text-sm text-danger">{error}</div>
+                    </GlassPanel> : null}
+                    <fieldset disabled={readOnly || saving} className="min-w-0 space-y-4">
+                        <legend className="sr-only">{readOnly ? 'Configuration details' : 'Configuration'}</legend>
+                        {sections.map((section) => section.id === 'advanced' ? (
+                            <details key={section.id} id={`${prefix}-${section.id}`} tabIndex={-1}
+                                className="glass-flat scroll-mt-2 rounded-2xl p-4">
+                                <summary className="cursor-pointer text-base font-semibold text-text-1">{section.label}</summary>
+                                {section.description ? <p className="mt-1 text-sm text-text-3">{section.description}</p> : null}
+                                <div className="mt-4 space-y-4">{section.content}</div>
+                            </details>
+                        ) : (
+                            <section key={section.id} id={`${prefix}-${section.id}`} tabIndex={-1}
+                                aria-labelledby={`${prefix}-${section.id}-title`} className="glass-flat scroll-mt-2 rounded-2xl p-4">
+                                <h3 id={`${prefix}-${section.id}-title`} className="text-base font-semibold text-text-1">{section.label}</h3>
+                                {section.description ? <p className="mt-1 text-sm text-text-3">{section.description}</p> : null}
+                                <div className="mt-4 space-y-4">{section.content}</div>
+                            </section>
+                        ))}
+                    </fieldset>
+                </div>
+            </div>
+            {blocker.state === 'blocked' ? (
+                <LeavePrompt saving={saving} onStay={() => blocker.reset()}
+                    onDiscard={() => { onDiscard(); blocker.proceed(); }} />
+            ) : null}
+        </form>
+    );
+}

--- a/application/v2_ui/src/components/workspaceActions/ActionAdvancedFields.tsx
+++ b/application/v2_ui/src/components/workspaceActions/ActionAdvancedFields.tsx
@@ -1,0 +1,128 @@
+// ActionAdvancedFields.tsx
+
+import { useId } from 'react';
+import { Toggle } from '../ui/primitives';
+import { ActionField, ActionJsonInput, ACTION_INPUT_CLASS } from './ActionFields';
+import { ActionSchemaFields } from './ActionSchemaFields';
+import { isRecord, type ActionTypeDefinition } from '../../lib/workspaceAuthoring';
+import { actionFieldError, actionHasStoredArraySecrets, actionText, actionValueAt, changeActionField } from '../../lib/workspaceActionLogic';
+import type { ActionEditorHints } from '../../lib/workspaceActionServices';
+import type { ActionConnectorProps } from '../../lib/workspaceActionTypes';
+
+const reminderPath = '/metadata/key_vault_secret_reminders/__all__';
+
+export function ActionAdvancedFields(props: ActionConnectorProps & {
+    definition: ActionTypeDefinition;
+    hints: ActionEditorHints | null;
+    hintsError: string | null;
+}) {
+    const { draft, onChange, readOnly, definition, hints, hintsError } = props;
+    const id = useId();
+    const rawReminder = actionValueAt(draft, reminderPath);
+    const reminder = isRecord(rawReminder) ? rawReminder : {};
+    const enabled = reminder.enabled === true;
+    const updateReminder = (key: string, value: unknown) => onChange((current) => changeActionField(current, `${reminderPath}/${key}`, value));
+    const sync = draft.metadata.key_vault_secret_reminder_sync;
+    const syncStates = isRecord(sync) ? Object.entries(sync) : [];
+    return (
+        <div className="min-w-0 space-y-6">
+            <div className="grid min-w-0 gap-4 sm:grid-cols-2">
+                <ActionField id={`${id}-machine-name`} label="Machine name" required
+                    help="Letters, numbers, underscores, and dashes only. Renaming does not change the action ID."
+                    error={actionFieldError(props.errors, '/name')}>
+                    <input id={`${id}-machine-name`} className={ACTION_INPUT_CLASS} value={draft.name} required
+                        pattern="[A-Za-z0-9_\-]+" disabled={readOnly}
+                        onChange={(event) => onChange((current) => ({ ...current, name: event.target.value }))} />
+                </ActionField>
+                <div className="min-w-0 space-y-1.5 text-xs text-text-3">
+                    <p className="text-sm font-medium text-text-1">Action ID</p>
+                    <p className="break-all">{draft.id || 'Assigned when the action is saved.'}</p>
+                    <p>The ID, not the display name, identifies this action in agent assignments.</p>
+                </div>
+            </div>
+            <ActionSchemaFields props={props} schema={definition.metadata_schema} path="/metadata"
+                coveredPaths={['/metadata/key_vault_secret_reminders', '/metadata/key_vault_secret_reminder_sync',
+                    ...(draft.type === 'log_analytics' ? ['/metadata/name'] : [])]}
+                allowCustom={false} />
+            {draft.type !== 'agent' ? (
+                <fieldset className="min-w-0 space-y-4 rounded-xl border border-edge p-4">
+                    <legend className="px-1 text-sm font-medium text-text-1">Secret expiration and reminders</legend>
+                    <p className="text-xs leading-relaxed text-text-3">
+                        Track expiration and send a rotation reminder for this action’s stored secrets. Tracking does not rotate credentials automatically.
+                    </p>
+                    {hints ? <p className="text-xs text-text-3">
+                        Key Vault storage is {hints.storageEnabled ? 'enabled' : 'disabled'}; reminder delivery is {hints.remindersEnabled ? 'enabled' : 'disabled'}.
+                        {hints.requireExpiration ? ' Your administrator requires expiration dates for tracked secrets.' : ''}
+                    </p> : <p className="text-xs text-text-3">{hintsError || 'Loading reminder defaults…'} Existing reminder settings are preserved.</p>}
+                    {!hints?.storageEnabled && hints ? <p className="rounded-lg bg-warn-soft p-2 text-xs text-warn">
+                        This configuration is retained, but reminders for Key Vault secrets require enabled Key Vault storage and reminder delivery.
+                    </p> : null}
+                    <Toggle checked={enabled} disabled={readOnly} label="Track secret expiration"
+                        description="Apply these defaults to all secret fields on this action. Existing field-specific settings are kept."
+                        onChange={(value) => onChange((current) => {
+                            const existing = actionValueAt(current, reminderPath);
+                            const previous = isRecord(existing) ? existing : {};
+                            return changeActionField(current, reminderPath, {
+                                ...previous, enabled: value,
+                                ...(value ? {
+                                    lead_days: previous.lead_days ?? hints?.reminderLeadDays ?? 30,
+                                    contact_email: previous.contact_email ?? previous.reminder_email ?? hints?.reminderEmail ?? '',
+                                    expires_on: previous.expires_on ?? previous.expiration_date ?? '',
+                                } : {}),
+                            });
+                        })} />
+                    {enabled ? <div className="grid min-w-0 gap-4 sm:grid-cols-2">
+                        <ActionField id={`${id}-expiration`} label="Secret expiration date" required
+                            error={actionFieldError(props.errors, `${reminderPath}/expires_on`)}>
+                            <input id={`${id}-expiration`} type="date" className={ACTION_INPUT_CLASS} required disabled={readOnly}
+                                value={actionText(reminder.expires_on ?? reminder.expiration_date).slice(0, 10)}
+                                onChange={(event) => updateReminder('expires_on', event.target.value)} />
+                        </ActionField>
+                        <ActionField id={`${id}-reminder-email`} label="Reminder email" required
+                            error={actionFieldError(props.errors, `${reminderPath}/contact_email`)}>
+                            <input id={`${id}-reminder-email`} type="email" className={ACTION_INPUT_CLASS} required disabled={readOnly}
+                                value={actionText(reminder.contact_email ?? reminder.reminder_email)}
+                                onChange={(event) => updateReminder('contact_email', event.target.value)} />
+                        </ActionField>
+                        <ActionField id={`${id}-reminder-days`} label="Reminder lead days" required
+                            error={actionFieldError(props.errors, `${reminderPath}/lead_days`)}>
+                            <input id={`${id}-reminder-days`} type="number" min={1} max={3650} step={1} className={ACTION_INPUT_CLASS} required disabled={readOnly}
+                                value={typeof reminder.lead_days === 'number' ? reminder.lead_days : ''}
+                                onChange={(event) => updateReminder('lead_days', event.target.value === '' ? undefined : event.target.valueAsNumber)} />
+                        </ActionField>
+                        <ActionField id={`${id}-reminder-label`} label="Reminder label">
+                            <input id={`${id}-reminder-label`} className={ACTION_INPUT_CLASS} disabled={readOnly}
+                                value={actionText(reminder.label ?? reminder.friendly_label)} onChange={(event) => updateReminder('label', event.target.value)} />
+                        </ActionField>
+                        <div className="sm:col-span-2">
+                            <ActionField id={`${id}-reminder-notes`} label="Rotation notes">
+                                <textarea id={`${id}-reminder-notes`} rows={3} className={ACTION_INPUT_CLASS} disabled={readOnly}
+                                    value={actionText(reminder.notes ?? reminder.rotation_notes)} onChange={(event) => updateReminder('notes', event.target.value)} />
+                            </ActionField>
+                        </div>
+                    </div> : null}
+                    {syncStates.length ? <div className="space-y-1 text-xs text-text-3">
+                        <p className="font-medium text-text-2">Last reminder synchronization</p>
+                        {syncStates.map(([path, state]) => <p key={path} className="break-words">
+                            {path}: {isRecord(state) ? actionText(state.status) || (state.success === true ? 'Synced' : 'Review required') : String(state)}
+                        </p>)}
+                    </div> : null}
+                </fieldset>
+            ) : null}
+            <div className="min-w-0 space-y-4">
+                <p className="text-xs leading-relaxed text-text-3">
+                    JSON and structured fields edit the same draft. Unrecognized properties are retained.
+                    Stored secrets appear only as masks; leave a mask unchanged to keep it, or explicitly clear/replace the corresponding field.
+                </p>
+                {draft.type !== 'agent' ? <ActionJsonInput id={`${id}-additional-json`} label="Additional fields JSON"
+                    value={draft.additionalFields} readOnly={readOnly} onValidityChange={props.onValidityChange}
+                    protectArraySecrets={actionHasStoredArraySecrets(draft, props.original, '/additionalFields')}
+                    onChange={(value) => { if (isRecord(value)) onChange((current) => ({ ...current, additionalFields: value })); }} /> : null}
+                <ActionJsonInput id={`${id}-metadata-json`} label="Metadata JSON" value={draft.metadata} readOnly={readOnly}
+                    onValidityChange={props.onValidityChange}
+                    protectArraySecrets={actionHasStoredArraySecrets(draft, props.original, '/metadata')}
+                    onChange={(value) => { if (isRecord(value)) onChange((current) => ({ ...current, metadata: value })); }} />
+            </div>
+        </div>
+    );
+}

--- a/application/v2_ui/src/components/workspaceActions/ActionAuthentication.tsx
+++ b/application/v2_ui/src/components/workspaceActions/ActionAuthentication.tsx
@@ -1,0 +1,158 @@
+// ActionAuthentication.tsx
+
+import { useId } from 'react';
+import { ActionField, ActionSecretInput, ACTION_INPUT_CLASS } from './ActionFields';
+import {
+    actionAuthMethod, actionAuthModes, actionFieldError, actionText, actionValueAt,
+    changeActionAuth, changeActionField, selectActionIdentity,
+} from '../../lib/workspaceActionLogic';
+import { nativeActionDefinition, sqlConnectionMethod } from '../../lib/workspaceActionRegistry';
+import type { ActionTypeDefinition } from '../../lib/workspaceAuthoring';
+import type { ActionConnectorProps } from '../../lib/workspaceActionTypes';
+
+export function ActionAuthentication(props: ActionConnectorProps & { definition: ActionTypeDefinition }) {
+    const { draft, onChange, readOnly, definition } = props;
+    const id = useId();
+    const native = nativeActionDefinition(draft.type);
+    const modes = actionAuthModes(draft.type, definition.allowed_auth_types);
+    const method = actionAuthMethod(draft);
+    const selected = modes.find((choice) => choice.value === method);
+    const identityTypes = native.identityTypes ?? ['api_key', 'bearer_token', 'client_secret', 'connection_string', 'managed_identity', 'username_password'];
+    const identities = props.identities.filter((identity) => identityTypes.includes(identity.auth_type));
+    const identity = identities.find((candidate) => candidate.id === draft.identity_id);
+    const identityMissing = Boolean(draft.identity_id && !identity);
+    const sql = ['sql_query', 'sql_schema'].includes(draft.type);
+
+    const textField = (path: string, label: string, help?: string, required = false) => props.original?.secret_paths.includes(path)
+        ? secretField(path, label, help) : (
+        <ActionField key={path} id={`${id}${path}`} label={label} error={actionFieldError(props.errors, path)} help={help} required={required}>
+            <input id={`${id}${path}`} className={ACTION_INPUT_CLASS} value={actionText(actionValueAt(draft, path))}
+                required={required} disabled={readOnly} aria-invalid={Boolean(actionFieldError(props.errors, path))}
+                onChange={(event) => onChange((current) => changeActionField(current, path, event.target.value))} />
+        </ActionField>
+    );
+    const secretField = (path: string, label: string, help?: string, multiline = false) => (
+        <ActionSecretInput key={path} id={`${id}${path}`} label={label} help={help} multiline={multiline}
+            value={actionValueAt(draft, path)} storedValue={actionValueAt(props.original?.record, path)}
+            disabled={readOnly} error={actionFieldError(props.errors, path)}
+            onChange={(value) => onChange((current) => changeActionField(current, path, value))} />
+    );
+
+    if (native.internal) return (
+        <p className="text-sm text-text-2">
+            {draft.auth.type === 'user'
+                ? 'Uses the signed-in user’s permissions. No credentials or reusable identity are needed.'
+                : 'No connector credentials are required. Application and workspace authorization still apply.'}
+        </p>
+    );
+
+    const keyLabel = draft.type === 'azure_maps_openlayers' ? 'Azure Maps subscription key' :
+        draft.type === 'cosmos_query' || draft.type === 'blob_storage' && draft.auth.type === 'key' ? 'Account key' :
+            draft.auth.type === 'connection_string' ? 'Connection string' :
+                draft.auth.type === 'servicePrincipal' ? 'Client secret' :
+                    draft.type === 'snowflake' && method === 'key_pair' ? 'PEM private key' :
+                        draft.type === 'snowflake' && method === 'oauth' ? 'OAuth access token' :
+                            ['username_password', 'basic'].includes(draft.auth.type) ? 'Password' :
+                                ['pat', 'personal_access_token'].includes(method) ? 'Personal access token' :
+                                    ['bearer', 'bearer_token'].includes(method) ? 'Bearer token' : 'API key';
+
+    return (
+        <div className="space-y-5">
+            {identityTypes.length || draft.identity_id ? (
+                <div className="space-y-2">
+                    <ActionField id={`${id}-identity`} label="Reusable identity"
+                        help="Use an existing identity from My Workspace, or enter credentials for this action. Credentials are resolved on the server."
+                        error={actionFieldError(props.errors, '/identity_id')}>
+                        <select id={`${id}-identity`} className={ACTION_INPUT_CLASS} value={draft.identity_id || ''}
+                            disabled={readOnly || props.identitiesLoading}
+                            onChange={(event) => {
+                                const next = identities.find((candidate) => candidate.id === event.target.value);
+                                if (event.target.value && !next) return;
+                                onChange((current) => {
+                                    const changed = selectActionIdentity(current, next ?? null);
+                                    return !next && modes.length ? changeActionAuth(changed, modes[0]) : changed;
+                                });
+                            }}>
+                            <option value="">Use action-specific credentials</option>
+                            {identityMissing ? <option value={draft.identity_id} disabled>Unavailable identity — {draft.identity_id}</option> : null}
+                            {identities.map((candidate) => <option key={candidate.id} value={candidate.id}>
+                                {candidate.name} · {candidate.auth_type.replaceAll('_', ' ')} · {candidate.scope_type || 'personal'} · {candidate.id}
+                            </option>)}
+                        </select>
+                    </ActionField>
+                    {props.identitiesLoading ? <p role="status" className="text-xs text-text-3">Loading permitted identities…</p> : null}
+                    {props.identitiesError ? <p role="alert" className="text-sm text-danger">{props.identitiesError} The existing identity has not been changed.</p> : null}
+                    {identityMissing ? <p role="status" className="rounded-xl bg-warn-soft p-3 text-sm text-warn">
+                        The selected identity is unavailable or no longer compatible. Its ID is retained until you explicitly choose a replacement; a same-name identity will never be substituted.
+                    </p> : null}
+                    {identity ? <p className="text-xs text-text-3">{identity.description || 'This action will use the selected identity when it runs.'}</p> : null}
+                </div>
+            ) : null}
+            {!draft.identity_id ? <>
+                <ActionField id={`${id}-auth`} label="Authentication method" error={actionFieldError(props.errors, '/auth/type')}>
+                    <select id={`${id}-auth`} className={ACTION_INPUT_CLASS} value={selected ? method : 'existing'}
+                        disabled={readOnly || modes.length === 0}
+                        onChange={(event) => {
+                            const choice = modes.find((candidate) => candidate.value === event.target.value);
+                            if (choice) onChange((current) => changeActionAuth(current, choice));
+                        }}>
+                        {!selected ? <option value="existing" disabled>Existing method: {method || draft.auth.type}</option> : null}
+                        {modes.map((choice) => <option key={choice.value} value={choice.value}>{choice.label}</option>)}
+                    </select>
+                </ActionField>
+                {sql && method === 'service_principal' ? <p role="status" className="rounded-xl bg-warn-soft p-3 text-sm text-warn">
+                    These service-principal fields are retained for compatibility, but the current SQL action runtime does not use them.
+                    Use a supported authentication mode or a complete connection string instead. A connection test will not report these fields as working credentials.
+                </p> : null}
+                {sql && sqlConnectionMethod(draft) === 'connection_string' ? <p className="text-xs text-text-3">
+                    Connection-string mode uses the authentication specified in the connection string, not separate database credentials.
+                </p> : null}
+                {sql && method === 'username_password' && sqlConnectionMethod(draft) === 'parameters' && draft.additionalFields.database_type !== 'sqlite' ? (
+                    <div className="grid gap-4 sm:grid-cols-2">
+                        {textField('/additionalFields/username', 'Database username', undefined, true)}
+                        {secretField('/additionalFields/password', 'Database password')}
+                    </div>
+                ) : null}
+                {draft.auth.type === 'servicePrincipal' ? <>
+                    <div className="grid gap-4 sm:grid-cols-2">
+                        {textField('/auth/identity', 'Client ID', undefined, true)}
+                        {textField('/auth/tenantId', 'Tenant ID', undefined, true)}
+                    </div>
+                    {secretField('/auth/key', keyLabel)}
+                </> : null}
+                {['username_password', 'basic'].includes(draft.auth.type) && draft.type !== 'snowflake'
+                    ? textField('/auth/identity', 'Username', undefined, true) : null}
+                {draft.type === 'tableau' && method === 'personal_access_token'
+                    ? textField('/auth/identity', 'Personal access token name', undefined, true) : null}
+                {['key', 'connection_string', 'username_password', 'basic'].includes(draft.auth.type)
+                    ? secretField('/auth/key', keyLabel, draft.type === 'snowflake' && method === 'key_pair'
+                        ? 'Paste the complete PEM private key, including BEGIN/END lines. A replacement is visible only while editing this field.'
+                        : undefined, draft.type === 'snowflake' && method === 'key_pair') : null}
+                {draft.type === 'snowflake' && method === 'key_pair'
+                    ? secretField('/additionalFields/private_key_passphrase', 'Private key passphrase', 'Only needed for an encrypted private key.') : null}
+                {draft.type === 'rocksdb' && method === 'api_key'
+                    ? textField('/additionalFields/api_key_header', 'API key header name', 'Defaults to X-API-Key.') : null}
+                {draft.auth.type === 'identity' && !sql && !['cosmos_query', 'databricks', 'databricks_table', 'blob_storage'].includes(draft.type)
+                    ? textField('/auth/identity', 'Managed identity client ID', 'Use managed_identity for the system-assigned application identity, or the configured user-assigned client ID.') : null}
+                {draft.auth.type === 'identity' ? <p className="text-xs text-text-3">
+                    {method === 'integrated' ? 'Integrated authentication uses the application server’s database login.' :
+                        method === 'connection_string_only' ? 'Credentials are supplied by the database connection string.' :
+                            'Managed identity uses the application’s Azure identity. Grant it the required data access on the target resource.'}
+                </p> : null}
+                {draft.auth.type === 'user' && !sql ? <p className="text-xs text-text-3">Runs on behalf of the signed-in user.</p> : null}
+                {draft.type === 'log_analytics' && draft.auth.type === 'key' ? <p className="text-xs text-warn">
+                    Key authentication is supported only by custom Log Analytics-compatible endpoints.
+                </p> : null}
+                {draft.auth.type === 'NoAuth' ? <p className="text-xs text-text-3">No authentication headers or credentials will be used.</p> : null}
+            </> : null}
+            {draft.identity_id && draft.type === 'tableau' && (identity?.auth_type === 'api_key' || method === 'personal_access_token')
+                ? textField('/additionalFields/pat_name', 'Personal access token name', 'The reusable identity contains the PAT secret; its token name is configured on this action.', true) : null}
+            {draft.identity_id && draft.type === 'snowflake' && method === 'key_pair'
+                ? secretField('/additionalFields/private_key_passphrase', 'Private key passphrase', 'Only needed for an encrypted private key.') : null}
+            <p className="text-xs leading-relaxed text-text-3">
+                Stored secrets are never returned to this form. Keep their masked state, enter a replacement, or choose Clear.
+                Changing another field does not replace credentials or erase hidden configuration.
+            </p>
+        </div>
+    );
+}

--- a/application/v2_ui/src/components/workspaceActions/ActionConfigurationFields.tsx
+++ b/application/v2_ui/src/components/workspaceActions/ActionConfigurationFields.tsx
@@ -1,0 +1,157 @@
+// ActionConfigurationFields.tsx
+
+import { useId, useState } from 'react';
+import { FlaskConical } from 'lucide-react';
+import { GlassButton, Toggle } from '../ui/primitives';
+import { ConfirmDialog } from '../ui/ConfirmDialog';
+import { ActionField, ActionJsonInput, ActionLinesInput, ActionSecretInput, ACTION_INPUT_CLASS } from './ActionFields';
+import { ActionSchemaFields } from './ActionSchemaFields';
+import { CallAgentActionConfiguration } from './CallAgentActionConfiguration';
+import { ConnectorFeedbackPanel, useConnectorRequest } from './OpenApiActionConfiguration';
+import {
+    actionFieldError, actionHasStoredArraySecrets, actionText, actionValueAt, changeActionField,
+    changeSqlConnectionMethod, deriveBlobEndpoint, displayedActionValue,
+} from '../../lib/workspaceActionLogic';
+import { nativeActionDefinition, sqlConnectionMethod, usesDirectBlobConnectionString } from '../../lib/workspaceActionRegistry';
+import { EDITOR_SECRET_MASK, isRecord, type ActionTypeDefinition } from '../../lib/workspaceAuthoring';
+import { testWorkspaceAction } from '../../lib/workspaceActionServices';
+import type { ActionConnectorProps, ActionFieldDescriptor } from '../../lib/workspaceActionTypes';
+
+export function ActionDescriptorField({ props, descriptor }: { props: ActionConnectorProps; descriptor: ActionFieldDescriptor }) {
+    const id = useId();
+    if (descriptor.visible && !descriptor.visible(props.draft)) return null;
+    const value = displayedActionValue(props.draft, descriptor.path);
+    const storedValue = actionValueAt(props.original?.record, descriptor.path);
+    const error = actionFieldError(props.errors, descriptor.path);
+    const disabled = props.readOnly || descriptor.readOnly;
+    const change = (next: unknown) => props.onChange((draft) => changeActionField(draft, descriptor.path, next));
+    if (descriptor.kind === 'secret' || value === EDITOR_SECRET_MASK || props.original?.secret_paths.includes(descriptor.path)) return <ActionSecretInput id={id} label={descriptor.label} value={value}
+        storedValue={storedValue} onChange={change} disabled={disabled} help={descriptor.help} error={error} />;
+    if (descriptor.kind === 'boolean') {
+        const defaults = actionValueAt(nativeActionDefinition(props.draft.type).defaults, descriptor.path);
+        return (
+            <div className="space-y-1">
+                <Toggle checked={typeof value === 'boolean' ? value : defaults === true} onChange={change}
+                    disabled={disabled} label={descriptor.label} description={descriptor.help} />
+                {error ? <p role="alert" className="text-sm text-danger">{error}</p> : null}
+            </div>
+        );
+    }
+    if (descriptor.kind === 'json') return <ActionJsonInput id={id} label={descriptor.label} value={value}
+        protectArraySecrets={actionHasStoredArraySecrets(props.draft, props.original, descriptor.path)}
+        onChange={change} readOnly={disabled} onValidityChange={props.onValidityChange} help={descriptor.help} error={error} />;
+    if (descriptor.kind === 'lines') return <ActionLinesInput id={id} label={descriptor.label} value={value}
+        onChange={change} disabled={disabled} help={descriptor.help} error={error} />;
+    const attributes = {
+        id, className: ACTION_INPUT_CLASS, disabled, required: descriptor.required,
+        'aria-invalid': Boolean(error), 'aria-describedby': `${id}-help ${id}-error`,
+    };
+    return (
+        <ActionField id={id} label={descriptor.label} help={descriptor.help} error={error} required={descriptor.required}>
+            {descriptor.kind === 'select' ? <select {...attributes} value={actionText(value)} onChange={(event) => change(event.target.value || undefined)}>
+                <option value="">Select a value</option>
+                {value !== undefined && value !== '' && !descriptor.options?.some((option) => option.value === value)
+                    ? <option value={String(value)} disabled>Current value: {String(value)}</option> : null}
+                {descriptor.options?.map((option) => <option key={option.value} value={option.value}>{option.label}</option>)}
+            </select> : descriptor.kind === 'number' ? <input {...attributes} type="number" min={descriptor.min} max={descriptor.max}
+                step={descriptor.step ?? 'any'} value={typeof value === 'number' ? value : ''}
+                onChange={(event) => change(event.target.value === '' ? undefined : event.target.valueAsNumber)} />
+                : descriptor.kind === 'textarea'
+                    ? <textarea {...attributes} rows={3} placeholder={descriptor.placeholder}
+                        value={actionText(value)} onChange={(event) => change(event.target.value)} />
+                    : <input {...attributes} type="text" placeholder={descriptor.placeholder} value={actionText(value)}
+                        onChange={(event) => change(event.target.value)} />}
+        </ActionField>
+    );
+}
+
+export function ActionConfigurationFields(props: ActionConnectorProps & { definition: ActionTypeDefinition }) {
+    const { draft, onChange, readOnly, definition } = props;
+    const id = useId();
+    const [confirmParameters, setConfirmParameters] = useState(false);
+    const native = nativeActionDefinition(draft.type);
+    const request = useConnectorRequest(props);
+    if (draft.type === 'agent') return <CallAgentActionConfiguration {...props} />;
+    const sql = ['sql_query', 'sql_schema'].includes(draft.type);
+    const capabilities = native.capabilities;
+    const rawCapabilities = capabilities ? actionValueAt(draft, capabilities.path) : undefined;
+    const capabilityValues = isRecord(rawCapabilities) ? rawCapabilities : {};
+    const derivedEndpoint = draft.type === 'blob_storage' ? deriveBlobEndpoint(actionText(draft.auth.key)) : '';
+    const coveredPaths = [
+        ...native.fields.map(({ path }) => path),
+        '/additionalFields/identity_auth_type',
+        ...(sql ? ['/additionalFields/auth_type', '/additionalFields/username', '/additionalFields/password', '/additionalFields/identity_uses_connection_string'] : []),
+        ...(['databricks', 'databricks_table', 'snowflake', 'tableau', 'yamcs'].includes(draft.type) ? ['/additionalFields/auth_method'] : []),
+        ...(['databricks', 'databricks_table'].includes(draft.type) ? ['/additionalFields/workspace_url'] : []),
+        ...(['tableau', 'yamcs'].includes(draft.type) ? ['/additionalFields/server_url'] : []),
+        ...(draft.type === 'tableau' ? ['/additionalFields/pat_name'] : []),
+        ...(draft.type === 'snowflake' ? ['/additionalFields/private_key_passphrase'] : []),
+        ...(draft.type === 'rocksdb' ? ['/additionalFields/auth_scheme', '/additionalFields/api_key_header', '/additionalFields/base_url'] : []),
+        ...(capabilities ? [capabilities.path] : []),
+    ];
+
+    return (
+        <div className="min-w-0 space-y-5" data-testid="action-configuration" data-action-type={draft.type}>
+            {native.help ? <p className="text-sm leading-relaxed text-text-2">{native.help}</p> : null}
+            {sql ? <ActionField id={`${id}-connection-method`} label="Connection mode"
+                help="A connection string takes precedence over individual parameters. Switching to parameters explicitly clears that stored connection string. Other settings are retained.">
+                <select id={`${id}-connection-method`} className={ACTION_INPUT_CLASS} value={sqlConnectionMethod(draft)}
+                    disabled={readOnly || draft.additionalFields.identity_uses_connection_string === true}
+                    onChange={(event) => {
+                        const method = event.target.value === 'connection_string' ? 'connection_string' : 'parameters';
+                        if (method === 'parameters' && draft.additionalFields.connection_string) setConfirmParameters(true);
+                        else onChange((current) => changeSqlConnectionMethod(current, method));
+                    }}>
+                    <option value="parameters">Individual parameters</option><option value="connection_string">Connection string</option>
+                </select>
+            </ActionField> : null}
+            <div className="grid min-w-0 gap-4 sm:grid-cols-2">
+                {native.fields.map((descriptor) => <div key={descriptor.path}
+                    className={['textarea', 'lines', 'secret', 'json'].includes(descriptor.kind ?? '') ? 'min-w-0 sm:col-span-2' : 'min-w-0'}>
+                    <ActionDescriptorField props={props} descriptor={descriptor} />
+                </div>)}
+            </div>
+            {usesDirectBlobConnectionString(draft) ? (
+                <div className="space-y-2 text-xs text-text-3">
+                    <p>The blob service endpoint is derived automatically when saving or testing. A stored connection string keeps the saved endpoint.</p>
+                    <p className="break-all" data-testid="blob-derived-endpoint">
+                        Blob service endpoint: {derivedEndpoint || draft.endpoint || 'Enter the connection string in Authentication.'}
+                    </p>
+                </div>
+            ) : null}
+            {capabilities ? <fieldset className="min-w-0 space-y-2">
+                <legend className="mb-2 text-sm font-medium text-text-1">Allowed capabilities</legend>
+                {capabilities.options.map((capability) => {
+                    const legacyUpload = draft.type === 'simplechat' &&
+                        ['upload_word_document', 'upload_powerpoint_document'].includes(capability.key) &&
+                        typeof capabilityValues.upload_markdown_document === 'boolean'
+                        ? capabilityValues.upload_markdown_document : capability.defaultEnabled !== false;
+                    return <Toggle key={capability.key} label={capability.label} description={capability.description}
+                        checked={typeof capabilityValues[capability.key] === 'boolean' ? capabilityValues[capability.key] === true : legacyUpload}
+                        disabled={readOnly}
+                        onChange={(value) => onChange((current) => changeActionField(current, `${capabilities.path}/${capability.key}`, value))} />;
+                })}
+                {actionFieldError(props.errors, capabilities.path) ? <p role="alert" className="text-sm text-danger">{actionFieldError(props.errors, capabilities.path)}</p> : null}
+            </fieldset> : null}
+            <ActionSchemaFields props={props} schema={definition.additional_fields_schema} coveredPaths={coveredPaths}
+                allowCustom={definition.additional_fields_schema.additionalProperties !== false} />
+            {native.testPath ? <div className="space-y-3 border-t border-edge pt-4">
+                <p className="text-xs leading-relaxed text-text-3">
+                    Test connection makes a small request using this draft. An edited action uses its owned stored credentials when their masked values are unchanged.
+                    Saving does not run this test.
+                </p>
+                <GlassButton type="button" size="sm" disabled={readOnly || Boolean(request.busy)}
+                    onClick={() => void request.run('Testing connection…', (signal) => testWorkspaceAction(draft, props.original, definition, signal))}>
+                    <FlaskConical size={15} />{request.busy || 'Test connection'}
+                </GlassButton>
+                <ConnectorFeedbackPanel feedback={request.feedback} stale={request.stale} />
+            </div> : null}
+            {confirmParameters ? <ConfirmDialog title="Use individual connection parameters?" tone="primary"
+                description="The saved connection string will be explicitly cleared when you save. Server, database, and authentication fields are kept for you to review."
+                confirmLabel="Use parameters" onClose={() => setConfirmParameters(false)}
+                onConfirm={() => { onChange((current) => changeSqlConnectionMethod(current, 'parameters')); setConfirmParameters(false); }}>
+                <p className="text-sm text-text-2">This changes which connection source the SQL action uses.</p>
+            </ConfirmDialog> : null}
+        </div>
+    );
+}

--- a/application/v2_ui/src/components/workspaceActions/ActionFields.tsx
+++ b/application/v2_ui/src/components/workspaceActions/ActionFields.tsx
@@ -1,0 +1,171 @@
+// ActionFields.tsx
+
+import { useEffect, useRef, useState, type ReactNode } from 'react';
+import { GlassButton } from '../ui/primitives';
+import { EDITOR_SECRET_MASK, isRecord } from '../../lib/workspaceAuthoring';
+
+export const ACTION_INPUT_CLASS =
+    'w-full min-w-0 rounded-xl border border-edge bg-surface-1 px-3 py-2 text-sm text-text-1 placeholder:text-text-3 focus:border-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-accent/30 disabled:opacity-60';
+
+export function ActionField({
+    id, label, help, error, children, required,
+}: {
+    id: string;
+    label: string;
+    help?: string;
+    error?: string;
+    children: ReactNode;
+    required?: boolean;
+}) {
+    return (
+        <div className="min-w-0 space-y-1.5">
+            <label htmlFor={id} className="block text-sm font-medium text-text-1">
+                {label}{required ? <span aria-hidden="true" className="ml-1 text-danger">*</span> : null}
+            </label>
+            {children}
+            {help ? <p id={`${id}-help`} className="break-words text-xs leading-relaxed text-text-3">{help}</p> : null}
+            {error ? <p id={`${id}-error`} role="alert" className="break-words text-sm text-danger">{error}</p> : null}
+        </div>
+    );
+}
+
+export function ActionSecretInput({
+    id, label, value, storedValue, onChange, disabled, help, error, multiline = false,
+}: {
+    id: string;
+    label: string;
+    value: unknown;
+    storedValue?: unknown;
+    onChange: (value: string) => void;
+    disabled?: boolean;
+    help?: string;
+    error?: string;
+    multiline?: boolean;
+}) {
+    const configured = value === EDITOR_SECRET_MASK;
+    const hadSecret = storedValue === EDITOR_SECRET_MASK;
+    return (
+        <ActionField id={id} label={label} error={error} help={help}>
+            {multiline ? <textarea id={id} rows={7} autoComplete="off" spellCheck={false}
+                value={configured ? '' : typeof value === 'string' ? value : ''}
+                placeholder={configured ? 'Stored securely — paste a replacement' : 'Paste the complete value, including line breaks'}
+                disabled={disabled} className={`${ACTION_INPUT_CLASS} font-mono text-xs`}
+                aria-invalid={Boolean(error)} aria-describedby={`${id}-help ${id}-secret-status`}
+                onChange={(event) => onChange(event.target.value)} /> : <input id={id} type="password" autoComplete="new-password"
+                value={configured ? '' : typeof value === 'string' ? value : ''}
+                placeholder={configured ? 'Stored securely — enter a replacement' : 'Enter a secret'}
+                disabled={disabled} className={ACTION_INPUT_CLASS}
+                aria-invalid={Boolean(error)} aria-describedby={`${id}-help ${id}-secret-status`}
+                onChange={(event) => onChange(event.target.value)} />}
+            <div className="flex flex-wrap items-center gap-2">
+                <p id={`${id}-secret-status`} className="text-xs text-text-3">
+                    {configured ? 'Configured. The existing secret will be kept.' :
+                        hadSecret && !value ? 'The stored secret will be cleared when you save.' :
+                            value ? 'Replacement stays in this tab until saved.' : 'Not configured.'}
+                </p>
+                {!disabled && (configured || Boolean(value)) ? (
+                    <GlassButton size="sm" type="button" onClick={() => onChange('')}>Clear {label.toLowerCase()}</GlassButton>
+                ) : null}
+                {!disabled && hadSecret && !configured ? (
+                    <GlassButton size="sm" type="button" onClick={() => onChange(EDITOR_SECRET_MASK)}>Keep stored {label.toLowerCase()}</GlassButton>
+                ) : null}
+            </div>
+        </ActionField>
+    );
+}
+
+export function ActionJsonInput({
+    id, label, value, onChange, onValidityChange, readOnly, help, error, rows = 8, objectOnly = true, protectArraySecrets = false,
+}: {
+    id: string;
+    label: string;
+    value: unknown;
+    onChange: (value: unknown) => void;
+    onValidityChange?: (key: string, message: string | null) => void;
+    readOnly?: boolean;
+    help?: string;
+    error?: string;
+    rows?: number;
+    objectOnly?: boolean;
+    protectArraySecrets?: boolean;
+}) {
+    const serialized = JSON.stringify(value ?? (objectOnly ? {} : []), null, 2);
+    const lastApplied = useRef(serialized);
+    const validityCallback = useRef(onValidityChange);
+    validityCallback.current = onValidityChange;
+    const [text, setText] = useState(serialized);
+    const [parseError, setParseError] = useState<string | null>(null);
+    const validityKey = `json:${id}`;
+    useEffect(() => {
+        if (serialized !== lastApplied.current) {
+            lastApplied.current = serialized;
+            setText(serialized);
+            setParseError(null);
+            validityCallback.current?.(validityKey, null);
+        }
+    }, [serialized, validityKey]);
+    useEffect(() => () => validityCallback.current?.(validityKey, null), [validityKey]);
+
+    const change = (next: string) => {
+        setText(next);
+        try {
+            const parsed: unknown = JSON.parse(next);
+            if (objectOnly && !isRecord(parsed)) throw new Error('Enter a JSON object, not an array or scalar.');
+            lastApplied.current = JSON.stringify(parsed, null, 2);
+            onChange(parsed);
+            setParseError(null);
+            onValidityChange?.(validityKey, null);
+        } catch (cause) {
+            const message = cause instanceof Error ? cause.message : 'Invalid JSON.';
+            setParseError(message);
+            onValidityChange?.(validityKey, `${label}: ${message}`);
+        }
+
+    };
+    return (
+        <ActionField id={id} label={label} error={parseError || error}
+            help={[help, protectArraySecrets
+                ? 'Stored array credentials are tied to their saved positions, not entry names or IDs. Use structured fields, or replace/clear those credentials before editing this JSON.'
+                : ''].filter(Boolean).join(' ')}>
+            <textarea id={id} rows={rows} value={text} spellCheck={false} readOnly={readOnly || protectArraySecrets}
+                className={`${ACTION_INPUT_CLASS} font-mono text-xs`}
+                aria-invalid={Boolean(parseError || error)} aria-describedby={`${id}-help ${id}-error`}
+                onChange={(event) => change(event.target.value)} />
+        </ActionField>
+    );
+}
+
+export function ActionLinesInput({
+    id, label, value, onChange, disabled, help, error,
+}: {
+    id: string;
+    label: string;
+    value: unknown;
+    onChange: (value: string[]) => void;
+    disabled?: boolean;
+    help?: string;
+    error?: string;
+}) {
+    const serialized = Array.isArray(value) ? value.map(String).join('\n') : typeof value === 'string' ? value : '';
+    const [text, setText] = useState(serialized);
+    const lastApplied = useRef(serialized);
+    useEffect(() => {
+        if (lastApplied.current !== serialized) {
+            lastApplied.current = serialized;
+            setText(serialized);
+        }
+    }, [serialized]);
+    return (
+        <ActionField id={id} label={label} help={help} error={error}>
+            <textarea id={id} rows={4} className={ACTION_INPUT_CLASS} value={text} disabled={disabled}
+                aria-invalid={Boolean(error)} aria-describedby={`${id}-help ${id}-error`}
+                onChange={(event) => {
+                    const next = event.target.value;
+                    const values = next.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+                    setText(next);
+                    lastApplied.current = values.join('\n');
+                    onChange(values);
+                }} />
+        </ActionField>
+    );
+}

--- a/application/v2_ui/src/components/workspaceActions/ActionSchemaFields.tsx
+++ b/application/v2_ui/src/components/workspaceActions/ActionSchemaFields.tsx
@@ -1,0 +1,220 @@
+// ActionSchemaFields.tsx
+
+import { useId, useState } from 'react';
+import { Plus, Trash2 } from 'lucide-react';
+import { GlassButton } from '../ui/primitives';
+import { ActionField, ActionJsonInput, ActionSecretInput, ACTION_INPUT_CLASS } from './ActionFields';
+import { EDITOR_SECRET_MASK, isRecord, pointerPart, type EditorSchema } from '../../lib/workspaceAuthoring';
+import {
+    actionArrayRemovalError, actionFieldError, actionHasStoredArraySecrets, actionSchemaDefaults,
+    actionText, actionValueAt, resolveActionSchema, withActionValue,
+} from '../../lib/workspaceActionLogic';
+import type { ActionConnectorProps } from '../../lib/workspaceActionTypes';
+
+const humanLabel = (key: string) => key.replace(/([a-z])([A-Z])/g, '$1 $2').replaceAll('_', ' ').replace(/^./, (letter) => letter.toUpperCase());
+const knownSecret = (key: string) => key.endsWith('__Secret') ||
+    /^(password|key|secret|token|api_key|connection_string|client_secret|private_key|private_key_passphrase)$/i.test(key);
+
+function schemaType(schema: EditorSchema, value: unknown): string {
+    const types = Array.isArray(schema.type) ? schema.type : [schema.type];
+    if (value !== undefined && value !== null) {
+        const actual = Array.isArray(value) ? 'array' : isRecord(value) ? 'object' : typeof value;
+        if (types.includes(actual)) return actual;
+    }
+    return types.find((type) => type && type !== 'null') ||
+        (schema.properties ? 'object' : Array.isArray(value) ? 'array' : isRecord(value) ? 'object' : typeof value === 'boolean' ? 'boolean' : typeof value === 'number' ? 'number' : 'string');
+}
+
+export function ActionSchemaValue({
+    props, schema, path, label, required = false, root = schema, depth = 0,
+}: {
+    props: ActionConnectorProps;
+    schema: EditorSchema;
+    path: string;
+    label: string;
+    required?: boolean;
+    root?: EditorSchema;
+    depth?: number;
+}) {
+    const id = useId();
+    const value = actionValueAt(props.draft, path);
+    const resolved = resolveActionSchema(schema, root);
+    const fieldType = schemaType(resolved, value);
+    const error = actionFieldError(props.errors, path);
+    const key = path.split('/').at(-1)?.replace(/~1/g, '/').replace(/~0/g, '~') || '';
+    const change = (next: unknown) => props.onChange((draft) => withActionValue(draft, path, next));
+    const secret = props.original?.secret_paths.includes(path) || value === EDITOR_SECRET_MASK ||
+        (fieldType === 'string' && knownSecret(key));
+
+    if (secret) return <ActionSecretInput id={id} label={label} value={value}
+        storedValue={actionValueAt(props.original?.record, path)} onChange={(next) => change(next)}
+        disabled={props.readOnly} error={error} help={resolved.description} />;
+    if (depth >= 12 && ['object', 'array'].includes(fieldType)) return (
+        <ActionJsonInput id={id} label={label} value={value} onChange={change} objectOnly={fieldType === 'object'}
+            readOnly={props.readOnly} error={error} onValidityChange={props.onValidityChange}
+            protectArraySecrets={actionHasStoredArraySecrets(props.draft, props.original, path)}
+            help="Deeply nested configuration can be edited here without replacing sibling properties." />
+    );
+    if (fieldType === 'object' && value === undefined && !required) return (
+        <div className="space-y-2">
+            <p className="text-sm font-medium text-text-1">{label} <span className="text-xs font-normal text-text-3">(optional)</span></p>
+            {resolved.description ? <p className="text-xs text-text-3">{resolved.description}</p> : null}
+            {props.readOnly ? <p className="text-xs text-text-3">Not configured.</p> :
+                <GlassButton type="button" size="sm" onClick={() => change(actionSchemaDefaults(resolved, root) ?? {})}>
+                    <Plus size={13} /> Configure {label.toLowerCase()}
+                </GlassButton>}
+        </div>
+    );
+    if (depth < 12 && fieldType === 'object') return (
+        <fieldset className="min-w-0 space-y-3 rounded-xl border border-edge p-3">
+            <legend className="px-1 text-sm font-medium text-text-1">{label}</legend>
+            {resolved.description ? <p className="text-xs text-text-3">{resolved.description}</p> : null}
+            <ActionSchemaFields props={props} schema={resolved} path={path} root={root} depth={depth + 1}
+                allowCustom={resolved.additionalProperties !== false} />
+            {!required && !props.readOnly ? <GlassButton type="button" size="sm" onClick={() => change(undefined)}>Remove {label.toLowerCase()} configuration</GlassButton> : null}
+            {error ? <p role="alert" className="text-sm text-danger">{error}</p> : null}
+        </fieldset>
+    );
+    if (depth < 12 && fieldType === 'array') {
+        const items = Array.isArray(value) ? value : [];
+        const itemSchema = resolved.items ?? {};
+        return (
+            <fieldset className="min-w-0 space-y-3 rounded-xl border border-edge p-3">
+                <legend className="px-1 text-sm font-medium text-text-1">{label}</legend>
+                {resolved.description ? <p className="text-xs text-text-3">{resolved.description}</p> : null}
+                {items.map((_, index) => {
+                    const removalError = actionArrayRemovalError(props.draft, props.original, path, index);
+                    return <div key={index} className="min-w-0 space-y-2 rounded-lg bg-surface-2 p-3">
+                        <ActionSchemaValue props={props} path={`${path}/${index}`} schema={itemSchema} root={root}
+                            label={`${label} ${index + 1}`} depth={depth + 1} />
+                        {!props.readOnly ? <GlassButton type="button" size="sm" disabled={Boolean(removalError)}
+                            aria-describedby={removalError ? `${id}-remove-${index}` : undefined}
+                            onClick={() => change(items.filter((_, itemIndex) => itemIndex !== index))}>
+                            <Trash2 size={13} /> Remove entry {index + 1}
+                        </GlassButton> : null}
+                        {!props.readOnly && removalError ? <p id={`${id}-remove-${index}`} role="status" className="text-xs text-warn">{removalError}</p> : null}
+                    </div>;
+                })}
+                {!items.length ? <p className="text-xs text-text-3">No entries configured.</p> : null}
+                {!props.readOnly ? <GlassButton type="button" size="sm" disabled={resolved.maxItems !== undefined && items.length >= resolved.maxItems}
+                    onClick={() => {
+                        const initial = actionSchemaDefaults(itemSchema, root);
+                        const itemType = schemaType(itemSchema, undefined);
+                        change([...items, initial ?? (itemType === 'object' ? {} : itemType === 'array' ? [] : itemType === 'boolean' ? false : itemType === 'number' || itemType === 'integer' ? 0 : '')]);
+                    }}><Plus size={13} /> Add {label.toLowerCase()} entry</GlassButton> : null}
+                {error ? <p role="alert" className="text-sm text-danger">{error}</p> : null}
+            </fieldset>
+        );
+    }
+    if (fieldType === 'boolean') return (
+        <ActionField id={id} label={label} help={resolved.description} error={error}>
+            <select id={id} value={value === undefined ? '' : String(value)} disabled={props.readOnly}
+                className={ACTION_INPUT_CLASS} aria-invalid={Boolean(error)}
+                onChange={(event) => change(event.target.value === '' ? undefined : event.target.value === 'true')}>
+                <option value="">Use runtime default{resolved.default !== undefined ? ` (${String(resolved.default)})` : ''}</option>
+                <option value="true">Enabled</option><option value="false">Disabled</option>
+            </select>
+        </ActionField>
+    );
+    const values = resolved.enum ?? (Object.hasOwn(resolved, 'const') ? [resolved.const] : undefined);
+    if (values) {
+        const selected = values.findIndex((item) => JSON.stringify(item) === JSON.stringify(value));
+        return (
+            <ActionField id={id} label={label} help={resolved.description} error={error} required={required}>
+                <select id={id} value={selected < 0 ? (value === undefined ? '' : 'unavailable') : String(selected)}
+                    required={required} disabled={props.readOnly || Object.hasOwn(resolved, 'const')} className={ACTION_INPUT_CLASS}
+                    onChange={(event) => change(event.target.value === '' ? undefined : values[Number(event.target.value)])}>
+                    <option value="">Select a value</option>
+                    {value !== undefined && selected < 0 ? <option value="unavailable" disabled>Current value: {String(value)}</option> : null}
+                    {values.map((item, index) => <option key={index} value={String(index)}>{String(item)}</option>)}
+                </select>
+            </ActionField>
+        );
+    }
+    const numeric = fieldType === 'number' || fieldType === 'integer';
+    const shared = {
+        id, className: ACTION_INPUT_CLASS, required, disabled: props.readOnly,
+        'aria-invalid': Boolean(error), 'aria-describedby': `${id}-help ${id}-error`,
+    };
+    return (
+        <ActionField id={id} label={label} help={resolved.description} error={error} required={required}>
+            {numeric ? <input {...shared} type="number" step={fieldType === 'integer' ? 1 : 'any'}
+                min={resolved.minimum} max={resolved.maximum} value={typeof value === 'number' ? value : ''}
+                onChange={(event) => change(event.target.value === '' ? undefined : event.target.valueAsNumber)} />
+                : <textarea {...shared} rows={typeof value === 'string' && (value.includes('\n') || value.length > 100) ? 4 : 2}
+                    value={actionText(value)} maxLength={resolved.maxLength}
+                    onChange={(event) => change(event.target.value)} />}
+        </ActionField>
+    );
+}
+
+export function ActionSchemaFields({
+    props, schema, path = '/additionalFields', coveredPaths = [], root = schema, depth = 0, allowCustom = true,
+}: {
+    props: ActionConnectorProps;
+    schema: EditorSchema;
+    path?: string;
+    coveredPaths?: string[];
+    root?: EditorSchema;
+    depth?: number;
+    allowCustom?: boolean;
+}) {
+    const resolved = resolveActionSchema(schema, root);
+    const value = actionValueAt(props.draft, path);
+    const record = isRecord(value) ? value : {};
+    const covered = (pointer: string) => coveredPaths.some((known) => pointer === known || pointer.startsWith(`${known}/`));
+    const properties = Object.entries(resolved.properties ?? {}).filter(([key]) => !covered(`${path}/${pointerPart(key)}`));
+    const unknown = Object.keys(record).filter((key) => !Object.hasOwn(resolved.properties ?? {}, key) && !covered(`${path}/${pointerPart(key)}`));
+    return (
+        <div className="min-w-0 space-y-4">
+            {properties.map(([key, definition]) => (
+                <ActionSchemaValue key={key} props={props} path={`${path}/${pointerPart(key)}`} schema={definition} root={root}
+                    label={definition.title || humanLabel(key)} required={resolved.required?.includes(key)} depth={depth} />
+            ))}
+            {unknown.map((key) => <div key={key} className="min-w-0 space-y-1">
+                <ActionSchemaValue props={props} path={`${path}/${pointerPart(key)}`} root={root}
+                    schema={isRecord(resolved.additionalProperties) ? resolved.additionalProperties : {}}
+                    label={humanLabel(key)} depth={depth} />
+                {!props.readOnly ? <GlassButton type="button" size="sm" aria-label={`Remove ${key}`}
+                    onClick={() => props.onChange((draft) => withActionValue(draft, `${path}/${pointerPart(key)}`, undefined))}>
+                    <Trash2 size={12} /> Remove field
+                </GlassButton> : null}
+            </div>)}
+            {allowCustom && !props.readOnly ? <ActionAddCustomField props={props} path={path} existing={Object.keys(record)} /> : null}
+        </div>
+    );
+}
+
+function ActionAddCustomField({ props, path, existing }: { props: ActionConnectorProps; path: string; existing: string[] }) {
+    const id = useId();
+    const [name, setName] = useState('');
+    const [type, setType] = useState('text');
+    const [error, setError] = useState('');
+    return (
+        <div className="rounded-xl border border-edge p-3">
+            <p className="mb-3 text-xs text-text-3">Add an installed connector’s custom property. Names ending in __Secret are treated as credentials.</p>
+            <div className="flex flex-wrap items-end gap-2">
+                <div className="min-w-36 flex-1">
+                    <ActionField id={`${id}-name`} label="Custom field name" error={error}>
+                        <input id={`${id}-name`} value={name} className={ACTION_INPUT_CLASS}
+                            onChange={(event) => { setName(event.target.value); setError(''); }} />
+                    </ActionField>
+                </div>
+                <ActionField id={`${id}-type`} label="Value type">
+                    <select id={`${id}-type`} value={type} className={ACTION_INPUT_CLASS} onChange={(event) => setType(event.target.value)}>
+                        <option value="text">Text</option><option value="number">Number</option><option value="boolean">Boolean</option>
+                        <option value="object">Object</option><option value="array">List</option><option value="secret">Secret</option>
+                    </select>
+                </ActionField>
+                <GlassButton type="button" size="sm" onClick={() => {
+                    const raw = name.trim();
+                    const key = type === 'secret' && !raw.endsWith('__Secret') ? `${raw}__Secret` : raw;
+                    if (!raw || existing.includes(key)) { setError(raw ? 'That property already exists.' : 'Enter a property name.'); return; }
+                    const initial = type === 'number' ? 0 : type === 'boolean' ? false : type === 'object' ? {} : type === 'array' ? [] : '';
+                    props.onChange((draft) => withActionValue(draft, `${path}/${pointerPart(key)}`, initial));
+                    setName(''); setError('');
+                }}><Plus size={14} /> Add field</GlassButton>
+            </div>
+        </div>
+    );
+}

--- a/application/v2_ui/src/components/workspaceActions/CallAgentActionConfiguration.tsx
+++ b/application/v2_ui/src/components/workspaceActions/CallAgentActionConfiguration.tsx
@@ -1,0 +1,95 @@
+// CallAgentActionConfiguration.tsx
+
+import { useEffect, useId, useMemo, useRef, useState } from 'react';
+import { RefreshCw } from 'lucide-react';
+import { GlassButton } from '../ui/primitives';
+import { ActionField, ACTION_INPUT_CLASS } from './ActionFields';
+import {
+    actionTarget, fetchAgentTargets, PERSONAL_DELEGATION_SCOPE, referenceKey, type AgentTargetCatalog,
+} from '../../lib/agentDelegation';
+import { actionFieldError, withActionValue } from '../../lib/workspaceActionLogic';
+import type { ActionConnectorProps } from '../../lib/workspaceActionTypes';
+import { errorMessage } from '../workspace/useSectionResource';
+
+export function CallAgentActionConfiguration(props: ActionConnectorProps) {
+    const id = useId();
+    const [catalogue, setCatalogue] = useState<AgentTargetCatalog | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [query, setQuery] = useState('');
+    const [version, setVersion] = useState(0);
+    const callback = useRef(props.onValidityChange);
+    callback.current = props.onValidityChange;
+    useEffect(() => {
+        const controller = new AbortController();
+        setLoading(true); setError(null);
+        void fetchAgentTargets(PERSONAL_DELEGATION_SCOPE, controller.signal).then((result) => {
+            if (controller.signal.aborted) return;
+            if (!result || !Array.isArray(result.targets)) throw new Error('The target catalogue returned an invalid response.');
+            setCatalogue(result);
+        }).catch((cause: unknown) => {
+            if (!controller.signal.aborted) setError(errorMessage(cause, 'Could not load permitted target agents.'));
+        }).finally(() => { if (!controller.signal.aborted) setLoading(false); });
+        return () => controller.abort();
+    }, [version]);
+    const target = actionTarget(props.draft);
+    const selectedKey = target ? referenceKey(target) : '';
+    const targets = catalogue?.targets ?? [];
+    const selected = targets.find((candidate) => referenceKey(candidate) === selectedKey);
+    const visible = useMemo(() => targets.filter((candidate) =>
+        referenceKey(candidate) === selectedKey ||
+        `${candidate.display_name} ${candidate.name} ${candidate.description} ${candidate.agent_type} ${candidate.scope_type} ${candidate.id}`
+            .toLowerCase().includes(query.trim().toLowerCase())), [targets, selectedKey, query]);
+    const validation = loading ? 'Wait for the permitted target agents to load.' : error ||
+        (catalogue?.can_manage === false ? 'You no longer have permission to configure Call agent actions.' :
+            !selected ? 'Select an available, authorized target agent.' : null);
+    useEffect(() => {
+        callback.current('call-agent-target', props.readOnly ? null : validation);
+        return () => callback.current('call-agent-target', null);
+    }, [props.readOnly, validation]);
+    return (
+        <div className="space-y-4" data-testid="call-agent-configuration">
+            <p className="text-sm text-text-2">This action calls one explicitly selected agent using your current permissions.</p>
+            <ActionField id={`${id}-search`} label="Search target agents">
+                <input id={`${id}-search`} type="search" className={ACTION_INPUT_CLASS} value={query}
+                    onChange={(event) => setQuery(event.target.value)} />
+            </ActionField>
+            <ActionField id={`${id}-target`} label="Target agent" required
+                error={actionFieldError(props.errors, '/additionalFields/target_agent')}>
+                <select id={`${id}-target`} className={ACTION_INPUT_CLASS} value={selectedKey} required
+                    disabled={props.readOnly || loading || Boolean(error) || catalogue?.can_manage === false}
+                    onChange={(event) => {
+                        const chosen = targets.find((candidate) => referenceKey(candidate) === event.target.value);
+                        if (!chosen) return;
+                        props.onChange((draft) => withActionValue(draft, '/additionalFields/target_agent', {
+                            id: chosen.id, scope_type: chosen.scope_type, scope_id: chosen.scope_id,
+                        }));
+                    }}>
+                    <option value="">Select a target agent</option>
+                    {target && !selected ? <option value={selectedKey} disabled>Unavailable target · {target.scope_type} · {target.id}</option> : null}
+                    {visible.map((candidate) => <option key={referenceKey(candidate)} value={referenceKey(candidate)}>
+                        {candidate.display_name || candidate.name} · {candidate.scope_type} · {candidate.agent_type} · {candidate.id}
+                    </option>)}
+                </select>
+            </ActionField>
+            {loading ? <p role="status" className="text-sm text-text-3">Loading permitted target agents…</p> : null}
+            {error ? <div role="alert" className="space-y-2 rounded-xl bg-danger-soft p-3 text-sm text-danger">
+                <p>{error}</p>
+                <GlassButton type="button" size="sm" onClick={() => setVersion((value) => value + 1)}><RefreshCw size={14} />Retry target agents</GlassButton>
+            </div> : null}
+            {!loading && !error && !targets.length ? <p role="status" className="text-sm text-text-3">No permitted target agents are available.</p> : null}
+            {!loading && target && !selected ? <p role="status" className="rounded-xl bg-warn-soft p-3 text-sm text-warn">
+                The saved target is unavailable or access was revoked. Its scope and ID are retained; no same-name agent will be selected automatically.
+            </p> : null}
+            {selected ? <p className="break-words text-sm text-text-2">{selected.description || 'Only this selected agent can be called by the action.'}</p> : null}
+            {target ? <dl className="grid gap-1 break-all text-xs text-text-3">
+                <div><dt className="inline font-medium">Scope: </dt><dd className="inline">{target.scope_type} · {target.scope_id}</dd></div>
+                <div><dt className="inline font-medium">Agent ID: </dt><dd className="inline">{target.id}</dd></div>
+            </dl> : null}
+            <p className="text-xs leading-relaxed text-text-3">
+                Only the task and explicit context are passed, not the full conversation. Self-calls and cycles are blocked by the server.
+                Limits are 3 levels, 10 calls per turn, and 120 seconds per call. No endpoint, credential, or connection test is needed.
+            </p>
+        </div>
+    );
+}

--- a/application/v2_ui/src/components/workspaceActions/McpActionConfiguration.tsx
+++ b/application/v2_ui/src/components/workspaceActions/McpActionConfiguration.tsx
@@ -1,0 +1,566 @@
+// McpActionConfiguration.tsx
+
+import { useEffect, useRef, useState } from 'react';
+import { GlassButton, GlassPanel, Toggle } from '../ui/primitives';
+import { ACTION_INPUT_CLASS, ActionField, ActionJsonInput, ActionSecretInput } from './ActionFields';
+import { ActionSchemaValue } from './ActionSchemaFields';
+import {
+    ConnectorFeedbackPanel, ConnectorIdentitySelect, useConnectorRequest, useConnectorValidity,
+} from './OpenApiActionConfiguration';
+import { EDITOR_SECRET_MASK, pointerPart } from '../../lib/workspaceAuthoring';
+import { actionHasStoredArraySecrets } from '../../lib/workspaceActionLogic';
+import type { ActionConnectorProps } from '../../lib/workspaceActionTypes';
+import {
+    allowedMcpAuthMethods, allowedMcpTransports, applyMcpPreconfiguration, applyMcpPreset,
+    changeConnectorAuthMethod, connectorAuthMethod, connectorFeedback, connectorLines, connectorObject,
+    connectorStrings, connectorText, discoverMcpAction, fetchMcpPreconfigurations, fetchMcpPresets,
+    MCP_AUTH_OPTIONS, MCP_GENERIC_PRESET, MCP_NUMBER_FIELDS, mcpHeaderNameError,
+    mcpImplementationFields, mcpToolChoices, mergeMcpTools, parseMcpTools, setMcpToolSelection,
+    testApiConnector, updateConnectorFields, validateApiConnector, validateConnectorAuthentication,
+    validateConnectorConfiguration, type McpCatalogEntry, type McpDiscoveryResult,
+} from '../../lib/workspaceActionConnectors';
+
+function useMcpCatalogues(props: ActionConnectorProps, includePreconfigurations: boolean) {
+    const [presets, setPresets] = useState<McpCatalogEntry[]>([MCP_GENERIC_PRESET]);
+    const [preconfigurations, setPreconfigurations] = useState<McpCatalogEntry[]>([]);
+    const [presetsError, setPresetsError] = useState<string | null>(null);
+    const [preconfigurationsError, setPreconfigurationsError] = useState<string | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [retry, setRetry] = useState(0);
+    const recordId = props.original?.record.id;
+    const type = props.draft.type;
+    useEffect(() => {
+        const controller = new AbortController();
+        setLoading(true);
+        const loadPresets = fetchMcpPresets(controller.signal).then((result) => {
+            if (controller.signal.aborted) return;
+            setPresets(result.some(({ id }) => id === 'generic') ? result : [MCP_GENERIC_PRESET, ...result]);
+            setPresetsError(null);
+        }).catch((error: unknown) => {
+            if (!controller.signal.aborted) setPresetsError(error instanceof Error ? error.message : 'Could not load MCP presets.');
+        });
+        const loadPreconfigurations = includePreconfigurations
+            ? fetchMcpPreconfigurations(controller.signal).then((result) => {
+                if (controller.signal.aborted) return;
+                setPreconfigurations(result);
+                setPreconfigurationsError(null);
+            }).catch((error: unknown) => {
+                if (!controller.signal.aborted) setPreconfigurationsError(error instanceof Error ? error.message : 'Could not load MCP preconfigurations.');
+            })
+            : Promise.resolve();
+        void Promise.all([loadPresets, loadPreconfigurations]).finally(() => {
+            if (!controller.signal.aborted) setLoading(false);
+        });
+        return () => controller.abort();
+    }, [recordId, type, retry, includePreconfigurations]);
+    return { presets, preconfigurations, presetsError, preconfigurationsError, loading, retry: () => setRetry((value) => value + 1) };
+}
+
+function McpLinesField({
+    id, label, value, onChange, readOnly, help, error, rows = 4,
+}: {
+    id: string; label: string; value: unknown; onChange: (value: string[]) => void;
+    readOnly?: boolean; help?: string; error?: string; rows?: number;
+}) {
+    const serialized = connectorStrings(value).join('\n');
+    const [text, setText] = useState(serialized);
+    const lastApplied = useRef(serialized);
+    useEffect(() => {
+        if (lastApplied.current !== serialized) {
+            lastApplied.current = serialized;
+            setText(serialized);
+        }
+    }, [serialized]);
+    return <ActionField id={id} label={label} help={help} error={error}>
+        <textarea id={id} rows={rows} readOnly={readOnly} spellCheck={false}
+            value={text} className={`${ACTION_INPUT_CLASS} font-mono text-xs`}
+            aria-describedby={`${id}-help ${id}-error`} aria-invalid={Boolean(error)}
+            onChange={(event) => {
+                const next = event.target.value;
+                const lines = connectorLines(next);
+                setText(next);
+                lastApplied.current = lines.join('\n');
+                onChange(lines);
+            }} />
+    </ActionField>;
+}
+
+function McpCatalogueDetails({ entry }: { entry: McpCatalogEntry | undefined }) {
+    if (!entry) return null;
+    return <div className="space-y-2 text-xs leading-relaxed text-text-3">
+        <p className="break-words">{connectorText(entry.ui.helpText) || entry.description}</p>
+        {entry.riskLabel || entry.catalogTier || entry.authRequirement ? <p>
+            {entry.catalogTier ? `Catalogue: ${entry.catalogTier}. ` : ''}
+            {entry.riskLabel ? `Risk: ${entry.riskLabel}. ` : ''}
+            {entry.authRequirement ? `Authentication: ${entry.authRequirement}.` : ''}
+        </p> : null}
+        {entry.requiredGovernanceGates?.length ? <p className="break-words">Required governance: {entry.requiredGovernanceGates.join(', ')}.</p> : null}
+        {entry.operatorNotes?.length ? <ul className="list-disc space-y-1 pl-5">
+            {entry.operatorNotes.map((note, index) => <li key={index} className="break-words">{note}</li>)}
+        </ul> : null}
+        {entry.warnings.length ? <ul className="alert alert-warning list-disc space-y-1 rounded-lg bg-warn-soft py-2 pr-3 pl-7 text-warn">
+            {entry.warnings.map((warning, index) => <li key={index} className="break-words">{warning}</li>)}
+        </ul> : null}
+        {entry.documentationUrl ? <p className="break-all">Documentation: {entry.documentationUrl}</p> : null}
+    </div>;
+}
+
+function McpImplementationConfiguration(props: ActionConnectorProps) {
+    const { draft, original, onChange, errors } = props;
+    const readOnly = props.readOnly || Boolean(original?.read_only);
+    const implementation = connectorObject(draft.additionalFields.implementation);
+    const implementationId = connectorText(implementation.id);
+    const fields = mcpImplementationFields(implementationId);
+    const settings = connectorObject(draft.additionalFields.additionalSettings);
+    const localErrors = validateConnectorConfiguration(draft, 'mcp');
+    const knownKeys = new Set(fields.map(({ key }) => key));
+    const extraSettings = Object.entries(settings).filter(([key]) => !knownKeys.has(key));
+    const originalSettings = connectorObject(original?.record.additionalFields.additionalSettings);
+    if (!implementationId && !Object.keys(settings).length) return null;
+    const updateSetting = (key: string, value: unknown) => onChange((current) => updateConnectorFields(current, {
+        additionalSettings: { ...connectorObject(current.additionalFields.additionalSettings), [key]: value },
+    }));
+    return <GlassPanel elevation="flat" className="space-y-4 p-4">
+        <div>
+            <h3 className="text-sm font-semibold text-text-1">Implementation settings</h3>
+            <p className="mt-1 break-words text-xs text-text-3">
+                {implementationId || 'Custom implementation'}{implementation.schemaVersion ? ` · schema ${connectorText(implementation.schemaVersion)}` : ''}
+            </p>
+            <p className="mt-1 text-xs text-text-3">These settings come from the applied server catalogue entry. Fixed safety requirements are not editable; provider-specific selections remain explicit.</p>
+        </div>
+        {fields.map((field) => {
+            const id = `mcp-implementation-${field.key}`;
+            const value = settings[field.key];
+            const errorKey = `additionalFields.additionalSettings.${field.key}`;
+            const error = errors[errorKey] || localErrors[errorKey];
+            if (field.kind === 'fixed') return <ActionField key={field.key} id={id} label={field.label} help={field.help} error={error}>
+                <input id={id} readOnly className={ACTION_INPUT_CLASS}
+                    value={value === undefined ? 'Not configured' : typeof value === 'boolean' ? value ? 'Yes' : 'No' : connectorText(value)} />
+                {!readOnly && value !== field.expected ? <GlassButton type="button" size="sm" variant="subtle"
+                    onClick={() => updateSetting(field.key, field.expected)}>
+                    Use {field.optional ? 'recommended' : 'required'} value: {String(field.expected)}
+                </GlassButton> : null}
+            </ActionField>;
+            if (field.kind === 'select') return <ActionField key={field.key} id={id} label={field.label} help={field.help} error={error}>
+                <select id={id} className={ACTION_INPUT_CLASS} value={connectorText(value)} disabled={readOnly}
+                    onChange={(event) => updateSetting(field.key, event.target.value)}>
+                    {!field.options?.some((option) => option.value === value) ? <option value={connectorText(value)} disabled>{value ? `Unavailable — ${connectorText(value)}` : 'Choose a value'}</option> : null}
+                    {field.options?.map((option) => <option key={option.value} value={option.value}>{option.label}</option>)}
+                </select>
+            </ActionField>;
+            if (field.kind === 'lines') return <McpLinesField key={field.key} id={id} label={field.label} value={value}
+                help={field.help} error={error} readOnly={readOnly} onChange={(next) => updateSetting(field.key, next)} />;
+            const selected = connectorStrings(value);
+            const unavailable = selected.filter((item) => !field.options?.some((option) => option.value === item));
+            return <fieldset key={field.key} className="space-y-2" disabled={readOnly}>
+                <legend className="text-sm font-medium text-text-1">{field.label}</legend>
+                {[...(field.options ?? []), ...unavailable.map((item) => ({ value: item, label: `${item} (unavailable — retained)` }))].map((option) =>
+                    <label key={option.value} className="flex items-start gap-2 text-sm text-text-2">
+                        <input type="checkbox" className="mt-1 accent-accent" checked={selected.includes(option.value)}
+                            onChange={(event) => updateSetting(field.key, event.target.checked
+                                ? [...new Set([...selected, option.value])] : selected.filter((item) => item !== option.value))} />
+                        <span className="break-words">{option.label}</span>
+                    </label>)}
+                {error ? <p role="alert" className="text-xs text-danger">{error}</p> : null}
+            </fieldset>;
+        })}
+        {extraSettings.length ? <div className="space-y-4 border-t border-edge pt-4">
+            <p className="text-xs text-text-3">Additional implementation properties are retained. The server remains authoritative for custom implementation validation.</p>
+            {extraSettings.map(([key, value]) => {
+                const id = `mcp-implementation-extra-${key}`;
+                if (value === EDITOR_SECRET_MASK || originalSettings[key] === EDITOR_SECRET_MASK) return <ActionSecretInput key={key}
+                    id={id} label={key} value={value} storedValue={originalSettings[key]} disabled={readOnly}
+                    onChange={(next) => updateSetting(key, next)} />;
+                if (typeof value === 'boolean') return <Toggle key={key} label={key} checked={value} disabled={readOnly}
+                    onChange={(next) => updateSetting(key, next)} />;
+                if (typeof value === 'string' || typeof value === 'number') return <ActionField key={key} id={id} label={key}>
+                    <input id={id} className={ACTION_INPUT_CLASS} type={typeof value === 'number' ? 'number' : 'text'}
+                        value={value} disabled={readOnly} onChange={(event) => updateSetting(key,
+                            typeof value === 'number' && event.target.value !== '' ? Number(event.target.value) : event.target.value)} />
+                </ActionField>;
+                return <ActionSchemaValue key={key} props={props} schema={{}}
+                    path={`/additionalFields/additionalSettings/${pointerPart(key)}`} label={key} />;
+            })}
+        </div> : null}
+    </GlassPanel>;
+}
+
+export function McpActionConfiguration(props: ActionConnectorProps) {
+    const { draft, original, onChange, errors } = props;
+    const readOnly = props.readOnly || Boolean(original?.read_only);
+    const fields = draft.additionalFields;
+    const catalogue = useMcpCatalogues(props, true);
+    const profile = connectorText(fields.server_profile) || 'generic';
+    const preconfigurationId = connectorText(fields.preconfiguration_id);
+    const transport = connectorText(fields.transport) || 'streamable_http';
+    const preset = catalogue.presets.find(({ id }) => id === profile);
+    const [presetChoice, setPresetChoice] = useState(profile);
+    const [preconfigurationChoice, setPreconfigurationChoice] = useState(preconfigurationId);
+    const [applyError, setApplyError] = useState<string | null>(null);
+    const [toolSearch, setToolSearch] = useState('');
+    const [toolLimit, setToolLimit] = useState(30);
+    const [discovery, setDiscovery] = useState<{ result: McpDiscoveryResult; endpoint: string; transport: string } | null>(null);
+    const { busy, feedback, stale, run } = useConnectorRequest(props);
+    useEffect(() => setPresetChoice(profile), [profile]);
+    useEffect(() => setPreconfigurationChoice(preconfigurationId), [preconfigurationId]);
+    const chosenPreset = catalogue.presets.find(({ id }) => id === presetChoice);
+    const chosenPreconfiguration = catalogue.preconfigurations.find(({ id }) => id === preconfigurationChoice);
+    const localErrors = validateConnectorConfiguration(draft, 'mcp', preset);
+    useConnectorValidity(props, 'mcp-configuration', Object.values(localErrors).join(' ') || null);
+    const fieldError = (key: string) => errors[`additionalFields.${key}`] || localErrors[`additionalFields.${key}`];
+    const updateField = (key: string, value: unknown) => onChange((current) => updateConnectorFields(current, { [key]: value }));
+    const availableTransports = allowedMcpTransports(preset);
+    const selectedTools = connectorStrings(fields.allowed_tool_names);
+    const lastDiscoveryMatches = discovery?.endpoint === draft.endpoint && discovery?.transport === transport;
+    const choices = mcpToolChoices(fields.mcp_tools, selectedTools,
+        lastDiscoveryMatches ? parseMcpTools(discovery?.result.tools).map(({ original_name }) => original_name) : undefined);
+    const filteredTools = choices.filter(({ name, tool }) =>
+        `${name} ${tool?.function_name || ''} ${tool?.description || ''}`.toLowerCase().includes(toolSearch.toLowerCase()));
+    const blockedExecution = readOnly || Boolean(busy) || Object.keys(localErrors).length > 0;
+    const doDiscovery = async () => {
+        const result = await run('Discovering MCP tools…', (signal) => discoverMcpAction(draft, original, signal),
+            (current, response) => updateConnectorFields(current, {
+                mcp_tools: mergeMcpTools(current.additionalFields.mcp_tools, response.tools, connectorStrings(current.additionalFields.allowed_tool_names)),
+            }),
+            (response) => ({
+                ...connectorFeedback(response),
+                message: response.success === true ? `Discovered ${parseMcpTools(response.tools).length} tools. Your existing allowlist has not been changed.` : response.error || 'Tool discovery failed.',
+                details: {
+                    transport: response.transport ?? transport,
+                    ...(response.mcp_operation_id ? { operation_id: response.mcp_operation_id } : {}),
+                },
+            }));
+        if (result) setDiscovery({ result, endpoint: draft.endpoint, transport });
+    };
+
+    return (
+        <div className="min-w-0 space-y-6" data-testid="mcp-configuration">
+            <p className="text-sm leading-relaxed text-text-2">Connect to a Model Context Protocol server and expose its tools or prompts to agents. Server discovery and connection testing are explicit commands; selecting a template or saving an action never runs either.</p>
+            <GlassPanel elevation="flat" className="space-y-4 p-4">
+                <h3 className="text-sm font-semibold text-text-1">Server starting points</h3>
+                <p className="text-xs text-text-3">Choose a preconfiguration or compatibility preset, review it, then apply its defaults. Existing custom fields, secret state, identity references, and selected tools are retained.</p>
+                {catalogue.loading ? <p role="status" className="text-xs text-text-3">Loading MCP catalogues…</p> : null}
+                {catalogue.presetsError || catalogue.preconfigurationsError ? <div role="alert" className="alert alert-warning space-y-2 rounded-xl bg-warn-soft p-3 text-sm text-warn">
+                    {catalogue.presetsError ? <p>{catalogue.presetsError} The built-in generic preset remains available.</p> : null}
+                    {catalogue.preconfigurationsError ? <p>{catalogue.preconfigurationsError} This is not an empty catalogue; your saved selection is retained.</p> : null}
+                    <GlassButton type="button" size="sm" disabled={catalogue.loading} onClick={catalogue.retry}>Retry catalogues</GlassButton>
+                </div> : null}
+                <ActionField id="mcp-preconfiguration" label="Preconfigured server">
+                    <select id="mcp-preconfiguration" className={ACTION_INPUT_CLASS} value={preconfigurationChoice} disabled={readOnly || catalogue.loading}
+                        onChange={(event) => setPreconfigurationChoice(event.target.value)}>
+                        <option value="">Custom configuration</option>
+                        {preconfigurationChoice && !chosenPreconfiguration ? <option value={preconfigurationChoice} disabled>Unavailable — {preconfigurationChoice}</option> : null}
+                        {catalogue.preconfigurations.map((entry) => <option key={entry.id} value={entry.id}>{entry.displayName}</option>)}
+                    </select>
+                </ActionField>
+                <McpCatalogueDetails entry={chosenPreconfiguration} />
+                {chosenPreconfiguration ? <p className="break-all text-xs text-text-3">Endpoint to apply: {chosenPreconfiguration.endpoint || 'No endpoint default'}</p> : null}
+                {preconfigurationId && !catalogue.preconfigurations.some(({ id }) => id === preconfigurationId) ? <p className="text-xs text-warn">Saved preconfiguration {preconfigurationId} is unavailable. Its implementation settings remain intact.</p> : null}
+                <GlassButton type="button" variant="subtle"
+                    disabled={readOnly || Boolean(busy) || catalogue.loading || Boolean(preconfigurationChoice && !chosenPreconfiguration)}
+                    onClick={() => {
+                        if (!chosenPreconfiguration) {
+                            updateField('preconfiguration_id', '');
+                            setApplyError(null);
+                            return;
+                        }
+                        const basePreset = catalogue.presets.find(({ id }) => id === (chosenPreconfiguration.presetId || 'generic'));
+                        if (!basePreset) { setApplyError('Load the preconfiguration’s compatibility preset before applying it.'); return; }
+                        try {
+                            applyMcpPreconfiguration(draft, chosenPreconfiguration, basePreset);
+                            onChange((current) => applyMcpPreconfiguration(current, chosenPreconfiguration, basePreset));
+                            setApplyError(null);
+                        } catch (error) {
+                            setApplyError(error instanceof Error ? error.message : 'Could not apply the preconfiguration.');
+                        }
+                    }}>
+                    {preconfigurationChoice ? 'Apply server preconfiguration' : 'Use custom configuration'}
+                </GlassButton>
+                <div className="space-y-3 border-t border-edge pt-4">
+                    <ActionField id="mcp-preset" label="Compatibility preset">
+                        <select id="mcp-preset" className={ACTION_INPUT_CLASS} value={presetChoice} disabled={readOnly || catalogue.loading}
+                            onChange={(event) => setPresetChoice(event.target.value)}>
+                            {!chosenPreset ? <option value={presetChoice} disabled>Unavailable — {presetChoice}</option> : null}
+                            {catalogue.presets.map((entry) => <option key={entry.id} value={entry.id}>{entry.displayName}</option>)}
+                        </select>
+                    </ActionField>
+                    <McpCatalogueDetails entry={chosenPreset} />
+                    {!preset ? <p className="text-xs text-warn">Saved preset {profile} is unavailable. It has not been replaced.</p> : null}
+                    <GlassButton type="button" variant="subtle" disabled={readOnly || Boolean(busy) || !chosenPreset || catalogue.loading}
+                        onClick={() => {
+                            if (!chosenPreset) return;
+                            try {
+                                applyMcpPreset(draft, chosenPreset);
+                                onChange((current) => applyMcpPreset(current, chosenPreset));
+                                setApplyError(null);
+                            } catch (error) {
+                                setApplyError(error instanceof Error ? error.message : 'Could not apply the preset.');
+                            }
+                        }}>Apply preset defaults</GlassButton>
+                </div>
+                {applyError ? <p role="alert" className="text-sm text-danger">{applyError}</p> : null}
+            </GlassPanel>
+            <div className="grid gap-4 sm:grid-cols-2">
+                <ActionField id="mcp-transport" label="Transport" required error={fieldError('transport')}
+                    help="Personal actions support remote transports only. Local commands and stdio are reserved for admin-managed global actions.">
+                    <select id="mcp-transport" className={ACTION_INPUT_CLASS} value={transport} disabled={readOnly}
+                        onChange={(event) => {
+                            const value = event.target.value;
+                            if (availableTransports.some((option) => option.value === value)) updateField('transport', value);
+                        }}>
+                        {!availableTransports.some(({ value }) => value === transport) ? <option value={transport} disabled>
+                            {transport === 'stdio' ? 'Stdio — admin-managed legacy configuration' : `Unavailable transport — ${transport}`}
+                        </option> : null}
+                        {availableTransports.map((option) => <option key={option.value} value={option.value}>{option.label}</option>)}
+                    </select>
+                </ActionField>
+                <ActionField id="mcp-endpoint" label="MCP server endpoint" required error={errors.endpoint || localErrors.endpoint}
+                    help="The server applies destination governance when connecting. Enter a server you are authorized to use.">
+                    <input id="mcp-endpoint" className={ACTION_INPUT_CLASS} type="url" value={draft.endpoint}
+                        disabled={readOnly || transport === 'stdio'}
+                        placeholder={connectorText(preset?.ui[transport === 'websocket' ? 'websocketEndpointPlaceholder' : 'endpointPlaceholder']) ||
+                            (transport === 'websocket' ? 'wss://example.com/mcp' : 'https://example.com/mcp')}
+                        onChange={(event) => {
+                            const endpoint = event.target.value;
+                            onChange((current) => ({ ...current, endpoint }));
+                        }} />
+                </ActionField>
+            </div>
+            {transport === 'stdio' ? <div className="alert alert-warning space-y-2 rounded-xl bg-warn-soft p-3 text-sm text-warn">
+                <p>This legacy configuration is preserved for review. Personal workspaces cannot edit or execute a local MCP command. Select a permitted remote transport to reconfigure an owned action.</p>
+                <dl className="space-y-1 text-xs">
+                    <div><dt className="font-medium">Command</dt><dd className="break-all">{connectorText(fields.command) || 'Not specified'}</dd></div>
+                    <div><dt className="font-medium">Arguments</dt><dd className="break-all">{connectorStrings(fields.args).join(' ') || 'None'}</dd></div>
+                    <div><dt className="font-medium">Environment variable names</dt><dd className="break-all">{Object.keys(connectorObject(fields.env)).join(', ') || 'None'}. Values remain hidden.</dd></div>
+                </dl>
+            </div> : null}
+            {transport === 'websocket' ? <p className="alert alert-warning rounded-xl bg-warn-soft p-3 text-sm text-warn">The current WebSocket connector supports neither authentication headers nor custom headers. Existing credentials and headers are retained until you explicitly change them.</p> : null}
+            <McpImplementationConfiguration {...props} />
+            <div className="space-y-3">
+                <h3 className="text-sm font-semibold text-text-1">Tools and prompts</h3>
+                <Toggle label="Load tools" description="Expose tools from this MCP server to agents using this action."
+                    checked={(fields.load_tools ?? true) === true} disabled={readOnly} onChange={(value) => updateField('load_tools', value)} />
+                <Toggle label="Load prompts" description="Load MCP server prompts in addition to any enabled tools."
+                    checked={(fields.load_prompts ?? false) === true} disabled={readOnly} onChange={(value) => updateField('load_prompts', value)} />
+                <Toggle label="Validate tool arguments" description="Check arguments against cached tool input schemas before invocation. Discover tools to populate the schema cache."
+                    checked={(fields.validate_tool_arguments ?? false) === true} disabled={readOnly} onChange={(value) => updateField('validate_tool_arguments', value)} />
+                <ActionField id="mcp-result-policy" label="Large-result policy" error={fieldError('tool_result_policy')}>
+                    <select id="mcp-result-policy" className={ACTION_INPUT_CLASS} value={connectorText(fields.tool_result_policy ?? 'truncate')} disabled={readOnly}
+                        onChange={(event) => updateField('tool_result_policy', event.target.value)}>
+                        {!['truncate', 'error_on_limit'].includes(connectorText(fields.tool_result_policy ?? 'truncate')) ? <option value={connectorText(fields.tool_result_policy)} disabled>Unavailable — {connectorText(fields.tool_result_policy)}</option> : null}
+                        <option value="truncate">Truncate results above the configured size limit</option>
+                        <option value="error_on_limit">Report an error instead of truncating</option>
+                    </select>
+                </ActionField>
+                <McpLinesField id="mcp-allowed-tools" label="Allowed tool names" value={fields.allowed_tool_names}
+                    readOnly={readOnly} error={fieldError('allowed_tool_names')}
+                    help="One original MCP tool name per line. An empty allowlist allows all server tools; disable Load tools if no tools should be exposed. Unavailable names remain selected until you remove them."
+                    onChange={(value) => updateField('allowed_tool_names', value)} />
+                {!selectedTools.length ? <p className="alert alert-warning rounded-lg bg-warn-soft p-2 text-xs text-warn">No tool allowlist is configured. All server tools may be exposed when Load tools is enabled.</p> : null}
+                <div className="flex flex-wrap items-center gap-2">
+                    <GlassButton type="button" variant="subtle" disabled={blockedExecution} onClick={() => void doDiscovery()}>Discover MCP tools</GlassButton>
+                    <p className="text-xs text-text-3">Discovery connects and lists tools; it does not invoke them.</p>
+                </div>
+                {discovery ? <GlassPanel elevation="flat" className="space-y-2 p-3">
+                    <h4 className="text-sm font-medium text-text-1">Last discovery capabilities</h4>
+                    {!lastDiscoveryMatches ? <p className="text-xs text-warn">The endpoint or transport changed after this discovery. Run discovery again to verify the current server.</p> : null}
+                    <dl className="grid gap-2 text-xs text-text-2 sm:grid-cols-2">
+                        {Object.entries(connectorObject(discovery.result.capabilities)).map(([key, value]) =>
+                            ['string', 'boolean', 'number'].includes(typeof value) ? <div key={key}>
+                                <dt className="font-medium">{key.replaceAll('_', ' ')}</dt>
+                                <dd className="break-words">{typeof value === 'boolean' ? value ? 'Yes' : 'No' : String(value)}</dd>
+                            </div> : null)}
+                    </dl>
+                    {discovery.result.warnings?.length ? <ul className="list-disc space-y-1 pl-5 text-xs text-warn">
+                        {discovery.result.warnings.map((warning, index) => <li key={index} className="break-words">{warning}</li>)}
+                    </ul> : null}
+                </GlassPanel> : null}
+                {choices.length ? <div className="space-y-3">
+                    <ActionField id="mcp-tool-search" label="Find a tool">
+                        <input id="mcp-tool-search" type="search" className={ACTION_INPUT_CLASS} value={toolSearch}
+                            placeholder="Tool name or description" onChange={(event) => { setToolSearch(event.target.value); setToolLimit(30); }} />
+                    </ActionField>
+                    <p className="text-xs text-text-3">{filteredTools.length} matching tools · {selectedTools.length} explicit allowlist entries. Check a tool to add it to the allowlist.</p>
+                    {filteredTools.slice(0, toolLimit).map(({ name, tool, selected, unavailable }, index) => {
+                        const id = `mcp-tool-${index}`;
+                        const schema = connectorObject(tool?.input_schema);
+                        const required = connectorStrings(schema.required);
+                        return <GlassPanel key={name} elevation="flat" className="space-y-2 p-3">
+                            <label htmlFor={id} className="flex items-start gap-3">
+                                <input id={id} type="checkbox" className="mt-1 accent-accent" checked={selected} disabled={readOnly}
+                                    onChange={(event) => {
+                                        const checked = event.target.checked;
+                                        onChange((current) => setMcpToolSelection(current, name, checked));
+                                    }} />
+                                <span className="min-w-0">
+                                    <span className="block break-all text-sm font-medium text-text-1">{name}</span>
+                                    {tool?.description ? <span className="mt-1 block whitespace-pre-wrap break-words text-xs text-text-2">{tool.description}</span> : null}
+                                </span>
+                            </label>
+                            {unavailable ? <p className="text-xs text-warn">Not available in the current tool catalogue. This selection is retained for review.</p> :
+                                !discovery ? <p className="text-xs text-text-3">Cached metadata; not verified in this editor session.</p> : null}
+                            {tool ? <details className="text-xs text-text-3">
+                                <summary className="cursor-pointer">Tool parameters and metadata</summary>
+                                <div className="mt-2 space-y-2">
+                                    <p className="break-all">Function name: {tool.function_name}</p>
+                                    {Object.keys(connectorObject(schema.properties)).length ? <ul className="space-y-1">
+                                        {Object.entries(connectorObject(schema.properties)).map(([parameter, spec]) => <li key={parameter} className="break-words">
+                                            <span className="font-mono">{parameter}</span> ({connectorText(connectorObject(spec).type) || 'value'}{required.includes(parameter) ? ', required' : ', optional'})
+                                            {connectorObject(spec).description ? ` — ${connectorText(connectorObject(spec).description)}` : ''}
+                                        </li>)}
+                                    </ul> : <p>No named input parameters are declared.</p>}
+                                    {Object.keys(connectorObject(tool.annotations)).length ? <dl className="space-y-1">
+                                        {Object.entries(connectorObject(tool.annotations)).map(([key, value]) =>
+                                            ['string', 'boolean', 'number'].includes(typeof value) ? <div key={key} className="break-words"><dt className="inline font-medium">{key}: </dt><dd className="inline">{String(value)}</dd></div> : null)}
+                                    </dl> : null}
+                                    <pre className="max-h-72 overflow-auto whitespace-pre-wrap break-all rounded-lg bg-surface-1 p-2">{JSON.stringify({
+                                        input_schema: tool.input_schema, output_schema: tool.output_schema,
+                                    }, null, 2)}</pre>
+                                </div>
+                            </details> : null}
+                        </GlassPanel>;
+                    })}
+                    {!filteredTools.length ? <p className="text-sm text-text-3">No tools match this search.</p> : null}
+                    {filteredTools.length > toolLimit ? <GlassButton type="button" variant="subtle" onClick={() => setToolLimit((value) => value + 30)}>Show more tools</GlassButton> : null}
+                </div> : <p className="text-sm text-text-3">No tool metadata is cached. Discover tools when ready, or enter known tool names above.</p>}
+                <details className="space-y-3">
+                    <summary className="cursor-pointer text-sm text-text-2">Advanced cached tool metadata</summary>
+                    <ActionJsonInput id="mcp-tool-metadata" label="Discovered tool metadata JSON" value={fields.mcp_tools ?? []}
+                        objectOnly={false} readOnly={readOnly} onValidityChange={props.onValidityChange}
+                        protectArraySecrets={actionHasStoredArraySecrets(draft, original, '/additionalFields/mcp_tools')}
+                        error={fieldError('mcp_tools')} rows={10}
+                        help="Preserve original_name and function_name. Editing cached metadata does not discover or run tools."
+                        onChange={(value) => updateField('mcp_tools', value)} />
+                </details>
+            </div>
+            <div className="space-y-3">
+                <h3 className="text-sm font-semibold text-text-1">Timeouts and retry policy</h3>
+                <div className="grid gap-4 sm:grid-cols-2">
+                    {MCP_NUMBER_FIELDS.map((field) => <ActionField key={field.key} id={`mcp-${field.key}`} label={field.label} error={fieldError(field.key)}>
+                        <input id={`mcp-${field.key}`} type="number" inputMode="numeric" step={1} min={field.min} max={field.max}
+                            className={ACTION_INPUT_CLASS} disabled={readOnly}
+                            value={typeof fields[field.key] === 'number' || typeof fields[field.key] === 'string' ? fields[field.key] as number | string : field.defaultValue}
+                            onChange={(event) => updateField(field.key, event.target.value === '' ? '' : Number(event.target.value))} />
+                    </ActionField>)}
+                </div>
+            </div>
+            <div className="space-y-3 border-t border-edge pt-4">
+                <p className="text-xs text-text-3">The connection test initializes a server session and lists its tools. It does not invoke tools or save discovered metadata. Authentication is configured in the Authentication section.</p>
+                <div className="flex flex-wrap items-center gap-2">
+                    <GlassButton type="button" variant="subtle" disabled={blockedExecution}
+                        onClick={() => void run('Validating MCP configuration…', (signal) => validateApiConnector(draft, original, 'mcp', signal))}>Validate MCP configuration</GlassButton>
+                    <GlassButton type="button" variant="subtle" disabled={blockedExecution}
+                        onClick={() => void run('Testing MCP connection…', (signal) => testApiConnector(draft, original, 'mcp', signal))}>Test MCP connection</GlassButton>
+                    {busy ? <p role="status" className="text-sm text-text-3">{busy}</p> : null}
+                </div>
+                {readOnly ? <p className="text-xs text-text-3">Provided actions are read-only. Discovery and connection testing are disabled.</p> : null}
+                {!readOnly && Object.keys(localErrors).length ? <p className="text-xs text-text-3">Resolve the highlighted configuration errors before validating or connecting.</p> : null}
+                <ConnectorFeedbackPanel feedback={feedback} stale={stale} />
+            </div>
+        </div>
+    );
+}
+
+export function McpActionAuthentication(props: ActionConnectorProps) {
+    const { draft, original, onChange, errors } = props;
+    const readOnly = props.readOnly || Boolean(original?.read_only);
+    const fields = draft.additionalFields;
+    const method = connectorAuthMethod(draft, 'mcp');
+    const transport = connectorText(fields.transport) || 'streamable_http';
+    const catalogue = useMcpCatalogues(props, false);
+    const preset = catalogue.presets.find(({ id }) => id === (fields.server_profile || 'generic'));
+    const allowedMethods = allowedMcpAuthMethods(transport, preset);
+    const headers = connectorObject(fields.custom_headers);
+    const originalHeaders = connectorObject(original?.record.additionalFields.custom_headers);
+    const [newHeaderName, setNewHeaderName] = useState('');
+    const [headerError, setHeaderError] = useState<string | null>(null);
+    const localErrors = {
+        ...validateConnectorAuthentication(draft, 'mcp', original),
+        ...Object.fromEntries(Object.entries(validateConnectorConfiguration(draft, 'mcp', preset))
+            .filter(([key]) => key.includes('custom_headers') || key.endsWith('auth_method'))),
+    };
+    useConnectorValidity(props, 'mcp-authentication', Object.values(localErrors).join(' ') || null);
+    const fieldError = (key: string) => errors[key] || localErrors[key];
+    const updateAuth = (key: string, value: string) => onChange((current) => ({ ...current, auth: { ...current.auth, [key]: value } }));
+    const updateHeader = (name: string, value: string) => onChange((current) => updateConnectorFields(current, {
+        custom_headers: { ...connectorObject(current.additionalFields.custom_headers), [name]: value },
+    }));
+    const removeHeader = (name: string) => onChange((current) => updateConnectorFields(current, {
+        custom_headers: Object.fromEntries(Object.entries(connectorObject(current.additionalFields.custom_headers)).filter(([key]) => key !== name)),
+    }));
+    const canAddHeaders = transport !== 'websocket' && preset?.constraints.customHeadersAllowed !== false;
+    const apiKeyIdentity = Boolean(draft.identity_id && fields.identity_auth_type === 'api_key');
+    return (
+        <div className="space-y-5" data-testid="mcp-authentication">
+            <ConnectorIdentitySelect {...props} identities={transport === 'websocket' ? [] : props.identities} kind="mcp" />
+            {catalogue.presetsError ? <p role="alert" className="text-xs text-warn">{catalogue.presetsError} Saved authentication and header values have not been changed.</p> : null}
+            <ActionField id="mcp-auth-method" label="Authentication method" error={fieldError('additionalFields.auth_method')}
+                help={draft.identity_id ? 'The selected identity is resolved on the server; no credentials are copied into the action.' : 'A method change only edits this draft. Inactive credentials are retained until explicitly cleared.'}>
+                <select id="mcp-auth-method" className={ACTION_INPUT_CLASS} value={method} disabled={readOnly || Boolean(draft.identity_id)}
+                    onChange={(event) => {
+                        const value = event.target.value;
+                        onChange((current) => changeConnectorAuthMethod(current, 'mcp', value));
+                    }}>
+                    {!allowedMethods.some(({ value }) => value === method) ? <option value={method} disabled>
+                        {method === 'identity' && draft.identity_id ? 'Reusable identity' : `Unavailable method — ${MCP_AUTH_OPTIONS.find(({ value }) => value === method)?.label || method}`}
+                    </option> : null}
+                    {allowedMethods.map((option) => <option key={option.value} value={option.value}>{option.label}</option>)}
+                </select>
+            </ActionField>
+            {(method === 'api_key' || apiKeyIdentity) ? <ActionField id="mcp-api-key-header" label="API key header name" required error={fieldError('additionalFields.api_key_header_name')}>
+                <input id="mcp-api-key-header" className={ACTION_INPUT_CLASS} disabled={readOnly}
+                    value={connectorText(fields.api_key_header_name ?? 'X-API-Key')}
+                    onChange={(event) => {
+                        const api_key_header_name = event.target.value;
+                        onChange((current) => updateConnectorFields(current, { api_key_header_name }));
+                    }} />
+            </ActionField> : null}
+            {method === 'basic' && !draft.identity_id ? draft.auth.identity === EDITOR_SECRET_MASK || original?.record.auth.identity === EDITOR_SECRET_MASK ? (
+                <ActionSecretInput id="mcp-basic-username" label="Username" value={draft.auth.identity} storedValue={original?.record.auth.identity}
+                    disabled={readOnly} error={fieldError('auth.identity')} onChange={(value) => updateAuth('identity', value)} />
+            ) : (
+                <ActionField id="mcp-basic-username" label="Username" required error={fieldError('auth.identity')}>
+                    <input id="mcp-basic-username" className={ACTION_INPUT_CLASS} disabled={readOnly} autoComplete="off"
+                        value={draft.auth.identity ?? ''} onChange={(event) => updateAuth('identity', event.target.value)} />
+                </ActionField>
+            ) : null}
+            {['bearer', 'api_key', 'basic'].includes(method) && !draft.identity_id ? <ActionSecretInput
+                id="mcp-credential" label={method === 'basic' ? 'Password' : method === 'api_key' ? 'API key' : 'Bearer token'}
+                value={draft.auth.key} storedValue={original?.record.auth.key} disabled={readOnly}
+                error={fieldError('auth.key')} onChange={(value) => updateAuth('key', value)} /> : null}
+            {method === 'identity' && !draft.identity_id ? <p role="alert" className="text-sm text-danger">Choose a compatible reusable identity above before testing or saving.</p> : null}
+            <div className="space-y-4 border-t border-edge pt-4">
+                <div>
+                    <h3 className="text-sm font-semibold text-text-1">Custom HTTP headers</h3>
+                    <p className="mt-1 text-xs leading-relaxed text-text-3">All header values are treated as secrets. Authentication headers override matching custom headers. To rename a stored header, remove it and add the new name with a replacement value.</p>
+                </div>
+                {!canAddHeaders ? <p className="alert alert-warning rounded-lg bg-warn-soft p-2 text-xs text-warn">This transport or preset does not support custom headers. Existing values are preserved for review; remove them explicitly before connecting, or select a compatible transport/preset.</p> : null}
+                {fieldError('additionalFields.custom_headers') ? <p role="alert" className="text-sm text-danger">{fieldError('additionalFields.custom_headers')}</p> : null}
+                {Object.entries(headers).map(([name, value], index) => <GlassPanel key={name} elevation="flat" className="space-y-2 p-3">
+                    <ActionSecretInput id={`mcp-header-value-${index}`} label={name} value={value} storedValue={originalHeaders[name]}
+                        disabled={readOnly} error={fieldError(`additionalFields.custom_headers.${name}`)}
+                        onChange={(next) => updateHeader(name, next)} />
+                    {!readOnly ? <GlassButton type="button" size="sm" variant="danger" onClick={() => removeHeader(name)}>Remove header {name}</GlassButton> : null}
+                </GlassPanel>)}
+                {!Object.keys(headers).length ? <p className="text-sm text-text-3">No custom headers configured.</p> : null}
+                {!readOnly ? <div className="space-y-2">
+                    <ActionField id="mcp-new-header-name" label="New header name" error={headerError ?? undefined}>
+                        <input id="mcp-new-header-name" className={ACTION_INPUT_CLASS} value={newHeaderName}
+                            placeholder="X-Request-Source" disabled={!canAddHeaders || Object.keys(headers).length >= 20}
+                            onChange={(event) => { setNewHeaderName(event.target.value); setHeaderError(null); }} />
+                    </ActionField>
+                    <GlassButton type="button" variant="subtle" disabled={!canAddHeaders || Object.keys(headers).length >= 20 || !newHeaderName.trim()}
+                        onClick={() => {
+                            const name = newHeaderName.trim();
+                            const error = mcpHeaderNameError(name, headers);
+                            if (error) { setHeaderError(error); return; }
+                            updateHeader(name, '');
+                            setNewHeaderName('');
+                            setHeaderError(null);
+                        }}>Add custom header</GlassButton>
+                    <p className="text-xs text-text-3">{Object.keys(headers).length}/20 headers. Values may contain up to 4096 characters and must not contain line breaks.</p>
+                </div> : null}
+            </div>
+        </div>
+    );
+}

--- a/application/v2_ui/src/components/workspaceActions/OpenApiActionConfiguration.tsx
+++ b/application/v2_ui/src/components/workspaceActions/OpenApiActionConfiguration.tsx
@@ -1,0 +1,437 @@
+// OpenApiActionConfiguration.tsx
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { GlassButton, GlassPanel } from '../ui/primitives';
+import { ActionField, ActionSecretInput, ACTION_INPUT_CLASS } from './ActionFields';
+import type { ActionConnectorProps } from '../../lib/workspaceActionTypes';
+import { EDITOR_SECRET_MASK, type ActionConfiguration } from '../../lib/workspaceAuthoring';
+import {
+    applyOpenApiSpecification, changeConnectorAuthMethod, changeOpenApiBasicCredential,
+    connectorAuthMethod, connectorFeedback, connectorIdentityOptions, connectorObject,
+    connectorSecretField, connectorText, connectorUrlError, OPENAPI_AUTH_OPTIONS,
+    OPENAPI_SOURCE_OPTIONS, openApiBasicCredentials, openApiInformation, openApiSourceDraft, processOpenApiText,
+    selectConnectorIdentity, testApiConnector, updateConnectorFields, updateOpenApiSourceDraft,
+    uploadOpenApiSpecification, validateApiConnector, validateConnectorAuthentication,
+    validateConnectorConfiguration,
+    type ApiConnector, type ConnectorFeedback, type OpenApiUploadResult,
+} from '../../lib/workspaceActionConnectors';
+
+export function useConnectorValidity(props: ActionConnectorProps, key: string, message: string | null) {
+    const callback = useRef(props.onValidityChange);
+    callback.current = props.onValidityChange;
+    const readOnly = props.readOnly || props.original?.read_only;
+    useEffect(() => {
+        callback.current(key, readOnly ? null : message);
+        return () => callback.current(key, null);
+    }, [key, message, readOnly]);
+}
+
+export function useConnectorRequest(props: ActionConnectorProps) {
+    const latest = useRef(props);
+    latest.current = props;
+    const activeRequest = useRef<{
+        controller: AbortController;
+        draft: ActionConfiguration;
+        original: ActionConnectorProps['original'];
+    } | null>(null);
+    const [busy, setBusy] = useState<string | null>(null);
+    const [feedback, setFeedback] = useState<{ value: ConnectorFeedback; draft: ActionConfiguration } | null>(null);
+
+    useEffect(() => {
+        const active = activeRequest.current;
+        if (active && (active.draft !== props.draft || active.original !== props.original || props.readOnly || props.original?.read_only)) {
+            active.controller.abort();
+            activeRequest.current = null;
+            setBusy(null);
+        }
+    }, [props.draft, props.original, props.readOnly]);
+    useEffect(() => () => {
+        activeRequest.current?.controller.abort();
+        activeRequest.current = null;
+    }, []);
+
+    async function run<T>(
+        label: string,
+        operation: (signal: AbortSignal) => Promise<T>,
+        apply?: (draft: ActionConfiguration, result: T) => ActionConfiguration,
+        describe?: (result: T) => ConnectorFeedback,
+    ): Promise<T | undefined> {
+        const snapshot = latest.current;
+        if (snapshot.readOnly || snapshot.original?.read_only) return;
+        activeRequest.current?.controller.abort();
+        const request = new AbortController();
+        activeRequest.current = { controller: request, draft: snapshot.draft, original: snapshot.original };
+        setBusy(label);
+        try {
+            const response = await operation(request.signal);
+            if (request.signal.aborted || latest.current.draft !== snapshot.draft ||
+                latest.current.original !== snapshot.original || latest.current.readOnly) return;
+            const value = describe ? describe(response) : connectorFeedback(response);
+            let resultDraft = snapshot.draft;
+            if (value.success && apply) {
+                resultDraft = apply(snapshot.draft, response);
+                snapshot.onChange((current) => current === snapshot.draft ? resultDraft : current);
+            }
+            setFeedback({ value, draft: resultDraft });
+            return value.success ? response : undefined;
+        } catch (error) {
+            if (!request.signal.aborted && latest.current.draft === snapshot.draft &&
+                latest.current.original === snapshot.original) {
+                setFeedback({ value: connectorFeedback(error), draft: snapshot.draft });
+            }
+            return undefined;
+        } finally {
+            if (activeRequest.current?.controller === request) {
+                activeRequest.current = null;
+                setBusy(null);
+            }
+        }
+    }
+    return { busy, feedback: feedback?.value ?? null, stale: Boolean(feedback && feedback.draft !== props.draft), run };
+}
+
+export function ConnectorFeedbackPanel({ feedback, stale }: { feedback: ConnectorFeedback | null; stale?: boolean }) {
+    if (!feedback) return null;
+    const details = Object.entries(feedback.details).filter(([, value]) => ['string', 'number', 'boolean'].includes(typeof value));
+    return (
+        <div role={feedback.success ? 'status' : 'alert'} aria-live="polite"
+            className={`alert rounded-xl border p-3 text-sm ${feedback.success
+                ? 'alert-success border-edge bg-surface-2 text-text-1'
+                : 'alert-danger border-danger/30 bg-danger-soft text-danger'}`}>
+            <p className="break-words">{feedback.message}</p>
+            {stale ? <p className="mt-1 text-xs text-text-3">This result describes an earlier draft. Run the command again to check your current configuration.</p> : null}
+            {feedback.errors.length ? <ul className="mt-2 list-disc space-y-1 pl-5">
+                {feedback.errors.map((message, index) => <li key={index} className="break-words">{message}</li>)}
+            </ul> : null}
+            {feedback.warnings.length ? <div className="alert alert-warning mt-2 rounded-lg bg-warn-soft p-2 text-warn">
+                <p className="font-medium">Warnings</p>
+                <ul className="list-disc space-y-1 pl-5">
+                    {feedback.warnings.map((message, index) => <li key={index} className="break-words">{message}</li>)}
+                </ul>
+            </div> : null}
+            {details.length ? <dl className="mt-2 grid gap-1 text-xs text-text-2">
+                {details.map(([name, value]) => <div key={name} className="flex flex-wrap gap-x-2">
+                    <dt className="font-medium">{name.replaceAll('_', ' ')}:</dt><dd className="break-all">{String(value)}</dd>
+                </div>)}
+            </dl> : null}
+        </div>
+    );
+}
+
+export function ConnectorIdentitySelect({ kind, ...props }: ActionConnectorProps & { kind: ApiConnector }) {
+    const selectedId = props.draft.identity_id || '';
+    const { identities, unavailable } = connectorIdentityOptions(props.identities, kind, selectedId);
+    const disabled = props.readOnly || props.original?.read_only || props.identitiesLoading;
+    const id = `${kind}-identity`;
+    return (
+        <div className="space-y-2">
+            <ActionField id={id} label="Reusable identity"
+                help="An identity is referenced by its stable ID. Its credentials are never copied into this draft."
+                error={props.errors.identity_id}>
+                <select id={id} className={ACTION_INPUT_CLASS} value={selectedId} disabled={disabled}
+                    aria-describedby={`${id}-help ${id}-status`}
+                    onChange={(event) => {
+                        const next = event.target.value;
+                        const identity = identities.find(({ id }) => id === next);
+                        if (next && !identity) return;
+                        props.onChange((current) => selectConnectorIdentity(current, kind, identity ?? null));
+                    }}>
+                    <option value="">Use action-specific credentials</option>
+                    {unavailable ? <option value={selectedId} disabled>Unavailable identity — {selectedId}</option> : null}
+                    {identities.map((identity) => <option key={identity.id} value={identity.id}>
+                        {identity.name} · {identity.auth_type.replaceAll('_', ' ')} · {identity.scope_type || 'personal'} · {identity.id}
+                    </option>)}
+                </select>
+            </ActionField>
+            <div id={`${id}-status`} className="space-y-1 text-xs text-text-3" aria-live="polite">
+                {props.identitiesLoading ? <p>Loading permitted identities…</p> : null}
+                {props.identitiesError ? <p role="alert" className="text-danger">{props.identitiesError} The current identity selection has not been changed.</p> : null}
+                {!props.identitiesLoading && !props.identitiesError && !identities.length ? <p>No compatible reusable identities are available. Action-specific credentials are still supported.</p> : null}
+                {unavailable ? <p className="alert alert-warning rounded-lg bg-warn-soft p-2 text-warn">
+                    The selected identity is unavailable or incompatible. Its ID is retained; choose a replacement explicitly. A same-name identity will not be substituted.
+                </p> : null}
+                {selectedId && !unavailable ? <p>{identities.find(({ id }) => id === selectedId)?.description || 'The server resolves this identity when the action runs.'}</p> : null}
+            </div>
+        </div>
+    );
+}
+
+export function OpenApiActionConfiguration(props: ActionConnectorProps) {
+    const { draft, original, onChange, errors } = props;
+    const readOnly = props.readOnly || Boolean(original?.read_only);
+    const specContent = draft.additionalFields.openapi_spec_content;
+    const source = useMemo(() => openApiSourceDraft(draft), [draft._openApiSourceDraft, specContent]);
+    const information = useMemo(() => openApiInformation(specContent), [specContent]);
+    const specJson = useMemo(() => JSON.stringify(specContent, null, 2), [specContent]);
+    const localErrors = validateConnectorConfiguration(draft, 'openapi');
+    const { busy, feedback, stale, run } = useConnectorRequest(props);
+    const [operationSearch, setOperationSearch] = useState('');
+    const [operationLimit, setOperationLimit] = useState(30);
+    useConnectorValidity(props, 'openapi-configuration', Object.values(localErrors).join(' ') || null);
+
+    const filteredOperations = information.operations.filter((operation) =>
+        `${operation.method} ${operation.path} ${operation.id} ${operation.summary} ${operation.tags.join(' ')}`
+            .toLowerCase().includes(operationSearch.toLowerCase()));
+    const applyUpload = (current: ActionConfiguration, result: OpenApiUploadResult) => applyOpenApiSpecification(current, result);
+    const uploadFeedback = (result: OpenApiUploadResult): ConnectorFeedback => ({
+        success: true,
+        message: `${result.original_filename || 'Specification'} was parsed and validated by the server.`,
+        errors: [], warnings: result.warnings ?? [],
+        details: { ...(result.file_id ? { file_id: result.file_id } : {}), operations: openApiInformation(result.spec_content).operations.length },
+    });
+
+    return (
+        <div className="min-w-0 space-y-6" data-testid="openapi-configuration">
+            <p className="text-sm leading-relaxed text-text-2">
+                Import an OpenAPI specification to expose its operations to an agent. Importing or validating a specification does not call those operations.
+            </p>
+            <ActionField id="openapi-source-mode" label="Specification source">
+                <select id="openapi-source-mode" className={ACTION_INPUT_CLASS} value={source.mode} disabled={readOnly || Boolean(busy)}
+                    onChange={(event) => {
+                        const mode = event.target.value === 'manual' ? 'manual' : 'file';
+                        onChange((current) => updateOpenApiSourceDraft(current, { mode }));
+                    }}>
+                    {OPENAPI_SOURCE_OPTIONS.map((option) => <option key={option.value} value={option.value}>{option.label}</option>)}
+                </select>
+            </ActionField>
+            {source.mode === 'file' ? (
+                <ActionField id="openapi-file" label="OpenAPI specification file"
+                    help="JSON, YAML, or YML, up to 5 MB. Validation uses the same server-side scanner as the classic editor. A failed import leaves the current specification unchanged."
+                    error={errors['additionalFields.openapi_spec_content'] || (!draft.additionalFields.openapi_spec_content ? localErrors['additionalFields.openapi_spec_content'] : undefined)}>
+                    <input id="openapi-file" type="file" accept=".json,.yaml,.yml" className={ACTION_INPUT_CLASS}
+                        disabled={readOnly || Boolean(busy)} aria-describedby="openapi-file-help"
+                        onChange={(event) => {
+                            const file = event.target.files?.[0];
+                            event.target.value = '';
+                            if (file) void run('Validating specification…', (signal) => uploadOpenApiSpecification(file, file.name, signal), applyUpload, uploadFeedback);
+                        }} />
+                    {source.filename ? <p className="mt-2 break-words text-xs text-text-3">Last imported: {source.filename}</p> : null}
+                    <p className="mt-2 text-xs text-text-3">
+                        For a specification hosted at a URL, download the JSON or YAML file, then upload it here.
+                        SimpleChat does not fetch remote specifications.
+                    </p>
+                </ActionField>
+            ) : (
+                <div className="space-y-3">
+                    <ActionField id="openapi-source-format" label="Source format">
+                        <select id="openapi-source-format" className={ACTION_INPUT_CLASS} value={source.format} disabled={readOnly || Boolean(busy)}
+                            onChange={(event) => {
+                                const format = event.target.value === 'yaml' ? 'yaml' : 'json';
+                                onChange((current) => updateOpenApiSourceDraft(current, { format }));
+                            }}>
+                            <option value="json">JSON</option><option value="yaml">YAML</option>
+                        </select>
+                    </ActionField>
+                    <ActionField id="openapi-source-text" label="Specification source"
+                        help="Source text stays in this tab. Process the text to parse and validate it before saving. YAML is parsed on the server, not by a browser-loaded library."
+                        error={localErrors['openapi-source'] || errors['additionalFields.openapi_spec_content']}>
+                        <textarea id="openapi-source-text" rows={16} spellCheck={false} readOnly={readOnly}
+                            className={`${ACTION_INPUT_CLASS} font-mono text-xs`} value={source.text}
+                            aria-describedby="openapi-source-text-help" aria-invalid={source.pending}
+                            onChange={(event) => {
+                                const text = event.target.value;
+                                onChange((current) => updateOpenApiSourceDraft(current, { text, pending: true }));
+                            }} />
+                    </ActionField>
+                    <div className="flex flex-wrap gap-2">
+                        <GlassButton type="button" variant="subtle" disabled={readOnly || Boolean(busy) || !source.text.trim()}
+                            onClick={() => void run('Processing specification…', (signal) => processOpenApiText(source.text, source.format, signal), applyUpload, uploadFeedback)}>
+                            Process specification
+                        </GlassButton>
+                        {source.pending && draft.additionalFields.openapi_spec_content ? <GlassButton type="button" disabled={readOnly || Boolean(busy)}
+                            onClick={() => onChange((current) => updateOpenApiSourceDraft(current, {
+                                pending: false, format: 'json', text: JSON.stringify(current.additionalFields.openapi_spec_content, null, 2),
+                            }))}>Discard unprocessed source changes</GlassButton> : null}
+                    </div>
+                </div>
+            )}
+            <ActionField id="openapi-base-url" label="API base URL" required
+                help="The URL against which the imported operations run. Changing it does not fetch or replace the specification."
+                error={errors.endpoint || localErrors.endpoint}>
+                <input id="openapi-base-url" type="url" value={draft.endpoint || connectorText(draft.additionalFields.base_url)}
+                    disabled={readOnly} className={ACTION_INPUT_CLASS} placeholder="https://api.example.com"
+                    aria-invalid={Boolean(errors.endpoint || localErrors.endpoint)} aria-describedby="openapi-base-url-help openapi-base-url-error"
+                    onChange={(event) => {
+                        const endpoint = event.target.value;
+                        onChange((current) => ({ ...current, endpoint, additionalFields: { ...current.additionalFields, base_url: endpoint } }));
+                    }} />
+            </ActionField>
+            {information.servers.length ? <div className="space-y-2">
+                <p className="text-sm font-medium text-text-1">Servers declared in the specification</p>
+                <ul className="space-y-2">
+                    {information.servers.map((server, index) => <li key={`${server.url}-${index}`} className="flex flex-wrap items-center justify-between gap-2 rounded-xl border border-edge p-3">
+                        <div className="min-w-0">
+                            <p className="break-all font-mono text-xs text-text-1">{server.url}</p>
+                            {server.description ? <p className="mt-1 break-words text-xs text-text-3">{server.description}</p> : null}
+                        </div>
+                        {!readOnly ? <GlassButton type="button" size="sm" variant="subtle" disabled={Boolean(connectorUrlError(server.url))}
+                            onClick={() => onChange((current) => ({
+                                ...current, endpoint: server.url, additionalFields: { ...current.additionalFields, base_url: server.url },
+                            }))}>Use this base URL</GlassButton> : null}
+                    </li>)}
+                </ul>
+            </div> : null}
+            {information.title || information.operations.length ? <GlassPanel elevation="flat" className="space-y-4 p-4">
+                <div>
+                    <h3 className="break-words font-semibold text-text-1">{information.title || 'API information'}</h3>
+                    <p className="mt-1 text-xs text-text-3">
+                        API version {information.version || 'not specified'} · OpenAPI {information.specificationVersion || 'not specified'} · {information.pathsCount} paths · {information.operations.length} operations
+                    </p>
+                    {information.description ? <p className="mt-2 whitespace-pre-wrap break-words text-sm text-text-2">{information.description}</p> : null}
+                </div>
+                <ActionField id="openapi-operation-search" label="Find an operation">
+                    <input id="openapi-operation-search" type="search" className={ACTION_INPUT_CLASS} value={operationSearch}
+                        placeholder="Method, path, operation ID, or tag" onChange={(event) => {
+                            setOperationSearch(event.target.value); setOperationLimit(30);
+                        }} />
+                </ActionField>
+                <p className="text-xs text-text-3">{filteredOperations.length} matching operations. This is a read-only description, not an operation runner.</p>
+                <div className="space-y-2">
+                    {filteredOperations.slice(0, operationLimit).map((operation) => <details key={`${operation.method}:${operation.path}`} className="rounded-xl border border-edge p-3">
+                        <summary className="cursor-pointer break-words text-sm text-text-1">
+                            <span className="mr-2 font-mono font-semibold">{operation.method}</span>
+                            <span className="break-all font-mono text-xs">{operation.path}</span>
+                            {operation.summary ? <span className="ml-2">{operation.summary}</span> : null}
+                            {operation.deprecated ? <span className="ml-2 text-xs text-warn">Deprecated</span> : null}
+                        </summary>
+                        <div className="mt-3 space-y-3 text-xs text-text-2">
+                            <p>Operation ID: <span className="break-all font-mono">{operation.id || 'Generated by the connector'}</span></p>
+                            {operation.description ? <p className="whitespace-pre-wrap break-words">{operation.description}</p> : null}
+                            {operation.tags.length ? <p>Tags: {operation.tags.join(', ')}</p> : null}
+                            {operation.parameters.length ? <ul className="space-y-2">
+                                {operation.parameters.map((parameter) => <li key={`${parameter.location}:${parameter.name}`}>
+                                    <span className="break-all font-mono">{parameter.name}</span> ({parameter.location}, {parameter.type}{parameter.required ? ', required' : ', optional'})
+                                    {parameter.description ? <p className="mt-0.5 break-words text-text-3">{parameter.description}</p> : null}
+                                </li>)}
+                            </ul> : <p>No declared parameters.</p>}
+                            {operation.contentTypes.length ? <p>Request body ({operation.bodyRequired ? 'required' : 'optional'}): {operation.contentTypes.join(', ')}</p> : null}
+                            <p>Responses: {operation.responses.join(', ') || 'Not specified'}</p>
+                            <p>Security schemes: {operation.security.join(', ') || 'No declared requirement'}</p>
+                        </div>
+                    </details>)}
+                    {!filteredOperations.length ? <p className="text-sm text-text-3">No operations match this search.</p> : null}
+                    {filteredOperations.length > operationLimit ? <GlassButton type="button" variant="subtle" onClick={() => setOperationLimit((current) => current + 30)}>Show more operations</GlassButton> : null}
+                </div>
+                <details className="text-xs text-text-3">
+                    <summary className="cursor-pointer">Validated specification JSON</summary>
+                    <pre className="mt-2 max-h-96 overflow-auto whitespace-pre-wrap break-all rounded-lg bg-surface-1 p-3">{specJson}</pre>
+                </details>
+            </GlassPanel> : null}
+            <div className="space-y-3 border-t border-edge pt-4">
+                <p className="text-xs leading-relaxed text-text-3">Validation checks the manifest without running it. Connection testing parses the specification and probes the authenticated base URL; it does not invoke an individual API operation.</p>
+                <div className="flex flex-wrap items-center gap-2">
+                    <GlassButton type="button" variant="subtle" disabled={readOnly || Boolean(busy) || source.pending}
+                        onClick={() => void run('Validating configuration…', (signal) => validateApiConnector(draft, original, 'openapi', signal))}>
+                        Validate OpenAPI configuration
+                    </GlassButton>
+                    <GlassButton type="button" variant="subtle" disabled={readOnly || Boolean(busy) || source.pending}
+                        onClick={() => void run('Testing OpenAPI connection…', (signal) => testApiConnector(draft, original, 'openapi', signal))}>
+                        Test OpenAPI connection
+                    </GlassButton>
+                    {busy ? <p role="status" className="text-sm text-text-3">{busy}</p> : null}
+                </div>
+                {readOnly ? <p className="text-xs text-text-3">Provided actions are read-only. Import, validation, and connection testing are disabled.</p> : null}
+                <ConnectorFeedbackPanel feedback={feedback} stale={stale} />
+            </div>
+        </div>
+    );
+}
+
+export function OpenApiActionAuthentication(props: ActionConnectorProps) {
+    const { draft, original, onChange, errors } = props;
+    const readOnly = props.readOnly || Boolean(original?.read_only);
+    const method = connectorAuthMethod(draft, 'openapi');
+    const apiKeyIdentity = Boolean(draft.identity_id && draft.additionalFields.identity_auth_type === 'api_key');
+    const credentialField = connectorSecretField(draft, 'openapi');
+    const basic = openApiBasicCredentials(draft);
+    const specContent = draft.additionalFields.openapi_spec_content;
+    const information = useMemo(() => openApiInformation(specContent), [specContent]);
+    const localErrors = validateConnectorAuthentication(draft, 'openapi', original);
+    useConnectorValidity(props, 'openapi-authentication', Object.values(localErrors).join(' ') || null);
+    const location = connectorText(draft.additionalFields.api_key_location ?? draft.auth.location ?? 'header');
+    const usernameMasked = draft.auth.username === EDITOR_SECRET_MASK || draft.auth.identity === EDITOR_SECRET_MASK;
+    const setAuthField = (field: string, value: string) => onChange((current) => ({ ...current, auth: { ...current.auth, [field]: value } }));
+    const authError = (field: string) => errors[field] || localErrors[field];
+    return (
+        <div className="space-y-5" data-testid="openapi-authentication">
+            <ConnectorIdentitySelect {...props} kind="openapi" />
+            <ActionField id="openapi-auth-method" label="Authentication method" error={authError('additionalFields.auth_method')}
+                help={draft.identity_id ? 'The selected reusable identity controls authentication.' : 'Changing a method does not test or run the action. Choosing no authentication clears action-specific credentials, including their legacy aliases.'}>
+                <select id="openapi-auth-method" className={ACTION_INPUT_CLASS} value={method} disabled={readOnly || Boolean(draft.identity_id)}
+                    onChange={(event) => {
+                        const next = event.target.value;
+                        onChange((current) => changeConnectorAuthMethod(current, 'openapi', next));
+                    }}>
+                    {method === 'identity' ? <option value="identity">Reusable identity</option> : null}
+                    {!OPENAPI_AUTH_OPTIONS.some(({ value }) => value === method) && method !== 'identity' ? <option value={method} disabled>Unavailable method — {method}</option> : null}
+                    {OPENAPI_AUTH_OPTIONS.map((option) => <option key={option.value} value={option.value}>{option.label}</option>)}
+                </select>
+            </ActionField>
+            {(method === 'api_key' && !draft.identity_id) || apiKeyIdentity ? <div className="grid gap-4 sm:grid-cols-2">
+                <ActionField id="openapi-key-location" label="API key location" error={authError('additionalFields.api_key_location')}>
+                    <select id="openapi-key-location" value={location} disabled={readOnly} className={ACTION_INPUT_CLASS}
+                        onChange={(event) => {
+                            const api_key_location = event.target.value;
+                            onChange((current) => updateConnectorFields(current, { api_key_location }));
+                        }}>
+                        {!['header', 'query'].includes(location) ? <option value={location} disabled>Unsupported location — {location}</option> : null}
+                        <option value="header">HTTP header</option><option value="query">Query parameter</option>
+                    </select>
+                </ActionField>
+                <ActionField id="openapi-key-name" label={location === 'query' ? 'Query parameter name' : 'Header name'} required error={authError('additionalFields.api_key_name')}>
+                    <input id="openapi-key-name" className={ACTION_INPUT_CLASS} disabled={readOnly}
+                        value={connectorText(draft.additionalFields.api_key_name ?? draft.auth.name ?? 'X-API-Key')}
+                        onChange={(event) => {
+                            const api_key_name = event.target.value;
+                            onChange((current) => updateConnectorFields(current, { api_key_name }));
+                        }} />
+                </ActionField>
+            </div> : null}
+            {method === 'basic' && !draft.identity_id ? <div className="space-y-4">
+                {basic.stored && credentialField === 'key' ? <p className="rounded-xl bg-surface-2 p-3 text-sm text-text-2">
+                    A stored username/password pair is configured. Its username is also hidden. Keep the stored pair unchanged, or enter both values to replace it.
+                </p> : null}
+                {usernameMasked && draft.auth.type === 'basic' ? <ActionSecretInput
+                    id="openapi-basic-username" label="Username" value={draft.auth.username ?? draft.auth.identity}
+                    storedValue={original?.record.auth.username ?? original?.record.auth.identity} disabled={readOnly}
+                    error={authError('auth.basic_username')}
+                    onChange={(value) => setAuthField(Object.hasOwn(draft.auth, 'username') ? 'username' : 'identity', value)} /> :
+                    <ActionField id="openapi-basic-username" label="Username" required error={authError('auth.basic_username')}>
+                        <input id="openapi-basic-username" value={basic.username} className={ACTION_INPUT_CLASS} disabled={readOnly}
+                            autoComplete="off" placeholder={basic.stored ? 'Stored with password — enter both to replace' : 'Username'}
+                            onChange={(event) => {
+                                const value = event.target.value;
+                                onChange((current) => changeOpenApiBasicCredential(current, 'username', value));
+                            }} />
+                    </ActionField>}
+                <ActionSecretInput id="openapi-basic-password" label="Password" value={basic.password}
+                    storedValue={original?.record.auth[credentialField]} disabled={readOnly} error={authError(`auth.${credentialField}`)}
+                    help={credentialField === 'key' ? 'OpenAPI basic credentials are stored together as username:password. Clearing this field clears the pair; replacing either part requires both values.' : undefined}
+                    onChange={(value) => onChange((current) => changeOpenApiBasicCredential(current, 'password', value))} />
+            </div> : null}
+            {['api_key', 'bearer', 'oauth2'].includes(method) && !draft.identity_id ? <ActionSecretInput
+                id="openapi-credential" label={method === 'api_key' ? 'API key' : method === 'oauth2' ? 'OAuth 2 access token' : 'Bearer token'}
+                value={draft.auth[credentialField]} storedValue={original?.record.auth[credentialField]}
+                disabled={readOnly} error={authError(`auth.${credentialField}`)}
+                help={method === 'oauth2' ? 'Supply an access token obtained from your provider. This connector does not perform an interactive OAuth sign-in or refresh-token flow.' : undefined}
+                onChange={(value) => setAuthField(credentialField, value)} /> : null}
+            {information.securitySchemes.length ? <div className="space-y-3">
+                <h3 className="text-sm font-semibold text-text-1">Authentication declared by the API</h3>
+                <p className="text-xs text-text-3">Selecting a scheme only configures its method and key location. Credentials and reusable identity references are never imported from a specification.</p>
+                {information.securitySchemes.map((scheme) => <GlassPanel key={scheme.id} elevation="flat" className="space-y-2 p-3">
+                    <p className="break-words text-sm font-medium text-text-1">{scheme.id} · {scheme.method || 'Unspecified scheme'}</p>
+                    {scheme.description ? <p className="whitespace-pre-wrap break-words text-xs text-text-2">{scheme.description}</p> : null}
+                    {scheme.method === 'api_key' ? <p className="break-words text-xs text-text-3">{scheme.location}: {scheme.name}</p> : null}
+                    {scheme.scopes.length ? <p className="break-words text-xs text-text-3">Declared scopes: {scheme.scopes.join(', ')}</p> : null}
+                    {scheme.supported ? <GlassButton type="button" size="sm" variant="subtle" disabled={readOnly || Boolean(draft.identity_id)}
+                        onClick={() => onChange((current) => {
+                            const next = changeConnectorAuthMethod(current, 'openapi', scheme.method);
+                            return scheme.method === 'api_key' ? updateConnectorFields(next, { api_key_location: scheme.location, api_key_name: scheme.name }) : next;
+                        })}>Use this authentication scheme</GlassButton> :
+                        <p className="text-xs text-warn">This scheme or location is not supported by the current OpenAPI connector. Choose one of the supported methods above.</p>}
+                </GlassPanel>)}
+            </div> : null}
+            {Object.keys(connectorObject(draft.additionalFields.openapi_authentication)).length ? <p className="text-xs text-text-3">Legacy authentication analysis is retained in additional fields.</p> : null}
+        </div>
+    );
+}

--- a/application/v2_ui/src/components/workspaceAgents/AgentActionPicker.tsx
+++ b/application/v2_ui/src/components/workspaceAgents/AgentActionPicker.tsx
@@ -1,0 +1,174 @@
+// AgentActionPicker.tsx
+
+import { useState, type Dispatch, type SetStateAction } from 'react';
+import { Plus, RefreshCw, Trash2 } from 'lucide-react';
+import { actionTarget, referenceKey, type AgentTargetCatalog } from '../../lib/agentDelegation';
+import type { ActionConfiguration, AgentConfiguration, AgentEditorOptions } from '../../lib/workspaceAuthoring';
+import {
+    AGENT_ACTION_CAPABILITIES, agentActionCapabilities, agentActionLabel, agentActionUnavailableReason,
+    agentHasAction, resolveAgentAction, toggleAgentAction, updateAgentCapability,
+} from '../../lib/workspaceAgentActions';
+import { AGENT_INPUT_CLASS } from '../../lib/workspaceAgentAuthoring';
+import { GlassButton, GlassPanel } from '../ui/primitives';
+import { Pill, SectionSearch } from '../workspace/primitives';
+import { AgentField, AgentNotice } from './AgentFields';
+
+export function AgentActionPicker({
+    draft, setDraft, actions, targets, loading, error, targetError, ownerId, builtinActions,
+    canCreateActions, onRefresh, onNewAction, readOnly,
+}: {
+    draft: AgentConfiguration;
+    setDraft: Dispatch<SetStateAction<AgentConfiguration>>;
+    actions: ActionConfiguration[];
+    targets: AgentTargetCatalog | null;
+    loading: boolean;
+    error: string | null;
+    targetError: string | null;
+    ownerId: string;
+    builtinActions: AgentEditorOptions['builtin_actions'];
+    canCreateActions: boolean;
+    onRefresh: () => void;
+    onNewAction: () => void;
+    readOnly: boolean;
+}) {
+    const [query, setQuery] = useState('');
+    const [typeFilter, setTypeFilter] = useState('');
+    const [selectedOnly, setSelectedOnly] = useState(false);
+    const [confirmDetach, setConfirmDetach] = useState(false);
+    const unresolved = draft.actions_to_load.filter((reference) => !resolveAgentAction(reference, actions));
+    const types = [...new Set(actions.map((action) => action.type))].sort();
+    const visible = actions.filter((action) =>
+        `${agentActionLabel(action)} ${action.name} ${action.description} ${action.type} ${action.type === 'agent' ? 'Call agent' : ''}`.toLowerCase().includes(query.trim().toLowerCase()) &&
+        (!typeFilter || action.type === typeFilter) && (!selectedOnly || agentHasAction(draft, action, actions)));
+
+    if (draft.agent_type !== 'local') {
+        return (
+            <div className="space-y-3">
+                <AgentNotice>Foundry manages this agent’s tools. Local action assignment and capability controls are not editable for this type.</AgentNotice>
+                {error ? <AgentNotice error>{error} Existing references remain in the draft.</AgentNotice> : null}
+                {targetError ? <AgentNotice error>{targetError}</AgentNotice> : null}
+                {draft.actions_to_load.length ? (
+                    <div className="space-y-3 rounded-xl border border-warn/40 p-3">
+                        <p className="text-sm text-text-2">These local actions are still in the draft. Detach them explicitly to save a Foundry agent, or switch back to Local.</p>
+                        <ul className="list-inside list-disc text-sm text-text-3">
+                            {draft.actions_to_load.map((reference) => {
+                                const action = resolveAgentAction(reference, actions);
+                                return <li key={reference}>{action ? agentActionLabel(action) : reference}</li>;
+                            })}
+                        </ul>
+                        {!readOnly ? confirmDetach ? (
+                            <div className="space-y-2">
+                                <p className="text-sm text-warn">Detach all {draft.actions_to_load.length} local action references? Their capability settings will be retained.</p>
+                                <div className="flex flex-wrap gap-2">
+                                    <GlassButton type="button" size="sm" onClick={() => setConfirmDetach(false)}>Keep actions</GlassButton>
+                                    <GlassButton type="button" size="sm" variant="danger" onClick={() => {
+                                        setDraft((current) => ({ ...current, actions_to_load: [] }));
+                                        setConfirmDetach(false);
+                                    }}>Confirm detach</GlassButton>
+                                </div>
+                            </div>
+                        ) : <GlassButton type="button" size="sm" onClick={() => setConfirmDetach(true)}>Detach local actions</GlassButton> : null}
+                    </div>
+                ) : null}
+            </div>
+        );
+    }
+    return (
+        <div className="space-y-4">
+            <p className="text-sm text-text-3">Select actions for this agent. Capability choices apply only to this assignment. Call agent appears here like any other action; its target remains configured on the action.</p>
+            <div className="flex flex-wrap gap-2">
+                {!readOnly && canCreateActions ? <GlassButton type="button" size="sm" onClick={onNewAction}><Plus size={14} />New action</GlassButton> : null}
+                <GlassButton type="button" size="sm" disabled={loading} onClick={onRefresh}><RefreshCw size={14} />Refresh actions</GlassButton>
+                <label className="flex items-center gap-2 text-xs text-text-2">
+                    <input type="checkbox" checked={selectedOnly} onChange={(event) => setSelectedOnly(event.target.checked)} className="accent-accent" />
+                    Selected only
+                </label>
+            </div>
+            {!canCreateActions && !readOnly ? <AgentNotice>Creating actions is unavailable in this workspace. You can still assign permitted existing actions from the authorized catalogue.</AgentNotice> : null}
+            {error ? <AgentNotice error>{error} Existing references have not been removed.</AgentNotice> : null}
+            {targetError ? <AgentNotice error>{targetError} Call agent targets could not be checked; existing assignments are preserved.</AgentNotice> : null}
+            {loading ? <p role="status" className="text-sm text-text-3">Loading available actions…</p> : null}
+            <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_12rem]">
+                <SectionSearch value={query} onChange={setQuery} placeholder="Search actions by name, description or type" />
+                <AgentField id="agent-action-type-filter" label="Action type">
+                    <select id="agent-action-type-filter" value={typeFilter} onChange={(event) => setTypeFilter(event.target.value)} className={AGENT_INPUT_CLASS}>
+                        <option value="">All action types</option>
+                        {types.map((type) => <option key={type} value={type}>{type === 'agent' ? 'Call agent' : type}</option>)}
+                    </select>
+                </AgentField>
+            </div>
+            <div className="space-y-2">
+                {visible.map((action) => {
+                    const checked = agentHasAction(draft, action, actions);
+                    const reason = agentActionUnavailableReason(draft, action, targets, ownerId);
+                    const target = actionTarget(action);
+                    const targetDetails = target ? targets?.targets.find((item) => referenceKey(item) === referenceKey(target)) : null;
+                    const capabilities = agentActionCapabilities(draft, action);
+                    const definitions = AGENT_ACTION_CAPABILITIES[action.type] ?? [];
+                    const label = agentActionLabel(action);
+                    return (
+                        <GlassPanel key={`${action.is_global ? 'global' : 'personal'}:${action.id}`} elevation="flat" className="space-y-3 border border-edge p-3">
+                            <label className="flex items-start gap-3">
+                                <input type="checkbox" className="mt-1 accent-accent" checked={checked} aria-label={`Assign ${label}`}
+                                    disabled={readOnly || (!checked && (loading || Boolean(error) || Boolean(reason)))}
+                                    onChange={(event) => setDraft((current) => toggleAgentAction(current, action, event.target.checked, actions))} />
+                                <span className="min-w-0 flex-1">
+                                    <span className="flex flex-wrap items-center gap-2 text-sm font-medium text-text-1">
+                                        {label}<Pill>{action.type === 'agent' ? 'Call agent' : action.type}</Pill>
+                                        {action.is_global ? <Pill tone="accent">Provided</Pill> : <Pill>Personal</Pill>}
+                                    </span>
+                                    <span className="mt-1 block break-words text-xs text-text-3">{action.description}</span>
+                                    <span className="mt-1 block break-all text-[11px] text-text-3">ID: {action.id}</span>
+                                    {action.type === 'agent' && target ? (
+                                        <span className="mt-1 block break-words text-xs text-text-2">Calls {targetDetails?.display_name || targetDetails?.name || target.id} · {target.scope_type}</span>
+                                    ) : null}
+                                    {reason ? <span className="mt-1 block text-xs text-warn">{reason}{checked ? ' This saved reference remains until you remove it.' : ''}</span> : null}
+                                </span>
+                            </label>
+                            {checked && definitions.length ? (
+                                <details className="rounded-lg border border-edge p-3" open>
+                                    <summary className="cursor-pointer text-xs font-medium text-text-2">Capabilities for {label}</summary>
+                                    <div className="mt-3 grid gap-2 sm:grid-cols-2">
+                                        {definitions.map((capability) => (
+                                            <label key={capability.key} className="flex items-start gap-2 text-xs text-text-2">
+                                                <input type="checkbox" className="mt-0.5 accent-accent" checked={Boolean(capabilities[capability.key])}
+                                                    disabled={readOnly || loading || Boolean(error)}
+                                                    onChange={(event) => setDraft((current) => updateAgentCapability(current, action, capability.key, event.target.checked))} />
+                                                <span>{capability.label}<code className="mt-0.5 block break-all text-[10px] text-text-3">{capability.key}</code></span>
+                                            </label>
+                                        ))}
+                                    </div>
+                                </details>
+                            ) : null}
+                        </GlassPanel>
+                    );
+                })}
+            </div>
+            {!visible.length && !loading && !error ? <p role="status" className="text-sm text-text-3">No actions match. Adjust the filters or refresh the authorized catalogue.</p> : null}
+            {unresolved.length ? (
+                <div className="space-y-2 rounded-xl border border-warn/30 p-3">
+                    <h4 className="text-sm font-medium text-text-1">Saved references to review</h4>
+                    <p className="text-xs text-text-3">Unlisted, ambiguous, and legacy references are kept during unrelated edits. Remove one only when you no longer want it assigned.</p>
+                    {unresolved.map((reference) => (
+                        <div key={reference} className="flex flex-wrap items-center justify-between gap-2 text-sm text-text-2">
+                            <code className="min-w-0 break-all">{reference}</code>
+                            {!readOnly ? <GlassButton type="button" size="sm" aria-label={`Remove action reference ${reference}`}
+                                onClick={() => setDraft((current) => ({ ...current, actions_to_load: current.actions_to_load.filter((item) => item !== reference) }))}>
+                                <Trash2 size={13} />Remove reference
+                            </GlassButton> : null}
+                        </div>
+                    ))}
+                </div>
+            ) : null}
+            {builtinActions.length ? (
+                <div className="rounded-xl border border-edge p-3">
+                    <h4 className="text-sm font-medium text-text-2">Enabled built-in tools</h4>
+                    <p className="mt-1 text-xs text-text-3">Provided by your administrator; these are not personal settings.</p>
+                    <ul className="mt-2 space-y-1 text-xs text-text-2">
+                        {builtinActions.map((action) => <li key={action.id}>{action.label}{action.description ? ` — ${action.description}` : ''}</li>)}
+                    </ul>
+                </div>
+            ) : null}
+        </div>
+    );
+}

--- a/application/v2_ui/src/components/workspaceAgents/AgentAdvancedFields.tsx
+++ b/application/v2_ui/src/components/workspaceAgents/AgentAdvancedFields.tsx
@@ -1,0 +1,109 @@
+// AgentAdvancedFields.tsx
+
+import type { Dispatch, SetStateAction } from 'react';
+import { getModelSupportedLevels } from '../../lib/reasoning';
+import type { AgentConfiguration, AgentEditorOptions, AuthoringResource } from '../../lib/workspaceAuthoring';
+import {
+    AGENT_INPUT_CLASS, agentModelChoices, agentStoredArrayEditError, agentText, clearAgentDraftFields, parseAgentSettings,
+    secretValueAt, selectedAgentModel, setAgentSecret,
+} from '../../lib/workspaceAgentAuthoring';
+import { GlassButton } from '../ui/primitives';
+import { AgentField, AgentNotice, AgentSecretField } from './AgentFields';
+
+export function agentAdvancedError(
+    draft: AgentConfiguration, original: AuthoringResource<AgentConfiguration> | null = null,
+): string | null {
+    const storedArrayError = agentText(draft._editor_array_secret_error) || agentStoredArrayEditError(draft, original);
+    if (storedArrayError) return storedArrayError;
+    if (typeof draft._editor_settings_text !== 'string') return null;
+    try {
+        const settings = parseAgentSettings(draft._editor_settings_text, draft.other_settings);
+        return agentStoredArrayEditError({ ...draft, other_settings: settings }, original);
+    } catch (error) {
+        return error instanceof Error ? error.message : 'Invalid additional-settings JSON.';
+    }
+}
+
+export function AgentAdvancedFields({
+    draft, setDraft, original, options,
+}: {
+    draft: AgentConfiguration;
+    setDraft: Dispatch<SetStateAction<AgentConfiguration>>;
+    original: AuthoringResource<AgentConfiguration> | null;
+    options: AgentEditorOptions;
+}) {
+    const selectedModel = selectedAgentModel(draft, agentModelChoices(options));
+    const levels = getModelSupportedLevels(selectedModel?.modelName || draft.model_id || draft.azure_openai_gpt_deployment || draft.azure_agent_apim_gpt_deployment);
+    const rawSettings = typeof draft._editor_settings_text === 'string' ? draft._editor_settings_text : JSON.stringify(draft.other_settings, null, 2);
+    const error = agentAdvancedError(draft, original);
+    return (
+        <div className="space-y-4">
+            {draft.agent_type === 'local' ? (
+                <div className="grid gap-4 sm:grid-cols-2">
+                    <AgentField id="agent-completion-tokens" label="Completion token limit" help="-1 uses the model default. Zero is retained as an explicit value. Maximum: 512000.">
+                        <input id="agent-completion-tokens" type="number" min={-1} max={512000} step={1} required
+                            value={typeof draft._editor_completion_text === 'string' ? draft._editor_completion_text : draft.max_completion_tokens}
+                            onChange={(event) => setDraft((current) => {
+                                const value = event.target.value;
+                                const next = { ...current, max_completion_tokens: value === '' ? Number.NaN : Number(value) };
+                                return value === '' ? { ...next, _editor_completion_text: value } : clearAgentDraftFields(next, '_editor_completion_text');
+                            })} className={AGENT_INPUT_CLASS} />
+                    </AgentField>
+                    <AgentField id="agent-reasoning-effort" label="Reasoning effort" help="Only levels supported by the selected model are offered. An existing unsupported value is retained for explicit review.">
+                        <select id="agent-reasoning-effort" value={draft.reasoning_effort ?? ''} className={AGENT_INPUT_CLASS}
+                            onChange={(event) => setDraft((current) => {
+                                const next = { ...current };
+                                if (event.target.value) next.reasoning_effort = event.target.value;
+                                else delete next.reasoning_effort;
+                                return next;
+                            })}>
+                            <option value="">Use configured default</option>
+                            {draft.reasoning_effort && !levels.some((level) => level === draft.reasoning_effort) ? <option value={draft.reasoning_effort}>Saved value (unsupported by selected model): {draft.reasoning_effort}</option> : null}
+                            {levels.map((level) => <option key={level} value={level}>{level[0].toUpperCase() + level.slice(1)}</option>)}
+                        </select>
+                    </AgentField>
+                </div>
+            ) : <p className="text-sm text-text-3">Token and reasoning behavior are managed by the selected Foundry resource. Saved local values remain intact.</p>}
+            <AgentField id="agent-additional-settings" label="Additional settings JSON"
+                help="This is the same draft used by the structured controls. Managed action, knowledge and provider siblings are preserved when omitted from a pasted object. Explicit values, including false, zero and empty arrays, are retained.">
+                <textarea id="agent-additional-settings" rows={16} value={rawSettings} spellCheck={false}
+                    aria-invalid={Boolean(error)} className={`${AGENT_INPUT_CLASS} font-mono text-xs`}
+                    onChange={(event) => {
+                        const raw = event.target.value;
+                        setDraft((current) => {
+                            try {
+                                return { ...current, other_settings: parseAgentSettings(raw, current.other_settings), _editor_settings_text: raw };
+                            } catch {
+                                return { ...current, _editor_settings_text: raw };
+                            }
+                        });
+                    }}
+                    onBlur={() => {
+                        if (!error) setDraft((current) => clearAgentDraftFields(current, '_editor_settings_text'));
+                    }} />
+            </AgentField>
+            {original?.secret_paths.length ? <p className="text-xs text-text-3">
+                Array credentials are tied to saved positions, not entry names or IDs. Individual credential controls can replace or clear them.
+                Unrelated JSON fields remain editable; changing a retained entry or array structure requires replacing or clearing the affected stored credentials first.
+            </p> : null}
+            {error ? (
+                <AgentNotice error>
+                    {error} Fix the JSON or reset its text before changing structured settings or saving.
+                    <div className="mt-2"><GlassButton type="button" size="sm" onClick={() => setDraft((current) => clearAgentDraftFields(current, '_editor_settings_text', '_editor_array_secret_error'))}>Reset JSON text to current settings</GlassButton></div>
+                </AgentNotice>
+            ) : null}
+            {original?.secret_paths.length ? (
+                <details className="rounded-xl border border-edge p-3">
+                    <summary className="cursor-pointer text-sm font-medium text-text-2">Stored credentials and custom secret fields</summary>
+                    <fieldset disabled={Boolean(error)} className="mt-3 space-y-4">
+                        <legend className="sr-only">Secret field changes</legend>
+                        {original.secret_paths.map((path) => <AgentSecretField key={path} label={path}
+                            value={secretValueAt(draft, path)} original={secretValueAt(original.record, path)}
+                            onChange={(value) => setDraft((current) => setAgentSecret(current, path, value))} />)}
+                    </fieldset>
+                </details>
+            ) : null}
+            <p className="text-xs text-text-3">Ownership and the stable ID are not editable JSON settings. {agentText(draft.id) ? `Agent ID: ${draft.id}` : 'A stable ID is allocated on save.'}</p>
+        </div>
+    );
+}

--- a/application/v2_ui/src/components/workspaceAgents/AgentFields.tsx
+++ b/application/v2_ui/src/components/workspaceAgents/AgentFields.tsx
@@ -1,0 +1,77 @@
+// AgentFields.tsx
+
+import { useId, useState, type InputHTMLAttributes, type ReactNode } from 'react';
+import { EDITOR_SECRET_MASK } from '../../lib/workspaceAuthoring';
+import { AGENT_INPUT_CLASS, agentText, secretIntent } from '../../lib/workspaceAgentAuthoring';
+
+export function AgentField({
+    label, help, children, id,
+}: { label: string; help?: string; children: ReactNode; id: string }) {
+    return (
+        <div className="min-w-0">
+            <label htmlFor={id} className="mb-1 block break-words text-sm font-medium text-text-2">{label}</label>
+            {children}
+            {help ? <p id={`${id}-help`} className="mt-1 text-xs leading-relaxed text-text-3">{help}</p> : null}
+        </div>
+    );
+}
+
+export function AgentTextField({
+    label, value, onChange, help, ...props
+}: Omit<InputHTMLAttributes<HTMLInputElement>, 'onChange' | 'value'> & {
+    label: string; value: unknown; onChange: (value: string) => void; help?: string;
+}) {
+    const generatedId = useId();
+    const id = props.id || generatedId;
+    return (
+        <AgentField id={id} label={label} help={help}>
+            <input {...props} id={id} value={agentText(value)} onChange={(event) => onChange(event.target.value)}
+                aria-describedby={help ? `${id}-help` : undefined} className={AGENT_INPUT_CLASS} />
+        </AgentField>
+    );
+}
+
+export function AgentSecretField({
+    label, value, original, onChange,
+}: { label: string; value: unknown; original: unknown; onChange: (value: string) => void }) {
+    const id = useId();
+    const stored = original === EDITOR_SECRET_MASK;
+    const [replacing, setReplacing] = useState(() => stored && secretIntent(value, original) === 'replace');
+    const intent = replacing ? 'replace' : secretIntent(value, original);
+    return (
+        <div className="min-w-0 space-y-2">
+            {stored ? (
+                <AgentField id={`${id}-intent`} label={label} help="The stored value is never sent to this page. Keep it, replace it, or explicitly clear it on save.">
+                    <select id={`${id}-intent`} value={intent} className={AGENT_INPUT_CLASS}
+                        onChange={(event) => {
+                            const mode = event.target.value;
+                            setReplacing(mode === 'replace');
+                            if (mode === 'keep') onChange(EDITOR_SECRET_MASK);
+                            if (mode === 'clear') onChange('');
+                            if (mode === 'replace' && !value) onChange(EDITOR_SECRET_MASK);
+                        }}>
+                        <option value="keep">Keep saved value</option>
+                        <option value="replace">Replace saved value</option>
+                        <option value="clear">Clear saved value</option>
+                    </select>
+                </AgentField>
+            ) : null}
+            {!stored || intent === 'replace' ? (
+                <AgentTextField label={stored ? `Replacement ${label.toLowerCase()}` : label} type="password"
+                    value={value === EDITOR_SECRET_MASK ? '' : value} autoComplete="new-password"
+                    onChange={(next) => onChange(stored && !next ? EDITOR_SECRET_MASK : next)}
+                    help={stored ? 'Enter a replacement. An empty replacement keeps the saved value; use Clear saved value to delete it.' : 'Optional. Never included in template submissions.'} />
+            ) : null}
+            {stored && intent === 'clear' ? <p role="status" className="text-xs text-warn">The saved value will be cleared when you save.</p> : null}
+        </div>
+    );
+}
+
+export function AgentNotice({ children, error = false }: { children: ReactNode; error?: boolean }) {
+    return (
+        <div role={error ? 'alert' : 'status'}
+            className={`rounded-xl border p-3 text-sm ${error ? 'border-danger/30 bg-danger-soft text-danger' : 'border-edge bg-surface-2 text-text-2'}`}>
+            {children}
+        </div>
+    );
+}

--- a/application/v2_ui/src/components/workspaceAgents/AgentIdentityFields.tsx
+++ b/application/v2_ui/src/components/workspaceAgents/AgentIdentityFields.tsx
@@ -1,0 +1,180 @@
+// AgentIdentityFields.tsx
+
+import { useEffect, useRef, useState, type Dispatch, type SetStateAction } from 'react';
+import { Bot } from 'lucide-react';
+import { api } from '../../lib/apiClient';
+import type { AgentConfiguration, AgentEditorOptions, WorkspaceAgentType } from '../../lib/workspaceAuthoring';
+import {
+    AGENT_INPUT_CLASS, AGENT_TYPE_LABELS, changeAgentType, clearAgentDraftFields, isAgentIconImage, renameAgentDraft,
+} from '../../lib/workspaceAgentAuthoring';
+import { GlassButton } from '../ui/primitives';
+import { AgentField, AgentNotice, AgentTextField } from './AgentFields';
+
+const ICON_FALLBACKS = [
+    'bi-robot', 'bi-stars', 'bi-lightbulb', 'bi-search', 'bi-graph-up', 'bi-shield-check',
+    'bi-code-square', 'bi-database', 'bi-envelope', 'bi-calendar-check', 'bi-file-earmark-text',
+    'bi-bar-chart', 'bi-diagram-3', 'bi-globe', 'bi-gear', 'bi-person-workspace',
+];
+
+export function AgentIcon({ icon }: { icon: AgentConfiguration['icon'] }) {
+    if (icon?.kind === 'image' && isAgentIconImage(icon.value)) return <img src={icon.value} alt="" className="h-10 w-10 shrink-0 rounded-xl object-contain" />;
+    if (icon?.kind === 'bootstrap' && /^bi-[a-z0-9][a-z0-9-]{0,80}$/.test(icon.value)) {
+        return <i aria-hidden="true" className={`bi ${icon.value} flex h-10 w-10 shrink-0 items-center justify-center text-xl text-accent`} />;
+    }
+    return <Bot aria-hidden="true" size={28} className="shrink-0 text-accent" />;
+}
+
+async function resizeAgentIcon(file: File): Promise<string> {
+    if (!['image/png', 'image/jpeg'].includes(file.type)) throw new Error('Choose a PNG or JPEG image.');
+    const url = URL.createObjectURL(file);
+    try {
+        const image = new Image();
+        image.src = url;
+        await image.decode();
+        const scale = Math.min(1, 128 / Math.max(image.width, image.height));
+        const canvas = document.createElement('canvas');
+        canvas.width = Math.max(1, Math.round(image.width * scale));
+        canvas.height = Math.max(1, Math.round(image.height * scale));
+        const context = canvas.getContext('2d');
+        if (!context) throw new Error('This browser cannot resize the icon.');
+        context.drawImage(image, 0, 0, canvas.width, canvas.height);
+        const data = canvas.toDataURL('image/png');
+        if (!isAgentIconImage(data)) throw new Error('The resized icon exceeds the 350000-character limit.');
+        return data;
+    } finally {
+        URL.revokeObjectURL(url);
+    }
+}
+
+export function AgentIdentityFields({
+    draft, setDraft, options, isNew, onIconBusyChange,
+}: {
+    draft: AgentConfiguration; setDraft: Dispatch<SetStateAction<AgentConfiguration>>;
+    options: AgentEditorOptions; isNew: boolean; onIconBusyChange?: (busy: boolean) => void;
+}) {
+    const [icons, setIcons] = useState(ICON_FALLBACKS);
+    const [iconSearch, setIconSearch] = useState('');
+    const [iconError, setIconError] = useState<string | null>(null);
+    const [imageBusy, setImageBusy] = useState(false);
+    const uploadSequence = useRef(0);
+    useEffect(() => () => { uploadSequence.current += 1; }, []);
+
+    const loadIcons = async () => {
+        setIconError(null);
+        try {
+            const css = await api.get<string>('/static/css/bootstrap-icons.css');
+            const available = [...new Set([...css.matchAll(/\.bi-([a-z0-9][a-z0-9-]*)::before/g)].map((match) => `bi-${match[1]}`))].sort();
+            if (!available.length) throw new Error('The local icon catalogue could not be read.');
+            setIcons(available);
+        } catch (error) {
+            setIconError(error instanceof Error ? error.message : 'Could not load the local icon catalogue.');
+        }
+    };
+
+    const uploadIcon = async (file: File) => {
+        const sequence = ++uploadSequence.current;
+        setImageBusy(true);
+        onIconBusyChange?.(true);
+        setIconError(null);
+        try {
+            const value = await resizeAgentIcon(file);
+            if (sequence === uploadSequence.current) setDraft((current) => ({ ...current, icon: { kind: 'image', value, mime_type: 'image/png' } }));
+        } catch (error) {
+            if (sequence === uploadSequence.current) setIconError(error instanceof Error ? error.message : 'Could not load the image.');
+        } finally {
+            if (sequence === uploadSequence.current) {
+                setImageBusy(false);
+                onIconBusyChange?.(false);
+            }
+        }
+    };
+    const currentIcon = draft.icon?.kind === 'bootstrap' ? draft.icon.value : '';
+    const visibleIcons = icons.filter((icon) => icon.includes(iconSearch.toLowerCase()));
+
+    return (
+        <div className="space-y-4">
+            <link rel="stylesheet" href="/static/css/bootstrap-icons.css" />
+            <AgentTextField id="agent-display-name" label="Display name" value={draft.display_name} required
+                onChange={(value) => setDraft((current) => renameAgentDraft(current, value, isNew))} />
+            <AgentField id="agent-description" label="Description" help="Explain what this agent does and when someone should choose it.">
+                <textarea id="agent-description" rows={3} value={draft.description} required className={AGENT_INPUT_CLASS}
+                    onChange={(event) => setDraft((current) => ({ ...current, description: event.target.value }))} />
+            </AgentField>
+            <AgentTextField label="Tags" value={typeof draft._editor_tags_text === 'string' ? draft._editor_tags_text : (draft.tags ?? []).join(', ')}
+                help="Comma-separated. Up to 20 tags, each at most 40 characters."
+                onChange={(value) => setDraft((current) => ({
+                    ...current, tags: [...new Set(value.split(',').map((tag) => tag.trim()).filter(Boolean))], _editor_tags_text: value,
+                }))} onBlur={() => setDraft((current) => clearAgentDraftFields(current, '_editor_tags_text'))} />
+            <fieldset className="space-y-2">
+                <legend className="mb-2 text-sm font-medium text-text-2">Agent type</legend>
+                <div className="grid gap-2 sm:grid-cols-2">
+                    {(Object.keys(AGENT_TYPE_LABELS) as WorkspaceAgentType[]).map((type) => {
+                        const option = options.agent_types.find((item) => item.value === type);
+                        return (
+                            <label key={type} className={`flex items-start gap-2 rounded-xl border p-3 ${draft.agent_type === type ? 'border-accent bg-accent-soft' : 'border-edge'} ${!option?.enabled ? 'opacity-60' : ''}`}>
+                                <input type="radio" name="workspace-agent-type" value={type} checked={draft.agent_type === type}
+                                    disabled={!option?.enabled} className="mt-1 accent-accent"
+                                    onChange={() => setDraft((current) => changeAgentType(current, type))} />
+                                <span className="min-w-0 text-sm text-text-1">{option?.label || AGENT_TYPE_LABELS[type]}
+                                    {!option?.enabled ? <span className="mt-1 block text-xs text-text-3">{option?.reason || 'Not available for your workspace.'}</span> : null}
+                                </span>
+                            </label>
+                        );
+                    })}
+                </div>
+                <p className="text-xs text-text-3">Changing type preserves existing settings. Foundry owns prompts and tools; any local action removal must be confirmed before saving.</p>
+            </fieldset>
+            <fieldset className="space-y-3">
+                <legend className="mb-2 text-sm font-medium text-text-2">Agent icon</legend>
+                <div className="flex flex-wrap items-center gap-3">
+                    <AgentIcon icon={draft.icon} />
+                    <GlassButton type="button" size="sm" onClick={() => {
+                        uploadSequence.current += 1;
+                        setImageBusy(false);
+                        onIconBusyChange?.(false);
+                        setDraft((current) => ({ ...current, icon: { kind: 'bootstrap', value: 'bi-robot' } }));
+                    }}>Use default icon</GlassButton>
+                </div>
+                <div className="grid gap-3 sm:grid-cols-2">
+                    <div className="space-y-2">
+                        <AgentTextField label="Search Bootstrap icons" type="search" value={iconSearch} onChange={setIconSearch} />
+                        <AgentField id="agent-bootstrap-icon" label="Bootstrap icon">
+                            <select id="agent-bootstrap-icon" className={AGENT_INPUT_CLASS} value={currentIcon}
+                                onChange={(event) => {
+                                    uploadSequence.current += 1;
+                                    setImageBusy(false);
+                                    onIconBusyChange?.(false);
+                                    setDraft((current) => ({ ...current, icon: { kind: 'bootstrap', value: event.target.value } }));
+                                }}>
+                                {!currentIcon ? <option value="">Choose an icon</option> : null}
+                                {currentIcon && !visibleIcons.includes(currentIcon) ? <option value={currentIcon}>{currentIcon}</option> : null}
+                                {visibleIcons.map((icon) => <option key={icon} value={icon}>{icon}</option>)}
+                            </select>
+                        </AgentField>
+                        <GlassButton type="button" size="sm" onClick={() => void loadIcons()}>Load all local icons</GlassButton>
+                    </div>
+                    <AgentField id="agent-icon-upload" label="Upload icon" help="PNG or JPEG, resized to at most 128 × 128 pixels. The stored PNG must fit the existing 350000-character limit.">
+                        <input id="agent-icon-upload" type="file" accept="image/png,image/jpeg" disabled={imageBusy}
+                            className={`${AGENT_INPUT_CLASS} file:mr-3 file:rounded-lg file:border-0 file:bg-surface-2 file:px-2 file:py-1 file:text-text-1`}
+                            onChange={(event) => {
+                                const file = event.target.files?.[0];
+                                if (file) void uploadIcon(file);
+                                event.target.value = '';
+                            }} />
+                        {imageBusy ? <p role="status" className="mt-2 text-xs text-text-3">Resizing icon…</p> : null}
+                    </AgentField>
+                </div>
+                {iconError ? <AgentNotice error>{iconError}</AgentNotice> : null}
+            </fieldset>
+            <details className="rounded-xl border border-edge p-3">
+                <summary className="cursor-pointer text-sm font-medium text-text-2">Internal identity</summary>
+                <div className="mt-3 space-y-3">
+                    <AgentTextField label="Internal name" value={draft.name} pattern="[A-Za-z0-9_\-]+" required
+                        help="Derived from the display name only for a new agent. Changing a saved display name does not rename this value or change its stable ID."
+                        onChange={(value) => setDraft((current) => ({ ...current, name: value }))} />
+                    <p className="break-all text-xs text-text-3">Stable ID: {draft.id || 'Allocated when this agent is first saved.'}</p>
+                </div>
+            </details>
+        </div>
+    );
+}

--- a/application/v2_ui/src/components/workspaceAgents/AgentInstructionsFields.tsx
+++ b/application/v2_ui/src/components/workspaceAgents/AgentInstructionsFields.tsx
@@ -1,0 +1,169 @@
+// AgentInstructionsFields.tsx
+
+import { useEffect, useId, useMemo, useRef, useState, type Dispatch, type SetStateAction } from 'react';
+import { Sparkles } from 'lucide-react';
+import type { ActionConfiguration, AgentConfiguration } from '../../lib/workspaceAuthoring';
+import { AGENT_INPUT_CLASS, agentText, clearAgentDraftFields } from '../../lib/workspaceAgentAuthoring';
+import { readAgentKnowledge, type AgentKnowledgeCatalog } from '../../lib/workspaceAgentKnowledge';
+import { agentMentions, agentMentionTrigger, filterAgentMentions, type AgentMention } from '../../lib/workspaceAgentReferences';
+import { draftAgentInstructions, withAgentInstructionProposal } from '../../lib/workspaceAgentCommands';
+import { GlassButton } from '../ui/primitives';
+import { AgentField, AgentNotice } from './AgentFields';
+
+export function AgentInstructionsFields({
+    draft, setDraft, actions, catalog, contextError, readOnly,
+}: {
+    draft: AgentConfiguration;
+    setDraft: Dispatch<SetStateAction<AgentConfiguration>>;
+    actions: ActionConfiguration[];
+    catalog: AgentKnowledgeCatalog | null;
+    contextError: string | null;
+    readOnly: boolean;
+}) {
+    const textarea = useRef<HTMLTextAreaElement>(null);
+    const request = useRef<AbortController | null>(null);
+    const [drafting, setDrafting] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [cursor, setCursor] = useState(0);
+    const [focused, setFocused] = useState(false);
+    const [dismissed, setDismissed] = useState(false);
+    const [activeIndex, setActiveIndex] = useState(0);
+    const [confirmReplace, setConfirmReplace] = useState(false);
+    const menuId = useId();
+    const mentions = useMemo(() => agentMentions(draft, actions, catalog), [draft, actions, catalog]);
+    const trigger = focused && !dismissed ? agentMentionTrigger(draft.instructions, cursor) : null;
+    const suggestions = trigger ? filterAgentMentions(mentions, trigger.query) : [];
+    const selectedIndex = Math.min(activeIndex, Math.max(0, suggestions.length - 1));
+    const brief = agentText(draft._editor_instruction_brief);
+    const proposal = agentText(draft._editor_instruction_proposal);
+    const baseline = agentText(draft._editor_instruction_baseline);
+    const needsKnowledge = readAgentKnowledge(draft).enabled && !catalog;
+    useEffect(() => () => request.current?.abort(), []);
+
+    const insertMention = (mention: AgentMention) => {
+        if (!trigger || !textarea.current) return;
+        const nextText = `${draft.instructions.slice(0, trigger.start)}${mention.token} ${draft.instructions.slice(cursor)}`;
+        const nextCursor = trigger.start + mention.token.length + 1;
+        setDraft((current) => ({ ...current, instructions: nextText }));
+        setDismissed(true);
+        setCursor(nextCursor);
+        requestAnimationFrame(() => {
+            textarea.current?.focus();
+            textarea.current?.setSelectionRange(nextCursor, nextCursor);
+        });
+    };
+
+    const generate = async () => {
+        if (draft.agent_type !== 'local' || readOnly) return;
+        request.current?.abort();
+        const controller = new AbortController();
+        request.current = controller;
+        setDrafting(true);
+        setError(null);
+        const snapshot = draft.instructions;
+        try {
+            const instructions = await draftAgentInstructions(draft, actions, catalog, controller.signal);
+            if (!controller.signal.aborted) {
+                setDraft((current) => withAgentInstructionProposal(current, instructions, snapshot));
+                setConfirmReplace(false);
+            }
+        } catch (cause) {
+            if (!controller.signal.aborted) setError(cause instanceof Error ? cause.message : 'Unable to draft instructions.');
+        } finally {
+            if (!controller.signal.aborted) setDrafting(false);
+        }
+    };
+    const applyProposal = () => {
+        if (draft.instructions !== baseline && !confirmReplace) {
+            setConfirmReplace(true);
+            return;
+        }
+        setDraft((current) => clearAgentDraftFields({ ...current, instructions: proposal }, '_editor_instruction_proposal', '_editor_instruction_baseline'));
+        setConfirmReplace(false);
+        textarea.current?.focus();
+    };
+
+    if (draft.agent_type !== 'local') {
+        return (
+            <div className="space-y-3">
+                <AgentNotice>Instructions are managed in Foundry. Any stored local prompt is retained, but cannot be edited or drafted for this type.</AgentNotice>
+                {draft.instructions ? <pre className="whitespace-pre-wrap break-words rounded-xl border border-edge p-3 text-xs text-text-3">{draft.instructions}</pre> : null}
+            </div>
+        );
+    }
+    return (
+        <div className="space-y-4">
+            <AgentField id="agent-instructions" label="Instructions" help={'Type # to reference selected actions, enabled capabilities, or assigned knowledge. Values with spaces or colons are quoted, for example #knowledge:doc:"Employee Handbook.pdf".'}>
+                <textarea id="agent-instructions" ref={textarea} value={draft.instructions} rows={18} required spellCheck
+                    className={`${AGENT_INPUT_CLASS} resize-y leading-relaxed`}
+                    aria-autocomplete="list" aria-controls={suggestions.length ? menuId : undefined}
+                    aria-activedescendant={suggestions.length ? `${menuId}-${selectedIndex}` : undefined}
+                    onChange={(event) => {
+                        setDraft((current) => ({ ...current, instructions: event.target.value }));
+                        setCursor(event.target.selectionStart);
+                        setDismissed(false);
+                        setActiveIndex(0);
+                        setConfirmReplace(false);
+                    }}
+                    onSelect={(event) => setCursor(event.currentTarget.selectionStart)}
+                    onFocus={() => setFocused(true)}
+                    onBlur={() => setFocused(false)}
+                    onKeyDown={(event) => {
+                        if (!suggestions.length) return;
+                        if (event.key === 'Escape') { event.preventDefault(); setDismissed(true); }
+                        if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+                            event.preventDefault();
+                            setActiveIndex((index) => (index + (event.key === 'ArrowDown' ? 1 : suggestions.length - 1)) % suggestions.length);
+                        }
+                        if (event.key === 'Enter' || event.key === 'Tab') { event.preventDefault(); insertMention(suggestions[selectedIndex]); }
+                    }} />
+            </AgentField>
+            {suggestions.length && !readOnly ? (
+                <ul id={menuId} role="listbox" aria-label="Instruction references" className="rounded-xl border border-edge bg-surface-1 p-1">
+                    {suggestions.map((mention, index) => (
+                        <li key={`${mention.token}:${index}`} id={`${menuId}-${index}`} role="option" aria-selected={index === selectedIndex}
+                            onMouseDown={(event) => event.preventDefault()} onMouseMove={() => setActiveIndex(index)}
+                            className={index === selectedIndex ? 'rounded-lg bg-accent-soft' : 'rounded-lg'}>
+                            <button type="button" tabIndex={-1} className="w-full break-words px-3 py-2 text-left text-xs text-text-2" onClick={() => insertMention(mention)}>
+                                <span className="block font-medium">{mention.label}</span>
+                                <code className="block break-all text-[11px] text-text-3">{mention.token}</code>
+                                <span className="text-[11px] text-text-3">{mention.description}</span>
+                            </button>
+                        </li>
+                    ))}
+                </ul>
+            ) : null}
+            {!readOnly ? (
+                <div className="space-y-3 rounded-xl border border-edge p-3">
+                    <AgentField id="agent-instruction-brief" label="Instruction brief" help="Describe the task, audience, guardrails, and desired output. Drafting runs only when requested and includes the selected action and knowledge context.">
+                        <textarea id="agent-instruction-brief" rows={3} value={brief} className={AGENT_INPUT_CLASS}
+                            onChange={(event) => setDraft((current) => ({ ...current, _editor_instruction_brief: event.target.value }))} />
+                    </AgentField>
+                    <GlassButton type="button" size="sm" disabled={drafting || needsKnowledge || Boolean(contextError) ||
+                        ![brief, draft.display_name, draft.description, draft.instructions].some((value) => value.trim())}
+                        onClick={() => void generate()}><Sparkles size={14} />{drafting ? 'Drafting instructions…' : 'Draft instructions'}</GlassButton>
+                    {needsKnowledge || contextError ? <AgentNotice>Load the selected action and knowledge context before drafting. {contextError}</AgentNotice> : null}
+                    {error ? <AgentNotice error>{error}</AgentNotice> : null}
+                    {proposal ? (
+                        <div className="space-y-3">
+                            <AgentField id="agent-generated-instructions" label="Generated instructions — not yet applied">
+                                <textarea id="agent-generated-instructions" rows={12} value={proposal} readOnly className={AGENT_INPUT_CLASS} />
+                            </AgentField>
+                            {draft.instructions !== baseline ? <AgentNotice>Your instructions changed while this draft was generated. They have not been overwritten.</AgentNotice> : null}
+                            {confirmReplace ? <AgentNotice>Replace your newer instructions with the generated proposal? This still does not save the agent.</AgentNotice> : null}
+                            <div className="flex flex-wrap gap-2">
+                                <GlassButton type="button" size="sm" variant={confirmReplace ? 'danger' : 'primary'} onClick={applyProposal}>
+                                    {confirmReplace ? 'Replace edited instructions' : 'Use generated instructions'}
+                                </GlassButton>
+                                <GlassButton type="button" size="sm" onClick={() => {
+                                    setDraft((current) => clearAgentDraftFields(current, '_editor_instruction_proposal', '_editor_instruction_baseline'));
+                                    setConfirmReplace(false);
+                                }}>Discard generated draft</GlassButton>
+                            </div>
+                        </div>
+                    ) : null}
+                </div>
+            ) : null}
+        </div>
+    );
+}

--- a/application/v2_ui/src/components/workspaceAgents/AgentKnowledgeFields.tsx
+++ b/application/v2_ui/src/components/workspaceAgents/AgentKnowledgeFields.tsx
@@ -1,0 +1,245 @@
+// AgentKnowledgeFields.tsx
+
+import { useState, type Dispatch, type SetStateAction } from 'react';
+import { Plus, RefreshCw, Trash2 } from 'lucide-react';
+import type { AgentConfiguration } from '../../lib/workspaceAuthoring';
+import { AGENT_INPUT_CLASS } from '../../lib/workspaceAgentAuthoring';
+import {
+    KNOWLEDGE_LIMITS, USER_KNOWLEDGE_ACTIONS, knowledgeSourceKey, normalizeAgentKnowledgeUrl,
+    readAgentKnowledge, resolvedAgentDocuments, selectedKnowledgeSources, toggleAgentKnowledgeSource,
+    toggleString, updateAgentKnowledge, type AgentKnowledgeCatalog, type AgentKnowledgeSource,
+} from '../../lib/workspaceAgentKnowledge';
+import { GlassButton, Toggle } from '../ui/primitives';
+import { SectionSearch } from '../workspace/primitives';
+import { AgentField, AgentNotice, AgentTextField } from './AgentFields';
+
+export function AgentKnowledgeFields({
+    draft, setDraft, catalog, loading, error, onRefresh, readOnly,
+}: {
+    draft: AgentConfiguration;
+    setDraft: Dispatch<SetStateAction<AgentConfiguration>>;
+    catalog: AgentKnowledgeCatalog | null;
+    loading: boolean;
+    error: string | null;
+    onRefresh: () => void;
+    readOnly: boolean;
+}) {
+    const [sourceQuery, setSourceQuery] = useState('');
+    const [documentQuery, setDocumentQuery] = useState('');
+    const [tagQuery, setTagQuery] = useState('');
+    const [documentLimit, setDocumentLimit] = useState(25);
+    const [activeLimit, setActiveLimit] = useState(20);
+    const [url, setUrl] = useState('');
+    const [mode, setMode] = useState('url_review');
+    const [inputError, setInputError] = useState<string | null>(null);
+    const config = readAgentKnowledge(draft);
+    const selectedKeys = new Set(selectedKnowledgeSources(config));
+    const sources = (catalog?.sources ?? []).filter((source) => ['personal', 'public'].includes(source.scope));
+    const documents = (catalog?.documents ?? []).filter((document) =>
+        sources.some((source) => source.scope === document.scope && source.id === document.source_id));
+    const unavailableSourceKeys = [...selectedKeys].filter((key) => !sources.some((source) => knowledgeSourceKey(source) === key));
+    const unavailableDocuments = config.document_ids.filter((id) => !documents.some((document) => document.id === id));
+    const tags = catalog?.tags ?? [];
+    const unavailableTags = config.tags.filter((tag) => !tags.some((item) => item.name === tag));
+    const visibleDocuments = documents.filter((document) =>
+        `${document.title} ${document.file_name} ${document.source_name} ${document.id}`.toLowerCase().includes(documentQuery.toLowerCase()) &&
+        (!selectedKeys.size || selectedKeys.has(`${document.scope}:${document.source_id}`) || config.document_ids.includes(document.id)));
+    const active = catalog ? resolvedAgentDocuments(config, catalog) : [];
+
+    const toggleSource = (source: AgentKnowledgeSource, enabled: boolean) => {
+        setInputError(null);
+        if (enabled && source.scope === 'public' && config.scopes.public_workspace_ids.length >= KNOWLEDGE_LIMITS.sources) {
+            setInputError('You can assign at most 50 public workspaces.');
+            return;
+        }
+        setDraft((current) => toggleAgentKnowledgeSource(current, source, enabled));
+    };
+    const addUrl = () => {
+        setInputError(null);
+        const normalized = normalizeAgentKnowledgeUrl(url);
+        if (!normalized) {
+            setInputError('Enter a valid HTTP or HTTPS URL without embedded credentials.');
+            return;
+        }
+        if (config.web_sources.length >= KNOWLEDGE_LIMITS.urls && !config.web_sources.some((source) => source.url === normalized)) {
+            setInputError('You can assign at most 50 URLs.');
+            return;
+        }
+        setDraft((current) => {
+            const next = readAgentKnowledge(current);
+            const webSources = next.web_sources.filter((source) => source.url !== normalized);
+            return updateAgentKnowledge(current, { web_sources: [...webSources, { url: normalized, mode }] });
+        });
+        setUrl('');
+    };
+    if (draft.agent_type !== 'local') {
+        return <AgentNotice>Knowledge assigned to a local agent is retained but is not applied to this Foundry type. Configure knowledge in Foundry. Workflow document context is controlled in Model &amp; connection.</AgentNotice>;
+    }
+    return (
+        <div className="space-y-4">
+            <Toggle label="Restrict to assigned knowledge" checked={config.enabled}
+                description="Ground this agent in selected authorized workspaces and URLs. Turning this off retains the configuration for later."
+                onChange={(enabled) => setDraft((current) => updateAgentKnowledge(current, { enabled }))} />
+            {!config.enabled && error ? <AgentNotice error>{error} <GlassButton type="button" size="sm" onClick={onRefresh}>Retry knowledge catalogue</GlassButton></AgentNotice> : null}
+            {config.enabled ? (
+                <>
+                    <div className="flex flex-wrap items-center gap-3">
+                        <GlassButton type="button" size="sm" disabled={loading} onClick={onRefresh}><RefreshCw size={14} />Refresh knowledge</GlassButton>
+                        <span className="text-xs text-text-3">{selectedKeys.size} sources · {config.document_ids.length} explicit documents · {config.tags.length} tags · {config.web_sources.length} URLs</span>
+                    </div>
+                    {loading ? <p role="status" className="text-sm text-text-3">Loading authorized knowledge sources…</p> : null}
+                    {error ? <AgentNotice error>{error} Existing selections are preserved.</AgentNotice> : null}
+                    {inputError ? <AgentNotice error>{inputError}</AgentNotice> : null}
+                    <fieldset className="space-y-3">
+                        <legend className="mb-2 text-sm font-medium text-text-1">Source workspaces</legend>
+                        <p className="text-xs text-text-3">Only your personal workspace and permitted public workspaces can be newly assigned. Removing a source does not silently remove stored document references.</p>
+                        <SectionSearch value={sourceQuery} onChange={setSourceQuery} placeholder="Search knowledge workspaces" />
+                        <div className="grid gap-2 sm:grid-cols-2">
+                            {sources.filter((source) => `${source.label} ${source.id}`.toLowerCase().includes(sourceQuery.toLowerCase())).map((source) => (
+                                <label key={knowledgeSourceKey(source)} className="flex items-start gap-2 rounded-xl border border-edge p-3 text-sm text-text-2">
+                                    <input type="checkbox" className="mt-1 accent-accent" checked={selectedKeys.has(knowledgeSourceKey(source))}
+                                        disabled={readOnly} onChange={(event) => toggleSource(source, event.target.checked)} />
+                                    <span className="min-w-0 break-words">{source.label}<span className="block break-all text-xs text-text-3">{source.scope} · {source.id}</span></span>
+                                </label>
+                            ))}
+                        </div>
+                        {!sources.length && !loading && !error ? <p className="text-xs text-text-3">No authorized workspace sources are available. You may still assign URLs.</p> : null}
+                        {unavailableSourceKeys.map((key) => (
+                            <div key={key} className="flex flex-wrap items-center justify-between gap-2 rounded-lg border border-warn/30 p-2">
+                                <span className="break-all text-xs text-warn">Saved source unavailable here: {key}</span>
+                                {!readOnly ? <GlassButton type="button" size="sm" aria-label={`Remove knowledge source ${key}`} onClick={() => {
+                                    setDraft((current) => {
+                                        const currentConfig = readAgentKnowledge(current);
+                                        return updateAgentKnowledge(current, { scopes: {
+                                            ...currentConfig.scopes,
+                                            personal: key === 'personal:personal' ? false : currentConfig.scopes.personal,
+                                            group_ids: currentConfig.scopes.group_ids.filter((id) => `group:${id}` !== key),
+                                            public_workspace_ids: currentConfig.scopes.public_workspace_ids.filter((id) => `public:${id}` !== key),
+                                        } });
+                                    });
+                                }}>Remove reference</GlassButton> : null}
+                            </div>
+                        ))}
+                    </fieldset>
+                    <fieldset className="space-y-3">
+                        <legend className="mb-2 text-sm font-medium text-text-1">Documents and tags</legend>
+                        <p className="text-xs text-text-3">With no document or tag limits, all indexed documents in selected sources are active. Otherwise, explicit documents are included alongside documents matching every selected tag.</p>
+                        <SectionSearch value={documentQuery} onChange={(value) => { setDocumentQuery(value); setDocumentLimit(25); }} placeholder="Search knowledge documents" />
+                        <div className="space-y-2">
+                            {visibleDocuments.slice(0, documentLimit).map((document) => {
+                                const checked = config.document_ids.includes(document.id);
+                                const inSources = selectedKeys.has(`${document.scope}:${document.source_id}`);
+                                return (
+                                    <label key={`${document.scope}:${document.id}`} className="flex items-start gap-2 rounded-xl border border-edge p-3 text-sm text-text-2">
+                                        <input type="checkbox" className="mt-1 accent-accent" checked={checked}
+                                            disabled={readOnly || (!checked && (config.document_ids.length >= KNOWLEDGE_LIMITS.documents ||
+                                                (!inSources && document.scope === 'public' && config.scopes.public_workspace_ids.length >= KNOWLEDGE_LIMITS.sources)))}
+                                            onChange={(event) => setDraft((current) => {
+                                                let next = current;
+                                                if (event.target.checked) {
+                                                    const source = sources.find((item) => item.scope === document.scope && item.id === document.source_id);
+                                                    if (source) next = toggleAgentKnowledgeSource(current, source, true);
+                                                }
+                                                return updateAgentKnowledge(next, {
+                                                    document_ids: toggleString(readAgentKnowledge(next).document_ids, document.id, event.target.checked),
+                                                });
+                                            })} />
+                                        <span className="min-w-0 break-words">{document.title || document.file_name}
+                                            <span className="block break-all text-xs text-text-3">{document.source_name} · {document.id}</span>
+                                            {document.tags.length ? <span className="block text-xs text-text-3">{document.tags.join(', ')}</span> : null}
+                                            {checked && !inSources ? <span className="block text-xs text-warn">Saved reference retained; its workspace is not selected.</span> : null}
+                                        </span>
+                                    </label>
+                                );
+                            })}
+                        </div>
+                        {visibleDocuments.length > documentLimit ? <GlassButton type="button" size="sm" onClick={() => setDocumentLimit((value) => value + 25)}>Show more documents ({visibleDocuments.length - documentLimit} remaining)</GlassButton> : null}
+                        {unavailableDocuments.map((id) => (
+                            <div key={id} className="flex flex-wrap items-center justify-between gap-2">
+                                <code className="break-all text-xs text-warn">Unavailable document: {id}</code>
+                                {!readOnly ? <GlassButton type="button" size="sm" aria-label={`Remove document reference ${id}`}
+                                    onClick={() => setDraft((current) => updateAgentKnowledge(current, { document_ids: readAgentKnowledge(current).document_ids.filter((item) => item !== id) }))}>Remove reference</GlassButton> : null}
+                            </div>
+                        ))}
+                        <SectionSearch value={tagQuery} onChange={setTagQuery} placeholder="Search knowledge tags" />
+                        <div className="flex flex-wrap gap-3">
+                            {tags.filter((tag) => tag.name.toLowerCase().includes(tagQuery.toLowerCase())).map((tag) => (
+                                <label key={tag.name} className="flex items-center gap-2 text-sm text-text-2">
+                                    <input type="checkbox" className="accent-accent" checked={config.tags.includes(tag.name)}
+                                        disabled={readOnly || (!config.tags.includes(tag.name) && config.tags.length >= KNOWLEDGE_LIMITS.tags)}
+                                        onChange={(event) => setDraft((current) => updateAgentKnowledge(current, {
+                                            tags: toggleString(readAgentKnowledge(current).tags, tag.name, event.target.checked),
+                                        }))} />
+                                    {tag.name} <span className="text-xs text-text-3">({tag.count})</span>
+                                </label>
+                            ))}
+                        </div>
+                        {unavailableTags.map((tag) => (
+                            <div key={tag} className="flex flex-wrap items-center justify-between gap-2">
+                                <span className="break-all text-xs text-warn">Saved tag not in current catalogue: {tag}</span>
+                                {!readOnly ? <GlassButton type="button" size="sm" aria-label={`Remove knowledge tag ${tag}`}
+                                    onClick={() => setDraft((current) => updateAgentKnowledge(current, { tags: readAgentKnowledge(current).tags.filter((item) => item !== tag) }))}>Remove reference</GlassButton> : null}
+                            </div>
+                        ))}
+                    </fieldset>
+                    <details className="rounded-xl border border-edge p-3" open>
+                        <summary className="cursor-pointer text-sm font-medium text-text-1">Active documents ({active.length})</summary>
+                        <p className="mt-2 text-xs text-text-3">Preview from the authorized catalogue. Catalogue queries are limited to 1000 documents; runtime authorization and indexing determine the final context.</p>
+                        {catalog ? (
+                            <ul className="mt-2 space-y-1 text-xs text-text-2">
+                                {active.slice(0, activeLimit).map((document) => <li key={document.id} className="break-words">{document.title || document.file_name} · {document.source_name}{config.document_ids.includes(document.id) ? ' · explicit' : ''}</li>)}
+                            </ul>
+                        ) : <p className="mt-2 text-xs text-text-3">Load the catalogue to resolve active documents.</p>}
+                        {active.length > activeLimit ? <GlassButton type="button" size="sm" onClick={() => setActiveLimit((value) => value + 50)}>Show more active documents</GlassButton> : null}
+                    </details>
+                    <div className="space-y-3 rounded-xl border border-edge p-3">
+                        <Toggle label="Allow user-added workspace context" checked={config.allow_user_workspace_context}
+                            description="Let chat users supplement the assigned sources within their own permissions."
+                            onChange={(value) => setDraft((current) => updateAgentKnowledge(current, { allow_user_workspace_context: value }))} />
+                        <fieldset disabled={!config.allow_user_workspace_context} className="flex flex-wrap gap-4">
+                            <legend className="mb-2 text-xs text-text-3">Allowed user-added context actions</legend>
+                            {USER_KNOWLEDGE_ACTIONS.map((action) => (
+                                <label key={action} className="flex items-center gap-2 text-sm text-text-2">
+                                    <input type="checkbox" className="accent-accent" checked={config.allowed_user_workspace_actions.includes(action)}
+                                        onChange={(event) => setDraft((current) => updateAgentKnowledge(current, {
+                                            allowed_user_workspace_actions: toggleString(readAgentKnowledge(current).allowed_user_workspace_actions, action, event.target.checked),
+                                        }))} />
+                                    {action[0].toUpperCase() + action.slice(1)}
+                                </label>
+                            ))}
+                        </fieldset>
+                    </div>
+                    <fieldset className="space-y-3">
+                        <legend className="mb-2 text-sm font-medium text-text-1">Assigned URLs</legend>
+                        <p className="text-xs text-text-3">URL review targets the assigned page. Deep research allows research from that source. Requests still follow the application’s web access policy.</p>
+                        {!readOnly ? <div className="grid items-end gap-3 sm:grid-cols-[minmax(0,1fr)_10rem_auto]">
+                            <AgentTextField label="Assigned URL" value={url} onChange={setUrl} placeholder="https://example.org/page" />
+                            <AgentField id="agent-new-url-mode" label="URL mode">
+                                <select id="agent-new-url-mode" value={mode} onChange={(event) => setMode(event.target.value)} className={AGENT_INPUT_CLASS}>
+                                    <option value="url_review">URL review</option><option value="deep_research">Deep research</option>
+                                </select>
+                            </AgentField>
+                            <GlassButton type="button" size="sm" onClick={addUrl}><Plus size={14} />Add URL</GlassButton>
+                        </div> : null}
+                        {config.web_sources.map((source, index) => (
+                            <div key={`${source.url}:${index}`} className="grid gap-2 rounded-xl border border-edge p-3 sm:grid-cols-[minmax(0,1fr)_10rem_auto]">
+                                <span className="break-all text-sm text-text-2">{source.url}</span>
+                                <select aria-label={`Mode for ${source.url}`} value={source.mode} className={AGENT_INPUT_CLASS}
+                                    onChange={(event) => setDraft((current) => updateAgentKnowledge(current, {
+                                        web_sources: readAgentKnowledge(current).web_sources.map((item, at) => at === index ? { ...item, mode: event.target.value } : item),
+                                    }))}>
+                                    {!['url_review', 'deep_research'].includes(source.mode) ? <option value={source.mode}>Unrecognized: {source.mode}</option> : null}
+                                    <option value="url_review">URL review</option><option value="deep_research">Deep research</option>
+                                </select>
+                                {!readOnly ? <GlassButton type="button" size="sm" aria-label={`Remove URL ${source.url}`}
+                                    onClick={() => setDraft((current) => updateAgentKnowledge(current, {
+                                        web_sources: readAgentKnowledge(current).web_sources.filter((_, at) => at !== index),
+                                    }))}><Trash2 size={14} /></GlassButton> : null}
+                            </div>
+                        ))}
+                    </fieldset>
+                </>
+            ) : <p className="text-sm text-text-3">This agent follows the normal chat context policy. Enable the restriction to define its assigned knowledge.</p>}
+        </div>
+    );
+}

--- a/application/v2_ui/src/components/workspaceAgents/AgentModelFields.tsx
+++ b/application/v2_ui/src/components/workspaceAgents/AgentModelFields.tsx
@@ -1,0 +1,284 @@
+// AgentModelFields.tsx
+
+import { useEffect, useRef, useState, type Dispatch, type SetStateAction } from 'react';
+import { RefreshCw } from 'lucide-react';
+import { ApiError } from '../../lib/apiClient';
+import type { AgentConfiguration, AgentEditorOptions, AuthoringResource } from '../../lib/workspaceAuthoring';
+import {
+    AGENT_INPUT_CLASS, FOUNDRY_SETTINGS_KEYS, agentModelChoices, agentText, applyFoundryDiscovery, clearAgentDraftFields,
+    foundryEndpointMatches, foundrySettings, selectAgentModel, selectedAgentModel, selectFoundryEndpoint,
+    updateAgentSetting, type FoundryDiscoveryRecord,
+} from '../../lib/workspaceAgentAuthoring';
+import { normalizeAgentKnowledgeUrl } from '../../lib/workspaceAgentKnowledge';
+import { discoverAgentFoundryResources } from '../../lib/workspaceAgentCommands';
+import { GlassButton, Toggle } from '../ui/primitives';
+import { AgentField, AgentNotice, AgentSecretField, AgentTextField } from './AgentFields';
+
+interface ModelFieldsProps {
+    draft: AgentConfiguration;
+    setDraft: Dispatch<SetStateAction<AgentConfiguration>>;
+    options: AgentEditorOptions;
+    original: AuthoringResource<AgentConfiguration> | null;
+}
+
+function LocalModelFields({ draft, setDraft, options, original }: ModelFieldsProps) {
+    const choices = agentModelChoices(options);
+    const selected = selectedAgentModel(draft, choices);
+    const customAllowed = options.settings.allow_user_custom_endpoints === true;
+    const [customOpen, setCustomOpen] = useState(Boolean(
+        !draft.model_endpoint_id && (draft.azure_openai_gpt_endpoint || draft.azure_openai_gpt_key || draft.enable_agent_gpt_apim),
+    ));
+    const update = (key: keyof AgentConfiguration, value: unknown) => setDraft((current) => ({ ...current, [key]: value }));
+    return (
+        <div className="space-y-4">
+            <AgentField id="agent-model-select" label="Model" help="Choose an enabled model on an authorized connection. An unavailable saved model is preserved until you choose a replacement.">
+                <select id="agent-model-select" className={AGENT_INPUT_CLASS} value={selected?.key ?? ''}
+                    onChange={(event) => {
+                        const choice = choices.find((item) => item.key === event.target.value);
+                        if (choice) setDraft((current) => selectAgentModel(current, choice));
+                    }}>
+                    <option value="">{draft.model_id || draft.azure_openai_gpt_deployment || draft.azure_agent_apim_gpt_deployment || 'Use configured default / choose a model'}</option>
+                    {choices.map((choice) => <option key={choice.key} value={choice.key}>{choice.label}</option>)}
+                </select>
+            </AgentField>
+            {!choices.length ? <AgentNotice>No enabled models are listed. You can retain the saved connection or configure a custom connection below.</AgentNotice> : null}
+            <dl className="grid gap-3 rounded-xl border border-edge p-3 text-xs sm:grid-cols-3">
+                <div className="min-w-0"><dt className="text-text-3">Endpoint ID</dt><dd className="break-all text-text-1">{draft.model_endpoint_id || 'Legacy / configured default'}</dd></div>
+                <div className="min-w-0"><dt className="text-text-3">Model ID</dt><dd className="break-all text-text-1">{draft.model_id || draft.azure_openai_gpt_deployment || draft.azure_agent_apim_gpt_deployment || 'Configured default'}</dd></div>
+                <div className="min-w-0"><dt className="text-text-3">Provider</dt><dd className="break-all text-text-1">{draft.model_provider || 'Configured default'}</dd></div>
+            </dl>
+            <details open={customOpen} onToggle={(event) => setCustomOpen(event.currentTarget.open)} className="rounded-xl border border-edge p-3">
+                <summary className="cursor-pointer text-sm font-medium text-text-2">Custom / legacy connection and APIM</summary>
+                <div className="mt-4 space-y-4">
+                    <p className="text-xs text-text-3">A selected endpoint takes precedence. Custom values and stored credentials are retained when you choose a model; they are never copied from app settings.</p>
+                    {!customAllowed ? <AgentNotice>Your administrator has disabled personal custom-connection changes. Existing values and credentials remain stored.</AgentNotice> : null}
+                    <fieldset disabled={!customAllowed} className="space-y-4">
+                    <legend className="sr-only">Custom connection settings</legend>
+                    {draft.model_endpoint_id ? (
+                        <GlassButton type="button" size="sm" onClick={() => setDraft((current) => ({
+                            ...current, model_endpoint_id: '', model_id: '', model_provider: '',
+                        }))}>Use custom connection instead of selected endpoint</GlassButton>
+                    ) : null}
+                    <Toggle label="Use APIM for this agent" checked={draft.enable_agent_gpt_apim === true}
+                        description="Switches which custom connection fields are used. Inactive connection values remain in the draft."
+                        onChange={(value) => update('enable_agent_gpt_apim', value)} />
+                    <div className="grid gap-4 sm:grid-cols-2">
+                        {draft.enable_agent_gpt_apim ? (
+                            <>
+                                <AgentTextField label="APIM endpoint" value={draft.azure_agent_apim_gpt_endpoint}
+                                    onChange={(value) => update('azure_agent_apim_gpt_endpoint', value)} />
+                                <AgentTextField label="APIM deployment" value={draft.azure_agent_apim_gpt_deployment}
+                                    onChange={(value) => update('azure_agent_apim_gpt_deployment', value)} />
+                                <AgentTextField label="APIM API version" value={draft.azure_agent_apim_gpt_api_version}
+                                    onChange={(value) => update('azure_agent_apim_gpt_api_version', value)} />
+                                <AgentSecretField label="APIM subscription key" value={draft.azure_agent_apim_gpt_subscription_key}
+                                    original={original?.record.azure_agent_apim_gpt_subscription_key}
+                                    onChange={(value) => update('azure_agent_apim_gpt_subscription_key', value)} />
+                            </>
+                        ) : (
+                            <>
+                                <AgentTextField label="Azure OpenAI endpoint" value={draft.azure_openai_gpt_endpoint}
+                                    onChange={(value) => update('azure_openai_gpt_endpoint', value)} />
+                                <AgentTextField label="Deployment name" value={draft.azure_openai_gpt_deployment}
+                                    onChange={(value) => update('azure_openai_gpt_deployment', value)} />
+                                <AgentTextField label="Azure OpenAI API version" value={draft.azure_openai_gpt_api_version}
+                                    onChange={(value) => update('azure_openai_gpt_api_version', value)} />
+                                <AgentSecretField label="Azure OpenAI API key" value={draft.azure_openai_gpt_key}
+                                    original={original?.record.azure_openai_gpt_key}
+                                    onChange={(value) => update('azure_openai_gpt_key', value)} />
+                            </>
+                        )}
+                    </div>
+                    </fieldset>
+                </div>
+            </details>
+        </div>
+    );
+}
+
+function FoundryModelFields({ draft, setDraft, options }: ModelFieldsProps) {
+    const [resources, setResources] = useState<FoundryDiscoveryRecord[]>([]);
+    const [responseVersion, setResponseVersion] = useState('');
+    const [loading, setLoading] = useState(false);
+    const [loaded, setLoaded] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [authUrl, setAuthUrl] = useState('');
+    const request = useRef<AbortController | null>(null);
+    const settings = foundrySettings(draft);
+    const type = draft.agent_type;
+    const endpointId = draft.model_endpoint_id || agentText(settings.endpoint_id);
+    const endpoints = options.model_endpoints.filter((endpoint) => foundryEndpointMatches(type, endpoint));
+    const selectedEndpoint = endpoints.find((endpoint) => endpoint.id === endpointId);
+    useEffect(() => {
+        setResources([]);
+        setLoaded(false);
+        setLoading(false);
+        setError(null);
+        setAuthUrl('');
+        return () => request.current?.abort();
+    }, [type, endpointId]);
+
+    if (type === 'local') return null;
+    const key = FOUNDRY_SETTINGS_KEYS[type];
+    const update = (field: string, value: unknown) => setDraft((current) => {
+        const reference = foundrySettings(current).agent_reference;
+        const referenceKey = field === 'workflow_agent_id' ? 'id' : field;
+        return updateAgentSetting(current, key, {
+            [field]: value,
+            authentication_type: 'delegated_user',
+            ...(type === 'foundry_workflow' && ['workflow_agent_id', 'application_id', 'application_version'].includes(field) &&
+                reference && typeof reference === 'object' && !Array.isArray(reference)
+                ? { agent_reference: { ...reference, [referenceKey]: value } } : {}),
+        });
+    });
+    const updateConnection = (field: 'endpoint' | 'project_name' | 'responses_api_version', value: string) => {
+        const topLevel = field === 'endpoint' ? 'azure_openai_gpt_endpoint'
+            : field === 'project_name' ? 'azure_openai_gpt_deployment' : 'azure_openai_gpt_api_version';
+        setDraft((current) => updateAgentSetting({ ...current, [topLevel]: value }, key, {
+            [field]: value, authentication_type: 'delegated_user',
+        }));
+    };
+    const discover = async () => {
+        if (!selectedEndpoint) return;
+        request.current?.abort();
+        const controller = new AbortController();
+        request.current = controller;
+        setLoading(true);
+        setError(null);
+        setAuthUrl('');
+        try {
+            const result = await discoverAgentFoundryResources(selectedEndpoint, type, controller.signal);
+            if (!controller.signal.aborted) {
+                setResources(result.agents);
+                setResponseVersion(result.responses_api_version || '');
+                setLoaded(true);
+            }
+        } catch (cause) {
+            if (controller.signal.aborted) return;
+            setError(cause instanceof Error ? cause.message : 'Unable to discover Foundry resources.');
+            if (cause instanceof ApiError && cause.payload && typeof cause.payload === 'object') {
+                const payload = cause.payload as Record<string, unknown>;
+                if (payload.auth_required === true) setAuthUrl(normalizeAgentKnowledgeUrl(agentText(payload.auth_url || payload.consent_url)));
+            }
+        } finally {
+            if (!controller.signal.aborted) setLoading(false);
+        }
+    };
+    return (
+        <div className="space-y-4">
+            <AgentNotice>Authentication uses the signed-in user’s delegated Foundry access. Prompts and tools are managed in Foundry, not in this editor.</AgentNotice>
+            <AgentField id="agent-foundry-connection" label="Saved Foundry connection" help="Optional. Choose a permitted saved connection to discover its agents, applications, or workflows.">
+                <select id="agent-foundry-connection" className={AGENT_INPUT_CLASS} value={endpointId}
+                    onChange={(event) => {
+                        const endpoint = endpoints.find((item) => item.id === event.target.value);
+                        request.current?.abort();
+                        if (endpoint) setDraft((current) => selectFoundryEndpoint(current, endpoint));
+                        else setDraft((current) => updateAgentSetting({ ...current, model_endpoint_id: '' }, key, { endpoint_id: '' }));
+                    }}>
+                    <option value="">Manual Foundry project connection</option>
+                    {endpointId && !selectedEndpoint ? <option value={endpointId}>Saved connection unavailable · {endpointId}</option> : null}
+                    {endpoints.map((endpoint) => <option key={endpoint.id} value={endpoint.id}>{endpoint.name || endpoint.id} · {agentText(endpoint.scope) || 'global'}</option>)}
+                </select>
+            </AgentField>
+            <div className="flex flex-wrap items-center gap-3">
+                <GlassButton type="button" size="sm" onClick={() => void discover()} disabled={!selectedEndpoint || loading}>
+                    <RefreshCw size={14} className={loading ? 'animate-spin' : ''} />
+                    {loading ? 'Discovering…' : type === 'foundry_workflow' ? 'Discover workflows' : type === 'new_foundry' ? 'Discover applications' : 'Discover agents'}
+                </GlassButton>
+                {loaded ? <span role="status" className="text-xs text-text-3">{resources.length} resources found.</span> : null}
+            </div>
+            {error ? <AgentNotice error>{error}{authUrl ? <> <a href={authUrl} target="_blank" rel="noopener noreferrer" className="underline">Sign in or grant Foundry access</a></> : null}</AgentNotice> : null}
+            {resources.length ? (
+                <AgentField id="agent-foundry-resource" label="Discovered resource" help="Selecting a resource updates only this draft. Review provider fields before saving.">
+                    <select id="agent-foundry-resource" defaultValue="" className={AGENT_INPUT_CLASS}
+                        onChange={(event) => {
+                            const selected = resources[Number(event.target.value)];
+                            if (selected) setDraft((current) => applyFoundryDiscovery(current, {
+                                ...selected, responses_api_version: selected.responses_api_version || responseVersion || undefined,
+                            }));
+                        }}>
+                        <option value="" disabled>Select a discovered resource</option>
+                        {resources.map((resource, index) => <option key={`${resource.id || resource.name}-${index}`} value={index}>
+                            {resource.display_name || resource.workflow_name || resource.application_name || resource.name || resource.id}
+                            {resource.application_version ? ` · v${resource.application_version}` : ''}
+                        </option>)}
+                    </select>
+                </AgentField>
+            ) : null}
+            <div className="grid gap-4 sm:grid-cols-2">
+                <AgentTextField label="Foundry project endpoint" required value={settings.endpoint || draft.azure_openai_gpt_endpoint}
+                    onChange={(value) => updateConnection('endpoint', value)} />
+                <AgentTextField label="Foundry project name" value={settings.project_name || draft.azure_openai_gpt_deployment}
+                    help="Needed when the endpoint does not already include /api/projects/<project>."
+                    onChange={(value) => updateConnection('project_name', value)} />
+                {type === 'aifoundry' ? (
+                    <>
+                        <AgentTextField label="Foundry agent ID" required value={settings.agent_id} onChange={(value) => update('agent_id', value)} />
+                        <AgentTextField label="Foundry API version" required value={draft.azure_openai_gpt_api_version}
+                            onChange={(value) => setDraft((current) => ({ ...current, azure_openai_gpt_api_version: value }))} />
+                    </>
+                ) : (
+                    <>
+                        <AgentTextField label="Responses API version" required value={settings.responses_api_version || draft.azure_openai_gpt_api_version}
+                            onChange={(value) => updateConnection('responses_api_version', value)} />
+                        {type === 'new_foundry' ? (
+                            <>
+                                <AgentTextField label="Application ID" required={!agentText(settings.application_name).trim()} value={settings.application_id}
+                                    help="Provide an application ID or application name. The backend normalizes name/version references."
+                                    onChange={(value) => update('application_id', value)} />
+                                <AgentTextField label="Application name" value={settings.application_name} onChange={(value) => update('application_name', value)} />
+                                <AgentTextField label="Application version" value={settings.application_version} onChange={(value) => update('application_version', value)} />
+                                <AgentTextField label="Activity API version" value={settings.activity_api_version} onChange={(value) => update('activity_api_version', value)} />
+                            </>
+                        ) : (
+                            <>
+                                <AgentTextField label="Workflow name" required value={settings.workflow_name}
+                                    onChange={(value) => setDraft((current) => {
+                                        const reference = foundrySettings(current).agent_reference;
+                                        return updateAgentSetting(current, key, {
+                                            workflow_name: value,
+                                            ...(reference && typeof reference === 'object' && !Array.isArray(reference)
+                                                ? { agent_reference: { ...reference, name: value } } : {}),
+                                        });
+                                    })} />
+                                <AgentTextField label="Workflow agent ID" value={settings.workflow_agent_id} onChange={(value) => update('workflow_agent_id', value)} />
+                                <AgentTextField label="Workflow application ID" value={settings.application_id} onChange={(value) => update('application_id', value)} />
+                                <AgentTextField label="Workflow application version" value={settings.application_version} onChange={(value) => update('application_version', value)} />
+                                <AgentTextField label="Responses path override" value={settings.responses_path}
+                                    help="Optional project Responses path; leave unset to use the runtime default."
+                                    onChange={(value) => update('responses_path', value)} />
+                                <AgentTextField label="Maximum context characters" type="number" min={1} step={1}
+                                    value={settings.max_context_chars === undefined ? '' : String(settings.max_context_chars)}
+                                    help="Optional limit for packed SimpleChat document context."
+                                    onChange={(value) => {
+                                        if (value) update('max_context_chars', Number(value));
+                                        else setDraft((current) => {
+                                            const next = { ...foundrySettings(current) };
+                                            delete next.max_context_chars;
+                                            return clearAgentDraftFields({ ...current, other_settings: { ...current.other_settings, [key]: next } }, '_editor_settings_text');
+                                        });
+                                    }} />
+                            </>
+                        )}
+                    </>
+                )}
+            </div>
+            {type === 'foundry_workflow' ? <Toggle label="Include SimpleChat document context"
+                checked={settings.include_document_context !== false}
+                description="Pack selected or uploaded document context into workflow prompts."
+                onChange={(value) => update('include_document_context', value)} /> : null}
+            <AgentTextField label="Foundry notes" value={settings.notes} onChange={(value) => update('notes', value)} />
+            {draft.enable_agent_gpt_apim ? (
+                <AgentNotice>Local APIM is incompatible with Foundry. Its fields and credentials can remain stored, but the local APIM switch must be disabled.
+                    <div className="mt-2"><GlassButton type="button" size="sm" onClick={() => setDraft((current) => ({ ...current, enable_agent_gpt_apim: false }))}>Disable local APIM</GlassButton></div>
+                </AgentNotice>
+            ) : null}
+        </div>
+    );
+}
+
+export function AgentModelFields(props: ModelFieldsProps) {
+    return props.draft.agent_type === 'local'
+        ? <LocalModelFields {...props} />
+        : <FoundryModelFields key={props.draft.agent_type} {...props} />;
+}

--- a/application/v2_ui/src/components/workspaceAgents/AgentTemplatesPanel.tsx
+++ b/application/v2_ui/src/components/workspaceAgents/AgentTemplatesPanel.tsx
@@ -1,0 +1,133 @@
+// AgentTemplatesPanel.tsx
+
+import { useEffect, useRef, useState, type Dispatch, type SetStateAction } from 'react';
+import { api } from '../../lib/apiClient';
+import type { ActionConfiguration, AgentConfiguration, AgentEditorOptions } from '../../lib/workspaceAuthoring';
+import {
+    agentDraftFromTemplate, agentTemplateSubmission, fetchAgentTemplates, safeAgentTemplateSettings, type AgentTemplate,
+} from '../../lib/workspaceAgentTemplates';
+import { GlassButton, GlassPanel } from '../ui/primitives';
+import { SectionSearch } from '../workspace/primitives';
+import { AgentNotice } from './AgentFields';
+
+function templateSettingsPreview(template: AgentTemplate): string {
+    try {
+        const parsed: unknown = typeof template.additional_settings === 'string' ? JSON.parse(template.additional_settings) : template.additional_settings;
+        return JSON.stringify(safeAgentTemplateSettings(parsed), null, 2);
+    } catch {
+        return 'The template contains invalid additional-settings JSON and cannot be applied.';
+    }
+}
+
+export function AgentTemplatesPanel({
+    draft, setDraft, actions, options, isNew, dirty, readOnly,
+}: {
+    draft: AgentConfiguration; setDraft: Dispatch<SetStateAction<AgentConfiguration>>;
+    actions: ActionConfiguration[]; options: AgentEditorOptions; isNew: boolean; dirty: boolean; readOnly: boolean;
+}) {
+    const enabled = options.settings.enable_agent_template_gallery === true;
+    const submissionsAllowed = enabled && options.settings.agent_templates_allow_user_submission !== false && !readOnly;
+    const [templates, setTemplates] = useState<AgentTemplate[]>([]);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [query, setQuery] = useState('');
+    const [revision, setRevision] = useState(0);
+    const [pending, setPending] = useState<AgentTemplate | null>(null);
+    const [submitting, setSubmitting] = useState(false);
+    const [notice, setNotice] = useState<string | null>(null);
+    const submitRequest = useRef<AbortController | null>(null);
+    useEffect(() => {
+        if (!enabled) return;
+        const controller = new AbortController();
+        setLoading(true);
+        setError(null);
+        void fetchAgentTemplates(controller.signal).then((items) => {
+            if (!controller.signal.aborted) setTemplates(items);
+        }).catch((cause: unknown) => {
+            if (!controller.signal.aborted) setError(cause instanceof Error ? cause.message : 'Could not load templates.');
+        }).finally(() => { if (!controller.signal.aborted) setLoading(false); });
+        return () => controller.abort();
+    }, [enabled, revision]);
+    useEffect(() => () => submitRequest.current?.abort(), []);
+
+    const apply = (template: AgentTemplate) => {
+        try {
+            const next = agentDraftFromTemplate(template, actions);
+            setDraft(next);
+            setPending(null);
+            setError(null);
+            setNotice('Template applied to a new, unsaved agent. Review the model and any unresolved action references.');
+        } catch (cause) {
+            setError(cause instanceof Error ? cause.message : 'Could not apply this template.');
+        }
+    };
+    const submit = async () => {
+        if (!submissionsAllowed) return;
+        if (!draft.display_name.trim() || !draft.description.trim() || !draft.instructions.trim()) {
+            setError('A template needs a display name, description, and instructions.');
+            return;
+        }
+        submitRequest.current?.abort();
+        const controller = new AbortController();
+        submitRequest.current = controller;
+        setSubmitting(true);
+        setError(null);
+        setNotice(null);
+        try {
+            const payload = await api.post<{ template: AgentTemplate }>('/api/agent-templates', agentTemplateSubmission(draft), controller.signal);
+            if (!payload.template) throw new Error('The template service returned an invalid response.');
+            if (!controller.signal.aborted) setNotice(payload.template.status === 'approved' ? 'Template published to the approved gallery.' : 'Personal template submitted for review.');
+        } catch (cause) {
+            if (!controller.signal.aborted) setError(cause instanceof Error ? cause.message : 'Could not submit this template.');
+        } finally {
+            if (!controller.signal.aborted) setSubmitting(false);
+        }
+    };
+    if (!enabled) return <AgentNotice>The example and approved-template gallery is disabled for this workspace.</AgentNotice>;
+
+    const visible = templates.filter((template) =>
+        `${template.title} ${template.display_name} ${template.description} ${(template.tags ?? []).join(' ')}`.toLowerCase().includes(query.toLowerCase()));
+    return (
+        <div className="space-y-4">
+            <p className="text-sm text-text-3">Start a new agent from an approved example or template. Instructions, tags, and recommended actions are copied into a draft, never saved automatically. Connection credentials are excluded.</p>
+            <div className="flex flex-wrap gap-2">
+                <GlassButton type="button" size="sm" disabled={loading} onClick={() => setRevision((value) => value + 1)}>Refresh templates</GlassButton>
+                {submissionsAllowed ? <GlassButton type="button" size="sm" disabled={submitting} onClick={() => void submit()}>
+                    {submitting ? 'Submitting template…' : 'Submit personal template'}
+                </GlassButton> : null}
+            </div>
+            {error ? <AgentNotice error>{error}</AgentNotice> : null}
+            {notice ? <AgentNotice>{notice}</AgentNotice> : null}
+            {loading ? <p role="status" className="text-sm text-text-3">Loading approved templates…</p> : null}
+            <SectionSearch value={query} onChange={setQuery} placeholder="Search examples and templates" />
+            {pending ? (
+                <AgentNotice>
+                    Replace the current new-agent draft with “{pending.title || pending.display_name}”? Nothing will be saved automatically.
+                    <div className="mt-3 flex flex-wrap gap-2">
+                        <GlassButton type="button" size="sm" onClick={() => setPending(null)}>Keep current draft</GlassButton>
+                        <GlassButton type="button" size="sm" variant="primary" onClick={() => apply(pending)}>Replace draft with template</GlassButton>
+                    </div>
+                </AgentNotice>
+            ) : null}
+            <div className="space-y-3">
+                {visible.map((template) => (
+                    <GlassPanel key={template.id} elevation="flat" className="space-y-3 border border-edge p-4">
+                        <h4 className="text-sm font-semibold text-text-1">{template.title || template.display_name}</h4>
+                        <p className="text-sm text-text-3">{template.description || template.helper_text}</p>
+                        {template.tags?.length ? <p className="text-xs text-text-3">{template.tags.join(' · ')}</p> : null}
+                        <details>
+                            <summary className="cursor-pointer text-xs font-medium text-accent">Preview template</summary>
+                            <pre className="mt-3 whitespace-pre-wrap break-words text-xs leading-relaxed text-text-2">{template.instructions}</pre>
+                            {template.actions_to_load?.length ? <p className="mt-3 break-words text-xs text-text-3">Recommended actions: {template.actions_to_load.join(', ')}</p> : null}
+                            {template.additional_settings ? <pre className="mt-3 whitespace-pre-wrap break-words rounded-lg border border-edge p-3 text-xs text-text-3">{templateSettingsPreview(template)}</pre> : null}
+                        </details>
+                        {isNew && !readOnly ? <GlassButton type="button" size="sm" onClick={() => dirty ? setPending(template) : apply(template)}>Use template</GlassButton> : null}
+                    </GlassPanel>
+                ))}
+            </div>
+            {!visible.length && !loading && !error ? <p role="status" className="text-sm text-text-3">No approved templates match.</p> : null}
+            {!isNew ? <p className="text-xs text-text-3">Templates start new agents; applying one will not overwrite this saved agent.</p> : null}
+            {submissionsAllowed ? <p className="text-xs text-text-3">Submission publishes a reusable recipe under the current gallery approval policy, not your connection credentials. {Object.keys(safeAgentTemplateSettings(draft.other_settings)).length ? 'Non-secret additional settings are included.' : ''}</p> : null}
+        </div>
+    );
+}

--- a/application/v2_ui/src/lib/agents.ts
+++ b/application/v2_ui/src/lib/agents.ts
@@ -31,14 +31,14 @@ function text(value: unknown): string {
 /**
  * Stable key identifying an agent within the picker.
  *
- * Agent catalog records carry `id`; `name` is the fallback for a record without one, and is
- * what the server matches on when no id is supplied.
+ * Prefer the scope-qualified catalog key. Older records still use their id/name, and old
+ * selections remain readable so a catalogue refresh does not discard a user's choice.
  */
 export function agentSelectionKey(agent: AgentRecord | undefined): string {
     if (!agent) {
         return '';
     }
-    return text(agent.id) || text(agent.name);
+    return text(agent.catalog_key) || text(agent.id) || text(agent.name);
 }
 
 /** Find the catalog record a picker selection refers to. */
@@ -49,7 +49,8 @@ export function findAgent(
     if (!selection || !agents?.length) {
         return undefined;
     }
-    return agents.find((agent) => agentSelectionKey(agent) === selection);
+    return agents.find((agent) => agentSelectionKey(agent) === selection) ??
+        agents.find((agent) => text(agent.id) === selection || (!agent.id && text(agent.name) === selection));
 }
 
 /**
@@ -73,8 +74,8 @@ export function buildAgentInfo(agent: AgentRecord | undefined): AgentInfo | null
         id: id || null,
         name,
         display_name: text(agent.display_name) || name,
-        is_global: agent.is_global === true,
-        is_group: agent.is_group === true,
+        is_global: agent.is_global === true || agent.scope_type === 'global',
+        is_group: agent.is_group === true || agent.scope_type === 'group',
         group_id: text(agent.group_id) || null,
         group_name: text(agent.group_name) || null,
     };

--- a/application/v2_ui/src/lib/conversationUrl.ts
+++ b/application/v2_ui/src/lib/conversationUrl.ts
@@ -20,6 +20,9 @@ export const CONVERSATION_PARAM = 'conversationId';
  * so the later writer restores whatever the earlier one deleted.
  */
 export const PROMPT_PARAM = 'prompt';
+export const WORKSPACE_AGENT_PARAM = 'agent_id';
+export const AGENT_SCOPE_PARAM = 'agent_scope';
+export const NEW_CHAT_PARAM = 'new';
 
 /**
  * The prompt a set of query parameters names, or null when it names none.
@@ -85,14 +88,20 @@ export function syncedConversationParams(
     const current = params.get(CONVERSATION_PARAM);
     const hasLegacy = params.has(LEGACY_CONVERSATION_PARAM);
     const hasPrompt = params.has(PROMPT_PARAM);
+    const hasAgentLaunch = params.has(WORKSPACE_AGENT_PARAM) || params.has(AGENT_SCOPE_PARAM);
 
-    if (!hasLegacy && !hasPrompt && (current ?? null) === conversationId) {
+    if (!hasLegacy && !hasPrompt && !hasAgentLaunch && (current ?? null) === conversationId) {
         return null;
     }
 
     const next = new URLSearchParams(params);
     next.delete(LEGACY_CONVERSATION_PARAM);
     next.delete(PROMPT_PARAM);
+    if (hasAgentLaunch) {
+        next.delete(WORKSPACE_AGENT_PARAM);
+        next.delete(AGENT_SCOPE_PARAM);
+        next.delete(NEW_CHAT_PARAM);
+    }
     if (conversationId) {
         next.set(CONVERSATION_PARAM, conversationId);
     } else {

--- a/application/v2_ui/src/lib/workspaceActionConnectors.ts
+++ b/application/v2_ui/src/lib/workspaceActionConnectors.ts
@@ -1,0 +1,969 @@
+// workspaceActionConnectors.ts
+
+import { api, ApiError, uploadFile } from './apiClient';
+import {
+    buildEditorWrite, EDITOR_SECRET_MASK, isRecord, pointerPart,
+    type ActionConfiguration, type AuthoringResource,
+} from './workspaceAuthoring';
+import type { ActionIdentity } from './workspaceActionTypes';
+
+export type ApiConnector = 'openapi' | 'mcp';
+export type ConnectorResource = AuthoringResource<ActionConfiguration> | null;
+export interface ConnectorOption { value: string; label: string }
+
+// Remote specification import was removed; both modes use the upload validator.
+export const OPENAPI_SOURCE_OPTIONS = [
+    { value: 'file', label: 'Upload a JSON or YAML file' },
+    { value: 'manual', label: 'Write or paste JSON / YAML' },
+] as const;
+
+export const STORED_CONNECTOR_SECRET = 'Stored_In_KeyVault';
+export const OPENAPI_AUTH_OPTIONS: ConnectorOption[] = [
+    { value: 'none', label: 'No authentication' },
+    { value: 'api_key', label: 'API key' },
+    { value: 'bearer', label: 'Bearer token' },
+    { value: 'basic', label: 'Basic authentication' },
+    { value: 'oauth2', label: 'OAuth 2 access token' },
+];
+export const MCP_AUTH_OPTIONS: ConnectorOption[] = [
+    ...OPENAPI_AUTH_OPTIONS.filter(({ value }) => value !== 'oauth2'),
+    { value: 'identity', label: 'Reusable identity' },
+];
+export const MCP_PERSONAL_TRANSPORTS: ConnectorOption[] = [
+    { value: 'streamable_http', label: 'Streamable HTTP' },
+    { value: 'sse', label: 'Server-sent events (SSE)' },
+    { value: 'websocket', label: 'WebSocket' },
+];
+export const MCP_DEFAULT_FIELDS: Record<string, unknown> = {
+    server_profile: 'generic', transport: 'streamable_http', auth_method: 'none',
+    api_key_header_name: 'X-API-Key', load_tools: true, load_prompts: false,
+    request_timeout: 30, connect_timeout: 10, sse_read_timeout: 300,
+    retry_count: 0, retry_backoff_seconds: 1, validate_tool_arguments: false,
+    tool_result_policy: 'truncate', allowed_tool_names: [],
+};
+export const MCP_NUMBER_FIELDS = [
+    { key: 'request_timeout', label: 'Request timeout (seconds)', min: 1, max: 300, defaultValue: 30 },
+    { key: 'connect_timeout', label: 'Connection timeout (seconds)', min: 1, max: 300, defaultValue: 10 },
+    { key: 'sse_read_timeout', label: 'SSE read timeout (seconds)', min: 1, max: 300, defaultValue: 300 },
+    { key: 'retry_count', label: 'Retry count', min: 0, max: 3, defaultValue: 0 },
+    { key: 'retry_backoff_seconds', label: 'Retry backoff (seconds)', min: 1, max: 30, defaultValue: 1 },
+];
+
+export function connectorText(value: unknown): string {
+    return typeof value === 'string' ? value : '';
+}
+
+export function connectorObject(value: unknown): Record<string, unknown> {
+    return isRecord(value) ? value : {};
+}
+
+export function connectorStrings(value: unknown): string[] {
+    return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : [];
+}
+
+export function connectorLines(value: string): string[] {
+    return [...new Set(value.split(/\r?\n/).map((line) => line.trim()).filter(Boolean))];
+}
+
+export function updateConnectorFields(
+    draft: ActionConfiguration, fields: Record<string, unknown>,
+): ActionConfiguration {
+    return { ...draft, additionalFields: { ...draft.additionalFields, ...fields } };
+}
+
+export function connectorAuthMethod(draft: ActionConfiguration, kind: ApiConnector): string {
+    if (draft.identity_id || draft.auth.type === 'identity') return 'identity';
+    const explicit = connectorText(draft.additionalFields.auth_method);
+    if (explicit) return explicit;
+    if (kind === 'mcp') return draft.auth.type === 'key' ? 'bearer' : 'none';
+    if (['api_key', 'bearer', 'basic', 'oauth2'].includes(draft.auth.type)) return draft.auth.type;
+    return draft.auth.type === 'key' && draft.auth.key ? 'api_key' : 'none';
+}
+
+export function connectorSecretField(draft: ActionConfiguration, kind: ApiConnector): string {
+    if (kind === 'openapi') {
+        if (draft.auth.type === 'api_key') return 'value';
+        if (['bearer', 'oauth2'].includes(draft.auth.type)) return 'token';
+        if (draft.auth.type === 'basic' && Object.hasOwn(draft.auth, 'password')) return 'password';
+    }
+    return 'key';
+}
+
+export function changeConnectorAuthMethod(
+    draft: ActionConfiguration, kind: ApiConnector, method: string,
+): ActionConfiguration {
+    const choices = kind === 'openapi' ? OPENAPI_AUTH_OPTIONS : MCP_AUTH_OPTIONS;
+    if (!choices.some(({ value }) => value === method)) throw new Error('Unsupported authentication method.');
+    const auth: ActionConfiguration['auth'] = {
+        ...draft.auth,
+        type: method === 'identity' ? 'identity' : kind === 'mcp' && method === 'none' ? 'NoAuth' : 'key',
+    };
+    // OpenAPI's V1 "none" manifest still uses type=key; legacy aliases must not supply a fallback.
+    if (kind === 'openapi' && method === 'none') {
+        auth.key = '';
+        for (const field of ['value', 'token', 'password']) {
+            if (Object.hasOwn(auth, field)) auth[field] = '';
+        }
+    }
+    if (method !== 'none' && method !== 'identity' && !Object.hasOwn(auth, 'key')) auth.key = '';
+    return {
+        ...draft,
+        auth,
+        additionalFields: {
+            ...draft.additionalFields,
+            auth_method: method,
+            ...(method === 'api_key' && kind === 'openapi' ? {
+                api_key_location: draft.additionalFields.api_key_location ?? draft.auth.location ?? 'header',
+                api_key_name: draft.additionalFields.api_key_name ?? draft.auth.name ?? 'X-API-Key',
+            } : {}),
+            ...(method === 'api_key' && kind === 'mcp' ? {
+                api_key_header_name: draft.additionalFields.api_key_header_name ?? 'X-API-Key',
+            } : {}),
+        },
+    };
+}
+
+export function availableConnectorIdentities(identities: ActionIdentity[], kind: ApiConnector): ActionIdentity[] {
+    const allowed = kind === 'mcp'
+        ? ['api_key', 'bearer_token', 'username_password', 'managed_identity']
+        : ['api_key', 'bearer_token', 'username_password'];
+    return identities.filter((identity) => identity.id && allowed.includes(identity.auth_type.toLowerCase()));
+}
+
+export function connectorIdentityOptions(
+    identities: ActionIdentity[], kind: ApiConnector, selectedId: string,
+): { identities: ActionIdentity[]; unavailable: boolean } {
+    const available = availableConnectorIdentities(identities, kind);
+    return { identities: available, unavailable: Boolean(selectedId && !available.some(({ id }) => id === selectedId)) };
+}
+
+export function selectConnectorIdentity(
+    draft: ActionConfiguration, kind: ApiConnector, identity: ActionIdentity | null,
+): ActionConfiguration {
+    if (identity) {
+        if (!availableConnectorIdentities([identity], kind).length) throw new Error('This identity cannot authenticate this connector.');
+        return {
+            ...draft,
+            identity_id: identity.id,
+            auth: { ...draft.auth, type: 'identity', identity: identity.id },
+            additionalFields: {
+                ...draft.additionalFields, auth_method: 'identity',
+                identity_auth_type: identity.auth_type.toLowerCase(),
+                ...(kind === 'openapi' && identity.auth_type.toLowerCase() === 'api_key' ? {
+                    api_key_location: draft.additionalFields.api_key_location ?? draft.auth.location ?? 'header',
+                    api_key_name: draft.additionalFields.api_key_name ?? draft.auth.name ?? 'X-API-Key',
+                } : {}),
+            },
+        };
+    }
+    const next = changeConnectorAuthMethod(draft, kind, 'none');
+    const additionalFields = { ...next.additionalFields };
+    delete additionalFields.identity_auth_type;
+    return { ...next, identity_id: '', additionalFields };
+}
+
+export function openApiBasicCredentials(draft: ActionConfiguration): { username: string; password: string; stored: boolean } {
+    if (draft.auth.type === 'basic' && Object.hasOwn(draft.auth, 'password')) {
+        return {
+            username: connectorText(draft.auth.username ?? draft.auth.identity),
+            password: connectorText(draft.auth.password),
+            stored: draft.auth.password === EDITOR_SECRET_MASK,
+        };
+    }
+    const key = connectorText(draft.auth.key);
+    if ([EDITOR_SECRET_MASK, STORED_CONNECTOR_SECRET].includes(key)) {
+        return { username: '', password: key, stored: true };
+    }
+    const separator = key.indexOf(':');
+    return {
+        username: separator < 0 ? '' : key.slice(0, separator),
+        password: separator < 0 ? '' : key.slice(separator + 1),
+        stored: false,
+    };
+}
+
+export function changeOpenApiBasicCredential(
+    draft: ActionConfiguration, part: 'username' | 'password', value: string,
+): ActionConfiguration {
+    if (draft.auth.type === 'basic' && Object.hasOwn(draft.auth, 'password')) {
+        return { ...draft, auth: { ...draft.auth, [part]: value } };
+    }
+    if (part === 'password' && (value === EDITOR_SECRET_MASK || value === '')) {
+        return { ...draft, auth: { ...draft.auth, key: value } };
+    }
+    const current = openApiBasicCredentials(draft);
+    const username = part === 'username' ? value : current.username;
+    const password = part === 'password' ? value : current.stored ? '' : current.password;
+    return { ...draft, auth: { ...draft.auth, key: `${username}:${password}` } };
+}
+
+export function connectorUrlError(value: unknown, websocket = false): string | null {
+    const text = connectorText(value);
+    if (!text.trim()) return 'Enter an endpoint URL.';
+    try {
+        const url = new URL(text);
+        const protocols = websocket ? ['ws:', 'wss:'] : ['http:', 'https:'];
+        if (!protocols.includes(url.protocol) || !url.hostname || url.username || url.password || url.hash || /\s/.test(text)) {
+            return `Use an absolute ${websocket ? 'ws:// or wss://' : 'http:// or https://'} URL without credentials, spaces, or a fragment.`;
+        }
+        return null;
+    } catch {
+        return 'Enter a valid absolute URL.';
+    }
+}
+
+export interface OpenApiOperation {
+    id: string;
+    method: string;
+    path: string;
+    summary: string;
+    description: string;
+    deprecated: boolean;
+    tags: string[];
+    parameters: { name: string; location: string; required: boolean; type: string; description: string }[];
+    bodyRequired: boolean;
+    contentTypes: string[];
+    responses: string[];
+    security: string[];
+}
+
+export interface OpenApiSecurityScheme {
+    id: string;
+    method: string;
+    description: string;
+    location: string;
+    name: string;
+    scopes: string[];
+    supported: boolean;
+}
+
+export interface OpenApiInformation {
+    title: string;
+    description: string;
+    version: string;
+    specificationVersion: string;
+    servers: { url: string; description: string }[];
+    pathsCount: number;
+    operations: OpenApiOperation[];
+    securitySchemes: OpenApiSecurityScheme[];
+}
+
+function resolveSpecObject(spec: Record<string, unknown>, value: unknown): Record<string, unknown> {
+    let current = connectorObject(value);
+    const visited = new Set<string>();
+    while (typeof current.$ref === 'string' && current.$ref.startsWith('#/')) {
+        if (visited.has(current.$ref)) break;
+        visited.add(current.$ref);
+        let target: unknown = spec;
+        for (const encoded of current.$ref.slice(2).split('/')) {
+            const key = encoded.replace(/~1/g, '/').replace(/~0/g, '~');
+            if (!isRecord(target) || !Object.hasOwn(target, key)) { target = undefined; break; }
+            target = target[key];
+        }
+        if (!isRecord(target)) break;
+        current = target;
+    }
+    return current;
+}
+
+export function openApiInformation(value: unknown): OpenApiInformation {
+    const spec = connectorObject(value);
+    const info = connectorObject(spec.info);
+    const paths = connectorObject(spec.paths);
+    const operations: OpenApiOperation[] = [];
+    const methods = new Set(['get', 'post', 'put', 'patch', 'delete', 'head', 'options', 'trace']);
+    for (const [path, rawPath] of Object.entries(paths)) {
+        const pathItem = resolveSpecObject(spec, rawPath);
+        for (const [method, rawOperation] of Object.entries(pathItem)) {
+            if (!methods.has(method) || !isRecord(rawOperation)) continue;
+            const operation = resolveSpecObject(spec, rawOperation);
+            const parameterMap = new Map<string, OpenApiOperation['parameters'][number]>();
+            for (const rawParameter of [
+                ...(Array.isArray(pathItem.parameters) ? pathItem.parameters : []),
+                ...(Array.isArray(operation.parameters) ? operation.parameters : []),
+            ]) {
+                const parameter = resolveSpecObject(spec, rawParameter);
+                const name = connectorText(parameter.name);
+                if (!name) continue;
+                const location = connectorText(parameter.in);
+                const schema = resolveSpecObject(spec, parameter.schema);
+                parameterMap.set(`${location}:${name}`, {
+                    name, location, required: parameter.required === true,
+                    type: connectorText(schema.type ?? parameter.type) || 'value',
+                    description: connectorText(parameter.description),
+                });
+            }
+            const body = resolveSpecObject(spec, operation.requestBody);
+            const security = operation.security ?? spec.security;
+            operations.push({
+                id: connectorText(operation.operationId), method: method.toUpperCase(), path,
+                summary: connectorText(operation.summary), description: connectorText(operation.description),
+                deprecated: operation.deprecated === true, tags: connectorStrings(operation.tags),
+                parameters: [...parameterMap.values()], bodyRequired: body.required === true,
+                contentTypes: Object.keys(connectorObject(body.content)),
+                responses: Object.keys(connectorObject(operation.responses)),
+                security: Array.isArray(security) ? security.flatMap((entry) => Object.keys(connectorObject(entry))) : [],
+            });
+        }
+    }
+    const securitySchemes = Object.entries(
+        connectorObject(connectorObject(spec.components).securitySchemes ?? spec.securityDefinitions),
+    ).map(([id, value]): OpenApiSecurityScheme => {
+        const scheme = resolveSpecObject(spec, value);
+        const type = connectorText(scheme.type).toLowerCase();
+        const method = type === 'apikey' ? 'api_key' : type === 'http' ? connectorText(scheme.scheme).toLowerCase() : type;
+        const location = connectorText(scheme.in) || 'header';
+        const scopes = Object.values(connectorObject(scheme.flows))
+            .flatMap((flow) => Object.keys(connectorObject(connectorObject(flow).scopes)));
+        return {
+            id, method, location, name: connectorText(scheme.name),
+            description: connectorText(scheme.description), scopes: [...new Set(scopes)],
+            supported: OPENAPI_AUTH_OPTIONS.some(({ value }) => value === method) &&
+                (method !== 'api_key' || ['header', 'query'].includes(location)),
+        };
+    });
+    const servers = (Array.isArray(spec.servers) ? spec.servers : []).filter(isRecord).map((server) => ({
+        url: connectorText(server.url).replace(/\{([^}]+)\}/g, (match, name: string) => {
+            const replacement = connectorObject(connectorObject(server.variables)[name]).default;
+            return typeof replacement === 'string' ? replacement : match;
+        }),
+        description: connectorText(server.description),
+    }));
+    if (!servers.length && typeof spec.host === 'string') {
+        servers.push({ url: `${connectorStrings(spec.schemes)[0] ?? 'https'}://${spec.host}${connectorText(spec.basePath)}`, description: '' });
+    }
+    return {
+        title: connectorText(info.title), version: connectorText(info.version),
+        description: connectorText(info.description),
+        specificationVersion: connectorText(spec.openapi ?? spec.swagger),
+        servers, pathsCount: Object.keys(paths).length, operations, securitySchemes,
+    };
+}
+
+export interface OpenApiUploadResult {
+    success: boolean;
+    file_id?: string;
+    original_filename?: string;
+    spec_content: Record<string, unknown>;
+    spec_info?: Record<string, unknown>;
+    authentication?: Record<string, unknown>;
+    warnings?: string[];
+    error?: string;
+}
+
+export interface OpenApiSourceDraft {
+    mode: (typeof OPENAPI_SOURCE_OPTIONS)[number]['value'];
+    format: 'json' | 'yaml';
+    text: string;
+    pending: boolean;
+    filename?: string;
+}
+
+export function openApiSourceDraft(draft: ActionConfiguration): OpenApiSourceDraft {
+    const source = connectorObject(draft._openApiSourceDraft);
+    return {
+        mode: source.mode === 'manual' ? 'manual' : 'file',
+        format: source.format === 'yaml' ? 'yaml' : 'json',
+        text: typeof source.text === 'string' ? source.text : JSON.stringify(draft.additionalFields.openapi_spec_content ?? {}, null, 2),
+        pending: source.pending === true,
+        filename: connectorText(source.filename),
+    };
+}
+
+export function updateOpenApiSourceDraft(
+    draft: ActionConfiguration, updates: Partial<OpenApiSourceDraft>,
+): ActionConfiguration {
+    // Draft-only source text survives section changes; shared editor writes omit root _ fields.
+    return { ...draft, _openApiSourceDraft: { ...openApiSourceDraft(draft), ...updates } };
+}
+
+export async function uploadOpenApiSpecification(file: File | Blob, filename?: string, signal?: AbortSignal): Promise<OpenApiUploadResult> {
+    const name = filename || (file instanceof File ? file.name : 'openapi.json');
+    if (!/\.(json|ya?ml)$/i.test(name)) throw new Error('Choose a .json, .yaml, or .yml specification.');
+    if (file.size > 5 * 1024 * 1024) throw new Error('OpenAPI specifications must be 5 MB or smaller.');
+    if (!file.size) throw new Error('The specification is empty.');
+    const formData = new FormData();
+    formData.append('file', file, name);
+    const result = await uploadFile<OpenApiUploadResult>('/api/openapi/upload', formData, signal);
+    if (!result || result.success !== true || !isRecord(result.spec_content)) {
+        throw new Error(result?.error || 'The server did not return a validated OpenAPI specification.');
+    }
+    return { ...result, warnings: connectorStrings(result.warnings) };
+}
+
+export function processOpenApiText(text: string, format: 'json' | 'yaml', signal?: AbortSignal): Promise<OpenApiUploadResult> {
+    return uploadOpenApiSpecification(
+        new Blob([text], { type: format === 'json' ? 'application/json' : 'application/yaml' }),
+        `openapi.${format}`, signal,
+    );
+}
+
+export function applyOpenApiSpecification(draft: ActionConfiguration, result: OpenApiUploadResult): ActionConfiguration {
+    if (!result.success || !isRecord(result.spec_content)) throw new Error('A validated specification is required.');
+    const information = openApiInformation(result.spec_content);
+    const source = openApiSourceDraft(draft);
+    const endpoint = draft.endpoint || connectorText(draft.additionalFields.base_url) ||
+        information.servers.find(({ url }) => !connectorUrlError(url))?.url || '';
+    return {
+        ...draft, endpoint,
+        additionalFields: {
+            ...draft.additionalFields,
+            openapi_spec_content: result.spec_content, openapi_source_type: 'content', base_url: endpoint,
+        },
+        _openApiSourceDraft: {
+            ...source, pending: false,
+            text: JSON.stringify(result.spec_content, null, 2), format: 'json',
+            filename: result.original_filename || '',
+        },
+    };
+}
+
+export interface McpCatalogEntry {
+    id: string;
+    displayName: string;
+    description: string;
+    defaults: Record<string, unknown>;
+    constraints: Record<string, unknown>;
+    ui: Record<string, unknown>;
+    warnings: string[];
+    implementation: Record<string, unknown>;
+    additionalSettings: Record<string, unknown>;
+    endpoint?: string;
+    transport?: string;
+    presetId?: string;
+    scopeEligibility?: string[];
+    requiredGovernanceGates?: string[];
+    operatorNotes?: string[];
+    authRequirement?: string;
+    riskLabel?: string;
+    catalogTier?: string;
+    documentationUrl?: string;
+}
+
+export const MCP_GENERIC_PRESET: McpCatalogEntry = {
+    id: 'generic', displayName: 'Generic MCP server',
+    description: 'Standards-compliant MCP server.',
+    defaults: MCP_DEFAULT_FIELDS, constraints: {}, ui: {}, warnings: [],
+    implementation: { id: 'generic', schemaVersion: '1.0.0' },
+    additionalSettings: { compatibilityProfile: 'standards_compliant' },
+};
+
+export function parseMcpCatalogue(payload: unknown, key: 'presets' | 'preconfigurations'): McpCatalogEntry[] {
+    let records: unknown = payload;
+    if (isRecord(records)) records = records[key] ?? connectorObject(records.data)[key] ?? records.data;
+    if (!Array.isArray(records)) throw new Error(`The server returned an invalid MCP ${key} catalogue.`);
+    const entries: McpCatalogEntry[] = records.map((value) => {
+        if (!isRecord(value) || !connectorText(value.id)) throw new Error(`The MCP ${key} catalogue contains an invalid entry.`);
+        return {
+            ...value, id: connectorText(value.id), displayName: connectorText(value.displayName) || connectorText(value.id),
+            description: connectorText(value.description), defaults: connectorObject(value.defaults),
+            constraints: connectorObject(value.constraints), ui: connectorObject(value.ui),
+            implementation: connectorObject(value.implementation), additionalSettings: connectorObject(value.additionalSettings),
+            warnings: connectorStrings(value.warnings), endpoint: typeof value.endpoint === 'string' ? value.endpoint : undefined,
+            transport: typeof value.transport === 'string' ? value.transport : undefined,
+            presetId: typeof value.presetId === 'string' ? value.presetId : undefined,
+            scopeEligibility: Array.isArray(value.scopeEligibility) ? connectorStrings(value.scopeEligibility) : undefined,
+            requiredGovernanceGates: connectorStrings(value.requiredGovernanceGates),
+            operatorNotes: connectorStrings(value.operatorNotes),
+            authRequirement: connectorText(value.authRequirement), riskLabel: connectorText(value.riskLabel),
+            catalogTier: connectorText(value.catalogTier), documentationUrl: connectorText(value.documentationUrl),
+        };
+    });
+    if (new Set(entries.map(({ id }) => id)).size !== entries.length) throw new Error(`The MCP ${key} catalogue contains duplicate identifiers.`);
+    return entries;
+}
+
+export async function fetchMcpPresets(signal?: AbortSignal): Promise<McpCatalogEntry[]> {
+    return parseMcpCatalogue(await api.get<unknown>('/api/plugins/mcp/presets', signal), 'presets');
+}
+
+export async function fetchMcpPreconfigurations(signal?: AbortSignal): Promise<McpCatalogEntry[]> {
+    return parseMcpCatalogue(await api.get<unknown>('/api/plugins/mcp/preconfigurations?scope=personal', signal), 'preconfigurations');
+}
+
+export function allowedMcpTransports(preset?: McpCatalogEntry): ConnectorOption[] {
+    const allowed = connectorStrings(preset?.constraints.allowedTransports);
+    return MCP_PERSONAL_TRANSPORTS.filter(({ value }) => !allowed.length || allowed.includes(value));
+}
+
+export function allowedMcpAuthMethods(transport: string, preset?: McpCatalogEntry): ConnectorOption[] {
+    const allowed = connectorStrings(preset?.constraints.allowedAuthMethods);
+    return MCP_AUTH_OPTIONS.filter(({ value }) =>
+        (transport !== 'websocket' || value === 'none') && (!allowed.length || allowed.includes(value)));
+}
+
+export interface McpImplementationField {
+    key: string;
+    label: string;
+    kind: 'fixed' | 'select' | 'multi' | 'lines';
+    options?: ConnectorOption[];
+    expected?: string | boolean;
+    help?: string;
+    optional?: boolean;
+}
+
+const options = (...values: string[]): ConnectorOption[] => values.map((value) => ({
+    value, label: value.replaceAll('_', ' '),
+}));
+const fixed = (key: string, label: string, expected: string | boolean, help?: string): McpImplementationField =>
+    ({ key, label, expected, help, kind: 'fixed' });
+const implementationFields: Record<string, McpImplementationField[]> = {
+    generic: [fixed('compatibilityProfile', 'Compatibility profile', 'standards_compliant')],
+    splunk: [
+        fixed('compatibilityProfile', 'Compatibility profile', 'splunk_mcp'),
+        fixed('credentialMode', 'Credential handling', 'scoped_test_or_workspace_identity'),
+        fixed('customHeaderValueHandling', 'Custom header values', 'secret'),
+        fixed('preferredTransport', 'Preferred transport', 'streamable_http'),
+    ],
+    microsoft_learn: [
+        { key: 'contentFocus', label: 'Documentation focus', kind: 'select', options: options('all_microsoft', 'azure') },
+        fixed('publicDocumentationOnly', 'Public documentation only', true),
+        { key: 'preferredTools', label: 'Preferred documentation tools', kind: 'multi', options: options('microsoft_docs_search', 'microsoft_docs_fetch', 'microsoft_code_sample_search') },
+    ],
+    github: [
+        fixed('hostedServer', 'Hosted GitHub server', true),
+        fixed('permissionModel', 'Permission model', 'supplied_identity_permissions'),
+        fixed('recommendedCredentialHandling', 'Credential guidance', 'least_privilege_pat_or_identity'),
+        { ...fixed('defaultRepositoryScope', 'Repository scope', 'user_selected'), optional: true },
+    ],
+    microsoft_sentinel: [
+        fixed('dataSensitivity', 'Data sensitivity', 'high'),
+        fixed('defaultAccessMode', 'Access mode', 'read_only'),
+        { key: 'requiredProducts', label: 'Required products', kind: 'multi', options: options('microsoft_sentinel_data_lake', 'microsoft_defender', 'microsoft_security_copilot_optional') },
+        { key: 'toolCollections', label: 'Tool collections', kind: 'multi', options: options('incidents_read', 'alerts_read', 'entities_read', 'hunting_read') },
+    ],
+    azure_mcp_server: [
+        fixed('defaultAccessMode', 'Access mode', 'read_only'),
+        fixed('localCommandExecution', 'Local command execution', false),
+        fixed('organizationHostedRemoteRequired', 'Organization-hosted remote endpoint required', true),
+        { key: 'serviceNamespaces', label: 'Azure service namespaces', kind: 'lines', help: 'One namespace per line, for example Azure.ResourceGroups. Keep this list limited to the services the agent needs.' },
+    ],
+    simplechat_local_dev: [
+        fixed('fixtureType', 'Fixture type', 'simplechat_local_mcp'),
+        fixed('intendedEnvironment', 'Intended environment', 'development'),
+        fixed('loopbackOnly', 'Loopback only', true),
+    ],
+};
+
+export function mcpImplementationFields(id: string): McpImplementationField[] {
+    return Object.hasOwn(implementationFields, id) ? implementationFields[id] : [];
+}
+
+function mergeConnectorObjects(before: Record<string, unknown>, after: Record<string, unknown>): Record<string, unknown> {
+    return Object.fromEntries([...new Set([...Object.keys(before), ...Object.keys(after)])].map((key) => {
+        if (!Object.hasOwn(after, key) || before[key] === EDITOR_SECRET_MASK || before[key] === STORED_CONNECTOR_SECRET) return [key, before[key]];
+        if (isRecord(before[key]) && isRecord(after[key])) return [key, mergeConnectorObjects(before[key], after[key])];
+        return [key, after[key]];
+    }));
+}
+
+function applyMcpImplementation(fields: Record<string, unknown>, entry: McpCatalogEntry): Record<string, unknown> {
+    if (!Object.keys(entry.implementation).length) return fields;
+    const previousImplementation = connectorObject(fields.implementation);
+    const changingImplementation = previousImplementation.id !== entry.implementation.id;
+    const oldKnownKeys = new Set(mcpImplementationFields(connectorText(previousImplementation.id)).map(({ key }) => key));
+    const previousSettings = Object.fromEntries(Object.entries(connectorObject(fields.additionalSettings))
+        .filter(([key]) => !changingImplementation || !oldKnownKeys.has(key) || Object.hasOwn(entry.additionalSettings, key)));
+    return {
+        ...fields,
+        implementation: { ...previousImplementation, ...entry.implementation },
+        additionalSettings: mergeConnectorObjects(previousSettings, entry.additionalSettings),
+    };
+}
+
+export function applyMcpPreset(draft: ActionConfiguration, preset: McpCatalogEntry): ActionConfiguration {
+    const transports = allowedMcpTransports(preset);
+    if (!transports.length) throw new Error('This preset has no transport permitted in a personal workspace.');
+    const defaults = { ...MCP_DEFAULT_FIELDS, ...preset.defaults };
+    const preferredTransport = connectorText(defaults.transport);
+    const transport = transports.some(({ value }) => value === preferredTransport) ? preferredTransport : transports[0].value;
+    let fields = mergeConnectorObjects(draft.additionalFields, {
+        ...defaults, server_profile: preset.id, transport,
+        allowed_tool_names: [...new Set([
+            ...connectorStrings(draft.additionalFields.allowed_tool_names),
+            ...connectorStrings(defaults.allowed_tool_names),
+        ])],
+    });
+    fields = applyMcpImplementation(fields, preset);
+    const next = { ...draft, additionalFields: fields };
+    return draft.identity_id ? {
+        ...next, additionalFields: { ...fields, auth_method: 'identity' },
+    } : changeConnectorAuthMethod(next, 'mcp', connectorText(defaults.auth_method) || 'none');
+}
+
+export function applyMcpPreconfiguration(
+    draft: ActionConfiguration, entry: McpCatalogEntry, preset = MCP_GENERIC_PRESET,
+): ActionConfiguration {
+    if (entry.scopeEligibility?.length && !entry.scopeEligibility.includes('personal')) {
+        throw new Error('This preconfiguration is not available in a personal workspace.');
+    }
+    if (entry.transport === 'stdio') throw new Error('Personal actions cannot use stdio.');
+    let next = applyMcpPreset(draft, preset);
+    let fields = mergeConnectorObjects(next.additionalFields, {
+        ...entry.defaults, preconfiguration_id: entry.id, server_profile: entry.presetId ?? preset.id,
+        ...(entry.transport !== undefined ? { transport: entry.transport } : {}),
+        allowed_tool_names: [...new Set([
+            ...connectorStrings(draft.additionalFields.allowed_tool_names),
+            ...connectorStrings(entry.defaults.allowed_tool_names),
+        ])],
+    });
+    fields = applyMcpImplementation(fields, entry);
+    next = {
+        ...next, additionalFields: fields, endpoint: entry.endpoint ?? next.endpoint,
+        displayName: draft.displayName || entry.displayName, description: draft.description || entry.description,
+    };
+    return draft.identity_id ? {
+        ...next, additionalFields: { ...fields, auth_method: 'identity' },
+    } : changeConnectorAuthMethod(next, 'mcp', connectorText(fields.auth_method) || 'none');
+}
+
+const headerNamePattern = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
+const reservedHeaders = new Set([
+    'connection', 'content-length', 'cookie', 'host', 'keep-alive', 'proxy-authenticate',
+    'proxy-authorization', 'set-cookie', 'te', 'trailer', 'transfer-encoding', 'upgrade',
+]);
+
+export function mcpHeaderNameError(name: string, headers: Record<string, unknown> = {}, previousName?: string): string | null {
+    if (!headerNamePattern.test(name) || reservedHeaders.has(name.toLowerCase())) return 'Use a valid, non-reserved HTTP header name.';
+    if (Object.keys(headers).some((key) => key !== previousName && key.toLowerCase() === name.toLowerCase())) return 'A header with this name already exists.';
+    return null;
+}
+
+export function renameMcpHeader(draft: ActionConfiguration, before: string, after: string): ActionConfiguration {
+    const headers = connectorObject(draft.additionalFields.custom_headers);
+    const error = mcpHeaderNameError(after, headers, before);
+    if (error) throw new Error(error);
+    if (before !== after && [EDITOR_SECRET_MASK, STORED_CONNECTOR_SECRET].includes(connectorText(headers[before]))) {
+        throw new Error('Replace the stored header value before renaming its header.');
+    }
+    return updateConnectorFields(draft, {
+        custom_headers: Object.fromEntries(Object.entries(headers).map(([name, value]) => [name === before ? after : name, value])),
+    });
+}
+
+export interface McpTool extends Record<string, unknown> {
+    original_name: string;
+    function_name: string;
+    description?: string;
+    input_schema?: Record<string, unknown>;
+    output_schema?: Record<string, unknown>;
+    annotations?: Record<string, unknown>;
+}
+
+export function parseMcpTools(value: unknown): McpTool[] {
+    if (!Array.isArray(value)) return [];
+    return value.filter(isRecord).flatMap((tool) => {
+        const name = connectorText(tool.original_name ?? tool.name);
+        return name ? [{
+            ...tool, original_name: name, function_name: connectorText(tool.function_name) || name,
+            description: connectorText(tool.description),
+            input_schema: connectorObject(tool.input_schema ?? tool.inputSchema),
+            output_schema: connectorObject(tool.output_schema ?? tool.outputSchema),
+            annotations: connectorObject(tool.annotations),
+        }] : [];
+    });
+}
+
+export function mergeMcpTools(previous: unknown, discovered: unknown, selected: string[]): McpTool[] {
+    const old = new Map(parseMcpTools(previous).map((tool) => [tool.original_name, tool]));
+    const next = new Map(parseMcpTools(discovered).map((tool) => [
+        tool.original_name,
+        { ...old.get(tool.original_name), ...tool } as McpTool,
+    ]));
+    for (const name of selected) {
+        const prior = old.get(name);
+        if (!next.has(name) && prior) next.set(name, prior);
+    }
+    return [...next.values()];
+}
+
+export function mcpToolChoices(tools: unknown, selected: unknown, discoveredNames?: string[]): {
+    name: string; tool?: McpTool; selected: boolean; unavailable: boolean;
+}[] {
+    const catalogue = new Map(parseMcpTools(tools).map((tool) => [tool.original_name, tool]));
+    const names = connectorStrings(selected);
+    const available = discoveredNames ? new Set(discoveredNames) : null;
+    return [...new Set([...names, ...catalogue.keys()])].map((name) => ({
+        name, tool: catalogue.get(name), selected: names.includes(name),
+        unavailable: available ? !available.has(name) : !catalogue.has(name),
+    }));
+}
+
+export function setMcpToolSelection(draft: ActionConfiguration, name: string, selected: boolean): ActionConfiguration {
+    const current = connectorStrings(draft.additionalFields.allowed_tool_names);
+    return updateConnectorFields(draft, {
+        allowed_tool_names: selected ? [...new Set([...current, name])] : current.filter((item) => item !== name),
+    });
+}
+
+function pointerValue(value: unknown, pointer: string): unknown {
+    let current = value;
+    for (const part of pointer.slice(1).split('/')) {
+        const key = part.replace(/~1/g, '/').replace(/~0/g, '~');
+        if (Array.isArray(current) && /^(0|[1-9][0-9]*)$/.test(key)) {
+            current = current[Number(key)];
+            continue;
+        }
+        if (!isRecord(current) || !Object.hasOwn(current, key)) return undefined;
+        current = current[key];
+    }
+    return current;
+}
+
+function supportedSecret(value: unknown, path: string, original: ConnectorResource): boolean {
+    if (value === EDITOR_SECRET_MASK || value === STORED_CONNECTOR_SECRET) {
+        return Boolean(original && !original.read_only && original.secret_paths.includes(path) &&
+            [EDITOR_SECRET_MASK, STORED_CONNECTOR_SECRET].includes(connectorText(pointerValue(original.record, path))));
+    }
+    return typeof value === 'string' && Boolean(value.trim());
+}
+
+export function validateConnectorAuthentication(
+    draft: ActionConfiguration, kind: ApiConnector, original: ConnectorResource,
+): Record<string, string> {
+    const errors: Record<string, string> = {};
+    const method = connectorAuthMethod(draft, kind);
+    if (kind === 'openapi' && (method === 'api_key' ||
+        method === 'identity' && draft.additionalFields.identity_auth_type === 'api_key')) {
+        const location = connectorText(draft.additionalFields.api_key_location ?? draft.auth.location ?? 'header');
+        const name = connectorText(draft.additionalFields.api_key_name ?? draft.auth.name ?? 'X-API-Key');
+        if (!['header', 'query'].includes(location)) errors['additionalFields.api_key_location'] = 'API keys support a header or query parameter.';
+        if (!name.trim() || (location === 'header' && !headerNamePattern.test(name))) errors['additionalFields.api_key_name'] = 'Enter a valid API key header or query parameter name.';
+    }
+    if (method === 'identity') {
+        if (!draft.identity_id) errors.identity_id = 'Choose a reusable identity.';
+        if (kind === 'mcp' && draft.additionalFields.identity_auth_type === 'api_key') {
+            const error = mcpHeaderNameError(connectorText(draft.additionalFields.api_key_header_name ?? 'X-API-Key'));
+            if (error) errors['additionalFields.api_key_header_name'] = error;
+        }
+        return errors;
+    }
+    const supported = kind === 'openapi' ? OPENAPI_AUTH_OPTIONS : MCP_AUTH_OPTIONS;
+    if (!supported.some(({ value }) => value === method)) errors['additionalFields.auth_method'] = 'Choose a supported authentication method.';
+    if (method === 'none') return errors;
+    const field = connectorSecretField(draft, kind);
+    if (!supportedSecret(draft.auth[field], `/auth/${field}`, original)) {
+        errors[`auth.${field}`] = 'Enter a credential, or explicitly keep the stored credential. Cleared credentials cannot be used for a test.';
+    }
+    if (kind === 'openapi' && method === 'basic') {
+        const pair = openApiBasicCredentials(draft);
+        if (draft.auth.type === 'basic' && !supportedSecret(draft.auth.username ?? draft.auth.identity,
+            Object.hasOwn(draft.auth, 'username') ? '/auth/username' : '/auth/identity', original)) {
+            errors['auth.basic_username'] = 'Enter a username, or keep its stored value.';
+        }
+        if (!pair.stored) {
+            if (!pair.username) errors['auth.basic_username'] = 'Enter a username. Replacing stored basic credentials requires both values.';
+            if (!pair.password) errors[`auth.${field}`] = 'Enter a password. Replacing stored basic credentials requires both values.';
+            if (pair.username.includes(':')) errors['auth.basic_username'] = 'Basic authentication usernames cannot contain a colon.';
+        }
+    }
+    if (kind === 'mcp' && method === 'basic' && !supportedSecret(draft.auth.identity, '/auth/identity', original)) {
+        errors['auth.identity'] = 'Enter the username, or keep its stored value.';
+    }
+    if (method === 'api_key' && kind === 'mcp') {
+        const name = connectorText(draft.additionalFields.api_key_header_name ?? 'X-API-Key');
+        const error = mcpHeaderNameError(name);
+        if (error) errors['additionalFields.api_key_header_name'] = error;
+    }
+    return errors;
+}
+
+export function validateConnectorConfiguration(
+    draft: ActionConfiguration, kind: ApiConnector, preset?: McpCatalogEntry,
+): Record<string, string> {
+    const errors: Record<string, string> = {};
+    const fields = draft.additionalFields;
+    const transport = connectorText(fields.transport) || 'streamable_http';
+    const endpointError = connectorUrlError(draft.endpoint || (kind === 'openapi' ? fields.base_url : ''), kind === 'mcp' && transport === 'websocket');
+    if (endpointError) errors.endpoint = endpointError;
+    if (kind === 'openapi') {
+        if (!isRecord(fields.openapi_spec_content) || !Object.keys(fields.openapi_spec_content).length) {
+            errors['additionalFields.openapi_spec_content'] = 'Upload or process an OpenAPI JSON/YAML specification.';
+        }
+        if (connectorObject(draft._openApiSourceDraft).pending === true) errors['openapi-source'] = 'Process the edited specification before saving or testing.';
+        return errors;
+    }
+    if (!allowedMcpTransports(preset).some(({ value }) => value === transport)) {
+        errors['additionalFields.transport'] = transport === 'stdio'
+            ? 'Stdio is only available for admin-managed global actions. Select a remote transport.'
+            : 'Select a personal-workspace transport supported by this preset.';
+    }
+    for (const field of MCP_NUMBER_FIELDS) {
+        const value = fields[field.key] ?? field.defaultValue;
+        if (typeof value !== 'number' || !Number.isInteger(value) || value < field.min || value > field.max) {
+            errors[`additionalFields.${field.key}`] = `Enter a whole number from ${field.min} to ${field.max}.`;
+        }
+    }
+    for (const key of ['load_tools', 'load_prompts', 'validate_tool_arguments']) {
+        if (fields[key] !== undefined && typeof fields[key] !== 'boolean') {
+            errors[`additionalFields.${key}`] = 'Choose an enabled or disabled value.';
+        }
+    }
+    if (fields.allowed_tool_names !== undefined &&
+        (!Array.isArray(fields.allowed_tool_names) || connectorStrings(fields.allowed_tool_names).length !== fields.allowed_tool_names.length)) {
+        errors['additionalFields.allowed_tool_names'] = 'Allowed tool names must be an array of strings.';
+    }
+    if (fields.mcp_tools !== undefined && (!Array.isArray(fields.mcp_tools) || fields.mcp_tools.some((tool) =>
+        !isRecord(tool) || !connectorText(tool.original_name) || !connectorText(tool.function_name)))) {
+        errors['additionalFields.mcp_tools'] = 'Tool metadata must be an array containing original_name and function_name for every tool.';
+    }
+    const headers = connectorObject(fields.custom_headers);
+    if (fields.custom_headers !== undefined && !isRecord(fields.custom_headers)) errors['additionalFields.custom_headers'] = 'Custom headers must be an object.';
+    if (Object.keys(headers).length > 20) errors['additionalFields.custom_headers'] = 'Use at most 20 custom headers.';
+    for (const [name, value] of Object.entries(headers)) {
+        const error = mcpHeaderNameError(name, headers, name);
+        if (error) errors[`additionalFields.custom_headers.${name}`] = error;
+        if (typeof value !== 'string' || /[\r\n]/.test(value) || value.length > 4096) {
+            errors[`additionalFields.custom_headers.${name}`] = 'Header values must be strings without line breaks, at most 4096 characters.';
+        }
+    }
+    const hasHeaders = Object.values(headers).some((value) => value !== '' && value != null);
+    if (hasHeaders && (transport === 'websocket' || preset?.constraints.customHeadersAllowed === false)) {
+        errors['additionalFields.custom_headers'] = 'This transport or preset does not support custom headers. Remove them explicitly, or change the transport/preset.';
+    }
+    const method = connectorAuthMethod(draft, 'mcp');
+    if (transport === 'websocket' && method !== 'none') errors['additionalFields.auth_method'] = 'The WebSocket connector does not support authentication headers.';
+    if (method !== 'identity' && !allowedMcpAuthMethods(transport, preset).some(({ value }) => value === method)) {
+        errors['additionalFields.auth_method'] = 'The selected authentication method is not supported by this preset.';
+    }
+    if (!['truncate', 'error_on_limit'].includes(connectorText(fields.tool_result_policy ?? 'truncate'))) {
+        errors['additionalFields.tool_result_policy'] = 'Choose a supported large-result policy.';
+    }
+    const implementationId = connectorText(connectorObject(fields.implementation).id);
+    const settings = connectorObject(fields.additionalSettings);
+    for (const field of mcpImplementationFields(implementationId)) {
+        const value = settings[field.key];
+        if (field.optional && value === undefined) continue;
+        if (field.kind === 'fixed' && value !== field.expected) errors[`additionalFields.additionalSettings.${field.key}`] = `This implementation requires ${String(field.expected)}.`;
+        if (field.kind === 'select' && !field.options?.some((option) => option.value === value)) {
+            errors[`additionalFields.additionalSettings.${field.key}`] = 'Choose a supported implementation setting.';
+        }
+        if (field.kind === 'multi' || field.kind === 'lines') {
+            const values = connectorStrings(value);
+            if (!Array.isArray(value) || values.length !== value.length || !values.length || values.length > (field.kind === 'lines' ? 50 : 20)) {
+                errors[`additionalFields.additionalSettings.${field.key}`] = 'Provide at least one valid entry within the implementation limit.';
+            } else if (field.options && values.some((item) => !field.options?.some(({ value }) => value === item))) {
+                errors[`additionalFields.additionalSettings.${field.key}`] = 'Review unavailable implementation selections.';
+            } else if (field.kind === 'lines' && values.some((item) => !/^[A-Za-z0-9][A-Za-z0-9._-]{0,80}$/.test(item))) {
+                errors[`additionalFields.additionalSettings.${field.key}`] = 'Namespaces must contain letters, numbers, dots, underscores, or hyphens (maximum 81 characters).';
+            }
+        }
+    }
+    return errors;
+}
+
+export interface ConnectorFeedback {
+    success: boolean;
+    message: string;
+    errors: string[];
+    warnings: string[];
+    details: Record<string, unknown>;
+}
+
+export function connectorFeedback(value: unknown): ConnectorFeedback {
+    const response = value instanceof ApiError ? connectorObject(value.payload) : connectorObject(value);
+    const success = !(value instanceof Error) && (response.success === true || response.valid === true);
+    const messages = Array.isArray(response.errors)
+        ? response.errors.map((item) => typeof item === 'string' ? item : connectorText(connectorObject(item).message)).filter(Boolean)
+        : [];
+    return {
+        success,
+        message: connectorText(response.error ?? response.message) ||
+            (value instanceof Error ? value.message : success ? 'Validation passed.' : 'The request did not succeed.'),
+        errors: messages, warnings: connectorStrings(response.warnings), details: connectorObject(response.details),
+    };
+}
+
+export function buildConnectorSupportPayload(
+    draft: ActionConfiguration, original: ConnectorResource, kind: ApiConnector,
+    purpose: 'test' | 'discover' | 'validate' = 'test',
+): Record<string, unknown> {
+    if (original?.read_only || draft.is_global || draft.is_group) throw new Error('Provided actions are read-only and cannot be tested.');
+    if (original && !connectorText(original.record.id).trim()) throw new Error('Reload this action before testing: its stable owned ID is missing.');
+    const errors = {
+        ...validateConnectorConfiguration(draft, kind),
+        ...validateConnectorAuthentication(draft, kind, original),
+    };
+    if (Object.keys(errors).length) throw new Error(Object.values(errors).join(' '));
+    const clearPaths = new Set(buildEditorWrite(draft, original).clear_secret_paths);
+    const translate = (value: unknown, path = ''): unknown => {
+        if (value === EDITOR_SECRET_MASK || value === STORED_CONNECTOR_SECRET) {
+            if (!original?.secret_paths.includes(path)) {
+                // Literal masks in descriptions are ordinary text, not credential references.
+                if (/^\/auth\/|^\/additionalFields\/custom_headers\//.test(path) ||
+                    /key|secret|password|token|credential|connection/i.test(path.split('/').at(-1) ?? '')) {
+                    throw new Error('A stored credential has no owned record to resolve it from.');
+                }
+                return value;
+            }
+            if (!supportedSecret(value, path, original)) throw new Error('The stored credential cannot be resolved from this action.');
+            return STORED_CONNECTOR_SECRET;
+        }
+        if (Array.isArray(value)) return value.map((item, index) => translate(item, `${path}/${index}`));
+        if (isRecord(value)) return Object.fromEntries(Object.entries(value)
+            .filter(([key, item]) => {
+                const childPath = `${path}/${pointerPart(key)}`;
+                if (clearPaths.has(childPath) || (/^\/additionalFields\/custom_headers$/.test(path) && (item === '' || item == null))) return false;
+                return item !== undefined;
+            })
+            .map(([key, item]) => [key, translate(item, `${path}/${pointerPart(key)}`)]));
+        return value;
+    };
+    const manifest = translate({
+        name: draft.name || `${kind}_${purpose}`, displayName: draft.displayName || `${kind.toUpperCase()} ${purpose}`,
+        type: draft.type, description: draft.description, endpoint: draft.endpoint || draft.additionalFields.base_url,
+        auth: draft.auth, additionalFields: draft.additionalFields, metadata: draft.metadata,
+        ...(draft.identity_id ? { identity_id: draft.identity_id } : {}),
+    }) as Record<string, unknown>;
+    if (connectorAuthMethod(draft, kind) === 'none') {
+        // Do not let V1's edit-time empty-value fallback resurrect an inactive credential.
+        manifest.auth = { type: kind === 'mcp' ? 'NoAuth' : 'key', ...(kind === 'openapi' ? { key: '' } : {}) };
+        for (const key of ['key', 'identity', 'tenantId', 'token', 'value', 'password']) clearPaths.add(`/auth/${key}`);
+    } else if (draft.identity_id) {
+        manifest.auth = { type: 'identity', identity: draft.identity_id };
+    }
+    if (kind === 'mcp') {
+        manifest.additionalFields = { ...MCP_DEFAULT_FIELDS, ...connectorObject(manifest.additionalFields) };
+    }
+    return {
+        ...manifest,
+        ...(purpose !== 'validate' ? {
+            action_scope: 'personal',
+            ...(original ? { plugin_context: { scope: 'personal', id: original.record.id, name: original.record.name } } : {}),
+            clear_secret_paths: [...clearPaths],
+        } : {}),
+    };
+}
+
+export function testApiConnector(draft: ActionConfiguration, original: ConnectorResource, kind: ApiConnector, signal?: AbortSignal): Promise<unknown> {
+    const payload = buildConnectorSupportPayload(draft, original, kind);
+    return api.post(`/api/plugins/test-${kind}-connection`, payload, signal);
+}
+
+export function validateApiConnector(draft: ActionConfiguration, original: ConnectorResource, kind: ApiConnector, signal?: AbortSignal): Promise<unknown> {
+    return api.post('/api/plugins/validate', buildConnectorSupportPayload(draft, original, kind, 'validate'), signal);
+}
+
+export interface McpDiscoveryResult {
+    success?: boolean;
+    tools?: unknown[];
+    capabilities?: Record<string, unknown>;
+    warnings?: string[];
+    error?: string;
+    errors?: string[];
+    transport?: string;
+    auth_method?: string;
+    mcp_operation_id?: string;
+}
+
+export async function discoverMcpAction(draft: ActionConfiguration, original: ConnectorResource, signal?: AbortSignal): Promise<McpDiscoveryResult> {
+    const result = await api.post<McpDiscoveryResult>('/api/plugins/mcp/discover', buildConnectorSupportPayload(draft, original, 'mcp', 'discover'), signal);
+    if (!result || (result.success === true && (!Array.isArray(result.tools) ||
+        parseMcpTools(result.tools).length !== result.tools.length))) {
+        throw new Error('The server returned an invalid MCP tool catalogue.');
+    }
+    return {
+        ...result, warnings: connectorStrings(result.warnings), capabilities: connectorObject(result.capabilities),
+        ...(Array.isArray(result.tools) ? { tools: parseMcpTools(result.tools) } : {}),
+    };
+}

--- a/application/v2_ui/src/lib/workspaceActionLogic.ts
+++ b/application/v2_ui/src/lib/workspaceActionLogic.ts
@@ -1,0 +1,610 @@
+// workspaceActionLogic.ts
+
+import {
+    EDITOR_SECRET_MASK, editorName, isRecord, pointerPart, sameEditorValue,
+    type ActionConfiguration, type ActionTypeDefinition, type AuthoringResource, type EditorSchema,
+} from './workspaceAuthoring';
+import { nativeActionDefinition, sqlConnectionMethod, usesDirectBlobConnectionString } from './workspaceActionRegistry';
+import type { ActionIdentity } from './workspaceActionTypes';
+
+export const ACTION_AUTHORING_UNAVAILABLE =
+    'Creating and editing actions is not enabled for your account. You can still view available actions and delete your own where permitted.';
+
+export function actionText(value: unknown): string {
+    return typeof value === 'string' ? value : '';
+}
+
+export function actionTypeLabel(type: unknown): string {
+    const raw = String(type ?? '').trim();
+    if (!raw) return 'Unknown';
+    if (raw === 'agent') return 'Call agent';
+    const spaced = raw.replace(/[_-]+/g, ' ');
+    return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+}
+
+export function actionScope(action: ActionConfiguration): 'provided' | 'personal' {
+    return action.is_global || action.read_only === true ? 'provided' : 'personal';
+}
+
+export function actionCanEdit(action: ActionConfiguration, canAuthor: boolean): boolean {
+    return canAuthor && actionScope(action) === 'personal';
+}
+
+export function hasUsableActionRevision(resource: AuthoringResource<ActionConfiguration>, scope = 'personal'): boolean {
+    const readOnly = scope === 'global' || resource.read_only || Boolean(resource.record.is_global);
+    return typeof resource.revision === 'string' && (readOnly || resource.revision.trim().length > 0);
+}
+
+export function actionResourceKey(action: ActionConfiguration): string {
+    return JSON.stringify([actionScope(action), action.id]);
+}
+
+export function actionDetailPath(action: ActionConfiguration): string {
+    return `/workspace/actions/${encodeURIComponent(action.id)}${actionScope(action) === 'provided' ? '?scope=global' : ''}`;
+}
+
+export function filterAuthoringActions(
+    actions: ActionConfiguration[],
+    query: string,
+    type: string,
+    scope: string,
+    catalogue: ActionTypeDefinition[] = [],
+): ActionConfiguration[] {
+    const labels = new Map(catalogue.map((definition) => [definition.type, definition.display]));
+    const needle = query.trim().toLowerCase();
+    return actions.filter((action) =>
+        (!type || action.type === type) &&
+        (!scope || actionScope(action) === scope) &&
+        `${action.displayName} ${action.name} ${action.description} ${action.type} ${labels.get(action.type) || actionTypeLabel(action.type)}`
+            .toLowerCase().includes(needle));
+}
+
+export function actionValueAt(value: unknown, pointer: string): unknown {
+    if (!pointer) return value;
+    return pointer.slice(1).split('/').reduce<unknown>((current, encoded) => {
+        const key = encoded.replace(/~1/g, '/').replace(/~0/g, '~');
+        if (Array.isArray(current)) return /^\d+$/.test(key) ? current[Number(key)] : undefined;
+        return isRecord(current) && Object.hasOwn(current, key) ? current[key] : undefined;
+    }, value);
+}
+
+export function actionArrayRemovalError(
+    draft: ActionConfiguration, original: AuthoringResource<ActionConfiguration> | null, path: string, index: number,
+): string | null {
+    const items = actionValueAt(draft, path);
+    if (!Array.isArray(items) || !Number.isInteger(index) || index < 0 || index >= items.length) {
+        return 'This list entry is no longer available. Reload the configuration.';
+    }
+    const prefix = `${path}/`;
+    const shiftsMaskedSecret = original?.secret_paths.some((secretPath) => {
+        if (!secretPath.startsWith(prefix) || actionValueAt(draft, secretPath) !== EDITOR_SECRET_MASK) return false;
+        const itemIndex = secretPath.slice(prefix.length).split('/')[0];
+        return /^\d+$/.test(itemIndex) && Number(itemIndex) > index;
+    });
+    return shiftsMaskedSecret
+        ? 'This removal would move stored credentials to different positions. Replace or clear stored secrets in later entries first.'
+        : null;
+}
+
+export function actionHasStoredArraySecrets(
+    draft: ActionConfiguration, original: AuthoringResource<ActionConfiguration> | null, rootPath: string,
+): boolean {
+    return original?.secret_paths.some((secretPath) => {
+        if (actionValueAt(draft, secretPath) !== EDITOR_SECRET_MASK) return false;
+        const parts = secretPath.slice(1).split('/');
+        for (let length = 1; length < parts.length; length += 1) {
+            const ancestor = `/${parts.slice(0, length).join('/')}`;
+            if ((!rootPath || ancestor === rootPath || ancestor.startsWith(`${rootPath}/`)) &&
+                Array.isArray(actionValueAt(draft, ancestor))) return true;
+        }
+        return false;
+    }) ?? false;
+}
+
+export function displayedActionValue(draft: ActionConfiguration, pointer: string): unknown {
+    const value = actionValueAt(draft, pointer);
+    if (value !== undefined && value !== null && value !== '') return value;
+    if (pointer === '/additionalFields/user' && draft.type === 'snowflake' && !draft.identity_id) return draft.auth.identity ?? value;
+    if (pointer === '/additionalFields/schema' && ['databricks', 'databricks_table'].includes(draft.type)) {
+        return draft.additionalFields.database ?? value;
+    }
+    if (draft.type === 'msgraph' && pointer.startsWith('/additionalFields/msgraph_')) {
+        const key = pointer.slice('/additionalFields/msgraph_'.length);
+        return draft.additionalFields[key] ?? actionValueAt(nativeActionDefinition(draft.type).defaults, pointer) ?? value;
+    }
+    if (pointer === '/endpoint') {
+        const mirrors: Record<string, string> = {
+            openapi: 'base_url', rocksdb: 'base_url', databricks: 'workspace_url',
+            databricks_table: 'workspace_url', tableau: 'server_url', yamcs: 'server_url',
+        };
+        const alias = Object.hasOwn(mirrors, draft.type) ? mirrors[draft.type] : undefined;
+        if (alias) return draft.additionalFields[alias] ?? value;
+    }
+    return value;
+}
+
+/** JSON pointers keep custom names containing dots, slashes, or prototype keys as data. */
+export function withActionValue<T>(value: T, pointer: string, nextValue: unknown): T {
+    const parts = pointer.slice(1).split('/').map((part) => part.replace(/~1/g, '/').replace(/~0/g, '~'));
+    const update = (current: unknown, index: number): unknown => {
+        if (index === parts.length) return nextValue;
+        const key = parts[index];
+        if (Array.isArray(current)) {
+            if (!/^\d+$/.test(key)) throw new Error('An array field needs an index.');
+            const next = current.slice();
+            if (index === parts.length - 1 && nextValue === undefined) next.splice(Number(key), 1);
+            else next[Number(key)] = update(current[Number(key)], index + 1);
+            return next;
+        }
+        const record = isRecord(current) ? current : {};
+        const entries = Object.entries(record).filter(([name]) => name !== key);
+        const replacement = update(Object.hasOwn(record, key) ? record[key] : undefined, index + 1);
+        if (replacement !== undefined) entries.push([key, replacement]);
+        return Object.fromEntries(entries);
+    };
+    return update(value, 0) as T;
+}
+
+export function actionFieldError(errors: Record<string, string>, pointer: string): string | undefined {
+    const dotted = pointer.slice(1).split('/').map((part) => part.replace(/~1/g, '/').replace(/~0/g, '~')).join('.');
+    return errors[pointer] || errors[dotted];
+}
+
+export function expandActionFieldErrors(errors: Record<string, string>): Record<string, string> {
+    const expanded = { ...errors };
+    for (const [path, message] of Object.entries(errors)) {
+        if (path.startsWith('/')) {
+            expanded[path.slice(1).split('/').map((part) => part.replace(/~1/g, '/').replace(/~0/g, '~')).join('.')] = message;
+        }
+    }
+    return expanded;
+}
+
+export function resolveActionSchema(schema: EditorSchema, root: EditorSchema = schema, depth = 0): EditorSchema {
+    if (depth > 12) return schema;
+    let resolved = schema;
+    if (schema.$ref?.startsWith('#/')) {
+        const target = actionValueAt(root, schema.$ref.slice(1));
+        if (isRecord(target)) resolved = { ...resolveActionSchema(target as EditorSchema, root, depth + 1), ...schema, $ref: undefined };
+    }
+    if (resolved.allOf) {
+        for (const part of resolved.allOf) {
+            const sub = resolveActionSchema(part, root, depth + 1);
+            // Conditional branches are left to the canonical server validator.
+            if (sub.properties) resolved = { ...resolved, properties: { ...resolved.properties, ...sub.properties } };
+            if (sub.required) resolved = { ...resolved, required: [...new Set([...(resolved.required ?? []), ...sub.required])] };
+        }
+    }
+    return resolved;
+}
+
+export function validateActionSchema(
+    value: unknown, schema: EditorSchema, path = '', root = schema, depth = 0,
+): Record<string, string> {
+    if (depth > 16 || value === EDITOR_SECRET_MASK) return {};
+    const resolved = resolveActionSchema(schema, root);
+    const errors: Record<string, string> = {};
+    const label = resolved.title || path.split('/').at(-1)?.replaceAll('_', ' ') || 'Value';
+    if (resolved.enum && !resolved.enum.some((item) => sameEditorValue(item, value))) {
+        errors[path] = `${label}: choose one of the supported values.`;
+    }
+    if (Object.hasOwn(resolved, 'const') && !sameEditorValue(resolved.const, value)) {
+        errors[path] = `${label}: must be ${String(resolved.const)}.`;
+    }
+    const types = Array.isArray(resolved.type) ? resolved.type : resolved.type ? [resolved.type] : [];
+    const matches = (type: string) => type === 'object' ? isRecord(value) :
+        type === 'array' ? Array.isArray(value) : type === 'null' ? value === null :
+            type === 'integer' ? typeof value === 'number' && Number.isInteger(value) :
+                type === 'number' ? typeof value === 'number' && Number.isFinite(value) : typeof value === type;
+    if (value !== undefined && types.length && !types.some(matches)) {
+        errors[path] = `${label}: enter ${types.join(' or ')}.`;
+        return errors;
+    }
+    if (isRecord(value)) {
+        for (const key of resolved.required ?? []) {
+            if (!Object.hasOwn(value, key) || value[key] === undefined) {
+                errors[`${path}/${pointerPart(key)}`] = `${resolved.properties?.[key]?.title || key.replaceAll('_', ' ')} is required.`;
+            }
+        }
+        for (const [key, sub] of Object.entries(resolved.properties ?? {})) {
+            if (Object.hasOwn(value, key) && value[key] !== undefined) {
+                Object.assign(errors, validateActionSchema(value[key], sub, `${path}/${pointerPart(key)}`, root, depth + 1));
+            }
+        }
+    } else if (Array.isArray(value)) {
+        if (resolved.minItems !== undefined && value.length < resolved.minItems) errors[path] = `${label}: at least ${resolved.minItems} entries are required.`;
+        if (resolved.maxItems !== undefined && value.length > resolved.maxItems) errors[path] = `${label}: no more than ${resolved.maxItems} entries are allowed.`;
+        if (resolved.items) value.forEach((item, index) => Object.assign(errors, validateActionSchema(item, resolved.items!, `${path}/${index}`, root, depth + 1)));
+    } else if (typeof value === 'string') {
+        if (resolved.minLength !== undefined && value.length < resolved.minLength) errors[path] = `${label}: use at least ${resolved.minLength} characters.`;
+        if (resolved.maxLength !== undefined && value.length > resolved.maxLength) errors[path] = `${label}: use no more than ${resolved.maxLength} characters.`;
+        if (resolved.pattern && value) {
+            try {
+                if (!new RegExp(resolved.pattern).test(value)) errors[path] = `${label}: the value does not match the required format.`;
+            } catch {
+                // A server-specific pattern remains subject to server validation.
+            }
+        }
+        if (resolved.format === 'email' && value && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value)) errors[path] = `${label}: enter an email address.`;
+    } else if (typeof value === 'number') {
+        if (resolved.minimum !== undefined && value < resolved.minimum) errors[path] = `${label}: enter at least ${resolved.minimum}.`;
+        if (resolved.maximum !== undefined && value > resolved.maximum) errors[path] = `${label}: enter no more than ${resolved.maximum}.`;
+    }
+    const conditional = resolved as EditorSchema & { if?: EditorSchema; then?: EditorSchema; else?: EditorSchema; not?: EditorSchema };
+    for (const part of resolved.allOf ?? []) {
+        Object.assign(errors, validateActionSchema(value, part, path, root, depth + 1));
+    }
+    const matchesSchema = (candidate: EditorSchema) => Object.keys(validateActionSchema(value, candidate, path, root, depth + 1)).length === 0;
+    if (resolved.anyOf && !resolved.anyOf.some(matchesSchema)) errors[path] = `${label}: the value does not match a supported configuration.`;
+    if (resolved.oneOf && resolved.oneOf.filter(matchesSchema).length !== 1) errors[path] = `${label}: choose exactly one supported configuration.`;
+    if (conditional.not && matchesSchema(conditional.not)) errors[path] = `${label}: this combination of settings is not allowed.`;
+    if (conditional.if) {
+        const branch = matchesSchema(conditional.if) ? conditional.then : conditional.else;
+        if (branch) Object.assign(errors, validateActionSchema(value, branch, path, root, depth + 1));
+    }
+    return errors;
+}
+
+/** Only explicit, type-correct defaults are values; descriptions and enum help never are. */
+export function actionSchemaDefaults(schema: EditorSchema, root = schema, depth = 0): unknown {
+    if (depth > 12) return undefined;
+    const resolved = resolveActionSchema(schema, root);
+    const defaultObjectAllowed = !isRecord(resolved.default) || resolved.additionalProperties !== false ||
+        Object.keys(resolved.default).every((key) => Object.hasOwn(resolved.properties ?? {}, key));
+    if (Object.hasOwn(resolved, 'default') && defaultObjectAllowed &&
+        Object.keys(validateActionSchema(resolved.default, resolved, '', root)).length === 0) {
+        return structuredClone(resolved.default);
+    }
+    if (resolved.properties) {
+        const entries = Object.entries(resolved.properties).flatMap(([key, sub]) => {
+            const value = actionSchemaDefaults(sub, root, depth + 1);
+            return value === undefined ? [] : [[key, value] as const];
+        });
+        if (!entries.length) return undefined;
+        const defaults = Object.fromEntries(entries);
+        const applyConstraints = (constraint: EditorSchema, constraintDepth = 0) => {
+            if (constraintDepth > 12) return;
+            const conditional = constraint as EditorSchema & { if?: EditorSchema; then?: EditorSchema; else?: EditorSchema; not?: EditorSchema };
+            for (const part of constraint.allOf ?? []) applyConstraints(part, constraintDepth + 1);
+            if (conditional.if) {
+                const conditionMatches = Object.keys(validateActionSchema(defaults, conditional.if, '', root)).length === 0;
+                const branch = conditionMatches ? conditional.then : conditional.else;
+                if (branch) applyConstraints(branch, constraintDepth + 1);
+            }
+            // Some installed schemas prohibit inactive option groups via `not.required`.
+            // Do not materialize optional defaults that make that group active.
+            if (conditional.not?.required && conditional.not.required.every((key) => Object.hasOwn(defaults, key))) {
+                for (const key of conditional.not.required) {
+                    if (!resolved.required?.includes(key)) delete defaults[key];
+                }
+            }
+        };
+        applyConstraints(resolved);
+        return Object.keys(defaults).length ? defaults : undefined;
+    }
+    return undefined;
+}
+
+export function createActionDraft(): ActionConfiguration {
+    return {
+        id: '', name: '', displayName: '', description: '', type: '', endpoint: '',
+        auth: { type: 'NoAuth' }, metadata: {}, additionalFields: {}, is_enabled: true,
+    };
+}
+
+function configurationForType(definition: ActionTypeDefinition): Partial<ActionConfiguration> {
+    const native = nativeActionDefinition(definition.type);
+    const fields = actionSchemaDefaults(definition.additional_fields_schema);
+    const metadata = actionSchemaDefaults(definition.metadata_schema);
+    const auth = structuredClone(native.defaults?.auth ?? { type: definition.allowed_auth_types[0] || 'NoAuth' });
+    if (definition.allowed_auth_types.length && !definition.allowed_auth_types.includes(auth.type)) {
+        auth.type = definition.allowed_auth_types[0];
+    }
+    const capabilities = native.capabilities
+        ? Object.fromEntries(native.capabilities.options.map(({ key, defaultEnabled }) => [key, defaultEnabled !== false]))
+        : undefined;
+    let initial = {
+        ...structuredClone(native.defaults ?? {}),
+        auth,
+        additionalFields: { ...structuredClone(native.defaults?.additionalFields ?? {}), ...(isRecord(fields) ? fields : {}) },
+        metadata: { ...structuredClone(native.defaults?.metadata ?? {}), ...(isRecord(metadata) ? metadata : {}) },
+    };
+    if (native.capabilities && capabilities) initial = withActionValue(initial, native.capabilities.path, capabilities);
+    return initial;
+}
+
+export function changeActionType(draft: ActionConfiguration, definition: ActionTypeDefinition): ActionConfiguration {
+    if (draft.type === definition.type) return draft;
+    const previous = isRecord(draft._actionTypeConfigurations) ? draft._actionTypeConfigurations : {};
+    const configurations = {
+        ...previous,
+        ...(draft.type ? { [draft.type]: {
+            endpoint: draft.endpoint, auth: draft.auth, identity_id: draft.identity_id ?? '',
+            additionalFields: draft.additionalFields,
+            ...(draft._openApiSourceDraft ? { _openApiSourceDraft: draft._openApiSourceDraft } : {}),
+            ...(draft._sqlConnectionMethod ? { _sqlConnectionMethod: draft._sqlConnectionMethod } : {}),
+        } } : {}),
+    };
+    const existing = Object.hasOwn(configurations, definition.type) ? configurations[definition.type] : undefined;
+    const initial = configurationForType(definition);
+    const configuration = isRecord(existing) ? existing : initial;
+    return {
+        ...draft,
+        ...configuration,
+        type: definition.type,
+        endpoint: actionText(configuration.endpoint),
+        auth: isRecord(configuration.auth) ? configuration.auth as ActionConfiguration['auth'] : { type: 'NoAuth' },
+        identity_id: actionText(configuration.identity_id),
+        additionalFields: isRecord(configuration.additionalFields) ? structuredClone(configuration.additionalFields) : {},
+        metadata: { ...(initial.metadata ?? {}), ...draft.metadata },
+        _openApiSourceDraft: configuration._openApiSourceDraft,
+        _sqlConnectionMethod: configuration._sqlConnectionMethod,
+        _actionTypeConfigurations: configurations,
+    };
+}
+
+export function changeActionDisplayName(draft: ActionConfiguration, value: string, isNew: boolean): ActionConfiguration {
+    const derived = editorName(actionText(draft.displayName), 'action');
+    return {
+        ...draft, displayName: value,
+        ...(isNew && (!draft.name || draft.name === derived) ? { name: value.trim() ? editorName(value, 'action') : '' } : {}),
+    };
+}
+
+export function changeActionField(draft: ActionConfiguration, path: string, value: unknown): ActionConfiguration {
+    let next = withActionValue(draft, path, value);
+    const endpointMirrors: Record<string, string> = {
+        openapi: 'base_url', rocksdb: 'base_url', databricks: 'workspace_url',
+        databricks_table: 'workspace_url', tableau: 'server_url', yamcs: 'server_url',
+    };
+    if (path === '/endpoint' && Object.hasOwn(endpointMirrors, draft.type)) {
+        next = withActionValue(next, `/additionalFields/${endpointMirrors[draft.type]}`, value);
+    }
+    if (path === '/additionalFields/user' && draft.type === 'snowflake' && !draft.identity_id) {
+        next = withActionValue(next, '/auth/identity', value);
+    }
+    if (path === '/additionalFields/cloud' && draft.type === 'log_analytics' && value !== 'custom') {
+        // This explicit cloud change removes incompatible custom overrides, not unrelated fields.
+        next = withActionValue(next, '/additionalFields/authorityHost', undefined);
+        next = withActionValue(next, '/additionalFields/endpointOverride', undefined);
+        next.endpoint = value === 'usgovernment' ? 'https://api.loganalytics.us' : 'https://api.loganalytics.io';
+    }
+    if (path === '/auth/identity' && draft.type === 'tableau' && draft.additionalFields.auth_method === 'personal_access_token') {
+        next = withActionValue(next, '/additionalFields/pat_name', value);
+    }
+    return next;
+}
+
+export function changeSqlConnectionMethod(draft: ActionConfiguration, method: 'parameters' | 'connection_string'): ActionConfiguration {
+    const next = { ...draft, _sqlConnectionMethod: method };
+    return method === 'parameters'
+        ? withActionValue(next, '/additionalFields/connection_string', undefined)
+        : next;
+}
+
+export interface ActionAuthMode { value: string; label: string; authType: string }
+const mode = (value: string, label: string, authType = value): ActionAuthMode => ({ value, label, authType });
+const AUTH_LABELS: Record<string, string> = {
+    NoAuth: 'No authentication', key: 'API key', identity: 'Managed identity',
+    user: 'Signed-in user', servicePrincipal: 'Service principal', connection_string: 'Connection string',
+    username_password: 'Username and password', basic: 'Basic authentication',
+};
+
+export function actionAuthModes(type: string, allowed: string[]): ActionAuthMode[] {
+    const sql = [
+        mode('username_password', 'Username and password', 'user'),
+        mode('managed_identity', 'Managed identity', 'identity'),
+        mode('service_principal', 'Service principal', 'servicePrincipal'),
+        mode('integrated', 'Integrated / Windows authentication', 'identity'),
+        mode('connection_string_only', 'Credentials in connection string', 'identity'),
+    ];
+    const definitions: Record<string, ActionAuthMode[]> = {
+        sql_query: sql, sql_schema: sql,
+        databricks: [
+            mode('pat', 'Personal access token', 'key'), mode('bearer', 'Bearer token', 'key'),
+            mode('service_principal', 'Service principal', 'servicePrincipal'), mode('managed_identity', 'Managed identity', 'identity'),
+        ],
+        snowflake: [mode('password', 'Password', 'username_password'), mode('key_pair', 'PEM key pair', 'key'), mode('oauth', 'OAuth token', 'key')],
+        tableau: [mode('personal_access_token', 'Personal access token', 'key'), mode('username_password', 'Username and password')],
+        yamcs: [mode('username_password', 'Username and password'), mode('api_key', 'API key', 'key'), mode('bearer_token', 'Bearer token', 'key'), mode('none', 'No authentication', 'NoAuth')],
+        rocksdb: [mode('none', 'No authentication', 'NoAuth'), mode('bearer', 'Bearer token', 'key'), mode('api_key', 'API key header', 'key')],
+    };
+    const nativeType = type === 'databricks_table' ? 'databricks' : type;
+    const choices = Object.hasOwn(definitions, nativeType) ? definitions[nativeType] :
+        (allowed.length ? allowed : ['NoAuth']).map((value) => mode(value, Object.hasOwn(AUTH_LABELS, value) ? AUTH_LABELS[value] : actionTypeLabel(value)));
+    return choices.filter((choice) => !allowed.length || allowed.includes(choice.authType));
+}
+
+export function actionAuthMethod(draft: ActionConfiguration): string {
+    if (draft.type === 'sql_query' || draft.type === 'sql_schema') {
+        return actionText(draft.additionalFields.auth_type) ||
+            (draft.auth.type === 'servicePrincipal' ? 'service_principal' : draft.auth.type === 'identity' ? 'managed_identity' : 'username_password');
+    }
+    if (draft.type === 'rocksdb') return actionText(draft.additionalFields.auth_scheme) || (draft.auth.type === 'key' ? 'bearer' : 'none');
+    if (['databricks', 'databricks_table', 'snowflake', 'tableau', 'yamcs'].includes(draft.type)) {
+        if (draft.additionalFields.auth_method) return actionText(draft.additionalFields.auth_method);
+        if (draft.type === 'snowflake') return draft.auth.type === 'username_password' ? 'password' : 'key_pair';
+        if (draft.type === 'tableau') return draft.auth.type === 'username_password' ? 'username_password' : 'personal_access_token';
+        if (draft.type === 'yamcs') return draft.auth.type === 'NoAuth' ? 'none' : draft.auth.type === 'key' ? 'api_key' : 'username_password';
+        return draft.auth.type === 'servicePrincipal' ? 'service_principal' : draft.auth.type === 'identity' ? 'managed_identity' : 'pat';
+    }
+    return draft.auth.type;
+}
+
+export function changeActionAuth(draft: ActionConfiguration, choice: ActionAuthMode): ActionConfiguration {
+    const additionalFields = { ...draft.additionalFields };
+    const sql = ['sql_query', 'sql_schema'].includes(draft.type);
+    if (sql) additionalFields.auth_type = choice.value;
+    else if (draft.type === 'rocksdb') additionalFields.auth_scheme = choice.value;
+    else if (['databricks', 'databricks_table', 'snowflake', 'tableau', 'yamcs'].includes(draft.type)) additionalFields.auth_method = choice.value;
+    const auth = { ...draft.auth, type: choice.authType };
+    if (choice.authType === 'identity' && !draft.identity_id) {
+        auth.identity = sql && choice.value !== 'managed_identity' ? '' : 'managed_identity';
+    }
+    return {
+        ...draft, auth, additionalFields,
+        ...(sql && choice.value === 'connection_string_only' ? { _sqlConnectionMethod: 'connection_string' } : {}),
+    };
+}
+
+export function selectActionIdentity(draft: ActionConfiguration, identity: ActionIdentity | null): ActionConfiguration {
+    const additionalFields = { ...draft.additionalFields };
+    if (!identity) {
+        delete additionalFields.identity_auth_type;
+        delete additionalFields.identity_uses_connection_string;
+        return { ...draft, identity_id: '', auth: { ...draft.auth, identity: '', type: 'NoAuth' }, additionalFields };
+    }
+    const allowed = nativeActionDefinition(draft.type).identityTypes;
+    if (allowed && !allowed.includes(identity.auth_type)) throw new Error('This identity is not compatible with the action type.');
+    additionalFields.identity_auth_type = identity.auth_type;
+    if (['sql_query', 'sql_schema'].includes(draft.type)) {
+        additionalFields.auth_type = identity.auth_type === 'connection_string' ? 'connection_string_only' : identity.auth_type;
+        additionalFields.identity_uses_connection_string = identity.auth_type === 'connection_string';
+    } else if (['databricks', 'databricks_table'].includes(draft.type)) {
+        additionalFields.auth_method = identity.auth_type === 'managed_identity' ? 'managed_identity' : identity.auth_type === 'bearer_token' ? 'bearer' : 'pat';
+    } else if (draft.type === 'snowflake') {
+        additionalFields.auth_method = identity.auth_type === 'api_key' ? 'key_pair' : identity.auth_type === 'bearer_token' ? 'oauth' : 'password';
+    } else if (draft.type === 'tableau') {
+        additionalFields.auth_method = identity.auth_type === 'api_key' ? 'personal_access_token' : 'username_password';
+    } else if (draft.type === 'yamcs') {
+        additionalFields.auth_method = identity.auth_type;
+    }
+    return { ...draft, identity_id: identity.id, auth: { ...draft.auth, type: 'identity', identity: identity.id }, additionalFields };
+}
+
+export function deriveBlobEndpoint(connectionString: string): string {
+    if (!connectionString || connectionString === EDITOR_SECRET_MASK) return '';
+    const parts = Object.fromEntries(connectionString.split(';').flatMap((segment) => {
+        const index = segment.indexOf('=');
+        return index < 0 ? [] : [[segment.slice(0, index).trim().toLowerCase(), segment.slice(index + 1).trim()]];
+    }));
+    if (parts.blobendpoint) return parts.blobendpoint.replace(/\/+$/, '');
+    if (!parts.accountname) return '';
+    return `${parts.defaultendpointsprotocol || 'https'}://${parts.accountname}.blob.${parts.endpointsuffix || 'core.windows.net'}`;
+}
+
+export function actionForSave(draft: ActionConfiguration): ActionConfiguration {
+    let next = { ...draft, displayName: actionText(draft.displayName ?? draft.name).trim(), name: actionText(draft.name).trim() };
+    if (!next.endpoint) next.endpoint = actionText(displayedActionValue(draft, '/endpoint'));
+    if (draft.type === 'agent') next = { ...next, endpoint: 'internal://agent', auth: { type: 'user' } };
+    if (draft.type === 'snowflake' && !draft.identity_id && !draft.auth.identity && draft.additionalFields.user) {
+        next.auth = { ...draft.auth, identity: actionText(draft.additionalFields.user) };
+    }
+    if (usesDirectBlobConnectionString(draft)) {
+        const derived = deriveBlobEndpoint(actionText(draft.auth.key));
+        if (derived) next.endpoint = derived;
+    }
+    return next;
+}
+
+export function validateActionDraft(
+    draft: ActionConfiguration, definition?: ActionTypeDefinition, original?: AuthoringResource<ActionConfiguration> | null,
+): Record<string, string> {
+    const errors: Record<string, string> = {};
+    if (!actionText(draft.displayName ?? draft.name).trim()) errors['/displayName'] = 'Action name is required.';
+    if (!/^[A-Za-z0-9_-]+$/.test(actionText(draft.name))) errors['/name'] = 'Machine name must contain only letters, numbers, underscores, or dashes.';
+    if (!definition) errors['/type'] = 'Choose an action type available in this workspace.';
+    if (definition && !draft.identity_id && definition.allowed_auth_types.length &&
+        !definition.allowed_auth_types.includes(draft.auth.type)) {
+        errors['/auth/type'] = 'Choose an authentication method supported by this action type.';
+    }
+    const native = nativeActionDefinition(draft.type);
+    for (const descriptor of native.fields) {
+        if (descriptor.visible && !descriptor.visible(draft)) continue;
+        const value = actionValueAt(draft, descriptor.path);
+        if (descriptor.required && (value === undefined || value === null || value === '')) errors[descriptor.path] = `${descriptor.label} is required.`;
+        if (typeof value === 'number') {
+            if (!Number.isFinite(value) || (descriptor.step === 1 && !Number.isInteger(value))) errors[descriptor.path] = `${descriptor.label}: enter a whole number.`;
+            if (descriptor.min !== undefined && value < descriptor.min) errors[descriptor.path] = `${descriptor.label}: enter at least ${descriptor.min}.`;
+            if (descriptor.max !== undefined && value > descriptor.max) errors[descriptor.path] = `${descriptor.label}: enter no more than ${descriptor.max}.`;
+        }
+        if (descriptor.kind === 'select' && value !== undefined && value !== '' && !descriptor.options?.some((item) => item.value === value)) {
+            errors[descriptor.path] = `${descriptor.label}: choose a supported value.`;
+        }
+    }
+    if (definition) {
+        Object.assign(errors, validateActionSchema(draft.additionalFields, definition.additional_fields_schema, '/additionalFields'));
+        Object.assign(errors, validateActionSchema(draft.metadata, definition.metadata_schema, '/metadata'));
+    }
+    const requireField = (path: string, label: string) => {
+        const value = actionValueAt(draft, path);
+        if (typeof value !== 'string' || !value.trim()) errors[path] = `${label} is required.`;
+        if (value === EDITOR_SECRET_MASK && !original?.secret_paths.includes(path)) errors[path] = `${label} has no stored value to keep. Enter a value.`;
+    };
+    if (draft.type === 'agent') {
+        const target = draft.additionalFields.target_agent;
+        if (!isRecord(target) || !actionText(target.id) || !actionText(target.scope_id) || !['personal', 'group', 'global'].includes(actionText(target.scope_type))) {
+            errors['/additionalFields/target_agent'] = 'Select an authorized target agent.';
+        }
+    } else if (!['openapi', 'mcp'].includes(draft.type) && !native.internal && !draft.identity_id) {
+        const sql = ['sql_query', 'sql_schema'].includes(draft.type);
+        const method = actionAuthMethod(draft);
+        if (sql && method === 'connection_string_only' && sqlConnectionMethod(draft) !== 'connection_string') {
+            errors['/auth/type'] = 'Credentials in a connection string require Connection string mode.';
+        }
+        if (sql && sqlConnectionMethod(draft) === 'connection_string') requireField('/additionalFields/connection_string', 'Connection string');
+        else if (sql && method === 'username_password' && draft.additionalFields.database_type !== 'sqlite') {
+            requireField('/additionalFields/username', 'Database username');
+            requireField('/additionalFields/password', 'Database password');
+        }
+        if (draft.auth.type === 'servicePrincipal') {
+            requireField('/auth/identity', 'Client ID'); requireField('/auth/tenantId', 'Tenant ID'); requireField('/auth/key', 'Client secret');
+        } else if (['key', 'connection_string', 'username_password', 'basic'].includes(draft.auth.type)) {
+            requireField('/auth/key', 'Credential');
+            if (['username_password', 'basic'].includes(draft.auth.type)) requireField('/auth/identity', 'Username');
+        }
+        if (draft.type === 'tableau' && method === 'personal_access_token') requireField('/auth/identity', 'Personal access token name');
+        if (draft.auth.type === 'identity' && !sql) requireField('/auth/identity', 'Managed identity');
+    }
+    if (draft.type === 'tableau' && draft.identity_id && draft.additionalFields.auth_method === 'personal_access_token') {
+        requireField('/additionalFields/pat_name', 'Personal access token name');
+    }
+    if (draft.type === 'snowflake' && ['key_pair', 'oauth'].includes(actionAuthMethod(draft)) &&
+        (!draft.auth.identity || draft.identity_id) && !draft.additionalFields.user) {
+        errors['/additionalFields/user'] = 'Snowflake user is required for key-pair or OAuth authentication.';
+    }
+    if (native.capabilities) {
+        const capabilities = actionValueAt(draft, native.capabilities.path);
+        if (isRecord(capabilities) && native.capabilities.options.every((entry) => capabilities[entry.key] === false)) {
+            errors[native.capabilities.path] = 'Allow at least one capability.';
+        }
+        if (draft.type === 'blob_storage') {
+            const capabilities = isRecord(draft.additionalFields.blob_storage_capabilities) ? draft.additionalFields.blob_storage_capabilities : {};
+            for (const [capability, field, defaultEnabled] of [
+                ['read_file_content', 'blob_storage_read_file_types', true],
+                ['upload_file_to_container', 'blob_storage_upload_file_types', false],
+            ] as const) {
+                const fileTypes = draft.additionalFields[field];
+                if ((capabilities[capability] ?? defaultEnabled) && isRecord(fileTypes) && fileTypes.markdown === false) {
+                    errors[`/additionalFields/${field}/markdown`] = 'Enable a supported file type or disable this capability.';
+                }
+            }
+        }
+    }
+    const reminder = actionValueAt(draft, '/metadata/key_vault_secret_reminders/__all__');
+    if (isRecord(reminder) && reminder.enabled) {
+        if (!/^\d{4}-\d{2}-\d{2}$/.test(actionText(reminder.expires_on ?? reminder.expiration_date).slice(0, 10))) errors['/metadata/key_vault_secret_reminders/__all__/expires_on'] = 'Choose an expiration date.';
+        if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(actionText(reminder.contact_email ?? reminder.reminder_email))) errors['/metadata/key_vault_secret_reminders/__all__/contact_email'] = 'Enter a valid reminder email.';
+        if (!Number.isInteger(reminder.lead_days) || Number(reminder.lead_days) < 1 || Number(reminder.lead_days) > 3650) errors['/metadata/key_vault_secret_reminders/__all__/lead_days'] = 'Lead days must be between 1 and 3650.';
+    }
+    return errors;
+}
+
+export function actionApiErrors(payload: unknown): Record<string, string> {
+    if (!isRecord(payload)) return {};
+    const raw = payload.errors ?? payload.validation_errors ?? payload.field_errors;
+    if (isRecord(raw)) return Object.fromEntries(Object.entries(raw).map(([key, value]) =>
+        [key, Array.isArray(value) ? value.map(String).join(' ') : String(value)]));
+    if (!Array.isArray(raw)) return {};
+    return Object.fromEntries(raw.map((error, index) => {
+        if (typeof error === 'string') {
+            const match = error.match(/^([A-Za-z_][\w.[\]/~-]*)\s*:\s*(.*)$/s);
+            return match ? [match[1], match[2]] : [`$${index}`, error];
+        }
+        if (isRecord(error)) {
+            const path = Array.isArray(error.path) ? `/${error.path.map((part) => pointerPart(String(part))).join('/')}` : actionText(error.path ?? error.field);
+            return [path || `$${index}`, actionText(error.message ?? error.error) || 'Invalid configuration.'];
+        }
+        return [`$${index}`, String(error)];
+    }));
+}

--- a/application/v2_ui/src/lib/workspaceActionRegistry.ts
+++ b/application/v2_ui/src/lib/workspaceActionRegistry.ts
@@ -1,0 +1,414 @@
+// workspaceActionRegistry.ts
+
+import { EDITOR_SECRET_MASK, type ActionConfiguration } from './workspaceAuthoring';
+import type { ActionCapability, ActionFieldDescriptor, ActionNativeDefinition } from './workspaceActionTypes';
+
+const options = (values: (string | [string, string])[]) => values.map((value) =>
+    typeof value === 'string' ? { value, label: value } : { value: value[0], label: value[1] });
+const field = (key: string, label: string, extra: Partial<ActionFieldDescriptor> = {}): ActionFieldDescriptor =>
+    ({ path: `/additionalFields/${key}`, label, ...extra });
+const endpoint = (label = 'Endpoint', help?: string): ActionFieldDescriptor =>
+    ({ path: '/endpoint', label, required: true, help });
+const number = (key: string, label: string, min: number, max?: number): ActionFieldDescriptor =>
+    field(key, label, { kind: 'number', min, max, step: 1 });
+const flag = (key: string, label: string, help?: string): ActionFieldDescriptor =>
+    field(key, label, { kind: 'boolean', help });
+const choice = (key: string, label: string, values: (string | [string, string])[], extra: Partial<ActionFieldDescriptor> = {}) =>
+    field(key, label, { kind: 'select', options: options(values), ...extra });
+
+export const SIMPLECHAT_ACTION_CAPABILITIES: ActionCapability[] = [
+    { key: 'create_group', label: 'Create groups', description: 'Create group workspaces with the current user’s permissions.' },
+    { key: 'add_group_member', label: 'Add group members', description: 'Add people directly to groups the user can manage.' },
+    { key: 'make_group_inactive', label: 'Make groups inactive', description: 'Mark a group inactive when the user has Control Center admin access.' },
+    { key: 'create_group_conversation', label: 'Create group conversations', description: 'Create invite-managed group conversations and add current group members.' },
+    { key: 'invite_group_conversation_members', label: 'Invite group conversation members', description: 'Invite current group members into an existing group conversation.' },
+    { key: 'create_personal_conversation', label: 'Create personal conversations', description: 'Create standard, one-user personal conversations.' },
+    { key: 'create_personal_workflow', label: 'Create personal workflows', description: 'Create workflows using the current user’s workflow permissions.' },
+    { key: 'add_conversation_message', label: 'Add conversation messages', description: 'Add a user-authored message to a permitted conversation.' },
+    { key: 'upload_markdown_document', label: 'Upload Markdown documents', description: 'Create Markdown documents in personal or permitted group workspaces.' },
+    { key: 'upload_word_document', label: 'Upload Word documents', description: 'Create Word documents in personal or permitted group workspaces.' },
+    { key: 'upload_powerpoint_document', label: 'Upload PowerPoint documents', description: 'Create presentations in personal or permitted group workspaces.' },
+    { key: 'create_personal_collaboration_conversation', label: 'Create collaborative conversations', description: 'Create personal collaborative conversations and invite participants.' },
+    { key: 'raise_workflow_alert', label: 'Raise workflow alerts', description: 'Raise an alert signal for the owner during a workflow run.', defaultEnabled: false },
+];
+
+export const MSGRAPH_ACTION_CAPABILITIES: ActionCapability[] = [
+    { key: 'get_my_profile', label: 'Read my profile', description: 'Read the signed-in user’s Microsoft 365 profile.' },
+    { key: 'get_my_timezone', label: 'Read my mailbox timezone', description: 'Read mailbox time zone and time-format settings.' },
+    { key: 'get_my_events', label: 'Read my calendar events', description: 'Read upcoming events for the signed-in user.' },
+    { key: 'create_calendar_invite', label: 'Create calendar invites', description: 'Create events, invite group members, and create Teams meetings.' },
+    { key: 'get_my_messages', label: 'Read my mail', description: 'Read recent mail for the signed-in user.' },
+    { key: 'mark_message_as_read', label: 'Update message read state', description: 'Mark mail messages as read or unread.' },
+    { key: 'send_mail', label: 'Send mail', description: 'Create manual drafts, delayed-delivery drafts, or send mail.' },
+    { key: 'search_users', label: 'Search directory users', description: 'Find Microsoft 365 users by name or email prefix.' },
+    { key: 'get_user_by_email', label: 'Look up users by email', description: 'Look up a directory user by exact email or UPN.' },
+    { key: 'list_drive_items', label: 'List OneDrive items', description: 'List items from the signed-in user’s OneDrive.' },
+    { key: 'get_my_security_alerts', label: 'Read security alerts', description: 'Read security alerts available to the signed-in user.' },
+];
+
+export const CHART_ACTION_CAPABILITIES: ActionCapability[] = [
+    ['line', 'Line charts', 'Compare trends with one or more series.'],
+    ['bar', 'Bar charts', 'Compare categories, including grouped series.'],
+    ['pie', 'Pie charts', 'Show proportions of a whole.'],
+    ['doughnut', 'Doughnut charts', 'Show proportions with a center cutout.'],
+    ['scatter', 'Scatter plots', 'Compare pairs of numerical values.'],
+    ['area', 'Area charts', 'Show trends with filled areas.'],
+    ['bubble', 'Bubble charts', 'Compare x, y, and size dimensions.'],
+    ['radar', 'Radar charts', 'Compare values across multiple axes.'],
+    ['stacked_bar', 'Stacked bar charts', 'Show cumulative category comparisons.'],
+    ['stacked_line', 'Stacked line charts', 'Show cumulative multi-series trends.'],
+].map(([key, label, description]) => ({ key, label, description }));
+
+export const BLOB_ACTION_CAPABILITIES: ActionCapability[] = [
+    { key: 'list_container_contents', label: 'List container contents', description: 'List blobs in this container and optional prefix.' },
+    { key: 'read_file_content', label: 'Read file content', description: 'Read supported file types from this container.' },
+    { key: 'upload_file_to_container', label: 'Upload files', description: 'Upload supported file types into this container.', defaultEnabled: false },
+];
+
+export function sqlConnectionMethod(draft: ActionConfiguration): 'parameters' | 'connection_string' {
+    if (draft.additionalFields.identity_uses_connection_string === true) return 'connection_string';
+    if (draft._sqlConnectionMethod === 'parameters' || draft._sqlConnectionMethod === 'connection_string') {
+        return draft._sqlConnectionMethod;
+    }
+    return draft.additionalFields.connection_string ? 'connection_string' : 'parameters';
+}
+
+export function usesDirectBlobConnectionString(draft: ActionConfiguration): boolean {
+    return draft.type === 'blob_storage' && draft.auth.type === 'connection_string' && !draft.identity_id;
+}
+
+const sqlParameters = (draft: ActionConfiguration) => sqlConnectionMethod(draft) === 'parameters';
+const sqlServer = (draft: ActionConfiguration) => sqlParameters(draft) && draft.additionalFields.database_type !== 'sqlite';
+const sqlFields: ActionFieldDescriptor[] = [
+    choice('database_type', 'Database engine', [
+        ['sqlserver', 'SQL Server'], ['azure_sql', 'Azure SQL'], ['postgresql', 'PostgreSQL'],
+        ['mysql', 'MySQL'], ['sqlite', 'SQLite'],
+    ], { required: true }),
+    field('connection_string', 'Database connection string', {
+        kind: 'secret', visible: (draft) => !sqlParameters(draft) && !draft.identity_id,
+        help: 'The connection string takes precedence over individual parameters. Keep a stored value, replace it, or explicitly clear it.',
+    }),
+    field('server', 'Database server', { visible: sqlServer, required: true }),
+    field('database', 'Database name or SQLite path', { visible: sqlParameters, required: true }),
+    { ...number('port', 'Port', 1, 65535), visible: sqlServer },
+    field('driver', 'ODBC driver', {
+        visible: (draft) => sqlServer(draft) && ['sqlserver', 'azure_sql'].includes(String(draft.additionalFields.database_type)),
+        placeholder: 'ODBC Driver 18 for SQL Server',
+        help: 'Use a driver installed on the application server. Driver 18 is the supported default.',
+    }),
+];
+const queryLimits: ActionFieldDescriptor[] = [
+    flag('read_only', 'Read-only queries', 'Restrict statements to retrieving data.'),
+    number('max_rows', 'Maximum rows', 1, 10000),
+    number('timeout', 'Query timeout (seconds)', 1, 300),
+];
+const databricksFields: ActionFieldDescriptor[] = [
+    endpoint('Databricks workspace URL', 'Use the workspace URL, not the SQL statements API path.'),
+    choice('cloud', 'Databricks cloud', [['azure_commercial', 'Azure Commercial']], { required: true }),
+    field('warehouse_id', 'SQL Warehouse ID', { required: true }),
+    field('catalog', 'Default catalog'),
+    field('schema', 'Default schema'),
+    ...queryLimits.map((descriptor) => descriptor.path === '/additionalFields/read_only'
+        ? { ...descriptor, readOnly: true } : descriptor),
+    number('wait_timeout', 'Statement wait timeout (seconds)', 1, 50),
+    number('byte_limit', 'Result size limit (bytes)', 1000, 2000000),
+];
+const documentSearchFields: ActionFieldDescriptor[] = [
+    choice('default_doc_scope', 'Default document scope', [
+        ['all', 'All permitted workspaces'], ['personal', 'My workspace'], ['group', 'Group workspaces'], ['public', 'Public workspaces'],
+    ]),
+    number('default_top_n', 'Default search result limit', 1, 500),
+    choice('default_window_unit', 'Preferred window unit', [['pages', 'Pages'], ['chunks', 'Chunks']]),
+    number('default_window_size', 'Preferred window size', 1, 100),
+    number('default_window_percent', 'Preferred window percent', 1, 100),
+    field('default_focus_instructions', 'Default focus instructions', { kind: 'textarea' }),
+    field('default_window_target_length', 'Window summary target length'),
+    field('default_final_target_length', 'Final summary target length'),
+];
+const searchDefaults = {
+    default_doc_scope: 'all', default_top_n: 50, default_window_unit: 'pages',
+    default_window_target_length: '2 pages', default_final_target_length: '2 pages',
+};
+const internalUtility = (type: string, help: string): ActionNativeDefinition => ({
+    fields: [endpoint('Endpoint', 'An internal marker required by the action manifest; it does not select a remote server. The agent supplies operation inputs at invocation time.')],
+    internal: true, defaults: { endpoint: `internal://${type}`, auth: { type: 'NoAuth' } }, help,
+});
+
+/** Native controls supplement, never replace, the governed catalogue and its schemas. */
+export const NATIVE_ACTION_TYPES: Record<string, ActionNativeDefinition> = {
+    openapi: { fields: [], identityTypes: ['api_key', 'bearer_token', 'username_password'], defaults: {
+        auth: { type: 'key', key: '' }, additionalFields: { auth_method: 'none', openapi_source_type: 'content' },
+    } },
+    mcp: { fields: [], identityTypes: ['api_key', 'bearer_token', 'managed_identity', 'username_password'], defaults: {
+        auth: { type: 'NoAuth' }, additionalFields: {
+            transport: 'streamable_http', server_profile: 'generic', auth_method: 'none', load_tools: true,
+            load_prompts: false, request_timeout: 30, connect_timeout: 10, sse_read_timeout: 300,
+            retry_count: 0, retry_backoff_seconds: 1, validate_tool_arguments: false,
+            tool_result_policy: 'truncate', allowed_tool_names: [], custom_headers: {},
+        },
+    } },
+    sql_query: {
+        fields: [...sqlFields, ...queryLimits],
+        defaults: { endpoint: '', auth: { type: 'user' }, additionalFields: {
+            auth_type: 'username_password', read_only: true, max_rows: 1000, timeout: 30,
+        } },
+        identityTypes: ['connection_string', 'managed_identity', 'username_password'],
+        testPath: '/api/plugins/test-sql-connection',
+        help: 'Query a database using a connection string or individual connection parameters. The query action can expose schema information as well as execute permitted statements.',
+    },
+    sql_schema: {
+        fields: [
+            ...sqlFields,
+            flag('include_system_tables', 'Include system tables', 'Include database system objects in schema discovery.'),
+            field('table_filter', 'Table name filter', { help: 'Optional wildcard pattern, for example sales_* or *_log.' }),
+        ],
+        defaults: { endpoint: '', auth: { type: 'user' }, additionalFields: {
+            auth_type: 'username_password', include_system_tables: false,
+        } },
+        identityTypes: ['connection_string', 'managed_identity', 'username_password'],
+        testPath: '/api/plugins/test-sql-connection',
+        help: 'Expose database schema discovery without the SQL query action’s execution controls.',
+    },
+    cosmos_query: {
+        fields: [
+            endpoint('Cosmos DB account endpoint'),
+            field('database_name', 'Database name', { required: true }),
+            field('container_name', 'Container name', { required: true }),
+            field('partition_key_path', 'Partition key path', { required: true, placeholder: '/tenantId' }),
+            field('field_hints', 'Preferred document fields', { kind: 'lines', help: 'One field or document property per line.' }),
+            number('max_items', 'Maximum items', 1, 1000),
+            number('timeout', 'Request timeout (seconds)', 1, 120),
+        ],
+        defaults: { auth: { type: 'identity', identity: 'managed_identity' }, additionalFields: {
+            field_hints: [], max_items: 100, timeout: 30,
+        } },
+        identityTypes: [],
+        testPath: '/api/plugins/test-cosmos-connection',
+        help: 'Query Azure Cosmos DB for NoSQL. Managed identity needs a Cosmos DB data-reader role on the target account.',
+    },
+    rocksdb: {
+        fields: [
+            endpoint('RocksDB service URL', 'Connect to an HTTP service exposing the RocksDB health, scan, and get contract.'),
+            field('column_family', 'Column family'),
+            choice('key_encoding', 'Key encoding', [['utf8', 'UTF-8'], ['base64', 'Base64']]),
+            choice('value_encoding', 'Value encoding', [['utf8', 'UTF-8'], ['json', 'JSON'], ['base64', 'Base64']]),
+            field('key_prefix_hints', 'Key prefix hints', { kind: 'lines', help: 'One prefix per line; helps the model choose narrower scans.' }),
+            flag('read_only', 'Read-only access', 'Disable writes to the RocksDB service.'),
+            number('max_results', 'Maximum results', 1, 1000),
+            number('max_value_bytes', 'Maximum value size (bytes)', 1, 1048576),
+            number('timeout', 'Request timeout (seconds)', 1, 300),
+        ],
+        defaults: { auth: { type: 'NoAuth' }, additionalFields: {
+            auth_scheme: 'none', column_family: 'default', key_encoding: 'utf8', value_encoding: 'utf8',
+            key_prefix_hints: [], read_only: true, max_results: 100, max_value_bytes: 32768, timeout: 30,
+        } },
+        identityTypes: [],
+        testPath: '/api/plugins/test-rocksdb-connection',
+    },
+    databricks: {
+        fields: databricksFields,
+        defaults: { auth: { type: 'key', key: '' }, additionalFields: {
+            cloud: 'azure_commercial', auth_method: 'pat', read_only: true,
+            max_rows: 1000, timeout: 30, wait_timeout: 30, byte_limit: 250000,
+        } },
+        identityTypes: ['api_key', 'bearer_token', 'managed_identity'],
+        testPath: '/api/plugins/test-databricks-connection',
+        help: 'Run read-only queries through an Azure Databricks SQL Warehouse. Use a PAT, bearer token, service principal, or managed identity.',
+    },
+    databricks_table: {
+        fields: [
+            ...databricksFields,
+            field('httpPath', 'Legacy warehouse HTTP path', { help: 'Retained for older Databricks table configurations.' }),
+            number('port', 'Legacy ODBC port', 1, 65535),
+            field('database', 'Legacy default database'),
+            field('table_name', 'Legacy catalog table'),
+        ],
+        defaults: { auth: { type: 'key', key: '' }, additionalFields: {
+            cloud: 'azure_commercial', auth_method: 'pat', read_only: true, max_rows: 1000, timeout: 30, wait_timeout: 30,
+        } },
+        identityTypes: ['api_key', 'bearer_token', 'managed_identity'],
+        testPath: '/api/plugins/test-databricks-connection',
+        help: 'A compatible Databricks table action uses the SQL Warehouse connector. Existing table-specific settings remain available.',
+    },
+    snowflake: {
+        fields: [
+            field('account', 'Snowflake account', { required: true, help: 'Account identifier without the snowflakecomputing.com suffix.' }),
+            field('user', 'Snowflake user', { help: 'Required for key-pair or OAuth identities. A username/password identity can provide its username.' }),
+            field('warehouse', 'Warehouse', { required: true }),
+            field('database', 'Default database'),
+            field('schema', 'Default schema'),
+            field('role', 'Role'),
+            ...queryLimits.map((descriptor) => descriptor.path === '/additionalFields/read_only'
+                ? { ...descriptor, readOnly: true } : descriptor),
+            number('login_timeout', 'Login timeout (seconds)', 1, 300),
+            number('byte_limit', 'Result size limit (bytes)', 1000, 2000000),
+        ],
+        defaults: { endpoint: 'snowflake://query', auth: { type: 'username_password' }, additionalFields: {
+            auth_method: 'password', read_only: true, max_rows: 1000, timeout: 30, login_timeout: 30, byte_limit: 250000,
+        } },
+        identityTypes: ['api_key', 'bearer_token', 'username_password'],
+        testPath: '/api/plugins/test-snowflake-connection',
+        help: 'Run read-only Snowflake queries with a password, PEM key pair, or OAuth access token.',
+    },
+    tableau: {
+        fields: [
+            endpoint('Tableau server URL'),
+            field('site_content_url', 'Site content URL', { help: 'Leave blank for the default Tableau Server site.' }),
+            number('page_size', 'Page size', 1, 1000),
+            number('max_results', 'Maximum results', 1, 1000),
+            number('timeout', 'Request timeout (seconds)', 1, 300),
+            flag('use_server_version', 'Negotiate server API version', 'Let Tableau Server Client select a supported REST API version.'),
+        ],
+        defaults: { auth: { type: 'key' }, additionalFields: {
+            auth_method: 'personal_access_token', page_size: 100, max_results: 100, timeout: 30, use_server_version: true,
+        } },
+        identityTypes: ['api_key', 'username_password'],
+        testPath: '/api/plugins/test-tableau-connection',
+        help: 'Read Tableau content using a personal access token or username/password. The token name is required with a PAT.',
+    },
+    yamcs: {
+        fields: [
+            endpoint('Yamcs server URL'),
+            field('instance', 'Yamcs instance', { required: true }),
+            field('processor', 'Processor'),
+            flag('tls_verify', 'Verify TLS certificates', 'Disable only for an internal ground segment using a self-signed certificate.'),
+            { ...flag('read_only', 'Read-only access', 'Yamcs actions never issue commands or change parameter/link state.'), readOnly: true },
+            flag('enable_archive_sql', 'Allow read-only archive SQL', 'Permit queries against Yamcs archive tables.'),
+            number('max_rows', 'Maximum rows', 1, 5000),
+            number('timeout', 'Request timeout (seconds)', 1, 300),
+            number('byte_limit', 'Result size limit (bytes)', 1000, 2000000),
+        ],
+        defaults: { auth: { type: 'username_password' }, additionalFields: {
+            processor: 'realtime', auth_method: 'username_password', tls_verify: true, read_only: true,
+            enable_archive_sql: false, max_rows: 500, timeout: 30, byte_limit: 250000,
+        } },
+        identityTypes: ['api_key', 'bearer_token', 'username_password'],
+        testPath: '/api/plugins/test-yamcs-connection',
+        help: 'Retrieve live telemetry and archive data from a Yamcs instance. No commanding capabilities are exposed.',
+    },
+    blob_storage: {
+        fields: [
+            {
+                ...endpoint('Blob service endpoint', 'Azure commercial, US Government, China, and Germany storage endpoints are supported.'),
+                visible: (draft) => !usesDirectBlobConnectionString(draft) ||
+                    (draft.auth.key === EDITOR_SECRET_MASK && !draft.endpoint),
+            },
+            field('container_name', 'Container name', { required: true }),
+            field('blob_prefix', 'Blob prefix', { help: 'Optional path prefix that narrows the files this action can access.' }),
+            flag('blob_storage_read_file_types/markdown', 'Read Markdown files', 'Supports UTF-8 .md and .markdown files.'),
+            flag('blob_storage_upload_file_types/markdown', 'Upload Markdown files', 'Permit Markdown uploads when the upload capability is enabled.'),
+        ],
+        defaults: { auth: { type: 'connection_string', key: '' }, additionalFields: {
+            blob_storage_read_file_types: { markdown: true }, blob_storage_upload_file_types: { markdown: true },
+        } },
+        capabilities: { path: '/additionalFields/blob_storage_capabilities', options: BLOB_ACTION_CAPABILITIES },
+        identityTypes: ['connection_string', 'api_key', 'managed_identity'],
+        testPath: '/api/plugins/test-blob-storage-connection',
+        help: 'Scope file access to one container and optional prefix. Choose listing, reading, and upload permissions separately.',
+    },
+    queue_storage: {
+        fields: [endpoint('Queue service endpoint'), field('queue_name', 'Queue name', { required: true })],
+        defaults: { auth: { type: 'identity', identity: 'managed_identity' } },
+        identityTypes: ['api_key', 'managed_identity'],
+        help: 'Send and receive messages from the configured Azure Storage Queue. Use the queue service endpoint, not the blob endpoint.',
+    },
+    azure_maps_openlayers: {
+        fields: [],
+        defaults: { endpoint: 'https://atlas.microsoft.com', auth: { type: 'key', key: '' } },
+        identityTypes: [],
+        testPath: '/api/plugins/test-azure-maps-connection',
+        help: 'Geocode locations, plan routes, and render maps with Azure Maps. The API endpoint is https://atlas.microsoft.com.',
+    },
+    document_search: {
+        fields: documentSearchFields,
+        internal: true,
+        defaults: { endpoint: 'internal://document-search', auth: { type: 'NoAuth' }, additionalFields: searchDefaults },
+        help: 'Search and summarize documents the current user is allowed to read. Agent-assigned knowledge and workspace permissions still apply.',
+    },
+    search: {
+        fields: documentSearchFields,
+        internal: true,
+        defaults: { endpoint: 'internal://document-search', auth: { type: 'NoAuth' }, additionalFields: { ...searchDefaults, default_top_n: 12 } },
+        help: 'Search permitted workspace documents using the existing document-search defaults.',
+    },
+    log_analytics: {
+        fields: [
+            field('workspaceId', 'Log Analytics workspace ID', { required: true, help: 'The workspace GUID, not the Azure resource ID.' }),
+            choice('cloud', 'Azure cloud', [['public', 'Azure Commercial'], ['usgovernment', 'Azure US Government'], ['custom', 'Custom cloud']], { required: true }),
+            { ...endpoint('Log Analytics API endpoint', 'The public endpoint is https://api.loganalytics.io; government uses https://api.loganalytics.us.'), required: false },
+            field('authorityHost', 'Custom authority host', { required: true, visible: (draft) => draft.additionalFields.cloud === 'custom' }),
+            field('endpointOverride', 'Custom API endpoint override', { required: true, visible: (draft) => draft.additionalFields.cloud === 'custom' }),
+            { path: '/metadata/name', label: 'Resource name', help: 'The name of the Log Analytics resource.', required: true },
+        ],
+        defaults: { endpoint: 'https://api.loganalytics.io', auth: { type: 'identity', identity: 'managed_identity' },
+            additionalFields: { cloud: 'public', query_history: [] } },
+        identityTypes: ['client_secret', 'managed_identity'],
+        testPath: '/api/plugins/test-log-analytics-connection',
+        help: 'Run KQL queries against a Log Analytics workspace. The selected identity needs Log Analytics Reader access.',
+    },
+    simplechat: {
+        fields: [], internal: true, defaults: { endpoint: '', auth: { type: 'user' } },
+        capabilities: { path: '/additionalFields/simplechat_capabilities', options: SIMPLECHAT_ACTION_CAPABILITIES },
+        help: 'Use workspace, conversation, and document tools as the signed-in user. Capabilities never bypass the user’s permissions.',
+    },
+    msgraph: {
+        fields: [
+            choice('msgraph_mail_send_mode', 'Mail delivery mode', [
+                ['draft_manual', 'Create a draft for manual review'], ['draft_delayed', 'Create a delayed-delivery draft'], ['auto_send', 'Send immediately'],
+            ]),
+            { ...number('msgraph_mail_delay_seconds', 'Mail delivery delay (seconds)', 5, 600),
+                visible: (draft) => draft.additionalFields.msgraph_mail_send_mode === 'draft_delayed' },
+            choice('msgraph_calendar_send_mode', 'Calendar invite delivery mode', [
+                ['draft_manual', 'Create a draft for manual review'], ['draft_delayed', 'Create a delayed-delivery draft'], ['auto_send', 'Send immediately'],
+            ]),
+            { ...number('msgraph_calendar_delay_seconds', 'Calendar delivery delay (seconds)', 5, 600),
+                visible: (draft) => draft.additionalFields.msgraph_calendar_send_mode === 'draft_delayed' },
+        ],
+        internal: true,
+        defaults: { endpoint: 'https://graph.microsoft.com', auth: { type: 'user' }, additionalFields: {
+            msgraph_mail_send_mode: 'draft_manual', msgraph_mail_delay_seconds: 60,
+            msgraph_calendar_send_mode: 'auto_send', msgraph_calendar_delay_seconds: 60,
+        } },
+        capabilities: { path: '/additionalFields/msgraph_capabilities', options: MSGRAPH_ACTION_CAPABILITIES },
+        help: 'Use Microsoft 365 as the signed-in user. Mail and calendar delivery policies determine when changes are sent.',
+    },
+    chart: {
+        fields: [], internal: true, defaults: { endpoint: 'chart://internal', auth: { type: 'user' } },
+        capabilities: { path: '/additionalFields/chart_capabilities', options: CHART_ACTION_CAPABILITIES },
+        help: 'Render interactive charts in chat. Permit the chart types the agent should be able to produce.',
+    },
+    agent: {
+        fields: [], internal: true, defaults: { endpoint: 'internal://agent', auth: { type: 'user' } },
+        help: 'Call one explicitly selected agent using the signed-in user’s permissions. Only the task and explicit context are passed.',
+    },
+    embedding_model: {
+        fields: [
+            endpoint('Embedding endpoint'),
+            { path: '/deployment', label: 'Embedding deployment', required: true },
+            { path: '/api_version', label: 'Embedding API version', required: true },
+        ],
+        defaults: { auth: { type: 'key', key: '' } },
+        identityTypes: ['api_key'],
+        help: 'Create text embeddings with the configured Azure OpenAI deployment and an API key. The current embedding action does not support managed identity. Endpoint, deployment, and API version are preserved in the runtime’s manifest locations.',
+    },
+    smart_http: internalUtility('smart_http', 'Retrieve and extract content from URLs supplied by the agent. Content limits and document processing are managed by the application; no connector credential is required.'),
+    http: internalUtility('http', 'Send HTTP requests for URLs supplied at invocation time. Use an OpenAPI action when an API needs a saved specification or connector-specific credentials.'),
+    text: internalUtility('text', 'Transform text using the built-in text operations. Inputs are supplied when an agent invokes the tool; there are no connection settings.'),
+    math: internalUtility('math', 'Calculate with the built-in arithmetic tools. Numbers are supplied at invocation time; no external connection is required.'),
+    time: internalUtility('time', 'Use the built-in date, time, and timezone tools. Their arguments are supplied during an agent call.'),
+    wait: internalUtility('wait', 'Allow an agent to pause using the built-in wait tool. Wait duration is supplied at invocation time.'),
+    fact_memory: internalUtility('fact_memory', 'Read and maintain facts in the authorized conversation/workspace context. Storage and scope are determined by the application, not a personal credential.'),
+    tabular_processing: internalUtility('tabular_processing', 'Analyze and transform permitted workspace spreadsheets and tables. Sources and operations are chosen during the agent call; workspace authorization remains enforced.'),
+    ui_test: {
+        fields: [endpoint()],
+        defaults: { auth: { type: 'NoAuth' } },
+        help: 'Configure the fields from the installed UI-test plugin schema. This type is shown only when permitted by the governed catalogue.',
+    },
+};
+
+export function nativeActionDefinition(type: string): ActionNativeDefinition {
+    return Object.hasOwn(NATIVE_ACTION_TYPES, type) ? NATIVE_ACTION_TYPES[type] : {
+        fields: [endpoint('Endpoint', 'Use the endpoint required by this installed connector.')],
+        help: 'Configure this installed action using its published schema. Custom fields remain available below and in Advanced.',
+    };
+}

--- a/application/v2_ui/src/lib/workspaceActionServices.ts
+++ b/application/v2_ui/src/lib/workspaceActionServices.ts
@@ -1,0 +1,197 @@
+// workspaceActionServices.ts
+
+import { api } from './apiClient';
+import { fetchIdentities } from './workspaceApi';
+import { fetchAgentEditorOptions } from './workspaceAuthoringApi';
+import {
+    buildEditorWrite, EDITOR_SECRET_MASK, isRecord, pointerPart,
+    type ActionConfiguration, type ActionTypeDefinition, type AuthoringResource,
+} from './workspaceAuthoring';
+import {
+    actionAuthMethod, actionForSave, actionText, actionValueAt, validateActionDraft,
+} from './workspaceActionLogic';
+import { nativeActionDefinition, sqlConnectionMethod } from './workspaceActionRegistry';
+import type { ActionIdentity } from './workspaceActionTypes';
+
+export interface ActionEditorHints {
+    canAuthor: boolean;
+    storageEnabled: boolean;
+    remindersEnabled: boolean;
+    requireExpiration: boolean;
+    reminderLeadDays: number;
+    reminderEmail: string;
+}
+
+export async function fetchActionEditorHints(signal?: AbortSignal): Promise<ActionEditorHints> {
+    const { settings } = await fetchAgentEditorOptions(signal);
+    const days = Number(settings.key_vault_secret_expiration_default_lead_days);
+    return {
+        canAuthor: settings.allow_user_plugins === true,
+        storageEnabled: settings.enable_key_vault_secret_storage === true,
+        remindersEnabled: settings.enable_key_vault_secret_expiration_reminders === true,
+        requireExpiration: settings.key_vault_secret_expiration_require_expiration === true,
+        reminderLeadDays: Number.isInteger(days) && days >= 1 && days <= 3650 ? days : 30,
+        reminderEmail: actionText(settings.key_vault_secret_expiration_default_contact_email),
+    };
+}
+
+export async function fetchActionIdentities(signal?: AbortSignal): Promise<ActionIdentity[]> {
+    const identities = await fetchIdentities(signal);
+    return identities.flatMap((identity) => {
+        const credentials = isRecord(identity.credentials) ? identity.credentials : {};
+        const id = actionText(identity.id || identity.identity_id);
+        if (!id) return [];
+        return [{
+            id,
+            name: identity.name || 'Workspace identity',
+            auth_type: actionText(identity.auth_type || credentials.auth_type).toLowerCase(),
+            description: identity.description,
+            scope_type: identity.scope_type,
+            scope_id: identity.scope_id,
+        }];
+    });
+}
+
+function translateActionSecrets(
+    draft: ActionConfiguration, original: AuthoringResource<ActionConfiguration> | null,
+): Record<string, unknown> {
+    const secretPaths = new Set(original?.secret_paths ?? []);
+    const clearPaths = new Set(buildEditorWrite(draft, original).clear_secret_paths);
+    const transform = (value: unknown, path = ''): unknown => {
+        if (value === EDITOR_SECRET_MASK && secretPaths.has(path)) {
+            if (actionValueAt(original?.record, path) !== EDITOR_SECRET_MASK) throw new Error('Stored credential state is inconsistent. Reload before testing.');
+            return 'Stored_In_KeyVault';
+        }
+        if (value === EDITOR_SECRET_MASK &&
+            (/^\/auth\//.test(path) || /(?:key|secret|password|token|credential|connection_string)$/i.test(path))) {
+            throw new Error('A credential mask has no owned stored value. Enter a credential before testing.');
+        }
+        if (Array.isArray(value)) return value.map((item, index) => transform(item, `${path}/${index}`));
+        if (isRecord(value)) return Object.fromEntries(Object.entries(value)
+            .filter(([key, item]) => !(!path && key.startsWith('_')) && item !== undefined && !clearPaths.has(`${path}/${pointerPart(key)}`))
+            .map(([key, item]) => [key, transform(item, `${path}/${pointerPart(key)}`)]));
+        return value;
+    };
+    const manifest = buildEditorWrite(actionForSave(draft), null).updates;
+    return transform(manifest) as Record<string, unknown>;
+}
+
+export function buildActionConnectionPayload(
+    draft: ActionConfiguration, original: AuthoringResource<ActionConfiguration> | null,
+): Record<string, unknown> {
+    if (draft.type === 'agent' || original?.read_only || draft.is_global || draft.is_group) {
+        throw new Error('This action cannot be connection-tested from My Workspace.');
+    }
+    if (original && !actionText(original.record.id).trim()) {
+        throw new Error('Reload this action before testing: its stable owned ID is missing.');
+    }
+    const manifest = translateActionSecrets(draft, original);
+    const fields = isRecord(manifest.additionalFields) ? manifest.additionalFields : {};
+    const sql = ['sql_query', 'sql_schema'].includes(draft.type);
+    const connectionMethod = sqlConnectionMethod(draft);
+    let sqlAuthType = actionAuthMethod(draft);
+    let auth = isRecord(manifest.auth) ? manifest.auth : {};
+    if (draft.identity_id) {
+        auth = { type: 'identity', identity: draft.identity_id };
+    } else if (sql && connectionMethod === 'connection_string') {
+        // A complete connection string controls auth; do not test stale parameter credentials.
+        auth = { type: 'identity', identity: '' };
+        sqlAuthType = 'connection_string_only';
+        delete fields.username;
+        delete fields.password;
+    } else if (draft.auth.type === 'NoAuth' || (draft.auth.type === 'user' && !sql)) {
+        auth = { type: draft.auth.type };
+    } else if (draft.auth.type === 'identity') {
+        auth = { type: 'identity', identity: sql && ['integrated', 'connection_string_only'].includes(sqlAuthType) ? '' : auth.identity };
+    } else if (draft.auth.type === 'key' || draft.auth.type === 'connection_string') {
+        auth = {
+            type: draft.auth.type,
+            ...(Object.hasOwn(auth, 'key') ? { key: auth.key } : {}),
+            ...(['snowflake', 'tableau'].includes(draft.type) && Object.hasOwn(auth, 'identity') ? { identity: auth.identity } : {}),
+        };
+    } else if (['username_password', 'basic'].includes(draft.auth.type)) {
+        auth = {
+            type: draft.auth.type,
+            ...(Object.hasOwn(auth, 'key') ? { key: auth.key } : {}),
+            ...(Object.hasOwn(auth, 'identity') ? { identity: auth.identity } : {}),
+        };
+    }
+    if (sql && connectionMethod === 'parameters') {
+        delete fields.connection_string;
+        if (draft.identity_id || sqlAuthType !== 'username_password' || fields.database_type === 'sqlite') {
+            delete fields.username;
+            delete fields.password;
+            if (!draft.identity_id && fields.database_type === 'sqlite' && draft.auth.type === 'user') auth = { type: 'user' };
+        } else if (draft.auth.type === 'user') {
+            if (Object.hasOwn(draft.additionalFields, 'username')) delete auth.identity;
+            if (Object.hasOwn(draft.additionalFields, 'password')) delete auth.key;
+            delete auth.tenantId;
+        }
+    }
+    if (draft.type !== 'snowflake' || actionAuthMethod(draft) !== 'key_pair') delete fields.private_key_passphrase;
+    if (sql) {
+        // Dedicated adapters prioritize canonical fields over their flat compatibility aliases.
+        fields.auth_type = sqlAuthType;
+        fields.connection_method = connectionMethod;
+    }
+    manifest.auth = auth;
+    manifest.additionalFields = fields;
+    const context = original ? { scope: 'personal', id: original.record.id, name: original.record.name } : undefined;
+    const contextKey = ['sql_query', 'sql_schema', 'cosmos_query', 'yamcs', 'rocksdb'].includes(draft.type)
+        ? 'existing_plugin' : 'plugin_context';
+    const clearPaths = buildEditorWrite(draft, original).clear_secret_paths;
+    // Legacy test endpoints may keep empty credentials. Fail before testing a cleared active secret.
+    for (const path of clearPaths) {
+        if ((path === '/auth/key' && !draft.identity_id && !['NoAuth', 'user', 'identity'].includes(String(auth.type))) ||
+            (sql && path === '/additionalFields/password' && !draft.identity_id && fields.database_type !== 'sqlite' &&
+                connectionMethod === 'parameters' && sqlAuthType === 'username_password') ||
+            (sql && path === '/additionalFields/connection_string' && connectionMethod === 'connection_string' && !draft.identity_id)) {
+            throw new Error('A required credential is marked for clearing. Enter a replacement before testing.');
+        }
+    }
+    const common = {
+        action_scope: 'personal', identity_id: draft.identity_id ?? '', clear_secret_paths: clearPaths,
+        ...(context ? { [contextKey]: context } : {}),
+    };
+    if (sql) return {
+        ...manifest, ...fields, ...common,
+        auth_type: sqlAuthType, connection_method: connectionMethod,
+        client_id: auth.identity, client_secret: auth.key, tenant_id: auth.tenantId,
+        timeout: Math.min(Number(fields.timeout ?? 10), 15),
+    };
+    if (draft.type === 'cosmos_query') return {
+        ...manifest, ...common, endpoint: manifest.endpoint, database_name: fields.database_name,
+        container_name: fields.container_name, auth_type: auth.type, auth_key: auth.key,
+        timeout: Math.min(Number(fields.timeout ?? 10), 30),
+    };
+    if (draft.type === 'rocksdb') return {
+        ...manifest, ...common, base_url: manifest.endpoint, auth_scheme: fields.auth_scheme ?? 'none',
+        api_key_header: fields.api_key_header ?? 'X-API-Key', auth_key: auth.key,
+        timeout: Math.min(Number(fields.timeout ?? 10), 30),
+    };
+    if (draft.type === 'yamcs') return {
+        ...manifest, ...common, server_url: manifest.endpoint, instance: fields.instance,
+        auth_method: fields.auth_method, username: auth.identity, auth_key: auth.key,
+        tls_verify: fields.tls_verify ?? true, timeout: Math.min(Number(fields.timeout ?? 10), 30),
+    };
+    return { ...manifest, ...common };
+}
+
+export function testWorkspaceAction(
+    draft: ActionConfiguration, original: AuthoringResource<ActionConfiguration> | null,
+    definition: ActionTypeDefinition, signal?: AbortSignal,
+): Promise<unknown> {
+    const path = nativeActionDefinition(draft.type).testPath;
+    if (!path) return Promise.reject(new Error('This connector does not expose a connection-test command.'));
+    const errors = validateActionDraft(actionForSave(draft), definition, original);
+    for (const field of ['/name', '/displayName', '/type']) delete errors[field];
+    if (Object.keys(errors).length) return Promise.reject(new Error(Object.values(errors).join(' ')));
+    return api.post(path, buildActionConnectionPayload(draft, original), signal);
+}
+
+export function validateWorkspaceAction(
+    draft: ActionConfiguration, original: AuthoringResource<ActionConfiguration> | null, signal?: AbortSignal,
+): Promise<unknown> {
+    const manifest = translateActionSecrets(draft, original);
+    return api.post('/api/plugins/validate', manifest, signal);
+}

--- a/application/v2_ui/src/lib/workspaceActionTypes.ts
+++ b/application/v2_ui/src/lib/workspaceActionTypes.ts
@@ -1,0 +1,57 @@
+// workspaceActionTypes.ts
+
+import type { Dispatch, SetStateAction } from 'react';
+import type { ActionConfiguration, AuthoringResource } from './workspaceAuthoring';
+
+export interface ActionIdentity {
+    id: string;
+    name: string;
+    auth_type: string;
+    description?: string;
+    scope_type?: string;
+    scope_id?: string;
+}
+
+export interface ActionConnectorProps {
+    draft: ActionConfiguration;
+    original: AuthoringResource<ActionConfiguration> | null;
+    onChange: Dispatch<SetStateAction<ActionConfiguration>>;
+    readOnly: boolean;
+    errors: Record<string, string>;
+    onValidityChange: (key: string, message: string | null) => void;
+    identities: ActionIdentity[];
+    identitiesLoading: boolean;
+    identitiesError: string | null;
+}
+
+export interface ActionFieldDescriptor {
+    path: string;
+    label: string;
+    kind?: 'text' | 'textarea' | 'number' | 'boolean' | 'select' | 'secret' | 'lines' | 'json';
+    help?: string;
+    placeholder?: string;
+    required?: boolean;
+    min?: number;
+    max?: number;
+    step?: number;
+    options?: { value: string; label: string }[];
+    visible?: (draft: ActionConfiguration) => boolean;
+    readOnly?: boolean;
+}
+
+export interface ActionCapability {
+    key: string;
+    label: string;
+    description: string;
+    defaultEnabled?: boolean;
+}
+
+export interface ActionNativeDefinition {
+    fields: ActionFieldDescriptor[];
+    defaults?: Partial<ActionConfiguration>;
+    help?: string;
+    internal?: boolean;
+    testPath?: string;
+    identityTypes?: string[];
+    capabilities?: { path: string; options: ActionCapability[] };
+}

--- a/application/v2_ui/src/lib/workspaceAgentActions.ts
+++ b/application/v2_ui/src/lib/workspaceAgentActions.ts
@@ -1,0 +1,169 @@
+// workspaceAgentActions.ts
+
+import { actionTarget, referenceKey, type AgentTargetCatalog } from './agentDelegation';
+import type { ActionConfiguration, AgentConfiguration } from './workspaceAuthoring';
+import { agentObject, agentText, updateAgentSetting } from './workspaceAgentAuthoring';
+
+export interface AgentActionCapability {
+    key: string;
+    label: string;
+    defaultEnabled?: boolean;
+}
+
+const capabilityList = (items: [string, string][]): AgentActionCapability[] =>
+    items.map(([key, label]) => ({ key, label }));
+
+// Matches the three capability families in the V1 agent controller and runtime plugins.
+export const AGENT_ACTION_CAPABILITIES: Record<string, AgentActionCapability[]> = {
+    simplechat: [
+        ...capabilityList([
+            ['create_group', 'Create groups'],
+            ['add_group_member', 'Add users to groups'],
+            ['make_group_inactive', 'Make groups inactive'],
+            ['create_group_conversation', 'Create group multi-user conversations'],
+            ['invite_group_conversation_members', 'Invite group conversation members'],
+            ['create_personal_conversation', 'Create personal conversations'],
+            ['create_personal_workflow', 'Create personal workflows'],
+            ['add_conversation_message', 'Add conversation messages'],
+            ['upload_markdown_document', 'Upload markdown documents'],
+            ['upload_word_document', 'Upload Word documents'],
+            ['upload_powerpoint_document', 'Upload PowerPoint documents'],
+            ['create_personal_collaboration_conversation', 'Create personal collaborative conversations'],
+        ]),
+        { key: 'raise_workflow_alert', label: 'Raise workflow alerts', defaultEnabled: false },
+    ],
+    msgraph: capabilityList([
+        ['get_my_profile', 'Read my profile'],
+        ['get_my_timezone', 'Read my mailbox timezone'],
+        ['get_my_events', 'Read my calendar events'],
+        ['create_calendar_invite', 'Create calendar invites'],
+        ['get_my_messages', 'Read my mail'],
+        ['mark_message_as_read', 'Update message read state'],
+        ['send_mail', 'Send mail'],
+        ['search_users', 'Search directory users'],
+        ['get_user_by_email', 'Lookup user by email'],
+        ['list_drive_items', 'List OneDrive items'],
+        ['get_my_security_alerts', 'Read my security alerts'],
+    ]),
+    chart: capabilityList([
+        ['line', 'Line charts'], ['bar', 'Bar charts'], ['pie', 'Pie charts'],
+        ['doughnut', 'Doughnut charts'], ['scatter', 'Scatter plots'], ['area', 'Area charts'],
+        ['bubble', 'Bubble charts'], ['radar', 'Radar charts'],
+        ['stacked_bar', 'Stacked bar charts'], ['stacked_line', 'Stacked line charts'],
+    ]),
+};
+
+export function agentActionLabel(action: ActionConfiguration): string {
+    return action.displayName || agentText(action.display_name) || action.name || 'Untitled action';
+}
+
+export function resolveAgentAction(reference: string, actions: ActionConfiguration[]): ActionConfiguration | undefined {
+    const byId = actions.filter((action) => action.id === reference);
+    if (byId.length === 1) return byId[0];
+    if (byId.length > 1) return undefined;
+    const byName = actions.filter((action) => action.name === reference);
+    return byName.length === 1 ? byName[0] : undefined;
+}
+
+export function agentHasAction(draft: AgentConfiguration, action: ActionConfiguration, actions: ActionConfiguration[]): boolean {
+    return draft.actions_to_load.some((reference) => resolveAgentAction(reference, actions) === action);
+}
+
+export function toggleAgentAction(
+    draft: AgentConfiguration, action: ActionConfiguration, enabled: boolean, actions: ActionConfiguration[],
+): AgentConfiguration {
+    return {
+        ...draft,
+        actions_to_load: enabled
+            ? agentHasAction(draft, action, actions) ? draft.actions_to_load : [...draft.actions_to_load, action.id || action.name]
+            : draft.actions_to_load.filter((reference) => resolveAgentAction(reference, actions) !== action),
+    };
+}
+
+export function agentActionUnavailableReason(
+    draft: AgentConfiguration,
+    action: ActionConfiguration,
+    targets: AgentTargetCatalog | null,
+    ownerId: string,
+): string | null {
+    if (action.is_enabled === false) return 'This action is disabled.';
+    if (action.type !== 'agent') return null;
+    const target = actionTarget(action);
+    if (!target) return 'The target agent reference is incomplete.';
+    const scope = draft.is_global ? 'global' : 'personal';
+    if (draft.id && target.id === draft.id && target.scope_type === scope &&
+        target.scope_id === (scope === 'global' ? 'global' : agentText(draft.user_id) || ownerId)) {
+        return 'This action calls this same agent. Direct self-calls are blocked.';
+    }
+    if (!targets) return 'Load the authorized target catalogue before assigning this action.';
+    if (!action.is_global && targets.can_manage !== true) {
+        return 'New personal Call agent attachments are unavailable under your current permissions.';
+    }
+    if (!targets.targets.some((item) => referenceKey(item) === referenceKey(target))) return 'The target agent is no longer available to you.';
+    return null;
+}
+
+export function newAgentActionErrors(
+    draft: AgentConfiguration,
+    previous: AgentConfiguration | null,
+    actions: ActionConfiguration[],
+    targets: AgentTargetCatalog | null,
+    ownerId: string,
+): string[] {
+    if (draft.agent_type !== 'local') return [];
+    return draft.actions_to_load.filter((reference) => !previous?.actions_to_load.includes(reference)).flatMap((reference) => {
+        const action = resolveAgentAction(reference, actions);
+        if (!action) return [];
+        const reason = agentActionUnavailableReason(draft, action, targets, ownerId);
+        return reason ? [`${agentActionLabel(action)}: ${reason}`] : [];
+    });
+}
+
+export function agentActionCapabilities(draft: AgentConfiguration, action: ActionConfiguration): Record<string, unknown> {
+    const definitions = AGENT_ACTION_CAPABILITIES[action.type] ?? [];
+    const field = `${action.type}_capabilities`;
+    const defaults = agentObject(action.additionalFields[field] ?? agentObject(action.additional_fields)[field] ?? action[field]);
+    const map = agentObject(draft.other_settings.action_capabilities);
+    const stored = agentObject(map[action.id] ?? map[action.name]);
+    const values: Record<string, unknown> = { ...stored };
+    for (const definition of definitions) {
+        values[definition.key] = Object.hasOwn(stored, definition.key) ? Boolean(stored[definition.key])
+            : Object.hasOwn(defaults, definition.key) ? Boolean(defaults[definition.key])
+            : definition.defaultEnabled !== false;
+    }
+    if (action.type === 'simplechat') {
+        for (const key of ['upload_word_document', 'upload_powerpoint_document']) {
+            if (!Object.hasOwn(stored, key) && Object.hasOwn(stored, 'upload_markdown_document')) {
+                values[key] = Boolean(stored.upload_markdown_document);
+            } else if (!Object.hasOwn(stored, key) && !Object.hasOwn(defaults, key) && Object.hasOwn(defaults, 'upload_markdown_document')) {
+                values[key] = Boolean(defaults.upload_markdown_document);
+            }
+        }
+    }
+    return values;
+}
+
+export function updateAgentCapability(
+    draft: AgentConfiguration, action: ActionConfiguration, key: string, enabled: boolean,
+): AgentConfiguration {
+    const map = agentObject(draft.other_settings.action_capabilities);
+    const storedKey = Object.hasOwn(map, action.id) ? action.id
+        : Object.hasOwn(map, action.name) ? action.name : action.id || action.name;
+    return updateAgentSetting(draft, 'action_capabilities', {
+        [storedKey]: { ...agentActionCapabilities(draft, action), [key]: enabled },
+    });
+}
+
+export function agentSelectedActionsContext(draft: AgentConfiguration, actions: ActionConfiguration[]) {
+    if (draft.agent_type !== 'local') return [];
+    return draft.actions_to_load.map((reference) => {
+        const action = resolveAgentAction(reference, actions);
+        if (!action) return { id: reference, name: reference, display_name: reference, type: 'unavailable', description: 'Unresolved saved reference', capabilities: [] };
+        const values = agentActionCapabilities(draft, action);
+        return {
+            id: action.id, name: action.name, display_name: agentActionLabel(action),
+            description: action.description, type: action.type, is_global: Boolean(action.is_global),
+            capabilities: (AGENT_ACTION_CAPABILITIES[action.type] ?? []).filter((item) => Boolean(values[item.key])),
+        };
+    });
+}

--- a/application/v2_ui/src/lib/workspaceAgentAuthoring.ts
+++ b/application/v2_ui/src/lib/workspaceAgentAuthoring.ts
@@ -1,0 +1,433 @@
+// workspaceAgentAuthoring.ts
+// Agent-only draft rules, shared by the routed editor and executable functional tests.
+
+import type { WorkspaceModelEndpoint } from './types';
+import {
+    EDITOR_SECRET_MASK,
+    editorName,
+    editorValueAt,
+    isRecord,
+    pointerPart,
+    sameEditorValue,
+    type AgentConfiguration,
+    type AgentEditorOptions,
+    type AuthoringResource,
+    type WorkspaceAgentType,
+} from './workspaceAuthoring';
+
+export const AGENT_TYPE_LABELS: Record<WorkspaceAgentType, string> = {
+    local: 'Local',
+    aifoundry: 'Azure AI Foundry',
+    new_foundry: 'New Foundry',
+    foundry_workflow: 'Foundry Workflow',
+};
+
+export const FOUNDRY_SETTINGS_KEYS = {
+    aifoundry: 'azure_ai_foundry',
+    new_foundry: 'new_foundry',
+    foundry_workflow: 'foundry_workflow',
+} as const;
+
+export const AGENT_INPUT_CLASS = 'w-full min-w-0 rounded-xl border border-edge bg-surface-1 px-3 py-2 text-sm text-text-1 placeholder:text-text-3 focus:border-accent focus:outline-none disabled:opacity-60';
+
+export function agentText(value: unknown): string {
+    return typeof value === 'string' ? value : '';
+}
+
+export function agentStrings(value: unknown): string[] {
+    return Array.isArray(value) ? value.filter((item): item is string => typeof item === 'string') : [];
+}
+
+export function agentObject(value: unknown): Record<string, unknown> {
+    return isRecord(value) ? value : {};
+}
+
+export function isAgentEditorEnvelope(value: unknown): boolean {
+    if (!isRecord(value) || !isRecord(value.record) || !Array.isArray(value.secret_paths) ||
+        !value.secret_paths.every((path) => typeof path === 'string')) return false;
+    return value.read_only === true || (typeof value.revision === 'string' && value.revision.trim().length > 0);
+}
+
+export function newAgentDraft(): AgentConfiguration {
+    return {
+        id: '',
+        name: '',
+        display_name: '',
+        description: '',
+        instructions: '',
+        agent_type: 'local',
+        is_global: false,
+        is_group: false,
+        tags: [],
+        actions_to_load: [],
+        other_settings: {},
+        max_completion_tokens: -1,
+    };
+}
+
+export function clearAgentDraftFields(draft: AgentConfiguration, ...keys: string[]): AgentConfiguration {
+    const next = { ...draft };
+    for (const key of keys) delete next[key];
+    return next;
+}
+
+function containsAgentSecretMask(value: unknown): boolean {
+    if (value === EDITOR_SECRET_MASK) return true;
+    if (Array.isArray(value)) return value.some(containsAgentSecretMask);
+    return isRecord(value) && Object.values(value).some(containsAgentSecretMask);
+}
+
+/** A kept array credential identifies a saved position, not a row name or ID. */
+export function agentStoredArrayEditError(
+    draft: AgentConfiguration, original: AuthoringResource<AgentConfiguration> | null,
+): string | null {
+    if (!original) return null;
+    const secrets = new Set(original.secret_paths);
+    const arrays = new Set<string>();
+    for (const secret of secrets) {
+        const parts = secret.slice(1).split('/');
+        for (let length = 1; length < parts.length; length += 1) {
+            const path = `/${parts.slice(0, length).join('/')}`;
+            if (Array.isArray(editorValueAt(original.record, path)) || Array.isArray(editorValueAt(draft, path))) arrays.add(path);
+        }
+    }
+    const sameKeptEntries = (before: unknown, after: unknown, path: string): boolean => {
+        if (secrets.has(path)) return true;
+        if (arrays.has(path)) {
+            if (!containsAgentSecretMask(after)) return true;
+            if (!Array.isArray(before) || !Array.isArray(after) || after.length > before.length) return false;
+            // Trimming a suffix is safe when every kept credential still has its unchanged entry.
+            return after.every((entry, index) => !containsAgentSecretMask(entry) ||
+                sameKeptEntries(before[index], entry, `${path}/${index}`));
+        }
+        if (isRecord(before) && isRecord(after)) {
+            return [...new Set([...Object.keys(before), ...Object.keys(after)])].every((key) =>
+                sameKeptEntries(
+                    Object.hasOwn(before, key) ? before[key] : undefined,
+                    Object.hasOwn(after, key) ? after[key] : undefined,
+                    `${path}/${pointerPart(key)}`,
+                ));
+        }
+        return sameEditorValue(before, after);
+    };
+    for (const path of arrays) {
+        if (!sameKeptEntries(editorValueAt(original.record, path), editorValueAt(draft, path), path)) {
+            return `Stored credentials in ${path} belong to their saved array positions, not entry names or IDs. Keep those entries unchanged, or replace/clear their credentials before editing entries or changing the array structure.`;
+        }
+    }
+    return null;
+}
+
+export function applySafeAgentDraft(
+    current: AgentConfiguration, next: AgentConfiguration, original: AuthoringResource<AgentConfiguration> | null,
+): AgentConfiguration {
+    const error = agentStoredArrayEditError(next, original);
+    if (!error) return clearAgentDraftFields(next, '_editor_array_secret_error');
+    return {
+        ...current,
+        ...(typeof next._editor_settings_text === 'string' ? { _editor_settings_text: next._editor_settings_text } : {}),
+        _editor_array_secret_error: error,
+    };
+}
+
+export function renameAgentDraft(draft: AgentConfiguration, displayName: string, isNew: boolean): AgentConfiguration {
+    const wasDerived = !draft.name || draft.name === editorName(draft.display_name);
+    return {
+        ...draft,
+        display_name: displayName,
+        ...(isNew && wasDerived ? { name: editorName(displayName) } : {}),
+    };
+}
+
+export function updateAgentSetting(
+    draft: AgentConfiguration,
+    key: string,
+    changes: Record<string, unknown>,
+): AgentConfiguration {
+    const settings = {
+        ...draft.other_settings,
+        [key]: { ...agentObject(draft.other_settings[key]), ...changes },
+    };
+    return clearAgentDraftFields({ ...draft, other_settings: settings }, '_editor_settings_text');
+}
+
+function mergeSettings(before: Record<string, unknown>, after: Record<string, unknown>): Record<string, unknown> {
+    return Object.fromEntries([...new Set([...Object.keys(before), ...Object.keys(after)])].map((key) => {
+        if (!Object.hasOwn(after, key)) return [key, before[key]];
+        return [key, isRecord(before[key]) && isRecord(after[key])
+            ? mergeSettings(before[key], after[key])
+            : after[key]];
+    }));
+}
+
+/** Managed sections cannot be erased by pasting an unrelated advanced-settings object. */
+export function parseAgentSettings(text: string, current: Record<string, unknown>): Record<string, unknown> {
+    const parsed: unknown = JSON.parse(text || '{}');
+    if (!isRecord(parsed)) throw new Error('Additional settings must be a JSON object, not an array or scalar.');
+    const managed = ['action_capabilities', 'assigned_knowledge', ...Object.values(FOUNDRY_SETTINGS_KEYS)];
+    const result = { ...parsed };
+    for (const key of managed) {
+        if (Object.hasOwn(current, key)) {
+            if (!Object.hasOwn(parsed, key)) result[key] = current[key];
+            else if (isRecord(current[key]) && isRecord(parsed[key])) result[key] = mergeSettings(current[key], parsed[key]);
+        }
+    }
+    const knowledge = agentObject(result.assigned_knowledge);
+    const incomingKnowledge = agentObject(parsed.assigned_knowledge);
+    const previousKnowledge = agentObject(current.assigned_knowledge);
+    if (Object.hasOwn(incomingKnowledge, 'document_ids') && !sameEditorValue(incomingKnowledge.document_ids, previousKnowledge.document_ids)) {
+        delete knowledge.selected_document_ids;
+    }
+    const incomingScopes = agentObject(incomingKnowledge.scopes);
+    const previousScopes = agentObject(previousKnowledge.scopes);
+    for (const [field, scope] of [['personal', 'personal'], ['group_ids', 'group'], ['public_workspace_ids', 'public']]) {
+        if (Object.hasOwn(incomingScopes, field) && !sameEditorValue(incomingScopes[field], previousScopes[field])) {
+            delete knowledge[field];
+            if (Array.isArray(knowledge.sources)) knowledge.sources = knowledge.sources.filter((source) => agentObject(source).scope !== scope);
+        }
+    }
+    if (Array.isArray(incomingKnowledge.web_sources) && !sameEditorValue(incomingKnowledge.web_sources, previousKnowledge.web_sources)) {
+        knowledge.web_sources = incomingKnowledge.web_sources.map((source) => {
+            if (!isRecord(source) || typeof source.mode !== 'string') return source;
+            const normalized = { ...source };
+            delete normalized.deep_research;
+            return normalized;
+        });
+    }
+    return result;
+}
+
+export function foundrySettings(draft: AgentConfiguration): Record<string, unknown> {
+    return draft.agent_type === 'local' ? {} : agentObject(draft.other_settings[FOUNDRY_SETTINGS_KEYS[draft.agent_type]]);
+}
+
+/** Type selection never prunes actions, provider settings, credentials, or knowledge. */
+export function changeAgentType(draft: AgentConfiguration, type: WorkspaceAgentType): AgentConfiguration {
+    return { ...draft, agent_type: type };
+}
+
+export interface AgentModelChoice {
+    key: string;
+    id: string;
+    endpointId: string;
+    provider: string;
+    deployment: string;
+    modelName: string;
+    label: string;
+    apim: boolean;
+}
+
+export function agentModelChoices(options: AgentEditorOptions): AgentModelChoice[] {
+    const choices: AgentModelChoice[] = [];
+    for (const endpoint of options.model_endpoints) {
+        if (endpoint.enabled === false) continue;
+        for (const model of endpoint.models ?? []) {
+            if (model.enabled === false) continue;
+            const id = agentText(model.id || model.deploymentName || model.deployment || model.modelName || model.name);
+            if (!id) continue;
+            const deployment = agentText(model.deploymentName || model.deployment || model.modelName || model.name || id);
+            choices.push({
+                key: JSON.stringify([endpoint.id, id]),
+                id,
+                endpointId: endpoint.id,
+                provider: agentText(endpoint.provider) || 'aoai',
+                deployment,
+                modelName: agentText(model.modelName || model.name || id),
+                label: `${agentText(model.displayName) || deployment} · ${endpoint.name || endpoint.id}`,
+                apim: false,
+            });
+        }
+    }
+    if (options.model_endpoints.length) return choices;
+    const settings = options.settings;
+    if (settings.enable_gpt_apim === true) {
+        return agentText(settings.azure_apim_gpt_deployment).split(',').map((item) => item.trim()).filter(Boolean).map((id) => ({
+            key: JSON.stringify(['apim', id]), id, endpointId: '', provider: '',
+            deployment: id, modelName: id, label: id, apim: true,
+        }));
+    }
+    const selected = agentObject(settings.gpt_model).selected;
+    for (const item of Array.isArray(selected) ? selected : []) {
+        const model = agentObject(item);
+        const id = agentText(model.id || model.deploymentName || model.deployment || model.modelName || model.name);
+        if (!id) continue;
+        choices.push({
+            key: JSON.stringify(['legacy', id]), id, endpointId: '', provider: '',
+            deployment: agentText(model.deploymentName || model.deployment || id),
+            modelName: agentText(model.modelName || model.name || id),
+            label: agentText(model.display_name || model.displayName || model.deploymentName || model.deployment || id),
+            apim: false,
+        });
+    }
+    return choices;
+}
+
+export function selectedAgentModel(draft: AgentConfiguration, choices: AgentModelChoice[]): AgentModelChoice | undefined {
+    if (draft.model_endpoint_id) {
+        return choices.find((choice) => choice.endpointId === draft.model_endpoint_id && choice.id === draft.model_id);
+    }
+    const deployment = draft.enable_agent_gpt_apim ? draft.azure_agent_apim_gpt_deployment : draft.azure_openai_gpt_deployment;
+    return choices.find((choice) => !choice.endpointId && choice.deployment === deployment);
+}
+
+export function selectAgentModel(draft: AgentConfiguration, choice: AgentModelChoice): AgentConfiguration {
+    return {
+        ...draft,
+        model_endpoint_id: choice.endpointId,
+        model_id: choice.endpointId ? choice.id : '',
+        model_provider: choice.provider,
+        enable_agent_gpt_apim: choice.apim,
+        ...(choice.apim
+            ? { azure_agent_apim_gpt_deployment: choice.deployment }
+            : { azure_openai_gpt_deployment: choice.deployment }),
+    };
+}
+
+export function foundryEndpointMatches(type: WorkspaceAgentType, endpoint: WorkspaceModelEndpoint): boolean {
+    if (endpoint.enabled === false) return false;
+    return type === 'foundry_workflow'
+        ? ['foundry_workflow', 'new_foundry', 'aifoundry'].includes(agentText(endpoint.provider))
+        : endpoint.provider === type;
+}
+
+export function selectFoundryEndpoint(draft: AgentConfiguration, endpoint: WorkspaceModelEndpoint): AgentConfiguration {
+    if (draft.agent_type === 'local') return draft;
+    const connection = agentObject(endpoint.connection);
+    const current = foundrySettings(draft);
+    const projectVersion = agentText(connection.project_api_version || connection.api_version) || 'v1';
+    const responseVersion = agentText(connection.openai_api_version || connection.api_version);
+    const version = draft.agent_type === 'aifoundry' ? projectVersion : responseVersion || agentText(current.responses_api_version);
+    return updateAgentSetting({
+        ...draft,
+        model_endpoint_id: endpoint.id,
+        model_provider: draft.agent_type === 'foundry_workflow' ? agentText(endpoint.provider) : draft.agent_type,
+        azure_openai_gpt_endpoint: agentText(connection.endpoint),
+        azure_openai_gpt_deployment: agentText(connection.project_name),
+        azure_openai_gpt_api_version: version,
+    }, FOUNDRY_SETTINGS_KEYS[draft.agent_type], {
+        endpoint_id: endpoint.id,
+        endpoint: agentText(connection.endpoint),
+        project_name: agentText(connection.project_name),
+        authentication_type: 'delegated_user',
+        ...(draft.agent_type !== 'aifoundry' && version ? { responses_api_version: version } : {}),
+    });
+}
+
+export interface FoundryDiscoveryRecord {
+    id?: string;
+    name?: string;
+    display_name?: string;
+    description?: string;
+    application_id?: string;
+    application_name?: string;
+    application_version?: string;
+    workflow_name?: string;
+    workflow_agent_id?: string;
+    responses_api_version?: string;
+    agent_reference?: Record<string, unknown>;
+    [key: string]: unknown;
+}
+
+export function applyFoundryDiscovery(draft: AgentConfiguration, selected: FoundryDiscoveryRecord): AgentConfiguration {
+    if (draft.agent_type === 'local') return draft;
+    const changes: Record<string, unknown> = {};
+    if (draft.agent_type === 'aifoundry') changes.agent_id = selected.id ?? '';
+    if (draft.agent_type === 'new_foundry') {
+        Object.assign(changes, {
+            application_id: selected.application_id || selected.id || '',
+            application_name: selected.application_name || selected.name || '',
+            application_version: selected.application_version || '',
+        });
+    }
+    if (draft.agent_type === 'foundry_workflow') {
+        const reference = agentObject(selected.agent_reference);
+        const name = selected.workflow_name || selected.application_name || selected.name || '';
+        const id = selected.workflow_agent_id || agentText(reference.id) || selected.id;
+        Object.assign(changes, {
+            workflow_name: name,
+            ...(id ? { workflow_agent_id: id } : {}),
+            ...(selected.application_id ? { application_id: selected.application_id } : {}),
+            ...(selected.application_version ? { application_version: selected.application_version } : {}),
+            agent_reference: {
+                ...reference,
+                type: agentText(reference.type) || 'agent_reference',
+                name,
+                ...(id ? { id } : {}),
+                ...(selected.application_id ? { application_id: selected.application_id } : {}),
+                ...(selected.application_version ? { application_version: selected.application_version } : {}),
+            },
+        });
+    }
+    if (selected.responses_api_version) changes.responses_api_version = selected.responses_api_version;
+    return updateAgentSetting({
+        ...draft,
+        ...(selected.responses_api_version ? { azure_openai_gpt_api_version: selected.responses_api_version } : {}),
+    }, FOUNDRY_SETTINGS_KEYS[draft.agent_type], changes);
+}
+
+export function agentValidationErrors(draft: AgentConfiguration, options: AgentEditorOptions): string[] {
+    const errors: string[] = [];
+    if (!draft.display_name.trim()) errors.push('Display name is required.');
+    if (!/^[A-Za-z0-9_-]+$/.test(draft.name)) errors.push('Internal name must contain only letters, digits, underscores, and dashes.');
+    if (!draft.description.trim()) errors.push('Description is required.');
+    if (!options.agent_types.some((type) => type.value === draft.agent_type && type.enabled)) errors.push('This agent type is not available for your workspace.');
+    if (!Number.isInteger(draft.max_completion_tokens) || draft.max_completion_tokens < -1 || draft.max_completion_tokens > 512000) {
+        errors.push('Completion token limit must be an integer between -1 and 512000.');
+    }
+    if ((draft.tags ?? []).length > 20 || (draft.tags ?? []).some((tag) => tag.length > 40)) errors.push('Use at most 20 tags, each at most 40 characters.');
+    if (draft.agent_type === 'local') {
+        if (!draft.instructions.trim()) errors.push('Instructions are required for a local agent.');
+    } else {
+        const settings = foundrySettings(draft);
+        if (draft.actions_to_load.length) errors.push('Foundry manages its own tools. Explicitly detach local actions before saving this type.');
+        if (draft.enable_agent_gpt_apim) errors.push('Disable the local APIM connection before saving a Foundry agent.');
+        const selectedEndpoint = options.model_endpoints.find((endpoint) => endpoint.id === draft.model_endpoint_id);
+        if (selectedEndpoint && !foundryEndpointMatches(draft.agent_type, selectedEndpoint)) errors.push('Choose a compatible Foundry connection or select manual connection before saving this type.');
+        if (!agentText(draft.azure_openai_gpt_endpoint || settings.endpoint).trim()) errors.push('A Foundry project endpoint is required.');
+        const version = draft.agent_type === 'aifoundry' ? draft.azure_openai_gpt_api_version : settings.responses_api_version || draft.azure_openai_gpt_api_version;
+        if (!agentText(version).trim()) errors.push('A Foundry API version is required.');
+        if (draft.agent_type === 'aifoundry' && !agentText(settings.agent_id).trim()) errors.push('Foundry agent ID is required.');
+        if (draft.agent_type === 'new_foundry' && !agentText(settings.application_id || settings.application_name).trim()) errors.push('Foundry application ID or name is required.');
+        if (draft.agent_type === 'foundry_workflow' && !agentText(settings.workflow_name).trim()) errors.push('Foundry workflow name is required.');
+    }
+    return errors;
+}
+
+export const secretValueAt = editorValueAt;
+
+export function setAgentSecret(draft: AgentConfiguration, path: string, value: string): AgentConfiguration {
+    const parts = path.slice(1).split('/').map((part) => part.replace(/~1/g, '/').replace(/~0/g, '~'));
+    const set = (record: unknown, index: number): unknown => {
+        if (Array.isArray(record)) {
+            const at = Number(parts[index]);
+            if (!/^(0|[1-9]\d*)$/.test(parts[index]) || at >= record.length) throw new Error('The secret array entry is no longer available.');
+            return record.map((entry, position) => position !== at ? entry
+                : index === parts.length - 1 ? value : set(entry, index + 1));
+        }
+        const object = agentObject(record);
+        return { ...object, [parts[index]]: index === parts.length - 1 ? value : set(object[parts[index]], index + 1) };
+    };
+    return clearAgentDraftFields({ ...draft, ...agentObject(set(draft, 0)) }, '_editor_settings_text');
+}
+
+export function isAgentIconImage(value: unknown): value is string {
+    return typeof value === 'string' && value.length <= 350000 &&
+        /^data:image\/(png|jpeg);base64,[A-Za-z0-9+/=]+$/.test(value);
+}
+
+/** An explicit save may fill Foundry's canonical placeholder, never replace a prompt. */
+export function agentForSave(draft: AgentConfiguration): AgentConfiguration {
+    return {
+        ...draft,
+        display_name: draft.display_name.trim(),
+        name: draft.name.trim(),
+        ...(draft.agent_type !== 'local' && !draft.instructions.trim()
+            ? { instructions: 'Placeholder instructions: Azure AI Foundry agent manages its own prompt.' }
+            : {}),
+    };
+}
+
+export function secretIntent(value: unknown, original: unknown): 'keep' | 'replace' | 'clear' {
+    if (value === EDITOR_SECRET_MASK || (value === undefined && original === undefined)) return 'keep';
+    return (value === '' || value === undefined || value === null) && original === EDITOR_SECRET_MASK ? 'clear' : 'replace';
+}

--- a/application/v2_ui/src/lib/workspaceAgentCommands.ts
+++ b/application/v2_ui/src/lib/workspaceAgentCommands.ts
@@ -1,0 +1,54 @@
+// workspaceAgentCommands.ts
+
+import { api } from './apiClient';
+import type { WorkspaceModelEndpoint } from './types';
+import type { ActionConfiguration, AgentConfiguration, WorkspaceAgentType } from './workspaceAuthoring';
+import { agentSelectedActionsContext } from './workspaceAgentActions';
+import { agentText, foundryEndpointMatches, type FoundryDiscoveryRecord } from './workspaceAgentAuthoring';
+import { agentKnowledgeReference, type AgentKnowledgeCatalog } from './workspaceAgentKnowledge';
+
+export function agentInstructionRequest(
+    draft: AgentConfiguration, actions: ActionConfiguration[], catalog: AgentKnowledgeCatalog | null,
+) {
+    return {
+        agent_scope: 'user',
+        display_name: draft.display_name,
+        description: draft.description,
+        brief: agentText(draft._editor_instruction_brief),
+        existing_instructions: draft.instructions,
+        selected_actions: agentSelectedActionsContext(draft, actions),
+        assigned_knowledge: agentKnowledgeReference(draft, catalog),
+    };
+}
+
+export async function draftAgentInstructions(
+    draft: AgentConfiguration, actions: ActionConfiguration[], catalog: AgentKnowledgeCatalog | null, signal?: AbortSignal,
+): Promise<string> {
+    if (draft.agent_type !== 'local') throw new Error('Foundry manages its own instructions.');
+    const result = await api.post<{ success: boolean; instructions: string }>(
+        '/api/agents/draft-instructions', agentInstructionRequest(draft, actions, catalog), signal,
+    );
+    if (!result.success || typeof result.instructions !== 'string' || !result.instructions.trim()) {
+        throw new Error('Instruction drafting returned no instructions.');
+    }
+    return result.instructions;
+}
+
+export function withAgentInstructionProposal(current: AgentConfiguration, instructions: string, baseline: string): AgentConfiguration {
+    return { ...current, _editor_instruction_proposal: instructions, _editor_instruction_baseline: baseline };
+}
+
+export async function discoverAgentFoundryResources(
+    endpoint: WorkspaceModelEndpoint, type: WorkspaceAgentType, signal?: AbortSignal,
+) {
+    if (type === 'local' || !foundryEndpointMatches(type, endpoint)) throw new Error('Select an available Foundry connection for this agent type.');
+    const result = await api.post<{ agents: FoundryDiscoveryRecord[]; responses_api_version?: string }>(
+        '/api/models/foundry/agents', {
+            endpoint_id: endpoint.id,
+            scope: agentText(endpoint.scope) || 'global',
+            resource_type: type === 'foundry_workflow' ? 'workflow' : '',
+        }, signal,
+    );
+    if (!Array.isArray(result.agents)) throw new Error('Foundry discovery returned an invalid resource list.');
+    return result;
+}

--- a/application/v2_ui/src/lib/workspaceAgentKnowledge.ts
+++ b/application/v2_ui/src/lib/workspaceAgentKnowledge.ts
@@ -1,0 +1,207 @@
+// workspaceAgentKnowledge.ts
+
+import { api } from './apiClient';
+import type { AgentConfiguration } from './workspaceAuthoring';
+import { agentObject, agentStrings, agentText, clearAgentDraftFields } from './workspaceAgentAuthoring';
+
+export interface AgentKnowledgeSource {
+    scope: string;
+    id: string;
+    label: string;
+}
+
+export interface AgentKnowledgeDocument {
+    id: string;
+    title: string;
+    file_name: string;
+    scope: string;
+    source_id: string;
+    source_name: string;
+    tags: string[];
+}
+
+export interface AgentKnowledgeCatalog {
+    sources: AgentKnowledgeSource[];
+    documents: AgentKnowledgeDocument[];
+    tags: { name: string; count: number }[];
+}
+
+export interface AgentWebSource {
+    url: string;
+    mode: string;
+    [key: string]: unknown;
+}
+
+export interface AgentKnowledgeConfiguration {
+    enabled: boolean;
+    scopes: {
+        personal: boolean;
+        group_ids: string[];
+        public_workspace_ids: string[];
+        [key: string]: unknown;
+    };
+    document_ids: string[];
+    tags: string[];
+    web_sources: AgentWebSource[];
+    allow_user_workspace_context: boolean;
+    allowed_user_workspace_actions: string[];
+    [key: string]: unknown;
+}
+
+export const USER_KNOWLEDGE_ACTIONS = ['search', 'analyze', 'compare'] as const;
+export const KNOWLEDGE_LIMITS = { documents: 200, tags: 50, sources: 50, urls: 50 };
+
+export async function fetchAgentKnowledgeCatalog(signal?: AbortSignal): Promise<AgentKnowledgeCatalog> {
+    const response = await api.get<AgentKnowledgeCatalog>('/api/agents/assigned-knowledge/catalog?agent_scope=personal', signal);
+    if (!response || !Array.isArray(response.sources) || !Array.isArray(response.documents) || !Array.isArray(response.tags)) {
+        throw new Error('The assigned knowledge catalogue returned an invalid response.');
+    }
+    return response;
+}
+
+export function normalizeAgentKnowledgeUrl(value: string): string {
+    try {
+        const url = new URL(value.trim());
+        if (!['http:', 'https:'].includes(url.protocol) || !url.hostname || url.username || url.password) return '';
+        url.hash = '';
+        return url.toString();
+    } catch {
+        return '';
+    }
+}
+
+function webMode(mode: unknown): string {
+    if (['deep', 'deep-research', 'research'].includes(agentText(mode))) return 'deep_research';
+    return agentText(mode) || 'url_review';
+}
+
+export function readAgentKnowledge(draft: AgentConfiguration): AgentKnowledgeConfiguration {
+    const value = agentObject(draft.other_settings.assigned_knowledge);
+    const scopes = agentObject(value.scopes);
+    const rawWeb = value.web_sources;
+    const webObject = agentObject(rawWeb);
+    const rawEntries = typeof rawWeb === 'string' || Array.isArray(rawWeb) ? rawWeb : webObject.sources ?? webObject.urls ?? [];
+    const webEntries = typeof rawEntries === 'string' ? rawEntries.split(/[\s,]+/).filter(Boolean) : Array.isArray(rawEntries) ? rawEntries : [];
+    const legacySources = (Array.isArray(value.sources) ? value.sources : []).map(agentObject);
+    const legacyIds = (scope: string) => legacySources.filter((source) => source.scope === scope)
+        .map((source) => agentText(source.id || source.source_id)).filter(Boolean);
+    const sourceIds = (field: 'group_ids' | 'public_workspace_ids', scope: string) =>
+        [...new Set([...(agentStrings(scopes[field]).length ? agentStrings(scopes[field]) : agentStrings(value[field])), ...legacyIds(scope)])];
+    return {
+        ...value,
+        enabled: value.enabled === true,
+        scopes: {
+            ...scopes,
+            personal: scopes.personal === true || value.personal === true || legacySources.some((source) => source.scope === 'personal'),
+            group_ids: sourceIds('group_ids', 'group'),
+            public_workspace_ids: sourceIds('public_workspace_ids', 'public'),
+        },
+        document_ids: agentStrings(value.document_ids).length ? agentStrings(value.document_ids) : agentStrings(value.selected_document_ids),
+        tags: agentStrings(value.tags),
+        web_sources: webEntries.map((entry) => typeof entry === 'string'
+            ? { url: entry, mode: webMode(webObject.mode || (webObject.deep_research === true ? 'deep_research' : undefined)) }
+            : {
+                ...agentObject(entry),
+                url: agentText(agentObject(entry).url || agentObject(entry).href || agentObject(entry).link),
+                mode: webMode(agentObject(entry).deep_research === true ? 'deep_research' : agentObject(entry).mode),
+            }),
+        allow_user_workspace_context: value.allow_user_workspace_context === true,
+        allowed_user_workspace_actions: agentStrings(value.allowed_user_workspace_actions ?? value.allowed_user_context_actions ?? USER_KNOWLEDGE_ACTIONS),
+    };
+}
+
+export function updateAgentKnowledge(draft: AgentConfiguration, changes: Partial<AgentKnowledgeConfiguration>): AgentConfiguration {
+    const next = { ...readAgentKnowledge(draft), ...changes };
+    // Legacy aliases must not resurrect references after the author explicitly removes them.
+    if (Object.hasOwn(changes, 'scopes')) {
+        for (const field of ['personal', 'group_ids', 'public_workspace_ids']) delete next[field];
+        const unknownSources = (Array.isArray(next.sources) ? next.sources : []).filter((source) =>
+            !['personal', 'group', 'public'].includes(agentText(agentObject(source).scope)));
+        if (unknownSources.length) next.sources = unknownSources;
+        else delete next.sources;
+    }
+    if (Object.hasOwn(changes, 'document_ids')) delete next.selected_document_ids;
+    if (Object.hasOwn(changes, 'allowed_user_workspace_actions')) delete next.allowed_user_context_actions;
+    if (Object.hasOwn(changes, 'web_sources')) {
+        next.web_sources = next.web_sources.map((source) => {
+            const updated = { ...source };
+            for (const field of ['href', 'link', 'deep_research']) delete updated[field];
+            return updated;
+        });
+    }
+    return clearAgentDraftFields({ ...draft, other_settings: { ...draft.other_settings, assigned_knowledge: next } }, '_editor_settings_text');
+}
+
+export function knowledgeSourceKey(source: Pick<AgentKnowledgeSource, 'scope' | 'id'>): string {
+    return `${source.scope}:${source.id}`;
+}
+
+export function selectedKnowledgeSources(config: AgentKnowledgeConfiguration): string[] {
+    return [
+        ...(config.scopes.personal ? ['personal:personal'] : []),
+        ...config.scopes.group_ids.map((id) => `group:${id}`),
+        ...config.scopes.public_workspace_ids.map((id) => `public:${id}`),
+    ];
+}
+
+export function toggleAgentKnowledgeSource(draft: AgentConfiguration, source: AgentKnowledgeSource, enabled: boolean): AgentConfiguration {
+    const config = readAgentKnowledge(draft);
+    if (!['personal', 'public'].includes(source.scope)) throw new Error('Personal agents can assign only authorized personal and public sources.');
+    const scopes = { ...config.scopes };
+    if (source.scope === 'personal') scopes.personal = enabled;
+    else scopes.public_workspace_ids = toggleString(scopes.public_workspace_ids, source.id, enabled);
+    return updateAgentKnowledge(draft, { scopes });
+}
+
+export function toggleString(values: string[], value: string, enabled: boolean): string[] {
+    return enabled ? [...new Set([...values, value])] : values.filter((item) => item !== value);
+}
+
+export function resolvedAgentDocuments(config: AgentKnowledgeConfiguration, catalog: AgentKnowledgeCatalog): AgentKnowledgeDocument[] {
+    if (!config.enabled) return [];
+    const sources = new Set(selectedKnowledgeSources(config));
+    const ids = new Set(config.document_ids);
+    const unrestricted = !ids.size && !config.tags.length;
+    const seen = new Set<string>();
+    return catalog.documents.filter((document) => {
+        if (!sources.has(`${document.scope}:${document.source_id}`) || seen.has(document.id)) return false;
+        // Explicit documents OR documents with every selected tag, matching the runtime.
+        const active = unrestricted || ids.has(document.id) ||
+            (config.tags.length > 0 && config.tags.every((tag) => document.tags.includes(tag)));
+        if (active) seen.add(document.id);
+        return active;
+    });
+}
+
+export function agentKnowledgeReference(draft: AgentConfiguration, catalog: AgentKnowledgeCatalog | null) {
+    const config = readAgentKnowledge(draft);
+    if (draft.agent_type !== 'local' || !config.enabled) return { enabled: false, sources: [], documents: [], tags: [], web_sources: [] };
+    const selected = new Set(selectedKnowledgeSources(config));
+    return {
+        enabled: true,
+        sources: (catalog?.sources ?? []).filter((source) => selected.has(knowledgeSourceKey(source))).map((source) => ({
+            scope: source.scope, id: source.id, name: source.label,
+        })),
+        documents: (catalog ? resolvedAgentDocuments(config, catalog) : []).map((document) => ({
+            ...document, is_explicit: config.document_ids.includes(document.id),
+        })),
+        tags: config.tags,
+        web_sources: config.web_sources.map((source) => ({
+            ...source, mode_label: source.mode === 'deep_research' ? 'Deep research' : 'URL review',
+        })),
+    };
+}
+
+export function agentKnowledgeErrors(draft: AgentConfiguration): string[] {
+    const config = readAgentKnowledge(draft);
+    if (draft.agent_type !== 'local' || !config.enabled) return [];
+    const errors: string[] = [];
+    if (!selectedKnowledgeSources(config).length && !config.web_sources.length) errors.push('Select a knowledge workspace or assign a URL.');
+    if (config.document_ids.length > KNOWLEDGE_LIMITS.documents) errors.push('Assigned knowledge supports at most 200 explicit documents.');
+    if (config.tags.length > KNOWLEDGE_LIMITS.tags) errors.push('Assigned knowledge supports at most 50 tags.');
+    if (config.scopes.public_workspace_ids.length > KNOWLEDGE_LIMITS.sources) errors.push('Assigned knowledge supports at most 50 public workspaces.');
+    if (config.web_sources.length > KNOWLEDGE_LIMITS.urls) errors.push('Assigned knowledge supports at most 50 URLs.');
+    if (config.web_sources.some((source) => !normalizeAgentKnowledgeUrl(source.url))) errors.push('Assigned URLs must be valid HTTP or HTTPS URLs without embedded credentials.');
+    if (config.web_sources.some((source) => !['url_review', 'deep_research'].includes(source.mode))) errors.push('Review the mode for each assigned URL.');
+    return errors;
+}

--- a/application/v2_ui/src/lib/workspaceAgentLaunch.ts
+++ b/application/v2_ui/src/lib/workspaceAgentLaunch.ts
@@ -1,0 +1,30 @@
+// workspaceAgentLaunch.ts
+
+import {
+    AGENT_SCOPE_PARAM, NEW_CHAT_PARAM, readConversationParam, WORKSPACE_AGENT_PARAM,
+} from './conversationUrl';
+import type { AgentOption } from './types';
+
+export interface WorkspaceAgentLaunch {
+    id: string;
+    scope: 'personal' | 'global';
+}
+
+export function readWorkspaceAgentLaunch(params: URLSearchParams): WorkspaceAgentLaunch | null {
+    if (readConversationParam(params) || params.get(NEW_CHAT_PARAM) !== '1') return null;
+    const id = params.get(WORKSPACE_AGENT_PARAM)?.trim() ?? '';
+    const scope = params.get(AGENT_SCOPE_PARAM) ?? 'personal';
+    if (!id || /[/\\\u0000-\u001f\u007f]/.test(id) || !['personal', 'global'].includes(scope)) return null;
+    return { id, scope: scope === 'global' ? 'global' : 'personal' };
+}
+
+/** The URL is a request, not authorization and never a reason to match an agent by name. */
+export function workspaceAgentForLaunch(
+    agents: AgentOption[] | undefined,
+    launch: WorkspaceAgentLaunch,
+): AgentOption | undefined {
+    return agents?.find((agent) => {
+        const scope = agent.scope_type || (agent.is_group ? 'group' : agent.is_global ? 'global' : 'personal');
+        return agent.id === launch.id && scope === launch.scope && agent.is_enabled !== false;
+    });
+}

--- a/application/v2_ui/src/lib/workspaceAgentReferences.ts
+++ b/application/v2_ui/src/lib/workspaceAgentReferences.ts
@@ -1,0 +1,66 @@
+// workspaceAgentReferences.ts
+// Literal mention grammar shared with V1: quoted whitespace/colons, bounded trigger scanning.
+
+import type { ActionConfiguration, AgentConfiguration } from './workspaceAuthoring';
+import { agentSelectedActionsContext } from './workspaceAgentActions';
+import { agentKnowledgeReference, type AgentKnowledgeCatalog } from './workspaceAgentKnowledge';
+
+export interface AgentMention {
+    token: string;
+    label: string;
+    description: string;
+}
+
+export function agentMentionValue(value: string): string {
+    const text = value.trim();
+    return /[\s:"]/.test(text) ? `"${text.replaceAll('"', "'")}"` : text;
+}
+
+export function agentActionToken(label: string, capability = ''): string {
+    if (!label.trim()) return '';
+    return `#action:${agentMentionValue(label)}${capability ? `:${agentMentionValue(capability)}` : ''}`;
+}
+
+export function agentKnowledgeToken(type: string, value: string): string {
+    return value.trim() && type.trim() ? `#knowledge:${type}:${agentMentionValue(value)}` : '';
+}
+
+export function agentMentionTrigger(text: string, cursor: number): { start: number; query: string } | null {
+    const windowStart = Math.max(0, cursor - 501);
+    for (let index = cursor - 1; index >= windowStart; index -= 1) {
+        const character = text[index];
+        if (character === '\n' || character === '\r') return null;
+        if (character !== '#') continue;
+        if (index && !/[\s([{>"'`]/.test(text[index - 1])) return null;
+        return { start: index, query: text.slice(index + 1, cursor) };
+    }
+    return null;
+}
+
+export function agentMentions(
+    draft: AgentConfiguration, actions: ActionConfiguration[], catalog: AgentKnowledgeCatalog | null,
+): AgentMention[] {
+    const mentions: AgentMention[] = [];
+    for (const action of agentSelectedActionsContext(draft, actions)) {
+        mentions.push({ token: agentActionToken(action.display_name), label: action.display_name, description: `Action · ${action.type}` });
+        for (const capability of action.capabilities) {
+            mentions.push({
+                token: agentActionToken(action.display_name, capability.key),
+                label: `${action.display_name} · ${capability.label}`, description: 'Action capability',
+            });
+        }
+    }
+    const knowledge = agentKnowledgeReference(draft, catalog);
+    for (const document of knowledge.documents) mentions.push({ token: agentKnowledgeToken('doc', document.title), label: document.title, description: 'Assigned document' });
+    for (const source of knowledge.sources) mentions.push({ token: agentKnowledgeToken('workspace', source.name), label: source.name, description: 'Assigned workspace' });
+    for (const tag of knowledge.tags) mentions.push({ token: agentKnowledgeToken('tag', tag), label: tag, description: 'Assigned tag' });
+    for (const source of knowledge.web_sources) mentions.push({ token: agentKnowledgeToken('web', source.url), label: source.url, description: 'Assigned URL' });
+    return mentions;
+}
+
+export function filterAgentMentions(mentions: AgentMention[], query: string): AgentMention[] {
+    const normalized = query.replaceAll('"', '').toLowerCase();
+    return mentions.filter((mention) => !normalized ||
+        mention.token.slice(1).replaceAll('"', '').toLowerCase().includes(normalized) ||
+        mention.label.toLowerCase().includes(normalized)).slice(0, 10);
+}

--- a/application/v2_ui/src/lib/workspaceAgentTemplates.ts
+++ b/application/v2_ui/src/lib/workspaceAgentTemplates.ts
@@ -1,0 +1,85 @@
+// workspaceAgentTemplates.ts
+
+import { api } from './apiClient';
+import { EDITOR_SECRET_MASK, editorName, isRecord, type ActionConfiguration, type AgentConfiguration } from './workspaceAuthoring';
+import { agentObject, agentStrings, newAgentDraft } from './workspaceAgentAuthoring';
+import { resolveAgentAction } from './workspaceAgentActions';
+
+export interface AgentTemplate {
+    id: string;
+    title: string;
+    display_name: string;
+    description: string;
+    helper_text?: string;
+    instructions: string;
+    additional_settings?: string | Record<string, unknown>;
+    actions_to_load?: string[];
+    tags?: string[];
+    status?: string;
+}
+
+const PRIVATE_TEMPLATE_FIELD = /secret|password|credential|connection|endpoint|api[_-]?key|subscription[_-]?key|private[_-]?key|account[_-]?key|access[_-]?token|refresh[_-]?token|bearer[_-]?token|authorization|cookie|^auth$|^key$|^token$|^sas$|sas[_-]?token|keyvault|key_vault/i;
+const PRIVATE_TEMPLATE_VALUES = new Set([EDITOR_SECRET_MASK, 'Stored_In_KeyVault', '[REDACTED]', '********', '**********']);
+
+/** Templates are shared recipes, never a mechanism for copying saved connection secrets. */
+export function safeAgentTemplateSettings(value: unknown): Record<string, unknown> {
+    const clean = (item: unknown): unknown => {
+        if (typeof item === 'string' && PRIVATE_TEMPLATE_VALUES.has(item)) return undefined;
+        if (typeof item === 'string' && /^https?:\/\//i.test(item)) {
+            try {
+                const url = new URL(item);
+                if (url.username || url.password || /\/secrets\//i.test(url.pathname) ||
+                    [...url.searchParams.keys()].some((key) => PRIVATE_TEMPLATE_FIELD.test(key))) return undefined;
+            } catch {
+                return undefined;
+            }
+        }
+        if (Array.isArray(item)) return item.map(clean).filter((entry) => entry !== undefined);
+        if (!isRecord(item)) return item;
+        return Object.fromEntries(Object.entries(item)
+            .filter(([key]) => !PRIVATE_TEMPLATE_FIELD.test(key))
+            .map(([key, entry]) => [key, clean(entry)])
+            .filter(([, entry]) => entry !== undefined));
+    };
+    return agentObject(clean(value));
+}
+
+export async function fetchAgentTemplates(signal?: AbortSignal): Promise<AgentTemplate[]> {
+    const payload = await api.get<{ templates: AgentTemplate[] }>('/api/agent-templates', signal);
+    if (!payload || !Array.isArray(payload.templates)) throw new Error('The template gallery returned an invalid response.');
+    return payload.templates;
+}
+
+export function agentDraftFromTemplate(template: AgentTemplate, actions: ActionConfiguration[]): AgentConfiguration {
+    const settings: unknown = typeof template.additional_settings === 'string'
+        ? JSON.parse(template.additional_settings || '{}') : template.additional_settings ?? {};
+    if (!isRecord(settings)) throw new Error('This template has invalid additional settings.');
+    const name = template.display_name || template.title;
+    return {
+        ...newAgentDraft(),
+        display_name: name,
+        name: editorName(name),
+        description: template.description || template.helper_text || '',
+        instructions: template.instructions || '',
+        tags: agentStrings(template.tags),
+        other_settings: safeAgentTemplateSettings(settings),
+        actions_to_load: [...new Set(agentStrings(template.actions_to_load).map((reference) => resolveAgentAction(reference, actions)?.id || reference))],
+    };
+}
+
+export function agentTemplateSubmission(draft: AgentConfiguration) {
+    return {
+        template: {
+            title: draft.display_name.trim(),
+            display_name: draft.display_name.trim(),
+            description: draft.description,
+            helper_text: draft.description,
+            instructions: draft.instructions,
+            additional_settings: JSON.stringify(safeAgentTemplateSettings(draft.other_settings)),
+            actions_to_load: draft.actions_to_load,
+            tags: draft.tags ?? [],
+            ...(draft.id ? { source_agent_id: draft.id } : {}),
+            source_scope: 'personal',
+        },
+    };
+}

--- a/application/v2_ui/src/lib/workspaceApi.ts
+++ b/application/v2_ui/src/lib/workspaceApi.ts
@@ -148,7 +148,7 @@ export async function generateAgentId(): Promise<string> {
 }
 
 export async function fetchAgents(signal?: AbortSignal): Promise<WorkspaceAgent[]> {
-    const response = await api.get<unknown>('/api/user/agents', signal);
+    const response = await api.get<unknown>('/api/user/agents?view=editor', signal);
     return asArray<WorkspaceAgent>(response, 'agents');
 }
 
@@ -167,7 +167,7 @@ export const deleteAgent = (agentId: string) =>
 /* -------------------------------------------------------------------------- Actions */
 
 export async function fetchActions(signal?: AbortSignal): Promise<WorkspaceAction[]> {
-    const response = await api.get<unknown>('/api/user/plugins', signal);
+    const response = await api.get<unknown>('/api/user/plugins?view=editor', signal);
     return asArray<WorkspaceAction>(response, 'plugins');
 }
 

--- a/application/v2_ui/src/lib/workspaceAuthoring.ts
+++ b/application/v2_ui/src/lib/workspaceAuthoring.ts
@@ -1,0 +1,214 @@
+// workspaceAuthoring.ts
+// Editor contracts are separate from persisted manifests and their secret values.
+
+import type { WorkspaceAction, WorkspaceAgent, WorkspaceModelEndpoint } from './types';
+
+export const EDITOR_SECRET_MASK = '***REDACTED***';
+export type WorkspaceAgentType = 'local' | 'aifoundry' | 'new_foundry' | 'foundry_workflow';
+
+export interface AgentConfiguration extends WorkspaceAgent {
+    name: string;
+    display_name: string;
+    description: string;
+    instructions: string;
+    agent_type: WorkspaceAgentType;
+    actions_to_load: string[];
+    other_settings: Record<string, unknown>;
+    max_completion_tokens: number;
+    icon?: { kind: 'bootstrap' | 'image'; value: string; mime_type?: string };
+    model_endpoint_id?: string;
+    model_id?: string;
+    model_provider?: string;
+    reasoning_effort?: string;
+    azure_openai_gpt_endpoint?: string;
+    azure_openai_gpt_key?: string;
+    azure_openai_gpt_deployment?: string;
+    azure_openai_gpt_api_version?: string;
+    enable_agent_gpt_apim?: boolean;
+    azure_agent_apim_gpt_endpoint?: string;
+    azure_agent_apim_gpt_subscription_key?: string;
+    azure_agent_apim_gpt_deployment?: string;
+    azure_agent_apim_gpt_api_version?: string;
+}
+
+export interface ActionConfiguration extends WorkspaceAction {
+    name: string;
+    displayName: string;
+    description: string;
+    type: string;
+    endpoint: string;
+    auth: {
+        type: string;
+        key?: string;
+        identity?: string;
+        tenantId?: string;
+        [key: string]: unknown;
+    };
+    identity_id?: string;
+    additionalFields: Record<string, unknown>;
+    metadata: Record<string, unknown>;
+    is_enabled?: boolean;
+}
+
+export interface AuthoringResource<T> {
+    record: T;
+    revision: string;
+    secret_paths: string[];
+    read_only: boolean;
+}
+
+export interface EditorWrite {
+    updates: Record<string, unknown>;
+    expected_revision?: string;
+    clear_secret_paths: string[];
+    removed_paths: string[];
+}
+
+export interface EditorSchema {
+    type?: string | string[];
+    title?: string;
+    description?: string;
+    format?: string;
+    default?: unknown;
+    enum?: unknown[];
+    const?: unknown;
+    properties?: Record<string, EditorSchema>;
+    required?: string[];
+    items?: EditorSchema;
+    additionalProperties?: boolean | EditorSchema;
+    minimum?: number;
+    maximum?: number;
+    minLength?: number;
+    maxLength?: number;
+    minItems?: number;
+    maxItems?: number;
+    pattern?: string;
+    definitions?: Record<string, EditorSchema>;
+    $ref?: string;
+    allOf?: EditorSchema[];
+    anyOf?: EditorSchema[];
+    oneOf?: EditorSchema[];
+}
+
+export interface ActionTypeDefinition {
+    type: string;
+    display: string;
+    description: string;
+    allowed_auth_types: string[];
+    additional_fields_schema: EditorSchema;
+    metadata_schema: EditorSchema;
+}
+
+export interface AgentEditorOptions {
+    agent_types: {
+        value: WorkspaceAgentType;
+        label: string;
+        enabled: boolean;
+        reason?: string;
+    }[];
+    settings: Record<string, unknown>;
+    model_endpoints: WorkspaceModelEndpoint[];
+    builtin_actions: { id: string; label: string; description?: string }[];
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+    return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+export function editorName(displayName: string, fallback = 'agent'): string {
+    return displayName.trim().replace(/[^A-Za-z0-9_-]+/g, '-').replace(/^-+|-+$/g, '') || fallback;
+}
+
+export function pointerPart(value: string): string {
+    return value.replace(/~/g, '~0').replace(/\//g, '~1');
+}
+
+export function editorValueAt(record: unknown, path: string): unknown {
+    if (!path.startsWith('/')) return undefined;
+    return path.slice(1).split('/').reduce<unknown>((value, part) => {
+        const key = part.replace(/~1/g, '/').replace(/~0/g, '~');
+        if (Array.isArray(value)) {
+            return /^(0|[1-9]\d*)$/.test(key) && Object.hasOwn(value, key) ? value[Number(key)] : undefined;
+        }
+        return isRecord(value) && Object.hasOwn(value, key) ? value[key] : undefined;
+    }, record);
+}
+
+export function sameEditorValue(left: unknown, right: unknown): boolean {
+    if (Object.is(left, right)) return true;
+    if (Array.isArray(left) && Array.isArray(right)) {
+        return left.length === right.length && left.every((item, index) => sameEditorValue(item, right[index]));
+    }
+    if (!isRecord(left) || !isRecord(right)) return false;
+    const keys = Object.keys(left);
+    return keys.length === Object.keys(right).length &&
+        keys.every((key) => Object.hasOwn(right, key) && sameEditorValue(left[key], right[key]));
+}
+
+const MANAGED_FIELDS = new Set(['user_id', 'last_updated', 'modified_at', 'modified_by', 'created_at', 'created_by', 'is_global', 'is_group', 'group_id']);
+
+/** Array changes replace the array; object changes name only changed leaves. */
+export function buildEditorWrite<T extends Record<string, unknown>>(
+    draft: T,
+    original: AuthoringResource<T> | null,
+): EditorWrite {
+    const clearSecretPaths = new Set<string>();
+    const removedPaths: string[] = [];
+    const secretPaths = new Set(original?.secret_paths ?? []);
+    const previous = original?.record ?? {};
+    // Arrays are replacements, so their removed/cleared credentials need separate intent.
+    for (const path of secretPaths) {
+        const value = editorValueAt(draft, path);
+        if (value === undefined || value === null || value === '') clearSecretPaths.add(path);
+    }
+    const diff = (before: Record<string, unknown>, after: Record<string, unknown>, parent = '') => {
+        const updates: [string, unknown][] = [];
+        for (const key of Object.keys(after)) {
+            if (!parent && (key.startsWith('_') || MANAGED_FIELDS.has(key) || (original && key === 'id'))) continue;
+            const path = `${parent}/${pointerPart(key)}`;
+            const value = after[key];
+            if (value === undefined || (secretPaths.has(path) && value === EDITOR_SECRET_MASK)) continue;
+            if (secretPaths.has(path) && (value === '' || value === null)) {
+                clearSecretPaths.add(path);
+                continue;
+            }
+            if (isRecord(value)) {
+                const nested = diff(isRecord(before[key]) ? before[key] : {}, value, path);
+                if (Object.keys(nested).length || !Object.hasOwn(before, key)) updates.push([key, nested]);
+            } else if (!sameEditorValue(before[key], value)) {
+                updates.push([key, value]);
+            }
+        }
+        for (const key of Object.keys(before)) {
+            if (!parent && (key.startsWith('_') || MANAGED_FIELDS.has(key) || key === 'id')) continue;
+            if (!Object.hasOwn(after, key)) {
+                const path = `${parent}/${pointerPart(key)}`;
+                if (secretPaths.has(path)) clearSecretPaths.add(path);
+                else removedPaths.push(path);
+            }
+        }
+        // Additional JSON property names, including __proto__, remain ordinary data.
+        return Object.fromEntries(updates);
+    };
+    return {
+        updates: diff(previous, draft),
+        ...(original ? { expected_revision: original.revision } : {}),
+        clear_secret_paths: [...clearSecretPaths],
+        removed_paths: removedPaths,
+    };
+}
+
+/** Only a known agent editor can receive a just-created action. */
+export function agentEditorReturnPath(value: string | null): string | null {
+    const match = value?.match(/^\/workspace\/agents\/([^/?#]+)$/);
+    if (!match) return null;
+    let identifier: string;
+    try {
+        identifier = decodeURIComponent(match[1]);
+    } catch (error) {
+        if (error instanceof URIError) return null;
+        throw error;
+    }
+    return identifier.trim() && !['.', '..'].includes(identifier) &&
+        !/[/\\\u0000-\u001f\u007f]/.test(identifier) ? value : null;
+}

--- a/application/v2_ui/src/lib/workspaceAuthoringApi.ts
+++ b/application/v2_ui/src/lib/workspaceAuthoringApi.ts
@@ -1,0 +1,89 @@
+// workspaceAuthoringApi.ts
+
+import { api } from './apiClient';
+import { generateAgentId } from './workspaceApi';
+import {
+    buildEditorWrite,
+    isRecord,
+    type ActionConfiguration,
+    type ActionTypeDefinition,
+    type AgentConfiguration,
+    type AgentEditorOptions,
+    type AuthoringResource,
+} from './workspaceAuthoring';
+
+const agentRoot = '/api/user/agents';
+const actionRoot = '/api/user/plugins';
+
+function editorUrl(root: string, id?: string, scope = 'personal'): string {
+    const query = new URLSearchParams({ view: 'editor' });
+    if (scope === 'global') query.set('scope', 'global');
+    return `${root}${id ? `/${encodeURIComponent(id)}` : ''}?${query}`;
+}
+
+async function collection<T>(path: string, signal?: AbortSignal): Promise<T[]> {
+    const response = await api.get<T[]>(path, signal);
+    if (!Array.isArray(response) || !response.every(isRecord)) throw new Error('The workspace returned an invalid resource list.');
+    return response;
+}
+
+async function editorResource<T extends AgentConfiguration | ActionConfiguration>(
+    request: Promise<AuthoringResource<T>>,
+): Promise<AuthoringResource<T>> {
+    const response = await request;
+    if (!isRecord(response) || !isRecord(response.record) ||
+        typeof response.read_only !== 'boolean' ||
+        (response.revision != null && typeof response.revision !== 'string') ||
+        (!response.read_only && (!response.revision || typeof response.record.id !== 'string' || !response.record.id)) ||
+        !Array.isArray(response.secret_paths) ||
+        !response.secret_paths.every((path) => typeof path === 'string' && path.startsWith('/'))) {
+        throw new Error('The workspace returned an invalid editor resource. Reload before trying again.');
+    }
+    return { ...response, revision: response.revision ?? '' };
+}
+
+export const fetchAuthoringAgents = (signal?: AbortSignal) =>
+    collection<AgentConfiguration>(editorUrl(agentRoot), signal);
+
+export const fetchAuthoringActions = (signal?: AbortSignal) =>
+    collection<ActionConfiguration>(editorUrl(actionRoot), signal);
+
+export const fetchAgentEditor = (id: string, scope = 'personal', signal?: AbortSignal) =>
+    editorResource(api.get<AuthoringResource<AgentConfiguration>>(editorUrl(agentRoot, id, scope), signal));
+
+export const fetchActionEditor = (id: string, scope = 'personal', signal?: AbortSignal) =>
+    editorResource(api.get<AuthoringResource<ActionConfiguration>>(editorUrl(actionRoot, id, scope), signal));
+
+export const fetchAgentEditorOptions = (signal?: AbortSignal) =>
+    api.get<AgentEditorOptions>('/api/user/agent/settings?view=editor', signal);
+
+export const fetchActionTypes = (signal?: AbortSignal) =>
+    collection<ActionTypeDefinition>('/api/user/plugins/types?view=editor', signal);
+
+export async function saveAgentConfiguration(
+    draft: AgentConfiguration,
+    original: AuthoringResource<AgentConfiguration> | null,
+): Promise<AuthoringResource<AgentConfiguration>> {
+    if (original?.read_only) throw new Error('Provided agents are read-only.');
+    const record = original ? draft : { ...draft, id: await generateAgentId() };
+    if (!record.id) throw new Error('Could not allocate an agent identifier. Try again.');
+    const write = buildEditorWrite(record, original);
+    return editorResource(original
+        ? api.patch<AuthoringResource<AgentConfiguration>>(editorUrl(agentRoot, original.record.id), write)
+        : api.post<AuthoringResource<AgentConfiguration>>(editorUrl(agentRoot), write));
+}
+
+export function saveActionConfiguration(
+    draft: ActionConfiguration,
+    original: AuthoringResource<ActionConfiguration> | null,
+): Promise<AuthoringResource<ActionConfiguration>> {
+    if (original?.read_only) throw new Error('Provided actions are read-only.');
+    const write = buildEditorWrite(draft, original);
+    if (!original) delete write.updates.id;
+    return editorResource(original
+        ? api.patch<AuthoringResource<ActionConfiguration>>(editorUrl(actionRoot, original.record.id), write)
+        : api.post<AuthoringResource<ActionConfiguration>>(editorUrl(actionRoot), write));
+}
+
+export const deleteAuthoringAgent = (id: string) => api.delete<{ success: boolean }>(editorUrl(agentRoot, id));
+export const deleteAuthoringAction = (id: string) => api.delete<{ success: boolean }>(editorUrl(actionRoot, id));

--- a/application/v2_ui/src/lib/workspaceEditorDrafts.ts
+++ b/application/v2_ui/src/lib/workspaceEditorDrafts.ts
@@ -1,0 +1,131 @@
+// workspaceEditorDrafts.ts
+// Drafts live only in this tab's memory, and only while they contain unsaved changes.
+
+import { useCallback, useState, type Dispatch, type SetStateAction } from 'react';
+import { useBootstrapStore } from '../stores/bootstrapStore';
+import {
+    agentEditorReturnPath,
+    sameEditorValue,
+    type ActionConfiguration,
+    type AgentConfiguration,
+    type AuthoringResource,
+} from './workspaceAuthoring';
+
+type Configuration = AgentConfiguration | ActionConfiguration;
+type EditorKind = 'agents' | 'actions';
+
+interface DraftState<T extends Configuration> {
+    draft: T;
+    baseline: T;
+    original: AuthoringResource<T> | null;
+}
+
+const drafts = new Map<string, DraftState<Configuration>>();
+const createdActions = new Map<string, ActionConfiguration>();
+let draftOwner = '';
+
+function warnBeforeDraftUnload(event: BeforeUnloadEvent): void {
+    event.preventDefault();
+    event.returnValue = '';
+}
+
+function syncDraftUnloadProtection(): void {
+    if (typeof window === 'undefined') return;
+    if (drafts.size || createdActions.size) {
+        window.addEventListener('beforeunload', warnBeforeDraftUnload);
+    } else {
+        window.removeEventListener('beforeunload', warnBeforeDraftUnload);
+    }
+}
+
+function ownerKey(): string {
+    const owner = useBootstrapStore.getState().data?.user?.id ?? '';
+    if (owner !== draftOwner) {
+        drafts.clear();
+        createdActions.clear();
+        draftOwner = owner;
+        syncDraftUnloadProtection();
+    }
+    return owner;
+}
+
+export function clearWorkspaceEditorDrafts(): void {
+    drafts.clear();
+    createdActions.clear();
+    syncDraftUnloadProtection();
+}
+
+export function useWorkspaceEditorDraft<T extends Configuration>(
+    kind: EditorKind,
+    key: string,
+    createDraft: () => T,
+): {
+    draft: T;
+    setDraft: Dispatch<SetStateAction<T>>;
+    original: AuthoringResource<T> | null;
+    load: (resource: AuthoringResource<T>) => void;
+    clear: () => void;
+    dirty: boolean;
+    restored: boolean;
+} {
+    const cacheKey = JSON.stringify([ownerKey(), kind, key]);
+    const [restored] = useState(() => drafts.has(cacheKey));
+    const [state, setState] = useState<DraftState<T>>(() => {
+        // The kind and resource key always identify the same concrete draft type.
+        const saved = drafts.get(cacheKey) as DraftState<T> | undefined;
+        if (saved) return saved;
+        const initial = createDraft();
+        return { draft: structuredClone(initial), baseline: initial, original: null };
+    });
+
+    const setDraft: Dispatch<SetStateAction<T>> = useCallback((update) => setState((current) => {
+        const draft = typeof update === 'function' ? update(current.draft) : update;
+        if (sameEditorValue(current.draft, draft)) return current;
+        const next = { ...current, draft };
+        if (sameEditorValue(next.baseline, draft)) drafts.delete(cacheKey);
+        else drafts.set(cacheKey, next);
+        syncDraftUnloadProtection();
+        return next;
+    }), [cacheKey]);
+
+    const load = useCallback((resource: AuthoringResource<T>) => {
+        drafts.delete(cacheKey);
+        syncDraftUnloadProtection();
+        setState({
+            draft: structuredClone(resource.record),
+            baseline: structuredClone(resource.record),
+            original: resource,
+        });
+    }, [cacheKey]);
+
+    const clear = useCallback(() => {
+        drafts.delete(cacheKey);
+        syncDraftUnloadProtection();
+        setState((current) => sameEditorValue(current.draft, current.baseline)
+            ? current : { ...current, draft: structuredClone(current.baseline) });
+    }, [cacheKey]);
+
+    return {
+        draft: state.draft,
+        setDraft,
+        original: state.original,
+        restored,
+        dirty: !sameEditorValue(state.baseline, state.draft),
+        load,
+        clear,
+    };
+}
+
+export function queueCreatedWorkspaceAction(returnPath: string, action: ActionConfiguration): void {
+    if (!agentEditorReturnPath(returnPath)) throw new Error('Invalid agent editor return path.');
+    createdActions.set(JSON.stringify([ownerKey(), returnPath]), action);
+    syncDraftUnloadProtection();
+}
+
+export function takeCreatedWorkspaceAction(returnPath: string): ActionConfiguration | null {
+    const key = JSON.stringify([ownerKey(), returnPath]);
+    const action = createdActions.get(key);
+    createdActions.delete(key);
+    syncDraftUnloadProtection();
+    return action ?? null;
+}

--- a/application/v2_ui/src/main.tsx
+++ b/application/v2_ui/src/main.tsx
@@ -4,7 +4,7 @@
 
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
-import { BrowserRouter } from 'react-router-dom';
+import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import { App } from './App';
 import './styles/theme.css';
 
@@ -14,10 +14,13 @@ if (!container) {
     throw new Error('Root container #root was not found in the document.');
 }
 
+const router = createBrowserRouter(
+    [{ path: '*', element: <App /> }],
+    { basename: '/v2' },
+);
+
 createRoot(container).render(
     <StrictMode>
-        <BrowserRouter basename="/v2">
-            <App />
-        </BrowserRouter>
+        <RouterProvider router={router} />
     </StrictMode>,
 );

--- a/application/v2_ui/src/pages/ChatPage.tsx
+++ b/application/v2_ui/src/pages/ChatPage.tsx
@@ -34,6 +34,10 @@ import { ParticipantsPanel } from '../components/chat/ParticipantsPanel';
 import { InviteBanner } from '../components/chat/InviteBanner';
 import { FileApprovals } from '../components/chat/FileApprovals';
 import { panelTargetForConversation, canShareConversation } from '../lib/sharing';
+import { readWorkspaceAgentLaunch, workspaceAgentForLaunch } from '../lib/workspaceAgentLaunch';
+import { agentSelectionKey } from '../lib/agents';
+import { toast } from '../stores/toastStore';
+import type { BootstrapPayload } from '../lib/types';
 
 /**
  * Keep the address bar and the open conversation describing each other.
@@ -54,6 +58,12 @@ function useConversationUrlSync() {
     const openLinkedConversation = useChatStore((state) => state.openLinkedConversation);
 
     const [linkedConversationId] = useState(() => readConversationParam(searchParams));
+    const [agentLaunch] = useState(() => readWorkspaceAgentLaunch(searchParams));
+    const [hasAgentRequest] = useState(() => !readConversationParam(searchParams) && searchParams.has('agent_id'));
+    const [agentLaunchHandled, setAgentLaunchHandled] = useState(!hasAgentRequest);
+    const [launchAgentSelection, setLaunchAgentSelection] = useState<string>();
+    const agentLinkConsumed = useRef(false);
+    const agentLaunchRequest = useRef<Promise<BootstrapPayload> | null>(null);
     // Two flags with two jobs. The ref makes opening the link happen exactly once: React's
     // StrictMode runs effects twice on mount, and a state flag is still false in the second
     // invocation's closure, so it would open the conversation — and refetch its messages —
@@ -83,9 +93,40 @@ function useConversationUrlSync() {
     }, [linkedConversationId, openLinkedConversation]);
 
     useEffect(() => {
+        if (!hasAgentRequest || agentLinkConsumed.current) return;
+        if (!agentLaunch) {
+            agentLinkConsumed.current = true;
+            toast.error('That agent link is not valid.');
+            setAgentLaunchHandled(true);
+            return;
+        }
+        let active = true;
+        // Both StrictMode setups observe one request, but only the active setup can launch.
+        agentLaunchRequest.current ??= useBootstrapStore.getState().refreshRequired();
+        void agentLaunchRequest.current.then((fresh) => {
+            if (!active || agentLinkConsumed.current) return;
+            agentLinkConsumed.current = true;
+            const agent = workspaceAgentForLaunch(fresh.catalogs?.agents, agentLaunch);
+            if (!agent) {
+                toast.error('That agent is no longer available in this workspace.');
+            } else {
+                useChatStore.getState().startNewConversation();
+                setLaunchAgentSelection(agentSelectionKey(agent));
+            }
+            setAgentLaunchHandled(true);
+        }, () => {
+            if (!active || agentLinkConsumed.current) return;
+            agentLinkConsumed.current = true;
+            toast.error('Could not refresh available agents. Try again.');
+            setAgentLaunchHandled(true);
+        });
+        return () => { active = false; };
+    }, [hasAgentRequest, agentLaunch]);
+
+    useEffect(() => {
         // Held back until the link has been consumed, so the parameter survives long enough
         // to be read.
-        if (!linkHandled) {
+        if (!linkHandled || !agentLaunchHandled) {
             return;
         }
 
@@ -98,7 +139,9 @@ function useConversationUrlSync() {
         // `history.replaceState`: the address bar should describe what is open, not turn the
         // back button into a list of every conversation visited.
         setSearchParams(next, { replace: true });
-    }, [activeConversationId, linkHandled, searchParams, setSearchParams]);
+    }, [activeConversationId, linkHandled, agentLaunchHandled, searchParams, setSearchParams]);
+
+    return { launchAgentSelection, agentLaunchPending: !agentLaunchHandled };
 }
 
 function ChatHeader({ onOpenDetails }: { onOpenDetails: () => void }) {
@@ -333,7 +376,7 @@ export function ChatPage() {
         (state) => state.setVisibleConversation,
     );
 
-    useConversationUrlSync();
+    const { launchAgentSelection, agentLaunchPending } = useConversationUrlSync();
 
     // Image approvals keep running after the reader goes elsewhere, and are reported by a
     // notice when they do. Only this page knows whether their cards are actually on screen:
@@ -352,6 +395,10 @@ export function ChatPage() {
         return () => setOrchestrationVisible(null);
     }, [activeConversationId, setOrchestrationVisible]);
 
+    if (agentLaunchPending) {
+        return <div role="status" className="flex flex-1 items-center justify-center text-sm text-text-3">Opening agent chat...</div>;
+    }
+
     return (
         <div className="flex min-h-0 flex-1">
             <div className="flex min-w-0 flex-1 flex-col">
@@ -359,7 +406,7 @@ export function ChatPage() {
                 <FileApprovals />
                 <InviteBanner />
                 <MessageList />
-                <Composer />
+                <Composer initialAgentSelection={launchAgentSelection} />
             </div>
             <ConversationDrawer />
             {/* Gated on there being a conversation as well as on the panel being open, so

--- a/application/v2_ui/src/pages/workspace/ActionEditorPage.tsx
+++ b/application/v2_ui/src/pages/workspace/ActionEditorPage.tsx
@@ -1,0 +1,344 @@
+// ActionEditorPage.tsx
+
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import { CheckCircle2, RefreshCw } from 'lucide-react';
+import { GlassButton, GlassPanel, Skeleton } from '../../components/ui/primitives';
+import { ConfirmDialog } from '../../components/ui/ConfirmDialog';
+import { WorkspaceEditorFrame } from '../../components/workspace/WorkspaceEditorFrame';
+import { errorMessage } from '../../components/workspace/useSectionResource';
+import { ActionField, ACTION_INPUT_CLASS } from '../../components/workspaceActions/ActionFields';
+import { ActionAuthentication } from '../../components/workspaceActions/ActionAuthentication';
+import { ActionConfigurationFields } from '../../components/workspaceActions/ActionConfigurationFields';
+import { ActionAdvancedFields } from '../../components/workspaceActions/ActionAdvancedFields';
+import {
+    ConnectorFeedbackPanel, OpenApiActionAuthentication, OpenApiActionConfiguration,
+} from '../../components/workspaceActions/OpenApiActionConfiguration';
+import { McpActionAuthentication, McpActionConfiguration } from '../../components/workspaceActions/McpActionConfiguration';
+import { ApiError } from '../../lib/apiClient';
+import {
+    agentEditorReturnPath, type ActionConfiguration, type ActionTypeDefinition,
+} from '../../lib/workspaceAuthoring';
+import { fetchActionEditor, fetchActionTypes, saveActionConfiguration } from '../../lib/workspaceAuthoringApi';
+import { queueCreatedWorkspaceAction, useWorkspaceEditorDraft } from '../../lib/workspaceEditorDrafts';
+import {
+    ACTION_AUTHORING_UNAVAILABLE, actionApiErrors, actionFieldError, actionForSave, actionTypeLabel, changeActionDisplayName,
+    changeActionType, createActionDraft, expandActionFieldErrors, hasUsableActionRevision, validateActionDraft,
+} from '../../lib/workspaceActionLogic';
+import {
+    fetchActionEditorHints, fetchActionIdentities, validateWorkspaceAction, type ActionEditorHints,
+} from '../../lib/workspaceActionServices';
+import {
+    connectorFeedback, validateConnectorAuthentication, validateConnectorConfiguration, type ConnectorFeedback,
+} from '../../lib/workspaceActionConnectors';
+import type { ActionConnectorProps, ActionIdentity } from '../../lib/workspaceActionTypes';
+import { useBootstrapStore } from '../../stores/bootstrapStore';
+
+export function ActionEditorPage() {
+    const { resourceId = 'new' } = useParams();
+    const owner = useBootstrapStore((state) => state.data?.user?.id ?? '');
+    const location = useLocation();
+    const query = new URLSearchParams(location.search);
+    const scope = query.get('scope') === 'global' ? 'global' : 'personal';
+    const returnTo = resourceId === 'new' ? agentEditorReturnPath(query.get('returnTo')) : null;
+    return <ActionEditor key={JSON.stringify([owner, resourceId, scope, returnTo])} resourceId={resourceId} scope={scope} returnTo={returnTo} />;
+}
+
+function ActionEditor({ resourceId, scope, returnTo }: { resourceId: string; scope: string; returnTo: string | null }) {
+    const navigate = useNavigate();
+    const location = useLocation();
+    const id = useId();
+    const isNew = resourceId === 'new';
+    const refreshBootstrap = useBootstrapStore((state) => state.refresh);
+    const {
+        draft, setDraft, original, load, clear, dirty, restored,
+    } = useWorkspaceEditorDraft<ActionConfiguration>('actions', JSON.stringify([scope, resourceId, returnTo]), createActionDraft);
+    const loadRef = useRef(load);
+    loadRef.current = load;
+    const draftRef = useRef(draft);
+    draftRef.current = draft;
+    const mounted = useRef(true);
+    const hasLoadedDraft = useRef(restored);
+    const [loading, setLoading] = useState(!isNew && !restored);
+    const [loadError, setLoadError] = useState<string | null>(null);
+    const [catalogue, setCatalogue] = useState<ActionTypeDefinition[]>([]);
+    const [catalogueLoading, setCatalogueLoading] = useState(true);
+    const [catalogueError, setCatalogueError] = useState<string | null>(null);
+    const [identities, setIdentities] = useState<ActionIdentity[]>([]);
+    const [identitiesLoading, setIdentitiesLoading] = useState(true);
+    const [identitiesError, setIdentitiesError] = useState<string | null>(null);
+    const [hints, setHints] = useState<ActionEditorHints | null>(null);
+    const [hintsError, setHintsError] = useState<string | null>(null);
+    const [hintsLoading, setHintsLoading] = useState(true);
+    const [saving, setSaving] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+    const [validity, setValidity] = useState<Record<string, string>>({});
+    const [typeSearch, setTypeSearch] = useState('');
+    const [pendingType, setPendingType] = useState<ActionTypeDefinition | null>(null);
+    const [version, setVersion] = useState(0);
+    const [editorGeneration, setEditorGeneration] = useState(0);
+    const [latestReadOnly, setLatestReadOnly] = useState(false);
+    const [reloadConfirmation, setReloadConfirmation] = useState(false);
+    const replaceDraft = useRef(false);
+    const [validationFeedback, setValidationFeedback] = useState<ConnectorFeedback | null>(null);
+    const [validating, setValidating] = useState(false);
+    const validationController = useRef<AbortController | null>(null);
+    const [validatedDraft, setValidatedDraft] = useState<ActionConfiguration | null>(null);
+
+    useEffect(() => {
+        const controller = new AbortController();
+        setCatalogueLoading(true); setCatalogueError(null);
+        void fetchActionTypes(controller.signal).then((types) => {
+            if (!controller.signal.aborted) setCatalogue(types);
+        }).catch((cause: unknown) => {
+            if (!controller.signal.aborted) setCatalogueError(errorMessage(cause, 'Could not load the governed action catalogue.'));
+        }).finally(() => { if (!controller.signal.aborted) setCatalogueLoading(false); });
+        setIdentitiesLoading(true); setIdentitiesError(null);
+        void fetchActionIdentities(controller.signal).then((items) => {
+            if (!controller.signal.aborted) setIdentities(items);
+        }).catch((cause: unknown) => {
+            if (!controller.signal.aborted) setIdentitiesError(errorMessage(cause, 'Could not load reusable identities.'));
+        }).finally(() => { if (!controller.signal.aborted) setIdentitiesLoading(false); });
+        setHintsLoading(true); setHintsError(null);
+        void fetchActionEditorHints(controller.signal).then((options) => {
+            if (!controller.signal.aborted) { setHints(options); setHintsError(null); }
+        }).catch((cause: unknown) => {
+            if (!controller.signal.aborted) setHintsError(errorMessage(cause, 'Action authoring permissions and reminder defaults are unavailable.'));
+        }).finally(() => { if (!controller.signal.aborted) setHintsLoading(false); });
+        return () => controller.abort();
+    }, [version]);
+    useEffect(() => {
+        if (isNew) return;
+        const controller = new AbortController();
+        setLoading(!hasLoadedDraft.current); setLoadError(null);
+        void fetchActionEditor(resourceId, scope, controller.signal).then((resource) => {
+            if (controller.signal.aborted) return;
+            if (!resource?.record || !hasUsableActionRevision(resource, scope)) throw new Error('The action editor returned an invalid resource.');
+            setLatestReadOnly(resource.read_only || Boolean(resource.record.is_global));
+            // A return from New action must not overwrite a draft or silently rebase its revision.
+            if ((!restored && !hasLoadedDraft.current) || replaceDraft.current) {
+                loadRef.current(resource);
+                setEditorGeneration((current) => current + 1);
+                replaceDraft.current = false;
+                hasLoadedDraft.current = true;
+            }
+        }).catch((cause: unknown) => {
+            if (!controller.signal.aborted) setLoadError(errorMessage(cause, 'Could not load this action.'));
+        }).finally(() => { if (!controller.signal.aborted) setLoading(false); });
+        return () => controller.abort();
+    }, [isNew, resourceId, scope, restored, version]);
+    useEffect(() => {
+        mounted.current = true;
+        return () => {
+            mounted.current = false;
+            validationController.current?.abort();
+        };
+    }, []);
+
+    const readOnly = scope === 'global' || latestReadOnly || original?.read_only === true || draft.is_global === true;
+    const canAuthor = !hintsLoading && !hintsError && hints?.canAuthor === true;
+    const definition = catalogue.find((type) => type.type === draft.type);
+    const visibleTypes = useMemo(() => catalogue.filter((type) => type.type === draft.type ||
+        `${type.display} ${type.type} ${type.description}`.toLowerCase().includes(typeSearch.trim().toLowerCase()))
+        .sort((left, right) => left.display.localeCompare(right.display)), [catalogue, draft.type, typeSearch]);
+    const fallbackDefinition: ActionTypeDefinition = {
+        type: draft.type, display: actionTypeLabel(draft.type), description: '',
+        allowed_auth_types: draft.auth.type ? [draft.auth.type] : [],
+        additional_fields_schema: {}, metadata_schema: {},
+    };
+    const displayDefinition = definition ?? fallbackDefinition;
+    const onValidityChange = useCallback((key: string, message: string | null) => {
+        setValidity((current) => {
+            if (message === null && !(key in current) || message !== null && current[key] === message) return current;
+            const next = { ...current };
+            if (message) next[key] = message;
+            else delete next[key];
+            return next;
+        });
+    }, []);
+    const connectorProps: ActionConnectorProps = {
+        draft, original, onChange: setDraft,
+        readOnly: readOnly || !canAuthor || saving || catalogueLoading || Boolean(catalogueError) || Boolean(loadError) || !definition,
+        errors: expandActionFieldErrors(fieldErrors), onValidityChange, identities, identitiesLoading, identitiesError,
+    };
+
+    const validateLocally = () => {
+        const errors = validateActionDraft(actionForSave(draft), definition, original);
+        if (draft.type === 'openapi' || draft.type === 'mcp') {
+            Object.assign(errors,
+                validateConnectorConfiguration(draft, draft.type),
+                validateConnectorAuthentication(draft, draft.type, original));
+        }
+        setFieldErrors(errors);
+        const messages = [...Object.values(errors), ...Object.values(validity)];
+        if (messages.length) {
+            setError([...new Set(messages)].join(' '));
+            return false;
+        }
+        setError(null);
+        return true;
+    };
+    const save = async () => {
+        if (saving || readOnly || !canAuthor || loadError || catalogueLoading || catalogueError || !validateLocally()) return;
+        validationController.current?.abort();
+        setSaving(true); setError(null); setValidationFeedback(null);
+        try {
+            const saved = await saveActionConfiguration(actionForSave(draft), original);
+            if (!mounted.current) return;
+            if (!saved?.record?.id) throw new Error('The server did not return a saved action ID. Reload before retrying.');
+            if (returnTo) queueCreatedWorkspaceAction(returnTo, saved.record);
+            load(saved);
+            clear();
+            void refreshBootstrap();
+            navigate(returnTo || '/workspace/actions', {
+                state: { workspaceEditorSaved: true, workspaceEditorFrom: location.key, ...(returnTo ? { preserveWorkspaceDraft: true } : {}) },
+            });
+        } catch (cause) {
+            if (!mounted.current) return;
+            const conflict = cause instanceof ApiError && cause.status === 409;
+            setFieldErrors(cause instanceof ApiError ? actionApiErrors(cause.payload) : {});
+            setError(conflict
+                ? 'This action changed in another session. Your draft is still here. Review it, or load the saved version before trying again.'
+                : errorMessage(cause, 'Could not save the action. Your draft is retained.'));
+        } finally {
+            if (mounted.current) setSaving(false);
+        }
+    };
+    const validate = async () => {
+        if (readOnly || !canAuthor || saving || validating || !validateLocally()) return;
+        validationController.current?.abort();
+        const controller = new AbortController();
+        validationController.current = controller;
+        const snapshot = draft;
+        setValidating(true);
+        try {
+            const result = await validateWorkspaceAction(snapshot, original, controller.signal);
+            if (controller.signal.aborted) return;
+            setValidationFeedback(connectorFeedback(result));
+            setValidatedDraft(snapshot);
+            if (draftRef.current === snapshot) setFieldErrors(actionApiErrors(result));
+        } catch (cause) {
+            if (controller.signal.aborted) return;
+            setValidationFeedback(connectorFeedback(cause));
+            setValidatedDraft(snapshot);
+            if (draftRef.current === snapshot && cause instanceof ApiError) setFieldErrors(actionApiErrors(cause.payload));
+        } finally {
+            if (validationController.current === controller) setValidating(false);
+        }
+    };
+    const reloadSaved = async () => {
+        setReloadConfirmation(false);
+        replaceDraft.current = true;
+        setError(null); setFieldErrors({}); setValidationFeedback(null);
+        setVersion((current) => current + 1);
+    };
+    const applyType = (type: ActionTypeDefinition) => {
+        if (readOnly || !canAuthor) {
+            setPendingType(null);
+            return;
+        }
+        validationController.current?.abort();
+        setDraft((current) => changeActionType(current, type));
+        setPendingType(null); setFieldErrors({}); setValidity({}); setError(null); setValidationFeedback(null);
+    };
+    const identitySection = (
+        <div className="space-y-5">
+            {returnTo ? <p className="rounded-xl bg-accent-soft p-3 text-sm text-accent">Save this action to return to your agent draft with it selected. The agent itself will not be saved.</p> : null}
+            {restored ? <p role="status" className="text-xs text-text-3">Your unsaved action draft has been restored in this tab.</p> : null}
+            {!readOnly && hintsLoading ? <p role="status" className="text-sm text-text-3">Checking action authoring permissions…</p> : null}
+            {!readOnly && !hintsLoading && !canAuthor ? <div role={hintsError ? 'alert' : 'status'}
+                className="space-y-2 rounded-xl bg-warn-soft p-3 text-sm text-warn">
+                <p>{hintsError || ACTION_AUTHORING_UNAVAILABLE}</p>
+                {dirty ? <p>Your unsaved draft has been retained. Reading it does not require creation permission.</p> : null}
+                {hintsError ? <GlassButton type="button" size="sm" onClick={() => setVersion((current) => current + 1)}>Retry authoring permissions</GlassButton> : null}
+            </div> : null}
+            {catalogueError ? <div role="alert" className="space-y-2 rounded-xl bg-danger-soft p-3 text-sm text-danger">
+                <p>{catalogueError} Existing configuration has not been changed.</p>
+                <GlassButton type="button" size="sm" onClick={() => setVersion((current) => current + 1)}>Retry action catalogue</GlassButton>
+            </div> : null}
+            {draft.type && !definition && !catalogueLoading && !catalogueError ? <p role="status" className="rounded-xl bg-warn-soft p-3 text-sm text-warn">
+                This action’s type is no longer offered to this workspace. Its configuration is preserved for review. Choose a permitted type before saving.
+            </p> : null}
+            {!readOnly && canAuthor ? <ActionField id={`${id}-type-search`} label="Search action types">
+                <input id={`${id}-type-search`} type="search" className={ACTION_INPUT_CLASS} value={typeSearch}
+                    onChange={(event) => setTypeSearch(event.target.value)} />
+            </ActionField> : null}
+            <ActionField id={`${id}-type`} label="Action type" required help={displayDefinition.description}
+                error={actionFieldError(fieldErrors, '/type')}>
+                <select id={`${id}-type`} className={ACTION_INPUT_CLASS} value={draft.type} required disabled={readOnly || !canAuthor || catalogueLoading}
+                    onChange={(event) => {
+                        const next = catalogue.find((type) => type.type === event.target.value);
+                        if (!next || next.type === draft.type) return;
+                        if (draft.type) setPendingType(next);
+                        else applyType(next);
+                    }}>
+                    <option value="">{catalogueLoading ? 'Loading action types…' : 'Select an action type'}</option>
+                    {draft.type && !definition ? <option value={draft.type}>{actionTypeLabel(draft.type)} (existing)</option> : null}
+                    {visibleTypes.map((type) => <option key={type.type} value={type.type}>{type.display}</option>)}
+                </select>
+            </ActionField>
+            {!catalogueLoading && !catalogueError && !catalogue.length ? <p role="status" className="text-sm text-text-3">No action types are permitted in this workspace. Contact your administrator.</p> : null}
+            <ActionField id={`${id}-name`} label="Action name" required error={actionFieldError(fieldErrors, '/displayName')}>
+                <input id={`${id}-name`} autoFocus={!readOnly && canAuthor} disabled={!canAuthor} className={ACTION_INPUT_CLASS} value={draft.displayName ?? draft.name ?? ''} required
+                    onChange={(event) => setDraft((current) => changeActionDisplayName(current, event.target.value, isNew))} />
+            </ActionField>
+            <ActionField id={`${id}-description`} label="Description" help="Explain what this action does and when an agent should use it.">
+                <textarea id={`${id}-description`} rows={3} disabled={!canAuthor} className={ACTION_INPUT_CLASS} value={draft.description}
+                    onChange={(event) => setDraft((current) => ({ ...current, description: event.target.value }))} />
+            </ActionField>
+            <ConnectorFeedbackPanel feedback={validationFeedback} stale={Boolean(validatedDraft && validatedDraft !== draft)} />
+        </div>
+    );
+    const configuration = draft.type === 'openapi' ? <OpenApiActionConfiguration {...connectorProps} /> :
+        draft.type === 'mcp' ? <McpActionConfiguration {...connectorProps} /> :
+            <ActionConfigurationFields {...connectorProps} definition={displayDefinition} />;
+    const authentication = draft.type === 'openapi' ? <OpenApiActionAuthentication {...connectorProps} /> :
+        draft.type === 'mcp' ? <McpActionAuthentication {...connectorProps} /> :
+            <ActionAuthentication {...connectorProps} definition={displayDefinition} />;
+    const sections = [
+        { id: 'identity', label: 'Identity and type', content: identitySection },
+        ...(draft.type ? [
+            { id: 'configuration', label: 'Configuration', content: configuration },
+            { id: 'authentication', label: 'Authentication', content: authentication },
+            { id: 'advanced', label: 'Advanced', content: <ActionAdvancedFields {...connectorProps} definition={displayDefinition} hints={hints} hintsError={hintsError} /> },
+        ] : []),
+    ];
+    if (loading) return <div role="status" className="space-y-4"><p className="text-sm text-text-3">Loading action…</p><Skeleton className="h-44 w-full" /></div>;
+    if (loadError && !original) return <GlassPanel elevation="flat" className="space-y-3 p-5">
+        <p role="alert" className="text-sm text-danger">{loadError}</p>
+        <div className="flex flex-wrap gap-2">
+            <GlassButton type="button" onClick={() => setVersion((current) => current + 1)}>Retry action</GlassButton>
+            <GlassButton type="button" onClick={() => navigate(returnTo || '/workspace/actions')}>Back to actions</GlassButton>
+        </div>
+        {restored ? <p className="text-xs text-text-3">The unsaved draft remains in this tab; it has not been overwritten by this failed read.</p> : null}
+    </GlassPanel>;
+
+    return (
+        <>
+            <WorkspaceEditorFrame title={readOnly ? 'Action details' : isNew ? 'New action' : canAuthor ? 'Edit action' : 'Action details'}
+                description={readOnly ? 'This provided action is managed by an administrator.' :
+                    isNew ? 'Configure an action, then explicitly save it. Connectors run only when you choose a discovery or test command.' : draft.displayName || draft.name}
+                backTo={returnTo || '/workspace/actions'} sections={sections.map((section) => ({
+                    ...section, content: <div key={editorGeneration} className="min-w-0">{section.content}</div>,
+                }))} dirty={dirty || Object.keys(validity).some((key) => key.startsWith('json:'))} saving={saving} readOnly={readOnly}
+                error={loadError || error} saveLabel="Save action" onSave={() => void save()} onDiscard={clear}
+                saveDisabled={!canAuthor || catalogueLoading || Boolean(catalogueError) || Boolean(loadError) || !definition}
+                actions={!readOnly ? <>
+                    {!isNew ? <GlassButton type="button" size="sm" disabled={saving} onClick={() => setReloadConfirmation(true)}><RefreshCw size={14} />Load saved version</GlassButton> : null}
+                    <GlassButton type="button" size="sm" disabled={!canAuthor || saving || validating || !definition}
+                        onClick={() => void validate()}><CheckCircle2 size={14} />{validating ? 'Validating…' : 'Validate configuration'}</GlassButton>
+                </> : undefined} />
+            {pendingType ? <ConfirmDialog title="Change action type?" tone="primary" confirmLabel="Change type"
+                description="Configuration and authentication will switch to the selected connector. The previous type’s draft stays in this tab if you switch back; it is not sent as configuration for the new type."
+                onClose={() => setPendingType(null)} onConfirm={() => applyType(pendingType)}>
+                <p className="text-sm text-text-2">The name, description, ID, and metadata are kept. Review configuration before saving.</p>
+            </ConfirmDialog> : null}
+            {reloadConfirmation ? <ConfirmDialog title="Load the saved action?" tone="primary" confirmLabel="Load saved version"
+                description="This replaces your unsaved action draft with the server’s latest version. It does not change any agent draft."
+                onClose={() => setReloadConfirmation(false)} onConfirm={() => void reloadSaved()}>
+                <p className="text-sm text-text-2">Keep editing to retain your current changes.</p>
+            </ConfirmDialog> : null}
+        </>
+    );
+}

--- a/application/v2_ui/src/pages/workspace/ActionsSection.tsx
+++ b/application/v2_ui/src/pages/workspace/ActionsSection.tsx
@@ -1,160 +1,207 @@
 // ActionsSection.tsx
-// Personal actions: the tools an agent is allowed to call.
-//
-// Call agent authoring is native; unrelated connector editors remain in classic.
 
-import { useMemo, useState } from 'react';
-import { Link } from 'react-router-dom';
-import { Plug, Shield, Trash2 } from 'lucide-react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { LayoutGrid, List, Plug, Plus, RefreshCw, Shield, Trash2 } from 'lucide-react';
+import { EmptyState, GlassButton, GlassPanel } from '../../components/ui/primitives';
+import { ConfirmAction, Pill, SectionError, SectionIntro, SectionSearch, SectionSkeleton } from '../../components/workspace/primitives';
+import { errorMessage, useSectionResource } from '../../components/workspace/useSectionResource';
+import { ACTION_INPUT_CLASS } from '../../components/workspaceActions/ActionFields';
+import { deleteAuthoringAction, fetchAuthoringActions, fetchActionTypes } from '../../lib/workspaceAuthoringApi';
 import {
-    ConfirmAction,
-    Pill,
-    ResourceRow,
-    SectionIntro,
-    SectionList,
-    SectionSearch,
-} from '../../components/workspace/primitives';
-import {
-    errorMessage,
-    useSectionResource,
-} from '../../components/workspace/useSectionResource';
-import { deleteAction, fetchActions } from '../../lib/workspaceApi';
-import { PERSONAL_DELEGATION_SCOPE } from '../../lib/agentDelegation';
-import { AgentDelegationManager } from '../../components/agents/AgentDelegationManager';
-import type { WorkspaceAction } from '../../lib/types';
+    ACTION_AUTHORING_UNAVAILABLE, actionCanEdit, actionDetailPath, actionResourceKey, actionScope,
+    actionTypeLabel, filterAuthoringActions,
+} from '../../lib/workspaceActionLogic';
+import { fetchActionEditorHints } from '../../lib/workspaceActionServices';
+import type { ActionConfiguration, ActionTypeDefinition } from '../../lib/workspaceAuthoring';
+import { useBootstrapStore } from '../../stores/bootstrapStore';
 
-/** Render a connector type as something readable: `document_search` -> `Document search`. */
-export function actionTypeLabel(type: unknown): string {
-    const raw = String(type ?? '').trim();
-    if (!raw) {
-        return 'Unknown';
-    }
-    if (raw === 'agent') {
-        return 'Call agent';
-    }
-    const spaced = raw.replace(/[_-]+/g, ' ');
-    return spaced.charAt(0).toUpperCase() + spaced.slice(1);
-}
+export { actionTypeLabel } from '../../lib/workspaceActionLogic';
+
+let collectionState = { owner: '', query: '', type: '', scope: '', view: 'list', scrollTop: 0 };
 
 export function ActionsSection({ agentsEnabled }: { agentsEnabled: boolean }) {
-    const { items, loading, error, setItems, setError } = useSectionResource<WorkspaceAction>(
-        fetchActions,
-        'Failed to load actions.',
-    );
-
-    const [query, setQuery] = useState('');
+    const navigate = useNavigate();
+    const owner = useBootstrapStore((state) => state.data?.user?.id ?? '');
+    const refreshBootstrap = useBootstrapStore((state) => state.refresh);
+    const { items, loading, error, refresh, setItems, setError } =
+        useSectionResource<ActionConfiguration>(fetchAuthoringActions, 'Failed to load actions.');
+    const [catalogue, setCatalogue] = useState<ActionTypeDefinition[]>([]);
+    const [catalogueError, setCatalogueError] = useState<string | null>(null);
+    const [catalogueVersion, setCatalogueVersion] = useState(0);
+    const [canAuthor, setCanAuthor] = useState<boolean | null>(null);
+    const [capabilityError, setCapabilityError] = useState<string | null>(null);
     const [busyId, setBusyId] = useState<string | null>(null);
-    const hasOtherActions = items.some((action) => action.type !== 'agent');
+    const list = useRef<HTMLDivElement>(null);
+    const loadedOwner = useRef(owner);
+    const scrollRestored = useRef(false);
+    const [filters, setFilters] = useState(() => {
+        if (collectionState.owner !== owner) collectionState = { owner, query: '', type: '', scope: '', view: 'list', scrollTop: 0 };
+        return { ...collectionState };
+    });
 
-    const visible = useMemo(() => {
-        const needle = query.trim().toLowerCase();
-        if (!needle) {
-            return items.filter((action) => action.type !== 'agent');
+    useEffect(() => {
+        if (filters.owner !== owner) {
+            collectionState = { owner, query: '', type: '', scope: '', view: 'list', scrollTop: 0 };
+            setFilters(collectionState);
+            scrollRestored.current = false;
+        } else {
+            collectionState = { ...filters, scrollTop: collectionState.scrollTop };
         }
-        return items.filter((action) => action.type !== 'agent' &&
-            `${action.displayName ?? ''} ${action.name ?? ''} ${action.type ?? ''}`
-                .toLowerCase()
-                .includes(needle),
-        );
-    }, [items, query]);
-
-    const onDelete = async (action: WorkspaceAction) => {
-        const previous = items;
-        const identifier = action.id || String(action.name ?? '');
-        setBusyId(identifier);
-        setItems(items.filter((item) => (item.id || item.name) !== (action.id || action.name)));
-        try {
-            await deleteAction(identifier);
-        } catch (deleteError) {
-            setItems(previous);
-            setError(errorMessage(deleteError, 'Could not delete the action.'));
-        } finally {
+    }, [owner, filters]);
+    useEffect(() => {
+        if (loadedOwner.current !== owner) {
+            loadedOwner.current = owner;
+            setItems([]);
             setBusyId(null);
+            void refresh();
+        }
+    }, [owner, refresh, setItems]);
+    useEffect(() => {
+        const controller = new AbortController();
+        setCatalogueError(null);
+        setCanAuthor(null);
+        setCapabilityError(null);
+        void fetchActionTypes(controller.signal).then(setCatalogue).catch((cause: unknown) => {
+            if (!controller.signal.aborted) setCatalogueError(errorMessage(cause, 'Could not load action types.'));
+        });
+        void fetchActionEditorHints(controller.signal).then((hints) => {
+            if (!controller.signal.aborted) setCanAuthor(hints.canAuthor);
+        }).catch((cause: unknown) => {
+            if (!controller.signal.aborted) {
+                setCanAuthor(false);
+                setCapabilityError(errorMessage(cause, 'Could not load action authoring permissions.'));
+            }
+        });
+        return () => controller.abort();
+    }, [owner, catalogueVersion]);
+    useEffect(() => {
+        if (!loading && !error && !scrollRestored.current && list.current) {
+            list.current.scrollTop = collectionState.scrollTop;
+            scrollRestored.current = true;
+        }
+    }, [loading, error, items.length]);
+
+    const labels = useMemo(() => new Map(catalogue.map((type) => [type.type, type.display])), [catalogue]);
+    const types = useMemo(() => [...new Set([...catalogue.map(({ type }) => type), ...items.map(({ type }) => type)])]
+        .sort((left, right) => (labels.get(left) || actionTypeLabel(left)).localeCompare(labels.get(right) || actionTypeLabel(right))),
+    [catalogue, items, labels]);
+    const visible = useMemo(() => filterAuthoringActions(items, filters.query, filters.type, filters.scope, catalogue),
+        [items, filters, catalogue]);
+
+    const remove = async (action: ActionConfiguration) => {
+        if (actionScope(action) === 'provided' || !action.id) return;
+        const key = actionResourceKey(action);
+        setBusyId(key);
+        setError(null);
+        try {
+            await deleteAuthoringAction(action.id);
+            if (loadedOwner.current !== owner) return;
+            await Promise.all([refresh(), refreshBootstrap()]);
+        } catch (cause) {
+            if (loadedOwner.current === owner) setError(errorMessage(cause, 'Could not delete the action.'));
+        } finally {
+            if (loadedOwner.current === owner) setBusyId(null);
         }
     };
 
     return (
-        <div className="space-y-4">
-            <SectionIntro
-                title="Actions"
-                description="Tools an agent may call on your behalf, such as an API, a database or an MCP server. An action does nothing until an agent is given permission to use it."
-            />
-
-            <p className="text-xs text-text-3">
-                Create and edit Call agent actions below. Other connectors are configured in the{' '}
-                <a href="/workspace" className="text-accent hover:underline">
-                    classic workspace
-                </a>
-                .{' '}
-                {agentsEnabled ? (
-                    <>
-                        Attach them to an{' '}
-                        <Link to="/workspace/agents" className="text-accent hover:underline">
-                            agent
-                        </Link>{' '}
-                        to put them to use.
-                    </>
-                ) : null}
-            </p>
-
-            <AgentDelegationManager scope={PERSONAL_DELEGATION_SCOPE} mode="actions" />
-
-            <h2 className="text-base font-semibold text-text-1">Other actions</h2>
-            <SectionSearch value={query} onChange={setQuery} placeholder="Search actions" />
-
-            <SectionList
-                items={visible}
-                loading={loading}
-                error={error}
-                emptyIcon={<Plug size={28} />}
-                emptyTitle={
-                    !hasOtherActions ? 'No other actions yet' : 'No actions match your search'
-                }
-                emptyDescription={
-                    !hasOtherActions
-                        ? 'Actions let an agent reach a system outside this chat.'
-                        : undefined
-                }
-                getKey={(action, index) => String(action.id ?? action.name ?? index)}
-                renderItem={(action) => {
-                    const managed = Boolean(action.is_global);
-                    const identifier = action.id || String(action.name ?? '');
-                    return (
-                        <ResourceRow
-                            icon={<Plug size={17} />}
-                            title={String(action.displayName || action.name || 'Untitled action')}
-                            subtitle={
-                                String(action.description || '') ||
-                                String(action.endpoint || '')
-                            }
-                            meta={
-                                <>
-                                    <Pill>{actionTypeLabel(action.type)}</Pill>
-                                    {managed ? (
-                                        <Pill tone="accent">
-                                            <span className="flex items-center gap-1">
-                                                <Shield size={10} />
-                                                Provided
-                                            </span>
-                                        </Pill>
-                                    ) : null}
-                                </>
-                            }
-                            actions={
-                                managed ? undefined : (
-                                    <ConfirmAction
-                                        icon={<Trash2 size={15} />}
-                                        label={`Delete ${action.displayName ?? action.name ?? 'action'}`}
-                                        confirmLabel="Delete"
-                                        busy={busyId === identifier}
-                                        onConfirm={() => void onDelete(action)}
-                                    />
-                                )
-                            }
-                        />
-                    );
-                }}
-            />
+        <div className="flex h-full min-h-0 flex-col gap-4" data-testid="workspace-actions">
+            <SectionIntro title="Actions"
+                description="Tools an agent may call on your behalf. Configure an API, database, application, or another agent here, then decide which agents may use it."
+                actions={<GlassButton type="button" variant="primary" size="sm" disabled={canAuthor !== true}
+                    onClick={() => navigate('/workspace/actions/new')}>
+                    <Plus size={16} /> New action
+                </GlassButton>} />
+            {agentsEnabled ? <p className="text-xs text-text-3">
+                Actions run only when permitted by an <Link to="/workspace/agents" className="text-accent hover:underline">agent</Link>.
+            </p> : null}
+            {canAuthor === null ? <p role="status" className="text-xs text-text-3">Checking action authoring permissions…</p> : null}
+            {canAuthor === false && !capabilityError ? <p role="status" className="text-xs text-text-3">{ACTION_AUTHORING_UNAVAILABLE}</p> : null}
+            <div className="flex flex-wrap items-end gap-2">
+                <div className="min-w-44 flex-1">
+                    <SectionSearch value={filters.query} onChange={(query) => setFilters((current) => ({ ...current, query }))}
+                        placeholder="Search actions" />
+                </div>
+                <label className="min-w-36 flex-1 text-xs text-text-3 sm:max-w-52">
+                    Type
+                    <select aria-label="Action type filter" className={`${ACTION_INPUT_CLASS} mt-1`} value={filters.type}
+                        onChange={(event) => setFilters((current) => ({ ...current, type: event.target.value }))}>
+                        <option value="">All types</option>
+                        {types.map((type) => <option key={type} value={type}>{labels.get(type) || actionTypeLabel(type)}</option>)}
+                    </select>
+                </label>
+                <label className="min-w-32 text-xs text-text-3">
+                    Scope
+                    <select aria-label="Action scope filter" className={`${ACTION_INPUT_CLASS} mt-1`} value={filters.scope}
+                        onChange={(event) => setFilters((current) => ({ ...current, scope: event.target.value }))}>
+                        <option value="">All scopes</option><option value="personal">My actions</option><option value="provided">Provided</option>
+                    </select>
+                </label>
+                <div className="flex items-center gap-1" role="group" aria-label="Action view">
+                    <GlassButton type="button" size="icon" title="List view" aria-label="List view" aria-pressed={filters.view === 'list'}
+                        onClick={() => setFilters((current) => ({ ...current, view: 'list' }))}><List size={17} /></GlassButton>
+                    <GlassButton type="button" size="icon" title="Card view" aria-label="Card view" aria-pressed={filters.view === 'cards'}
+                        onClick={() => setFilters((current) => ({ ...current, view: 'cards' }))}><LayoutGrid size={17} /></GlassButton>
+                    <GlassButton type="button" size="icon" title="Refresh actions" aria-label="Refresh actions" disabled={loading}
+                        onClick={() => { void refresh(); setCatalogueVersion((version) => version + 1); }}><RefreshCw size={16} /></GlassButton>
+                </div>
+            </div>
+            {error ? <SectionError message={error} /> : null}
+            {catalogueError ? <SectionError message={`${catalogueError} Existing actions are still listed; retry with Refresh actions.`} /> : null}
+            {capabilityError ? <SectionError message={`${capabilityError} Reading actions and permitted deletion remain available. Retry with Refresh actions.`} /> : null}
+            <div ref={list} className="min-h-0 flex-1 overflow-y-auto pb-3 pr-1"
+                onScroll={(event) => { collectionState.scrollTop = event.currentTarget.scrollTop; }}>
+                {loading ? <SectionSkeleton /> : !error && !visible.length ? (
+                    <EmptyState icon={<Plug size={28} />}
+                        title={items.length ? 'No actions match these filters' : 'No actions yet'}
+                        description={items.length ? 'Search by name, description, or connector type.' :
+                            canAuthor === true ? 'Create an action to make a tool available to your agents.' : 'No readable actions are available in this workspace.'}
+                        action={items.length ? <GlassButton type="button" onClick={() => setFilters((current) => ({ ...current, query: '', type: '', scope: '' }))}>
+                            Clear filters
+                        </GlassButton> : canAuthor === true ? <GlassButton type="button" variant="primary"
+                            onClick={() => navigate('/workspace/actions/new')}>New action</GlassButton> : undefined} />
+                ) : (
+                    <ul className={filters.view === 'cards' ? 'grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-3' : 'space-y-2'}>
+                        {visible.map((action, index) => {
+                            const provided = actionScope(action) === 'provided';
+                            const editable = actionCanEdit(action, canAuthor === true);
+                            const label = action.displayName || action.name || 'Untitled action';
+                            return (
+                                <li key={action.id ? actionResourceKey(action) : `missing-${index}`} className="min-w-0"
+                                    data-testid="workspace-action" data-action-id={action.id}
+                                    data-action-scope={provided ? 'global' : 'personal'} data-action-type={action.type}>
+                                    <GlassPanel elevation="flat" className={`flex min-w-0 gap-3 p-4 ${filters.view === 'cards' ? 'h-full flex-col' : 'flex-wrap items-center'}`}>
+                                        <div className="flex min-w-0 flex-1 items-start gap-3">
+                                            <Plug size={18} className="mt-0.5 shrink-0 text-text-3" />
+                                            <div className="min-w-0">
+                                                {action.id ? <Link to={actionDetailPath(action)} className="break-words text-sm font-semibold text-text-1 hover:text-accent hover:underline">{label}</Link>
+                                                    : <span className="text-sm font-semibold text-text-1">{label}</span>}
+                                                <p className="mt-1 line-clamp-2 break-words text-xs text-text-3">{action.description || 'No description.'}</p>
+                                                <p className="mt-1 break-all text-[11px] text-text-3">{action.id || 'Missing resource ID — reload before editing.'}</p>
+                                            </div>
+                                        </div>
+                                        <div className="flex flex-wrap items-center gap-2">
+                                            <Pill>{labels.get(action.type) || actionTypeLabel(action.type)}</Pill>
+                                            <Pill tone={provided ? 'accent' : 'neutral'}>{provided ? <span className="inline-flex items-center gap-1"><Shield size={11} />Provided · Read only</span> : 'Personal'}</Pill>
+                                            {!provided && !editable ? <Pill>Read only</Pill> : null}
+                                        </div>
+                                        <div className="flex items-center justify-end gap-2">
+                                            {action.id ? <Link to={actionDetailPath(action)} aria-label={`${editable ? 'Edit' : 'View'} ${label}`}
+                                                className="rounded-lg px-2 py-1.5 text-sm text-accent hover:bg-accent-soft">
+                                                {editable ? 'Edit' : 'View details'}
+                                            </Link> : null}
+                                            {!provided && action.id ? <ConfirmAction icon={<Trash2 size={15} />} label={`Delete ${label}`}
+                                                confirmLabel="Delete action" busy={busyId === actionResourceKey(action)} disabled={busyId !== null}
+                                                onConfirm={() => void remove(action)} /> : null}
+                                        </div>
+                                    </GlassPanel>
+                                </li>
+                            );
+                        })}
+                    </ul>
+                )}
+            </div>
         </div>
     );
 }

--- a/application/v2_ui/src/pages/workspace/AgentEditorPage.tsx
+++ b/application/v2_ui/src/pages/workspace/AgentEditorPage.tsx
@@ -1,0 +1,258 @@
+// AgentEditorPage.tsx
+
+import { useEffect, useRef, useState, type Dispatch, type ReactNode, type SetStateAction } from 'react';
+import { Link, useLocation, useNavigate, useParams } from 'react-router-dom';
+import { GlassButton } from '../../components/ui/primitives';
+import { WorkspaceEditorFrame } from '../../components/workspace/WorkspaceEditorFrame';
+import { SectionSkeleton } from '../../components/workspace/primitives';
+import { AgentIdentityFields } from '../../components/workspaceAgents/AgentIdentityFields';
+import { AgentModelFields } from '../../components/workspaceAgents/AgentModelFields';
+import { AgentActionPicker } from '../../components/workspaceAgents/AgentActionPicker';
+import { AgentKnowledgeFields } from '../../components/workspaceAgents/AgentKnowledgeFields';
+import { AgentInstructionsFields } from '../../components/workspaceAgents/AgentInstructionsFields';
+import { AgentAdvancedFields, agentAdvancedError } from '../../components/workspaceAgents/AgentAdvancedFields';
+import { AgentTemplatesPanel } from '../../components/workspaceAgents/AgentTemplatesPanel';
+import { AgentNotice } from '../../components/workspaceAgents/AgentFields';
+import { ApiError } from '../../lib/apiClient';
+import { fetchAgentTargets, PERSONAL_DELEGATION_SCOPE, type AgentTargetCatalog } from '../../lib/agentDelegation';
+import {
+    fetchAuthoringActions, fetchAgentEditor, fetchAgentEditorOptions, saveAgentConfiguration,
+} from '../../lib/workspaceAuthoringApi';
+import {
+    isRecord, type ActionConfiguration, type AgentConfiguration, type AgentEditorOptions,
+} from '../../lib/workspaceAuthoring';
+import { takeCreatedWorkspaceAction, useWorkspaceEditorDraft } from '../../lib/workspaceEditorDrafts';
+import { agentForSave, agentText, agentValidationErrors, applySafeAgentDraft, isAgentEditorEnvelope, newAgentDraft } from '../../lib/workspaceAgentAuthoring';
+import { newAgentActionErrors } from '../../lib/workspaceAgentActions';
+import { agentKnowledgeErrors, fetchAgentKnowledgeCatalog, type AgentKnowledgeCatalog } from '../../lib/workspaceAgentKnowledge';
+import { useBootstrapStore } from '../../stores/bootstrapStore';
+
+function message(cause: unknown): string {
+    return cause instanceof Error ? cause.message : 'The operation could not be completed.';
+}
+
+function AgentEditorSession({ resourceId, scope }: { resourceId: string; scope: string }) {
+    const navigate = useNavigate();
+    const location = useLocation();
+    const ownerId = useBootstrapStore((state) => state.data?.user?.id ?? '');
+    const canCreateActions = useBootstrapStore((state) => state.data?.workspace?.sections.actions?.enabled === true);
+    const refreshBootstrap = useBootstrapStore((state) => state.refresh);
+    const isNew = resourceId === 'new';
+    const { draft, setDraft: setStoredDraft, original, load, clear, dirty, restored } =
+        useWorkspaceEditorDraft<AgentConfiguration>('agents', `${scope}:${resourceId}`, newAgentDraft);
+    const setDraft: Dispatch<SetStateAction<AgentConfiguration>> = (update) => setStoredDraft((current) =>
+        applySafeAgentDraft(current, typeof update === 'function' ? update(current) : update, original));
+    const [options, setOptions] = useState<AgentEditorOptions | null>(null);
+    const [bootLoading, setBootLoading] = useState(true);
+    const [bootError, setBootError] = useState<string | null>(null);
+    const [bootRevision, setBootRevision] = useState(0);
+    const [accessReadOnly, setAccessReadOnly] = useState(scope === 'global');
+    const [saving, setSaving] = useState(false);
+    const [iconBusy, setIconBusy] = useState(false);
+    const [saveError, setSaveError] = useState<string | null>(null);
+    const [hasSaveConflict, setHasSaveConflict] = useState(false);
+    const [actions, setActions] = useState<ActionConfiguration[]>([]);
+    const [actionsLoading, setActionsLoading] = useState(false);
+    const [actionsError, setActionsError] = useState<string | null>(null);
+    const [targets, setTargets] = useState<AgentTargetCatalog | null>(null);
+    const [targetError, setTargetError] = useState<string | null>(null);
+    const [actionsRevision, setActionsRevision] = useState(0);
+    const [knowledge, setKnowledge] = useState<AgentKnowledgeCatalog | null>(null);
+    const [knowledgeLoading, setKnowledgeLoading] = useState(false);
+    const [knowledgeError, setKnowledgeError] = useState<string | null>(null);
+    const [knowledgeRevision, setKnowledgeRevision] = useState(0);
+    const returnedAction = useRef<ActionConfiguration | null>(null);
+    const handoffChecked = useRef(false);
+    const templatesAnchor = useRef<HTMLDivElement>(null);
+    const readOnly = accessReadOnly || original?.read_only === true;
+    const advancedError = agentAdvancedError(draft, original);
+    const arraySecretError = agentText(draft._editor_array_secret_error) || null;
+
+    useEffect(() => {
+        if (bootLoading || new URLSearchParams(location.search).get('templates') !== '1') return;
+        templatesAnchor.current?.scrollIntoView({ block: 'start' });
+        templatesAnchor.current?.focus({ preventScroll: true });
+    }, [bootLoading, location.search]);
+
+    useEffect(() => {
+        const controller = new AbortController();
+        setBootLoading(true);
+        setBootError(null);
+        void Promise.all([
+            fetchAgentEditorOptions(controller.signal),
+            isNew ? Promise.resolve(null) : fetchAgentEditor(resourceId, scope, controller.signal),
+        ]).then(([editorOptions, resource]) => {
+            if (controller.signal.aborted) return;
+            if (!editorOptions || !Array.isArray(editorOptions.agent_types) || !Array.isArray(editorOptions.model_endpoints) ||
+                !Array.isArray(editorOptions.builtin_actions) || !isRecord(editorOptions.settings)) {
+                throw new Error('The agent editor options returned an invalid response.');
+            }
+            if (resource && !isAgentEditorEnvelope(resource)) {
+                throw new Error('The agent editor returned an invalid resource.');
+            }
+            setOptions(editorOptions);
+            setAccessReadOnly(scope === 'global' || resource?.read_only === true);
+            // A restored draft keeps its original revision so another save cannot hide a conflict.
+            if (resource && !restored) load(resource);
+        }).catch((cause: unknown) => {
+            if (!controller.signal.aborted) setBootError(message(cause));
+        }).finally(() => { if (!controller.signal.aborted) setBootLoading(false); });
+        return () => controller.abort();
+        // The outer keyed component scopes these callbacks and the draft to one resource.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [resourceId, scope, isNew, bootRevision]);
+
+    useEffect(() => {
+        if (bootLoading || bootError || readOnly || handoffChecked.current) return;
+        handoffChecked.current = true;
+        const action = takeCreatedWorkspaceAction(location.pathname);
+        if (!action) return;
+        returnedAction.current = action;
+        setActions((current) => [...current.filter((item) => item.id !== action.id || item.is_global !== action.is_global), action]);
+        setDraft((current) => ({
+            ...current,
+            actions_to_load: current.actions_to_load.includes(action.id) ? current.actions_to_load : [...current.actions_to_load, action.id],
+        }));
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [bootLoading, bootError, readOnly, location.pathname]);
+
+    useEffect(() => {
+        if (bootLoading || bootError) return;
+        const controller = new AbortController();
+        setActionsLoading(true);
+        setActionsError(null);
+        setTargetError(null);
+        setTargets(null);
+        void fetchAuthoringActions(controller.signal).then((items) => {
+            if (controller.signal.aborted) return;
+            const created = returnedAction.current;
+            const available = created && !items.some((item) => item.id === created.id && item.is_global === created.is_global)
+                ? [...items, created] : items;
+            setActions(available);
+            if (available.some((item) => item.type === 'agent')) {
+                void fetchAgentTargets(PERSONAL_DELEGATION_SCOPE, controller.signal).then((catalog) => {
+                    if (!Array.isArray(catalog.targets)) throw new Error('The authorized agent catalogue returned an invalid response.');
+                    if (!controller.signal.aborted) setTargets(catalog);
+                }).catch((cause: unknown) => { if (!controller.signal.aborted) setTargetError(message(cause)); });
+            }
+        }).catch((cause: unknown) => {
+            if (!controller.signal.aborted) setActionsError(message(cause));
+        }).finally(() => { if (!controller.signal.aborted) setActionsLoading(false); });
+        return () => controller.abort();
+    }, [bootLoading, bootError, actionsRevision]);
+
+    useEffect(() => {
+        if (bootLoading || bootError || draft.agent_type !== 'local') return;
+        const controller = new AbortController();
+        setKnowledgeLoading(true);
+        setKnowledgeError(null);
+        void fetchAgentKnowledgeCatalog(controller.signal).then((catalog) => {
+            if (!controller.signal.aborted) setKnowledge(catalog);
+        }).catch((cause: unknown) => {
+            if (!controller.signal.aborted) setKnowledgeError(message(cause));
+        }).finally(() => { if (!controller.signal.aborted) setKnowledgeLoading(false); });
+        return () => controller.abort();
+    }, [bootLoading, bootError, draft.agent_type, knowledgeRevision]);
+
+    const save = async () => {
+        if (!options || readOnly || saving || iconBusy) return;
+        const errors = [
+            ...agentValidationErrors(draft, options),
+            ...agentKnowledgeErrors(draft),
+            ...newAgentActionErrors(draft, original?.record ?? null, actions, targets, ownerId),
+            ...(advancedError ? [advancedError] : []),
+        ];
+        if (errors.length) {
+            setHasSaveConflict(false);
+            setSaveError(errors.join(' '));
+            return;
+        }
+        setSaving(true);
+        setSaveError(null);
+        setHasSaveConflict(false);
+        try {
+            const resource = await saveAgentConfiguration(agentForSave(draft), original);
+            if (!resource.record?.id) throw new Error('The save response did not include an agent identifier. Reload before trying again.');
+            load(resource);
+            clear();
+            await refreshBootstrap();
+            navigate('/workspace/agents', { replace: true, state: { workspaceEditorSaved: true, workspaceEditorFrom: location.key } });
+        } catch (cause) {
+            const conflict = cause instanceof ApiError && cause.status === 409;
+            setHasSaveConflict(conflict && !isNew);
+            setSaveError(conflict && !isNew
+                ? 'This agent changed in another session. Your draft has been retained. Open the latest agent in a new tab to compare before discarding or reapplying your changes.'
+                : conflict ? `${message(cause)} Your draft has been retained.` : message(cause));
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    if (bootLoading) return <div className="p-4"><p role="status" className="mb-3 text-sm text-text-3">Loading agent editor…</p><SectionSkeleton /></div>;
+    if (bootError || !options) return (
+        <div className="space-y-3 p-4">
+            <AgentNotice error>{bootError || 'Editor options are unavailable.'} Any restored draft remains in memory.</AgentNotice>
+            <div className="flex flex-wrap gap-2">
+                <GlassButton type="button" onClick={() => setBootRevision((value) => value + 1)}>Retry editor</GlassButton>
+                <Link to="/workspace/agents" className="rounded-lg px-3 py-2 text-sm text-accent">Back to agents</Link>
+            </div>
+        </div>
+    );
+
+    const structured = (content: ReactNode) => <fieldset disabled={Boolean(advancedError) || iconBusy} className="min-w-0">{content}</fieldset>;
+    return (
+        <WorkspaceEditorFrame
+            title={isNew ? 'New agent' : draft.display_name || draft.name || 'Agent details'}
+            description={isNew ? 'Configure a reusable assistant. Changes are saved only when you choose Save agent.' : `Stable ID: ${draft.id}`}
+            backTo="/workspace/agents" dirty={dirty || iconBusy} saving={saving} readOnly={readOnly} error={arraySecretError || saveError}
+            onSave={() => void save()} onDiscard={clear} saveLabel="Save agent" saveDisabled={Boolean(advancedError) || iconBusy}
+            actions={<>
+                {advancedError ? <span role="status" className="max-w-xs text-xs text-danger">
+                    {arraySecretError ? 'Review stored array credentials before saving.' : 'Fix Additional settings JSON to enable saving.'}
+                </span> : null}
+                {hasSaveConflict ? (
+                    <Link to={`${location.pathname}${location.search}`} target="_blank" rel="noopener noreferrer"
+                        className="rounded-lg px-3 py-2 text-sm text-accent hover:bg-accent-soft">Open latest in a new tab</Link>
+                ) : null}
+                {!isNew && !dirty && draft.is_enabled !== false ? (
+                <Link to={`/chat?agent_id=${encodeURIComponent(draft.id)}&agent_scope=${draft.is_global ? 'global' : 'personal'}&new=1`}
+                    className="rounded-lg px-3 py-2 text-sm text-accent hover:bg-accent-soft">Use in chat</Link>
+                ) : null}
+            </>}
+            sections={[
+                {
+                    id: 'identity', label: 'Identity',
+                    content: <><AgentIdentityFields draft={draft} setDraft={setDraft} options={options} isNew={isNew} onIconBusyChange={setIconBusy} />
+                        {restored ? <p role="status" className="mt-3 text-xs text-text-3">Your unsaved draft was restored from this tab’s memory.</p> : null}</>,
+                },
+                { id: 'model', label: 'Model & connection', content: structured(<AgentModelFields draft={draft} setDraft={setDraft} options={options} original={original} />) },
+                { id: 'actions', label: 'Actions', content: structured(<AgentActionPicker draft={draft} setDraft={setDraft}
+                    actions={actions} targets={targets} loading={actionsLoading} error={actionsError} targetError={targetError}
+                    builtinActions={options.builtin_actions} ownerId={ownerId} canCreateActions={canCreateActions} readOnly={readOnly}
+                    onRefresh={() => setActionsRevision((value) => value + 1)}
+                    onNewAction={() => navigate(`/workspace/actions/new?returnTo=${encodeURIComponent(location.pathname)}`, { state: { preserveWorkspaceDraft: true, workspaceEditorFrom: location.key } })} />) },
+                { id: 'knowledge', label: 'Assigned knowledge', content: structured(<AgentKnowledgeFields draft={draft} setDraft={setDraft}
+                    catalog={knowledge} loading={knowledgeLoading} error={knowledgeError} readOnly={readOnly}
+                    onRefresh={() => setKnowledgeRevision((value) => value + 1)} />) },
+                { id: 'instructions', label: 'Instructions', content: <AgentInstructionsFields key={draft.agent_type}
+                    draft={draft} setDraft={setDraft} actions={actions} catalog={knowledge} readOnly={readOnly}
+                    contextError={actionsError || (readAgentKnowledgeEnabled(draft) ? knowledgeError : null)} /> },
+                { id: 'advanced', label: 'Advanced', content: <AgentAdvancedFields draft={draft} setDraft={setDraft} options={options} original={original} /> },
+                { id: 'templates', label: 'Examples & templates', content: structured(<div ref={templatesAnchor} tabIndex={-1}>
+                    <AgentTemplatesPanel draft={draft} setDraft={setDraft} options={options} actions={actions} isNew={isNew} dirty={dirty} readOnly={readOnly} />
+                </div>) },
+            ]}
+        />
+    );
+}
+
+function readAgentKnowledgeEnabled(draft: AgentConfiguration): boolean {
+    return isRecord(draft.other_settings.assigned_knowledge) && draft.other_settings.assigned_knowledge.enabled === true;
+}
+
+export function AgentEditorPage() {
+    const { resourceId = 'new' } = useParams<{ resourceId?: string }>();
+    const location = useLocation();
+    const scope = new URLSearchParams(location.search).get('scope') === 'global' ? 'global' : 'personal';
+    return <AgentEditorSession key={`${scope}:${resourceId}`} resourceId={resourceId} scope={scope} />;
+}

--- a/application/v2_ui/src/pages/workspace/AgentsSection.tsx
+++ b/application/v2_ui/src/pages/workspace/AgentsSection.tsx
@@ -1,358 +1,146 @@
 // AgentsSection.tsx
-// Personal agents: list, create, edit and delete.
-//
-// Identity, instructions and Call agent bindings are native. Model, knowledge and other
-// action types retain their existing classic editors.
 
-import { useMemo, useState } from 'react';
-import { Link } from 'react-router-dom';
-import { Pencil, Plus, Shield, Sparkles, Trash2 } from 'lucide-react';
-import { GlassButton, GlassPanel } from '../../components/ui/primitives';
-import {
-    ConfirmAction,
-    Pill,
-    ResourceRow,
-    RowAction,
-    SectionIntro,
-    SectionList,
-    SectionSearch,
-} from '../../components/workspace/primitives';
-import {
-    errorMessage,
-    useSectionResource,
-} from '../../components/workspace/useSectionResource';
-import {
-    createAgent,
-    deleteAgent,
-    fetchAgents,
-    generateAgentId,
-    updateAgent,
-} from '../../lib/workspaceApi';
-import type { WorkspaceAgent } from '../../lib/types';
-import { PERSONAL_DELEGATION_SCOPE } from '../../lib/agentDelegation';
-import { AgentDelegationManager } from '../../components/agents/AgentDelegationManager';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
+import { LayoutGrid, List, Plus, RefreshCw, Sparkles, Trash2 } from 'lucide-react';
+import { EmptyState, GlassButton, GlassPanel } from '../../components/ui/primitives';
+import { ConfirmAction, Pill, SectionIntro, SectionSearch, SectionSkeleton } from '../../components/workspace/primitives';
+import { errorMessage, useSectionResource } from '../../components/workspace/useSectionResource';
+import { AgentIcon } from '../../components/workspaceAgents/AgentIdentityFields';
+import { AgentNotice } from '../../components/workspaceAgents/AgentFields';
+import { deleteAuthoringAgent, fetchAuthoringAgents } from '../../lib/workspaceAuthoringApi';
+import type { AgentConfiguration } from '../../lib/workspaceAuthoring';
+import { AGENT_INPUT_CLASS, AGENT_TYPE_LABELS, agentText } from '../../lib/workspaceAgentAuthoring';
+import { readAgentKnowledge } from '../../lib/workspaceAgentKnowledge';
+import { useBootstrapStore } from '../../stores/bootstrapStore';
 
-interface DraftAgent {
-    id: string | null;
-    displayName: string;
-    description: string;
-    instructions: string;
-}
-
-const EMPTY_DRAFT: DraftAgent = {
-    id: null,
-    displayName: '',
-    description: '',
-    instructions: '',
-};
-
-/**
- * Derive the stored `name` from what the user typed.
- *
- * The agent schema constrains `name` to letters, digits, underscore and dash, while the
- * display name is free text. Rather than ask for both, the machine-readable one is derived
- * and only the display name is edited.
- */
-export function agentNameFromDisplayName(displayName: string): string {
-    const slug = displayName
-        .trim()
-        .replace(/[^A-Za-z0-9_-]+/g, '-')
-        .replace(/^-+|-+$/g, '');
-    return slug || 'agent';
-}
-
-function AgentEditor({
-    draft,
-    saving,
-    onChange,
-    onSave,
-    onCancel,
-}: {
-    draft: DraftAgent;
-    saving: boolean;
-    onChange: (next: DraftAgent) => void;
-    onSave: () => void;
-    onCancel: () => void;
-}) {
-    const canSave = draft.displayName.trim().length > 0;
-
-    return (
-        <GlassPanel elevation="flat" className="space-y-3 p-4">
-            <div>
-                <label
-                    htmlFor="agent-display-name"
-                    className="mb-1 block text-xs font-medium text-text-2"
-                >
-                    Name
-                </label>
-                <input
-                    id="agent-display-name"
-                    type="text"
-                    value={draft.displayName}
-                    onChange={(event) =>
-                        onChange({ ...draft, displayName: event.target.value })
-                    }
-                    placeholder="Contract reviewer"
-                    className="w-full rounded-xl border border-edge bg-surface-1 px-3 py-2 text-sm text-text-1 placeholder:text-text-3 focus:border-accent focus:outline-none"
-                />
-                {draft.id === null && draft.displayName.trim() ? (
-                    <p className="mt-1 text-[11px] text-text-3">
-                        Stored as{' '}
-                        <code className="text-text-2">
-                            {agentNameFromDisplayName(draft.displayName)}
-                        </code>
-                    </p>
-                ) : null}
-            </div>
-
-            <div>
-                <label
-                    htmlFor="agent-description"
-                    className="mb-1 block text-xs font-medium text-text-2"
-                >
-                    Description
-                </label>
-                <input
-                    id="agent-description"
-                    type="text"
-                    value={draft.description}
-                    onChange={(event) =>
-                        onChange({ ...draft, description: event.target.value })
-                    }
-                    placeholder="Reviews contracts against our standard terms."
-                    className="w-full rounded-xl border border-edge bg-surface-1 px-3 py-2 text-sm text-text-1 placeholder:text-text-3 focus:border-accent focus:outline-none"
-                />
-            </div>
-
-            <div>
-                <label
-                    htmlFor="agent-instructions"
-                    className="mb-1 block text-xs font-medium text-text-2"
-                >
-                    Instructions
-                </label>
-                <textarea
-                    id="agent-instructions"
-                    rows={6}
-                    value={draft.instructions}
-                    onChange={(event) =>
-                        onChange({ ...draft, instructions: event.target.value })
-                    }
-                    placeholder="You are a careful contract reviewer. Quote the clause you are referring to before commenting on it."
-                    className="w-full resize-y rounded-xl border border-edge bg-surface-1 px-3 py-2 text-sm text-text-1 placeholder:text-text-3 focus:border-accent focus:outline-none"
-                />
-            </div>
-
-            <div className="flex justify-end gap-2">
-                <GlassButton size="sm" onClick={onCancel} disabled={saving}>
-                    Cancel
-                </GlassButton>
-                <GlassButton
-                    variant="primary"
-                    size="sm"
-                    onClick={onSave}
-                    disabled={!canSave || saving}
-                >
-                    {saving ? 'Saving' : draft.id ? 'Save changes' : 'Create agent'}
-                </GlassButton>
-            </div>
-        </GlassPanel>
-    );
-}
+let collectionState = { owner: '', query: '', type: '', scope: '', view: 'list', scrollTop: 0 };
 
 export function AgentsSection({ actionsEnabled }: { actionsEnabled: boolean }) {
+    const owner = useBootstrapStore((state) => state.data?.user?.id ?? '');
+    const refreshBootstrap = useBootstrapStore((state) => state.refresh);
+    const navigate = useNavigate();
+    const location = useLocation();
+    const list = useRef<HTMLDivElement>(null);
+    const scrollRestored = useRef(false);
     const { items, loading, error, refresh, setItems, setError } =
-        useSectionResource<WorkspaceAgent>(fetchAgents, 'Failed to load agents.');
-
-    const [query, setQuery] = useState('');
-    const [draft, setDraft] = useState<DraftAgent | null>(null);
-    const [saving, setSaving] = useState(false);
+        useSectionResource<AgentConfiguration>(fetchAuthoringAgents, 'Failed to load agents.');
+    const [filters, setFilters] = useState(() => {
+        if (collectionState.owner !== owner) collectionState = { owner, query: '', type: '', scope: '', view: 'list', scrollTop: 0 };
+        return { ...collectionState };
+    });
     const [busyId, setBusyId] = useState<string | null>(null);
-    const [delegationRevision, setDelegationRevision] = useState(0);
-    const [delegationDirty, setDelegationDirty] = useState(false);
-
-    const visible = useMemo(() => {
-        const needle = query.trim().toLowerCase();
-        if (!needle) {
-            return items;
+    useEffect(() => {
+        if (filters.owner !== owner) {
+            collectionState = { owner, query: '', type: '', scope: '', view: 'list', scrollTop: 0 };
+            setFilters(collectionState);
+            scrollRestored.current = false;
         }
-        return items.filter((agent) =>
-            `${agent.display_name ?? ''} ${agent.name ?? ''}`.toLowerCase().includes(needle),
-        );
-    }, [items, query]);
-
-    const onSave = async () => {
-        if (!draft) {
-            return;
+        else collectionState = { ...filters, scrollTop: collectionState.scrollTop };
+    }, [filters, owner]);
+    useEffect(() => {
+        if (!loading && !error && items.length && !scrollRestored.current && list.current) {
+            list.current.scrollTop = collectionState.scrollTop;
+            scrollRestored.current = true;
         }
-        setSaving(true);
+    }, [loading, error, items.length]);
+    const visible = useMemo(() => items.filter((agent) => {
+        const label = AGENT_TYPE_LABELS[agent.agent_type] ?? agent.agent_type;
+        return `${agent.display_name} ${agent.name} ${agent.description} ${agent.agent_type} ${label}`.toLowerCase().includes(filters.query.trim().toLowerCase()) &&
+            (!filters.type || filters.type === agent.agent_type) &&
+            (!filters.scope || (filters.scope === 'provided') === Boolean(agent.is_global));
+    }), [items, filters]);
+    const remove = async (agent: AgentConfiguration) => {
+        if (agent.is_global) return;
+        setBusyId(agent.id);
         setError(null);
         try {
-            if (draft.id) {
-                await updateAgent(draft.id, {
-                    display_name: draft.displayName.trim(),
-                    description: draft.description,
-                    instructions: draft.instructions,
-                });
-            } else {
-                const id = await generateAgentId();
-                // Every one of these is required by the agent schema, which is checked
-                // before the record is stored, so a partial object is rejected outright.
-                await createAgent({
-                    id,
-                    name: agentNameFromDisplayName(draft.displayName),
-                    display_name: draft.displayName.trim(),
-                    description: draft.description,
-                    instructions: draft.instructions,
-                    is_global: false,
-                    is_group: false,
-                    actions_to_load: [],
-                    other_settings: {},
-                    max_completion_tokens: -1,
-                    agent_type: 'local',
-                });
-            }
-            setDraft(null);
-            await refresh();
-            setDelegationRevision((value) => value + 1);
-        } catch (saveError) {
-            setError(errorMessage(saveError, 'Could not save the agent.'));
-        } finally {
-            setSaving(false);
-        }
-    };
-
-    const onDelete = async (agent: WorkspaceAgent) => {
-        const previous = items;
-        setBusyId(agent.id);
-        setItems(items.filter((item) => item.id !== agent.id));
-        try {
-            await deleteAgent(agent.id);
-            setDelegationRevision((value) => value + 1);
-        } catch (deleteError) {
-            setItems(previous);
-            setError(errorMessage(deleteError, 'Could not delete the agent.'));
+            await deleteAuthoringAgent(agent.id);
+            setItems(items.filter((item) => item.is_global || item.id !== agent.id));
+            await Promise.all([refresh(), refreshBootstrap()]);
+        } catch (cause) {
+            setError(errorMessage(cause, 'Could not delete the agent.'));
         } finally {
             setBusyId(null);
         }
     };
 
     return (
-        <div className="space-y-4">
-            <SectionIntro
-                title="Agents"
-                description="Assistants you configure once and reuse, with instructions and approved actions. Agents you build here appear in the chat agent picker."
-                actions={
-                    <GlassButton
-                        variant="primary"
-                        size="sm"
-                        onClick={() => setDraft({ ...EMPTY_DRAFT })}
-                        disabled={Boolean(draft) || delegationDirty}
-                    >
-                        <Plus size={14} />
-                        New agent
-                    </GlassButton>
-                }
-            />
-
-            <p className="text-xs text-text-3">
-                Create an agent here, then attach Call agent actions below. Create those{' '}
-                {actionsEnabled ? (
-                    <Link to="/workspace/actions" className="text-accent hover:underline">
-                        actions
-                    </Link>
-                ) : (
-                    'actions'
-                )}{' '}
-                in your Actions section. Model, knowledge and other connector bindings remain in the{' '}
-                <a href="/workspace" className="text-accent hover:underline">
-                    classic workspace
-                </a>
-                .
-            </p>
-
-            {draft ? (
-                <AgentEditor
-                    draft={draft}
-                    saving={saving}
-                    onChange={setDraft}
-                    onSave={() => void onSave()}
-                    onCancel={() => setDraft(null)}
-                />
-            ) : null}
-
-            <SectionSearch value={query} onChange={setQuery} placeholder="Search agents" />
-
-            <SectionList
-                items={visible}
-                loading={loading}
-                error={error}
-                emptyIcon={<Sparkles size={28} />}
-                emptyTitle={items.length === 0 ? 'No agents yet' : 'No agents match your search'}
-                emptyDescription={
-                    items.length === 0
-                        ? 'Create an agent to reuse a set of instructions across conversations.'
-                        : undefined
-                }
-                getKey={(agent, index) => String(agent.id ?? agent.name ?? index)}
-                renderItem={(agent) => {
-                    // Administrator-supplied agents are listed because they are selectable in
-                    // chat, but they are not this user's to change.
-                    const managed = Boolean(agent.is_global);
-                    return (
-                        <ResourceRow
-                            icon={<Sparkles size={17} />}
-                            title={String(agent.display_name || agent.name || 'Untitled agent')}
-                            subtitle={String(agent.description || agent.name || '')}
-                            meta={
-                                managed ? (
-                                    <Pill tone="accent">
-                                        <span className="flex items-center gap-1">
-                                            <Shield size={10} />
-                                            Provided
-                                        </span>
-                                    </Pill>
-                                ) : undefined
-                            }
-                            actions={
-                                managed ? undefined : (
-                                    <>
-                                        <RowAction
-                                            icon={<Pencil size={15} />}
-                                            label={`Edit ${agent.display_name ?? agent.name ?? 'agent'}`}
-                                            disabled={delegationDirty}
-                                            onClick={() =>
-                                                setDraft({
-                                                    id: agent.id,
-                                                    displayName: String(
-                                                        agent.display_name || agent.name || '',
-                                                    ),
-                                                    description: String(agent.description ?? ''),
-                                                    instructions: String(
-                                                        agent.instructions ?? '',
-                                                    ),
-                                                })
-                                            }
-                                        />
-                                        <ConfirmAction
-                                            icon={<Trash2 size={15} />}
-                                            label={`Delete ${agent.display_name ?? agent.name ?? 'agent'}`}
-                                            confirmLabel="Delete"
-                                            busy={busyId === agent.id}
-                                            disabled={delegationDirty}
-                                            onConfirm={() => void onDelete(agent)}
-                                        />
-                                    </>
-                                )
-                            }
-                        />
-                    );
-                }}
-            />
-            {actionsEnabled && !draft ? (
-                <AgentDelegationManager scope={PERSONAL_DELEGATION_SCOPE} mode="bindings"
-                    revision={delegationRevision} onDirtyChange={setDelegationDirty} />
-            ) : null}
+        <div className="flex h-full min-h-0 flex-col gap-4">
+            <link rel="stylesheet" href="/static/css/bootstrap-icons.css" />
+            <div className="shrink-0 space-y-4">
+                <SectionIntro title="Agents"
+                    description="Build reusable assistants with their own model, instructions, knowledge, and actions. Provided agents can be viewed and used, but not changed here."
+                    actions={<GlassButton type="button" variant="primary" size="sm" onClick={() => navigate('/workspace/agents/new')}><Plus size={14} />New agent</GlassButton>} />
+                <div className="flex flex-wrap items-center gap-2">
+                    <GlassButton type="button" size="sm" onClick={() => navigate('/workspace/agents/new?templates=1')}><Sparkles size={14} />Examples &amp; templates</GlassButton>
+                    <GlassButton type="button" size="sm" disabled={loading} onClick={() => void refresh()}><RefreshCw size={14} />Refresh</GlassButton>
+                    <div className="ml-auto flex gap-1" aria-label="Agent browsing view">
+                        <GlassButton type="button" size="icon" aria-label="List view" aria-pressed={filters.view === 'list'} onClick={() => setFilters((current) => ({ ...current, view: 'list' }))}><List size={17} /></GlassButton>
+                        <GlassButton type="button" size="icon" aria-label="Card view" aria-pressed={filters.view === 'cards'} onClick={() => setFilters((current) => ({ ...current, view: 'cards' }))}><LayoutGrid size={17} /></GlassButton>
+                    </div>
+                </div>
+                <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_10rem_9rem]">
+                    <SectionSearch value={filters.query} onChange={(query) => setFilters((current) => ({ ...current, query }))} placeholder="Search agents by name, description or type" />
+                    <select aria-label="Filter agent type" value={filters.type} className={AGENT_INPUT_CLASS} onChange={(event) => setFilters((current) => ({ ...current, type: event.target.value }))}>
+                        <option value="">All agent types</option>
+                        {Object.entries(AGENT_TYPE_LABELS).map(([value, label]) => <option key={value} value={value}>{label}</option>)}
+                    </select>
+                    <select aria-label="Filter agent scope" value={filters.scope} className={AGENT_INPUT_CLASS} onChange={(event) => setFilters((current) => ({ ...current, scope: event.target.value }))}>
+                        <option value="">All ownership</option><option value="personal">Personal</option><option value="provided">Provided</option>
+                    </select>
+                </div>
+                {error ? <AgentNotice error>{error}</AgentNotice> : null}
+                {location.state?.workspaceEditorSaved === true ? <p role="status" className="text-xs text-ok">Agent saved.</p> : null}
+            </div>
+            <div ref={list} className="min-h-0 flex-1 overflow-y-auto pb-4 pr-1"
+                onScroll={(event) => { collectionState.scrollTop = event.currentTarget.scrollTop; }}>
+                {loading ? <SectionSkeleton /> : null}
+                {!loading && !visible.length && !error ? <EmptyState icon={<Sparkles size={28} />}
+                    title={items.length ? 'No agents match your search' : 'No agents yet'}
+                    description={items.length ? 'Try another name, description or type.' : 'Create an agent or start from an approved template.'} /> : null}
+                <ul className={filters.view === 'cards' ? 'grid gap-3 lg:grid-cols-2 2xl:grid-cols-3' : 'space-y-3'}>
+                    {visible.map((agent) => {
+                        const provided = Boolean(agent.is_global);
+                        const label = agent.display_name || agent.name || 'Untitled agent';
+                        const path = `/workspace/agents/${encodeURIComponent(agent.id)}${provided ? '?scope=global' : ''}`;
+                        const knowledge = readAgentKnowledge(agent);
+                        return (
+                            <li key={`${provided ? 'global' : 'personal'}:${agent.id}`} className="min-w-0">
+                                <GlassPanel elevation="flat" className={`h-full p-4 ${filters.view === 'cards' ? 'space-y-3' : 'flex flex-wrap items-start gap-3'}`}>
+                                    <div className="flex min-w-0 flex-1 items-start gap-3">
+                                        <AgentIcon icon={agent.icon} />
+                                        <div className="min-w-0 flex-1">
+                                            <h3 className="break-words text-sm font-semibold text-text-1"><Link to={path} className="hover:text-accent hover:underline">{label}</Link></h3>
+                                            <p className="mt-1 break-words text-sm text-text-3">{agent.description}</p>
+                                            <div className="mt-2 flex flex-wrap items-center gap-2">
+                                                <Pill>{AGENT_TYPE_LABELS[agent.agent_type] || agent.agent_type}</Pill>
+                                                <Pill tone={provided ? 'accent' : 'neutral'}>{provided ? 'Provided · read only' : 'Personal'}</Pill>
+                                                {agent.is_enabled === false ? <Pill tone="warn">Disabled</Pill> : null}
+                                            </div>
+                                            <p className="mt-2 break-words text-xs text-text-3">
+                                                {agent.model_id || agent.azure_openai_gpt_deployment || agent.azure_agent_apim_gpt_deployment || (agent.agent_type === 'local' ? 'Configured model default' : 'Foundry-managed model')}
+                                                {' · '}{agent.actions_to_load?.length ?? 0} actions{knowledge.enabled ? ` · ${knowledge.document_ids.length} explicit knowledge documents` : ''}
+                                            </p>
+                                            <p className="mt-1 break-all text-[10px] text-text-3">{provided ? 'global' : 'personal'} · {agent.id}</p>
+                                            {agent.tags?.length ? <p className="mt-1 break-words text-xs text-text-3">{agent.tags.join(' · ')}</p> : null}
+                                        </div>
+                                    </div>
+                                    <div className="flex flex-wrap items-center gap-2">
+                                        <GlassButton type="button" size="sm" onClick={() => navigate(path)}>{provided ? 'View details' : 'Edit'}</GlassButton>
+                                        {agent.is_enabled !== false ? <Link to={`/chat?agent_id=${encodeURIComponent(agent.id)}&agent_scope=${provided ? 'global' : 'personal'}&new=1`} className="rounded-lg px-2 py-1.5 text-xs font-medium text-accent hover:bg-accent-soft">Use in chat</Link> : null}
+                                        {!provided ? <ConfirmAction icon={<Trash2 size={15} />} label={`Delete ${label}`} confirmLabel="Delete agent"
+                                            busy={busyId === agent.id} disabled={busyId !== null} onConfirm={() => void remove(agent)} /> : null}
+                                    </div>
+                                </GlassPanel>
+                            </li>
+                        );
+                    })}
+                </ul>
+                {!actionsEnabled ? <p className="mt-3 text-xs text-text-3">Action creation is unavailable. Agent editors can still assign permitted existing actions.</p> : null}
+                {loading && items.length ? <p className="mt-2 text-xs text-text-3">Refreshing the saved catalogue…</p> : null}
+                {agentText(filters.query) ? <p role="status" className="mt-3 text-xs text-text-3">{visible.length} matching agents</p> : null}
+            </div>
         </div>
     );
 }

--- a/application/v2_ui/src/pages/workspace/WorkspacePage.tsx
+++ b/application/v2_ui/src/pages/workspace/WorkspacePage.tsx
@@ -26,7 +26,8 @@ import type { WorkspaceSectionContext } from './sections';
 
 export function WorkspacePage() {
     const workspace = useBootstrapStore((state) => state.data?.workspace);
-    const { section: requestedSection } = useParams<{ section?: string }>();
+    const ownerId = useBootstrapStore((state) => state.data?.user?.id);
+    const { section: requestedSection, resourceId } = useParams<{ section?: string; resourceId?: string }>();
 
     const railCollapsed = useUserSettingsStore(
         (state) => state.settings.v2WorkspaceRailCollapsed === true,
@@ -43,10 +44,12 @@ export function WorkspacePage() {
 
     const context: WorkspaceSectionContext = useMemo(
         () => ({
+            resourceId,
+            ownerId,
             isEnabled: (sectionId: string) =>
                 resolved.some((entry) => entry.section.id === sectionId && entry.enabled),
         }),
-        [resolved],
+        [resolved, resourceId, ownerId],
     );
 
     // The whole page is gated on enable_user_workspace upstream, but the flag is reported
@@ -100,6 +103,9 @@ export function WorkspacePage() {
                 />
             );
         }
+        if (resourceId && !['agents', 'actions'].includes(activeEntry.section.id)) {
+            return <EmptyState title="Editor not found" description="That editor does not exist in this workspace section." />;
+        }
         return activeEntry.section.render(context);
     };
 
@@ -124,7 +130,7 @@ export function WorkspacePage() {
                     aria-label="Workspace sections"
                     className={clsx(
                         'flex shrink-0 flex-col gap-3 overflow-y-auto transition-[width]',
-                        railCollapsed ? 'w-12' : 'w-52',
+                        railCollapsed ? 'w-12' : 'w-12 md:w-52',
                     )}
                 >
                     <button
@@ -153,7 +159,7 @@ export function WorkspacePage() {
                         ) : (
                             <>
                                 <PanelLeftClose size={15} />
-                                <span>Collapse</span>
+                                <span className="hidden md:inline">Collapse</span>
                             </>
                         )}
                     </button>
@@ -168,7 +174,7 @@ export function WorkspacePage() {
                         {railCollapsed ? (
                             <span className="sr-only">Overview</span>
                         ) : (
-                            <span className="truncate">Overview</span>
+                            <span className="sr-only md:not-sr-only md:truncate">Overview</span>
                         )}
                     </NavLink>
 
@@ -182,7 +188,7 @@ export function WorkspacePage() {
                                     className="mx-2 my-1.5 border-t border-edge"
                                 />
                             ) : (
-                                <p className="px-2.5 text-[11px] font-semibold tracking-wide text-text-3 uppercase">
+                                <p className="hidden px-2.5 text-[11px] font-semibold tracking-wide text-text-3 uppercase md:block">
                                     {group.label}
                                 </p>
                             )}
@@ -203,7 +209,7 @@ export function WorkspacePage() {
                                         {railCollapsed ? (
                                             <span className="sr-only">{section.label}</span>
                                         ) : (
-                                            <span className="truncate">{section.label}</span>
+                                            <span className="sr-only md:not-sr-only md:truncate">{section.label}</span>
                                         )}
                                     </NavLink>
                                 );

--- a/application/v2_ui/src/pages/workspace/sections.tsx
+++ b/application/v2_ui/src/pages/workspace/sections.tsx
@@ -26,6 +26,8 @@ import type { WorkspaceSectionGroup } from '../../lib/types';
 import type { WorkspaceSectionDescriptor } from '../../lib/workspaceSections';
 import { ActionsSection } from './ActionsSection';
 import { AgentsSection } from './AgentsSection';
+import { ActionEditorPage } from './ActionEditorPage';
+import { AgentEditorPage } from './AgentEditorPage';
 import { DocumentsSection } from './DocumentsSection';
 import { EndpointsSection } from './EndpointsSection';
 import { FileSourcesSection } from './FileSourcesSection';
@@ -35,6 +37,8 @@ import { TagsSection } from './TagsSection';
 import { WorkflowsSection } from './WorkflowsSection';
 
 export interface WorkspaceSectionContext {
+    resourceId?: string;
+    ownerId?: string;
     /** Whether another section is available, for cross-links that should not dead-end. */
     isEnabled: (sectionId: string) => boolean;
 }
@@ -101,7 +105,10 @@ export const WORKSPACE_SECTIONS: WorkspaceSectionDefinition[] = [
         group: 'automation',
         icon: Sparkles,
         blurb: 'Assistants you configure once: instructions, knowledge and actions.',
-        render: (context) => <AgentsSection actionsEnabled={context.isEnabled('actions')} />,
+        layout: 'full',
+        render: (context) => context.resourceId
+            ? <AgentEditorPage key={`${context.ownerId}:${context.resourceId}`} />
+            : <AgentsSection actionsEnabled={context.isEnabled('actions')} />,
     },
     {
         id: 'actions',
@@ -109,7 +116,10 @@ export const WORKSPACE_SECTIONS: WorkspaceSectionDefinition[] = [
         group: 'automation',
         icon: Plug,
         blurb: 'Tools an agent may call, such as an API, a database or an MCP server.',
-        render: (context) => <ActionsSection agentsEnabled={context.isEnabled('agents')} />,
+        layout: 'full',
+        render: (context) => context.resourceId
+            ? <ActionEditorPage key={`${context.ownerId}:${context.resourceId}`} />
+            : <ActionsSection agentsEnabled={context.isEnabled('agents')} />,
     },
     {
         id: 'workflows',

--- a/application/v2_ui/src/stores/bootstrapStore.ts
+++ b/application/v2_ui/src/stores/bootstrapStore.ts
@@ -33,6 +33,8 @@ interface BootstrapState {
      * those has to reload the browser before the change is visible without this.
      */
     refresh: () => Promise<void>;
+    /** Refresh before an explicit selection; failures must not reuse cached authorization. */
+    refreshRequired: () => Promise<BootstrapPayload>;
     /**
      * Put a prompt into the catalog straight away, before a refresh has been round-tripped.
      *
@@ -84,6 +86,16 @@ export const useBootstrapStore = create<BootstrapState>((set) => ({
             // refetch the reader never asked for. The caller's own write already
             // succeeded, so a briefly stale shell is cosmetic and the next load fixes it.
         }
+    },
+
+    refreshRequired: async () => {
+        const sequence = ++refreshSequence;
+        const data = await fetchBootstrap();
+        if (sequence !== refreshSequence) {
+            throw new Error('Application availability changed during refresh. Try again.');
+        }
+        set({ data });
+        return data;
     },
 
     upsertPromptInCatalog: (prompt) =>

--- a/docs/explanation/features/REACT_V2_UI.md
+++ b/docs/explanation/features/REACT_V2_UI.md
@@ -7,10 +7,11 @@ server-rendered SimpleChat UI. It exists to evaluate a different visual and inte
 direction — a glassmorphism design system, a single collapsible left rail with no top bar,
 and a search-first admin surface — without disturbing the interface people use today.
 
-It reuses the existing Flask JSON APIs unchanged. No existing route, template, or
-JavaScript module was modified to support it.
+It reuses the existing Flask domain APIs. Personal agent/action authoring adds an
+opt-in editor representation while leaving classic callers compatible.
 
 **Implemented in version:** 0.261.003
+**Personal agent/action authoring:** 0.261.096 (`application/single_app/config.py`)
 **Deployer version:** 1.0.26
 
 ### Dependencies
@@ -1031,8 +1032,25 @@ stats. With Stats rebuilt, the Profile entry has nothing left to lead to and is 
 tabs remain: those are the fallback for tabs V2 has not rebuilt, not profile navigation.
 ### Not rebuilt yet
 
-Agents, group workspaces and public workspaces appear in the rail and link through to their
-classic pages rather than dead-ending.
+The standalone agent catalogue and broader group/public workspace management are
+separate from personal authoring. Their existing fallback and focused delegation
+surfaces remain unchanged.
+
+## My Workspace agent and action editors
+
+Personal Agents and Actions have native full-page editors with section navigation,
+explicit saves, and protection against losing unfinished changes. The action
+collection and agent action picker include Call agent as a normal type, not a
+separate management section.
+
+Agent authoring includes model connections, assigned knowledge, instructions,
+capability-aware action selection, and the existing agent types/templates.
+Action configuration covers the currently offered connector types. Creating an
+action from an agent returns to the retained agent draft without saving that
+agent prematurely.
+
+See [V2 Workspace Agent and Action Authoring](V2_WORKSPACE_AGENTS_ACTIONS.md) and
+the [workspace guide](../../guides/workspace-agents-and-actions.md).
 
 ## Building
 

--- a/docs/explanation/features/V2_MY_WORKSPACE.md
+++ b/docs/explanation/features/V2_MY_WORKSPACE.md
@@ -15,6 +15,9 @@ serve file sources and actions.
 
 **Implemented in version:** 0.261.042
 
+**Agent/action authoring expanded in version:** 0.261.096, recorded in
+`application/single_app/config.py`.
+
 ### Dependencies
 
 | Dependency | Purpose |
@@ -153,23 +156,23 @@ What each section supports in this release:
 | Documents | Upload, search, filter by tag, delete |
 | File sources | List, sync now, run history, delete |
 | Prompts | Full create, edit and delete |
-| Agents | List, create, edit name, description and instructions, delete |
-| Actions | List, delete |
+| Agents | Full-page authoring for all permitted agent types, models, knowledge, actions, instructions, and templates; use in chat |
+| Actions | Unified list and full-page create/edit/delete, with native type-specific configuration |
 | Workflows | List, run, cancel, run history, delete |
 | Identities | List, delete |
 | Endpoints | List, enable or disable, delete |
 
 ## Known limitations
 
-Authoring surfaces that are specific to a connector or a schedule are not rebuilt yet and
-remain in the classic workspace. Each section links to it rather than offering a control
-that does nothing.
+Personal agent and action authoring no longer requires the classic workspace.
+See [V2 Workspace Agent and Action Authoring](V2_WORKSPACE_AGENTS_ACTIONS.md) for
+editor navigation, draft handoff, and credential-preserving saves.
 
-- Action configuration, which differs across more than twenty connector types.
+The following separate management surfaces still use their existing editors:
+
 - The workflow designer: tasks, document actions and scheduling.
 - Model endpoint connection details: provider, API versions, authentication, model list.
 - File source configuration, and identity creation with its auth-type-specific fields.
-- Agent model binding, action attachment and assigned knowledge.
 
 ## Testing and validation
 

--- a/docs/explanation/features/V2_WORKSPACE_AGENTS_ACTIONS.md
+++ b/docs/explanation/features/V2_WORKSPACE_AGENTS_ACTIONS.md
@@ -1,0 +1,190 @@
+# V2 Workspace Agent and Action Authoring
+
+## Overview
+
+My Workspace provides native V2 authoring for personal agents and actions. Agents
+combine a consistent role, model, approved tools, and knowledge; actions describe
+the individual tools an agent is allowed to use. Keeping their configuration
+connected makes it possible to build an assistant without switching interfaces.
+
+Implemented in version: **0.261.096**, recorded in
+`application/single_app/config.py`.
+
+The change is limited to personal workspace management. Group/global management,
+the standalone agent catalogue, and the delegation execution rules are unchanged.
+
+### Dependencies
+
+| Dependency | Purpose |
+| --- | --- |
+| React 18 and TypeScript | Native editor components and typed configuration |
+| React Router | Deep editor routes and unsaved-navigation protection |
+| Existing Flask agent/action APIs | Authorization, schema validation, and persistence |
+| Existing plugin schemas and discovery | Governed action types and configuration |
+| Existing Vite/Tailwind pipeline | V2 styling and locally served runtime assets |
+
+## Information architecture
+
+Agents and Actions remain siblings under My Workspace's Automation group. Both
+collections offer search and explicit create, edit, and delete operations.
+Provided resources are distinguished from owned resources and cannot be edited
+through personal management.
+
+Call agent is an ordinary action type. It appears in the same collection and
+agent action picker as other tools. Choosing that type reveals its target-agent
+configuration; it does not create a separate navigation destination, list, or
+binding workflow.
+
+### Editor routes
+
+| Route | Purpose |
+| --- | --- |
+| `/v2/workspace/agents` | Agent collection |
+| `/v2/workspace/agents/new` | Create an agent |
+| `/v2/workspace/agents/<id>` | Edit an agent or view permitted provided details |
+| `/v2/workspace/actions` | Unified action collection |
+| `/v2/workspace/actions/new` | Choose a type and create an action |
+| `/v2/workspace/actions/<id>` | Edit an action or view permitted provided details |
+
+Each editor uses a full page with section navigation, persistent save controls,
+and one content scroll area. Sections are directly accessible instead of being
+mandatory wizard steps. Advanced configuration stays available without occupying
+the primary workflow.
+
+## Agent configuration
+
+The editor supports Local, Azure AI Foundry, New Foundry, and Foundry Workflow
+agents according to the existing personal-agent and governance policies.
+
+Local agents can configure identity, model connection, instructions, assigned
+knowledge, and approved actions. Capability overrides narrow the operations an
+individual agent can use. Foundry-managed agent types expose the relevant
+provider configuration instead of suggesting that local actions or instructions
+will change a remote agent.
+
+Assigned knowledge retains the existing source, tag, document, and active-document
+semantics. User-added context permissions and assigned URL review modes remain
+subject to server policy. Instruction drafting uses the selected action and
+knowledge context, including the existing `#action:` and `#knowledge:` grammar.
+
+Examples and approved templates are starting points for a draft, not permission
+grants. Applying a template does not run an action or copy another agent's
+credentials.
+
+## Action configuration
+
+The action type catalogue comes from the governed personal plugin discovery
+endpoint. A shared editor and type-specific configuration components cover the
+existing connector families, authentication modes, reusable identities, and
+supported discovery/connection-test commands.
+
+OpenAPI specifications and MCP discovery use the existing server APIs. Database,
+analytics, storage, search, application, and utility actions retain their
+type-specific configuration. Advanced metadata/additional fields remain available
+for supported custom configuration.
+
+OpenAPI import remains upload/content-based. Download a remotely hosted
+specification before importing it; the V2 editor does not restore the
+[deliberately removed URL import endpoints](../fixes/v0.241.001/OPENAPI_URL_IMPORT_REMOVAL_FIX.md).
+
+For Call agent, configuration is a stable target reference containing its ID and
+scope. Authentication uses the current user's permissions and the endpoint is
+internal. There is no credential or connection-test step. Saving the action
+does not invoke its target.
+
+## Connected editing
+
+An agent's action picker can open the normal New action page. The unfinished
+agent is retained in tab memory. Saving the action returns it to the agent draft
+as a selection; the agent is still unsaved until its own Save command.
+
+Ordinary navigation away from a dirty editor asks whether to discard the changes.
+Cancelled or failed saves leave the draft available. Drafts and credentials are
+not written to browser local/session storage and do not survive closing the tab.
+Reloading a dirty editor therefore requires confirmation rather than promising
+recovery that is not available.
+
+Unload protection also covers an agent draft suspended while creating an action
+and an action waiting to be attached on return. Save/return navigation markers
+are scoped to the originating editor; an older history entry cannot bypass a
+later editor's discard or saving guard.
+
+Use in chat opens a new personal V2 conversation with the authorized saved agent.
+It refreshes the permitted catalogue first; a failed refresh or revoked target is
+reported instead of using an old cached selection.
+It does not change the agent on an existing conversation. The selected agent
+supplies its own model; the launch does not send a competing model override.
+
+## API and persistence boundaries
+
+The native authoring client uses an opt-in `view=editor` representation of the
+existing personal resource APIs. Classic callers retain their existing contract.
+Editor details separate the persisted record from revision, read-only, and
+configured-secret metadata.
+
+Updates are per-record and carry changed fields instead of replacing the whole
+collection. Nested values, unresolved references, and unedited credentials are
+preserved. Explicit removal and secret-clear intent are distinct from leaving a
+field unchanged. Redaction markers are never credentials to be saved.
+
+Settings-derived editor options are narrowed and sanitized. Resource secret
+values are masked whether Key Vault storage is enabled or not. Scoped server-side
+authorization and validation remain authoritative even when the browser already
+hid a control.
+
+Conditional writes reject stale editor revisions rather than silently replacing
+another editor's configuration. The UI retains the unsaved draft when reporting
+a conflict.
+
+A lost write response can be retried by the storage SDK and then reported as a
+conflict even though the first attempt committed. Once a write has started,
+fresh credential references are retained conservatively rather than deleting a
+secret that a committed record may use. Classic agent cleanup reads the actual
+stored references, so it also works with credentials staged by the V2 editor.
+
+## File structure
+
+| Path | Responsibility |
+| --- | --- |
+| `application/v2_ui/src/pages/workspace/AgentsSection.tsx` | Personal agent collection |
+| `application/v2_ui/src/pages/workspace/ActionsSection.tsx` | Unified action collection |
+| `application/v2_ui/src/pages/workspace/AgentEditorPage.tsx` | Agent authoring page |
+| `application/v2_ui/src/pages/workspace/ActionEditorPage.tsx` | Action authoring page |
+| `application/v2_ui/src/components/workspace/WorkspaceEditorFrame.tsx` | Sections, save state, and navigation confirmation |
+| `application/v2_ui/src/lib/workspaceAuthoring.ts` | Typed records and changed-field serialization |
+| `application/v2_ui/src/lib/workspaceAuthoringApi.ts` | Editor API boundary |
+| `application/v2_ui/src/lib/workspaceEditorDrafts.ts` | Tab-memory draft handoff |
+| `application/v2_ui/src/lib/workspaceAgentLaunch.ts` | Scoped new-chat launch resolution |
+| `application/single_app/route_backend_agents.py` | Agent authoring route integration |
+| `application/single_app/route_backend_plugins.py` | Action authoring route integration |
+| `application/single_app/functions_workspace_authoring.py` | Safe editor projections, scoped updates, and conditional persistence |
+| `application/single_app/functions_personal_agents.py` | Classic reads and cleanup of actual stored credential references |
+
+## Testing and validation
+
+`functional_tests/test_v2_workspace_authoring_logic.mjs` executes the real
+changed-field serializer, secret intent, reference preservation, scoped agent
+launch, and URL-consumption helpers. Existing workspace, conversation-link,
+model/agent exclusivity, schema, knowledge, and delegation tests protect the
+shared behavior.
+
+`functional_tests/test_workspace_authoring_credential_compatibility.py` covers
+the installed Cosmos SDK's response-loss retry policy and V2-to-classic
+credential edit/delete compatibility. `ui_tests/test_v2_workspace_draft_navigation.py`
+covers historical save markers and unload protection across editor handoffs.
+
+Python Playwright coverage under `ui_tests/` exercises the real routed V2 editor
+with synthetic API fixtures and production CSS. It covers ordinary and Call agent
+workflows, draft handoff, navigation, visible failures, and responsive behavior
+without invoking live models or connectors. The existing Azure Playwright
+connection fixture supports a configured remote workspace or a local browser.
+
+Connector availability and successful connection tests still depend on deployment
+policy and the configured remote service. Tests of the editor do not imply that
+a particular deployment's connector credentials are valid.
+
+## Related
+
+- [My Workspace in V2](V2_MY_WORKSPACE.md)
+- [Workspace agent and action guide](../../guides/workspace-agents-and-actions.md)
+- [Call another agent](../../guides/call-another-agent.md)

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,24 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/features) and [Fixes by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/fixes).
 
+### **(v0.261.096)**
+
+#### User Interface Enhancements
+
+*   **Full-Page Agent And Action Editors In My Workspace**
+    *   Configure personal agents and actions directly in V2, with section navigation instead of popup wizards. Agent authoring includes model connections, knowledge, instructions, capabilities, and templates; action authoring includes the existing connector-specific configuration and authentication workflows.
+    *   **Call agent is a normal action type**, appearing alongside other tools in the Actions collection and the agent's action picker. There is no separate personal delegation section.
+    *   Create an action from an unfinished agent and return to the retained draft. Saving the action does not save the agent prematurely; leaving an unfinished editor asks before discarding changes.
+    *   Provided resources remain read-only, and existing authorized actions can be attached independently of permission to create new actions. Group and administrator management retain their existing interfaces.
+    *   (Ref: `AgentEditorPage.tsx`, `ActionEditorPage.tsx`, `WorkspaceEditorFrame.tsx`, [V2 Workspace Agent And Action Authoring](features/V2_WORKSPACE_AGENTS_ACTIONS.md))
+
+#### Bug Fixes
+
+*   **Workspace Edits Preserve Existing Configuration**
+    *   Per-record saves retain unedited nested settings, action references, and credentials. Stored secrets stay masked, explicit clearing is distinguished from keeping a value, and conflicting edits are reported rather than silently overwriting another session.
+    *   **Use in chat** refreshes the authorized agent catalogue before starting a new conversation with the chosen agent. Failed refreshes or unavailable agents do not retarget an existing conversation or substitute a manual model.
+    *   (Ref: `functions_workspace_authoring.py`, `workspaceAuthoring.ts`, `workspaceAuthoringApi.ts`, `workspaceEditorDrafts.ts`, `workspaceAgentLaunch.ts`)
+
 ### **(v0.261.095)**
 
 #### New Features

--- a/docs/guides/call-another-agent.md
+++ b/docs/guides/call-another-agent.md
@@ -4,7 +4,7 @@ title: "Call another agent"
 description: "Connect a coordinating agent to approved specialists without sharing its whole conversation."
 section: "Guides"
 audience: user
-version: "0.261.093"
+version: "0.261.096"
 ---
 
 ## What this does
@@ -47,19 +47,24 @@ citations when the target supplies them.
 In the **classic interface**, use the normal action wizard and the agent's
 **Actions** step in the personal workspace, group workspace, or admin area.
 
-In **V2**, personal Actions and Agents include focused delegation controls.
-The Groups page provides group selection and delegation management without
-switching the active workspace. The admin Agents & Actions area provides the
-equivalent controls for global agents. Other connector configuration and
-unrelated group management remain in their existing interfaces.
+In **V2 My Workspace**, choose Call agent through the ordinary **New action**
+flow, then attach it in the agent editor's **Actions** section. It shares the
+same list and picker as other action types. Full-page personal authoring was
+implemented in **0.261.096**, recorded in `application/single_app/config.py`;
+see the [workspace guide]({{ '/guides/workspace-agents-and-actions/' | relative_url }}).
+
+The Groups page still provides focused delegation management without switching
+the active workspace. The admin Agents & Actions area retains the equivalent
+controls for global agents. Broader group/global authoring is unchanged.
 
 Owned Call agent actions can also be deleted in V2 after confirmation. Deleting
 an action stops future calls through that action; it does not rewrite agents or
 roll back work the target already performed.
 
-V2 binding updates change only the selected Call agent actions. They preserve
-other attached actions, model settings, instructions, and assigned knowledge.
-If someone changes the agent while it is open, reload before saving again.
+The personal editor saves the configuration you changed and preserves unedited
+settings and references. The focused group/global binding controls change only
+the selected Call agent actions. If someone changes the agent while it is open,
+review the current configuration before saving again.
 
 ## Decide what to share
 

--- a/docs/guides/create-an-action.md
+++ b/docs/guides/create-an-action.md
@@ -4,6 +4,7 @@ title: "Create an action"
 description: "Create a reusable tool that an agent can call when chat alone is not enough."
 section: "Guides"
 audience: user
+version: "0.261.096"
 ---
 
 ## What this does
@@ -25,7 +26,15 @@ Use an action when a model needs to do more than write an answer, such as query 
 - Workspace actions require `per_user_semantic_kernel` when actions are personal or group scoped.
 - Have the OpenAPI file, endpoint, credential, reusable identity, or MCP server details required by the action type.
 
-## Steps
+## Personal actions in V2
+
+In V2, **My Workspace > Actions > New action** opens the native type chooser and
+full-page editor. Ordinary connectors and Call agent use this same workflow.
+See [Build agents and actions in My Workspace]({{ '/guides/workspace-agents-and-actions/' | relative_url }})
+for the native experience, implemented in **0.261.096** in
+`application/single_app/config.py`.
+
+## Classic interface steps
 
 1. Open **Personal Workspace** or the target **Group Workspace**.
 2. Choose **Your Actions** or the **Actions** tab.

--- a/docs/guides/create-an-agent-with-actions.md
+++ b/docs/guides/create-an-agent-with-actions.md
@@ -4,6 +4,7 @@ title: "Create an agent with actions"
 description: "Attach approved actions to an agent so it can use tools while answering."
 section: "Guides"
 audience: user
+version: "0.261.096"
 ---
 
 ## What this does
@@ -25,7 +26,19 @@ Binding an action to an agent turns a broad tool into a safer task assistant. Us
 - Create and test the action first.
 - Decide which capabilities the agent may use before attaching the action.
 
-## Steps
+## Personal agents in V2
+
+In the V2 agent editor, the **Actions** section uses one picker for ordinary
+connectors and Call agent actions. Review the selected action's capabilities in
+context. **New action** opens the normal action editor and returns to the
+retained agent draft after the action is saved; the attachment takes effect only
+when you save the agent.
+
+This workflow was implemented in **0.261.096**, recorded in
+`application/single_app/config.py`. See the [workspace guide]({{ '/guides/workspace-agents-and-actions/' | relative_url }})
+for navigation and unsaved-change behavior.
+
+## Classic interface steps
 
 1. Open the workspace that owns the agent.
 2. Open **Your Agents** or **Agents** and create or edit an agent.

--- a/docs/guides/create-an-agent.md
+++ b/docs/guides/create-an-agent.md
@@ -4,6 +4,7 @@ title: "Create an agent"
 description: "Build a reusable assistant with a clear role, model, knowledge, and instructions."
 section: "Guides"
 audience: user
+version: "0.261.096"
 ---
 
 ## What this does
@@ -25,7 +26,15 @@ Create an agent when a task benefits from consistent behavior, such as policy re
 - At least one GPT model endpoint must be configured; see [AI Models]({{ '/admin/ai-models/' | relative_url }}).
 - Upload and process workspace documents first if the agent should use assigned knowledge.
 
-## Steps
+## Personal agents in V2
+
+In V2, **My Workspace > Agents > New agent** opens a full-page editor. Use its
+sections to configure the model, approved actions, knowledge, and instructions
+without following a modal wizard. See [Build agents and actions in My Workspace]({{ '/guides/workspace-agents-and-actions/' | relative_url }})
+for the native workflow, implemented in **0.261.096** in
+`application/single_app/config.py`.
+
+## Classic interface steps
 
 1. Open **Personal Workspace** or the target **Group Workspace**.
 2. Choose **Your Agents** or the **Agents** tab.

--- a/docs/guides/workspace-agents-and-actions.md
+++ b/docs/guides/workspace-agents-and-actions.md
@@ -1,0 +1,123 @@
+---
+layout: page
+title: "Build agents and actions in My Workspace"
+description: "Configure a reusable assistant and its approved tools without leaving the V2 workspace."
+section: "Guides"
+audience: user
+version: "0.261.096"
+---
+
+## What this does
+
+Use **My Workspace > Agents** to give an assistant a lasting role, model, knowledge
+pool, and approved tools. Use **My Workspace > Actions** to configure those tools
+once and reuse them across agents. Both open full-page editors in V2 instead of
+the classic popup wizards.
+
+Implemented in version: **0.261.096**, recorded in
+`application/single_app/config.py`.
+
+This guide concerns your personal workspace. Group and administrator management
+continue to use their existing interfaces and permissions.
+
+## Decide what belongs where
+
+An agent describes a job, such as reviewing a contract against an approved policy.
+An action supplies a capability that the job needs, such as searching documents,
+querying a database, or calling a specialist agent.
+
+Keep connection and authentication details on the action. Explain when the tool
+should be used in the agent's instructions, and narrow the agent's action
+capabilities when it does not need every available operation.
+
+The available types depend on your administrator's configuration and governance
+policy. A provided resource may be usable without being yours to edit.
+
+## Configure an agent
+
+Start with **New agent**, or use an available example/template as a draft. Choose
+Local when SimpleChat should manage the instructions, knowledge, and actions.
+Choose a Foundry type when connecting a remote agent or workflow; controls explain
+which behavior remains managed in Foundry.
+
+Give the agent a recognizable display name and a description of its responsibility.
+Select a permitted model connection. Custom connection details and additional
+configuration are available without making them necessary for an ordinary agent.
+
+For a policy-bound assistant, use assigned knowledge to choose the source
+workspaces and then narrow that pool with tags or specific documents. Review
+the active documents rather than assuming that selecting a tag adds every file
+you expected. User-provided context and assigned URL review remain separate
+permissions.
+
+Write instructions that say when to use the selected actions and knowledge. The
+instruction-brief drafting command can help produce an initial draft; review it
+before saving. Action and knowledge references make those instructions more
+specific without expanding the agent's permissions.
+
+## Configure an action
+
+**New action** opens the normal type chooser. Select the tool the agent needs,
+then configure only the connection, authentication, and capability fields that
+apply to that type. For example, OpenAPI actions use a specification, while MCP
+actions can discover the server's available tools.
+
+If an OpenAPI specification is hosted at a URL, download it first and import its
+content. Direct URL import remains disabled; entering the API's base URL is not
+the same operation as downloading its specification.
+
+Use a saved reusable identity where appropriate. A field that reports a stored
+secret does not reveal its value; leave it unchanged to keep the credential,
+replace it deliberately, or use its explicit clear control.
+
+Connection tests and discovery are separate commands. Saving configuration
+does not run the action. If a test fails, resolve the connection or permission
+problem rather than assuming that a successful configuration save proves the
+remote service is reachable.
+
+## Connect the two without losing a draft
+
+An agent's **Actions** section lists all permitted action types together.
+Select an existing action and review its capabilities.
+
+If the needed action does not exist, choose **New action** from that section.
+The agent draft stays in this tab's memory while the action editor opens. After
+saving the new action, you return to the agent with that action selected.
+Save the agent separately to apply the attachment. Cancelling action creation
+does not save or replace the agent.
+
+**Call agent** follows this same flow. Choose it as an action type and select its
+target; then attach it like any other action. There is no separate Call agent
+management section. See [Call another agent]({{ '/guides/call-another-agent/' | relative_url }})
+for what context is shared and how nested calls are limited.
+
+## Save and use the agent
+
+Save explicitly when the configuration is ready. Navigation away from an
+unfinished editor asks before discarding changes. Failed saves keep the draft
+and explain the problem. If another editor changed the record, review the
+current configuration before retrying.
+
+Drafts are not browser backups: they are not stored across tab closure or reload.
+Keep the tab open when moving from an agent draft to action setup.
+
+After saving, **Use in chat** starts a new conversation with that agent. It does
+not change an existing conversation's agent or replace its model configuration
+with a manual model selection.
+
+## Troubleshooting
+
+| Symptom | What to do |
+| --- | --- |
+| An agent/action type is unavailable | Check the personal workspace and type-specific governance settings with an administrator. |
+| A resource says it is provided | Use it where permitted, but do not expect personal edit/delete controls. |
+| An attached resource becomes unavailable | Review the unresolved reference. An unrelated edit should not silently replace it with another resource of the same name. |
+| A Foundry agent has no local action controls | Configure tools in Foundry, or choose a Local agent for SimpleChat-managed actions. |
+| A save reports a conflict | Keep the draft available, reload/review the current record, and apply the intended changes against that revision. |
+
+## Related
+
+- [Create an agent]({{ '/guides/create-an-agent/' | relative_url }})
+- [Create an action]({{ '/guides/create-an-action/' | relative_url }})
+- [Create an agent with actions]({{ '/guides/create-an-agent-with-actions/' | relative_url }})
+- [Agents and Actions settings]({{ '/admin/agents-actions/' | relative_url }})

--- a/functional_tests/test_action_connection_test_secret_redaction.py
+++ b/functional_tests/test_action_connection_test_secret_redaction.py
@@ -1,8 +1,7 @@
-#!/usr/bin/env python3
 # test_action_connection_test_secret_redaction.py
 """
 Functional test for action connection test error sanitization.
-Version: 0.250.217
+Version: 0.261.096
 Implemented in: 0.250.217
 
 This test ensures that action Test Connection failures never echo stored
@@ -19,6 +18,7 @@ import os
 import sys
 import traceback
 import types
+from unittest.mock import patch
 
 
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -59,15 +59,16 @@ def _install_test_stubs():
 
 def _load_tester_module():
     """Load functions_action_connection_tests.py without the full app config."""
-    _install_test_stubs()
-    spec = importlib.util.spec_from_file_location("functions_action_connection_tests", TESTER_FILE)
-    if spec is None or spec.loader is None:
-        raise RuntimeError("Unable to load the action connection test module.")
+    with patch.dict(sys.modules):
+        _install_test_stubs()
+        spec = importlib.util.spec_from_file_location("functions_action_connection_tests", TESTER_FILE)
+        if spec is None or spec.loader is None:
+            raise RuntimeError("Unable to load the action connection test module.")
 
-    module = importlib.util.module_from_spec(spec)
-    sys.modules["functions_action_connection_tests"] = module
-    spec.loader.exec_module(module)
-    return module
+        module = importlib.util.module_from_spec(spec)
+        sys.modules["functions_action_connection_tests"] = module
+        spec.loader.exec_module(module)
+        return module
 
 
 def test_manifest_secrets_are_redacted():

--- a/functional_tests/test_action_workspace_identity_scoping.py
+++ b/functional_tests/test_action_workspace_identity_scoping.py
@@ -1,9 +1,8 @@
-#!/usr/bin/env python3
 # test_action_workspace_identity_scoping.py
 """
 Functional test for action workspace identity scoping.
-Version: 0.241.095
-Implemented in: 0.241.095
+Version: 0.261.096
+Implemented in: 0.241.095; 0.261.096
 
 This test ensures reusable workspace identities can be referenced by personal,
 group, and global actions without copying secrets, while public identities and
@@ -14,6 +13,7 @@ import ast
 import json
 import sys
 from pathlib import Path
+from typing import Any, Dict, List, Optional, Set
 from test_support.versioning import assert_app_version_at_least
 
 
@@ -62,9 +62,33 @@ def test_workspace_identity_action_helpers():
 
     assert "ACTION_IDENTITY_AUTH_TYPES" in identity_text
     assert "Public workspace identities cannot be used by actions" in identity_text
-    assert 'allowed_usage_contexts = {"action"}' in identity_text
-    assert 'allowed_usage_contexts = {"file_sync", "action"}' in identity_text
-    assert 'allowed_usage_contexts = {"file_sync"}' in identity_text
+    namespace = {"Any": Any, "Dict": Dict, "List": List, "Optional": Optional, "Set": Set}
+    selected = [
+        node for node in parsed.body
+        if (
+            isinstance(node, ast.Assign)
+            and any(
+                isinstance(target, ast.Name) and target.id.startswith(("WORKSPACE_IDENTITY_", "ACTION_IDENTITY_"))
+                for target in node.targets
+            )
+        ) or (
+            isinstance(node, ast.FunctionDef)
+            and node.name in {"_normalize_text", "_normalize_list", "identity_supports_usage"}
+        )
+    ]
+    exec(compile(ast.Module(body=selected, type_ignores=[]), "functions_workspace_identities.py", "exec"), namespace)
+    supports = namespace["identity_supports_usage"]
+    identity = {
+        "usage_contexts": ["action"], "supported_source_types": ["action"],
+        "auth": {"auth_type": "api_key"},
+    }
+    assert supports(identity, "action", source_type="action", auth_types=namespace["ACTION_IDENTITY_YAMCS_AUTH_TYPES"])
+    assert not supports(identity, "file_sync")
+    assert not supports(identity, "action", source_type="action", auth_types=namespace["ACTION_IDENTITY_SQL_AUTH_TYPES"])
+    identity["auth"]["auth_type"] = "username_password"
+    assert supports(identity, "action", source_type="action", auth_types=namespace["ACTION_IDENTITY_SQL_AUTH_TYPES"])
+    identity["auth"]["auth_type"] = "client_secret"
+    assert not supports(identity, "action", source_type="action", auth_types=namespace["ACTION_IDENTITY_SQL_AUTH_TYPES"])
 
 
 def test_action_storage_validates_and_hydrates_identities():

--- a/functional_tests/test_keyvault_plugin_secret_scope_enforcement.py
+++ b/functional_tests/test_keyvault_plugin_secret_scope_enforcement.py
@@ -1,8 +1,8 @@
 # test_keyvault_plugin_secret_scope_enforcement.py
 """
 Functional test for Key Vault plugin secret scope enforcement.
-Version: 0.250.121
-Implemented in: 0.241.011; 0.241.022; 0.250.121
+Version: 0.261.096
+Implemented in: 0.241.011; 0.241.022; 0.250.121; 0.261.096
 
 This test ensures plugin Key Vault references are validated against the
 expected scope and source before they are preserved, resolved, or deleted.
@@ -222,10 +222,11 @@ def test_sql_secret_resolution_helper_binds_expected_scope_and_source():
 
     namespace, _ = load_functions(
         PLUGIN_ROUTE_FILE,
-        {"_resolve_secret_value_for_sql_test"},
+        {"_resolve_secret_value_for_sql_test", "_resolve_secret_value_for_action_test"},
         {
             "validate_secret_name_dynamic": lambda value: True,
             "resolve_secret_reference_for_context": fake_resolver,
+            "ACTION_ADDITIONAL_SECRET_SOURCES": {"action-addset"},
         },
     )
 
@@ -242,6 +243,13 @@ def test_sql_secret_resolution_helper_binds_expected_scope_and_source():
     assert captured["scope"] == "user"
     assert captured["allowed_sources"] == {"action-addset"}
     assert captured["context_label"] == "SQL field 'connection_string'"
+
+    try:
+        resolve_sql_secret("***REDACTED***", "password", scope_value="user-123", scope="user")
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("An unhydrated editor mask must never reach a connection test.")
 
     print("✅ SQL test-connection secret resolution helper passed")
 

--- a/functional_tests/test_openapi_upload_only_flow.py
+++ b/functional_tests/test_openapi_upload_only_flow.py
@@ -1,18 +1,21 @@
-#!/usr/bin/env python3
 # test_openapi_upload_only_flow.py
 """
-Functional test for upload-only OpenAPI configuration flow.
-Version: 0.239.143
-Implemented in: 0.239.143
+Functional test for upload/content-only OpenAPI configuration.
+Version: 0.261.096
+Implemented in: 0.239.143; 0.261.096
 
-This test ensures the OpenAPI plugin flow no longer exposes backend URL import
-endpoints or legacy URL source handling, and continues to rely on uploaded spec
-content in the frontend configuration flow.
+Both interfaces import specification content through the existing upload route.
+Neither new URL endpoints nor a JSON URL branch on the upload route may restore
+the deliberately removed remote-specification fetch surface.
 """
 
 import sys
 from pathlib import Path
 
+from flask import Blueprint, Flask, jsonify, request
+
+from test_support.agent_delegation import execute_functions
+from test_support.versioning import assert_app_version_at_least
 
 ROOT = Path(__file__).resolve().parents[1]
 ROUTE_FILE = ROOT / 'application' / 'single_app' / 'route_openapi.py'
@@ -40,6 +43,8 @@ def test_openapi_upload_only_flow() -> bool:
     assert_contains(ROUTE_FILE, "@bp.route('/api/openapi/upload', methods=['POST'])")
     assert_not_contains(ROUTE_FILE, "/api/openapi/validate-url")
     assert_not_contains(ROUTE_FILE, "/api/openapi/download-from-url")
+    assert_not_contains(ROUTE_FILE, "_import_openapi_url_response")
+    assert_not_contains(ROUTE_FILE, "import_openapi_spec_url")
 
     assert_not_contains(SECURITY_FILE, 'def validate_url(')
     assert_not_contains(SECURITY_FILE, 'def validate_url_content(')
@@ -48,10 +53,32 @@ def test_openapi_upload_only_flow() -> bool:
     assert_not_contains(FACTORY_FILE, "source_type == 'url'")
     assert_contains(STEPPER_FILE, "throw new Error('Please upload an OpenAPI specification file')")
     assert_contains(STEPPER_FILE, "additionalFields.openapi_source_type = 'content';")
-    assert_contains(CONFIG_FILE, 'VERSION = "0.239.143"')
+    assert_app_version_at_least("0.239.143")
 
     print('OpenAPI upload-only flow checks passed!')
     return True
+
+
+def test_upload_route_does_not_fetch_a_json_specification_url():
+    """URL import cannot be hidden inside the otherwise supported upload route."""
+    namespace = {
+        "request": request,
+        "jsonify": jsonify,
+        "swagger_route": lambda **kwargs: lambda function: function,
+        "get_auth_security": lambda: [],
+        "login_required": lambda function: function,
+        "user_required": lambda function: function,
+    }
+    execute_functions("route_openapi.py", {"register_openapi_routes"}, namespace)
+    app = Flask("openapi_upload_only")
+    blueprint = Blueprint("openapi_upload_only", __name__)
+    namespace["register_openapi_routes"](blueprint)
+    app.register_blueprint(blueprint)
+    with app.test_request_context("/api/openapi/upload", method="POST", json={"url": "https://example.invalid/spec.json"}):
+        response = app.full_dispatch_request()
+    assert response.status_code == 400
+    assert response.get_json()["success"] is False
+    assert "file" in response.get_json()["error"].lower()
 
 
 if __name__ == '__main__':

--- a/functional_tests/test_v2_bootstrap_refresh_logic.mjs
+++ b/functional_tests/test_v2_bootstrap_refresh_logic.mjs
@@ -1,8 +1,9 @@
 // test_v2_bootstrap_refresh_logic.mjs
 //
 // Runtime test for the V2 bootstrap store's refresh action.
-// Version: 0.261.046
+// Version: 0.261.096
 // Implemented in: 0.261.046
+// Required authoring selection refresh added in: 0.261.096
 //
 // The companion test, test_v2_admin_settings_live_shell_refresh.py, asserts that the pieces
 // are wired together. Those are source assertions: they prove the call exists, not that it
@@ -261,12 +262,54 @@ async function testAStaleRefreshCannotOverwriteANewerOne() {
     console.log('Refresh ordering test passed!');
 }
 
+async function testRequiredRefreshReturnsFreshDataWithoutBlanking() {
+    await loadWith(BANNER_OFF);
+    const fresh = payloadWithBanner(BANNER_ON);
+    fresh.catalogs = { agents: [{ id: 'authorized', scope_type: 'personal' }] };
+    fetchImpl = async () => jsonResponse(fresh);
+    let result;
+    const states = await recordStates(async () => {
+        result = await useBootstrapStore.getState().refreshRequired();
+    });
+    assert.equal(result, fresh);
+    assert.equal(useBootstrapStore.getState().data, fresh);
+    assert.ok(states.every((state) => !state.loading && !state.error));
+}
+
+async function testRequiredRefreshRejectsInsteadOfReturningCachedAgents() {
+    const previous = (await loadWith(BANNER_ON)).data;
+    fetchImpl = async () => jsonResponse({ error: 'Unavailable' }, 503);
+    await assert.rejects(useBootstrapStore.getState().refreshRequired(), /Unavailable/);
+    assert.equal(useBootstrapStore.getState().data, previous);
+    fetchImpl = async () => { throw new TypeError('Network unavailable'); };
+    await assert.rejects(useBootstrapStore.getState().refreshRequired(), /Network unavailable/);
+    assert.equal(useBootstrapStore.getState().data, previous);
+    assert.equal(useBootstrapStore.getState().error, null);
+}
+
+async function testSupersededRequiredRefreshCannotAuthorizeFromAnOlderResult() {
+    await loadWith(BANNER_OFF);
+    let release;
+    fetchImpl = () => new Promise((resolve) => { release = resolve; });
+    const requested = useBootstrapStore.getState().refreshRequired();
+    const latest = payloadWithBanner(BANNER_ON);
+    latest.catalogs = { agents: [] };
+    fetchImpl = async () => jsonResponse(latest);
+    await useBootstrapStore.getState().refresh();
+    release(jsonResponse(payloadWithBanner(BANNER_OFF)));
+    await assert.rejects(requested, /availability changed during refresh/);
+    assert.equal(useBootstrapStore.getState().data, latest);
+}
+
 const tests = [
     testRefreshAppliesTheNewPayload,
     testRefreshNeverBlanksTheInterface,
     testAFailedRefreshIsAdvisory,
     testARejectedRefreshDoesNotEscape,
     testAStaleRefreshCannotOverwriteANewerOne,
+    testRequiredRefreshReturnsFreshDataWithoutBlanking,
+    testRequiredRefreshRejectsInsteadOfReturningCachedAgents,
+    testSupersededRequiredRefreshCannotAuthorizeFromAnOlderResult,
 ];
 
 let passed = 0;

--- a/functional_tests/test_v2_conversation_deep_link.py
+++ b/functional_tests/test_v2_conversation_deep_link.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
+# test_v2_conversation_deep_link.py
 """
 Functional test for conversation deep linking in the V2 interface.
 
-Version: 0.261.043
+Version: 0.261.096
 Implemented in: 0.261.032
 Kind resolution moved to a single endpoint in: 0.261.043
+Workspace agent launch coordination added in: 0.261.096
 
 The classic interface has supported linking straight to a conversation since v0.237.001:
 chat-onload.js reads ?conversationId= (or the older ?conversation_id=) on load, and
@@ -123,8 +125,8 @@ def test_incoming_link_is_captured_before_any_effect_runs():
     # Consumed once. Without the guard, returning to the chat page would re-open the
     # conversation and discard a running stream.
     assert "linkHandled" in hook_body, "The link must be consumed exactly once"
-    assert "if (!linkHandled) {" in hook_body, (
-        "The write must wait for the read, or the parameter is cleared before it is used"
+    assert "if (!linkHandled || !agentLaunchHandled) {" in hook_body, (
+        "The write must wait for both conversation and agent launch reads"
     )
     assert "useChatStore.getState().activeConversationId" in hook_body, (
         "The already-open conversation must not be re-opened"

--- a/functional_tests/test_v2_workspace_action_authoring_logic.mjs
+++ b/functional_tests/test_v2_workspace_action_authoring_logic.mjs
@@ -1,0 +1,967 @@
+// test_v2_workspace_action_authoring_logic.mjs
+// Version: 0.261.096
+// Implemented in: 0.261.096
+// Executes the real native registry, schema/defaults, draft, identity, and connector API logic.
+
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import vm from 'node:vm';
+import { fileURLToPath } from 'node:url';
+import ts from '../application/v2_ui/node_modules/typescript/lib/typescript.js';
+import './test_support/tsResolve.mjs';
+
+const {
+    actionApiErrors, actionArrayRemovalError, actionAuthMethod, actionAuthModes, actionCanEdit, actionDetailPath,
+    actionFieldError, actionForSave, actionHasStoredArraySecrets,
+    actionResourceKey, actionSchemaDefaults, actionScope, actionTypeLabel, actionValueAt,
+    changeActionAuth, changeActionDisplayName, changeActionField, changeActionType,
+    changeSqlConnectionMethod, createActionDraft, deriveBlobEndpoint, displayedActionValue, expandActionFieldErrors, filterAuthoringActions,
+    hasUsableActionRevision, resolveActionSchema, selectActionIdentity, validateActionDraft, validateActionSchema, withActionValue,
+} = await import('../application/v2_ui/src/lib/workspaceActionLogic.ts');
+const {
+    BLOB_ACTION_CAPABILITIES, NATIVE_ACTION_TYPES, nativeActionDefinition, sqlConnectionMethod, usesDirectBlobConnectionString,
+} = await import('../application/v2_ui/src/lib/workspaceActionRegistry.ts');
+const {
+    buildActionConnectionPayload, fetchActionEditorHints, fetchActionIdentities, testWorkspaceAction, validateWorkspaceAction,
+} = await import('../application/v2_ui/src/lib/workspaceActionServices.ts');
+const {
+    buildEditorWrite, EDITOR_SECRET_MASK,
+} = await import('../application/v2_ui/src/lib/workspaceAuthoring.ts');
+const { ApiError } = await import('../application/v2_ui/src/lib/apiClient.ts');
+const { fetchActionEditor, fetchAuthoringActions } = await import('../application/v2_ui/src/lib/workspaceAuthoringApi.ts');
+const {
+    applyOpenApiSpecification, validateConnectorAuthentication, validateConnectorConfiguration,
+} = await import('../application/v2_ui/src/lib/workspaceActionConnectors.ts');
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const schemas = path.join(root, 'application', 'single_app', 'static', 'json', 'schemas');
+const baseAuth = JSON.parse(fs.readFileSync(path.join(schemas, 'plugin.schema.json'), 'utf8')).definitions.AuthType.enum;
+const readSchema = (name) => {
+    const location = path.join(schemas, name);
+    return fs.existsSync(location) ? JSON.parse(fs.readFileSync(location, 'utf8')) : {};
+};
+function definition(type, extra = {}) {
+    const normalized = type.replace(/[^a-zA-Z0-9_]/g, '_').toLowerCase();
+    return {
+        type, display: actionTypeLabel(type), description: `Fixture for ${type}`,
+        allowed_auth_types: readSchema(`${normalized}.definition.json`).allowedAuthTypes || baseAuth,
+        additional_fields_schema: readSchema(`${normalized}_plugin.additional_settings.schema.json`),
+        metadata_schema: readSchema(`${normalized}_plugin.metadata.schema.json`),
+        ...extra,
+    };
+}
+function action(type = 'sql_query') {
+    let result = changeActionType(createActionDraft(), definition(type));
+    result = { ...result, id: `owned-${type}`, name: `test_${type}`, displayName: `Test ${type}`, description: 'A synthetic action.' };
+    for (const descriptor of nativeActionDefinition(type).fields) {
+        if (!descriptor.required || descriptor.visible && !descriptor.visible(result)) continue;
+        const existing = actionValueAt(result, descriptor.path);
+        if (existing !== undefined && existing !== '') continue;
+        const value = descriptor.kind === 'select' ? descriptor.options[0].value :
+            descriptor.kind === 'number' ? descriptor.min ?? 1 :
+                descriptor.path === '/endpoint' ? 'https://connector.example.test' :
+                    descriptor.path.endsWith('partition_key_path') ? '/tenantId' : 'fixture';
+        result = changeActionField(result, descriptor.path, value);
+    }
+    if (type === 'agent') result.additionalFields.target_agent = { id: 'target-1', scope_type: 'personal', scope_id: 'user-fixture' };
+    if (type === 'sql_query' || type === 'sql_schema') {
+        result.additionalFields.username = 'fixture-user';
+        result.additionalFields.password = 'fixture-password';
+    }
+    if (['key', 'connection_string', 'username_password', 'servicePrincipal', 'basic'].includes(result.auth.type)) result.auth.key = 'fixture-secret';
+    if (['username_password', 'servicePrincipal', 'basic'].includes(result.auth.type)) result.auth.identity = 'fixture-user';
+    if (result.auth.type === 'servicePrincipal') result.auth.tenantId = 'fixture-tenant';
+    if (type === 'tableau') {
+        result.auth.identity = 'fixture-token-name';
+        result.additionalFields.pat_name = 'fixture-token-name';
+    }
+    if (type === 'snowflake') result.additionalFields.user = result.auth.identity;
+    if (type === 'blob_storage') {
+        result.auth.key = 'AccountName=fixtureaccount;AccountKey=fixture-key;EndpointSuffix=core.windows.net';
+        result.endpoint = deriveBlobEndpoint(result.auth.key);
+    }
+    if (type === 'ui_test') {
+        result.additionalFields.string = 'fixture';
+        result.additionalFields.string__Secret = 'fixture-secret';
+        result.additionalFields.enum = 'bob';
+    }
+    return result;
+}
+function resource(record, secret_paths = []) {
+    return { record: structuredClone(record), revision: 'opaque-fixture-revision', secret_paths, read_only: false };
+}
+let checks = 0;
+function check(label, run) {
+    run();
+    checks += 1;
+    console.log(`ok ${label}`);
+}
+async function asyncCheck(label, run) {
+    await run();
+    checks += 1;
+    console.log(`ok ${label}`);
+}
+
+check('native registry covers every shipped action module, not a small creation whitelist', () => {
+    const pluginDirectory = path.join(root, 'application', 'single_app', 'semantic_kernel_plugins');
+    const shipped = fs.readdirSync(pluginDirectory).filter((name) => name.endsWith('_plugin.py') && name !== 'base_plugin.py');
+    for (const filename of shipped) assert.ok(NATIVE_ACTION_TYPES[filename.replace('_plugin.py', '')], filename);
+    assert.ok(shipped.length >= 29);
+});
+
+check('all current native types support an immutable edit round trip without losing unknown fields', () => {
+    for (const type of Object.keys(NATIVE_ACTION_TYPES)) {
+        const original = action(type);
+        original.additionalFields.future_settings = { enabled: false, retries: 0, list: [] };
+        original.metadata.future_metadata = { enabled: false, value: '' };
+        original.future_root = { preserved: true };
+        const before = resource(original);
+        const edited = { ...structuredClone(original), description: 'Updated description.' };
+        const write = buildEditorWrite(actionForSave(edited), before);
+        assert.deepEqual(write.updates, { description: 'Updated description.' }, `${type}: unexpected unrelated edits`);
+        assert.deepEqual(write.clear_secret_paths, []);
+        assert.deepEqual(write.removed_paths, []);
+        assert.deepEqual(before.record, original, `${type}: original mutated`);
+    }
+});
+
+check('every native descriptor family produces a valid configured draft using the canonical schemas', () => {
+    for (const type of Object.keys(NATIVE_ACTION_TYPES)) {
+        if (['openapi', 'mcp'].includes(type)) continue;
+        const configured = action(type);
+        const errors = validateActionDraft(configured, definition(type));
+        assert.deepEqual(errors, {}, `${type}: ${JSON.stringify(errors)}`);
+    }
+});
+check('internal utilities have usable manifest markers without requiring a pretend remote endpoint', () => {
+    for (const type of ['smart_http', 'http', 'text', 'math', 'time', 'wait', 'fact_memory', 'tabular_processing']) {
+        const draft = changeActionDisplayName(changeActionType(createActionDraft(), definition(type)), `Fixture ${type}`, true);
+        assert.equal(draft.endpoint, `internal://${type}`);
+        assert.equal(draft.auth.type, 'NoAuth');
+        assert.deepEqual(validateActionDraft(draft, definition(type)), {});
+        assert.equal(nativeActionDefinition(type).testPath, undefined);
+    }
+});
+
+check('schema defaults retain false zero empty arrays and empty strings but never help text', () => {
+    const schema = { type: 'object', properties: {
+        enabled: { type: 'boolean', default: false },
+        attempts: { type: 'integer', default: 0 },
+        label: { type: 'string', default: '' },
+        names: { type: 'array', default: [] },
+        note: { type: 'string', description: 'Put your API key here.' },
+        mode: { type: 'string', enum: ['a', 'b'], description: 'a | b' },
+        wrongMode: { type: 'string', enum: ['a', 'b'], default: 'a | b' },
+        wrongType: { type: 'integer', default: '20' },
+        fractional: { type: 'integer', default: 1.5 },
+        nested: { type: 'object', properties: { zero: { type: 'number', default: 0 } } },
+    } };
+    assert.deepEqual(actionSchemaDefaults(schema), { enabled: false, attempts: 0, label: '', names: [], nested: { zero: 0 } });
+});
+
+check('new custom types use their governed catalogue and nested native schema fields', () => {
+    const custom = definition('installed_connector', {
+        allowed_auth_types: ['username_password'],
+        additional_fields_schema: { type: 'object', properties: {
+            mode: { type: 'string', enum: ['safe', 'fast'], default: 'safe' },
+            configured: { type: 'boolean', default: false },
+            retry: { type: 'integer', default: 0 },
+        } },
+        metadata_schema: { type: 'object', properties: { source: { type: 'string', default: 'custom' } } },
+    });
+    check('prototype-like installed type names still use the generic native editor', () => {
+        for (const type of ['constructor', '__proto__', 'toString']) {
+            const custom = definition(type, { allowed_auth_types: ['NoAuth'] });
+            const draft = changeActionType(createActionDraft(), custom);
+            assert.ok(nativeActionDefinition(type).fields.some((field) => field.path === '/endpoint'));
+            assert.equal(changeActionField(draft, '/endpoint', 'https://fixture.example.test').additionalFields['[object Object]'], undefined);
+            assert.deepEqual(actionAuthModes(type, ['NoAuth']), [{ value: 'NoAuth', label: 'No authentication', authType: 'NoAuth' }]);
+        }
+    });
+    const draft = changeActionType(createActionDraft(), custom);
+    assert.equal(draft.type, 'installed_connector');
+    assert.equal(draft.auth.type, 'username_password');
+    assert.deepEqual(draft.additionalFields, { mode: 'safe', configured: false, retry: 0 });
+    assert.equal(draft.metadata.source, 'custom');
+    assert.ok(nativeActionDefinition(custom.type).fields.some((field) => field.path === '/endpoint'));
+});
+
+check('local schema references and composed property defaults are resolved without network calls', () => {
+    const schema = {
+        $ref: '#/definitions/config',
+        definitions: { config: { type: 'object', allOf: [
+            { properties: { one: { type: 'integer', default: 1 } }, required: ['one'] },
+            { properties: { two: { type: 'boolean', default: false } } },
+        ] } },
+    };
+    assert.deepEqual(actionSchemaDefaults(schema), { one: 1, two: false });
+    assert.equal(resolveActionSchema(schema).type, 'object');
+    assert.ok(validateActionSchema({}, schema)['/one']);
+});
+
+check('typed validation rejects pipe enums numeric strings fractional integers and limits', () => {
+    const invalid = { type: 'object', required: ['required'], properties: {
+        mode: { enum: ['a', 'b'] }, limit: { type: 'integer', minimum: 1, maximum: 5 },
+        number: { type: 'number' }, items: { type: 'array', minItems: 1, items: { type: 'boolean' } },
+    } };
+    const errors = validateActionSchema({ mode: 'a|b', limit: 1.25, number: '0', items: [] }, invalid, '/additionalFields');
+    for (const key of ['required', 'mode', 'limit', 'number', 'items']) assert.ok(errors[`/additionalFields/${key}`], key);
+    assert.deepEqual(validateActionSchema({ number: 0, enabled: false, custom: 1 }, { type: 'object', properties: {
+        number: { type: 'number' }, enabled: { type: 'boolean' },
+    }, additionalProperties: false }), {}, 'unknown persisted values remain for authoritative server validation');
+});
+check('conditional schemas do not initialize forbidden inactive defaults and still validate branches', () => {
+    const schema = readSchema('ui_test_plugin.additional_settings.schema.json');
+    const defaults = actionSchemaDefaults(schema);
+    assert.equal(defaults.boolean, false);
+    assert.equal(defaults.number, undefined);
+    assert.equal(defaults.integer, undefined);
+    const valid = { ...defaults, string: 'fixture', string__Secret: 'fixture-secret', enum: 'bob' };
+    assert.deepEqual(validateActionSchema(valid, schema), {});
+    assert.ok(validateActionSchema({ ...valid, boolean: true }, schema)['/number']);
+    assert.ok(validateActionSchema({ ...valid, number: 10, integer: 5 }, schema)['']);
+    assert.ok(validateActionSchema('c', { anyOf: [{ const: 'a' }, { const: 'b' }] })['']);
+});
+
+check('JSON-pointer field editing preserves escaped names arrays and prototype-like data', () => {
+    const original = JSON.parse('{"additionalFields":{"__proto__":{"safe":1},"a/b~c":{"nested.value":0},"items":[{"keep":false}]},"metadata":{"keep":true}}');
+    const edited = withActionValue(original, '/additionalFields/a~1b~0c/nested.value', false);
+    const prototype = withActionValue(edited, '/additionalFields/__proto__/new', 'data');
+    assert.equal(actionValueAt(prototype, '/additionalFields/a~1b~0c/nested.value'), false);
+    assert.equal(actionValueAt(prototype, '/additionalFields/__proto__/safe'), 1);
+    assert.equal(Object.getPrototypeOf(prototype.additionalFields), Object.prototype);
+    assert.equal(Object.prototype.new, undefined);
+    assert.equal(original.additionalFields['a/b~c']['nested.value'], 0);
+    const removed = withActionValue(prototype, '/additionalFields/items/0', undefined);
+    assert.deepEqual(removed.additionalFields.items, []);
+    assert.deepEqual(removed.metadata, { keep: true });
+});
+check('array removals never shift later masked credentials to another stored position', () => {
+    const draft = action('databricks');
+    draft.additionalFields['accounts/list'] = [
+        { label: 'First', password: EDITOR_SECRET_MASK },
+        { label: 'Second', nested: [{ token: EDITOR_SECRET_MASK, unknown: 0 }] },
+    ];
+    const original = resource(draft, [
+        '/additionalFields/accounts~1list/0/password',
+        '/additionalFields/accounts~1list/1/nested/0/token',
+    ]);
+    assert.match(actionArrayRemovalError(draft, original, '/additionalFields/accounts~1list', 0), /different positions/);
+    assert.equal(actionArrayRemovalError(draft, original, '/additionalFields/accounts~1list', 1), null);
+    const replaced = withActionValue(draft, '/additionalFields/accounts~1list/1/nested/0/token', 'replacement-fixture');
+    assert.equal(actionArrayRemovalError(replaced, original, '/additionalFields/accounts~1list', 0), null);
+    const cleared = withActionValue(draft, '/additionalFields/accounts~1list/1/nested/0/token', '');
+    assert.equal(actionArrayRemovalError(cleared, original, '/additionalFields/accounts~1list', 0), null);
+    assert.match(actionArrayRemovalError(draft, original, '/additionalFields/accounts~1list', 3), /no longer available/);
+    assert.equal(original.record.additionalFields['accounts/list'][1].nested[0].unknown, 0);
+    assert.equal(draft.additionalFields['accounts/list'][1].nested[0].token, EDITOR_SECRET_MASK);
+});
+check('bulk JSON protection is scoped to arrays containing actual owned stored credentials', () => {
+    const draft = action('databricks');
+    draft.additionalFields.connections = [{ nested: [{ token: EDITOR_SECRET_MASK }] }];
+    draft.metadata.example_strings = [EDITOR_SECRET_MASK];
+    const secretPath = '/additionalFields/connections/0/nested/0/token';
+    const original = resource(draft, [secretPath]);
+    assert.equal(actionHasStoredArraySecrets(draft, original, '/additionalFields'), true);
+    assert.equal(actionHasStoredArraySecrets(draft, original, '/additionalFields/connections'), true);
+    assert.equal(actionHasStoredArraySecrets(draft, original, '/additionalFields/connections/0'), true);
+    assert.equal(actionHasStoredArraySecrets(draft, original, '/additionalFields/connections/0/nested/0'), false);
+    assert.equal(actionHasStoredArraySecrets(draft, original, '/metadata'), false, 'ordinary literal masks are not credential bindings');
+    assert.equal(actionHasStoredArraySecrets(draft, null, '/additionalFields'), false);
+    assert.equal(actionHasStoredArraySecrets(withActionValue(draft, secretPath, 'replacement'), original, '/additionalFields'), false);
+    assert.equal(actionHasStoredArraySecrets(withActionValue(draft, secretPath, null), original, '/additionalFields'), false);
+});
+check('action array edits emit explicit positional clears through the updated shared serializer', () => {
+    const draft = action('databricks');
+    draft.additionalFields['credentials/list~typed'] = [
+        { credential__Secret: EDITOR_SECRET_MASK, keep: 0, enabled: false, labels: [] },
+        { token: EDITOR_SECRET_MASK },
+    ];
+    const arrayPath = '/additionalFields/credentials~1list~0typed';
+    const firstPath = `${arrayPath}/0/credential__Secret`;
+    const secondPath = `${arrayPath}/1/token`;
+    const original = resource(draft, [firstPath, secondPath, firstPath]);
+    for (const value of ['', null, undefined]) {
+        const changed = withActionValue(draft, firstPath, value);
+        const write = buildEditorWrite(changed, original);
+        assert.deepEqual(write.clear_secret_paths, [firstPath]);
+        assert.equal(write.updates.additionalFields['credentials/list~typed'][0].keep, 0);
+        assert.equal(write.updates.additionalFields['credentials/list~typed'][0].enabled, false);
+        assert.deepEqual(write.updates.additionalFields['credentials/list~typed'][0].labels, []);
+        assert.equal(write.updates.additionalFields['credentials/list~typed'][1].token, EDITOR_SECRET_MASK);
+    }
+    const removeLast = withActionValue(draft, `${arrayPath}/1`, undefined);
+    assert.equal(actionArrayRemovalError(draft, original, arrayPath, 1), null);
+    assert.deepEqual(buildEditorWrite(removeLast, original).clear_secret_paths, [secondPath]);
+    const removeParent = withActionValue(draft, arrayPath, undefined);
+    const parentWrite = buildEditorWrite(removeParent, original);
+    assert.deepEqual(new Set(parentWrite.clear_secret_paths), new Set([firstPath, secondPath]));
+    assert.ok(parentWrite.removed_paths.includes(arrayPath));
+    assert.deepEqual(buildEditorWrite(draft, original).clear_secret_paths, []);
+    assert.deepEqual(buildEditorWrite(withActionValue(draft, firstPath, 'replacement-fixture'), original).clear_secret_paths, []);
+    assert.equal(draft.additionalFields['credentials/list~typed'][0].credential__Secret, EDITOR_SECRET_MASK);
+});
+
+check('switching type retains per-type drafts but does not pass foreign credentials into Call agent', () => {
+    const original = action('cosmos_query');
+    original.auth = { type: 'key', key: EDITOR_SECRET_MASK };
+    original.additionalFields.custom_secret__Secret = EDITOR_SECRET_MASK;
+    original.metadata.keep = { value: false };
+    const agent = changeActionType(original, definition('agent'));
+    assert.deepEqual(agent.auth, { type: 'user' });
+    assert.deepEqual(agent.additionalFields, {});
+    assert.equal(agent.endpoint, 'internal://agent');
+    assert.equal(agent.identity_id, '');
+    assert.deepEqual(agent.metadata.keep, { value: false });
+    const returned = changeActionType(agent, definition('cosmos_query'));
+    assert.deepEqual(returned.additionalFields, original.additionalFields);
+    assert.deepEqual(returned.auth, original.auth);
+    assert.equal(returned.id, original.id);
+    const write = buildEditorWrite(agent, resource(original, ['/auth/key', '/additionalFields/custom_secret__Secret']));
+    assert.ok(!JSON.stringify(write).includes('_actionTypeConfigurations'));
+    assert.ok(!JSON.stringify(write.updates).includes(EDITOR_SECRET_MASK));
+});
+
+check('display-name changes derive new machine names without rewriting explicitly chosen or saved names', () => {
+    let draft = changeActionDisplayName(createActionDraft(), 'Action One', true);
+    assert.equal(draft.name, 'Action-One');
+    draft = changeActionDisplayName(draft, 'Action Two', true);
+    assert.equal(draft.name, 'Action-Two');
+    assert.equal(changeActionDisplayName({ ...draft, name: 'explicit' }, 'Three', true).name, 'explicit');
+    assert.equal(changeActionDisplayName(draft, 'Renamed later', false).name, 'Action-Two');
+});
+check('raw legacy records without optional displayName remain editable without renaming their machine identity', () => {
+    const legacy = action('databricks');
+    delete legacy.displayName;
+    const original = resource(legacy);
+    const prepared = actionForSave({ ...legacy, description: 'Edited legacy description.' });
+    assert.equal(prepared.displayName, legacy.name);
+    assert.equal(prepared.name, legacy.name);
+    assert.equal(prepared.id, legacy.id);
+    assert.deepEqual(validateActionDraft(prepared, definition(legacy.type), original), {});
+    assert.deepEqual(buildEditorWrite(prepared, original).updates, {
+        description: 'Edited legacy description.', displayName: legacy.name,
+    });
+    assert.equal(changeActionDisplayName(legacy, 'Readable label', false).name, legacy.name);
+    assert.ok(validateActionDraft({ ...legacy, displayName: '' }, definition(legacy.type))['/displayName']);
+    assert.ok(validateActionDraft({ ...legacy, name: undefined }, definition(legacy.type))['/name']);
+});
+
+check('native authentication methods are constrained by backend definitions and preserve hidden siblings', () => {
+    for (const type of Object.keys(NATIVE_ACTION_TYPES)) {
+        const allowed = definition(type).allowed_auth_types;
+        const choices = actionAuthModes(type, allowed);
+        for (const choice of choices) {
+            assert.ok(allowed.includes(choice.authType), `${type}/${choice.value}`);
+            const original = action(type);
+            original.auth.hidden = { keep: 0 };
+            original.additionalFields.hidden = { keep: false };
+            const next = changeActionAuth(original, choice);
+            assert.equal(next.auth.type, choice.authType);
+            assert.deepEqual(next.auth.hidden, { keep: 0 });
+            assert.deepEqual(next.additionalFields.hidden, { keep: false });
+        }
+    }
+    assert.equal(actionAuthMethod(changeActionAuth(action('rocksdb'), { value: 'api_key', label: 'API key', authType: 'key' })), 'api_key');
+});
+
+check('reusable identities keep stable IDs and do not copy credential-bearing data', () => {
+    const original = action('snowflake');
+    original.additionalFields.unknown = { keep: false };
+    const selected = selectActionIdentity(original, {
+        id: 'identity-2', name: 'Duplicate display name', auth_type: 'api_key', credentials: { key: 'must-not-copy' },
+    });
+    assert.equal(selected.identity_id, 'identity-2');
+    assert.equal(selected.auth.identity, 'identity-2');
+    assert.equal(selected.additionalFields.auth_method, 'key_pair');
+    assert.equal(selected.additionalFields.identity_auth_type, 'api_key');
+    assert.deepEqual(selected.additionalFields.unknown, { keep: false });
+    assert.ok(!JSON.stringify(selected).includes('must-not-copy'));
+    assert.throws(() => selectActionIdentity(action('cosmos_query'), { id: 'x', name: 'x', auth_type: 'api_key' }));
+    const unavailable = { ...original, identity_id: 'revoked-id' };
+    assert.equal(changeActionField(unavailable, '/description', 'Only changed description').identity_id, 'revoked-id');
+});
+
+check('SQL modes explicitly clear only the connection string while preserving parameters and nested values', () => {
+    const original = action('sql_query');
+    original.additionalFields.connection_string = EDITOR_SECRET_MASK;
+    original.additionalFields.server = 'database.example.test';
+    original.additionalFields.custom = { keep: 0 };
+    assert.equal(sqlConnectionMethod(original), 'connection_string');
+    const changed = changeSqlConnectionMethod(original, 'parameters');
+    assert.equal(sqlConnectionMethod(changed), 'parameters');
+    assert.equal(changed.additionalFields.connection_string, undefined);
+    assert.equal(changed.additionalFields.server, 'database.example.test');
+    assert.deepEqual(changed.additionalFields.custom, { keep: 0 });
+    assert.deepEqual(buildEditorWrite(changed, resource(original, ['/additionalFields/connection_string'])).clear_secret_paths, ['/additionalFields/connection_string']);
+    const identity = selectActionIdentity(changed, { id: 'db-identity', name: 'Database', auth_type: 'connection_string' });
+    assert.equal(sqlConnectionMethod(identity), 'connection_string');
+    assert.equal(identity.additionalFields.identity_uses_connection_string, true);
+});
+
+check('endpoint changes synchronize only the connector aliases that runtime reads', () => {
+    for (const [type, alias] of Object.entries({ databricks: 'workspace_url', databricks_table: 'workspace_url', tableau: 'server_url', yamcs: 'server_url', rocksdb: 'base_url', openapi: 'base_url' })) {
+        const original = action(type);
+        original.additionalFields.keep = { enabled: false };
+        const changed = changeActionField(original, '/endpoint', 'https://new.example.test');
+        assert.equal(changed.additionalFields[alias], changed.endpoint);
+        assert.deepEqual(changed.additionalFields.keep, { enabled: false });
+    }
+    const log = action('log_analytics');
+    log.additionalFields.authorityHost = 'https://old.example.test';
+    log.additionalFields.endpointOverride = 'https://old-api.example.test';
+    log.additionalFields.query_history = [{ query: 'SyntheticTable | take 1' }];
+    const government = changeActionField(log, '/additionalFields/cloud', 'usgovernment');
+    assert.equal(government.endpoint, 'https://api.loganalytics.us');
+    assert.equal(government.additionalFields.authorityHost, undefined);
+    assert.deepEqual(government.additionalFields.query_history, log.additionalFields.query_history);
+});
+check('legacy endpoint schema and username aliases display without rewriting unrelated fields', () => {
+    const databricks = action('databricks');
+    databricks.endpoint = '';
+    databricks.additionalFields.workspace_url = 'https://legacy.example.test';
+    databricks.additionalFields.database = 'legacy-schema';
+    delete databricks.additionalFields.schema;
+    assert.equal(displayedActionValue(databricks, '/endpoint'), 'https://legacy.example.test');
+    assert.equal(displayedActionValue(databricks, '/additionalFields/schema'), 'legacy-schema');
+    assert.equal(actionForSave(databricks).endpoint, 'https://legacy.example.test');
+    const snowflake = action('snowflake');
+    delete snowflake.additionalFields.user;
+    assert.equal(displayedActionValue(snowflake, '/additionalFields/user'), snowflake.auth.identity);
+    assert.equal(snowflake.additionalFields.user, undefined);
+});
+
+check('Blob defaults deny upload and endpoint derivation does not expose account keys', () => {
+    const draft = changeActionType(createActionDraft(), definition('blob_storage'));
+    assert.equal(draft.additionalFields.blob_storage_capabilities.upload_file_to_container, false);
+    assert.equal(BLOB_ACTION_CAPABILITIES.find(({ key }) => key === 'upload_file_to_container').defaultEnabled, false);
+    assert.equal(deriveBlobEndpoint('DefaultEndpointsProtocol=https;AccountName=fixtureaccount;AccountKey=synthetic;EndpointSuffix=core.usgovcloudapi.net'), 'https://fixtureaccount.blob.core.usgovcloudapi.net');
+    assert.equal(deriveBlobEndpoint('BlobEndpoint=https://fixtureaccount.blob.core.windows.net/;AccountKey=synthetic'), 'https://fixtureaccount.blob.core.windows.net');
+    assert.equal(deriveBlobEndpoint(EDITOR_SECRET_MASK), '');
+    assert.equal(deriveBlobEndpoint('AccountKey=synthetic'), '');
+});
+check('Blob connection-string authoring derives the endpoint without a redundant required input', () => {
+    const draft = action('blob_storage');
+    draft.endpoint = '';
+    const descriptor = nativeActionDefinition('blob_storage').fields.find(({ path }) => path === '/endpoint');
+    assert.equal(usesDirectBlobConnectionString(draft), true);
+    assert.equal(descriptor.visible(draft), false);
+    const prepared = actionForSave(draft);
+    assert.equal(prepared.endpoint, 'https://fixtureaccount.blob.core.windows.net');
+    assert.deepEqual(validateActionDraft(prepared, definition('blob_storage')), {});
+    assert.equal(draft.endpoint, '');
+    const storedWithoutEndpoint = { ...draft, auth: { type: 'connection_string', key: EDITOR_SECRET_MASK } };
+    assert.equal(descriptor.visible(storedWithoutEndpoint), true, 'legacy stored strings can supply a missing endpoint explicitly');
+    const identity = selectActionIdentity(draft, { id: 'storage-identity', name: 'Storage', auth_type: 'connection_string' });
+    assert.equal(usesDirectBlobConnectionString(identity), false);
+    assert.equal(descriptor.visible(identity), true, 'a reusable identity never exposes its connection string to derive an endpoint');
+});
+check('embedding identities are limited to API keys supported by the real runtime', () => {
+    assert.deepEqual(nativeActionDefinition('embedding_model').identityTypes, ['api_key']);
+    const draft = action('embedding_model');
+    assert.throws(() => selectActionIdentity(draft, { id: 'managed', name: 'Managed', auth_type: 'managed_identity' }), /not compatible/);
+    const selected = selectActionIdentity(draft, { id: 'api-key', name: 'Key', auth_type: 'api_key' });
+    assert.equal(selected.identity_id, 'api-key');
+    assert.equal(selected.additionalFields.identity_auth_type, 'api_key');
+});
+
+check('Call agent submission keeps fixed internal authentication and complete target identity', () => {
+    const draft = action('agent');
+    draft.endpoint = 'https://must-not-be-used.example.test';
+    draft.auth = { type: 'key', key: 'not-a-call-agent-credential' };
+    const submitted = actionForSave(draft);
+    assert.equal(submitted.endpoint, 'internal://agent');
+    assert.deepEqual(submitted.auth, { type: 'user' });
+    assert.deepEqual(submitted.additionalFields.target_agent, { id: 'target-1', scope_type: 'personal', scope_id: 'user-fixture' });
+    assert.throws(() => buildActionConnectionPayload(submitted, null), /cannot be connection-tested/);
+});
+
+check('one collection searches descriptions and types and distinguishes provided same-name IDs', () => {
+    const api = action('openapi');
+    api.description = 'Financial retrieval';
+    const agent = action('agent');
+    agent.id = api.id;
+    agent.displayName = api.displayName;
+    agent.is_global = true;
+    assert.equal(filterAuthoringActions([api, agent], '', '', '').length, 2);
+    assert.deepEqual(filterAuthoringActions([api, agent], 'financial', '', ''), [api]);
+    assert.deepEqual(filterAuthoringActions([api, agent], 'call agent', '', ''), [agent]);
+    assert.deepEqual(filterAuthoringActions([api, agent], '', 'agent', 'provided'), [agent]);
+    assert.notEqual(actionResourceKey(api), actionResourceKey(agent));
+    assert.equal(actionScope(agent), 'provided');
+    assert.ok(actionDetailPath(agent).endsWith('?scope=global'));
+    assert.equal(actionTypeLabel('agent'), 'Call agent');
+    assert.equal(actionTypeLabel('document_search'), 'Document search');
+});
+check('read-only action details accept empty revisions while writable records require usable revisions', () => {
+    const owned = resource(action('databricks'));
+    assert.equal(hasUsableActionRevision(owned), true);
+    assert.equal(hasUsableActionRevision({ ...owned, revision: '' }), false);
+    assert.equal(hasUsableActionRevision({ ...owned, revision: '   ' }), false);
+    assert.equal(hasUsableActionRevision({ ...owned, revision: '', read_only: true }), true);
+    assert.equal(hasUsableActionRevision({ ...owned, revision: '', record: { ...owned.record, is_global: true } }), true);
+    assert.equal(hasUsableActionRevision({ ...owned, revision: '' }, 'global'), true);
+    assert.equal(hasUsableActionRevision({ ...owned, revision: undefined, read_only: true }), false);
+    assert.equal(hasUsableActionRevision({ ...owned, revision: null }), false);
+});
+check('disabled authoring does not hide readable actions or misclassify personal ownership', () => {
+    const owned = action('databricks');
+    const provided = { ...action('agent'), is_global: true };
+    assert.equal(actionCanEdit(owned, true), true);
+    assert.equal(actionCanEdit(owned, false), false);
+    assert.equal(actionCanEdit(provided, true), false);
+    assert.equal(actionScope(owned), 'personal');
+    assert.equal(actionDetailPath(owned).includes('scope=global'), false);
+    assert.deepEqual(filterAuthoringActions([owned, provided], '', '', ''), [owned, provided]);
+});
+
+check('stored credentials use keep replace and explicit clear intent with opaque revision', () => {
+    const original = action('sql_query');
+    original.auth = { type: 'servicePrincipal', key: EDITOR_SECRET_MASK, identity: 'client-fixture', tenantId: 'tenant-fixture' };
+    original.additionalFields.password = EDITOR_SECRET_MASK;
+    const before = resource(original, ['/auth/key', '/additionalFields/password']);
+    const unchanged = buildEditorWrite(original, before);
+    assert.deepEqual(unchanged.updates, {});
+    const changed = changeActionField(changeActionField(original, '/auth/key', 'new-fixture-secret'), '/additionalFields/password', '');
+    const write = buildEditorWrite(changed, before);
+    assert.deepEqual(write.updates, { auth: { key: 'new-fixture-secret' } });
+    assert.deepEqual(write.clear_secret_paths, ['/additionalFields/password']);
+    assert.equal(write.expected_revision, before.revision);
+});
+
+check('connector test payloads use explicit owned contexts and resolve masks without changing drafts', () => {
+    for (const type of ['sql_query', 'cosmos_query', 'rocksdb', 'yamcs', 'databricks', 'snowflake', 'tableau', 'blob_storage', 'log_analytics', 'azure_maps_openlayers']) {
+        const draft = action(type);
+        draft.auth.key = EDITOR_SECRET_MASK;
+        if (['NoAuth', 'identity'].includes(draft.auth.type)) draft.auth.type = 'key';
+        draft.additionalFields.password = EDITOR_SECRET_MASK;
+        const before = resource(draft, ['/auth/key', '/additionalFields/password']);
+        const payload = buildActionConnectionPayload(draft, before);
+        const contextKey = ['sql_query', 'sql_schema', 'cosmos_query', 'yamcs', 'rocksdb'].includes(type)
+            ? 'existing_plugin' : 'plugin_context';
+        assert.deepEqual(payload[contextKey], { scope: 'personal', id: draft.id, name: draft.name });
+        assert.equal(payload[contextKey === 'existing_plugin' ? 'plugin_context' : 'existing_plugin'], undefined);
+        assert.equal(payload.action_scope, 'personal');
+        if (type === 'sql_query') {
+            assert.equal(payload.password, 'Stored_In_KeyVault');
+            assert.equal(payload.auth.key, undefined, 'parameter credentials must not resolve an inactive root key');
+        } else {
+            assert.equal(payload.auth.key, 'Stored_In_KeyVault');
+        }
+        assert.ok(!JSON.stringify(payload).includes('_actionTypeConfigurations'));
+        assert.equal(draft.auth.key, EDITOR_SECRET_MASK);
+    }
+});
+check('SQL test authentication follows the selected connection mode without stale managed-identity fallbacks', () => {
+    let draft = action('sql_query');
+    const choices = actionAuthModes('sql_query', definition('sql_query').allowed_auth_types);
+    draft.auth.key = EDITOR_SECRET_MASK;
+    draft.additionalFields.password = EDITOR_SECRET_MASK;
+    draft = changeActionAuth(draft, choices.find(({ value }) => value === 'integrated'));
+    assert.equal(draft.auth.identity, '');
+    draft.auth.identity = 'managed_identity';
+    const original = resource(draft, ['/auth/key', '/additionalFields/password']);
+    const integrated = buildActionConnectionPayload(draft, original);
+    assert.equal(integrated.auth_type, 'integrated');
+    assert.deepEqual(integrated.auth, { type: 'identity', identity: '' });
+    assert.equal(integrated.password, undefined);
+    assert.equal(integrated.additionalFields.password, undefined);
+    assert.equal(draft.auth.identity, 'managed_identity');
+    assert.equal(draft.additionalFields.password, EDITOR_SECRET_MASK);
+
+    const connection = changeActionAuth(draft, choices.find(({ value }) => value === 'connection_string_only'));
+    assert.equal(sqlConnectionMethod(connection), 'connection_string');
+    connection.additionalFields.connection_string = EDITOR_SECRET_MASK;
+    connection.additionalFields.auth_type = 'username_password';
+    connection.auth.type = 'user';
+    const stored = resource(connection, ['/auth/key', '/additionalFields/password', '/additionalFields/connection_string']);
+    const payload = buildActionConnectionPayload(connection, stored);
+    assert.equal(payload.auth_type, 'connection_string_only');
+    assert.equal(payload.connection_method, 'connection_string');
+    assert.equal(payload.additionalFields.auth_type, payload.auth_type);
+    assert.equal(payload.additionalFields.connection_method, payload.connection_method);
+    assert.equal(payload.connection_string, 'Stored_In_KeyVault');
+    assert.equal(payload.password, undefined);
+    assert.equal(payload.auth.key, undefined);
+    assert.equal(connection.additionalFields.auth_type, 'username_password', 'transient normalization must not rewrite the saved draft');
+    assert.deepEqual(payload.clear_secret_paths, []);
+});
+check('connection tests omit inactive stored credentials without clearing the saved configuration', () => {
+    const managed = action('databricks');
+    managed.auth = { type: 'identity', identity: 'managed_identity', key: EDITOR_SECRET_MASK, tenantId: EDITOR_SECRET_MASK };
+    managed.additionalFields.auth_method = 'managed_identity';
+    managed.additionalFields.private_key_passphrase = EDITOR_SECRET_MASK;
+    const original = resource(managed, ['/auth/key', '/auth/tenantId', '/additionalFields/private_key_passphrase']);
+    const payload = buildActionConnectionPayload(managed, original);
+    assert.deepEqual(payload.auth, { type: 'identity', identity: 'managed_identity' });
+    assert.equal(payload.additionalFields.private_key_passphrase, undefined);
+    assert.deepEqual(payload.clear_secret_paths, []);
+    assert.deepEqual(managed, original.record);
+
+    const log = action('log_analytics');
+    log.auth = { type: 'user', key: EDITOR_SECRET_MASK, identity: EDITOR_SECRET_MASK, tenantId: EDITOR_SECRET_MASK };
+    const logPayload = buildActionConnectionPayload(log, resource(log, ['/auth/key', '/auth/identity', '/auth/tenantId']));
+    assert.deepEqual(logPayload.auth, { type: 'user' });
+    assert.deepEqual(logPayload.clear_secret_paths, []);
+});
+
+check('cleared required test credentials fail closed and optional passphrases are not rehydrated', () => {
+    const draft = action('snowflake');
+    draft.auth.type = 'key'; draft.additionalFields.auth_method = 'key_pair';
+    draft.auth.key = EDITOR_SECRET_MASK;
+    draft.additionalFields.private_key_passphrase = EDITOR_SECRET_MASK;
+    const before = resource(draft, ['/auth/key', '/additionalFields/private_key_passphrase']);
+    assert.throws(() => buildActionConnectionPayload({ ...draft, auth: { ...draft.auth, key: '' } }, before), /clearing/);
+    const clearedPassphrase = changeActionField(draft, '/additionalFields/private_key_passphrase', '');
+    const payload = buildActionConnectionPayload(clearedPassphrase, before);
+    assert.equal(Object.hasOwn(payload.additionalFields, 'private_key_passphrase'), false);
+    assert.deepEqual(payload.clear_secret_paths, ['/additionalFields/private_key_passphrase']);
+    assert.throws(() => buildActionConnectionPayload(draft, null), /no owned stored value/);
+    assert.throws(() => buildActionConnectionPayload(draft, { ...before, read_only: true }), /cannot be connection-tested/);
+    assert.throws(() => buildActionConnectionPayload(draft, { ...before, record: { ...before.record, id: '' } }), /stable owned ID/);
+});
+
+check('identity tests do not carry inactive credentials and retain false or zero fields', () => {
+    const original = action('yamcs');
+    original.auth.key = EDITOR_SECRET_MASK;
+    const selected = selectActionIdentity(original, { id: 'identity-fixture', name: 'Same name', auth_type: 'api_key' });
+    selected.additionalFields.tls_verify = false;
+    selected.additionalFields.custom = { zero: 0, values: [] };
+    const payload = buildActionConnectionPayload(selected, resource(original, ['/auth/key']));
+    assert.equal(payload.identity_id, 'identity-fixture');
+    assert.deepEqual(payload.auth, { type: 'identity', identity: 'identity-fixture' });
+    assert.equal(payload.auth_key, undefined);
+    assert.equal(payload.tls_verify, false);
+    assert.deepEqual(payload.additionalFields.custom, { zero: 0, values: [] });
+});
+
+check('reminder validation and updates preserve per-field configuration and zero-like settings', () => {
+    const draft = action('databricks');
+    draft.metadata.key_vault_secret_reminders = {
+        'auth.key': { enabled: true, contact_email: 'specific@example.test', lead_days: 10 },
+        __all__: { enabled: true, expires_on: '2030-01-01', contact_email: 'owner@example.test', lead_days: 30, custom: false },
+    };
+    assert.deepEqual(validateActionDraft(draft, definition(draft.type)), {});
+    const changed = changeActionField(draft, '/metadata/key_vault_secret_reminders/__all__/enabled', false);
+    assert.deepEqual(changed.metadata.key_vault_secret_reminders['auth.key'], draft.metadata.key_vault_secret_reminders['auth.key']);
+    assert.equal(changed.metadata.key_vault_secret_reminders.__all__.custom, false);
+    assert.equal(changed.metadata.key_vault_secret_reminders.__all__.expires_on, '2030-01-01');
+    const bad = changeActionField(draft, '/metadata/key_vault_secret_reminders/__all__/lead_days', 0);
+    assert.ok(validateActionDraft(bad, definition(bad.type))['/metadata/key_vault_secret_reminders/__all__/lead_days']);
+});
+
+check('field and global API errors preserve structured paths and escaped field names', () => {
+    const errors = actionApiErrors({ errors: [
+        { path: ['additionalFields', 'a/b'], message: 'Invalid value' },
+        { field: 'auth.key', error: 'Credential required' },
+        'endpoint: Use an allowed endpoint',
+        'A global validation error',
+    ] });
+    assert.equal(actionFieldError(errors, '/additionalFields/a~1b'), 'Invalid value');
+    assert.equal(actionFieldError(errors, '/auth/key'), 'Credential required');
+    assert.equal(actionFieldError(errors, '/endpoint'), 'Use an allowed endpoint');
+    assert.equal(errors.$3, 'A global validation error');
+    assert.equal(expandActionFieldErrors(errors)['additionalFields.a/b'], 'Invalid value');
+});
+
+function actionPageHandler(page, variableName, context) {
+    const filename = path.join(root, 'application', 'v2_ui', 'src', 'pages', 'workspace', `${page}.tsx`);
+    const source = ts.createSourceFile(filename, fs.readFileSync(filename, 'utf8'), ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+    let handler;
+    const visit = (node) => {
+        if (ts.isVariableDeclaration(node) && node.name.getText(source) === variableName && node.initializer && ts.isArrowFunction(node.initializer)) {
+            handler = node.initializer;
+        }
+        ts.forEachChild(node, visit);
+    };
+    visit(source);
+    assert.ok(handler, `The real ${page} ${variableName} handler must be present.`);
+    const compiled = ts.transpileModule(`const pageHandler = ${handler.getText(source)};`, {
+        compilerOptions: { target: ts.ScriptTarget.ES2022, module: ts.ModuleKind.ESNext },
+    }).outputText;
+    return vm.runInNewContext(`${compiled}\npageHandler;`, context);
+}
+
+const actionEditorSaveHandler = (context) => actionPageHandler('ActionEditorPage', 'save', context);
+
+await asyncCheck('the real save path rejects unprocessed specification edits without relying on component effects', async () => {
+    const processedSpec = { openapi: '3.0.3', info: { title: 'Processed API', version: '1' }, paths: {} };
+    const editedSpec = { ...processedSpec, info: { title: 'Edited API', version: '2' } };
+    const saved = action('openapi');
+    saved.endpoint = 'https://api.example.test';
+    saved.additionalFields.openapi_spec_content = processedSpec;
+    const pending = {
+        ...saved,
+        _openApiSourceDraft: { mode: 'manual', format: 'json', text: JSON.stringify(editedSpec), pending: true },
+    };
+    const original = resource(saved);
+    let message;
+    let fieldErrors;
+    let writes = 0;
+    let cleared = false;
+    let navigated = false;
+    const context = {
+        draft: pending, original, definition: definition('openapi'),
+        actionForSave, validateActionDraft, validateConnectorConfiguration, validateConnectorAuthentication,
+        validity: {}, // Child effects have not published validity yet.
+        setFieldErrors: (value) => { fieldErrors = value; },
+        setError: (value) => { message = value; },
+    };
+    const validateLocally = actionPageHandler('ActionEditorPage', 'validateLocally', context);
+    const save = actionEditorSaveHandler({
+        ...context,
+        saving: false, readOnly: false, canAuthor: true, loadError: null, catalogueLoading: false, catalogueError: null,
+        validateLocally, validationController: { current: null }, mounted: { current: true },
+        setSaving: () => {}, setValidationFeedback: () => {},
+        saveActionConfiguration: async () => { writes += 1; return original; },
+        returnTo: null, refreshBootstrap: async () => {}, load: () => {},
+        clear: () => { cleared = true; }, navigate: () => { navigated = true; },
+        ApiError, actionApiErrors, errorMessage: (cause) => cause.message,
+    });
+    await save();
+    assert.match(message, /Process the edited specification/);
+    assert.ok(fieldErrors['openapi-source']);
+    assert.equal(writes, 0);
+    assert.equal(cleared, false);
+    assert.equal(navigated, false);
+    assert.equal(pending._openApiSourceDraft.text, JSON.stringify(editedSpec));
+    assert.deepEqual(pending.additionalFields.openapi_spec_content, processedSpec);
+    assert.equal(original.revision, 'opaque-fixture-revision');
+
+    const imported = applyOpenApiSpecification(pending, { success: true, spec_content: editedSpec });
+    const validateProcessed = actionPageHandler('ActionEditorPage', 'validateLocally', { ...context, draft: imported });
+    assert.equal(validateProcessed(), true);
+    assert.deepEqual(imported.additionalFields.openapi_spec_content, editedSpec);
+});
+
+await asyncCheck('the real editor hydrates saved revision and masks before clearing and returning to an agent', async () => {
+    const initial = action('databricks');
+    const saved = resource({ ...initial, auth: { ...initial.auth, key: EDITOR_SECRET_MASK } }, ['/auth/key']);
+    saved.revision = 'saved-revision';
+    const events = [];
+    let baseline = initial;
+    let visible = { ...initial, description: 'Unsaved text' };
+    let revision = 'previous-revision';
+    let destination;
+    const handler = actionEditorSaveHandler({
+        saving: false, readOnly: false, canAuthor: true, loadError: null, catalogueLoading: false, catalogueError: null,
+        validateLocally: () => true, validationController: { current: null }, mounted: { current: true },
+        draft: visible, original: resource(initial), actionForSave, ApiError, actionApiErrors,
+        saveActionConfiguration: async () => saved,
+        returnTo: '/workspace/agents/new',
+        location: { key: 'current-editor' },
+        queueCreatedWorkspaceAction: (returnTo, record) => {
+            assert.equal(returnTo, '/workspace/agents/new');
+            assert.equal(record, saved.record);
+            events.push('queue');
+        },
+        load: (resource) => {
+            events.push('load');
+            baseline = resource.record;
+            revision = resource.revision;
+        },
+        clear: () => { events.push('clear'); visible = baseline; },
+        refreshBootstrap: () => Promise.resolve(),
+        navigate: (to, options) => { events.push('navigate'); destination = { to, options }; },
+        setSaving: () => {}, setError: () => {}, setValidationFeedback: () => {}, setFieldErrors: () => {},
+        errorMessage: (cause) => cause.message,
+    });
+    await handler();
+    assert.deepEqual(events, ['queue', 'load', 'clear', 'navigate']);
+    assert.equal(revision, 'saved-revision');
+    assert.equal(visible.auth.key, EDITOR_SECRET_MASK);
+    assert.equal(destination.to, '/workspace/agents/new');
+    assert.equal(destination.options.state.workspaceEditorSaved, true);
+    assert.equal(destination.options.state.preserveWorkspaceDraft, true);
+    assert.equal(destination.options.state.workspaceEditorFrom, 'current-editor');
+});
+
+await asyncCheck('the real editor keeps the draft and revision on a failed save', async () => {
+    let message;
+    let hydrated = false;
+    let cleared = false;
+    let navigated = false;
+    const handler = actionEditorSaveHandler({
+        saving: false, readOnly: false, canAuthor: true, loadError: null, catalogueLoading: false, catalogueError: null,
+        validateLocally: () => true, validationController: { current: null }, mounted: { current: true },
+        draft: action('databricks'), original: resource(action('databricks')), actionForSave, ApiError, actionApiErrors,
+        saveActionConfiguration: async () => { throw new ApiError('Conflict', 409, { errors: [] }); },
+        returnTo: null, queueCreatedWorkspaceAction: () => { throw new Error('Must not queue a failed save.'); },
+        load: () => { hydrated = true; }, clear: () => { cleared = true; },
+        refreshBootstrap: () => Promise.resolve(), navigate: () => { navigated = true; },
+        setSaving: () => {}, setError: (value) => { message = value; }, setValidationFeedback: () => {}, setFieldErrors: () => {},
+        errorMessage: (cause) => cause.message,
+    });
+    await handler();
+    assert.match(message, /changed in another session/);
+    assert.equal(hydrated, false);
+    assert.equal(cleared, false);
+    assert.equal(navigated, false);
+});
+await asyncCheck('the real editor blocks creation-disabled writes while retaining the loaded draft', async () => {
+    const draft = action('databricks');
+    let writes = 0;
+    let cleared = false;
+    const save = actionEditorSaveHandler({
+        saving: false, readOnly: false, canAuthor: false, loadError: null, catalogueLoading: false, catalogueError: null,
+        draft, original: resource(draft),
+        validateLocally: () => { throw new Error('Disabled authoring must stop before submit validation.'); },
+        saveActionConfiguration: () => { writes += 1; },
+        clear: () => { cleared = true; },
+    });
+    await save();
+    assert.equal(writes, 0);
+    assert.equal(cleared, false);
+    assert.equal(draft.id, 'owned-databricks');
+});
+await asyncCheck('the real collection retains owned deletion when creation is disabled', async () => {
+    const draft = action('databricks');
+    const deleted = [];
+    let refreshed = false;
+    const remove = actionPageHandler('ActionsSection', 'remove', {
+        canAuthor: false, actionScope, actionResourceKey,
+        owner: 'fixture-user', loadedOwner: { current: 'fixture-user' },
+        setBusyId: () => {}, setError: () => {}, errorMessage: (cause) => cause.message,
+        deleteAuthoringAction: async (id) => { deleted.push(id); },
+        refresh: async () => { refreshed = true; }, refreshBootstrap: async () => {},
+    });
+    await remove(draft);
+    assert.deepEqual(deleted, [draft.id]);
+    assert.equal(refreshed, true);
+    await remove({ ...draft, is_global: true });
+    assert.equal(deleted.length, 1);
+});
+
+await asyncCheck('overlapping collection deletes cannot restore an already deleted action on failure', async () => {
+    for (const failure of ['delete', 'refresh']) {
+        const first = action('databricks');
+        const second = action('tableau');
+        const initial = [first, second];
+        let serverItems = initial.slice();
+        let visibleItems = initial.slice();
+        let refreshes = 0;
+        const errors = [];
+        let finishFirst;
+        let finishSecond;
+        let rejectSecond;
+        const firstRequest = new Promise((resolve) => { finishFirst = resolve; });
+        const secondRequest = new Promise((resolve, reject) => { finishSecond = resolve; rejectSecond = reject; });
+        const remove = actionPageHandler('ActionsSection', 'remove', {
+            actionScope, actionResourceKey, owner: 'fixture-user', loadedOwner: { current: 'fixture-user' },
+            items: initial,
+            setItems: (items) => { visibleItems = items; },
+            setBusyId: () => {}, setError: (message) => { if (message) errors.push(message); },
+            errorMessage: (cause) => cause.message,
+            deleteAuthoringAction: (id) => id === first.id ? firstRequest : secondRequest,
+            refresh: async () => {
+                refreshes += 1;
+                if (failure === 'refresh' && refreshes === 2) {
+                    errors.push('Collection refresh failed');
+                    return;
+                }
+                visibleItems = serverItems.slice();
+            },
+            refreshBootstrap: () => Promise.resolve(),
+        });
+        const pendingFirst = remove(first);
+        const pendingSecond = remove(second);
+        serverItems = serverItems.filter((item) => item.id !== first.id);
+        finishFirst();
+        await pendingFirst;
+        assert.equal(visibleItems.some((item) => item.id === first.id), false);
+        if (failure === 'delete') rejectSecond(new Error('Second deletion failed'));
+        else {
+            serverItems = serverItems.filter((item) => item.id !== second.id);
+            finishSecond();
+        }
+        await pendingSecond;
+        assert.equal(visibleItems.some((item) => item.id === first.id), false, `${failure} failure restored the first action`);
+        assert.equal(errors.length, 1);
+    }
+});
+
+const originalFetch = globalThis.fetch;
+const requests = [];
+let response = {};
+globalThis.fetch = async (url, options = {}) => {
+    requests.push({ url: String(url), options, body: options.body ? JSON.parse(options.body) : undefined });
+    return new Response(JSON.stringify(response), { status: 200, headers: { 'Content-Type': 'application/json' } });
+};
+try {
+    check('selecting a type identity or native field never calls a connector', () => {
+        const draft = action('databricks');
+        changeActionField(draft, '/endpoint', 'https://other.example.test');
+        changeActionAuth(draft, actionAuthModes(draft.type, definition(draft.type).allowed_auth_types)[0]);
+        selectActionIdentity(draft, { id: 'identity', name: 'Identity', auth_type: 'api_key' });
+        assert.equal(requests.length, 0);
+    });
+    await asyncCheck('identity catalogue projection retains only authoring-safe identity details', async () => {
+        response = { identities: [{ id: 'id-1', name: 'Reusable', credentials: { auth_type: 'api_key', key: 'must-not-copy' }, internal: 'hidden' }] };
+        const identities = await fetchActionIdentities();
+        assert.equal(requests.at(-1).url, '/api/workspace-identities/personal/identities');
+        assert.equal(identities[0].auth_type, 'api_key');
+        assert.equal(identities[0].id, 'id-1');
+        assert.equal(Object.hasOwn(identities[0], 'credentials'), false);
+        assert.equal(Object.hasOwn(identities[0], 'internal'), false);
+    });
+    await asyncCheck('safe reminder defaults use the opt-in editor options and retain false values', async () => {
+        response = { settings: {
+            allow_user_plugins: false,
+            enable_key_vault_secret_storage: false, enable_key_vault_secret_expiration_reminders: false,
+            key_vault_secret_expiration_default_lead_days: 7,
+            key_vault_secret_expiration_default_contact_email: 'owner@example.test',
+            key_vault_secret_expiration_require_expiration: true,
+        } };
+        const hints = await fetchActionEditorHints();
+        assert.ok(requests.at(-1).url.endsWith('/api/user/agent/settings?view=editor'));
+        assert.deepEqual(hints, {
+            canAuthor: false,
+            storageEnabled: false, remindersEnabled: false, requireExpiration: true,
+            reminderLeadDays: 7, reminderEmail: 'owner@example.test',
+        });
+        response.settings.allow_user_plugins = true;
+        assert.equal((await fetchActionEditorHints()).canAuthor, true);
+        delete response.settings.allow_user_plugins;
+        assert.equal((await fetchActionEditorHints()).canAuthor, false, 'unknown authoring capability must fail closed');
+    });
+    await asyncCheck('provided empty or omitted revisions survive API normalization and the page read guard', async () => {
+        const provided = { ...action('agent'), is_global: true };
+        for (const revision of ['', undefined]) {
+            response = { record: provided, read_only: true, secret_paths: [], ...(revision === undefined ? {} : { revision }) };
+            const result = await fetchActionEditor(provided.id, 'global');
+            assert.equal(result.revision, '');
+            assert.equal(hasUsableActionRevision(result, 'global'), true);
+        }
+        response = { record: action('agent'), read_only: false, secret_paths: [], revision: '' };
+        await assert.rejects(fetchActionEditor('owned-agent'), /invalid editor resource/);
+        response = [action('databricks'), provided];
+        assert.equal((await fetchAuthoringActions()).length, 2);
+    });
+    await asyncCheck('explicit testing uses existing connector routes and abort signals', async () => {
+        response = { success: true, message: 'Synthetic test only' };
+        const draft = action('databricks');
+        const signal = new AbortController().signal;
+        await testWorkspaceAction(draft, resource(draft), definition(draft.type), signal);
+        assert.equal(requests.at(-1).url, '/api/plugins/test-databricks-connection');
+        assert.equal(requests.at(-1).options.signal, signal);
+        assert.equal(requests.at(-1).body.plugin_context.id, draft.id);
+        const count = requests.length;
+        await assert.rejects(() => testWorkspaceAction(action('agent'), null, definition('agent')), /does not expose/);
+        assert.equal(requests.length, count);
+    });
+    await asyncCheck('explicit validation calls canonical validation without executing the action', async () => {
+        response = { valid: false, errors: ['endpoint: Synthetic validation failure'] };
+        const draft = action('databricks');
+        const result = await validateWorkspaceAction(draft, null);
+        assert.equal(requests.at(-1).url, '/api/plugins/validate');
+        assert.equal(result.valid, false);
+        assert.equal(requests.at(-1).body.type, draft.type);
+        assert.equal(Object.hasOwn(requests.at(-1).body, 'plugin_context'), false);
+        assert.equal(Object.hasOwn(requests.at(-1).body, '_actionTypeConfigurations'), false);
+    });
+} finally {
+    globalThis.fetch = originalFetch;
+}
+
+console.log(`${checks} workspace action authoring logic checks passed.`);

--- a/functional_tests/test_v2_workspace_action_connectors_logic.mjs
+++ b/functional_tests/test_v2_workspace_action_connectors_logic.mjs
@@ -1,0 +1,663 @@
+// test_v2_workspace_action_connectors_logic.mjs
+// Version: 0.261.096
+// Implemented in: 0.261.096
+// Executes the real OpenAPI/MCP connector parsing, draft, credential, and API helpers.
+
+import assert from 'node:assert/strict';
+import './test_support/tsResolve.mjs';
+
+const {
+    allowedMcpAuthMethods, allowedMcpTransports, applyMcpPreconfiguration, applyMcpPreset,
+    applyOpenApiSpecification, availableConnectorIdentities, buildConnectorSupportPayload,
+    changeConnectorAuthMethod, changeOpenApiBasicCredential, connectorAuthMethod, connectorFeedback,
+    connectorIdentityOptions, connectorLines, connectorSecretField, connectorUrlError,
+    discoverMcpAction, fetchMcpPreconfigurations, fetchMcpPresets, MCP_GENERIC_PRESET, OPENAPI_SOURCE_OPTIONS,
+    mcpHeaderNameError, mcpImplementationFields, mcpToolChoices, mergeMcpTools,
+    openApiBasicCredentials, openApiInformation, openApiSourceDraft, parseMcpCatalogue,
+    parseMcpTools, processOpenApiText, renameMcpHeader, selectConnectorIdentity,
+    setMcpToolSelection, STORED_CONNECTOR_SECRET, testApiConnector, updateConnectorFields,
+    updateOpenApiSourceDraft, uploadOpenApiSpecification, validateApiConnector,
+    validateConnectorAuthentication, validateConnectorConfiguration,
+} = await import('../application/v2_ui/src/lib/workspaceActionConnectors.ts');
+const { buildEditorWrite, EDITOR_SECRET_MASK } = await import('../application/v2_ui/src/lib/workspaceAuthoring.ts');
+const { ApiError } = await import('../application/v2_ui/src/lib/apiClient.ts');
+
+let checks = 0;
+function check(label, run) {
+    run();
+    checks += 1;
+    console.log(`ok ${label}`);
+}
+async function asyncCheck(label, run) {
+    await run();
+    checks += 1;
+    console.log(`ok ${label}`);
+}
+
+const specification = {
+    openapi: '3.0.3',
+    info: { title: '<img src=x onerror=alert(1)>', version: '1', description: 'Synthetic API' },
+    servers: [
+        { url: 'https://{region}.example.test/v1', variables: { region: { default: 'api' } } },
+    ],
+    components: {
+        parameters: { itemId: { name: 'id', in: 'path', required: true, schema: { type: 'string' } } },
+        securitySchemes: {
+            queryKey: { type: 'apiKey', in: 'query', name: 'api-key' },
+            headerKey: { type: 'apiKey', in: 'header', name: 'X-API-Key' },
+            cookieKey: { type: 'apiKey', in: 'cookie', name: 'session' },
+            token: { type: 'http', scheme: 'bearer' },
+            login: { type: 'http', scheme: 'basic' },
+            oauth: { type: 'oauth2', flows: { clientCredentials: { scopes: { read: 'Read data' } } } },
+            external: { $ref: 'https://untrusted.example.test/scheme.json' },
+        },
+    },
+    security: [{ queryKey: [] }],
+    paths: {
+        '/items/{id}': {
+            parameters: [{ $ref: '#/components/parameters/itemId' }],
+            'x-description': { not: 'an operation' },
+            get: {
+                operationId: 'read_item', summary: 'Read an item', tags: ['items'],
+                parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'integer' } }],
+                responses: { 200: { description: 'OK' } },
+            },
+            patch: {
+                operationId: 'update_item', deprecated: true, security: [],
+                requestBody: { required: true, content: { 'application/json': { schema: { type: 'object' } } } },
+                responses: { 204: { description: 'Updated' } },
+            },
+        },
+        '/remote': { $ref: 'https://untrusted.example.test/path.json' },
+    },
+};
+
+function action(type = 'openapi') {
+    return {
+        id: 'action-owned', name: 'saved-machine-name', displayName: 'Synthetic action',
+        description: 'Connector regression fixture', type, endpoint: 'https://api.example.test',
+        auth: { type: type === 'mcp' ? 'NoAuth' : 'key', key: '', customAuthFlag: false },
+        additionalFields: type === 'mcp' ? {
+            server_profile: 'generic', transport: 'streamable_http', auth_method: 'none',
+            request_timeout: 30, connect_timeout: 10, sse_read_timeout: 300,
+            retry_count: 0, retry_backoff_seconds: 1, load_tools: true, load_prompts: false,
+            custom_headers: {}, allowed_tool_names: [], mcp_tools: [],
+            custom: { keep: 0 },
+        } : {
+            openapi_spec_content: structuredClone(specification), openapi_source_type: 'content',
+            base_url: 'https://api.example.test', auth_method: 'none', custom: { keep: 0 },
+        },
+        metadata: { custom: { enabled: false } },
+    };
+}
+function resource(record, secret_paths = []) {
+    return { record: structuredClone(record), revision: 'opaque-revision', secret_paths, read_only: false };
+}
+function catalogEntry(overrides = {}) {
+    return {
+        ...structuredClone(MCP_GENERIC_PRESET), ...overrides,
+        defaults: { ...MCP_GENERIC_PRESET.defaults, ...overrides.defaults },
+    };
+}
+
+check('OpenAPI information is readable and only HTTP operations are enumerated', () => {
+    const info = openApiInformation(specification);
+    assert.equal(info.title, specification.info.title);
+    assert.equal(info.operations.length, 2);
+    assert.equal(info.servers[0].url, 'https://api.example.test/v1');
+    assert.equal(info.operations[0].parameters.length, 1);
+    assert.equal(info.operations[0].parameters[0].type, 'integer');
+    assert.deepEqual(info.operations[0].security, ['queryKey']);
+    assert.deepEqual(info.operations[1].security, []);
+    assert.equal(info.operations[1].bodyRequired, true);
+    assert.deepEqual(info.operations[1].contentTypes, ['application/json']);
+    assert.equal(info.operations[1].deprecated, true);
+    assert.equal(info.securitySchemes.find(({ id }) => id === 'cookieKey').supported, false);
+    assert.equal(info.securitySchemes.find(({ id }) => id === 'external').supported, false);
+    assert.deepEqual(info.securitySchemes.find(({ id }) => id === 'oauth').scopes, ['read']);
+});
+check('local OpenAPI reference cycles stop without remote fetching or evaluation', () => {
+    const info = openApiInformation({
+        ...specification,
+        paths: { '/cycle': { $ref: '#/paths/~1cycle' } },
+    });
+    assert.deepEqual(info.operations, []);
+    assert.deepEqual(openApiInformation(null).operations, []);
+});
+check('import applies V1 content fields and preserves unrelated nested values', () => {
+    const before = action();
+    const next = applyOpenApiSpecification(before, { success: true, spec_content: specification, original_filename: 'source.yaml', file_id: 'f1' });
+    assert.equal(next.additionalFields.openapi_source_type, 'content');
+    assert.equal(next.additionalFields.base_url, before.endpoint);
+    assert.deepEqual(next.additionalFields.custom, { keep: 0 });
+    assert.deepEqual(next.auth, before.auth);
+    assert.deepEqual(next.metadata, before.metadata);
+    assert.equal(openApiSourceDraft(next).filename, 'source.yaml');
+    assert.equal(before._openApiSourceDraft, undefined);
+    assert.throws(() => applyOpenApiSpecification(before, { success: false, spec_content: specification }), /validated/);
+    before.endpoint = '';
+    delete before.additionalFields.base_url;
+    assert.equal(applyOpenApiSpecification(before, { success: true, spec_content: specification }).endpoint, 'https://api.example.test/v1');
+});
+check('manual YAML stays in the in-memory draft and cannot bypass processing', () => {
+    const before = action();
+    const yaml = 'openapi: 3.0.3\ninfo:\n  title: Example\n  version: "1"\npaths: {}';
+    const next = updateOpenApiSourceDraft(before, { mode: 'manual', format: 'yaml', text: yaml, pending: true });
+    assert.equal(openApiSourceDraft(next).text, yaml);
+    assert.deepEqual(next.additionalFields.openapi_spec_content, before.additionalFields.openapi_spec_content);
+    assert.throws(() => buildConnectorSupportPayload(next, resource(before), 'openapi'), /Process the edited specification/);
+    assert.ok(!('_openApiSourceDraft' in buildEditorWrite(next, resource(before)).updates));
+    const processed = applyOpenApiSpecification(next, { success: true, spec_content: specification });
+    assert.equal(openApiSourceDraft(processed).pending, false);
+    assert.ok(!('_openApiSourceDraft' in buildConnectorSupportPayload(processed, resource(before), 'openapi')));
+});
+check('OpenAPI source choices stay upload/content-only and stale URL drafts cannot bypass processing', () => {
+    assert.deepEqual(OPENAPI_SOURCE_OPTIONS.map(({ value }) => value), ['file', 'manual']);
+    const before = action();
+    const pending = {
+        ...before,
+        _openApiSourceDraft: { mode: 'url', url: 'https://specification.example.test/openapi.yaml', pending: true },
+    };
+    assert.equal(openApiSourceDraft(pending).mode, 'file');
+    assert.deepEqual(pending.additionalFields.openapi_spec_content, before.additionalFields.openapi_spec_content);
+    assert.throws(() => buildConnectorSupportPayload(pending, resource(before), 'openapi'), /Process the edited specification/);
+    const imported = applyOpenApiSpecification(pending, { success: true, spec_content: specification });
+    assert.equal(imported.additionalFields.openapi_source_type, 'content');
+    assert.equal(openApiSourceDraft(imported).pending, false);
+    assert.ok(!JSON.stringify(buildEditorWrite(imported, resource(before)).updates).includes('specification.example.test'));
+});
+check('auth method changes use V1 mappings without deleting hidden properties', () => {
+    let draft = action();
+    draft.auth.key = EDITOR_SECRET_MASK;
+    draft.auth.hiddenCredential = 'retained';
+    draft.additionalFields.future = { enabled: false, count: 0 };
+    for (const method of ['api_key', 'bearer', 'basic', 'oauth2']) {
+        const changed = changeConnectorAuthMethod(draft, 'openapi', method);
+        assert.equal(changed.auth.type, 'key');
+        assert.equal(changed.auth.key, EDITOR_SECRET_MASK);
+        assert.equal(changed.additionalFields.auth_method, method);
+        assert.equal(changed.auth.hiddenCredential, 'retained');
+        assert.deepEqual(changed.additionalFields.future, { enabled: false, count: 0 });
+    }
+    draft = changeConnectorAuthMethod(draft, 'openapi', 'none');
+    assert.equal(draft.auth.key, '');
+    assert.equal(draft.auth.hiddenCredential, 'retained');
+    assert.throws(() => changeConnectorAuthMethod(draft, 'mcp', 'oauth2'), /Unsupported/);
+    assert.equal(changeConnectorAuthMethod(action('mcp'), 'mcp', 'none').auth.type, 'NoAuth');
+});
+check('legacy auth storage is recognized without rewriting old masks', () => {
+    const draft = action();
+    delete draft.additionalFields.auth_method;
+    draft.auth = { type: 'api_key', value: EDITOR_SECRET_MASK, name: 'X-Test', location: 'query' };
+    assert.equal(connectorAuthMethod(draft, 'openapi'), 'api_key');
+    assert.equal(connectorSecretField(draft, 'openapi'), 'value');
+    draft.auth = { type: 'bearer', token: EDITOR_SECRET_MASK };
+    assert.equal(connectorSecretField(draft, 'openapi'), 'token');
+    assert.equal(connectorAuthMethod(draft, 'openapi'), 'bearer');
+    const anonymous = changeConnectorAuthMethod(draft, 'openapi', 'none');
+    assert.equal(anonymous.auth.token, '');
+    assert.equal(anonymous.auth.key, '');
+    draft.auth = { type: 'api_key', value: EDITOR_SECRET_MASK, customFlag: 'retained' };
+    const anonymousKey = changeConnectorAuthMethod(draft, 'openapi', 'none');
+    assert.equal(anonymousKey.auth.value, '');
+    assert.equal(anonymousKey.auth.customFlag, 'retained');
+});
+check('basic credentials preserve colons in passwords and require full replacement of a masked pair', () => {
+    let draft = changeConnectorAuthMethod(action(), 'openapi', 'basic');
+    draft.auth.key = 'synthetic-user:synthetic:password';
+    assert.deepEqual(openApiBasicCredentials(draft), { username: 'synthetic-user', password: 'synthetic:password', stored: false });
+    draft.auth.key = EDITOR_SECRET_MASK;
+    const original = resource(draft, ['/auth/key']);
+    assert.deepEqual(validateConnectorAuthentication(draft, 'openapi', original), {});
+    let next = changeOpenApiBasicCredential(draft, 'username', 'replacement-user');
+    assert.equal(next.auth.key, 'replacement-user:');
+    assert.ok(validateConnectorAuthentication(next, 'openapi', original)['auth.key']);
+    next = changeOpenApiBasicCredential(next, 'password', 'replacement:password');
+    assert.equal(next.auth.key, 'replacement-user:replacement:password');
+    assert.deepEqual(validateConnectorAuthentication(next, 'openapi', original), {});
+    const passwordFirst = changeOpenApiBasicCredential(draft, 'password', 'replacement');
+    assert.ok(validateConnectorAuthentication(passwordFirst, 'openapi', original)['auth.basic_username']);
+    assert.equal(changeOpenApiBasicCredential(next, 'password', '').auth.key, '');
+    assert.equal(changeOpenApiBasicCredential(next, 'password', EDITOR_SECRET_MASK).auth.key, EDITOR_SECRET_MASK);
+});
+check('reusable identities are filtered by capability and selected only by stable ID', () => {
+    const identities = [
+        { id: 'a', name: 'Same name', auth_type: 'api_key', credentials: { key: 'not-for-copying' } },
+        { id: 'b', name: 'Same name', auth_type: 'bearer_token' },
+        { id: 'c', name: 'Managed', auth_type: 'managed_identity' },
+        { id: 'd', name: 'Unsupported', auth_type: 'client_secret' },
+    ];
+    assert.deepEqual(availableConnectorIdentities(identities, 'openapi').map(({ id }) => id), ['a', 'b']);
+    assert.deepEqual(availableConnectorIdentities(identities, 'mcp').map(({ id }) => id), ['a', 'b', 'c']);
+    const draft = action();
+    draft.auth.key = EDITOR_SECRET_MASK;
+    const next = selectConnectorIdentity(draft, 'openapi', identities[1]);
+    assert.equal(next.identity_id, 'b');
+    assert.equal(next.auth.identity, 'b');
+    assert.equal(next.auth.type, 'identity');
+    assert.equal(next.auth.key, EDITOR_SECRET_MASK);
+    assert.equal(next.additionalFields.identity_auth_type, 'bearer_token');
+    assert.ok(!JSON.stringify(next).includes('not-for-copying'));
+    assert.equal(connectorIdentityOptions(identities, 'openapi', 'missing-id').unavailable, true);
+    assert.equal(connectorIdentityOptions(identities, 'openapi', 'c').unavailable, true);
+    assert.throws(() => selectConnectorIdentity(draft, 'openapi', identities[2]), /cannot authenticate/);
+    const cleared = selectConnectorIdentity(next, 'openapi', null);
+    assert.equal(cleared.identity_id, '');
+    assert.equal(cleared.additionalFields.auth_method, 'none');
+    assert.equal(cleared.additionalFields.identity_auth_type, undefined);
+    assert.deepEqual(cleared.additionalFields.custom, { keep: 0 });
+    const mcp = selectConnectorIdentity(action('mcp'), 'mcp', identities[0]);
+    mcp.additionalFields.api_key_header_name = '';
+    assert.ok(validateConnectorAuthentication(mcp, 'mcp', null)['additionalFields.api_key_header_name']);
+});
+check('clearing key names and unsupported URL schemes produce real validation errors', () => {
+    for (const url of ['javascript:alert(1)', 'https://user:password@example.test', '/relative', 'https://example.test/#fragment']) {
+        assert.ok(connectorUrlError(url));
+    }
+    assert.equal(connectorUrlError('https://example.test/mcp'), null);
+    assert.equal(connectorUrlError('wss://example.test/mcp', true), null);
+    assert.ok(connectorUrlError('https://example.test/mcp', true));
+    const draft = changeConnectorAuthMethod(action(), 'openapi', 'api_key');
+    draft.auth.key = 'synthetic-key';
+    draft.additionalFields.api_key_name = '';
+    assert.ok(validateConnectorAuthentication(draft, 'openapi', null)['additionalFields.api_key_name']);
+});
+check('catalogue wrappers are parsed while failures and duplicate IDs are not empty success', () => {
+    const entry = catalogEntry();
+    for (const payload of [[entry], { presets: [entry] }, { data: { presets: [entry] } }, { data: [entry] }]) {
+        assert.equal(parseMcpCatalogue(payload, 'presets')[0].id, 'generic');
+    }
+    assert.equal(parseMcpCatalogue({ preconfigurations: [] }, 'preconfigurations').length, 0);
+    assert.throws(() => parseMcpCatalogue({ error: 'denied' }, 'presets'), /invalid/);
+    assert.throws(() => parseMcpCatalogue({ presets: [{ label: 'Missing ID' }] }, 'presets'), /invalid entry/);
+    assert.throws(() => parseMcpCatalogue({ presets: [entry, entry] }, 'presets'), /duplicate/);
+});
+check('personal transport choices never include stdio even if a preset permits it', () => {
+    assert.deepEqual(allowedMcpTransports().map(({ value }) => value), ['streamable_http', 'sse', 'websocket']);
+    assert.deepEqual(allowedMcpTransports(catalogEntry({ constraints: { allowedTransports: ['stdio', 'sse'] } })).map(({ value }) => value), ['sse']);
+    assert.deepEqual(allowedMcpTransports(catalogEntry({ constraints: { allowedTransports: ['stdio'] } })), []);
+    assert.equal(applyMcpPreset(action('mcp'), catalogEntry({ defaults: { transport: 'stdio' } })).additionalFields.transport, 'streamable_http');
+    assert.throws(() => applyMcpPreset(action('mcp'), catalogEntry({ constraints: { allowedTransports: ['stdio'] } })), /no transport/);
+    assert.throws(() => applyMcpPreconfiguration(action('mcp'), catalogEntry({ transport: 'stdio' })), /cannot use stdio/);
+    assert.throws(() => applyMcpPreconfiguration(action('mcp'), catalogEntry({ scopeEligibility: ['global'] })), /not available/);
+    assert.deepEqual(allowedMcpAuthMethods('websocket').map(({ value }) => value), ['none']);
+});
+check('preset application preserves false, zero, secret masks and unknown tool selections', () => {
+    const draft = action('mcp');
+    draft.additionalFields.allowed_tool_names = ['unavailable-tool'];
+    draft.additionalFields.custom_headers = { 'X-Stored': EDITOR_SECRET_MASK };
+    const next = applyMcpPreset(draft, catalogEntry({
+        id: 'custom',
+        defaults: {
+            load_tools: false, load_prompts: false, retry_count: 0, validate_tool_arguments: false,
+            custom_headers: { 'X-Stored': 'never-overwrite-a-mask' }, allowed_tool_names: ['new-tool'],
+        },
+    }));
+    assert.equal(next.additionalFields.load_tools, false);
+    assert.equal(next.additionalFields.retry_count, 0);
+    assert.equal(next.additionalFields.custom_headers['X-Stored'], EDITOR_SECRET_MASK);
+    assert.deepEqual(next.additionalFields.allowed_tool_names, ['unavailable-tool', 'new-tool']);
+    assert.deepEqual(next.additionalFields.custom, { keep: 0 });
+    assert.equal(draft.additionalFields.server_profile, 'generic');
+});
+check('preconfiguration settings apply explicitly without copying identity secrets or erasing unknown settings', () => {
+    const draft = selectConnectorIdentity(action('mcp'), 'mcp', { id: 'identity-a', name: 'A', auth_type: 'managed_identity' });
+    draft.additionalFields.implementation = { id: 'generic', schemaVersion: '1.0.0', customVersionNote: 'keep' };
+    draft.additionalFields.additionalSettings = { compatibilityProfile: 'standards_compliant', customSetting: { enabled: false } };
+    draft.additionalFields.allowed_tool_names = ['unknown-old-tool'];
+    const next = applyMcpPreconfiguration(draft, catalogEntry({
+        id: 'azure_mcp_server', presetId: 'generic', transport: 'streamable_http',
+        endpoint: 'https://azure.example.test/mcp',
+        implementation: { id: 'azure_mcp_server', schemaVersion: '1.0.0' },
+        additionalSettings: {
+            defaultAccessMode: 'read_only', localCommandExecution: false,
+            organizationHostedRemoteRequired: true, serviceNamespaces: ['Azure.ResourceGroups'],
+        },
+        defaults: { load_tools: false, retry_count: 0, auth_method: 'identity' },
+    }));
+    assert.equal(next.endpoint, 'https://azure.example.test/mcp');
+    assert.equal(next.identity_id, 'identity-a');
+    assert.equal(next.additionalFields.identity_auth_type, 'managed_identity');
+    assert.equal(next.additionalFields.auth_method, 'identity');
+    assert.equal(next.additionalFields.additionalSettings.localCommandExecution, false);
+    assert.deepEqual(next.additionalFields.additionalSettings.customSetting, { enabled: false });
+    assert.equal(next.additionalFields.additionalSettings.compatibilityProfile, undefined);
+    assert.equal(next.additionalFields.implementation.customVersionNote, 'keep');
+    assert.deepEqual(next.additionalFields.allowed_tool_names, ['unknown-old-tool']);
+    assert.equal(next.additionalFields.load_tools, false);
+    assert.deepEqual(validateConnectorConfiguration(next, 'mcp'), {});
+});
+check('implementation safety constants and selected references are validated without deleting them', () => {
+    const draft = action('mcp');
+    draft.additionalFields.implementation = { id: 'azure_mcp_server', schemaVersion: '1.0.0' };
+    draft.additionalFields.additionalSettings = {
+        defaultAccessMode: 'read_only', localCommandExecution: true,
+        organizationHostedRemoteRequired: true, serviceNamespaces: ['invalid namespace'],
+    };
+    const errors = validateConnectorConfiguration(draft, 'mcp');
+    assert.ok(errors['additionalFields.additionalSettings.localCommandExecution']);
+    assert.ok(errors['additionalFields.additionalSettings.serviceNamespaces']);
+    assert.equal(draft.additionalFields.additionalSettings.localCommandExecution, true);
+    assert.deepEqual(mcpImplementationFields('constructor'), []);
+    assert.deepEqual(mcpImplementationFields('__proto__'), []);
+});
+check('MCP native limits distinguish zero, false, invalid strings, and deliberate empty collections', () => {
+    const draft = action('mcp');
+    draft.additionalFields.load_tools = false;
+    assert.deepEqual(validateConnectorConfiguration(draft, 'mcp'), {});
+    draft.additionalFields.request_timeout = 0;
+    draft.additionalFields.retry_count = 0.5;
+    draft.additionalFields.load_prompts = 'false';
+    draft.additionalFields.allowed_tool_names = [1];
+    draft.additionalFields.mcp_tools = {};
+    const errors = validateConnectorConfiguration(draft, 'mcp');
+    for (const field of ['request_timeout', 'retry_count', 'load_prompts', 'allowed_tool_names', 'mcp_tools']) {
+        assert.ok(errors[`additionalFields.${field}`], field);
+    }
+});
+check('custom header controls reject reserved names, duplicates, line breaks and masked renames', () => {
+    for (const name of ['Host', 'Cookie', 'Connection', 'Content-Length', 'Bad Name', '']) assert.ok(mcpHeaderNameError(name));
+    assert.ok(mcpHeaderNameError('x-test', { 'X-Test': '' }));
+    assert.equal(mcpHeaderNameError('X-Custom'), null);
+    const draft = action('mcp');
+    draft.additionalFields.custom_headers = { 'X-Stored': EDITOR_SECRET_MASK, 'X-Plain': 'synthetic' };
+    assert.throws(() => renameMcpHeader(draft, 'X-Stored', 'X-Renamed'), /Replace the stored/);
+    const renamed = renameMcpHeader(draft, 'X-Plain', 'X-Renamed');
+    assert.equal(renamed.additionalFields.custom_headers['X-Renamed'], 'synthetic');
+    assert.equal(renamed.additionalFields.custom_headers['X-Stored'], EDITOR_SECRET_MASK);
+    draft.additionalFields.custom_headers['X-Plain'] = 'line\r\nbreak';
+    assert.ok(validateConnectorConfiguration(draft, 'mcp')['additionalFields.custom_headers.X-Plain']);
+    draft.additionalFields.transport = 'websocket';
+    draft.endpoint = 'wss://example.test/mcp';
+    assert.ok(validateConnectorConfiguration(draft, 'mcp')['additionalFields.custom_headers']);
+});
+check('discovery merges tool metadata while retaining unavailable selected tool names', () => {
+    const old = [
+        { original_name: 'known', function_name: 'oldKnown', description: 'Old', customMetadata: { keep: true } },
+        { original_name: 'missing', function_name: 'missing', description: 'Stored missing tool' },
+        { original_name: 'unselected-old', function_name: 'old' },
+    ];
+    const discovered = [{ original_name: 'known', function_name: 'known', description: 'Updated', input_schema: { type: 'object' } }];
+    const merged = mergeMcpTools(old, discovered, ['known', 'missing', 'no-metadata']);
+    assert.equal(merged.length, 2);
+    assert.equal(merged[0].description, 'Updated');
+    assert.deepEqual(merged[0].customMetadata, { keep: true });
+    const choices = mcpToolChoices(merged, ['known', 'missing', 'no-metadata'], ['known']);
+    assert.equal(choices.find(({ name }) => name === 'missing').unavailable, true);
+    assert.equal(choices.find(({ name }) => name === 'no-metadata').selected, true);
+    let draft = action('mcp');
+    draft.additionalFields.allowed_tool_names = ['missing', 'no-metadata'];
+    draft = setMcpToolSelection(draft, 'known', true);
+    assert.deepEqual(draft.additionalFields.allowed_tool_names, ['missing', 'no-metadata', 'known']);
+    draft = setMcpToolSelection(draft, 'missing', false);
+    assert.deepEqual(draft.additionalFields.allowed_tool_names, ['no-metadata', 'known']);
+    assert.deepEqual(connectorLines('one\r\ntwo\none\n\n'), ['one', 'two']);
+    assert.equal(parseMcpTools([{ name: 'legacy', inputSchema: { type: 'object' } }])[0].original_name, 'legacy');
+});
+check('support payloads bind stored credentials to original user scope and stable identity', () => {
+    const draft = changeConnectorAuthMethod(action(), 'openapi', 'bearer');
+    draft.auth.key = EDITOR_SECRET_MASK;
+    draft.auth.tenantId = EDITOR_SECRET_MASK;
+    draft.additionalFields.customSecret = EDITOR_SECRET_MASK;
+    const original = resource(draft, ['/auth/key', '/auth/tenantId', '/additionalFields/customSecret']);
+    draft.id = 'unsaved-id';
+    draft.name = 'renamed-machine-name';
+    draft.auth.tenantId = '';
+    const payload = buildConnectorSupportPayload(draft, original, 'openapi');
+    assert.deepEqual(payload.plugin_context, { scope: 'personal', id: 'action-owned', name: 'saved-machine-name' });
+    assert.equal(payload.action_scope, 'personal');
+    assert.equal(payload.auth.key, STORED_CONNECTOR_SECRET);
+    assert.equal(payload.auth.tenantId, undefined);
+    assert.equal(payload.additionalFields.customSecret, STORED_CONNECTOR_SECRET);
+    assert.ok(payload.clear_secret_paths.includes('/auth/tenantId'));
+    assert.equal(original.record.auth.key, EDITOR_SECRET_MASK);
+    assert.ok(!JSON.stringify(payload).includes(EDITOR_SECRET_MASK));
+});
+check('API-key identities retain native header/query placement and do not test inactive credentials', () => {
+    const before = action();
+    before.auth.key = EDITOR_SECRET_MASK;
+    const original = resource(before, ['/auth/key']);
+    const identity = { id: 'identity-key', name: 'API identity', auth_type: 'api_key' };
+    let selected = selectConnectorIdentity(before, 'openapi', identity);
+    assert.equal(selected.additionalFields.api_key_location, 'header');
+    assert.equal(selected.additionalFields.api_key_name, 'X-API-Key');
+    selected = updateConnectorFields(selected, { api_key_location: 'query', api_key_name: 'subscription-key' });
+    assert.deepEqual(validateConnectorAuthentication(selected, 'openapi', original), {});
+    const payload = buildConnectorSupportPayload(selected, original, 'openapi');
+    assert.deepEqual(payload.auth, { type: 'identity', identity: identity.id });
+    assert.equal(payload.additionalFields.api_key_location, 'query');
+    assert.equal(payload.additionalFields.api_key_name, 'subscription-key');
+    assert.equal(selected.auth.key, EDITOR_SECRET_MASK);
+    assert.ok(validateConnectorAuthentication(updateConnectorFields(selected, { api_key_name: '' }), 'openapi', original)['additionalFields.api_key_name']);
+    assert.ok(validateConnectorAuthentication(updateConnectorFields(selected, { api_key_location: 'cookie' }), 'openapi', original)['additionalFields.api_key_location']);
+    assert.equal(selectConnectorIdentity(selected, 'openapi', identity).additionalFields.api_key_name, 'subscription-key');
+});
+check('literal masks in ordinary text are not secret references and nested secret pointers are supported', () => {
+    const draft = action('mcp');
+    draft.description = EDITOR_SECRET_MASK;
+    draft.additionalFields.custom_headers = { 'X-Scoped': EDITOR_SECRET_MASK };
+    draft.additionalFields.items = [{ 'a/b~token': EDITOR_SECRET_MASK }];
+    const original = resource(draft, ['/additionalFields/custom_headers/X-Scoped', '/additionalFields/items/0/a~1b~0token']);
+    const payload = buildConnectorSupportPayload(draft, original, 'mcp', 'discover');
+    assert.equal(payload.description, EDITOR_SECRET_MASK);
+    assert.equal(payload.additionalFields.items[0]['a/b~token'], STORED_CONNECTOR_SECRET);
+    assert.equal(payload.additionalFields.custom_headers['X-Scoped'], STORED_CONNECTOR_SECRET);
+});
+check('intentional auth clears never fall back to stored credentials for tests', () => {
+    let draft = changeConnectorAuthMethod(action(), 'openapi', 'bearer');
+    draft.auth.key = EDITOR_SECRET_MASK;
+    const original = resource(draft, ['/auth/key']);
+    draft.auth.key = '';
+    assert.throws(() => buildConnectorSupportPayload(draft, original, 'openapi'), /Cleared credentials/);
+    draft = changeConnectorAuthMethod(draft, 'openapi', 'none');
+    const payload = buildConnectorSupportPayload(draft, original, 'openapi');
+    assert.deepEqual(payload.auth, { type: 'key', key: '' });
+    assert.ok(payload.clear_secret_paths.includes('/auth/key'));
+    assert.ok(!JSON.stringify(payload).includes(STORED_CONNECTOR_SECRET));
+});
+check('cleared and removed custom headers are omitted rather than rehydrated', () => {
+    const draft = action('mcp');
+    draft.additionalFields.custom_headers = { 'X-Keep': EDITOR_SECRET_MASK, 'X-Clear': EDITOR_SECRET_MASK, 'X-Remove': EDITOR_SECRET_MASK };
+    const original = resource(draft, Object.keys(draft.additionalFields.custom_headers).map((name) => `/additionalFields/custom_headers/${name}`));
+    draft.additionalFields.custom_headers['X-Clear'] = '';
+    delete draft.additionalFields.custom_headers['X-Remove'];
+    draft.additionalFields.custom_headers['X-New-Empty'] = '';
+    const payload = buildConnectorSupportPayload(draft, original, 'mcp', 'discover');
+    assert.deepEqual(payload.additionalFields.custom_headers, { 'X-Keep': STORED_CONNECTOR_SECRET });
+    assert.ok(payload.clear_secret_paths.includes('/additionalFields/custom_headers/X-Clear'));
+    assert.ok(payload.clear_secret_paths.includes('/additionalFields/custom_headers/X-Remove'));
+    assert.equal(draft.additionalFields.custom_headers['X-Clear'], '');
+});
+check('new or foreign masks and read-only resources cannot be used to run a connector', () => {
+    const draft = changeConnectorAuthMethod(action(), 'openapi', 'bearer');
+    draft.auth.key = EDITOR_SECRET_MASK;
+    assert.throws(() => buildConnectorSupportPayload(draft, null, 'openapi'), /credential/);
+    const original = resource(draft, ['/auth/key']);
+    original.read_only = true;
+    assert.throws(() => buildConnectorSupportPayload(draft, original, 'openapi'), /read-only/);
+    const mcp = action('mcp');
+    mcp.additionalFields.custom_headers = { 'X-Foreign': EDITOR_SECRET_MASK };
+    assert.throws(() => buildConnectorSupportPayload(mcp, null, 'mcp'), /owned record/);
+    mcp.additionalFields.custom_headers = {};
+    mcp.additionalFields.futureSecret = EDITOR_SECRET_MASK;
+    assert.throws(() => buildConnectorSupportPayload(mcp, null, 'mcp'), /owned record/);
+});
+check('legacy Stored_In_KeyVault markers remain bound to an owned stored path', () => {
+    const draft = changeConnectorAuthMethod(action(), 'openapi', 'bearer');
+    draft.auth.key = STORED_CONNECTOR_SECRET;
+    const original = resource(draft, ['/auth/key']);
+    assert.equal(buildConnectorSupportPayload(draft, original, 'openapi').auth.key, STORED_CONNECTOR_SECRET);
+    assert.throws(() => buildConnectorSupportPayload(draft, null, 'openapi'), /credential/);
+});
+check('failure feedback retains server warnings, field errors, and false/zero details', () => {
+    const feedback = connectorFeedback(new ApiError('Denied', 403, {
+        error: 'Governance denied the destination', errors: ['Review allowlist'], warnings: ['Tools remain disabled'],
+        details: { retry_count: 0, active: false },
+    }));
+    assert.equal(feedback.success, false);
+    assert.deepEqual(feedback.errors, ['Review allowlist']);
+    assert.deepEqual(feedback.warnings, ['Tools remain disabled']);
+    assert.deepEqual(feedback.details, { retry_count: 0, active: false });
+});
+
+const actualFetch = globalThis.fetch;
+const requests = [];
+let responseBody = { success: true };
+let responseStatus = 200;
+globalThis.fetch = async (url, init = {}) => {
+    requests.push({
+        url, ...init,
+        body: typeof init.body === 'string' ? JSON.parse(init.body) : init.body,
+    });
+    if (init.signal?.aborted) throw new DOMException('Aborted', 'AbortError');
+    return new Response(JSON.stringify(responseBody), {
+        status: responseStatus, headers: { 'Content-Type': 'application/json' },
+    });
+};
+try {
+    await asyncCheck('configuration, identity, preset and tool selection never execute a connector', async () => {
+        const count = requests.length;
+        applyMcpPreset(action('mcp'), catalogEntry());
+        selectConnectorIdentity(action(), 'openapi', { id: 'a', name: 'A', auth_type: 'api_key' });
+        changeConnectorAuthMethod(action(), 'openapi', 'api_key');
+        setMcpToolSelection(action('mcp'), 'known-tool', true);
+        assert.equal(requests.length, count);
+    });
+    await asyncCheck('catalogue reads use the existing personal endpoints and pass abort signals', async () => {
+        const controller = new AbortController();
+        responseBody = { presets: [catalogEntry()] };
+        assert.equal((await fetchMcpPresets(controller.signal)).length, 1);
+        assert.equal(requests.at(-1).url, '/api/plugins/mcp/presets');
+        assert.equal(requests.at(-1).signal, controller.signal);
+        responseBody = { scope: 'personal', preconfigurations: [] };
+        assert.deepEqual(await fetchMcpPreconfigurations(controller.signal), []);
+        assert.equal(requests.at(-1).url, '/api/plugins/mcp/preconfigurations?scope=personal');
+        assert.equal(requests.at(-1).credentials, 'same-origin');
+    });
+    await asyncCheck('file and manual YAML imports go through authenticated multipart canonical upload', async () => {
+        responseBody = { success: true, file_id: 'file-1', original_filename: 'input.json', spec_content: specification };
+        const controller = new AbortController();
+        await uploadOpenApiSpecification(new File([JSON.stringify(specification)], 'input.json'), undefined, controller.signal);
+        let call = requests.at(-1);
+        assert.equal(call.url, '/api/openapi/upload');
+        assert.equal(call.method, 'POST');
+        assert.equal(call.credentials, 'same-origin');
+        assert.equal(call.signal, controller.signal);
+        assert.ok(call.body instanceof FormData);
+        assert.equal(call.body.get('file').name, 'input.json');
+        assert.deepEqual(JSON.parse(await call.body.get('file').text()), specification);
+        const yaml = 'openapi: 3.0.3\ninfo: { title: Example, version: "1" }\npaths: {}';
+        await processOpenApiText(yaml, 'yaml');
+        call = requests.at(-1);
+        assert.equal(call.url, '/api/openapi/upload');
+        assert.equal(call.body.get('file').name, 'openapi.yaml');
+        assert.equal(await call.body.get('file').text(), yaml);
+        assert.ok(requests.every(({ url }) => url.startsWith('/api/')));
+    });
+    await asyncCheck('invalid uploads fail without additional requests or changing existing content', async () => {
+        const count = requests.length;
+        await assert.rejects(uploadOpenApiSpecification(new File(['no'], 'bad.exe')), /Choose a/);
+        await assert.rejects(uploadOpenApiSpecification(new File([], 'empty.json')), /empty/);
+        await assert.rejects(uploadOpenApiSpecification(new Blob([new Uint8Array(5 * 1024 * 1024 + 1)]), 'large.json'), /5 MB/);
+        assert.equal(requests.length, count);
+        responseBody = { success: false, error: 'Validation rejected this specification' };
+        await assert.rejects(processOpenApiText('invalid: yaml', 'yaml'), /Validation rejected/);
+        responseBody = { success: true, spec_content: 'not an object' };
+        await assert.rejects(processOpenApiText('{}', 'json'), /validated OpenAPI/);
+    });
+    await asyncCheck('manual JSON processing uses multipart content, never a remote-specification request', async () => {
+        responseBody = { success: true, file_id: 'manual-file', original_filename: 'openapi.json', spec_content: specification };
+        const signal = new AbortController().signal;
+        const count = requests.length;
+        const result = await processOpenApiText(JSON.stringify(specification), 'json', signal);
+        const call = requests.at(-1);
+        assert.equal(call.url, '/api/openapi/upload');
+        assert.equal(call.method, 'POST');
+        assert.equal(call.signal, signal);
+        assert.ok(call.body instanceof FormData);
+        assert.equal(call.body.has('url'), false);
+        assert.equal(call.body.get('file').name, 'openapi.json');
+        assert.deepEqual(JSON.parse(await call.body.get('file').text()), specification);
+        assert.deepEqual(result.spec_content, specification);
+        assert.equal(requests.length, count + 1);
+        assert.ok(requests.every(({ url }) => String(url).startsWith('/api/')));
+    });
+    await asyncCheck('OpenAPI testing sends the full edited manifest and the original owned context', async () => {
+        const draft = changeConnectorAuthMethod(action(), 'openapi', 'bearer');
+        draft.auth.key = EDITOR_SECRET_MASK;
+        const original = resource(draft, ['/auth/key']);
+        draft.name = 'new-name';
+        responseBody = { success: true, message: 'Probe succeeded', details: { operation_count: 2 } };
+        const controller = new AbortController();
+        await testApiConnector(draft, original, 'openapi', controller.signal);
+        const call = requests.at(-1);
+        assert.equal(call.url, '/api/plugins/test-openapi-connection');
+        assert.deepEqual(call.body.plugin_context, { scope: 'personal', id: 'action-owned', name: 'saved-machine-name' });
+        assert.equal(call.body.auth.key, STORED_CONNECTOR_SECRET);
+        assert.equal(call.body.action_scope, 'personal');
+        assert.equal(call.signal, controller.signal);
+        assert.deepEqual(call.body.additionalFields.custom, { keep: 0 });
+        const count = requests.length;
+        draft.auth.key = '';
+        await assert.rejects(async () => testApiConnector(draft, original, 'openapi'), /Cleared credentials/);
+        assert.equal(requests.length, count);
+    });
+    await asyncCheck('MCP discovery and testing are separate explicit requests with edit-time credentials', async () => {
+        const draft = changeConnectorAuthMethod(action('mcp'), 'mcp', 'basic');
+        draft.auth.key = EDITOR_SECRET_MASK;
+        draft.auth.identity = EDITOR_SECRET_MASK;
+        const original = resource(draft, ['/auth/key', '/auth/identity']);
+        responseBody = {
+            success: true, tools: [{ original_name: 'known', function_name: 'known' }],
+            capabilities: { tools: true, prompts_requested: false }, warnings: ['Review mutating tools', { untrusted: 'not a string' }],
+        };
+        const result = await discoverMcpAction(draft, original);
+        let call = requests.at(-1);
+        assert.equal(call.url, '/api/plugins/mcp/discover');
+        assert.equal(call.body.auth.key, STORED_CONNECTOR_SECRET);
+        assert.equal(call.body.auth.identity, STORED_CONNECTOR_SECRET);
+        assert.equal(call.body.action_scope, 'personal');
+        assert.equal(call.body.plugin_context.scope, 'personal');
+        assert.deepEqual(result.warnings, ['Review mutating tools']);
+        responseBody = { success: true, message: 'Connected' };
+        await testApiConnector(draft, original, 'mcp');
+        call = requests.at(-1);
+        assert.equal(call.url, '/api/plugins/test-mcp-connection');
+        assert.equal(call.body.auth.identity, STORED_CONNECTOR_SECRET);
+        const count = requests.length;
+        original.read_only = true;
+        await assert.rejects(async () => discoverMcpAction(draft, original), /read-only/);
+        assert.equal(requests.length, count);
+    });
+    await asyncCheck('canonical validation never calls a test endpoint and retains server errors', async () => {
+        responseBody = { valid: false, errors: ['Canonical schema validation error'], warnings: [] };
+        const result = await validateApiConnector(action(), null, 'openapi');
+        const call = requests.at(-1);
+        assert.equal(call.url, '/api/plugins/validate');
+        assert.equal(call.body.type, 'openapi');
+        assert.equal(call.body.plugin_context, undefined);
+        assert.equal(connectorFeedback(result).success, false);
+        assert.deepEqual(connectorFeedback(result).errors, ['Canonical schema validation error']);
+    });
+    await asyncCheck('failed or malformed discovery remains a failure, and abort signals are forwarded', async () => {
+        responseStatus = 403;
+        responseBody = { error: 'Destination denied', warnings: ['Check governance'] };
+        await assert.rejects(discoverMcpAction(action('mcp'), null), (error) => {
+            assert.equal(connectorFeedback(error).message, 'Destination denied');
+            assert.deepEqual(connectorFeedback(error).warnings, ['Check governance']);
+            return true;
+        });
+        responseStatus = 200;
+        responseBody = { success: true };
+        await assert.rejects(discoverMcpAction(action('mcp'), null), /invalid MCP tool catalogue/);
+        responseBody = { success: true, tools: [{ invalid: 'tool metadata' }] };
+        await assert.rejects(discoverMcpAction(action('mcp'), null), /invalid MCP tool catalogue/);
+        const controller = new AbortController();
+        controller.abort();
+        await assert.rejects(fetchMcpPresets(controller.signal), { name: 'AbortError' });
+    });
+} finally {
+    globalThis.fetch = actualFetch;
+}
+
+console.log(`${checks} OpenAPI/MCP connector logic checks passed.`);

--- a/functional_tests/test_v2_workspace_agent_authoring_logic.mjs
+++ b/functional_tests/test_v2_workspace_agent_authoring_logic.mjs
@@ -1,0 +1,562 @@
+// test_v2_workspace_agent_authoring_logic.mjs
+// Version: 0.261.096
+// Implemented in: 0.261.096
+// Executes native agent draft, model, action, knowledge, template, and command behavior.
+
+import assert from 'node:assert/strict';
+import './test_support/tsResolve.mjs';
+
+const {
+    newAgentDraft, renameAgentDraft, updateAgentSetting, parseAgentSettings, changeAgentType, clearAgentDraftFields,
+    agentModelChoices, selectedAgentModel, selectAgentModel, foundryEndpointMatches,
+    selectFoundryEndpoint, applyFoundryDiscovery, agentValidationErrors, agentForSave,
+    secretValueAt, setAgentSecret, secretIntent, isAgentIconImage, isAgentEditorEnvelope,
+    agentStoredArrayEditError, applySafeAgentDraft,
+} = await import('../application/v2_ui/src/lib/workspaceAgentAuthoring.ts');
+const {
+    readAgentKnowledge, updateAgentKnowledge, toggleAgentKnowledgeSource, selectedKnowledgeSources,
+    resolvedAgentDocuments, agentKnowledgeReference, normalizeAgentKnowledgeUrl, agentKnowledgeErrors,
+    fetchAgentKnowledgeCatalog,
+} = await import('../application/v2_ui/src/lib/workspaceAgentKnowledge.ts');
+const {
+    AGENT_ACTION_CAPABILITIES, resolveAgentAction, toggleAgentAction, agentHasAction,
+    agentActionUnavailableReason, agentActionCapabilities, updateAgentCapability, agentSelectedActionsContext, newAgentActionErrors,
+} = await import('../application/v2_ui/src/lib/workspaceAgentActions.ts');
+const {
+    agentActionToken, agentKnowledgeToken, agentMentionTrigger, agentMentions, filterAgentMentions,
+} = await import('../application/v2_ui/src/lib/workspaceAgentReferences.ts');
+const {
+    safeAgentTemplateSettings, agentDraftFromTemplate, agentTemplateSubmission, fetchAgentTemplates,
+} = await import('../application/v2_ui/src/lib/workspaceAgentTemplates.ts');
+const {
+    agentInstructionRequest, draftAgentInstructions, withAgentInstructionProposal, discoverAgentFoundryResources,
+} = await import('../application/v2_ui/src/lib/workspaceAgentCommands.ts');
+const { buildEditorWrite, EDITOR_SECRET_MASK, sameEditorValue } = await import('../application/v2_ui/src/lib/workspaceAuthoring.ts');
+const { saveAgentConfiguration } = await import('../application/v2_ui/src/lib/workspaceAuthoringApi.ts');
+
+const options = {
+    agent_types: ['local', 'aifoundry', 'new_foundry', 'foundry_workflow'].map((value) => ({ value, label: value, enabled: true })),
+    settings: { allow_user_custom_endpoints: true },
+    model_endpoints: [], builtin_actions: [],
+};
+const originalDraft = {
+    ...newAgentDraft(),
+    id: 'agent-one', user_id: 'owner', name: 'unchanged-name', display_name: 'Reviewer',
+    description: 'Reviews documents.', instructions: 'Quote the evidence.',
+    azure_openai_gpt_key: EDITOR_SECRET_MASK,
+    actions_to_load: ['ordinary', 'call-agent', 'legacy-action'],
+    other_settings: {
+        custom: { retained: 42 }, action_capabilities: { ordinary: { read: true, unknown: false } },
+        assigned_knowledge: {
+            enabled: true, scopes: { personal: true, group_ids: [], public_workspace_ids: ['public-one', 'unavailable-public'] },
+            document_ids: ['explicit', 'unavailable-document'], tags: ['policy', 'approved'],
+            web_sources: [{ url: 'https://example.org/source', mode: 'url_review' }],
+            allow_user_workspace_context: true, allowed_user_workspace_actions: [],
+            future_option: { keep: false },
+        },
+    },
+};
+const original = { record: originalDraft, revision: 'one', secret_paths: ['/azure_openai_gpt_key'], read_only: false };
+const action = (id, type, extra = {}) => ({
+    id, type, name: id, displayName: id, description: '', endpoint: '', auth: { type: 'user' },
+    additionalFields: {}, metadata: {}, ...extra,
+});
+const ordinary = action('ordinary', 'http');
+const call = action('call-agent', 'agent', {
+    additionalFields: { target_agent: { id: 'target', scope_type: 'personal', scope_id: 'owner' } },
+});
+const actions = [ordinary, call];
+const catalog = {
+    sources: [
+        { scope: 'personal', id: 'personal', label: 'Personal workspace' },
+        { scope: 'public', id: 'public-one', label: 'Policies' },
+    ],
+    documents: [
+        { id: 'explicit', title: 'Explicit.pdf', file_name: 'Explicit.pdf', scope: 'personal', source_id: 'personal', source_name: 'Personal workspace', tags: [] },
+        { id: 'all-tags', title: 'Handbook.pdf', file_name: 'Handbook.pdf', scope: 'public', source_id: 'public-one', source_name: 'Policies', tags: ['policy', 'approved'] },
+        { id: 'one-tag', title: 'Draft.pdf', file_name: 'Draft.pdf', scope: 'public', source_id: 'public-one', source_name: 'Policies', tags: ['policy'] },
+        { id: 'other-source', title: 'Other.pdf', file_name: 'Other.pdf', scope: 'public', source_id: 'unselected', source_name: 'Other', tags: ['policy', 'approved'] },
+    ],
+    tags: [{ name: 'policy', count: 3 }, { name: 'approved', count: 2 }],
+};
+
+let checks = 0;
+async function check(label, run) {
+    await run();
+    checks += 1;
+    console.log(`ok ${label}`);
+}
+
+await check('read-only detail envelopes need no revision while writable records require one', () => {
+    assert.ok(isAgentEditorEnvelope({ ...original, read_only: true, revision: '' }));
+    assert.ok(isAgentEditorEnvelope({ record: originalDraft, read_only: true, secret_paths: [] }));
+    assert.ok(isAgentEditorEnvelope(original));
+    for (const revision of ['', ' ', undefined, null, 0]) {
+        assert.equal(isAgentEditorEnvelope({ ...original, revision }), false);
+    }
+    assert.equal(isAgentEditorEnvelope({ ...original, read_only: 'true', revision: '' }), false);
+});
+await check('read-only permission does not bypass record and secret-path shape checks', () => {
+    const resource = { ...original, read_only: true, revision: '' };
+    for (const record of [null, undefined, [], 'invalid']) assert.equal(isAgentEditorEnvelope({ ...resource, record }), false);
+    for (const secret_paths of [null, undefined, {}, 'invalid', [42]]) assert.equal(isAgentEditorEnvelope({ ...resource, secret_paths }), false);
+});
+
+await check('new drafts use the schema sentinel and existing internal names do not change with display names', () => {
+    assert.equal(newAgentDraft().max_completion_tokens, -1);
+    const created = renameAgentDraft(newAgentDraft(), 'Contract reviewer', true);
+    assert.equal(created.name, 'Contract-reviewer');
+    assert.equal(renameAgentDraft(originalDraft, 'Renamed', false).name, 'unchanged-name');
+    assert.equal(renameAgentDraft({ ...created, name: 'explicit-name' }, 'Other', true).name, 'explicit-name');
+});
+await check('all four types preserve incompatible settings until an explicit action', () => {
+    for (const type of options.agent_types.map((item) => item.value)) {
+        const changed = changeAgentType(originalDraft, type);
+        assert.equal(changed.agent_type, type);
+        assert.deepEqual(changed.other_settings, originalDraft.other_settings);
+        assert.deepEqual(changed.actions_to_load, originalDraft.actions_to_load);
+        assert.equal(changed.azure_openai_gpt_key, EDITOR_SECRET_MASK);
+        if (type !== 'local') assert.match(agentValidationErrors(changed, options).join(' '), /Explicitly detach local actions/);
+    }
+});
+await check('structured edits and pasted JSON retain managed sibling settings, false and empty arrays', () => {
+    const next = updateAgentSetting(originalDraft, 'custom', { added: 0 });
+    assert.deepEqual(next.other_settings.custom, { retained: 42, added: 0 });
+    const parsed = parseAgentSettings('{"custom":{"replacement":true},"assigned_knowledge":{"enabled":false,"scopes":{"personal":false},"allowed_user_workspace_actions":[]}}', originalDraft.other_settings);
+    assert.equal(parsed.assigned_knowledge.scopes.personal, false);
+    assert.deepEqual(parsed.assigned_knowledge.scopes.public_workspace_ids, ['public-one', 'unavailable-public']);
+    assert.deepEqual(parsed.assigned_knowledge.allowed_user_workspace_actions, []);
+    assert.deepEqual(parsed.action_capabilities, originalDraft.other_settings.action_capabilities);
+    assert.equal(parsed.assigned_knowledge.future_option.keep, false);
+    assert.throws(() => parseAgentSettings('[]', originalDraft.other_settings), /JSON object/);
+    assert.throws(() => parseAgentSettings('{', originalDraft.other_settings), SyntaxError);
+});
+await check('ending an untouched advanced edit does not create phantom dirty metadata', () => {
+    assert.ok(sameEditorValue(clearAgentDraftFields(originalDraft, '_editor_settings_text'), originalDraft));
+    assert.ok(sameEditorValue(updateAgentSetting(originalDraft, 'custom', { retained: 42 }), originalDraft));
+    const raw = { ...originalDraft, _editor_settings_text: JSON.stringify(originalDraft.other_settings) };
+    assert.ok(sameEditorValue(clearAgentDraftFields(raw, '_editor_settings_text'), originalDraft));
+});
+await check('duplicate model IDs remain bound to their endpoint identity and preserve credentials', () => {
+    const endpoints = ['east', 'west'].map((id) => ({
+        id, provider: 'aoai', name: id, models: [{ id: 'same-model', deploymentName: `${id}-deployment`, modelName: 'gpt-5' }],
+    }));
+    const choices = agentModelChoices({ ...options, model_endpoints: endpoints });
+    assert.notEqual(choices[0].key, choices[1].key);
+    const next = selectAgentModel(originalDraft, choices[1]);
+    assert.equal(next.model_endpoint_id, 'west');
+    assert.equal(next.model_id, 'same-model');
+    assert.equal(next.model_provider, 'aoai');
+    assert.equal(next.azure_openai_gpt_deployment, 'west-deployment');
+    assert.equal(next.azure_openai_gpt_key, EDITOR_SECRET_MASK);
+    assert.equal(selectedAgentModel(next, choices).endpointId, 'west');
+});
+await check('disabled model choices are excluded and legacy APIM fields stay separate', () => {
+    const disabled = agentModelChoices({ ...options, model_endpoints: [{ id: 'off', enabled: false, models: [{ id: 'hidden' }] }] });
+    assert.deepEqual(disabled, []);
+    const choices = agentModelChoices({ ...options, settings: { enable_gpt_apim: true, azure_apim_gpt_deployment: 'one, two' } });
+    const next = selectAgentModel(originalDraft, choices[1]);
+    assert.equal(next.azure_agent_apim_gpt_deployment, 'two');
+    assert.equal(next.enable_agent_gpt_apim, true);
+    const legacy = agentModelChoices({ ...options, settings: { gpt_model: { selected: [{ deploymentName: 'chat', modelName: 'gpt-4o' }] } } });
+    assert.equal(legacy[0].deployment, 'chat');
+});
+await check('Foundry types accept their scoped providers and synchronize endpoint fields without dropping siblings', () => {
+    const endpoint = { id: 'foundry', provider: 'new_foundry', scope: 'personal', connection: {
+        endpoint: 'https://example.org/api/projects/review', project_name: 'review', openai_api_version: '2025-01-01-preview',
+    } };
+    assert.ok(foundryEndpointMatches('foundry_workflow', endpoint));
+    assert.ok(!foundryEndpointMatches('aifoundry', endpoint));
+    const start = {
+        ...originalDraft, agent_type: 'new_foundry',
+        other_settings: { ...originalDraft.other_settings, new_foundry: { endpoint: 'old', notes: 'keep', application_id: 'saved-app' } },
+    };
+    const next = selectFoundryEndpoint(start, endpoint);
+    assert.equal(next.other_settings.new_foundry.endpoint, endpoint.connection.endpoint);
+    assert.equal(next.other_settings.new_foundry.responses_api_version, '2025-01-01-preview');
+    assert.equal(next.other_settings.new_foundry.notes, 'keep');
+    assert.equal(next.other_settings.new_foundry.application_id, 'saved-app');
+    assert.equal(next.other_settings.new_foundry.authentication_type, 'delegated_user');
+    assert.deepEqual(next.actions_to_load, start.actions_to_load);
+});
+await check('discovered workflow reference retains full identity and additional reference attributes', () => {
+    const next = applyFoundryDiscovery({ ...originalDraft, agent_type: 'foundry_workflow' }, {
+        workflow_name: 'Review workflow', workflow_agent_id: 'workflow-id',
+        application_id: 'review:1', application_version: '1',
+        agent_reference: { type: 'agent_reference', future_attribute: 'keep' },
+        responses_api_version: 'v1',
+    });
+    assert.deepEqual(next.other_settings.foundry_workflow.agent_reference, {
+        type: 'agent_reference', future_attribute: 'keep', name: 'Review workflow', id: 'workflow-id',
+        application_id: 'review:1', application_version: '1',
+    });
+    assert.equal(next.azure_openai_gpt_api_version, 'v1');
+    assert.deepEqual(next.other_settings.custom, originalDraft.other_settings.custom);
+});
+await check('all four type drafts validate with canonical required fields and gates remain authoritative', () => {
+    for (const type of options.agent_types.map((item) => item.value)) {
+        const key = type === 'aifoundry' ? 'azure_ai_foundry' : type;
+        const settings = type === 'aifoundry' ? { agent_id: 'remote' }
+            : type === 'new_foundry' ? { application_id: 'app:1', responses_api_version: 'v1' }
+            : { workflow_name: 'workflow', responses_api_version: 'v1' };
+        const next = {
+            ...originalDraft, agent_type: type, actions_to_load: [],
+            azure_openai_gpt_endpoint: 'https://example.org/project', azure_openai_gpt_api_version: 'v1',
+            other_settings: type === 'local' ? {} : { [key]: settings },
+        };
+        assert.deepEqual(agentValidationErrors(next, options), [], type);
+        const gated = { ...options, agent_types: options.agent_types.map((item) => ({ ...item, enabled: false })) };
+        assert.match(agentValidationErrors(next, gated).join(' '), /not available/);
+    }
+    assert.equal(agentForSave({ ...originalDraft, agent_type: 'new_foundry', instructions: '' }).instructions,
+        'Placeholder instructions: Azure AI Foundry agent manages its own prompt.');
+    assert.equal(agentForSave({ ...originalDraft, agent_type: 'new_foundry' }).instructions, originalDraft.instructions);
+});
+await check('completion token zero is intentional and limits are validated', () => {
+    assert.deepEqual(agentValidationErrors({ ...originalDraft, max_completion_tokens: 0 }, options), []);
+    assert.match(agentValidationErrors({ ...originalDraft, max_completion_tokens: -2 }, options).join(' '), /Completion token limit/);
+    assert.equal(buildEditorWrite({ ...originalDraft, max_completion_tokens: 0 }, original).updates.max_completion_tokens, 0);
+});
+await check('ordinary and Call agent actions share assignment logic without dropping legacy references', () => {
+    const removed = toggleAgentAction(originalDraft, call, false, actions);
+    assert.deepEqual(removed.actions_to_load, ['ordinary', 'legacy-action']);
+    const readded = toggleAgentAction(removed, call, true, actions);
+    assert.ok(agentHasAction(readded, call, actions));
+    assert.deepEqual(readded.actions_to_load, ['ordinary', 'legacy-action', 'call-agent']);
+    assert.equal(resolveAgentAction('duplicate', [action('one', 'http', { name: 'duplicate' }), action('two', 'agent', { name: 'duplicate' })]), undefined);
+    assert.deepEqual(removed.other_settings, originalDraft.other_settings);
+});
+await check('self-calls compare the full scope identity and unavailable targets remain explicit', () => {
+    const self = action('self', 'agent', { additionalFields: { target_agent: { id: originalDraft.id, scope_type: 'personal', scope_id: 'owner' } } });
+    const targets = { targets: [{ id: 'target', scope_type: 'personal', scope_id: 'owner' }], scope_type: 'personal', scope_id: 'owner', can_manage: true };
+    assert.match(agentActionUnavailableReason(originalDraft, self, targets, 'owner'), /self-calls/);
+    assert.equal(agentActionUnavailableReason(originalDraft, call, targets, 'owner'), null);
+    assert.match(agentActionUnavailableReason(originalDraft, call, { ...targets, targets: [] }, 'owner'), /no longer available/);
+    assert.equal(agentActionUnavailableReason(originalDraft, ordinary, null, 'owner'), null);
+    const globalTarget = { ...self, additionalFields: { target_agent: { id: originalDraft.id, scope_type: 'global', scope_id: 'global' } } };
+    assert.equal(agentActionUnavailableReason(originalDraft, globalTarget, { ...targets, targets: [globalTarget.additionalFields.target_agent] }, 'owner'), null);
+});
+await check('new action handoffs cannot save a self-call while unrelated unavailable references are retained', () => {
+    const self = action('self', 'agent', { additionalFields: { target_agent: { id: originalDraft.id, scope_type: 'personal', scope_id: 'owner' } } });
+    const draft = { ...originalDraft, actions_to_load: [...originalDraft.actions_to_load, 'self'] };
+    assert.match(newAgentActionErrors(draft, originalDraft, [...actions, self], null, 'owner').join(' '), /self-calls/);
+    assert.deepEqual(newAgentActionErrors(draft, draft, [...actions, self], null, 'owner'), []);
+    assert.deepEqual(newAgentActionErrors({ ...newAgentDraft(), actions_to_load: ['template-reference'] }, null, [], null, 'owner'), []);
+});
+await check('server-disabled personal Call agent attachment does not block provided calls or unchanged bindings', () => {
+    const globalTarget = { id: 'global-target', scope_type: 'global', scope_id: 'global' };
+    const providedCall = {
+        ...call, id: 'provided-call', name: 'provided-call', is_global: true,
+        additionalFields: { target_agent: globalTarget },
+    };
+    const targets = {
+        targets: [call.additionalFields.target_agent, globalTarget],
+        scope_type: 'personal', scope_id: 'owner', can_manage: false,
+    };
+    assert.match(agentActionUnavailableReason(originalDraft, call, targets, 'owner'), /New personal Call agent attachments/);
+    assert.equal(agentActionUnavailableReason(originalDraft, providedCall, targets, 'owner'), null);
+    assert.equal(agentActionUnavailableReason(originalDraft, ordinary, targets, 'owner'), null);
+    assert.deepEqual(newAgentActionErrors(originalDraft, originalDraft, actions, targets, 'owner'), []);
+    assert.match(newAgentActionErrors(originalDraft, { ...originalDraft, actions_to_load: [] }, actions, targets, 'owner').join(' '), /New personal Call agent attachments/);
+    assert.equal(agentActionUnavailableReason(originalDraft, call, { ...targets, can_manage: true }, 'owner'), null);
+});
+await check('all capability families preserve inherited upload behavior and unknown overrides', () => {
+    assert.equal(AGENT_ACTION_CAPABILITIES.simplechat.length, 13);
+    assert.equal(AGENT_ACTION_CAPABILITIES.msgraph.length, 11);
+    assert.equal(AGENT_ACTION_CAPABILITIES.chart.length, 10);
+    const simplechat = action('simple', 'simplechat', { additionalFields: { simplechat_capabilities: { upload_markdown_document: false } } });
+    const values = agentActionCapabilities(originalDraft, simplechat);
+    assert.equal(values.upload_word_document, false);
+    assert.equal(values.upload_powerpoint_document, false);
+    assert.equal(values.raise_workflow_alert, false);
+    const start = { ...originalDraft, other_settings: { ...originalDraft.other_settings, action_capabilities: { simple: { future: 'keep' }, untouched: { custom: true } } } };
+    const next = updateAgentCapability(start, simplechat, 'create_group', false);
+    assert.equal(next.other_settings.action_capabilities.simple.create_group, false);
+    assert.equal(next.other_settings.action_capabilities.simple.future, 'keep');
+    assert.deepEqual(next.other_settings.action_capabilities.untouched, { custom: true });
+    assert.deepEqual(next.other_settings.assigned_knowledge, start.other_settings.assigned_knowledge);
+});
+await check('knowledge preview uses explicit documents OR all tags within selected sources', () => {
+    const config = readAgentKnowledge(originalDraft);
+    assert.deepEqual(resolvedAgentDocuments(config, catalog).map((document) => document.id), ['explicit', 'all-tags']);
+    assert.deepEqual(resolvedAgentDocuments({ ...config, document_ids: [], tags: [] }, catalog).map((document) => document.id), ['explicit', 'all-tags', 'one-tag']);
+    assert.deepEqual(resolvedAgentDocuments({ ...config, enabled: false }, catalog), []);
+});
+await check('knowledge toggles retain unavailable document/source references and unknown settings', () => {
+    const next = toggleAgentKnowledgeSource(originalDraft, catalog.sources[0], false);
+    assert.deepEqual(readAgentKnowledge(next).document_ids, ['explicit', 'unavailable-document']);
+    assert.ok(selectedKnowledgeSources(readAgentKnowledge(next)).includes('public:unavailable-public'));
+    assert.equal(readAgentKnowledge(next).future_option.keep, false);
+    assert.deepEqual(readAgentKnowledge(next).allowed_user_workspace_actions, []);
+    assert.throws(() => toggleAgentKnowledgeSource(next, { scope: 'group', id: 'group', label: 'Group' }, true), /only authorized personal and public/);
+    assert.deepEqual(readAgentKnowledge(updateAgentKnowledge(next, { enabled: false })).document_ids, ['explicit', 'unavailable-document']);
+});
+await check('legacy knowledge aliases display and cannot resurrect explicitly removed references', () => {
+    const legacy = { ...originalDraft, other_settings: { assigned_knowledge: {
+        enabled: true, personal: true, public_workspace_ids: ['legacy-public'], selected_document_ids: ['legacy-document'],
+        sources: [{ scope: 'public', id: 'source-public' }, { scope: 'future', id: 'retain-future' }],
+        web_sources: [{ href: 'https://example.org/page', deep_research: true, extra: false }],
+    } } };
+    assert.equal(readAgentKnowledge(legacy).scopes.personal, true);
+    assert.deepEqual(readAgentKnowledge(legacy).scopes.public_workspace_ids, ['legacy-public', 'source-public']);
+    assert.deepEqual(readAgentKnowledge(legacy).document_ids, ['legacy-document']);
+    let next = updateAgentKnowledge(legacy, { document_ids: [] });
+    next = toggleAgentKnowledgeSource(next, { scope: 'personal', id: 'personal', label: 'Personal' }, false);
+    const config = readAgentKnowledge(next);
+    assert.deepEqual(config.document_ids, []);
+    assert.equal(config.scopes.personal, false);
+    assert.deepEqual(config.sources, [{ scope: 'future', id: 'retain-future' }]);
+    assert.deepEqual(config.scopes.public_workspace_ids, ['legacy-public', 'source-public']);
+    next = updateAgentKnowledge(next, { web_sources: [{ ...config.web_sources[0], mode: 'url_review' }] });
+    assert.equal(readAgentKnowledge(next).web_sources[0].mode, 'url_review');
+    assert.equal(readAgentKnowledge(next).web_sources[0].extra, false);
+    const write = buildEditorWrite(next, { ...original, record: legacy });
+    assert.ok(write.removed_paths.includes('/other_settings/assigned_knowledge/selected_document_ids'));
+    assert.ok(write.removed_paths.includes('/other_settings/assigned_knowledge/personal'));
+    const pasted = parseAgentSettings('{"assigned_knowledge":{"document_ids":[],"scopes":{"personal":false}}}', legacy.other_settings);
+    const pastedConfig = readAgentKnowledge({ ...legacy, other_settings: pasted });
+    assert.deepEqual(pastedConfig.document_ids, []);
+    assert.equal(pastedConfig.scopes.personal, false);
+    assert.deepEqual(pastedConfig.scopes.public_workspace_ids, ['legacy-public', 'source-public']);
+    assert.deepEqual(legacy.other_settings.assigned_knowledge.selected_document_ids, ['legacy-document']);
+});
+await check('assigned URL normalization, legacy mode, explicit limits and empty user actions are correct', () => {
+    assert.equal(normalizeAgentKnowledgeUrl('https://example.org/page#part'), 'https://example.org/page');
+    for (const url of ['javascript:alert(1)', '/relative', 'https://user:password@example.org']) assert.equal(normalizeAgentKnowledgeUrl(url), '');
+    const legacy = { ...originalDraft, other_settings: { assigned_knowledge: { web_sources: { urls: ['https://example.org'], deep_research: true } } } };
+    assert.equal(readAgentKnowledge(legacy).web_sources[0].mode, 'deep_research');
+    assert.match(agentKnowledgeErrors(updateAgentKnowledge(originalDraft, { document_ids: Array.from({ length: 201 }, (_, index) => String(index)) })).join(' '), /200/);
+    assert.deepEqual(readAgentKnowledge(originalDraft).allowed_user_workspace_actions, []);
+});
+await check('instruction references use the exact quoting grammar and bounded non-word trigger', () => {
+    assert.equal(agentActionToken('Calendar helper', 'send_mail'), '#action:"Calendar helper":send_mail');
+    assert.equal(agentKnowledgeToken('doc', 'Q3: "Review".pdf'), '#knowledge:doc:"Q3: \'Review\'.pdf"');
+    assert.equal(agentKnowledgeToken('web', 'https://example.org'), '#knowledge:web:"https://example.org"');
+    assert.equal(agentMentionTrigger('mid#word', 8), null);
+    assert.equal(agentMentionTrigger('#old\nnext', 9), null);
+    assert.equal(agentMentionTrigger(`${'x'.repeat(100000)} #action:cal`, 100012)?.query, 'action:cal');
+    const mentions = agentMentions(originalDraft, actions, catalog);
+    assert.ok(mentions.some((item) => item.token === '#action:call-agent'));
+    assert.ok(mentions.some((item) => item.token === '#knowledge:doc:Handbook.pdf'));
+    assert.ok(filterAgentMentions(mentions, 'knowledge:doc').every((item) => item.description === 'Assigned document'));
+});
+await check('draft requests carry action capabilities and selected knowledge without credentials', () => {
+    const payload = agentInstructionRequest(originalDraft, actions, catalog);
+    assert.equal(payload.agent_scope, 'user');
+    assert.equal(payload.selected_actions[1].type, 'agent');
+    assert.equal(payload.selected_actions[2].type, 'unavailable');
+    assert.equal(payload.assigned_knowledge.documents.length, 2);
+    assert.equal(payload.assigned_knowledge.documents[0].is_explicit, true);
+    assert.ok(!JSON.stringify(payload).includes(EDITOR_SECRET_MASK));
+    assert.deepEqual(agentSelectedActionsContext({ ...originalDraft, agent_type: 'new_foundry' }, actions), []);
+    assert.equal(agentKnowledgeReference({ ...originalDraft, agent_type: 'new_foundry' }, catalog).enabled, false);
+});
+await check('late instruction results are proposals and cannot overwrite newer text', () => {
+    const latest = { ...originalDraft, instructions: 'User edited while request was pending.' };
+    const next = withAgentInstructionProposal(latest, 'Generated proposal', originalDraft.instructions);
+    assert.equal(next.instructions, latest.instructions);
+    assert.equal(next._editor_instruction_proposal, 'Generated proposal');
+    assert.equal(next._editor_instruction_baseline, originalDraft.instructions);
+    const write = buildEditorWrite(next, original);
+    assert.ok(!Object.keys(write.updates).some((key) => key.startsWith('_editor')));
+});
+await check('template recipes strip credentials and preserve unresolved action references', () => {
+    const safe = safeAgentTemplateSettings({
+        custom: { password: 'synthetic', additional__Secret: 'synthetic', visible: false, zero: 0 },
+        endpoint: 'https://example.org', mask: EDITOR_SECRET_MASK,
+        vault: 'https://vault.example.org/secrets/credential', unsafe_url: 'https://user:password@example.org',
+        assigned_knowledge: { enabled: false, scopes: { personal: false } },
+    });
+    assert.deepEqual(safe, { custom: { visible: false, zero: 0 }, assigned_knowledge: { enabled: false, scopes: { personal: false } } });
+    const template = { id: 'template', title: 'Sample', display_name: 'Sample agent', description: 'Example', instructions: 'Do the task.',
+        actions_to_load: ['ordinary', 'missing'], additional_settings: JSON.stringify({ key: 'synthetic', keep: 0 }) };
+    const next = agentDraftFromTemplate(template, actions);
+    assert.deepEqual(next.actions_to_load, ['ordinary', 'missing']);
+    assert.deepEqual(next.other_settings, { keep: 0 });
+    assert.equal(next.id, '');
+    assert.equal(next.max_completion_tokens, -1);
+    const payload = agentTemplateSubmission(originalDraft).template;
+    assert.equal(payload.source_scope, 'personal');
+    assert.equal(payload.source_agent_id, originalDraft.id);
+    assert.ok(!JSON.stringify(payload).includes(EDITOR_SECRET_MASK));
+    assert.throws(() => agentDraftFromTemplate({ ...template, additional_settings: '[]' }, actions), /invalid additional settings/);
+});
+await check('stored secret controls handle escaped pointers, array siblings, and explicit keep/replace/clear', () => {
+    const source = {
+        ...originalDraft, other_settings: { 'a/b~c': { token: EDITOR_SECRET_MASK }, list: [{ key: EDITOR_SECRET_MASK, keep: 1 }, { key: EDITOR_SECRET_MASK }] },
+    };
+    assert.equal(secretValueAt(source, '/other_settings/a~1b~0c/token'), EDITOR_SECRET_MASK);
+    const next = setAgentSecret(source, '/other_settings/list/0/key', 'synthetic-replacement');
+    assert.ok(Array.isArray(next.other_settings.list));
+    assert.equal(next.other_settings.list[0].key, 'synthetic-replacement');
+    assert.equal(next.other_settings.list[0].keep, 1);
+    assert.equal(next.other_settings.list[1].key, EDITOR_SECRET_MASK);
+    assert.equal(secretValueAt(source, '/other_settings/list/0/key'), EDITOR_SECRET_MASK);
+    assert.equal(secretIntent(EDITOR_SECRET_MASK, EDITOR_SECRET_MASK), 'keep');
+    assert.equal(secretIntent('', EDITOR_SECRET_MASK), 'clear');
+    assert.equal(secretIntent(undefined, EDITOR_SECRET_MASK), 'clear');
+    assert.equal(secretIntent('replacement', EDITOR_SECRET_MASK), 'replace');
+    assert.deepEqual(buildEditorWrite({ ...originalDraft, azure_openai_gpt_key: '' }, original).clear_secret_paths, ['/azure_openai_gpt_key']);
+    assert.ok(!JSON.stringify(buildEditorWrite(originalDraft, original).updates).includes(EDITOR_SECRET_MASK));
+});
+const arraySecretResource = {
+    ...original,
+    record: {
+        ...originalDraft,
+        other_settings: {
+            'a/b~c': [
+                { id: 'first', destination: 'first', key: EDITOR_SECRET_MASK },
+                { id: 'second', destination: 'second', key: EDITOR_SECRET_MASK },
+            ],
+            outside: { preserved: 0 },
+        },
+    },
+    secret_paths: ['/other_settings/a~1b~0c/0/key', '/other_settings/a~1b~0c/1/key'],
+};
+await check('kept array secrets permit unrelated JSON changes and explicit same-position replacement or clear', () => {
+    const next = structuredClone(arraySecretResource.record);
+    next.other_settings.outside.preserved = 1;
+    assert.equal(agentStoredArrayEditError(next, arraySecretResource), null);
+    const replaced = setAgentSecret(next, arraySecretResource.secret_paths[0], 'synthetic-replacement');
+    replaced.other_settings['a/b~c'][0].destination = 'explicit-replacement-destination';
+    assert.equal(agentStoredArrayEditError(replaced, arraySecretResource), null);
+    const cleared = setAgentSecret(next, arraySecretResource.secret_paths[0], '');
+    assert.equal(agentStoredArrayEditError(cleared, arraySecretResource), null);
+    assert.deepEqual(buildEditorWrite(cleared, arraySecretResource).clear_secret_paths, [arraySecretResource.secret_paths[0]]);
+});
+await check('array reordering insertion removal and retained-entry identity changes cannot move hidden credentials', () => {
+    const before = structuredClone(arraySecretResource);
+    for (const mutate of [
+        (items) => items.reverse(),
+        (items) => items.splice(0, 1),
+        (items) => items.push({ id: 'third', key: '' }),
+        (items) => { items[0].id = 'second'; },
+        (items) => { items[0].destination = 'different'; },
+    ]) {
+        const next = structuredClone(arraySecretResource.record);
+        mutate(next.other_settings['a/b~c']);
+        assert.match(agentStoredArrayEditError(next, arraySecretResource), /saved array positions/);
+    }
+    assert.deepEqual(arraySecretResource, before);
+});
+await check('trimming only trailing credential entries retains the unchanged prefix and clears removed secrets', () => {
+    const next = structuredClone(arraySecretResource.record);
+    next.other_settings['a/b~c'].pop();
+    assert.equal(agentStoredArrayEditError(next, arraySecretResource), null);
+    assert.deepEqual(buildEditorWrite(next, arraySecretResource).clear_secret_paths, [arraySecretResource.secret_paths[1]]);
+    assert.deepEqual(next.other_settings['a/b~c'][0], arraySecretResource.record.other_settings['a/b~c'][0]);
+});
+await check('resolving every array credential permits explicit restructuring or whole-array removal', () => {
+    let next = structuredClone(arraySecretResource.record);
+    for (const path of arraySecretResource.secret_paths) next = setAgentSecret(next, path, '');
+    next.other_settings['a/b~c'].reverse();
+    assert.equal(agentStoredArrayEditError(next, arraySecretResource), null);
+    assert.deepEqual(buildEditorWrite(next, arraySecretResource).clear_secret_paths, arraySecretResource.secret_paths);
+    const removed = structuredClone(arraySecretResource.record);
+    delete removed.other_settings['a/b~c'];
+    assert.equal(agentStoredArrayEditError(removed, arraySecretResource), null);
+    assert.deepEqual(buildEditorWrite(removed, arraySecretResource).clear_secret_paths, arraySecretResource.secret_paths);
+});
+await check('unsafe agent updates retain their previous values and buffer a visible resettable error', () => {
+    const current = structuredClone(arraySecretResource.record);
+    const next = structuredClone(current);
+    next.other_settings['a/b~c'].reverse();
+    next._editor_settings_text = JSON.stringify(next.other_settings);
+    const rejected = applySafeAgentDraft(current, next, arraySecretResource);
+    assert.deepEqual(rejected.other_settings, current.other_settings);
+    assert.equal(rejected._editor_settings_text, next._editor_settings_text);
+    assert.match(rejected._editor_array_secret_error, /saved array positions/);
+    assert.deepEqual(buildEditorWrite(rejected, arraySecretResource).updates, {});
+    const reset = applySafeAgentDraft(rejected, clearAgentDraftFields(rejected, '_editor_settings_text', '_editor_array_secret_error'), arraySecretResource);
+    assert.ok(sameEditorValue(reset, current));
+});
+await check('nested secret arrays remain positional and numeric object keys are not treated as arrays', () => {
+    const nested = {
+        ...original,
+        record: { ...originalDraft, other_settings: { groups: [{ id: 'group', credentials: [
+            { id: 'one', key: EDITOR_SECRET_MASK }, { id: 'two', key: EDITOR_SECRET_MASK },
+        ] }] } },
+        secret_paths: ['/other_settings/groups/0/credentials/0/key', '/other_settings/groups/0/credentials/1/key'],
+    };
+    const moved = structuredClone(nested.record);
+    moved.other_settings.groups[0].credentials.reverse();
+    assert.match(agentStoredArrayEditError(moved, nested), /saved array positions/);
+    const replaced = setAgentSecret(nested.record, nested.secret_paths[0], 'synthetic');
+    replaced.other_settings.groups[0].credentials[0].id = 'updated-explicit-entry';
+    assert.equal(agentStoredArrayEditError(replaced, nested), null);
+    const objectRecord = {
+        ...original, record: { ...originalDraft, other_settings: { mapping: { 0: { key: EDITOR_SECRET_MASK, label: 'before' } } } },
+        secret_paths: ['/other_settings/mapping/0/key'],
+    };
+    const objectDraft = structuredClone(objectRecord.record);
+    objectDraft.other_settings.mapping[0].label = 'after';
+    assert.equal(agentStoredArrayEditError(objectDraft, objectRecord), null);
+});
+await check('image icon sources are restricted to bounded PNG/JPEG data', () => {
+    assert.ok(isAgentIconImage('data:image/png;base64,aGVsbG8='));
+    assert.ok(isAgentIconImage('data:image/jpeg;base64,aGVsbG8='));
+    assert.ok(!isAgentIconImage('data:image/svg+xml;base64,aGVsbG8='));
+    assert.ok(!isAgentIconImage('https://example.org/icon.png'));
+    assert.ok(!isAgentIconImage(`data:image/png;base64,${'A'.repeat(350000)}`));
+});
+
+await check('a conflict sends one conditional write and never replaces the original revision', async () => {
+    const originalFetch = globalThis.fetch;
+    const snapshot = structuredClone(original);
+    const draft = { ...originalDraft, description: 'Unsaved changes remain for review.' };
+    let requests = 0;
+    globalThis.fetch = async (url, init) => {
+        requests += 1;
+        assert.equal(url, '/api/user/agents/agent-one?view=editor');
+        assert.equal(init.method, 'PATCH');
+        assert.equal(JSON.parse(init.body).expected_revision, 'one');
+        return new Response(JSON.stringify({ error: 'This agent changed in another session.' }), {
+            status: 409, headers: { 'content-type': 'application/json' },
+        });
+    };
+    try {
+        await assert.rejects(() => saveAgentConfiguration(draft, original), (error) => error.status === 409);
+        assert.equal(requests, 1);
+        assert.deepEqual(original, snapshot);
+        assert.equal(draft.description, 'Unsaved changes remain for review.');
+    } finally {
+        globalThis.fetch = originalFetch;
+    }
+});
+
+await check('explicit commands use existing scoped APIs and visible failures propagate', async () => {
+    const originalFetch = globalThis.fetch;
+    const requests = [];
+    globalThis.fetch = async (url, init = {}) => {
+        requests.push({ url, init, body: init.body ? JSON.parse(init.body) : undefined });
+        const result = String(url).includes('draft-instructions') ? { success: true, instructions: 'Generated text' }
+            : String(url).includes('foundry/agents') ? { agents: [{ id: 'remote' }], responses_api_version: 'v1' }
+            : String(url).includes('agent-templates') ? { templates: [] } : catalog;
+        return new Response(JSON.stringify(result), { status: 200, headers: { 'content-type': 'application/json' } });
+    };
+    try {
+        const controller = new AbortController();
+        assert.equal(await draftAgentInstructions(originalDraft, actions, catalog, controller.signal), 'Generated text');
+        assert.equal(requests[0].url, '/api/agents/draft-instructions');
+        assert.equal(requests[0].init.signal, controller.signal);
+        assert.equal(requests[0].body.selected_actions[1].type, 'agent');
+        await discoverAgentFoundryResources({ id: 'personal-foundry', provider: 'new_foundry', scope: 'personal' }, 'foundry_workflow', controller.signal);
+        assert.deepEqual(requests[1].body, { endpoint_id: 'personal-foundry', scope: 'personal', resource_type: 'workflow' });
+        await fetchAgentKnowledgeCatalog(controller.signal);
+        assert.equal(requests[2].url, '/api/agents/assigned-knowledge/catalog?agent_scope=personal');
+        await fetchAgentTemplates(controller.signal);
+        assert.equal(requests[3].url, '/api/agent-templates');
+        globalThis.fetch = async () => new Response(JSON.stringify({ error: 'Discovery denied.' }), { status: 403, headers: { 'content-type': 'application/json' } });
+        await assert.rejects(() => fetchAgentKnowledgeCatalog(), /Discovery denied/);
+        await assert.rejects(() => draftAgentInstructions(originalDraft, actions, catalog), /Discovery denied/);
+        await assert.rejects(() => fetchAgentTemplates(), /Discovery denied/);
+        globalThis.fetch = async () => new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } });
+        await assert.rejects(() => fetchAgentKnowledgeCatalog(), /invalid response/);
+        await assert.rejects(() => draftAgentInstructions(originalDraft, actions, catalog), /no instructions/);
+        await assert.rejects(() => fetchAgentTemplates(), /invalid response/);
+        await assert.rejects(() => discoverAgentFoundryResources({ id: 'endpoint', provider: 'new_foundry' }, 'new_foundry'), /invalid resource list/);
+    } finally {
+        globalThis.fetch = originalFetch;
+    }
+});
+console.log(`${checks} native agent authoring runtime checks passed.`);

--- a/functional_tests/test_v2_workspace_agent_picker_rendering.mjs
+++ b/functional_tests/test_v2_workspace_agent_picker_rendering.mjs
@@ -1,0 +1,186 @@
+// test_v2_workspace_agent_picker_rendering.mjs
+// Version: 0.261.096
+// Implemented in: 0.261.096
+// Renders native agent controls for attachment permissions and positional-secret feedback.
+
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { createRequire, registerHooks } from 'node:module';
+import './test_support/tsResolve.mjs';
+
+const require = createRequire(new URL('../application/v2_ui/package.json', import.meta.url));
+const ts = require('typescript');
+const React = require('react');
+const { renderToStaticMarkup } = require('react-dom/server');
+
+// Reuse the installed UI compiler, without building or writing production assets.
+registerHooks({
+    load(url, context, nextLoad) {
+        if (!url.startsWith('file:') || !url.endsWith('.tsx')) return nextLoad(url, context);
+        const source = ts.transpileModule(readFileSync(new URL(url), 'utf8'), {
+            compilerOptions: { target: ts.ScriptTarget.ES2022, module: ts.ModuleKind.ESNext, jsx: ts.JsxEmit.ReactJSX },
+            fileName: url,
+        }).outputText;
+        return { format: 'module', source, shortCircuit: true };
+    },
+});
+
+const { AgentActionPicker } = await import('../application/v2_ui/src/components/workspaceAgents/AgentActionPicker.tsx');
+const { AgentIdentityFields } = await import('../application/v2_ui/src/components/workspaceAgents/AgentIdentityFields.tsx');
+const { AgentAdvancedFields, agentAdvancedError } = await import('../application/v2_ui/src/components/workspaceAgents/AgentAdvancedFields.tsx');
+const { newAgentDraft, applySafeAgentDraft } = await import('../application/v2_ui/src/lib/workspaceAgentAuthoring.ts');
+const { toggleAgentAction, updateAgentCapability } = await import('../application/v2_ui/src/lib/workspaceAgentActions.ts');
+const { buildEditorWrite, EDITOR_SECRET_MASK } = await import('../application/v2_ui/src/lib/workspaceAuthoring.ts');
+
+const ordinary = {
+    id: 'personal-http', name: 'personal-http', displayName: 'Personal HTTP', type: 'http', description: '',
+    endpoint: '', auth: { type: 'user' }, metadata: {}, additionalFields: {},
+};
+const provided = {
+    ...ordinary, id: 'provided-chart', name: 'provided-chart', displayName: 'Provided chart', type: 'chart', is_global: true,
+};
+const target = { id: 'global-target', scope_type: 'global', scope_id: 'global', name: 'Global target', agent_type: 'local' };
+const providedCall = {
+    ...provided, id: 'provided-call', name: 'provided-call', displayName: 'Provided call', type: 'agent',
+    additionalFields: { target_agent: target },
+};
+const actions = [ordinary, provided, providedCall];
+const draft = {
+    ...newAgentDraft(), id: 'local-agent', user_id: 'owner', display_name: 'Caller',
+    actions_to_load: ['personal-http', 'provided-chart', 'unlisted-legacy'],
+    other_settings: { action_capabilities: { 'provided-chart': { line: false, future: 'keep' } }, custom: { preserved: 0 } },
+};
+const props = {
+    draft, setDraft: () => {}, actions, targets: { targets: [target], can_manage: false, scope_type: 'personal', scope_id: 'owner' },
+    loading: false, error: null, targetError: null, ownerId: 'owner', builtinActions: [],
+    canCreateActions: false, onRefresh: () => {}, onNewAction: () => {}, readOnly: false,
+};
+const render = (overrides = {}) => renderToStaticMarkup(React.createElement(AgentActionPicker, { ...props, ...overrides }));
+const DISABLED_ATTRIBUTE = /\sdisabled(?:=|(?=[\s/>]))/;
+const inputFor = (markup, label) => {
+    const input = [...markup.matchAll(/<input\b[^>]*>/g)].map((match) => match[0]).find((tag) => tag.includes(`aria-label="${label}"`));
+    assert.ok(input, `Missing checkbox ${label}`);
+    return input;
+};
+const buttonFor = (markup, text) => {
+    const button = [...markup.matchAll(/<button\b[^>]*>[\s\S]*?<\/button>/g)].map((match) => match[0]).find((element) => element.includes(text));
+    assert.ok(button, `Missing button ${text}`);
+    return button;
+};
+let checks = 0;
+function check(label, run) {
+    run();
+    checks += 1;
+    console.log(`ok ${label}`);
+}
+
+check('management disabled hides creation without disabling authorized existing assignments', () => {
+    const markup = render();
+    assert.doesNotMatch(markup, /New action<\/button>/);
+    assert.doesNotMatch(inputFor(markup, 'Assign Personal HTTP'), DISABLED_ATTRIBUTE);
+    assert.doesNotMatch(inputFor(markup, 'Assign Provided chart'), DISABLED_ATTRIBUTE);
+    assert.doesNotMatch(inputFor(markup, 'Assign Provided call'), DISABLED_ATTRIBUTE);
+    assert.doesNotMatch(buttonFor(markup, 'Refresh actions'), DISABLED_ATTRIBUTE);
+    assert.match(markup, /unlisted-legacy/);
+});
+check('rendered internal-name pattern is valid under HTML Unicode-set semantics', () => {
+    const options = { settings: {}, agent_types: [{ value: 'local', label: 'Local agent', enabled: true }], model_endpoints: [], builtin_actions: [] };
+    const markup = renderToStaticMarkup(React.createElement(AgentIdentityFields, { draft, setDraft: () => {}, options, isNew: false }));
+    const pattern = markup.match(/<input\b[^>]*\bpattern="([^"]+)"/)?.[1];
+    assert.ok(pattern);
+    const expression = new RegExp(`^(?:${pattern})$`, 'v');
+    assert.ok(expression.test('Agent-123_name'));
+    assert.ok(!expression.test('Agent with spaces'));
+    assert.ok(!expression.test('Agent/name'));
+});
+check('personal Call agent permission is distinct from readable actions and provided calls', () => {
+    const personalCall = { ...providedCall, id: 'personal-call', name: 'personal-call', displayName: 'Personal call', is_global: false };
+    const available = [...actions, personalCall];
+    const denied = render({ actions: available });
+    assert.match(inputFor(denied, 'Assign Personal call'), DISABLED_ATTRIBUTE);
+    assert.doesNotMatch(inputFor(denied, 'Assign Provided call'), DISABLED_ATTRIBUTE);
+    assert.doesNotMatch(inputFor(denied, 'Assign Personal HTTP'), DISABLED_ATTRIBUTE);
+    const bound = render({ actions: available, draft: { ...draft, actions_to_load: [...draft.actions_to_load, personalCall.id] } });
+    assert.match(inputFor(bound, 'Assign Personal call'), /\schecked=/);
+    assert.doesNotMatch(inputFor(bound, 'Assign Personal call'), DISABLED_ATTRIBUTE);
+    const allowed = render({ actions: available, targets: { ...props.targets, can_manage: true } });
+    assert.doesNotMatch(inputFor(allowed, 'Assign Personal call'), DISABLED_ATTRIBUTE);
+});
+check('creation is offered only when the management capability is present', () => {
+    assert.match(render({ canCreateActions: true }), /New action<\/button>/);
+    assert.doesNotMatch(render({ canCreateActions: true, readOnly: true }), /New action<\/button>/);
+});
+check('optional display names use the machine name in both local and Foundry views', () => {
+    const legacy = { ...ordinary, id: 'legacy-action', name: 'LegacyAction' };
+    delete legacy.displayName;
+    const configured = { ...draft, actions_to_load: [legacy.id] };
+    assert.ok(inputFor(render({ actions: [legacy], draft: configured }), 'Assign LegacyAction'));
+    const foundry = render({ actions: [legacy], draft: { ...configured, agent_type: 'new_foundry' } });
+    assert.match(foundry, /<li>LegacyAction<\/li>/);
+    assert.ok(inputFor(render({ actions: [{ ...legacy, name: '' }], draft: configured }), 'Assign Untitled action'));
+    assert.equal(legacy.id, 'legacy-action');
+    assert.equal(legacy.name, 'LegacyAction');
+});
+check('capability controls remain editable without action-management permission', () => {
+    const markup = render();
+    const label = [...markup.matchAll(/<label\b[^>]*>[\s\S]*?<\/label>/g)].map((match) => match[0]).find((element) => element.includes('Line charts'));
+    assert.ok(label);
+    assert.doesNotMatch(label, DISABLED_ATTRIBUTE);
+    let next = toggleAgentAction(draft, providedCall, true, actions);
+    next = toggleAgentAction(next, ordinary, false, actions);
+    next = updateAgentCapability(next, provided, 'line', true);
+    const write = buildEditorWrite(next, { record: draft, revision: 'original', secret_paths: [], read_only: false });
+    assert.deepEqual(write.updates.actions_to_load, ['provided-chart', 'unlisted-legacy', 'provided-call']);
+    assert.equal(next.other_settings.action_capabilities['provided-chart'].future, 'keep');
+    assert.equal(next.other_settings.custom.preserved, 0);
+    assert.equal(write.updates.other_settings.action_capabilities['provided-chart'].line, true);
+});
+check('read-only envelopes and unavailable targets still prevent attachment', () => {
+    const readOnly = render({ readOnly: true });
+    assert.match(inputFor(readOnly, 'Assign Personal HTTP'), DISABLED_ATTRIBUTE);
+    assert.match(inputFor(readOnly, 'Assign Provided call'), DISABLED_ATTRIBUTE);
+    const unavailable = render({ targets: { ...props.targets, targets: [] } });
+    assert.match(inputFor(unavailable, 'Assign Provided call'), DISABLED_ATTRIBUTE);
+    assert.match(unavailable, /no longer available/);
+});
+check('a failed or pending catalogue cannot authorize a new selection', () => {
+    const denied = render({ error: 'Catalogue access denied.' });
+    assert.match(denied, /Catalogue access denied/);
+    assert.match(inputFor(denied, 'Assign Provided call'), DISABLED_ATTRIBUTE);
+    assert.doesNotMatch(inputFor(denied, 'Assign Personal HTTP'), DISABLED_ATTRIBUTE);
+    assert.match(inputFor(render({ loading: true }), 'Assign Provided call'), DISABLED_ATTRIBUTE);
+});
+check('direct self-call detection is unchanged by the creation capability split', () => {
+    const self = {
+        ...ordinary, id: 'self-call', name: 'self-call', displayName: 'Self call', type: 'agent',
+        additionalFields: { target_agent: { id: draft.id, scope_type: 'personal', scope_id: 'owner' } },
+    };
+    const markup = render({ actions: [...actions, self] });
+    assert.match(inputFor(markup, 'Assign Self call'), DISABLED_ATTRIBUTE);
+    assert.match(markup, /Direct self-calls are blocked/);
+});
+check('advanced JSON keeps unrelated editing available and reports rejected positional secret changes', () => {
+    const original = {
+        record: { ...draft, other_settings: { credentials: [
+            { name: 'first', key: EDITOR_SECRET_MASK }, { name: 'second', key: EDITOR_SECRET_MASK },
+        ] } },
+        revision: 'saved', secret_paths: ['/other_settings/credentials/0/key', '/other_settings/credentials/1/key'], read_only: false,
+    };
+    const options = { settings: {}, agent_types: [], model_endpoints: [], builtin_actions: [] };
+    const initial = renderToStaticMarkup(React.createElement(AgentAdvancedFields, { draft: original.record, original, options, setDraft: () => {} }));
+    const textarea = initial.match(/<textarea\b[^>]*id="agent-additional-settings"[^>]*>/)?.[0];
+    assert.ok(textarea);
+    assert.doesNotMatch(textarea, /\sreadonly(?:=|(?=[\s/>]))/i);
+    assert.match(initial, /Array credentials are tied to saved positions/);
+    const attempted = structuredClone(original.record);
+    attempted.other_settings.credentials.reverse();
+    attempted._editor_settings_text = JSON.stringify(attempted.other_settings);
+    const rejected = applySafeAgentDraft(original.record, attempted, original);
+    assert.match(agentAdvancedError(rejected, original), /saved array positions/);
+    assert.deepEqual(rejected.other_settings, original.record.other_settings);
+    const markup = renderToStaticMarkup(React.createElement(AgentAdvancedFields, { draft: rejected, original, options, setDraft: () => {} }));
+    assert.match(markup, /role="alert"/);
+    assert.match(markup, /Reset JSON text to current settings/);
+});
+
+console.log(`${checks} real-source agent picker rendering checks passed.`);

--- a/functional_tests/test_v2_workspace_authoring_logic.mjs
+++ b/functional_tests/test_v2_workspace_authoring_logic.mjs
@@ -1,0 +1,295 @@
+// test_v2_workspace_authoring_logic.mjs
+// Version: 0.261.096
+// Implemented in: 0.261.096
+// Executes the real draft-diff, scoped chat launch, and one-shot URL helpers.
+
+import assert from 'node:assert/strict';
+import './test_support/tsResolve.mjs';
+
+const { buildEditorWrite, sameEditorValue, editorName, agentEditorReturnPath, EDITOR_SECRET_MASK } =
+    await import('../application/v2_ui/src/lib/workspaceAuthoring.ts');
+const { readWorkspaceAgentLaunch, workspaceAgentForLaunch } =
+    await import('../application/v2_ui/src/lib/workspaceAgentLaunch.ts');
+const { syncedConversationParams } = await import('../application/v2_ui/src/lib/conversationUrl.ts');
+const { agentSelectionKey, findAgent, buildAgentInfo } = await import('../application/v2_ui/src/lib/agents.ts');
+const {
+    fetchAuthoringActions, fetchActionEditor, saveActionConfiguration, saveAgentConfiguration,
+} = await import('../application/v2_ui/src/lib/workspaceAuthoringApi.ts');
+
+const original = {
+    record: {
+        id: 'agent-1', name: 'original-name', display_name: 'Original',
+        is_global: false, user_id: 'owner', max_completion_tokens: -1,
+        actions_to_load: ['ordinary', 'legacy-reference'],
+        auth: { type: 'key', key: EDITOR_SECRET_MASK, identity: 'unchanged' },
+        other_settings: { custom: { retained: 42 }, action_capabilities: { ordinary: ['read', 'write'] } },
+        additionalFields: { 'a/b~c__Secret': EDITOR_SECRET_MASK },
+    },
+    revision: 'revision-1',
+    secret_paths: ['/auth/key', '/additionalFields/a~1b~0c__Secret'],
+    read_only: false,
+};
+let checks = 0;
+function check(label, run) {
+    run();
+    checks += 1;
+    console.log(`ok ${label}`);
+}
+
+check('unchanged drafts carry only revision and no modifications', () => {
+    assert.deepEqual(buildEditorWrite(structuredClone(original.record), original), {
+        updates: {}, expected_revision: 'revision-1', clear_secret_paths: [], removed_paths: [],
+    });
+});
+check('nested changes preserve unknown siblings and arrays replace intentionally', () => {
+    const draft = structuredClone(original.record);
+    draft.other_settings.action_capabilities.ordinary = ['read'];
+    draft.actions_to_load.push('agent-action');
+    assert.deepEqual(buildEditorWrite(draft, original).updates, {
+        actions_to_load: ['ordinary', 'legacy-reference', 'agent-action'],
+        other_settings: { action_capabilities: { ordinary: ['read'] } },
+    });
+    assert.equal(original.record.other_settings.custom.retained, 42);
+});
+check('clear and replace never submit the saved secret mask', () => {
+    const draft = structuredClone(original.record);
+    draft.auth.key = '';
+    draft.additionalFields['a/b~c__Secret'] = 'synthetic-replacement';
+    const write = buildEditorWrite(draft, original);
+    assert.deepEqual(write.clear_secret_paths, ['/auth/key']);
+    assert.deepEqual(write.updates, { additionalFields: { 'a/b~c__Secret': 'synthetic-replacement' } });
+    assert.ok(!JSON.stringify(write).includes(EDITOR_SECRET_MASK));
+});
+check('advanced deletion uses escaped pointers without deleting siblings', () => {
+    const draft = structuredClone(original.record);
+    delete draft.other_settings.custom.retained;
+    delete draft.additionalFields['a/b~c__Secret'];
+    const write = buildEditorWrite(draft, original);
+    assert.deepEqual(write.removed_paths, ['/other_settings/custom/retained']);
+    assert.deepEqual(write.clear_secret_paths, ['/additionalFields/a~1b~0c__Secret']);
+});
+const arrayOriginal = {
+    record: {
+        id: 'action-array',
+        additionalFields: {
+            credentials: [
+                { name: 'first', 'token/__Secret': EDITOR_SECRET_MASK, keep: true },
+                { name: 'second', 'token/__Secret': EDITOR_SECRET_MASK },
+            ],
+        },
+    },
+    revision: 'array-revision',
+    secret_paths: [
+        '/additionalFields/credentials/0/token~1__Secret',
+        '/additionalFields/credentials/1/token~1__Secret',
+    ],
+    read_only: false,
+};
+check('array secret clears are explicit for blank null missing and truncated entries', () => {
+    for (const value of ['', null, undefined]) {
+        const draft = structuredClone(arrayOriginal.record);
+        if (value === undefined) delete draft.additionalFields.credentials[0]['token/__Secret'];
+        else draft.additionalFields.credentials[0]['token/__Secret'] = value;
+        const write = buildEditorWrite(draft, arrayOriginal);
+        assert.deepEqual(write.clear_secret_paths, [arrayOriginal.secret_paths[0]]);
+        assert.equal(write.updates.additionalFields.credentials[1]['token/__Secret'], EDITOR_SECRET_MASK);
+    }
+    const truncated = structuredClone(arrayOriginal.record);
+    truncated.additionalFields.credentials.length = 1;
+    assert.deepEqual(buildEditorWrite(truncated, arrayOriginal).clear_secret_paths, [arrayOriginal.secret_paths[1]]);
+});
+check('removing a parent emits each nested credential clear exactly once', () => {
+    const draft = structuredClone(arrayOriginal.record);
+    delete draft.additionalFields.credentials;
+    const write = buildEditorWrite(draft, arrayOriginal);
+    assert.deepEqual(write.clear_secret_paths, arrayOriginal.secret_paths);
+    assert.deepEqual(write.removed_paths, ['/additionalFields/credentials']);
+});
+check('changed array masks stay positional and new masks are not guessed from names', () => {
+    const draft = structuredClone(arrayOriginal.record);
+    draft.additionalFields.credentials[0].name = 'second';
+    draft.additionalFields.credentials[1].name = 'first';
+    draft.additionalFields.credentials.push({ name: 'first', 'token/__Secret': EDITOR_SECRET_MASK });
+    const write = buildEditorWrite(draft, arrayOriginal);
+    assert.deepEqual(write.clear_secret_paths, []);
+    assert.deepEqual(write.updates.additionalFields.credentials, draft.additionalFields.credentials);
+});
+check('false zero and empty collections are real updates', () => {
+    const draft = { ...original.record, is_enabled: false, max_completion_tokens: 0, actions_to_load: [] };
+    assert.deepEqual(buildEditorWrite(draft, original).updates, {
+        max_completion_tokens: 0, actions_to_load: [], is_enabled: false,
+    });
+});
+check('identifiers and ownership never travel as editable configuration', () => {
+    const draft = { ...original.record, id: 'different-id', is_global: true, user_id: 'different-owner', last_updated: 'forged' };
+    assert.deepEqual(buildEditorWrite(draft, original).updates, {});
+});
+check('a literal mask in ordinary text is not silently discarded', () => {
+    assert.equal(buildEditorWrite({ description: EDITOR_SECRET_MASK }, null).updates.description, EDITOR_SECRET_MASK);
+});
+check('object key ordering alone is not a change', () => {
+    assert.ok(sameEditorValue({ a: 1, b: [false, 0] }, { b: [false, 0], a: 1 }));
+    assert.ok(!sameEditorValue({ a: null }, {}));
+    assert.equal(editorName(' Contract reviewer '), 'Contract-reviewer');
+});
+check('advanced JSON property names cannot change object prototypes', () => {
+    const other_settings = JSON.parse('{"__proto__":{"polluted":true},"constructor":"annotation"}');
+    const write = buildEditorWrite({ other_settings }, null);
+    assert.ok(Object.hasOwn(write.updates.other_settings, '__proto__'));
+    assert.equal(Object.getPrototypeOf(write.updates.other_settings), Object.prototype);
+    assert.equal(write.updates.other_settings.__proto__.polluted, true);
+    assert.equal({}.polluted, undefined);
+});
+check('only known agent editor destinations can receive an action', () => {
+    for (const path of ['/workspace/agents/new', '/workspace/agents/agent-1', '/workspace/agents/agent%3A1']) assert.equal(agentEditorReturnPath(path), path);
+    for (const path of [null, 'https://example.com', '//example.com', '/workspace/actions/new', '/workspace/agents/../actions', '/workspace/agents/a?redirect=x', '/workspace/agents/%2e%2e', '/workspace/agents/a%2fb', '/workspace/agents/%bad']) {
+        assert.equal(agentEditorReturnPath(path), null);
+    }
+});
+check('agent launch requires explicit new-chat intent and respects conversation links', () => {
+    assert.deepEqual(readWorkspaceAgentLaunch(new URLSearchParams('agent_id=a&new=1')), { id: 'a', scope: 'personal' });
+    assert.equal(readWorkspaceAgentLaunch(new URLSearchParams('agent_id=a')), null);
+    assert.equal(readWorkspaceAgentLaunch(new URLSearchParams('agent_id=a&new=1&agent_scope=group')), null);
+    assert.equal(readWorkspaceAgentLaunch(new URLSearchParams('agent_id=a&new=1&conversationId=existing')), null);
+});
+check('launch resolves id and scope, never display name or disabled agents', () => {
+    const personal = { id: 'same-id', name: 'Same', scope_type: 'personal', catalog_key: 'personal:same-id' };
+    const global = { id: 'same-id', name: 'Same', scope_type: 'global', catalog_key: 'global:same-id' };
+    const catalogue = [personal, global, { id: 'off', scope_type: 'personal', is_enabled: false }];
+    assert.equal(workspaceAgentForLaunch(catalogue, { id: 'same-id', scope: 'global' }), global);
+    assert.equal(workspaceAgentForLaunch(catalogue, { id: 'Same', scope: 'global' }), undefined);
+    assert.equal(workspaceAgentForLaunch(catalogue, { id: 'off', scope: 'personal' }), undefined);
+    assert.equal(findAgent(catalogue, agentSelectionKey(global)), global);
+    assert.equal(buildAgentInfo(findAgent(catalogue, agentSelectionKey(global))).is_global, true);
+    assert.equal(findAgent(catalogue, 'same-id'), personal);
+});
+check('consumed launch parameters do not start new chats on reload', () => {
+    const params = new URLSearchParams('agent_id=a&agent_scope=personal&new=1&keep=value');
+    assert.equal(syncedConversationParams(params, null).toString(), 'keep=value');
+    assert.equal(syncedConversationParams(params, 'conversation-1').toString(), 'keep=value&conversationId=conversation-1');
+    assert.equal(syncedConversationParams(new URLSearchParams('conversationId=conversation-1'), 'conversation-1'), null);
+});
+
+const actualFetch = globalThis.fetch;
+const requests = [];
+let responseBody = [];
+let responseStatus = 200;
+globalThis.fetch = async (url, init = {}) => {
+    requests.push({ url, ...init, body: init.body ? JSON.parse(init.body) : undefined });
+    const payload = url === '/api/agents/generate_id' ? { id: 'reserved-agent-id' } : responseBody;
+    return new Response(JSON.stringify(payload), {
+        status: responseStatus, headers: { 'Content-Type': 'application/json' },
+    });
+};
+async function asyncCheck(label, run) {
+    await run();
+    checks += 1;
+    console.log(`ok ${label}`);
+}
+try {
+    await asyncCheck('authoring collections use safe views and reject malformed lists', async () => {
+        responseBody = [{ id: 'a', type: 'agent' }, { id: 'b', type: 'openapi' }];
+        assert.deepEqual(await fetchAuthoringActions(), responseBody);
+        assert.equal(requests.at(-1).url, '/api/user/plugins?view=editor');
+        assert.equal(requests.at(-1).credentials, 'same-origin');
+        responseBody = { wrong_key: [] };
+        await assert.rejects(fetchAuthoringActions(), /invalid resource list/);
+    });
+    await asyncCheck('provided details use an explicit read-only scope query', async () => {
+        responseBody = { record: { id: 'provided' }, revision: '', secret_paths: [], read_only: true };
+        const detail = await fetchActionEditor('provided', 'global');
+        assert.equal(requests.at(-1).url, '/api/user/plugins/provided?view=editor&scope=global');
+        const before = requests.length;
+        assert.throws(() => saveActionConfiguration(detail.record, detail), /read-only/);
+        assert.equal(requests.length, before);
+        delete responseBody.revision;
+        assert.equal((await fetchActionEditor('provided', 'global')).revision, '');
+        responseBody.revision = null;
+        assert.equal((await fetchActionEditor('provided', 'global')).revision, '');
+    });
+    await asyncCheck('invalid editor envelopes are errors rather than editable empty records', async () => {
+        for (const invalid of [
+            { success: true },
+            { record: 'not a record', revision: 'v1', read_only: false, secret_paths: [] },
+            { record: { id: 'a' }, revision: '', read_only: false, secret_paths: [] },
+            { record: { id: 'a' }, revision: 'v1', read_only: false, secret_paths: ['auth.key'] },
+        ]) {
+            responseBody = invalid;
+            await assert.rejects(fetchActionEditor('a'), /invalid editor resource/);
+        }
+    });
+    await asyncCheck('normal action creation is one record, never a collection replacement', async () => {
+        const draft = {
+            id: '', name: 'utility', displayName: 'Utility', type: 'text', description: 'Format text',
+            endpoint: '', auth: { type: 'NoAuth' }, metadata: {}, additionalFields: {},
+        };
+        responseBody = { record: { ...draft, id: 'created-action' }, revision: 'new', secret_paths: [], read_only: false };
+        assert.equal((await saveActionConfiguration(draft, null)).record.id, 'created-action');
+        const call = requests.at(-1);
+        assert.equal(call.method, 'POST');
+        assert.equal(call.url, '/api/user/plugins?view=editor');
+        assert.ok(!Array.isArray(call.body));
+        assert.ok(!('id' in call.body.updates));
+        assert.equal(call.body.updates.type, 'text');
+    });
+    await asyncCheck('agent creation reserves a server identifier before posting its manifest', async () => {
+        const draft = {
+            id: '', name: 'new-agent', display_name: 'New agent', description: '', instructions: 'Help.',
+            agent_type: 'local', actions_to_load: [], other_settings: {}, max_completion_tokens: -1,
+        };
+        const before = requests.length;
+        responseBody = { record: { ...draft, id: 'reserved-agent-id' }, revision: 'new', secret_paths: [], read_only: false };
+        await saveAgentConfiguration(draft, null);
+        assert.deepEqual(requests.slice(before).map((item) => item.url), [
+            '/api/agents/generate_id', '/api/user/agents?view=editor',
+        ]);
+        assert.equal(requests.at(-1).body.updates.id, 'reserved-agent-id');
+    });
+    await asyncCheck('edit transport carries revision and only intended fields', async () => {
+        responseBody = original;
+        await saveAgentConfiguration({ ...original.record, display_name: 'Renamed' }, original);
+        const call = requests.at(-1);
+        assert.equal(call.url, '/api/user/agents/agent-1?view=editor');
+        assert.equal(call.method, 'PATCH');
+        assert.deepEqual(call.body.updates, { display_name: 'Renamed' });
+        assert.equal(call.body.expected_revision, 'revision-1');
+        responseStatus = 409;
+        responseBody = { error: 'Changed in another editor.' };
+        await assert.rejects(saveAgentConfiguration(original.record, original), /Changed in another editor/);
+        assert.equal(original.revision, 'revision-1');
+    });
+} finally {
+    globalThis.fetch = actualFetch;
+}
+
+await asyncCheck('editor draft callbacks retain React setter identity across renders', async () => {
+    const { createRequire } = await import('node:module');
+    const require = createRequire(new URL('../application/v2_ui/package.json', import.meta.url));
+    const React = require('react');
+    const { renderToString } = require('react-dom/server');
+    const { useWorkspaceEditorDraft, clearWorkspaceEditorDrafts } =
+        await import('../application/v2_ui/src/lib/workspaceEditorDrafts.ts');
+    let renders = 0;
+    function Probe() {
+        const draft = useWorkspaceEditorDraft('agents', 'callback-probe', () => structuredClone(original.record));
+        const first = React.useRef(null);
+        const [again, setAgain] = React.useState(false);
+        renders += 1;
+        if (!first.current) first.current = { setDraft: draft.setDraft, load: draft.load, clear: draft.clear };
+        if (!again) setAgain(true);
+        else {
+            assert.equal(draft.setDraft, first.current.setDraft);
+            assert.equal(draft.load, first.current.load);
+            assert.equal(draft.clear, first.current.clear);
+        }
+        return React.createElement('span', null, 'Stable callbacks');
+    }
+    try {
+        assert.ok(renderToString(React.createElement(Probe)).includes('Stable callbacks'));
+        assert.equal(renders, 2);
+    } finally {
+        clearWorkspaceEditorDrafts();
+    }
+});
+
+console.log(`${checks} workspace authoring logic checks passed.`);

--- a/functional_tests/test_workspace_authoring_backend.py
+++ b/functional_tests/test_workspace_authoring_backend.py
@@ -1,0 +1,1636 @@
+# test_workspace_authoring_backend.py
+"""Executable contracts for native personal agent/action authoring.
+
+Version: 0.261.096
+Implemented in: 0.261.096
+
+Real Flask route definitions, validators, payload normalizers, Key Vault helpers,
+and conditional-write code run against scoped in-memory Cosmos/Key Vault seams.
+No application startup, provider invocation, or live Azure resource is required.
+"""
+
+import importlib.util
+import json
+import logging
+import re
+import sys
+import uuid
+from contextlib import ExitStack
+from copy import deepcopy
+from functools import wraps
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+from flask import Blueprint, Flask, jsonify, request, session
+
+from test_support.agent_delegation import (
+    APP_ROOT,
+    CosmosHttpResponseError,
+    MatchConditions,
+    delegation_environment,
+    execute_functions,
+    module_stub,
+    reference,
+)
+
+
+MASK = "***REDACTED***"
+CURRENT_TYPES = sorted({
+    path.stem.removesuffix("_plugin")
+    for path in (APP_ROOT / "semantic_kernel_plugins").glob("*_plugin.py")
+    if path.stem != "base_plugin"
+})
+
+
+def _load_module(stack, name, relative_path=None):
+    spec = importlib.util.spec_from_file_location(name, APP_ROOT / (relative_path or f"{name}.py"))
+    module = importlib.util.module_from_spec(spec)
+    stack.enter_context(patch.dict(sys.modules, {name: module}))
+    spec.loader.exec_module(module)
+    return module
+
+
+def _install_conditional_cosmos(services):
+    services.writes = []
+    services.sequence = 0
+    services.before_replace = None
+
+    def container_functions(kind, scope):
+        records = services.records[kind, scope]
+
+        def query_items(*, query, parameters=None, partition_key=None, **kwargs):
+            values = {parameter["name"]: parameter["value"] for parameter in parameters or []}
+            result = []
+            for (partition, _), record in records.items():
+                if partition_key and partition != partition_key:
+                    continue
+                user_id = values.get("@user_id", values.get("@scope_id"))
+                if user_id and record.get("user_id" if scope == "personal" else "group_id") != user_id:
+                    continue
+                if "@type" in values and record.get("type") != values["@type"]:
+                    continue
+                if "@name" in values:
+                    name, expected = record.get("name", ""), values["@name"]
+                    if (name.lower() != expected.lower()) if "STRINGEQUALS" in query else (name != expected):
+                        continue
+                result.append(deepcopy(record))
+            return result
+
+        def store(body):
+            services.sequence += 1
+            result = deepcopy(body)
+            result["_etag"] = f'"revision-{services.sequence}"'
+            partition = result["id"] if scope == "global" else result["user_id" if scope == "personal" else "group_id"]
+            records[partition, result["id"]] = result
+            return deepcopy(result)
+
+        def create_item(*, body):
+            assert scope == "personal"
+            key = (body["user_id"], body["id"])
+            if key in records:
+                raise CosmosHttpResponseError(409)
+            services.writes.append(("create", kind, deepcopy(body)))
+            return store(body)
+
+        def replace_item(*, item, body, etag, match_condition):
+            assert match_condition is MatchConditions.IfNotModified
+            assert scope == "personal"
+            key = (body["user_id"], item)
+            if services.before_replace:
+                callback, services.before_replace = services.before_replace, None
+                callback(records, key)
+            current = records.get(key)
+            if not current or current.get("_etag") != etag:
+                raise CosmosHttpResponseError(412)
+            assert body["id"] == item
+            services.writes.append(("replace", kind, deepcopy(body)))
+            return store(body)
+
+        def delete_item(*, item, partition_key, etag, match_condition):
+            assert match_condition is MatchConditions.IfNotModified
+            key = (partition_key, item)
+            if records[key].get("_etag") != etag:
+                raise CosmosHttpResponseError(412)
+            services.writes.append(("delete", kind, item))
+            records.pop(key)
+
+        def patch_item(*, item, partition_key, patch_operations, etag, match_condition):
+            assert match_condition is MatchConditions.IfNotModified
+            current = records[partition_key, item]
+            if current.get("_etag") != etag:
+                raise CosmosHttpResponseError(412)
+            updated = deepcopy(current)
+            for operation in patch_operations:
+                assert operation["path"] == "/metadata/key_vault_secret_reminder_sync"
+                updated["metadata"]["key_vault_secret_reminder_sync"] = operation["value"]
+            services.writes.append(("patch", kind, deepcopy(updated)))
+            return store(updated)
+
+        return query_items, create_item, replace_item, delete_item, patch_item
+
+    for (kind, scope), container in services.containers.items():
+        query, create, replace, delete, patch_record = container_functions(kind, scope)
+        container.query_items.side_effect = query
+        container.create_item.side_effect = create
+        container.replace_item.side_effect = replace
+        container.delete_item.side_effect = delete
+        container.patch_item.side_effect = patch_record
+        container.upsert_item.side_effect = AssertionError("Editor writes must never upsert.")
+
+
+@pytest.fixture
+def environment(monkeypatch):
+    monkeypatch.syspath_prepend(str(APP_ROOT))
+    with delegation_environment() as (delegation, services), ExitStack() as stack:
+        services.settings.update({
+            "per_user_semantic_kernel": True, "enable_user_workspace": True,
+            "allow_personal_ai_foundry_agents": True, "allow_personal_new_foundry_agents": True,
+            "allow_user_custom_endpoints": True, "enable_key_vault_secret_storage": False,
+            "key_vault_name": "test-only-vault", "enable_time_plugin": True,
+        })
+        services.denied_types = set()
+        services.denied_endpoints = set()
+
+        def check_type(feature, user_id, action_type, scope):
+            services.check_action_type(feature, user_id, action_type, scope)
+            if action_type in services.denied_types:
+                raise PermissionError("private denied type diagnostic")
+
+        services.governance.ensure_action_type_access.side_effect = check_type
+        services.governance.is_action_scope_access_allowed = Mock(
+            side_effect=lambda feature, user_id, scope: feature not in services.denied_features,
+        )
+        services.governance.is_action_type_access_allowed = Mock(
+            side_effect=lambda feature, user_id, action_type, scope: feature not in services.denied_features and action_type not in services.denied_types,
+        )
+        services.governance.filter_governed_model_endpoints = Mock(
+            side_effect=lambda user_id, endpoints, feature: [
+                endpoint for endpoint in endpoints if endpoint["id"] not in services.denied_endpoints
+            ],
+        )
+        _install_conditional_cosmos(services)
+        services.vault = {}
+        services.secret_writes = []
+        services.secret_reads = []
+        services.secret_deletes = []
+        services.expiration_updates = []
+
+        class SecretClient:
+            def __init__(self, **kwargs):
+                pass
+
+            def set_secret(self, name, value):
+                services.secret_writes.append((name, value))
+                services.vault[name] = value
+                return SimpleNamespace(value=value, id=f"https://test-only-vault.vault.azure.net/secrets/{name}/version")
+
+            def get_secret(self, name, version=None):
+                services.secret_reads.append(name)
+                return SimpleNamespace(value=services.vault[name], id=f"https://test-only-vault.vault.azure.net/secrets/{name}/version")
+
+            def begin_delete_secret(self, name):
+                services.secret_deletes.append(name)
+                services.vault.pop(name, None)
+
+            def update_secret_properties(self, name, expires_on=None):
+                services.expiration_updates.append((name, expires_on))
+
+        services.modules["config"].KEY_VAULT_DOMAIN = ".vault.azure.net"
+        services.modules["config"].SECRET_KEY = "test-only-not-a-production-credential"
+        services.appinsights.sanitize_log_message = lambda message: message
+        services.appinsights.debug_print = Mock()
+        for prefix in ("agent", "action"):
+            for operation in ("creation", "update", "deletion"):
+                setattr(services.activity, f"log_{prefix}_{operation}", Mock())
+
+        identities = module_stub(
+            "functions_workspace_identities", validate_action_identity_reference=Mock(),
+            hydrate_action_identity_reference=Mock(),
+        )
+        reminder = module_stub(
+            "functions_keyvault_reminders",
+            mark_key_vault_secret_reminder_disabled=Mock(),
+            resolve_key_vault_secret_reminder_config=lambda record, path: (
+                record.get("metadata", {}).get("key_vault_secret_reminders", {}).get(".".join(path))
+                or record.get("metadata", {}).get("key_vault_secret_reminders", {}).get("__all__")
+            ),
+            upsert_key_vault_secret_reminder=Mock(),
+        )
+        stubs = {
+            "functions_agent_delegation": delegation,
+            "functions_authentication": module_stub("functions_authentication", get_current_user_id=lambda: "actor"),
+            "functions_workspace_identities": identities,
+            "functions_keyvault_reminders": reminder,
+            "app_settings_cache": module_stub("app_settings_cache", get_settings_cache=lambda: deepcopy(services.settings)),
+            "azure.identity": module_stub("azure.identity", DefaultAzureCredential=Mock()),
+            "azure.keyvault": module_stub("azure.keyvault"),
+            "azure.keyvault.secrets": module_stub("azure.keyvault.secrets", SecretClient=SecretClient),
+            "semantic_kernel": module_stub("semantic_kernel"),
+            "semantic_kernel.functions": module_stub("semantic_kernel.functions", kernel_function=lambda **kwargs: lambda function: function),
+            "semantic_kernel_plugins.plugin_invocation_logger": module_stub(
+                "semantic_kernel_plugins.plugin_invocation_logger", plugin_function_logger=lambda *args, **kwargs: lambda function: function,
+            ),
+            "functions_simplechat_operations": module_stub(
+                "functions_simplechat_operations", SIMPLECHAT_PLUGIN_TYPE="simplechat",
+                SIMPLECHAT_DEFAULT_ENDPOINT="simplechat://internal",
+            ),
+            "functions_azure_maps": module_stub(
+                "functions_azure_maps", AZURE_MAPS_PLUGIN_TYPE="azure_maps_openlayers",
+                AZURE_MAPS_DEFAULT_ENDPOINT="https://atlas.microsoft.com",
+            ),
+        }
+        stack.enter_context(patch.dict(sys.modules, stubs))
+        modules = [stubs["functions_simplechat_operations"], stubs["functions_azure_maps"]]
+        for name in (
+            "functions_mcp_operations", "functions_snowflake_operations", "functions_yamcs_operations",
+            "functions_databricks_operations", "functions_tableau_operations", "functions_blob_storage_operations",
+            "functions_chart_operations", "functions_msgraph_operations",
+            "functions_azure_endpoint_validation", "functions_icon_utils",
+        ):
+            modules.append(_load_module(stack, name))
+        rocks = _load_module(stack, "semantic_kernel_plugins.rocksdb_plugin", r"semantic_kernel_plugins\rocksdb_plugin.py")
+        modules.append(rocks)
+        modules.append(_load_module(stack, "semantic_kernel_plugins.sql_odbc_utils", r"semantic_kernel_plugins\sql_odbc_utils.py"))
+        keyvault = _load_module(stack, "functions_keyvault")
+        schema = _load_module(stack, "json_schema_validation")
+        payload = _load_module(stack, "functions_agent_payload")
+        health = _load_module(stack, "semantic_kernel_plugins.plugin_health_checker", r"semantic_kernel_plugins\plugin_health_checker.py")
+        authoring = _load_module(stack, "functions_workspace_authoring")
+        # Execute the actual settings sanitizer without application startup.
+        settings_namespace = {
+            "TABULAR_GENERATION_BACKEND_SETTING_KEYS": set(),
+            "get_public_workspace_label_context": lambda values: {},
+            "sanitize_model_endpoints_for_frontend": lambda values: [
+                {**deepcopy(value), "auth": {key: item for key, item in value.get("auth", {}).items() if key not in {"api_key", "client_secret"}}}
+                for value in values
+            ],
+        }
+        execute_functions("functions_settings.py", {"sanitize_settings_for_user"}, settings_namespace)
+        services.settings_module.sanitize_settings_for_user = Mock(
+            side_effect=settings_namespace["sanitize_settings_for_user"],
+        )
+
+        app = Flask("workspace_editor_backend", root_path=str(APP_ROOT))
+        app.config.update(TESTING=True, SECRET_KEY="test-only-session-signing")
+        namespace = {
+            "__name__": __name__, "Blueprint": Blueprint, "jsonify": jsonify, "request": request,
+            "session": session, "wraps": wraps, "logging": logging, "re": re, "uuid": uuid,
+            "get_settings": services.settings_module.get_settings, "log_event": services.appinsights.log_event,
+            "debug_print": Mock(), "check_user_access_status": Mock(return_value=(True, None)),
+            "swagger_route": lambda **kwargs: lambda function: function, "get_auth_security": lambda: [],
+            "personal_editor_response": authoring.personal_editor_response,
+            "editor_error_response": authoring.editor_error_response,
+            "ensure_editor_access": authoring.ensure_editor_access,
+            "ensure_editor_options_access": authoring.ensure_editor_options_access,
+            "build_agent_editor_options": authoring.build_agent_editor_options,
+            "build_action_editor_types": authoring.build_action_editor_types,
+            "clear_editor_test_secrets": authoring.clear_editor_test_secrets,
+            "WorkspaceAuthoringValidation": authoring.WorkspaceAuthoringValidation,
+            "validate_editor_action_manifest": authoring.validate_editor_action_manifest,
+            "sanitize_agent_payload": payload.sanitize_agent_payload,
+            "is_azure_ai_foundry_agent": payload.is_azure_ai_foundry_agent,
+            "AgentPayloadError": payload.AgentPayloadError,
+            "AssignedKnowledgeError": type("AssignedKnowledgeError", (ValueError,), {}),
+            "apply_assigned_knowledge_to_agent_payload": Mock(side_effect=lambda value, **kwargs: value),
+            "validate_agent": schema.validate_agent, "validate_plugin": schema.validate_plugin,
+            "PLUGIN_STORAGE_MANAGED_FIELDS": schema.PLUGIN_STORAGE_MANAGED_FIELDS,
+            "PluginHealthChecker": health.PluginHealthChecker,
+            "validate_agent_delegation_bindings": delegation.validate_agent_delegation_bindings,
+            "ensure_governance_access": services.governance.ensure_governance_access,
+            "ensure_action_type_access": services.governance.ensure_action_type_access,
+            "is_action_type_access_allowed": services.governance.is_action_type_access_allowed,
+            "validate_action_identity_reference": identities.validate_action_identity_reference,
+            "hydrate_action_identity_reference": identities.hydrate_action_identity_reference,
+            "WORKSPACE_IDENTITY_SCOPE_PERSONAL": "personal",
+            "McpDestinationPolicyError": type("McpDestinationPolicyError", (ValueError,), {}),
+            "_enforce_mcp_destination_policy": Mock(),
+            "_redact_plugin_for_logging": keyvault.redact_plugin_secret_values,
+            "ensure_migration_complete": Mock(),
+            "DOCUMENT_SEARCH_INTERNAL_ENDPOINT": "internal://document-search",
+            "AGENT_PLUGIN_TYPE": delegation.AGENT_PLUGIN_TYPE,
+            "AGENT_DEFAULT_ENDPOINT": delegation.AGENT_DEFAULT_ENDPOINT,
+            "ui_trigger_word": keyvault.ui_trigger_word,
+            "validate_secret_name_dynamic": keyvault.validate_secret_name_dynamic,
+            "resolve_secret_reference_for_context": keyvault.resolve_secret_reference_for_context,
+            "ACTION_CONNECTION_TEST_AUTH_SECRET_FIELDS": ("key", "identity", "tenantId"),
+            "ACTION_CONNECTION_TEST_ADDITIONAL_SECRET_FIELDS": ("private_key_passphrase",),
+            "ACTION_AUTH_SECRET_SOURCES": {"action"},
+        }
+        for module in modules:
+            namespace.update({key: value for key, value in vars(module).items() if not key.startswith("_")})
+        namespace.update({"log_event": services.appinsights.log_event, "logging": logging})
+        namespace["build_combined_model_endpoints"] = Mock(return_value=[])
+        namespace["get_global_agent_settings"] = Mock(return_value="classic settings")
+        namespace["get_plugin_types"] = lambda allowed_type_filter: jsonify([
+            {"type": name, "display": name.replace("_", " ").title(), "description": f"Configure {name}"}
+            for name in CURRENT_TYPES if allowed_type_filter(name)
+        ])
+        namespace["get_personal_agents"] = lambda user_id: [
+            {key: deepcopy(value) for key, value in record.items() if not key.startswith("_")}
+            for (owner, _), record in services.records["agents", "personal"].items() if owner == user_id
+        ]
+        namespace["get_global_agents"] = lambda: [
+            deepcopy(value) for value in services.records["agents", "global"].values()
+        ]
+        namespace["get_personal_action"] = lambda user_id, action_id, **kwargs: next((
+            deepcopy(record) for (owner, _), record in services.records["actions", "personal"].items()
+            if owner == user_id and action_id in {record["id"], record["name"]}
+        ), None)
+        namespace["SecretReturnType"] = keyvault.SecretReturnType
+        namespace["ACTION_PERMISSION_ERROR_MESSAGE"] = "Not permitted."
+        execute_functions("functions_authentication.py", {
+            "apply_blueprint_auth", "login_required_blueprint", "login_required", "user_required", "get_current_user_id",
+        }, namespace)
+        execute_functions("functions_settings.py", {"enabled_required"}, namespace)
+        execute_functions("route_backend_agents.py", {
+            "_is_agent_allowed_for_user_selection", "_find_personal_agent",
+            "_strip_disallowed_local_custom_connection_fields",
+            "_prepare_personal_agent_for_editor", "_prepare_personal_agent_payload",
+            "get_user_agents", "set_user_agents", "get_user_agent", "update_user_agent", "delete_user_agent",
+            "get_global_agent_settings_for_users",
+        }, namespace, blueprint="bpa")
+        execute_functions("route_backend_plugins.py", {
+            "_apply_plugin_runtime_defaults", "_validate_action_identity_for_scope", "_reject_non_admin_mcp_stdio",
+            "_prepare_personal_action_for_editor", "_prepare_personal_action_payload",
+            "get_user_plugins", "set_user_plugins", "get_user_plugin", "update_user_plugin", "delete_user_plugin",
+            "get_user_plugin_types", "_rehydrate_action_test_secret", "_hydrate_mcp_custom_headers_for_test",
+            "_resolve_secret_value_for_action_test", "_load_existing_plugin_for_test",
+            "_resolve_action_identity_context", "_resolve_plugin_secret_context",
+            "_prepare_action_test_manifest",
+            "_flatten_editor_test_fields", "_prepare_editor_sql_test_data", "_prepare_editor_yamcs_test_data",
+            "_is_personal_editor_test_request", "_assert_personal_editor_test_access",
+            "_hydrate_sql_test_identity", "_load_existing_plugin_for_sql_test", "_resolve_secret_value_for_sql_test",
+            "test_sql_connection", "test_yamcs_connection",
+        }, namespace, blueprint="bpap")
+        namespace["ACTION_ADDITIONAL_SECRET_SOURCES"] = {"action-addset"}
+        app.register_blueprint(namespace["bpa"])
+        app.register_blueprint(namespace["bpap"])
+        client = app.test_client()
+        with client.session_transaction() as state:
+            state["user"] = {"oid": "actor", "roles": ["User"], "name": "Test actor"}
+        yield SimpleNamespace(
+            helper=authoring, services=services, client=client, app=app, namespace=namespace,
+            keyvault=keyvault, schema=schema, identities=identities, reminders=reminder,
+        )
+
+
+def agent_payload(kind="local"):
+    record = {
+        "id": str(uuid.uuid4()), "name": f"test_{kind}", "display_name": "Same display name",
+        "description": "", "instructions": "Be helpful.", "agent_type": kind,
+        "actions_to_load": [], "other_settings": {}, "max_completion_tokens": -1,
+    }
+    if kind != "local":
+        record.update({
+            "azure_openai_gpt_endpoint": "https://project.services.ai.azure.com/api/projects/demo",
+            "azure_openai_gpt_deployment": "test-agent", "azure_openai_gpt_api_version": "2025-11-15-preview",
+        })
+        section = {"aifoundry": "azure_ai_foundry", "new_foundry": "new_foundry", "foundry_workflow": "foundry_workflow"}[kind]
+        record["other_settings"][section] = {
+            "agent_id": "asst_test", "application_id": "app:1", "workflow_name": "workflow",
+            "responses_api_version": "2025-11-15-preview", "client_secret": "foundry-test-credential",
+            "authentication_type": "service_principal", "client_id": "client", "tenant_id": "tenant",
+        }
+    return record
+
+
+def action_payload(kind="openapi"):
+    record = {
+        "name": f"test_{kind}", "displayName": "Same display name", "description": "Description",
+        "type": kind, "endpoint": "https://api.example.test", "auth": {"type": "key", "key": "test-credential"},
+        "metadata": {}, "additionalFields": {},
+    }
+    if kind == "agent":
+        record.update({"endpoint": "internal://agent", "auth": {"type": "user"}, "additionalFields": {"target_agent": reference()}})
+    return record
+
+
+def configured_action_payload(environment, kind):
+    record = action_payload(kind)
+    if kind == "agent":
+        return record
+    allowed = environment.schema.get_allowed_auth_types_for_plugin_type(kind)
+    auth_type = next(value for value in ("NoAuth", "user", "key", "identity", "username_password", "servicePrincipal", "basic", "connection_string") if value in allowed)
+    record["auth"] = {"type": auth_type}
+    if auth_type not in {"NoAuth", "user"}:
+        record["auth"].update({"identity": "test-identity", "key": "test-credential", "tenantId": "test-tenant"})
+    fields = record["additionalFields"]
+    if kind in {"sql_query", "sql_schema"}:
+        fields.update({"database_type": "sqlserver", "server": "server.example.test", "database": "test-db"})
+    elif kind == "blob_storage":
+        record["endpoint"] = "https://testaccount.blob.core.windows.net"
+        fields["container_name"] = "documents"
+    elif kind == "queue_storage":
+        record["endpoint"] = "https://testaccount.queue.core.windows.net"
+        fields["queue_name"] = "work"
+    elif kind in {"databricks", "databricks_table"}:
+        record["endpoint"] = "https://adb-1234567890123456.7.azuredatabricks.net"
+        fields.update({"warehouse_id": "test-warehouse", "cloud": "azure_commercial"})
+    elif kind == "snowflake":
+        record["endpoint"] = "snowflake://query"
+        record["auth"] = {"type": "username_password", "identity": "analyst", "key": "test-credential"}
+        fields.update({"account": "org-account", "warehouse": "compute", "user": "analyst", "auth_method": "password"})
+    elif kind == "tableau":
+        record["auth"] = {"type": "key", "identity": "test-pat", "key": "test-credential"}
+        fields.update({"site_content_url": "test-site", "pat_name": "test-pat"})
+    elif kind == "yamcs":
+        fields.update({"instance": "test-instance", "processor": "realtime"})
+    elif kind == "cosmos_query":
+        record["endpoint"] = "https://testaccount.documents.azure.com"
+        fields.update({"database_name": "db", "container_name": "items", "partition_key_path": "/id"})
+    elif kind == "log_analytics":
+        fields["workspaceId"] = "test-workspace"
+    elif kind == "mcp":
+        fields.update({"transport": "streamable_http", "auth_method": "none"})
+    elif kind == "embedding_model":
+        record.update({"api_version": "2024-06-01", "deployment": "test-embedding"})
+    elif kind in {"chart", "simplechat", "msgraph"}:
+        record["endpoint"] = ""
+    return record
+
+
+def write_payload(updates, revision=None, **fields):
+    return {
+        "updates": updates, "clear_secret_paths": [], "removed_paths": [],
+        **({"expected_revision": revision} if revision else {}), **fields,
+    }
+
+
+def create(environment, kind, record):
+    response = environment.client.post(f"/api/user/{kind}?view=editor", json=write_payload(record))
+    assert response.status_code == 201, response.get_json()
+    return response.get_json()
+
+
+def patch_record(environment, kind, resource, updates, **fields):
+    return environment.client.patch(
+        f"/api/user/{kind}/{resource['record']['id']}?view=editor",
+        json=write_payload(updates, resource["revision"], **fields),
+    )
+
+
+@pytest.mark.parametrize("kind", ["local", "aifoundry", "new_foundry", "foundry_workflow"])
+@pytest.mark.parametrize("vault_enabled", [False, True])
+def test_agent_types_create_edit_and_redact(environment, kind, vault_enabled):
+    env = environment
+    env.services.settings["enable_key_vault_secret_storage"] = vault_enabled
+    draft = agent_payload(kind)
+    if kind == "local":
+        draft["azure_openai_gpt_key"] = "local-test-credential"
+        draft["other_settings"] = {"unknown": {"false": False, "zero": 0, "empty": []}}
+    resource = create(env, "agents", draft)
+    assert resource["read_only"] is False and resource["revision"]
+    assert "test-credential" not in json.dumps(resource)
+    assert "_etag" not in resource["record"]
+    updated = patch_record(env, "agents", resource, {"description": "Edited"})
+    assert updated.status_code == 200, updated.get_json()
+    latest = updated.get_json()
+    stored = env.services.records["agents", "personal"]["actor", draft["id"]]
+    assert stored["description"] == "Edited"
+    assert stored["user_id"] == stored["modified_by"] == stored["created_by"] == "actor"
+    assert latest["revision"] != resource["revision"]
+    assert stored["max_completion_tokens"] == -1
+    if kind == "local":
+        assert stored["other_settings"] == draft["other_settings"]
+    fetched = env.client.get(f"/api/user/agents/{draft['id']}?view=editor")
+    assert fetched.get_json() == latest
+    assert fetched.headers["Cache-Control"] == "no-store"
+
+
+@pytest.mark.parametrize("kind", CURRENT_TYPES)
+def test_every_action_type_create_edit_reload_delete(environment, kind):
+    env = environment
+    env.services.add_agent()
+    draft = configured_action_payload(env, kind)
+    resource = create(env, "plugins", draft)
+    saved_type = "databricks" if kind == "databricks_table" else kind
+    assert resource["record"]["type"] == saved_type
+    assert "test-credential" not in json.dumps(resource)
+    update = patch_record(env, "plugins", resource, {
+        "description": "Updated without executing the connector",
+        "metadata": {"custom_configuration": {"enabled": False, "maximum": 0, "items": []}},
+    })
+    assert update.status_code == 200, update.get_json()
+    latest = update.get_json()
+    assert latest["record"]["metadata"]["custom_configuration"] == {"enabled": False, "maximum": 0, "items": []}
+    assert env.client.get(f"/api/user/plugins/{resource['record']['id']}?view=editor").get_json() == latest
+    assert env.client.delete(f"/api/user/plugins/{resource['record']['id']}?view=editor").status_code == 200
+
+
+@pytest.mark.parametrize("vault_enabled", [False, True])
+def test_action_secret_intent_and_nested_round_trip(environment, vault_enabled):
+    env = environment
+    env.services.settings["enable_key_vault_secret_storage"] = vault_enabled
+    draft = action_payload()
+    draft["additionalFields"] = {
+        "custom__Secret": "custom-secret-value", "unknown": {"scope": "keep", "enabled": False, "limit": 0, "values": []},
+    }
+    resource = create(env, "plugins", draft)
+    assert set(resource["secret_paths"]) == {"/auth/key", "/additionalFields/custom__Secret"}
+    stored_key = env.services.records["actions", "personal"]["actor", resource["record"]["id"]]["auth"]["key"]
+    response = patch_record(env, "plugins", resource, {
+        "auth": {"key": MASK}, "additionalFields": {"unknown": {"limit": 12}},
+    })
+    assert response.status_code == 200, response.get_json()
+    current = response.get_json()
+    stored = env.services.records["actions", "personal"]["actor", resource["record"]["id"]]
+    assert stored["auth"]["key"] == stored_key
+    assert stored["additionalFields"]["unknown"] == {"scope": "keep", "enabled": False, "limit": 12, "values": []}
+    assert "custom-secret-value" not in json.dumps(current)
+    replacement = patch_record(env, "plugins", current, {"auth": {"key": "replacement-credential"}})
+    assert replacement.status_code == 200
+    assert "replacement-credential" not in json.dumps(replacement.get_json())
+    cleared = patch_record(
+        env, "plugins", replacement.get_json(), {},
+        clear_secret_paths=["/additionalFields/custom__Secret"], removed_paths=["/additionalFields/unknown/limit"],
+    )
+    assert cleared.status_code == 200, cleared.get_json()
+    final = env.services.records["actions", "personal"]["actor", resource["record"]["id"]]
+    assert "custom__Secret" not in final["additionalFields"]
+    assert "limit" not in final["additionalFields"]["unknown"]
+    assert "/additionalFields/custom__Secret" not in cleared.get_json()["secret_paths"]
+
+
+@pytest.mark.parametrize("kind,secret_fields", [
+    ("sql_query", {"connection_string": "Server=x;Password=secret", "password": "sql-secret"}),
+    ("snowflake", {"private_key": "private-key-material", "private_key_passphrase": "snowflake-phrase-test-value", "token": "snowflake-token"}),
+    ("yamcs", {"password": "yamcs-secret", "token": "yamcs-token"}),
+    ("mcp", {"custom_headers": {"X-Access/Token~1": "header-secret", "X-Other": "another-secret"}}),
+])
+@pytest.mark.parametrize("vault_enabled", [False, True])
+def test_canonical_connector_secrets_never_reach_editor(environment, kind, secret_fields, vault_enabled):
+    env = environment
+    env.services.settings["enable_key_vault_secret_storage"] = vault_enabled
+    stored = env.services.add("actions", "personal", "actor", {
+        **action_payload(kind), "id": f"{kind}-stored", "additionalFields": secret_fields,
+    })
+    detail = env.client.get(f"/api/user/plugins/{stored['id']}?view=editor")
+    assert detail.status_code == 200
+    encoded = json.dumps(detail.get_json())
+    for value in secret_fields.values():
+        for secret in value.values() if isinstance(value, dict) else [value]:
+            assert secret not in encoded
+    if kind == "mcp":
+        assert "/additionalFields/custom_headers/X-Access~1Token~01" in detail.get_json()["secret_paths"]
+
+
+def test_stale_and_racing_saves_do_not_change_stored_credentials(environment):
+    env = environment
+    env.services.settings["enable_key_vault_secret_storage"] = True
+    resource = create(env, "plugins", action_payload())
+    original = deepcopy(env.services.records["actions", "personal"]["actor", resource["record"]["id"]])
+    original_key = original["auth"]["key"]
+    env.services.secret_writes.clear()
+    stale = {**resource, "revision": '"stale"'}
+    response = patch_record(env, "plugins", stale, {"auth": {"key": "stale-secret"}})
+    assert response.status_code == 409
+    assert env.services.secret_writes == []
+    env.services.before_replace = lambda records, key: records[key].update({"description": "Other tab", "_etag": '"other-tab"'})
+    response = patch_record(env, "plugins", resource, {"auth": {"key": "racing-secret"}})
+    assert response.status_code == 409
+    stored = env.services.records["actions", "personal"]["actor", resource["record"]["id"]]
+    assert stored["auth"]["key"] == original_key
+    assert env.services.vault[original_key] == "test-credential"
+    assert stored["description"] == "Other tab"
+    # A surfaced conflict may be an SDK retry after a commit; unused fresh values
+    # are retained conservatively instead of risking deletion of live credentials.
+    assert any(value == "racing-secret" for value in env.services.vault.values())
+    assert all(
+        name not in env.services.secret_deletes
+        for name, value in env.services.secret_writes if value == "racing-secret"
+    )
+    assert all(name != original_key for name in env.services.secret_deletes)
+
+
+def test_legacy_shared_name_secret_is_not_overwritten_or_deleted(environment):
+    env = environment
+    env.services.settings["enable_key_vault_secret_storage"] = True
+    reference_name = env.keyvault.build_full_secret_name("legacy", "actor", "action", "user")
+    env.services.vault[reference_name] = "legacy-credential"
+    first = env.services.add("actions", "personal", "actor", {
+        **action_payload(), "id": "first", "auth": {"type": "key", "key": reference_name},
+    })
+    env.services.add("actions", "personal", "actor", {
+        **action_payload(), "id": "second", "name": "second", "auth": {"type": "key", "key": reference_name},
+    })
+    resource = env.helper.editor_resource(first, "actions")
+    response = patch_record(env, "plugins", resource, {"auth": {"key": "replacement"}})
+    assert response.status_code == 200, response.get_json()
+    assert env.services.vault[reference_name] == "legacy-credential"
+    assert reference_name not in env.services.secret_deletes
+    assert response.get_json()["record"]["auth"]["key"] == MASK
+
+
+@pytest.mark.parametrize("updates,fields", [
+    ({"auth": {"key": ""}}, {}),
+    ({"auth": {"key": None}}, {}),
+    ({"auth": None}, {}),
+    ({"auth": {"key": "other--action--user--credential"}}, {}),
+    ({"auth": {"key": "actor--action--user--foreign-action"}}, {}),
+    ({}, {"removed_paths": ["/auth"]}),
+    ({}, {"removed_paths": ["/auth/key"]}),
+    ({}, {"clear_secret_paths": ["/description"]}),
+    ({}, {"removed_paths": ["/additionalFields/bad~2pointer"]}),
+    ({"id": "other"}, {}),
+    ({"user_id": "other"}, {}),
+    ({"scope": "global"}, {}),
+    ({"created_by": "other"}, {}),
+    ({"_etag": "fake"}, {}),
+])
+def test_invalid_patch_intent_cannot_change_owned_state(environment, updates, fields):
+    env = environment
+    resource = create(env, "plugins", action_payload())
+    before = deepcopy(env.services.records)
+    response = patch_record(env, "plugins", resource, updates, **fields)
+    assert response.status_code == 400, response.get_json()
+    assert env.services.records == before
+
+
+def test_missing_revision_and_new_record_masks_are_rejected(environment):
+    env = environment
+    resource = create(env, "plugins", action_payload())
+    response = env.client.patch(
+        f"/api/user/plugins/{resource['record']['id']}?view=editor", json=write_payload({"description": "No revision"}),
+    )
+    assert response.status_code == 400
+    draft = {**action_payload(), "name": "masked-new", "auth": {"type": "key", "key": MASK}}
+    response = env.client.post("/api/user/plugins?view=editor", json=write_payload(draft))
+    assert response.status_code == 400
+
+
+def test_scope_governance_and_global_read_only(environment):
+    env = environment
+    personal = env.services.add("agents", "personal", "actor", agent_payload())
+    provided = env.services.add("agents", "global", "global", {**agent_payload(), "id": personal["id"], "azure_openai_gpt_key": "global-credential"})
+    env.services.add("agents", "personal", "other", {**agent_payload(), "id": "foreign"})
+    listed = env.client.get("/api/user/agents?view=editor").get_json()
+    assert len(listed) == 2 and {record["is_global"] for record in listed} == {False, True}
+    detail = env.client.get(f"/api/user/agents/{provided['id']}?view=editor&scope=global")
+    assert detail.status_code == 200 and detail.get_json()["read_only"] is True
+    assert "global-credential" not in json.dumps(detail.get_json())
+    for method in ("patch", "delete"):
+        response = getattr(env.client, method)(
+            f"/api/user/agents/{provided['id']}?view=editor&scope=global",
+            json=write_payload({"description": "No"}, detail.get_json()["revision"]),
+        )
+        assert response.status_code == 403
+    assert env.client.get("/api/user/agents/foreign?view=editor").status_code == 404
+    env.services.denied_agents.add(provided["id"])
+    assert env.client.get(f"/api/user/agents/{provided['id']}?view=editor&scope=global").status_code == 403
+    assert len(env.client.get("/api/user/agents?view=editor").get_json()) == 1
+    env.services.settings["merge_global_semantic_kernel_with_workspace"] = False
+    assert env.client.get(f"/api/user/agents/{provided['id']}?view=editor&scope=global").status_code == 404
+
+
+@pytest.mark.parametrize("kind,flag,feature", [
+    ("agents", "allow_user_agents", "governance_user_agents"),
+    ("plugins", "allow_user_plugins", "governance_user_actions"),
+])
+def test_feature_and_governance_denials_cover_reads_and_writes(environment, kind, flag, feature):
+    env = environment
+    for disabled in ("flag", "governance", "kernel", "workspace"):
+        env.services.settings[flag] = disabled != "flag"
+        env.services.settings["enable_semantic_kernel"] = disabled != "kernel"
+        env.services.settings["enable_user_workspace"] = disabled != "workspace"
+        env.services.denied_features = {feature} if disabled == "governance" else set()
+        for method, suffix in (("get", ""), ("get", "/missing"), ("post", ""), ("patch", "/missing"), ("delete", "/missing")):
+            response = getattr(env.client, method)(f"/api/user/{kind}{suffix}?view=editor", json=write_payload({}))
+            if kind == "plugins" and method in {"get", "delete"}:
+                expected_statuses = {200} if not suffix else {404}
+            else:
+                expected_statuses = {400, 403} if disabled == "flag" else {403}
+            assert response.status_code in expected_statuses, (
+                disabled, method, suffix, response.get_json(),
+            )
+    assert not env.services.writes
+
+
+def test_action_type_governance_checks_existing_type_before_change(environment):
+    env = environment
+    resource = create(env, "plugins", action_payload())
+    env.services.denied_types.add("openapi")
+    assert env.client.get("/api/user/plugins?view=editor").get_json() == []
+    assert env.client.get(f"/api/user/plugins/{resource['record']['id']}?view=editor").status_code == 403
+    assert patch_record(env, "plugins", resource, {"type": "http"}).status_code == 403
+    assert env.client.delete(f"/api/user/plugins/{resource['record']['id']}?view=editor").status_code == 403
+
+
+def test_preserves_unavailable_agent_references_and_capabilities(environment):
+    env = environment
+    draft = agent_payload()
+    draft["actions_to_load"] = ["legacy-action-name", "missing-action"]
+    draft["other_settings"] = {
+        "action_capabilities": {"missing-action": {"read": True, "write": False}},
+        "assigned_knowledge": {"enabled": True, "document_ids": ["missing-document"], "scopes": {"personal": True}},
+        "advanced": {"scope": "custom", "id": "retained", "zero": 0},
+    }
+    stored = env.services.add("agents", "personal", "actor", draft)
+    env.namespace["apply_assigned_knowledge_to_agent_payload"].side_effect = AssertionError("Unchanged knowledge must not be reselected.")
+    response = patch_record(env, "agents", env.helper.editor_resource(stored, "agents"), {"instructions": "Edited instructions"})
+    assert response.status_code == 200, response.get_json()
+    record = env.services.records["agents", "personal"]["actor", draft["id"]]
+    assert record["actions_to_load"] == draft["actions_to_load"]
+    assert record["other_settings"] == draft["other_settings"]
+
+
+def test_call_agent_is_an_ordinary_action_with_existing_target_validation(environment):
+    env = environment
+    env.services.add_agent()
+    action = create(env, "plugins", action_payload("agent"))
+    local = agent_payload()
+    local["actions_to_load"] = [action["record"]["id"], "legacy-unavailable"]
+    local_agent = create(env, "agents", local)
+    assert local_agent["record"]["actions_to_load"] == local["actions_to_load"]
+    response = patch_record(env, "agents", local_agent, {"agent_type": "new_foundry"})
+    assert response.status_code == 400
+    denied = action_payload("agent")
+    denied["name"] = "foreign-target"
+    denied["additionalFields"]["target_agent"] = reference(scope_id="other")
+    response = env.client.post("/api/user/plugins?view=editor", json=write_payload(denied))
+    assert response.status_code in {400, 403, 404}
+    assert len(env.services.records["actions", "personal"]) == 1
+
+
+def test_scoped_identity_validation_and_personal_stdio_policy(environment):
+    env = environment
+    env.identities.validate_action_identity_reference.side_effect = LookupError("foreign identity credential")
+    identity = {**action_payload(), "identity_id": "other-identity"}
+    response = env.client.post("/api/user/plugins?view=editor", json=write_payload(identity))
+    assert response.status_code == 400
+    assert "foreign identity credential" not in json.dumps(response.get_json())
+    env.identities.validate_action_identity_reference.side_effect = None
+    stdio = action_payload("mcp")
+    stdio["endpoint"] = "stdio://local"
+    stdio["additionalFields"] = {"transport": "stdio", "command": "executable"}
+    response = env.client.post("/api/user/plugins?view=editor", json=write_payload(stdio))
+    assert response.status_code == 400
+    assert not env.services.writes
+
+
+def test_editor_settings_are_allowlisted_and_global_endpoint_governance_applies(environment):
+    env = environment
+    env.services.settings.update({
+        "azure_openai_gpt_key": "global-secret", "semantic_kernel_agents": [{"key": "global-agent-secret"}],
+        "global_selected_agent": {"instructions": "private-global-instructions"},
+        "unrelated_internal_endpoint": "https://internal.example.test",
+        "gpt_model": {"selected": [{"deploymentName": "gpt-test", "api_key": "catalogue-secret"}]},
+        "enable_agent_template_gallery": True, "agent_templates_allow_user_submission": False,
+        "key_vault_secret_expiration_default_lead_days": 45,
+        "key_vault_secret_expiration_default_contact_email": "owner@example.test",
+    })
+    env.services.denied_endpoints.add("blocked")
+    env.namespace["build_combined_model_endpoints"].return_value = [
+        {"id": "allowed", "scope": "global", "models": [{"id": "model"}]},
+        {"id": "blocked", "scope": "global", "models": [{"id": "private"}]},
+        {"id": "personal", "scope": "user", "models": []},
+    ]
+    response = env.client.get("/api/user/agent/settings?view=editor")
+    assert response.status_code == 200
+    options = response.get_json()
+    encoded = json.dumps(options)
+    for value in ("global-secret", "global-agent-secret", "private-global-instructions", "internal.example.test", "catalogue-secret"):
+        assert value not in encoded
+    assert {item["id"] for item in options["model_endpoints"]} == {"allowed", "personal"}
+    assert {item["value"] for item in options["agent_types"]} == {"local", "aifoundry", "new_foundry", "foundry_workflow"}
+    assert options["settings"]["key_vault_secret_expiration_default_lead_days"] == 45
+    assert options["settings"]["agent_templates_allow_user_submission"] is False
+    assert options["builtin_actions"] == [{"id": "time", "label": "Time"}]
+    env.services.governance.filter_governed_model_endpoints.assert_called_once()
+    assert env.services.governance.filter_governed_model_endpoints.call_args.args[2] == "governance_global_endpoints"
+    assert env.services.settings_module.sanitize_settings_for_user.call_count == 3
+    env.namespace["get_global_agent_settings"].assert_not_called()
+
+
+def test_all_discovered_types_get_canonical_schemas_and_allowed_auth(environment):
+    env = environment
+    response = env.client.get("/api/user/plugins/types?view=editor")
+    assert response.status_code == 200
+    definitions = {item["type"]: item for item in response.get_json()}
+    assert set(definitions) == set(CURRENT_TYPES)
+    for kind, definition in definitions.items():
+        assert set(definition["allowed_auth_types"]) == env.schema.get_allowed_auth_types_for_plugin_type(kind)
+        assert "additional_fields_schema" in definition and "metadata_schema" in definition
+        schema_path = APP_ROOT / "static" / "json" / "schemas" / f"{kind}_plugin.additional_settings.schema.json"
+        if schema_path.is_file():
+            assert definition["additional_fields_schema"] == json.loads(schema_path.read_text(encoding="utf-8"))
+    env.services.denied_types.add("agent")
+    assert "agent" not in {item["type"] for item in env.client.get("/api/user/plugins/types?view=editor").get_json()}
+
+
+def test_editor_openapi_type_description_does_not_inherit_retired_url_download_claim(environment):
+    env = environment
+    legacy = [
+        {"type": "openapi", "display": "OpenAPI", "description": "Supports file upload, URL download, and various authentication methods."},
+        {"type": "math", "display": "Math", "description": "Keep this existing description."},
+    ]
+    env.namespace["get_plugin_types"] = lambda allowed_type_filter: jsonify([
+        deepcopy(definition) for definition in legacy if allowed_type_filter(definition["type"])
+    ])
+    response = env.client.get("/api/user/plugins/types?view=editor")
+    assert response.status_code == 200
+    definitions = {definition["type"]: definition for definition in response.get_json()}
+    assert "URL download" not in definitions["openapi"]["description"]
+    assert "Download hosted specifications before uploading" in definitions["openapi"]["description"]
+    assert definitions["math"]["description"] == legacy[1]["description"]
+    assert "URL download" in legacy[0]["description"]
+
+
+def test_delete_is_owned_conditional_and_cleans_only_unreferenced_secrets(environment):
+    env = environment
+    env.services.settings["enable_key_vault_secret_storage"] = True
+    resource = create(env, "plugins", action_payload())
+    foreign = env.services.add("actions", "personal", "other", {**action_payload(), "id": "foreign"})
+    assert env.client.delete(f"/api/user/plugins/{foreign['id']}?view=editor").status_code == 404
+    response = env.client.delete(f"/api/user/plugins/{resource['record']['id']}?view=editor")
+    assert response.status_code == 200 and response.get_json() == {"success": True}
+    assert ("actor", resource["record"]["id"]) not in env.services.records["actions", "personal"]
+    assert not env.services.vault
+    assert ("other", "foreign") in env.services.records["actions", "personal"]
+
+
+def test_reminders_only_sync_after_successful_main_conditional_write(environment):
+    env = environment
+    env.services.settings["enable_key_vault_secret_storage"] = True
+    draft = action_payload()
+    draft["metadata"] = {"key_vault_secret_reminders": {"auth.key": {"enabled": True, "expires_on": "2030-01-01"}}}
+    resource = create(env, "plugins", draft)
+    assert env.services.expiration_updates
+    env.services.expiration_updates.clear()
+    env.reminders.upsert_key_vault_secret_reminder.reset_mock()
+    env.services.before_replace = lambda records, key: records[key].update({"_etag": '"changed"'})
+    response = patch_record(env, "plugins", resource, {
+        "auth": {"key": "losing-secret"}, "metadata": {"key_vault_secret_reminders": {"auth.key": {"expires_on": "2031-01-01"}}},
+    })
+    assert response.status_code == 409
+    assert env.services.expiration_updates == []
+    env.reminders.upsert_key_vault_secret_reminder.assert_not_called()
+
+
+def test_classic_reads_and_stored_secret_test_hydration_remain_compatible(environment):
+    env = environment
+    stored = env.services.add("actions", "personal", "actor", {**action_payload(), "id": "classic"})
+    classic = env.client.get("/api/user/plugins/classic")
+    assert classic.status_code == 200 and classic.get_json()["auth"]["key"] == stored["auth"]["key"]
+    assert "record" not in classic.get_json()
+    for mask in (MASK, "Stored_In_KeyVault"):
+        assert env.namespace["_rehydrate_action_test_secret"](mask, "owned-credential", "OpenAPI", "auth.key") == "owned-credential"
+    with pytest.raises(ValueError):
+        env.namespace["_rehydrate_action_test_secret"](MASK, None, "OpenAPI", "auth.key")
+
+
+def test_unknown_storage_errors_do_not_leak_provider_diagnostics(environment):
+    env = environment
+    env.services.containers["agents", "personal"].query_items.side_effect = RuntimeError("provider credential=never-expose")
+    response = env.client.get("/api/user/agents?view=editor")
+    assert response.status_code == 503
+    assert "never-expose" not in json.dumps(response.get_json())
+
+
+def test_ambiguous_storage_result_never_deletes_potentially_committed_credentials(environment):
+    env = environment
+    env.services.settings["enable_key_vault_secret_storage"] = True
+    resource = create(env, "plugins", action_payload())
+    container = env.services.containers["actions", "personal"]
+    replace = container.replace_item.side_effect
+
+    def commit_then_disconnect(**kwargs):
+        replace(**kwargs)
+        raise RuntimeError("provider response lost")
+
+    container.replace_item.side_effect = commit_then_disconnect
+    response = patch_record(env, "plugins", resource, {"auth": {"key": "committed-credential"}})
+    assert response.status_code == 503
+    stored = env.services.records["actions", "personal"]["actor", resource["record"]["id"]]
+    assert env.services.vault[stored["auth"]["key"]] == "committed-credential"
+
+
+def test_array_replacement_and_secret_removal_allow_normal_call_agent_type_change(environment):
+    env = environment
+    env.services.add_agent()
+    draft = action_payload()
+    draft["metadata"] = {"values": ["before", "another"]}
+    resource = create(env, "plugins", draft)
+    response = patch_record(
+        env, "plugins", resource,
+        {
+            "type": "agent", "endpoint": "internal://agent", "auth": {"type": "user"},
+            "additionalFields": {"target_agent": reference()}, "metadata": {"values": []},
+        },
+        clear_secret_paths=["/auth/key"],
+    )
+    assert response.status_code == 200, response.get_json()
+    assert response.get_json()["record"]["auth"] == {"type": "user"}
+    assert response.get_json()["record"]["metadata"]["values"] == []
+
+
+def test_authorization_is_checked_before_legacy_migration(environment):
+    env = environment
+    assert env.client.get("/api/user/plugins?view=editor").status_code == 200
+    env.namespace["ensure_migration_complete"].assert_called_once_with("actor")
+    env.namespace["ensure_migration_complete"].reset_mock()
+    env.services.denied_features.add("governance_user_actions")
+    assert env.client.get("/api/user/plugins?view=editor").get_json() == []
+    env.namespace["ensure_migration_complete"].assert_not_called()
+
+
+def test_model_choice_is_not_a_custom_connection_and_legacy_connections_survive(environment):
+    env = environment
+    env.services.settings["allow_user_custom_endpoints"] = False
+    draft = agent_payload()
+    draft.update({
+        "model_endpoint_id": "provided-endpoint", "model_id": "provided-model", "model_provider": "aoai",
+        "azure_openai_gpt_deployment": "provided-deployment", "enable_agent_gpt_apim": False,
+    })
+    resource = create(env, "agents", draft)
+    assert resource["record"]["azure_openai_gpt_deployment"] == "provided-deployment"
+    assert patch_record(env, "agents", resource, {"azure_openai_gpt_endpoint": "https://custom.example.test"}).status_code == 403
+    stored = env.services.records["agents", "personal"]["actor", resource["record"]["id"]]
+    stored["azure_openai_gpt_endpoint"] = "https://legacy.example.test"
+    stored["azure_openai_gpt_key"] = "legacy-test-credential"
+    current = env.helper.editor_resource(stored, "agents")
+    update = patch_record(env, "agents", current, {"instructions": "Only change instructions"})
+    assert update.status_code == 200, update.get_json()
+    assert update.get_json()["record"]["azure_openai_gpt_endpoint"] == "https://legacy.example.test"
+    assert update.get_json()["record"]["azure_openai_gpt_key"] == MASK
+
+
+def test_legacy_sql_auth_fields_survive_but_new_unsupported_properties_are_rejected(environment):
+    env = environment
+    record = configured_action_payload(env, "sql_query")
+    record["auth"]["client_secret"] = "legacy-client-credential"
+    record["legacy_extension"] = {"id": "old-extension-id", "limit": 0}
+    stored = env.services.add("actions", "personal", "actor", {**record, "id": "legacy-sql"})
+    resource = env.helper.editor_resource(stored, "actions")
+    update = patch_record(env, "plugins", resource, {"description": "Edited"})
+    assert update.status_code == 200, update.get_json()
+    assert update.get_json()["record"]["auth"]["client_secret"] == MASK
+    assert update.get_json()["record"]["legacy_extension"] == record["legacy_extension"]
+    invalid = patch_record(env, "plugins", update.get_json(), {"auth": {"new_unsupported_field": "not allowed"}})
+    assert invalid.status_code == 400
+
+
+def test_changed_assigned_knowledge_uses_real_personal_scope_policy(environment):
+    env = environment
+    with ExitStack() as stack:
+        config = env.services.modules["config"]
+        for name in ("cosmos_user_documents_container", "cosmos_group_documents_container", "cosmos_public_documents_container"):
+            stack.enter_context(patch.object(config, name, Mock(), create=True))
+        documents = module_stub(
+            "functions_documents",
+            get_document_record=Mock(side_effect=lambda user_id, document_id, **scope: (
+                {"id": document_id, "user_id": user_id} if document_id == "owned-document" and not scope else None
+            )),
+            sanitize_tags_for_filter=lambda tags: list(dict.fromkeys(str(tag).lower() for tag in tags or [])),
+            select_current_documents=lambda values: values,
+            sort_documents=lambda values, *args, **kwargs: values,
+        )
+        sources = {
+            "functions_documents": documents,
+            "functions_group": module_stub(
+                "functions_group", find_group_by_id=Mock(return_value={"id": "group"}),
+                get_user_role_in_group=Mock(return_value=None),
+            ),
+            "functions_public_workspaces": module_stub(
+                "functions_public_workspaces", find_public_workspace_by_id=Mock(return_value=None),
+                get_all_public_workspaces=Mock(return_value=[]),
+            ),
+            "functions_source_review": module_stub("functions_source_review", normalize_review_url=lambda value: value),
+        }
+        stack.enter_context(patch.dict(sys.modules, sources))
+        policy = _load_module(stack, "functions_assigned_knowledge")
+        env.namespace["apply_assigned_knowledge_to_agent_payload"] = policy.apply_assigned_knowledge_to_agent_payload
+        env.namespace["AssignedKnowledgeError"] = policy.AssignedKnowledgeError
+        draft = agent_payload()
+        draft["other_settings"]["assigned_knowledge"] = {
+            "enabled": True, "scopes": {"personal": True}, "document_ids": ["owned-document"],
+            "tags": ["Finance"], "allow_user_workspace_context": False, "allowed_user_workspace_actions": [],
+        }
+        resource = create(env, "agents", draft)
+        knowledge = resource["record"]["other_settings"]["assigned_knowledge"]
+        assert knowledge["tags"] == ["finance"]
+        assert knowledge["allowed_user_workspace_actions"] == []
+        invalid = patch_record(env, "agents", resource, {
+            "other_settings": {"assigned_knowledge": {"document_ids": ["foreign-document"]}},
+        })
+        assert invalid.status_code == 400
+        stored = env.services.records["agents", "personal"]["actor", resource["record"]["id"]]
+        assert stored["other_settings"]["assigned_knowledge"]["document_ids"] == ["owned-document"]
+        documents.get_document_record.assert_any_call("actor", "foreign-document")
+
+
+@pytest.mark.parametrize("kind,path", [
+    ("agents", ("azure_openai_gpt_key",)),
+    ("actions", ("auth", "key")),
+    ("actions", ("additionalFields", "custom__Secret")),
+])
+def test_legacy_stored_placeholders_resolve_only_the_owned_existing_secret(environment, kind, path):
+    env = environment
+    env.services.settings["enable_key_vault_secret_storage"] = True
+    record = agent_payload() if kind == "agents" else {**action_payload(), "id": "legacy-action"}
+    if len(path) == 1:
+        record[path[0]] = "Stored_In_KeyVault"
+    else:
+        record[path[0]][path[1]] = "Stored_In_KeyVault"
+    stored = env.services.add(kind, "personal", "actor", record)
+    scope_value = stored["id"] if kind == "agents" else "actor"
+    source = "agent" if kind == "agents" else "action" if path[0] == "auth" else "action-addset"
+    secret_name = stored["name"] if path[-1] != "custom__Secret" else f"{stored['name']}-custom"
+    expected_reference = env.keyvault.build_full_secret_name(secret_name, scope_value, source, "user")
+    env.services.vault[expected_reference] = "owned-legacy-credential"
+    resource = env.helper.editor_resource(stored, kind)
+    route_kind = "agents" if kind == "agents" else "plugins"
+    stale = {**resource, "revision": '"stale"'}
+    assert patch_record(env, route_kind, stale, {"description": "Stale"}).status_code == 409
+    assert env.services.secret_reads == []
+    updated = patch_record(env, route_kind, resource, {"description": "Edited"})
+    assert updated.status_code == 200, updated.get_json()
+    current = env.services.records[kind, "personal"]["actor", stored["id"]]
+    value = current[path[0]] if len(path) == 1 else current[path[0]][path[1]]
+    assert value == expected_reference
+    assert env.services.secret_reads == [expected_reference]
+    assert env.services.vault[expected_reference] == "owned-legacy-credential"
+
+
+def test_missing_legacy_credential_needs_reentry_not_a_guessed_reference(environment):
+    env = environment
+    env.services.settings["enable_key_vault_secret_storage"] = True
+    stored = env.services.add("actions", "personal", "actor", {
+        **action_payload(), "id": "missing-legacy", "auth": {"type": "key", "key": "Stored_In_KeyVault"},
+    })
+    resource = env.helper.editor_resource(stored, "actions")
+    failed = patch_record(env, "plugins", resource, {"description": "No credential"})
+    assert failed.status_code == 400
+    assert env.services.records["actions", "personal"]["actor", stored["id"]] == stored
+    env.services.settings["enable_key_vault_secret_storage"] = False
+    repaired = patch_record(env, "plugins", resource, {"auth": {"key": "replacement-test-credential"}})
+    assert repaired.status_code == 200, repaired.get_json()
+    assert "replacement-test-credential" not in json.dumps(repaired.get_json())
+    assert env.services.records["actions", "personal"]["actor", stored["id"]]["auth"]["key"] == "replacement-test-credential"
+
+
+def test_action_only_authors_can_read_reminder_defaults_without_agent_access(environment):
+    env = environment
+    stored_agent = env.services.add("agents", "personal", "actor", {
+        **agent_payload(), "instructions": "private-agent-instructions",
+    })
+    env.services.settings["allow_user_agents"] = False
+    env.services.settings["allow_user_plugins"] = True
+    env.services.settings["key_vault_secret_expiration_default_lead_days"] = 45
+    env.services.settings["semantic_kernel_agents"] = [{"instructions": "private-global-agent"}]
+    env.services.settings["gpt_model"] = {"selected": [{"deploymentName": "private-agent-model"}]}
+    env.namespace["build_combined_model_endpoints"].side_effect = AssertionError("Do not load an unavailable agent catalogue.")
+    response = env.client.get("/api/user/agent/settings?view=editor")
+    assert response.status_code == 200, response.get_json()
+    options = response.get_json()
+    assert options["settings"]["key_vault_secret_expiration_default_lead_days"] == 45
+    assert options["settings"]["allow_user_agents"] is False
+    assert not any(agent_type["enabled"] for agent_type in options["agent_types"])
+    assert options["model_endpoints"] == options["builtin_actions"] == []
+    assert "private-agent" not in json.dumps(options)
+    assert "private-global-agent" not in json.dumps(options)
+    env.namespace["build_combined_model_endpoints"].assert_not_called()
+    for method, path in (
+        ("get", "/api/user/agents"),
+        ("get", f"/api/user/agents/{stored_agent['id']}"),
+        ("post", "/api/user/agents"),
+        ("patch", f"/api/user/agents/{stored_agent['id']}"),
+        ("delete", f"/api/user/agents/{stored_agent['id']}"),
+    ):
+        denied = getattr(env.client, method)(f"{path}?view=editor", json=write_payload({}))
+        assert denied.status_code in {400, 403}
+    assert env.services.records["agents", "personal"]["actor", stored_agent["id"]] == stored_agent
+    env.services.denied_features.add("governance_user_actions")
+    assert env.client.get("/api/user/agent/settings?view=editor").status_code == 403
+    env.services.denied_features.clear()
+    env.services.settings["allow_user_plugins"] = False
+    assert env.client.get("/api/user/agent/settings?view=editor").status_code == 403
+
+
+@pytest.mark.parametrize("kind,root", [("agents", "other_settings"), ("plugins", "additionalFields")])
+@pytest.mark.parametrize("vault_enabled", [False, True])
+def test_replaced_arrays_preserve_owned_masks_but_not_omitted_object_fields(environment, kind, root, vault_enabled):
+    env = environment
+    env.services.settings["enable_key_vault_secret_storage"] = vault_enabled
+    draft = agent_payload() if kind == "agents" else action_payload()
+    draft[root]["foo"] = [
+        {"id": "first", "token": "array-first-credential", "remove_me": "old", "nested": {"keep": 1, "discard": 3}},
+        {"id": "second", "token": "array-second-credential", "keep": 2},
+    ]
+    resource = create(env, kind, draft)
+    assert f"/{root}/foo/0/token" in resource["secret_paths"]
+    replacement = deepcopy(resource["record"][root]["foo"])
+    replacement[0].pop("remove_me")
+    replacement[0]["nested"] = {"keep": 4}
+    response = patch_record(env, kind, resource, {root: {"foo": replacement}})
+    assert response.status_code == 200, response.get_json()
+    stored_kind = "agents" if kind == "agents" else "actions"
+    stored = env.services.records[stored_kind, "personal"]["actor", resource["record"]["id"]][root]["foo"]
+    assert stored[0]["token"] == "array-first-credential"
+    assert stored[1]["token"] == "array-second-credential"
+    assert "remove_me" not in stored[0]
+    assert stored[0]["nested"] == {"keep": 4}
+    assert "array-first-credential" not in json.dumps(response.get_json())
+    assert "array-second-credential" not in json.dumps(response.get_json())
+
+
+def test_array_credential_omissions_require_explicit_clearing(environment):
+    env = environment
+    draft = agent_payload()
+    draft["other_settings"]["foo"] = [{"token": "array-credential", "keep": 1}]
+    resource = create(env, "agents", draft)
+    original = deepcopy(env.services.records)
+    replacement = {"other_settings": {"foo": [{"keep": 2}]}}
+    rejected = patch_record(env, "agents", resource, replacement)
+    assert rejected.status_code == 400
+    assert env.services.records == original
+    cleared = patch_record(
+        env, "agents", resource, replacement, clear_secret_paths=["/other_settings/foo/0/token"],
+    )
+    assert cleared.status_code == 200, cleared.get_json()
+    assert cleared.get_json()["record"]["other_settings"]["foo"] == [{"keep": 2}]
+    assert "/other_settings/foo/0/token" not in cleared.get_json()["secret_paths"]
+
+
+@pytest.mark.parametrize("empty_value", ["", None])
+def test_explicit_array_secret_clears_accept_empty_values_in_array_replacements(environment, empty_value):
+    env = environment
+    draft = agent_payload()
+    draft["other_settings"]["foo"] = [{"token": "array-credential", "keep": 1}]
+    resource = create(env, "agents", draft)
+    replacement = {"other_settings": {"foo": [{"token": empty_value, "keep": 2}]}}
+    assert patch_record(env, "agents", resource, replacement).status_code == 400
+    cleared = patch_record(
+        env, "agents", resource, replacement, clear_secret_paths=["/other_settings/foo/0/token"],
+    )
+    assert cleared.status_code == 200, cleared.get_json()
+    assert cleared.get_json()["record"]["other_settings"]["foo"] == [{"keep": 2}]
+
+
+def test_a_mask_at_a_new_array_path_cannot_borrow_another_entries_credential(environment):
+    env = environment
+    draft = agent_payload()
+    draft["other_settings"]["foo"] = [{"token": "array-credential"}]
+    resource = create(env, "agents", draft)
+    original = deepcopy(env.services.records)
+    response = patch_record(env, "agents", resource, {
+        "other_settings": {"foo": [{"token": MASK}, {"token": MASK}]},
+    })
+    assert response.status_code == 400
+    assert env.services.records == original
+
+
+@pytest.mark.parametrize("vault_enabled", [False, True])
+def test_connection_test_clear_intent_never_rehydrates_the_cleared_credential(environment, vault_enabled):
+    env = environment
+    env.services.settings["enable_key_vault_secret_storage"] = vault_enabled
+    draft = action_payload()
+    draft["additionalFields"]["openapi_spec_content"] = {
+        "openapi": "3.0.0", "info": {"title": "Test", "version": "1"}, "paths": {},
+    }
+    resource = create(env, "plugins", draft)
+    original = deepcopy(env.services.records)
+    data = {
+        "endpoint": draft["endpoint"], "auth": {"type": "key", "key": MASK},
+        "plugin_context": {"scope": "user", "id": resource["record"]["id"], "name": draft["name"]},
+        "action_scope": "personal",
+    }
+    with env.app.test_request_context("/"):
+        session["user"] = {"oid": "actor", "roles": ["User"]}
+        kept, scope_type, scope_id = env.namespace["_prepare_action_test_manifest"](data, "openapi", "OpenAPI")
+        assert kept["auth"]["key"] == "test-credential"
+        assert (scope_type, scope_id) == ("personal", "actor")
+        data["auth"]["key"] = ""
+        classic, _, _ = env.namespace["_prepare_action_test_manifest"](data, "openapi", "OpenAPI")
+        assert classic["auth"]["key"] == "test-credential"
+        data["clear_secret_paths"] = ["/auth/key"]
+        env.services.secret_reads.clear()
+        cleared, _, _ = env.namespace["_prepare_action_test_manifest"](data, "openapi", "OpenAPI")
+    assert not cleared["auth"].get("key")
+    assert env.services.secret_reads == []
+    assert env.services.records == original
+
+
+def test_mcp_test_clears_one_header_while_preserving_other_owned_headers(environment):
+    env = environment
+    stored = env.services.add("actions", "personal", "actor", {
+        **action_payload("mcp"), "id": "mcp-header-clear", "auth": {"type": "NoAuth"},
+        "additionalFields": {
+            "transport": "streamable_http", "auth_method": "none",
+            "custom_headers": {"X-Removed": "removed-credential", "X-Kept": "kept-credential"},
+        },
+    })
+    data = {
+        "endpoint": stored["endpoint"], "auth": {"type": "NoAuth"},
+        "plugin_context": {"scope": "personal", "id": stored["id"], "name": stored["name"]},
+        "action_scope": "personal",
+        "additionalFields": {
+            "transport": "streamable_http", "auth_method": "none",
+            "custom_headers": {"X-Removed": "", "X-Kept": MASK},
+        },
+        "clear_secret_paths": ["/additionalFields/custom_headers/X-Removed"],
+    }
+    with env.app.test_request_context("/"):
+        session["user"] = {"oid": "actor", "roles": ["User"]}
+        manifest, _, _ = env.namespace["_prepare_action_test_manifest"](data, "mcp", "MCP")
+    assert manifest["additionalFields"]["custom_headers"] == {"X-Kept": "kept-credential"}
+    assert env.services.records["actions", "personal"]["actor", stored["id"]] == stored
+
+
+def test_transient_clear_paths_cannot_remove_owner_fields(environment):
+    env = environment
+    stored = env.services.add("actions", "personal", "actor", {**action_payload(), "id": "owned"})
+    with pytest.raises(env.helper.WorkspaceAuthoringValidation):
+        env.helper.clear_editor_test_secrets(stored, ["/user_id"])
+    assert env.services.records["actions", "personal"]["actor", stored["id"]] == stored
+
+
+@pytest.mark.parametrize("vault_enabled", [False, True])
+def test_sql_editor_full_auth_uses_owned_secret_and_canonical_flat_parameters(environment, vault_enabled):
+    env = environment
+    env.services.settings["enable_key_vault_secret_storage"] = vault_enabled
+    draft = configured_action_payload(env, "sql_query")
+    draft["auth"] = {"type": "user", "identity": "db-user", "key": "sql-test-credential"}
+    draft["additionalFields"].update({"username": "db-user", "password": "sql-test-credential"})
+    resource = create(env, "plugins", draft)
+    original = deepcopy(env.services.records)
+    connection = Mock()
+    connect = Mock(return_value=connection)
+    data = {
+        "auth": resource["record"]["auth"], "additionalFields": resource["record"]["additionalFields"],
+        "existing_plugin": {"scope": "user", "id": resource["record"]["id"], "name": draft["name"]},
+        "action_scope": "personal", "server": "stale-flat-value", "database": "stale-flat-value",
+    }
+    with patch.dict(sys.modules, {"pyodbc": module_stub("pyodbc", connect=connect)}):
+        response = env.client.post("/api/plugins/test-sql-connection", json=data)
+    assert response.status_code == 200, response.get_json()
+    connection_string = connect.call_args.args[0]
+    assert "SERVER=server.example.test" in connection_string
+    assert "DATABASE=test-db" in connection_string
+    assert "UID=db-user" in connection_string
+    assert "sql-test-credential" in connection_string
+    assert "stale-flat-value" not in connection_string
+    assert "sql-test-credential" not in json.dumps(response.get_json())
+    assert env.services.records == original
+
+
+def test_sql_editor_service_principal_does_not_silently_test_another_authentication_mode(environment):
+    env = environment
+    connect = Mock()
+    data = {
+        "auth": {"type": "servicePrincipal", "identity": "client-id", "tenantId": "tenant-id", "key": "sp-test-credential"},
+        "additionalFields": {"database_type": "azure_sql", "server": "server.example.test", "database": "test-db"},
+        "auth_type": "service_principal", "action_scope": "personal",
+    }
+    with patch.dict(sys.modules, {"pyodbc": module_stub("pyodbc", connect=connect)}):
+        response = env.client.post("/api/plugins/test-sql-connection", json=data)
+    assert response.status_code == 400
+    assert "not supported by the SQL action runtime" in response.get_json()["error"]
+    assert "sp-test-credential" not in json.dumps(response.get_json())
+    connect.assert_not_called()
+
+
+def test_sql_editor_identity_credentials_override_stale_flat_auth_hints(environment):
+    env = environment
+
+    def hydrate(manifest, scope_type, scope_id, *, return_type):
+        assert (scope_type, scope_id, return_type) == ("personal", "actor", env.keyvault.SecretReturnType.VALUE)
+        result = deepcopy(manifest)
+        result["auth"] = {"type": "user"}
+        result["additionalFields"].update({
+            "identity_auth_type": "username_password", "username": "identity-user", "password": "identity-sql-credential",
+        })
+        return result
+
+    env.identities.hydrate_action_identity_reference.side_effect = hydrate
+    connect = Mock(return_value=Mock())
+    data = {
+        "identity_id": "owned-identity", "auth": {"type": "identity", "identity": "owned-identity"},
+        "additionalFields": {"database_type": "sqlserver", "server": "server.example.test", "database": "db"},
+        "auth_type": "identity", "action_scope": "personal",
+    }
+    with patch.dict(sys.modules, {"pyodbc": module_stub("pyodbc", connect=connect)}):
+        response = env.client.post("/api/plugins/test-sql-connection", json=data)
+    assert response.status_code == 200, response.get_json()
+    assert "UID=identity-user" in connect.call_args.args[0]
+    assert "identity-sql-credential" in connect.call_args.args[0]
+    env.identities.hydrate_action_identity_reference.assert_called_once()
+
+
+def test_unsaved_yamcs_editor_can_test_a_scoped_identity(environment):
+    env = environment
+
+    def hydrate(manifest, scope_type, scope_id, *, return_type):
+        assert (scope_type, scope_id, return_type) == ("personal", "actor", env.keyvault.SecretReturnType.VALUE)
+        assert manifest["type"] == "yamcs" and manifest["identity_id"] == "owned-identity"
+        result = deepcopy(manifest)
+        result["auth"] = {"type": "key", "key": "identity-yamcs-credential"}
+        result["additionalFields"]["auth_method"] = "api_key"
+        return result
+
+    env.identities.hydrate_action_identity_reference.side_effect = hydrate
+    client = Mock()
+    client.ctx = None
+    client.get_server_info.return_value = SimpleNamespace(version="test")
+    client.list_instances.return_value = [SimpleNamespace(name="demo")]
+    credential = Mock(side_effect=lambda value: SimpleNamespace(key=value))
+    client_factory = Mock(return_value=client)
+    yamcs_client = module_stub(
+        "yamcs.client", APIKeyCredentials=credential, Credentials=Mock(), YamcsClient=client_factory,
+    )
+    data = {
+        "identity_id": "owned-identity", "auth": {"type": "identity", "identity": "owned-identity"},
+        "endpoint": "https://yamcs.example.test",
+        "additionalFields": {"instance": "demo", "auth_method": "identity", "tls_verify": False},
+        "action_scope": "personal",
+    }
+    with patch.dict(sys.modules, {"yamcs": module_stub("yamcs"), "yamcs.client": yamcs_client}):
+        response = env.client.post("/api/plugins/test-yamcs-connection", json=data)
+    assert response.status_code == 200, response.get_json()
+    credential.assert_called_once_with("identity-yamcs-credential")
+    assert client_factory.call_args.kwargs["tls_verify"] is False
+    assert "identity-yamcs-credential" not in json.dumps(response.get_json())
+    client.close.assert_called_once()
+    env.identities.hydrate_action_identity_reference.assert_called_once()
+    assert env.services.writes == []
+
+
+@pytest.mark.parametrize("endpoint", ["/api/plugins/test-sql-connection", "/api/plugins/test-yamcs-connection"])
+def test_editor_connection_identities_fail_closed_without_provider_diagnostics(environment, endpoint):
+    env = environment
+    env.identities.hydrate_action_identity_reference.side_effect = PermissionError("private identity provider credential")
+    response = env.client.post(endpoint, json={
+        "identity_id": "foreign-identity", "auth": {"type": "identity", "identity": "foreign-identity"},
+        "additionalFields": {
+            "database_type": "sqlserver", "server": "server.example.test", "database": "db", "instance": "demo",
+        },
+        "endpoint": "https://yamcs.example.test", "action_scope": "personal",
+    })
+    assert response.status_code == 403
+    assert "private identity provider credential" not in json.dumps(response.get_json())
+    assert env.services.writes == []
+
+
+def test_sql_cleared_password_does_not_fall_back_to_duplicate_auth_secret(environment):
+    env = environment
+    draft = configured_action_payload(env, "sql_query")
+    draft["auth"] = {"type": "user", "identity": "db-user", "key": "duplicate-sql-credential"}
+    draft["additionalFields"].update({"username": "db-user", "password": "duplicate-sql-credential"})
+    resource = create(env, "plugins", draft)
+    fields = {**resource["record"]["additionalFields"], "password": ""}
+    original = deepcopy(env.services.records)
+    connect = Mock()
+    with patch.dict(sys.modules, {"pyodbc": module_stub("pyodbc", connect=connect)}):
+        response = env.client.post("/api/plugins/test-sql-connection", json={
+            "auth": resource["record"]["auth"], "additionalFields": fields,
+            "existing_plugin": {"scope": "personal", "id": resource["record"]["id"]},
+            "action_scope": "personal", "clear_secret_paths": ["/additionalFields/password"],
+        })
+    assert response.status_code == 400
+    assert "username and password are required" in response.get_json()["error"]
+    connect.assert_not_called()
+    assert env.services.records == original
+
+
+def test_sql_editor_driver_failures_do_not_echo_resolved_credentials(environment):
+    env = environment
+    connect = Mock(side_effect=RuntimeError("Driver rejected private-sql-credential"))
+    with patch.dict(sys.modules, {"pyodbc": module_stub("pyodbc", connect=connect)}):
+        response = env.client.post("/api/plugins/test-sql-connection", json={
+            "auth": {"type": "user"},
+            "additionalFields": {
+                "database_type": "sqlserver", "server": "server.example.test", "database": "db",
+                "username": "db-user", "password": "private-sql-credential",
+            },
+            "action_scope": "personal",
+        })
+    assert response.status_code == 400
+    assert "private-sql-credential" not in json.dumps(response.get_json())
+
+
+def test_new_yamcs_identity_testing_does_not_expand_group_or_admin_behavior(environment):
+    env = environment
+    for scope in ("group", "global"):
+        response = env.client.post("/api/plugins/test-yamcs-connection", json={
+            "identity_id": "another-scope-identity",
+            "auth": {"type": "identity", "identity": "another-scope-identity"},
+            "additionalFields": {"instance": "demo"},
+            "server_url": "https://yamcs.example.test", "instance": "demo", "action_scope": scope,
+        })
+        assert response.status_code == 400
+    env.identities.hydrate_action_identity_reference.assert_not_called()
+
+
+@pytest.mark.parametrize("endpoint,action_type", [
+    ("/api/plugins/test-sql-connection", "sql_query"),
+    ("/api/plugins/test-yamcs-connection", "yamcs"),
+])
+def test_editor_identity_tests_enforce_personal_action_type_governance(environment, endpoint, action_type):
+    env = environment
+    env.services.denied_types.update({"sql_query", "sql_schema", "yamcs"})
+    response = env.client.post(endpoint, json={
+        "type": action_type, "identity_id": "owned-identity",
+        "auth": {"type": "identity", "identity": "owned-identity"},
+        "additionalFields": {
+            "server": "server.example.test", "database": "db", "instance": "demo",
+        },
+        "endpoint": "https://yamcs.example.test", "action_scope": "personal",
+    })
+    assert response.status_code == 403
+    env.identities.hydrate_action_identity_reference.assert_not_called()
+
+
+@pytest.mark.parametrize("vault_enabled", [False, True])
+def test_embedding_editor_root_fields_survive_and_drive_the_existing_runtime(environment, vault_enabled):
+    env = environment
+    env.services.settings["enable_key_vault_secret_storage"] = vault_enabled
+    draft = configured_action_payload(env, "embedding_model")
+    resource = create(env, "plugins", draft)
+    assert resource["record"]["api_version"] == "2024-06-01"
+    assert resource["record"]["deployment"] == "test-embedding"
+    updated = patch_record(env, "plugins", resource, {
+        "deployment": "custom-vectors", "api_version": "2024-10-21",
+    })
+    assert updated.status_code == 200, updated.get_json()
+    latest = updated.get_json()
+    assert latest["record"]["api_version"] == "2024-10-21"
+    assert latest["record"]["deployment"] == "custom-vectors"
+    assert "api_version" not in latest["record"]["additionalFields"]
+    assert "deployment" not in latest["record"]["additionalFields"]
+    assert env.client.get(f"/api/user/plugins/{resource['record']['id']}?view=editor").get_json() == latest
+    stored = env.services.records["actions", "personal"]["actor", resource["record"]["id"]]
+    runtime_manifest = env.keyvault.keyvault_plugin_get_helper(
+        stored, scope_value="actor", scope="user", return_type=env.keyvault.SecretReturnType.VALUE,
+    )
+    with ExitStack() as stack:
+        module = _load_module(stack, "semantic_kernel_plugins.embedding_model_plugin", r"semantic_kernel_plugins\embedding_model_plugin.py")
+        response = Mock()
+        response.json.return_value = {"data": [{"embedding": [0.25, 0.75]}]}
+        post = stack.enter_context(patch.object(module.requests, "post", return_value=response))
+        plugin = module.EmbeddingModelPlugin(runtime_manifest)
+        assert plugin.embed("test input") == [0.25, 0.75]
+        assert post.call_args.args[0] == f"{draft['endpoint']}/openai/deployments/custom-vectors/embeddings?api-version=2024-10-21"
+        assert post.call_args.kwargs["headers"]["api-key"] == "test-credential"
+    assert env.schema.validate_plugin(draft), "Classic/shared schema behavior must stay unchanged."
+
+
+@pytest.mark.parametrize("field,value", [
+    ("api_version", 7), ("api_version", None), ("api_version", ""),
+    ("deployment", []), ("deployment", {"name": "wrong type"}), ("deployment", "   "),
+])
+def test_embedding_editor_rejects_invalid_root_field_types(environment, field, value):
+    env = environment
+    draft = configured_action_payload(env, "embedding_model")
+    draft[field] = value
+    response = env.client.post("/api/user/plugins?view=editor", json=write_payload(draft))
+    assert response.status_code == 400
+    assert not env.services.writes
+
+
+def test_embedding_editor_root_field_exception_does_not_apply_to_other_action_types(environment):
+    env = environment
+    draft = {**action_payload(), "api_version": "2024-06-01", "deployment": "must-not-be-accepted"}
+    response = env.client.post("/api/user/plugins?view=editor", json=write_payload(draft))
+    assert response.status_code == 400
+    assert not env.services.writes
+
+
+@pytest.mark.parametrize("disabled_flag", ["allow_user_plugins", "enable_semantic_kernel", "enable_user_workspace"])
+def test_action_read_and_cleanup_do_not_require_authoring_flags(environment, disabled_flag):
+    env = environment
+    env.services.settings["enable_key_vault_secret_storage"] = True
+    resource = create(env, "plugins", action_payload())
+    provided = env.services.add("actions", "global", "global", {
+        **action_payload(), "id": "provided-action", "name": "provided-action",
+        "auth": {"type": "key", "key": "provided-credential"},
+    })
+    env.services.settings[disabled_flag] = False
+    listed = env.client.get("/api/user/plugins?view=editor")
+    assert listed.status_code == 200
+    assert {item["id"] for item in listed.get_json()} == {resource["record"]["id"], provided["id"]}
+    assert "test-credential" not in json.dumps(listed.get_json())
+    assert "provided-credential" not in json.dumps(listed.get_json())
+    assert env.client.get(f"/api/user/plugins/{resource['record']['id']}?view=editor").status_code == 200
+    global_detail = env.client.get("/api/user/plugins/provided-action?view=editor&scope=global")
+    assert global_detail.status_code == 200 and global_detail.get_json()["read_only"] is True
+    assert env.client.get("/api/user/plugins/types?view=editor").status_code == 200
+    assert patch_record(env, "plugins", resource, {"description": "Denied edit"}).status_code in {400, 403}
+    assert env.client.post("/api/user/plugins?view=editor", json=write_payload(action_payload())).status_code in {400, 403}
+    deleted = env.client.delete(f"/api/user/plugins/{resource['record']['id']}?view=editor")
+    assert deleted.status_code == 200 and deleted.get_json() == {"success": True}
+    assert not env.services.vault
+    assert env.services.records["actions", "global"][provided["id"], provided["id"]] == provided
+    assert env.client.delete("/api/user/plugins/provided-action?view=editor&scope=global").status_code == 403
+
+
+def test_provided_actions_remain_readable_when_personal_action_governance_denies_authoring(environment):
+    env = environment
+    resource = create(env, "plugins", action_payload())
+    provided = env.services.add("actions", "global", "global", {
+        **action_payload(), "id": "provided", "name": "provided",
+    })
+    env.services.denied_features.add("governance_user_actions")
+    env.services.containers["actions", "personal"].query_items.reset_mock()
+    listed = env.client.get("/api/user/plugins?view=editor")
+    assert listed.status_code == 200
+    assert [record["id"] for record in listed.get_json()] == [provided["id"]]
+    env.services.containers["actions", "personal"].query_items.assert_not_called()
+    assert env.client.get(f"/api/user/plugins/{resource['record']['id']}?view=editor").status_code == 403
+    assert env.client.delete(f"/api/user/plugins/{resource['record']['id']}?view=editor").status_code == 403
+    assert env.client.get("/api/user/plugins/provided?view=editor&scope=global").status_code == 200
+    options = env.client.get("/api/user/agent/settings?view=editor")
+    assert options.status_code == 200 and options.get_json()["settings"]["allow_user_plugins"] is False
+    env.services.denied_actions.add(provided["id"])
+    assert env.client.get("/api/user/plugins?view=editor").get_json() == []
+    assert env.client.get("/api/user/plugins/provided?view=editor&scope=global").status_code == 403
+
+
+def test_existing_ordinary_and_provided_call_agent_actions_can_be_attached_without_creation_permission(environment):
+    env = environment
+    env.services.add_agent("global-target", scope="global", scope_id="global")
+    ordinary = create(env, "plugins", action_payload())
+    call_agent = env.services.add("actions", "global", "global", {
+        **action_payload("agent"), "id": "provided-call",
+        "additionalFields": {"target_agent": reference("global-target", "global", "global")},
+    })
+    env.services.settings["allow_user_plugins"] = False
+    available = env.client.get("/api/user/plugins?view=editor")
+    assert available.status_code == 200
+    assert {record["id"] for record in available.get_json()} == {
+        ordinary["record"]["id"], call_agent["id"],
+    }
+    draft = agent_payload()
+    draft["actions_to_load"] = [ordinary["record"]["id"], call_agent["id"]]
+    saved = create(env, "agents", draft)
+    assert saved["record"]["actions_to_load"] == draft["actions_to_load"]
+    options = env.client.get("/api/user/agent/settings?view=editor").get_json()
+    assert options["settings"]["allow_user_agents"] is True
+    assert options["settings"]["allow_user_plugins"] is False
+
+
+def test_personal_call_agent_existing_bindings_survive_without_bypassing_runtime_flag(environment):
+    env = environment
+    env.services.add_agent()
+    call_agent = create(env, "plugins", action_payload("agent"))
+    draft = agent_payload()
+    draft["actions_to_load"] = [call_agent["record"]["id"]]
+    resource = create(env, "agents", draft)
+    env.services.settings["allow_user_plugins"] = False
+    assert env.client.get(f"/api/user/plugins/{call_agent['record']['id']}?view=editor").status_code == 200
+    edited = patch_record(env, "agents", resource, {"instructions": "Unrelated edit"})
+    assert edited.status_code == 200, edited.get_json()
+    assert edited.get_json()["record"]["actions_to_load"] == draft["actions_to_load"]
+    new_agent = {**agent_payload(), "name": "another-caller", "actions_to_load": draft["actions_to_load"]}
+    rejected = env.client.post("/api/user/agents?view=editor", json=write_payload(new_agent))
+    assert rejected.status_code == 403
+    assert ("actor", new_agent["id"]) not in env.services.records["agents", "personal"]
+
+
+def test_agent_name_uniqueness_uses_the_normalized_saved_name(environment):
+    env = environment
+    create(env, "agents", {**agent_payload(), "name": "existing_name"})
+    other = create(env, "agents", {**agent_payload(), "name": "other_name"})
+    original = deepcopy(env.services.records)
+    renamed = patch_record(env, "agents", other, {"name": " existing_name "})
+    assert renamed.status_code == 409, renamed.get_json()
+    duplicate = env.client.post("/api/user/agents?view=editor", json=write_payload({
+        **agent_payload(), "name": " existing_name ",
+    }))
+    assert duplicate.status_code == 409, duplicate.get_json()
+    assert env.services.records == original
+
+
+@pytest.mark.parametrize("vault_enabled", [False, True])
+def test_sql_connection_string_tests_do_not_require_separate_credentials(environment, vault_enabled):
+    env = environment
+    env.services.settings["enable_key_vault_secret_storage"] = vault_enabled
+    connection_string = (
+        "DRIVER={ODBC Driver 18 for SQL Server};SERVER=server.example.test;"
+        "DATABASE=db;UID=db-user;PWD=connection-string-credential;"
+    )
+    draft = configured_action_payload(env, "sql_query")
+    draft["auth"] = {"type": "user"}
+    draft["additionalFields"].update({
+        "connection_method": "connection_string", "connection_string": connection_string,
+    })
+    resource = create(env, "plugins", draft)
+    connect = Mock(return_value=Mock())
+    context = {"scope": "personal", "id": resource["record"]["id"], "name": draft["name"]}
+    with patch.dict(sys.modules, {"pyodbc": module_stub("pyodbc", connect=connect)}):
+        classic = env.client.post("/api/plugins/test-sql-connection", json={
+            "database_type": "sqlserver", "connection_method": "connection_string",
+            "connection_string": connection_string, "existing_plugin": context,
+        })
+        assert classic.status_code == 200, classic.get_json()
+        connect.reset_mock()
+        response = env.client.post("/api/plugins/test-sql-connection", json={
+            "auth": resource["record"]["auth"], "additionalFields": resource["record"]["additionalFields"],
+            "action_scope": "personal", "existing_plugin": context,
+        })
+    assert response.status_code == 200, response.get_json()
+    assert connect.call_args.args[0] == connection_string
+    assert "connection-string-credential" not in json.dumps(response.get_json())
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/functional_tests/test_workspace_authoring_credential_compatibility.py
+++ b/functional_tests/test_workspace_authoring_credential_compatibility.py
@@ -1,0 +1,208 @@
+# test_workspace_authoring_credential_compatibility.py
+"""Regression coverage for conditional editor writes and classic credential cleanup.
+
+Version: 0.261.096
+Implemented in: 0.261.096
+
+The real editor and classic functions share isolated Cosmos/Key Vault services.
+Lost write responses must not delete committed credentials, and classic operations
+must use the actual stored references created by the V2 staging path.
+"""
+
+import sys
+from copy import deepcopy
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+from azure.core.exceptions import ServiceResponseError
+from azure.core.pipeline import PipelineContext, PipelineRequest, PipelineResponse
+from azure.core.pipeline.transport import HttpRequest
+from azure.cosmos._retry_utility import ConnectionRetryPolicy
+
+from test_support.agent_delegation import CosmosHttpResponseError, execute_functions
+from test_workspace_authoring_backend import (
+    action_payload,
+    agent_payload,
+    create,
+    environment,
+    patch_record,
+    write_payload,
+)
+
+
+@pytest.mark.parametrize("kind,route_kind", [("agents", "agents"), ("actions", "plugins")])
+@pytest.mark.parametrize("operation", ["create", "replace"])
+def test_committed_write_followed_by_sdk_conflict_retains_its_credentials(environment, kind, route_kind, operation):
+    env = environment
+    env.services.settings["enable_key_vault_secret_storage"] = True
+    draft = agent_payload() if kind == "agents" else action_payload()
+    if kind == "agents":
+        draft["azure_openai_gpt_key"] = "initial-test-credential"
+    path = ("azure_openai_gpt_key",) if kind == "agents" else ("auth", "key")
+    container = env.services.containers[kind, "personal"]
+
+    if operation == "replace":
+        original = create(env, route_kind, draft)
+        replace = container.replace_item.side_effect
+
+        def commit_then_conflict(**kwargs):
+            replace(**kwargs)
+            raise CosmosHttpResponseError(412)
+
+        container.replace_item.side_effect = commit_then_conflict
+        updates = {"azure_openai_gpt_key": "replacement-test-credential"} if kind == "agents" else {
+            "auth": {"key": "replacement-test-credential"},
+        }
+        response = patch_record(env, route_kind, original, updates)
+        expected_value = "replacement-test-credential"
+    else:
+        create_item = container.create_item.side_effect
+
+        def commit_then_conflict(**kwargs):
+            create_item(**kwargs)
+            raise CosmosHttpResponseError(409)
+
+        container.create_item.side_effect = commit_then_conflict
+        response = env.client.post(f"/api/user/{route_kind}?view=editor", json=write_payload(draft))
+        expected_value = "initial-test-credential" if kind == "agents" else "test-credential"
+
+    assert response.status_code == 409
+    committed = next(iter(env.services.records[kind, "personal"].values()))
+    reference = committed
+    for segment in path:
+        reference = reference[segment]
+    assert env.services.vault[reference] == expected_value
+    assert reference not in env.services.secret_deletes
+    assert expected_value not in response.get_data(as_text=True)
+
+
+def test_real_sdk_retry_preserves_potentially_committed_credentials(environment):
+    """Run the installed SDK retry policy, not just a directly injected 412."""
+    env = environment
+    env.services.settings["enable_key_vault_secret_storage"] = True
+    resource = create(env, "plugins", action_payload())
+    container = env.services.containers["actions", "personal"]
+    conditional_replace = container.replace_item.side_effect
+    attempts = []
+
+    def replace_with_sdk_retry(**kwargs):
+        request = PipelineRequest(
+            HttpRequest("PUT", "https://example.invalid/offline"),
+            PipelineContext(Mock()),
+        )
+        request.http_request.headers["If-Match"] = kwargs["etag"]
+        policy = ConnectionRetryPolicy(retry_backoff_factor=0)
+
+        def send(pipeline_request):
+            attempts.append(pipeline_request.http_request.headers["If-Match"])
+            try:
+                conditional_replace(**{
+                    **kwargs, "etag": pipeline_request.http_request.headers["If-Match"],
+                })
+            except CosmosHttpResponseError as exc:
+                return PipelineResponse(
+                    pipeline_request.http_request,
+                    SimpleNamespace(status_code=exc.status_code, headers={}),
+                    pipeline_request.context,
+                )
+            raise ServiceResponseError("Offline: response lost after commit")
+
+        policy.next = SimpleNamespace(send=send)
+        response = policy.send(request)
+        raise CosmosHttpResponseError(response.http_response.status_code)
+
+    container.replace_item.side_effect = replace_with_sdk_retry
+    response = patch_record(env, "plugins", resource, {
+        "auth": {"key": "offline-committed-replacement"},
+    })
+    stored = env.services.records["actions", "personal"]["actor", resource["record"]["id"]]
+    reference = stored["auth"]["key"]
+    assert attempts == [resource["revision"], resource["revision"]]
+    assert response.status_code == 409
+    assert env.services.vault[reference] == "offline-committed-replacement"
+    assert reference not in env.services.secret_deletes
+
+
+def _wire_classic_agent_functions(env):
+    container = env.services.containers["agents", "personal"]
+    namespace = {
+        "cosmos_personal_agents_container": container,
+        "exceptions": sys.modules["azure.cosmos.exceptions"],
+        "SecretReturnType": env.keyvault.SecretReturnType,
+        "keyvault_agent_get_helper": env.keyvault.keyvault_agent_get_helper,
+        "keyvault_agent_save_helper": env.keyvault.keyvault_agent_save_helper,
+        "keyvault_agent_delete_helper": env.keyvault.keyvault_agent_delete_helper,
+        "sanitize_agent_payload": env.namespace["sanitize_agent_payload"],
+        "validate_agent_delegation_bindings": env.namespace["validate_agent_delegation_bindings"],
+        "ensure_governance_access": env.services.governance.ensure_governance_access,
+        "bump_chat_bootstrap_user_cache_version": Mock(),
+        "debug_print": Mock(),
+        "datetime": datetime,
+    }
+    names = {"get_personal_agent", "get_personal_agents", "save_personal_agent", "delete_personal_agent"}
+    execute_functions("functions_personal_agents.py", names, namespace)
+    env.namespace.update({name: namespace[name] for name in names})
+    for operation in ("creation", "update", "deletion"):
+        env.namespace[f"log_agent_{operation}"] = getattr(env.services.activity, f"log_agent_{operation}")
+
+    def upsert_item(*, body):
+        stored = {**deepcopy(body), "_etag": '"classic-edit"'}
+        assert stored["user_id"] == "actor"
+        env.services.records["agents", "personal"]["actor", stored["id"]] = stored
+        return deepcopy(stored)
+
+    def delete_item(*, item, partition_key):
+        assert partition_key == "actor"
+        del env.services.records["agents", "personal"][partition_key, item]
+
+    container.upsert_item.side_effect = upsert_item
+    container.delete_item.side_effect = delete_item
+    return namespace
+
+
+@pytest.mark.parametrize("delete_mode", ["id", "name", "collection"])
+@pytest.mark.parametrize("replace_secret", [False, True])
+def test_classic_edit_and_delete_preserve_then_clean_actual_editor_reference(environment, delete_mode, replace_secret):
+    env = environment
+    env.services.settings["enable_key_vault_secret_storage"] = True
+    draft = {**agent_payload(), "azure_openai_gpt_key": "original-test-credential"}
+    resource = create(env, "agents", draft)
+    if replace_secret:
+        response = patch_record(env, "agents", resource, {"azure_openai_gpt_key": "replaced-test-credential"})
+        assert response.status_code == 200
+        resource = response.get_json()
+    agent_id = resource["record"]["id"]
+    records = env.services.records["agents", "personal"]
+    stored_reference = records["actor", agent_id]["azure_openai_gpt_key"]
+    assert "editor-" in stored_reference
+    expected_secret = env.services.vault[stored_reference]
+    _wire_classic_agent_functions(env)
+
+    read = env.client.get(f"/api/user/agents/{agent_id}")
+    assert read.status_code == 200
+    assert read.get_json()["azure_openai_gpt_key"] == "Stored_In_KeyVault"
+    saved = env.client.patch(f"/api/user/agents/{agent_id}", json={"description": "Edited in classic"})
+    assert saved.status_code == 200, saved.get_json()
+    assert records["actor", agent_id]["azure_openai_gpt_key"] == stored_reference
+    assert env.services.vault[stored_reference] == expected_secret
+
+    def strict_delete(_client, name):
+        if name not in env.services.vault:
+            error = LookupError("The requested test secret does not exist.")
+            error.status_code = 404
+            raise error
+        env.services.secret_deletes.append(name)
+        del env.services.vault[name]
+
+    with patch.object(env.keyvault.SecretClient, "begin_delete_secret", strict_delete):
+        if delete_mode == "collection":
+            deleted = env.client.post("/api/user/agents", json=[])
+        else:
+            identifier = agent_id if delete_mode == "id" else draft["name"]
+            deleted = env.client.delete(f"/api/user/agents/{identifier}")
+        assert deleted.status_code == 200, deleted.get_json()
+    assert ("actor", agent_id) not in records
+    assert stored_reference in env.services.secret_deletes
+    assert stored_reference not in env.services.vault

--- a/functional_tests/test_workspace_authoring_persistence.py
+++ b/functional_tests/test_workspace_authoring_persistence.py
@@ -1,0 +1,302 @@
+# test_workspace_authoring_persistence.py
+"""Editor persistence across real SDK retries and classic personal-agent flows.
+
+Version: 0.261.096
+Implemented in: 0.261.096
+
+The installed Cosmos ConnectionRetryPolicy executes against a fake HTTP
+transport. Classic routes and personal persistence helpers execute unchanged
+against the existing fake Cosmos/Key Vault services.
+"""
+
+import json
+import sys
+from contextlib import ExitStack
+from copy import deepcopy
+from unittest.mock import Mock, patch
+
+from azure.core.exceptions import ResourceNotFoundError, ServiceResponseError
+from azure.core.pipeline import Pipeline
+from azure.core.pipeline.transport import HttpRequest, HttpResponse, HttpTransport
+from azure.cosmos import exceptions as sdk_exceptions
+from azure.cosmos._retry_utility import ConnectionRetryPolicy
+import pytest
+
+from test_support.agent_delegation import (
+    CosmosHttpResponseError as HarnessCosmosHttpResponseError,
+    CosmosResourceNotFoundError,
+    execute_functions,
+    module_stub,
+)
+from test_workspace_authoring_backend import (
+    _load_module,
+    action_payload,
+    agent_payload,
+    create,
+    environment,
+    patch_record,
+)
+
+
+class RetryResponse(HttpResponse):
+    def __init__(self, request, status):
+        super().__init__(request, None)
+        self.status_code = status
+        self.headers = {"content-type": "application/json"}
+        self.reason = "Precondition Failed"
+        self.content_type = "application/json"
+
+    def body(self):
+        return b'{"message":"The original ETag no longer matches."}'
+
+    def text(self, encoding=None):
+        return self.body().decode(encoding or "utf-8")
+
+
+class CommitThenLoseResponseTransport(HttpTransport):
+    def __init__(self, replace):
+        self.replace = replace
+        self.requests = []
+
+    def open(self):
+        pass
+
+    def close(self):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+
+    def send(self, request, **kwargs):
+        self.requests.append((request.method, request.headers.get("If-Match")))
+        try:
+            self.replace(request)
+        except HarnessCosmosHttpResponseError as exc:
+            return RetryResponse(request, exc.status_code)
+        raise ServiceResponseError("Connection dropped after the server committed the conditional PUT.")
+
+
+@pytest.mark.parametrize("kind,field", [
+    ("agents", "azure_openai_gpt_key"),
+    ("plugins", "key"),
+])
+def test_real_cosmos_retry_keeps_credentials_after_committed_put_returns_412(environment, kind, field):
+    env = environment
+    env.services.settings["enable_key_vault_secret_storage"] = True
+    draft = agent_payload() if kind == "agents" else action_payload()
+    if kind == "agents":
+        draft[field] = "initial-credential"
+    resource = create(env, kind, draft)
+    stored_kind = "agents" if kind == "agents" else "actions"
+    records = env.services.records[stored_kind, "personal"]
+    key = ("actor", resource["record"]["id"])
+    container = env.services.containers[stored_kind, "personal"]
+    original_replace = container.replace_item.side_effect
+    retry_requests = []
+
+    def retrying_replace(**kwargs):
+        transport = CommitThenLoseResponseTransport(lambda request: original_replace(**{
+            **kwargs,
+            "etag": request.headers["If-Match"],
+            "body": json.loads(request.body),
+        }))
+        policy = ConnectionRetryPolicy(retry_total=1, retry_read=1, retry_backoff_factor=0)
+        pipeline = Pipeline(transport=transport, policies=[policy])
+        request = HttpRequest(
+            "PUT", "https://cosmos.example.test/dbs/test/colls/records/docs/owned-record",
+            headers={"If-Match": kwargs["etag"], "Content-Type": "application/json"},
+            data=json.dumps(kwargs["body"]),
+        )
+        response = pipeline.run(request)
+        retry_requests.extend(transport.requests)
+        assert response.http_response.status_code == 412
+        raise sdk_exceptions.CosmosAccessConditionFailedError(
+            message=response.http_response.text(), response=response.http_response,
+        )
+
+    container.replace_item.side_effect = retrying_replace
+    updates = {field: "committed-replacement"} if kind == "agents" else {"auth": {field: "committed-replacement"}}
+    env.services.secret_deletes.clear()
+    with patch.dict(sys.modules, {"azure.cosmos.exceptions": sdk_exceptions}):
+        result = patch_record(env, kind, resource, updates)
+    assert result.status_code == 409, result.get_json()
+    assert retry_requests == [("PUT", resource["revision"]), ("PUT", resource["revision"])]
+    committed = records[key]
+    reference = committed[field] if kind == "agents" else committed["auth"][field]
+    assert env.services.vault[reference] == "committed-replacement"
+    assert reference not in env.services.secret_deletes
+    assert committed["_etag"] != resource["revision"]
+    reloaded = env.client.get(f"/api/user/{kind}/{resource['record']['id']}?view=editor")
+    assert reloaded.status_code == 200
+    assert reloaded.get_json()["revision"] == committed["_etag"]
+    assert "committed-replacement" not in json.dumps(reloaded.get_json())
+
+
+@pytest.fixture
+def classic_environment(environment):
+    env = environment
+    with ExitStack() as stack:
+        stack.enter_context(patch.dict(sys.modules, {
+            "functions_debug": module_stub("functions_debug", debug_print=Mock()),
+        }))
+        personal = _load_module(stack, "functions_personal_agents")
+        container = env.services.containers["agents", "personal"]
+        conditional_delete = container.delete_item.side_effect
+        records = env.services.records["agents", "personal"]
+
+        def upsert_item(*, body):
+            env.services.sequence += 1
+            result = deepcopy(body)
+            result["_etag"] = f'"classic-{env.services.sequence}"'
+            records[result["user_id"], result["id"]] = result
+            env.services.writes.append(("classic-upsert", "agents", deepcopy(result)))
+            return deepcopy(result)
+
+        def delete_item(*, item, partition_key, **kwargs):
+            if kwargs:
+                return conditional_delete(item=item, partition_key=partition_key, **kwargs)
+            key = (partition_key, item)
+            if key not in records:
+                raise CosmosResourceNotFoundError()
+            env.services.writes.append(("classic-delete", "agents", item))
+            records.pop(key)
+
+        container.upsert_item.side_effect = upsert_item
+        container.delete_item.side_effect = delete_item
+        env.namespace.update({
+            "get_personal_agents": personal.get_personal_agents,
+            "save_personal_agent": personal.save_personal_agent,
+            "delete_personal_agent": personal.delete_personal_agent,
+            **{
+                name: getattr(env.services.activity, name)
+                for name in ("log_agent_creation", "log_agent_update", "log_agent_deletion")
+            },
+        })
+        execute_functions("route_backend_agents.py", {"_create_personal_agent"}, env.namespace)
+        # Key Vault really returns 404 for an invented/deleted name. The normal
+        # fixture's permissive deletion would hide reconstruction of a legacy name.
+        original_delete = env.keyvault.SecretClient.begin_delete_secret
+
+        def delete_existing_secret(client, name):
+            if name not in env.services.vault:
+                raise ResourceNotFoundError("Key Vault secret not found.", status_code=404)
+            return original_delete(client, name)
+
+        stack.enter_context(patch.object(env.keyvault.SecretClient, "begin_delete_secret", delete_existing_secret))
+        env.personal_agents = personal
+        yield env
+
+
+def _agent_with_secret(apim=False):
+    draft = agent_payload()
+    field = "azure_agent_apim_gpt_subscription_key" if apim else "azure_openai_gpt_key"
+    draft["enable_agent_gpt_apim"] = apim
+    draft[field] = "initial-agent-credential"
+    return draft, field
+
+
+@pytest.mark.parametrize("apim", [False, True])
+@pytest.mark.parametrize("save_method", ["patch", "collection"])
+@pytest.mark.parametrize("delete_method", ["item", "name", "collection"])
+def test_editor_agent_secrets_survive_classic_reads_saves_and_removal(classic_environment, apim, save_method, delete_method):
+    env = classic_environment
+    env.services.settings["enable_key_vault_secret_storage"] = True
+    draft, field = _agent_with_secret(apim)
+    resource = create(env, "agents", draft)
+    replaced = patch_record(env, "agents", resource, {field: "rotated-agent-credential"})
+    assert replaced.status_code == 200, replaced.get_json()
+    agent_id = resource["record"]["id"]
+    stored = env.services.records["agents", "personal"]["actor", agent_id]
+    actual_reference = stored[field]
+    assert "--editor-" in actual_reference
+    classic = env.client.get(f"/api/user/agents/{agent_id}")
+    assert classic.status_code == 200
+    assert classic.get_json()[field] == env.keyvault.ui_trigger_word
+    env.services.secret_writes.clear()
+    if save_method == "patch":
+        saved = env.client.patch(f"/api/user/agents/{agent_id}", json=classic.get_json())
+    else:
+        collection = env.client.get("/api/user/agents").get_json()
+        saved = env.client.post("/api/user/agents", json=collection)
+    assert saved.status_code == 200, saved.get_json()
+    assert env.services.records["agents", "personal"]["actor", agent_id][field] == actual_reference
+    assert env.services.vault[actual_reference] == "rotated-agent-credential"
+    assert env.services.secret_writes == []
+    if delete_method == "collection":
+        deleted = env.client.post("/api/user/agents", json=[])
+    else:
+        identifier = agent_id if delete_method == "item" else draft["name"]
+        deleted = env.client.delete(f"/api/user/agents/{identifier}")
+    assert deleted.status_code == 200, deleted.get_json()
+    assert ("actor", agent_id) not in env.services.records["agents", "personal"]
+    assert actual_reference in env.services.secret_deletes
+    assert actual_reference not in env.services.vault
+
+
+def test_classic_create_then_editor_replace_then_classic_rename_preserves_actual_reference(classic_environment):
+    env = classic_environment
+    env.services.settings["enable_key_vault_secret_storage"] = True
+    draft, field = _agent_with_secret()
+    classic_created = env.client.post("/api/user/agents", json=draft)
+    assert classic_created.status_code == 201, classic_created.get_json()
+    detail = env.client.get(f"/api/user/agents/{draft['id']}?view=editor").get_json()
+    changed = patch_record(env, "agents", detail, {field: "editor-rotated-credential"})
+    assert changed.status_code == 200, changed.get_json()
+    reference = env.services.records["agents", "personal"]["actor", draft["id"]][field]
+    classic = env.client.get(f"/api/user/agents/{draft['id']}").get_json()
+    classic["name"] = "renamed_classically"
+    env.services.secret_writes.clear()
+    renamed = env.client.post("/api/user/agents", json=[classic])
+    assert renamed.status_code == 200, renamed.get_json()
+    assert env.services.records["agents", "personal"]["actor", draft["id"]][field] == reference
+    assert env.services.secret_writes == []
+    deleted = env.client.delete("/api/user/agents/renamed_classically")
+    assert deleted.status_code == 200, deleted.get_json()
+    assert reference not in env.services.vault
+
+
+def test_classic_agent_cleanup_uses_only_the_current_users_stored_references(classic_environment):
+    env = classic_environment
+    env.services.settings["enable_key_vault_secret_storage"] = True
+    draft, field = _agent_with_secret()
+    resource = create(env, "agents", draft)
+    owner_reference = env.services.records["agents", "personal"]["actor", draft["id"]][field]
+    other_reference = env.keyvault.build_full_secret_name("editor-other-user", draft["id"], "agent", "user")
+    env.services.vault[other_reference] = "another-users-credential"
+    other = env.services.add("agents", "personal", "other-user", {
+        **draft, field: other_reference,
+    })
+    response = env.client.delete(f"/api/user/agents/{resource['record']['id']}")
+    assert response.status_code == 200, response.get_json()
+    assert owner_reference not in env.services.vault
+    assert env.services.vault[other_reference] == "another-users-credential"
+    assert env.services.records["agents", "personal"]["other-user", draft["id"]] == other
+
+
+def test_staging_failure_before_any_cosmos_write_can_clean_up_its_fresh_secret(environment):
+    env = environment
+    env.services.settings["enable_key_vault_secret_storage"] = True
+    resource = create(env, "plugins", action_payload())
+    original = deepcopy(env.services.records)
+    staged_reference = env.keyvault.build_full_secret_name("editor-uncommitted", "actor", "action", "user")
+
+    def fail_staging(record, kind, user_id, settings, staged):
+        env.services.vault[staged_reference] = "uncommitted-credential"
+        staged.append(staged_reference)
+        raise RuntimeError("Key Vault rejected a subsequent secret.")
+
+    container = env.services.containers["actions", "personal"]
+    container.replace_item.reset_mock()
+    with patch.object(env.helper, "_stage_editor_secrets", side_effect=fail_staging):
+        response = patch_record(env, "plugins", resource, {"auth": {"key": "replacement"}})
+    assert response.status_code == 503
+    container.replace_item.assert_not_called()
+    assert staged_reference not in env.services.vault
+    assert env.services.records == original
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/ui_tests/fixtures/agent_delegation/harness_entry.tsx
+++ b/ui_tests/fixtures/agent_delegation/harness_entry.tsx
@@ -1,16 +1,14 @@
 // harness_entry.tsx
-// Version: 0.261.093. Real V2 components with API responses supplied by Playwright.
+// Version: 0.261.096. Group/admin wrappers; personal authoring uses the real-SPA suite.
 
 import { createRoot } from 'react-dom/client';
 import { MemoryRouter } from 'react-router-dom';
-import { ActionsSection } from '../../../application/v2_ui/src/pages/workspace/ActionsSection';
-import { AgentsSection } from '../../../application/v2_ui/src/pages/workspace/AgentsSection';
 import { GroupAgentDelegationPage } from '../../../application/v2_ui/src/pages/GroupAgentDelegationPage';
 import { AdminSettingsPage } from '../../../application/v2_ui/src/pages/AdminSettingsPage';
 import { useBootstrapStore } from '../../../application/v2_ui/src/stores/bootstrapStore';
 import type { BootstrapPayload } from '../../../application/v2_ui/src/lib/types';
 
-type View = 'actions' | 'agents' | 'groups' | 'admin';
+type View = 'groups' | 'admin';
 
 declare global {
     interface Window {
@@ -28,8 +26,6 @@ window.AgentDelegationHarness = {
         // Only identity is read by the pages under test; all resource data crosses the real API client.
         useBootstrapStore.setState({ data: { user: { is_admin: admin } } as BootstrapPayload, loading: false });
         const pages = {
-            actions: <ActionsSection agentsEnabled />,
-            agents: <AgentsSection actionsEnabled />,
             groups: <GroupAgentDelegationPage />,
             admin: <AdminSettingsPage />,
         };

--- a/ui_tests/fixtures/workspace_authoring.py
+++ b/ui_tests/fixtures/workspace_authoring.py
@@ -1,0 +1,967 @@
+# workspace_authoring.py
+"""
+Closed API fixtures for the production V2 My Workspace authoring SPA.
+Version: 0.261.096
+Implemented in: 0.261.096
+
+The browser loads the real built application and CSS. Only HTTP responses and
+synthetic resource persistence are replaced; no components, stores, navigation,
+validation, or DOM behavior are simulated. Saved secrets stay on the fixture's
+server side, and every editor write is recorded before applying nested changes.
+
+SIMPLECHAT_UI_EXPECTED_JS and SIMPLECHAT_UI_EXPECTED_CSS can pin an explicitly
+released build when worktree source-copy timestamps are newer. Both filenames
+must match the real index and exist on disk. Without pins, source freshness is
+required. Browser assets and UI assertions are never replaced by this option.
+
+The shared connect_options fixture supports DefaultAzureCredential and
+azure-mgmt-playwright when PLAYWRIGHT_SERVICE_URL is configured, with the same
+explicit local-browser fallback as the existing admin suite.
+"""
+
+import copy
+import json
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import parse_qs, unquote, urlsplit
+
+import pytest
+from playwright.sync_api import Page, Route, expect
+
+from ui_tests.fixtures.v2_admin_settings import connect_options  # noqa: F401
+
+
+ROOT = Path(__file__).resolve().parents[2]
+STATIC_ROOT = ROOT / "application" / "single_app" / "static"
+SCHEMA_ROOT = STATIC_ROOT / "json" / "schemas"
+PLUGIN_ROOT = ROOT / "application" / "single_app" / "semantic_kernel_plugins"
+SPA_INDEX = STATIC_ROOT / "v2" / "index.html"
+ORIGIN = "http://simplechat.test"
+VERSION = "0.261.096"
+SECRET_MASK = "***REDACTED***"
+OWNER_ID = "workspace-editor-user"
+AGENT_ID = "00000000-0000-4000-8000-000000000001"
+TARGET_ID = "00000000-0000-4000-8000-000000000002"
+GLOBAL_AGENT_ID = "00000000-0000-4000-8000-000000000003"
+ACTION_ID = "10000000-0000-4000-8000-000000000001"
+CALL_ACTION_ID = "10000000-0000-4000-8000-000000000002"
+GLOBAL_ACTION_ID = "10000000-0000-4000-8000-000000000003"
+SELF_ACTION_ID = "10000000-0000-4000-8000-000000000004"
+MCP_ACTION_ID = "10000000-0000-4000-8000-000000000005"
+CHART_ACTION_ID = "10000000-0000-4000-8000-000000000006"
+CREATED_AGENT_ID = "00000000-0000-4000-8000-000000000101"
+CREATED_ACTION_ID = "10000000-0000-4000-8000-000000000101"
+STORED_KEY = "fixture-only-existing-credential"
+STORED_HEADER = "fixture-only-existing-header"
+MISSING = object()
+
+
+def agent_record(identifier=AGENT_ID, **overrides):
+    record = {
+        "id": identifier,
+        "name": "workspace-reviewer",
+        "display_name": "Workspace reviewer",
+        "description": "Review work with authorized sources and actions.",
+        "instructions": "Review carefully. Use #action:legacy-tool when relevant.",
+        "agent_type": "local",
+        "actions_to_load": ["legacy-tool", "unavailable-action"],
+        "other_settings": {
+            "action_capabilities": {"legacy-tool": ["read"], "unavailable-action": ["keep"]},
+            "custom_policy": {"enabled": False, "limit": 0, "nested": {"retain": "value"}},
+        },
+        "max_completion_tokens": -1,
+        "model_endpoint_id": "workspace-model-endpoint",
+        "model_id": "workspace-model",
+        "model_provider": "aoai",
+        "azure_openai_gpt_deployment": "workspace-gpt",
+        "tags": ["review"],
+        "is_global": False,
+        "user_id": OWNER_ID,
+    }
+    record.update(copy.deepcopy(overrides))
+    return record
+
+
+def action_record(identifier=ACTION_ID, **overrides):
+    record = {
+        "id": identifier,
+        "name": "legacy-tool",
+        "displayName": "Workspace API",
+        "description": "Read the approved workspace API.",
+        "type": "openapi",
+        "endpoint": "https://api.example.test/v1",
+        "auth": {"type": "key", "key": STORED_KEY},
+        "additionalFields": {
+            "openapi_spec_content": {
+                "openapi": "3.0.0",
+                "info": {"title": "Workspace API", "version": "1.0.0"},
+                "paths": {
+                    "/items": {
+                        "get": {
+                            "operationId": "listItems",
+                            "summary": "List approved items",
+                            "responses": {"200": {"description": "Approved items"}},
+                        },
+                    },
+                },
+            },
+            "custom": {"enabled": False, "limit": 0, "items": [], "nested": {"keep": "yes"}},
+        },
+        "metadata": {"retention": {"enabled": False, "days": 0}, "labels": []},
+        "is_enabled": True,
+        "is_global": False,
+        "user_id": OWNER_ID,
+    }
+    record.update(copy.deepcopy(overrides))
+    return record
+
+
+def call_action(identifier=CALL_ACTION_ID, *, target_id=TARGET_ID, **overrides):
+    return action_record(
+        identifier,
+        name="call-reviewer" if identifier == CALL_ACTION_ID else "call-self",
+        displayName="Call reviewer" if identifier == CALL_ACTION_ID else "Call self",
+        description="Delegate a review to another authorized agent.",
+        type="agent",
+        endpoint="internal://agent",
+        auth={"type": "user"},
+        additionalFields={
+            "target_agent": {"id": target_id, "scope_type": "personal", "scope_id": OWNER_ID},
+        },
+        **overrides,
+    )
+
+
+def _schema(path):
+    return json.loads(path.read_text(encoding="utf-8")) if path.is_file() else {
+        "type": "object", "properties": {}, "additionalProperties": True,
+    }
+
+
+def action_types():
+    """Offer shipped modules using their checked-in definitions and schemas."""
+    types = []
+    for module_path in sorted(PLUGIN_ROOT.glob("*_plugin.py")):
+        action_type = module_path.stem.removesuffix("_plugin")
+        if action_type == "base":
+            continue
+        definition = _schema(SCHEMA_ROOT / f"{action_type}.definition.json")
+        types.append({
+            "type": action_type,
+            "display": {
+                "agent": "Call agent",
+                "openapi": "OpenAPI",
+                "mcp": "MCP",
+                "msgraph": "Microsoft Graph",
+                "simplechat": "SimpleChat",
+            }.get(action_type, action_type.replace("_", " ").title()),
+            "description": f"Configure the {action_type.replace('_', ' ')} connector.",
+            "allowed_auth_types": definition.get("allowedAuthTypes", ["NoAuth"]),
+            "additional_fields_schema": _schema(
+                SCHEMA_ROOT / f"{action_type}_plugin.additional_settings.schema.json"
+            ),
+            "metadata_schema": _schema(SCHEMA_ROOT / f"{action_type}_plugin.metadata.schema.json"),
+        })
+    types.append({
+        "type": "fixture_custom",
+        "display": "Custom governed connector",
+        "description": "A server-discovered action that is not hardcoded in the browser.",
+        "allowed_auth_types": ["NoAuth"],
+        "additional_fields_schema": {
+            "type": "object",
+            "properties": {
+                "region": {"type": "string", "title": "Region", "enum": ["east", "west"]},
+                "limit": {"type": "integer", "title": "Result limit", "default": 0, "minimum": 0},
+                "enabled": {"type": "boolean", "title": "Include archived", "default": False},
+            },
+            "additionalProperties": True,
+        },
+        "metadata_schema": {"type": "object", "properties": {}, "additionalProperties": True},
+    })
+    return types
+
+
+def editor_options():
+    return {
+        "agent_types": [
+            {"value": value, "label": label, "enabled": True}
+            for value, label in (
+                ("local", "Local agent"),
+                ("aifoundry", "Azure AI Foundry"),
+                ("new_foundry", "New Foundry"),
+                ("foundry_workflow", "Foundry Workflow"),
+            )
+        ],
+        "settings": {
+            "enable_semantic_kernel": True,
+            "per_user_semantic_kernel": True,
+            "allow_user_agents": True,
+            "allow_user_plugins": True,
+            "allow_user_custom_endpoints": True,
+            "allow_personal_ai_foundry_agents": True,
+            "allow_personal_new_foundry_agents": True,
+            "enable_multi_model_endpoints": True,
+            "merge_global_semantic_kernel_with_workspace": True,
+            "enable_agent_template_gallery": True,
+            "agent_templates_allow_user_submission": True,
+            "enable_user_workspace": True,
+            "enable_public_workspaces": True,
+            "enable_url_access": True,
+            "enable_web_search": True,
+            "enable_math_plugin": True,
+        },
+        "model_endpoints": [{
+            "id": "workspace-model-endpoint",
+            "name": "Workspace model endpoint",
+            "provider": "aoai",
+            "enabled": True,
+            "models": [{
+                "id": "workspace-model",
+                "deploymentName": "workspace-gpt",
+                "modelName": "gpt-4o",
+                "displayName": "Workspace GPT",
+                "enabled": True,
+            }],
+        }],
+        "builtin_actions": [
+            {"id": "math", "label": "Math", "description": "Built-in arithmetic tools."},
+        ],
+    }
+
+
+def _pointer_parts(pointer):
+    assert pointer.startswith("/"), f"Expected a JSON pointer, received {pointer!r}"
+    return [part.replace("~1", "/").replace("~0", "~") for part in pointer[1:].split("/")]
+
+
+def _pointer_index(value):
+    return int(value) if re.fullmatch(r"0|[1-9][0-9]*", value) else None
+
+
+def _get_pointer(record, pointer):
+    current = record
+    for key in _pointer_parts(pointer):
+        if isinstance(current, dict) and key in current:
+            current = current[key]
+        elif isinstance(current, list) and (index := _pointer_index(key)) is not None and index < len(current):
+            current = current[index]
+        else:
+            return MISSING
+    return current
+
+
+def _set_pointer(record, pointer, value):
+    parts = _pointer_parts(pointer)
+    parent = record
+    for key in parts[:-1]:
+        parent = parent[int(key)] if isinstance(parent, list) else parent.setdefault(key, {})
+    if isinstance(parent, list):
+        parent[int(parts[-1])] = value
+    else:
+        parent[parts[-1]] = value
+
+
+def _remove_pointer(record, pointer):
+    parts = _pointer_parts(pointer)
+    parent = record
+    for key in parts[:-1]:
+        if isinstance(parent, dict) and key in parent:
+            parent = parent[key]
+        elif isinstance(parent, list) and (index := _pointer_index(key)) is not None and index < len(parent):
+            parent = parent[index]
+        else:
+            return
+    if isinstance(parent, dict):
+        parent.pop(parts[-1], None)
+    elif isinstance(parent, list) and (index := _pointer_index(parts[-1])) is not None and index < len(parent):
+        parent[index] = ""
+
+
+def _merge_updates(record, updates):
+    for key, value in updates.items():
+        if isinstance(value, dict) and isinstance(record.get(key), dict):
+            _merge_updates(record[key], value)
+        else:
+            record[key] = copy.deepcopy(value)
+
+
+def _walk_values(value, parent=""):
+    if isinstance(value, dict):
+        children = value.items()
+    elif isinstance(value, list):
+        children = enumerate(value)
+    else:
+        yield parent, value
+        return
+    for key, item in children:
+        escaped = str(key).replace("~", "~0").replace("/", "~1")
+        yield from _walk_values(item, f"{parent}/{escaped}")
+
+
+class EditorSecretError(ValueError):
+    """The synthetic request violates explicit, owned secret intent."""
+
+
+def _editor_candidate(record, updates, secret_paths, clear_paths, removed_paths):
+    known, cleared, removed = set(secret_paths), set(clear_paths), set(removed_paths)
+    if cleared - known or cleared & removed:
+        raise EditorSecretError()
+    candidate = copy.deepcopy(record)
+    _merge_updates(candidate, updates)
+    for pointer, value in _walk_values(candidate):
+        if value == SECRET_MASK:
+            original = _get_pointer(record, pointer)
+            if pointer not in known or original is MISSING or original == SECRET_MASK:
+                raise EditorSecretError()
+            # Array masks retain only the secret at this exact original position.
+            _set_pointer(candidate, pointer, copy.deepcopy(original))
+    for pointer in removed:
+        _remove_pointer(candidate, pointer)
+    for pointer in secret_paths:
+        if pointer in cleared:
+            _remove_pointer(candidate, pointer)
+        else:
+            value = _get_pointer(candidate, pointer)
+            if value is MISSING or value is None or value == "":
+                raise EditorSecretError()
+    return candidate
+
+
+@dataclass
+class ApiRequest:
+    method: str
+    path: str
+    query: dict
+    body: object
+
+
+class WorkspaceAuthoringFixture:
+    """A closed synthetic server, not a replacement implementation of the UI."""
+
+    def __init__(self, page: Page):
+        self.page = page
+        self.pages = []
+        self.preferences = {}
+        self.options = editor_options()
+        self.types = action_types()
+        self.agents = {
+            AGENT_ID: agent_record(),
+            TARGET_ID: agent_record(
+                TARGET_ID, name="target-reviewer", display_name="Target reviewer", actions_to_load=[]
+            ),
+            GLOBAL_AGENT_ID: agent_record(
+                GLOBAL_AGENT_ID, name="provided-reviewer", display_name="Provided reviewer",
+                is_global=True, user_id="global", actions_to_load=[],
+            ),
+        }
+        self.actions = {
+            ACTION_ID: action_record(),
+            CALL_ACTION_ID: call_action(),
+            SELF_ACTION_ID: call_action(SELF_ACTION_ID, target_id=AGENT_ID),
+            GLOBAL_ACTION_ID: action_record(
+                GLOBAL_ACTION_ID, name="provided-api", displayName="Provided API",
+                is_global=True, user_id="global",
+            ),
+            MCP_ACTION_ID: action_record(
+                MCP_ACTION_ID, name="workspace-mcp", displayName="Workspace MCP", type="mcp",
+                endpoint="https://mcp.example.test/mcp",
+                additionalFields={
+                    "server_profile": "generic", "transport": "streamable_http",
+                    "auth_method": "bearer", "custom_headers": {"X-Workspace": STORED_HEADER},
+                    "load_tools": True, "load_prompts": False, "request_timeout": 30,
+                    "allowed_tool_names": ["search"], "mcp_tools": [],
+                    "custom": {"keep": {"false_value": False, "zero_value": 0}},
+                },
+            ),
+            CHART_ACTION_ID: action_record(
+                CHART_ACTION_ID, name="legacy-chart", displayName="Workspace charts", type="chart",
+                endpoint="internal://chart", auth={"type": "user"},
+                additionalFields={"chart_capabilities": {"line": False, "bar": True}},
+            ),
+        }
+        self.secret_paths = {
+            ACTION_ID: ["/auth/key"],
+            GLOBAL_ACTION_ID: ["/auth/key"],
+            MCP_ACTION_ID: ["/auth/key", "/additionalFields/custom_headers/X-Workspace"],
+        }
+        self.revisions = {identifier: 1 for identifier in (*self.agents, *self.actions)}
+        self.empty_revisions = set()
+        self.missing_revisions = set()
+        self.targets = [
+            {
+                "id": item["id"], "scope_type": "global" if item["is_global"] else "personal",
+                "scope_id": "global" if item["is_global"] else OWNER_ID,
+                "name": item["name"], "display_name": item["display_name"],
+                "description": item["description"], "agent_type": item["agent_type"],
+            }
+            for item in self.agents.values()
+        ]
+        self.can_manage = True
+        self.workspace_enabled = True
+        self.disabled_sections = {}
+        self.denied_resources = set()
+        self.requests = []
+        self.writes = []
+        self.responses = []
+        self.errors = []
+        self.console_errors = []
+        self.private_values = {STORED_KEY, STORED_HEADER, SECRET_MASK}
+        self.expected_http_errors = set()
+        self.unexpected_requests = []
+        self.failures = []
+        self.deferred_paths = set()
+        self.pending_responses = []
+        self.created_counts = {"agents": 0, "plugins": 0}
+        self.loaded_assets = set()
+        self.knowledge_catalog = {
+            "sources": [
+                {"scope": "personal", "id": "personal", "label": "Personal workspace"},
+                {"scope": "public", "id": "public-handbook", "label": "Published handbook"},
+            ],
+            "documents": [
+                {
+                    "id": "personal-brief", "title": "Private review brief",
+                    "file_name": "review-brief.pdf", "scope": "personal", "source_id": "personal",
+                    "source_name": "Personal workspace", "tags": ["Finance"],
+                },
+                {
+                    "id": "public-guide", "title": "Public review guide",
+                    "file_name": "review-guide.pdf", "scope": "public", "source_id": "public-handbook",
+                    "source_name": "Published handbook", "tags": ["Finance", "Operations"],
+                },
+                {
+                    "id": "public-checklist", "title": "Public finance checklist",
+                    "file_name": "finance-checklist.pdf", "scope": "public", "source_id": "public-handbook",
+                    "source_name": "Published handbook", "tags": ["Finance"],
+                },
+            ],
+            "tags": [{"name": "Finance", "count": 3}, {"name": "Operations", "count": 1}],
+        }
+        self.templates = [{
+            "id": "approved-review-template", "title": "Approved review example",
+            "display_name": "Approved review example", "description": "Review with an approved starting prompt.",
+            "instructions": "Use #action:missing-template-tool when it becomes available.",
+            "actions_to_load": ["missing-template-tool"], "tags": ["review"],
+            "additional_settings": {
+                "custom_policy": {"enabled": False, "limit": 0},
+                "private": {"api_key": SECRET_MASK},
+            },
+        }]
+        self.openapi_import_spec = {
+            "openapi": "3.0.0",
+            "info": {"title": "Imported review API", "version": "1.0.0"},
+            "servers": [{"url": "https://review-api.example.test/v1"}],
+            "paths": {
+                "/status": {
+                    "get": {
+                        "operationId": "getReviewStatus", "summary": "Read review status",
+                        "responses": {"200": {"description": "Review status"}},
+                    },
+                },
+            },
+        }
+        self.mcp_presets = [{
+            "id": "generic", "displayName": "Generic MCP server",
+            "description": "Standards-compliant MCP server.",
+            "defaults": {"server_profile": "generic", "transport": "streamable_http", "auth_method": "none"},
+            "constraints": {}, "ui": {}, "warnings": [],
+            "implementation": {"id": "generic", "schemaVersion": "1.0.0"},
+            "additionalSettings": {"compatibilityProfile": "standards_compliant"},
+        }]
+        self.mcp_preconfigurations = [{
+            "id": "review-server", "displayName": "Review MCP server", "presetId": "generic",
+            "description": "The approved review server.",
+            "endpoint": "https://mcp.example.test/review", "transport": "streamable_http",
+            "scopeEligibility": ["personal"],
+            "defaults": {"load_tools": True}, "constraints": {}, "ui": {}, "warnings": [],
+            "implementation": {"id": "generic", "schemaVersion": "1.0.0"},
+            "additionalSettings": {"compatibilityProfile": "standards_compliant"},
+        }]
+        self.conversations = [{
+            "id": "existing-workspace-chat", "title": "Existing conversation",
+            "user_id": OWNER_ID, "last_updated": "2026-09-05T12:00:00Z",
+        }]
+        self.messages = {
+            "existing-workspace-chat": [{
+                "id": "existing-message", "role": "user", "content": "An earlier conversation.",
+                "conversation_id": "existing-workspace-chat", "timestamp": "2026-09-05T12:00:00Z",
+            }],
+        }
+        self.extra_gets = {
+            "/api/prompts": {"prompts": []},
+            "/api/documents/facets": {
+                "total": 1, "untagged": 0, "processing": 0, "errors": 0,
+                "recent": 1, "shared_with_me": 0, "by_tag": {"Finance": 1},
+            },
+            "/api/documents/tags": {"tags": [{"name": "Finance"}]},
+            "/api/orchestration_types": [{"value": "default_agent", "label": "Single agent"}],
+            "/api/orchestration_settings": {"orchestration_type": "default_agent", "max_rounds_per_agent": 1},
+        }
+        self.extra_posts = {
+            "/api/agents/draft-instructions": {
+                "success": True, "instructions": "Generated review instructions for the selected actions and knowledge.",
+            },
+            "/api/agent-templates": {"template": {"id": "submitted-template", "status": "pending"}},
+            "/api/openapi/upload": {
+                "success": True, "file_id": "fixture-openapi-upload",
+                "original_filename": "review.openapi.json", "spec_content": self.openapi_import_spec,
+            },
+            "/api/plugins/validate": {"valid": True, "message": "Fixture manifest is valid."},
+            "/api/plugins/test-openapi-connection": {
+                "success": True, "message": "Fixture OpenAPI connection succeeded.",
+            },
+            "/api/plugins/test-mcp-connection": {
+                "success": True, "message": "Fixture MCP connection succeeded.",
+            },
+            "/api/plugins/mcp/discover": {
+                "success": True,
+                "tools": [
+                    {
+                        "original_name": "search", "function_name": "search",
+                        "description": "Search approved knowledge.",
+                        "input_schema": {
+                            "type": "object", "properties": {"query": {"type": "string"}},
+                            "required": ["query"],
+                        },
+                    },
+                    {
+                        "original_name": "summarize", "function_name": "summarize",
+                        "description": "Summarize an approved source.",
+                        "input_schema": {"type": "object", "properties": {}},
+                    },
+                ],
+                "capabilities": {"tools": True, "prompts": False},
+                "transport": "streamable_http", "auth_method": "bearer",
+            },
+        }
+        self._watch_page(page)
+        page.context.on("page", self._watch_page)
+        page.context.route("**/*", self._route)
+
+    def _watch_page(self, page: Page):
+        self.pages.append(page)
+        page.on("pageerror", lambda error: self.errors.append(f"{page.url}: {error}"))
+        page.on("console", self._console)
+
+    @property
+    def editor_writes(self):
+        return [
+            request for request in self.writes
+            if re.fullmatch(r"/api/user/(agents|plugins)(/[^/]+)?", request.path)
+        ]
+
+    def revision(self, identifier):
+        return f"fixture-revision:{identifier}:{self.revisions[identifier]}"
+
+    def projected(self, record):
+        result = copy.deepcopy(record)
+        for pointer in self.secret_paths.get(record["id"], []):
+            _set_pointer(result, pointer, SECRET_MASK)
+        return result
+
+    def envelope(self, record):
+        empty_revision = record["id"] in self.empty_revisions
+        missing_revision = record["id"] in self.missing_revisions
+        assert not (empty_revision or missing_revision) or record.get("is_global"), "Writable fixtures require a revision."
+        resource = {
+            "record": self.projected(record),
+            "revision": "" if empty_revision else self.revision(record["id"]),
+            "secret_paths": copy.deepcopy(self.secret_paths.get(record["id"], [])),
+            "read_only": bool(record.get("is_global")),
+        }
+        if missing_revision:
+            del resource["revision"]
+        return resource
+
+    def reject_next(self, method, path, *, status=503, error="Fixture request failed.", **payload):
+        self.failures.append((method, path, status, {"error": error, **payload}))
+
+    def defer_next(self, method, path):
+        self.deferred_paths.add((method, path))
+
+    def release_responses(self):
+        pending, self.pending_responses = self.pending_responses, []
+        for route, entry in pending:
+            self._dispatch(route, entry)
+
+    def _console(self, message):
+        if message.type == "error":
+            self.console_errors.append((message.text, message.location.get("url", "")))
+
+    def _json(self, route, payload, status=200):
+        self.responses.append((route.request.url, copy.deepcopy(payload)))
+        if status >= 400:
+            self.expected_http_errors.add((route.request.url, status))
+        route.fulfill(status=status, json=payload)
+
+    def _bootstrap(self):
+        return {
+            "version": VERSION,
+            "user": {
+                "id": OWNER_ID, "display_name": "Workspace editor", "is_admin": False,
+                "roles": ["User"],
+            },
+            "branding": {
+                "app_title": "SimpleChat", "show_logo": False, "hide_app_title": False,
+                "logo_url": None, "logo_dark_url": None, "classification_banner": None,
+            },
+            "features": {
+                "enable_user_workspace": True,
+                "enable_semantic_kernel": True,
+                "per_user_semantic_kernel": True,
+                "enable_agent_template_gallery": True,
+            },
+            "catalogs": {
+                "models": [], "prompts": [], "initial_model_selection": None,
+                "agents": [
+                    {
+                        **self.projected(record),
+                        "catalog_key": f"{'global' if record.get('is_global') else 'personal'}:{record['id']}",
+                        "scope_type": "global" if record.get("is_global") else "personal",
+                        "scope_label": "Provided" if record.get("is_global") else "Personal",
+                    }
+                    for record in self.agents.values()
+                ],
+            },
+            "scope": {"groups": [], "public_workspaces": []},
+            "navigation": {
+                "custom_pages": {"enabled": False, "items": []},
+                "external_links": {"enabled": False, "items": []},
+            },
+            "workspace": {
+                "enabled": self.workspace_enabled,
+                "governance": {},
+                "sections": {
+                    section: {
+                        "enabled": section not in self.disabled_sections,
+                        "reason": self.disabled_sections.get(section), "group": group,
+                    }
+                    for section, group in (
+                        ("agents", "automation"), ("actions", "automation"),
+                        ("prompts", "knowledge"), ("documents", "knowledge"),
+                        ("identities", "connections"), ("endpoints", "connections"),
+                    )
+                },
+            },
+            "settings": {},
+        }
+
+    def _route(self, route: Route):
+        request = route.request
+        parsed = urlsplit(request.url)
+        if f"{parsed.scheme}://{parsed.netloc}" != ORIGIN:
+            self.unexpected_requests.append(f"{request.method} {request.url}")
+            route.abort()
+            return
+        path = unquote(parsed.path)
+        if request.method == "GET" and re.fullmatch(
+            r"/v2/(workspace(?:/(?:agents|actions|prompts|documents)(?:/[^/]+)?)?|chat)", path
+        ):
+            route.fulfill(path=str(SPA_INDEX), content_type="text/html")
+            return
+        if request.method == "GET" and path.startswith("/static/"):
+            asset = (STATIC_ROOT / path.removeprefix("/static/")).resolve()
+            if asset.is_relative_to(STATIC_ROOT.resolve()) and asset.is_file():
+                self.loaded_assets.add(path)
+                route.fulfill(path=str(asset))
+                return
+            self.unexpected_requests.append(f"Missing local asset: {path}")
+            route.fulfill(status=404, body="Fixture asset not found.")
+            return
+        body = None
+        if request.post_data:
+            if "application/json" in request.headers.get("content-type", ""):
+                body = request.post_data_json
+            else:
+                body = request.post_data
+        entry = ApiRequest(request.method, path, parse_qs(parsed.query), copy.deepcopy(body))
+        self.requests.append(entry)
+        if request.method != "GET":
+            self.writes.append(entry)
+        for index, (method, failed_path, status, payload) in enumerate(self.failures):
+            if (method, failed_path) == (entry.method, path):
+                self.failures.pop(index)
+                self._json(route, payload, status)
+                return
+        if (entry.method, path) in self.deferred_paths:
+            self.deferred_paths.remove((entry.method, path))
+            self.pending_responses.append((route, entry))
+            return
+        self._dispatch(route, entry)
+
+    def _dispatch(self, route, entry):
+        path, method = entry.path, entry.method
+        if path == "/api/v2/bootstrap" and method == "GET":
+            self._json(route, self._bootstrap())
+        elif path == "/api/user/settings" and method == "GET":
+            self._json(route, {"settings": self.preferences})
+        elif path == "/api/user/settings" and method == "POST":
+            assert set(entry.body) == {"settings"}
+            self.preferences.update(copy.deepcopy(entry.body["settings"]))
+            self._json(route, {"message": "Saved fixture preferences."})
+        elif path == "/api/user/agent/settings" and method == "GET":
+            assert entry.query == {"view": ["editor"]}
+            self._json(route, self.options)
+        elif path == "/api/user/plugins/types" and method == "GET":
+            assert entry.query == {"view": ["editor"]}
+            self._json(route, self.types)
+        elif path == "/api/agents/generate_id" and method == "GET":
+            self.created_counts["agents"] += 1
+            self._json(route, {"id": f"00000000-0000-4000-8000-{100 + self.created_counts['agents']:012d}"})
+        elif path == "/api/plugins/agent-targets" and method == "GET":
+            assert entry.query.get("scope") == ["personal"]
+            assert "group_id" not in entry.query
+            self._json(route, {
+                "targets": self.targets, "can_manage": self.can_manage,
+                "scope_type": "personal", "scope_id": OWNER_ID,
+            })
+        elif path == "/api/agents/catalog" and method == "GET":
+            self._json(route, {"agents": self._bootstrap()["catalogs"]["agents"]})
+        elif path == "/api/agents/assigned-knowledge/catalog" and method == "GET":
+            assert entry.query == {"agent_scope": ["personal"]}
+            self._json(route, self.knowledge_catalog)
+        elif path == "/api/agent-templates" and method == "GET":
+            self._json(route, {"templates": self.templates})
+        elif path == "/api/plugins/mcp/presets" and method == "GET":
+            assert not entry.query
+            self._json(route, {"presets": self.mcp_presets})
+        elif path == "/api/plugins/mcp/preconfigurations" and method == "GET":
+            assert entry.query == {"scope": ["personal"]}
+            self._json(route, {"preconfigurations": self.mcp_preconfigurations})
+        elif path == "/api/user/model-endpoints" and method == "GET":
+            self._json(route, {"endpoints": self.options["model_endpoints"]})
+        elif path == "/api/workspace-identities/personal/identities" and method == "GET":
+            self._json(route, {"identities": [{
+                "id": "workspace-identity", "display_name": "Workspace managed identity",
+                "name": "Workspace managed identity", "type": "managed_identity",
+                "auth_type": "managed_identity", "is_enabled": True,
+            }]})
+        elif path == "/api/conversations/feed" and method == "GET":
+            self._json(route, {
+                "success": True, "conversations": self.conversations, "has_more": False,
+                "next_cursor": None, "page_size": 30, "hidden_count": 0, "priority_count": 0,
+                "recent_count": len(self.conversations), "source_offsets": {},
+            })
+        elif path == "/api/get_messages" and method == "GET":
+            identifier = entry.query["conversation_id"][0]
+            assert identifier in self.messages, entry
+            self._json(route, {"messages": self.messages[identifier]})
+        elif method == "GET" and re.fullmatch(r"/api/conversations/[^/]+/kind", path):
+            identifier = path.split("/")[3]
+            assert identifier in self.messages, entry
+            self._json(route, {"conversation_id": identifier, "kind": "personal"})
+        elif method == "GET" and re.fullmatch(r"/api/conversations/[^/]+/metadata", path):
+            identifier = path.split("/")[3]
+            record = next(item for item in self.conversations if item["id"] == identifier)
+            self._json(route, {
+                **record, "conversation_id": identifier, "tags": [], "context": [],
+                "classification": [], "used_documents": [], "linked_workspace_documents": [],
+            })
+        elif method == "GET" and re.fullmatch(r"/api/chat/stream/status/[^/]+", path):
+            identifier = path.rsplit("/", 1)[-1]
+            assert identifier in self.messages, entry
+            self._json(route, {"active": False, "pending": False, "reattachable": False})
+        elif path == "/api/create_conversation" and method == "POST":
+            assert set(entry.body) == {"initial_message"}
+            identifier = f"created-workspace-chat-{len(self.conversations)}"
+            record = {"id": identifier, "title": "New workspace chat", "user_id": OWNER_ID}
+            self.conversations.append(record)
+            self.messages[identifier] = []
+            self._json(route, {"conversation_id": identifier, "title": record["title"]})
+        elif path == "/api/chat/stream" and method == "POST":
+            identifier = entry.body["conversation_id"]
+            assert identifier in self.messages, entry
+            self.messages[identifier].append({
+                "id": "workspace-message", "role": "user", "content": entry.body["message"],
+                "conversation_id": identifier, "timestamp": "2026-09-05T12:01:00Z",
+            })
+            frames = [
+                {"content": "Workspace review response."},
+                {"done": True, "conversation_id": identifier, "message_id": "workspace-answer"},
+            ]
+            route.fulfill(
+                content_type="text/event-stream",
+                body="".join(f"data: {json.dumps(frame)}\n\n" for frame in frames),
+            )
+        elif path == "/api/openapi/upload" and method == "POST":
+            if not route.request.headers.get("content-type", "").lower().startswith("multipart/form-data"):
+                self.unexpected_requests.append("Unsupported non-file OpenAPI import request.")
+                self._json(route, {"error": "OpenAPI specifications must be uploaded as files."}, 400)
+            else:
+                self._json(route, self.extra_posts[path])
+        elif method == "GET" and path in self.extra_gets:
+            self._json(route, self.extra_gets[path])
+        elif method == "POST" and path in self.extra_posts:
+            self._json(route, self.extra_posts[path])
+        elif re.fullmatch(r"/api/user/(agents|plugins)(/[^/]+)?", path):
+            self._resource(route, entry)
+        else:
+            self.unexpected_requests.append(f"{method} {path}?{urlsplit(route.request.url).query}")
+            route.fulfill(status=404, json={"error": "Unexpected workspace fixture request."})
+
+    def _resource(self, route, entry):
+        _, _, _, kind, *identifiers = entry.path.split("/")
+        resources = self.agents if kind == "agents" else self.actions
+        identifier = identifiers[0] if identifiers else None
+        assert entry.query.get("view") == ["editor"], entry
+        assert set(entry.query) <= {"view", "scope"}, entry
+        scope = entry.query.get("scope", ["personal"])[0]
+        assert scope in ("personal", "global"), entry
+        if scope == "global" and entry.method != "GET":
+            self._json(route, {"error": "Provided resources are read-only."}, 403)
+            return
+        if identifier in self.denied_resources:
+            self._json(route, {"error": "You no longer have permission to access this resource."}, 403)
+            return
+        record = resources.get(identifier)
+        if record and bool(record.get("is_global")) != (scope == "global"):
+            record = None
+        if entry.method == "GET":
+            if not identifier:
+                self._json(route, [self.projected(item) for item in resources.values()])
+            elif record:
+                self._json(route, self.envelope(record))
+            else:
+                self._json(route, {"error": "Resource not found."}, 404)
+            return
+        if record and record.get("is_global"):
+            self._json(route, {"error": "Provided resources are read-only."}, 403)
+            return
+        if entry.method == "DELETE" and record:
+            assert entry.body is None
+            del resources[identifier]
+            self._json(route, {"success": True})
+            return
+        assert entry.method in ("POST", "PATCH"), entry
+        assert isinstance(entry.body, dict), "Whole-collection authoring writes are prohibited."
+        expected_keys = {"updates", "clear_secret_paths", "removed_paths"}
+        if entry.method == "PATCH":
+            expected_keys.add("expected_revision")
+        assert set(entry.body) == expected_keys, entry
+        updates = entry.body["updates"]
+        assert isinstance(updates, dict)
+        assert not {"user_id", "created_by", "is_global", "is_group", "revision", "secret_paths"} & set(updates)
+        assert not any(key.startswith("_") for key in updates), "Ephemeral editor state must not be persisted."
+        if entry.method == "PATCH":
+            assert identifier and record, entry
+            assert "id" not in updates, "An edit cannot replace the resource identifier."
+            if entry.body["expected_revision"] != self.revision(identifier):
+                self._json(route, {"error": "This resource changed in another session. Reload before saving."}, 409)
+                return
+        else:
+            assert identifier is None, entry
+            if kind == "agents":
+                identifier = updates["id"]
+            else:
+                assert "id" not in updates
+                self.created_counts["plugins"] += 1
+                identifier = f"10000000-0000-4000-8000-{100 + self.created_counts['plugins']:012d}"
+            assert identifier not in resources
+            record = {"id": identifier, "user_id": OWNER_ID, "is_global": False}
+        paths = self.secret_paths.get(identifier, [])
+        try:
+            record = _editor_candidate(
+                record, updates, paths,
+                entry.body["clear_secret_paths"], entry.body["removed_paths"],
+            )
+        except EditorSecretError:
+            self._json(route, {
+                "error": "Stored credentials must be kept at their original paths, replaced, or explicitly cleared.",
+            }, 400)
+            return
+        self.secret_paths[identifier] = [
+            pointer for pointer in paths if pointer not in entry.body["clear_secret_paths"]
+        ]
+        if record.get("auth", {}).get("key"):
+            paths = self.secret_paths.setdefault(identifier, [])
+            if "/auth/key" not in paths:
+                paths.append("/auth/key")
+        resources[identifier] = record
+        self.revisions[identifier] = self.revisions.get(identifier, 0) + 1
+        self._json(route, self.envelope(record), 201 if entry.method == "POST" else 200)
+
+    def open(self, path="/workspace/actions", *, theme="light", width=1440, height=900):
+        if not SPA_INDEX.is_file():
+            pytest.fail("Build the real V2 SPA before running workspace authoring UI tests.")
+        expected_js = os.getenv("SIMPLECHAT_UI_EXPECTED_JS", "")
+        expected_css = os.getenv("SIMPLECHAT_UI_EXPECTED_CSS", "")
+        if expected_js or expected_css:
+            if not expected_js or not expected_css:
+                pytest.fail("Set both SIMPLECHAT_UI_EXPECTED_JS and SIMPLECHAT_UI_EXPECTED_CSS.")
+            index = SPA_INDEX.read_text(encoding="utf-8")
+            for filename, attribute, suffix in (
+                (expected_js, "src", "js"), (expected_css, "href", "css"),
+            ):
+                if not re.fullmatch(rf"[A-Za-z0-9_.-]+\.{suffix}", filename):
+                    pytest.fail("Expected build assets must be local filenames.")
+                asset = STATIC_ROOT / "v2" / "assets" / filename
+                reference = f'/static/v2/assets/{filename}'
+                if not asset.is_file() or not re.search(rf'{attribute}=["\']{re.escape(reference)}["\']', index):
+                    pytest.fail("The explicitly released SPA assets are missing or have changed.")
+        else:
+            source_root = ROOT / "application" / "v2_ui" / "src"
+            if any(
+                source.stat().st_mtime > SPA_INDEX.stat().st_mtime
+                for source in source_root.rglob("*") if source.is_file()
+            ):
+                pytest.fail("The production V2 bundle is stale; rebuild it before running this suite.")
+        self.preferences.update({
+            "darkModeEnabled": theme == "dark", "v2RailCollapsed": width < 1024,
+            "v2WorkspaceRailCollapsed": width < 1024, "fontSizePreference": "m",
+        })
+        self.page.set_viewport_size({"width": width, "height": height})
+        self.page.goto(f"{ORIGIN}/v2{path}", wait_until="networkidle")
+        expect(self.page.locator("html")).to_have_css("color-scheme", theme)
+        assert any(path.endswith(".js") for path in self.loaded_assets), "Real SPA JavaScript was not loaded."
+        assert any(path.endswith(".css") for path in self.loaded_assets), "Production CSS was not loaded."
+
+    def assert_no_overflow(self):
+        assert self.page.evaluate(
+            "document.documentElement.scrollWidth <= window.innerWidth"
+        ), "Workspace overflows the viewport horizontally."
+        main = self.page.get_by_role("main")
+        assert main.evaluate(
+            "element => element.scrollWidth <= element.clientWidth + 1"
+        ), "Workspace content is clipped horizontally."
+
+    def assert_no_secret_storage(self, *draft_values, page=None):
+        self.private_values.update(draft_values)
+        storage = (page or self.page).evaluate(
+            "() => JSON.stringify({local: {...localStorage}, session: {...sessionStorage}})"
+        ) + json.dumps(self.preferences)
+        for value in self.private_values:
+            assert value not in storage, f"Editor data must not be persisted in storage or preferences: {value!r}"
+
+    def assert_clean(self):
+        unexpected_console = [
+            (text, url) for text, url in self.console_errors
+            if not any(
+                url == expected_url
+                and re.fullmatch(
+                    rf"Failed to load resource: the server responded with a status of {status} \([^)]*\)",
+                    text,
+                )
+                for expected_url, status in self.expected_http_errors
+            )
+        ]
+        assert not self.pending_responses, "A test left an explicit request gate closed."
+        assert not self.failures, "An expected failed request was never made."
+        assert not self.unexpected_requests, self.unexpected_requests
+        assert not self.errors, self.errors
+        assert not unexpected_console, unexpected_console
+        for page in self.pages:
+            if not page.is_closed() and page.url.startswith(ORIGIN):
+                self.assert_no_secret_storage(page=page)
+        for _, payload in self.responses:
+            serialized = json.dumps(payload)
+            assert STORED_KEY not in serialized, "A stored credential crossed the fixture API boundary."
+            assert STORED_HEADER not in serialized, "A stored MCP header crossed the fixture API boundary."
+
+
+@pytest.fixture
+def workspace_ui(page):
+    fixture = WorkspaceAuthoringFixture(page)
+    yield fixture
+    fixture.assert_clean()

--- a/ui_tests/test_agent_delegation_v2.py
+++ b/ui_tests/test_agent_delegation_v2.py
@@ -1,13 +1,16 @@
 # test_agent_delegation_v2.py
 """
-Real V2 Call agent create/edit/attach workflows for personal, group and global scopes.
-Version: 0.261.093
+Real V2 Call agent create/edit/attach workflows for group and global scopes.
+Version: 0.261.096
 Implemented in: 0.261.093
 
 Deterministic local Playwright coverage using the existing orchestration harness pattern.
 No deployed service, model calls, credentials or remote browser workspace is needed.
 The real components and API client run against scoped response fixtures. Browser errors
-fail tests, and desktop/mobile runs load the real production V2 CSS.
+fail tests, and desktop/mobile runs load the real production V2 CSS. Personal
+create/edit/delete, mixed bindings, conflicts, unavailable targets, keyboard
+selection, and target-type coverage now live in test_v2_workspace_authoring.py,
+which loads the production SPA and its data router rather than MemoryRouter.
 """
 
 import copy
@@ -192,56 +195,7 @@ def create_call(page, name, label):
     expect(page.get_by_role("status").filter(has_text="Call agent action saved.")).to_be_visible()
 
 
-@pytest.mark.parametrize("viewport", [{"width": 1440, "height": 900}, {"width": 390, "height": 844}])
-def test_personal_create_edit_and_safe_rendering(ui, viewport):
-    page, api = ui
-    page.set_viewport_size(viewport)
-    mount(page, "actions")
-    create_call(page, "<img src=x onerror=alert(1)>", "global shared · global · foundry_workflow")
-    first = api.writes[-1]
-    assert first[:2] == ("POST", "/api/user/plugins")
-    assert first[3]["endpoint"] == "internal://agent"
-    assert first[3]["auth"] == {"type": "user"}
-    assert first[3]["additionalFields"]["target_agent"] == {
-        "id": "shared", "scope_type": "global", "scope_id": "global",
-    }
-    expect(page.locator("img")).to_have_count(0)
-    page.get_by_role("button", name="Edit Call agent action <img src=x onerror=alert(1)>").click()
-    page.get_by_label("Action name", exact=True).fill("Renamed action")
-    page.get_by_role("button", name="Save Call agent action", exact=True).click()
-    expect(page.get_by_text("Renamed action", exact=True)).to_be_visible()
-    assert api.writes[-1][:2] == ("PATCH", "/api/user/plugins/new-action")
-    assert api.writes[-1][3]["id"] == "new-action"
-    assert page.evaluate("document.documentElement.scrollWidth <= window.innerWidth")
-
-
-def test_personal_bindings_preserve_unknown_refs_and_conflict(ui):
-    page, api = ui
-    before = copy.deepcopy(api.agents["personal"][0])
-    mount(page, "agents")
-    page.get_by_role("button", name="Attach Call agent actions to Local caller").click()
-    expect(page.get_by_role("checkbox", name="Call self")).to_be_disabled()
-    expect(page.get_by_text("Target only — configure tools in Foundry")).to_be_visible()
-    page.get_by_role("checkbox", name="Call call-1").check()
-    api.conflict = True
-    page.get_by_role("button", name="Save bindings", exact=True).click()
-    expect(page.get_by_role("alert").filter(has_text="changed in another session")).to_be_visible()
-    expect(page.get_by_role("button", name="Save bindings", exact=True)).to_be_disabled()
-    assert api.writes[-1][3] == {
-        "action_ids": ["call-1"], "expected_actions_to_load": ["legacy-name", "unknown-id"],
-    }
-    page.get_by_role("button", name="Reload Call agent resources").click()
-    page.get_by_role("button", name="Discard changes and reload").click()
-    api.conflict = False
-    page.get_by_role("button", name="Attach Call agent actions to Local caller").click()
-    page.get_by_role("checkbox", name="Call call-1").check()
-    page.get_by_role("button", name="Save bindings", exact=True).click()
-    expect(page.get_by_role("status").filter(has_text="bindings saved")).to_be_visible()
-    assert api.agents["personal"][0] == {**before, "actions_to_load": ["legacy-name", "unknown-id", "call-1"]}
-
-
 @pytest.mark.parametrize("scope,view,action_id", [
-    ("personal", "actions", "call-1"),
     ("group", "groups", "group-call"),
     ("global", "admin", "global-call"),
 ])
@@ -262,21 +216,6 @@ def test_native_call_action_deletion_requires_confirmation_and_preserves_callers
     assert api.writes[-1][:2] == ("DELETE", f"/api/{owner}/plugins/{action_id}")
     assert api.writes[-1][2] == ({"group_id": ["group-1"]} if scope == "group" else {})
     assert api.agents == original_agents
-
-
-def test_personal_new_agent_then_attach(ui):
-    page, api = ui
-    mount(page, "agents")
-    page.get_by_role("button", name="New agent", exact=True).click()
-    page.get_by_label("Name", exact=True).fill("New caller")
-    page.get_by_label("Instructions", exact=True).fill("Delegate careful reviews.")
-    page.get_by_role("button", name="Create agent", exact=True).click()
-    page.get_by_role("button", name="Attach Call agent actions to New caller").click()
-    page.get_by_role("checkbox", name="Call call-1").check()
-    page.get_by_role("button", name="Save bindings", exact=True).click()
-    expect(page.get_by_role("status").filter(has_text="bindings saved")).to_be_visible()
-    assert api.writes[-1][:2] == ("PATCH", "/api/user/agents/new-agent/agent-actions")
-    assert api.writes[-1][3]["expected_actions_to_load"] == []
 
 
 def test_group_native_scoping_permissions_and_unsaved_changes(ui):
@@ -348,54 +287,3 @@ def test_non_admin_does_not_fetch_global_resources(ui):
     mount(page, "admin", admin=False)
     expect(page.get_by_text("Administrator access required")).to_be_visible()
     assert not api.reads
-
-
-def test_unavailable_target_empty_catalog_denial_and_keyboard(ui):
-    page, api = ui
-    api.targets["personal"] = []
-    mount(page, "actions")
-    page.get_by_role("button", name="Edit Call agent action Call call-1").click()
-    expect(page.get_by_role("alert").filter(has_text="saved target is unavailable")).to_be_visible()
-    expect(page.get_by_role("button", name="Save Call agent action", exact=True)).to_be_disabled()
-    expect(page.get_by_role("status").filter(has_text="No permitted target")).to_be_visible()
-    page.get_by_role("button", name="Cancel", exact=True).click()
-    api.targets["personal"] = [target()]
-    page.get_by_role("button", name="Reload Call agent resources").click()
-    page.get_by_role("button", name="New Call agent action", exact=True).click()
-    expect(page.get_by_label("Action name", exact=True)).to_be_focused()
-    page.get_by_label("Action name", exact=True).fill("Keyboard action")
-    page.get_by_label("Target agent", exact=True).focus()
-    page.keyboard.press("ArrowDown")
-    page.keyboard.press("Enter")
-    expect(page.get_by_role("button", name="Save Call agent action", exact=True)).to_be_enabled()
-    page.get_by_role("button", name="Cancel", exact=True).click()
-    api.denied = True
-    page.get_by_role("button", name="Reload Call agent resources").click()
-    expect(page.get_by_role("alert").filter(has_text="Access denied")).to_be_visible()
-    expect(page.get_by_role("button", name="New Call agent action", exact=True)).to_have_count(0)
-
-
-@pytest.mark.parametrize("agent_type", ["local", "aifoundry", "new_foundry", "foundry_workflow"])
-def test_all_supported_target_types_can_be_selected(ui, agent_type):
-    page, api = ui
-    api.targets["personal"] = [target(agent_type=agent_type)]
-    mount(page, "actions")
-    create_call(page, f"Delegate {agent_type}", f"personal target · personal · {agent_type}")
-    assert api.writes[-1][3]["additionalFields"]["target_agent"]["id"] == "target"
-
-
-def test_existing_unavailable_binding_can_be_detached(ui):
-    page, api = ui
-    api.agents["personal"][0]["actions_to_load"].append("call-1")
-    api.targets["personal"] = []
-    mount(page, "agents")
-    page.get_by_role("button", name="Attach Call agent actions to Local caller").click()
-    selected = page.get_by_role("checkbox", name="Call call-1")
-    expect(selected).to_be_checked()
-    expect(selected).to_be_enabled()
-    selected.uncheck()
-    page.get_by_role("button", name="Save bindings", exact=True).click()
-    expect(page.get_by_role("status").filter(has_text="bindings saved")).to_be_visible()
-    assert api.writes[-1][3] == {
-        "action_ids": [], "expected_actions_to_load": ["legacy-name", "unknown-id", "call-1"],
-    }

--- a/ui_tests/test_v2_workspace_authoring.py
+++ b/ui_tests/test_v2_workspace_authoring.py
@@ -1,0 +1,1700 @@
+# test_v2_workspace_authoring.py
+"""
+Real-SPA browser workflows for native V2 My Workspace Agents and Actions.
+Version: 0.261.096
+Implemented in: 0.261.096
+
+Run against a fresh production V2 build with the existing pytest-playwright
+runner. The imported connect_options fixture supports an authenticated Azure
+Playwright workspace and the existing local fallback. No live application,
+model calls, credentials, isolated component harness, or extra dependencies are
+needed. Failed requests are explicit fixtures; other browser errors and all
+unexpected requests fail the test.
+
+Personal delegation regressions formerly in test_agent_delegation_v2.py are
+covered here through the unified collection and full-page editors. The original
+group/admin wrapper coverage remains in that suite.
+"""
+
+import copy
+import json
+import re
+from datetime import date, timedelta
+from urllib.parse import parse_qs, urlsplit
+
+import pytest
+from playwright.sync_api import expect
+
+from ui_tests.fixtures.workspace_authoring import (
+    ACTION_ID,
+    AGENT_ID,
+    CALL_ACTION_ID,
+    CHART_ACTION_ID,
+    CREATED_ACTION_ID,
+    CREATED_AGENT_ID,
+    GLOBAL_ACTION_ID,
+    GLOBAL_AGENT_ID,
+    MCP_ACTION_ID,
+    ORIGIN,
+    OWNER_ID,
+    SECRET_MASK,
+    STORED_HEADER,
+    STORED_KEY,
+    TARGET_ID,
+    connect_options,  # noqa: F401
+    workspace_ui,  # noqa: F401
+)
+
+
+pytestmark = pytest.mark.ui
+LAYOUTS = [
+    pytest.param("light", 1440, 900, id="desktop-light"),
+    pytest.param("dark", 1440, 900, id="desktop-dark"),
+    pytest.param("light", 390, 844, id="mobile-light"),
+    pytest.param("dark", 390, 844, id="mobile-dark"),
+]
+
+
+def editor_section(page, label):
+    """Use the real section navigation in either supported responsive layout."""
+    mobile_sections = page.get_by_role("combobox", name=re.compile("^Jump to section"))
+    if page.viewport_size and page.viewport_size["width"] < 1024:
+        expect(mobile_sections).to_be_visible()
+        mobile_sections.select_option(label=label)
+    else:
+        page.get_by_role("navigation", name="Editor sections", exact=True).get_by_role(
+            "button", name=label, exact=True
+        ).click()
+
+
+def save_resource(ui, resource, *, identifier=None):
+    return_to = parse_qs(urlsplit(ui.page.url).query).get("returnTo", [None])[0]
+    method = "PATCH" if identifier else "POST"
+    path = f"/api/user/{'agents' if resource == 'agent' else 'plugins'}"
+    if identifier:
+        path += f"/{identifier}"
+    with ui.page.expect_response(
+        lambda response: response.request.method == method and urlsplit(response.url).path == path
+    ) as response:
+        ui.page.get_by_role("button", name=f"Save {resource}", exact=True).click()
+    result = response.value
+    if result.ok:
+        destination = "/workspace/agents" if resource == "agent" else "/workspace/actions"
+        if resource == "action" and return_to and re.fullmatch(r"/workspace/agents/[^/?#]+", return_to):
+            destination = return_to
+        expect(ui.page).to_have_url(f"{ORIGIN}/v2{destination}")
+    return result
+
+
+def assert_patch(ui, path, revision, updates, *, clear=(), removed=()):
+    write = ui.editor_writes[-1]
+    assert (write.method, write.path, write.query, write.body) == (
+        "PATCH",
+        path,
+        {"view": ["editor"]},
+        {
+            "updates": updates,
+            "expected_revision": revision,
+            "clear_secret_paths": list(clear),
+            "removed_paths": list(removed),
+        },
+    )
+
+
+def assert_action_save_blocked(ui):
+    """Disabled Save and visible submit-time validation must both prevent writes."""
+    count = len(ui.editor_writes)
+    save = ui.page.get_by_role("button", name="Save action", exact=True)
+    if save.is_enabled():
+        save.click()
+        expect(ui.page.get_by_role("alert").and_(ui.page.locator('[tabindex="-1"]'))).to_be_visible()
+    else:
+        expect(save).to_be_disabled()
+    assert len(ui.editor_writes) == count
+
+
+def select_call_target(page, label="Target reviewer"):
+    page.get_by_label("Search target agents", exact=True).fill(label)
+    target = action_field(page, "Target agent")
+    option = target.get_by_role("option").filter(has_text=label)
+    expect(option).to_have_count(1)
+    target.select_option(option.get_attribute("value"))
+
+
+def assigned_action(page, name):
+    return page.get_by_role("checkbox", name=f"Assign {name}", exact=True)
+
+
+def collection_item(page, identifier):
+    return page.get_by_role("listitem").filter(has_text=identifier)
+
+
+def action_field(page, label):
+    return page.get_by_label(re.compile(rf"^{re.escape(label)}(?:\s*\*)?\s*$"))
+
+
+def name_field(page, resource):
+    if resource in ("action", "actions"):
+        return action_field(page, "Action name")
+    return page.get_by_label("Display name", exact=True)
+
+
+def seed_array_credentials(ui):
+    ui.agents[AGENT_ID]["other_settings"]["custom_credentials"] = [
+        {
+            "label": "first", "token": STORED_KEY, "legacy": "remove first",
+            "nested": {"retained": False, "obsolete": 9},
+        },
+        {
+            "label": "second", "token": STORED_HEADER, "legacy": "remove second",
+            "nested": {"retained": 0, "obsolete": 8},
+        },
+    ]
+    ui.secret_paths[AGENT_ID] = [
+        "/other_settings/custom_credentials/0/token",
+        "/other_settings/custom_credentials/1/token",
+    ]
+
+
+def configure_agent(page, agent_type, name):
+    labels = {
+        "local": "Local agent", "aifoundry": "Azure AI Foundry",
+        "new_foundry": "New Foundry", "foundry_workflow": "Foundry Workflow",
+    }
+    page.get_by_label("Display name", exact=True).fill(name)
+    page.get_by_label("Description", exact=True).fill(f"Authoring coverage for {agent_type}.")
+    page.get_by_role("radio", name=labels[agent_type], exact=True).check()
+    editor_section(page, "Model & connection")
+    if agent_type == "local":
+        page.get_by_label("Model", exact=True).select_option(
+            label="Workspace GPT · Workspace model endpoint"
+        )
+        editor_section(page, "Instructions")
+        page.get_by_role("textbox", name="Instructions", exact=True).fill("Review the supplied evidence carefully.")
+    else:
+        page.get_by_label("Foundry project endpoint", exact=True).fill(
+            "https://foundry.example.test/api/projects/review"
+        )
+        if agent_type == "aifoundry":
+            page.get_by_label("Foundry agent ID", exact=True).fill("foundry-reviewer")
+            page.get_by_label("Foundry API version", exact=True).fill("v1")
+        else:
+            page.get_by_label("Responses API version", exact=True).fill("2025-11-15-preview")
+            label = "Application ID" if agent_type == "new_foundry" else "Workflow name"
+            page.get_by_label(label, exact=True).fill("review-workflow")
+
+
+def begin_action(page, action_type, name):
+    action_field(page, "Action type").select_option(action_type)
+    name_field(page, "action").fill(name)
+    page.get_by_label("Description", exact=True).fill("A browser-authored workspace action.")
+    if action_type == "agent":
+        editor_section(page, "Configuration")
+        select_call_target(page)
+    else:
+        editor_section(page, "Configuration")
+        action_field(page, "Endpoint").fill("https://service.example.test/api")
+        expect(page.get_by_label("Region", exact=True)).to_have_value("")
+        page.get_by_label("Region", exact=True).select_option(label="east")
+        page.get_by_label("Result limit", exact=True).fill("3")
+        page.get_by_label("Result limit", exact=True).fill("0")
+        page.get_by_label("Include archived", exact=True).select_option("true")
+        page.get_by_label("Include archived", exact=True).select_option("false")
+
+
+def keep_editing(page):
+    dialog = page.get_by_role("dialog", name="Discard unsaved changes?", exact=True)
+    expect(dialog).to_be_visible()
+    expect(dialog.get_by_role("button", name="Keep editing", exact=True)).to_be_focused()
+    dialog.get_by_role("button", name="Keep editing", exact=True).click()
+    expect(dialog).not_to_be_visible()
+
+
+def discard_changes(page):
+    dialog = page.get_by_role("dialog", name="Discard unsaved changes?", exact=True)
+    expect(dialog).to_be_visible()
+    dialog.get_by_role("button", name="Discard changes", exact=True).click()
+    expect(dialog).not_to_be_visible()
+
+
+@pytest.mark.parametrize("theme,width,height", LAYOUTS)
+@pytest.mark.parametrize("action_type", ["fixture_custom", "agent"])
+def test_unified_actions_create_reload_edit_delete(workspace_ui, theme, width, height, action_type):
+    """Ordinary and Call-agent actions have exactly the same collection/editor lifecycle."""
+    ui, page = workspace_ui, workspace_ui.page
+    ui.open(theme=theme, width=width, height=height)
+    expect(page.get_by_role("heading", name="Actions", exact=True)).to_be_visible()
+    expect(page.get_by_text("Other actions", exact=True)).to_have_count(0)
+    expect(page.get_by_role("button", name="New Call agent action", exact=True)).to_have_count(0)
+    expect(page.get_by_role("button", name="New action", exact=True)).to_be_visible()
+    expect(page.get_by_text("Workspace API", exact=True)).to_be_visible()
+    expect(page.get_by_text("Call reviewer", exact=True)).to_be_visible()
+    ui.assert_no_overflow()
+    original_agents = copy.deepcopy(ui.agents)
+    original_actions = copy.deepcopy(ui.actions)
+
+    page.get_by_role("button", name="New action", exact=True).click()
+    expect(page).to_have_url(f"{ORIGIN}/v2/workspace/actions/new")
+    expect(page.get_by_role("dialog")).to_have_count(0)
+    name = "<img src=x onerror=alert(1)> Workspace action"
+    begin_action(page, action_type, name)
+    if action_type == "agent":
+        expect(action_field(page, "Endpoint")).to_have_count(0)
+        authentication = page.get_by_role("region", name="Authentication", exact=True)
+        expect(authentication.get_by_role("combobox")).to_have_count(0)
+        expect(authentication.locator('input[type="password"]')).to_have_count(0)
+        expect(page.get_by_role("button", name="Test connection", exact=True)).to_have_count(0)
+    else:
+        expect(page.get_by_label("Region", exact=True).get_by_role(
+            "option", selected=True
+        )).to_have_text("east")
+    ui.assert_no_overflow()
+    assert not ui.editor_writes
+    assert save_resource(ui, "action").status == 201
+    created = copy.deepcopy(ui.actions[CREATED_ACTION_ID])
+    assert created["displayName"] == name
+    assert re.fullmatch(r"[A-Za-z0-9_-]+", created["name"])
+    assert created["type"] == action_type
+    assert ui.editor_writes[-1].body["clear_secret_paths"] == []
+    assert ui.editor_writes[-1].body["removed_paths"] == []
+    assert "expected_revision" not in ui.editor_writes[-1].body
+    if action_type == "agent":
+        assert created["endpoint"] == "internal://agent"
+        assert created["auth"] == {"type": "user"}
+        assert created["additionalFields"]["target_agent"] == {
+            "id": TARGET_ID, "scope_type": "personal", "scope_id": OWNER_ID,
+        }
+    else:
+        assert created["auth"] == {"type": "NoAuth"}
+        assert created["additionalFields"] == {"region": "east", "limit": 0, "enabled": False}
+        assert "east|west" not in json.dumps(created)
+    assert not any("/test" in request.path or "/discover" in request.path for request in ui.writes)
+
+    page.goto(f"{ORIGIN}/v2/workspace/actions/{CREATED_ACTION_ID}", wait_until="networkidle")
+    expect(name_field(page, "action")).to_have_value(name)
+    expect(page.locator("img[src='x']")).to_have_count(0)
+    revision = ui.revision(CREATED_ACTION_ID)
+    name_field(page, "action").fill("Renamed workspace action")
+    assert save_resource(ui, "action", identifier=CREATED_ACTION_ID).status == 200
+    assert_patch(
+        ui, f"/api/user/plugins/{CREATED_ACTION_ID}", revision,
+        {"displayName": "Renamed workspace action"},
+    )
+    assert ui.actions[CREATED_ACTION_ID] == {**created, "displayName": "Renamed workspace action"}
+    expect(page).to_have_url(f"{ORIGIN}/v2/workspace/actions")
+    page.get_by_role("button", name="Delete Renamed workspace action", exact=True).click()
+    writes_before_confirmation = len(ui.editor_writes)
+    expect(page.get_by_role("button", name="Delete action", exact=True)).to_be_visible()
+    assert CREATED_ACTION_ID in ui.actions
+    page.get_by_role("button", name="Delete action", exact=True).click()
+    expect(page.get_by_text("Renamed workspace action", exact=True)).to_have_count(0)
+    assert len(ui.editor_writes) == writes_before_confirmation + 1
+    assert ui.editor_writes[-1].method == "DELETE"
+    assert ui.editor_writes[-1].path == f"/api/user/plugins/{CREATED_ACTION_ID}"
+    assert ui.actions == original_actions
+    assert ui.agents == original_agents
+    ui.assert_no_secret_storage(name)
+    ui.assert_no_overflow()
+
+
+@pytest.mark.parametrize("agent_type,scope", [
+    ("local", "personal"), ("aifoundry", "personal"), ("new_foundry", "personal"),
+    ("foundry_workflow", "personal"), ("foundry_workflow", "global"),
+])
+def test_every_supported_call_target_type_uses_ordinary_editor(workspace_ui, agent_type, scope):
+    ui, page = workspace_ui, workspace_ui.page
+    identifier = GLOBAL_AGENT_ID if scope == "global" else TARGET_ID
+    target = next(item for item in ui.targets if item["id"] == identifier)
+    ui.targets = [{**target, "display_name": "Target reviewer", "agent_type": agent_type}]
+    ui.agents[identifier].update({"display_name": "Target reviewer", "agent_type": agent_type})
+    ui.open("/workspace/actions/new")
+    begin_action(page, "agent", f"Delegate {agent_type}")
+    target = action_field(page, "Target agent")
+    expect(target.get_by_role("option", selected=True)).to_contain_text(agent_type)
+    target.focus()
+    expect(target).to_be_focused()
+    page.keyboard.press("ArrowUp")
+    page.keyboard.press("ArrowDown")
+    page.keyboard.press("Enter")
+    assert save_resource(ui, "action").status == 201
+    assert ui.actions[CREATED_ACTION_ID]["additionalFields"]["target_agent"] == {
+        "id": identifier, "scope_type": scope, "scope_id": "global" if scope == "global" else OWNER_ID,
+    }
+
+
+def test_action_rename_preserves_credentials_and_nested_unknown_values(workspace_ui):
+    ui, page = workspace_ui, workspace_ui.page
+    before = copy.deepcopy(ui.actions[MCP_ACTION_ID])
+    revision = ui.revision(MCP_ACTION_ID)
+    ui.open(f"/workspace/actions/{MCP_ACTION_ID}")
+    name_field(page, "action").fill("Renamed MCP")
+    assert save_resource(ui, "action", identifier=MCP_ACTION_ID).status == 200
+    assert_patch(ui, f"/api/user/plugins/{MCP_ACTION_ID}", revision, {"displayName": "Renamed MCP"})
+    assert ui.actions[MCP_ACTION_ID] == {**before, "displayName": "Renamed MCP"}
+    assert ui.actions[MCP_ACTION_ID]["auth"]["key"] == STORED_KEY
+    assert ui.actions[MCP_ACTION_ID]["additionalFields"]["custom_headers"]["X-Workspace"] == STORED_HEADER
+    page.goto(f"{ORIGIN}/v2/workspace/actions/{MCP_ACTION_ID}", wait_until="networkidle")
+    page.reload(wait_until="networkidle")
+    expect(name_field(page, "action")).to_have_value("Renamed MCP")
+    assert STORED_KEY not in page.content()
+    assert STORED_HEADER not in page.content()
+    ui.assert_no_secret_storage()
+
+
+def test_mixed_bindings_preserve_legacy_unknown_references_and_self_call_protection(workspace_ui):
+    ui, page = workspace_ui, workspace_ui.page
+    before = copy.deepcopy(ui.agents[AGENT_ID])
+    revision = ui.revision(AGENT_ID)
+    ui.open(f"/workspace/agents/{AGENT_ID}")
+    editor_section(page, "Actions")
+    expect(assigned_action(page, "Workspace API")).to_be_checked()
+    expect(assigned_action(page, "Call self")).to_be_disabled()
+    expect(page.get_by_text("unavailable-action", exact=True)).to_be_visible()
+    assigned_action(page, "Call reviewer").check()
+    assigned_action(page, "Workspace MCP").check()
+    assert save_resource(ui, "agent", identifier=AGENT_ID).status == 200
+    expected_refs = ["legacy-tool", "unavailable-action", CALL_ACTION_ID, MCP_ACTION_ID]
+    assert_patch(ui, f"/api/user/agents/{AGENT_ID}", revision, {"actions_to_load": expected_refs})
+    assert ui.agents[AGENT_ID] == {**before, "actions_to_load": expected_refs}
+    assert not any(request.path.endswith("/agent-actions") for request in ui.writes)
+
+
+def test_existing_unavailable_call_binding_can_be_detached(workspace_ui):
+    ui, page = workspace_ui, workspace_ui.page
+    ui.agents[AGENT_ID]["actions_to_load"].append(CALL_ACTION_ID)
+    ui.targets = []
+    before = copy.deepcopy(ui.agents[AGENT_ID])
+    revision = ui.revision(AGENT_ID)
+    ui.open(f"/workspace/agents/{AGENT_ID}")
+    editor_section(page, "Actions")
+    checkbox = assigned_action(page, "Call reviewer")
+    expect(checkbox).to_be_checked()
+    expect(checkbox).to_be_enabled()
+    checkbox.uncheck()
+    assert save_resource(ui, "agent", identifier=AGENT_ID).status == 200
+    assert_patch(
+        ui, f"/api/user/agents/{AGENT_ID}", revision,
+        {"actions_to_load": ["legacy-tool", "unavailable-action"]},
+    )
+    assert ui.agents[AGENT_ID] == {**before, "actions_to_load": ["legacy-tool", "unavailable-action"]}
+
+
+def test_denied_action_catalog_does_not_block_unrelated_agent_edit(workspace_ui):
+    ui, page = workspace_ui, workspace_ui.page
+    before = copy.deepcopy(ui.agents[AGENT_ID])
+    revision = ui.revision(AGENT_ID)
+    ui.reject_next(
+        "GET", "/api/user/plugins", status=403,
+        error="Actions cannot be listed in this workspace.",
+    )
+    ui.open(f"/workspace/agents/{AGENT_ID}")
+    expect(page.get_by_label("Display name", exact=True)).to_be_enabled()
+    editor_section(page, "Actions")
+    expect(page.get_by_role("alert").filter(has_text="Actions cannot be listed")).to_be_visible()
+    expect(page.get_by_role("checkbox", name=re.compile("^Assign "))).to_have_count(0)
+    expect(page.get_by_text("legacy-tool", exact=True)).to_be_visible()
+    expect(page.get_by_text("unavailable-action", exact=True)).to_be_visible()
+    editor_section(page, "Instructions")
+    instructions = page.get_by_role("textbox", name="Instructions", exact=True)
+    expect(instructions).to_be_enabled()
+    instructions.fill("Edited safely even though actions are unavailable.")
+    assert save_resource(ui, "agent", identifier=AGENT_ID).status == 200
+    assert_patch(
+        ui, f"/api/user/agents/{AGENT_ID}", revision,
+        {"instructions": "Edited safely even though actions are unavailable."},
+    )
+    assert ui.agents[AGENT_ID] == {
+        **before, "instructions": "Edited safely even though actions are unavailable.",
+    }
+
+
+def test_disabled_action_management_still_allows_authorized_bindings_and_capabilities(workspace_ui):
+    ui, page = workspace_ui, workspace_ui.page
+    ui.disabled_sections["actions"] = "Action management is disabled."
+    ui.options["settings"]["allow_user_plugins"] = False
+    ui.can_manage = False
+    ui.actions[CALL_ACTION_ID]["additionalFields"]["target_agent"] = {
+        "id": GLOBAL_AGENT_ID, "scope_type": "global", "scope_id": "global",
+    }
+    personal_call_id = "10000000-0000-4000-8000-000000000010"
+    ui.actions[personal_call_id] = {
+        **copy.deepcopy(ui.actions[CALL_ACTION_ID]),
+        "id": personal_call_id, "name": "personal-reviewer",
+        "displayName": "Personal reviewer", "is_global": False,
+    }
+    ui.revisions[personal_call_id] = 1
+    ui.actions[CALL_ACTION_ID]["is_global"] = True
+    ui.agents[AGENT_ID]["actions_to_load"].append(MCP_ACTION_ID)
+    before = copy.deepcopy(ui.agents[AGENT_ID])
+    original_actions = copy.deepcopy(ui.actions)
+    revision = ui.revision(AGENT_ID)
+    ui.open(f"/workspace/agents/{AGENT_ID}")
+    editor_section(page, "Actions")
+    assert any(request.path == "/api/user/plugins" for request in ui.requests)
+    expect(page.get_by_role("button", name="New action", exact=True)).to_have_count(0)
+    expect(assigned_action(page, "Workspace API")).to_be_checked()
+    expect(assigned_action(page, "Provided API")).to_be_enabled()
+    expect(assigned_action(page, "Call reviewer")).to_be_enabled()
+    expect(assigned_action(page, "Personal reviewer")).to_be_disabled()
+    expect(assigned_action(page, "Call self")).to_be_disabled()
+    ui.defer_next("GET", "/api/user/plugins")
+    with page.expect_request(
+        lambda request: request.method == "GET" and urlsplit(request.url).path == "/api/user/plugins"
+    ):
+        page.get_by_role("button", name="Refresh actions", exact=True).click()
+    expect(assigned_action(page, "Provided API")).to_be_disabled()
+    expect(assigned_action(page, "Workspace MCP")).to_be_enabled()
+    assigned_action(page, "Workspace MCP").uncheck()
+    ui.release_responses()
+    expect(assigned_action(page, "Provided API")).to_be_enabled()
+    expect(assigned_action(page, "Workspace MCP")).not_to_be_checked()
+    assigned_action(page, "Provided API").check()
+    assigned_action(page, "Call reviewer").check()
+    assigned_action(page, "Workspace charts").check()
+    page.get_by_role("checkbox", name=re.compile("^Line charts")).check()
+    assert save_resource(ui, "agent", identifier=AGENT_ID).status == 200
+    references = ["legacy-tool", "unavailable-action", GLOBAL_ACTION_ID, CALL_ACTION_ID, CHART_ACTION_ID]
+    capabilities = {
+        key: True for key in (
+            "line", "bar", "pie", "doughnut", "scatter", "area", "bubble", "radar", "stacked_bar", "stacked_line"
+        )
+    }
+    assert_patch(
+        ui, f"/api/user/agents/{AGENT_ID}", revision,
+        {"actions_to_load": references, "other_settings": {"action_capabilities": {CHART_ACTION_ID: capabilities}}},
+    )
+    expected = copy.deepcopy(before)
+    expected["actions_to_load"] = references
+    expected["other_settings"]["action_capabilities"][CHART_ACTION_ID] = capabilities
+    assert ui.agents[AGENT_ID] == expected
+    assert ui.actions == original_actions
+    assert [(request.method, request.path) for request in ui.editor_writes] == [
+        ("PATCH", f"/api/user/agents/{AGENT_ID}"),
+    ]
+
+
+@pytest.mark.parametrize("status", [400, 403, 409, 503])
+@pytest.mark.parametrize("resource,identifier", [("action", ACTION_ID), ("agent", AGENT_ID)])
+def test_failed_or_conflicting_save_keeps_draft_and_stored_resource(workspace_ui, status, resource, identifier):
+    ui, page = workspace_ui, workspace_ui.page
+    collection = "actions" if resource == "action" else "agents"
+    api_collection = "plugins" if resource == "action" else "agents"
+    records = ui.actions if resource == "action" else ui.agents
+    before = copy.deepcopy(records[identifier])
+    ui.open(f"/workspace/{collection}/{identifier}")
+    name_field(page, resource).fill("Unsaved review draft")
+    error = {
+        400: "Please correct the highlighted display name.",
+        403: "You no longer have permission to save this resource.",
+        409: "This resource changed in another session. Reload before saving.",
+        503: "The workspace is temporarily unavailable. Try again.",
+    }[status]
+    ui.reject_next(
+        "PATCH", f"/api/user/{api_collection}/{identifier}", status=status, error=error,
+        **({"field_errors": {"displayName" if resource == "action" else "display_name": error}} if status == 400 else {}),
+    )
+    assert save_resource(ui, resource, identifier=identifier).status == status
+    visible_error = "changed in another session" if status == 409 else error
+    alert = page.get_by_role("alert").and_(page.locator('[tabindex="-1"]')).filter(has_text=visible_error)
+    expect(alert).to_be_visible()
+    expect(alert).to_be_focused()
+    expect(name_field(page, resource)).to_have_value("Unsaved review draft")
+    expect(page.get_by_role("status").filter(has_text="Unsaved changes")).to_be_visible()
+    assert records[identifier] == before
+    assert len(ui.editor_writes) == 1
+    ui.assert_no_secret_storage("Unsaved review draft")
+
+
+@pytest.mark.parametrize("collection,identifier", [("actions", GLOBAL_ACTION_ID), ("agents", GLOBAL_AGENT_ID)])
+@pytest.mark.parametrize("revision_state", ["opaque", "empty", "missing"])
+def test_provided_resources_remain_read_only_on_direct_routes(workspace_ui, collection, identifier, revision_state):
+    ui, page = workspace_ui, workspace_ui.page
+    if revision_state == "empty":
+        ui.empty_revisions.add(identifier)
+    elif revision_state == "missing":
+        ui.missing_revisions.add(identifier)
+    before = copy.deepcopy((ui.actions, ui.agents))
+    ui.open(f"/workspace/{collection}/{identifier}?scope=global", theme="dark", width=390, height=844)
+    expect(page.get_by_text("Provided - read only", exact=True)).to_be_visible()
+    expect(name_field(page, collection)).to_be_disabled()
+    expect(page.get_by_role("button", name=re.compile(r"^Save (agent|action)$"))).to_have_count(0)
+    assert not ui.editor_writes
+    assert (ui.actions, ui.agents) == before
+    ui.assert_no_overflow()
+
+
+@pytest.mark.parametrize("collection,identifier", [("actions", ACTION_ID), ("agents", AGENT_ID)])
+def test_denied_or_disabled_deep_links_do_not_offer_an_editor(workspace_ui, collection, identifier):
+    ui, page = workspace_ui, workspace_ui.page
+    ui.disabled_sections[collection] = "Your administrator has disabled authoring."
+    ui.open(f"/workspace/{collection}/{identifier}")
+    expect(page.get_by_text(f"{collection.title()} is not available", exact=True)).to_be_visible()
+    expect(page.get_by_text("Your administrator has disabled authoring.", exact=True)).to_be_visible()
+    assert not any(request.path.startswith(f"/api/user/{'plugins' if collection == 'actions' else 'agents'}") for request in ui.requests)
+    assert not ui.editor_writes
+
+
+def test_unavailable_target_and_failed_target_catalog_are_not_empty_success(workspace_ui):
+    ui, page = workspace_ui, workspace_ui.page
+    before = copy.deepcopy(ui.actions[CALL_ACTION_ID])
+    target = before["additionalFields"]["target_agent"]
+    target_value = json.dumps(
+        [target["scope_type"], target["scope_id"], target["id"]], separators=(",", ":")
+    )
+    ui.targets = []
+    ui.open(f"/workspace/actions/{CALL_ACTION_ID}")
+    editor_section(page, "Configuration")
+    expect(page.get_by_role("status").filter(has_text="The saved target is unavailable")).to_be_visible()
+    assert_action_save_blocked(ui)
+    expect(action_field(page, "Target agent")).to_have_value(target_value)
+    assert ui.actions[CALL_ACTION_ID] == before
+    assert not ui.editor_writes
+
+    ui.reject_next(
+        "GET", "/api/plugins/agent-targets", status=403,
+        error="Access denied to target agents.",
+    )
+    page.reload(wait_until="networkidle")
+    expect(page.get_by_role("alert").filter(has_text="Access denied")).to_be_visible()
+    assert_action_save_blocked(ui)
+    expect(action_field(page, "Target agent")).to_have_value(target_value)
+    assert ui.actions[CALL_ACTION_ID] == before
+    assert not ui.editor_writes
+
+
+@pytest.mark.parametrize("existing", [False, True])
+def test_new_action_roundtrip_retains_agent_draft_without_premature_save(workspace_ui, existing):
+    ui, page = workspace_ui, workspace_ui.page
+    identifier = AGENT_ID if existing else "new"
+    ui.open(f"/workspace/agents/{identifier}")
+    page.get_by_label("Display name", exact=True).fill("Retained authoring draft")
+    if not existing:
+        page.get_by_label("Description", exact=True).fill("An unsaved agent and its new action.")
+    editor_section(page, "Instructions")
+    instructions = "Keep this unpublished instruction draft through the action editor."
+    page.get_by_role("textbox", name="Instructions", exact=True).fill(instructions)
+    editor_section(page, "Actions")
+    assigned_action(page, "Call reviewer").check()
+    page.get_by_role("button", name="New action", exact=True).click()
+    expect(page).to_have_url(re.compile(r"/v2/workspace/actions/new\?"))
+    assert parse_qs(urlsplit(page.url).query)["returnTo"] == [f"/workspace/agents/{identifier}"]
+    assert not ui.editor_writes
+    begin_action(page, "agent", "Draft companion action")
+    assert save_resource(ui, "action").status == 201
+    expect(page).to_have_url(f"{ORIGIN}/v2/workspace/agents/{identifier}")
+    expect(page.get_by_label("Display name", exact=True)).to_have_value("Retained authoring draft")
+    editor_section(page, "Instructions")
+    expect(page.get_by_role("textbox", name="Instructions", exact=True)).to_have_value(instructions)
+    editor_section(page, "Actions")
+    expect(assigned_action(page, "Call reviewer")).to_be_checked()
+    expect(assigned_action(page, "Draft companion action")).to_be_checked()
+    assert [(write.method, write.path) for write in ui.editor_writes] == [("POST", "/api/user/plugins")]
+    ui.assert_no_secret_storage("Retained authoring draft", instructions)
+
+    assert save_resource(ui, "agent", identifier=AGENT_ID if existing else None).ok
+    saved_id = AGENT_ID if existing else CREATED_AGENT_ID
+    expected_refs = (
+        ["legacy-tool", "unavailable-action", CALL_ACTION_ID, CREATED_ACTION_ID]
+        if existing else [CALL_ACTION_ID, CREATED_ACTION_ID]
+    )
+    assert ui.agents[saved_id]["actions_to_load"] == expected_refs
+    assert ui.agents[saved_id]["instructions"] == instructions
+    assert ui.agents[saved_id]["display_name"] == "Retained authoring draft"
+    assert len(ui.editor_writes) == 2
+
+
+@pytest.mark.parametrize("action_type", ["fixture_custom", "agent"])
+def test_clean_agent_action_return_waits_for_detail_and_uses_hydrated_revision(workspace_ui, action_type):
+    ui, page = workspace_ui, workspace_ui.page
+    before = copy.deepcopy(ui.agents[AGENT_ID])
+    ui.open(f"/workspace/agents/{AGENT_ID}")
+    expect(page.get_by_role("status").filter(has_text="No unsaved changes")).to_be_visible()
+    editor_section(page, "Actions")
+    page.get_by_role("button", name="New action", exact=True).click()
+    begin_action(page, action_type, "Clean context companion")
+    ui.revisions[AGENT_ID] += 1
+    hydrated_revision = ui.revision(AGENT_ID)
+    ui.defer_next("GET", f"/api/user/agents/{AGENT_ID}")
+    with page.expect_request(
+        lambda request: request.method == "GET" and urlsplit(request.url).path == f"/api/user/agents/{AGENT_ID}"
+    ):
+        assert save_resource(ui, "action").status == 201
+    expect(page.get_by_role("status").filter(has_text="Loading agent editor")).to_be_visible()
+    assert [(write.method, write.path) for write in ui.editor_writes] == [("POST", "/api/user/plugins")]
+    assert ui.agents[AGENT_ID] == before
+    assert page.evaluate("""() => {
+        const event = new Event('beforeunload', {cancelable: true});
+        window.dispatchEvent(event);
+        return event.defaultPrevented;
+    }""")
+    ui.release_responses()
+    expect(page.get_by_label("Display name", exact=True)).to_have_value(before["display_name"])
+    editor_section(page, "Instructions")
+    expect(page.get_by_role("textbox", name="Instructions", exact=True)).to_have_value(before["instructions"])
+    editor_section(page, "Actions")
+    expect(assigned_action(page, "Clean context companion")).to_be_checked()
+    assert save_resource(ui, "agent", identifier=AGENT_ID).status == 200
+    references = [*before["actions_to_load"], CREATED_ACTION_ID]
+    assert_patch(
+        ui, f"/api/user/agents/{AGENT_ID}", hydrated_revision,
+        {"actions_to_load": references},
+    )
+    assert ui.agents[AGENT_ID] == {**before, "actions_to_load": references}
+    assert len(ui.editor_writes) == 2
+
+
+def test_cancelled_new_action_returns_unchanged_unsaved_agent(workspace_ui):
+    ui, page = workspace_ui, workspace_ui.page
+    ui.open("/workspace/agents/new")
+    page.get_by_label("Display name", exact=True).fill("Agent draft before cancellation")
+    editor_section(page, "Actions")
+    page.get_by_role("button", name="New action", exact=True).click()
+    begin_action(page, "agent", "Discard this action")
+    page.get_by_role("button", name="Cancel", exact=True).click()
+    discard_changes(page)
+    expect(page).to_have_url(f"{ORIGIN}/v2/workspace/agents/new")
+    expect(page.get_by_label("Display name", exact=True)).to_have_value("Agent draft before cancellation")
+    expect(assigned_action(page, "Discard this action")).to_have_count(0)
+    assert not ui.editor_writes
+
+
+def test_dirty_cancel_workspace_navigation_back_forward_and_reload(workspace_ui):
+    ui, page = workspace_ui, workspace_ui.page
+    ui.open("/workspace/actions")
+    page.get_by_role("button", name="New action", exact=True).click()
+    page.get_by_role("button", name="Cancel", exact=True).click()
+    expect(page).to_have_url(f"{ORIGIN}/v2/workspace/actions")
+    page.go_back()
+    expect(page).to_have_url(f"{ORIGIN}/v2/workspace/actions/new")
+    begin_action(page, "agent", "Keep my navigation draft")
+    page.go_forward()
+    keep_editing(page)
+    expect(name_field(page, "action")).to_have_value("Keep my navigation draft")
+    page.go_back()
+    keep_editing(page)
+    page.get_by_role("button", name="Cancel", exact=True).click()
+    page.get_by_role("dialog").press("Escape")
+    expect(page.get_by_role("dialog")).not_to_be_visible()
+    expect(name_field(page, "action")).to_have_value("Keep my navigation draft")
+
+    reload_dialogs = []
+
+    def cancel_reload(dialog):
+        reload_dialogs.append(dialog.type)
+        dialog.dismiss()
+
+    page.once("dialog", cancel_reload)
+    with page.expect_event("dialog"):
+        page.evaluate("() => window.location.reload()")
+    assert reload_dialogs == ["beforeunload"]
+    expect(name_field(page, "action")).to_have_value("Keep my navigation draft")
+    page.get_by_role("navigation", name="Workspace sections", exact=True).get_by_role(
+        "link", name="Agents", exact=True
+    ).click()
+    discard_changes(page)
+    expect(page).to_have_url(f"{ORIGIN}/v2/workspace/agents")
+    assert not ui.editor_writes
+
+
+def test_unsafe_action_return_path_stays_inside_workspace(workspace_ui):
+    ui, page = workspace_ui, workspace_ui.page
+    ui.open("/workspace/actions/new?returnTo=https%3A%2F%2Fexternal.example.test%2Fsteal")
+    page.get_by_role("button", name="Cancel", exact=True).click()
+    expect(page).to_have_url(f"{ORIGIN}/v2/workspace/actions")
+    assert not ui.editor_writes
+
+
+@pytest.mark.parametrize("agent_type", ["local", "aifoundry", "new_foundry", "foundry_workflow"])
+def test_create_reload_edit_each_agent_type_with_applicable_controls(workspace_ui, agent_type):
+    ui, page = workspace_ui, workspace_ui.page
+    ui.open("/workspace/agents")
+    page.get_by_role("button", name="New agent", exact=True).click()
+    expect(page).to_have_url(f"{ORIGIN}/v2/workspace/agents/new")
+    name = f"Native {agent_type} reviewer"
+    configure_agent(page, agent_type, name)
+    if agent_type == "local":
+        expect(page.get_by_label("Foundry project endpoint", exact=True)).to_have_count(0)
+    else:
+        expect(page.get_by_label("Model", exact=True)).to_have_count(0)
+        editor_section(page, "Actions")
+        expect(assigned_action(page, "Call reviewer")).to_have_count(0)
+        expect(page.get_by_text("Foundry manages this agent’s tools.", exact=False)).to_be_visible()
+        expect(page.get_by_role("button", name="Draft instructions", exact=True)).to_have_count(0)
+    assert not ui.editor_writes
+    assert save_resource(ui, "agent").status == 201
+    record = copy.deepcopy(ui.agents[CREATED_AGENT_ID])
+    assert record["display_name"] == name
+    assert record["agent_type"] == agent_type
+    assert record["actions_to_load"] == []
+    assert record["max_completion_tokens"] == -1
+    if agent_type == "local":
+        assert record["model_endpoint_id"] == "workspace-model-endpoint"
+        assert record["model_id"] == "workspace-model"
+        assert record["model_provider"] == "aoai"
+        assert record["azure_openai_gpt_deployment"] == "workspace-gpt"
+    else:
+        key = "azure_ai_foundry" if agent_type == "aifoundry" else agent_type
+        settings = record["other_settings"][key]
+        assert settings["endpoint"] == "https://foundry.example.test/api/projects/review"
+        identity_key = {
+            "aifoundry": "agent_id", "new_foundry": "application_id",
+            "foundry_workflow": "workflow_name",
+        }[agent_type]
+        assert settings[identity_key] == ("foundry-reviewer" if agent_type == "aifoundry" else "review-workflow")
+
+    page.goto(f"{ORIGIN}/v2/workspace/agents/{CREATED_AGENT_ID}", wait_until="networkidle")
+    expect(page.get_by_label("Display name", exact=True)).to_have_value(name)
+    revision = ui.revision(CREATED_AGENT_ID)
+    page.get_by_label("Description", exact=True).fill("Revised without dropping provider settings.")
+    assert save_resource(ui, "agent", identifier=CREATED_AGENT_ID).status == 200
+    assert_patch(
+        ui, f"/api/user/agents/{CREATED_AGENT_ID}", revision,
+        {"description": "Revised without dropping provider settings."},
+    )
+    assert ui.agents[CREATED_AGENT_ID] == {
+        **record, "description": "Revised without dropping provider settings.",
+    }
+    ui.assert_no_overflow()
+
+
+def test_agent_type_change_requires_explicit_detachment_of_local_actions(workspace_ui):
+    ui, page = workspace_ui, workspace_ui.page
+    original = copy.deepcopy(ui.agents[AGENT_ID])
+    ui.open(f"/workspace/agents/{AGENT_ID}")
+    page.get_by_role("radio", name="Azure AI Foundry", exact=True).check()
+    editor_section(page, "Actions")
+    expect(page.get_by_text("Workspace API", exact=True)).to_be_visible()
+    assert ui.agents[AGENT_ID] == original
+    page.get_by_role("button", name="Detach local actions", exact=True).click()
+    page.get_by_role("button", name="Keep actions", exact=True).click()
+    expect(page.get_by_text("Workspace API", exact=True)).to_be_visible()
+    page.get_by_role("button", name="Detach local actions", exact=True).click()
+    page.get_by_role("button", name="Confirm detach", exact=True).click()
+    editor_section(page, "Identity")
+    page.get_by_role("radio", name="Local agent", exact=True).check()
+    editor_section(page, "Actions")
+    expect(assigned_action(page, "Workspace API")).not_to_be_checked()
+    assert not ui.editor_writes
+    assert ui.agents[AGENT_ID] == original
+
+
+def test_agent_knowledge_sources_tags_documents_urls_and_user_context(workspace_ui):
+    ui, page = workspace_ui, workspace_ui.page
+    before = copy.deepcopy(ui.agents[AGENT_ID])
+    revision = ui.revision(AGENT_ID)
+    ui.open(f"/workspace/agents/{AGENT_ID}")
+    editor_section(page, "Assigned knowledge")
+    restrict = page.get_by_role("checkbox", name=re.compile("^Restrict to assigned knowledge"))
+    restrict.focus()
+    page.keyboard.press("Space")
+    expect(restrict).to_be_checked()
+    page.get_by_role("checkbox", name=re.compile("^Published handbook")).check()
+    expect(page.get_by_text("Active documents (2)", exact=True)).to_be_visible()
+    page.get_by_role("checkbox", name=re.compile(r"^Finance\s+\(")).check()
+    page.get_by_role("checkbox", name=re.compile(r"^Operations\s+\(")).check()
+    expect(page.get_by_text("Active documents (1)", exact=True)).to_be_visible()
+    page.get_by_role("checkbox", name=re.compile("^Public finance checklist")).check()
+    expect(page.get_by_text("Active documents (2)", exact=True)).to_be_visible()
+    user_context = page.get_by_role("checkbox", name=re.compile("^Allow user-added workspace context"))
+    user_context.focus()
+    page.keyboard.press("Space")
+    expect(user_context).to_be_checked()
+    page.get_by_role("checkbox", name="Compare", exact=True).uncheck()
+    page.get_by_label("Assigned URL", exact=True).fill("https://docs.example.test/review#overview")
+    page.get_by_label("URL mode", exact=True).select_option("deep_research")
+    page.get_by_role("button", name="Add URL", exact=True).click()
+    expect(page.get_by_text("https://docs.example.test/review", exact=True)).to_be_visible()
+    assigned_knowledge = {
+        "enabled": True,
+        "scopes": {"personal": False, "group_ids": [], "public_workspace_ids": ["public-handbook"]},
+        "document_ids": ["public-checklist"],
+        "tags": ["Finance", "Operations"],
+        "web_sources": [{"url": "https://docs.example.test/review", "mode": "deep_research"}],
+        "allow_user_workspace_context": True,
+        "allowed_user_workspace_actions": ["search", "analyze"],
+    }
+    assert save_resource(ui, "agent", identifier=AGENT_ID).status == 200
+    assert_patch(
+        ui, f"/api/user/agents/{AGENT_ID}", revision,
+        {"other_settings": {"assigned_knowledge": assigned_knowledge}},
+    )
+    assert ui.agents[AGENT_ID] == {
+        **before, "other_settings": {**before["other_settings"], "assigned_knowledge": assigned_knowledge},
+    }
+    ui.assert_no_secret_storage()
+
+
+@pytest.mark.parametrize("collection,identifier", [("actions", ACTION_ID), ("agents", AGENT_ID)])
+def test_direct_resource_permission_denial_never_exposes_configuration(workspace_ui, collection, identifier):
+    ui, page = workspace_ui, workspace_ui.page
+    ui.denied_resources.add(identifier)
+    ui.open(f"/workspace/{collection}/{identifier}")
+    expect(page.get_by_role("alert").filter(has_text="You no longer have permission")).to_be_visible()
+    expect(name_field(page, collection)).to_have_count(0)
+    expect(page.get_by_role("button", name=re.compile(r"^Save (agent|action)$"))).to_have_count(0)
+    assert not ui.editor_writes
+
+
+def test_real_revision_conflict_preserves_concurrent_edit_and_requires_reload(workspace_ui):
+    ui, page = workspace_ui, workspace_ui.page
+    ui.open(f"/workspace/agents/{AGENT_ID}")
+    revision = ui.revision(AGENT_ID)
+    page.get_by_label("Display name", exact=True).fill("My conflicting edit")
+    ui.agents[AGENT_ID]["description"] = "Concurrent server-side description."
+    ui.revisions[AGENT_ID] += 1
+    concurrent = copy.deepcopy(ui.agents[AGENT_ID])
+    assert save_resource(ui, "agent", identifier=AGENT_ID).status == 409
+    expect(page.get_by_role("alert").filter(has_text="changed in another session")).to_be_visible()
+    expect(page.get_by_label("Display name", exact=True)).to_have_value("My conflicting edit")
+    assert_patch(ui, f"/api/user/agents/{AGENT_ID}", revision, {"display_name": "My conflicting edit"})
+    assert ui.agents[AGENT_ID] == concurrent
+    latest_link = page.get_by_role("link", name="Open latest in a new tab", exact=True)
+    expect(latest_link).to_have_attribute("target", "_blank")
+    expect(latest_link).to_have_attribute("rel", re.compile(r"\bnoopener\b"))
+    with page.expect_popup() as popup:
+        latest_link.click()
+    latest = popup.value
+    expect(latest.get_by_label("Description", exact=True)).to_have_value("Concurrent server-side description.")
+    expect(latest.get_by_label("Display name", exact=True)).to_have_value(concurrent["display_name"])
+    expect(page.get_by_label("Display name", exact=True)).to_have_value("My conflicting edit")
+    assert len(ui.editor_writes) == 1
+    ui.assert_no_secret_storage("My conflicting edit", page=latest)
+    latest.close()
+    page.get_by_role("button", name="Back", exact=True).click()
+    discard_changes(page)
+    page.goto(f"{ORIGIN}/v2/workspace/agents/{AGENT_ID}", wait_until="networkidle")
+    expect(page.get_by_label("Description", exact=True)).to_have_value("Concurrent server-side description.")
+    refreshed_revision = ui.revision(AGENT_ID)
+    page.get_by_label("Display name", exact=True).fill("My explicit post-reload edit")
+    assert save_resource(ui, "agent", identifier=AGENT_ID).status == 200
+    assert_patch(
+        ui, f"/api/user/agents/{AGENT_ID}", refreshed_revision,
+        {"display_name": "My explicit post-reload edit"},
+    )
+    assert ui.agents[AGENT_ID] == {**concurrent, "display_name": "My explicit post-reload edit"}
+
+
+def test_capability_change_preserves_legacy_key_and_unrelated_capabilities(workspace_ui):
+    ui, page = workspace_ui, workspace_ui.page
+    ui.agents[AGENT_ID]["actions_to_load"].append("legacy-chart")
+    ui.agents[AGENT_ID]["other_settings"]["action_capabilities"]["legacy-chart"] = {
+        "line": False, "bar": True, "custom": {"retained": 0},
+    }
+    before = copy.deepcopy(ui.agents[AGENT_ID])
+    revision = ui.revision(AGENT_ID)
+    ui.open(f"/workspace/agents/{AGENT_ID}")
+    editor_section(page, "Actions")
+    expect(assigned_action(page, "Workspace charts")).to_be_checked()
+    line = page.get_by_role("checkbox", name=re.compile("^Line charts"))
+    expect(line).not_to_be_checked()
+    line.check()
+    assert save_resource(ui, "agent", identifier=AGENT_ID).status == 200
+    updates = {
+        key: True for key in (
+            "line", "pie", "doughnut", "scatter", "area", "bubble", "radar", "stacked_bar", "stacked_line"
+        )
+    }
+    assert_patch(
+        ui, f"/api/user/agents/{AGENT_ID}", revision,
+        {"other_settings": {"action_capabilities": {"legacy-chart": updates}}},
+    )
+    expected = copy.deepcopy(before)
+    expected["other_settings"]["action_capabilities"]["legacy-chart"].update(updates)
+    assert ui.agents[AGENT_ID] == expected
+    assert CHART_ACTION_ID not in ui.agents[AGENT_ID]["other_settings"]["action_capabilities"]
+
+
+def test_agent_advanced_json_validation_nested_changes_false_zero_and_default_tokens(workspace_ui):
+    ui, page = workspace_ui, workspace_ui.page
+    ui.agents[AGENT_ID]["max_completion_tokens"] = 64
+    ui.agents[AGENT_ID]["other_settings"]["custom_policy"].update({"enabled": True, "limit": 7})
+    before = copy.deepcopy(ui.agents[AGENT_ID])
+    revision = ui.revision(AGENT_ID)
+    ui.open(f"/workspace/agents/{AGENT_ID}")
+    editor_section(page, "Advanced")
+    settings_input = page.get_by_label("Additional settings JSON", exact=True)
+    settings_input.fill('{"custom_policy":')
+    expect(settings_input).to_have_attribute("aria-invalid", "true")
+    expect(page.get_by_role("button", name="Save agent", exact=True)).to_be_disabled()
+    expect(page.get_by_role("alert").filter(has_text="Fix the JSON")).to_be_visible()
+    assert not ui.editor_writes
+    settings_input.fill("[]")
+    expect(page.get_by_role("alert").filter(has_text="JSON object")).to_be_visible()
+    page.get_by_role("button", name="Reset JSON text to current settings", exact=True).click()
+    assert json.loads(settings_input.input_value()) == before["other_settings"]
+    edited_settings = copy.deepcopy(before["other_settings"])
+    edited_settings["custom_policy"].update({"enabled": False, "limit": 0, "items": []})
+    settings_input.fill(json.dumps(edited_settings))
+    page.get_by_label("Completion token limit", exact=True).fill("0")
+    assert save_resource(ui, "agent", identifier=AGENT_ID).status == 200
+    assert_patch(
+        ui, f"/api/user/agents/{AGENT_ID}", revision,
+        {"max_completion_tokens": 0, "other_settings": {"custom_policy": {"enabled": False, "limit": 0, "items": []}}},
+    )
+    assert ui.agents[AGENT_ID] == {
+        **before, "other_settings": edited_settings, "max_completion_tokens": 0,
+    }
+    page.goto(f"{ORIGIN}/v2/workspace/agents/{AGENT_ID}", wait_until="networkidle")
+    editor_section(page, "Advanced")
+    expect(page.get_by_label("Completion token limit", exact=True)).to_have_value("0")
+    revision = ui.revision(AGENT_ID)
+    page.get_by_label("Completion token limit", exact=True).fill("-1")
+    assert save_resource(ui, "agent", identifier=AGENT_ID).status == 200
+    assert_patch(ui, f"/api/user/agents/{AGENT_ID}", revision, {"max_completion_tokens": -1})
+
+
+def test_agent_credentials_have_distinct_keep_replace_clear_intent(workspace_ui):
+    ui, page = workspace_ui, workspace_ui.page
+    ui.agents[AGENT_ID]["azure_openai_gpt_key"] = STORED_KEY
+    ui.secret_paths[AGENT_ID] = ["/azure_openai_gpt_key"]
+    original = copy.deepcopy(ui.agents[AGENT_ID])
+    ui.open(f"/workspace/agents/{AGENT_ID}")
+    editor_section(page, "Model & connection")
+    page.get_by_text("Custom / legacy connection and APIM", exact=True).click()
+    intent = page.get_by_label("Azure OpenAI API key", exact=True)
+    expect(intent).to_have_value("keep")
+    revision = ui.revision(AGENT_ID)
+    editor_section(page, "Identity")
+    page.get_by_label("Display name", exact=True).fill("Credential-preserving rename")
+    assert save_resource(ui, "agent", identifier=AGENT_ID).status == 200
+    assert_patch(ui, f"/api/user/agents/{AGENT_ID}", revision, {"display_name": "Credential-preserving rename"})
+    assert ui.agents[AGENT_ID]["azure_openai_gpt_key"] == STORED_KEY
+
+    page.goto(f"{ORIGIN}/v2/workspace/agents/{AGENT_ID}", wait_until="networkidle")
+    editor_section(page, "Model & connection")
+    page.get_by_text("Custom / legacy connection and APIM", exact=True).click()
+    page.get_by_label("Azure OpenAI API key", exact=True).select_option("replace")
+    replacement = "fixture-only-replacement-credential"
+    page.get_by_label("Replacement azure openai api key", exact=True).fill(replacement)
+    ui.assert_no_secret_storage(replacement)
+    revision = ui.revision(AGENT_ID)
+    assert save_resource(ui, "agent", identifier=AGENT_ID).status == 200
+    assert_patch(ui, f"/api/user/agents/{AGENT_ID}", revision, {"azure_openai_gpt_key": replacement})
+    assert ui.agents[AGENT_ID]["azure_openai_gpt_key"] == replacement
+    assert all(replacement not in json.dumps(payload) for _, payload in ui.responses)
+
+    page.goto(f"{ORIGIN}/v2/workspace/agents/{AGENT_ID}", wait_until="networkidle")
+    editor_section(page, "Model & connection")
+    page.get_by_text("Custom / legacy connection and APIM", exact=True).click()
+    page.get_by_label("Azure OpenAI API key", exact=True).select_option("clear")
+    expect(page.get_by_role("status").filter(has_text="will be cleared")).to_be_visible()
+    revision = ui.revision(AGENT_ID)
+    assert save_resource(ui, "agent", identifier=AGENT_ID).status == 200
+    assert_patch(ui, f"/api/user/agents/{AGENT_ID}", revision, {}, clear=["/azure_openai_gpt_key"])
+    expected = {**original, "display_name": "Credential-preserving rename"}
+    del expected["azure_openai_gpt_key"]
+    assert ui.agents[AGENT_ID] == expected
+
+
+def test_array_replacement_keeps_secrets_by_position_and_removes_omitted_fields(workspace_ui):
+    ui, page = workspace_ui, workspace_ui.page
+    seed_array_credentials(ui)
+    before = copy.deepcopy(ui.agents[AGENT_ID])
+    revision = ui.revision(AGENT_ID)
+    ui.open(f"/workspace/agents/{AGENT_ID}")
+    editor_section(page, "Advanced")
+    field = page.get_by_label("Additional settings JSON", exact=True)
+    settings = json.loads(field.input_value())
+    safe_settings = copy.deepcopy(settings)
+    replacement = [
+        {"label": "second", "token": SECRET_MASK, "nested": {"retained": 0}},
+        {"label": "first", "token": SECRET_MASK, "nested": {"retained": False}},
+    ]
+    settings["custom_credentials"] = replacement
+    field.fill(json.dumps(settings))
+    expect(page.get_by_role("button", name="Save agent", exact=True)).to_be_disabled()
+    expect(field).to_have_attribute("aria-invalid", "true")
+    expect(page.get_by_role("status").filter(has_text="Review stored array credentials before saving.")).to_be_visible()
+    assert not ui.editor_writes
+    assert ui.agents[AGENT_ID] == before
+    assert json.loads(field.input_value()) == settings
+    page.get_by_role("button", name="Reset JSON text to current settings", exact=True).click()
+    assert json.loads(field.input_value()) == safe_settings
+    expect(field).to_have_attribute("aria-invalid", "false")
+    assert not ui.editor_writes
+    # Re-associating entries is explicit only after every affected credential is replaced.
+    replacement[0]["token"] = "replacement-second-array-credential"
+    replacement[1]["token"] = "replacement-first-array-credential"
+    field.fill(json.dumps(settings))
+    assert save_resource(ui, "agent", identifier=AGENT_ID).status == 200
+    assert_patch(
+        ui, f"/api/user/agents/{AGENT_ID}", revision,
+        {"other_settings": {"custom_credentials": replacement}},
+    )
+    expected = copy.deepcopy(before)
+    expected["other_settings"]["custom_credentials"] = replacement
+    assert ui.agents[AGENT_ID] == expected
+    page.goto(f"{ORIGIN}/v2/workspace/agents/{AGENT_ID}", wait_until="networkidle")
+    editor_section(page, "Advanced")
+    assert json.loads(field.input_value())["custom_credentials"] == [
+        {**entry, "token": SECRET_MASK} for entry in replacement
+    ]
+    ui.assert_no_secret_storage()
+
+
+@pytest.mark.parametrize("clear_mode", ["empty", "null", "omitted", "entry-removed", "control"])
+def test_array_credentials_require_explicit_clear_pointers(workspace_ui, clear_mode):
+    ui, page = workspace_ui, workspace_ui.page
+    seed_array_credentials(ui)
+    before = copy.deepcopy(ui.agents[AGENT_ID])
+    revision = ui.revision(AGENT_ID)
+    clear_path = "/other_settings/custom_credentials/1/token"
+    ui.open(f"/workspace/agents/{AGENT_ID}")
+    editor_section(page, "Advanced")
+    field = page.get_by_label("Additional settings JSON", exact=True)
+    settings = json.loads(field.input_value())
+    replacement = settings["custom_credentials"]
+    if clear_mode == "entry-removed":
+        replacement.pop()
+    elif clear_mode == "omitted":
+        del replacement[1]["token"]
+    else:
+        replacement[1]["token"] = None if clear_mode == "null" else ""
+    if clear_mode == "control":
+        page.get_by_text("Stored credentials and custom secret fields", exact=True).click()
+        intent = page.get_by_label(clear_path, exact=True)
+        expect(intent).to_have_value("keep")
+        intent.select_option("clear")
+    else:
+        field.fill(json.dumps(settings))
+    assert save_resource(ui, "agent", identifier=AGENT_ID).status == 200
+    assert_patch(
+        ui, f"/api/user/agents/{AGENT_ID}", revision,
+        {"other_settings": {"custom_credentials": replacement}},
+        clear=[clear_path],
+    )
+    expected = copy.deepcopy(before)
+    if clear_mode == "entry-removed":
+        expected["other_settings"]["custom_credentials"].pop()
+    else:
+        del expected["other_settings"]["custom_credentials"][1]["token"]
+    assert ui.agents[AGENT_ID] == expected
+    assert ui.secret_paths[AGENT_ID] == ["/other_settings/custom_credentials/0/token"]
+    assert SECRET_MASK not in json.dumps(ui.agents[AGENT_ID])
+
+
+def test_new_array_mask_is_rejected_without_writing_or_dropping_the_draft(workspace_ui):
+    ui, page = workspace_ui, workspace_ui.page
+    seed_array_credentials(ui)
+    before = copy.deepcopy(ui.agents[AGENT_ID])
+    revision = ui.revision(AGENT_ID)
+    ui.open(f"/workspace/agents/{AGENT_ID}")
+    editor_section(page, "Advanced")
+    field = page.get_by_label("Additional settings JSON", exact=True)
+    settings = json.loads(field.input_value())
+    settings["custom_credentials"].append({"label": "unowned position", "token": SECRET_MASK})
+    field.fill(json.dumps(settings))
+    expect(page.get_by_role("button", name="Save agent", exact=True)).to_be_disabled()
+    expect(field).to_have_attribute("aria-invalid", "true")
+    expect(page.get_by_role("alert").filter(has_text="credentials").first).to_be_visible()
+    assert json.loads(field.input_value()) == settings
+    assert ui.agents[AGENT_ID] == before
+    assert ui.revision(AGENT_ID) == revision
+    assert len(ui.editor_writes) == 0
+
+
+def test_instruction_references_and_generation_never_overwrite_newer_draft(workspace_ui):
+    ui, page = workspace_ui, workspace_ui.page
+    ui.agents[AGENT_ID]["other_settings"]["assigned_knowledge"] = {
+        "enabled": True, "scopes": {"personal": True}, "document_ids": ["personal-brief"],
+    }
+    before = copy.deepcopy(ui.agents[AGENT_ID])
+    revision = ui.revision(AGENT_ID)
+    ui.open(f"/workspace/agents/{AGENT_ID}")
+    editor_section(page, "Instructions")
+    instructions = page.get_by_role("textbox", name="Instructions", exact=True)
+    instructions.fill("Use #action:Workspace")
+    suggestions = page.get_by_role("listbox", name="Instruction references", exact=True)
+    expect(suggestions).to_be_visible()
+    instructions.press("Enter")
+    expect(instructions).to_have_value('Use #action:"Workspace API" ')
+    instructions.press("End")
+    instructions.press_sequentially("#knowledge:doc:")
+    expect(suggestions.get_by_role("option")).to_have_count(1)
+    instructions.press("Tab")
+    expected_instructions = 'Use #action:"Workspace API" #knowledge:doc:"Private review brief" '
+    expect(instructions).to_have_value(expected_instructions)
+    expect(instructions).to_be_focused()
+    page.get_by_label("Instruction brief", exact=True).fill("Write a careful evidence review.")
+    ui.defer_next("POST", "/api/agents/draft-instructions")
+    with page.expect_request(
+        lambda request: request.method == "POST" and urlsplit(request.url).path == "/api/agents/draft-instructions"
+    ):
+        page.get_by_role("button", name="Draft instructions", exact=True).click()
+    assert not ui.editor_writes
+    request = ui.writes[-1]
+    assert request.body == {
+        "agent_scope": "user",
+        "display_name": before["display_name"],
+        "description": before["description"],
+        "brief": "Write a careful evidence review.",
+        "existing_instructions": expected_instructions,
+        "selected_actions": [
+            {
+                "id": ACTION_ID, "name": "legacy-tool", "display_name": "Workspace API",
+                "description": ui.actions[ACTION_ID]["description"], "type": "openapi",
+                "is_global": False, "capabilities": [],
+            },
+            {
+                "id": "unavailable-action", "name": "unavailable-action",
+                "display_name": "unavailable-action", "type": "unavailable",
+                "description": "Unresolved saved reference", "capabilities": [],
+            },
+        ],
+        "assigned_knowledge": {
+            "enabled": True,
+            "sources": [{"scope": "personal", "id": "personal", "name": "Personal workspace"}],
+            "documents": [{**ui.knowledge_catalog["documents"][0], "is_explicit": True}],
+            "tags": [], "web_sources": [],
+        },
+    }
+    instructions.fill("These are newer user instructions.")
+    ui.release_responses()
+    proposal = page.get_by_label("Generated instructions — not yet applied", exact=True)
+    expect(proposal).to_have_value(ui.extra_posts["/api/agents/draft-instructions"]["instructions"])
+    expect(instructions).to_have_value("These are newer user instructions.")
+    expect(page.get_by_role("status").filter(has_text="They have not been overwritten.")).to_be_visible()
+    page.get_by_role("button", name="Use generated instructions", exact=True).click()
+    expect(instructions).to_have_value("These are newer user instructions.")
+    page.get_by_role("button", name="Replace edited instructions", exact=True).click()
+    generated = ui.extra_posts["/api/agents/draft-instructions"]["instructions"]
+    expect(instructions).to_have_value(generated)
+    assert not ui.editor_writes
+    assert ui.agents[AGENT_ID] == before
+    ui.assert_no_secret_storage(generated, "Write a careful evidence review.")
+    assert save_resource(ui, "agent", identifier=AGENT_ID).status == 200
+    assert_patch(ui, f"/api/user/agents/{AGENT_ID}", revision, {"instructions": generated})
+
+
+def test_templates_preview_confirm_apply_and_submit_without_saving_agent(workspace_ui):
+    ui, page = workspace_ui, workspace_ui.page
+    ui.open("/workspace/agents/new")
+    page.get_by_label("Display name", exact=True).fill("Keep my existing draft")
+    editor_section(page, "Examples & templates")
+    page.get_by_text("Preview template", exact=True).click()
+    expect(page.get_by_text(ui.templates[0]["instructions"], exact=True)).to_be_visible()
+    page.get_by_role("button", name="Use template", exact=True).click()
+    page.get_by_role("button", name="Keep current draft", exact=True).click()
+    expect(page.get_by_label("Display name", exact=True)).to_have_value("Keep my existing draft")
+    page.get_by_role("button", name="Use template", exact=True).click()
+    page.get_by_role("button", name="Replace draft with template", exact=True).click()
+    expect(page.get_by_label("Display name", exact=True)).to_have_value("Approved review example")
+    assert not ui.editor_writes
+    editor_section(page, "Actions")
+    expect(page.get_by_text("missing-template-tool", exact=True)).to_be_visible()
+    editor_section(page, "Advanced")
+    template_settings = json.loads(page.get_by_label("Additional settings JSON", exact=True).input_value())
+    assert template_settings == {"custom_policy": {"enabled": False, "limit": 0}, "private": {}}
+    editor_section(page, "Examples & templates")
+    with page.expect_response(
+        lambda response: response.request.method == "POST" and urlsplit(response.url).path == "/api/agent-templates"
+    ):
+        page.get_by_role("button", name="Submit personal template", exact=True).click()
+    expect(page.get_by_role("status").filter(has_text="Personal template submitted for review.")).to_be_visible()
+    assert ui.writes[-1].body == {"template": {
+        "title": "Approved review example", "display_name": "Approved review example",
+        "description": ui.templates[0]["description"], "helper_text": ui.templates[0]["description"],
+        "instructions": ui.templates[0]["instructions"],
+        "additional_settings": json.dumps(template_settings, separators=(",", ":")),
+        "actions_to_load": ["missing-template-tool"], "tags": ["review"], "source_scope": "personal",
+    }}
+    assert not ui.editor_writes
+    editor_section(page, "Actions")
+    page.get_by_role("button", name="Remove action reference missing-template-tool", exact=True).click()
+    assert save_resource(ui, "agent").status == 201
+    assert ui.agents[CREATED_AGENT_ID]["actions_to_load"] == []
+    assert SECRET_MASK not in json.dumps(ui.agents[CREATED_AGENT_ID])
+    assert "api_key" not in json.dumps(ui.agents[CREATED_AGENT_ID])
+
+
+def test_agent_filters_and_browsing_view_survive_cancelled_edit(workspace_ui):
+    ui, page = workspace_ui, workspace_ui.page
+    ui.open("/workspace/agents", theme="dark", width=390, height=844)
+    search = page.get_by_placeholder("Search agents by name, description or type", exact=True)
+    search.fill("reviewer")
+    page.get_by_label("Filter agent scope", exact=True).select_option("personal")
+    page.get_by_label("Filter agent type", exact=True).select_option("local")
+    page.get_by_role("button", name="Card view", exact=True).click()
+    collection_item(page, AGENT_ID).get_by_role("button", name="Edit", exact=True).click()
+    expect(page).to_have_url(f"{ORIGIN}/v2/workspace/agents/{AGENT_ID}")
+    page.get_by_label("Description", exact=True).fill("Discard this collection-navigation draft.")
+    page.get_by_role("button", name="Cancel", exact=True).click()
+    keep_editing(page)
+    page.get_by_role("button", name="Cancel", exact=True).click()
+    discard_changes(page)
+    expect(page).to_have_url(f"{ORIGIN}/v2/workspace/agents")
+    expect(search).to_have_value("reviewer")
+    expect(page.get_by_label("Filter agent scope", exact=True)).to_have_value("personal")
+    expect(page.get_by_label("Filter agent type", exact=True)).to_have_value("local")
+    expect(page.get_by_role("button", name="Card view", exact=True)).to_have_attribute("aria-pressed", "true")
+    expect(collection_item(page, GLOBAL_AGENT_ID)).to_have_count(0)
+    assert not ui.editor_writes
+    ui.assert_no_overflow()
+
+
+def test_action_filters_cards_and_scope_identity_survive_cancelled_edit(workspace_ui):
+    ui, page = workspace_ui, workspace_ui.page
+    ui.actions[GLOBAL_ACTION_ID]["displayName"] = ui.actions[ACTION_ID]["displayName"]
+    ui.open("/workspace/actions", theme="dark", width=390, height=844)
+    provided = collection_item(page, GLOBAL_ACTION_ID)
+    expect(provided.get_by_role("link", name="Edit Workspace API", exact=True)).to_have_count(0)
+    expect(provided.get_by_role("button", name="Delete Workspace API", exact=True)).to_have_count(0)
+    expect(provided.get_by_role("link", name="View Workspace API", exact=True)).to_have_attribute(
+        "href", f"/v2/workspace/actions/{GLOBAL_ACTION_ID}?scope=global"
+    )
+    search = page.get_by_placeholder("Search actions", exact=True)
+    search.fill("workspace")
+    page.get_by_label("Action type filter", exact=True).select_option("openapi")
+    page.get_by_label("Action scope filter", exact=True).select_option("personal")
+    page.get_by_role("button", name="Card view", exact=True).click()
+    expect(provided).to_have_count(0)
+    ui.assert_no_overflow()
+    collection_item(page, ACTION_ID).get_by_role("link", name="Edit Workspace API", exact=True).click()
+    expect(page).to_have_url(f"{ORIGIN}/v2/workspace/actions/{ACTION_ID}")
+    name_field(page, "action").fill("Discard this filtered action draft")
+    ui.assert_no_secret_storage("Discard this filtered action draft")
+    page.get_by_role("button", name="Cancel", exact=True).click()
+    discard_changes(page)
+    expect(page).to_have_url(f"{ORIGIN}/v2/workspace/actions")
+    expect(search).to_have_value("workspace")
+    expect(page.get_by_label("Action type filter", exact=True)).to_have_value("openapi")
+    expect(page.get_by_label("Action scope filter", exact=True)).to_have_value("personal")
+    expect(page.get_by_role("button", name="Card view", exact=True)).to_have_attribute("aria-pressed", "true")
+    expect(collection_item(page, ACTION_ID)).to_contain_text("Workspace API")
+    assert not ui.editor_writes
+    ui.assert_no_overflow()
+
+
+def test_same_named_agents_keep_scope_identity_and_read_only_commands(workspace_ui):
+    ui, page = workspace_ui, workspace_ui.page
+    ui.agents[GLOBAL_AGENT_ID]["display_name"] = ui.agents[AGENT_ID]["display_name"]
+    ui.open("/workspace/agents")
+    personal = collection_item(page, AGENT_ID)
+    provided = collection_item(page, GLOBAL_AGENT_ID)
+    expect(personal.get_by_role("button", name="Edit", exact=True)).to_be_visible()
+    expect(provided.get_by_role("button", name="Edit", exact=True)).to_have_count(0)
+    expect(provided.get_by_role("button", name="View details", exact=True)).to_be_visible()
+    expect(provided.get_by_role("button", name="Delete Workspace reviewer", exact=True)).to_have_count(0)
+    expect(provided.get_by_text("Provided · read only", exact=True)).to_be_visible()
+    expect(personal.get_by_role("link", name="Use in chat", exact=True)).to_have_attribute(
+        "href", f"/v2/chat?agent_id={AGENT_ID}&agent_scope=personal&new=1"
+    )
+    expect(provided.get_by_role("link", name="Use in chat", exact=True)).to_have_attribute(
+        "href", f"/v2/chat?agent_id={GLOBAL_AGENT_ID}&agent_scope=global&new=1"
+    )
+    provided.get_by_role("button", name="View details", exact=True).click()
+    expect(page.get_by_label("Display name", exact=True)).to_be_disabled()
+    assert not ui.editor_writes
+
+
+def test_agent_deletion_requires_confirmation_without_rewriting_call_actions(workspace_ui):
+    ui, page = workspace_ui, workspace_ui.page
+    before = copy.deepcopy(ui.actions)
+    ui.open("/workspace/agents")
+    item = collection_item(page, AGENT_ID)
+    item.get_by_role("button", name="Delete Workspace reviewer", exact=True).click()
+    assert not ui.editor_writes
+    expect(item.get_by_role("button", name="Delete agent", exact=True)).to_be_visible()
+    item.get_by_role("button", name="Delete agent", exact=True).click()
+    expect(collection_item(page, AGENT_ID)).to_have_count(0)
+    assert [(request.method, request.path, request.query, request.body) for request in ui.editor_writes] == [
+        ("DELETE", f"/api/user/agents/{AGENT_ID}", {"view": ["editor"]}, None),
+    ]
+    assert ui.actions == before
+
+
+def test_failed_agent_catalog_is_not_reported_as_empty_and_can_be_retried(workspace_ui):
+    ui, page = workspace_ui, workspace_ui.page
+    ui.reject_next("GET", "/api/user/agents", error="The agent catalogue is temporarily unavailable.")
+    ui.open("/workspace/agents")
+    expect(page.get_by_role("alert").filter(has_text="catalogue is temporarily unavailable")).to_be_visible()
+    expect(page.get_by_text("No agents yet", exact=True)).to_have_count(0)
+    page.get_by_role("button", name="Refresh", exact=True).click()
+    expect(collection_item(page, AGENT_ID)).to_be_visible()
+    expect(page.get_by_role("alert")).to_have_count(0)
+    assert not ui.editor_writes
+
+
+@pytest.mark.parametrize("identifier,scope", [(AGENT_ID, "personal"), (GLOBAL_AGENT_ID, "global")])
+def test_use_in_chat_starts_fresh_with_exact_scoped_agent_and_no_model_override(workspace_ui, identifier, scope):
+    ui, page = workspace_ui, workspace_ui.page
+    before_messages = copy.deepcopy(ui.messages["existing-workspace-chat"])
+    ui.agents[GLOBAL_AGENT_ID]["display_name"] = ui.agents[AGENT_ID]["display_name"]
+    ui.open("/chat?conversationId=existing-workspace-chat")
+    expect(page.get_by_text("An earlier conversation.", exact=True)).to_be_visible()
+    page.get_by_role("link", name="My Workspace", exact=True).click()
+    page.get_by_role("navigation", name="Workspace sections", exact=True).get_by_role(
+        "link", name="Agents", exact=True
+    ).click()
+    collection_item(page, identifier).get_by_role("link", name="Use in chat", exact=True).click()
+    expect(page.get_by_text("An earlier conversation.", exact=True)).to_have_count(0)
+    expect(page.locator("#composer-input")).to_be_enabled()
+    assert "existing-workspace-chat" not in page.url
+    page.locator("#composer-input").fill("Review this evidence with the selected workspace agent.")
+    with page.expect_request(
+        lambda request: request.method == "POST" and urlsplit(request.url).path == "/api/chat/stream"
+    ) as stream_request:
+        page.get_by_role("button", name="Send message", exact=True).click()
+    body = stream_request.value.post_data_json
+    assert body["agent_info"] == {
+        "id": identifier, "name": ui.agents[identifier]["name"],
+        "display_name": "Workspace reviewer", "is_global": scope == "global", "is_group": False,
+        "group_id": None, "group_name": None,
+    }
+    assert not {"model_deployment", "model_id", "model_endpoint_id", "model_provider"} & set(body)
+    assert body["conversation_id"] != "existing-workspace-chat"
+    assert ui.messages["existing-workspace-chat"] == before_messages
+    assert len([request for request in ui.writes if request.path == "/api/create_conversation"]) == 1
+    expect(page.get_by_text("Workspace review response.", exact=True)).to_be_visible()
+    assert not ui.editor_writes
+
+
+def test_use_in_chat_refreshes_authorization_instead_of_using_stale_catalog(workspace_ui):
+    ui, page = workspace_ui, workspace_ui.page
+    ui.open("/workspace/agents")
+    initial_bootstraps = len([request for request in ui.requests if request.path == "/api/v2/bootstrap"])
+    del ui.agents[AGENT_ID]
+    collection_item(page, AGENT_ID).get_by_role("link", name="Use in chat", exact=True).click()
+    expect(page.get_by_text("That agent is no longer available in this workspace.", exact=True)).to_be_visible()
+    assert len([request for request in ui.requests if request.path == "/api/v2/bootstrap"]) > initial_bootstraps
+    assert not any(request.path in ("/api/create_conversation", "/api/chat/stream") for request in ui.writes)
+
+
+def test_failed_agent_authorization_refresh_retains_the_existing_conversation(workspace_ui):
+    ui, page = workspace_ui, workspace_ui.page
+    original_messages = copy.deepcopy(ui.messages["existing-workspace-chat"])
+    ui.open("/chat?conversationId=existing-workspace-chat")
+    expect(page.get_by_text("An earlier conversation.", exact=True)).to_be_visible()
+    page.get_by_role("link", name="My Workspace", exact=True).click()
+    page.get_by_role("navigation", name="Workspace sections", exact=True).get_by_role(
+        "link", name="Agents", exact=True
+    ).click()
+    expect(collection_item(page, AGENT_ID)).to_be_visible()
+    ui.reject_next("GET", "/api/v2/bootstrap", error="The authorized catalogue could not be refreshed.")
+    collection_item(page, AGENT_ID).get_by_role("link", name="Use in chat", exact=True).click()
+    expect(page.get_by_text("Could not refresh available agents. Try again.", exact=True)).to_be_visible()
+    expect(page.get_by_text("An earlier conversation.", exact=True)).to_be_visible()
+    expect(page).to_have_url(f"{ORIGIN}/v2/chat?conversationId=existing-workspace-chat")
+    assert ui.messages["existing-workspace-chat"] == original_messages
+    assert not any(request.path in ("/api/create_conversation", "/api/chat/stream") for request in ui.writes)
+    assert not ui.editor_writes
+
+
+@pytest.mark.parametrize("source_mode", ["file", "manual"])
+def test_openapi_import_authentication_and_explicit_connection_test(workspace_ui, source_mode):
+    ui, page = workspace_ui, workspace_ui.page
+    ui.open("/workspace/actions/new")
+    action_field(page, "Action type").select_option("openapi")
+    name_field(page, "action").fill("Imported review connector")
+    page.get_by_label("Description", exact=True).fill("Access approved review status.")
+    editor_section(page, "Configuration")
+    source = json.dumps(ui.openapi_import_spec)
+    with page.expect_request(
+        lambda request: request.method == "POST" and urlsplit(request.url).path == "/api/openapi/upload"
+    ) as upload:
+        if source_mode == "file":
+            page.get_by_label("OpenAPI specification file", exact=True).set_input_files({
+                "name": "review.openapi.json", "mimeType": "application/json", "buffer": source.encode(),
+            })
+        else:
+            page.get_by_role("combobox", name="Specification source", exact=True).select_option("manual")
+            page.get_by_role("textbox", name="Specification source", exact=True).fill(source)
+            assert_action_save_blocked(ui)
+            expect(page.get_by_role("textbox", name="Specification source", exact=True)).to_have_value(source)
+            page.get_by_role("button", name="Process specification", exact=True).click()
+    assert source in upload.value.post_data
+    expect(page.get_by_role("heading", name="Imported review API", exact=True)).to_be_visible()
+    expect(action_field(page, "API base URL")).to_have_value("https://review-api.example.test/v1")
+    expect(page.get_by_text("1 matching operations.", exact=False)).to_be_visible()
+    assert not ui.editor_writes
+    assert not any("/test-" in request.path for request in ui.writes)
+    editor_section(page, "Authentication")
+    page.get_by_label("Authentication method", exact=True).select_option("api_key")
+    page.get_by_label("API key location", exact=True).select_option("header")
+    action_field(page, "Header name").fill("X-Review-Key")
+    new_key = "fixture-only-new-api-credential"
+    page.get_by_label("API key", exact=True).fill(new_key)
+    ui.assert_no_secret_storage(new_key, source)
+    editor_section(page, "Configuration")
+    with page.expect_request(
+        lambda request: request.method == "POST" and urlsplit(request.url).path == "/api/plugins/test-openapi-connection"
+    ) as connection:
+        page.get_by_role("button", name="Test OpenAPI connection", exact=True).click()
+    body = connection.value.post_data_json
+    assert body["action_scope"] == "personal"
+    assert "plugin_context" not in body
+    assert body["auth"] == {"type": "key", "key": new_key}
+    assert body["additionalFields"]["openapi_spec_content"] == ui.openapi_import_spec
+    assert body["additionalFields"]["auth_method"] == "api_key"
+    assert body["additionalFields"]["api_key_name"] == "X-Review-Key"
+    assert body["additionalFields"]["api_key_location"] == "header"
+    assert body["clear_secret_paths"] == []
+    expect(page.get_by_role("status").filter(has_text="Fixture OpenAPI connection succeeded.")).to_be_visible()
+    assert not ui.editor_writes
+    assert save_resource(ui, "action").status == 201
+    record = ui.actions[CREATED_ACTION_ID]
+    assert record["type"] == "openapi"
+    assert record["additionalFields"]["openapi_spec_content"] == ui.openapi_import_spec
+    assert record["auth"] == {"type": "key", "key": new_key}
+    assert "_openApiSourceDraft" not in record
+    assert len([request for request in ui.writes if "/test-" in request.path]) == 1
+
+
+def test_openapi_remote_specs_require_download_then_file_import(workspace_ui):
+    ui, page = workspace_ui, workspace_ui.page
+    ui.open("/workspace/actions/new")
+    action_field(page, "Action type").select_option("openapi")
+    editor_section(page, "Configuration")
+    source = page.get_by_role("combobox", name="Specification source", exact=True)
+    assert set(source.get_by_role("option").evaluate_all(
+        "options => options.map(option => option.value)"
+    )) == {"file", "manual"}
+    expect(page.get_by_label("OpenAPI specification URL", exact=True)).to_have_count(0)
+    expect(page.get_by_role("button", name="Import specification URL", exact=True)).to_have_count(0)
+    expect(page.get_by_text(re.compile(r"download.*(?:import|upload)", re.I))).to_be_visible()
+    assert not ui.editor_writes
+    assert not any(request.path == "/api/openapi/upload" for request in ui.writes)
+
+
+def test_existing_openapi_connection_uses_owned_stored_credentials(workspace_ui):
+    ui, page = workspace_ui, workspace_ui.page
+    before = copy.deepcopy(ui.actions[ACTION_ID])
+    ui.open(f"/workspace/actions/{ACTION_ID}")
+    editor_section(page, "Configuration")
+    with page.expect_request(
+        lambda request: request.method == "POST" and urlsplit(request.url).path == "/api/plugins/test-openapi-connection"
+    ) as connection:
+        page.get_by_role("button", name="Test OpenAPI connection", exact=True).click()
+    assert connection.value.post_data_json == {
+        "name": before["name"], "displayName": before["displayName"], "type": "openapi",
+        "description": before["description"], "endpoint": before["endpoint"],
+        "auth": {"type": "key", "key": "Stored_In_KeyVault"},
+        "additionalFields": before["additionalFields"], "metadata": before["metadata"],
+        "action_scope": "personal",
+        "plugin_context": {"scope": "personal", "id": ACTION_ID, "name": before["name"]},
+        "clear_secret_paths": [],
+    }
+    expect(page.get_by_role("status").filter(has_text="Fixture OpenAPI connection succeeded.")).to_be_visible()
+    assert ui.actions[ACTION_ID] == before
+    assert not ui.editor_writes
+    assert STORED_KEY not in connection.value.post_data
+    assert SECRET_MASK not in connection.value.post_data
+
+
+def test_failed_openapi_import_retains_processed_specification_and_pending_source(workspace_ui):
+    ui, page = workspace_ui, workspace_ui.page
+    before = copy.deepcopy(ui.actions[ACTION_ID])
+    ui.open(f"/workspace/actions/{ACTION_ID}")
+    editor_section(page, "Configuration")
+    page.get_by_role("combobox", name="Specification source", exact=True).select_option("manual")
+    source = page.get_by_role("textbox", name="Specification source", exact=True)
+    source.fill('{"openapi": "unfinished')
+    ui.reject_next("POST", "/api/openapi/upload", status=400, error="The specification is not valid JSON.")
+    page.get_by_role("button", name="Process specification", exact=True).click()
+    expect(page.get_by_role("alert").filter(has_text="The specification is not valid JSON.")).to_be_visible()
+    expect(source).to_have_value('{"openapi": "unfinished')
+    assert_action_save_blocked(ui)
+    expect(source).to_have_value('{"openapi": "unfinished')
+    expect(action_field(page, "API base URL")).to_have_value(before["endpoint"])
+    expect(page.get_by_role("region", name="Authentication", exact=True).get_by_label(
+        "API key", exact=True
+    )).to_have_attribute("placeholder", re.compile("Stored securely"))
+    expect(page.get_by_test_id("openapi-configuration").get_by_role(
+        "heading", name="Workspace API", exact=True
+    )).to_be_visible()
+    page.get_by_role("button", name="Discard unprocessed source changes", exact=True).click()
+    assert json.loads(source.input_value()) == before["additionalFields"]["openapi_spec_content"]
+    assert ui.actions[ACTION_ID] == before
+    assert not ui.editor_writes
+
+
+def test_mcp_discovery_failure_retry_preserves_credentials_and_unavailable_tools(workspace_ui):
+    ui, page = workspace_ui, workspace_ui.page
+    legacy_tool = {
+        "original_name": "legacy-tool", "function_name": "legacy-tool",
+        "description": "Previously allowed tool.",
+        "input_schema": {}, "output_schema": {}, "annotations": {},
+    }
+    ui.actions[MCP_ACTION_ID]["additionalFields"].update({
+        "allowed_tool_names": ["legacy-tool"], "mcp_tools": [legacy_tool],
+    })
+    before = copy.deepcopy(ui.actions[MCP_ACTION_ID])
+    revision = ui.revision(MCP_ACTION_ID)
+    ui.open(f"/workspace/actions/{MCP_ACTION_ID}")
+    editor_section(page, "Configuration")
+    expect(action_field(page, "Transport").get_by_role("option", name=re.compile("Stdio"))).to_have_count(0)
+    ui.reject_next("POST", "/api/plugins/mcp/discover", error="MCP discovery is temporarily unavailable.")
+    page.get_by_role("button", name="Discover MCP tools", exact=True).click()
+    expect(page.get_by_role("alert").filter(has_text="MCP discovery is temporarily unavailable.")).to_be_visible()
+    expect(page.get_by_label("Allowed tool names", exact=True)).to_have_value("legacy-tool")
+    assert ui.actions[MCP_ACTION_ID] == before
+    assert not ui.editor_writes
+
+    with page.expect_request(
+        lambda request: request.method == "POST" and urlsplit(request.url).path == "/api/plugins/mcp/discover"
+    ) as discovery:
+        page.get_by_role("button", name="Discover MCP tools", exact=True).click()
+    body = discovery.value.post_data_json
+    assert body["action_scope"] == "personal"
+    assert body["plugin_context"] == {"scope": "personal", "id": MCP_ACTION_ID, "name": before["name"]}
+    assert body["auth"] == {"type": "key", "key": "Stored_In_KeyVault"}
+    assert body["additionalFields"]["custom_headers"] == {"X-Workspace": "Stored_In_KeyVault"}
+    assert body["additionalFields"]["custom"] == before["additionalFields"]["custom"]
+    assert body["metadata"] == before["metadata"]
+    assert body["clear_secret_paths"] == []
+    expect(page.get_by_role("status").filter(has_text="Discovered 2 tools.")).to_be_visible()
+    expect(page.get_by_role("checkbox", name=re.compile("^legacy-tool"))).to_be_checked()
+    expect(page.get_by_text("Not available in the current tool catalogue.", exact=False)).to_be_visible()
+    page.get_by_role("checkbox", name=re.compile("^search ")).check()
+    expected_tools = [
+        {**tool, "output_schema": {}, "annotations": {}}
+        for tool in ui.extra_posts["/api/plugins/mcp/discover"]["tools"]
+    ] + [legacy_tool]
+    assert ui.actions[MCP_ACTION_ID] == before
+    assert not ui.editor_writes
+    assert save_resource(ui, "action", identifier=MCP_ACTION_ID).status == 200
+    assert_patch(
+        ui, f"/api/user/plugins/{MCP_ACTION_ID}", revision,
+        {"additionalFields": {"allowed_tool_names": ["legacy-tool", "search"], "mcp_tools": expected_tools}},
+    )
+    assert ui.actions[MCP_ACTION_ID] == {
+        **before,
+        "additionalFields": {
+            **before["additionalFields"],
+            "allowed_tool_names": ["legacy-tool", "search"], "mcp_tools": expected_tools,
+        },
+    }
+
+
+def test_mcp_reusable_identity_and_explicit_secret_header_removal(workspace_ui):
+    ui, page = workspace_ui, workspace_ui.page
+    before = copy.deepcopy(ui.actions[MCP_ACTION_ID])
+    revision = ui.revision(MCP_ACTION_ID)
+    ui.open(f"/workspace/actions/{MCP_ACTION_ID}")
+    editor_section(page, "Authentication")
+    page.get_by_label("Reusable identity", exact=True).select_option("workspace-identity")
+    expect(page.get_by_label("Authentication method", exact=True)).to_be_disabled()
+    page.get_by_role("button", name="Remove header X-Workspace", exact=True).click()
+    expect(page.get_by_label("X-Workspace", exact=True)).to_have_count(0)
+    assert not ui.editor_writes
+    assert save_resource(ui, "action", identifier=MCP_ACTION_ID).status == 200
+    assert_patch(
+        ui, f"/api/user/plugins/{MCP_ACTION_ID}", revision,
+        {
+            "identity_id": "workspace-identity",
+            "auth": {"type": "identity", "identity": "workspace-identity"},
+            "additionalFields": {"auth_method": "identity", "identity_auth_type": "managed_identity"},
+        },
+        clear=["/additionalFields/custom_headers/X-Workspace"],
+    )
+    assert ui.actions[MCP_ACTION_ID]["auth"]["key"] == before["auth"]["key"]
+    assert ui.actions[MCP_ACTION_ID]["additionalFields"]["custom_headers"] == {}
+    assert ui.actions[MCP_ACTION_ID]["additionalFields"]["custom"] == before["additionalFields"]["custom"]
+    assert not any("/test-" in request.path or "/discover" in request.path for request in ui.writes)
+    ui.assert_no_secret_storage()
+
+
+def test_action_only_author_uses_safe_reminder_defaults_without_agent_access(workspace_ui):
+    ui, page = workspace_ui, workspace_ui.page
+    ui.disabled_sections["agents"] = "Agent authoring is disabled."
+    ui.options["settings"].update({
+        "allow_user_agents": False,
+        "allow_user_plugins": True,
+        "enable_key_vault_secret_storage": True,
+        "enable_key_vault_secret_expiration_reminders": True,
+        "key_vault_secret_expiration_default_lead_days": 21,
+        "key_vault_secret_expiration_default_contact_email": "rotation-owner@example.test",
+        "key_vault_secret_expiration_require_expiration": True,
+    })
+    ui.options["agent_types"] = [{**entry, "enabled": False} for entry in ui.options["agent_types"]]
+    ui.options["model_endpoints"] = []
+    ui.options["builtin_actions"] = []
+    before = copy.deepcopy(ui.actions[ACTION_ID])
+    revision = ui.revision(ACTION_ID)
+    ui.open(f"/workspace/actions/{ACTION_ID}")
+    expect(name_field(page, "action")).to_be_enabled()
+    editor_section(page, "Advanced")
+    expect(page.get_by_text("Key Vault storage is enabled; reminder delivery is enabled.", exact=False)).to_be_visible()
+    tracking = page.get_by_role("checkbox", name=re.compile("^Track secret expiration"))
+    tracking.focus()
+    page.keyboard.press("Space")
+    expect(tracking).to_be_checked()
+    expect(action_field(page, "Reminder lead days")).to_have_value("21")
+    expect(action_field(page, "Reminder email")).to_have_value("rotation-owner@example.test")
+    expiration = (date.today() + timedelta(days=90)).isoformat()
+    action_field(page, "Secret expiration date").fill(expiration)
+    assert save_resource(ui, "action", identifier=ACTION_ID).status == 200
+    reminder = {
+        "enabled": True, "lead_days": 21,
+        "contact_email": "rotation-owner@example.test", "expires_on": expiration,
+    }
+    assert_patch(
+        ui, f"/api/user/plugins/{ACTION_ID}", revision,
+        {"metadata": {"key_vault_secret_reminders": {"__all__": reminder}}},
+    )
+    assert ui.actions[ACTION_ID] == {
+        **before, "metadata": {**before["metadata"], "key_vault_secret_reminders": {"__all__": reminder}},
+    }
+    assert any(request.path == "/api/user/agent/settings" for request in ui.requests)
+    assert not any(request.path.startswith("/api/user/agents") for request in ui.requests)
+
+
+def test_failed_mcp_preconfiguration_catalog_preserves_saved_configuration(workspace_ui):
+    ui, page = workspace_ui, workspace_ui.page
+    before = copy.deepcopy(ui.actions[MCP_ACTION_ID])
+    ui.reject_next("GET", "/api/plugins/mcp/preconfigurations", error="MCP starting points could not be loaded.")
+    ui.open(f"/workspace/actions/{MCP_ACTION_ID}")
+    editor_section(page, "Configuration")
+    expect(page.get_by_role("alert").filter(has_text="MCP starting points could not be loaded.")).to_be_visible()
+    expect(action_field(page, "MCP server endpoint")).to_have_value(before["endpoint"])
+    page.get_by_role("button", name="Retry catalogues", exact=True).click()
+    expect(page.get_by_label("Preconfigured server", exact=True).get_by_role(
+        "option", name="Review MCP server", exact=True
+    )).to_be_attached()
+    assert ui.actions[MCP_ACTION_ID] == before
+    assert not ui.editor_writes
+
+
+def test_action_type_picker_uses_complete_governed_catalog_including_custom_types(workspace_ui):
+    ui, page = workspace_ui, workspace_ui.page
+    ui.open("/workspace/actions/new")
+    chooser = action_field(page, "Action type")
+    values = chooser.get_by_role("option").evaluate_all(
+        "options => options.map(option => option.value).filter(Boolean)"
+    )
+    assert set(values) == {definition["type"] for definition in ui.types}
+    assert len(values) == len(set(values))
+    expect(chooser.get_by_role("option", name="Call agent", exact=True)).to_have_count(1)
+    expect(chooser.get_by_role("option", name="Custom governed connector", exact=True)).to_have_count(1)
+    assert not ui.editor_writes
+
+
+def test_keyboard_save_uses_the_same_conditional_per_record_write(workspace_ui):
+    ui, page = workspace_ui, workspace_ui.page
+    revision = ui.revision(AGENT_ID)
+    ui.open(f"/workspace/agents/{AGENT_ID}")
+    name = page.get_by_label("Display name", exact=True)
+    name.fill("Keyboard-saved agent")
+    with page.expect_response(
+        lambda response: response.request.method == "PATCH" and urlsplit(response.url).path == f"/api/user/agents/{AGENT_ID}"
+    ) as response:
+        name.press("Control+s")
+    assert response.value.status == 200
+    expect(page).to_have_url(f"{ORIGIN}/v2/workspace/agents")
+    assert_patch(ui, f"/api/user/agents/{AGENT_ID}", revision, {"display_name": "Keyboard-saved agent"})
+
+
+def test_agent_required_fields_focus_the_invalid_control_without_writing(workspace_ui):
+    ui, page = workspace_ui, workspace_ui.page
+    ui.open("/workspace/agents/new", width=390, height=844)
+    save = page.get_by_role("button", name="Save agent", exact=True)
+    save.click()
+    expect(page.get_by_label("Display name", exact=True)).to_be_focused()
+    page.get_by_label("Display name", exact=True).fill("Required-field review")
+    save.click()
+    expect(page.get_by_label("Description", exact=True)).to_be_focused()
+    page.get_by_label("Description", exact=True).fill("Validate required instructions.")
+    save.click()
+    expect(page.get_by_role("textbox", name="Instructions", exact=True)).to_be_focused()
+    assert not ui.editor_writes
+    assert not any(request.path == "/api/agents/generate_id" for request in ui.requests)

--- a/ui_tests/test_v2_workspace_draft_navigation.py
+++ b/ui_tests/test_v2_workspace_draft_navigation.py
@@ -1,0 +1,89 @@
+# test_v2_workspace_draft_navigation.py
+"""Real-router regressions for completed-save history and suspended editor drafts.
+
+Version: 0.261.096
+Implemented in: 0.261.096
+"""
+
+import re
+from urllib.parse import urlsplit
+
+import pytest
+from playwright.sync_api import expect
+
+from ui_tests.fixtures.workspace_authoring import (
+    AGENT_ID,
+    ORIGIN,
+    connect_options,  # noqa: F401
+    workspace_ui,  # noqa: F401
+)
+from ui_tests.test_v2_workspace_authoring import editor_section, save_resource
+
+
+pytestmark = pytest.mark.ui
+
+
+def unload_is_protected(page):
+    return page.evaluate("""() => {
+        const event = new Event('beforeunload', {cancelable: true});
+        window.dispatchEvent(event);
+        return event.defaultPrevented;
+    }""")
+
+
+@pytest.mark.parametrize("saving", [False, True])
+def test_old_save_history_entry_cannot_bypass_a_later_editor_guard(workspace_ui, saving):
+    ui, page = workspace_ui, workspace_ui.page
+    ui.open(f"/workspace/agents/{AGENT_ID}")
+    page.get_by_role("textbox", name="Description", exact=True).fill("Saved first edit")
+    assert save_resource(ui, "agent", identifier=AGENT_ID).ok
+
+    page.locator(f'a[href="/v2/workspace/agents/{AGENT_ID}"]').first.click()
+    description = page.get_by_role("textbox", name="Description", exact=True)
+    expect(description).to_have_value("Saved first edit")
+    description.fill("Unsaved subsequent edit")
+    if saving:
+        ui.defer_next("PATCH", f"/api/user/agents/{AGENT_ID}")
+        with page.expect_request(
+            lambda request: request.method == "PATCH" and urlsplit(request.url).path == f"/api/user/agents/{AGENT_ID}"
+        ):
+            page.get_by_role("button", name="Save agent", exact=True).click()
+
+    page.evaluate("history.back()")
+    dialog = page.get_by_role(
+        "dialog",
+        name="Your changes are still being saved" if saving else "Discard unsaved changes?",
+        exact=True,
+    )
+    expect(dialog).to_be_visible()
+    expect(page).to_have_url(f"{ORIGIN}/v2/workspace/agents/{AGENT_ID}")
+    expect(description).to_have_value("Unsaved subsequent edit")
+    if saving:
+        expect(dialog.get_by_role("button", name="Discard changes", exact=True)).to_be_disabled()
+    dialog.get_by_role("button", name="Keep editing", exact=True).click()
+    if saving:
+        ui.release_responses()
+        expect(page).to_have_url(f"{ORIGIN}/v2/workspace/agents")
+
+
+def test_suspended_agent_draft_keeps_unload_protection_in_a_clean_action_editor(workspace_ui):
+    ui, page = workspace_ui, workspace_ui.page
+    ui.open(f"/workspace/agents/{AGENT_ID}")
+    description = page.get_by_role("textbox", name="Description", exact=True)
+    description.fill("Keep this unfinished agent")
+    assert unload_is_protected(page)
+    editor_section(page, "Actions")
+    page.get_by_role("button", name="New action", exact=True).click()
+    expect(page.get_by_role("combobox", name=re.compile("^Action type"))).to_be_visible()
+    expect(page.get_by_role("status").filter(has_text="No unsaved changes")).to_be_visible()
+    assert unload_is_protected(page)
+
+    page.evaluate("history.back()")
+    expect(description).to_have_value("Keep this unfinished agent")
+    assert unload_is_protected(page)
+    page.get_by_role("button", name="Cancel", exact=True).click()
+    page.get_by_role("dialog", name="Discard unsaved changes?", exact=True).get_by_role(
+        "button", name="Discard changes", exact=True
+    ).click()
+    expect(page).to_have_url(f"{ORIGIN}/v2/workspace/agents")
+    assert not unload_is_protected(page)


### PR DESCRIPTION
<!-- Thanks for contributing to SimpleChat! Keep this practical and delete sections that truly do not apply. -->

## Summary

<!-- What changed and why? Include the user/admin impact in 2-4 bullets. -->

- Add full-page Agents and Actions editors to V2 My Workspace, including the existing agent types, model connections, assigned knowledge, instruction drafting, templates, and connector-specific configuration.
- Treat **Call agent as an ordinary action** in the unified collection and agent action picker; remove the separate personal delegation sections.
- Preserve unfinished drafts across agent/action handoffs, protect navigation and credentials, and use scoped, conditional per-record writes without replacing whole collections.
- Keep group/admin management and existing execution policies intact. Update documentation, release notes, and the application version to **0.261.096**.

**Base branch:** `paullizer-react-v2-ui`, so this PR contains only the workspace build-out rather than the existing V2 branch history.

## Linked issue

<!-- Use one when applicable: Fixes #123, Closes #123, Refs #123. -->

N/A — issue creation was declined for this work.

## Release Notes & Latest Features

<!-- Check the most relevant category. Release notes go under the current VERSION from application/single_app/config.py in docs/explanation/release_notes.md. -->

- [x] New Feature
- [x] Bug Fix
- [x] UI Enhancement
- [ ] Breaking Change
- [ ] Internal only

Is this visible to end users?

- [x] Yes
- [ ] No

Is this admin-facing (Admin Settings, governance, deployment, config)?

- [ ] Yes
- [x] No

Should this become a Latest Feature card?

- [ ] Yes
- [x] No
- [ ] Already added

Screenshot needed for the card?

- [ ] Yes
- [x] No
- [ ] Attached

## Version bump

<!-- Confirm application/single_app/config.py VERSION patch segment was bumped for code changes. If deployers/ changed, also bump deployers/version.txt. -->

- [x] `application/single_app/config.py` `VERSION` third segment bumped: `0.261.095` → `0.261.096`
- [x] `deployers/version.txt` not changed because `deployers/` was not changed

## Testing / validation

<!-- List commands run and any manual validation. -->

- `npm --prefix .\application\v2_ui run build` — TypeScript and production build passed.
- Native authoring, connector, agent-rendering, draft/transport, and bootstrap-refresh Node suites passed.
- `python -m pytest .\ui_tests\test_v2_workspace_authoring.py .\ui_tests\test_v2_workspace_draft_navigation.py .\ui_tests\test_agent_delegation_v2.py -q --disable-warnings` — **94 passed**, including desktop/mobile and retained group/global workflows.
- Targeted backend, credential-persistence, legacy-compatibility, route-policy, and documentation suites — **410 passed**. Coverage includes the actual Cosmos SDK commit/lost-response/retry behavior and classic cleanup of staged Key Vault references.
- Final bundle freshness, documentation/version alignment, upload-only OpenAPI guards, and diff hygiene passed. Browser screenshots/traces remain local and are excluded from the commit.

## Documentation

<!-- Feature docs: docs/explanation/features/. Fix docs: docs/explanation/fixes/. -->

- [x] Release notes updated
- [x] Feature documentation and V2 workspace guides updated
- [x] Fix behavior documented with the feature; existing OpenAPI upload/content-only policy preserved

## Security checklist

<!-- These are common SimpleChat review requirements. -->

- [x] Modified Flask routes retain `@swagger_route(security=get_auth_security())`; no new URL-import routes added
- [x] Settings sent to non-admin frontends use `sanitize_settings_for_user()` and narrowed editor projections
- [x] Browser JavaScript is served from local SimpleChat static assets only; no CDN-hosted JS
- [x] No real secrets, keys, connection strings, or local-only artifacts are included

No deployment changes or data migration are required. OpenAPI specifications remain upload/content-based; direct URL import is not reintroduced.