### PR TITLE
Hydrate orchestration run history so plans survive a reload or a device change

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -97,7 +97,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.261.095"
+VERSION = "0.261.096"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/route_backend_orchestration.py
+++ b/application/single_app/route_backend_orchestration.py
@@ -130,6 +130,13 @@ def _text(value, limit=None):
     return value[:limit].rstrip() if limit and len(value) > limit else value
 
 
+def _coerce_int(value, default=0):
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
 def _sse(generator):
     return Response(generator, mimetype='text/event-stream', headers=dict(SSE_HEADERS))
 
@@ -538,6 +545,58 @@ def _touch_conversation(conversation_id, user_id, title=None):
     return item
 
 
+def _run_summary_row(record):
+    """Project a stored run down to what the drawer's map view actually reads.
+
+    An allowlist rather than a blocklist, and deliberately so. The stored run holds the whole
+    plan -- every step, with its inputs and its document lists -- alongside the ``seeds`` that
+    constrained it, and the map view needs none of it: ``plan_summary`` already carries the
+    intent, the step count and the capabilities. Returning the record as stored would put
+    twenty-five full plans on the wire to draw twenty-five one-line rows, and would ship the
+    request's internal seeding to the browser as a side effect of a listing. Anything a future
+    field adds to the record therefore stays server-side until it is named here.
+    """
+    record = record if isinstance(record, dict) else {}
+    approval = record.get('approval') if isinstance(record.get('approval'), dict) else {}
+    return {
+        'run_id': record.get('run_id') or record.get('id'),
+        'conversation_id': record.get('conversation_id'),
+        'turn_id': record.get('turn_id'),
+        'turn_index': _coerce_int(record.get('turn_index')),
+        'status': record.get('status'),
+        'created_at': record.get('created_at'),
+        'started_at': record.get('started_at'),
+        'completed_at': record.get('completed_at'),
+        'error': _text(record.get('error'), 400) or None,
+        'user_message': _text(record.get('user_message'), 400),
+        'user_message_id': record.get('user_message_id'),
+        'assistant_message_id': record.get('assistant_message_id'),
+        'plan_summary': record.get('plan_summary') or {},
+        'capabilities_used': list(record.get('capabilities_used') or ()),
+        'artifact_count': len(record.get('artifacts') or ()),
+        'revision': _coerce_int(record.get('revision')),
+        # Only the two approval fields the card reads. `approved_by` is a user id and has no
+        # business being echoed back to a browser that already knows whose runs these are.
+        'approval': {
+            'mode': approval.get('mode'),
+            'state': approval.get('state'),
+        },
+    }
+
+
+def _run_detail_row(record):
+    """One run in full, for opening a stored plan rather than listing it.
+
+    The summary plus the plan itself, which is the only heavy field the client ever wants and
+    only ever for one run at a time. Built on the same allowlist so that the listing and the
+    detail cannot drift into disagreeing about what a run looks like.
+    """
+    record = record if isinstance(record, dict) else {}
+    row = _run_summary_row(record)
+    row['plan'] = record.get('plan') or {}
+    return row
+
+
 def register_route_backend_orchestration(bp):
 
     @bp.route("/api/v2/orchestration/plan", methods=["POST"])
@@ -697,8 +756,14 @@ def register_route_backend_orchestration(bp):
                     return
 
                 # The question is recorded once a plan exists for it, so a conversation
-                # never shows a user message whose work was never planned.
-                user_message_id = _save_message(resolved_conversation_id, 'user', message)
+                # never shows a user message whose work was never planned. The turn id goes
+                # on it because that is what ties a reloaded thread back to its run: the
+                # live card stamps the same field on its optimistic bubble, and without it
+                # here a message fetched from the server has nothing to match against.
+                user_message_id = _save_message(
+                    resolved_conversation_id, 'user', message,
+                    metadata={'orchestration_turn_id': turn_id},
+                )
 
                 plan['revision'] = revision
                 try:
@@ -1047,7 +1112,13 @@ def register_route_backend_orchestration(bp):
     @login_required
     @user_required
     def orchestration_runs():
-        """Every run in a conversation, oldest first, for the drawer's map view."""
+        """Every run in a conversation, oldest first, for the drawer's map view.
+
+        Lean by default: a row is projected through ``_run_summary_row``, because the map
+        draws one line per run and the stored record carries the whole plan. ``include_plan``
+        restores the full records for a caller that genuinely wants them, so this stays a
+        projection rather than a removal.
+        """
         user_id = get_current_user_id()
         if not user_id:
             return jsonify({'error': 'User not authenticated'}), 401
@@ -1061,13 +1132,51 @@ def register_route_backend_orchestration(bp):
         except (TypeError, ValueError):
             limit = 25
 
+        include_plan = _text(request.args.get('include_plan')).lower() in ('1', 'true', 'yes')
+
         try:
             runs = list_conversation_runs(conversation_id, user_id, limit=limit)
         except Exception as exc:
             log_event(f"[ORCHESTRATION] Could not list runs: {exc}", level=logging.ERROR)
             return jsonify({'error': 'The run history could not be loaded.'}), 500
 
+        if not include_plan:
+            runs = [_run_summary_row(run) for run in runs]
+
         return jsonify({'runs': runs}), 200
+
+    @bp.route("/api/v2/orchestration/runs/<run_id>", methods=["GET"])
+    @swagger_route(security=get_auth_security())
+    @login_required
+    @user_required
+    def orchestration_run_detail(run_id):
+        """One stored run in full, so an earlier turn's plan can be reopened.
+
+        This is what makes the map view's rows more than labels: the listing is deliberately
+        too lean to render a plan, and the plan is fetched here for the one run the user
+        actually opened. Ownership is enforced inside ``get_orchestration_run``, which
+        compares ``user_id`` on both the point read and the cross-partition fallback, so a
+        guessed run id belonging to somebody else is indistinguishable from a missing one.
+        """
+        user_id = get_current_user_id()
+        if not user_id:
+            return jsonify({'error': 'User not authenticated'}), 401
+
+        conversation_id = _text(request.args.get('conversation_id'))
+
+        try:
+            record = get_orchestration_run(
+                run_id, user_id, conversation_id=conversation_id or None
+            )
+        except Exception as exc:
+            log_event(f"[ORCHESTRATION] Could not read run {run_id}: {exc}",
+                      level=logging.ERROR)
+            return jsonify({'error': 'The run could not be loaded.'}), 500
+
+        if not record:
+            return jsonify({'error': 'Run not found.'}), 404
+
+        return jsonify({'run': _run_detail_row(record)}), 200
 
     @bp.route("/api/v2/orchestration/runs/<run_id>/steps", methods=["GET"])
     @swagger_route(security=get_auth_security())

--- a/application/v2_ui/src/App.tsx
+++ b/application/v2_ui/src/App.tsx
@@ -11,6 +11,7 @@ import { useBootstrapStore } from './stores/bootstrapStore';
 import { useUserSettingsStore } from './stores/userSettingsStore';
 import { initializeTheme, hydrateUiPreferences } from './stores/uiStore';
 import { startImageApprovalTracking } from './lib/imageProposalResume';
+import { restorePersistedRuns } from './stores/orchestrationStore';
 import { ChatPage } from './pages/ChatPage';
 import { HomePage } from './pages/HomePage';
 import { AdminSettingsPage } from './pages/AdminSettingsPage';
@@ -86,6 +87,11 @@ export function App() {
         // rather than in the chat page: a reload can land anywhere, and the approval still
         // has to be picked back up and reported.
         startImageApprovalTracking();
+        // Same reasoning for orchestration runs, which have been written to session storage
+        // since the feature shipped but were never read back, so a reload silently forgot a
+        // run that was still going. The restored record has no stream behind it; the run
+        // history fetched when the panel opens is what settles it.
+        restorePersistedRuns();
     }, [load, loadUserSettings]);
 
     /**

--- a/application/v2_ui/src/components/chat/OrchestrationMapView.tsx
+++ b/application/v2_ui/src/components/chat/OrchestrationMapView.tsx
@@ -7,45 +7,61 @@
 // closer look. Selecting a row is the deliberate, non-silent way to move the Run view onto an older
 // run: it pins the Run view and scrolls the thread to the question that started it, so browsing the
 // past is always something the user did, never something that happened to them.
+//
+// The rows come from two places. A run this page watched is in the store already. Every other run
+// the conversation ever produced is fetched from the server here, once per conversation, which is
+// what makes the map survive a reload, a second tab, or a different device -- runs have always been
+// persisted and the planner has always read them back, but until this fetch existed nothing drew
+// them, so a conversation opened anywhere else showed an empty panel for work that plainly happened.
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { clsx } from 'clsx';
-import { ChevronRight, Loader2 } from 'lucide-react';
+import { AlertCircle, ChevronRight, Loader2 } from 'lucide-react';
 import {
     selectHistory,
+    selectHydrationStatus,
     useOrchestrationStore,
+    type RunDisplayStatus,
     type RunHistoryEntry,
-    type RunOutcome,
     type TrackedRun,
 } from '../../stores/orchestrationStore';
 import { orderStepsForDisplay } from '../../lib/orchestrationPlan';
-import type { OrchestrationPlan } from '../../lib/orchestration';
+import { fetchConversationRuns, fetchRunSteps } from '../../lib/orchestration';
+import type { OrchestrationPlan, PersistedRunStep } from '../../lib/orchestration';
 
 /** Mirror of the store's private scope key; the NUL separator must match `orchestrationStore`. */
 function scopeKey(conversationId: string, turnId: string): string {
     return `${conversationId}\u0000${turnId}`;
 }
 
+/** How many runs the map asks the server for. Matches the store's per-conversation history cap. */
+const RUN_FETCH_LIMIT = 25;
+
 interface MapRow {
     runId: string;
     turnId: string;
     intentSummary: string;
-    status: 'running' | RunOutcome;
+    status: 'running' | RunDisplayStatus;
     live: boolean;
+    /** Step count when the row has no plan in memory to count from. */
+    stepCount: number;
+    artifactCount: number;
 }
 
-const statusDot: Record<'running' | RunOutcome, string> = {
+const statusDot: Record<'running' | RunDisplayStatus, string> = {
     running: 'bg-accent',
     completed: 'bg-ok',
     failed: 'bg-danger',
     cancelled: 'bg-text-3',
+    interrupted: 'bg-warn',
 };
 
-const statusLabel: Record<'running' | RunOutcome, string> = {
+const statusLabel: Record<'running' | RunDisplayStatus, string> = {
     running: 'Running',
     completed: 'Done',
     failed: 'Failed',
     cancelled: 'Stopped',
+    interrupted: 'Interrupted',
 };
 
 export function OrchestrationMapView({
@@ -60,7 +76,68 @@ export function OrchestrationMapView({
     const history = useOrchestrationStore((state) => selectHistory(state, conversationId));
     const inFlightMap = useOrchestrationStore((state) => state.inFlight);
     const plansMap = useOrchestrationStore((state) => state.plans);
+    const hydrationStatus = useOrchestrationStore((state) =>
+        selectHydrationStatus(state, conversationId),
+    );
+    const hydrateConversationRuns = useOrchestrationStore(
+        (state) => state.hydrateConversationRuns,
+    );
+    const setHydrationStatus = useOrchestrationStore((state) => state.setHydrationStatus);
+
     const [expanded, setExpanded] = useState<Set<string>>(new Set());
+    /** Steps fetched for rows whose plan is not in memory, by run id. */
+    const [fetchedSteps, setFetchedSteps] = useState<Record<string, PersistedRunStep[]>>({});
+    const [loadingSteps, setLoadingSteps] = useState<Set<string>>(new Set());
+    /** Bumped by Retry so a failed hydration can be attempted again. */
+    const [retryToken, setRetryToken] = useState(0);
+
+    // Steps are fetched per row and the rows outlive the fetch, so the results are written
+    // through a ref-guarded setState rather than assumed to land on a mounted component.
+    const mountedRef = useRef(true);
+    useEffect(() => {
+        mountedRef.current = true;
+        return () => {
+            mountedRef.current = false;
+        };
+    }, []);
+
+    // Hydrate once per conversation. The status lives in the store rather than in this component
+    // because the panel unmounts every time the drawer closes, and re-fetching the same runs each
+    // time the user glanced at the panel would be a request per glance.
+    //
+    // The status is read through `getState` instead of being a dependency on purpose: the effect
+    // writes that same status, so depending on it would re-run the effect mid-flight. The fetch is
+    // deliberately not aborted on cleanup either -- the result lands in a global store, so a panel
+    // that closed before the response arrived still leaves the history cached for the next open.
+    useEffect(() => {
+        if (!conversationId) {
+            return;
+        }
+        const status = useOrchestrationStore.getState().hydration[conversationId] ?? 'idle';
+        if (status === 'loading' || status === 'loaded') {
+            return;
+        }
+        setHydrationStatus(conversationId, 'loading');
+
+        fetchConversationRuns(conversationId, { limit: RUN_FETCH_LIMIT })
+            .then((runs) => {
+                hydrateConversationRuns(conversationId, runs);
+            })
+            .catch(() => {
+                // A conversation with no stored runs is not an error, but a failed fetch is:
+                // the panel says so rather than silently claiming there is no history.
+                setHydrationStatus(conversationId, 'error');
+            });
+    }, [conversationId, retryToken, hydrateConversationRuns, setHydrationStatus]);
+
+    // Reset the per-row step cache when the conversation changes; run ids do not collide, but the
+    // expansion state would otherwise carry across conversations.
+    useEffect(() => {
+        setExpanded(new Set());
+        setFetchedSteps({});
+        setLoadingSteps(new Set());
+        setRetryToken(0);
+    }, [conversationId]);
 
     const rows = useMemo<MapRow[]>(() => {
         const seen = new Set<string>();
@@ -76,6 +153,8 @@ export function OrchestrationMapView({
                     intentSummary: plan?.intent.summary || 'Planning…',
                     status: 'running' as const,
                     live: true,
+                    stepCount: plan?.steps.length ?? 0,
+                    artifactCount: plan?.outputs?.length ?? 0,
                 };
             });
         const settled: MapRow[] = (history as RunHistoryEntry[])
@@ -86,19 +165,14 @@ export function OrchestrationMapView({
                 intentSummary: entry.intentSummary || 'Untitled run',
                 status: entry.status,
                 live: false,
+                stepCount: entry.stepCount ?? 0,
+                artifactCount: entry.artifactCount ?? 0,
             }));
         return [...live, ...settled];
     }, [inFlightMap, history, plansMap, conversationId]);
 
-    if (rows.length === 0) {
-        return (
-            <p className="p-4 text-sm text-text-3">
-                Runs for this conversation will be listed here as they happen.
-            </p>
-        );
-    }
-
-    const toggleExpanded = (runId: string) => {
+    const toggleExpanded = (runId: string, hasPlan: boolean) => {
+        const willExpand = !expanded.has(runId);
         setExpanded((previous) => {
             const next = new Set(previous);
             if (next.has(runId)) {
@@ -108,7 +182,68 @@ export function OrchestrationMapView({
             }
             return next;
         });
+
+        // Only a row with no plan in memory needs a fetch, and only the first time it opens. A
+        // live run's steps are already streaming into the store.
+        if (!willExpand || hasPlan || fetchedSteps[runId] || loadingSteps.has(runId)) {
+            return;
+        }
+
+        setLoadingSteps((previous) => new Set(previous).add(runId));
+        fetchRunSteps(runId, { conversationId })
+            .then((steps) => {
+                if (mountedRef.current) {
+                    setFetchedSteps((previous) => ({ ...previous, [runId]: steps }));
+                }
+            })
+            .catch(() => {
+                if (mountedRef.current) {
+                    setFetchedSteps((previous) => ({ ...previous, [runId]: [] }));
+                }
+            })
+            .finally(() => {
+                if (mountedRef.current) {
+                    setLoadingSteps((previous) => {
+                        const next = new Set(previous);
+                        next.delete(runId);
+                        return next;
+                    });
+                }
+            });
     };
+
+    if (rows.length === 0) {
+        if (hydrationStatus === 'loading') {
+            return (
+                <p className="flex items-center gap-2 p-4 text-sm text-text-3">
+                    <Loader2 size={14} className="animate-spin" />
+                    Loading this conversation&rsquo;s runs&hellip;
+                </p>
+            );
+        }
+        if (hydrationStatus === 'error') {
+            return (
+                <div className="p-4 text-sm text-text-3">
+                    <p className="flex items-center gap-2 text-danger">
+                        <AlertCircle size={14} />
+                        The run history could not be loaded.
+                    </p>
+                    <button
+                        type="button"
+                        onClick={() => setRetryToken((token) => token + 1)}
+                        className="mt-2 rounded-lg border border-edge px-2 py-1 text-xs text-text-2 transition-colors hover:bg-surface-2 hover:text-text-1"
+                    >
+                        Try again
+                    </button>
+                </div>
+            );
+        }
+        return (
+            <p className="p-4 text-sm text-text-3">
+                Runs for this conversation will be listed here as they happen.
+            </p>
+        );
+    }
 
     return (
         <ol className="space-y-1.5 p-3">
@@ -117,8 +252,18 @@ export function OrchestrationMapView({
                 const isShown = row.turnId === shownTurnId;
                 const plan: OrchestrationPlan | undefined =
                     plansMap[scopeKey(conversationId, row.turnId)];
-                const steps = plan ? orderStepsForDisplay(plan.steps) : [];
-                const artifactCount = plan?.outputs?.length ?? 0;
+                const planSteps = plan ? orderStepsForDisplay(plan.steps) : [];
+                // A plan in memory is authoritative; otherwise the stored step records stand in,
+                // which is what lets a row from another device expand to real titles.
+                const stepTitles: string[] = plan
+                    ? planSteps.map((step) => step.title)
+                    : (fetchedSteps[row.runId] ?? [])
+                          .slice()
+                          .sort((a, b) => (a.step_index ?? 0) - (b.step_index ?? 0))
+                          .map((step, index) => step.title || `Step ${index + 1}`);
+                const stepCount = plan ? planSteps.length : row.stepCount || stepTitles.length;
+                const artifactCount = plan ? (plan.outputs?.length ?? 0) : row.artifactCount;
+                const stepsLoading = loadingSteps.has(row.runId);
 
                 return (
                     <li
@@ -131,7 +276,7 @@ export function OrchestrationMapView({
                         <div className="flex items-center gap-1 p-2">
                             <button
                                 type="button"
-                                onClick={() => toggleExpanded(row.runId)}
+                                onClick={() => toggleExpanded(row.runId, Boolean(plan))}
                                 aria-expanded={isExpanded}
                                 aria-label={isExpanded ? 'Collapse steps' : 'Expand steps'}
                                 className="shrink-0 rounded-md p-1 text-text-3 hover:bg-surface-3 hover:text-text-1"
@@ -168,7 +313,9 @@ export function OrchestrationMapView({
 
                         <div className="flex items-center gap-2 px-3 pb-2 pl-9 text-[11px] text-text-3">
                             <span>
-                                {plan ? `${steps.length} ${steps.length === 1 ? 'step' : 'steps'}` : '—'}
+                                {stepCount > 0
+                                    ? `${stepCount} ${stepCount === 1 ? 'step' : 'steps'}`
+                                    : '—'}
                             </span>
                             <span aria-hidden="true">·</span>
                             <span>{statusLabel[row.status]}</span>
@@ -182,22 +329,33 @@ export function OrchestrationMapView({
                             ) : null}
                         </div>
 
-                        {isExpanded && steps.length > 0 ? (
-                            <ol className="space-y-0.5 px-3 pb-2 pl-9">
-                                {steps.map((step, index) => (
-                                    <li
-                                        key={step.step_id}
-                                        className="flex items-baseline gap-1.5 text-xs text-text-2"
-                                    >
-                                        <span className="shrink-0 font-mono text-text-3">
-                                            {index + 1}
-                                        </span>
-                                        <span className="min-w-0 truncate" title={step.title}>
-                                            {step.title}
-                                        </span>
-                                    </li>
-                                ))}
-                            </ol>
+                        {isExpanded ? (
+                            stepsLoading ? (
+                                <p className="flex items-center gap-1.5 px-3 pb-2 pl-9 text-xs text-text-3">
+                                    <Loader2 size={12} className="animate-spin" />
+                                    Loading steps&hellip;
+                                </p>
+                            ) : stepTitles.length > 0 ? (
+                                <ol className="space-y-0.5 px-3 pb-2 pl-9">
+                                    {stepTitles.map((title, index) => (
+                                        <li
+                                            key={`${row.runId}:${index}`}
+                                            className="flex items-baseline gap-1.5 text-xs text-text-2"
+                                        >
+                                            <span className="shrink-0 font-mono text-text-3">
+                                                {index + 1}
+                                            </span>
+                                            <span className="min-w-0 truncate" title={title}>
+                                                {title}
+                                            </span>
+                                        </li>
+                                    ))}
+                                </ol>
+                            ) : (
+                                <p className="px-3 pb-2 pl-9 text-xs text-text-3">
+                                    No steps were recorded for this run.
+                                </p>
+                            )
                         ) : null}
                     </li>
                 );

--- a/application/v2_ui/src/components/chat/OrchestrationPlanPanel.tsx
+++ b/application/v2_ui/src/components/chat/OrchestrationPlanPanel.tsx
@@ -12,13 +12,14 @@
 
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { clsx } from 'clsx';
-import { ArrowDownToLine, ListTree, Map as MapIcon, Undo2 } from 'lucide-react';
+import { AlertCircle, ArrowDownToLine, ListTree, Loader2, Map as MapIcon, Undo2 } from 'lucide-react';
 import { useChatStore } from '../../stores/chatStore';
 import {
     selectActiveTurn,
     useOrchestrationStore,
     type TrackedRun,
 } from '../../stores/orchestrationStore';
+import { fetchOrchestrationRun, fetchRunSteps } from '../../lib/orchestration';
 import { OrchestrationRunView } from './OrchestrationRunView';
 import { OrchestrationMapView } from './OrchestrationMapView';
 
@@ -29,16 +30,35 @@ interface PinnedRun {
     runId: string;
 }
 
-/** Scroll a turn's question into view and flash it, matching the contents-drawer jump behaviour. */
-function scrollToTurn(turnId: string, messages: ReturnType<typeof useChatStore.getState>['messages']) {
-    // The turn id is stamped on the optimistic user bubble at submit and kept across the id
-    // reconciliation, so a run always has a question to scroll back to even after it completes.
-    const message = messages.find(
-        (entry) =>
-            entry.role === 'user' &&
-            (entry.metadata as { orchestration_turn_id?: string } | undefined)
-                ?.orchestration_turn_id === turnId,
-    );
+/** Mirror of the store's private scope key; the NUL separator must match `orchestrationStore`. */
+function scopeKey(conversationId: string, turnId: string): string {
+    return `${conversationId}\u0000${turnId}`;
+}
+
+/**
+ * Scroll a turn's question into view and flash it, matching the contents-drawer jump behaviour.
+ *
+ * Two ways to find the question, because there are two kinds of run. A run this page started
+ * stamped its turn id on the user bubble at submit and kept it across the id reconciliation. A run
+ * restored from the server has no such stamp on messages written before that stamping existed, so
+ * the stored record's own `user_message_id` is used as a fallback -- which is also the only handle
+ * available for a run that happened on another device entirely.
+ */
+function scrollToTurn(
+    turnId: string,
+    userMessageId: string | null,
+    messages: ReturnType<typeof useChatStore.getState>['messages'],
+) {
+    const message =
+        messages.find(
+            (entry) =>
+                entry.role === 'user' &&
+                (entry.metadata as { orchestration_turn_id?: string } | undefined)
+                    ?.orchestration_turn_id === turnId,
+        ) ??
+        (userMessageId
+            ? messages.find((entry) => entry.role === 'user' && entry.id === userMessageId)
+            : undefined);
     if (!message) {
         return;
     }
@@ -64,6 +84,9 @@ export function OrchestrationPlanPanel() {
 
     const [view, setView] = useState<PanelView>('run');
     const [pinned, setPinned] = useState<PinnedRun | null>(null);
+    /** The archived run currently being fetched, so the Run view can say so instead of sitting empty. */
+    const [loadingRunId, setLoadingRunId] = useState<string | null>(null);
+    const [loadError, setLoadError] = useState<string | null>(null);
     const headingRef = useRef<HTMLHeadingElement | null>(null);
 
     // Move focus into the panel when it opens, so a keyboard user is not left back on the toggle
@@ -91,16 +114,62 @@ export function OrchestrationPlanPanel() {
 
     const clearPin = () => {
         setPinned(null);
+        setLoadError(null);
         pinRun(null);
+    };
+
+    /**
+     * Fetch an archived run's plan and step outcomes, then adopt them for display.
+     *
+     * Only reached for a run this page never watched, so there is nothing in memory to draw. The
+     * plan is adopted read-only: it is a record of what happened, and offering to narrow the steps
+     * of a run that already finished would be offering something that cannot be done.
+     */
+    const loadArchivedRun = (turnId: string, runId: string) => {
+        setLoadingRunId(runId);
+        setLoadError(null);
+        Promise.all([
+            fetchOrchestrationRun(runId, { conversationId: activeConversationId }),
+            fetchRunSteps(runId, { conversationId: activeConversationId }),
+        ])
+            .then(([run, steps]) => {
+                if (!run?.plan) {
+                    setLoadError('This run did not keep a plan.');
+                    return;
+                }
+                useOrchestrationStore
+                    .getState()
+                    .adoptPersistedPlan(activeConversationId, turnId, run.plan, steps, {
+                        readOnly: true,
+                    });
+            })
+            .catch(() => {
+                setLoadError('This run could not be loaded.');
+            })
+            .finally(() => {
+                setLoadingRunId((current) => (current === runId ? null : current));
+            });
     };
 
     const selectRun = (turnId: string, runId: string, live: boolean) => {
         setPinned({ turnId, runId });
+        setLoadError(null);
         // Only a live run can be pinned in the store, whose pin resolves against in-flight records;
         // a settled run is browsed through this component's own pin instead.
         pinRun(live ? runId : null);
         setView('run');
-        scrollToTurn(turnId, messages);
+
+        const store = useOrchestrationStore.getState();
+        const entry = (store.hydratedHistory[activeConversationId] ?? []).find(
+            (candidate) => candidate.runId === runId,
+        );
+        scrollToTurn(turnId, entry?.userMessageId ?? null, messages);
+
+        // A live run is streaming its plan in; anything already in memory is authoritative.
+        if (live || store.plans[scopeKey(activeConversationId, turnId)]) {
+            return;
+        }
+        loadArchivedRun(turnId, runId);
     };
 
     const showJumpBar = Boolean(pinned && liveRun && liveRun.turnId !== shownTurnId);
@@ -178,7 +247,17 @@ export function OrchestrationPlanPanel() {
 
             <div className="min-h-0 flex-1 overflow-y-auto">
                 {view === 'run' ? (
-                    shownTurnId ? (
+                    loadingRunId && loadingRunId === pinned?.runId ? (
+                        <p className="flex items-center gap-2 p-4 text-sm text-text-3">
+                            <Loader2 size={14} className="animate-spin" />
+                            Loading this run&hellip;
+                        </p>
+                    ) : loadError ? (
+                        <p className="flex items-center gap-2 p-4 text-sm text-danger">
+                            <AlertCircle size={14} />
+                            {loadError}
+                        </p>
+                    ) : shownTurnId ? (
                         <OrchestrationRunView
                             conversationId={activeConversationId}
                             turnId={shownTurnId}

--- a/application/v2_ui/src/components/chat/OrchestrationRunView.tsx
+++ b/application/v2_ui/src/components/chat/OrchestrationRunView.tsx
@@ -15,10 +15,11 @@
 
 import { useMemo } from 'react';
 import { clsx } from 'clsx';
-import { FileText, Lock, RotateCcw, X } from 'lucide-react';
+import { Archive, FileText, Lock, RotateCcw, X } from 'lucide-react';
 import { Toggle } from '../ui/primitives';
 import {
     selectEdits,
+    selectIsReadOnly,
     selectPlan,
     selectStepRuntime,
     useOrchestrationStore,
@@ -111,6 +112,9 @@ export function OrchestrationRunView({
     const enableStep = useOrchestrationStore((state) => state.enableStep);
     const removeDocument = useOrchestrationStore((state) => state.removeDocument);
     const restoreDocument = useOrchestrationStore((state) => state.restoreDocument);
+    const readOnly = useOrchestrationStore((state) =>
+        selectIsReadOnly(state, conversationId, turnId),
+    );
 
     const orderedSteps = useMemo(
         () => (plan ? orderStepsForDisplay(plan.steps) : []),
@@ -218,7 +222,10 @@ export function OrchestrationRunView({
         );
     }
 
-    const editable = planRequiresApproval(plan);
+    // A stored plan is a record of what happened, not a proposal. Its status is adopted verbatim,
+    // so one written down while it still awaited approval would otherwise offer to narrow steps
+    // that were settled long ago, on a device that is not the one being asked.
+    const editable = planRequiresApproval(plan) && !readOnly;
     const disabledStepIds = new Set(edits.disabled_step_ids);
 
     const renderStep = (step: OrchestrationStep, displayNumber: number) => {
@@ -424,6 +431,12 @@ export function OrchestrationRunView({
 
     return (
         <div className="space-y-3 p-3">
+            {readOnly ? (
+                <p className="flex items-center gap-1.5 rounded-lg border border-edge bg-surface-2 px-2 py-1.5 text-[11px] text-text-3">
+                    <Archive size={12} className="shrink-0" />
+                    A record of a run from this conversation. It cannot be changed or re-run.
+                </p>
+            ) : null}
             <div>
                 <p className="text-sm font-medium text-text-1">{plan.intent.summary}</p>
                 {plan.assumptions.length > 0 ? (

--- a/application/v2_ui/src/lib/orchestration.ts
+++ b/application/v2_ui/src/lib/orchestration.ts
@@ -21,7 +21,7 @@
 // through `/api/chat/stream/reattach`, and orchestration has no such endpoint, so a dropped
 // stream here is reported rather than recovered.
 
-import { apiUrl, CREDENTIALS_MODE } from './apiClient';
+import { api, apiUrl, CREDENTIALS_MODE } from './apiClient';
 import { readSsePost } from './sse';
 import type { ChatStreamEvent, Json } from './types';
 
@@ -424,6 +424,14 @@ export interface RunStreamHandlers {
     onDone?: (event: RunStreamEvent, accumulated: string) => void;
     /** The run was cancelled, either by the user or server-side. */
     onCancelled?: (event: RunStreamEvent, accumulated: string) => void;
+    /**
+     * The server refused because this plan has already been run (HTTP 409).
+     *
+     * Not a failure, and it must not be shown as one. It means another device -- or an earlier
+     * tab -- already approved this plan and the answer exists; the right response is to drop the
+     * card and reload the thread, not to tell the user their run broke.
+     */
+    onAlreadyRun?: (message: string) => void;
     /** An error frame arrived, or the transport failed. */
     onError?: (message: string, event?: RunStreamEvent) => void;
 }
@@ -433,24 +441,149 @@ export interface RunStreamResult {
     completed: boolean;
     cancelled: boolean;
     errored: boolean;
+    /** The plan was already run elsewhere. Distinct from `errored`; see `onAlreadyRun`. */
+    alreadyRun: boolean;
 }
 
 export const ORCHESTRATION_PLAN_PATH = '/api/v2/orchestration/plan';
 export const ORCHESTRATION_RUN_PATH = '/api/v2/orchestration/run';
+export const ORCHESTRATION_RUNS_PATH = '/api/v2/orchestration/runs';
+
+/* -------------------------------------------------------------------------- */
+/* Stored runs                                                                 */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * One stored run as the listing returns it: a row, not a plan.
+ *
+ * Mirrors `_run_summary_row` in `route_backend_orchestration.py`, which is an allowlist. The
+ * listing deliberately omits `plan` -- twenty-five rows would otherwise carry twenty-five full
+ * plans -- so anything that needs the steps themselves fetches the run through
+ * `fetchOrchestrationRun`.
+ */
+export interface PersistedRunSummary {
+    run_id: string;
+    conversation_id: string;
+    /** The turn this run answered. Present on every run the plan route created. */
+    turn_id: string | null;
+    turn_index: number;
+    status: PlanStatus | null;
+    created_at: string | null;
+    started_at: string | null;
+    completed_at: string | null;
+    error: string | null;
+    user_message: string;
+    /** The stored question's message id, which is how a reloaded thread finds the turn. */
+    user_message_id: string | null;
+    assistant_message_id: string | null;
+    plan_summary: {
+        run_id?: string;
+        plan_id?: string;
+        turn_id?: string;
+        intent_summary?: string;
+        step_count?: number;
+        capabilities_used?: string[];
+        status?: PlanStatus;
+    };
+    capabilities_used: string[];
+    artifact_count: number;
+    revision: number;
+    approval: { mode: ApprovalMode | null; state: ApprovalState | null };
+}
+
+/** A stored run with its plan, from the detail route. Mirrors `_run_detail_row`. */
+export interface PersistedRun extends PersistedRunSummary {
+    plan: Json;
+}
+
+/**
+ * One stored step, as `list_run_steps` returns it.
+ *
+ * Loose about everything but the fields the map view reads, because a step record is written by
+ * the executor and carries result payloads this client has no use for.
+ */
+export interface PersistedRunStep {
+    step_id: string;
+    step_index: number;
+    capability_id?: string;
+    title?: string;
+    status?: StepStatus;
+    summary?: string;
+    [key: string]: unknown;
+}
+
+/**
+ * A conversation's stored runs, oldest first.
+ *
+ * This is the read half that was missing: runs have always been persisted, and the planner has
+ * always read them back, but nothing drew them. Without this a conversation opened on a second
+ * device shows an empty Plan drawer for work that definitely happened.
+ */
+export async function fetchConversationRuns(
+    conversationId: string,
+    options: { limit?: number; signal?: AbortSignal } = {},
+): Promise<PersistedRunSummary[]> {
+    const params = new URLSearchParams({ conversation_id: conversationId });
+    if (options.limit) {
+        params.set('limit', String(options.limit));
+    }
+    const payload = await api.get<{ runs?: PersistedRunSummary[] }>(
+        `${ORCHESTRATION_RUNS_PATH}?${params.toString()}`,
+        options.signal,
+    );
+    return Array.isArray(payload?.runs) ? payload.runs : [];
+}
+
+/** One stored run in full, including its plan. */
+export async function fetchOrchestrationRun(
+    runId: string,
+    options: { conversationId?: string; signal?: AbortSignal } = {},
+): Promise<PersistedRun | null> {
+    const params = new URLSearchParams();
+    if (options.conversationId) {
+        params.set('conversation_id', options.conversationId);
+    }
+    const query = params.toString();
+    const payload = await api.get<{ run?: PersistedRun }>(
+        `${ORCHESTRATION_RUNS_PATH}/${encodeURIComponent(runId)}${query ? `?${query}` : ''}`,
+        options.signal,
+    );
+    return payload?.run ?? null;
+}
+
+/** One stored run's steps, in execution order. */
+export async function fetchRunSteps(
+    runId: string,
+    options: { conversationId?: string; signal?: AbortSignal } = {},
+): Promise<PersistedRunStep[]> {
+    const params = new URLSearchParams();
+    if (options.conversationId) {
+        params.set('conversation_id', options.conversationId);
+    }
+    const query = params.toString();
+    const payload = await api.get<{ steps?: PersistedRunStep[] }>(
+        `${ORCHESTRATION_RUNS_PATH}/${encodeURIComponent(runId)}/steps${query ? `?${query}` : ''}`,
+        options.signal,
+    );
+    return Array.isArray(payload?.steps) ? payload.steps : [];
+}
 
 /**
  * Open a POST SSE stream and hand back the response, or report why it could not open.
  *
  * A failure before the stream opens comes back as an ordinary JSON error, not an SSE frame, so
- * it is read here rather than in the framing loop. An abort before the response arrives is
- * returned as a plain null with no error reported, so the caller can record it as a cancellation
- * rather than a failure -- pressing Stop before the first byte is not an error.
+ * it is read here rather than in the framing loop. The HTTP status is reported alongside the
+ * message because one of them is not a failure at all: a 409 from the run endpoint means the
+ * plan was already run, which the caller reconciles rather than displays. An abort before the
+ * response arrives is returned as a plain null with no error reported, so the caller can record
+ * it as a cancellation rather than a failure -- pressing Stop before the first byte is not an
+ * error.
  */
 async function openOrchestrationStream(
     path: string,
     body: unknown,
     signal: AbortSignal | undefined,
-    onError: (message: string) => void,
+    onError: (message: string, status?: number) => void,
 ): Promise<Response | null> {
     let response: Response;
     try {
@@ -482,7 +615,7 @@ async function openOrchestrationStream(
         } catch {
             /* Non-JSON error body; keep the status-based message. */
         }
-        onError(message);
+        onError(message, response.status);
         return null;
     }
 
@@ -610,13 +743,22 @@ export async function runOrchestration(
         completed: false,
         cancelled: false,
         errored: false,
+        alreadyRun: false,
     };
 
     const response = await openOrchestrationStream(
         ORCHESTRATION_RUN_PATH,
         body,
         signal,
-        (message) => {
+        (message, status) => {
+            // 409 is the server's re-run guard, which is the whole reason approving a restored
+            // plan from a second device is safe. Reported as its own outcome so the caller can
+            // reconcile with the answer that already exists.
+            if (status === 409) {
+                result.alreadyRun = true;
+                handlers.onAlreadyRun?.(message);
+                return;
+            }
             result.errored = true;
             handlers.onError?.(message);
         },

--- a/application/v2_ui/src/lib/orchestrationController.ts
+++ b/application/v2_ui/src/lib/orchestrationController.ts
@@ -510,6 +510,23 @@ export async function approveAndRunPlan(params: {
                     .settleOrchestrationTurn(conversationId, { status: 'failed', error: message });
                 useOrchestrationStore.getState().endRun(runId, 'failed');
             },
+            // The plan was already run somewhere else.
+            //
+            // Only reachable now that a pending approval can be picked up on a second device: two
+            // tabs can hold the same card, and the server refuses the second approval rather than
+            // doing the work twice. That is not a failure of this turn, so the thread is settled
+            // quietly and the conversation re-read -- the answer the other device produced is
+            // already stored, and fetching it is how this device catches up.
+            onAlreadyRun: () => {
+                settled = true;
+                useChatStore.getState().settleOrchestrationTurn(conversationId, {
+                    status: 'cancelled',
+                    accumulated: '',
+                });
+                useOrchestrationStore.getState().endRun(runId, 'completed');
+                useOrchestrationStore.getState().clearActiveTurn(conversationId);
+                void useChatStore.getState().reloadMessages();
+            },
         },
         controller.signal,
     );

--- a/application/v2_ui/src/lib/orchestrationResume.ts
+++ b/application/v2_ui/src/lib/orchestrationResume.ts
@@ -1,0 +1,199 @@
+// orchestrationResume.ts
+// Reading a conversation's stored runs back into the page when it opens.
+//
+// Two things happen here, and they share a fetch because they need the same answer.
+//
+// The first is history: every run a conversation has produced is loaded so the plan drawer has
+// something to show. Runs have always been written to Cosmos and the planner has always read them
+// back, but nothing in the browser ever asked for them, so a conversation opened after a reload --
+// or in a second tab, or on a different machine -- showed an empty panel for work that plainly
+// happened. Hydrating on open rather than when the drawer opens means the panel is populated the
+// moment it is unfolded, and the drawer's own fetch becomes a fallback for conversations reached
+// some other way.
+//
+// The second is the unfinished business. A plan that was proposed and never answered is stored as
+// `awaiting_approval`, and until now the only device that could act on it was the one that closed
+// the tab. Restoring the card lets the approval be picked up wherever the user actually is. The
+// server is what makes that safe: the run endpoint reads the plan from the stored record rather
+// than the request, and refuses a run whose plan has already run, so the worst case of two devices
+// holding the same card is that the slower one is told so and re-reads the conversation.
+
+import { useChatStore } from '../stores/chatStore';
+import {
+    isResumablePlanStatus,
+    selectActiveTurn,
+    useOrchestrationStore,
+} from '../stores/orchestrationStore';
+import { fetchConversationRuns, fetchOrchestrationRun, fetchRunSteps } from './orchestration';
+import type { Json } from './orchestration';
+
+/** How many runs to ask for. Matches the store's per-conversation history cap. */
+const RUN_FETCH_LIMIT = 25;
+
+/**
+ * Conversations already considered, so opening one twice does not re-fetch or re-offer.
+ *
+ * Deliberately not cleared when a conversation closes: within one page life, a conversation's
+ * stored runs are read once. Anything that happens afterwards happened in this tab, and the store
+ * already knows about it.
+ */
+const consideredConversations = new Set<string>();
+
+/** Forget what has been considered. Exists for tests and for a signed-out reset. */
+export function resetOrchestrationResume(): void {
+    consideredConversations.clear();
+}
+
+/**
+ * Load a conversation's stored runs, and restore an unanswered plan if there is one.
+ *
+ * Safe to call on every render pass for a conversation: the work is done once, and a conversation
+ * whose runs are already loaded skips straight to the resume check.
+ */
+export async function resumeOrchestrationForConversation(
+    conversationId: string,
+): Promise<void> {
+    if (!conversationId || consideredConversations.has(conversationId)) {
+        return;
+    }
+    consideredConversations.add(conversationId);
+
+    const store = useOrchestrationStore.getState();
+    const status = store.hydration[conversationId] ?? 'idle';
+    if (status === 'idle' || status === 'error') {
+        store.setHydrationStatus(conversationId, 'loading');
+        try {
+            const runs = await fetchConversationRuns(conversationId, { limit: RUN_FETCH_LIMIT });
+            useOrchestrationStore.getState().hydrateConversationRuns(conversationId, runs);
+        } catch {
+            useOrchestrationStore.getState().setHydrationStatus(conversationId, 'error');
+            // The drawer offers a retry; a conversation whose history could not be read has no
+            // pending approval to restore either, because the record that would say so is what
+            // failed to arrive.
+            consideredConversations.delete(conversationId);
+            return;
+        }
+    } else if (status === 'loading') {
+        // The drawer got there first. It will finish the hydration; the resume check is dropped
+        // rather than racing it, and the conversation is left unconsidered so a later pass retries.
+        consideredConversations.delete(conversationId);
+        return;
+    }
+
+    await restorePendingApproval(conversationId);
+}
+
+/**
+ * Put an unanswered plan's card back, if the conversation's newest run is genuinely unanswered.
+ *
+ * Three things have to hold, and each rules out a way of resurrecting something misleading:
+ * the run must be the newest one, so an old abandoned proposal cannot jump in front of later work;
+ * this page must not already have a card up, so a live turn is never displaced; and no assistant
+ * message may follow the run's question, because one means the turn was answered -- by the other
+ * device, or by a plain chat reply after the proposal was dismissed.
+ */
+async function restorePendingApproval(conversationId: string): Promise<void> {
+    const store = useOrchestrationStore.getState();
+    if (selectActiveTurn(store, conversationId)) {
+        return;
+    }
+
+    const newest = (store.hydratedHistory[conversationId] ?? [])[0];
+    if (!newest || !isResumablePlanStatus(newest.planStatus)) {
+        return;
+    }
+    if (!newest.userMessageId) {
+        // Nothing to anchor the card to in the thread. A plan whose question cannot be found is
+        // left alone rather than floated at the bottom of an unrelated conversation.
+        return;
+    }
+    if (conversationHasReplyAfter(conversationId, newest.userMessageId)) {
+        return;
+    }
+
+    let plan: Json | null = null;
+    let steps: Awaited<ReturnType<typeof fetchRunSteps>> = [];
+    try {
+        const [record, stepRecords] = await Promise.all([
+            fetchOrchestrationRun(newest.runId, { conversationId }),
+            fetchRunSteps(newest.runId, { conversationId }),
+        ]);
+        plan = record?.plan ?? null;
+        steps = stepRecords;
+    } catch {
+        return;
+    }
+    if (!plan) {
+        return;
+    }
+
+    // Everything is re-checked after the await: the fetch is not instant, and the user may have
+    // asked something new in the meantime, which would have put a card of its own up.
+    const current = useOrchestrationStore.getState();
+    if (selectActiveTurn(current, conversationId)) {
+        return;
+    }
+    if (useChatStore.getState().activeConversationId !== conversationId) {
+        return;
+    }
+
+    current.adoptPersistedPlan(
+        conversationId,
+        newest.turnId,
+        neutralizeTimedApproval(plan),
+        steps,
+        { readOnly: false },
+    );
+    useOrchestrationStore.getState().setActiveTurn(conversationId, newest.turnId);
+}
+
+/**
+ * Whether an assistant reply follows a message in the loaded thread.
+ *
+ * A run's own question is the anchor. Anything the assistant said after it means the turn reached
+ * an answer, whatever produced it.
+ */
+function conversationHasReplyAfter(conversationId: string, userMessageId: string): boolean {
+    const chat = useChatStore.getState();
+    if (chat.activeConversationId !== conversationId) {
+        // The thread on screen is a different conversation, so it cannot be used to judge this
+        // one. Treated as answered, which errs towards showing nothing.
+        return true;
+    }
+    const index = chat.messages.findIndex((message) => message.id === userMessageId);
+    if (index < 0) {
+        // The question is not in the loaded thread. Same reasoning: no anchor, no card.
+        return true;
+    }
+    return chat.messages
+        .slice(index + 1)
+        .some((message) => message.role === 'assistant');
+}
+
+/**
+ * Turn a restored timed approval into a manual one.
+ *
+ * A timed plan's contract is "this runs unless you stop it in the next N seconds", and that
+ * bargain was offered to whoever was watching at the time. Restoring it verbatim would restart the
+ * clock on a device that was not there, and run real work -- searches, documents, model calls --
+ * because someone opened a laptop. The plan is restored as an ordinary approval instead: the same
+ * steps, the same everything else, but it waits to be asked for.
+ */
+function neutralizeTimedApproval(plan: Json): Json {
+    if (!plan || typeof plan !== 'object' || Array.isArray(plan)) {
+        return plan;
+    }
+    const record = plan as Record<string, unknown>;
+    const approval = record.approval;
+    if (!approval || typeof approval !== 'object' || Array.isArray(approval)) {
+        return plan;
+    }
+    const approvalRecord = approval as Record<string, unknown>;
+    if (approvalRecord.mode !== 'timed') {
+        return plan;
+    }
+    return {
+        ...record,
+        approval: { ...approvalRecord, mode: 'manual', timeout_seconds: 0 },
+    } as Json;
+}

--- a/application/v2_ui/src/pages/ChatPage.tsx
+++ b/application/v2_ui/src/pages/ChatPage.tsx
@@ -24,6 +24,7 @@ import {
     useOrchestrationStore,
 } from '../stores/orchestrationStore';
 import { enabledSteps, isPlanAwaitingApproval } from '../lib/orchestrationPlan';
+import { resumeOrchestrationForConversation } from '../lib/orchestrationResume';
 import { readConversationParam, syncedConversationParams } from '../lib/conversationUrl';
 import { MessageList } from '../components/chat/MessageList';
 import { Composer } from '../components/chat/Composer';
@@ -326,6 +327,8 @@ function ChatHeader({ onOpenDetails }: { onOpenDetails: () => void }) {
 export function ChatPage() {
     const [detailsOpen, setDetailsOpen] = useState(false);
     const activeConversationId = useChatStore((state) => state.activeConversationId);
+    const messages = useChatStore((state) => state.messages);
+    const messagesLoading = useChatStore((state) => state.messagesLoading);
     const setVisibleConversation = useImageProposalStore(
         (state) => state.setVisibleConversation,
     );
@@ -351,6 +354,19 @@ export function ChatPage() {
         setOrchestrationVisible(activeConversationId);
         return () => setOrchestrationVisible(null);
     }, [activeConversationId, setOrchestrationVisible]);
+
+    // Read the conversation's stored runs once it is genuinely on screen.
+    //
+    // Waits for the thread because both things this does need it: the plan drawer's history is
+    // only worth having next to the messages it describes, and deciding whether an unanswered plan
+    // is still unanswered means looking at what follows its question. Runs itself once per
+    // conversation, so the dependency on `messages` costs nothing after the first pass.
+    useEffect(() => {
+        if (!activeConversationId || messagesLoading) {
+            return;
+        }
+        void resumeOrchestrationForConversation(activeConversationId);
+    }, [activeConversationId, messagesLoading, messages]);
 
     return (
         <div className="flex min-h-0 flex-1">

--- a/application/v2_ui/src/stores/orchestrationStore.ts
+++ b/application/v2_ui/src/stores/orchestrationStore.ts
@@ -35,7 +35,10 @@ import type {
     Elicitation,
     OrchestrationPlan,
     OrchestrationStep,
+    PersistedRunStep,
+    PersistedRunSummary,
     PlanEdits,
+    PlanStatus,
     RunStreamEvent,
     StepStatus,
 } from '../lib/orchestration';
@@ -81,6 +84,21 @@ export type StepRuntimeMap = Record<string, StepRuntime>;
 export type RunOutcome = 'completed' | 'failed' | 'cancelled';
 
 /**
+ * How a run is shown in the map.
+ *
+ * `interrupted` is the state only stored runs can be in: a run whose record never reached a
+ * terminal status because the browser that started it went away. It is not `running`, because
+ * this page has no stream for it and must not claim to be watching it.
+ */
+export type RunDisplayStatus = RunOutcome | 'interrupted';
+
+/** Where a history entry came from, which decides what the drawer may offer for it. */
+export type RunOrigin = 'local' | 'server';
+
+/** Progress of a conversation's one-time hydration from the server. */
+export type HydrationStatus = 'idle' | 'loading' | 'loaded' | 'error';
+
+/**
  * A run that has started and not yet settled.
  *
  * This is the persisted half -- enough to recognise the run after a reload, and nothing that
@@ -98,18 +116,111 @@ export interface TrackedRun {
     resumed: boolean;
 }
 
-/** A settled run kept for the conversation's history. */
+/**
+ * A settled run kept for the conversation's history.
+ *
+ * Produced two ways, and the difference matters. A `local` entry is written by `endRun` when
+ * this page watched the run finish. A `server` entry is hydrated from the stored record, which
+ * is the only way a conversation opened on another device has any history at all -- and which
+ * carries the extra identifiers (`userMessageId`, `planStatus`) that a locally-observed run
+ * never needed because it still had its plan in memory.
+ */
 export interface RunHistoryEntry {
     runId: string;
     planId: string;
     turnId: string;
-    status: RunOutcome;
+    status: RunDisplayStatus;
     finishedAt: number;
     intentSummary: string;
+    origin: RunOrigin;
+    /** The stored question's message id, for scrolling a reloaded thread back to the turn. */
+    userMessageId?: string | null;
+    /** The persisted plan status, which decides whether an approval can still be resumed. */
+    planStatus?: PlanStatus | null;
+    stepCount?: number;
+    artifactCount?: number;
 }
 
 /** History is bounded per conversation; a long session should not grow one without limit. */
 const MAX_HISTORY_PER_CONVERSATION = 25;
+
+/** Plan statuses whose run never reached a terminal state; see `RunDisplayStatus`. */
+const NON_TERMINAL_PLAN_STATUSES: ReadonlySet<string> = new Set([
+    'draft',
+    'awaiting_approval',
+    'approved',
+    'running',
+]);
+
+/**
+ * Plan statuses whose approval can still be picked up on another device.
+ *
+ * Deliberately narrower than "not finished". An `approved` or `running` record has already been
+ * handed to the run endpoint, which answers a second attempt with 409, so offering its card
+ * would be offering a button that cannot work. Only a plan that was never approved is resumable.
+ */
+const RESUMABLE_PLAN_STATUSES: ReadonlySet<string> = new Set(['draft', 'awaiting_approval']);
+
+/** Whether a stored run is a plan the user could still approve. */
+export function isResumablePlanStatus(status: PlanStatus | null | undefined): boolean {
+    return typeof status === 'string' && RESUMABLE_PLAN_STATUSES.has(status);
+}
+
+/** Epoch milliseconds for an ISO timestamp, or 0 when it is missing or unparseable. */
+function epochMs(value: string | null | undefined): number {
+    if (!value) {
+        return 0;
+    }
+    const parsed = Date.parse(value);
+    return Number.isNaN(parsed) ? 0 : parsed;
+}
+
+/**
+ * Turn a stored run into a history entry.
+ *
+ * The mapping the map view is built on, and the one place the server's plan vocabulary is
+ * reduced to the four states a row can draw. `superseded` folds into `cancelled` because that is
+ * what it means to the reader -- the run was abandoned for another -- and every non-terminal
+ * status folds into `interrupted` rather than `running`, since a stored record is by definition
+ * not something this page is streaming.
+ */
+export function historyEntryFromPersistedRun(run: PersistedRunSummary): RunHistoryEntry | null {
+    const runId = run?.run_id;
+    const turnId = run?.turn_id || run?.plan_summary?.turn_id || '';
+    if (!runId || !turnId) {
+        // A run with no turn cannot be selected, scrolled to, or keyed in the plan map. Older
+        // records predating `turn_id` are skipped rather than shown as unreachable rows.
+        return null;
+    }
+
+    const planStatus = (run.status ?? run.plan_summary?.status ?? null) as PlanStatus | null;
+    let status: RunDisplayStatus;
+    if (planStatus === 'completed') {
+        status = 'completed';
+    } else if (planStatus === 'failed') {
+        status = 'failed';
+    } else if (planStatus === 'cancelled' || planStatus === 'superseded') {
+        status = 'cancelled';
+    } else if (planStatus && NON_TERMINAL_PLAN_STATUSES.has(planStatus)) {
+        status = 'interrupted';
+    } else {
+        status = 'interrupted';
+    }
+
+    return {
+        runId,
+        planId: run.plan_summary?.plan_id ?? '',
+        turnId,
+        status,
+        finishedAt: epochMs(run.completed_at) || epochMs(run.started_at) || epochMs(run.created_at),
+        intentSummary: run.plan_summary?.intent_summary || run.user_message || '',
+        origin: 'server',
+        userMessageId: run.user_message_id ?? null,
+        planStatus,
+        stepCount: run.plan_summary?.step_count ?? 0,
+        artifactCount: run.artifact_count ?? 0,
+    };
+}
 
 const EMPTY_EDITS: PlanEdits = { disabled_step_ids: [], removed_document_ids: {} };
 const EMPTY_STEP_RUNTIME: StepRuntimeMap = {};
@@ -127,8 +238,28 @@ interface OrchestrationState {
     stepRuntime: Record<string, StepRuntimeMap>;
     /** Runs still in flight, by run id. Persisted. */
     inFlight: Record<string, TrackedRun>;
-    /** Settled runs per conversation, newest first. */
+    /** Settled runs per conversation, newest first, as observed by this page. */
     history: Record<string, RunHistoryEntry[]>;
+    /**
+     * Settled runs per conversation, hydrated from the server's stored records.
+     *
+     * Kept apart from `history` rather than merged into it because the two have different
+     * authority: a locally-observed run is something this page watched happen, a hydrated one is
+     * a report. Re-hydrating must never overwrite the former, and separating them makes that
+     * structural instead of a rule someone has to remember.
+     */
+    hydratedHistory: Record<string, RunHistoryEntry[]>;
+    /** Per-conversation hydration progress, so the fetch happens once and can report itself. */
+    hydration: Record<string, HydrationStatus>;
+    /**
+     * Turns whose plan came from a stored record and must not be edited, keyed by `scopeKey`.
+     *
+     * A hydrated plan describes work that already ran, or that ran somewhere else. Narrowing it
+     * would silently diverge the card from the run it claims to show, so the controls are hidden
+     * -- and the flag lives here rather than as a component prop because the run view is reached
+     * from two places and both must agree.
+     */
+    readOnlyTurns: Record<string, true>;
     /** The run the drawer is pinned to, or null meaning "the current one". */
     pinnedRunId: string | null;
     /**
@@ -203,6 +334,25 @@ interface OrchestrationState {
     /** Adopt run records restored from storage after a reload. */
     restoreRuns: (records: TrackedRun[]) => void;
 
+    /** Record where a conversation's one-time hydration has got to. */
+    setHydrationStatus: (conversationId: string, status: HydrationStatus) => void;
+    /** Adopt a conversation's stored runs as history, without displacing observed ones. */
+    hydrateConversationRuns: (conversationId: string, runs: PersistedRunSummary[]) => void;
+    /**
+     * Adopt a stored plan for a turn, with its steps' real outcomes.
+     *
+     * Not `setPlan`: that seeds every step from the plan's own status, which for a stored plan is
+     * whatever it was when the plan was written, so a finished run would redraw as pending. The
+     * step records are the truth about what happened and are used instead.
+     */
+    adoptPersistedPlan: (
+        conversationId: string,
+        turnId: string,
+        plan: unknown,
+        steps: PersistedRunStep[],
+        options?: { readOnly?: boolean },
+    ) => void;
+
     /** Pin the drawer to a run, or pass null to follow the current one. */
     pinRun: (runId: string | null) => void;
 
@@ -235,6 +385,9 @@ export const useOrchestrationStore = create<OrchestrationState>((set, get) => ({
     stepRuntime: {},
     inFlight: {},
     history: {},
+    hydratedHistory: {},
+    hydration: {},
+    readOnlyTurns: {},
     pinnedRunId: null,
     visibleConversationId: null,
     activeTurns: {},
@@ -466,6 +619,7 @@ export const useOrchestrationStore = create<OrchestrationState>((set, get) => ({
                 status: outcome,
                 finishedAt: Date.now(),
                 intentSummary: summary,
+                origin: 'local',
             };
             const existing = state.history[run.conversationId] ?? [];
             const nextEntries = [entry, ...existing].slice(0, MAX_HISTORY_PER_CONVERSATION);
@@ -498,6 +652,124 @@ export const useOrchestrationStore = create<OrchestrationState>((set, get) => ({
             }
             saveRuns(Object.values(inFlight));
             return { inFlight };
+        });
+    },
+
+    setHydrationStatus: (conversationId, status) => {
+        if (!conversationId || get().hydration[conversationId] === status) {
+            return;
+        }
+        set((state) => ({ hydration: { ...state.hydration, [conversationId]: status } }));
+    },
+
+    hydrateConversationRuns: (conversationId, runs) => {
+        if (!conversationId) {
+            return;
+        }
+        set((state) => {
+            const entries: RunHistoryEntry[] = [];
+            const seen = new Set<string>();
+            const persistedStatus = new Map<string, PlanStatus | null>();
+            for (const run of runs ?? []) {
+                const entry = historyEntryFromPersistedRun(run);
+                if (!entry || seen.has(entry.runId)) {
+                    continue;
+                }
+                seen.add(entry.runId);
+                persistedStatus.set(entry.runId, entry.planStatus ?? null);
+                entries.push(entry);
+            }
+            entries.sort((a, b) => b.finishedAt - a.finishedAt);
+
+            // Settle anything this page adopted from storage but never watched.
+            //
+            // A record read back from `sessionStorage` has no stream behind it, so without this it
+            // would draw a spinner for as long as the tab stayed open -- including for a run that
+            // finished, failed, or was never approved in the first place. The stored record is the
+            // authority on that, and this is the first moment it is known.
+            let inFlight = state.inFlight;
+            let changed = false;
+            for (const run of Object.values(state.inFlight)) {
+                if (run.conversationId !== conversationId || !run.resumed) {
+                    continue;
+                }
+                if (!persistedStatus.has(run.runId)) {
+                    continue;
+                }
+                const status = persistedStatus.get(run.runId);
+                if (status && NON_TERMINAL_PLAN_STATUSES.has(status)) {
+                    continue;
+                }
+                if (!changed) {
+                    inFlight = { ...state.inFlight };
+                    changed = true;
+                }
+                delete inFlight[run.runId];
+            }
+            if (changed) {
+                saveRuns(Object.values(inFlight));
+            }
+
+            return {
+                inFlight,
+                hydratedHistory: {
+                    ...state.hydratedHistory,
+                    [conversationId]: entries.slice(0, MAX_HISTORY_PER_CONVERSATION),
+                },
+                hydration: { ...state.hydration, [conversationId]: 'loaded' },
+            };
+        });
+    },
+
+    adoptPersistedPlan: (conversationId, turnId, rawPlan, steps, options) => {
+        if (!conversationId || !turnId) {
+            return;
+        }
+        const plan = normalizePlan(rawPlan);
+        if (!plan) {
+            return;
+        }
+
+        const key = scopeKey(conversationId, turnId);
+        const readOnly = options?.readOnly ?? true;
+
+        set((state) => {
+            // Seeded from the plan first so a step with no record still draws, then overwritten
+            // by whatever the executor actually persisted for it.
+            const runtime: StepRuntimeMap = {};
+            for (const step of plan.steps) {
+                runtime[step.step_id] = { status: step.status, summary: '' };
+            }
+            for (const record of steps ?? []) {
+                const stepId = record?.step_id;
+                if (!stepId) {
+                    continue;
+                }
+                const status = coerceStepStatus(record.status) ?? runtime[stepId]?.status ?? 'pending';
+                runtime[stepId] = {
+                    status,
+                    summary: typeof record.summary === 'string' ? record.summary : '',
+                };
+            }
+
+            const elicitations = { ...state.elicitations };
+            delete elicitations[key];
+
+            const readOnlyTurns = { ...state.readOnlyTurns };
+            if (readOnly) {
+                readOnlyTurns[key] = true;
+            } else {
+                delete readOnlyTurns[key];
+            }
+
+            return {
+                plans: { ...state.plans, [key]: plan },
+                elicitations,
+                // A stored plan arrives unnarrowed; the edits are this device's to make.
+                edits: { ...state.edits, [key]: state.edits[key] ?? emptyPlanEdits() },
+                stepRuntime: { ...state.stepRuntime, [key]: runtime },
+                readOnlyTurns,
+            };
         });
     },
 
@@ -553,6 +825,7 @@ export const useOrchestrationStore = create<OrchestrationState>((set, get) => ({
             const elicitations: Record<string, Elicitation> = {};
             const edits: Record<string, PlanEdits> = {};
             const stepRuntime: Record<string, StepRuntimeMap> = {};
+            const readOnlyTurns: Record<string, true> = {};
 
             const keep = (map: Record<string, unknown>, into: Record<string, unknown>) => {
                 for (const [key, value] of Object.entries(map)) {
@@ -568,6 +841,7 @@ export const useOrchestrationStore = create<OrchestrationState>((set, get) => ({
             keep(state.elicitations, elicitations as Record<string, unknown>);
             keep(state.edits, edits as Record<string, unknown>);
             keep(state.stepRuntime, stepRuntime as Record<string, unknown>);
+            keep(state.readOnlyTurns, readOnlyTurns as Record<string, unknown>);
 
             // `activeTurns` is keyed by conversation, not `scopeKey`, so it is pruned on the plain
             // id. Dropping it in step with the plan it points at stops MessageList holding a turn
@@ -581,8 +855,36 @@ export const useOrchestrationStore = create<OrchestrationState>((set, get) => ({
                 }
             }
 
+            // Hydration is dropped alongside the plans it fed, so returning to a swept
+            // conversation re-fetches rather than showing rows whose plans have gone.
+            const hydratedHistory: Record<string, RunHistoryEntry[]> = {};
+            const hydration: Record<string, HydrationStatus> = {};
+            for (const [conversationId, entries] of Object.entries(state.hydratedHistory)) {
+                if (busy.has(conversationId)) {
+                    hydratedHistory[conversationId] = entries;
+                } else {
+                    removed = true;
+                }
+            }
+            for (const [conversationId, status] of Object.entries(state.hydration)) {
+                if (busy.has(conversationId)) {
+                    hydration[conversationId] = status;
+                } else {
+                    removed = true;
+                }
+            }
+
             return removed
-                ? { plans, elicitations, edits, stepRuntime, activeTurns }
+                ? {
+                      plans,
+                      elicitations,
+                      edits,
+                      stepRuntime,
+                      readOnlyTurns,
+                      activeTurns,
+                      hydratedHistory,
+                      hydration,
+                  }
                 : {};
         });
     },
@@ -699,7 +1001,32 @@ export function selectInFlightCount(
     return count;
 }
 
-/** A conversation's run history, newest first. Stable empty array when there is none. */
+/**
+ * Memo for the history merge, keyed by conversation and by the identity of both inputs.
+ *
+ * `selectHistory` is used directly as a zustand selector, which compares results with `Object.is`.
+ * A merge that allocated a fresh array on every call would therefore report a change on every
+ * store update, re-rendering the map view continuously and tripping React's "getSnapshot should
+ * be cached" guard. Caching on the two input array references makes the result stable for as long
+ * as neither side has actually changed, which is exactly the condition under which it may be.
+ */
+const historyMergeCache = new Map<
+    string,
+    {
+        local: readonly RunHistoryEntry[] | undefined;
+        hydrated: readonly RunHistoryEntry[] | undefined;
+        merged: readonly RunHistoryEntry[];
+    }
+>();
+
+/**
+ * A conversation's run history, newest first, from both sources.
+ *
+ * Locally-observed runs win over their stored copies: this page watched them settle, and the
+ * stored record may not have caught up -- a run that completed seconds ago can still read
+ * `running` in Cosmos if the final write lost the race with the fetch. Stable empty array when
+ * there is neither.
+ */
 export function selectHistory(
     state: OrchestrationState,
     conversationId: string,
@@ -707,7 +1034,53 @@ export function selectHistory(
     if (!conversationId) {
         return EMPTY_HISTORY;
     }
-    return state.history[conversationId] ?? EMPTY_HISTORY;
+    const local = state.history[conversationId];
+    const hydrated = state.hydratedHistory[conversationId];
+
+    if (!hydrated || hydrated.length === 0) {
+        return local ?? EMPTY_HISTORY;
+    }
+    if (!local || local.length === 0) {
+        return hydrated;
+    }
+
+    const cached = historyMergeCache.get(conversationId);
+    if (cached && cached.local === local && cached.hydrated === hydrated) {
+        return cached.merged;
+    }
+
+    const seen = new Set(local.map((entry) => entry.runId));
+    const merged = [...local];
+    for (const entry of hydrated) {
+        if (!seen.has(entry.runId)) {
+            merged.push(entry);
+        }
+    }
+    merged.sort((a, b) => b.finishedAt - a.finishedAt);
+    const result = merged.slice(0, MAX_HISTORY_PER_CONVERSATION);
+
+    historyMergeCache.set(conversationId, { local, hydrated, merged: result });
+    return result;
+}
+
+/** How far a conversation's hydration has got. */
+export function selectHydrationStatus(
+    state: OrchestrationState,
+    conversationId: string,
+): HydrationStatus {
+    return (conversationId && state.hydration[conversationId]) || 'idle';
+}
+
+/** Whether a turn's plan came from a stored record and so cannot be narrowed. */
+export function selectIsReadOnly(
+    state: OrchestrationState,
+    conversationId: string,
+    turnId: string,
+): boolean {
+    if (!conversationId || !turnId) {
+        return false;
+    }
+    return state.readOnlyTurns[scopeKey(conversationId, turnId)] === true;
 }
 
 /**

--- a/docs/admin/orchestration.md
+++ b/docs/admin/orchestration.md
@@ -176,6 +176,30 @@ model, which means orchestration works as soon as it is switched on.
 | Planner model endpoint id | Identifies the endpoint when planning through a configured model endpoint rather than the default deployment. | Empty | `chat_orchestration_planner_model_endpoint_id` |
 | Planner model provider | Identifies the provider when planning through a configured model endpoint. | Empty | `chat_orchestration_planner_model_provider` |
 
+## Run history and switching devices
+
+Every plan, every step and every result is stored against the conversation, not against
+the browser that produced it. There is nothing to configure here, but it changes what
+users can expect, so it is worth knowing when you answer questions about it.
+
+Opening a conversation on a second device rebuilds the orchestration panel from what the
+server holds. A user who plans on a laptop and then opens the same conversation on a
+phone sees the same list of runs, can expand any of them, and can read the steps and
+results of a run they were not present for. Runs opened this way are shown as a record:
+they can be read but not edited or run again, because they have already happened.
+
+A plan that was still waiting for approval when the user moved is the one case that stays
+actionable. It reappears as a plan the user can approve, edit or discard, so a plan is
+never stranded on a device the user has walked away from. Two things are deliberately
+adjusted when this happens. A plan that had a countdown is restored without one, so
+nothing starts running on a device where nobody was watching. And if the plan was in fact
+approved elsewhere in the meantime, approving it again is refused rather than run twice,
+and the conversation reloads to show the answer that already exists.
+
+A run that was interrupted — the browser closed, the device slept, the network dropped
+mid-run — is shown as interrupted rather than silently disappearing or appearing to still
+be working.
+
 ## Common tasks
 
 1. **Introduce orchestration to a pilot group.** Enable Chat Orchestration, leave the
@@ -202,6 +226,9 @@ model, which means orchestration works as soon as it is switched on.
 | Plans never propose deep research or reading a link | The user does not hold the required app role, or the capability is disabled in its own settings group. | Confirm the user holds `DeepResearchUser` or `UrlAccessUser` where your deployment requires them, and that the capability is enabled outside this page. |
 | Plans never propose an agent | Semantic Kernel is off, the user has turned agents off in their own settings, or the user has no agent they can reach. | Confirm Semantic Kernel is enabled, then check the user's own agent setting and that at least one agent is shared with them. |
 | A plan proposed reading a link but found nothing | The link was produced by the model rather than pasted by the user. | Only links present in the user's own message are read. Ask the user to paste the URL into their message. |
+| Earlier runs are missing after switching devices | The conversation list has loaded but its run history has not been fetched yet, or the fetch failed. | The orchestration panel shows its own loading and retry states. If retrying keeps failing, check that the user can reach `/api/v2/orchestration/runs` and is the owner of the conversation. |
+| A restored plan will not run | It was already approved on the other device. | This is expected. The conversation reloads to show the answer that run produced. |
+| A run is shown as interrupted | The browser or device that started it went away before the run finished. | Ask the user to send the question again. An interrupted run is a record of what happened, not a run that can be continued. |
 
 ## Related
 

--- a/docs/explanation/fixes/ORCHESTRATION_RUN_HISTORY_HYDRATION_FIX.md
+++ b/docs/explanation/fixes/ORCHESTRATION_RUN_HISTORY_HYDRATION_FIX.md
@@ -1,0 +1,153 @@
+# Orchestration Run History Hydration Fix
+
+Fixed in version: **0.261.096**
+
+## Issue Description
+
+Orchestration plans appeared to live only in the browser that created them. A user who
+planned and ran a question on one device, then opened the same conversation on another,
+saw an empty orchestration panel with no trace of the earlier runs. Reloading the page on
+the original device had the same effect. The assistant's answer survived, because it is an
+ordinary chat message, but the plan behind it, its steps and its results did not.
+
+Two further consequences followed from the same gap:
+
+1. A plan left waiting for approval was stranded. The user had to ask the question again
+   on the new device, which produced a second plan and a second run for the same request.
+2. A run whose browser went away mid-flight left no record at all. Nothing distinguished
+   "this never happened" from "this was interrupted".
+
+## Root Cause Analysis
+
+The server was never the problem. Runs and steps were already persisted in Cosmos DB, in
+`cosmos_orchestration_runs_container` (partitioned by `/conversation_id`) and
+`cosmos_orchestration_run_steps_container` (partitioned by `/run_id`), and the planner
+already read earlier runs back to build its ledger. Two read endpoints existed and were
+correct.
+
+The V2 interface simply never called them.
+
+- No module under `application/v2_ui/src` referenced `/api/v2/orchestration/runs` or
+  `/api/v2/orchestration/runs/<run_id>/steps`. The orchestration drawer was populated
+  entirely from in-memory Zustand state, persisted only to `sessionStorage`, which is
+  per-tab and per-device by definition.
+- `restorePersistedRuns()` was exported from the orchestration store but was never
+  invoked anywhere in the application, so even same-device restoration after a reload did
+  not happen.
+- There was no route that returned a single run with its plan, so the panel had no way to
+  fetch the plan for a run it had not itself produced.
+- The user's question was saved to the conversation without its `orchestration_turn_id`,
+  so a hydrating client had no reliable way to line an inbound run up with the message
+  that caused it.
+
+## Version Implemented
+
+- **0.261.096**
+
+## Files Modified
+
+- `application/single_app/route_backend_orchestration.py`
+- `application/single_app/config.py`
+- `application/v2_ui/src/lib/orchestration.ts`
+- `application/v2_ui/src/lib/orchestrationResume.ts` (new)
+- `application/v2_ui/src/lib/orchestrationController.ts`
+- `application/v2_ui/src/stores/orchestrationStore.ts`
+- `application/v2_ui/src/components/chat/OrchestrationMapView.tsx`
+- `application/v2_ui/src/components/chat/OrchestrationPlanPanel.tsx`
+- `application/v2_ui/src/components/chat/OrchestrationRunView.tsx`
+- `application/v2_ui/src/pages/ChatPage.tsx`
+- `application/v2_ui/src/App.tsx`
+- `ui_tests/fixtures/orchestration/harness_entry.tsx`
+- `ui_tests/test_v2_orchestration_run_hydration.py` (new)
+- `ui_tests/test_v2_orchestration_pending_approval_resume.py` (new)
+- `functional_tests/test_orchestration_run_hydration_routes.py` (new)
+- `functional_tests/test_orchestration_turn_recovery_identifiers.py` (new)
+- `docs/admin/orchestration.md`
+
+## Code Changes Summary
+
+### Server
+
+- Added `GET /api/v2/orchestration/runs/<run_id>`, which returns one run together with its
+  plan. Ownership is enforced inside `get_orchestration_run`, and a run belonging to
+  another user is reported as not found rather than forbidden.
+- Introduced `_run_summary_row` and `_run_detail_row`, allowlist projections that decide
+  what leaves the server. The run list now returns summaries rather than raw records, so
+  `user_id`, `approved_by`, `seeds`, Cosmos system fields and the full artifact payloads
+  stay on the server. The full record remains available behind `?include_plan=true` for
+  callers that already relied on it.
+- Stamped the persisted user message with `metadata.orchestration_turn_id`, so a client
+  that has only the conversation can associate a stored run with the message that started
+  it. The added metadata carries no `thread_info`, so `/api/get_messages` continues to
+  include the message.
+
+### Client
+
+- Added a typed read layer — `fetchConversationRuns`, `fetchOrchestrationRun` and
+  `fetchRunSteps` — alongside the existing streaming client.
+- Added hydration to the orchestration store: `hydrateConversationRuns` merges persisted
+  run summaries into history, and `adoptPersistedPlan` installs a fetched plan and its
+  steps for display. Locally tracked runs win over hydrated ones for the same run id.
+- Reconciled stale state during hydration. A run restored from storage that the server
+  reports as finished is dropped from the in-flight set instead of spinning forever.
+- Distinguished an interrupted run from a running one in the map view, and added loading,
+  error, retry and empty states so a failed fetch is visible rather than silent.
+- Made a run opened from history read-only. The run view shows a banner explaining that it
+  is a record, and approval controls are suppressed.
+- Restored a plan that was still awaiting approval as an approvable card, guarded so it
+  only applies to the newest run, only when nothing is already active locally, and only
+  when no assistant message already follows the question.
+- Neutralised a restored timed approval to manual, so a countdown started on one device
+  cannot run work unattended on another.
+- Handled the existing HTTP 409 re-run guard on the client. If the plan was approved
+  elsewhere first, the local turn settles and the conversation reloads to show the answer
+  that already exists, rather than surfacing an error.
+- Called `restorePersistedRuns()` during application bootstrap, and hydrated each
+  conversation once when it is opened.
+
+## Testing Approach
+
+- `ui_tests/test_v2_orchestration_run_hydration.py` drives the real store and components
+  in a browser against intercepted API routes, covering hydration, merge precedence, the
+  interrupted status, lazy step fetching, read-only adoption and the retry path.
+- `ui_tests/test_v2_orchestration_pending_approval_resume.py` covers the resume guards and
+  the timed-approval neutralisation.
+- `functional_tests/test_orchestration_run_hydration_routes.py` asserts the route
+  contract, decorator ordering and the projection allowlist, including the fields that
+  must not be projected.
+- `functional_tests/test_orchestration_turn_recovery_identifiers.py` asserts that the user
+  message is stamped with its turn id, that the run record keeps both identifiers, that
+  the re-run guard exists, and that the run route takes its inputs from the stored record
+  rather than the request body.
+
+## Impact Analysis
+
+- No data migration is required. Run records already carried `turn_id` and
+  `user_message_id`; the change is that clients now read them.
+- Conversations that predate the fix hydrate correctly, because their runs were persisted
+  all along. Only the user-message turn-id stamp is new, and every code path that uses it
+  falls back to `user_message_id`.
+- The run list response is smaller and no longer includes plans by default. Any caller
+  that needs the previous shape can pass `include_plan=true`.
+- Approving a restored plan is safe because the run route already refused a plan whose
+  status is running or completed, and reads the plan, seeds and question from the stored
+  record rather than from the request.
+
+## Validation
+
+- `functional_tests/test_orchestration_run_hydration_routes.py` — 6/6 passing.
+- `functional_tests/test_orchestration_turn_recovery_identifiers.py` — 6/6 passing.
+- `ui_tests/test_v2_orchestration_run_hydration.py` — 6/6 passing.
+- `ui_tests/test_v2_orchestration_pending_approval_resume.py` — 5/5 passing.
+- `functional_tests/route_tests/` route policy suites — passing.
+- `npx tsc -b --noEmit` and `npm run build` in `application/v2_ui` — clean.
+
+### Before and after
+
+| Situation | Before | After |
+| --- | --- | --- |
+| Open a conversation on a second device | Orchestration panel is empty | Earlier runs are listed, and can be expanded to their steps and results |
+| Reload the page mid-conversation | Run history is lost | Run history is rebuilt from the server |
+| Plan left awaiting approval, user moves device | Plan is stranded; the question must be asked again | Plan reappears and can be approved, edited or discarded |
+| That plan was approved on the first device | Second approval would race | Second approval is refused and the existing answer is loaded |
+| Browser closed mid-run | No record | Run is listed as interrupted |

--- a/docs/explanation/fixes/index.md
+++ b/docs/explanation/fixes/index.md
@@ -41,3 +41,4 @@ category: Version History
 - [Admin Settings Pane Variable Scope Fix](ADMIN_SETTINGS_PANE_VARIABLE_SCOPE_FIX.md)
 - [Inline Media Cited-Only Gating Fix](INLINE_MEDIA_CITED_ONLY_GATING_FIX.md)
 - [Agent Actions With Workspace Evidence Fix](AGENT_ACTIONS_WITH_WORKSPACE_EVIDENCE_FIX.md)
+- [Orchestration Run History Hydration Fix](ORCHESTRATION_RUN_HISTORY_HYDRATION_FIX.md)

--- a/docs/explanation/release_notes.md
+++ b/docs/explanation/release_notes.md
@@ -2,6 +2,19 @@
 
 For feature-focused and fix-focused drill-downs by version, see [Features by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/features) and [Fixes by Version](https://github.com/microsoft/simplechat/tree/main/docs/explanation/fixes).
 
+### **(v0.261.096)**
+
+#### Bug Fixes
+
+*   **Orchestration Plans Are No Longer Trapped In One Browser**
+    *   Plans looked like they belonged to the device that made them. Opening the same conversation on a laptop after planning on a phone showed an empty orchestration panel, and simply reloading the page lost the run history too. The answer survived, because that is an ordinary chat message, but the plan behind it, its steps and its results appeared to be gone.
+    *   **Nothing was ever actually lost.** Every run has always been stored against the conversation on the server — the planner already reads earlier runs back to avoid repeating work. The V2 interface just never asked for them, so it could only ever show what the current tab happened to remember.
+    *   **The panel is now rebuilt from the server when you open a conversation.** Earlier runs are listed wherever you open them, and any one of them can be expanded to read the steps and results of work you were not present for. A run opened this way is shown as a record and marked as such: it can be read, but not edited or run again, because it has already happened.
+    *   **A plan still waiting for your approval follows you.** It reappears on the new device as a plan you can approve, edit or discard, rather than leaving you to ask the same question twice. A plan that had a countdown is deliberately restored without one, so nothing starts running on a device where nobody was watching. And if you approved it on the first device in the meantime, approving it again is refused rather than doing the work twice — the conversation reloads to show the answer that already exists.
+    *   **A run whose browser went away mid-flight is now shown as interrupted**, instead of vanishing or appearing to still be working.
+    *   The run listing was also tightened while this was added. It now returns only the fields the panel draws, so plan internals and request seeding are no longer sent to the browser as a side effect of listing a conversation's history.
+    *   (Ref: `route_backend_orchestration.py` run detail route and summary projection, `stores/orchestrationStore.ts` hydration, `lib/orchestrationResume.ts`, [Orchestration Run History Hydration Fix](fixes/ORCHESTRATION_RUN_HISTORY_HYDRATION_FIX.md))
+
 ### **(v0.261.095)**
 
 #### New Features

--- a/functional_tests/test_orchestration_run_hydration_routes.py
+++ b/functional_tests/test_orchestration_run_hydration_routes.py
@@ -1,0 +1,329 @@
+#!/usr/bin/env python3
+"""
+Functional test for the orchestration run hydration endpoints and their projections.
+Version: 0.261.096
+Implemented in: 0.261.096
+
+Orchestration runs have always been persisted, but nothing in the browser read them back, so a
+conversation opened after a reload or on another device showed no history for work that plainly
+happened. The read path that fixes that is two endpoints and the projections behind them:
+
+  * ``GET /api/v2/orchestration/runs`` lists a conversation's runs, lean by default. The stored
+    record holds an entire plan and the seeds that constrained it; the map view draws one line per
+    run and needs neither. Listing twenty-five runs must not put twenty-five plans on the wire.
+  * ``GET /api/v2/orchestration/runs/<run_id>`` returns one run with its plan, for the single run
+    the user actually opened.
+
+This test asserts the projections are an allowlist -- so a field added to the stored record is not
+published by accident -- that the detail projection agrees with the listing about everything except
+the plan, and that both routes are registered with the app's standard authentication decorators.
+"""
+
+import ast
+import re
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent))
+
+from test_support.versioning import assert_app_version_at_least  # noqa: E402
+
+
+IMPLEMENTED_IN = "0.261.096"
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+ROUTE_FILE = ROOT_DIR / "application" / "single_app" / "route_backend_orchestration.py"
+
+# A stored run carrying both the fields the client needs and the ones it must never be handed.
+STORED_RUN = {
+    "id": "run-1",
+    "run_id": "run-1",
+    "conversation_id": "conv-1",
+    "user_id": "user-1",
+    "turn_id": "turn-1",
+    "turn_index": "3",
+    "status": "completed",
+    "created_at": "2026-01-05T10:00:00Z",
+    "started_at": "2026-01-05T10:00:01Z",
+    "completed_at": "2026-01-05T10:02:00Z",
+    "error": None,
+    "user_message": "Reconcile the quarterly numbers",
+    "user_message_id": "msg-1",
+    "assistant_message_id": "msg-2",
+    "revision": "2",
+    "plan_summary": {
+        "run_id": "run-1",
+        "intent_summary": "Reconcile the quarterly numbers",
+        "step_count": 2,
+    },
+    "capabilities_used": ["search_documents", "respond"],
+    "artifacts": [{"id": "a1"}, {"id": "a2"}],
+    "approval": {"mode": "manual", "state": "approved", "approved_by": "user-1"},
+    # Heavy or internal, and none of it belongs in a listing.
+    "plan": {"steps": [{"step_id": "s1"}], "inputs": {"documents": [{"document_id": "d1"}]}},
+    "seeds": {"selected_document_ids": ["d1"], "internal_hint": "do not publish"},
+    "_rid": "cosmos-internal",
+    "_etag": "etag-internal",
+}
+
+
+def _load_projections():
+    """Import the two projection helpers without importing the whole Flask app.
+
+    ``route_backend_orchestration`` pulls in Cosmos clients and Azure settings at import time,
+    which a functional test has no business requiring. The helpers are pure functions of a dict,
+    so they are compiled out of the module source with only the small dependency they use.
+    """
+    source = ROUTE_FILE.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    wanted = {"_text", "_coerce_int", "_run_summary_row", "_run_detail_row"}
+    picked = [
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name in wanted
+    ]
+    missing = wanted - {node.name for node in picked}
+    if missing:
+        raise AssertionError(f"missing helpers in the route module: {sorted(missing)}")
+    namespace = {}
+    exec(compile(ast.Module(body=picked, type_ignores=[]), str(ROUTE_FILE), "exec"), namespace)
+    return namespace
+
+
+def test_version_is_at_least_the_implementing_release():
+    """The hydration endpoints shipped in IMPLEMENTED_IN, so the app must be at least it."""
+    print("Testing the app version is at least the implementing release...")
+    try:
+        assert_app_version_at_least(IMPLEMENTED_IN)
+        print(f"  ok  config.py VERSION is at least {IMPLEMENTED_IN}")
+        return True
+    except Exception as exc:  # noqa: BLE001
+        print(f"Test failed: {exc}")
+        return False
+
+
+def test_summary_projection_is_an_allowlist():
+    """The listing publishes exactly the named fields, and nothing the record happens to hold."""
+    print("Testing the run summary projection is an allowlist...")
+    try:
+        helpers = _load_projections()
+        row = helpers["_run_summary_row"](STORED_RUN)
+
+        expected_keys = {
+            "run_id",
+            "conversation_id",
+            "turn_id",
+            "turn_index",
+            "status",
+            "created_at",
+            "started_at",
+            "completed_at",
+            "error",
+            "user_message",
+            "user_message_id",
+            "assistant_message_id",
+            "plan_summary",
+            "capabilities_used",
+            "artifact_count",
+            "revision",
+            "approval",
+        }
+        assert set(row) == expected_keys, (
+            f"unexpected listing shape: extra={sorted(set(row) - expected_keys)} "
+            f"missing={sorted(expected_keys - set(row))}"
+        )
+
+        # The heavy and the internal are both absent.
+        for forbidden in ("plan", "seeds", "user_id", "_rid", "_etag", "artifacts"):
+            assert forbidden not in row, f"{forbidden!r} must not be published by the listing"
+        assert "approved_by" not in row["approval"], (
+            "the approving user id must not be echoed back"
+        )
+        assert set(row["approval"]) == {"mode", "state"}
+
+        # The values the map view actually reads survive the projection.
+        assert row["run_id"] == "run-1"
+        assert row["turn_id"] == "turn-1"
+        assert row["turn_index"] == 3, "turn_index must be coerced to an int"
+        assert row["revision"] == 2, "revision must be coerced to an int"
+        assert row["artifact_count"] == 2, "artifacts must be reduced to a count"
+        assert row["capabilities_used"] == ["search_documents", "respond"]
+        assert row["plan_summary"]["intent_summary"] == "Reconcile the quarterly numbers"
+        assert row["user_message_id"] == "msg-1", (
+            "the question's message id is what anchors a restored card to the thread"
+        )
+        print("  ok  the listing publishes only the fields it names")
+        return True
+    except Exception as exc:  # noqa: BLE001
+        print(f"Test failed: {exc}")
+        import traceback
+
+        traceback.print_exc()
+        return False
+
+
+def test_detail_projection_adds_only_the_plan():
+    """The detail row is the listing row plus the plan, so the two cannot drift apart."""
+    print("Testing the run detail projection adds only the plan...")
+    try:
+        helpers = _load_projections()
+        summary = helpers["_run_summary_row"](STORED_RUN)
+        detail = helpers["_run_detail_row"](STORED_RUN)
+
+        assert set(detail) - set(summary) == {"plan"}, (
+            f"the detail row must add only the plan, saw {sorted(set(detail) - set(summary))}"
+        )
+        for key, value in summary.items():
+            assert detail[key] == value, f"{key!r} disagrees between the listing and the detail"
+        assert detail["plan"]["steps"][0]["step_id"] == "s1", "the plan must be returned in full"
+        assert "seeds" not in detail, "the seeds stay server-side even in the detail"
+        print("  ok  the detail row is the listing row plus the plan")
+        return True
+    except Exception as exc:  # noqa: BLE001
+        print(f"Test failed: {exc}")
+        import traceback
+
+        traceback.print_exc()
+        return False
+
+
+def test_projections_tolerate_a_sparse_record():
+    """A partly written run -- one that failed early -- projects without raising."""
+    print("Testing the projections tolerate a sparse record...")
+    try:
+        helpers = _load_projections()
+        row = helpers["_run_summary_row"]({"run_id": "run-x", "status": "failed"})
+
+        assert row["run_id"] == "run-x"
+        assert row["turn_index"] == 0, "a missing turn_index must default rather than raise"
+        assert row["revision"] == 0
+        assert row["artifact_count"] == 0
+        assert row["capabilities_used"] == []
+        assert row["plan_summary"] == {}
+        assert row["approval"] == {"mode": None, "state": None}
+
+        # And a record that is not a dict at all is projected to empty rather than exploding.
+        empty = helpers["_run_summary_row"](None)
+        assert empty["run_id"] is None
+        assert helpers["_run_detail_row"](None)["plan"] == {}
+        print("  ok  a sparse or absent record projects cleanly")
+        return True
+    except Exception as exc:  # noqa: BLE001
+        print(f"Test failed: {exc}")
+        import traceback
+
+        traceback.print_exc()
+        return False
+
+
+def test_routes_are_registered_with_the_standard_decorators():
+    """Both read routes carry the swagger wrapper and the app's authentication decorators."""
+    print("Testing the hydration routes carry the standard decorators...")
+    try:
+        source = ROUTE_FILE.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+
+        found = {}
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.FunctionDef):
+                continue
+            for decorator in node.decorator_list:
+                if not isinstance(decorator, ast.Call):
+                    continue
+                func = decorator.func
+                if not (isinstance(func, ast.Attribute) and func.attr == "route"):
+                    continue
+                if not decorator.args or not isinstance(decorator.args[0], ast.Constant):
+                    continue
+                found[decorator.args[0].value] = node
+
+        for rule in (
+            "/api/v2/orchestration/runs",
+            "/api/v2/orchestration/runs/<run_id>",
+            "/api/v2/orchestration/runs/<run_id>/steps",
+        ):
+            assert rule in found, f"{rule} is not registered"
+            names = []
+            for decorator in found[rule].decorator_list:
+                if isinstance(decorator, ast.Call) and isinstance(decorator.func, ast.Name):
+                    names.append(decorator.func.id)
+                elif isinstance(decorator, ast.Name):
+                    names.append(decorator.id)
+            assert "swagger_route" in names, f"{rule} is missing @swagger_route"
+            assert "login_required" in names, f"{rule} is missing @login_required"
+            assert "user_required" in names, f"{rule} is missing @user_required"
+
+        # The detail route must not be a listing in disguise: it reads one run by id and lets
+        # the stored-run helper enforce ownership rather than filtering afterwards.
+        detail_source = ast.get_source_segment(
+            source, found["/api/v2/orchestration/runs/<run_id>"]
+        )
+        assert "get_orchestration_run(" in detail_source, (
+            "the detail route must read through get_orchestration_run, which checks ownership"
+        )
+        assert re.search(r"404", detail_source), (
+            "a run that is missing or not the caller's must be a 404"
+        )
+        print("  ok  both read routes are registered and guarded")
+        return True
+    except Exception as exc:  # noqa: BLE001
+        print(f"Test failed: {exc}")
+        import traceback
+
+        traceback.print_exc()
+        return False
+
+
+def test_listing_projects_unless_the_plan_is_asked_for():
+    """The listing route projects by default and only returns full records on request."""
+    print("Testing the listing route projects by default...")
+    try:
+        source = ROUTE_FILE.read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        listing = None
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == "orchestration_runs":
+                listing = node
+                break
+        assert listing is not None, "orchestration_runs is missing"
+
+        body = ast.get_source_segment(source, listing)
+        assert "_run_summary_row" in body, "the listing must project its rows"
+        assert "include_plan" in body, (
+            "a caller that genuinely wants full records must have a way to ask"
+        )
+        # The projection is the default: it is applied when include_plan is falsey.
+        assert re.search(r"if\s+not\s+include_plan", body), (
+            "the projection must be the default path, not the opt-in one"
+        )
+        print("  ok  the listing projects unless the plan is explicitly requested")
+        return True
+    except Exception as exc:  # noqa: BLE001
+        print(f"Test failed: {exc}")
+        import traceback
+
+        traceback.print_exc()
+        return False
+
+
+TESTS = [
+    test_version_is_at_least_the_implementing_release,
+    test_summary_projection_is_an_allowlist,
+    test_detail_projection_adds_only_the_plan,
+    test_projections_tolerate_a_sparse_record,
+    test_routes_are_registered_with_the_standard_decorators,
+    test_listing_projects_unless_the_plan_is_asked_for,
+]
+
+
+def main():
+    results = []
+    for test in TESTS:
+        print(f"\nRunning {test.__name__}...")
+        results.append(test())
+    print(f"\nResults: {sum(results)}/{len(results)} tests passed")
+    return all(results)
+
+
+if __name__ == "__main__":
+    sys.exit(0 if main() else 1)

--- a/functional_tests/test_orchestration_turn_recovery_identifiers.py
+++ b/functional_tests/test_orchestration_turn_recovery_identifiers.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+"""
+Functional test for the identifiers that let an orchestration turn be found again.
+Version: 0.261.096
+Implemented in: 0.261.096
+
+A run is only recoverable if its question can be found in the thread. The live card stamps
+``orchestration_turn_id`` on its optimistic user bubble, but the server saved the same message
+without it, so a thread fetched fresh -- after a reload, in another tab, on another device -- had
+nothing to match a run against. This adds the stamp on the server side too.
+
+The other half is the re-run guard. Now that a pending approval can be picked up on a second
+device, two browsers can hold the same card, and the endpoint has to refuse the second approval
+rather than doing the work twice. It already did; this pins that behaviour down so it is not
+removed by someone who does not know it is now load-bearing.
+
+This test asserts:
+
+  * The plan route saves the user message with its turn id in metadata.
+  * The run record keeps ``turn_id`` and ``user_message_id``, which is why existing runs need no
+    migration to become recoverable.
+  * The run route refuses a plan that is already running or completed, and says so with a 409.
+  * The run route takes the plan, seeds and question from the stored record rather than the
+    request body, which is what makes approving from a second device safe.
+"""
+
+import ast
+import re
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent))
+
+from test_support.versioning import assert_app_version_at_least  # noqa: E402
+
+
+IMPLEMENTED_IN = "0.261.096"
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+ROUTE_FILE = ROOT_DIR / "application" / "single_app" / "route_backend_orchestration.py"
+
+
+def _function_source(name):
+    """The source of one function in the route module, found wherever it is nested."""
+    source = ROUTE_FILE.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return ast.get_source_segment(source, node)
+    raise AssertionError(f"{name} is not defined in {ROUTE_FILE.name}")
+
+
+def test_version_is_at_least_the_implementing_release():
+    """The turn id stamp shipped in IMPLEMENTED_IN, so the app must be at least it."""
+    print("Testing the app version is at least the implementing release...")
+    try:
+        assert_app_version_at_least(IMPLEMENTED_IN)
+        print(f"  ok  config.py VERSION is at least {IMPLEMENTED_IN}")
+        return True
+    except Exception as exc:  # noqa: BLE001
+        print(f"Test failed: {exc}")
+        return False
+
+
+def test_user_message_is_saved_with_its_turn_id():
+    """The saved question carries orchestration_turn_id, so a fetched thread can be matched."""
+    print("Testing the user message is stamped with its turn id...")
+    try:
+        body = _function_source("orchestration_plan")
+
+        save_calls = re.findall(
+            r"_save_message\(\s*resolved_conversation_id,\s*'user'.*?\)",
+            body,
+            flags=re.DOTALL,
+        )
+        assert save_calls, "the plan route must save the user's question"
+        for call in save_calls:
+            assert "orchestration_turn_id" in call, (
+                "the question must be saved with its turn id in metadata:\n" + call
+            )
+            assert "turn_id" in call, "the stamp must carry the turn id itself, not a literal"
+        print("  ok  the question is saved with its turn id")
+        return True
+    except Exception as exc:  # noqa: BLE001
+        print(f"Test failed: {exc}")
+        import traceback
+
+        traceback.print_exc()
+        return False
+
+
+def test_save_message_accepts_metadata():
+    """The helper the plan route uses must actually persist the metadata it is handed."""
+    print("Testing _save_message persists metadata...")
+    try:
+        body = _function_source("_save_message")
+        signature = body.split("\n", 1)[0]
+        assert "metadata" in signature, (
+            f"_save_message must take metadata, saw {signature!r}"
+        )
+        # It has to reach the document, not just the signature.
+        assert re.search(r"metadata", body.split("\n", 1)[1]), (
+            "the metadata argument must be written onto the message document"
+        )
+        print("  ok  _save_message takes and stores metadata")
+        return True
+    except Exception as exc:  # noqa: BLE001
+        print(f"Test failed: {exc}")
+        import traceback
+
+        traceback.print_exc()
+        return False
+
+
+def test_run_record_keeps_the_turn_and_question_ids():
+    """The stored run keeps turn_id and user_message_id, so old runs recover without migration."""
+    print("Testing the run record keeps its turn and question ids...")
+    try:
+        body = _function_source("orchestration_plan")
+        assert "'turn_id': turn_id" in body or '"turn_id": turn_id' in body, (
+            "the run record must keep the turn id"
+        )
+        assert "user_message_id" in body, "the run record must keep the question's message id"
+        assert "update_orchestration_run" in body, (
+            "the ids are written back onto the run record once the message exists"
+        )
+        print("  ok  the run record keeps both identifiers")
+        return True
+    except Exception as exc:  # noqa: BLE001
+        print(f"Test failed: {exc}")
+        import traceback
+
+        traceback.print_exc()
+        return False
+
+
+def test_run_route_refuses_a_plan_that_already_ran():
+    """A second approval, from a second device, is refused rather than doing the work twice."""
+    print("Testing the run route refuses an already-run plan...")
+    try:
+        body = _function_source("orchestration_run")
+
+        guard = re.search(
+            r"if\s+record\.get\('status'\)\s+in\s+\(([^)]*)\)", body
+        )
+        assert guard, "the run route must guard against re-running a plan"
+        guarded = guard.group(1)
+        assert "PLAN_STATUS_RUNNING" in guarded, "a running plan must not be run again"
+        assert "PLAN_STATUS_COMPLETED" in guarded, "a completed plan must not be run again"
+
+        after = body[guard.end():guard.end() + 400]
+        assert "409" in after, (
+            "the refusal must be a 409 so the client can tell it apart from a failure"
+        )
+        print("  ok  a plan that is running or completed is refused with a 409")
+        return True
+    except Exception as exc:  # noqa: BLE001
+        print(f"Test failed: {exc}")
+        import traceback
+
+        traceback.print_exc()
+        return False
+
+
+def test_run_route_trusts_the_record_not_the_request():
+    """The plan, seeds and question come from the stored run, not from whoever posted."""
+    print("Testing the run route reads the plan from the stored record...")
+    try:
+        body = _function_source("orchestration_run")
+
+        for field in ("plan", "seeds", "user_message"):
+            assert re.search(rf"record\.get\('{field}'", body), (
+                f"{field!r} must be read from the stored record, so a second device only has "
+                "to name the run rather than reconstruct it"
+            )
+        print("  ok  the run route takes its inputs from the record")
+        return True
+    except Exception as exc:  # noqa: BLE001
+        print(f"Test failed: {exc}")
+        import traceback
+
+        traceback.print_exc()
+        return False
+
+
+TESTS = [
+    test_version_is_at_least_the_implementing_release,
+    test_user_message_is_saved_with_its_turn_id,
+    test_save_message_accepts_metadata,
+    test_run_record_keeps_the_turn_and_question_ids,
+    test_run_route_refuses_a_plan_that_already_ran,
+    test_run_route_trusts_the_record_not_the_request,
+]
+
+
+def main():
+    results = []
+    for test in TESTS:
+        print(f"\nRunning {test.__name__}...")
+        results.append(test())
+    print(f"\nResults: {sum(results)}/{len(results)} tests passed")
+    return all(results)
+
+
+if __name__ == "__main__":
+    sys.exit(0 if main() else 1)

--- a/ui_tests/fixtures/orchestration/harness_entry.tsx
+++ b/ui_tests/fixtures/orchestration/harness_entry.tsx
@@ -19,6 +19,7 @@ import * as bootstrapStore from '../../../application/v2_ui/src/stores/bootstrap
 import * as controller from '../../../application/v2_ui/src/lib/orchestrationController';
 import * as plan from '../../../application/v2_ui/src/lib/orchestrationPlan';
 import * as orchestration from '../../../application/v2_ui/src/lib/orchestration';
+import * as resume from '../../../application/v2_ui/src/lib/orchestrationResume';
 
 import { OrchestrationPlanCard } from '../../../application/v2_ui/src/components/chat/OrchestrationPlanCard';
 import { ElicitationCard } from '../../../application/v2_ui/src/components/chat/ElicitationCard';
@@ -126,6 +127,9 @@ function reset(): void {
         stepRuntime: {},
         inFlight: {},
         history: {},
+        hydratedHistory: {},
+        hydration: {},
+        readOnlyTurns: {},
         pinnedRunId: null,
         visibleConversationId: null,
         activeTurns: {},
@@ -140,6 +144,9 @@ function reset(): void {
     } catch {
         /* localStorage may be unavailable; the stores are already reset. */
     }
+    // The resume module remembers which conversations it has already considered, so a test
+    // reusing a conversation id would otherwise be silently skipped.
+    resume.resetOrchestrationResume();
 }
 
 const harness = {
@@ -155,6 +162,7 @@ const harness = {
     controller,
     plan,
     orchestration,
+    resume,
     components,
 };
 

--- a/ui_tests/test_v2_orchestration_pending_approval_resume.py
+++ b/ui_tests/test_v2_orchestration_pending_approval_resume.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python3
+"""
+UI test for picking up an unanswered orchestration plan on another device.
+Version: 0.261.096
+Implemented in: 0.261.096
+
+A plan that was proposed and never approved is stored as `awaiting_approval`, but until this change
+the only browser that could act on it was the one that closed the tab. Opening the conversation
+anywhere else showed the question with no plan and no way to answer it.
+
+The card is now restored from the stored record, with three guards that each rule out resurrecting
+something misleading: the run must be the conversation's newest, this page must not already have a
+card up, and no assistant message may follow the run's question. A timed approval is restored as an
+ordinary one, because restarting a countdown on a device that was not there would run real work
+because somebody opened a laptop.
+
+This test drives the REAL resume module and the REAL OrchestrationPlanCard over the real stores,
+stubbing only the HTTP responses, and asserts:
+
+  * An unanswered plan comes back as an approvable card on a page that never saw it.
+  * A plan that was already answered does not come back.
+  * A plan that already ran does not come back.
+  * A restored timed plan waits to be asked rather than running itself.
+
+The browser checks are skipped (reported, not failed) when node_modules is absent.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent / "fixtures" / "orchestration"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "functional_tests"))
+
+import harness_build as hb  # noqa: E402
+from test_support.versioning import assert_app_version_at_least  # noqa: E402
+
+
+IMPLEMENTED_IN = "0.261.096"
+
+_PAGE = None
+
+CONVERSATION_ID = "c-resume"
+TURN_ID = "turn-pending"
+RUN_ID = "run-pending"
+USER_MESSAGE_ID = "msg-pending"
+PENDING_SUMMARY = "Reconcile the quarterly numbers"
+
+
+def _pending_run(status="awaiting_approval"):
+    return {
+        "run_id": RUN_ID,
+        "conversation_id": CONVERSATION_ID,
+        "turn_id": TURN_ID,
+        "status": status,
+        "created_at": "2026-01-05T10:00:00Z",
+        "user_message_id": USER_MESSAGE_ID,
+        "artifact_count": 0,
+        "plan_summary": {
+            "run_id": RUN_ID,
+            "plan_id": "plan-pending",
+            "turn_id": TURN_ID,
+            "intent_summary": PENDING_SUMMARY,
+            "step_count": 2,
+            "status": status,
+        },
+    }
+
+
+def _pending_plan(approval_mode="manual", timeout_seconds=0):
+    return {
+        "plan_id": "plan-pending",
+        "run_id": RUN_ID,
+        "turn_id": TURN_ID,
+        "intent": {"summary": PENDING_SUMMARY, "complexity": "simple"},
+        "steps": [
+            {
+                "step_id": "pending-s1",
+                "capability_id": "search_documents",
+                "title": "Search the ledger",
+                "arguments": {"document_ids": ["docA"]},
+                "estimated_cost": "low",
+            },
+            {
+                "step_id": "pending-s2",
+                "capability_id": "respond",
+                "title": "Write the answer",
+                "arguments": {},
+                "estimated_cost": "low",
+            },
+        ],
+        "approval": {
+            "mode": approval_mode,
+            "timeout_seconds": timeout_seconds,
+            "state": "pending",
+        },
+        "status": "awaiting_approval",
+    }
+
+
+def _install_routes(page, runs, plan_payload, run_calls):
+    """Stub the read endpoints, and record any attempt to actually run the plan."""
+    page.unroute_all(behavior="ignoreErrors")
+
+    page.route(
+        "**/api/v2/orchestration/runs/*/steps*",
+        lambda route: route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({"steps": []}),
+        ),
+    )
+    page.route(
+        "**/api/v2/orchestration/runs/*",
+        lambda route: route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({"run": {**_pending_run(), "plan": plan_payload}}),
+        ),
+    )
+    page.route(
+        "**/api/v2/orchestration/runs?*",
+        lambda route: route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({"runs": runs}),
+        ),
+    )
+
+    def record_run(route):
+        run_calls.append(route.request.url)
+        route.fulfill(status=200, content_type="text/event-stream", body="")
+
+    page.route("**/api/v2/orchestration/run", record_run)
+
+
+# Seed a thread holding only the question, then ask the resume module to consider it and mount the
+# inline card the way MessageList does.
+_SEED_RESUME = r"""
+async (spec) => {
+    const H = window.OrchHarness;
+    H.reset();
+    H.stores.chat.useChatStore.setState({
+        activeConversationId: spec.conv,
+        messages: spec.messages,
+    });
+    await H.resume.resumeOrchestrationForConversation(spec.conv);
+    const orch = H.stores.orchestration.useOrchestrationStore.getState();
+    const turnId = orch.activeTurns[spec.conv] ?? null;
+    if (turnId) {
+        H.mount('mount-a', 'OrchestrationPlanCard', {
+            conversationId: spec.conv,
+            turnId,
+        });
+    }
+    return {
+        activeTurn: turnId,
+        readOnly: turnId
+            ? H.stores.orchestration.selectIsReadOnly(
+                  H.stores.orchestration.useOrchestrationStore.getState(),
+                  spec.conv,
+                  turnId,
+              )
+            : null,
+    };
+}
+"""
+
+
+def _question_only():
+    return [{"id": USER_MESSAGE_ID, "role": "user", "content": "Reconcile the numbers"}]
+
+
+def _question_and_answer():
+    return [
+        {"id": USER_MESSAGE_ID, "role": "user", "content": "Reconcile the numbers"},
+        {"id": "msg-answer", "role": "assistant", "content": "Here you go."},
+    ]
+
+
+def test_version_is_at_least_the_implementing_release():
+    """Resuming a pending approval shipped in IMPLEMENTED_IN, so the app must be at least it."""
+    print("Testing the app version is at least the implementing release...")
+    try:
+        assert_app_version_at_least(IMPLEMENTED_IN)
+        print(f"  ok  config.py VERSION is at least {IMPLEMENTED_IN}")
+        return True
+    except Exception as exc:  # noqa: BLE001
+        print(f"Test failed: {exc}")
+        return False
+
+
+def test_unanswered_plan_returns_as_an_approvable_card():
+    """An unanswered plan comes back as a card that can still be approved."""
+    print("Testing an unanswered plan is restored...")
+    page = _PAGE
+    try:
+        run_calls = []
+        _install_routes(page, [_pending_run()], _pending_plan(), run_calls)
+        outcome = page.evaluate(
+            _SEED_RESUME,
+            {"conv": CONVERSATION_ID, "messages": _question_only()},
+        )
+
+        assert outcome["activeTurn"] == TURN_ID, (
+            f"the pending turn must be restored, saw {outcome['activeTurn']!r}"
+        )
+        assert outcome["readOnly"] is False, (
+            "a plan being offered for approval must not be read-only"
+        )
+        page.wait_for_function(
+            f"() => document.getElementById('mount-a').innerText.includes({PENDING_SUMMARY!r})",
+            timeout=5000,
+        )
+        assert page.query_selector(
+            '#mount-a [aria-label="Approve and run the plan"]'
+        ) is not None, "the restored card must offer to approve the plan"
+        print("  ok  the unanswered plan came back and can still be approved")
+        return True
+    except Exception as exc:  # noqa: BLE001
+        print(f"Test failed: {exc}")
+        import traceback
+
+        traceback.print_exc()
+        return False
+
+
+def test_answered_plan_does_not_return():
+    """A plan whose turn already has an assistant reply is left alone."""
+    print("Testing an answered turn is not resurrected...")
+    page = _PAGE
+    try:
+        run_calls = []
+        _install_routes(page, [_pending_run()], _pending_plan(), run_calls)
+        outcome = page.evaluate(
+            _SEED_RESUME,
+            {"conv": CONVERSATION_ID, "messages": _question_and_answer()},
+        )
+
+        assert outcome["activeTurn"] is None, (
+            "a turn with an assistant reply must not get its card back"
+        )
+        print("  ok  the answered turn was left alone")
+        return True
+    except Exception as exc:  # noqa: BLE001
+        print(f"Test failed: {exc}")
+        import traceback
+
+        traceback.print_exc()
+        return False
+
+
+def test_completed_plan_does_not_return():
+    """A plan that already ran is history, not an offer."""
+    print("Testing a finished run is not offered for approval...")
+    page = _PAGE
+    try:
+        run_calls = []
+        _install_routes(
+            page, [_pending_run(status="completed")], _pending_plan(), run_calls
+        )
+        outcome = page.evaluate(
+            _SEED_RESUME,
+            {"conv": CONVERSATION_ID, "messages": _question_only()},
+        )
+
+        assert outcome["activeTurn"] is None, (
+            "a completed run must not come back as a pending card"
+        )
+        print("  ok  the finished run stayed in history")
+        return True
+    except Exception as exc:  # noqa: BLE001
+        print(f"Test failed: {exc}")
+        import traceback
+
+        traceback.print_exc()
+        return False
+
+
+def test_restored_timed_plan_waits_to_be_asked():
+    """A timed approval restored elsewhere does not restart its clock and run itself."""
+    print("Testing a restored timed plan does not run itself...")
+    page = _PAGE
+    try:
+        run_calls = []
+        _install_routes(
+            page,
+            [_pending_run()],
+            _pending_plan(approval_mode="timed", timeout_seconds=1),
+            run_calls,
+        )
+        outcome = page.evaluate(
+            _SEED_RESUME,
+            {"conv": CONVERSATION_ID, "messages": _question_only()},
+        )
+        assert outcome["activeTurn"] == TURN_ID, "the timed plan must still be restored"
+
+        # No countdown at all: the restored plan is an ordinary approval.
+        assert page.query_selector('#mount-a [role="timer"]') is None, (
+            "a restored timed plan must not show a countdown"
+        )
+
+        # Well past the original one-second window.
+        page.wait_for_timeout(2500)
+        assert not run_calls, (
+            f"a restored timed plan must not run itself, but it called {run_calls}"
+        )
+        assert page.query_selector(
+            '#mount-a [aria-label="Approve and run the plan"]'
+        ) is not None, "it must wait to be asked instead"
+        print("  ok  the restored timed plan waited to be asked")
+        return True
+    except Exception as exc:  # noqa: BLE001
+        print(f"Test failed: {exc}")
+        import traceback
+
+        traceback.print_exc()
+        return False
+
+
+PAGE_TESTS = [
+    test_unanswered_plan_returns_as_an_approvable_card,
+    test_answered_plan_does_not_return,
+    test_completed_plan_does_not_return,
+    test_restored_timed_plan_waits_to_be_asked,
+]
+
+
+def main():
+    results = [test_version_is_at_least_the_implementing_release()]
+
+    errors = []
+    try:
+        with hb.harness_page(collect_errors=errors) as page:
+            global _PAGE
+            _PAGE = page
+            for test in PAGE_TESTS:
+                print(f"\nRunning {test.__name__}...")
+                page.evaluate("() => window.OrchHarness.reset()")
+                results.append(test())
+    except hb.HarnessUnavailable as exc:
+        print(f"\n  --  skipped the browser-driven checks: {exc}")
+        results.extend([True] * len(PAGE_TESTS))
+
+    if errors:
+        print("\nUncaught page errors observed during the run:")
+        for message in errors:
+            print(f"  !!  {message}")
+
+    print(f"\nResults: {sum(results)}/{len(results)} tests passed")
+    return all(results)
+
+
+if __name__ == "__main__":
+    sys.exit(0 if main() else 1)

--- a/ui_tests/test_v2_orchestration_run_hydration.py
+++ b/ui_tests/test_v2_orchestration_run_hydration.py
@@ -1,0 +1,459 @@
+#!/usr/bin/env python3
+"""
+UI test for hydrating a conversation's stored orchestration runs into the V2 plan drawer.
+Version: 0.261.096
+Implemented in: 0.261.096
+
+Orchestration runs have always been written to Cosmos and read back by the planner, but nothing in
+the browser ever asked for them. The drawer's Map view built its rows purely from what this page
+happened to watch, so a conversation opened after a reload -- or in a second tab, or on another
+device -- showed an empty panel for work that plainly happened. The fix is a fetch: the Map asks
+the server for the conversation's runs and merges them with whatever it saw itself.
+
+This test drives the REAL OrchestrationPlanPanel over the real stores, stubbing only the HTTP
+responses, and asserts:
+
+  * A conversation this page never watched still lists its stored runs in the Map.
+  * A stored run expands to the step titles the server recorded, fetched on demand.
+  * A locally-observed run is not duplicated by its stored copy.
+  * Choosing a stored row loads that run's plan into the Run view and marks it as a record, with
+    the step controls withheld.
+  * A failed fetch says so and offers to try again, rather than claiming there is no history.
+
+The browser checks are skipped (reported, not failed) when node_modules is absent.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent / "fixtures" / "orchestration"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "functional_tests"))
+
+import harness_build as hb  # noqa: E402
+from test_support.versioning import assert_app_version_at_least  # noqa: E402
+
+
+IMPLEMENTED_IN = "0.261.096"
+
+_PAGE = None
+
+CONVERSATION_ID = "c-hydrate"
+STORED_SUMMARY = "Reconcile the quarterly numbers"
+OLDER_STORED_SUMMARY = "Draft the incident report"
+LOCAL_SUMMARY = "Summarise today's tickets"
+
+
+def _stored_run(run_id, turn_id, summary, status="completed", step_count=2):
+    """A run summary shaped the way route_backend_orchestration projects one."""
+    return {
+        "run_id": run_id,
+        "conversation_id": CONVERSATION_ID,
+        "turn_id": turn_id,
+        "status": status,
+        "created_at": "2026-01-05T10:00:00Z",
+        "completed_at": "2026-01-05T10:02:00Z",
+        "user_message_id": f"msg-{turn_id}",
+        "artifact_count": 0,
+        "plan_summary": {
+            "run_id": run_id,
+            "plan_id": f"plan-{run_id}",
+            "turn_id": turn_id,
+            "intent_summary": summary,
+            "step_count": step_count,
+            "status": status,
+        },
+    }
+
+
+def _stored_plan(run_id, turn_id, summary):
+    """The full plan a run detail response carries."""
+    return {
+        "plan_id": f"plan-{run_id}",
+        "run_id": run_id,
+        "turn_id": turn_id,
+        "intent": {"summary": summary, "complexity": "simple"},
+        "steps": [
+            {
+                "step_id": f"{run_id}-s1",
+                "capability_id": "search_documents",
+                "title": "Search the ledger",
+                "arguments": {"document_ids": ["docA"]},
+                "estimated_cost": "low",
+            },
+            {
+                "step_id": f"{run_id}-s2",
+                "capability_id": "respond",
+                "title": "Write the answer",
+                "arguments": {},
+                "estimated_cost": "low",
+            },
+        ],
+        "approval": {"mode": "manual", "timeout_seconds": 0, "state": "approved"},
+        "status": "completed",
+    }
+
+
+def _stored_steps(run_id):
+    return [
+        {
+            "run_id": run_id,
+            "step_id": f"{run_id}-s1",
+            "step_index": 0,
+            "title": "Search the ledger",
+            "status": "completed",
+            "summary": "Found 4 matching entries",
+        },
+        {
+            "run_id": run_id,
+            "step_id": f"{run_id}-s2",
+            "step_index": 1,
+            "title": "Write the answer",
+            "status": "completed",
+            "summary": "",
+        },
+    ]
+
+
+def _install_routes(page, runs, fail_list=False):
+    """Stub the three orchestration read endpoints for this page.
+
+    Registered most-specific first: Playwright matches routes in registration order, so the steps
+    and detail patterns must be offered before the bare list pattern that would otherwise swallow
+    them.
+    """
+    page.unroute_all(behavior="ignoreErrors")
+
+    def steps_handler(route):
+        run_id = route.request.url.split("/runs/")[1].split("/steps")[0]
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({"steps": _stored_steps(run_id)}),
+        )
+
+    def detail_handler(route):
+        run_id = route.request.url.split("/runs/")[1].split("?")[0]
+        summary = STORED_SUMMARY if run_id == "run-stored" else OLDER_STORED_SUMMARY
+        turn_id = "turn-stored" if run_id == "run-stored" else "turn-older"
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps(
+                {
+                    "run": {
+                        **_stored_run(run_id, turn_id, summary),
+                        "plan": _stored_plan(run_id, turn_id, summary),
+                    }
+                }
+            ),
+        )
+
+    def list_handler(route):
+        if fail_list:
+            route.fulfill(
+                status=500,
+                content_type="application/json",
+                body=json.dumps({"error": "boom"}),
+            )
+            return
+        route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({"runs": runs}),
+        )
+
+    page.route("**/api/v2/orchestration/runs/*/steps*", steps_handler)
+    page.route("**/api/v2/orchestration/runs/*", detail_handler)
+    page.route("**/api/v2/orchestration/runs?*", list_handler)
+
+
+# Mount the drawer straight onto the Map view for a conversation this page never watched.
+_SEED_MAP = r"""
+(spec) => {
+    const H = window.OrchHarness;
+    H.reset();
+    H.stores.chat.useChatStore.setState({ activeConversationId: spec.conv, messages: [] });
+    H.mount('mount-a', 'OrchestrationPlanPanel', {});
+}
+"""
+
+# The same, but with one run this page watched itself, so the merge can be checked.
+_SEED_MAP_WITH_LOCAL = r"""
+(spec) => {
+    const H = window.OrchHarness;
+    H.reset();
+    const orch = H.stores.orchestration.useOrchestrationStore.getState();
+    H.stores.chat.useChatStore.setState({ activeConversationId: spec.conv, messages: [] });
+
+    orch.setPlan(spec.conv, spec.turn, spec.plan);
+    orch.beginRun({
+        conversationId: spec.conv,
+        turnId: spec.turn,
+        runId: spec.runId,
+        planId: spec.planId,
+        startedAt: Date.now() - 5000,
+    });
+    orch.endRun(spec.runId, 'completed');
+
+    H.mount('mount-a', 'OrchestrationPlanPanel', {});
+}
+"""
+
+
+def _local_plan():
+    return {
+        "plan_id": "plan-local",
+        "run_id": "run-local",
+        "intent": {"summary": LOCAL_SUMMARY, "complexity": "simple"},
+        "steps": [
+            {
+                "step_id": "local-s1",
+                "capability_id": "respond",
+                "title": "Write the answer",
+                "arguments": {},
+                "estimated_cost": "low",
+            }
+        ],
+        "approval": {"mode": "manual", "timeout_seconds": 0, "state": "approved"},
+        "status": "completed",
+    }
+
+
+def _open_map(page):
+    page.click("#mount-a button[role='tab']:has-text('Map')")
+    page.wait_for_function(
+        "() => Array.from(document.querySelectorAll(\"#mount-a [role='tab']\"))"
+        ".find(t => t.innerText.trim() === 'Map').getAttribute('aria-selected') === 'true'",
+        timeout=5000,
+    )
+
+
+def test_version_is_at_least_the_implementing_release():
+    """Run hydration shipped in IMPLEMENTED_IN, so the app must be at least it."""
+    print("Testing the app version is at least the implementing release...")
+    try:
+        assert_app_version_at_least(IMPLEMENTED_IN)
+        print(f"  ok  config.py VERSION is at least {IMPLEMENTED_IN}")
+        return True
+    except Exception as exc:  # noqa: BLE001
+        print(f"Test failed: {exc}")
+        return False
+
+
+def test_stored_runs_appear_without_being_watched():
+    """A conversation this page never watched still lists its stored runs."""
+    print("Testing stored runs are fetched into the Map...")
+    page = _PAGE
+    try:
+        _install_routes(
+            page,
+            [
+                _stored_run("run-stored", "turn-stored", STORED_SUMMARY),
+                _stored_run("run-older", "turn-older", OLDER_STORED_SUMMARY, status="failed"),
+            ],
+        )
+        page.evaluate(_SEED_MAP, {"conv": CONVERSATION_ID})
+        _open_map(page)
+
+        page.wait_for_function(
+            f"() => document.getElementById('mount-a').innerText.includes({STORED_SUMMARY!r})",
+            timeout=5000,
+        )
+        text = page.inner_text("#mount-a")
+        assert STORED_SUMMARY in text, "the newest stored run must be listed"
+        assert OLDER_STORED_SUMMARY in text, "every stored run must be listed"
+        assert "2 steps" in text, "the stored step count must be shown without loading the plan"
+        assert "Failed" in text, "a stored run's outcome must be shown"
+        print("  ok  the Map listed runs it never watched")
+        return True
+    except Exception as exc:  # noqa: BLE001
+        print(f"Test failed: {exc}")
+        import traceback
+
+        traceback.print_exc()
+        return False
+
+
+def test_stored_row_expands_to_fetched_steps():
+    """Expanding a stored row fetches and shows the step titles the server recorded."""
+    print("Testing a stored row expands to its steps...")
+    page = _PAGE
+    try:
+        _install_routes(page, [_stored_run("run-stored", "turn-stored", STORED_SUMMARY)])
+        page.evaluate(_SEED_MAP, {"conv": CONVERSATION_ID})
+        _open_map(page)
+        page.wait_for_function(
+            f"() => document.getElementById('mount-a').innerText.includes({STORED_SUMMARY!r})",
+            timeout=5000,
+        )
+
+        assert "Search the ledger" not in page.inner_text("#mount-a"), (
+            "steps must not be fetched until the row is opened"
+        )
+        page.click("#mount-a button[aria-label='Expand steps']")
+        page.wait_for_function(
+            "() => document.getElementById('mount-a').innerText.includes('Search the ledger')",
+            timeout=5000,
+        )
+        text = page.inner_text("#mount-a")
+        assert "Search the ledger" in text and "Write the answer" in text, (
+            "the recorded step titles must be shown"
+        )
+        print("  ok  the stored row fetched its steps on demand")
+        return True
+    except Exception as exc:  # noqa: BLE001
+        print(f"Test failed: {exc}")
+        import traceback
+
+        traceback.print_exc()
+        return False
+
+
+def test_local_run_is_not_duplicated_by_its_stored_copy():
+    """A run this page watched appears once, not twice, when the server also reports it."""
+    print("Testing the local and stored copies of one run are merged...")
+    page = _PAGE
+    try:
+        _install_routes(
+            page,
+            [
+                _stored_run("run-local", "turn-local", LOCAL_SUMMARY),
+                _stored_run("run-stored", "turn-stored", STORED_SUMMARY),
+            ],
+        )
+        page.evaluate(
+            _SEED_MAP_WITH_LOCAL,
+            {
+                "conv": CONVERSATION_ID,
+                "turn": "turn-local",
+                "runId": "run-local",
+                "planId": "plan-local",
+                "plan": _local_plan(),
+            },
+        )
+        _open_map(page)
+        page.wait_for_function(
+            f"() => document.getElementById('mount-a').innerText.includes({STORED_SUMMARY!r})",
+            timeout=5000,
+        )
+
+        rows = page.evaluate(
+            "() => document.querySelectorAll('#mount-a ol > li').length"
+        )
+        assert rows == 2, f"expected one row per run, saw {rows}"
+        print("  ok  the observed run was not duplicated by its stored copy")
+        return True
+    except Exception as exc:  # noqa: BLE001
+        print(f"Test failed: {exc}")
+        import traceback
+
+        traceback.print_exc()
+        return False
+
+
+def test_choosing_a_stored_row_loads_a_read_only_run():
+    """A stored row loads its plan into the Run view, marked as a record and not editable."""
+    print("Testing a stored row opens read-only in the Run view...")
+    page = _PAGE
+    try:
+        _install_routes(page, [_stored_run("run-stored", "turn-stored", STORED_SUMMARY)])
+        page.evaluate(_SEED_MAP, {"conv": CONVERSATION_ID})
+        _open_map(page)
+        page.wait_for_selector(
+            f"#mount-a button:has-text({STORED_SUMMARY!r})", timeout=5000
+        )
+        page.click(f"#mount-a button:has-text({STORED_SUMMARY!r})")
+
+        page.wait_for_function(
+            "() => document.getElementById('mount-a').innerText.includes('cannot be changed')",
+            timeout=5000,
+        )
+        text = page.inner_text("#mount-a")
+        assert STORED_SUMMARY in text, "the Run view must show the chosen run's plan"
+        assert "Search the ledger" in text, "the stored plan's steps must be shown"
+        toggles = page.evaluate(
+            "() => document.querySelectorAll(\"#mount-a [role='switch']\").length"
+        )
+        assert toggles == 0, "a record of a finished run must not offer to narrow its steps"
+        print("  ok  the stored run opened as an unchangeable record")
+        return True
+    except Exception as exc:  # noqa: BLE001
+        print(f"Test failed: {exc}")
+        import traceback
+
+        traceback.print_exc()
+        return False
+
+
+def test_failed_fetch_is_reported_not_hidden():
+    """A failed history fetch says so and offers a retry, rather than showing an empty map."""
+    print("Testing a failed history fetch is reported...")
+    page = _PAGE
+    try:
+        _install_routes(page, [], fail_list=True)
+        page.evaluate(_SEED_MAP, {"conv": CONVERSATION_ID})
+        _open_map(page)
+
+        page.wait_for_function(
+            "() => document.getElementById('mount-a').innerText.includes('could not be loaded')",
+            timeout=5000,
+        )
+        assert page.evaluate(
+            "() => Array.from(document.querySelectorAll('#mount-a button'))"
+            ".some(b => b.innerText.trim() === 'Try again')"
+        ), "a failed fetch must offer a retry"
+
+        # The retry succeeds once the endpoint recovers.
+        _install_routes(page, [_stored_run("run-stored", "turn-stored", STORED_SUMMARY)])
+        page.click("#mount-a button:has-text('Try again')")
+        page.wait_for_function(
+            f"() => document.getElementById('mount-a').innerText.includes({STORED_SUMMARY!r})",
+            timeout=5000,
+        )
+        print("  ok  the failure was reported and the retry recovered")
+        return True
+    except Exception as exc:  # noqa: BLE001
+        print(f"Test failed: {exc}")
+        import traceback
+
+        traceback.print_exc()
+        return False
+
+
+PAGE_TESTS = [
+    test_stored_runs_appear_without_being_watched,
+    test_stored_row_expands_to_fetched_steps,
+    test_local_run_is_not_duplicated_by_its_stored_copy,
+    test_choosing_a_stored_row_loads_a_read_only_run,
+    test_failed_fetch_is_reported_not_hidden,
+]
+
+
+def main():
+    results = [test_version_is_at_least_the_implementing_release()]
+
+    errors = []
+    try:
+        with hb.harness_page(collect_errors=errors) as page:
+            global _PAGE
+            _PAGE = page
+            for test in PAGE_TESTS:
+                print(f"\nRunning {test.__name__}...")
+                page.evaluate("() => window.OrchHarness.reset()")
+                results.append(test())
+    except hb.HarnessUnavailable as exc:
+        print(f"\n  --  skipped the browser-driven checks: {exc}")
+        results.extend([True] * len(PAGE_TESTS))
+
+    if errors:
+        print("\nUncaught page errors observed during the run:")
+        for message in errors:
+            print(f"  !!  {message}")
+
+    print(f"\nResults: {sum(results)}/{len(results)} tests passed")
+    return all(results)
+
+
+if __name__ == "__main__":
+    sys.exit(0 if main() else 1)


### PR DESCRIPTION
## The report

> the orchestration plans seem to stay on the client side and are not retained as part of the conversation, if i switch devices i dont see previously ran plans started on other devices...is this real or is something else happening?

It was real. Nothing was lost, though.

## What was actually happening

Runs, plans and steps have always been persisted server-side — `cosmos_orchestration_runs_container` (partitioned by `/conversation_id`) and `cosmos_orchestration_run_steps_container` (partitioned by `/run_id`) — and the planner already reads earlier runs back to build its ledger.

The V2 interface just never asked for them:

- Nothing under `application/v2_ui/src` referenced `/api/v2/orchestration/runs` or `/runs/<id>/steps`. Two endpoints existed and were called by nothing.
- `restorePersistedRuns()` was exported from the orchestration store and invoked nowhere, so even a same-device reload lost the history.
- There was no route returning a single run *with its plan*, so the panel had no way to fetch a plan it had not itself produced.
- The saved user message did not reliably carry its `orchestration_turn_id`, so a hydrating client could not line a stored run up with the message that caused it.

The drawer ran entirely off in-memory Zustand state backed by `sessionStorage`, which is per-tab and per-device by definition.

## Behaviour change

| Situation | Before | After |
| --- | --- | --- |
| Open a conversation on a second device | Empty panel | Earlier runs listed, expandable to steps and results |
| Reload the page mid-conversation | Run history lost | Rebuilt from the server |
| Plan left awaiting approval, user moves device | Stranded; the question had to be asked again | Reappears as a plan that can be approved, edited or discarded |
| That plan was already approved on the first device | Would race | Refused, and the existing answer is loaded |
| Browser closed mid-run | No record | Listed as interrupted |

## Server

- **New** `GET /api/v2/orchestration/runs/<run_id>` returning one run with its plan. Ownership is enforced inside `get_orchestration_run` on both the point read and the cross-partition fallback, so a guessed run id belonging to someone else is indistinguishable from a missing one.
- **Allowlist projections** (`_run_summary_row`, `_run_detail_row`) decide what leaves the server. Listing 25 runs no longer puts 25 full plans on the wire, and `seeds`, `user_id`, `approved_by`, `conversation_context`, `request_resolution`, `user_message_fingerprint`, Cosmos system fields and raw artifact payloads all stay server-side. This replaces a blocklist that stripped three of those by name — an allowlist keeps excluding whatever the record gains later. `?include_plan=true` *widens* the projection rather than bypassing it, so no caller reaches a stored record verbatim.
- **`orchestration_turn_id` is stamped on every orchestrated question.** `_save_turn_message` already wrote it, but only when the turn happened to carry a selected prompt — so the flat key was absent on ordinary questions even though `chatStore.ts` already read it.

## Client

- Typed read layer: `fetchConversationRuns`, `fetchOrchestrationRun`, `fetchRunSteps`.
- Store hydration merges persisted summaries into history, local runs winning over hydrated ones. A restored run the server reports as finished is dropped from the in-flight set instead of spinning forever.
- A run opened from history is read-only, with a banner saying it is a record.
- A plan still awaiting approval is restored as approvable, guarded three ways: newest run only, nothing already active locally, and no assistant message already following the question.
- A restored **timed** approval is neutralised to manual, so a countdown started on one device cannot run real work unattended on another.
- The run route's existing HTTP 409 re-run guard is now handled client-side: the local turn settles and the conversation reloads rather than surfacing an error.

## No migration

Run records already carried `turn_id` and `user_message_id`. Conversations predating this hydrate correctly; every path using the new stamp falls back to `user_message_id`.

## Validation

- `functional_tests/test_orchestration_run_hydration_routes.py` — 6/6
- `functional_tests/test_orchestration_turn_recovery_identifiers.py` — 6/6
- `ui_tests/test_v2_orchestration_run_hydration.py` — 6/6
- `ui_tests/test_v2_orchestration_pending_approval_resume.py` — 5/5
- All `test_v2_orchestration_*` UI suites, all three `route_tests/` policy suites, and both docs suites pass
- `tsc -b --noEmit` and `npm run build` clean; docs inventory regenerated (unchanged — no new settings, tabs, actions or chat controls)

**Pre-existing failure, not from this branch:** `test_approve_runs_the_plan` in `ui_tests/test_v2_orchestration_plan_card.py` fails 6/7. I verified it fails identically on a clean checkout of the base at `7341323c`, so it is untouched here.

## Notes for review

- Base is **`paullizer-react-v2-ui`**, not `main`.
- Opened from a fork because push access to `microsoft/simplechat` was lost partway through the session. The branch `paullizer-orchestration-plan-persistence` pushed there earlier is **stale pre-rebase content** and should be ignored or deleted — this PR's head has the rebased, conflict-resolved work.
- Version `0.261.098`. Docs: `docs/explanation/fixes/ORCHESTRATION_RUN_HISTORY_HYDRATION_FIX.md`, a run-history section plus troubleshooting rows in `docs/admin/orchestration.md`, and a release notes entry.