### PR TITLE
Fix V2 orchestration approval preference persistence

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -97,7 +97,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.261.100"
+VERSION = "0.261.101"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/route_backend_users.py
+++ b/application/single_app/route_backend_users.py
@@ -30,6 +30,7 @@ from functions_message_visual_styles import (
     VisualStyleError,
     sanitize_visual_style,
 )
+from functions_orchestration_schema import APPROVAL_MODES
 from functions_public_workspaces import update_active_public_workspace_for_user
 from functions_settings import *
 from swagger_wrapper import swagger_route, get_auth_security
@@ -514,6 +515,7 @@ def register_route_backend_users(bp):
                     # Chat UI settings
                     'navbar_layout', 'chatLayout', 'showChatTitle', 'chatSplitSizes',
                     'deepResearchDefaultEnabled',
+                    'orchestrationApprovalMode',
                     'aiNoticeDismissal',
                     'sidebarToggleStyle', 'sidebarMenuState', 'fontSizePreference',
                     'conversationContentsDrawerEnabled',
@@ -566,6 +568,11 @@ def register_route_backend_users(bp):
 
 
                 settings_to_update = dict(settings_to_update)
+
+                if "orchestrationApprovalMode" in settings_to_update:
+                    approval_mode = settings_to_update["orchestrationApprovalMode"]
+                    if not isinstance(approval_mode, str) or approval_mode not in APPROVAL_MODES:
+                        return jsonify({"error": "Invalid orchestration approval mode"}), 400
 
                 if "sidebarToggleStyle" in settings_to_update:
                     sidebar_toggle_style = str(settings_to_update.get("sidebarToggleStyle") or "large").strip().lower()

--- a/application/v2_ui/src/components/chat/Composer.tsx
+++ b/application/v2_ui/src/components/chat/Composer.tsx
@@ -62,7 +62,10 @@ import {
     resolveContextHandoff,
     type ContextHandoffState,
 } from '../../lib/chatContextHandoff';
-import type { ApprovalMode } from '../../lib/orchestration';
+import {
+    isApprovalMode,
+    resolveOrchestrationApproval,
+} from '../../lib/orchestrationApproval';
 import {
     cancelOrchestration,
     hasActiveOrchestration,
@@ -293,24 +296,30 @@ export function Composer({ initialAgentSelection }: { initialAgentSelection?: st
     const manualControlsVisible =
         !orchestrating || (manualControlsGovernable && manualControlsOpen);
 
-    // The approval mode the plan will carry. Seeded from the deployment default and only editable
-    // where the administrator allows an override; where they do not, the control is hidden and the
-    // default is what ships.
-    const [approvalMode, setApprovalMode] = useState<ApprovalMode>(
-        orchestrationConfig?.default_approval_mode ?? 'manual',
+    const approvalPreference = useUserSettingsStore(
+        (state) => state.settings.orchestrationApprovalMode,
     );
-    // The default arrives with the bootstrap, which can resolve after the first render, so adopt it
-    // when it lands. Keyed on the value itself, so a later refresh carrying the same default does
-    // not overwrite a choice the user has since made.
-    useEffect(() => {
-        if (orchestrationConfig?.default_approval_mode) {
-            setApprovalMode(orchestrationConfig.default_approval_mode);
-        }
-    }, [orchestrationConfig?.default_approval_mode]);
+    const preferencesSaving = useUserSettingsStore((state) => state.saving);
+    const preferenceSaveError = useUserSettingsStore((state) => state.saveError);
     const approvalOverridable = Boolean(orchestrationConfig?.allow_user_approval_override);
-    const effectiveApprovalMode: ApprovalMode = approvalOverridable
-        ? approvalMode
-        : (orchestrationConfig?.default_approval_mode ?? 'manual');
+    const { mode: effectiveApprovalMode, invalidPreference: invalidApprovalPreference } =
+        resolveOrchestrationApproval(orchestrationConfig, approvalPreference);
+    // Bootstrap may arrive before preferences. Do not run an administrator's automatic mode
+    // while the user's saved requirement to review is still unknown.
+    const approvalBlocked = approvalOverridable && (!settingsLoaded || invalidApprovalPreference);
+    const chooseApprovalMode = (value: string | undefined) => {
+        if (!settingsLoaded || !approvalOverridable) {
+            toast.error('Your approval preference is not currently editable.');
+            return;
+        }
+        if (!isApprovalMode(value)) {
+            toast.error('Choose a valid approval mode.');
+            return;
+        }
+        const preferences = useUserSettingsStore.getState();
+        preferences.update({ orchestrationApprovalMode: value });
+        void preferences.flush();
+    };
 
     // An agent supplies its own deployment and never receives a reasoning level, so a
     // selection the server can actually resolve is what puts the model picker into its
@@ -694,6 +703,16 @@ export function Composer({ initialAgentSelection }: { initialAgentSelection?: st
 
     const submit = (allowUnfilled = false) => {
         if (streaming || !canPost || uploadsBlocked) {
+            return;
+        }
+        if (orchestrating && approvalBlocked) {
+            toast.error(
+                settingsFailed
+                    ? 'Retry loading your approval preference before sending.'
+                    : invalidApprovalPreference && settingsLoaded
+                      ? 'Choose a valid approval mode before sending.'
+                      : 'Your approval preference is still loading.',
+            );
             return;
         }
         // An attached prompt is a complete message on its own, so a turn carrying one may be
@@ -1086,6 +1105,39 @@ export function Composer({ initialAgentSelection }: { initialAgentSelection?: st
                     next to the message it is about, not below the send button. */}
                 <WebSearchNotice active={options.webSearch} />
 
+                {orchestrating && approvalOverridable && (
+                    <div className="space-y-1 text-xs">
+                        {settingsLoading ? (
+                            <p role="status" className="mb-2 text-text-3">
+                                Loading your approval preference before orchestration can start...
+                            </p>
+                        ) : settingsFailed ? (
+                            <div role="alert" className="mb-2 rounded-xl bg-danger-soft px-3 py-2 text-danger">
+                                Your approval preference could not be loaded. Your draft is unchanged.
+                                <button
+                                    type="button"
+                                    onClick={() => void useUserSettingsStore.getState().load()}
+                                    className="ml-2 font-medium underline"
+                                >
+                                    Retry loading approval preference
+                                </button>
+                            </div>
+                        ) : invalidApprovalPreference ? (
+                            <p role="alert" className="mb-2 rounded-xl bg-warn-soft px-3 py-2 text-warn">
+                                Your saved approval preference is invalid. Choose an approval mode before sending.
+                            </p>
+                        ) : null}
+                        {preferencesSaving && (
+                            <p role="status" className="mb-2 text-text-3">Saving preferences...</p>
+                        )}
+                        {preferenceSaveError && (
+                            <p role="alert" className="mb-2 rounded-xl bg-danger-soft px-3 py-2 text-danger">
+                                {preferenceSaveError} Try changing the preference again.
+                            </p>
+                        )}
+                    </div>
+                )}
+
                 <div className="glass glass-edge relative rounded-2xl p-2">
                     {replyTo && (
                         <div className="mb-1 flex items-start gap-2 rounded-xl bg-surface-2 px-3 py-2">
@@ -1186,12 +1238,12 @@ export function Composer({ initialAgentSelection }: { initialAgentSelection?: st
                         {orchestrating && approvalOverridable && (
                             <Dropdown
                                 options={approvalOptions}
-                                value={effectiveApprovalMode}
+                                value={settingsLoaded && !invalidApprovalPreference ? effectiveApprovalMode : undefined}
                                 placeholder="Approval"
                                 icon={<ShieldCheck size={15} />}
-                                onChange={(value) =>
-                                    value && setApprovalMode(value as ApprovalMode)
-                                }
+                                title="Approval mode"
+                                disabled={!settingsLoaded}
+                                onChange={chooseApprovalMode}
                             />
                         )}
 
@@ -1443,7 +1495,7 @@ export function Composer({ initialAgentSelection }: { initialAgentSelection?: st
                                 <button
                                     type="button"
                                     onClick={() => submit()}
-                                    disabled={(!text.trim() && !attachedPrompt) || !canPost || uploadsBlocked}
+                                    disabled={(!text.trim() && !attachedPrompt) || !canPost || uploadsBlocked || (orchestrating && approvalBlocked)}
                                     aria-label={
                                         shared && !streaming
                                             ? 'Send to this conversation'

--- a/application/v2_ui/src/lib/orchestrationApproval.ts
+++ b/application/v2_ui/src/lib/orchestrationApproval.ts
@@ -1,0 +1,28 @@
+// orchestrationApproval.ts
+
+import type { ApprovalMode } from './orchestration';
+import type { OrchestrationBootstrap } from './types';
+
+type ApprovalPolicy = Pick<
+    OrchestrationBootstrap,
+    'default_approval_mode' | 'allow_user_approval_override'
+>;
+
+export function isApprovalMode(value: unknown): value is ApprovalMode {
+    return value === 'manual' || value === 'timed' || value === 'auto';
+}
+
+export function resolveOrchestrationApproval(
+    policy: ApprovalPolicy | undefined,
+    preference: unknown,
+): { mode: ApprovalMode; invalidPreference: boolean } {
+    const defaultMode = isApprovalMode(policy?.default_approval_mode)
+        ? policy.default_approval_mode
+        : 'manual';
+    const overridable = Boolean(policy?.allow_user_approval_override);
+
+    return {
+        mode: overridable && isApprovalMode(preference) ? preference : defaultMode,
+        invalidPreference: overridable && preference !== undefined && !isApprovalMode(preference),
+    };
+}

--- a/application/v2_ui/src/lib/userSettings.ts
+++ b/application/v2_ui/src/lib/userSettings.ts
@@ -13,6 +13,7 @@
 // save had been lost. They get their own call when the workspace tabs are built.
 
 import type { SidebarMenuState } from './sidebarMenuState';
+import type { ApprovalMode } from './orchestration';
 import type { DocumentExplorerPrefs, DocumentSavedView } from './types';
 
 /** Text scale, matching the values the route normalises to. */
@@ -103,6 +104,9 @@ export interface UserSettings {
      */
     reasoningEffortSettings?: Record<string, string>;
 
+    /** Used when approval overrides are allowed; absent until the user chooses a mode. */
+    orchestrationApprovalMode?: ApprovalMode;
+
     chatCompletionAudioEnabled?: boolean;
     chatCompletionAudioMuted?: boolean;
     chatCompletionAudioSound?: string;
@@ -173,6 +177,7 @@ export const WRITABLE_USER_SETTING_KEYS = [
     'preferredModelId',
     'preferredModelDeployment',
     'reasoningEffortSettings',
+    'orchestrationApprovalMode',
     'chatCompletionAudioEnabled',
     'chatCompletionAudioMuted',
     'chatCompletionAudioSound',

--- a/application/v2_ui/src/stores/userSettingsStore.ts
+++ b/application/v2_ui/src/stores/userSettingsStore.ts
@@ -5,8 +5,7 @@
 // time behind an explicit Save button. Here a change is applied to the store immediately and
 // the write is debounced, so a slider being dragged produces one request rather than thirty.
 // Pending keys are merged into a single payload because the route merges partial updates
-// server-side; sending them separately would race, and the last response would win rather
-// than the last change.
+// server-side. Writes are serialized so a slow earlier request cannot overwrite a later one.
 //
 // A failed save rolls the affected keys back to what the server last confirmed. Leaving a
 // control showing a value that was never stored is worse than showing the change being
@@ -64,19 +63,37 @@ export const useUserSettingsStore = create<UserSettingsState>((set, get) => {
         set({ saving: true, saveError: null });
         try {
             await api.post<{ message?: string }>('/api/user/settings', { settings: payload });
+            for (const key of Object.keys(payload)) {
+                if (key in pending) {
+                    rollback[key] = payload[key];
+                }
+            }
             set({ saving: false });
         } catch (error) {
             // Only the keys this request carried are reverted; anything changed since is
-            // still pending and should not be disturbed.
+            // still pending. Its rollback target must also exclude this failed write.
+            const reverted: UserSettings = {};
+            for (const key of Object.keys(payload)) {
+                if (key in pending) {
+                    rollback[key] = previous[key];
+                } else {
+                    reverted[key] = previous[key];
+                }
+            }
             set((state) => ({
                 saving: false,
                 saveError:
                     error instanceof ApiError
                         ? error.message
                         : 'Your preference could not be saved.',
-                settings: { ...state.settings, ...previous },
+                settings: { ...state.settings, ...reverted },
             }));
         }
+    };
+
+    const queueWrite = (): Promise<void> => {
+        inFlight = (inFlight ?? Promise.resolve()).then(writePending);
+        return inFlight;
     };
 
     const scheduleWrite = () => {
@@ -85,7 +102,7 @@ export const useUserSettingsStore = create<UserSettingsState>((set, get) => {
         }
         saveTimer = setTimeout(() => {
             saveTimer = null;
-            inFlight = writePending();
+            void queueWrite();
         }, SAVE_DEBOUNCE_MS);
     };
 
@@ -132,9 +149,8 @@ export const useUserSettingsStore = create<UserSettingsState>((set, get) => {
             if (saveTimer !== null) {
                 clearTimeout(saveTimer);
                 saveTimer = null;
-                inFlight = writePending();
             }
-            await inFlight;
+            await queueWrite();
         },
     };
 });

--- a/docs/admin/orchestration.md
+++ b/docs/admin/orchestration.md
@@ -84,11 +84,22 @@ Countdown mode is a middle position worth understanding: the plan appears with a
 doing nothing runs it. It suits users who mostly agree with the plan but want the chance to
 stop an obviously wrong one, without a confirmation on every message.
 
+From version **0.261.101**, a user's approval selection is saved to their account.
+When overrides are allowed, that selection survives chat navigation, reloads, and
+future visits from another device. The deployment default applies to users who have
+not chosen a mode. Changing that default does not replace an existing user choice.
+
+Disabling user overrides enforces the deployment default without erasing saved
+preferences; those preferences apply again if overrides are re-enabled. When an
+override is allowed but preferences cannot be loaded, orchestration waits for a retry
+rather than risking a different approval mode. The draft remains editable, and
+ordinary chat is still available by switching Orchestrate off.
+
 #### Settings
 
 | Setting | What it does | Default | Notes |
 | --- | --- | --- | --- |
-| Default approval mode | Selects whether a plan waits for the user, runs after a countdown, or runs immediately. | Review before running | `chat_orchestration_default_approval_mode` |
+| Default approval mode | Determines whether a plan waits for review, runs after a countdown, or runs immediately when the user has no saved choice or overrides are disabled. | Review before running | `chat_orchestration_default_approval_mode` |
 | Countdown before running | How long the user has to intervene in countdown mode. Supported range is 3-120 seconds. | 10 | `chat_orchestration_timed_approval_seconds` |
 | Let users change their own approval mode | When off, everyone stays on the deployment default and the control is hidden from the composer. | On | `chat_orchestration_allow_user_approval_override` |
 | Keep the manual composer controls available | Keeps the document, web, model and agent pickers reachable behind a disclosure. Anything chosen there constrains the plan rather than being ignored. | On | `chat_orchestration_show_manual_controls` |

--- a/docs/explanation/features/CHAT_ORCHESTRATION.md
+++ b/docs/explanation/features/CHAT_ORCHESTRATION.md
@@ -1,6 +1,6 @@
 # Chat Orchestration
 
-**Version: 0.261.100** (tracked in `application/single_app/config.py`)
+**Version: 0.261.101** (tracked in `application/single_app/config.py`)
 
 **Implemented in version: 0.261.086**
 **Knowledge phase added in version: 0.261.089**
@@ -8,6 +8,7 @@
 **Research selection and multi-query execution updated in version: 0.261.099**
 **Direct action access implemented in version: 0.261.098**
 **Conversation continuity implemented in version: 0.261.096**
+**Approval preference persistence fixed in version: 0.261.101**
 
 ## Overview
 
@@ -522,6 +523,22 @@ Anything selected inside the manual controls is passed as a seed and constrains 
 so a power user can still pin the work to a particular document or agent and let
 orchestration decide the rest.
 
+When the administrator allows approval overrides, choosing **Auto**, **After Ns**,
+or **Review** saves `orchestrationApprovalMode` to your account immediately, without
+sending a message. The choice follows you across chats and is restored from the
+server after a reload or a later sign-in on another device. The countdown duration
+still comes from administrator settings.
+
+Users without a saved choice receive the deployment default. An enforced deployment
+mode takes precedence without deleting a saved choice. If preferences cannot be
+loaded, the composer keeps the draft and offers **Retry loading approval preference**
+before orchestration can start. An unsuccessful save shows an error and rolls back
+to the last confirmed selection unless a newer choice is still pending. Choose the
+mode again to retry saving. Existing plans retain their own approval state.
+
+See [the approval persistence fix](../fixes/V2_ORCHESTRATION_APPROVAL_PERSISTENCE_FIX.md)
+for the persistence contract and failure handling.
+
 Administrators changing these settings from the classic Admin Settings page do not need to
 reload an open chat tab: the interface re-reads its configuration when the tab comes back
 to the front.
@@ -532,6 +549,8 @@ to the front.
 | --- | --- |
 | `functional_tests/test_orchestration_registry_contract.py` | Descriptor shape, gating, administrator narrowing, and that internal fields never reach the planner |
 | `functional_tests/test_orchestration_plan_schema.py` | Unknown and disabled capabilities, document authorization, argument coercion and bounds, cycles, step caps, narrowing-only edits, approval states |
+| `functional_tests/test_v2_orchestration_approval_persistence.py` | Current-user approval preference round-trips, enum validation, and runtime preference resolution and save ordering |
+| `ui_tests/test_v2_orchestration_approval_persistence.py` | Approval selection across navigation and fresh browser contexts, administrator precedence, loading/retry, save failures, and pending writes |
 | `functional_tests/test_orchestration_elicitation_schema.py` | The MCP flat-object restriction, paging staying outside the schema, response validation |
 | `functional_tests/test_orchestration_elicitation_context.py` | Authoritative pending questions, accepted context, and the real plan/answer/run handoff |
 | `functional_tests/test_v2_elicitation_answers.py` | Primitive answers, single/multiple files, alternate sources, readiness, and answer-local prompt resolution |

--- a/docs/explanation/fixes/V2_ORCHESTRATION_APPROVAL_PERSISTENCE_FIX.md
+++ b/docs/explanation/fixes/V2_ORCHESTRATION_APPROVAL_PERSISTENCE_FIX.md
@@ -1,0 +1,97 @@
+# V2 Orchestration Approval Persistence Fix (v0.261.101)
+
+**Fixed in version: 0.261.101**
+
+The application version is tracked in `application/single_app/config.py`.
+
+## Issue
+
+Selecting an orchestration approval mode in the React v2 chat interface did not
+save it. Leaving chat and returning restored the administrator-defined default,
+not the user's last selection.
+
+## Root cause
+
+`Composer.tsx` kept the mode in local React state. The dropdown only changed that
+state; it never called the user-settings API. Remounting the composer initialized
+the value from `default_approval_mode` again. A separate effect also replaced the
+local selection whenever that administrator default changed.
+
+Bootstrap and account preferences load independently, so simply reading a saved
+value with an administrator fallback would still allow an unintended mode to run
+before preferences arrived. The shared settings store also needed serialized writes
+and selective rollback so an older request could not replace a newer selection.
+
+## Changes
+
+The optional account preference `orchestrationApprovalMode` accepts `manual`,
+`timed`, or `auto`. The existing authenticated GET/POST `/api/user/settings` route
+reads and writes it for the current user. Invalid values or types return HTTP 400
+before any part of the update is saved.
+
+The composer derives its displayed and submitted mode from the same policy:
+
+- With overrides allowed, a saved user choice takes precedence.
+- Without a saved choice, the current deployment default applies.
+- With overrides disabled, the deployment default is enforced without deleting
+  the user's preference.
+- With preferences still loading or a read failure, orchestration waits. A retry
+  reloads preferences without clearing the draft.
+- Invalid stored data requires a valid replacement instead of silently selecting
+  a potentially automatic mode.
+
+An explicit selection immediately flushes the existing settings store. Requests
+are serialized, updates queued during a write are retained, and an older failure
+does not roll back a newer choice. A failed latest write restores the last confirmed
+value and exposes an error. Other controls retain their existing save debounce.
+
+No default is written merely by opening chat. No database migration, new endpoint,
+browser-storage fallback, or new administrator setting is required. Existing plans,
+the classic interface, countdown duration, and the Orchestrate toggle are unchanged.
+
+## Files changed
+
+| File | Responsibility |
+| --- | --- |
+| `application/v2_ui/src/components/chat/Composer.tsx` | Account preference selection, loading/retry, save feedback, and submission guards |
+| `application/v2_ui/src/lib/orchestrationApproval.ts` | Typed mode validation and administrator/user precedence |
+| `application/v2_ui/src/lib/userSettings.ts` | Optional preference type and writable-key declaration |
+| `application/v2_ui/src/stores/userSettingsStore.ts` | Serialized writes, immediate flush, and pending-aware rollback |
+| `application/single_app/route_backend_users.py` | Allowlist and approval enum validation |
+| `application/single_app/config.py` | Application version increment to 0.261.101 |
+| `ui_tests/fixtures/orchestration/harness_entry.tsx` | Real-store navigation coverage and removal of a duplicate import that prevented bundling |
+
+## Validation
+
+| Regression coverage | What it exercises |
+| --- | --- |
+| `functional_tests/test_v2_orchestration_approval_persistence.py` | Current-user route round-trips, partial updates, missing values, invalid input, storage failures, and the real Node runtime suite |
+| `functional_tests/test_v2_orchestration_approval_logic.mjs` | Mode precedence, debounce, serialized flushes, both failed-write rollback cases, unrelated preference preservation, and read retry |
+| `ui_tests/test_v2_orchestration_approval_persistence.py` | Real Composer interactions on desktop/mobile, navigation, fresh contexts, delayed saves, loading failure/retry, administrator enforcement, and existing-plan isolation |
+| `functional_tests/test_v2_settings_and_workspace_tags.py` | Existing preference behavior with the corrected pending-aware rollback contract |
+
+The API cases isolate storage and authentication dependencies around the real route
+body. Browser cases use the real components and stores with a persistent HTTP fixture;
+fresh browser contexts prove restoration comes from the settings API, not retained
+browser memory. These tests do not provision Azure resources or invoke live models.
+The shared Playwright connection supports either local Chromium or a configured
+Azure Playwright workspace.
+
+| User action | Before | After |
+| --- | --- | --- |
+| Choose Review, leave chat, return | Administrator default | Saved Review choice |
+| Reload or use another device | Administrator default | Last successfully saved account choice |
+| Administrator changes the default | Local choice replaced | Saved choice retained while overrides are allowed |
+| Administrator temporarily disables overrides | Default enforced | Default enforced; saved choice available when overrides return |
+| Preferences fail to load | Could run using the deployment default | Draft retained; orchestration waits for retry |
+| An older save fails after a newer choice | Could restore an outdated value | Newer choice retained; latest failure restores the confirmed value |
+
+Persistence is acknowledged only after the server accepts a write. Closing the
+browser before acknowledgement is not a durability guarantee, and live cross-tab
+preference synchronization is outside this fix.
+
+## Related documentation
+
+- [Chat Orchestration](../features/CHAT_ORCHESTRATION.md)
+- [Orchestration settings](../../admin/orchestration.md)
+- [Chat interface controls](../../reference/chat-controls.md)

--- a/docs/reference/chat-controls.md
+++ b/docs/reference/chat-controls.md
@@ -160,6 +160,23 @@ The variable picker, knowledge fill, and persistent card enhancements were imple
 in **0.261.096**. See [Use prompts in chat]({{ '/guides/use-prompts-in-chat/' | relative_url }})
 for the complete workflow.
 
+## Orchestration approval (V2 interface)
+
+Account-level approval persistence was fixed in **0.261.101**. These controls appear
+while Orchestrate is active and the administrator allows users to change approval
+modes. The saved choice applies across chats and future visits; it does not alter
+plans that already exist. An administrator can enforce the deployment default
+without deleting your saved preference.
+
+| Control | What it does | Why you would use it | Enabled by |
+| --- | --- | --- | --- |
+| Approval mode | Saves **Auto**, **After Ns**, or **Review** to your account without requiring a message to be sent. Auto runs the plan when ready, After Ns allows the displayed countdown to expire, and Review waits for explicit approval. | Keep the amount of review you want instead of choosing it again each time you return to chat. | `enable_chat_orchestration` and `chat_orchestration_allow_user_approval_override` |
+| Retry loading approval preference | Loads your account preferences again after a failure, retaining the draft. Orchestration submission waits until the preference is known. | Recover without accidentally running a plan under a different approval mode. Ordinary chat remains available with Orchestrate off. | Same as Approval mode; shown after a preference-loading failure |
+
+The composer reports an unsuccessful save rather than claiming the new mode was
+remembered. Choose the mode again to retry. If no choice has been saved, the current
+deployment default applies. See [Orchestration settings]({{ '/admin/orchestration/' | relative_url }}).
+
 ## Inline follow-up questions (V2 interface)
 
 Implemented in **0.261.096**. These controls appear when chat orchestration needs more

--- a/functional_tests/test_v2_orchestration_approval_logic.mjs
+++ b/functional_tests/test_v2_orchestration_approval_logic.mjs
@@ -1,0 +1,214 @@
+// test_v2_orchestration_approval_logic.mjs
+// Version: 0.261.101
+// Implemented in: 0.261.101
+// Executes the real approval resolver and settings store, including overlapping saves.
+
+import assert from 'node:assert/strict';
+import { registerHooks } from 'node:module';
+import { mock } from 'node:test';
+import { setImmediate as nextTurn } from 'node:timers/promises';
+import {
+    isApprovalMode,
+    resolveOrchestrationApproval,
+} from '../application/v2_ui/src/lib/orchestrationApproval.ts';
+
+registerHooks({
+    resolve(specifier, context, nextResolve) {
+        if (specifier.startsWith('.') && !/\.[cm]?[jt]sx?$/.test(specifier)) {
+            return nextResolve(`${specifier}.ts`, context);
+        }
+        return nextResolve(specifier, context);
+    },
+});
+
+let fetchImpl = () => {
+    throw new Error('Unexpected request without an installed settings fixture.');
+};
+globalThis.fetch = (...args) => fetchImpl(...args);
+const { useUserSettingsStore } = await import('../application/v2_ui/src/stores/userSettingsStore.ts');
+const state = () => useUserSettingsStore.getState();
+const key = 'orchestrationApprovalMode';
+const modes = ['manual', 'timed', 'auto'];
+
+function response(body, status = 200) {
+    return new Response(JSON.stringify(body), {
+        status,
+        headers: { 'Content-Type': 'application/json' },
+    });
+}
+
+async function loadSettings(settings = { [key]: 'manual', darkModeEnabled: false }) {
+    await state().flush();
+    fetchImpl = async (url, init) => {
+        assert.equal(url, '/api/user/settings');
+        assert.equal(init.method, 'GET');
+        return response({ settings });
+    };
+    await state().load();
+    assert.equal(state().loading, false);
+    assert.equal(state().error, null);
+}
+
+function holdWrites() {
+    const writes = [];
+    fetchImpl = (url, init) => {
+        assert.equal(url, '/api/user/settings');
+        assert.equal(init.method, 'POST');
+        return new Promise((resolve) => {
+            writes.push({
+                payload: JSON.parse(init.body).settings,
+                finish(status = 200) {
+                    resolve(response(
+                        status === 200 ? { message: 'Saved' } : { error: 'Could not save preference' },
+                        status,
+                    ));
+                },
+            });
+        });
+    };
+    return writes;
+}
+
+function testResolution() {
+    for (const defaultMode of modes) {
+        const policy = { default_approval_mode: defaultMode, allow_user_approval_override: true };
+        assert.deepEqual(resolveOrchestrationApproval(policy, undefined), {
+            mode: defaultMode, invalidPreference: false,
+        });
+        for (const saved of modes) {
+            assert.equal(isApprovalMode(saved), true);
+            assert.deepEqual(resolveOrchestrationApproval(policy, saved), {
+                mode: saved, invalidPreference: false,
+            });
+            assert.deepEqual(resolveOrchestrationApproval(
+                { ...policy, allow_user_approval_override: false }, saved,
+            ), { mode: defaultMode, invalidPreference: false });
+        }
+        for (const invalid of [null, '', 'Manual', 'unknown', 1, false, {}, []]) {
+            assert.equal(isApprovalMode(invalid), false);
+            assert.equal(resolveOrchestrationApproval(policy, invalid).invalidPreference, true);
+        }
+    }
+    assert.deepEqual(resolveOrchestrationApproval(undefined, 'auto'), {
+        mode: 'manual', invalidPreference: false,
+    });
+    assert.deepEqual(resolveOrchestrationApproval({
+        default_approval_mode: 'unknown', allow_user_approval_override: true,
+    }, undefined), { mode: 'manual', invalidPreference: false });
+}
+
+async function testDebounceAndPartialUpdates() {
+    await loadSettings({ [key]: 'manual', reasoningEffortSettings: { 'gpt-5': 'high' } });
+    const writes = holdWrites();
+    mock.timers.enable({ apis: ['setTimeout'] });
+    try {
+        state().update({ [key]: 'auto' });
+        state().update({ [key]: 'timed', darkModeEnabled: true });
+        mock.timers.tick(399);
+        await nextTurn();
+        assert.equal(writes.length, 0);
+        mock.timers.tick(1);
+        await nextTurn();
+        assert.equal(writes.length, 1);
+        assert.deepEqual(writes[0].payload, { [key]: 'timed', darkModeEnabled: true });
+        writes[0].finish();
+        await state().flush();
+        assert.equal(writes.length, 1);
+        assert.deepEqual(state().settings.reasoningEffortSettings, { 'gpt-5': 'high' });
+    } finally {
+        mock.timers.reset();
+    }
+}
+
+async function testFlushSerializesAndKeepsLatestChoice() {
+    await loadSettings();
+    const writes = holdWrites();
+    state().update({ [key]: 'auto' });
+    const first = state().flush();
+    await nextTurn();
+    state().update({ [key]: 'timed', darkModeEnabled: true });
+    let secondFinished = false;
+    const second = state().flush().then(() => { secondFinished = true; });
+    await nextTurn();
+    assert.equal(writes.length, 1, 'The second request must wait for the first.');
+    assert.equal(state().settings[key], 'timed');
+    writes[0].finish();
+    await first;
+    await nextTurn();
+    assert.equal(writes.length, 2);
+    assert.equal(secondFinished, false, 'Flush must wait for its queued write.');
+    assert.deepEqual(writes[1].payload, { [key]: 'timed', darkModeEnabled: true });
+    writes[1].finish();
+    await second;
+    assert.equal(state().settings[key], 'timed');
+    assert.equal(state().settings.darkModeEnabled, true);
+    assert.equal(state().saveError, null);
+}
+
+async function testOlderFailureDoesNotRevertNewerChoice() {
+    await loadSettings();
+    const writes = holdWrites();
+    state().update({ [key]: 'auto', darkModeEnabled: true });
+    const first = state().flush();
+    await nextTurn();
+    state().update({ [key]: 'timed' });
+    const seen = [];
+    const unsubscribe = useUserSettingsStore.subscribe((value) => seen.push(value.settings[key]));
+    try {
+        writes[0].finish(500);
+        await first;
+        assert.equal(state().settings[key], 'timed');
+        assert.equal(state().settings.darkModeEnabled, false, 'Only unchanged failed keys roll back.');
+        assert.ok(state().saveError);
+        assert.ok(seen.every((mode) => mode === 'timed'));
+        const second = state().flush();
+        await nextTurn();
+        writes[1].finish(500);
+        await second;
+        assert.equal(state().settings[key], 'manual', 'Both failures must restore the confirmed mode.');
+        assert.ok(state().saveError);
+    } finally {
+        unsubscribe();
+    }
+}
+
+async function testRollbackUsesLastSuccessfulWrite() {
+    await loadSettings();
+    const writes = holdWrites();
+    state().update({ [key]: 'auto' });
+    const first = state().flush();
+    await nextTurn();
+    state().update({ [key]: 'timed' });
+    const second = state().flush();
+    writes[0].finish();
+    await first;
+    await nextTurn();
+    writes[1].finish(500);
+    await second;
+    assert.equal(state().settings[key], 'auto');
+    assert.equal(state().saving, false);
+    assert.ok(state().saveError);
+}
+
+async function testReadFailureAndRetry() {
+    await loadSettings();
+    fetchImpl = async () => response({ error: 'Preferences unavailable' }, 500);
+    await state().load();
+    assert.equal(state().loading, false);
+    assert.equal(state().error, 'Preferences unavailable');
+    await loadSettings({ [key]: 'timed' });
+    assert.equal(state().settings[key], 'timed');
+}
+
+const tests = [
+    testResolution,
+    testDebounceAndPartialUpdates,
+    testFlushSerializesAndKeepsLatestChoice,
+    testOlderFailureDoesNotRevertNewerChoice,
+    testRollbackUsesLastSuccessfulWrite,
+    testReadFailureAndRetry,
+];
+for (const test of tests) {
+    await test();
+    console.log(`Passed: ${test.name}`);
+}

--- a/functional_tests/test_v2_orchestration_approval_persistence.py
+++ b/functional_tests/test_v2_orchestration_approval_persistence.py
@@ -1,0 +1,170 @@
+# test_v2_orchestration_approval_persistence.py
+"""
+Functional regressions for account-level orchestration approval preferences.
+Version: 0.261.101
+Implemented in: 0.261.101
+
+Exercise the real settings route with isolated authentication/storage dependencies,
+its approval vocabulary, and the real TypeScript resolver and preference store.
+Run with python -m pytest functional_tests/test_v2_orchestration_approval_persistence.py.
+"""
+
+import ast
+import copy
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+from flask import Flask, jsonify, request
+
+from test_support.versioning import assert_app_version_at_least
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+APP_ROOT = REPO_ROOT / "application" / "single_app"
+V2_ROOT = REPO_ROOT / "application" / "v2_ui" / "src"
+SETTING = "orchestrationApprovalMode"
+
+
+def _approval_modes():
+    source = APP_ROOT / "functions_orchestration_schema.py"
+    names = {"APPROVAL_MODE_MANUAL", "APPROVAL_MODE_TIMED", "APPROVAL_MODE_AUTO", "APPROVAL_MODES"}
+    assignments = [
+        node for node in ast.parse(source.read_text(encoding="utf-8")).body
+        if isinstance(node, ast.Assign)
+        and any(isinstance(target, ast.Name) and target.id in names for target in node.targets)
+    ]
+    namespace = {}
+    exec(compile(ast.Module(body=assignments, type_ignores=[]), str(source), "exec"), namespace)
+    return namespace["APPROVAL_MODES"]
+
+
+@pytest.fixture
+def settings_api():
+    source = APP_ROOT / "route_backend_users.py"
+    tree = ast.parse(source.read_text(encoding="utf-8"))
+    registrar = next(
+        node for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == "register_route_backend_users"
+    )
+    route = next(
+        node for node in registrar.body
+        if isinstance(node, ast.FunctionDef) and node.name == "user_settings"
+    )
+    route.decorator_list = []
+    state = {
+        "actor": "alice",
+        "fail_write": False,
+        "writes": [],
+        "documents": {
+            "alice": {"id": "alice", "settings": {"darkModeEnabled": True}},
+            "bob": {"id": "bob", "settings": {SETTING: "timed"}},
+        },
+    }
+
+    def update_settings(user_id, partial):
+        if state["fail_write"]:
+            return False
+        state["writes"].append((user_id, copy.deepcopy(partial)))
+        state["documents"][user_id]["settings"].update(copy.deepcopy(partial))
+        return True
+
+    namespace = {
+        "APPROVAL_MODES": _approval_modes(),
+        "AI_NOTICE_USER_SETTINGS_KEY": "aiNoticeDismissal",
+        "LATEST_FEATURES_HIDDEN_VERSION_SETTING": "latestFeaturesHiddenVersion",
+        "get_current_user_id": lambda: state["actor"],
+        "get_user_settings": lambda user_id: copy.deepcopy(state["documents"][user_id]),
+        "update_user_settings": update_settings,
+        "jsonify": jsonify,
+        "request": request,
+    }
+    module = ast.fix_missing_locations(ast.Module(body=[route], type_ignores=[]))
+    exec(compile(module, str(source), "exec"), namespace)
+    app = Flask(__name__)
+
+    def call_route(method="GET", body=None):
+        with app.test_request_context("/api/user/settings", method=method, json=body):
+            response, status = namespace["user_settings"]()
+            response.status_code = status
+            return response
+
+    return call_route, state
+
+
+def test_implementation_version():
+    assert_app_version_at_least("0.261.101")
+
+
+def test_preference_key_is_typed_and_declared_writable():
+    source = (V2_ROOT / "lib" / "userSettings.ts").read_text(encoding="utf-8")
+    assert f"{SETTING}?: ApprovalMode;" in source
+    writable = re.search(r"WRITABLE_USER_SETTING_KEYS = \[(.*?)\] as const", source, re.DOTALL)
+    assert writable and f"'{SETTING}'" in writable.group(1)
+    assert set(_approval_modes()) == {"manual", "timed", "auto"}
+
+
+@pytest.mark.parametrize("mode", _approval_modes())
+def test_preference_round_trip_preserves_other_settings(settings_api, mode):
+    client, state = settings_api
+    response = client("POST", {"settings": {SETTING: mode}})
+    assert response.status_code == 200
+    assert state["writes"] == [("alice", {SETTING: mode})]
+    assert client().get_json() == {
+        "id": "alice", "settings": {"darkModeEnabled": True, SETTING: mode}
+    }
+
+
+def test_absent_preference_is_not_materialized(settings_api):
+    client, state = settings_api
+    assert SETTING not in client().get_json()["settings"]
+    assert not state["writes"]
+
+
+@pytest.mark.parametrize("value", ["", "Manual", "invalid", None, True, 1, [], {}])
+def test_invalid_preference_rejects_entire_update(settings_api, value):
+    client, state = settings_api
+    before = copy.deepcopy(state["documents"])
+    response = client("POST", {"settings": {SETTING: value, "darkModeEnabled": False}})
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "Invalid orchestration approval mode"}
+    assert state["documents"] == before
+    assert not state["writes"]
+
+
+def test_preference_is_scoped_to_authenticated_user(settings_api):
+    client, state = settings_api
+    response = client("POST", {"user_id": "bob", "settings": {SETTING: "auto"}})
+    assert response.status_code == 200
+    assert state["writes"] == [("alice", {SETTING: "auto"})]
+    state["actor"] = "bob"
+    assert client().get_json()["settings"][SETTING] == "timed"
+    client("POST", {"settings": {SETTING: "manual"}})
+    state["actor"] = "alice"
+    assert client().get_json()["settings"][SETTING] == "auto"
+
+
+def test_storage_failure_is_not_reported_as_success(settings_api):
+    client, state = settings_api
+    state["fail_write"] = True
+    response = client("POST", {"settings": {SETTING: "auto"}})
+    assert response.status_code == 500
+    assert response.get_json() == {"error": "Failed to update settings"}
+    assert SETTING not in client().get_json()["settings"]
+
+
+def test_runtime_resolution_and_save_ordering():
+    node = shutil.which("node")
+    assert node, "Node is required for the existing v2 TypeScript runtime tests."
+    result = subprocess.run(
+        [node, str(REPO_ROOT / "functional_tests" / "test_v2_orchestration_approval_logic.mjs")],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        timeout=60,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/functional_tests/test_v2_settings_and_workspace_tags.py
+++ b/functional_tests/test_v2_settings_and_workspace_tags.py
@@ -1,9 +1,10 @@
-#!/usr/bin/env python3
+# test_v2_settings_and_workspace_tags.py
 """
 Functional test for the V2 personal settings page and conversation workspace tags.
 
-Version: 0.261.023
+Version: 0.261.101
 Implemented in: 0.261.020
+Pending-write rollback coverage updated in: 0.261.101
 
 Two things are pinned here.
 
@@ -162,8 +163,11 @@ def test_settings_saves_are_debounced_and_recoverable():
         "A failed save must revert the control, otherwise the user sees a value the "
         "server never stored and has no way to find out"
     )
-    assert re.search(r"catch \(error\)(.|\n)*?\.\.\.previous", store), (
-        "The rollback must be applied in the failure branch"
+    assert re.search(r"catch \(error\)(.|\n)*?\.\.\.reverted", store), (
+        "The failure branch must roll back only keys without a newer pending change"
+    )
+    assert "rollback[key] = previous[key]" in store, (
+        "A pending newer change must not retain a failed write as its rollback target"
     )
 
     print("Settings save behaviour test passed!")

--- a/ui_tests/fixtures/orchestration/harness_entry.tsx
+++ b/ui_tests/fixtures/orchestration/harness_entry.tsx
@@ -11,12 +11,13 @@
 
 import { createElement, StrictMode, type ComponentProps, type ReactElement } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
-import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+import { Link, MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
 
 import * as orchestrationStore from '../../../application/v2_ui/src/stores/orchestrationStore';
 import * as chatStore from '../../../application/v2_ui/src/stores/chatStore';
 import * as bootstrapStore from '../../../application/v2_ui/src/stores/bootstrapStore';
 import * as collaborationStore from '../../../application/v2_ui/src/stores/collaborationStore';
+import * as userSettingsStore from '../../../application/v2_ui/src/stores/userSettingsStore';
 import * as controller from '../../../application/v2_ui/src/lib/orchestrationController';
 import * as plan from '../../../application/v2_ui/src/lib/orchestrationPlan';
 import * as orchestration from '../../../application/v2_ui/src/lib/orchestration';
@@ -29,7 +30,6 @@ import { OrchestrationRunView } from '../../../application/v2_ui/src/components/
 import { OrchestrationMapView } from '../../../application/v2_ui/src/components/chat/OrchestrationMapView';
 import { MessageList } from '../../../application/v2_ui/src/components/chat/MessageList';
 import { Composer } from '../../../application/v2_ui/src/components/chat/Composer';
-import { MessageList } from '../../../application/v2_ui/src/components/chat/MessageList';
 import { DocumentExplorer } from '../../../application/v2_ui/src/components/documents/DocumentExplorer';
 
 function PromptExperience() {
@@ -54,6 +54,21 @@ function ContextWorkflow() {
     );
 }
 
+function ApprovalPreferenceWorkflow() {
+    return (
+        <>
+            <nav aria-label="Test navigation">
+                <Link to="/chat">Return to chat</Link>
+                <Link to="/away">Leave chat</Link>
+            </nav>
+            <Routes>
+                <Route path="/chat" element={<Composer />} />
+                <Route path="/away" element={<p>Away from chat</p>} />
+            </Routes>
+        </>
+    );
+}
+
 type ComponentName =
     | 'OrchestrationPlanCard'
     | 'ElicitationCard'
@@ -63,6 +78,7 @@ type ComponentName =
     | 'MessageList'
     | 'Composer'
     | 'PromptExperience'
+    | 'ApprovalPreferenceWorkflow'
     | 'ContextWorkflow';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -75,6 +91,7 @@ const components: Record<ComponentName, (props: any) => ReactElement | null> = {
     MessageList,
     Composer,
     PromptExperience,
+    ApprovalPreferenceWorkflow,
     ContextWorkflow,
 };
 
@@ -156,6 +173,13 @@ function reset(): void {
         drawerMode: null,
         messages: [],
     });
+    userSettingsStore.useUserSettingsStore.setState({
+        settings: {},
+        loading: false,
+        error: null,
+        saving: false,
+        saveError: null,
+    });
     try {
         window.localStorage.clear();
     } catch {
@@ -176,6 +200,7 @@ const harness = {
         chat: chatStore,
         bootstrap: bootstrapStore,
         collaboration: collaborationStore,
+        userSettings: userSettingsStore,
     },
     controller,
     plan,

--- a/ui_tests/test_v2_orchestration_approval_persistence.py
+++ b/ui_tests/test_v2_orchestration_approval_persistence.py
@@ -1,0 +1,528 @@
+# test_v2_orchestration_approval_persistence.py
+"""
+Browser regressions for account-level orchestration approval persistence.
+Version: 0.261.101
+Implemented in: 0.261.101
+
+Drive the real Composer, router and settings store. Only HTTP is replaced: the
+settings fixture persists across reloads and fresh browser contexts. Planning
+requests are captured and receive a manual pending fixture plan, without running
+tools or calling a model. Reuse local/Azure Playwright with DefaultAzureCredential.
+
+Run: python -m pytest ui_tests/test_v2_orchestration_approval_persistence.py -q
+"""
+
+import copy
+import json
+import re
+import sys
+from pathlib import Path
+from urllib.parse import urlsplit
+
+import pytest
+from playwright.sync_api import expect, sync_playwright
+
+# The repository's shared UI fixtures live outside the Python application package.
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "ui_tests" / "fixtures"))
+sys.path.insert(0, str(REPO_ROOT / "ui_tests" / "fixtures" / "orchestration"))
+
+import harness_build as hb  # noqa: E402
+from playwright_connection import connect_options  # noqa: E402, F401
+
+
+pytestmark = pytest.mark.ui
+ORIGIN = "https://simplechat.test"
+HARNESS_PATH = f"/{hb.HARNESS_HTML_REL}"
+SETTINGS_PATH = "/api/user/settings"
+PLAN_PATH = "/api/v2/orchestration/plan"
+CHAT_PATH = "/api/chat/stream"
+SETTING = "orchestrationApprovalMode"
+LABELS = {"manual": "Review", "timed": "After 8s", "auto": "Auto"}
+
+
+class ApprovalApi:
+    def __init__(self, assets):
+        self.assets = assets
+        self.settings = {"darkModeEnabled": True}
+        self.writes = []
+        self.plans = []
+        self.chats = []
+        self.read_count = 0
+        self.read_status = 200
+        self.write_status = 200
+        self.hold_reads = False
+        self.hold_writes = False
+        self.pending_reads = []
+        self.pending_writes = []
+        self.unexpected = []
+        self.expected_http_errors = set()
+        self.bootstrap = {
+            "features": {"enable_chat_orchestration": True},
+            "orchestration": {
+                "enabled": True,
+                "show_manual_controls": True,
+                "default_approval_mode": "manual",
+                "allow_user_approval_override": True,
+                "timed_approval_seconds": 8,
+            },
+            "branding": {"app_title": "SimpleChat"},
+            "catalogs": {"prompts": [], "models": [], "agents": []},
+            "settings": {},
+            "scope": {"groups": [], "public_workspaces": []},
+            "user": {"id": "approval-user", "display_name": "Approval User"},
+        }
+
+    def respond(self, route, body, status=200):
+        if status >= 400:
+            self.expected_http_errors.add((urlsplit(route.request.url).path, status))
+        route.fulfill(status=status, json=body)
+
+    def read(self, route):
+        self.respond(
+            route,
+            {"settings": copy.deepcopy(self.settings)}
+            if self.read_status == 200 else {"error": "Preferences unavailable"},
+            self.read_status,
+        )
+
+    def write(self, route, status=None):
+        status = self.write_status if status is None else status
+        if status == 200:
+            self.settings.update(copy.deepcopy(route.request.post_data_json["settings"]))
+        self.respond(
+            route,
+            {"message": "Saved"} if status == 200 else {"error": "Could not save preference"},
+            status,
+        )
+
+    def release_reads(self):
+        pending, self.pending_reads = self.pending_reads, []
+        for route in pending:
+            self.read(route)
+
+    def release_write(self, status=200):
+        self.write(self.pending_writes.pop(0), status)
+
+    def handle(self, route):
+        request = route.request
+        url = urlsplit(request.url)
+        path = url.path
+        if f"{url.scheme}://{url.netloc}" != ORIGIN:
+            self.unexpected.append(request.url)
+            route.abort()
+            return
+        if request.method == "GET" and path in self.assets:
+            route.fulfill(path=str(self.assets[path]))
+        elif path == "/favicon.ico":
+            route.fulfill(status=204)
+        elif path == SETTINGS_PATH and request.method == "GET":
+            self.read_count += 1
+            if self.hold_reads:
+                self.pending_reads.append(route)
+            else:
+                self.read(route)
+        elif path == SETTINGS_PATH and request.method == "POST":
+            self.writes.append(copy.deepcopy(request.post_data_json))
+            if self.hold_writes:
+                self.pending_writes.append(route)
+            else:
+                self.write(route)
+        elif path == "/api/v2/bootstrap" and request.method == "GET":
+            self.respond(route, self.bootstrap)
+        elif path == PLAN_PATH and request.method == "POST":
+            body = request.post_data_json
+            self.plans.append(copy.deepcopy(body))
+            event = {
+                "type": "orchestration_plan",
+                "plan": {
+                    "plan_id": "fixture-plan", "run_id": "fixture-run", "turn_id": body["turn_id"],
+                    "intent": {"summary": "Approval fixture", "complexity": "simple"},
+                    "steps": [{
+                        "step_id": "answer", "capability_id": "respond", "title": "Answer",
+                        "arguments": {}, "estimated_cost": "low",
+                    }],
+                    "approval": {"mode": "manual", "timeout_seconds": 0, "state": "pending"},
+                    "status": "awaiting_approval",
+                },
+            }
+            route.fulfill(content_type="text/event-stream", body=f"data: {json.dumps(event)}\n\n")
+        elif path == CHAT_PATH and request.method == "POST":
+            self.chats.append(copy.deepcopy(request.post_data_json))
+            route.fulfill(
+                content_type="text/event-stream",
+                body='data: {"response":"Fixture answer"}\n\ndata: {"done":true}\n\n',
+            )
+        elif path == "/api/get_messages" and request.method == "GET":
+            self.respond(route, {"messages": []})
+        elif path == "/api/conversations/feed" and request.method == "GET":
+            self.respond(route, {"conversations": [], "has_more": False})
+        else:
+            self.unexpected.append(f"{request.method} {path}")
+            self.respond(route, {"error": "Unexpected approval fixture request"}, 404)
+
+
+@pytest.fixture(scope="module")
+def approval_assets():
+    static_root = REPO_ROOT / "application" / "single_app" / "static"
+    index = static_root / "v2" / "index.html"
+    assert index.is_file(), "Run the existing v2 npm build before browser coverage."
+    assets = {
+        HARNESS_PATH: hb.HERE / "harness.html",
+        "/ui_tests/fixtures/orchestration/harness.bundle.js": hb.ensure_bundle(),
+    }
+    styles = re.findall(r'<link\b[^>]*href="([^"]+\.css)"', index.read_text(encoding="utf-8"))
+    assert styles, "The production build must reference its local stylesheet."
+    for url in styles:
+        parsed = urlsplit(url)
+        assert not parsed.netloc and parsed.path.startswith("/static/")
+        asset = (static_root / parsed.path.removeprefix("/static/")).resolve()
+        assert asset.is_relative_to(static_root.resolve()) and asset.is_file()
+        assets[parsed.path] = asset
+    return assets
+
+
+@pytest.fixture(scope="module")
+def approval_browser(connect_options):
+    with sync_playwright() as playwright:
+        browser = (
+            playwright.chromium.connect(**connect_options)
+            if connect_options else playwright.chromium.launch()
+        )
+        try:
+            yield browser
+        finally:
+            browser.close()
+
+
+@pytest.fixture
+def approval_ui(approval_browser, approval_assets):
+    api = ApprovalApi(approval_assets)
+    contexts = []
+    errors = []
+
+    def console_error(message):
+        if message.type == "error":
+            path = urlsplit(message.location.get("url", "")).path
+            if not any(
+                path == expected_path and f"status of {status}" in message.text
+                for expected_path, status in api.expected_http_errors
+            ):
+                errors.append(message.text)
+
+    def open_page(width=1440):
+        context = approval_browser.new_context(viewport={"width": width, "height": 900})
+        contexts.append(context)
+        page = context.new_page()
+        page.route("**/*", api.handle)
+        page.on("pageerror", lambda error: errors.append(str(error)))
+        page.on("console", console_error)
+        return page
+
+    try:
+        yield open_page, api
+    finally:
+        for context in contexts:
+            context.close()
+        assert not api.unexpected, f"Unexpected requests: {api.unexpected}"
+        assert not errors, f"Unexpected browser errors: {errors}"
+
+
+def mount(page, api):
+    response = page.goto(f"{ORIGIN}{HARNESS_PATH}", wait_until="domcontentloaded")
+    assert response and response.ok
+    page.wait_for_function("() => Boolean(window.OrchHarness)")
+    for path in api.assets:
+        if path.endswith(".css"):
+            page.add_style_tag(url=f"{ORIGIN}{path}")
+    page.evaluate(
+        """(bootstrap) => {
+            const H = window.OrchHarness;
+            H.reset();
+            H.stores.bootstrap.useBootstrapStore.setState({ data: bootstrap });
+            H.stores.chat.useChatStore.setState({
+                activeConversationId: 'approval-chat',
+                activeConversationKind: 'personal',
+                conversations: [{ id: 'approval-chat', title: 'Approval preferences' }],
+                streaming: false,
+                messagesLoading: false,
+            });
+            void H.stores.userSettings.useUserSettingsStore.getState().load();
+            H.mount('mount-a', 'ApprovalPreferenceWorkflow', {}, { initialEntries: ['/chat'] });
+        }""",
+        api.bootstrap,
+    )
+    expect(message_box(page)).to_be_visible()
+
+
+def message_box(page):
+    return page.get_by_role("textbox", name="Message", exact=True)
+
+
+def approval_picker(page):
+    return page.get_by_title("Approval mode", exact=True)
+
+
+def send_button(page):
+    return page.get_by_role("button", name="Send message", exact=True)
+
+
+def settings_response(response):
+    return urlsplit(response.url).path == SETTINGS_PATH and response.request.method == "POST"
+
+
+def choose(page, mode, wait=True):
+    def click_option():
+        approval_picker(page).click()
+        page.get_by_role("option", name=re.compile(f"^{re.escape(LABELS[mode])}")).click()
+
+    if wait:
+        with page.expect_response(settings_response):
+            click_option()
+    else:
+        click_option()
+
+
+def refresh_policy(page, api, **changes):
+    api.bootstrap["orchestration"].update(changes)
+    page.evaluate("() => window.OrchHarness.stores.bootstrap.useBootstrapStore.getState().refresh()")
+
+
+def send(page, path=PLAN_PATH):
+    message_box(page).fill("Use my selected approval mode.")
+    with page.expect_response(lambda response: urlsplit(response.url).path == path):
+        send_button(page).click()
+
+
+@pytest.mark.parametrize("width", [1440, 390])
+@pytest.mark.parametrize("mode", ["auto", "timed", "manual"])
+def test_choice_is_saved_without_sending_and_survives_navigation(approval_ui, width, mode):
+    open_page, api = approval_ui
+    api.bootstrap["orchestration"]["default_approval_mode"] = "manual" if mode == "auto" else "auto"
+    page = open_page(width)
+    mount(page, api)
+    expect(approval_picker(page)).to_be_enabled()
+    choose(page, mode)
+    expect(approval_picker(page)).to_contain_text(LABELS[mode])
+    assert api.writes == [{"settings": {SETTING: mode}}]
+    assert not api.plans
+    page.get_by_role("link", name="Leave chat", exact=True).click()
+    expect(page.get_by_text("Away from chat", exact=True)).to_be_visible()
+    page.get_by_role("link", name="Return to chat", exact=True).click()
+    expect(approval_picker(page)).to_contain_text(LABELS[mode])
+    page.evaluate(
+        "() => window.OrchHarness.stores.chat.useChatStore.setState({ activeConversationId: 'other-chat' })"
+    )
+    send(page)
+    assert api.plans[-1]["approval_mode"] == mode
+    assert api.plans[-1]["conversation_id"] == "other-chat"
+    assert api.settings["darkModeEnabled"] is True
+
+
+@pytest.mark.parametrize("mode", ["auto", "timed", "manual"])
+def test_reload_and_fresh_context_restore_from_account_settings(approval_ui, mode):
+    open_page, api = approval_ui
+    page = open_page()
+    mount(page, api)
+    expect(approval_picker(page)).to_be_enabled()
+    choose(page, mode)
+    for current_page in (page, open_page()):
+        mount(current_page, api)
+        expect(approval_picker(current_page)).to_contain_text(LABELS[mode])
+        assert api.settings[SETTING] == mode
+    assert api.read_count == 3
+    assert api.writes == [{"settings": {SETTING: mode}}]
+
+
+def test_leaving_chat_does_not_cancel_an_unacknowledged_save(approval_ui):
+    open_page, api = approval_ui
+    api.hold_writes = True
+    page = open_page()
+    mount(page, api)
+    expect(approval_picker(page)).to_be_enabled()
+    with page.expect_request(lambda request: urlsplit(request.url).path == SETTINGS_PATH):
+        choose(page, "auto", wait=False)
+    page.get_by_role("link", name="Leave chat", exact=True).click()
+    expect(page.get_by_text("Away from chat", exact=True)).to_be_visible()
+    with page.expect_response(settings_response):
+        api.release_write()
+    page.get_by_role("link", name="Return to chat", exact=True).click()
+    expect(approval_picker(page)).to_contain_text("Auto")
+    mount(page, api)
+    expect(approval_picker(page)).to_contain_text("Auto")
+    assert api.settings[SETTING] == "auto"
+
+
+def test_admin_refresh_and_lockout_do_not_erase_saved_choice(approval_ui):
+    open_page, api = approval_ui
+    api.settings[SETTING] = "timed"
+    page = open_page()
+    mount(page, api)
+    expect(approval_picker(page)).to_contain_text(LABELS["timed"])
+    refresh_policy(page, api, default_approval_mode="auto")
+    expect(approval_picker(page)).to_contain_text(LABELS["timed"])
+    refresh_policy(page, api, allow_user_approval_override=False)
+    expect(approval_picker(page)).to_have_count(0)
+    send(page)
+    assert api.plans[-1]["approval_mode"] == "auto"
+    refresh_policy(page, api, allow_user_approval_override=True, default_approval_mode="manual")
+    expect(approval_picker(page)).to_contain_text(LABELS["timed"])
+    assert api.settings[SETTING] == "timed"
+    assert not api.writes
+
+
+@pytest.mark.parametrize("mode", ["auto", "timed", "manual"])
+def test_default_is_used_without_creating_a_user_choice(approval_ui, mode):
+    open_page, api = approval_ui
+    api.bootstrap["orchestration"]["default_approval_mode"] = mode
+    page = open_page()
+    mount(page, api)
+    expect(approval_picker(page)).to_contain_text(LABELS[mode])
+    send(page)
+    assert api.plans[-1]["approval_mode"] == mode
+    assert SETTING not in api.settings
+    assert not api.writes
+
+
+def test_slow_settings_load_blocks_mouse_and_keyboard_submission(approval_ui):
+    open_page, api = approval_ui
+    api.settings[SETTING] = "manual"
+    api.bootstrap["orchestration"]["default_approval_mode"] = "auto"
+    api.hold_reads = True
+    page = open_page()
+    mount(page, api)
+    expect(approval_picker(page)).to_be_disabled()
+    message_box(page).fill("Do not run before my preference arrives.")
+    expect(send_button(page)).to_be_disabled()
+    message_box(page).press("Enter")
+    expect(page.get_by_role("status").filter(has_text="Loading your approval preference")).to_be_visible()
+    assert not api.plans
+    assert len(api.pending_reads) == 1
+    api.release_reads()
+    expect(approval_picker(page)).to_contain_text("Review")
+    expect(send_button(page)).to_be_enabled()
+    expect(message_box(page)).to_have_value("Do not run before my preference arrives.")
+    send(page)
+    assert api.plans[-1]["approval_mode"] == "manual"
+
+
+def test_failed_load_retries_without_losing_the_draft(approval_ui):
+    open_page, api = approval_ui
+    api.settings[SETTING] = "timed"
+    api.read_status = 500
+    page = open_page()
+    mount(page, api)
+    retry = page.get_by_role("button", name="Retry loading approval preference", exact=True)
+    expect(retry).to_be_visible()
+    message_box(page).fill("Keep this draft.")
+    message_box(page).press("Enter")
+    expect(send_button(page)).to_be_disabled()
+    assert not api.plans
+    api.read_status = 200
+    retry.click()
+    expect(approval_picker(page)).to_contain_text(LABELS["timed"])
+    expect(send_button(page)).to_be_enabled()
+    expect(message_box(page)).to_have_value("Keep this draft.")
+    expect(retry).to_have_count(0)
+
+
+@pytest.mark.parametrize("invalid", ["future-mode", None])
+def test_invalid_stored_mode_requires_a_valid_replacement(approval_ui, invalid):
+    open_page, api = approval_ui
+    api.settings[SETTING] = invalid
+    api.bootstrap["orchestration"]["default_approval_mode"] = "auto"
+    page = open_page()
+    mount(page, api)
+    warning = page.get_by_role("alert").filter(has_text="saved approval preference is invalid")
+    expect(warning).to_be_visible()
+    message_box(page).fill("Wait for a deliberate approval choice.")
+    expect(send_button(page)).to_be_disabled()
+    expect(approval_picker(page)).to_be_enabled()
+    choose(page, "manual")
+    expect(warning).to_have_count(0)
+    expect(send_button(page)).to_be_enabled()
+    assert api.settings[SETTING] == "manual"
+
+
+def test_failed_save_is_visible_and_restores_confirmed_choice(approval_ui):
+    open_page, api = approval_ui
+    api.settings[SETTING] = "manual"
+    api.write_status = 500
+    page = open_page()
+    mount(page, api)
+    expect(approval_picker(page)).to_be_enabled()
+    choose(page, "auto")
+    expect(page.get_by_role("alert").filter(has_text="Could not save preference")).to_be_visible()
+    expect(approval_picker(page)).to_contain_text("Review")
+    assert api.settings[SETTING] == "manual"
+    api.write_status = 200
+    choose(page, "auto")
+    expect(page.get_by_role("alert")).to_have_count(0)
+    mount(page, api)
+    expect(approval_picker(page)).to_contain_text("Auto")
+
+
+def test_older_failed_save_cannot_overwrite_a_newer_selection(approval_ui):
+    open_page, api = approval_ui
+    api.settings[SETTING] = "manual"
+    api.hold_writes = True
+    page = open_page()
+    mount(page, api)
+    expect(approval_picker(page)).to_be_enabled()
+    with page.expect_request(lambda request: urlsplit(request.url).path == SETTINGS_PATH):
+        choose(page, "auto", wait=False)
+    choose(page, "timed", wait=False)
+    expect(approval_picker(page)).to_contain_text(LABELS["timed"])
+    assert len(api.writes) == 1
+    with page.expect_request(lambda request: urlsplit(request.url).path == SETTINGS_PATH):
+        api.release_write(500)
+    expect(approval_picker(page)).to_contain_text(LABELS["timed"])
+    with page.expect_response(settings_response):
+        api.release_write()
+    expect(page.get_by_role("alert")).to_have_count(0)
+    assert api.settings[SETTING] == "timed"
+    mount(page, api)
+    expect(approval_picker(page)).to_contain_text(LABELS["timed"])
+
+
+def test_admin_enforced_mode_does_not_wait_for_unused_preference(approval_ui):
+    open_page, api = approval_ui
+    api.settings[SETTING] = "auto"
+    api.read_status = 500
+    api.bootstrap["orchestration"].update({
+        "allow_user_approval_override": False, "default_approval_mode": "timed",
+    })
+    page = open_page()
+    mount(page, api)
+    expect(approval_picker(page)).to_have_count(0)
+    send(page)
+    assert api.plans[-1]["approval_mode"] == "timed"
+    assert api.settings[SETTING] == "auto"
+
+
+def test_ordinary_chat_stays_available_when_preferences_fail(approval_ui):
+    open_page, api = approval_ui
+    api.read_status = 500
+    page = open_page()
+    mount(page, api)
+    expect(page.get_by_role("button", name="Retry loading approval preference")).to_be_visible()
+    page.get_by_role("button", name="Orchestrate", exact=True).click()
+    send(page, CHAT_PATH)
+    assert len(api.chats) == 1
+    assert not api.plans
+
+
+def test_changing_preference_leaves_existing_plan_approval_unchanged(approval_ui):
+    open_page, api = approval_ui
+    page = open_page()
+    mount(page, api)
+    expect(approval_picker(page)).to_be_enabled()
+    existing = {"plan_id": "existing", "approval": {"mode": "manual", "state": "pending"}}
+    page.evaluate(
+        "(plan) => window.OrchHarness.stores.orchestration.useOrchestrationStore.setState({ plans: { existing: plan } })",
+        existing,
+    )
+    choose(page, "auto")
+    assert page.evaluate(
+        "() => window.OrchHarness.stores.orchestration.useOrchestrationStore.getState().plans.existing"
+    ) == existing


### PR DESCRIPTION
## Summary

- Save the V2 orchestration approval mode to the user's account so it survives chat navigation, reloads, and visits from another device.
- Preserve administrator enforcement without erasing the saved choice. Wait for preferences to load and offer retry instead of starting orchestration with an unintended mode.
- Serialize preference writes and make rollback pending-aware so an older failed save cannot overwrite a newer choice.

Targets the `paullizer-react-v2-ui` integration branch. No new endpoint, database migration, administrator setting, or classic-interface change is required.

## Linked issue

None. This was reported directly, and issue creation was declined.

## Release Notes & Latest Features

- [ ] New Feature
- [x] Bug Fix
- [ ] UI Enhancement
- [ ] Breaking Change
- [ ] Internal only

Is this visible to end users?

- [x] Yes
- [ ] No

Is this admin-facing (Admin Settings, governance, deployment, config)?

- [ ] Yes
- [x] No — existing administrator enforcement is preserved.

Should this become a Latest Feature card?

- [ ] Yes
- [x] No
- [ ] Already added

Screenshot needed for the card?

- [ ] Yes
- [x] No
- [ ] Attached

## Version bump

- [x] `application/single_app/config.py` `VERSION` third segment bumped: `0.261.100` → `0.261.101`.
- [x] `deployers/version.txt` not needed because `deployers/` was not changed.

## Testing / validation

- `python -m pytest .\functional_tests\test_v2_orchestration_approval_persistence.py .\functional_tests\test_v2_settings_and_workspace_tags.py -q` — 26 passed, including the real TypeScript resolver/store runtime checks.
- `python -m pytest .\ui_tests\test_v2_orchestration_approval_persistence.py -q` — 23 passed with local Chromium, covering desktop/mobile, navigation, fresh contexts, delayed saves, failed reads/writes, admin precedence, and existing-plan isolation.
- `python .\ui_tests\test_v2_orchestration_composer.py` — 5 passed.
- Existing user-settings allowlist, reasoning-effort, route-policy inventory, unauthenticated-access, and route-policy coverage checks passed.
- `npm --prefix .\application\v2_ui run typecheck` and `npm --prefix .\application\v2_ui run build` passed.
- Documentation application-surface coverage and site-quality checks passed. The regenerated inventory has no semantic changes.

## Documentation

- [ ] Release notes updated, or not needed — left unchanged because approval was unavailable.
- [x] Feature, administrator, and chat-control reference documentation updated.
- [x] Fix documentation added at `docs/explanation/fixes/V2_ORCHESTRATION_APPROVAL_PERSISTENCE_FIX.md`.

## Security checklist

- [x] No new Flask routes; the existing settings route retains its Swagger and authentication decorators.
- [x] Current-user authorization and existing settings boundaries are preserved; the new preference accepts only `manual`, `timed`, or `auto`.
- [x] Browser JavaScript is served from local SimpleChat static assets only; no CDN-hosted JavaScript was added.
- [x] No secrets, keys, connection strings, or local-only artifacts are included.