### PR TITLE
Add conversational editing for orchestration plans

### DIFF
--- a/application/single_app/config.py
+++ b/application/single_app/config.py
@@ -97,7 +97,7 @@ DOTENV_LOAD_RESULT = load_simplechat_dotenv()
 EXECUTOR_TYPE = 'thread'
 EXECUTOR_MAX_WORKERS = 30
 SESSION_TYPE = 'filesystem'
-VERSION = "0.261.101"
+VERSION = "0.261.102"
 IS_DEVELOPMENT = is_development_env_enabled()
 
 SESSION_COOKIE_SAMESITE = os.getenv('SESSION_COOKIE_SAMESITE', 'Lax')

--- a/application/single_app/functions_orchestration_context.py
+++ b/application/single_app/functions_orchestration_context.py
@@ -1292,6 +1292,27 @@ def conversation_user_urls(user_message, snapshot=None, message_ids=None, answer
     return _string_list(urls, limit=8)
 
 
+def build_capability_request_context(
+    user_id, identity, user_message, agent_catalog, action_catalog=None, *, allowed_user_urls=None,
+):
+    """Apply the same caller-specific capability gates to planning, revisions, and execution."""
+    identity = identity or {}
+    urls = (
+        list(allowed_user_urls) if allowed_user_urls is not None
+        else conversation_user_urls(user_message)
+    )
+    return {
+        'user_id': user_id,
+        'user_message': user_message or '',
+        'message_urls': urls,
+        'user_roles': identity.get('user_roles') or [],
+        'user_email': identity.get('user_email'),
+        'user_enable_agents': identity.get('user_enable_agents', True),
+        'agent_catalog': list(agent_catalog or ()),
+        'action_catalog': list(action_catalog or ()),
+    }
+
+
 def build_conversation_signals(messages, user_message, *, truncated=False, message_ids=None):
     """Project already bounded history for the planner; the route owns loading it."""
     allowed = set(message_ids) if message_ids is not None else None

--- a/application/single_app/functions_orchestration_plan_editing.py
+++ b/application/single_app/functions_orchestration_plan_editing.py
@@ -1,0 +1,365 @@
+# functions_orchestration_plan_editing.py
+"""
+Planner-assisted changes to a saved, unexecuted plan.
+
+The revision store owns concurrency and publication. This module prepares the scoped
+request, reuses the planner and source authorization boundaries, and never executes work
+or writes conversation messages.
+
+Version: 0.261.102
+"""
+
+import json
+from copy import deepcopy
+from datetime import datetime, timezone
+
+from functions_mixed_source_orchestration import resolve_authorized_source_manifest
+from functions_orchestration_context import (
+    build_capability_request_context,
+    build_conversation_signals,
+    build_elicitation_user_request,
+    build_planner_context,
+    conversation_user_urls,
+    merge_elicitation_context,
+    normalize_elicitation_answer,
+    resolve_action_catalog,
+    resolve_agent_catalog,
+    resolve_candidate_documents,
+    resolve_elicitation_references,
+    validate_clarification_answers,
+)
+from functions_orchestration_plan_revisions import PlanRevisionError, read_revision_run
+from functions_orchestration_planner import plan_request
+from functions_orchestration_registry import resolve_available_capabilities
+from functions_orchestration_schema import (
+    PlanValidationError,
+    apply_plan_edits,
+    normalize_plan,
+    plan_document_ids,
+)
+
+TURN_CONTEXT_FIELDS = (
+    'conversation_id', 'turn_id', 'user_message', 'user_message_id',
+    'user_message_fingerprint', 'seeds', 'original_seeds', 'answered_questions',
+    'conversation_context', 'request_resolution', 'resolved_message',
+    'planning_token_usage', 'prompt_selection', 'edit_user_urls',
+)
+
+
+def _turn_context(record):
+    return {key: deepcopy(record[key]) for key in TURN_CONTEXT_FIELDS if key in record}
+
+
+def _chat_turn(role, content):
+    return {
+        'role': role, 'content': content,
+        'timestamp': datetime.now(timezone.utc).isoformat(),
+    }
+
+
+def _add_usage(context, usage):
+    previous = context.get('planning_token_usage') or {}
+    context['planning_token_usage'] = {
+        key: (previous.get(key) or 0) + ((usage or {}).get(key) or 0)
+        for key in ('prompt_tokens', 'completion_tokens', 'total_tokens')
+    }
+
+
+def _editor_urls(context, instruction='', chat=()):
+    prior_user_urls = [
+        url
+        for turn in reversed(chat[-20:])
+        if isinstance(turn, dict) and turn.get('role') == 'user' and isinstance(turn.get('content'), str)
+        for url in conversation_user_urls(turn.get('content'))
+    ]
+    return list(dict.fromkeys([
+        *conversation_user_urls(instruction),
+        *prior_user_urls,
+        *(context.get('edit_user_urls') or []),
+    ]))[:8]
+
+
+def revision_allowed_urls(context):
+    """Only actual user edits and accepted answers can authorize an additional URL."""
+    snapshot = context.get('conversation_context') or {}
+    resolution = context.get('request_resolution') or {}
+    return list(dict.fromkeys([
+        *(context.get('edit_user_urls') or []),
+        *conversation_user_urls(
+            context['user_message'], snapshot, resolution.get('message_ids'),
+            context.get('answered_questions'),
+        ),
+    ]))[:8]
+
+
+def _available_sources(context, plan, user_id, settings, candidates=()):
+    seeds = context.get('seeds') or {}
+    offered = {item['document_id']: item for item in candidates}
+    ids = list(dict.fromkeys([
+        *(seeds.get('document_ids') or []),
+        *plan_document_ids(plan, include_disabled=True),
+        *offered,
+    ]))
+    if not ids:
+        return []
+    try:
+        manifest = resolve_authorized_source_manifest(
+            ids, user_id, conversation_id=context['conversation_id'],
+            doc_scope=seeds.get('doc_scope') or 'all',
+            active_group_ids=seeds.get('active_group_ids') or None,
+            active_public_workspace_ids=seeds.get('active_public_workspace_ids') or None,
+        )
+    except ValueError as exc:
+        raise PlanRevisionError(
+            'The selected sources could not be used. Start a new request with fewer sources.',
+            code='invalid_request', status_code=400,
+        ) from exc
+    available = {
+        item['document_id']: item for item in manifest
+        if item.get('authorization_status') == 'authorized'
+    }
+    if set(seeds.get('document_ids') or []) - set(available):
+        raise PlanRevisionError(
+            'A selected source is no longer available. Start a new request with accessible sources.',
+            code='source_changed',
+        )
+    return [
+        {
+            **offered.get(document_id, {}),
+            'document_id': document_id,
+            'file_name': item.get('file_name') or item.get('display_name') or document_id,
+            'title': item.get('display_name') or item.get('file_name') or document_id,
+            'scope': item.get('scope'),
+            'selected_by_user': document_id in (seeds.get('document_ids') or []),
+        }
+        for document_id, item in available.items()
+    ]
+
+
+def _revision_catalogs(context, user_id, settings, identity):
+    seeds = context.get('seeds') or {}
+    # Resolve current access even for a pinned agent; the ordinary first-plan fast path
+    # assumes that the composer's selection is still fresh.
+    agents = resolve_agent_catalog(
+        user_id, seeds={**seeds, 'agent': None}, settings=settings,
+    )
+    selected = seeds.get('agent')
+    if selected:
+        scope = selected.get('scope_type') or (
+            'group' if selected.get('is_group') else
+            'global' if selected.get('is_global') else 'personal'
+        )
+        agents = [
+            agent for agent in agents
+            if agent.get('name') == selected.get('name')
+            and agent.get('scope_type') == scope
+            and (not selected.get('id') or agent.get('id') == selected['id'])
+            and (
+                scope != 'group'
+                or agent.get('group_id') == (selected.get('group_id') or selected.get('scope_id'))
+            )
+        ]
+        if len(agents) != 1:
+            raise PlanRevisionError(
+                'The selected agent is no longer available. Start a new request to choose an agent.',
+                code='source_changed',
+            )
+    actions = resolve_action_catalog(user_id, seeds=seeds, settings=settings)
+    caller = build_capability_request_context(
+        user_id, identity, context.get('resolved_message') or context['user_message'],
+        agents, actions, allowed_user_urls=revision_allowed_urls(context),
+    )
+    return agents, actions, caller
+
+
+def validate_edited_plan(plan, context, user_id, settings, identity):
+    """Recheck a restored/generated plan before committing it, including current access."""
+    seeds = context.get('seeds') or {}
+    resolve_elicitation_references(
+        seeds.get('elicitation_references') or [],
+        user_id, context['conversation_id'], settings=settings,
+    )
+    candidates = _available_sources(context, plan, user_id, settings)
+    authorized = {item['document_id'] for item in candidates}
+    if set(plan_document_ids(plan, include_disabled=True)) - authorized:
+        raise PlanRevisionError(
+            'That version names sources that are no longer available. Your current plan is unchanged.',
+            code='source_changed',
+        )
+    agents, actions, caller = _revision_catalogs(context, user_id, settings, identity)
+    capabilities = resolve_available_capabilities(
+        settings, allowed_ids=settings.get('chat_orchestration_enabled_capabilities'),
+        request_context=caller,
+    )
+    try:
+        checked = normalize_plan(
+            deepcopy(plan), context['conversation_id'], user_id, settings=settings,
+            approval_mode='manual', authorized_document_ids=authorized,
+            available_capability_ids=[item['id'] for item in capabilities],
+            turn_id=context['turn_id'], seeds=seeds,
+            document_labels={item['document_id']: item['file_name'] for item in candidates},
+            agent_names=[item['name'] for item in agents], actions=actions,
+        )
+    except PlanValidationError as exc:
+        raise PlanRevisionError(
+            'That version cannot be used with the current capabilities. Your current plan is unchanged.',
+            code='source_changed',
+        ) from exc
+    if checked['validation']['errors']:
+        raise PlanRevisionError(
+            'That version contains work that is no longer available. Your current plan is unchanged.',
+            code='source_changed',
+        )
+    checked['validation']['repairs'] = list(dict.fromkeys([
+        *(plan.get('validation', {}).get('repairs') or []),
+        *checked['validation']['repairs'],
+    ]))
+    return checked
+
+
+def build_plan_edit_outcome(
+    record, data, user_id, settings, *, identity, conversation_context, ledger=None,
+):
+    """Return publication arguments; no model response is a committed revision yet."""
+    context = _turn_context(record)
+    context['conversation_context'] = conversation_context
+    chat = deepcopy(record.get('edit_chat') or [])
+    action = data['action']
+    current_plan = apply_plan_edits(
+        deepcopy(record['plan']), data.get('edits', record.get('edit_narrowing')),
+    )
+    instruction = data.get('instruction', '')
+    user_content = instruction
+    allow_elicitation = True
+    if action == 'discard':
+        return {
+            'kind': 'discard',
+            'chat': [*chat, _chat_turn('assistant', 'The proposed change was cancelled. The current plan is unchanged.')],
+        }
+    if action == 'restore':
+        source = read_revision_run(data['source_run_id'], user_id, context['conversation_id'])
+        if (
+            source.get('turn_id') != record['turn_id'] or source.get('started_at')
+            or source.get('user_message_id') != record.get('user_message_id')
+            or source.get('user_message_fingerprint') != record.get('user_message_fingerprint')
+            or (source.get('revision_root_run_id') or source['id'])
+            != (record.get('revision_root_run_id') or record['id'])
+        ):
+            raise PlanRevisionError('Choose a version of this unexecuted plan.', code='invalid_request', status_code=400)
+        restored_context = _turn_context(source)
+        restored_context['conversation_context'] = conversation_context
+        note = f"Restored version {int(source.get('revision') or 0) + 1}."
+        return {
+            'kind': 'plan', 'document': deepcopy(source['plan']),
+            'turn_context': restored_context, 'origin': 'restore', 'instruction': note,
+            'chat': [*chat, _chat_turn('user', note), _chat_turn('assistant', note)],
+        }
+    if action == 'answer':
+        pending = record['edit_pending']
+        question = pending['elicitation']
+        context = deepcopy(pending['turn_context'])
+        context['conversation_context'] = conversation_context
+        current_plan = deepcopy(pending['base_plan'])
+        instruction = pending['instruction']
+        validated, answer_context = normalize_elicitation_answer(
+            question, data['elicitation_response'], data.get('elicitation_context'),
+            user_id, context['conversation_id'], settings=settings,
+        )
+        if validated['action'] == 'cancel':
+            return {
+                'kind': 'discard',
+                'chat': [*chat, _chat_turn('assistant', 'The proposed change was cancelled. The current plan is unchanged.')],
+            }
+        context['answered_questions'] = [
+            *(context.get('answered_questions') or []),
+            {
+                'elicitation_id': question['elicitation_id'], 'revision': question['revision'],
+                'question': question['message'], 'action': validated['action'],
+                'answer': validated['content'], 'context': answer_context,
+            },
+        ]
+        if validated['action'] == 'accept':
+            context['seeds'] = merge_elicitation_context(context.get('seeds'), answer_context)
+        allow_elicitation = validated['action'] == 'accept'
+        answer_text = json.dumps(validated['content'], ensure_ascii=False)
+        user_content = (
+            'Declined to provide more information.' if validated['action'] == 'decline'
+            else f"Answer: {answer_text[:1900]}" + (' (excerpt)' if len(answer_text) > 1900 else '')
+        )
+
+    validate_clarification_answers(context.get('answered_questions') or [])
+    seeds = context.get('seeds') or {}
+    resolve_elicitation_references(
+        seeds.get('elicitation_references') or [],
+        user_id, context['conversation_id'], settings=settings,
+    )
+    context['edit_user_urls'] = _editor_urls(context, instruction, chat)
+    current_request = context.get('resolved_message') or context['user_message']
+    changed_request = (
+        f'Current task:\n{current_request}\n\n'
+        f'User-requested change (takes precedence where it changes the task):\n{instruction}'
+    )
+    candidates, _probed = resolve_candidate_documents(
+        build_elicitation_user_request(changed_request, context.get('answered_questions')),
+        user_id, seeds=seeds, conversation_id=context['conversation_id'], settings=settings,
+    )
+    candidates = _available_sources(context, current_plan, user_id, settings, candidates)
+    agents, actions, caller = _revision_catalogs(context, user_id, settings, identity)
+    resolution = context.get('request_resolution') or {}
+    signals = build_conversation_signals(
+        conversation_context['messages'], context['user_message'],
+        truncated=conversation_context.get('truncated', False),
+        message_ids=resolution.get('message_ids'),
+    )
+    signals['urls'] = revision_allowed_urls(context)
+    planner_context = build_planner_context(
+        changed_request, candidates=candidates, seeds=seeds, ledger=ledger,
+        signals=signals, agents=agents, actions=actions,
+        original_message=context['user_message'], request_resolution=resolution,
+        answered_questions=context.get('answered_questions'),
+    )
+    edit_context = {
+        'current_plan': {
+            key: deepcopy(current_plan.get(key)) for key in ('intent', 'assumptions', 'steps')
+        },
+        'current_request': current_request, 'instruction': instruction,
+        'chat': [{key: turn[key] for key in ('role', 'content')} for turn in chat[-20:]],
+    }
+    kind, document = plan_request(
+        changed_request, planner_context, context['conversation_id'], user_id,
+        settings=settings, approval_mode='manual',
+        authorized_document_ids={item['document_id'] for item in candidates},
+        turn_id=context['turn_id'], seeds=seeds,
+        document_labels={item['document_id']: item['file_name'] for item in candidates},
+        request_context=caller, edit_context=edit_context, allow_elicitation=allow_elicitation,
+        revision=int(record.get('revision') or 0) + 1,
+    )
+    _add_usage(context, document.get('token_usage'))
+    chat.append(_chat_turn('user', user_content))
+    if kind == 'elicitation':
+        document.update({
+            'conversation_id': context['conversation_id'], 'turn_id': context['turn_id'],
+        })
+        return {
+            'kind': kind, 'document': document, 'turn_context': context,
+            'chat': [*chat, _chat_turn('assistant', document['message'])],
+            'pending': {
+                'elicitation': document, 'turn_context': context,
+                'instruction': instruction, 'base_plan': current_plan,
+            },
+        }
+    if kind == 'message':
+        return {
+            'kind': kind, 'turn_context': context,
+            'chat': [*chat, _chat_turn('assistant', document['message'])],
+        }
+    context['resolved_message'] = document.pop('revised_request').strip()
+    count = sum(step.get('enabled', True) for step in document['steps'])
+    summary = f"Updated the plan to {count} {'step' if count == 1 else 'steps'}. Review it before running."
+    if document['validation']['repairs']:
+        summary += ' Adjustments: ' + ' '.join(document['validation']['repairs'])
+    return {
+        'kind': 'plan', 'document': document, 'turn_context': context,
+        'instruction': instruction, 'origin': 'ai',
+        'chat': [*chat, _chat_turn('assistant', summary)],
+    }

--- a/application/single_app/functions_orchestration_plan_revisions.py
+++ b/application/single_app/functions_orchestration_plan_revisions.py
@@ -1,0 +1,784 @@
+# functions_orchestration_plan_revisions.py
+"""
+Conditional pre-execution editing and execution claims for orchestration plans.
+
+Revision publication uses a transactional batch in the conversation partition. Neither
+an editor lease nor a browser approval may bypass the run's ETag boundary.
+
+Version: 0.261.102
+"""
+
+import hashlib
+import json
+import logging
+import uuid
+from copy import deepcopy
+from datetime import datetime, timedelta, timezone
+
+from azure.core import MatchConditions
+from azure.core.exceptions import AzureError
+from azure.cosmos import exceptions
+
+import functions_orchestration_runs as run_store
+from functions_appinsights import log_event
+from functions_orchestration_schema import apply_plan_edits, summarize_plan
+
+
+EDIT_CLAIM_SECONDS = 900
+EDIT_RETAINED_SUBMISSIONS = 12
+EDIT_CHAT_LIMIT = 20
+EDIT_CHAT_CONTENT_LIMIT = 4000
+EDIT_HISTORY_PAGE_SIZE = 20
+EDIT_REQUEST_MAX_BYTES = 131072
+EDIT_INSTRUCTION_LIMIT = 2000
+EDIT_NOTE_LIMIT = 600
+
+_EDITABLE_STATUSES = {'draft', 'awaiting_approval'}
+_RUNNABLE_STATUSES = _EDITABLE_STATUSES | {'approved'}
+_CONTEXT_FIELDS = (
+    'seeds', 'answered_questions', 'request_resolution', 'resolved_message',
+    'planning_token_usage', 'prompt_selection', 'edit_user_urls',
+)
+_IMMUTABLE_FIELDS = (
+    'user_message', 'user_message_id', 'user_message_fingerprint', 'turn_id',
+    'original_seeds', 'conversation_context', 'snapshot', 'request_fingerprint',
+)
+_PLAN_FIELDS = (
+    'plan_id', 'run_id', 'turn_id', 'revision', 'conversation_id', 'user_id',
+    'planner_contract_version', 'intent', 'assumptions', 'approval', 'status',
+    'steps', 'inputs', 'outputs', 'validation', 'edit_version',
+)
+_STEP_FIELDS = (
+    'step_id', 'capability_id', 'title', 'rationale', 'arguments', 'depends_on',
+    'optional', 'enabled', 'estimated_cost', 'phase', 'status',
+)
+_QUESTION_FIELDS = (
+    'elicitation_id', 'contract_version', 'run_id', 'revision', 'message',
+    'requested_schema', 'ui_hints', 'conversation_id', 'turn_id',
+)
+_REQUEST_FIELDS = {
+    'conversation_id', 'expected_version', 'submission_id', 'action', 'edits',
+}
+_ACTION_FIELDS = {
+    'ask': {'instruction'},
+    'restore': {'source_run_id'},
+    'answer': {
+        'elicitation_id', 'elicitation_revision', 'elicitation_response',
+        'elicitation_context',
+    },
+    'discard': {'elicitation_id', 'elicitation_revision'},
+}
+
+
+class PlanRevisionError(ValueError):
+    """An actionable error whose message is safe to return to an API client."""
+
+    def __init__(self, message, code='plan_changed', status_code=409, current_run_id=None):
+        super().__init__(message)
+        self.message = message
+        self.code = code
+        self.status_code = status_code
+        self.current_run_id = current_run_id
+
+
+def _now():
+    return datetime.now(timezone.utc)
+
+
+def _valid_id(value):
+    return (
+        isinstance(value, str) and 0 < len(value) <= 200 and value == value.strip()
+        and not any(
+            ord(character) < 32 or 0xD800 <= ord(character) <= 0xDFFF
+            or character in '/\\?#' for character in value
+        )
+    )
+
+
+def _invalid(message='Invalid plan edit request.'):
+    return PlanRevisionError(message, code='invalid_request', status_code=400)
+
+
+def _not_found():
+    return PlanRevisionError('The plan could not be found.', code='not_found', status_code=404)
+
+
+def _turn_id(record):
+    return record.get('turn_id') or (record.get('plan') or {}).get('turn_id')
+
+
+def _root_id(record):
+    return record.get('revision_root_run_id') or record['id']
+
+
+def _revision(record):
+    value = record.get('revision', 0)
+    return value if isinstance(value, int) and not isinstance(value, bool) and value >= 0 else 0
+
+
+def _owned_run(record, run_id, user_id, conversation_id):
+    if (
+        not all(_valid_id(value) for value in (run_id, user_id, conversation_id))
+        or not run_store._is_run_record(record)
+        or record.get('id') != run_id
+        or record.get('user_id') != user_id
+        or record.get('conversation_id') != conversation_id
+        or not isinstance(record.get('plan'), dict)
+    ):
+        return False
+    plan = record['plan']
+    return (
+        _valid_id(plan.get('plan_id')) and record.get('run_id', run_id) == run_id
+        and plan.get('run_id') == run_id
+        and plan.get('user_id', user_id) == user_id
+        and plan.get('conversation_id', conversation_id) == conversation_id
+        and (
+            not record.get('turn_id') or not plan.get('turn_id')
+            or record['turn_id'] == plan['turn_id']
+        )
+    )
+
+
+def _same_lineage(left, right):
+    return (
+        left['user_id'] == right.get('user_id')
+        and left['conversation_id'] == right.get('conversation_id')
+        and _turn_id(left) == _turn_id(right)
+        and _root_id(left) == _root_id(right)
+    )
+
+
+def read_revision_run(run_id, user_id, conversation_id, *, follow_current=False):
+    """Read an owned raw run, optionally following only its own revision chain."""
+    if not all(_valid_id(value) for value in (run_id, user_id, conversation_id)):
+        raise _not_found()
+    original = None
+    previous = None
+    visited = set()
+    while True:
+        if run_id in visited:
+            raise _not_found()
+        visited.add(run_id)
+        try:
+            record = run_store.cosmos_orchestration_runs_container.read_item(
+                item=run_id, partition_key=conversation_id,
+            )
+        except exceptions.CosmosResourceNotFoundError as exc:
+            raise _not_found() from exc
+        if not _owned_run(record, run_id, user_id, conversation_id):
+            raise _not_found()
+        if original is not None and (
+            not _same_lineage(original, record)
+            or _revision(record) <= _revision(previous)
+            or record.get('parent_run_id', previous['id']) != previous['id']
+        ):
+            raise _not_found()
+        if not follow_current or 'superseded_by_run_id' not in record:
+            return record
+        target = record['superseded_by_run_id']
+        if not _valid_id(target):
+            raise _not_found()
+        original = original or record
+        previous = record
+        run_id = target
+
+
+def _changed(record):
+    current_run_id = None
+    if 'superseded_by_run_id' in record:
+        current = read_revision_run(
+            record['id'], record['user_id'], record['conversation_id'], follow_current=True,
+        )
+        current_run_id = current['id']
+    return PlanRevisionError(
+        'This plan changed. Reload the latest plan before continuing.',
+        current_run_id=current_run_id,
+    )
+
+
+def _busy():
+    return PlanRevisionError(
+        'A plan edit or planner question is in progress. Finish it before continuing.',
+        code='edit_in_progress',
+    )
+
+
+def _assert_editable(record):
+    if (
+        record.get('status') not in _EDITABLE_STATUSES or record.get('started_at')
+        or 'superseded_by_run_id' in record
+    ):
+        raise _changed(record)
+
+
+def _version(record):
+    return record.get('edit_version') or record['plan'].get('edit_version') or ''
+
+
+def _check_version(record, expected_version, *, required=False):
+    current = _version(record)
+    if (
+        (required and not current)
+        or (current and record.get('edit_version') != record['plan'].get('edit_version'))
+        or (required and expected_version != current)
+        or (expected_version is not None and expected_version != current)
+    ):
+        raise _changed(record)
+
+
+def _check_plan_id(record, plan_id, *, required=False):
+    if (required or plan_id is not None) and (
+        not _valid_id(plan_id) or plan_id != record['plan'].get('plan_id')
+    ):
+        raise _changed(record)
+
+
+def _json_text(value):
+    try:
+        text = json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(',', ':'), allow_nan=False)
+        size = len(text.encode('utf-8'))
+    except (TypeError, ValueError, UnicodeError, RecursionError) as exc:
+        raise _invalid() from exc
+    if size > EDIT_REQUEST_MAX_BYTES:
+        raise PlanRevisionError(
+            'The plan edit request is too large.', code='request_too_large', status_code=413,
+        )
+    return text
+
+
+def _normalize_edits(plan, edits):
+    if edits is None:
+        return {'disabled_step_ids': [], 'removed_document_ids': {}}
+    _json_text(edits)
+    if not isinstance(edits, dict) or set(edits) - {'disabled_step_ids', 'removed_document_ids'}:
+        raise _invalid('Only step disabling and document removal are allowed.')
+    steps = {step['step_id']: step for step in plan.get('steps') or []}
+    disabled = edits.get('disabled_step_ids', [])
+    removed = edits.get('removed_document_ids', {})
+    if not isinstance(disabled, list) or not isinstance(removed, dict):
+        raise _invalid('Invalid step or document removals.')
+    if any(not _valid_id(step_id) or step_id not in steps for step_id in disabled):
+        raise _invalid('Choose steps from the current plan.')
+    if any(steps[step_id].get('capability_id') == 'respond' for step_id in disabled):
+        raise _invalid('The final answering step cannot be disabled.')
+    clean_removed = {}
+    for step_id, document_ids in removed.items():
+        if (
+            not _valid_id(step_id) or step_id not in steps
+            or not isinstance(document_ids, list)
+        ):
+            raise _invalid('Choose documents from the current plan.')
+        arguments = steps[step_id].get('arguments') or {}
+        available = {
+            document_id for field in ('document_ids', 'right_document_ids')
+            for document_id in arguments.get(field) or []
+        }
+        if any(not _valid_id(document_id) or document_id not in available for document_id in document_ids):
+            raise _invalid('Choose documents from the current plan.')
+        if document_ids:
+            clean_removed[step_id] = list(dict.fromkeys(document_ids))
+    return {
+        'disabled_step_ids': list(dict.fromkeys(disabled)),
+        'removed_document_ids': clean_removed,
+    }
+
+
+def _bounded_chat(chat):
+    if not isinstance(chat, list):
+        return []
+    return [
+        {
+            'role': entry['role'],
+            'content': entry['content'][:EDIT_CHAT_CONTENT_LIMIT],
+            'timestamp': entry['timestamp'][:64] if isinstance(entry.get('timestamp'), str) else _now().isoformat(),
+        }
+        for entry in chat
+        if isinstance(entry, dict) and entry.get('role') in ('user', 'assistant')
+        and isinstance(entry.get('content'), str)
+    ][-EDIT_CHAT_LIMIT:]
+
+
+def _manual_plan(plan, version):
+    result = deepcopy(plan)
+    result.update(status='awaiting_approval', edit_version=version)
+    result['approval'] = {
+        **(result.get('approval') or {}), 'mode': 'manual', 'state': 'pending',
+        'approved_at': None, 'approved_by': None,
+    }
+    return result
+
+
+def _replace(record, updates):
+    if not record.get('_etag'):
+        raise _changed(record)
+    replacement = deepcopy(run_store._strip_cosmos_metadata(record))
+    replacement.update(deepcopy(updates))
+    replacement['updated_at'] = _now().isoformat()
+    try:
+        result = run_store.cosmos_orchestration_runs_container.replace_item(
+            item=record['id'], body=replacement, etag=record['_etag'],
+            match_condition=MatchConditions.IfNotModified,
+        )
+    except exceptions.CosmosHttpResponseError as exc:
+        if exc.status_code in (404, 409, 412):
+            latest = read_revision_run(record['id'], record['user_id'], record['conversation_id'])
+            raise _changed(latest) from exc
+        raise
+    if isinstance(result, dict) and result.get('_etag'):
+        return result
+    return read_revision_run(record['id'], record['user_id'], record['conversation_id'])
+
+
+def begin_plan_edit(
+    run_id, user_id, conversation_id, *, plan_id, edits=None, expected_version=None,
+):
+    """Establish a manual hold without changing the original executable steps."""
+    record = read_revision_run(run_id, user_id, conversation_id)
+    _assert_editable(record)
+    _check_plan_id(record, plan_id, required=True)
+    _check_version(record, expected_version)
+    if _version(record):
+        return record
+    overlay = _normalize_edits(record['plan'], edits)
+    version = str(uuid.uuid4())
+    plan = _manual_plan(record['plan'], version)
+    return _replace(record, {
+        'plan': plan, 'approval': deepcopy(plan['approval']), 'status': 'awaiting_approval',
+        'plan_summary': summarize_plan(plan), 'edit_version': version,
+        'revision_root_run_id': _root_id(record), 'edit_narrowing': overlay,
+        'edit_chat': _bounded_chat(record.get('edit_chat')),
+        'edit_pending': None, 'edit_claim': None, 'edit_submissions': [], 'edit_attempts': [],
+        'revision_origin': record.get('revision_origin') or 'original',
+        'revision_note': record.get('revision_note') or 'Original plan.',
+    })
+
+
+def _claim_is_active(claim):
+    if not isinstance(claim, dict) or not claim:
+        return False
+    try:
+        started = datetime.fromisoformat(claim['started_at'])
+        deadline = started + timedelta(seconds=EDIT_CLAIM_SECONDS)
+        if claim.get('expires_at'):
+            deadline = min(deadline, datetime.fromisoformat(claim['expires_at']))
+        return _now() < deadline
+    except (KeyError, TypeError, ValueError, OverflowError):
+        return True
+
+
+def _public_plan(plan):
+    result = {key: deepcopy(plan[key]) for key in _PLAN_FIELDS if key in plan}
+    result['steps'] = [
+        {key: deepcopy(step[key]) for key in _STEP_FIELDS if key in step}
+        for step in plan.get('steps') or []
+    ]
+    return result
+
+
+def plan_editor_state(record, user_id, *, before_revision=None):
+    """Project only the canonical plan and bounded, owned editor conversation/history."""
+    if not isinstance(record, dict) or not _owned_run(
+        record, record.get('id'), user_id, record.get('conversation_id'),
+    ):
+        raise _not_found()
+    if before_revision is not None and (
+        not isinstance(before_revision, int) or isinstance(before_revision, bool)
+        or before_revision < 0
+    ):
+        raise _invalid('Invalid history cursor.')
+    parameters = [
+        {'name': '@conversation_id', 'value': record['conversation_id']},
+        {'name': '@user_id', 'value': user_id},
+        {'name': '@turn_id', 'value': _turn_id(record)},
+        {'name': '@revision_root_run_id', 'value': _root_id(record)},
+    ]
+    cursor_filter = ''
+    if before_revision is not None:
+        parameters.append({'name': '@before_revision', 'value': before_revision})
+        cursor_filter = 'AND c.revision < @before_revision '
+    rows = run_store.cosmos_orchestration_runs_container.query_items(
+        query=(
+            f'SELECT TOP {EDIT_HISTORY_PAGE_SIZE + 1} * FROM c '
+            'WHERE c.conversation_id = @conversation_id AND c.user_id = @user_id '
+            'AND (c.turn_id = @turn_id OR (NOT IS_DEFINED(c.turn_id) AND c.plan.turn_id = @turn_id)) '
+            'AND (NOT IS_DEFINED(c.record_type) OR c.record_type = "run" OR c.record_type = "orchestration_run") '
+            'AND (c.revision_root_run_id = @revision_root_run_id OR c.id = @revision_root_run_id) '
+            f'{cursor_filter}ORDER BY c.revision DESC'
+        ),
+        parameters=parameters, partition_key=record['conversation_id'],
+    )
+    history_records = [
+        row for row in rows
+        if _owned_run(row, row.get('id'), user_id, record['conversation_id'])
+        and _same_lineage(record, row)
+        and (before_revision is None or _revision(row) < before_revision)
+    ]
+    history_records.sort(key=_revision, reverse=True)
+    page = history_records[:EDIT_HISTORY_PAGE_SIZE]
+    history = [
+        {
+            'run_id': row['id'], 'plan_id': row['plan'].get('plan_id'),
+            'revision': _revision(row),
+            'created_at': row['created_at'][:64] if isinstance(row.get('created_at'), str) else None,
+            'origin': (
+                row['revision_origin'] if row.get('revision_origin') in ('ai', 'restore')
+                else 'original' if row['id'] == _root_id(row) else 'ai'
+            ),
+            'note': row['revision_note'][:EDIT_NOTE_LIMIT] if isinstance(row.get('revision_note'), str) else '',
+        }
+        for row in page
+    ]
+    pending = (record.get('edit_pending') or {}).get('elicitation')
+    return {
+        'plan': _public_plan(record['plan']),
+        'version': _version(record),
+        'edits': deepcopy(record.get('edit_narrowing') or _normalize_edits(record['plan'], None)),
+        'chat': _bounded_chat(record.get('edit_chat')),
+        'history': history,
+        'next_before_revision': _revision(page[-1]) if len(history_records) > len(page) else None,
+        'pending': {
+            key: deepcopy(pending[key]) for key in _QUESTION_FIELDS if key in pending
+        } if isinstance(pending, dict) else None,
+        'busy': _claim_is_active(record.get('edit_claim')),
+    }
+
+
+def _normalize_request(data, conversation_id):
+    _json_text(data)
+    if not isinstance(data, dict):
+        raise _invalid()
+    action = data.get('action')
+    if not isinstance(action, str) or action not in _ACTION_FIELDS:
+        raise _invalid('Choose a supported plan edit action.')
+    if set(data) - (_REQUEST_FIELDS | _ACTION_FIELDS[action]):
+        raise _invalid('Invalid plan edit request fields.')
+    if data.get('conversation_id') != conversation_id:
+        raise _not_found()
+    if not _valid_id(data.get('submission_id')):
+        raise _invalid('A submission ID is required.')
+    version = data.get('expected_version')
+    if not isinstance(version, str) or len(version) > 200:
+        raise PlanRevisionError('Reload the plan before editing it.')
+    result = deepcopy(data)
+    if action == 'ask':
+        instruction = data.get('instruction')
+        if (
+            not isinstance(instruction, str) or not instruction.strip()
+            or len(instruction) > EDIT_INSTRUCTION_LIMIT
+        ):
+            raise _invalid('Enter a plan change of at most 2,000 characters.')
+        result['instruction'] = instruction.strip()
+    if action == 'restore' and not _valid_id(data.get('source_run_id')):
+        raise _invalid('Choose a saved version to restore.')
+    if action == 'answer' or any(
+        key in data for key in ('elicitation_id', 'elicitation_revision')
+    ):
+        revision = data.get('elicitation_revision')
+        if (
+            not _valid_id(data.get('elicitation_id')) or not isinstance(revision, int)
+            or isinstance(revision, bool) or revision < 0
+        ):
+            raise _invalid('Use the current planner question.')
+    if action == 'answer':
+        response = data.get('elicitation_response')
+        context = data.get('elicitation_context')
+        if (
+            not isinstance(response, dict) or set(response) - {'action', 'content'}
+            or response.get('action') not in ('accept', 'decline', 'cancel')
+            or ('content' in response and not isinstance(response['content'], dict))
+            or (context is not None and not isinstance(context, dict))
+        ):
+            raise _invalid('Invalid planner question response.')
+    return result
+
+
+def _submission_receipt(record, request, fingerprint):
+    for entry in [
+        *(record.get('edit_submissions') or []), *(record.get('edit_attempts') or []),
+        record.get('edit_claim') or {},
+    ]:
+        if entry.get('submission_id') != request['submission_id']:
+            continue
+        if entry.get('fingerprint') != fingerprint:
+            raise PlanRevisionError(
+                'That submission ID was already used for a different edit.',
+                code='submission_conflict',
+            )
+        if entry.get('result_run_id'):
+            result = read_revision_run(
+                entry['result_run_id'], record['user_id'], record['conversation_id'],
+            )
+            if not _same_lineage(record, result):
+                raise _not_found()
+            return {
+                'record': record, 'request': request, 'claim_id': None,
+                'replayed': True, 'outcome_run_id': result['id'],
+            }
+    return None
+
+
+def claim_plan_revision(run_id, user_id, conversation_id, data):
+    """Claim one bounded edit lease, or replay an already committed identical request."""
+    record = read_revision_run(run_id, user_id, conversation_id)
+    request = _normalize_request(data, conversation_id)
+    fingerprint = hashlib.sha256(_json_text(request).encode('utf-8')).hexdigest()
+    replay = _submission_receipt(record, request, fingerprint)
+    if replay:
+        return replay
+    _assert_editable(record)
+    _check_version(record, request['expected_version'], required=True)
+    active_claim = record.get('edit_claim') or {}
+    discarding = request['action'] == 'discard'
+    if _claim_is_active(active_claim) and (
+        not discarding or active_claim.get('submission_id') == request['submission_id']
+    ):
+        raise _busy()
+    pending = record.get('edit_pending')
+    if request['action'] in ('ask', 'restore') and pending:
+        raise _busy()
+    if request['action'] in ('answer', 'discard'):
+        question = (pending or {}).get('elicitation')
+        # A discard can revoke an abandoned worker even before it produces a question.
+        if not isinstance(question, dict) and not (discarding and active_claim):
+            raise _changed(record)
+        if request['action'] == 'answer' or 'elicitation_id' in request:
+            if (
+                not isinstance(question, dict)
+                or request['elicitation_id'] != question.get('elicitation_id')
+                or request['elicitation_revision'] != question.get('revision')
+            ):
+                raise _changed(record)
+    if request['action'] == 'restore':
+        source = read_revision_run(request['source_run_id'], user_id, conversation_id)
+        if not _same_lineage(record, source) or source.get('started_at'):
+            raise _not_found()
+    overlay = _normalize_edits(
+        record['plan'], request.get('edits') if request.get('edits') is not None
+        else record.get('edit_narrowing'),
+    )
+    request['edits'] = overlay
+    now = _now()
+    lease = {
+        'claim_id': str(uuid.uuid4()), 'submission_id': request['submission_id'],
+        'fingerprint': fingerprint, 'started_at': now.isoformat(),
+        'expires_at': (now + timedelta(seconds=EDIT_CLAIM_SECONDS)).isoformat(),
+    }
+    attempts = [
+        item for item in record.get('edit_attempts') or []
+        if item.get('submission_id') != request['submission_id']
+    ]
+    attempts.append({'submission_id': request['submission_id'], 'fingerprint': fingerprint})
+    try:
+        held = _replace(record, {
+            'edit_claim': lease, 'edit_narrowing': overlay,
+            'edit_attempts': attempts[-EDIT_RETAINED_SUBMISSIONS:],
+        })
+    except PlanRevisionError:
+        latest = read_revision_run(run_id, user_id, conversation_id)
+        replay = _submission_receipt(latest, request, fingerprint)
+        if replay:
+            return replay
+        if _claim_is_active(latest.get('edit_claim')):
+            raise _busy()
+        raise
+    return {'record': held, 'request': request, 'claim_id': lease['claim_id'], 'replayed': False}
+
+
+def _claimed_record(claim):
+    if not isinstance(claim, dict) or claim.get('replayed') or not claim.get('claim_id'):
+        raise PlanRevisionError('This edit is no longer active. Reload the plan.')
+    original = claim['record']
+    record = read_revision_run(original['id'], original['user_id'], original['conversation_id'])
+    saved = record.get('edit_claim') or {}
+    if (
+        saved.get('claim_id') != claim['claim_id']
+        or saved.get('submission_id') != claim['request']['submission_id']
+        or saved.get('fingerprint') != (original.get('edit_claim') or {}).get('fingerprint')
+        or record.get('_etag') != original.get('_etag')
+        or _version(record) != _version(original)
+        or not _claim_is_active(saved)
+    ):
+        raise _changed(record)
+    _assert_editable(record)
+    return record
+
+
+def _completion_updates(record, result_run_id, kind):
+    lease = record['edit_claim']
+    receipt = {
+        'submission_id': lease['submission_id'], 'fingerprint': lease['fingerprint'],
+        'result_run_id': result_run_id, 'kind': kind, 'completed_at': _now().isoformat(),
+    }
+    receipts = [
+        item for item in record.get('edit_submissions') or []
+        if item.get('submission_id') != lease['submission_id']
+    ]
+    return {
+        'edit_claim': None,
+        'edit_submissions': (receipts + [receipt])[-EDIT_RETAINED_SUBMISSIONS:],
+        'edit_attempts': [
+            item for item in record.get('edit_attempts') or []
+            if item.get('submission_id') != lease['submission_id']
+        ][-EDIT_RETAINED_SUBMISSIONS:],
+    }
+
+
+def _new_revision(record, document, turn_context, chat, instruction, origin):
+    if not isinstance(document, dict) or not isinstance(document.get('steps'), list):
+        raise _invalid('A validated plan is required.')
+    if origin not in ('ai', 'restore'):
+        raise _invalid('Invalid revision origin.')
+    identity = json.dumps([
+        record['conversation_id'], record['user_id'], record['id'],
+        record['edit_claim']['submission_id'],
+    ], separators=(',', ':'))
+    run_id = f'run_{uuid.uuid5(uuid.NAMESPACE_URL, identity + ":run").hex}'
+    plan_id = f'plan_{uuid.uuid5(uuid.NAMESPACE_URL, identity + ":plan").hex}'
+    version = str(uuid.uuid4())
+    plan = _manual_plan(_public_plan(document), version)
+    plan.update({
+        'plan_id': plan_id, 'run_id': run_id, 'revision': _revision(record) + 1,
+        'turn_id': _turn_id(record), 'conversation_id': record['conversation_id'],
+        'user_id': record['user_id'],
+    })
+    for step in plan['steps']:
+        step['status'] = 'pending'
+    summary = summarize_plan(plan)
+    now = _now().isoformat()
+    result = {
+        'id': run_id, 'run_id': run_id, 'record_type': run_store.RUN_RECORD_TYPE,
+        'conversation_id': record['conversation_id'], 'user_id': record['user_id'],
+        'turn_index': record.get('turn_index', 0), 'plan': plan, 'plan_summary': summary,
+        'revision': plan['revision'], 'status': 'awaiting_approval',
+        'created_at': now, 'updated_at': now, 'started_at': None, 'completed_at': None,
+        'error': None, 'approval': deepcopy(plan['approval']),
+        'capabilities_used': list(summary['capabilities_used']),
+        'documents_touched': [], 'artifacts': [], 'token_usage': {},
+        'unresolved': [], 'answered_questions': [],
+        'edit_version': version, 'edit_narrowing': _normalize_edits(plan, None),
+        'edit_chat': _bounded_chat(chat), 'edit_pending': None, 'edit_claim': None,
+        'edit_submissions': [], 'edit_attempts': [],
+        'revision_root_run_id': _root_id(record), 'parent_run_id': record['id'],
+        'revision_origin': origin,
+        'revision_note': instruction[:EDIT_NOTE_LIMIT] if isinstance(instruction, str) else '',
+    }
+    for key in (*_IMMUTABLE_FIELDS, *_CONTEXT_FIELDS):
+        if key in record:
+            result[key] = deepcopy(record[key])
+    result['turn_id'] = _turn_id(record)
+    for key in _CONTEXT_FIELDS:
+        if isinstance(turn_context, dict) and key in turn_context:
+            result[key] = deepcopy(turn_context[key])
+    return result
+
+
+def complete_plan_revision(
+    claim, *, kind, document=None, turn_context=None, chat=None, instruction='',
+    origin='ai', pending=None,
+):
+    """Commit a new plan and its supersession together, or save a same-plan outcome."""
+    record = _claimed_record(claim)
+    desired_chat = record.get('edit_chat') if chat is None else chat
+    if kind == 'plan':
+        result = _new_revision(record, document, turn_context, desired_chat, instruction, origin)
+        predecessor = deepcopy(run_store._strip_cosmos_metadata(record))
+        predecessor.update(_completion_updates(record, result['id'], kind))
+        predecessor.update({
+            'status': 'superseded', 'superseded_by_run_id': result['id'],
+            'superseded_at': _now().isoformat(), 'updated_at': _now().isoformat(),
+            'edit_pending': None,
+        })
+        # The SDK's per-operation option is if_match_etag, not replace_item's etag.
+        operations = [
+            ('replace', (record['id'], predecessor), {'if_match_etag': record['_etag']}),
+            ('create', (result,)),
+        ]
+        try:
+            responses = run_store.cosmos_orchestration_runs_container.execute_item_batch(
+                batch_operations=operations, partition_key=record['conversation_id'],
+            )
+        except (exceptions.CosmosBatchOperationError, exceptions.CosmosHttpResponseError) as exc:
+            if exc.status_code in (404, 409, 412):
+                latest = read_revision_run(record['id'], record['user_id'], record['conversation_id'])
+                raise _changed(latest) from exc
+            raise
+        claim['completed'] = True
+        saved = responses[1].get('resourceBody') if responses and len(responses) > 1 else None
+        if isinstance(saved, dict) and saved.get('_etag'):
+            return saved
+        return read_revision_run(result['id'], result['user_id'], result['conversation_id'])
+    if kind not in ('elicitation', 'message', 'discard'):
+        raise _invalid('Invalid plan edit outcome.')
+    if kind == 'elicitation' and (
+        not isinstance(pending, dict) or not isinstance(pending.get('elicitation'), dict)
+    ):
+        raise _invalid('A saved planner question is required.')
+    version = str(uuid.uuid4())
+    plan = _manual_plan(record['plan'], version)
+    updates = {
+        **_completion_updates(record, record['id'], kind),
+        'plan': plan, 'approval': deepcopy(plan['approval']), 'status': 'awaiting_approval',
+        'edit_version': version, 'edit_chat': _bounded_chat(desired_chat),
+        'edit_pending': deepcopy(pending) if kind == 'elicitation' else None,
+    }
+    if isinstance(turn_context, dict) and 'planning_token_usage' in turn_context:
+        updates['planning_token_usage'] = deepcopy(turn_context['planning_token_usage'])
+    result = _replace(record, updates)
+    claim['completed'] = True
+    return result
+
+
+def release_plan_revision(claim):
+    """Best-effort cleanup of our own still-live lease, never another worker's outcome."""
+    if not claim or claim.get('replayed') or claim.get('completed'):
+        return
+    try:
+        record = _claimed_record(claim)
+        _replace(record, {'edit_claim': None})
+    except PlanRevisionError:
+        log_event(
+            '[ORCHESTRATION_RUNS] Kept a newer or completed plan edit during lease cleanup.',
+            level=logging.INFO, debug_only=True,
+        )
+    except AzureError as exc:
+        log_event(
+            '[ORCHESTRATION_RUNS] Plan edit lease cleanup could not be saved.',
+            extra={'exception_type': type(exc).__name__}, level=logging.ERROR,
+        )
+
+
+def claim_plan_run(
+    run_id, user_id, conversation_id, *, plan_id=None, expected_version=None,
+    edits=None, conversation_context=None,
+):
+    """Atomically turn a current pre-execution plan into the one executable run."""
+    record = read_revision_run(run_id, user_id, conversation_id)
+    if record.get('started_at') or record.get('status') in ('running', 'completed'):
+        raise PlanRevisionError('This plan has already started.', code='already_run')
+    if record.get('status') not in _RUNNABLE_STATUSES or 'superseded_by_run_id' in record:
+        raise _changed(record)
+    _check_plan_id(record, plan_id)
+    _check_version(record, expected_version, required=bool(_version(record)))
+    if _claim_is_active(record.get('edit_claim')) or record.get('edit_pending'):
+        raise _busy()
+    overlay = _normalize_edits(
+        record['plan'], edits if edits is not None else record.get('edit_narrowing'),
+    )
+    plan = apply_plan_edits(deepcopy(record['plan']), overlay)
+    now = _now().isoformat()
+    plan['status'] = 'running'
+    plan['approval'] = {
+        **(plan.get('approval') or {}), 'state': 'approved',
+        'approved_at': now, 'approved_by': user_id,
+    }
+    summary = summarize_plan(plan)
+    updates = {
+        'plan': plan, 'plan_summary': summary, 'approval': deepcopy(plan['approval']),
+        'status': 'running', 'started_at': now, 'edit_claim': None,
+        'capabilities_used': list(summary['capabilities_used']),
+    }
+    if conversation_context is not None:
+        if not isinstance(conversation_context, dict):
+            raise _invalid('Invalid conversation context.')
+        updates['conversation_context'] = deepcopy(conversation_context)
+    return _replace(record, updates)

--- a/application/single_app/functions_orchestration_planner.py
+++ b/application/single_app/functions_orchestration_planner.py
@@ -27,7 +27,7 @@ tries several strategies before giving up, and a total failure degrades to a sin
 answering step rather than to an error -- a user who asked a question should get an
 answer even when the planning layer had a bad day.
 
-Version: 0.261.099
+Version: 0.261.102
 """
 
 import json
@@ -52,6 +52,7 @@ from functions_orchestration_schema import (
     PlanValidationError,
     normalize_elicitation,
     normalize_plan,
+    plan_document_ids,
 )
 
 PLANNER_MAX_TOKENS = 2000
@@ -368,8 +369,33 @@ Do not repeat a question that clarifications or earlier runs already answered or
 Only ask when you truly cannot proceed; a reasonable assumption stated in "assumptions"
 is better than a question."""
 
+PLAN_EDIT_INSTRUCTIONS = """
+You are now in the plan editor, not executing a request. No step of this plan has run.
+The plan_edit object contains the current effective plan, the current task, the user's
+latest change, and this plan's own editing conversation. Revise THAT plan rather than
+starting a new conversation or answering the original task.
 
-def build_planner_messages(planner_context, replan_hint=None):
+Preserve the user's previous changes, disabled steps, source selections, and constraints
+unless the latest instruction explicitly changes them. An earlier version or chat turn
+does not undo the current plan. Keep existing step IDs for work that remains the same.
+You may add, remove, or change work only using the offered capabilities and authorized
+sources. Adding a capability to a plan cannot enable a disabled product feature. All
+capability gates, limits, argument schemas, and the final respond step still apply.
+
+For a change, return kind "plan" with the normal plan fields AND "revised_request": a
+self-contained description of the complete updated task, at most 6000 characters. This
+request will guide retrieval and the final answer, so include the latest changes and
+retain the relevant earlier constraints. Do not claim to have performed any planned work.
+
+If the user asks about the plan, or requests unavailable work, you may instead return
+{"kind": "message", "message": "<a concise explanation, at most 2000 characters>"}.
+That keeps the current plan unchanged. Do not silently substitute a different capability
+for one the user specifically requested. If necessary information is missing, return the
+existing elicitation shape; the editor will ask without discarding the current plan.
+"""
+
+
+def build_planner_messages(planner_context, replan_hint=None, edit_context=None):
     """The two messages the planner sees.
 
     The context is passed as JSON rather than prose because it is data the model has to
@@ -377,6 +403,8 @@ def build_planner_messages(planner_context, replan_hint=None):
     paraphrased document id is a plan step that fails validation.
     """
     payload = dict(planner_context or {})
+    if edit_context is not None:
+        payload['plan_edit'] = edit_context
 
     user_content = json.dumps(payload, ensure_ascii=False, separators=(',', ':'), default=str)
 
@@ -389,7 +417,12 @@ def build_planner_messages(planner_context, replan_hint=None):
         )
 
     return [
-        {'role': 'system', 'content': PLANNER_SYSTEM_PROMPT},
+        {
+            'role': 'system',
+            'content': PLANNER_SYSTEM_PROMPT + (
+                '\n\n' + PLAN_EDIT_INSTRUCTIONS if edit_context is not None else ''
+            ),
+        },
         {'role': 'user', 'content': user_content},
     ]
 
@@ -620,10 +653,12 @@ def plan_request(
     seeds=None,
     document_labels=None,
     request_context=None,
+    edit_context=None,
 ):
     """Produce a validated plan, or a question set, for one request.
 
-    Returns ``(kind, document)`` where ``kind`` is ``'plan'`` or ``'elicitation'``.
+    Returns ``(kind, document)`` where ``kind`` is ``'plan'`` or ``'elicitation'``,
+    or ``'message'`` for an editor-only explanation.
 
     ``request_context`` describes *this caller*, as opposed to the deployment: their app
     roles, whether their message contains a URL, whether they have an agent to invoke. It
@@ -636,7 +671,8 @@ def plan_request(
     A planner that fails -- unreachable, unparseable, or producing something that cannot
     be validated -- degrades to a single answering step rather than raising. The user
     asked a question; an orchestration layer having a bad day is not a reason to refuse to
-    answer it.
+    answer it. An editor request is different: a failed change must preserve the prior
+    plan, so ``edit_context`` disables that fallback and permits an explanatory message.
     """
     settings = settings if isinstance(settings, dict) else {}
 
@@ -655,6 +691,14 @@ def plan_request(
     actions = context.get('actions') or []
 
     def _fallback(reason):
+        if edit_context is not None:
+            log_event(
+                '[ORCHESTRATION_PLANNER] Could not revise the plan.',
+                level=logging.WARNING, extra={'reason': reason},
+            )
+            raise PlannerError(
+                'The requested change could not be planned. Your previous plan is unchanged.'
+            )
         log_event(
             f"[ORCHESTRATION_PLANNER] Falling back to a direct answer: {reason}",
             level=logging.WARNING,
@@ -684,7 +728,9 @@ def plan_request(
 
     try:
         reply, usage = _call_planner(
-            client, deployment, build_planner_messages(context, replan_hint=replan_hint)
+            client, deployment, build_planner_messages(
+                context, replan_hint=replan_hint, edit_context=edit_context,
+            )
         )
     except Exception as exc:
         return _fallback(f'the planner call failed: {exc}')
@@ -694,6 +740,29 @@ def plan_request(
         return _fallback('the planner returned nothing parseable')
 
     kind = str(parsed.get('kind') or '').strip().lower()
+
+    if edit_context is not None:
+        if kind == 'message':
+            message = parsed.get('message')
+            if not isinstance(message, str) or not message.strip() or len(message) > 2000:
+                return _fallback('the editor explanation was invalid')
+            return 'message', {
+                'message': message.strip(),
+                'token_usage': {
+                    field: getattr(usage, field)
+                    for field in ('prompt_tokens', 'completion_tokens', 'total_tokens')
+                    if isinstance(getattr(usage, field, None), int)
+                },
+            }
+        if kind not in ('plan', 'elicitation'):
+            return _fallback('the editor response did not identify a plan or question')
+        if kind == 'plan':
+            revised_request = parsed.get('revised_request')
+            if (
+                not isinstance(revised_request, str) or not revised_request.strip()
+                or len(revised_request) > RESOLVED_REQUEST_MAX_LENGTH
+            ):
+                return _fallback('the revised task was missing or too large')
 
     if kind == 'elicitation' and allow_elicitation:
         try:
@@ -740,10 +809,15 @@ def plan_request(
                 seeds=seeds,
                 document_labels=document_labels,
                 request_context=request_context,
+                edit_context=edit_context,
             )
 
     if kind == 'elicitation':
         return _fallback('the planner asked a question when it had already asked one')
+
+    if edit_context is not None and authorized_document_ids is not None:
+        if set(plan_document_ids(parsed, include_disabled=True)) - set(authorized_document_ids):
+            return _fallback('the revised plan named unavailable documents')
 
     try:
         plan = normalize_plan(
@@ -762,6 +836,9 @@ def plan_request(
         )
     except PlanValidationError as exc:
         return _fallback(f'no runnable step survived validation: {exc}')
+
+    if edit_context is not None and plan.get('validation', {}).get('errors'):
+        return _fallback('the revised plan contained unavailable or invalid work')
 
     plan['revision'] = revision
     plan['planner_model'] = deployment

--- a/application/single_app/functions_orchestration_runs.py
+++ b/application/single_app/functions_orchestration_runs.py
@@ -21,7 +21,7 @@ rather than trusting the key.
 Shaped and styled after ``functions_personal_workflows.py`` so the run/step CRUD reads the
 same as the workflow-run CRUD it sits beside.
 
-Version: 0.261.099
+Version: 0.261.102
 """
 
 import hashlib
@@ -56,7 +56,9 @@ PENDING_TURN_PREFIX = 'oturn_'
 PENDING_TURN_MAX_BYTES = 65536
 RUN_RECORD_FILTER = (
     '(NOT IS_DEFINED(c.record_type) OR c.record_type = "run" '
-    'OR c.record_type = "orchestration_run")'
+    'OR c.record_type = "orchestration_run") '
+    'AND NOT IS_DEFINED(c.superseded_by_run_id) '
+    'AND (NOT IS_DEFINED(c.status) OR c.status != "superseded")'
 )
 
 
@@ -80,6 +82,13 @@ def _coerce_int(value, default=0):
 def _is_run_record(document):
     return isinstance(document, dict) and document.get('record_type') in (
         None, RUN_RECORD_TYPE, 'orchestration_run',
+    )
+
+
+def _is_current_run_record(document):
+    return (
+        _is_run_record(document) and 'superseded_by_run_id' not in document
+        and document.get('status') != 'superseded'
     )
 
 
@@ -207,6 +216,7 @@ def create_orchestration_run(
     initial_updates=None,
     idempotent=False,
     turn_context=None,
+    expected_previous_run=None,
 ):
     """Persist a new run record for a validated plan.
 
@@ -214,6 +224,9 @@ def create_orchestration_run(
     resolved from the conversation when the caller does not supply one -- the ordering that
     the ledger and the map view rely on has to be assigned somewhere, and assigning it at
     creation keeps it monotonic without the route having to track a counter.
+
+    ``expected_previous_run`` is the owned raw record observed before ordinary replanning.
+    It makes publication conditional on that unstarted plan remaining unchanged.
     """
     plan = plan if isinstance(plan, dict) else {}
     conversation_id = conversation_id or plan.get('conversation_id')
@@ -225,6 +238,17 @@ def create_orchestration_run(
     run_id = plan.get('run_id') or new_run_id()
     if str(run_id).startswith((PENDING_TURN_PREFIX, 'elicitation_')):
         raise ValueError('The plan uses a reserved run ID.')
+    if expected_previous_run is not None:
+        if (
+            not _is_run_record(expected_previous_run)
+            or expected_previous_run.get('user_id') != user_id
+            or expected_previous_run.get('conversation_id') != conversation_id
+            or not expected_previous_run.get('_etag')
+            or not expected_previous_run.get('id')
+        ):
+            raise ConversationContextError('The previous plan could not be matched to this turn.')
+        if turn_index is None:
+            turn_index = expected_previous_run.get('turn_index', 0)
     if turn_index is None:
         turn_index = next_turn_index(conversation_id, user_id)
 
@@ -279,7 +303,11 @@ def create_orchestration_run(
     })
 
     try:
-        if idempotent:
+        if expected_previous_run is not None:
+            record = _publish_replanned_run(
+                record, expected_previous_run, idempotent=idempotent,
+            )
+        elif idempotent:
             try:
                 cosmos_orchestration_runs_container.create_item(body=record)
             except exceptions.CosmosResourceExistsError:
@@ -302,6 +330,105 @@ def create_orchestration_run(
         raise
 
     return _strip_cosmos_metadata(record)
+
+
+def _replanned_outcome(record, previous):
+    """Replay only a matching owned run, never a guessed or unrelated result ID."""
+    if (
+        not _is_run_record(previous)
+        or previous.get('user_id') != record['user_id']
+        or previous.get('conversation_id') != record['conversation_id']
+        or previous.get('turn_id') != record.get('turn_id')
+    ):
+        raise ConversationContextError('The saved plan could not be matched to this turn.')
+    if previous['id'] == record['id']:
+        existing = previous
+    elif previous.get('superseded_by_run_id') == record['id']:
+        existing = cosmos_orchestration_runs_container.read_item(
+            item=record['id'], partition_key=record['conversation_id'],
+        )
+        if (
+            existing.get('parent_run_id') != previous['id']
+            or existing.get('revision_root_run_id')
+            != (previous.get('revision_root_run_id') or previous['id'])
+        ):
+            raise ConversationContextError('The saved plan could not be matched to this turn.')
+    else:
+        return None
+    if (
+        not _is_run_record(existing)
+        or existing.get('id') != record['id']
+        or existing.get('user_id') != record['user_id']
+        or existing.get('conversation_id') != record['conversation_id']
+        or existing.get('turn_id') != record.get('turn_id')
+        or (existing.get('plan') or {}).get('plan_id') != record['plan'].get('plan_id')
+        or existing.get('revision') != record.get('revision')
+    ):
+        raise ConversationContextError('The saved plan could not be matched to this turn.')
+    return existing
+
+
+def _publish_replanned_run(record, expected_previous_run, *, idempotent=False):
+    """An ordinary replan must also lose to an editor hold or execution claim."""
+    previous = cosmos_orchestration_runs_container.read_item(
+        item=expected_previous_run['id'], partition_key=record['conversation_id'],
+    )
+    if idempotent:
+        replay = _replanned_outcome(record, previous)
+        if replay is not None:
+            return replay
+    if (
+        not _is_current_run_record(previous)
+        or previous.get('user_id') != record['user_id']
+        or previous.get('conversation_id') != record['conversation_id']
+        or previous.get('turn_id') != record.get('turn_id')
+        or previous.get('_etag') != expected_previous_run['_etag']
+        or previous.get('status') not in ('draft', 'awaiting_approval', 'approved')
+        or previous.get('started_at') or previous.get('edit_version')
+        or (previous.get('plan') or {}).get('edit_version')
+        or previous['id'] == record['id']
+        or _coerce_int(record.get('revision')) <= _coerce_int(previous.get('revision'))
+    ):
+        raise ConversationContextError('The plan changed while planning. Reload the latest plan.')
+    for key in (
+        'user_message', 'user_message_id', 'user_message_fingerprint', 'turn_id',
+        'original_seeds', 'conversation_context', 'snapshot', 'request_fingerprint',
+    ):
+        if key in previous:
+            record[key] = deepcopy(previous[key])
+    record['turn_index'] = previous.get('turn_index', 0)
+    record['revision_root_run_id'] = previous.get('revision_root_run_id') or previous['id']
+    record['parent_run_id'] = previous['id']
+    record['revision_origin'] = 'ai'
+    record['revision_note'] = 'Plan regenerated.'
+    predecessor = deepcopy(_strip_cosmos_metadata(previous))
+    predecessor.update({
+        'status': 'superseded', 'superseded_by_run_id': record['id'],
+        'revision_root_run_id': record['revision_root_run_id'],
+        'superseded_at': _utc_now_iso(), 'updated_at': _utc_now_iso(),
+    })
+    try:
+        cosmos_orchestration_runs_container.execute_item_batch(
+            batch_operations=[
+                ('replace', (previous['id'], predecessor), {'if_match_etag': previous['_etag']}),
+                ('create', (record,)),
+            ],
+            partition_key=record['conversation_id'],
+        )
+    except (exceptions.CosmosBatchOperationError, exceptions.CosmosHttpResponseError) as exc:
+        if exc.status_code in (404, 409, 412):
+            if idempotent:
+                latest = cosmos_orchestration_runs_container.read_item(
+                    item=previous['id'], partition_key=record['conversation_id'],
+                )
+                replay = _replanned_outcome(record, latest)
+                if replay is not None:
+                    return replay
+            raise ConversationContextError(
+                'The plan changed while planning. Reload the latest plan.'
+            ) from exc
+        raise
+    return record
 
 
 def get_orchestration_run(run_id, user_id, conversation_id=None):
@@ -372,7 +499,12 @@ def get_latest_turn_run(conversation_id, user_id, turn_id):
         ],
         partition_key=conversation_id,
     ))
-    return _strip_cosmos_metadata(rows[0]) if rows else None
+    current = [
+        row for row in rows if _is_current_run_record(row)
+        and row.get('conversation_id') == conversation_id
+        and row.get('user_id') == user_id and row.get('turn_id') == turn_id
+    ]
+    return _strip_cosmos_metadata(current[0]) if current else None
 
 
 def update_orchestration_run(run_id, user_id, updates, conversation_id=None):
@@ -451,7 +583,10 @@ def list_conversation_runs(conversation_id, user_id, limit=10):
         )
         return []
 
-    trimmed = [item for item in items if _is_run_record(item)][:limit]
+    trimmed = [
+        item for item in items if _is_current_run_record(item)
+        and item.get('user_id') == user_id and item.get('conversation_id') == conversation_id
+    ][:limit]
     trimmed.reverse()
     return [_strip_cosmos_metadata(item) for item in trimmed]
 

--- a/application/single_app/functions_orchestration_schema.py
+++ b/application/single_app/functions_orchestration_schema.py
@@ -775,6 +775,22 @@ def validate_plan(
     return plan
 
 
+def plan_document_ids(plan, *, include_disabled=False):
+    """Read named sources before authorization, without treating their presence as access."""
+    document_ids = []
+    for step in (plan or {}).get('steps') or ():
+        if not isinstance(step, dict) or (
+            not include_disabled and not step.get('enabled', True)
+        ):
+            continue
+        arguments = step.get('arguments')
+        if not isinstance(arguments, dict):
+            continue
+        for field in ('document_ids', 'right_document_ids', 'left_document_id'):
+            document_ids.extend(_string_list(arguments.get(field)))
+    return list(dict.fromkeys(document_ids))
+
+
 def build_plan_inputs(plan, seeds=None, document_labels=None, actions=None):
     """Describe what the plan will actually act on, for the approval card.
 
@@ -789,7 +805,7 @@ def build_plan_inputs(plan, seeds=None, document_labels=None, actions=None):
     seeds = seeds if isinstance(seeds, dict) else {}
     labels = document_labels if isinstance(document_labels, dict) else {}
 
-    document_ids = []
+    document_ids = plan_document_ids(plan)
     action_refs = []
     uses_web = False
     for step in (plan or {}).get('steps') or ():
@@ -802,14 +818,6 @@ def build_plan_inputs(plan, seeds=None, document_labels=None, actions=None):
             action_ref = arguments.get('action_ref')
             if action_ref and action_ref not in action_refs:
                 action_refs.append(action_ref)
-        for field in ('document_ids', 'right_document_ids'):
-            for value in arguments.get(field) or ():
-                if value not in document_ids:
-                    document_ids.append(value)
-        single = arguments.get('left_document_id')
-        if single and single not in document_ids:
-            document_ids.append(single)
-
     selected = set(seeds.get('document_ids') or ())
 
     # Named, not quoted. The plan document is stored and shown, and the prompt's full wording

--- a/application/single_app/route_backend_orchestration.py
+++ b/application/single_app/route_backend_orchestration.py
@@ -18,7 +18,7 @@ response outlives the request context, so touching ``request`` from inside the g
 raises rather than returning the value it would have had -- a failure that only appears
 once streaming is actually exercised.
 
-Version: 0.261.099
+Version: 0.261.102
 """
 
 import hashlib
@@ -52,6 +52,7 @@ from functions_orchestration_context import (
     HISTORY_MAX_MESSAGES,
     HISTORY_SCAN_LIMIT,
     ConversationContextError,
+    build_capability_request_context as _capability_request_context,
     build_conversation_snapshot,
     build_conversation_signals,
     build_elicitation_user_request,
@@ -84,10 +85,27 @@ from functions_orchestration_events import (
     build_step_thought,
     build_synthesis_thought,
     build_triage_thought,
+    serialize_sse,
 )
 from functions_orchestration_executor import RunContext, execute_plan
+from functions_orchestration_plan_editing import (
+    build_plan_edit_outcome,
+    revision_allowed_urls,
+    validate_edited_plan,
+)
+from functions_orchestration_plan_revisions import (
+    PlanRevisionError,
+    begin_plan_edit,
+    claim_plan_revision,
+    claim_plan_run,
+    complete_plan_revision,
+    plan_editor_state,
+    read_revision_run,
+    release_plan_revision,
+)
 from functions_orchestration_planner import (
     ConversationResolutionError,
+    PlannerError,
     build_trivial_plan,
     plan_request,
     resolve_conversation_request,
@@ -114,7 +132,6 @@ from functions_orchestration_runs import (
     update_orchestration_run,
 )
 from functions_orchestration_schema import (
-    APPROVAL_STATE_APPROVED,
     COMPLEXITY_TRIVIAL,
     ELICITATION_ACTION_ACCEPT,
     ELICITATION_ACTION_CANCEL,
@@ -122,7 +139,6 @@ from functions_orchestration_schema import (
     PLAN_STATUS_COMPLETED,
     PLAN_STATUS_FAILED,
     PLAN_STATUS_RUNNING,
-    apply_plan_edits,
     normalize_plan,
     normalize_elicitation,
     summarize_plan,
@@ -605,35 +621,6 @@ def _request_identity(user_id=None, seeded_agent=None):
     }
 
 
-def _capability_request_context(
-    user_id, identity, user_message, agent_catalog, action_catalog=None, *, allowed_user_urls=None
-):
-    """Describe this caller, so the capability request gates can answer for them.
-
-    Distinct from the deployment-level gates: those answer "does this installation have
-    URL access at all", these answer "may this person read a URL, and is there one to
-    read". Without it the planner would be offered capabilities the caller cannot use --
-    reading links in a message containing none, or an agent they have none of -- and
-    produce plans whose steps could only fail.
-
-    Built in the route because that is where the request is. The registry stays free of
-    Flask, and the gates stay next to the capabilities they belong to.
-    """
-    identity = identity or {}
-    urls = list(allowed_user_urls) if allowed_user_urls is not None else conversation_user_urls(user_message)
-
-    return {
-        'user_id': user_id,
-        'user_message': user_message or '',
-        'message_urls': urls,
-        'user_roles': identity.get('user_roles') or [],
-        'user_email': identity.get('user_email'),
-        'user_enable_agents': identity.get('user_enable_agents', True),
-        'agent_catalog': list(agent_catalog or ()),
-        'action_catalog': list(action_catalog or ()),
-    }
-
-
 def _partition_citations(citations):
     """Split citations into the document, web, and tool fields chat already renders.
 
@@ -732,7 +719,14 @@ def _elicitation_outcome_events(outcome):
         yield build_plan_event(outcome['document'])
 
 
-def _persist_planned_turn(plan, turn_context, user_id, conversation_id, submission=None):
+def _persist_planned_turn(
+    plan, turn_context, user_id, conversation_id, submission=None, expected_previous_run=None,
+):
+    latest = get_latest_turn_run(conversation_id, user_id, turn_context['turn_id'])
+    if latest and latest['run_id'] != plan['run_id']:
+        expected_previous_run = expected_previous_run or read_revision_run(
+            latest['run_id'], user_id, conversation_id,
+        )
     message_id, fingerprint = _save_turn_message(
         conversation_id, user_id, turn_context['turn_id'], turn_context['user_message'],
         previous=turn_context, prompt_selection=turn_context.get('prompt_selection'),
@@ -741,7 +735,7 @@ def _persist_planned_turn(plan, turn_context, user_id, conversation_id, submissi
     turn_context['user_message_fingerprint'] = fingerprint
     create_orchestration_run(
         plan, user_id, conversation_id=conversation_id, idempotent=True,
-        turn_context=turn_context,
+        turn_context=turn_context, expected_previous_run=expected_previous_run,
     )
     if submission:
         prepare_elicitation_outcome(submission, 'plan', plan, turn_context)
@@ -903,6 +897,71 @@ def _run_detail_row(record):
     row = _run_summary_row(record)
     row['plan'] = record.get('plan') or {}
     return row
+
+
+def _plan_edit_identity(data, settings):
+    if not isinstance(data, dict):
+        raise PlanRevisionError('An editor request must be an object.', code='invalid_request', status_code=400)
+    user_id = get_current_user_id()
+    if not user_id:
+        raise PlanRevisionError('User not authenticated.', code='unauthenticated', status_code=401)
+    if not _orchestration_enabled(settings):
+        raise PlanRevisionError('Chat orchestration is not enabled.', code='disabled', status_code=403)
+    conversation_id = data.get('conversation_id')
+    if not isinstance(conversation_id, str) or not conversation_id.strip():
+        raise PlanRevisionError('A conversation is required.', code='invalid_request', status_code=400)
+    conversation_id = conversation_id.strip()
+    try:
+        _authorize_context_conversation(conversation_id, user_id)
+    except ConversationContextError as exc:
+        raise PlanRevisionError('Plan not found.', code='not_found', status_code=404) from exc
+    return user_id, conversation_id
+
+
+def _plan_edit_error(exc):
+    if isinstance(exc, PlanRevisionError):
+        payload = {'error': exc.message, 'code': exc.code}
+        if exc.current_run_id:
+            payload['current_run_id'] = exc.current_run_id
+        status = exc.status_code
+    elif isinstance(exc, ElicitationContextError):
+        payload = {'error': 'The answers were not valid.', 'code': 'invalid_request', 'details': [exc.message]}
+        if exc.field:
+            payload['field_errors'] = {exc.field: exc.message}
+        status = 400
+    elif isinstance(exc, ConversationContextError):
+        payload = {
+            'error': 'Conversation context changed or is unavailable. Create a new plan.',
+            'code': 'plan_changed',
+        }
+        status = 409
+    elif isinstance(exc, PlannerError):
+        payload = {
+            'error': 'The requested change could not be planned. Your previous plan is unchanged. Please retry.',
+            'code': 'unavailable',
+        }
+        status = 503
+    else:
+        payload = {
+            'error': 'The plan change could not be confirmed. Reload the plan or retry to recover its saved state.',
+            'code': 'unavailable',
+        }
+        status = 503
+    log_event(
+        '[ORCHESTRATION] Plan editor request could not be completed.',
+        level=logging.WARNING, extra={'error_type': type(exc).__name__, 'code': payload['code']},
+    )
+    return payload, status
+
+
+def _plan_editor_event(record, user_id):
+    editor = plan_editor_state(record, user_id)
+    question = editor['pending']
+    return serialize_sse({
+        'type': 'orchestration_elicitation' if question else 'orchestration_plan',
+        **({'elicitation': question} if question else {'plan': editor['plan']}),
+        'editor': editor, 'done': True,
+    })
 
 
 def register_route_backend_orchestration(bp):
@@ -1133,6 +1192,7 @@ def register_route_backend_orchestration(bp):
 
                 observed_pending = None
                 current_revision = revision
+                planning_base = None
                 if submission:
                     snapshot = _conversation_context_for_run({
                         **turn_context, 'conversation_id': resolved_conversation_id,
@@ -1163,6 +1223,17 @@ def register_route_backend_orchestration(bp):
                             if not previous:
                                 raise ConversationContextError('The last plan could not be opened. Submit a new request.')
                     if previous:
+                        planning_base = read_revision_run(
+                            previous['run_id'], user_id, resolved_conversation_id,
+                        )
+                        if (
+                            planning_base.get('edit_version') or planning_base.get('started_at')
+                            or planning_base.get('status') not in ('draft', 'awaiting_approval', 'approved')
+                        ):
+                            raise PlanRevisionError(
+                                'Use the plan editor to revise this plan, or send a new request.',
+                                current_run_id=planning_base.get('superseded_by_run_id') or planning_base['run_id'],
+                            )
                         if previous.get('user_message') != message:
                             raise ConversationContextError('This turn changed. Submit a new request.')
                         snapshot = _conversation_context_for_run(previous, user_id, settings)
@@ -1333,11 +1404,17 @@ def register_route_backend_orchestration(bp):
                 outcome = {'kind': kind, 'document': plan}
                 if submission:
                     outcome = prepare_elicitation_outcome(submission, kind, plan, turn_context)
-                _persist_planned_turn(plan, turn_context, user_id, resolved_conversation_id, submission)
+                _persist_planned_turn(
+                    plan, turn_context, user_id, resolved_conversation_id, submission,
+                    expected_previous_run=planning_base,
+                )
                 if submission:
                     complete_elicitation_submission(submission)
                 yield from _elicitation_outcome_events(outcome)
 
+            except PlanRevisionError as exc:
+                payload, _status = _plan_edit_error(exc)
+                yield serialize_sse(payload)
             except (ConversationContextError, ConversationResolutionError) as exc:
                 log_event(
                     '[ORCHESTRATION] Conversation context could not be used for planning.',
@@ -1361,6 +1438,100 @@ def register_route_backend_orchestration(bp):
             streamed.call_on_close(lambda: release_elicitation_submission(submission))
         return streamed
 
+    @bp.route("/api/v2/orchestration/runs/<run_id>/editor", methods=["GET"])
+    @swagger_route(security=get_auth_security())
+    @login_required
+    @user_required
+    def orchestration_plan_editor(run_id):
+        """Read the current revision and paged history without approving or pausing it."""
+        try:
+            settings = get_settings()
+            user_id, conversation_id = _plan_edit_identity(request.args.to_dict(), settings)
+            before = request.args.get('before_revision')
+            if before is not None:
+                if len(before) > 10 or not before.isdecimal():
+                    raise PlanRevisionError('Invalid history cursor.', code='invalid_request', status_code=400)
+                before = int(before)
+            record = read_revision_run(run_id, user_id, conversation_id, follow_current=True)
+            return jsonify({'editor': plan_editor_state(record, user_id, before_revision=before)})
+        except (PlanRevisionError, ConversationContextError, AzureError) as exc:
+            payload, status = _plan_edit_error(exc)
+            return jsonify(payload), status
+
+    @bp.route("/api/v2/orchestration/runs/<run_id>/edit", methods=["POST"])
+    @swagger_route(security=get_auth_security())
+    @login_required
+    @user_required
+    def orchestration_begin_plan_edit(run_id):
+        """Acquire a durable manual approval hold before editing."""
+        try:
+            settings = get_settings()
+            data = request.get_json(silent=True)
+            user_id, conversation_id = _plan_edit_identity(data, settings)
+            if set(data) - {'conversation_id', 'plan_id', 'edits', 'expected_version'}:
+                raise PlanRevisionError('Invalid edit request fields.', code='invalid_request', status_code=400)
+            record = read_revision_run(run_id, user_id, conversation_id)
+            _conversation_context_for_run(record, user_id, settings)
+            record = begin_plan_edit(
+                run_id, user_id, conversation_id, plan_id=data.get('plan_id'),
+                edits=data.get('edits'), expected_version=data.get('expected_version'),
+            )
+            return jsonify({'editor': plan_editor_state(record, user_id)})
+        except (PlanRevisionError, ConversationContextError, AzureError) as exc:
+            payload, status = _plan_edit_error(exc)
+            return jsonify(payload), status
+
+    @bp.route("/api/v2/orchestration/runs/<run_id>/revisions", methods=["POST"])
+    @swagger_route(security=get_auth_security())
+    @login_required
+    @user_required
+    def orchestration_revise_plan(run_id):
+        """Ask, answer a planner question, restore a version, or discard a pending change."""
+        claim = None
+        try:
+            settings = get_settings()
+            data = request.get_json(silent=True)
+            user_id, conversation_id = _plan_edit_identity(data, settings)
+            record = read_revision_run(run_id, user_id, conversation_id)
+            snapshot = _conversation_context_for_run(record, user_id, settings)
+            claim = claim_plan_revision(run_id, user_id, conversation_id, data)
+            identity = _request_identity(user_id, seeded_agent=(record.get('seeds') or {}).get('agent'))
+        except (PlanRevisionError, ConversationContextError, ElicitationContextError, AzureError) as exc:
+            release_plan_revision(claim)
+            payload, status = _plan_edit_error(exc)
+            return jsonify(payload), status
+
+        def generate_revision():
+            try:
+                if claim.get('replayed'):
+                    saved = read_revision_run(
+                        claim['outcome_run_id'], user_id, conversation_id, follow_current=True,
+                    )
+                else:
+                    yield build_planning_thought('Updating the plan without running it.')
+                    outcome = build_plan_edit_outcome(
+                        claim['record'], claim['request'], user_id, settings,
+                        identity=identity, conversation_context=snapshot,
+                        ledger=_load_ledger(conversation_id, user_id, settings),
+                    )
+                    _conversation_context_for_run(record, user_id, settings)
+                    if outcome['kind'] == 'plan':
+                        outcome['document'] = validate_edited_plan(
+                            outcome['document'], outcome['turn_context'], user_id,
+                            get_settings(), identity,
+                        )
+                    saved = complete_plan_revision(claim, **outcome)
+                yield _plan_editor_event(saved, user_id)
+            except (PlanRevisionError, ConversationContextError, ElicitationContextError, PlannerError, AzureError) as exc:
+                payload, _status = _plan_edit_error(exc)
+                yield serialize_sse(payload)
+            finally:
+                release_plan_revision(claim)
+
+        streamed = _sse(generate_revision())
+        streamed.call_on_close(lambda: release_plan_revision(claim))
+        return streamed
+
     @bp.route("/api/v2/orchestration/run", methods=["POST"])
     @swagger_route(security=get_auth_security())
     @login_required
@@ -1376,6 +1547,8 @@ def register_route_backend_orchestration(bp):
             return jsonify({'error': 'User not authenticated'}), 401
 
         data = request.get_json(silent=True) or {}
+        if not isinstance(data, dict) or 'plan' in data:
+            return jsonify({'error': 'Run the saved plan by its ID, not a submitted plan.'}), 400
         run_id = _text(data.get('run_id'))
         conversation_id = _text(data.get('conversation_id'))
         if not run_id:
@@ -1389,20 +1562,15 @@ def register_route_backend_orchestration(bp):
 
         plan = record.get('plan') or {}
         if record.get('status') in (PLAN_STATUS_RUNNING, PLAN_STATUS_COMPLETED):
-            return jsonify({'error': 'This plan has already been run.'}), 409
-
-        try:
-            plan = apply_plan_edits(plan, data.get('edits'))
-        except Exception as exc:
-            log_event(f"[ORCHESTRATION] Rejected plan edits: {exc}", level=logging.WARNING)
-            return jsonify({'error': 'The plan edits were not valid.'}), 400
+            return jsonify({'error': 'This plan has already been run.', 'code': 'already_run'}), 409
 
         conversation_id = conversation_id or _text(record.get('conversation_id'))
         try:
             snapshot = _conversation_context_for_run(record, user_id, settings)
         except ConversationContextError:
             return jsonify({
-                'error': 'Conversation context changed or is unavailable. Create a new plan.'
+                'error': 'Conversation context changed or is unavailable. Create a new plan.',
+                'code': 'plan_changed',
             }), 409
         except AzureError as exc:
             log_event(
@@ -1423,6 +1591,7 @@ def register_route_backend_orchestration(bp):
         except ElicitationContextError as exc:
             return jsonify({
                 'error': 'Some accepted answer context is no longer available.',
+                'code': 'plan_changed',
                 'details': [exc.message],
             }), 409
 
@@ -1439,9 +1608,9 @@ def register_route_backend_orchestration(bp):
         )
         resolution = record.get('request_resolution') or {}
         context_message_ids = resolution.get('message_ids')
-        allowed_user_urls = conversation_user_urls(
-            user_message, snapshot, context_message_ids, record.get('answered_questions')
-        )
+        allowed_user_urls = revision_allowed_urls({
+            **record, 'user_message': user_message, 'conversation_context': snapshot,
+        })
 
         # Captured out here, on the request thread, and closed over by the generator. A
         # streamed response's generator body runs after the view has returned, so reading
@@ -1471,24 +1640,18 @@ def register_route_backend_orchestration(bp):
             'active_group_ids': seeds.get('active_group_ids') or [],
         }
 
-        def generate():
-            approved_at = _now_iso()
-            try:
-                update_orchestration_run(run_id, user_id, {
-                    'status': PLAN_STATUS_RUNNING,
-                    'started_at': approved_at,
-                    'plan': plan,
-                    'plan_summary': summarize_plan(plan),
-                    'conversation_context': snapshot,
-                    'approval': {**(plan.get('approval') or {}),
-                                 'state': APPROVAL_STATE_APPROVED,
-                                 'approved_at': approved_at,
-                                 'approved_by': user_id},
-                }, conversation_id=conversation_id)
-            except Exception as exc:
-                log_event(f"[ORCHESTRATION] Could not mark a run started: {exc}",
-                          level=logging.ERROR)
+        try:
+            record = claim_plan_run(
+                run_id, user_id, conversation_id, plan_id=data.get('plan_id'),
+                expected_version=data.get('expected_version'), edits=data.get('edits'),
+                conversation_context=snapshot,
+            )
+        except (PlanRevisionError, AzureError) as exc:
+            payload, status = _plan_edit_error(exc)
+            return jsonify(payload), status
+        plan = record['plan']
 
+        def generate():
             # Progress is streamed from a worker thread rather than collected and flushed at
             # the end. The executor is synchronous and calls `emit` from inside its own loop,
             # and a generator cannot yield from a callback -- so buffering was the obvious

--- a/application/v2_ui/src/components/chat/ElicitationCard.tsx
+++ b/application/v2_ui/src/components/chat/ElicitationCard.tsx
@@ -23,7 +23,7 @@ import {
 } from '../../lib/elicitationAnswers';
 import { messageToPlainText } from '../../lib/messageText';
 import type { ComposerDraft } from '../../lib/composerDraft';
-import type { Elicitation, ElicitationAction } from '../../lib/orchestration';
+import type { Elicitation, ElicitationAction, ElicitationContext, ElicitationResponse } from '../../lib/orchestration';
 import type { PromptResolutionContext } from '../../lib/promptVariables';
 
 export function ElicitationCard({
@@ -37,6 +37,46 @@ export function ElicitationCard({
         selectElicitation(state, conversationId, turnId));
     const draft = useOrchestrationStore((state) =>
         selectElicitationDraft(state, conversationId, turnId));
+    if (!elicitation || !draft) {
+        return null;
+    }
+    return (
+        <ElicitationForm
+            conversationId={conversationId}
+            elicitation={elicitation}
+            draft={draft}
+            onDraftChange={(update) => useOrchestrationStore.getState().updateElicitationDraft(
+                conversationId, turnId, elicitation.elicitation_id, elicitation.revision ?? 0, update,
+            )}
+            onAnswer={(response, context) => void answerElicitation({
+                conversationId, turnId, response, context,
+                elicitationId: elicitation.elicitation_id,
+                elicitationRevision: elicitation.revision ?? 0,
+            })}
+        />
+    );
+}
+
+/** Shared question inputs; the caller owns either the main-turn or editor-scoped continuation. */
+export function ElicitationForm({
+    conversationId,
+    elicitation,
+    draft,
+    onDraftChange,
+    onAnswer,
+    onCancel,
+    cancelLabel = 'Cancel and abandon this request',
+    ariaLabel = 'Follow-up questions',
+}: {
+    conversationId: string;
+    elicitation: Elicitation;
+    draft: ElicitationDraft;
+    onDraftChange: (update: (current: ElicitationDraft) => ElicitationDraft) => void;
+    onAnswer: (response: ElicitationResponse, context?: ElicitationContext) => void;
+    onCancel?: () => void;
+    cancelLabel?: string;
+    ariaLabel?: string;
+}) {
     const bootstrap = useBootstrapStore((state) => state.data);
     const messages = useChatStore((state) => state.messages);
     const conversations = useChatStore((state) => state.conversations);
@@ -72,24 +112,21 @@ export function ElicitationCard({
     }
     const isLastPage = pageIndex === pages.length - 1;
     const canFinish = Object.keys(answer.errors).length === 0 && !answer.pendingUploads;
-    const updateDraft = (update: (current: ElicitationDraft) => ElicitationDraft) =>
-        useOrchestrationStore.getState().updateElicitationDraft(
-            conversationId, turnId, elicitation.elicitation_id, elicitation.revision ?? 0, update,
-        );
+    const updateDraft = onDraftChange;
     const changePage = (index: number) =>
         updateDraft((current) => ({ ...current, pageIndex: index }));
     const send = (action: ElicitationAction) => {
         if (draft.submitting || (action === 'accept' && !canFinish)) {
             return;
         }
-        void answerElicitation({
-            conversationId,
-            turnId,
-            elicitationId: elicitation.elicitation_id,
-            elicitationRevision: elicitation.revision ?? 0,
-            response: action === 'accept' ? answer.response : { action, content: {} },
-            context: action === 'accept' ? answer.context : undefined,
-        });
+        if (action === 'cancel' && onCancel) {
+            onCancel();
+        } else {
+            onAnswer(
+                action === 'accept' ? answer.response : { action, content: {} },
+                action === 'accept' ? answer.context : undefined,
+            );
+        }
     };
     const advance = () => {
         if (draft.submitting) {
@@ -104,7 +141,7 @@ export function ElicitationCard({
 
     return (
         <section
-            aria-label="Follow-up questions"
+            aria-label={ariaLabel}
             className="my-3 rounded-2xl border border-edge-strong bg-surface-sunken p-3"
         >
             <div className="flex items-start gap-2">
@@ -162,7 +199,7 @@ export function ElicitationCard({
                         variant="ghost"
                         onClick={() => send('cancel')}
                         disabled={draft.submitting}
-                        aria-label="Cancel and abandon this request"
+                        aria-label={cancelLabel}
                     >
                         <X size={14} aria-hidden="true" />
                         Cancel

--- a/application/v2_ui/src/components/chat/OrchestrationPlanCard.tsx
+++ b/application/v2_ui/src/components/chat/OrchestrationPlanCard.tsx
@@ -14,12 +14,16 @@
 // is drawn to reflect. See `orchestrationStore.ts` and `InlineImageProposal.tsx`.
 
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { Check, Eye, ListChecks, Loader2, TriangleAlert, X } from 'lucide-react';
+import { Check, Eye, ListChecks, Loader2, PenLine, TriangleAlert, X } from 'lucide-react';
 import { GlassButton } from '../ui/primitives';
 import { useChatStore } from '../../stores/chatStore';
 import {
     selectEdits,
+    selectCanEditPlan,
+    selectHasPlanHold,
     selectPlan,
+    selectPlanEditor,
+    selectPlanRunBlocked,
     selectStepRuntime,
     useOrchestrationStore,
 } from '../../stores/orchestrationStore';
@@ -33,6 +37,7 @@ import {
 import {
     approveAndRunPlan,
     dismissOrchestrationTurn,
+    openOrchestrationPlanEditor,
 } from '../../lib/orchestrationController';
 import type { CostClass, OrchestrationPlan } from '../../lib/orchestration';
 
@@ -104,6 +109,10 @@ export function OrchestrationPlanCard({
 }) {
     const plan = useOrchestrationStore((state) => selectPlan(state, conversationId, turnId));
     const edits = useOrchestrationStore((state) => selectEdits(state, conversationId, turnId));
+    const editor = useOrchestrationStore((state) => selectPlanEditor(state, conversationId, turnId));
+    const held = useOrchestrationStore((state) => selectHasPlanHold(state, conversationId, turnId));
+    const canEdit = useOrchestrationStore((state) => selectCanEditPlan(state, conversationId, turnId));
+    const runBlocked = useOrchestrationStore((state) => selectPlanRunBlocked(state, conversationId, turnId));
     const stepRuntime = useOrchestrationStore((state) =>
         selectStepRuntime(state, conversationId, turnId),
     );
@@ -135,7 +144,7 @@ export function OrchestrationPlanCard({
         [historyMap, conversationId, turnId],
     );
 
-    const isTimed = plan?.approval.mode === 'timed';
+    const isTimed = plan?.approval.mode === 'timed' && !held;
     const awaitingApproval =
         plan !== null &&
         !runInFlight &&
@@ -165,7 +174,7 @@ export function OrchestrationPlanCard({
                 setRemainingMs(0);
                 if (!expiredRef.current) {
                     expiredRef.current = true;
-                    void approveAndRunPlan({ conversationId, turnId });
+                    void approveAndRunPlan({ conversationId, turnId, automatic: true });
                 }
                 window.clearInterval(id);
                 return;
@@ -233,7 +242,7 @@ export function OrchestrationPlanCard({
     // Awaiting approval (manual or timed), or approved-but-not-yet-running for the brief instant
     // before the run registers. The blocking state: this is the only place the card takes space.
     const cost = highestCost(editedPlan ?? plan);
-    const runnable = editedPlan ? isPlanRunnable(editedPlan) : false;
+    const runnable = editedPlan ? isPlanRunnable(editedPlan) && !runBlocked : false;
     const repairs = plan.validation.repairs;
     const remainingSeconds = Math.ceil(remainingMs / 1000);
 
@@ -275,7 +284,19 @@ export function OrchestrationPlanCard({
                 </div>
             ) : null}
 
-            <div className="mt-3 flex items-center gap-2">
+            {held ? (
+                <p className="mt-2 text-xs text-text-3" role="status">
+                    {editor?.loading ? 'Saving the manual-approval hold…'
+                        : editor?.state || plan.edit_version ? 'Manual approval required — this plan will not run automatically.'
+                        : 'Approval paused in this tab. Open Edit to retry saving the hold.'}
+                </p>
+            ) : null}
+            {editor?.error ? (
+                <p role="alert" className="alert mt-2 rounded-xl bg-danger-soft px-2.5 py-2 text-xs text-danger">
+                    {editor.error}
+                </p>
+            ) : null}
+            <div className="mt-3 flex flex-wrap items-center gap-2">
                 {runTimed ? (
                     <span
                         className="flex items-center gap-1.5 text-xs text-text-3"
@@ -286,7 +307,7 @@ export function OrchestrationPlanCard({
                         <span className="tabular-nums">Runs in {remainingSeconds}s</span>
                     </span>
                 ) : null}
-                <div className="ml-auto flex items-center gap-2">
+                <div className="ml-auto flex flex-wrap items-center justify-end gap-2">
                     <GlassButton
                         size="sm"
                         variant="ghost"
@@ -305,15 +326,26 @@ export function OrchestrationPlanCard({
                         <Eye size={14} />
                         Review
                     </GlassButton>
+                    {canEdit ? (
+                        <GlassButton
+                            size="sm"
+                            variant="subtle"
+                            onClick={() => void openOrchestrationPlanEditor({ conversationId, turnId })}
+                            aria-label="Edit the plan"
+                        >
+                            <PenLine size={14} />
+                            Edit
+                        </GlassButton>
+                    ) : null}
                     <GlassButton
                         size="sm"
                         variant="primary"
                         disabled={!runnable}
                         onClick={() => void approveAndRunPlan({ conversationId, turnId })}
-                        aria-label="Approve and run the plan"
+                        aria-label={held ? 'Run the saved plan' : 'Approve and run the plan'}
                     >
                         <Check size={14} />
-                        Approve
+                        {held ? 'Run' : 'Approve'}
                     </GlassButton>
                 </div>
             </div>

--- a/application/v2_ui/src/components/chat/OrchestrationPlanEditor.tsx
+++ b/application/v2_ui/src/components/chat/OrchestrationPlanEditor.tsx
@@ -1,0 +1,413 @@
+// OrchestrationPlanEditor.tsx
+
+import { useEffect, useId, useMemo, useRef } from 'react';
+import { createPortal } from 'react-dom';
+import { clsx } from 'clsx';
+import { Check, History, Loader2, RotateCcw, Send, Sparkles, X } from 'lucide-react';
+import { GlassButton, GlassPanel } from '../ui/primitives';
+import { ElicitationForm } from './ElicitationCard';
+import { OrchestrationRunView } from './OrchestrationRunView';
+import { useChatStore } from '../../stores/chatStore';
+import {
+    selectCanEditPlan,
+    selectEdits,
+    selectPlan,
+    selectPlanEditor,
+    selectPlanRunBlocked,
+    useOrchestrationStore,
+    type PlanEditorTarget,
+} from '../../stores/orchestrationStore';
+import { applyPlanEdits, isPlanRunnable } from '../../lib/orchestrationPlan';
+import { MAX_PLAN_INSTRUCTION_LENGTH } from '../../lib/orchestration';
+import {
+    approveAndRunPlan,
+    loadPlanEditorHistory,
+    openOrchestrationPlanEditor,
+    previewPlanEditorRevision,
+    refreshOrchestrationPlanEditor,
+    submitPlanRevision,
+} from '../../lib/orchestrationController';
+
+const originLabels = { original: 'Original plan', ai: 'Planner revision', restore: 'Restored plan' };
+
+function timestampLabel(value: string): string {
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? '' : date.toLocaleString();
+}
+
+/** Mounted by ChatPage, never by a message/card that streaming can replace. */
+export function OrchestrationPlanEditorHost() {
+    const target = useOrchestrationStore((state) => state.editorTarget);
+    const visibleConversationId = useOrchestrationStore((state) => state.visibleConversationId);
+    const activeConversationId = useChatStore((state) => state.activeConversationId);
+    if (!target || target.conversationId !== visibleConversationId
+        || target.conversationId !== activeConversationId) {
+        return null;
+    }
+    return <OrchestrationPlanEditor key={`${target.conversationId}:${target.turnId}`} {...target} />;
+}
+
+function OrchestrationPlanEditor({ conversationId, turnId }: PlanEditorTarget) {
+    const session = useOrchestrationStore((state) => selectPlanEditor(state, conversationId, turnId));
+    const plan = useOrchestrationStore((state) => selectPlan(state, conversationId, turnId));
+    const edits = useOrchestrationStore((state) => selectEdits(state, conversationId, turnId));
+    const canEdit = useOrchestrationStore((state) => selectCanEditPlan(state, conversationId, turnId));
+    const runBlocked = useOrchestrationStore((state) => selectPlanRunBlocked(state, conversationId, turnId));
+    const dialogRef = useRef<HTMLDivElement>(null);
+    const closeRef = useRef<HTMLButtonElement>(null);
+    const id = useId();
+    const target = useMemo(() => ({ conversationId, turnId }), [conversationId, turnId]);
+    const currentPreview = useMemo(() => plan ? applyPlanEdits(plan, edits) : null, [plan, edits]);
+    const close = () => useOrchestrationStore.getState().setEditorTarget(null);
+
+    useEffect(() => {
+        const previous = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+        const oldOverflow = document.body.style.overflow;
+        document.body.style.overflow = 'hidden';
+        closeRef.current?.focus();
+        const keyDown = (event: KeyboardEvent) => {
+            if (event.defaultPrevented) {
+                return;
+            }
+            if (event.key === 'Escape') {
+                event.preventDefault();
+                event.stopPropagation();
+                useOrchestrationStore.getState().setEditorTarget(null);
+            } else if (event.key === 'Tab') {
+                const focusable = Array.from(dialogRef.current?.querySelectorAll<HTMLElement>(
+                    'button:not([disabled]), a[href], input:not([disabled]), textarea:not([disabled]), '
+                    + 'select:not([disabled]), [tabindex]:not([tabindex="-1"]), [contenteditable="true"]',
+                ) ?? []).filter((element) => element.tabIndex >= 0 && element.getClientRects().length > 0);
+                const first = focusable[0];
+                const last = focusable[focusable.length - 1];
+                const inside = dialogRef.current?.contains(document.activeElement);
+                if (!inside || (event.shiftKey && document.activeElement === first)
+                    || (!event.shiftKey && document.activeElement === last)) {
+                    event.preventDefault();
+                    (event.shiftKey ? last : first)?.focus();
+                }
+            }
+        };
+        document.addEventListener('keydown', keyDown);
+        return () => {
+            document.removeEventListener('keydown', keyDown);
+            document.body.style.overflow = oldOverflow;
+            if (previous?.isConnected && useChatStore.getState().activeConversationId === conversationId) {
+                previous.focus();
+            }
+        };
+    }, [conversationId, turnId]);
+
+    if (!session || !plan || !currentPreview) {
+        return null;
+    }
+    const editor = session.state;
+    const pending = editor?.pending;
+    const busy = session.loading || session.submitting || Boolean(editor?.busy);
+    const canRequest = canEdit && Boolean(editor) && !busy && !session.blocked;
+    const preview = session.previewRunId ? session.previewPlan : currentPreview;
+    const canRun = canEdit && !runBlocked && isPlanRunnable(currentPreview);
+    const setTab = (tab: 'ask' | 'history') =>
+        useOrchestrationStore.getState().updatePlanEditor(conversationId, turnId,
+            (current) => ({
+                ...current, tab,
+                ...(tab === 'ask' ? { previewRunId: null, previewPlan: null, previewLoading: false } : {}),
+            }));
+    const ask = () => {
+        if (canRequest && !pending && session.instruction.trim()) {
+            void submitPlanRevision(target, { action: 'ask', instruction: session.instruction });
+        }
+    };
+    const cancelChange = () => void submitPlanRevision(target, {
+        action: 'discard',
+        ...(pending ? {
+            elicitation_id: pending.elicitation_id,
+            elicitation_revision: pending.revision ?? 0,
+        } : {}),
+    });
+    const retryLoad = () => {
+        if (editor) {
+            void refreshOrchestrationPlanEditor(target);
+        } else {
+            void openOrchestrationPlanEditor(target);
+        }
+    };
+
+    return createPortal(
+        <div
+            ref={dialogRef}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby={`${id}-title`}
+            aria-describedby={`${id}-hold`}
+            className="fixed inset-0 z-[70] flex items-center justify-center bg-black/60 p-0 sm:p-4"
+            onClick={(event) => { if (event.target === event.currentTarget) close(); }}
+        >
+            <GlassPanel
+                elevation="modal"
+                edge
+                className="relative flex h-full w-full max-w-[1600px] flex-col overflow-hidden"
+            >
+                <header className="flex shrink-0 items-center gap-2 border-b border-edge px-3 py-3 sm:px-5">
+                    <div className="min-w-0 flex-1">
+                        <h2 id={`${id}-title`} className="text-sm font-semibold text-text-1">Edit orchestration plan</h2>
+                        <p className="text-xs text-text-3">Saved revision {plan.revision}</p>
+                    </div>
+                    <GlassButton
+                        size="sm"
+                        variant="primary"
+                        disabled={!canRun}
+                        onClick={() => void approveAndRunPlan(target)}
+                        aria-label="Run saved revision"
+                    >
+                        <Check size={14} aria-hidden="true" />
+                        Run
+                    </GlassButton>
+                    <button
+                        ref={closeRef}
+                        type="button"
+                        aria-label="Close the plan editor"
+                        onClick={close}
+                        className="shrink-0 rounded-lg p-2 text-text-3 hover:bg-surface-2 hover:text-text-1"
+                    >
+                        <X size={18} aria-hidden="true" />
+                    </button>
+                </header>
+                <div className="flex shrink-0 flex-wrap items-center gap-2 border-b border-edge px-3 py-2 sm:px-5">
+                    <p id={`${id}-hold`} role="status" className="min-w-0 flex-1 text-xs text-text-3">
+                        {session.loading ? 'Saving the manual-approval hold…'
+                            : !editor ? 'Approval is paused in this tab. The server hold is not yet confirmed.'
+                            : 'Manual approval required. Closing this editor never runs the plan.'}
+                    </p>
+                    {busy ? <Loader2 size={14} className="animate-spin text-accent" aria-hidden="true" /> : null}
+                    {editor && (pending || editor.busy || session.submitting
+                        || session.cancellationStatus !== 'idle') ? (
+                        <GlassButton size="sm" variant="ghost"
+                            disabled={!canEdit || session.loading || session.cancellationStatus === 'cancelling'}
+                            onClick={cancelChange}
+                            aria-label="Cancel change">
+                            <X size={13} aria-hidden="true" />
+                            {session.cancellationStatus === 'cancelling' ? 'Cancelling…'
+                                : session.cancellationStatus === 'failed' ? 'Retry cancel change' : 'Cancel change'}
+                        </GlassButton>
+                    ) : null}
+                    {!session.loading && !session.submitting ? (
+                        <GlassButton size="sm" variant="ghost" onClick={retryLoad}
+                            aria-label={editor ? 'Refresh saved plan' : 'Retry saving manual hold'}>
+                            <RotateCcw size={13} aria-hidden="true" />
+                            {editor ? 'Refresh' : 'Retry'}
+                        </GlassButton>
+                    ) : null}
+                </div>
+                {session.error ? (
+                    <p role="alert" className="alert shrink-0 border-b border-danger/30 bg-danger-soft px-3 py-2 text-sm text-danger sm:px-5">
+                        {session.error}
+                    </p>
+                ) : null}
+                {!canEdit ? (
+                    <p role="status" className="shrink-0 px-3 py-2 text-sm text-text-3">
+                        This plan is no longer pending and cannot be edited or run here.
+                    </p>
+                ) : null}
+
+                <div className="grid min-h-0 flex-1 grid-rows-[minmax(0,2fr)_minmax(0,3fr)] md:grid-cols-[minmax(0,3fr)_minmax(20rem,2fr)] md:grid-rows-1">
+                    <section aria-label="Plan preview" data-testid="plan-editor-preview"
+                        className="flex min-h-0 min-w-0 flex-col border-b border-edge md:border-r md:border-b-0">
+                        <div className="flex shrink-0 flex-wrap items-center gap-2 border-b border-edge px-3 py-2">
+                            <h3 className="min-w-0 flex-1 text-xs font-semibold text-text-2">
+                                {session.previewRunId
+                                    ? `History preview${preview ? ` — revision ${preview.revision}` : ''}`
+                                    : 'Current saved plan'}
+                            </h3>
+                            {session.previewRunId ? (
+                                <GlassButton size="sm" variant="subtle"
+                                    onClick={() => void previewPlanEditorRevision(target, plan.run_id)}>
+                                    Back to current plan
+                                </GlassButton>
+                            ) : null}
+                        </div>
+                        <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain">
+                            {session.previewLoading ? <p role="status" className="p-3 text-sm text-text-3">Loading revision…</p>
+                                : preview ? (
+                                    <>
+                                        <OrchestrationRunView conversationId={conversationId} turnId={turnId} previewPlan={preview} />
+                                        {preview.validation.repairs.length ? (
+                                            <div className="m-3 rounded-xl bg-warn-soft p-3 text-xs text-warn">
+                                                <p className="font-medium">Planner adjustments</p>
+                                                <ul className="mt-1 list-disc pl-4">
+                                                    {preview.validation.repairs.map((repair, index) => <li key={index}>{repair}</li>)}
+                                                </ul>
+                                            </div>
+                                        ) : null}
+                                    </>
+                                ) : <p className="p-3 text-sm text-text-3">Preview unavailable. Your current plan is unchanged.</p>}
+                        </div>
+                    </section>
+                    <aside aria-label="Plan editing" className="flex min-h-0 min-w-0 flex-col">
+                        <div role="tablist" aria-label="Plan editor tools" className="flex shrink-0 gap-1 border-b border-edge p-2">
+                            {(['ask', 'history'] as const).map((tab) => (
+                                <button
+                                    key={tab}
+                                    id={`${id}-${tab}-tab`}
+                                    type="button"
+                                    role="tab"
+                                    aria-controls={`${id}-${tab}-panel`}
+                                    aria-selected={session.tab === tab}
+                                    tabIndex={session.tab === tab ? 0 : -1}
+                                    onClick={() => setTab(tab)}
+                                    onKeyDown={(event) => {
+                                        if (event.key === 'ArrowLeft' || event.key === 'ArrowRight'
+                                            || event.key === 'Home' || event.key === 'End') {
+                                            event.preventDefault();
+                                            const next = event.key === 'Home' ? 'ask' : event.key === 'End'
+                                                ? 'history' : tab === 'ask' ? 'history' : 'ask';
+                                            setTab(next);
+                                            document.getElementById(`${id}-${next}-tab`)?.focus();
+                                        }
+                                    }}
+                                    className={clsx('flex items-center gap-1.5 rounded-lg px-3 py-2 text-sm',
+                                        session.tab === tab ? 'bg-accent-soft font-medium text-accent'
+                                            : 'text-text-3 hover:bg-surface-2 hover:text-text-1')}
+                                >
+                                    {tab === 'ask' ? <Sparkles size={14} aria-hidden="true" /> : <History size={14} aria-hidden="true" />}
+                                    {tab === 'ask' ? 'Ask planner' : 'History'}
+                                </button>
+                            ))}
+                        </div>
+                        <div role="tabpanel" id={`${id}-${session.tab}-panel`}
+                            aria-labelledby={`${id}-${session.tab}-tab`}
+                            className="flex min-h-0 flex-1 flex-col">
+                            {session.tab === 'ask' ? (
+                                <>
+                                    <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain p-3" role="log" aria-label="Planner conversation">
+                                        {!editor?.chat.length ? (
+                                            <p className="text-sm text-text-3">
+                                                Ask to add, remove, or rework steps. The planner checks available capabilities before saving a revision.
+                                                This conversation stays in the editor.
+                                            </p>
+                                        ) : (
+                                            <ol className="space-y-3">
+                                                {editor.chat.map((entry, index) => (
+                                                    <li key={`${entry.timestamp}:${index}`} className={clsx(
+                                                        'rounded-xl p-3 text-sm',
+                                                        entry.role === 'user' ? 'bg-accent-soft text-text-1' : 'bg-surface-2 text-text-2',
+                                                    )}>
+                                                        <p className="mb-1 text-xs font-medium text-text-3">{entry.role === 'user' ? 'You' : 'Planner'}</p>
+                                                        <p className="whitespace-pre-wrap break-words">{entry.content}</p>
+                                                    </li>
+                                                ))}
+                                            </ol>
+                                        )}
+                                        {session.submitting || editor?.busy ? (
+                                            <p role="status" className="mt-3 flex items-center gap-2 text-sm text-text-3">
+                                                <Loader2 size={14} className="animate-spin" aria-hidden="true" />
+                                                {session.cancellationStatus === 'cancelling' ? 'Cancelling the pending change…'
+                                                    : session.submitting ? 'Planner is working…'
+                                                    : 'An edit is in progress. Refresh for its result or cancel the change to keep the saved plan.'}
+                                            </p>
+                                        ) : null}
+                                        {pending && session.pendingDraft ? (
+                                            <ElicitationForm
+                                                conversationId={conversationId}
+                                                elicitation={pending}
+                                                draft={{
+                                                    ...session.pendingDraft,
+                                                    submitting: busy || !canEdit || session.blocked,
+                                                }}
+                                                ariaLabel="Planner edit questions"
+                                                cancelLabel="Cancel edit request and keep current plan"
+                                                onDraftChange={(update) => useOrchestrationStore.getState().updatePlanEditor(
+                                                    conversationId, turnId, (current) =>
+                                                        current.pendingDraft?.elicitationId === pending.elicitation_id
+                                                        && current.pendingDraft.revision === (pending.revision ?? 0)
+                                                            ? { ...current, pendingDraft: update(current.pendingDraft) } : current,
+                                                )}
+                                                onAnswer={(response, context) => void submitPlanRevision(target, {
+                                                    action: 'answer',
+                                                    elicitation_id: pending.elicitation_id,
+                                                    elicitation_revision: pending.revision ?? 0,
+                                                    elicitation_response: response,
+                                                    ...(context ? { elicitation_context: context } : {}),
+                                                })}
+                                                onCancel={cancelChange}
+                                            />
+                                        ) : null}
+                                    </div>
+                                    {!pending ? (
+                                        <form className="shrink-0 border-t border-edge p-3" onSubmit={(event) => { event.preventDefault(); ask(); }}>
+                                            <label htmlFor={`${id}-instruction`} className="mb-1 block text-xs font-medium text-text-2">Ask planner</label>
+                                            <textarea
+                                                id={`${id}-instruction`}
+                                                value={session.instruction}
+                                                rows={3}
+                                                maxLength={MAX_PLAN_INSTRUCTION_LENGTH}
+                                                placeholder="For example: add a web search, then focus the comparison on pricing."
+                                                className="w-full resize-none rounded-xl border border-edge bg-surface-2 px-3 py-2 text-sm text-text-1 focus:outline-none focus:ring-2 focus:ring-accent-ring"
+                                                onChange={(event) => {
+                                                    const instruction = event.target.value;
+                                                    useOrchestrationStore.getState().updatePlanEditor(conversationId, turnId,
+                                                        (current) => ({ ...current, instruction }));
+                                                }}
+                                                onKeyDown={(event) => {
+                                                    if (event.key === 'Enter' && (event.ctrlKey || event.metaKey)) {
+                                                        event.preventDefault();
+                                                        ask();
+                                                    }
+                                                }}
+                                            />
+                                            <div className="mt-2 flex items-center justify-between gap-2">
+                                                <span className="text-xs text-text-3">{session.instruction.length}/{MAX_PLAN_INSTRUCTION_LENGTH} · Ctrl/⌘ + Enter</span>
+                                                <GlassButton type="submit" size="sm" variant="primary"
+                                                    disabled={!canRequest || !session.instruction.trim()}
+                                                    aria-label="Send planner request">
+                                                    <Send size={14} aria-hidden="true" />
+                                                    Send
+                                                </GlassButton>
+                                            </div>
+                                        </form>
+                                    ) : null}
+                                </>
+                            ) : (
+                                <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain p-3">
+                                    <p className="mb-3 text-xs text-text-3">Previewing history never changes the active plan. Restore saves a newly validated revision.</p>
+                                    <ol className="space-y-3">
+                                        {(editor?.history ?? []).map((entry) => (
+                                            <li key={entry.run_id} className="rounded-xl border border-edge bg-surface-2 p-3">
+                                                <p className="text-sm font-medium text-text-1">
+                                                    Revision {entry.revision} · {originLabels[entry.origin]}
+                                                    {entry.run_id === plan.run_id ? ' · Current' : ''}
+                                                </p>
+                                                <p className="mt-1 whitespace-pre-wrap break-words text-xs text-text-2">{entry.note}</p>
+                                                <p className="mt-1 text-xs text-text-3">{timestampLabel(entry.created_at)}</p>
+                                                <div className="mt-2 flex flex-wrap gap-2">
+                                                    <GlassButton size="sm" variant="subtle"
+                                                        onClick={() => void previewPlanEditorRevision(target, entry.run_id)}
+                                                        aria-label={`Preview revision ${entry.revision}`}>Preview</GlassButton>
+                                                    {entry.run_id !== plan.run_id ? (
+                                                        <GlassButton size="sm" variant="ghost" disabled={!canRequest || Boolean(pending)}
+                                                            onClick={() => void submitPlanRevision(target, { action: 'restore', source_run_id: entry.run_id })}
+                                                            aria-label={`Restore revision ${entry.revision}`}>
+                                                            <RotateCcw size={13} aria-hidden="true" />
+                                                            Restore
+                                                        </GlassButton>
+                                                    ) : null}
+                                                </div>
+                                            </li>
+                                        ))}
+                                    </ol>
+                                    {editor && editor.next_before_revision !== null ? (
+                                        <GlassButton size="sm" className="mt-3" disabled={session.historyLoading}
+                                            onClick={() => void loadPlanEditorHistory(target)}>
+                                            {session.historyLoading ? 'Loading history…' : 'Load earlier revisions'}
+                                        </GlassButton>
+                                    ) : null}
+                                </div>
+                            )}
+                        </div>
+                    </aside>
+                </div>
+            </GlassPanel>
+        </div>,
+        document.body,
+    );
+}

--- a/application/v2_ui/src/components/chat/OrchestrationPlanPanel.tsx
+++ b/application/v2_ui/src/components/chat/OrchestrationPlanPanel.tsx
@@ -12,14 +12,20 @@
 
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { clsx } from 'clsx';
-import { AlertCircle, ArrowDownToLine, ListTree, Loader2, Map as MapIcon, Undo2 } from 'lucide-react';
+import { AlertCircle, ArrowDownToLine, ListTree, Loader2, Map as MapIcon, PenLine, Undo2 } from 'lucide-react';
 import { useChatStore } from '../../stores/chatStore';
 import {
     selectActiveTurn,
+    selectCanEditPlan,
+    selectPlan,
     useOrchestrationStore,
+    type StepRuntimeMap,
     type TrackedRun,
 } from '../../stores/orchestrationStore';
-import { fetchOrchestrationRun, fetchRunSteps } from '../../lib/orchestration';
+import { fetchOrchestrationRun, fetchRunSteps, type OrchestrationPlan } from '../../lib/orchestration';
+import { normalizePlan } from '../../lib/orchestrationPlan';
+import { openOrchestrationPlanEditor } from '../../lib/orchestrationController';
+import { GlassButton } from '../ui/primitives';
 import { OrchestrationRunView } from './OrchestrationRunView';
 import { OrchestrationMapView } from './OrchestrationMapView';
 
@@ -87,6 +93,10 @@ export function OrchestrationPlanPanel() {
     /** The archived run currently being fetched, so the Run view can say so instead of sitting empty. */
     const [loadingRunId, setLoadingRunId] = useState<string | null>(null);
     const [loadError, setLoadError] = useState<string | null>(null);
+    const [archivedPreview, setArchivedPreview] = useState<{
+        runId: string; plan: OrchestrationPlan; runtime: StepRuntimeMap;
+    } | null>(null);
+    const archiveRequest = useRef<object | null>(null);
     const headingRef = useRef<HTMLHeadingElement | null>(null);
 
     // Move focus into the panel when it opens, so a keyboard user is not left back on the toggle
@@ -96,6 +106,18 @@ export function OrchestrationPlanPanel() {
     }, []);
 
     const shownTurnId = pinned?.turnId ?? currentTurnId ?? null;
+    const shownPlan = useOrchestrationStore((state) => selectPlan(state, activeConversationId, shownTurnId ?? ''));
+    const canEdit = useOrchestrationStore((state) => selectCanEditPlan(state, activeConversationId, shownTurnId ?? ''));
+
+    useEffect(() => {
+        archiveRequest.current = null;
+        setPinned(null);
+        setArchivedPreview(null);
+        setLoadingRunId(null);
+        setLoadError(null);
+        pinRun(null);
+        return () => { archiveRequest.current = null; };
+    }, [activeConversationId, pinRun]);
 
     // The newest run still in flight for this conversation, whichever turn it belongs to. Drives
     // the jump bar: a run is live "off-screen" when it exists and its turn is not the shown one.
@@ -113,7 +135,10 @@ export function OrchestrationPlanPanel() {
     }, [inFlightMap, activeConversationId]);
 
     const clearPin = () => {
+        archiveRequest.current = null;
         setPinned(null);
+        setArchivedPreview(null);
+        setLoadingRunId(null);
         setLoadError(null);
         pinRun(null);
     };
@@ -126,6 +151,10 @@ export function OrchestrationPlanPanel() {
      * of a run that already finished would be offering something that cannot be done.
      */
     const loadArchivedRun = (turnId: string, runId: string) => {
+        const request = {};
+        archiveRequest.current = request;
+        const isCurrent = () => archiveRequest.current === request
+            && useChatStore.getState().activeConversationId === activeConversationId;
         setLoadingRunId(runId);
         setLoadError(null);
         Promise.all([
@@ -133,26 +162,41 @@ export function OrchestrationPlanPanel() {
             fetchRunSteps(runId, { conversationId: activeConversationId }),
         ])
             .then(([run, steps]) => {
-                if (!run?.plan) {
+                if (!isCurrent()) {
+                    return;
+                }
+                const plan = normalizePlan(run?.plan);
+                if (!plan) {
                     setLoadError('This run did not keep a plan.');
                     return;
                 }
-                useOrchestrationStore
-                    .getState()
-                    .adoptPersistedPlan(activeConversationId, turnId, run.plan, steps, {
+                const store = useOrchestrationStore.getState();
+                const current = selectPlan(store, activeConversationId, turnId);
+                if (current && (current.run_id !== runId
+                    || selectCanEditPlan(store, activeConversationId, turnId))) {
+                    const runtime: StepRuntimeMap = {};
+                    for (const step of steps) {
+                        runtime[step.step_id] = { status: step.status ?? 'pending', summary: step.summary ?? '' };
+                    }
+                    setArchivedPreview({ runId, plan, runtime });
+                } else {
+                    store.adoptPersistedPlan(activeConversationId, turnId, run?.plan, steps, {
                         readOnly: true,
                     });
+                }
             })
             .catch(() => {
-                setLoadError('This run could not be loaded.');
+                if (isCurrent()) setLoadError('This run could not be loaded.');
             })
             .finally(() => {
-                setLoadingRunId((current) => (current === runId ? null : current));
+                if (isCurrent()) setLoadingRunId(null);
             });
     };
 
     const selectRun = (turnId: string, runId: string, live: boolean) => {
         setPinned({ turnId, runId });
+        archiveRequest.current = null;
+        setArchivedPreview(null);
         setLoadError(null);
         // Only a live run can be pinned in the store, whose pin resolves against in-flight records;
         // a settled run is browsed through this component's own pin instead.
@@ -166,7 +210,7 @@ export function OrchestrationPlanPanel() {
         scrollToTurn(turnId, entry?.userMessageId ?? null, messages);
 
         // A live run is streaming its plan in; anything already in memory is authoritative.
-        if (live || store.plans[scopeKey(activeConversationId, turnId)]) {
+        if (live || store.plans[scopeKey(activeConversationId, turnId)]?.run_id === runId) {
             return;
         }
         loadArchivedRun(turnId, runId);
@@ -222,6 +266,20 @@ export function OrchestrationPlanPanel() {
                 </div>
             </div>
 
+            {view === 'run' && canEdit && shownTurnId && (!pinned || pinned.runId === shownPlan?.run_id) ? (
+                <div className="border-b border-edge px-3 py-2">
+                    <GlassButton size="sm" variant="subtle" aria-label="Edit the plan"
+                        onClick={() => {
+                            clearPin();
+                            void openOrchestrationPlanEditor({
+                                conversationId: activeConversationId, turnId: shownTurnId,
+                            });
+                        }}>
+                        <PenLine size={14} aria-hidden="true" />
+                        Edit
+                    </GlassButton>
+                </div>
+            ) : null}
             {pinned ? (
                 <button
                     type="button"
@@ -261,6 +319,8 @@ export function OrchestrationPlanPanel() {
                         <OrchestrationRunView
                             conversationId={activeConversationId}
                             turnId={shownTurnId}
+                            previewPlan={archivedPreview?.runId === pinned?.runId ? archivedPreview?.plan : undefined}
+                            previewRuntime={archivedPreview?.runId === pinned?.runId ? archivedPreview?.runtime : undefined}
                         />
                     ) : (
                         <p className="p-4 text-sm text-text-3">

--- a/application/v2_ui/src/components/chat/OrchestrationRunView.tsx
+++ b/application/v2_ui/src/components/chat/OrchestrationRunView.tsx
@@ -19,10 +19,13 @@ import { Archive, FileText, Lock, RotateCcw, X } from 'lucide-react';
 import { Toggle } from '../ui/primitives';
 import {
     selectEdits,
+    selectCanEditPlan,
     selectIsReadOnly,
     selectPlan,
     selectStepRuntime,
+    selectPlanEditor,
     useOrchestrationStore,
+    type StepRuntimeMap,
 } from '../../stores/orchestrationStore';
 import { useBootstrapStore } from '../../stores/bootstrapStore';
 import {
@@ -37,12 +40,17 @@ import { ORCHESTRATION_PHASES } from '../../lib/orchestration';
 import type {
     CostClass,
     Json,
+    OrchestrationPlan,
+    PlanEdits,
     OrchestrationPhase,
     OrchestrationPlanAction,
     OrchestrationStep,
     StepStatus,
 } from '../../lib/orchestration';
 import { useDocumentTitles } from '../../lib/documentTitles';
+
+const PREVIEW_EDITS: PlanEdits = { disabled_step_ids: [], removed_document_ids: {} };
+const PREVIEW_RUNTIME: StepRuntimeMap = {};
 
 const statusTone: Record<StepStatus, string> = {
     pending: 'bg-surface-3 text-text-3',
@@ -104,15 +112,25 @@ function readableArguments(step: OrchestrationStep): Array<[string, string]> {
 export function OrchestrationRunView({
     conversationId,
     turnId,
+    previewPlan,
+    previewRuntime,
 }: {
     conversationId: string;
     turnId: string;
+    /** A display-only plan; history previews never replace the live execution target. */
+    previewPlan?: OrchestrationPlan;
+    previewRuntime?: StepRuntimeMap;
 }) {
-    const plan = useOrchestrationStore((state) => selectPlan(state, conversationId, turnId));
-    const edits = useOrchestrationStore((state) => selectEdits(state, conversationId, turnId));
-    const stepRuntime = useOrchestrationStore((state) =>
+    const storedPlan = useOrchestrationStore((state) => selectPlan(state, conversationId, turnId));
+    const storedEdits = useOrchestrationStore((state) => selectEdits(state, conversationId, turnId));
+    const storedRuntime = useOrchestrationStore((state) =>
         selectStepRuntime(state, conversationId, turnId),
     );
+    const canEdit = useOrchestrationStore((state) => selectCanEditPlan(state, conversationId, turnId));
+    const editor = useOrchestrationStore((state) => selectPlanEditor(state, conversationId, turnId));
+    const plan = previewPlan ?? storedPlan;
+    const edits = previewPlan ? PREVIEW_EDITS : storedEdits;
+    const stepRuntime = previewPlan ? previewRuntime ?? PREVIEW_RUNTIME : storedRuntime;
     const disableStep = useOrchestrationStore((state) => state.disableStep);
     const enableStep = useOrchestrationStore((state) => state.enableStep);
     const removeDocument = useOrchestrationStore((state) => state.removeDocument);
@@ -237,7 +255,8 @@ export function OrchestrationRunView({
     // A stored plan is a record of what happened, not a proposal. Its status is adopted verbatim,
     // so one written down while it still awaited approval would otherwise offer to narrow steps
     // that were settled long ago, on a device that is not the one being asked.
-    const editable = planRequiresApproval(plan) && !readOnly;
+    const editable = planRequiresApproval(plan) && !readOnly && !previewPlan && canEdit
+        && !editor?.loading && !editor?.submitting && !editor?.state?.busy && !editor?.state?.pending;
     const disabledStepIds = new Set(edits.disabled_step_ids);
 
     const renderStep = (step: OrchestrationStep, displayNumber: number) => {
@@ -379,7 +398,7 @@ export function OrchestrationRunView({
                                                     yours
                                                 </span>
                                             ) : null}
-                                            {isRemoved ? (
+                                            {isRemoved && editable ? (
                                                 <button
                                                     type="button"
                                                     onClick={() =>
@@ -458,7 +477,7 @@ export function OrchestrationRunView({
 
     return (
         <div className="space-y-3 p-3">
-            {readOnly ? (
+            {readOnly && !previewPlan ? (
                 <p className="flex items-center gap-1.5 rounded-lg border border-edge bg-surface-2 px-2 py-1.5 text-[11px] text-text-3">
                     <Archive size={12} className="shrink-0" />
                     A record of a run from this conversation. It cannot be changed or re-run.

--- a/application/v2_ui/src/lib/orchestration.ts
+++ b/application/v2_ui/src/lib/orchestration.ts
@@ -204,6 +204,8 @@ export interface OrchestrationPlanInputs {
 export interface OrchestrationPlan {
     plan_id: string;
     run_id: string;
+    /** Conditional approval token for a manually held or revised plan. */
+    edit_version?: string;
     /**
      * The turn this plan answers, echoed from the plan request.
      *
@@ -322,6 +324,54 @@ export interface ElicitationFieldContext {
 
 export type ElicitationContext = Record<string, ElicitationFieldContext>;
 
+export interface PlanEditorHistoryEntry {
+    run_id: string;
+    plan_id: string;
+    revision: number;
+    created_at: string;
+    origin: 'original' | 'ai' | 'restore';
+    note: string;
+}
+
+/** Server-owned editor state. `edits` overlays the raw canonical plan. */
+export interface PlanEditorState {
+    plan: OrchestrationPlan;
+    version: string;
+    edits: PlanEdits;
+    chat: Array<{ role: 'user' | 'assistant'; content: string; timestamp: string }>;
+    history: PlanEditorHistoryEntry[];
+    next_before_revision: number | null;
+    pending: Elicitation | null;
+    busy: boolean;
+}
+
+export type PlanRevisionAction =
+    | { action: 'ask'; instruction: string }
+    | { action: 'restore'; source_run_id: string }
+    | {
+        action: 'answer';
+        elicitation_id: string;
+        elicitation_revision: number;
+        elicitation_response: ElicitationResponse;
+        elicitation_context?: ElicitationContext;
+    }
+    | { action: 'discard'; elicitation_id?: string; elicitation_revision?: number };
+
+export type PlanRevisionRequest = PlanRevisionAction & {
+    conversation_id: string;
+    expected_version: string;
+    submission_id: string;
+    edits?: PlanEdits;
+};
+
+export interface OrchestrationRequestError {
+    status?: number;
+    code?: string;
+    current_run_id?: string;
+}
+
+export const MAX_PLAN_INSTRUCTION_LENGTH = 2000;
+
 /* -------------------------------------------------------------------------- */
 /* Request bodies                                                              */
 /* -------------------------------------------------------------------------- */
@@ -367,6 +417,7 @@ export interface OrchestrationRunRequest {
     plan_id?: string;
     conversation_id?: string | null;
     edits?: PlanEdits;
+    expected_version?: string;
     [key: string]: unknown;
 }
 
@@ -385,6 +436,7 @@ export interface PlanStreamEvent {
     type?: 'thought' | 'orchestration_plan' | 'orchestration_elicitation' | string;
     plan?: OrchestrationPlan;
     elicitation?: Elicitation;
+    editor?: PlanEditorState;
     done?: boolean;
     error?: string;
     details?: unknown;
@@ -425,13 +477,16 @@ export interface PlanStreamHandlers {
     onPlan?: (plan: OrchestrationPlan) => void;
     /** The planner asked a question instead of planning; the stream is over. */
     onElicitation?: (elicitation: Elicitation) => void;
+    /** Editor results never need to enter the main conversation's message dispatch. */
+    onEditor?: (editor: PlanEditorState) => void;
     /** An error frame arrived, or the transport failed. */
-    onError?: (message: string) => void;
+    onError?: (message: string, error?: OrchestrationRequestError) => void;
 }
 
 export interface PlanStreamResult {
     plan: OrchestrationPlan | null;
     elicitation: Elicitation | null;
+    editor: PlanEditorState | null;
     completed: boolean;
     cancelled: boolean;
     errored: boolean;
@@ -463,6 +518,8 @@ export interface RunStreamHandlers {
      * card and reload the thread, not to tell the user their run broke.
      */
     onAlreadyRun?: (message: string) => void;
+    /** A stale approval is still pending; do not treat it as a completed run. */
+    onConflict?: (message: string, error: OrchestrationRequestError) => void;
     /** An error frame arrived, or the transport failed. */
     onError?: (message: string, event?: RunStreamEvent) => void;
 }
@@ -474,6 +531,7 @@ export interface RunStreamResult {
     errored: boolean;
     /** The plan was already run elsewhere. Distinct from `errored`; see `onAlreadyRun`. */
     alreadyRun: boolean;
+    conflict?: OrchestrationRequestError;
 }
 
 export const ORCHESTRATION_PLAN_PATH = '/api/v2/orchestration/plan';
@@ -599,6 +657,51 @@ export async function fetchRunSteps(
     return Array.isArray(payload?.steps) ? payload.steps : [];
 }
 
+export async function beginPlanEdit(
+    runId: string,
+    body: {
+        conversation_id: string;
+        plan_id: string;
+        edits?: PlanEdits;
+        expected_version?: string;
+    },
+    signal?: AbortSignal,
+): Promise<PlanEditorState> {
+    const payload = await api.post<{ editor: PlanEditorState }>(
+        `${ORCHESTRATION_RUNS_PATH}/${encodeURIComponent(runId)}/edit`, body, signal,
+    );
+    return payload.editor;
+}
+
+export async function fetchPlanEditor(
+    runId: string,
+    conversationId: string,
+    options: { beforeRevision?: number; signal?: AbortSignal } = {},
+): Promise<PlanEditorState> {
+    const params = new URLSearchParams({ conversation_id: conversationId });
+    if (options.beforeRevision !== undefined) {
+        params.set('before_revision', String(options.beforeRevision));
+    }
+    const payload = await api.get<{ editor: PlanEditorState }>(
+        `${ORCHESTRATION_RUNS_PATH}/${encodeURIComponent(runId)}/editor?${params}`,
+        options.signal,
+    );
+    return payload.editor;
+}
+
+export function orchestrationErrorInfo(
+    payload: unknown,
+    status?: number,
+): OrchestrationRequestError {
+    const data = payload && typeof payload === 'object'
+        ? payload as Record<string, unknown> : {};
+    return {
+        status,
+        code: typeof data.code === 'string' ? data.code : undefined,
+        current_run_id: typeof data.current_run_id === 'string' ? data.current_run_id : undefined,
+    };
+}
+
 function errorDetails(payload: { details?: unknown; field_errors?: unknown }): string {
     const details = payload.field_errors ?? payload.details;
     if (Array.isArray(details)) {
@@ -616,9 +719,9 @@ function errorDetails(payload: { details?: unknown; field_errors?: unknown }): s
  * Open a POST SSE stream and hand back the response, or report why it could not open.
  *
  * A failure before the stream opens comes back as an ordinary JSON error, not an SSE frame, so
- * it is read here rather than in the framing loop. The HTTP status is reported alongside the
- * message because one of them is not a failure at all: a 409 from the run endpoint means the
- * plan was already run, which the caller reconciles rather than displays. An abort before the
+ * it is read here rather than in the framing loop. The error code and HTTP status accompany the
+ * safe message: an already-run conflict needs different recovery from a stale version or an
+ * edit in progress. An abort before the
  * response arrives is returned as a plain null with no error reported, so the caller can record
  * it as a cancellation rather than a failure -- pressing Stop before the first byte is not an
  * error.
@@ -627,7 +730,7 @@ async function openOrchestrationStream(
     path: string,
     body: unknown,
     signal: AbortSignal | undefined,
-    onError: (message: string, status?: number) => void,
+    onError: (message: string, error?: OrchestrationRequestError) => void,
 ): Promise<Response | null> {
     let response: Response;
     try {
@@ -641,16 +744,17 @@ async function openOrchestrationStream(
             body: JSON.stringify(body),
             signal,
         });
-    } catch (error) {
+    } catch {
         if (signal?.aborted) {
             return null;
         }
-        onError(error instanceof Error ? error.message : 'Network error');
+        onError('The request could not connect. Please try again.');
         return null;
     }
 
     if (!response.ok || !response.body) {
         let message = `Request failed with status ${response.status}`;
+        let info: OrchestrationRequestError = { status: response.status };
         try {
             const payload = (await response.json()) as {
                 error?: string;
@@ -660,10 +764,11 @@ async function openOrchestrationStream(
             if (payload?.error) {
                 message = [payload.error, errorDetails(payload)].filter(Boolean).join(' ');
             }
+            info = orchestrationErrorInfo(payload, response.status);
         } catch {
             /* Non-JSON error body; keep the status-based message. */
         }
-        onError(message, response.status);
+        onError(message, info);
         return null;
     }
 
@@ -682,21 +787,43 @@ export async function planOrchestration(
     handlers: PlanStreamHandlers,
     signal?: AbortSignal,
 ): Promise<PlanStreamResult> {
+    return readPlanStream(ORCHESTRATION_PLAN_PATH, body, handlers, signal);
+}
+
+export async function reviseOrchestrationPlan(
+    runId: string,
+    body: PlanRevisionRequest,
+    handlers: PlanStreamHandlers,
+    signal?: AbortSignal,
+): Promise<PlanStreamResult> {
+    return readPlanStream(
+        `${ORCHESTRATION_RUNS_PATH}/${encodeURIComponent(runId)}/revisions`,
+        body, handlers, signal,
+    );
+}
+
+async function readPlanStream(
+    path: string,
+    body: OrchestrationPlanRequest | PlanRevisionRequest,
+    handlers: PlanStreamHandlers,
+    signal?: AbortSignal,
+): Promise<PlanStreamResult> {
     const result: PlanStreamResult = {
         plan: null,
         elicitation: null,
+        editor: null,
         completed: false,
         cancelled: false,
         errored: false,
     };
 
     const response = await openOrchestrationStream(
-        ORCHESTRATION_PLAN_PATH,
+        path,
         body,
         signal,
-        (message) => {
+        (message, error) => {
             result.errored = true;
-            handlers.onError?.(message);
+            handlers.onError?.(message, error);
         },
     );
     if (!response) {
@@ -709,7 +836,10 @@ export async function planOrchestration(
     const onEvent = (event: PlanStreamEvent): boolean => {
         if (typeof event.error === 'string' && event.error) {
             result.errored = true;
-            handlers.onError?.([event.error, errorDetails(event)].filter(Boolean).join(' '));
+            handlers.onError?.(
+                [event.error, errorDetails(event)].filter(Boolean).join(' '),
+                orchestrationErrorInfo(event),
+            );
             return true;
         }
 
@@ -726,6 +856,10 @@ export async function planOrchestration(
         }
 
         if (event.type === 'orchestration_plan') {
+            result.editor = event.editor ?? null;
+            if (result.editor) {
+                handlers.onEditor?.(result.editor);
+            }
             result.plan = event.plan ?? null;
             result.completed = true;
             if (result.plan) {
@@ -735,6 +869,10 @@ export async function planOrchestration(
         }
 
         if (event.type === 'orchestration_elicitation') {
+            result.editor = event.editor ?? null;
+            if (result.editor) {
+                handlers.onEditor?.(result.editor);
+            }
             result.elicitation = event.elicitation ?? null;
             result.completed = true;
             if (result.elicitation) {
@@ -798,11 +936,20 @@ export async function runOrchestration(
         ORCHESTRATION_RUN_PATH,
         body,
         signal,
-        (message, status) => {
-            // 409 is the server's re-run guard, which is the whole reason approving a restored
-            // plan from a second device is safe. Reported as its own outcome so the caller can
-            // reconcile with the answer that already exists.
-            if (status === 409) {
+        (message, error) => {
+            if (error?.status === 409
+                && (error.code === 'plan_changed' || error.code === 'edit_in_progress')) {
+                result.errored = true;
+                result.conflict = error;
+                if (handlers.onConflict) {
+                    handlers.onConflict(message, error);
+                } else {
+                    handlers.onError?.(message);
+                }
+                return;
+            }
+            // Uncoded/legacy 409s and already_run retain the existing duplicate-run recovery.
+            if (error?.status === 409) {
                 result.alreadyRun = true;
                 handlers.onAlreadyRun?.(message);
                 return;

--- a/application/v2_ui/src/lib/orchestrationController.ts
+++ b/application/v2_ui/src/lib/orchestrationController.ts
@@ -15,8 +15,15 @@
 // same reason.
 
 import { createConversation } from './endpoints';
+import { ApiError } from './apiClient';
 import {
+    beginPlanEdit,
+    fetchOrchestrationRun,
+    fetchPlanEditor,
+    MAX_PLAN_INSTRUCTION_LENGTH,
+    orchestrationErrorInfo,
     planOrchestration,
+    reviseOrchestrationPlan,
     runOrchestration,
     type ApprovalMode,
     type ElicitationContext,
@@ -25,17 +32,25 @@ import {
     type OrchestrationPlan,
     type OrchestrationPlanRequest,
     type OrchestrationRunRequest,
+    type OrchestrationRequestError,
+    type PlanRevisionAction,
+    type PlanRevisionRequest,
     type RunStreamEvent,
 } from './orchestration';
-import { applyPlanEdits, isPlanApproved, isPlanAwaitingApproval, isPlanRunnable } from './orchestrationPlan';
+import { applyPlanEdits, isPlanApproved, isPlanAwaitingApproval, isPlanRunnable, normalizePlan } from './orchestrationPlan';
 import type { Json } from './types';
 import { useChatStore } from '../stores/chatStore';
 import {
     selectEdits,
+    selectCanEditPlan,
     selectElicitation,
     selectElicitationDraft,
     selectPlan,
+    selectHasPlanHold,
+    selectPlanEditor,
+    selectPlanRunBlocked,
     useOrchestrationStore,
+    type PlanEditorTarget,
 } from '../stores/orchestrationStore';
 
 /** Mirrors `orchestrationStore`'s own `scopeKey`; the separator has to match to share a key space. */
@@ -87,6 +102,8 @@ const turnContexts = new Map<string, TurnContext>();
  * re-plan superseding a plan — reaches the right one while another conversation's run is untouched.
  */
 const activeControllers = new Map<string, AbortController>();
+/** Editor requests never abort, begin, settle, or append a main-thread turn. */
+const editorControllers = new Map<string, AbortController>();
 
 export type ElicitationSubmitResult = { ok: true } | { ok: false; error: string };
 
@@ -401,10 +418,13 @@ async function dispatchPlan(
         const autoRun =
             settledPlan !== null &&
             settledPlan.approval.mode === 'auto' &&
+            !selectHasPlanHold(useOrchestrationStore.getState(), currentConversationId, currentTurnId) &&
             isPlanApproved(settledPlan) &&
             isPlanRunnable(settledPlan);
         if (autoRun) {
-            void approveAndRunPlan({ conversationId: currentConversationId, turnId: currentTurnId });
+            void approveAndRunPlan({
+                conversationId: currentConversationId, turnId: currentTurnId, automatic: true,
+            });
         } else {
             useChatStore
                 .getState()
@@ -563,11 +583,13 @@ export async function answerElicitation(params: {
 export async function approveAndRunPlan(params: {
     conversationId: string;
     turnId: string;
+    automatic?: boolean;
 }): Promise<void> {
     const { conversationId, turnId } = params;
     const store = useOrchestrationStore.getState();
     const plan = selectPlan(store, conversationId, turnId);
-    if (!plan) {
+    if (!plan || selectPlanRunBlocked(store, conversationId, turnId)
+        || (params.automatic && selectHasPlanHold(store, conversationId, turnId))) {
         return;
     }
     const edits = selectEdits(store, conversationId, turnId);
@@ -587,6 +609,9 @@ export async function approveAndRunPlan(params: {
     if (!began) {
         return;
     }
+    if (store.editorTarget?.conversationId === conversationId && store.editorTarget.turnId === turnId) {
+        store.setEditorTarget(null);
+    }
 
     const context = turnContexts.get(scopeKey(conversationId, turnId));
     // Enter the streaming state for the answer without a second user bubble — the question is
@@ -602,9 +627,11 @@ export async function approveAndRunPlan(params: {
         plan_id: planId,
         conversation_id: conversationId,
         edits,
+        ...(plan.edit_version ? { expected_version: plan.edit_version } : {}),
     };
 
     let settled = false;
+    let conflictMessage = '';
     const result = await runOrchestration(
         runBody,
         {
@@ -643,6 +670,16 @@ export async function approveAndRunPlan(params: {
                     .settleOrchestrationTurn(conversationId, { status: 'failed', error: message });
                 useOrchestrationStore.getState().endRun(runId, 'failed');
             },
+            onConflict: (message) => {
+                settled = true;
+                conflictMessage = message;
+                const current = useOrchestrationStore.getState();
+                current.releaseRunAttempt(runId);
+                current.updatePlanEditor(conversationId, turnId, (editor) => ({
+                    ...editor, blocked: true, error: message,
+                }));
+                useChatStore.getState().settleOrchestrationTurn(conversationId, { status: 'planned' });
+            },
             // The plan was already run somewhere else.
             //
             // Only reachable now that a pending approval can be picked up on a second device: two
@@ -666,6 +703,11 @@ export async function approveAndRunPlan(params: {
 
     if (activeControllers.get(conversationId) === controller) {
         activeControllers.delete(conversationId);
+    }
+    if (result.conflict) {
+        await refreshOrchestrationPlanEditor(
+            { conversationId, turnId }, result.conflict.current_run_id ?? runId, conflictMessage,
+        );
     }
 
     if (!settled) {
@@ -705,6 +747,9 @@ export function hasActiveOrchestration(conversationId: string): boolean {
  */
 export function dismissOrchestrationTurn(conversationId: string, turnId: string): void {
     cancelOrchestration(conversationId);
+    const key = scopeKey(conversationId, turnId);
+    editorControllers.get(key)?.abort();
+    editorControllers.delete(key);
     const store = useOrchestrationStore.getState();
     store.clearPlan(conversationId, turnId);
     store.clearElicitation(conversationId, turnId);
@@ -712,4 +757,368 @@ export function dismissOrchestrationTurn(conversationId: string, turnId: string)
     useChatStore
         .getState()
         .settleOrchestrationTurn(conversationId, { status: 'cancelled', accumulated: '' });
+}
+
+function editorRequestFailure(error: unknown): { message: string; info: OrchestrationRequestError } {
+    if (error instanceof ApiError) {
+        const payload = error.payload as { error?: unknown } | null;
+        return {
+            message: typeof payload?.error === 'string'
+                ? payload.error : 'The saved plan could not be loaded. Please try again.',
+            info: orchestrationErrorInfo(error.payload, error.status),
+        };
+    }
+    return {
+        message: 'The request could not connect. Your current plan and instruction have been kept.',
+        info: {},
+    };
+}
+
+function isEditorRequestCurrent(target: PlanEditorTarget, controller: AbortController): boolean {
+    return !controller.signal.aborted
+        && editorControllers.get(scopeKey(target.conversationId, target.turnId)) === controller
+        && Boolean(selectPlanEditor(useOrchestrationStore.getState(), target.conversationId, target.turnId));
+}
+
+async function loadPlanEditorState(
+    target: PlanEditorTarget,
+    begin: boolean,
+    runId?: string,
+    preservedError?: string,
+): Promise<ElicitationSubmitResult> {
+    const { conversationId, turnId } = target;
+    const key = scopeKey(conversationId, turnId);
+    const store = useOrchestrationStore.getState();
+    const plan = selectPlan(store, conversationId, turnId);
+    if (!plan || !selectCanEditPlan(store, conversationId, turnId)) {
+        return { ok: false, error: 'Only a pending plan can be edited.' };
+    }
+    if (editorControllers.has(key)) {
+        return { ok: true };
+    }
+    const controller = new AbortController();
+    editorControllers.set(key, controller);
+    store.updatePlanEditor(conversationId, turnId, (editor) => ({
+        ...editor,
+        loading: true,
+        error: preservedError ?? (begin && editor.state && !editor.blocked ? editor.error : null),
+    }));
+    const currentRunId = runId ?? plan.run_id;
+    try {
+        const editor = begin
+            ? await beginPlanEdit(currentRunId, {
+                conversation_id: conversationId,
+                plan_id: plan.plan_id,
+                edits: selectEdits(store, conversationId, turnId),
+                ...(plan.edit_version ? { expected_version: plan.edit_version } : {}),
+            }, controller.signal)
+            : await fetchPlanEditor(currentRunId, conversationId, { signal: controller.signal });
+        if (!isEditorRequestCurrent(target, controller)) {
+            return { ok: false, error: 'This editor request is no longer active.' };
+        }
+        if (!useOrchestrationStore.getState().adoptPlanEditor(
+            conversationId, turnId, editor, { retainLocalEdits: begin },
+        )) {
+            throw new Error('Invalid or stale editor identity');
+        }
+        return { ok: true };
+    } catch (error) {
+        const { message, info } = editorRequestFailure(error);
+        if (isEditorRequestCurrent(target, controller)) {
+            if (info.code === 'plan_changed' || info.code === 'edit_in_progress') {
+                try {
+                    const editor = await fetchPlanEditor(
+                        info.current_run_id ?? currentRunId, conversationId, { signal: controller.signal },
+                    );
+                    if (isEditorRequestCurrent(target, controller)
+                        && useOrchestrationStore.getState().adoptPlanEditor(conversationId, turnId, editor)) {
+                        useOrchestrationStore.getState().updatePlanEditor(conversationId, turnId,
+                            (session) => ({ ...session, error: message }));
+                        return { ok: true };
+                    }
+                } catch {
+                    // The local pause remains; a failed refresh must not authorize stale work.
+                }
+            }
+            useOrchestrationStore.getState().updatePlanEditor(conversationId, turnId, (editor) => ({
+                ...editor, blocked: true, error: message,
+            }));
+        }
+        return { ok: false, error: message };
+    } finally {
+        if (isEditorRequestCurrent(target, controller)) {
+            editorControllers.delete(key);
+            useOrchestrationStore.getState().updatePlanEditor(conversationId, turnId, (editor) => ({
+                ...editor, loading: false,
+            }));
+        }
+    }
+}
+
+/** Pause synchronously, then acquire the durable hold; closing never undoes either. */
+export async function openOrchestrationPlanEditor(target: PlanEditorTarget): Promise<void> {
+    const store = useOrchestrationStore.getState();
+    if (!selectCanEditPlan(store, target.conversationId, target.turnId)) {
+        return;
+    }
+    store.updatePlanEditor(target.conversationId, target.turnId, (editor) => editor);
+    store.setEditorTarget(target);
+    await loadPlanEditorState(target, true);
+}
+
+/** Read-only hydration also works with an old run ID; the server resolves the current revision. */
+export async function refreshOrchestrationPlanEditor(
+    target: PlanEditorTarget,
+    runId?: string,
+    preservedError?: string,
+): Promise<ElicitationSubmitResult> {
+    return loadPlanEditorState(target, false, runId, preservedError);
+}
+
+export async function submitPlanRevision(
+    target: PlanEditorTarget,
+    action: PlanRevisionAction,
+): Promise<ElicitationSubmitResult> {
+    const { conversationId, turnId } = target;
+    const key = scopeKey(conversationId, turnId);
+    const store = useOrchestrationStore.getState();
+    const session = selectPlanEditor(store, conversationId, turnId);
+    const plan = selectPlan(store, conversationId, turnId);
+    const discarding = action.action === 'discard';
+    if (!session?.state || !plan || !selectCanEditPlan(store, conversationId, turnId)
+        || session.loading || session.cancellationStatus === 'cancelling'
+        || (!discarding && (session.submitting || session.blocked || session.state.busy
+            || editorControllers.has(key) || plan.edit_version !== session.state.version))) {
+        return { ok: false, error: 'Wait for the current plan to be saved before editing.' };
+    }
+    const pending = session.state.pending;
+    const cancellationChangedError = 'The plan changed. Review the current change before cancelling it.';
+    if (action.action === 'discard' && action.elicitation_id !== undefined
+        && (action.elicitation_id !== pending?.elicitation_id
+            || action.elicitation_revision !== pending?.revision)) {
+        store.updatePlanEditor(conversationId, turnId, (editor) => ({
+            ...editor, error: cancellationChangedError,
+        }));
+        return { ok: false, error: cancellationChangedError };
+    }
+    if ((pending && (action.action === 'ask' || action.action === 'restore'))
+        || (action.action === 'answer' && (!pending
+            || action.elicitation_id !== pending.elicitation_id
+            || action.elicitation_revision !== (pending.revision ?? 0)))) {
+        return { ok: false, error: 'Answer or cancel the current edit question first.' };
+    }
+    if (action.action === 'ask') {
+        action = { ...action, instruction: action.instruction.trim() };
+        if (!action.instruction || action.instruction.length > MAX_PLAN_INSTRUCTION_LENGTH) {
+            const error = `Enter an instruction of 1–${MAX_PLAN_INSTRUCTION_LENGTH} characters.`;
+            store.updatePlanEditor(conversationId, turnId, (editor) => ({ ...editor, error }));
+            return { ok: false, error };
+        }
+    }
+    const controller = new AbortController();
+    const previousController = editorControllers.get(key);
+    editorControllers.set(key, controller);
+    if (discarding) {
+        // The explicit discard owns this turn now. Aborting the reader alone is not
+        // cancellation: the server must acknowledge the token-rotating discard below.
+        previousController?.abort();
+    }
+    store.updatePlanEditor(conversationId, turnId, (editor) => ({
+        ...editor,
+        submitting: true,
+        cancellationStatus: discarding ? 'cancelling' : 'idle',
+        error: null,
+        pendingDraft: editor.pendingDraft ? { ...editor.pendingDraft, submitting: true } : null,
+    }));
+    let failure = 'The planner did not return a saved revision. Your current plan has been kept.';
+    let info: OrchestrationRequestError | undefined;
+    let accepted = false;
+    try {
+        let requestPlan = plan;
+        let version = session.state.version;
+        if (discarding) {
+            const latest = await fetchPlanEditor(plan.run_id, conversationId, { signal: controller.signal });
+            if (!isEditorRequestCurrent(target, controller)) {
+                return { ok: false, error: 'This editor request is no longer active.' };
+            }
+            if (!useOrchestrationStore.getState().adoptPlanEditor(conversationId, turnId, latest)) {
+                throw new Error('Invalid or stale editor identity');
+            }
+            requestPlan = latest.plan;
+            version = latest.version;
+            if (!latest.busy && !latest.pending && (!previousController
+                || latest.version !== session.state.version || latest.plan.run_id !== plan.run_id)) {
+                accepted = true;
+                useOrchestrationStore.getState().updatePlanEditor(conversationId, turnId, (editor) => ({
+                    ...editor,
+                    submission: null,
+                    error: 'No pending change remains. Review the latest saved plan before running it.',
+                }));
+                return { ok: true };
+            }
+            const sameQuestion = pending === null
+                ? latest.pending === null
+                : latest.pending?.elicitation_id === pending.elicitation_id
+                    && latest.pending?.revision === pending.revision;
+            if (latest.plan.run_id !== plan.run_id || latest.plan.plan_id !== plan.plan_id
+                || latest.version !== session.state.version || !sameQuestion) {
+                failure = cancellationChangedError;
+                useOrchestrationStore.getState().updatePlanEditor(conversationId, turnId, (editor) => ({
+                    ...editor, submission: null, error: failure,
+                }));
+                return { ok: false, error: failure };
+            }
+            if (pending) {
+                action = {
+                    action: 'discard',
+                    elicitation_id: pending.elicitation_id,
+                    elicitation_revision: pending.revision ?? 0,
+                };
+            }
+        }
+        const edits = discarding ? undefined : selectEdits(store, conversationId, turnId);
+        const fingerprint = JSON.stringify({ runId: requestPlan.run_id, version, edits, action });
+        const submissionId = session.submission?.fingerprint === fingerprint
+            ? session.submission.id : makeTurnId();
+        const body: PlanRevisionRequest = {
+            ...action,
+            conversation_id: conversationId,
+            expected_version: version,
+            ...(edits ? { edits } : {}),
+            submission_id: submissionId,
+        };
+        useOrchestrationStore.getState().updatePlanEditor(conversationId, turnId, (editor) => ({
+            ...editor, submission: { id: submissionId, fingerprint },
+        }));
+        const result = await reviseOrchestrationPlan(requestPlan.run_id, body, {
+            onError: (message, error) => { failure = message; info = error; },
+        }, controller.signal);
+        if (!isEditorRequestCurrent(target, controller)) {
+            return { ok: false, error: 'This editor request is no longer active.' };
+        }
+        accepted = !result.errored && !result.cancelled && Boolean(result.editor)
+            && useOrchestrationStore.getState().adoptPlanEditor(conversationId, turnId, result.editor!);
+        if (accepted) {
+            const context = turnContexts.get(key);
+            if (context && result.editor) {
+                context.revision = result.editor.plan.revision;
+            }
+            useOrchestrationStore.getState().updatePlanEditor(conversationId, turnId, (editor) => ({
+                ...editor,
+                instruction: action.action === 'ask' && !result.editor?.pending
+                    && editor.instruction.trim() === action.instruction ? '' : editor.instruction,
+                submission: null,
+            }));
+        } else {
+            useOrchestrationStore.getState().updatePlanEditor(conversationId, turnId, (editor) => ({
+                ...editor, error: failure,
+                blocked: discarding || info?.code === 'plan_changed' || info?.code === 'edit_in_progress'
+                    || info?.code === 'already_run' || info?.status === 403 || info?.status === 404,
+            }));
+        }
+    } catch (error) {
+        failure = editorRequestFailure(error).message;
+        if (isEditorRequestCurrent(target, controller)) {
+            useOrchestrationStore.getState().updatePlanEditor(conversationId, turnId,
+                (editor) => ({ ...editor, error: failure, blocked: discarding || editor.blocked }));
+        }
+    } finally {
+        if (isEditorRequestCurrent(target, controller)) {
+            editorControllers.delete(key);
+            useOrchestrationStore.getState().updatePlanEditor(conversationId, turnId, (editor) => ({
+                ...editor,
+                submitting: false,
+                cancellationStatus: discarding && !accepted ? 'failed' : 'idle',
+                pendingDraft: editor.pendingDraft ? { ...editor.pendingDraft, submitting: false } : null,
+            }));
+        }
+    }
+    if (info?.code === 'plan_changed' || info?.code === 'edit_in_progress') {
+        await refreshOrchestrationPlanEditor(target, info.current_run_id ?? plan.run_id, failure);
+    }
+    return accepted ? { ok: true } : { ok: false, error: failure };
+}
+
+export async function loadPlanEditorHistory(target: PlanEditorTarget): Promise<void> {
+    const { conversationId, turnId } = target;
+    const session = selectPlanEditor(useOrchestrationStore.getState(), conversationId, turnId);
+    const editor = session?.state;
+    if (!editor || session.historyLoading || editor.next_before_revision === null) {
+        return;
+    }
+    useOrchestrationStore.getState().updatePlanEditor(conversationId, turnId,
+        (current) => ({ ...current, historyLoading: true }));
+    try {
+        const page = await fetchPlanEditor(editor.plan.run_id, conversationId, {
+            beforeRevision: editor.next_before_revision,
+        });
+        const current = selectPlanEditor(useOrchestrationStore.getState(), conversationId, turnId);
+        if (current?.state?.version !== editor.version || page.version !== editor.version) {
+            return;
+        }
+        const byRun = new Map([...current.state.history, ...page.history].map((entry) => [entry.run_id, entry]));
+        useOrchestrationStore.getState().updatePlanEditor(conversationId, turnId, (value) => ({
+            ...value,
+            state: value.state ? {
+                ...value.state,
+                history: [...byRun.values()].sort((left, right) => right.revision - left.revision),
+                next_before_revision: page.next_before_revision,
+            } : null,
+        }));
+    } catch (error) {
+        if (selectPlanEditor(useOrchestrationStore.getState(), conversationId, turnId)) {
+            useOrchestrationStore.getState().updatePlanEditor(conversationId, turnId,
+                (current) => ({ ...current, error: editorRequestFailure(error).message }));
+        }
+    } finally {
+        if (selectPlanEditor(useOrchestrationStore.getState(), conversationId, turnId)) {
+            useOrchestrationStore.getState().updatePlanEditor(conversationId, turnId,
+                (current) => ({ ...current, historyLoading: false }));
+        }
+    }
+}
+
+export async function previewPlanEditorRevision(target: PlanEditorTarget, runId: string): Promise<void> {
+    const { conversationId, turnId } = target;
+    const store = useOrchestrationStore.getState();
+    const session = selectPlanEditor(store, conversationId, turnId);
+    if (!session?.state) {
+        return;
+    }
+    if (session.state.plan.run_id === runId) {
+        store.updatePlanEditor(conversationId, turnId, (editor) => ({
+            ...editor, previewRunId: null, previewPlan: null, previewLoading: false,
+        }));
+        return;
+    }
+    store.updatePlanEditor(conversationId, turnId, (editor) => ({
+        ...editor, previewRunId: runId, previewPlan: null, previewLoading: true, error: null,
+    }));
+    const stillSelected = () => {
+        const current = selectPlanEditor(useOrchestrationStore.getState(), conversationId, turnId);
+        return current?.previewRunId === runId && current.state?.version === session.state?.version;
+    };
+    try {
+        const run = await fetchOrchestrationRun(runId, { conversationId });
+        const plan = normalizePlan(run?.plan);
+        if (!stillSelected()) {
+            return;
+        }
+        if (!plan || plan.run_id !== runId || plan.turn_id !== turnId
+            || plan.conversation_id !== conversationId) {
+            throw new Error('Invalid history identity');
+        }
+        useOrchestrationStore.getState().updatePlanEditor(conversationId, turnId,
+            (editor) => ({ ...editor, previewPlan: plan }));
+    } catch {
+        if (stillSelected()) {
+            useOrchestrationStore.getState().updatePlanEditor(conversationId, turnId,
+                (editor) => ({ ...editor, error: 'This revision could not be previewed. The current plan is unchanged.' }));
+        }
+    } finally {
+        if (stillSelected()) {
+            useOrchestrationStore.getState().updatePlanEditor(conversationId, turnId,
+                (editor) => ({ ...editor, previewLoading: false }));
+        }
+    }
 }

--- a/application/v2_ui/src/lib/orchestrationPlan.ts
+++ b/application/v2_ui/src/lib/orchestrationPlan.ts
@@ -214,6 +214,7 @@ export function normalizePlan(raw: unknown): OrchestrationPlan | null {
     return {
         plan_id: asString(source.plan_id),
         run_id: asString(source.run_id),
+        edit_version: typeof source.edit_version === 'string' ? source.edit_version : undefined,
         turn_id: asString(source.turn_id),
         revision: typeof source.revision === 'number' ? source.revision : 0,
         conversation_id: asString(source.conversation_id),

--- a/application/v2_ui/src/lib/orchestrationResume.ts
+++ b/application/v2_ui/src/lib/orchestrationResume.ts
@@ -22,9 +22,11 @@ import { useChatStore } from '../stores/chatStore';
 import {
     isResumablePlanStatus,
     selectActiveTurn,
+    selectPlan,
     useOrchestrationStore,
 } from '../stores/orchestrationStore';
 import { fetchConversationRuns, fetchOrchestrationRun, fetchRunSteps } from './orchestration';
+import { refreshOrchestrationPlanEditor } from './orchestrationController';
 import type { Json } from './orchestration';
 
 /** How many runs to ask for. Matches the store's per-conversation history cap. */
@@ -134,6 +136,7 @@ async function restorePendingApproval(conversationId: string): Promise<void> {
         return;
     }
     if (useChatStore.getState().activeConversationId !== conversationId) {
+        consideredConversations.delete(conversationId);
         return;
     }
 
@@ -145,6 +148,10 @@ async function restorePendingApproval(conversationId: string): Promise<void> {
         { readOnly: false },
     );
     useOrchestrationStore.getState().setActiveTurn(conversationId, newest.turnId);
+    const restored = selectPlan(useOrchestrationStore.getState(), conversationId, newest.turnId);
+    if (restored?.edit_version) {
+        await refreshOrchestrationPlanEditor({ conversationId, turnId: newest.turnId }, newest.runId);
+    }
 }
 
 /**

--- a/application/v2_ui/src/pages/ChatPage.tsx
+++ b/application/v2_ui/src/pages/ChatPage.tsx
@@ -29,6 +29,7 @@ import { readConversationParam, syncedConversationParams } from '../lib/conversa
 import { MessageList } from '../components/chat/MessageList';
 import { Composer } from '../components/chat/Composer';
 import { ConversationDrawer } from '../components/chat/ConversationDrawer';
+import { OrchestrationPlanEditorHost } from '../components/chat/OrchestrationPlanEditor';
 import { ConversationDetails } from '../components/chat/ConversationDetails';
 import { ConversationBadges } from '../components/chat/ConversationBadges';
 import { ParticipantsPanel } from '../components/chat/ParticipantsPanel';
@@ -428,6 +429,7 @@ export function ChatPage() {
                 <Composer initialAgentSelection={launchAgentSelection} />
             </div>
             <ConversationDrawer />
+            <OrchestrationPlanEditorHost />
             {/* Gated on there being a conversation as well as on the panel being open, so
                 starting a new chat cannot leave a details panel describing the conversation
                 just left. The button that opened it is drawn from the same condition. */}

--- a/application/v2_ui/src/stores/orchestrationStore.ts
+++ b/application/v2_ui/src/stores/orchestrationStore.ts
@@ -38,6 +38,7 @@ import type {
     OrchestrationStep,
     PersistedRunStep,
     PersistedRunSummary,
+    PlanEditorState,
     PlanEdits,
     PlanStatus,
     RunStreamEvent,
@@ -228,6 +229,48 @@ const EMPTY_STEP_RUNTIME: StepRuntimeMap = {};
 const EMPTY_HISTORY: readonly RunHistoryEntry[] = [];
 const EMPTY_RUNS: readonly TrackedRun[] = [];
 
+export interface PlanEditorTarget {
+    conversationId: string;
+    turnId: string;
+}
+
+/** Browser-only drafts and request state outlive the modal, not the server's revision record. */
+export interface PlanEditorSession {
+    state: PlanEditorState | null;
+    loading: boolean;
+    submitting: boolean;
+    cancellationStatus: 'idle' | 'cancelling' | 'failed';
+    blocked: boolean;
+    error: string | null;
+    instruction: string;
+    pendingDraft: ElicitationDraft | null;
+    submission: { id: string; fingerprint: string } | null;
+    tab: 'ask' | 'history';
+    previewRunId: string | null;
+    previewPlan: OrchestrationPlan | null;
+    previewLoading: boolean;
+    historyLoading: boolean;
+}
+
+function newPlanEditorSession(): PlanEditorSession {
+    return {
+        state: null,
+        loading: false,
+        submitting: false,
+        cancellationStatus: 'idle',
+        blocked: false,
+        error: null,
+        instruction: '',
+        pendingDraft: null,
+        submission: null,
+        tab: 'ask',
+        previewRunId: null,
+        previewPlan: null,
+        previewLoading: false,
+        historyLoading: false,
+    };
+}
+
 interface OrchestrationState {
     /** The current plan per turn, keyed by `scopeKey`. */
     plans: Record<string, OrchestrationPlan>;
@@ -283,6 +326,21 @@ interface OrchestrationState {
      * card, and so a fresh submit simply overwrites the one turn a conversation shows inline.
      */
     activeTurns: Record<string, string>;
+    /** Presence immediately pauses automatic approval, even before the hold POST completes. */
+    planEditors: Record<string, PlanEditorSession>;
+    editorTarget: PlanEditorTarget | null;
+    setEditorTarget: (target: PlanEditorTarget | null) => void;
+    updatePlanEditor: (
+        conversationId: string,
+        turnId: string,
+        update: (session: PlanEditorSession) => PlanEditorSession,
+    ) => void;
+    adoptPlanEditor: (
+        conversationId: string,
+        turnId: string,
+        editor: PlanEditorState,
+        options?: { retainLocalEdits?: boolean },
+    ) => boolean;
 
     /** Adopt a plan for a turn, replacing any pending question and re-seeding on a new revision. */
     setPlan: (conversationId: string, turnId: string, plan: unknown) => void;
@@ -354,6 +412,8 @@ interface OrchestrationState {
     beginRun: (record: Omit<TrackedRun, 'resumed'>) => boolean;
     /** Forget a run, recording how it ended in the conversation's history. */
     endRun: (runId: string, outcome: RunOutcome) => void;
+    /** A rejected approval never executed and must not become a completed/failed run. */
+    releaseRunAttempt: (runId: string) => void;
     /** Adopt run records restored from storage after a reload. */
     restoreRuns: (records: TrackedRun[]) => void;
 
@@ -415,6 +475,85 @@ export const useOrchestrationStore = create<OrchestrationState>((set, get) => ({
     pinnedRunId: null,
     visibleConversationId: null,
     activeTurns: {},
+    planEditors: {},
+    editorTarget: null,
+
+    setEditorTarget: (editorTarget) => set({ editorTarget }),
+
+    updatePlanEditor: (conversationId, turnId, update) => {
+        const key = scopeKey(conversationId, turnId);
+        set((state) => ({
+            planEditors: {
+                ...state.planEditors,
+                [key]: update(state.planEditors[key] ?? newPlanEditorSession()),
+            },
+        }));
+    },
+
+    adoptPlanEditor: (conversationId, turnId, editor, options) => {
+        const plan = normalizePlan(editor?.plan);
+        if (!plan?.plan_id || !plan.run_id || typeof editor.version !== 'string' || !editor.version
+            || plan.conversation_id !== conversationId || plan.turn_id !== turnId) {
+            return false;
+        }
+        const key = scopeKey(conversationId, turnId);
+        const current = get().plans[key];
+        if ((current && current.revision > plan.revision)
+            || Object.values(get().inFlight).some((run) =>
+                run.conversationId === conversationId && run.turnId === turnId)
+            || (get().history[conversationId] ?? []).some((run) => run.turnId === turnId)) {
+            return false;
+        }
+        const canonical = { ...plan, edit_version: editor.version };
+        set((state) => {
+            const previous = state.planEditors[key] ?? newPlanEditorSession();
+            const pending = editor.pending;
+            const sameQuestion = pending && previous.pendingDraft?.elicitationId === pending.elicitation_id
+                && previous.pendingDraft.revision === (pending.revision ?? 0);
+            const runtime: StepRuntimeMap = {};
+            for (const step of canonical.steps) {
+                runtime[step.step_id] = { status: step.status, summary: '' };
+            }
+            const readOnlyTurns = { ...state.readOnlyTurns };
+            if (isResumablePlanStatus(canonical.status)) {
+                delete readOnlyTurns[key];
+            } else {
+                readOnlyTurns[key] = true;
+            }
+            return {
+                plans: { ...state.plans, [key]: canonical },
+                // Unlike setPlan, this adopts the authoritative overlay in the same update.
+                // Unsaved Review changes may survive reopening only against the identical
+                // server version. A stale tab must adopt the server's overlay instead.
+                edits: {
+                    ...state.edits,
+                    [key]: options?.retainLocalEdits && current?.run_id === canonical.run_id
+                        && current.edit_version === editor.version
+                        && previous.state?.version === editor.version
+                        ? state.edits[key] ?? editor.edits : editor.edits,
+                },
+                stepRuntime: { ...state.stepRuntime, [key]: runtime },
+                readOnlyTurns,
+                planEditors: {
+                    ...state.planEditors,
+                    [key]: {
+                        ...previous,
+                        state: { ...editor, plan: canonical },
+                        blocked: false,
+                        cancellationStatus: previous.cancellationStatus === 'cancelling'
+                            ? 'cancelling' : 'idle',
+                        pendingDraft: pending
+                            ? sameQuestion ? previous.pendingDraft : createElicitationDraft(pending)
+                            : null,
+                        previewRunId: null,
+                        previewPlan: null,
+                        previewLoading: false,
+                    },
+                },
+            };
+        });
+        return true;
+    },
 
     setPlan: (conversationId, turnId, rawPlan) => {
         if (!conversationId || !turnId) {
@@ -466,12 +605,16 @@ export const useOrchestrationStore = create<OrchestrationState>((set, get) => ({
     clearPlan: (conversationId, turnId) => {
         const key = scopeKey(conversationId, turnId);
         set((state) => {
-            if (!(key in state.plans)) {
-                return {};
-            }
             const plans = { ...state.plans };
+            const planEditors = { ...state.planEditors };
             delete plans[key];
-            return { plans };
+            delete planEditors[key];
+            return {
+                plans,
+                planEditors,
+                editorTarget: state.editorTarget?.conversationId === conversationId
+                    && state.editorTarget.turnId === turnId ? null : state.editorTarget,
+            };
         });
     },
 
@@ -693,6 +836,13 @@ export const useOrchestrationStore = create<OrchestrationState>((set, get) => ({
         return true;
     },
 
+    releaseRunAttempt: (runId) => {
+        const inFlight = { ...get().inFlight };
+        delete inFlight[runId];
+        set({ inFlight });
+        saveRuns(Object.values(inFlight));
+    },
+
     endRun: (runId, outcome) => {
         const run = get().inFlight[runId];
         if (!run) {
@@ -880,7 +1030,11 @@ export const useOrchestrationStore = create<OrchestrationState>((set, get) => ({
         if (get().visibleConversationId === conversationId) {
             return;
         }
-        set({ visibleConversationId: conversationId });
+        set((state) => ({
+            visibleConversationId: conversationId,
+            editorTarget: state.editorTarget?.conversationId === conversationId
+                ? state.editorTarget : null,
+        }));
     },
 
     setActiveTurn: (conversationId, turnId) => {
@@ -903,6 +1057,8 @@ export const useOrchestrationStore = create<OrchestrationState>((set, get) => ({
                 activeTurns: { ...state.activeTurns, [conversationId]: turnId },
                 elicitations,
                 elicitationDrafts,
+                editorTarget: state.editorTarget?.conversationId === conversationId
+                    && state.editorTarget.turnId !== turnId ? null : state.editorTarget,
             };
         });
     },
@@ -929,6 +1085,11 @@ export const useOrchestrationStore = create<OrchestrationState>((set, get) => ({
         for (const key of Object.keys(get().elicitations)) {
             busy.add(conversationOfScope(key));
         }
+        for (const [key, editor] of Object.entries(get().planEditors)) {
+            if (editor.submitting || isResumablePlanStatus(get().plans[key]?.status)) {
+                busy.add(conversationOfScope(key));
+            }
+        }
 
         set((state) => {
             let removed = false;
@@ -938,6 +1099,7 @@ export const useOrchestrationStore = create<OrchestrationState>((set, get) => ({
             const edits: Record<string, PlanEdits> = {};
             const stepRuntime: Record<string, StepRuntimeMap> = {};
             const readOnlyTurns: Record<string, true> = {};
+            const planEditors: Record<string, PlanEditorSession> = {};
 
             const keep = (map: Record<string, unknown>, into: Record<string, unknown>) => {
                 for (const [key, value] of Object.entries(map)) {
@@ -955,6 +1117,7 @@ export const useOrchestrationStore = create<OrchestrationState>((set, get) => ({
             keep(state.edits, edits as Record<string, unknown>);
             keep(state.stepRuntime, stepRuntime as Record<string, unknown>);
             keep(state.readOnlyTurns, readOnlyTurns as Record<string, unknown>);
+            keep(state.planEditors, planEditors as Record<string, unknown>);
 
             // `activeTurns` is keyed by conversation, not `scopeKey`, so it is pruned on the plain
             // id. Dropping it in step with the plan it points at stops MessageList holding a turn
@@ -995,6 +1158,7 @@ export const useOrchestrationStore = create<OrchestrationState>((set, get) => ({
                       edits,
                       stepRuntime,
                       readOnlyTurns,
+                      planEditors,
                       activeTurns,
                       hydratedHistory,
                       hydration,
@@ -1007,6 +1171,54 @@ export const useOrchestrationStore = create<OrchestrationState>((set, get) => ({
 /* -------------------------------------------------------------------------- */
 /* Reading                                                                     */
 /* -------------------------------------------------------------------------- */
+
+export function selectPlanEditor(
+    state: OrchestrationState,
+    conversationId: string,
+    turnId: string,
+): PlanEditorSession | null {
+    return state.planEditors[scopeKey(conversationId, turnId)] ?? null;
+}
+
+export function selectHasPlanHold(
+    state: OrchestrationState,
+    conversationId: string,
+    turnId: string,
+): boolean {
+    return Boolean(selectPlanEditor(state, conversationId, turnId)
+        || selectPlan(state, conversationId, turnId)?.edit_version);
+}
+
+export function selectCanEditPlan(
+    state: OrchestrationState,
+    conversationId: string,
+    turnId: string,
+): boolean {
+    const plan = selectPlan(state, conversationId, turnId);
+    return Boolean(plan && isResumablePlanStatus(plan.status)
+        && plan.approval.state === 'pending'
+        && !state.readOnlyTurns[scopeKey(conversationId, turnId)]
+        && !Object.values(state.inFlight).some((run) =>
+            run.conversationId === conversationId && run.turnId === turnId)
+        && !(state.history[conversationId] ?? []).some((run) => run.turnId === turnId));
+}
+
+export function selectPlanRunBlocked(
+    state: OrchestrationState,
+    conversationId: string,
+    turnId: string,
+): boolean {
+    const editor = selectPlanEditor(state, conversationId, turnId);
+    const plan = selectPlan(state, conversationId, turnId);
+    return Boolean(state.readOnlyTurns[scopeKey(conversationId, turnId)]
+        || (plan?.edit_version && !editor?.state)
+        || (editor && (!editor.state || editor.loading || editor.submitting || editor.blocked
+            || editor.cancellationStatus !== 'idle'
+            || editor.state.busy || editor.state.pending
+            || editor.state.version !== plan?.edit_version
+            || (editor.previewRunId && state.editorTarget?.conversationId === conversationId
+                && state.editorTarget.turnId === turnId))));
+}
 
 /** The plan for a turn, or null. */
 export function selectPlan(

--- a/docs/admin/orchestration.md
+++ b/docs/admin/orchestration.md
@@ -95,6 +95,13 @@ override is allowed but preferences cannot be loaded, orchestration waits for a 
 rather than risking a different approval mode. The draft remains editable, and
 ordinary chat is still available by switching Orchestrate off.
 
+From version **0.261.102**, opening **Edit** on a pending plan stops the countdown and
+saves a manual-approval hold for that plan. It stays paused after the editor closes or
+the conversation reloads; an explicit **Run** is required. This intervention does not
+change the deployment default or the user's approval preference. Immediate Auto plans
+still start without an editing window. See
+[Review and edit orchestration plans]({{ '/guides/review-and-edit-orchestration-plans/' | relative_url }}).
+
 #### Settings
 
 | Setting | What it does | Default | Notes |

--- a/docs/explanation/features/CHAT_ORCHESTRATION.md
+++ b/docs/explanation/features/CHAT_ORCHESTRATION.md
@@ -1,6 +1,6 @@
 # Chat Orchestration
 
-**Version: 0.261.101** (tracked in `application/single_app/config.py`)
+**Version: 0.261.102** (tracked in `application/single_app/config.py`)
 
 **Implemented in version: 0.261.086**
 **Knowledge phase added in version: 0.261.089**
@@ -9,6 +9,7 @@
 **Direct action access implemented in version: 0.261.098**
 **Conversation continuity implemented in version: 0.261.096**
 **Approval preference persistence fixed in version: 0.261.101**
+**Conversational plan editing implemented in version: 0.261.102**
 
 ## Overview
 
@@ -358,9 +359,9 @@ answer.
 
 ## API
 
-Two endpoints, deliberately separate. The plan is durable between them, so a dropped
-connection cannot lose it, editing is straightforward, and the existing 24,600-line chat
-route is untouched.
+Planning and execution are deliberately separate requests. The plan is durable between
+them, so a dropped connection cannot lose it. Editor operations revise that saved plan
+without starting its steps or adding messages to the main conversation.
 
 | Endpoint | Method | Purpose |
 | --- | --- | --- |
@@ -368,6 +369,9 @@ route is untouched.
 | `/api/v2/orchestration/run` | POST | Executes an approved plan, streaming step progress and the answer. |
 | `/api/v2/orchestration/cancel/<run_id>` | POST | Asks a running plan to stop. |
 | `/api/v2/orchestration/runs` | GET | Every run in a conversation, oldest first, for the drawer's map view. |
+| `/api/v2/orchestration/runs/<run_id>/editor` | GET | Current editor state and paged revision history. |
+| `/api/v2/orchestration/runs/<run_id>/edit` | POST | Hold an unexecuted plan for manual approval before editing. |
+| `/api/v2/orchestration/runs/<run_id>/revisions` | POST | Ask the planner for a change, answer its question, restore a version, or discard a pending change. |
 | `/api/v2/orchestration/runs/<run_id>/steps` | GET | One run's steps, for expanding a row in the map view. |
 
 Cancellation is recorded on the run rather than signalled in process memory. The run is a
@@ -391,6 +395,23 @@ and `orchestration_synthesis`, each carrying `activity.lane_key = "orchestration
 
 Three event types are genuinely new, because nothing existing meant the same thing:
 `orchestration_plan`, `orchestration_elicitation` and `orchestration_step`.
+
+## Editing before execution
+
+**Review** remains the plan drawer with narrowing-only step and document controls.
+**Edit** opens a full-screen preview, scoped planner conversation, and revision history.
+The planner can add, remove, or revise steps, but only within current capability and
+source permissions. The browser never constructs an executable plan.
+
+Opening Edit stops a countdown and saves a manual-approval hold. Closing or reloading
+does not restart the timer: the current version needs an explicit **Run**. Conditional
+version checks prevent an old tab from approving a superseded plan or editing one that
+has already started.
+
+The revised task guides the actual execution and final answer, while the original user
+message remains unchanged. Failed changes preserve the last valid version. See
+[V2 Orchestration Plan Editing](V2_ORCHESTRATION_PLAN_EDITING.md) and the
+[user guide]({{ '/guides/review-and-edit-orchestration-plans/' | relative_url }}).
 
 ## Clarifying questions
 
@@ -496,6 +517,8 @@ See [the Orchestration settings page](../../admin/orchestration.md) for the full
 | `functions_action_catalog.py` | Metadata-only action discovery, scoped references and fresh authorization |
 | `functions_orchestration_actions.py` | Isolated, bounded execution of one selected action |
 | `functions_orchestration_planner.py` | Follow-up resolution, triage, plan synthesis, elicitation, re-planning |
+| `functions_orchestration_plan_editing.py` | Scoped plan changes, current source checks, and revised execution requests |
+| `functions_orchestration_plan_revisions.py` | Durable edit holds, conditional revision publication, history, and execution claims |
 | `functions_orchestration_adapters.py` | Capability adapters over existing functions |
 | `functions_orchestration_executor.py` | Step engine, budgets, cancellation, re-authorization |
 | `functions_orchestration_runs.py` | Run and step persistence |
@@ -516,7 +539,8 @@ See [the Orchestration settings page](../../admin/orchestration.md) for the full
    controls**; file upload and voice input stay where they are. The **Orchestrate** toggle
    turns it off again for anyone who wants the classic composer.
 4. Ask a question. If an inline clarification appears, answer it using choices, text, references, or uploads, then select **Finish**.
-5. Review the resulting plan; approve, adjust, or cancel it.
+5. Review the resulting plan. Use **Edit** to discuss changes with the planner, then
+   explicitly run the accepted version or cancel the plan.
 6. Watch progress in the Plan panel of the right-hand drawer.
 
 Anything selected inside the manual controls is passed as a seed and constrains the plan,
@@ -551,6 +575,8 @@ to the front.
 | `functional_tests/test_orchestration_plan_schema.py` | Unknown and disabled capabilities, document authorization, argument coercion and bounds, cycles, step caps, narrowing-only edits, approval states |
 | `functional_tests/test_v2_orchestration_approval_persistence.py` | Current-user approval preference round-trips, enum validation, and runtime preference resolution and save ordering |
 | `ui_tests/test_v2_orchestration_approval_persistence.py` | Approval selection across navigation and fresh browser contexts, administrator precedence, loading/retry, save failures, and pending writes |
+| `functional_tests/test_orchestration_plan_revision_store.py` | Durable edit holds, atomic publication, stale approvals, idempotent submissions, and revision history |
+| `functional_tests/test_orchestration_plan_revision_routes.py` | Conversational add/remove/restore, clarification, error recovery, preserved original messages, and revised-task execution |
 | `functional_tests/test_orchestration_elicitation_schema.py` | The MCP flat-object restriction, paging staying outside the schema, response validation |
 | `functional_tests/test_orchestration_elicitation_context.py` | Authoritative pending questions, accepted context, and the real plan/answer/run handoff |
 | `functional_tests/test_v2_elicitation_answers.py` | Primitive answers, single/multiple files, alternate sources, readiness, and answer-local prompt resolution |

--- a/docs/explanation/features/V2_ORCHESTRATION_PLAN_EDITING.md
+++ b/docs/explanation/features/V2_ORCHESTRATION_PLAN_EDITING.md
@@ -1,0 +1,152 @@
+# V2 Orchestration Plan Editing
+
+**Version: 0.261.102**
+
+**Implemented in version: 0.261.102**, tracked in
+`application/single_app/config.py`.
+
+## Overview
+
+A proposed orchestration plan is not necessarily the plan a user wants to run.
+They might want another search, less research, a different comparison, or a
+change to the answer's focus. **Edit** lets them discuss those changes with the
+planner before any step executes.
+
+The editor follows the image, chart, and diagram editing pattern: a full-screen
+preview, a scoped AI conversation, and revision history. Its storage is different
+because a plan is executable work, not a revision of a message's rendered content.
+Editor exchanges do not add duplicate messages to the main conversation.
+
+**Review** still opens the plan drawer. Its existing step switches and document
+removal controls only narrow a plan. Adding or restructuring work goes through
+the server-side planner and the same capability and source-access validation used
+when a plan is first created.
+
+## Dependencies and boundaries
+
+The V2 interface, `enable_chat_orchestration`, a configured planner or chat model,
+and an unexecuted pending plan are required. There is no new administrator switch,
+browser dependency, or Cosmos container.
+
+Only capabilities already enabled for the deployment and available to the user
+can be added. Editing cannot enable an integration, grant access to a document,
+or introduce an output capability that orchestration does not support.
+
+Running and finished plans are not editable. Immediate Auto mode remains
+immediate for untouched plans; select Review or countdown approval when a
+pre-execution editing opportunity is needed.
+
+## Approval and revision lifecycle
+
+Opening Edit pauses the local countdown immediately and saves a manual-approval
+hold on the server. The plan then needs an explicit **Run**, including after
+closing the editor or reloading the conversation. This is a safety intervention
+for that plan, not a change to the deployment's default approval setting.
+
+The hold changes the version token required to approve the plan. A stale tab
+cannot run it with an approval captured before editing began. Execution and
+editing use conditional persistence: whichever claims the plan first wins, and
+the other request receives a conflict rather than changing work already underway.
+Question cancellation carries the displayed question's identity and version. A
+refresh that discovers newer work does not silently retarget the cancellation.
+
+A successful change creates a new plan/run revision and supersedes its predecessor
+atomically. Old versions remain available for history but are not additional
+executed runs in the conversation's map or planner ledger. Restoring a version
+creates a new current revision after checking its sources and capabilities again.
+
+A failed model call, invalid plan, or failed save keeps the previous valid plan.
+The editor does not substitute a direct-answer fallback for an unsuccessful edit.
+Submission identifiers make a retried completed request reuse its saved outcome.
+
+## Planner context and execution
+
+The planner receives the current effective plan, including Review's narrowing
+changes, the current task, the latest instruction, and a bounded editor
+conversation. The saved original request, selected sources, and conversation
+snapshot retain their identities.
+
+The planner can return an updated plan, an explanation without changing the plan,
+or a clarifying question. Questions remain inside the editor; answering one
+continues that edit without removing the last valid preview.
+
+An updated plan also contains a self-contained revised request. It is saved
+separately from the original user message and used for retrieval, delegated tasks,
+and the final answer. A change therefore affects the work, not just the titles
+shown in the preview.
+
+User-written links and accepted clarification answers retain their provenance.
+A link invented while the model rewrites the task is not permission to fetch it.
+
+## API
+
+All editor routes use the authenticated orchestration Blueprint and check
+conversation and run ownership.
+
+| Endpoint | Method | Purpose |
+| --- | --- | --- |
+| `/api/v2/orchestration/runs/<run_id>/editor` | GET | Read current editor state and a page of revision history. Does not start an edit or approve work. |
+| `/api/v2/orchestration/runs/<run_id>/edit` | POST | Establish the manual-approval hold and return canonical editor state. |
+| `/api/v2/orchestration/runs/<run_id>/revisions` | POST | Stream an `ask`, `answer`, `restore`, or `discard` operation. |
+| `/api/v2/orchestration/run` | POST | Run the saved current plan, including its expected edit-version token when held. |
+
+Revision requests name the conversation, expected version, and submission ID.
+They contain an instruction, a stored source-version ID, or a clarification
+response, never a browser-authored executable plan. Instructions are limited to
+2,000 characters; an oversized instruction is rejected rather than truncated.
+
+Terminal revision frames reuse `orchestration_plan` and
+`orchestration_elicitation`, with an `editor` projection containing the current
+plan, narrowing edits, chat, history, and pending question. Private source
+snapshots, seeds, storage metadata, and in-flight claims are not included.
+
+History is paged with `before_revision`; it is not an ever-growing array of full
+plans in one Cosmos document. The scoped conversation retains recent turns, while
+plan versions remain separate records under the existing retention behavior.
+
+## File structure
+
+| File | Responsibility |
+| --- | --- |
+| `application/v2_ui/src/components/chat/OrchestrationPlanEditor.tsx` | Full-screen preview, planner conversation, and history |
+| `application/v2_ui/src/components/chat/OrchestrationPlanCard.tsx` | Inline Edit entry and countdown intervention |
+| `application/v2_ui/src/components/chat/OrchestrationPlanPanel.tsx` | Review-drawer integration |
+| `application/v2_ui/src/lib/orchestrationController.ts` | Scoped requests and explicit execution |
+| `application/v2_ui/src/stores/orchestrationStore.ts` | Plan/editor state across component and conversation changes |
+| `application/single_app/functions_orchestration_plan_editing.py` | Edit context, current source authorization, planner integration, and restore validation |
+| `application/single_app/functions_orchestration_plan_revisions.py` | Holds, claims, atomic publication, version history, and execution guards |
+| `application/single_app/functions_orchestration_planner.py` | Revision prompt and failure behavior |
+| `application/single_app/route_backend_orchestration.py` | Owned editor HTTP/SSE operations and run integration |
+
+## Usage
+
+See [Review and edit orchestration plans]({{ '/guides/review-and-edit-orchestration-plans/' | relative_url }})
+for the complete workflow. A typical refinement is to add a focused evidence-gathering
+step, inspect the new preview, remove unnecessary work, and then run the accepted
+version. No planned search, integration action, or answer step executes merely because the
+editor is opened or an instruction is sent.
+
+## Testing and limitations
+
+`functional_tests/test_orchestration_plan_revision_store.py` covers ownership,
+conditional transitions, idempotency, history, and edit/run conflicts.
+`functional_tests/test_orchestration_plan_revision_routes.py` covers the real
+planner-to-persistence-to-execution flow, including clarification, error recovery,
+preserved source selections, and the final revised request.
+`functional_tests/test_orchestration_plan_revision_planner.py` covers the strict
+edit-output contract and the separation from initial planning's failure fallback.
+
+The orchestration UI harness covers the editor and existing narrowing-only Review
+behavior. Model responses are deterministic in these tests; they establish the
+application contract, not that every natural-language request will produce the
+desired plan on its first attempt.
+
+`ui_tests/test_v2_orchestration_plan_editor.py` covers browser interactions and
+recovery states. `ui_tests/test_v2_orchestration_plan_editor_backend.py` forwards
+real browser requests through the Flask handlers to cover the combined
+add/remove, clarification, restore, and explicit-run workflow.
+
+Each AI refinement costs a planner call and may require metadata/search work to
+resolve eligible sources. It does not execute the proposed steps. Existing
+capability limits still apply. There is no raw JSON editor, running-plan replanner,
+or classic-interface counterpart.

--- a/docs/guides/review-and-edit-orchestration-plans.md
+++ b/docs/guides/review-and-edit-orchestration-plans.md
@@ -1,0 +1,92 @@
+---
+layout: page
+title: "Review and edit orchestration plans"
+description: "Refine proposed work with the planner before running it."
+section: "Guides"
+audience: user
+version: "0.261.102"
+---
+
+## Decide what should run
+
+An orchestration plan explains how SimpleChat intends to answer your question.
+Review it when you want to check its sources or cost before committing to that
+work. Edit it when the approach needs another step, less research, or a different
+focus.
+
+Conversational plan editing was implemented in version **0.261.102**, recorded in
+`application/single_app/config.py`. It is available in the V2 interface for plans
+that have not started.
+
+## Review versus Edit
+
+**Review** opens the existing drawer. You can inspect steps and their rationales,
+switch off non-answering steps, and remove documents from a step. These controls
+only reduce the work already proposed.
+
+**Edit** opens a full-screen preview with **Ask planner** and **History**. Use it
+to discuss a change instead of asking a new question in the main conversation.
+The planner creates a new version of the same plan.
+
+If plans currently run immediately, choose Review or countdown approval before
+asking your question, if your administrator permits that choice. A plan that has
+already started cannot be edited.
+
+## Refine the plan with the planner
+
+1. Ask your question with orchestration enabled and wait for the proposed plan.
+2. Select **Edit** beside Review, or open Edit from the plan drawer.
+3. In **Ask planner**, describe what should change. For example: "Add a second
+   document search focused on pricing" or "Remove the extra research and compare
+   only the selected contracts."
+4. Read the updated preview. Check the steps, source selections, assumptions,
+   and any adjustments reported by the planner.
+5. Continue refining the same plan, or select **Run** when the current version
+   describes the work you want.
+
+The planner may ask a clarifying question or explain why a requested capability
+is unavailable. Answer within the editor to continue the change. A request to add
+a feature does not enable that feature for the deployment or grant access to its
+sources.
+
+Editor exchanges do not create duplicate messages in your main conversation.
+The eventual answer follows your accepted changes while the original question
+remains intact.
+
+## Understand the countdown pause
+
+Opening Edit stops any countdown and establishes a manual-approval hold. The
+plan waits for an explicit **Run**, even if you close the editor without changing
+anything or reload the conversation.
+
+Closing the editor is not approval. A failed edit also does not cause the previous
+plan to run automatically. If another tab already started the work before the
+edit hold was acquired, the editor reports a conflict instead of pretending it
+can modify that run.
+
+## Return to an earlier version
+
+Use **History** to inspect prior versions and restore one that better matches
+your intent. Restoring creates a new current version; it does not delete later
+history or reactivate an old execution.
+
+Capabilities and source access are checked again. A version that depends on a
+document or integration you can no longer use may not be restorable.
+
+## Recover from a failed change
+
+The last valid plan remains available when an instruction cannot be planned or
+saved. Read the error and retry the change rather than sending the original
+question again. If a clarification is no longer needed, cancel the proposed
+change to return to the existing plan.
+
+When another tab changes the plan, refresh the editor's current version before
+continuing. An outdated approval cannot run a superseded plan.
+If Cancel discovers a newer pending change, the editor shows that change without
+cancelling it. Review it before explicitly choosing Cancel again.
+
+## Related
+
+- [Chat orchestration]({{ '/explanation/features/CHAT_ORCHESTRATION/' | relative_url }})
+- [Plan editing architecture]({{ '/explanation/features/V2_ORCHESTRATION_PLAN_EDITING/' | relative_url }})
+- [Orchestration settings]({{ '/admin/orchestration/' | relative_url }})

--- a/docs/reference/chat-controls.md
+++ b/docs/reference/chat-controls.md
@@ -193,3 +193,17 @@ without adding another model, agent, or execution toolbar. See
 | Clear suggested selections | Clears chosen file suggestions without clearing the answer editor. | Use your own referenced or uploaded file when none of the suggestions is right. | `enable_chat_orchestration` |
 | Back / Next / Finish | Keeps each page's answer while navigating; Finish submits the answers for the same request and waits for required answers and ready uploads. | Complete a multi-question clarification without losing drafts or continuing with unfinished files. | `enable_chat_orchestration` |
 | Decline / Cancel | Sends no answer text, selected references, or attached-prompt metadata. | Decline to provide the requested information or abandon the current answer. | `enable_chat_orchestration` |
+
+## Plan editing (V2 interface)
+
+Implemented in **0.261.102**. These controls refine an unexecuted orchestration
+plan rather than editing the main chat message. See
+[Review and edit orchestration plans]({{ '/guides/review-and-edit-orchestration-plans/' | relative_url }}).
+
+| Control | What it does | Why you would use it | Enabled by |
+| --- | --- | --- | --- |
+| Review | Opens the plan drawer with step details and narrowing-only controls. | Inspect the proposed sources and work, or remove something unnecessary. | `enable_chat_orchestration` |
+| Edit | Opens the full-screen plan editor and holds the plan for manual approval, stopping its countdown. | Change the proposed approach before it runs. | Same as Review; the plan must not have started |
+| Ask planner | Sends a change request to the planner for a validated revision, or answers its scoped clarification. | Add a permitted step, remove work, or refine the task without duplicating the main conversation. | Same as Edit; existing capability and source permissions apply |
+| History and restore | Shows previous plan versions and creates a newly validated current version when restoring one. | Return to an earlier approach without deleting later history. | Same as Edit |
+| Run after editing | Executes the saved current revision only after explicit approval. Closing the editor does not approve it. | Start the work once its steps and sources match your intent. | Same as Edit; no revision or clarification may be pending |

--- a/functional_tests/route_tests/test_route_blueprint_policy_inventory.py
+++ b/functional_tests/route_tests/test_route_blueprint_policy_inventory.py
@@ -2,8 +2,9 @@
 # test_route_blueprint_policy_inventory.py
 """
 Functional test for route blueprint policy inventory.
-Version: 0.250.055
+Version: 0.261.102
 Implemented in: 0.242.069
+Plan editor policy coverage: 0.261.102
 
 This test ensures every SimpleChat route is assigned to a Blueprint-based
 security policy or an explicit reviewed route exemption.
@@ -291,6 +292,24 @@ def test_public_routes_are_explicitly_listed() -> None:
     )
 
 
+def test_plan_editor_routes_keep_the_orchestration_security_policy() -> None:
+    """Every editor operation stays on the authenticated orchestration Blueprint."""
+    expected = {
+        "/api/v2/orchestration/runs/<run_id>/editor": "orchestration_plan_editor",
+        "/api/v2/orchestration/runs/<run_id>/edit": "orchestration_begin_plan_edit",
+        "/api/v2/orchestration/runs/<run_id>/revisions": "orchestration_revise_plan",
+    }
+    routes = {
+        route.path: route for route in iter_route_functions()
+        if route.file_name == "route_backend_orchestration.py" and route.path in expected
+    }
+    assert set(routes) == set(expected)
+    for path, route in routes.items():
+        assert route.function_name == expected[path]
+        assert route.route_target == "bp"
+        assert {"swagger_route", "login_required", "user_required"} <= set(route.decorator_names)
+
+
 if __name__ == "__main__":
     tests = [
         test_route_policy_inventory_assets_and_version_are_current,
@@ -299,6 +318,7 @@ if __name__ == "__main__":
         test_registered_route_blueprints_have_policy_classification,
         test_explicit_app_route_exemptions_have_expected_security,
         test_public_routes_are_explicitly_listed,
+        test_plan_editor_routes_keep_the_orchestration_security_policy,
     ]
     results = []
     for test in tests:

--- a/functional_tests/test_orchestration_conversation_context_routes.py
+++ b/functional_tests/test_orchestration_conversation_context_routes.py
@@ -1,10 +1,11 @@
 # test_orchestration_conversation_context_routes.py
 """
 Functional tests for conversation context across real orchestration HTTP/SSE routes.
-Version: 0.261.098
+Version: 0.261.102
 Implemented in: 0.261.096
 Prompt attachment integration: 0.261.097
 Direct action integration: 0.261.098
+Atomic plan revision persistence: 0.261.102
 
 Uses Flask, the real planner/executor/adapters/run store, an in-memory Cosmos boundary,
 and deterministic model completions. Authentication is a signed-in test user; actual
@@ -14,7 +15,6 @@ conversation ownership checks remain active. No external service is contacted.
 import importlib
 import importlib.util
 import json
-import re
 import sys
 import unittest
 from copy import deepcopy
@@ -22,9 +22,6 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 from azure.core.exceptions import AzureError
-from azure.cosmos.exceptions import (
-    CosmosAccessConditionFailedError, CosmosResourceExistsError, CosmosResourceNotFoundError,
-)
 from flask import Blueprint, Flask
 from werkzeug.test import Client
 from werkzeug.wrappers import Response
@@ -33,85 +30,11 @@ from test_orchestration_conversation_context import (
     LATEST, RESOLVED, fake_module, load_modules, message, winery_history,
 )
 from test_support.app_stubs import APP_ROOT, stubbed_config
+from test_support.orchestration_revisions import AtomicMemoryContainer
 from test_support.versioning import assert_app_version_at_least
 
 
-class MemoryContainer:
-    def __init__(self, partition_field):
-        self.partition_field = partition_field
-        self.items = {}
-        self.queries = []
-        self.fail_queries = False
-        self.fail_writes = False
-        self.sequence = 0
-
-    def upsert_item(self, body):
-        if self.fail_writes:
-            raise AzureError('Test storage failure')
-        key = (body[self.partition_field], body['id'])
-        self.sequence += 1
-        self.items[key] = {**deepcopy(body), '_etag': str(self.sequence)}
-        return deepcopy(self.items[key])
-
-    def create_item(self, body):
-        if (body[self.partition_field], body['id']) in self.items:
-            raise CosmosResourceExistsError(status_code=409, message='Test record exists')
-        return self.upsert_item(body)
-
-    def replace_item(self, item, body, **kwargs):
-        existing = self.read_item(item, body[self.partition_field])
-        if kwargs.get('etag') != existing['_etag']:
-            raise CosmosAccessConditionFailedError(status_code=412, message='Test version changed')
-        return self.upsert_item(body)
-
-    def delete_item(self, item, partition_key, **kwargs):
-        existing = self.read_item(item, partition_key)
-        if kwargs.get('etag') != existing['_etag']:
-            raise CosmosAccessConditionFailedError(status_code=412, message='Test version changed')
-        del self.items[(partition_key, item)]
-
-    def read_item(self, item, partition_key):
-        record = self.items.get((partition_key, item))
-        if record is None:
-            raise CosmosResourceNotFoundError(status_code=404, message='Test record not found')
-        return deepcopy(record)
-
-    def query_items(self, query, parameters=None, partition_key=None, **kwargs):
-        self.queries.append((query, deepcopy(parameters), partition_key))
-        if self.fail_queries:
-            raise AzureError('Test query failure')
-        params = {entry['name']: entry['value'] for entry in parameters or []}
-        rows = [
-            deepcopy(item) for (partition, _), item in self.items.items()
-            if partition_key is None or partition == partition_key
-        ]
-        for parameter, field in (
-            ('@conversation_id', 'conversation_id'), ('@user_id', 'user_id'),
-            ('@turn_id', 'turn_id'), ('@run_id', 'id'),
-        ):
-            if parameter in params:
-                rows = [row for row in rows if row.get(field) == params[parameter]]
-        if '@message_ids' in params:
-            rows = [row for row in rows if row['id'] in params['@message_ids']]
-        if '@before_timestamp' in params:
-            rows = [row for row in rows if row.get('timestamp', '') < params['@before_timestamp']]
-        if 'c.record_type' in query:
-            rows = [row for row in rows if row.get('record_type', 'run') == 'run']
-        if 'c.role IN' in query:
-            rows = [
-                row for row in rows
-                if row.get('role') in ('user', 'assistant')
-                and not (row.get('metadata') or {}).get('masked')
-                and not (row.get('metadata') or {}).get('is_generated_chat_artifact')
-                and (row.get('metadata') or {}).get('thread_info', {}).get('active_thread') is not False
-            ]
-        if 'SELECT VALUE MAX' in query:
-            return [max((row.get('turn_index', 0) for row in rows), default=None)]
-        for field in ('timestamp', 'created_at', 'turn_index'):
-            if f'ORDER BY c.{field} DESC' in query:
-                rows.sort(key=lambda row: row.get(field, ''), reverse=True)
-        top = re.search(r'SELECT TOP (\d+)', query)
-        return rows[:int(top.group(1))] if top else rows
+MemoryContainer = AtomicMemoryContainer
 
 
 class ModelBoundary:

--- a/functional_tests/test_orchestration_plan_revision_planner.py
+++ b/functional_tests/test_orchestration_plan_revision_planner.py
@@ -1,0 +1,130 @@
+# test_orchestration_plan_revision_planner.py
+"""
+Functional tests for the plan editor's strict planner contract.
+Version: 0.261.102
+Implemented in: 0.261.102
+
+An edit must produce a validated revision, a scoped explanation, or a question.
+It must never replace the existing plan with the initial planner's failure fallback.
+"""
+
+import json
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from test_orchestration_conversation_context import load_modules
+
+
+class PlanRevisionPlannerTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.planner = load_modules().planner
+
+    def setUp(self):
+        self.context = {
+            'message': 'Compare the two products.',
+            'candidate_documents': [{'document_id': 'allowed-document'}],
+        }
+        self.edit = {
+            'current_plan': {'steps': [{'step_id': 'old-search', 'enabled': False}]},
+            'current_request': 'Compare the two products.',
+            'instruction': 'Focus on price and keep the extra search disabled.',
+            'chat': [{'role': 'user', 'content': 'Remove the extra search.'}],
+        }
+
+    def call(self, reply, **overrides):
+        arguments = {
+            'settings': {'enable_user_workspace': True}, 'approval_mode': 'manual',
+            'authorized_document_ids': {'allowed-document'},
+            'edit_context': self.edit, **overrides,
+        }
+        with (
+            patch.object(self.planner, 'resolve_planner_client', return_value=(object(), 'planner')),
+            patch.object(
+                self.planner, '_call_planner',
+                return_value=(json.dumps(reply), SimpleNamespace(prompt_tokens=7, completion_tokens=3, total_tokens=10)),
+            ),
+        ):
+            return self.planner.plan_request('Compare prices.', self.context, 'conversation', 'owner', **arguments)
+
+    def plan(self, **overrides):
+        return {
+            'kind': 'plan', 'revised_request': 'Compare prices for the two products.',
+            'steps': [
+                {
+                    'step_id': 'search', 'capability_id': 'document_search',
+                    'arguments': {'query': 'Compare product prices.', 'document_ids': ['allowed-document']},
+                },
+                {'step_id': 'answer', 'capability_id': 'respond', 'arguments': {}},
+            ],
+            **overrides,
+        }
+
+    def test_edit_context_is_scoped_and_distinct_from_execution_feedback(self):
+        messages = self.planner.build_planner_messages(self.context, edit_context=self.edit)
+        payload = json.loads(messages[1]['content'])
+        self.assertEqual(payload['plan_edit'], self.edit)
+        self.assertIn('No step of this plan has run.', messages[0]['content'])
+        self.assertNotIn('A step in your previous plan reported', messages[1]['content'])
+        self.assertIn('revised_request', messages[0]['content'])
+
+    def test_valid_revision_retains_self_contained_task_and_usage(self):
+        kind, plan = self.call(self.plan())
+        self.assertEqual(kind, 'plan')
+        self.assertEqual(plan['revised_request'], 'Compare prices for the two products.')
+        self.assertEqual(plan['approval']['mode'], 'manual')
+        self.assertEqual(plan['status'], 'awaiting_approval')
+        self.assertEqual(plan['token_usage']['total_tokens'], 10)
+        self.assertNotIn('planner_fallback_reason', plan)
+
+    def test_missing_or_oversized_effective_task_is_not_a_successful_edit(self):
+        for task in (None, '', 'x' * 6001):
+            with self.subTest(task_length=len(task) if task is not None else None):
+                with self.assertRaises(self.planner.PlannerError):
+                    self.call(self.plan(revised_request=task))
+
+    def test_disabled_work_is_not_dropped_into_an_apparent_success(self):
+        reply = self.plan()
+        reply['steps'][0]['capability_id'] = 'missing-capability'
+        with self.assertRaises(self.planner.PlannerError):
+            self.call(reply)
+
+    def test_unreadable_documents_are_not_silently_removed(self):
+        reply = self.plan()
+        reply['steps'][0]['arguments']['document_ids'] = ['unreadable-document', 'allowed-document']
+        with self.assertRaises(self.planner.PlannerError):
+            self.call(reply)
+
+    def test_explanation_has_bounded_content_and_no_execution_plan(self):
+        kind, result = self.call({'kind': 'message', 'message': 'That integration is not enabled.'})
+        self.assertEqual(kind, 'message')
+        self.assertNotIn('steps', result)
+        self.assertEqual(result['token_usage']['total_tokens'], 10)
+        with self.assertRaises(self.planner.PlannerError):
+            self.call({'kind': 'message', 'message': 'x' * 2001})
+
+    def test_unknown_response_kind_is_not_normalized_to_a_plan(self):
+        with self.assertRaises(self.planner.PlannerError):
+            self.call(self.plan(kind='tool_call'))
+
+    def test_declined_clarification_cannot_fall_back_to_an_answer_plan(self):
+        with self.assertRaises(self.planner.PlannerError):
+            self.call({'kind': 'elicitation'}, allow_elicitation=False)
+
+    def test_provider_failure_is_safe_and_does_not_fall_back(self):
+        with (
+            patch.object(self.planner, 'resolve_planner_client', return_value=(object(), 'planner')),
+            patch.object(self.planner, '_call_planner', side_effect=RuntimeError('PRIVATE_PROVIDER_DETAIL')),
+        ):
+            with self.assertRaises(self.planner.PlannerError) as raised:
+                self.planner.plan_request(
+                    'Change the plan.', self.context, 'conversation', 'owner',
+                    settings={'enable_user_workspace': True}, edit_context=self.edit,
+                )
+        self.assertNotIn('PRIVATE_PROVIDER_DETAIL', str(raised.exception))
+        self.assertIn('previous plan is unchanged', str(raised.exception))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/functional_tests/test_orchestration_plan_revision_routes.py
+++ b/functional_tests/test_orchestration_plan_revision_routes.py
@@ -1,0 +1,427 @@
+# test_orchestration_plan_revision_routes.py
+"""
+Functional tests for conversational, pre-execution plan revisions.
+Version: 0.261.102
+Implemented in: 0.261.102
+
+Exercises the real Flask routes, planner, executor, and atomic revision persistence.
+Only model, search, source-access, and Cosmos service boundaries are replaced.
+"""
+
+import json
+import unittest
+import uuid
+from copy import deepcopy
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from azure.core.exceptions import AzureError
+
+import test_orchestration_conversation_context_routes as context_routes
+from test_support.versioning import assert_app_version_at_least
+
+
+frames = context_routes.frames
+
+
+def revised_plan(task='Compare pricing for the wineries near Grants Pass.', searches=2):
+    steps = [
+        {
+            'step_id': f'search_{index}', 'capability_id': 'document_search',
+            'title': f'Gather evidence {index + 1}', 'arguments': {'query': task},
+        }
+        for index in range(searches)
+    ]
+    steps.append({
+        'step_id': 'answer', 'capability_id': 'respond', 'title': 'Answer the revised request',
+        'arguments': {}, 'depends_on': [step['step_id'] for step in steps],
+    })
+    return {
+        'kind': 'plan', 'revised_request': task,
+        'intent': {'summary': task, 'complexity': 'simple'}, 'steps': steps,
+    }
+
+
+def question():
+    return {
+        'kind': 'elicitation', 'message': 'Which weekday should the comparison cover?',
+        'requested_schema': {
+            'type': 'object', 'properties': {'day': {'type': 'string', 'title': 'Weekday'}},
+            'required': ['day'],
+        },
+    }
+
+
+class PlanRevisionRouteTests(unittest.TestCase):
+    plan = context_routes.ConversationRouteTests.plan
+    planned = context_routes.ConversationRouteTests.planned
+
+    def setUp(self):
+        context_routes.ConversationRouteTests.setUp(self)
+        self.edit_responses = []
+        self.edit_calls = []
+        self.allowed_documents = set()
+        self.before_edit_reply = None
+        self.before_plan_reply = None
+        normal_completion = self.model.create
+
+        def completion(**kwargs):
+            if self.modules.planner.PLAN_EDIT_INSTRUCTIONS not in kwargs['messages'][0]['content']:
+                if self.before_plan_reply:
+                    self.before_plan_reply()
+                return normal_completion(**kwargs)
+            self.edit_calls.append(deepcopy(kwargs))
+            if self.before_edit_reply:
+                self.before_edit_reply()
+            reply = self.edit_responses.pop(0)
+            if isinstance(reply, Exception):
+                raise reply
+            return SimpleNamespace(
+                choices=[SimpleNamespace(message=SimpleNamespace(content=json.dumps(reply)))],
+                usage=SimpleNamespace(prompt_tokens=10, completion_tokens=5, total_tokens=15),
+            )
+
+        def manifest(ids, user_id, **kwargs):
+            return [
+                {
+                    'document_id': document_id, 'file_name': f'{document_id}.pdf',
+                    'scope': 'personal',
+                    'authorization_status': 'authorized' if document_id in self.allowed_documents else 'denied',
+                }
+                for document_id in ids
+            ]
+
+        self.model.chat.completions.create = completion
+        # The config-stub loader restores sys.modules; patch the route-bound module.
+        patcher = patch.dict(self.route.build_plan_edit_outcome.__globals__, {
+            'resolve_agent_catalog': lambda *args, **kwargs: [],
+            'resolve_action_catalog': lambda *args, **kwargs: [],
+            'resolve_authorized_source_manifest': manifest,
+        })
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def open_editor(self, plan=None, edits=None):
+        plan = plan or self.planned()
+        response = self.client.post(
+            f"/api/v2/orchestration/runs/{plan['run_id']}/edit",
+            json={'conversation_id': 'conv1', 'plan_id': plan['plan_id'], 'edits': edits},
+        )
+        self.assertEqual(response.status_code, 200, response.get_data(as_text=True))
+        return response.get_json()['editor']
+
+    def editor(self, run_id):
+        response = self.client.get(
+            f'/api/v2/orchestration/runs/{run_id}/editor?conversation_id=conv1',
+        )
+        self.assertEqual(response.status_code, 200, response.get_data(as_text=True))
+        return response.get_json()['editor']
+
+    def request_revision(self, editor, action='ask', **fields):
+        body = {
+            'conversation_id': 'conv1', 'expected_version': editor['version'],
+            'submission_id': str(uuid.uuid4()), 'action': action, 'edits': editor['edits'],
+            **fields,
+        }
+        if action == 'ask':
+            body.setdefault('instruction', 'Add another search focused on pricing.')
+        response = self.client.post(
+            f"/api/v2/orchestration/runs/{editor['plan']['run_id']}/revisions",
+            json=body, buffered=True,
+        )
+        return response, frames(response), body
+
+    def revise(self, editor, reply=None, action='ask', **fields):
+        if reply is not None:
+            self.edit_responses.append(reply)
+        response, events, body = self.request_revision(editor, action, **fields)
+        self.assertEqual(response.status_code, 200, response.get_data(as_text=True))
+        self.assertFalse(any(event.get('error') for event in events), events)
+        result = next(event['editor'] for event in events if event.get('editor'))
+        return result, body
+
+    def run_editor_plan(self, editor, **fields):
+        return self.client.post('/api/v2/orchestration/run', json={
+            'conversation_id': 'conv1', 'run_id': editor['plan']['run_id'],
+            'plan_id': editor['plan']['plan_id'], 'expected_version': editor['version'],
+            'edits': editor['edits'], **fields,
+        }, buffered=True)
+
+    def test_application_version(self):
+        assert_app_version_at_least('0.261.102')
+
+    def test_get_does_not_pause_but_edit_holds_countdown_durably(self):
+        self.settings.update({
+            'chat_orchestration_default_approval_mode': 'timed',
+            'chat_orchestration_allow_user_approval_override': False,
+        })
+        plan = self.planned()
+        self.assertEqual(self.editor(plan['run_id'])['plan']['approval']['mode'], 'timed')
+        editor = self.open_editor(plan)
+        self.assertEqual(editor['plan']['approval']['mode'], 'manual')
+        self.assertEqual(editor['plan']['approval']['state'], 'pending')
+        self.assertEqual(self.editor(plan['run_id'])['version'], editor['version'])
+        self.assertEqual(self.editor(plan['run_id'])['plan']['approval']['mode'], 'manual')
+        stale = self.run_editor_plan(editor, expected_version=None)
+        self.assertEqual(stale.status_code, 409)
+        self.assertEqual(stale.get_json()['code'], 'plan_changed')
+        self.assertEqual(self.runs.read_item(plan['run_id'], 'conv1')['status'], 'awaiting_approval')
+
+    def test_add_remove_restore_and_retry_keep_one_original_message(self):
+        editor = self.open_editor()
+        original_id = editor['plan']['run_id']
+        original_message_count = len(self.messages.items)
+        first, body = self.revise(editor, revised_plan())
+        self.assertEqual(len(first['plan']['steps']), 3)
+        self.assertNotEqual(first['plan']['run_id'], original_id)
+        response = self.client.post(
+            f'/api/v2/orchestration/runs/{original_id}/revisions', json=body, buffered=True,
+        )
+        replay = next(event['editor'] for event in frames(response) if event.get('editor'))
+        self.assertEqual(replay['plan']['run_id'], first['plan']['run_id'])
+        self.assertEqual(len(self.edit_calls), 1)
+        second, _body = self.revise(
+            first, revised_plan('Summarize the already available comparison.', searches=0),
+            instruction='Remove the searches and summarize what is already available.',
+        )
+        self.assertEqual([step['capability_id'] for step in second['plan']['steps']], ['respond'])
+        restored, _body = self.revise(second, action='restore', source_run_id=original_id)
+        self.assertEqual(len(restored['plan']['steps']), len(editor['plan']['steps']))
+        self.assertGreater(restored['plan']['revision'], second['plan']['revision'])
+        self.assertNotEqual(restored['plan']['run_id'], original_id)
+        self.assertEqual(len(self.messages.items), original_message_count)
+        self.assertEqual(self.editor(original_id)['plan']['run_id'], restored['plan']['run_id'])
+        latest, _body = self.revise(restored, revised_plan('Focus the restored comparison on price.', searches=1))
+        prompt = json.loads(self.edit_calls[-1]['messages'][1]['content'])
+        self.assertEqual(
+            prompt['plan_edit']['current_plan']['steps'],
+            restored['plan']['steps'],
+        )
+        self.assertEqual(self.runs.read_item(latest['plan']['run_id'], 'conv1')['user_message'],
+                         self.runs.read_item(original_id, 'conv1')['user_message'])
+
+    def test_review_narrowing_reaches_the_planner(self):
+        editor = self.open_editor(edits={
+            'disabled_step_ids': ['search'], 'removed_document_ids': {},
+        })
+        updated, _body = self.revise(editor, revised_plan(searches=0))
+        supplied = json.loads(self.edit_calls[-1]['messages'][1]['content'])['plan_edit']['current_plan']
+        self.assertFalse(next(step for step in supplied['steps'] if step['step_id'] == 'search')['enabled'])
+        self.assertEqual(updated['edits'], {'disabled_step_ids': [], 'removed_document_ids': {}})
+
+    def test_document_removal_is_not_lost_when_editor_opens(self):
+        self.allowed_documents = {'docA', 'docB'}
+        self.model.plan_override = revised_plan(searches=1)
+        self.model.plan_override['steps'][0]['arguments']['document_ids'] = ['docA', 'docB']
+        plan = self.planned(selected_document_ids=['docA', 'docB'])
+        editor = self.open_editor(plan, {
+            'disabled_step_ids': [], 'removed_document_ids': {'search_0': ['docA']},
+        })
+        reply = revised_plan(searches=1)
+        reply['steps'][0]['arguments']['document_ids'] = ['docB']
+        updated, _body = self.revise(editor, reply)
+        supplied = json.loads(self.edit_calls[-1]['messages'][1]['content'])
+        self.assertEqual(supplied['plan_edit']['current_plan']['steps'][0]['arguments']['document_ids'], ['docB'])
+        self.assertEqual(updated['plan']['steps'][0]['arguments']['document_ids'], ['docB'])
+
+    def test_unavailable_capability_and_invalid_model_output_keep_previous_plan(self):
+        editor = self.open_editor()
+        invalid = revised_plan()
+        invalid['steps'][0]['capability_id'] = 'not_enabled_or_registered'
+        for reply in (invalid, {'kind': 'plan', 'steps': []}, RuntimeError('provider-secret')):
+            with self.subTest(reply=type(reply).__name__):
+                self.edit_responses.append(reply)
+                _response, events, _body = self.request_revision(editor)
+                self.assertTrue(any(event.get('error') for event in events), events)
+                self.assertNotIn('provider-secret', json.dumps(events))
+                current = self.editor(editor['plan']['run_id'])
+                self.assertEqual(current['plan']['run_id'], editor['plan']['run_id'])
+                self.assertEqual(current['version'], editor['version'])
+                self.assertFalse(current['busy'])
+
+    def test_model_explanation_is_scoped_chat_not_a_new_plan(self):
+        editor = self.open_editor()
+        count = len(self.messages.items)
+        updated, _body = self.revise(editor, {'kind': 'message', 'message': 'The search gathers evidence before answering.'})
+        self.assertEqual(updated['plan']['run_id'], editor['plan']['run_id'])
+        self.assertEqual(updated['chat'][-1]['content'], 'The search gathers evidence before answering.')
+        self.assertEqual(len(self.messages.items), count)
+
+    def test_clarification_continues_the_same_edit_without_running(self):
+        editor = self.open_editor()
+        pending, _body = self.revise(editor, question(), instruction='Compare these wineries on a different weekday.')
+        self.assertIsNotNone(pending['pending'])
+        self.assertEqual(pending['plan']['run_id'], editor['plan']['run_id'])
+        blocked = self.run_editor_plan(pending)
+        self.assertEqual(blocked.status_code, 409)
+        self.assertEqual(blocked.get_json()['code'], 'edit_in_progress')
+        clarification = pending['pending']
+        final, _body = self.revise(
+            pending, revised_plan('Compare the wineries near Grants Pass on Friday.', searches=1),
+            action='answer', elicitation_id=clarification['elicitation_id'],
+            elicitation_revision=clarification['revision'],
+            elicitation_response={'action': 'accept', 'content': {'day': 'Friday'}},
+        )
+        prompt = json.loads(self.edit_calls[-1]['messages'][1]['content'])
+        self.assertEqual(prompt['plan_edit']['instruction'], 'Compare these wineries on a different weekday.')
+        self.assertEqual(prompt['clarifications'][-1]['answer'], {'day': 'Friday'})
+        self.assertIsNone(final['pending'])
+        self.assertIn('Friday', self.runs.read_item(final['plan']['run_id'], 'conv1')['resolved_message'])
+
+    def test_discard_question_leaves_original_plan_manually_runnable(self):
+        editor = self.open_editor()
+        pending, _body = self.revise(editor, question())
+        final, _body = self.revise(pending, action='discard')
+        self.assertIsNone(final['pending'])
+        self.assertEqual(final['plan']['run_id'], editor['plan']['run_id'])
+        self.assertEqual(final['plan']['approval']['mode'], 'manual')
+        self.assertFalse(any(event.get('error') for event in frames(self.run_editor_plan(final))))
+
+    def test_latest_effective_request_reaches_real_execution(self):
+        editor = self.open_editor()
+        task = 'Compare only pricing for the wineries near Grants Pass on Friday.'
+        final, _body = self.revise(editor, revised_plan(task, searches=1), instruction=task)
+        self.search_queries.clear()
+        response = self.run_editor_plan(final)
+        events = frames(response)
+        self.assertEqual(response.status_code, 200, events)
+        self.assertFalse(any(event.get('error') for event in events), events)
+        self.assertEqual(self.search_queries, [task])
+        synthesis = self.model.calls[-1]['messages']
+        self.assertTrue(any(task in turn['content'] for turn in synthesis), synthesis)
+        old = self.run_editor_plan(editor)
+        self.assertEqual(old.status_code, 409)
+        self.assertEqual(old.get_json()['code'], 'plan_changed')
+
+    def test_model_rewording_cannot_authorize_new_urls(self):
+        editor = self.open_editor()
+        final, _body = self.revise(
+            editor, revised_plan('Read https://invented.example.test and summarize it.', searches=0),
+            instruction='Also consider https://supplied.example.test in the comparison.',
+        )
+        stored = self.runs.read_item(final['plan']['run_id'], 'conv1')
+        allowed = self.route.revision_allowed_urls(stored)
+        self.assertTrue(any(url.startswith('https://supplied.example.test') for url in allowed))
+        self.assertFalse(any(url.startswith('https://invented.example.test') for url in allowed))
+
+    def test_editor_followup_can_use_a_link_from_an_earlier_user_message(self):
+        editor = self.open_editor()
+        explained, _body = self.revise(
+            editor, {'kind': 'message', 'message': 'We can use your source, not https://invented.example.test.'},
+            instruction='Can the plan use https://supplied.example.test as a source?',
+        )
+        final, _body = self.revise(
+            explained, revised_plan('Compare the wineries using the supplied source.', searches=0),
+            instruction='Yes, use that source for the comparison.',
+        )
+        stored = self.runs.read_item(final['plan']['run_id'], 'conv1')
+        allowed = self.route.revision_allowed_urls(stored)
+        self.assertIn('https://supplied.example.test', allowed)
+        self.assertFalse(any(url.startswith('https://invented.example.test') for url in allowed))
+
+    def test_failed_execution_claim_never_reaches_an_adapter(self):
+        editor = self.open_editor()
+        self.search_queries.clear()
+        self.model.calls.clear()
+        with patch.object(self.route, 'claim_plan_run', side_effect=AzureError('claim unavailable')):
+            response = self.run_editor_plan(editor)
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(self.search_queries, [])
+        self.assertEqual(self.model.calls, [])
+        self.assertEqual(self.runs.read_item(editor['plan']['run_id'], 'conv1')['status'], 'awaiting_approval')
+
+    def test_changed_context_is_not_reported_as_an_already_executed_plan(self):
+        editor = self.open_editor()
+        record = self.runs.read_item(editor['plan']['run_id'], 'conv1')
+        original = self.messages.read_item(record['user_message_id'], 'conv1')
+        self.messages.upsert_item({**original, 'content': 'A different request.'})
+        self.model.calls.clear()
+        response = self.run_editor_plan(editor)
+        self.assertEqual(response.status_code, 409)
+        self.assertEqual(response.get_json()['code'], 'plan_changed')
+        self.assertEqual(self.model.calls, [])
+        self.assertIsNone(self.runs.read_item(record['run_id'], 'conv1')['started_at'])
+
+    def test_storage_failure_does_not_publish_or_discard_previous_plan(self):
+        editor = self.open_editor()
+        self.edit_responses.append(revised_plan())
+        with patch.object(self.runs, 'execute_item_batch', side_effect=AzureError('private-storage-error')):
+            _response, events, _body = self.request_revision(editor)
+        self.assertTrue(any(event.get('error') for event in events), events)
+        self.assertNotIn('private-storage-error', json.dumps(events))
+        current = self.editor(editor['plan']['run_id'])
+        self.assertEqual(current['version'], editor['version'])
+        self.assertFalse(current['busy'])
+
+    def test_plain_replan_cannot_bypass_an_edit_hold(self):
+        editor = self.open_editor()
+        _response, events = self.plan(revision=1)
+        self.assertTrue(any(event.get('code') == 'plan_changed' for event in events), events)
+        self.assertEqual(self.editor(editor['plan']['run_id'])['version'], editor['version'])
+
+    def test_lost_confirmation_recovers_committed_revision_without_second_model_call(self):
+        editor = self.open_editor()
+        self.edit_responses.append(revised_plan())
+        with patch.object(self.route, 'plan_editor_state', side_effect=AzureError('read unavailable')):
+            _response, events, body = self.request_revision(editor)
+        error = next(event['error'] for event in events if event.get('error'))
+        self.assertNotIn('unchanged', error)
+        response = self.client.post(
+            f"/api/v2/orchestration/runs/{editor['plan']['run_id']}/revisions",
+            json=body, buffered=True,
+        )
+        recovered = next(event['editor'] for event in frames(response) if event.get('editor'))
+        self.assertNotEqual(recovered['plan']['run_id'], editor['plan']['run_id'])
+        self.assertEqual(len(self.edit_calls), 1)
+
+    def test_inflight_plain_replan_loses_to_edit_hold(self):
+        plan = self.planned()
+        held = []
+        self.before_plan_reply = lambda: held.append(self.open_editor(plan))
+        _response, events = self.plan(revision=1)
+        self.assertTrue(any(event.get('error') for event in events), events)
+        self.assertEqual(self.editor(plan['run_id'])['version'], held[-1]['version'])
+        self.assertEqual(self.runs.read_item(plan['run_id'], 'conv1')['status'], 'awaiting_approval')
+
+    def test_read_and_edit_routes_enforce_conversation_ownership(self):
+        editor = self.open_editor()
+        with patch.object(self.route, 'get_current_user_id', return_value='another-user'):
+            for method, suffix, body in (
+                ('get', 'editor?conversation_id=conv1', None),
+                ('post', 'edit', {'conversation_id': 'conv1', 'plan_id': editor['plan']['plan_id']}),
+                ('post', 'revisions', {'conversation_id': 'conv1', 'action': 'ask'}),
+            ):
+                response = getattr(self.client, method)(
+                    f"/api/v2/orchestration/runs/{editor['plan']['run_id']}/{suffix}",
+                    **({'json': body} if body else {}),
+                )
+                self.assertEqual(response.status_code, 404)
+
+    def test_invalid_requests_and_stale_versions_do_not_call_the_model(self):
+        editor = self.open_editor()
+        for fields, status in (
+            ({'instruction': ' '}, 400),
+            ({'instruction': 'x' * 2001}, 400),
+            ({'plan': revised_plan()}, 400),
+            ({'expected_version': 'stale-token'}, 409),
+        ):
+            with self.subTest(fields=list(fields)):
+                response, _events, _body = self.request_revision(editor, **fields)
+                self.assertEqual(response.status_code, status, response.get_data(as_text=True))
+        self.assertEqual(self.edit_calls, [])
+
+    def test_editor_projection_does_not_expose_private_context_or_claims(self):
+        editor = self.open_editor()
+        serialized = json.dumps(editor)
+        for private in ('_etag', 'original_seeds', 'conversation_context', 'user_message_fingerprint',
+                        'edit_pending', 'edit_submissions', 'request_fingerprint'):
+            self.assertNotIn(f'"{private}"', serialized)
+        response = self.client.get(
+            f"/api/v2/orchestration/runs/{editor['plan']['run_id']}/editor"
+            '?conversation_id=conv1&before_revision=-1',
+        )
+        self.assertEqual(response.status_code, 400)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/functional_tests/test_orchestration_plan_revision_store.py
+++ b/functional_tests/test_orchestration_plan_revision_store.py
@@ -1,0 +1,841 @@
+# test_orchestration_plan_revision_store.py
+"""
+Functional tests for the pre-execution plan revision persistence boundary.
+Version: 0.261.102
+Implemented in: 0.261.102
+
+Uses real storage helpers and SDK batch formatting with an atomic in-memory container.
+No Azure network, model, or main-thread message writes are needed.
+"""
+
+import importlib
+import json
+import unittest
+import uuid
+from copy import deepcopy
+from datetime import timedelta
+from unittest.mock import patch
+
+from azure.core.exceptions import AzureError
+from azure.cosmos import exceptions
+
+from test_support.app_stubs import stubbed_config
+from test_support.orchestration_revisions import AtomicMemoryContainer
+from test_support.versioning import assert_app_version_at_least
+
+
+def canonical_plan():
+    return {
+        'run_id': 'run_original', 'plan_id': 'plan_original',
+        'turn_id': 'turn1', 'conversation_id': 'conv1', 'user_id': 'user1',
+        'revision': 0, 'status': 'awaiting_approval', 'planner_contract_version': 1,
+        'intent': {'summary': 'Compare the selected sources.', 'complexity': 'simple'},
+        'approval': {'mode': 'timed', 'state': 'pending', 'timeout_seconds': 10},
+        'steps': [
+            {
+                'step_id': 'search', 'capability_id': 'document_search', 'title': 'Find sources',
+                'arguments': {'query': 'Original request', 'document_ids': ['doc1', 'doc2']},
+                'enabled': True, 'depends_on': [], 'status': 'pending',
+            },
+            {
+                'step_id': 'compare', 'capability_id': 'document_compare', 'title': 'Compare sources',
+                'arguments': {'document_ids': ['doc1'], 'right_document_ids': ['doc2']},
+                'enabled': True, 'depends_on': ['search'], 'status': 'pending',
+            },
+            {
+                'step_id': 'answer', 'capability_id': 'respond', 'title': 'Answer',
+                'arguments': {}, 'enabled': True, 'depends_on': ['compare'], 'status': 'pending',
+            },
+        ],
+    }
+
+
+def editor_question():
+    return {
+        'elicitation_id': 'ask_current', 'run_id': 'run_original', 'revision': 1,
+        'message': 'Which topic should the answer focus on?',
+        'requested_schema': {
+            'type': 'object', 'properties': {'topic': {'type': 'string'}},
+            'required': ['topic'],
+        },
+        'ui_hints': {},
+    }
+
+
+class PlanRevisionStoreTests(unittest.TestCase):
+    def setUp(self):
+        self.runs = AtomicMemoryContainer('conversation_id')
+        with stubbed_config(
+            cosmos_orchestration_runs_container=self.runs,
+            cosmos_orchestration_run_steps_container=AtomicMemoryContainer('run_id'),
+            cognitive_services_scope='https://cognitiveservices.azure.com/.default',
+        ):
+            self.store = importlib.import_module('functions_orchestration_runs')
+            self.revisions = importlib.import_module('functions_orchestration_plan_revisions')
+        patcher = patch.object(self.store, 'cosmos_orchestration_runs_container', self.runs)
+        patcher.start()
+        self.addCleanup(patcher.stop)
+        self.context = {
+            'turn_id': 'turn1', 'user_message': 'Original request',
+            'user_message_id': 'message1', 'user_message_fingerprint': 'original-message-fingerprint',
+            'original_seeds': {'document_ids': ['doc1', 'doc2']},
+            'seeds': {'document_ids': ['doc1', 'doc2']},
+            'resolved_message': 'Original effective request',
+            'conversation_context': {
+                'messages': [{'id': 'prior-user', 'fingerprint': 'original-snapshot'}],
+                'truncated': False,
+            },
+            'answered_questions': [], 'planning_token_usage': {'total_tokens': 10},
+        }
+        self.store.create_orchestration_run(
+            canonical_plan(), 'user1', 'conv1', turn_index=7,
+            request_fingerprint='original-seed-fingerprint', turn_context=self.context,
+            initial_updates={'snapshot': {'fingerprint': 'immutable-snapshot'}},
+            idempotent=True,
+        )
+        self.original = self.read()
+
+    def read(self, run_id='run_original', **kwargs):
+        return self.revisions.read_revision_run(run_id, 'user1', 'conv1', **kwargs)
+
+    def hold(self, **kwargs):
+        return self.revisions.begin_plan_edit(
+            'run_original', 'user1', 'conv1', plan_id='plan_original', **kwargs,
+        )
+
+    def request(self, record, **overrides):
+        return {
+            'conversation_id': 'conv1', 'expected_version': record.get('edit_version', ''),
+            'submission_id': str(uuid.uuid4()), 'action': 'ask',
+            'instruction': 'Focus the comparison on pricing.', **overrides,
+        }
+
+    def claim(self, record, body=None, **overrides):
+        return self.revisions.claim_plan_revision(
+            record['id'], 'user1', 'conv1', body or self.request(record, **overrides),
+        )
+
+    def publish(self, record, *, body=None, **kwargs):
+        claim = self.claim(record, body)
+        return self.revisions.complete_plan_revision(
+            claim, kind='plan', document=deepcopy(record['plan']), **kwargs,
+        )
+
+    def ordinary_replan(self, *, expected=None, plan=None):
+        if plan is None:
+            plan = canonical_plan()
+            plan.update(run_id='run_replanned', plan_id='plan_replanned', revision=1)
+        return self.store.create_orchestration_run(
+            plan, 'user1', 'conv1', turn_context=self.context,
+            idempotent=True, expected_previous_run=expected or self.original,
+        )
+
+    def discard_request(self, record, **overrides):
+        return {
+            'conversation_id': 'conv1', 'submission_id': str(uuid.uuid4()),
+            'expected_version': record['edit_version'], 'action': 'discard', **overrides,
+        }
+
+    def assert_error(self, code, function, *args, status=409, **kwargs):
+        with self.assertRaises(self.revisions.PlanRevisionError) as caught:
+            function(*args, **kwargs)
+        self.assertEqual(caught.exception.code, code)
+        self.assertEqual(caught.exception.status_code, status)
+        return caught.exception
+
+    def run_plan(self, record, **kwargs):
+        return self.revisions.claim_plan_run(record['id'], 'user1', 'conv1', **kwargs)
+
+    def test_application_version(self):
+        assert_app_version_at_least('0.261.102')
+
+    def test_hold_is_durable_and_overlay_does_not_change_canonical_steps(self):
+        overlay = {'disabled_step_ids': ['compare'], 'removed_document_ids': {'search': ['doc2']}}
+        held = self.hold(edits=overlay)
+        self.assertEqual(held['plan']['steps'], self.original['plan']['steps'])
+        self.assertEqual(held['edit_narrowing'], overlay)
+        self.assertEqual(held['edit_version'], held['plan']['edit_version'])
+        uuid.UUID(held['edit_version'])
+        self.assertEqual(held['plan']['approval']['mode'], 'manual')
+        self.assertEqual(held['approval'], held['plan']['approval'])
+        self.assertEqual(held['status'], 'awaiting_approval')
+        self.assertEqual(held['revision_root_run_id'], held['id'])
+        self.assertNotEqual(held['_etag'], self.original['_etag'])
+        again = self.hold(edits={'disabled_step_ids': []})
+        self.assertEqual(again, held)
+        self.assert_error('plan_changed', self.hold, expected_version='old')
+
+    def test_unheld_hydration_is_read_only(self):
+        state = self.revisions.plan_editor_state(self.original, 'user1')
+        self.assertEqual(state['version'], '')
+        self.assertEqual(state['plan']['approval']['mode'], 'timed')
+        self.assertEqual(self.read(), self.original)
+        self.assertEqual([row['origin'] for row in state['history']], ['original'])
+
+    def test_container_patch_seam_is_resolved_dynamically(self):
+        replacement = AtomicMemoryContainer('conversation_id')
+        replacement.create_item(self.original)
+        with patch.object(self.store, 'cosmos_orchestration_runs_container', replacement):
+            held = self.hold()
+            self.assertEqual(self.read()['edit_version'], held['edit_version'])
+        self.assertNotIn('edit_version', self.read())
+        self.assertIn('edit_version', replacement.read_item('run_original', 'conv1'))
+
+    def test_hold_rejects_wrong_plan_and_settled_or_started_states(self):
+        self.assert_error(
+            'plan_changed', self.revisions.begin_plan_edit,
+            'run_original', 'user1', 'conv1', plan_id='wrong-plan',
+        )
+        for status in ('running', 'completed', 'failed', 'cancelled', 'superseded', 'approved'):
+            with self.subTest(status=status):
+                self.runs.upsert_item({**self.original, 'status': status})
+                self.assert_error('plan_changed', self.hold)
+        self.runs.upsert_item({**self.original, 'started_at': '2026-09-07T12:00:00+00:00'})
+        self.assert_error('plan_changed', self.hold)
+
+    def test_run_wins_race_with_first_hold(self):
+        winner = []
+        self.runs.before_replace = lambda: winner.append(self.run_plan(self.original))
+        self.assert_error('plan_changed', self.hold)
+        self.assertEqual(self.read()['status'], 'running')
+        self.assertNotIn('edit_version', self.read())
+        self.assertEqual(len(winner), 1)
+
+    def test_ordinary_replan_is_atomic_and_keeps_the_same_turn_index(self):
+        saved = self.ordinary_replan()
+        self.assertEqual(saved['turn_index'], self.original['turn_index'])
+        self.assertEqual(self.read(follow_current=True)['id'], saved['id'])
+        self.assertEqual(self.read()['status'], 'superseded')
+        self.assertEqual(
+            [row['id'] for row in self.store.list_conversation_runs('conv1', 'user1')],
+            [saved['id']],
+        )
+
+    def test_ordinary_replan_loses_to_a_concurrent_hold(self):
+        self.runs.before_batch = self.hold
+        with self.assertRaises(self.store.ConversationContextError):
+            self.ordinary_replan()
+        self.assertEqual(len(self.runs.items), 1)
+        self.assertEqual(self.read()['approval']['mode'], 'manual')
+        self.assertNotIn('superseded_by_run_id', self.read())
+
+    def test_ordinary_replan_cannot_replace_a_hold_observed_before_publication(self):
+        self.hold()
+        with self.assertRaises(self.store.ConversationContextError):
+            self.ordinary_replan()
+        self.assertEqual(self.runs.batch_calls, [])
+        self.assertEqual(len(self.runs.items), 1)
+
+    def test_ordinary_replan_retry_returns_the_saved_run_without_removing_its_hold(self):
+        saved = self.ordinary_replan()
+        held = self.revisions.begin_plan_edit(
+            saved['id'], 'user1', 'conv1', plan_id=saved['plan']['plan_id'],
+        )
+        replay = self.ordinary_replan()
+        self.assertEqual(replay, self.store._strip_cosmos_metadata(held))
+        self.assertEqual(self.read(saved['id']), held)
+        self.assertEqual(len(self.runs.batch_calls), 1)
+
+    def test_ordinary_replan_lost_response_replays_the_existing_outcome(self):
+        def lose_response():
+            raise AzureError('Private lost replan response')
+
+        self.runs.after_batch = lose_response
+        with self.assertRaises(AzureError):
+            self.ordinary_replan()
+        saved = self.read('run_replanned')
+        replay = self.ordinary_replan()
+        self.assertEqual(replay, self.store._strip_cosmos_metadata(saved))
+        self.assertEqual(len(self.runs.items), 2)
+        self.assertEqual(len(self.runs.batch_calls), 1)
+
+    def test_concurrent_same_run_replans_replay_one_atomic_outcome(self):
+        winner = []
+        self.runs.before_batch = lambda: winner.append(self.ordinary_replan())
+        replay = self.ordinary_replan()
+        self.assertEqual(replay, winner[0])
+        self.assertEqual(len(self.runs.items), 2)
+        self.assertEqual(self.read()['superseded_by_run_id'], replay['id'])
+
+    def test_idempotent_same_run_retry_never_resets_a_newer_hold(self):
+        held = self.hold()
+        replay = self.ordinary_replan(plan=canonical_plan())
+        self.assertEqual(replay, self.store._strip_cosmos_metadata(held))
+        self.assertEqual(self.read(), held)
+        self.assertEqual(self.runs.batch_calls, [])
+
+    def test_ordinary_replan_rejects_started_and_settled_previous_records(self):
+        for status, started_at in (
+            ('running', None), ('completed', None), ('failed', None),
+            ('cancelled', None), ('superseded', None), ('archived', None),
+            ('draft', '2026-09-07T12:00:00+00:00'),
+        ):
+            with self.subTest(status=status, started_at=started_at):
+                self.runs.upsert_item({**self.original, 'status': status, 'started_at': started_at})
+                with self.assertRaises(self.store.ConversationContextError):
+                    self.ordinary_replan(expected=self.read())
+                self.assertEqual(len(self.runs.items), 1)
+        self.assertEqual(self.runs.batch_calls, [])
+
+    def test_ordinary_replan_replay_cannot_return_another_owners_record(self):
+        saved = self.ordinary_replan()
+        self.runs.upsert_item({**saved, 'user_id': 'other-user'})
+        with self.assertRaises(self.store.ConversationContextError):
+            self.ordinary_replan()
+        self.assertEqual(len(self.runs.batch_calls), 1)
+
+    def test_hold_wins_race_with_legacy_run(self):
+        winner = []
+        self.runs.before_replace = lambda: winner.append(self.hold())
+        self.assert_error('plan_changed', self.run_plan, self.original)
+        self.assertEqual(self.read()['status'], 'awaiting_approval')
+        self.assertEqual(self.read()['edit_version'], winner[0]['edit_version'])
+
+    def test_competing_claims_have_one_winner(self):
+        held = self.hold()
+        winner = []
+        self.runs.before_replace = lambda: winner.append(self.claim(held))
+        self.assert_error('edit_in_progress', self.claim, held)
+        self.assertEqual(self.read()['edit_claim']['claim_id'], winner[0]['claim_id'])
+        self.assertTrue(self.revisions.plan_editor_state(self.read(), 'user1')['busy'])
+        self.assert_error('edit_in_progress', self.run_plan, held, expected_version=held['edit_version'])
+
+    def test_claim_captures_latest_overlay_without_mutating_plan(self):
+        held = self.hold(edits={'disabled_step_ids': ['search']})
+        saved = self.claim(held)
+        self.assertEqual(saved['request']['edits']['disabled_step_ids'], ['search'])
+        self.assertEqual(saved['record']['plan']['steps'], self.original['plan']['steps'])
+        self.revisions.release_plan_revision(saved)
+        overlay = {'disabled_step_ids': ['compare'], 'removed_document_ids': {'search': ['doc2']}}
+        newer = self.claim(self.read(), edits=overlay)
+        self.assertEqual(newer['record']['edit_narrowing'], overlay)
+        self.assertEqual(newer['request']['edits'], overlay)
+
+    def test_unknown_full_plan_oversized_and_invalid_payloads_are_rejected(self):
+        held = self.hold()
+        for overrides in (
+            {'plan': canonical_plan()}, {'action': 'execute'}, {'instruction': ' '},
+            {'instruction': 'a' * 2001}, {'instruction': []}, {'submission_id': []},
+            {'source_run_id': 'not-an-ask-field'}, {'edits': {'steps': []}},
+            {'edits': {'disabled_step_ids': ['unknown']}},
+            {'edits': {'disabled_step_ids': ['answer']}},
+            {'edits': {'removed_document_ids': {'search': ['not-present']}}},
+            {'edits': {'removed_document_ids': {'unknown': ['doc1']}}},
+            {'edits': {'disabled_step_ids': 'search'}},
+        ):
+            with self.subTest(overrides=overrides):
+                self.assert_error('invalid_request', self.claim, held, status=400, **overrides)
+        self.assert_error(
+            'request_too_large', self.claim, held, status=413,
+            instruction='x' * (self.revisions.EDIT_REQUEST_MAX_BYTES + 1),
+        )
+        self.assertIsNone(self.read()['edit_claim'])
+        self.assert_error('plan_changed', self.claim, held, expected_version='stale')
+        self.assert_error('plan_changed', self.claim, self.original, expected_version='')
+
+    def test_publication_mints_identity_and_preserves_immutable_context(self):
+        held = self.hold()
+        claim = self.claim(held)
+        candidate = deepcopy(held['plan'])
+        candidate.update({
+            'plan_id': 'model-plan', 'run_id': 'model-run', 'revision': 999,
+            'user_id': 'model-user', 'turn_id': 'model-turn', 'conversation_id': 'model-conversation',
+            'started_at': 'yesterday', 'token_usage': {'provider': 'private-provider'},
+            'evidence': ['stale'], 'raw_provider_response': 'private-provider',
+        })
+        for step in candidate['steps']:
+            step.update(status='completed', result={'private': 'runtime'}, started_at='yesterday')
+        candidate_context = {
+            **deepcopy(self.context), 'user_message': 'attempted replacement',
+            'user_message_id': 'replacement', 'user_message_fingerprint': 'replacement',
+            'conversation_context': {'messages': []}, 'snapshot': {'changed': True},
+            'original_seeds': {}, 'turn_id': 'replacement', 'conversation_id': 'replacement',
+            'user_id': 'replacement', 'request_fingerprint': 'replacement', 'turn_index': 99,
+            'seeds': {'document_ids': ['doc1']}, 'resolved_message': 'A revised effective task.',
+            'edit_user_urls': ['https://user.example.test'], 'config': {'secret': 'private-config'},
+        }
+        chat = [{'role': 'assistant', 'content': 'Updated the plan.', 'timestamp': '2026-09-07'}]
+        saved = self.revisions.complete_plan_revision(
+            claim, kind='plan', document=candidate, turn_context=candidate_context, chat=chat,
+            instruction='Focus on pricing.',
+        )
+        self.assertNotIn(saved['id'], ('model-run', held['id']))
+        self.assertNotIn(saved['plan']['plan_id'], ('model-plan', held['plan']['plan_id']))
+        self.assertEqual(saved['plan']['run_id'], saved['id'])
+        self.assertEqual(saved['revision'], 1)
+        self.assertEqual(saved['plan']['revision'], 1)
+        self.assertEqual(saved['turn_index'], 7)
+        for key in self.revisions._IMMUTABLE_FIELDS:
+            self.assertEqual(saved[key], held[key], key)
+        self.assertEqual(saved['resolved_message'], candidate_context['resolved_message'])
+        self.assertEqual(saved['seeds'], candidate_context['seeds'])
+        self.assertEqual(saved['edit_user_urls'], candidate_context['edit_user_urls'])
+        self.assertEqual(saved['edit_chat'], chat)
+        self.assertEqual(saved['edit_narrowing'], {'disabled_step_ids': [], 'removed_document_ids': {}})
+        self.assertEqual(saved['parent_run_id'], held['id'])
+        self.assertEqual(saved['revision_root_run_id'], held['id'])
+        self.assertEqual(saved['approval']['mode'], 'manual')
+        self.assertIsNone(saved['started_at'])
+        self.assertEqual(saved['artifacts'], [])
+        self.assertNotIn('config', saved)
+        self.assertNotIn('private-provider', json.dumps(saved))
+        for step in saved['plan']['steps']:
+            self.assertEqual(step['status'], 'pending')
+            self.assertNotIn('result', step)
+            self.assertNotIn('started_at', step)
+        before = self.read()
+        self.assertEqual(before['status'], 'superseded')
+        self.assertEqual(before['superseded_by_run_id'], saved['id'])
+        self.assertEqual(before['plan']['steps'], held['plan']['steps'])
+        self.assertEqual(before['edit_submissions'][0]['result_run_id'], saved['id'])
+        self.assertEqual(self.runs.batch_calls[-1][0]['ifMatch'], claim['record']['_etag'])
+
+    def test_completed_retry_replays_before_old_version_or_supersession_checks(self):
+        held = self.hold()
+        body = self.request(held)
+        saved = self.publish(held, body=body)
+        replay = self.claim(held, body)
+        self.assertTrue(replay['replayed'])
+        self.assertEqual(replay['outcome_run_id'], saved['id'])
+        self.assertEqual(len(self.runs.batch_calls), 1)
+        self.assert_error('submission_conflict', self.claim, held, {**body, 'instruction': 'Different'})
+        self.assert_error('plan_changed', self.revisions.complete_plan_revision, replay, kind='message')
+
+    def test_runtime_url_provenance_survives_later_revisions_without_new_context(self):
+        held = self.hold()
+        urls = [f'https://user{index}.example.test/report' for index in range(8)]
+        first = self.publish(held, turn_context={'edit_user_urls': urls})
+        later = self.publish(first)
+        self.assertEqual(first['edit_user_urls'], urls)
+        self.assertEqual(later['edit_user_urls'], urls)
+        self.assertNotIn('edit_user_urls', self.revisions.plan_editor_state(later, 'user1'))
+        executed = self.run_plan(later, expected_version=later['edit_version'])
+        self.assertEqual(executed['edit_user_urls'], urls)
+
+    def test_lost_batch_response_is_replayed_without_a_second_publication(self):
+        held = self.hold()
+        body = self.request(held)
+        claim = self.claim(held, body)
+
+        def lose_response():
+            raise AzureError('Private lost response')
+
+        self.runs.after_batch = lose_response
+        with self.assertRaises(AzureError):
+            self.revisions.complete_plan_revision(claim, kind='plan', document=held['plan'])
+        self.revisions.release_plan_revision(claim)
+        replay = self.claim(held, body)
+        self.assertTrue(replay['replayed'])
+        self.assertEqual(self.read(follow_current=True)['id'], replay['outcome_run_id'])
+        self.assertEqual(len(self.runs.items), 2)
+        self.assertEqual(len(self.runs.batch_calls), 1)
+
+    def test_failure_of_second_batch_operation_is_atomic_and_retry_ids_are_stable(self):
+        held = self.hold()
+        body = self.request(held)
+        claim = self.claim(held, body)
+        before = deepcopy(self.runs.items)
+        self.runs.fail_batch_at = 1
+        with self.assertRaises(exceptions.CosmosBatchOperationError):
+            self.revisions.complete_plan_revision(claim, kind='plan', document=held['plan'])
+        self.assertEqual(self.runs.items, before)
+        attempted = self.runs.batch_calls[-1][1]['resourceBody']
+        self.revisions.release_plan_revision(claim)
+        self.runs.fail_batch_at = None
+        retry = self.claim(self.read(), body)
+        saved = self.revisions.complete_plan_revision(retry, kind='plan', document=held['plan'])
+        self.assertEqual(saved['id'], attempted['id'])
+        self.assertEqual(saved['plan']['plan_id'], attempted['plan']['plan_id'])
+
+    def test_expired_claim_cannot_publish_or_clear_newer_lease(self):
+        held = self.hold()
+        body = self.request(held)
+        first = self.claim(held, body)
+        later = self.revisions._now() + timedelta(seconds=self.revisions.EDIT_CLAIM_SECONDS + 1)
+        with patch.object(self.revisions, '_now', return_value=later):
+            self.assert_error(
+                'plan_changed', self.revisions.complete_plan_revision,
+                first, kind='plan', document=held['plan'],
+            )
+            retry = self.claim(held, body)
+            self.assertNotEqual(first['claim_id'], retry['claim_id'])
+            self.revisions.release_plan_revision(first)
+            self.assertEqual(self.read()['edit_claim']['claim_id'], retry['claim_id'])
+            saved = self.revisions.complete_plan_revision(retry, kind='plan', document=held['plan'])
+        self.assertEqual(saved['revision'], 1)
+        self.assert_error(
+            'plan_changed', self.revisions.complete_plan_revision,
+            first, kind='plan', document=held['plan'],
+        )
+
+    def test_delayed_batch_cannot_overwrite_a_newer_publication(self):
+        held = self.hold()
+        original_claim = self.claim(held)
+        saved = []
+
+        def competitor():
+            later = self.revisions._now() + timedelta(seconds=self.revisions.EDIT_CLAIM_SECONDS + 1)
+            with patch.object(self.revisions, '_now', return_value=later):
+                replacement_claim = self.claim(held)
+                saved.append(self.revisions.complete_plan_revision(
+                    replacement_claim, kind='plan', document=held['plan'],
+                ))
+
+        self.runs.before_batch = competitor
+        error = self.assert_error(
+            'plan_changed', self.revisions.complete_plan_revision,
+            original_claim, kind='plan', document=held['plan'],
+        )
+        self.assertEqual(error.current_run_id, saved[0]['id'])
+        self.assertEqual(len(self.runs.items), 2)
+        self.assertEqual(self.read(follow_current=True)['id'], saved[0]['id'])
+
+    def test_released_submission_id_cannot_be_rebound_to_a_different_request(self):
+        held = self.hold()
+        body = self.request(held)
+        claim = self.claim(held, body)
+        self.revisions.release_plan_revision(claim)
+        self.assertIsNone(self.read()['edit_claim'])
+        self.assert_error('submission_conflict', self.claim, held, {**body, 'instruction': 'Other task'})
+        self.assertFalse(self.claim(held, body)['replayed'])
+
+    def test_question_outcome_keeps_private_context_off_the_live_plan(self):
+        held = self.hold()
+        claim = self.claim(held)
+        question = editor_question()
+        private = {
+            'elicitation': question, 'instruction': 'private-instruction',
+            'turn_context': {'seeds': {'private': 'private-seed'}, 'resolved_message': 'Unaccepted task'},
+            'base_plan': deepcopy(held['plan']), 'user_content': 'private-user-content',
+        }
+        saved = self.revisions.complete_plan_revision(
+            claim, kind='elicitation', document=question, pending=private,
+            turn_context={'resolved_message': 'Unaccepted task', 'planning_token_usage': {'total_tokens': 25}},
+            chat=[{'role': 'assistant', 'content': question['message']}],
+        )
+        self.assertEqual(saved['plan']['steps'], held['plan']['steps'])
+        self.assertEqual(saved['resolved_message'], held['resolved_message'])
+        self.assertEqual(saved['planning_token_usage']['total_tokens'], 25)
+        self.assertNotEqual(saved['edit_version'], held['edit_version'])
+        state = self.revisions.plan_editor_state(saved, 'user1')
+        self.assertEqual(state['pending'], question)
+        self.assertNotIn('private-', json.dumps(state))
+        self.assert_error('edit_in_progress', self.claim, saved)
+        self.assert_error('edit_in_progress', self.run_plan, saved, expected_version=saved['edit_version'])
+        body = {
+            'conversation_id': 'conv1', 'submission_id': 'answer1',
+            'expected_version': saved['edit_version'], 'action': 'answer',
+            'elicitation_id': question['elicitation_id'], 'elicitation_revision': question['revision'],
+            'elicitation_response': {'action': 'accept', 'content': {'topic': 'pricing'}},
+            'elicitation_context': {},
+        }
+        self.assert_error('plan_changed', self.claim, saved, {**body, 'elicitation_id': 'ask_stale'})
+        answer = self.claim(saved, body)
+        self.assertEqual(answer['record']['edit_pending'], private)
+        final = self.revisions.complete_plan_revision(answer, kind='plan', document=held['plan'])
+        self.assertIsNone(final['edit_pending'])
+        self.assertEqual(final['revision'], 1)
+
+    def test_discard_preserves_plan_and_replays_after_question_is_cleared(self):
+        held = self.hold()
+        question_claim = self.claim(held)
+        asked = self.revisions.complete_plan_revision(
+            question_claim, kind='elicitation',
+            pending={'elicitation': editor_question(), 'turn_context': self.context},
+        )
+        body = {
+            'conversation_id': 'conv1', 'submission_id': 'discard1',
+            'expected_version': asked['edit_version'], 'action': 'discard',
+        }
+        claim = self.claim(asked, body)
+        saved = self.revisions.complete_plan_revision(claim, kind='discard')
+        self.assertIsNone(saved['edit_pending'])
+        self.assertEqual(saved['plan']['steps'], held['plan']['steps'])
+        self.assertEqual(saved['resolved_message'], held['resolved_message'])
+        self.assertTrue(self.claim(asked, body)['replayed'])
+        self.assert_error(
+            'plan_changed', self.claim, saved,
+            {**body, 'submission_id': 'discard2', 'expected_version': saved['edit_version']},
+        )
+        self.assertEqual(self.run_plan(saved, expected_version=saved['edit_version'])['status'], 'running')
+
+    def test_discard_revokes_an_active_worker_without_a_pending_question(self):
+        held = self.hold(edits={'disabled_step_ids': ['compare']})
+        worker = self.claim(held)
+        body = self.discard_request(held)
+        self.assert_error(
+            'plan_changed', self.claim, held, {**body, 'expected_version': 'stale'},
+        )
+        discard = self.claim(held, body)
+        self.assertNotEqual(discard['claim_id'], worker['claim_id'])
+        self.revisions.release_plan_revision(worker)
+        self.assertEqual(self.read()['edit_claim']['claim_id'], discard['claim_id'])
+        self.assert_error('edit_in_progress', self.claim, held, body)
+        self.assert_error(
+            'plan_changed', self.revisions.complete_plan_revision,
+            worker, kind='plan', document=held['plan'],
+        )
+        saved = self.revisions.complete_plan_revision(discard, kind='discard')
+        self.assertEqual(saved['plan']['steps'], held['plan']['steps'])
+        self.assertEqual(saved['edit_narrowing'], held['edit_narrowing'])
+        self.assertEqual(saved['status'], 'awaiting_approval')
+        self.assertEqual(saved['approval']['mode'], 'manual')
+        self.assertIsNone(saved['edit_claim'])
+        self.assertIsNone(saved['edit_pending'])
+        self.assertNotEqual(saved['edit_version'], held['edit_version'])
+        self.assertTrue(self.claim(held, body)['replayed'])
+        self.assertEqual(len(self.runs.items), 1)
+        self.assertEqual(self.run_plan(saved, expected_version=saved['edit_version'])['status'], 'running')
+
+    def test_discard_loses_when_an_edit_commits_before_its_conditional_write(self):
+        held = self.hold()
+        worker = self.claim(held)
+        outcomes = []
+        self.runs.before_replace = lambda: outcomes.append(self.revisions.complete_plan_revision(
+            worker, kind='plan', document=held['plan'],
+        ))
+        error = self.assert_error('plan_changed', self.claim, held, self.discard_request(held))
+        self.assertEqual(error.current_run_id, outcomes[0]['id'])
+        self.assertEqual(self.read(follow_current=True)['id'], outcomes[0]['id'])
+        self.assertEqual(len(self.runs.items), 2)
+
+    def test_discard_prevents_an_already_prepared_late_batch_from_publishing(self):
+        held = self.hold()
+        worker = self.claim(held)
+        outcomes = []
+
+        def discard_first():
+            discard = self.claim(held, self.discard_request(held))
+            outcomes.append(self.revisions.complete_plan_revision(discard, kind='discard'))
+
+        self.runs.before_batch = discard_first
+        self.assert_error(
+            'plan_changed', self.revisions.complete_plan_revision,
+            worker, kind='plan', document=held['plan'],
+        )
+        self.revisions.release_plan_revision(worker)
+        self.assertEqual(self.read(), outcomes[0])
+        self.assertEqual(len(self.runs.items), 1)
+        self.assertEqual(self.read()['plan']['steps'], held['plan']['steps'])
+
+    def test_run_uses_saved_narrowing_and_rejects_duplicate_start(self):
+        overlay = {'disabled_step_ids': ['compare'], 'removed_document_ids': {'search': ['doc2']}}
+        held = self.hold(edits=overlay)
+        self.assert_error('plan_changed', self.run_plan, held)
+        self.assert_error('plan_changed', self.run_plan, held, expected_version='stale')
+        claimed = self.run_plan(held, expected_version=held['edit_version'], plan_id='plan_original')
+        self.assertEqual(claimed['status'], 'running')
+        self.assertEqual(claimed['plan']['status'], 'running')
+        self.assertEqual(claimed['approval']['state'], 'approved')
+        self.assertEqual(claimed['approval']['approved_by'], 'user1')
+        self.assertEqual(claimed['approval'], claimed['plan']['approval'])
+        self.assertFalse(claimed['plan']['steps'][1]['enabled'])
+        self.assertEqual(claimed['plan']['steps'][0]['arguments']['document_ids'], ['doc1'])
+        self.assertEqual(claimed['plan']['steps'][2]['capability_id'], 'respond')
+        self.assert_error('already_run', self.run_plan, claimed, expected_version=claimed['edit_version'])
+
+    def test_untouched_legacy_plan_runs_without_version_and_write_failure_propagates(self):
+        self.runs.fail_writes = True
+        with self.assertRaises(AzureError):
+            self.run_plan(self.original)
+        self.assertEqual(self.read(), self.original)
+        self.runs.fail_writes = False
+        claimed = self.run_plan(
+            self.original, edits={'disabled_step_ids': ['compare']},
+            conversation_context=self.context['conversation_context'],
+        )
+        self.assertEqual(claimed['status'], 'running')
+        self.assertNotIn('edit_version', claimed)
+        self.assertFalse(claimed['plan']['steps'][1]['enabled'])
+
+    def test_run_rejects_cancelled_settled_and_previously_started_records(self):
+        for status in ('cancelled', 'failed', 'superseded', 'archived'):
+            with self.subTest(status=status):
+                self.runs.upsert_item({**self.original, 'status': status})
+                self.assert_error('plan_changed', self.run_plan, self.original)
+        for status in ('running', 'completed'):
+            with self.subTest(status=status):
+                self.runs.upsert_item({**self.original, 'status': status})
+                self.assert_error('already_run', self.run_plan, self.original)
+        self.runs.upsert_item({**self.original, 'status': 'failed', 'started_at': 'yesterday'})
+        self.assert_error('already_run', self.run_plan, self.original)
+
+    def test_ownership_non_run_ids_and_availability_failures(self):
+        for run_id, user_id, conversation_id in (
+            ('run_original', 'other-user', 'conv1'),
+            ('run_original', 'user1', 'other-conversation'),
+            (['run_original'], 'user1', 'conv1'),
+            ('../run_original', 'user1', 'conv1'),
+            ('\ud800', 'user1', 'conv1'),
+        ):
+            self.assert_error(
+                'not_found', self.revisions.read_revision_run,
+                run_id, user_id, conversation_id, status=404,
+            )
+        non_run = {**self.original, 'record_type': 'pending_elicitation'}
+        self.runs.upsert_item(non_run)
+        self.assert_error('not_found', self.read, status=404)
+        self.runs.upsert_item({**self.original, 'record_type': None, 'plan': {}})
+        self.assert_error('not_found', self.read, status=404)
+        self.runs.upsert_item(self.original)
+        self.runs.fail_reads = True
+        with self.assertRaises(AzureError):
+            self.read()
+        self.runs.fail_reads = False
+        self.runs.fail_queries = True
+        with self.assertRaises(AzureError):
+            self.revisions.plan_editor_state(self.original, 'user1')
+
+    def test_foreign_revision_targets_and_restore_sources_are_not_followed(self):
+        held = self.hold()
+        other = deepcopy(held)
+        other.update(id='run_other', run_id='run_other', revision=1)
+        other['plan'].update(run_id='run_other', plan_id='plan_other', revision=1)
+        for changes in (
+            {'user_id': 'other-user'}, {'turn_id': 'other-turn'},
+            {'revision_root_run_id': 'other-root'}, {'conversation_id': 'other-conversation'},
+        ):
+            with self.subTest(changes=changes):
+                candidate = deepcopy(other)
+                candidate.update(changes)
+                for key in ('user_id', 'turn_id', 'conversation_id'):
+                    if key in changes:
+                        candidate['plan'][key] = changes[key]
+                self.runs.upsert_item(candidate)
+                self.runs.upsert_item({**held, 'superseded_by_run_id': 'run_other', 'status': 'superseded'})
+                self.assert_error('not_found', self.read, status=404, follow_current=True)
+                self.runs.upsert_item(held)
+                body = {
+                    'conversation_id': 'conv1', 'expected_version': held['edit_version'],
+                    'submission_id': str(uuid.uuid4()), 'action': 'restore', 'source_run_id': 'run_other',
+                }
+                self.assert_error('not_found', self.claim, held, body, status=404)
+                self.runs.items.pop(('conv1', 'run_other'), None)
+
+    def test_superseded_runs_are_readable_but_hidden_from_normal_run_views(self):
+        held = self.hold()
+        current = self.publish(held)
+        self.assertEqual(self.read()['id'], held['id'])
+        self.assertEqual(self.store.get_orchestration_run(held['id'], 'user1', 'conv1')['id'], held['id'])
+        self.assertEqual(self.read(follow_current=True)['id'], current['id'])
+        self.assertEqual(
+            [row['id'] for row in self.store.list_conversation_runs('conv1', 'user1')], [current['id']],
+        )
+        self.assertEqual(self.store.get_latest_turn_run('conv1', 'user1', 'turn1')['id'], current['id'])
+        self.assertEqual(self.store.next_turn_index('conv1', 'user1'), 8)
+        error = self.assert_error(
+            'plan_changed', self.run_plan, held, expected_version=held['edit_version'],
+        )
+        self.assertEqual(error.current_run_id, current['id'])
+        with patch.object(self.runs, 'query_items', return_value=[self.read(), current]):
+            self.assertEqual(len(self.store.list_conversation_runs('conv1', 'user1')), 1)
+            self.assertEqual(self.store.get_latest_turn_run('conv1', 'user1', 'turn1')['id'], current['id'])
+
+    def test_history_is_paged_and_preserves_original_without_snapshot_arrays(self):
+        current = self.hold()
+        for index in range(45):
+            current = self.publish(current, instruction=f'Edit {index + 1}')
+        unrelated = deepcopy(current)
+        unrelated.update(id='run_other', run_id='run_other', revision=500, revision_root_run_id='run_other')
+        unrelated['plan'].update(run_id='run_other', plan_id='plan_other', revision=500)
+        self.runs.upsert_item(unrelated)
+        cursor = None
+        history = []
+        while True:
+            state = self.revisions.plan_editor_state(current, 'user1', before_revision=cursor)
+            self.assertLessEqual(len(state['history']), self.revisions.EDIT_HISTORY_PAGE_SIZE)
+            history.extend(state['history'])
+            cursor = state['next_before_revision']
+            if cursor is None:
+                break
+        self.assertEqual([entry['revision'] for entry in history], list(range(45, -1, -1)))
+        self.assertEqual(history[-1]['run_id'], self.original['id'])
+        self.assertEqual(history[-1]['origin'], 'original')
+        self.assertEqual(len(self.runs.items), 47)
+        self.assertNotIn('history', current)
+        self.assertEqual(self.read(follow_current=True)['id'], current['id'])
+        self.assert_error(
+            'invalid_request', self.revisions.plan_editor_state,
+            current, 'user1', before_revision=-1, status=400,
+        )
+
+    def test_restore_creates_a_fresh_current_revision(self):
+        held = self.hold()
+        revised = self.publish(held, turn_context={'resolved_message': 'Pricing only'})
+        body = {
+            'conversation_id': 'conv1', 'submission_id': 'restore1',
+            'expected_version': revised['edit_version'], 'action': 'restore',
+            'source_run_id': held['id'],
+        }
+        claim = self.claim(revised, body)
+        restored = self.revisions.complete_plan_revision(
+            claim, kind='plan', document=self.read()['plan'], origin='restore',
+            instruction='Restored original plan.', turn_context=self.context,
+        )
+        self.assertNotIn(restored['id'], (held['id'], revised['id']))
+        self.assertEqual(restored['revision'], 2)
+        self.assertEqual(restored['resolved_message'], self.context['resolved_message'])
+        self.assertEqual(self.revisions.plan_editor_state(restored, 'user1')['history'][0]['origin'], 'restore')
+
+    def test_editor_chat_and_completed_receipts_are_bounded(self):
+        current = self.hold()
+        chat = [
+            {'role': 'user' if index % 2 else 'assistant', 'content': f'Turn {index}', 'timestamp': 'today'}
+            for index in range(50)
+        ]
+        bodies = []
+        for index in range(15):
+            body = self.request(current)
+            bodies.append(body)
+            claim = self.claim(current, body)
+            current = self.revisions.complete_plan_revision(claim, kind='message', chat=chat)
+        self.assertEqual(len(current['edit_submissions']), self.revisions.EDIT_RETAINED_SUBMISSIONS)
+        self.assertEqual(len(current['edit_chat']), 20)
+        self.assertEqual(current['edit_chat'], chat[-20:])
+        self.assertEqual(current['plan']['steps'], self.original['plan']['steps'])
+        self.assertTrue(self.claim(current, bodies[-1])['replayed'])
+        self.assertEqual(current['edit_attempts'], [])
+
+    def test_safe_projection_excludes_private_record_and_provider_metadata(self):
+        held = self.hold()
+        held.update({
+            'seeds': {'private': 'PRIVATE_SEEDS'}, 'config': {'key': 'PRIVATE_CONFIG'},
+            'edit_chat': [
+                {'role': 'system', 'content': 'PRIVATE_SYSTEM'},
+                {'role': 'assistant', 'content': 'Safe reply', 'timestamp': 'today', 'raw': 'PRIVATE_CHAT'},
+            ],
+            'edit_pending': {
+                'elicitation': {**editor_question(), 'token_usage': {'key': 'PRIVATE_PROVIDER'}},
+                'instruction': 'PRIVATE_INSTRUCTION', 'turn_context': {'key': 'PRIVATE_CONTEXT'},
+            },
+        })
+        held['plan'].update(raw_provider_response='PRIVATE_PLAN', seeds={'key': 'PRIVATE_PLAN_SEED'})
+        held['plan']['steps'][0]['result'] = {'key': 'PRIVATE_STEP'}
+        state = self.revisions.plan_editor_state(held, 'user1')
+        self.assertNotIn('PRIVATE_', json.dumps(state))
+        self.assertNotIn('_etag', json.dumps(state))
+        self.assertEqual(state['chat'][0]['content'], 'Safe reply')
+        self.assertEqual(state['pending'], editor_question())
+        self.assert_error('not_found', self.revisions.plan_editor_state, held, 'other-user', status=404)
+
+    def test_release_does_not_hide_operational_failure_or_clear_pending_outcome(self):
+        held = self.hold()
+        claim = self.claim(held)
+        self.runs.fail_writes = True
+        with patch.object(self.revisions, 'log_event') as logged:
+            self.revisions.release_plan_revision(claim)
+        logged.assert_called_once()
+        self.assertEqual(logged.call_args.kwargs['extra']['exception_type'], 'AzureError')
+        self.assertNotIn('Private test storage failure', str(logged.call_args))
+        self.assertEqual(self.read()['edit_claim']['claim_id'], claim['claim_id'])
+        self.runs.fail_writes = False
+        saved = self.revisions.complete_plan_revision(
+            claim, kind='elicitation', pending={'elicitation': editor_question()},
+        )
+        self.revisions.release_plan_revision(claim)
+        self.revisions.release_plan_revision(None)
+        self.assertEqual(self.read(), saved)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/functional_tests/test_support/orchestration_revisions.py
+++ b/functional_tests/test_support/orchestration_revisions.py
@@ -1,0 +1,204 @@
+# orchestration_revisions.py
+"""
+In-memory Cosmos boundary for conditional orchestration revision tests.
+
+Version: 0.261.102
+Implemented in: 0.261.102
+
+Batch operations are formatted by the installed SDK and applied to a copy. A failed
+operation never makes preceding operations visible. Hooks permit deterministic races.
+"""
+
+import re
+from copy import deepcopy
+from threading import RLock
+
+from azure.core import MatchConditions
+from azure.core.exceptions import AzureError
+from azure.cosmos import _base, exceptions
+
+
+class AtomicMemoryContainer:
+    def __init__(self, partition_field):
+        self.partition_field = partition_field
+        self.items = {}
+        self.queries = []
+        self.sequence = 0
+        self.fail_reads = False
+        self.fail_queries = False
+        self.fail_writes = False
+        self.fail_batch_at = None
+        self.before_replace = None
+        self.before_batch = None
+        self.after_batch = None
+        self.batch_calls = []
+        self._lock = RLock()
+
+    def _hook(self, name):
+        callback = getattr(self, name)
+        if callback:
+            setattr(self, name, None)
+            callback()
+
+    def _save(self, body):
+        if self.fail_writes:
+            raise AzureError('Private test storage failure')
+        self.sequence += 1
+        saved = {**deepcopy(body), '_etag': str(self.sequence)}
+        self.items[(body[self.partition_field], body['id'])] = saved
+        return deepcopy(saved)
+
+    def upsert_item(self, body):
+        with self._lock:
+            return self._save(body)
+
+    def create_item(self, body):
+        with self._lock:
+            if (body[self.partition_field], body['id']) in self.items:
+                raise exceptions.CosmosResourceExistsError(status_code=409, message='Test record exists')
+            return self._save(body)
+
+    def read_item(self, item, partition_key):
+        with self._lock:
+            if self.fail_reads:
+                raise AzureError('Private test read failure')
+            record = self.items.get((partition_key, item))
+            if record is None:
+                raise exceptions.CosmosResourceNotFoundError(status_code=404, message='Test record not found')
+            return deepcopy(record)
+
+    def replace_item(self, item, body, **kwargs):
+        self._hook('before_replace')
+        with self._lock:
+            existing = self.read_item(item, body[self.partition_field])
+            if (
+                kwargs.get('match_condition') != MatchConditions.IfNotModified
+                or kwargs.get('etag') != existing['_etag']
+            ):
+                raise exceptions.CosmosAccessConditionFailedError(status_code=412, message='Test version changed')
+            if item != body['id']:
+                raise ValueError('Replacement changed identity')
+            return self._save(body)
+
+    def delete_item(self, item, partition_key, **kwargs):
+        with self._lock:
+            existing = self.read_item(item, partition_key)
+            if kwargs.get('etag') != existing['_etag']:
+                raise exceptions.CosmosAccessConditionFailedError(status_code=412, message='Test version changed')
+            del self.items[(partition_key, item)]
+
+    def execute_item_batch(self, batch_operations, partition_key, **kwargs):
+        self._hook('before_batch')
+        operations = _base._format_batch_operations(deepcopy(batch_operations))
+        self.batch_calls.append(deepcopy(operations))
+        with self._lock:
+            if self.fail_writes:
+                raise AzureError('Private test batch failure')
+            working = deepcopy(self.items)
+            sequence = self.sequence
+            responses = []
+            for index, operation in enumerate(operations):
+                if index == self.fail_batch_at:
+                    raise exceptions.CosmosBatchOperationError(
+                        error_index=index, headers={}, status_code=503,
+                        message='Private injected batch failure', operation_responses=[],
+                    )
+                body = operation.get('resourceBody')
+                item_id = operation.get('id') or (body or {}).get('id')
+                key = (partition_key, item_id)
+                existing = working.get(key)
+                kind = operation['operationType']
+                status = 200
+                if kind == 'Create' and existing is not None:
+                    status = 409
+                elif kind in ('Replace', 'Read', 'Delete') and existing is None:
+                    status = 404
+                elif operation.get('ifMatch') is not None and (
+                    existing is None or existing['_etag'] != operation['ifMatch']
+                ):
+                    status = 412
+                elif body is not None and (
+                    body.get(self.partition_field) != partition_key or body.get('id') != item_id
+                ):
+                    status = 400
+                if status >= 400:
+                    raise exceptions.CosmosBatchOperationError(
+                        error_index=index, headers={}, status_code=status,
+                        message='Private conditional batch failure',
+                        operation_responses=[
+                            {'statusCode': status if position == index else 424}
+                            for position in range(len(operations))
+                        ],
+                    )
+                if kind in ('Create', 'Replace', 'Upsert'):
+                    sequence += 1
+                    working[key] = {**deepcopy(body), '_etag': str(sequence)}
+                    responses.append({
+                        'statusCode': 201 if kind == 'Create' else 200,
+                        'resourceBody': deepcopy(working[key]),
+                        'eTag': str(sequence),
+                    })
+                elif kind == 'Read':
+                    responses.append({'statusCode': 200, 'resourceBody': deepcopy(existing)})
+                elif kind == 'Delete':
+                    del working[key]
+                    responses.append({'statusCode': 204})
+                else:
+                    raise AssertionError(f'Unsupported test batch operation: {kind}')
+            self.items = working
+            self.sequence = sequence
+        self._hook('after_batch')
+        return responses
+
+    def query_items(self, query, parameters=None, partition_key=None, **kwargs):
+        with self._lock:
+            self.queries.append((query, deepcopy(parameters), partition_key))
+            if self.fail_queries:
+                raise AzureError('Private test query failure')
+            params = {entry['name']: entry['value'] for entry in parameters or []}
+            rows = [
+                deepcopy(item) for (partition, _), item in self.items.items()
+                if partition_key is None or partition == partition_key
+            ]
+        for parameter, field in (
+            ('@conversation_id', 'conversation_id'), ('@user_id', 'user_id'), ('@run_id', 'id'),
+        ):
+            if parameter in params:
+                rows = [row for row in rows if row.get(field) == params[parameter]]
+        if '@turn_id' in params:
+            rows = [
+                row for row in rows
+                if (row.get('turn_id') or (row.get('plan') or {}).get('turn_id')) == params['@turn_id']
+            ]
+        if '@revision_root_run_id' in params:
+            rows = [
+                row for row in rows
+                if (row.get('revision_root_run_id') or row['id']) == params['@revision_root_run_id']
+            ]
+        if '@before_revision' in params:
+            rows = [row for row in rows if row.get('revision', 0) < params['@before_revision']]
+        if '@message_ids' in params:
+            rows = [row for row in rows if row['id'] in params['@message_ids']]
+        if '@before_timestamp' in params:
+            rows = [row for row in rows if row.get('timestamp', '') < params['@before_timestamp']]
+        if 'c.record_type' in query:
+            rows = [row for row in rows if row.get('record_type') in (None, 'run', 'orchestration_run')]
+        if 'NOT IS_DEFINED(c.superseded_by_run_id)' in query:
+            rows = [row for row in rows if 'superseded_by_run_id' not in row]
+        if 'c.status != "superseded"' in query:
+            rows = [row for row in rows if row.get('status') != 'superseded']
+        if 'c.role IN' in query:
+            rows = [
+                row for row in rows
+                if row.get('role') in ('user', 'assistant')
+                and not (row.get('metadata') or {}).get('masked')
+                and not (row.get('metadata') or {}).get('is_generated_chat_artifact')
+                and (row.get('metadata') or {}).get('thread_info', {}).get('active_thread') is not False
+            ]
+        if 'SELECT VALUE MAX' in query:
+            return [max((row.get('turn_index', 0) for row in rows), default=None)]
+        for field in ('timestamp', 'created_at', 'turn_index', 'revision'):
+            if f'ORDER BY c.{field} DESC' in query:
+                rows.sort(key=lambda row: row.get(field, 0 if field in ('revision', 'turn_index') else ''), reverse=True)
+        top = re.search(r'SELECT TOP (\d+)', query)
+        return rows[:int(top.group(1))] if top else rows

--- a/ui_tests/fixtures/orchestration/harness_entry.tsx
+++ b/ui_tests/fixtures/orchestration/harness_entry.tsx
@@ -9,7 +9,7 @@
 // them on window.OrchHarness so a test can seed the stores, mount a component into a real DOM, and
 // drive it with genuine clicks. Nothing here is stubbed: the code under test is the code that ships.
 
-import { createElement, StrictMode, type ComponentProps, type ReactElement } from 'react';
+import { createElement, StrictMode, useEffect, type ComponentProps, type ReactElement } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { Link, MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
 
@@ -28,9 +28,29 @@ import { ElicitationCard } from '../../../application/v2_ui/src/components/chat/
 import { OrchestrationPlanPanel } from '../../../application/v2_ui/src/components/chat/OrchestrationPlanPanel';
 import { OrchestrationRunView } from '../../../application/v2_ui/src/components/chat/OrchestrationRunView';
 import { OrchestrationMapView } from '../../../application/v2_ui/src/components/chat/OrchestrationMapView';
+import { OrchestrationPlanEditorHost } from '../../../application/v2_ui/src/components/chat/OrchestrationPlanEditor';
 import { MessageList } from '../../../application/v2_ui/src/components/chat/MessageList';
 import { Composer } from '../../../application/v2_ui/src/components/chat/Composer';
 import { DocumentExplorer } from '../../../application/v2_ui/src/components/documents/DocumentExplorer';
+
+function PlanEditorExperience() {
+    const conversationId = chatStore.useChatStore((state) => state.activeConversationId);
+    const drawer = chatStore.useChatStore((state) => state.drawerMode);
+    const setVisible = orchestrationStore.useOrchestrationStore((state) => state.setVisibleConversation);
+    useEffect(() => {
+        setVisible(conversationId);
+        return () => setVisible(null);
+    }, [conversationId, setVisible]);
+    return (
+        <div className="flex h-[100dvh] min-h-0 min-w-0">
+            <div className="flex min-h-0 min-w-0 flex-1 flex-col"><MessageList /></div>
+            {drawer === 'plan' ? (
+                <aside aria-label="Review drawer" className="w-80 shrink-0"><OrchestrationPlanPanel /></aside>
+            ) : null}
+            <OrchestrationPlanEditorHost />
+        </div>
+    );
+}
 
 function PromptExperience() {
     return (
@@ -79,6 +99,8 @@ type ComponentName =
     | 'Composer'
     | 'PromptExperience'
     | 'ApprovalPreferenceWorkflow'
+    | 'PlanEditorExperience'
+    | 'OrchestrationPlanEditorHost'
     | 'ContextWorkflow';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -92,6 +114,8 @@ const components: Record<ComponentName, (props: any) => ReactElement | null> = {
     Composer,
     PromptExperience,
     ApprovalPreferenceWorkflow,
+    PlanEditorExperience,
+    OrchestrationPlanEditorHost,
     ContextWorkflow,
 };
 
@@ -167,6 +191,8 @@ function reset(): void {
         pinnedRunId: null,
         visibleConversationId: null,
         activeTurns: {},
+        planEditors: {},
+        editorTarget: null,
     });
     chatStore.useChatStore.setState({
         activeConversationId: null,

--- a/ui_tests/test_v2_orchestration_plan_card.py
+++ b/ui_tests/test_v2_orchestration_plan_card.py
@@ -1,7 +1,7 @@
-#!/usr/bin/env python3
+# test_v2_orchestration_plan_card.py
 """
 UI test for the V2 chat orchestration plan card: approve, cancel, review, and the timed countdown.
-Version: 0.261.085
+Version: 0.261.101
 Implemented in: 0.261.085
 
 This test drives the REAL OrchestrationPlanCard component (bundled from application/v2_ui/src by
@@ -168,7 +168,7 @@ def test_approve_runs_the_plan():
         assert "edits" in state["body"], "the run must carry the user's (empty) edit set"
         assert state["historyStatus"] == "completed", state["historyStatus"]
         # The settled card collapses to a single review line naming the outcome.
-        assert "view" in state["text"] and "done" in state["text"], state["text"]
+        assert state["text"] == "", "settled plans leave the inline thread; Review remains in the drawer"
         print("  ok  Approve posted the run with the plan and settled it as completed")
         return True
     except Exception as exc:  # noqa: BLE001

--- a/ui_tests/test_v2_orchestration_plan_editing.py
+++ b/ui_tests/test_v2_orchestration_plan_editing.py
@@ -1,7 +1,7 @@
-#!/usr/bin/env python3
+# test_v2_orchestration_plan_editing.py
 """
-UI test for the V2 chat orchestration plan editing: narrowing only, never widening.
-Version: 0.261.085
+UI test for the V2 orchestration Review controls: narrowing only, never client-side widening.
+Version: 0.261.101
 Implemented in: 0.261.085
 
 A user may narrow a plan before it runs -- switch a step off, or drop a document from one -- but
@@ -17,8 +17,9 @@ This test drives the REAL OrchestrationRunView against a seeded plan and asserts
     toggling it back on clears that edit rather than widening past the plan's own default.
   * A document can be removed and restored; a document the step merely references
     (`left_document_id`) is shown but has no remove control.
-  * There is no widening affordance anywhere: no "add" control, no free-text field, and the store
-    exposes no method that could add a step, capability or document.
+  * Review has no widening affordance: no "add" control or free-text field, and the store exposes
+    no method that could add executable steps. Planner-assisted revisions have separate coverage
+    in test_v2_orchestration_plan_editor.py; they are not browser-authored PlanEdits.
 
 No Azure credentials or server are required; the component and store are the shipped code. The
 browser checks are skipped (reported, not failed) when application/v2_ui/node_modules is absent.
@@ -239,7 +240,7 @@ def test_document_removes_and_restores_and_pinned_is_readonly():
 
 
 def test_there_is_no_widening_affordance():
-    """No control or store method can add a step, capability or document to the plan."""
+    """Review cannot add executable steps, capabilities or documents client-side."""
     print("Testing there is no way to widen the plan...")
     page = _PAGE
     try:

--- a/ui_tests/test_v2_orchestration_plan_editor.py
+++ b/ui_tests/test_v2_orchestration_plan_editor.py
@@ -1,0 +1,1069 @@
+# test_v2_orchestration_plan_editor.py
+"""
+Focused real-component browser tests for conversational orchestration plan editing.
+Version: 0.261.102
+Implemented in: 0.261.102
+
+Only HTTP boundaries are mocked. The real store, shared SSE reader, controller,
+MessageList, Review drawer, editor, and elicitation inputs run in Chromium with
+production CSS. Backend validation/concurrency has separate functional coverage.
+Missing tools or built assets fail; no browser check is silently skipped.
+
+Local Chromium is the default. The shared connect_options fixture supports Azure
+Playwright using azure-mgmt-playwright and DefaultAzureCredential without creating
+resources or persisting credentials.
+
+Build CSS with the existing V2 build, keeping outputs in UI test artifacts:
+npm --prefix .\\application\\v2_ui run build -- --outDir ..\\..\\ui_tests\\artifacts\\orchestration-plan-editor
+Run: python -m pytest .\\ui_tests\\test_v2_orchestration_plan_editor.py -q
+"""
+
+import copy
+import json
+import re
+import sys
+from pathlib import Path
+from urllib.parse import parse_qs, unquote, urlsplit
+
+import pytest
+from playwright.sync_api import expect, sync_playwright
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FIXTURES = REPO_ROOT / "ui_tests" / "fixtures"
+BUILD = REPO_ROOT / "ui_tests" / "artifacts" / "orchestration-plan-editor"
+sys.path.insert(0, str(FIXTURES))
+sys.path.insert(0, str(FIXTURES / "orchestration"))
+
+# These shared helpers live outside the test module's import directory.
+import harness_build as hb  # noqa: E402
+from playwright_connection import connect_options  # noqa: E402, F401
+
+
+pytestmark = pytest.mark.ui
+ORIGIN = "https://simplechat.test"
+HARNESS = f"/{hb.HARNESS_HTML_REL}"
+RUNS = "/api/v2/orchestration/runs"
+RUN = "/api/v2/orchestration/run"
+
+
+def make_plan(conversation="editor-chat", turn="editor-turn", mode="manual", revision=0):
+    return {
+        "plan_id": f"{conversation}-plan-{revision}",
+        "run_id": f"{conversation}-run-{revision}",
+        "turn_id": turn,
+        "conversation_id": conversation,
+        "revision": revision,
+        "user_id": "editor-tester",
+        "intent": {"summary": f"Compare quarterly reports for {conversation}", "complexity": "complex"},
+        "inputs": {"documents": [
+            {"document_id": "doc-a", "display_name": "Report A", "selected_by_user": True},
+            {"document_id": "doc-b", "display_name": "Report B", "selected_by_user": True},
+        ], "web": False},
+        "steps": [
+            {"step_id": "read", "capability_id": "search_documents", "title": "Read quarterly reports",
+             "arguments": {"document_ids": ["doc-a", "doc-b"]}, "phase": "knowledge",
+             "estimated_cost": "low", "enabled": True, "status": "pending"},
+            {"step_id": "research", "capability_id": "deep_research", "title": "Investigate context",
+             "arguments": {}, "phase": "knowledge", "estimated_cost": "medium",
+             "enabled": True, "status": "pending"},
+            {"step_id": "answer", "capability_id": "respond", "title": "Write the comparison",
+             "arguments": {}, "phase": "reasoning", "estimated_cost": "low",
+             "enabled": True, "status": "pending"},
+        ],
+        "approval": {"mode": mode, "timeout_seconds": 1, "state": "pending"},
+        "status": "awaiting_approval",
+    }
+
+
+def empty_edits():
+    return {"disabled_step_ids": [], "removed_document_ids": {}}
+
+
+class EditorApi:
+    """A deterministic planner boundary, with explicit response-loss and race gates."""
+
+    def __init__(self, assets):
+        self.assets = assets
+        self.editors = {}
+        self.records = {}
+        self.requests = []
+        self.unexpected = []
+        self.expected_errors = set()
+        self.submissions = {}
+        self.waiting = []
+        self.next_revision = "success"
+        self.hold_response = "success"
+        self.delay_preview = False
+        self.run_conflict = None
+        self.successful_runs = []
+        self.sequence = 0
+
+    def add(self, conversation="editor-chat", turn="editor-turn", mode="manual"):
+        plan = make_plan(conversation, turn, mode)
+        editor = {
+            "plan": plan, "version": "", "edits": empty_edits(), "chat": [],
+            "history": [self.history(plan, "original", "As planned")],
+            "next_before_revision": None, "pending": None, "busy": False,
+        }
+        self.editors[conversation] = editor
+        self.records[plan["run_id"]] = copy.deepcopy(plan)
+        return plan
+
+    @staticmethod
+    def history(plan, origin, note):
+        return {
+            "run_id": plan["run_id"], "plan_id": plan["plan_id"], "revision": plan["revision"],
+            "created_at": f"2026-09-07T15:00:{plan['revision']:02d}Z", "origin": origin, "note": note,
+        }
+
+    def touch(self, editor):
+        self.sequence += 1
+        editor["version"] = f"saved-{self.sequence}"
+        editor["plan"]["edit_version"] = editor["version"]
+        editor["plan"]["approval"] = {"mode": "manual", "timeout_seconds": 0, "state": "pending"}
+        self.records[editor["plan"]["run_id"]] = copy.deepcopy(editor["plan"])
+
+    def projection(self, editor, before=None):
+        result = copy.deepcopy(editor)
+        history = [entry for entry in result["history"] if before is None or entry["revision"] < before]
+        result["history"] = history[:2]
+        result["next_before_revision"] = history[1]["revision"] if len(history) > 2 else None
+        return result
+
+    def publish(self, editor, instruction="Focus on pricing", source=None):
+        old = copy.deepcopy(editor["plan"])
+        plan = copy.deepcopy(source or old)
+        edits = editor["edits"] if source is None else empty_edits()
+        plan["steps"] = [step for step in plan["steps"] if step["step_id"] not in edits["disabled_step_ids"]]
+        for step in plan["steps"]:
+            if "document_ids" in step["arguments"]:
+                removed = edits["removed_document_ids"].get(step["step_id"], [])
+                step["arguments"]["document_ids"] = [
+                    value for value in step["arguments"]["document_ids"] if value not in removed
+                ]
+        if source is None:
+            if "add" in instruction.lower():
+                plan["steps"].insert(-1, {
+                    "step_id": f"web-{old['revision'] + 1}", "capability_id": "web_search",
+                    "title": "Search the web", "arguments": {"query": instruction},
+                    "phase": "knowledge", "enabled": True, "estimated_cost": "low", "status": "pending",
+                })
+            if "remove" in instruction.lower():
+                plan["steps"] = [step for step in plan["steps"] if step["capability_id"] != "web_search"]
+            plan["intent"]["summary"] = f"Revised: {instruction}"
+        plan["revision"] = old["revision"] + 1
+        plan["run_id"] = f"{old['conversation_id']}-run-{plan['revision']}"
+        plan["plan_id"] = f"{old['conversation_id']}-plan-{plan['revision']}"
+        plan["status"] = "awaiting_approval"
+        self.records[old["run_id"]]["status"] = "superseded"
+        editor["plan"] = plan
+        editor["edits"] = empty_edits()
+        editor["pending"] = None
+        editor["busy"] = False
+        note = f"Restored revision {source['revision']}." if source else instruction
+        editor["history"].insert(0, self.history(plan, "restore" if source else "ai", note))
+        self.touch(editor)
+
+    def error(self, route, status, message, code, current=None):
+        self.expected_errors.add((urlsplit(route.request.url).path, status))
+        payload = {"error": message, "code": code}
+        if current:
+            payload["current_run_id"] = current
+        route.fulfill(status=status, json=payload)
+
+    @staticmethod
+    def stream(route, event):
+        route.fulfill(
+            content_type="text/event-stream",
+            body='data: {"type":"thought","content":"Editor-only planner progress"}\n\n'
+            + f"data: {json.dumps(event)}\n\n",
+        )
+
+    def result(self, editor):
+        pending = editor["pending"]
+        return {
+            "type": "orchestration_elicitation" if pending else "orchestration_plan",
+            "elicitation" if pending else "plan": copy.deepcopy(pending or editor["plan"]),
+            "editor": self.projection(editor), "done": True,
+        }
+
+    def revise(self, route, editor, body, behavior):
+        submission = body["submission_id"]
+        if submission in self.submissions:
+            saved_body, event = self.submissions[submission]
+            assert saved_body == body, "An idempotency token must not identify changed input."
+            self.stream(route, event)
+            return
+        if body["expected_version"] != editor["version"]:
+            self.error(route, 409, "The plan changed. Review its current saved revision.",
+                       "plan_changed", editor["plan"]["run_id"])
+            return
+        assert "plan" not in body and "elicitation" not in body, "Only server-owned identities may be submitted."
+        if behavior == "error":
+            self.error(route, 503, "Planner unavailable. Your last saved plan is unchanged.", "unavailable")
+            return
+        if behavior in ("invalid", "foreign"):
+            event = {"type": "orchestration_plan", "plan": make_plan("unrelated"), "done": True}
+            if behavior == "foreign":
+                event["editor"] = {**self.projection(editor), "plan": make_plan("unrelated")}
+            self.stream(route, event)
+            return
+        action = body["action"]
+        if "edits" in body:
+            editor["edits"] = copy.deepcopy(body["edits"])
+        if action == "ask":
+            instruction = body["instruction"]
+            editor["chat"].append({"role": "user", "content": instruction, "timestamp": "2026-09-07T15:00:00Z"})
+            if behavior == "question":
+                editor["pending"] = {
+                    "elicitation_id": f"question-{self.sequence}", "contract_version": 1,
+                    "run_id": editor["plan"]["run_id"], "turn_id": editor["plan"]["turn_id"],
+                    "revision": editor["plan"]["revision"] + 1, "message": "Which focus should the revised plan use?",
+                    "requested_schema": {"type": "object", "properties": {
+                        "focus": {"type": "string", "title": "Plan focus", "enum": ["Pricing", "Delivery"]},
+                    }, "required": ["focus"]},
+                    "ui_hints": {"order": ["focus"], "pages": [["focus"]]},
+                }
+                self.touch(editor)
+            elif behavior == "explain":
+                editor["chat"].append({
+                    "role": "assistant", "content": f"Kept the saved plan. Your request was: {instruction}",
+                    "timestamp": "2026-09-07T15:00:01Z",
+                })
+                self.touch(editor)
+            else:
+                self.publish(editor, instruction)
+        elif action == "restore":
+            self.publish(editor, source=self.records[body["source_run_id"]])
+        elif action == "answer":
+            assert body["elicitation_id"] == editor["pending"]["elicitation_id"]
+            assert body["elicitation_revision"] == editor["pending"]["revision"]
+            response = body["elicitation_response"]
+            self.publish(editor, f"Focus on {response['content'].get('focus', 'the original request')}")
+        elif action == "discard":
+            if editor["pending"]:
+                assert body["elicitation_id"] == editor["pending"]["elicitation_id"]
+                assert body["elicitation_revision"] == editor["pending"]["revision"]
+            editor["pending"] = None
+            editor["busy"] = False
+            self.touch(editor)
+        if behavior != "question" and behavior != "explain":
+            editor["chat"].append({
+                "role": "assistant",
+                "content": "Kept the current plan." if action == "discard" else editor["history"][0]["note"],
+                "timestamp": "2026-09-07T15:00:02Z",
+            })
+        event = self.result(editor)
+        self.submissions[submission] = (copy.deepcopy(body), event)
+        if behavior == "lost":
+            self.expected_errors.add((urlsplit(route.request.url).path, "net::ERR_FAILED"))
+            route.abort("failed")
+        else:
+            self.stream(route, event)
+
+    def handle(self, route):
+        request = route.request
+        parsed = urlsplit(request.url)
+        path = parsed.path
+        if f"{parsed.scheme}://{parsed.netloc}" != ORIGIN:
+            self.unexpected.append(request.url)
+            route.abort()
+            return
+        if request.method == "GET" and path in self.assets:
+            route.fulfill(path=str(self.assets[path]))
+            return
+        body = request.post_data_json if request.method == "POST" else {}
+        self.requests.append({"path": path, "method": request.method, "body": body, "query": parsed.query})
+        if path == RUN:
+            editor = self.editors[body["conversation_id"]]
+            code = self.run_conflict
+            if editor["busy"] or editor["pending"]:
+                code = "edit_in_progress"
+            elif editor["version"] and body.get("expected_version") != editor["version"]:
+                code = "plan_changed"
+            if code:
+                self.error(route, 409, f"Approval refused: {code}. Refresh the saved plan.",
+                           code, editor["plan"]["run_id"])
+                return
+            assert body["run_id"] == editor["plan"]["run_id"]
+            self.successful_runs.append(copy.deepcopy(body))
+            editor["plan"]["status"] = "completed"
+            self.stream(route, {
+                "done": True, "message_id": "saved-answer", "content": f"Ran: {editor['plan']['intent']['summary']}",
+            })
+            return
+        if path == "/api/v2/orchestration/plan":
+            plan = self.add(body["conversation_id"], body["turn_id"], body["approval_mode"])
+            if body["approval_mode"] == "auto":
+                plan["approval"]["state"] = "approved"
+                plan["status"] = "approved"
+            self.stream(route, {"type": "orchestration_plan", "plan": plan, "done": True})
+            return
+        if path == RUNS:
+            conversation = parse_qs(parsed.query)["conversation_id"][0]
+            runs = [{
+                "run_id": plan["run_id"], "turn_id": plan["turn_id"], "status": plan["status"],
+                "user_message_id": f"user-{conversation}", "user_message": "Compare quarterly reports.",
+                "created_at": f"2026-09-07T15:00:{plan['revision']:02d}Z",
+                "plan_summary": {
+                    "plan_id": plan["plan_id"], "turn_id": plan["turn_id"], "status": plan["status"],
+                    "intent_summary": plan["intent"]["summary"], "step_count": len(plan["steps"]),
+                },
+            } for plan in self.records.values() if plan["conversation_id"] == conversation]
+            route.fulfill(json={"runs": runs})
+            return
+        match = re.fullmatch(re.escape(RUNS) + r"/([^/]+)(?:/(edit|editor|revisions|steps))?", path)
+        if match:
+            run_id, operation = unquote(match[1]), match[2]
+            record = self.records[run_id]
+            conversation = body.get("conversation_id") or parse_qs(parsed.query)["conversation_id"][0]
+            assert record["conversation_id"] == conversation
+            editor = self.editors[conversation]
+            if operation == "edit":
+                if self.hold_response == "delay":
+                    self.waiting.append(lambda: self.fulfill_hold(route, editor, body))
+                    return
+                if self.hold_response == "error":
+                    self.hold_response = "success"
+                    self.error(route, 503, "The manual hold could not be saved.", "unavailable")
+                    return
+                self.fulfill_hold(route, editor, body)
+            elif operation == "editor":
+                before = parse_qs(parsed.query).get("before_revision", [None])[0]
+                route.fulfill(json={"editor": self.projection(editor, int(before) if before is not None else None)})
+            elif operation == "revisions":
+                behavior, self.next_revision = self.next_revision, "success"
+                if behavior == "delay":
+                    editor["busy"] = True
+                    if "edits" in body:
+                        editor["edits"] = copy.deepcopy(body["edits"])
+                    self.waiting.append(lambda: self.revise(route, editor, body, "success"))
+                else:
+                    self.revise(route, editor, body, behavior)
+            elif operation == "steps":
+                route.fulfill(json={"steps": []})
+            elif self.delay_preview:
+                self.waiting.append(lambda: route.fulfill(json={"run": {"plan": record}}))
+            else:
+                route.fulfill(json={"run": {"plan": record}})
+            return
+        if path == "/favicon.ico":
+            route.fulfill(status=204)
+            return
+        self.unexpected.append(f"{request.method} {path}")
+        route.fulfill(status=404, json={"error": "Unmocked request"})
+
+    def fulfill_hold(self, route, editor, body):
+        if not editor["version"]:
+            editor["edits"] = copy.deepcopy(body.get("edits", empty_edits()))
+            self.touch(editor)
+        route.fulfill(json={"editor": self.projection(editor)})
+
+    def release(self):
+        waiting, self.waiting = self.waiting, []
+        for callback in waiting:
+            callback()
+
+    def calls(self, suffix):
+        return [request for request in self.requests if request["path"].endswith(suffix)]
+
+
+@pytest.fixture(scope="module")
+def editor_assets():
+    bundle = hb.ensure_bundle()
+    index = BUILD / "index.html"
+    assert index.is_file(), "Build the V2 UI into ui_tests/artifacts/orchestration-plan-editor first."
+    urls = re.findall(r'<link\b[^>]*href="([^"]+\.css)"', index.read_text("utf-8"))
+    assert urls, "Production styles, not approximated harness CSS, are required."
+    return {
+        HARNESS: hb.HERE / "harness.html",
+        "/ui_tests/fixtures/orchestration/harness.bundle.js": bundle,
+        **{url: BUILD / "assets" / url.rsplit("/", 1)[-1] for url in urls},
+    }
+
+
+@pytest.fixture(scope="module")
+def editor_browser(connect_options):
+    with sync_playwright() as playwright:
+        browser = playwright.chromium.connect(**connect_options) if connect_options else playwright.chromium.launch()
+        yield browser
+        browser.close()
+
+
+@pytest.fixture
+def editor_ui(editor_browser, editor_assets):
+    context = editor_browser.new_context(viewport={"width": 1440, "height": 900})
+    page = context.new_page()
+    api = EditorApi(editor_assets)
+    errors = []
+    page.route("**/*", api.handle)
+    page.on("pageerror", lambda error: errors.append(str(error)))
+
+    def console_error(message):
+        if message.type != "error":
+            return
+        path = urlsplit(message.location.get("url", "")).path
+        if any(path == expected_path and str(status) in message.text for expected_path, status in api.expected_errors):
+            return
+        errors.append(message.text)
+
+    page.on("console", console_error)
+    try:
+        yield page, api
+    finally:
+        api.release()
+        context.close()
+        assert not api.unexpected, f"Unexpected browser requests: {api.unexpected}"
+        assert not errors, f"Unexpected browser errors: {errors}"
+
+
+def mount(page, api, conversation="editor-chat", turn="editor-turn", *, mode="manual", resume=False, reset=True):
+    plan = api.editors.get(conversation, {}).get("plan") or api.add(conversation, turn, mode)
+    if page.url != ORIGIN + HARNESS:
+        page.goto(ORIGIN + HARNESS)
+    page.wait_for_function("() => Boolean(window.OrchHarness)")
+    for url in api.assets:
+        if url.endswith(".css"):
+            page.add_style_tag(url=ORIGIN + url)
+    page.evaluate(
+        """(spec) => {
+            const H = window.OrchHarness;
+            if (spec.reset) H.reset();
+            H.stores.bootstrap.useBootstrapStore.setState({ data: {
+                version: '0.261.102', settings: {}, branding: { app_title: 'SimpleChat' },
+                features: { enable_chat_orchestration: true },
+                user: { id: 'editor-tester', display_name: 'Editor Tester' },
+                scope: { groups: [], public_workspaces: [] },
+                orchestration: { enabled: true, allow_user_approval_override: false, capabilities: [] },
+                catalogs: { models: [], agents: [], prompts: [] },
+            } });
+            H.stores.chat.useChatStore.setState({
+                activeConversationId: spec.conversation, activeConversationKind: 'personal',
+                messagesLoading: false, messagesError: null, streaming: false,
+                streamingContent: '', streamError: null, thoughts: [],
+                conversations: [{ id: spec.conversation, title: 'Quarterly comparison' }],
+                messages: [{ id: 'user-' + spec.conversation, role: 'user',
+                    content: 'Compare quarterly reports.', metadata: { orchestration_turn_id: spec.turn } }],
+            });
+            const store = H.stores.orchestration.useOrchestrationStore.getState();
+            if (!spec.resume) {
+                if (!H.stores.orchestration.selectPlan(store, spec.conversation, spec.turn)) {
+                    store.setPlan(spec.conversation, spec.turn, spec.plan);
+                }
+                store.setActiveTurn(spec.conversation, spec.turn);
+            }
+            H.mount('mount-a', 'PlanEditorExperience', {}, { strictMode: true });
+        }""",
+        {"conversation": conversation, "turn": turn, "plan": plan, "resume": resume, "reset": reset},
+    )
+    if resume:
+        page.evaluate("(conversation) => window.OrchHarness.resume.resumeOrchestrationForConversation(conversation)",
+                      conversation)
+    expect(page.get_by_role("button", name="Edit the plan", exact=True).first).to_be_visible()
+
+
+def open_editor(page):
+    page.get_by_role("button", name="Edit the plan", exact=True).first.click()
+    dialog = page.get_by_role("dialog", name="Edit orchestration plan")
+    expect(dialog).to_be_visible()
+    return dialog
+
+
+def ask(page, instruction):
+    dialog = page.get_by_role("dialog", name="Edit orchestration plan")
+    dialog.get_by_role("tab", name="Ask planner", exact=True).click()
+    dialog.get_by_role("textbox", name="Ask planner", exact=True).fill(instruction)
+    dialog.get_by_role("button", name="Send planner request").click()
+
+
+def state(page, conversation="editor-chat", turn="editor-turn"):
+    return page.evaluate(
+        """({conversation, turn}) => {
+            const H = window.OrchHarness, store = H.stores.orchestration.useOrchestrationStore.getState();
+            return {
+                plan: H.stores.orchestration.selectPlan(store, conversation, turn),
+                editor: H.stores.orchestration.selectPlanEditor(store, conversation, turn),
+                edits: H.stores.orchestration.selectEdits(store, conversation, turn),
+                history: store.history[conversation] || [],
+                mainQuestions: Object.keys(store.elicitations),
+                active: store.activeTurns[conversation],
+                messages: H.stores.chat.useChatStore.getState().messages,
+                thoughts: H.stores.chat.useChatStore.getState().thoughts,
+                streamError: H.stores.chat.useChatStore.getState().streamError,
+            };
+        }""", {"conversation": conversation, "turn": turn},
+    )
+
+
+def wait_revision(page, revision, conversation="editor-chat", turn="editor-turn"):
+    page.wait_for_function(
+        """(spec) => window.OrchHarness.stores.orchestration.selectPlan(
+            window.OrchHarness.stores.orchestration.useOrchestrationStore.getState(),
+            spec.conversation, spec.turn)?.revision === spec.revision""",
+        arg={"conversation": conversation, "turn": turn, "revision": revision},
+    )
+
+
+def test_review_entry_preserves_narrowing_and_stable_modal(editor_ui):
+    page, api = editor_ui
+    mount(page, api)
+    page.get_by_role("button", name="Review the plan in the drawer").click()
+    review = page.get_by_role("complementary", name="Review drawer")
+    review.get_by_role("button", name="Remove document doc-a from this step").click()
+    review.locator("ol > li").filter(has_text="Investigate context").locator("label").click()
+    review.get_by_role("button", name="Edit the plan", exact=True).click()
+    dialog = page.get_by_role("dialog", name="Edit orchestration plan")
+    expect(dialog.get_by_role("button", name="Run saved revision")).to_be_enabled()
+    assert api.calls("/edit")[0]["body"]["edits"] == {
+        "disabled_step_ids": ["research"], "removed_document_ids": {"read": ["doc-a"]},
+    }
+    assert state(page)["edits"] == api.editors["editor-chat"]["edits"]
+    expect(dialog.get_by_text("Report A", exact=True)).to_have_count(0)
+    page.evaluate("""() => window.OrchHarness.stores.chat.useChatStore.setState(
+        (value) => ({ messages: value.messages.map(message => ({ ...message })) }))""")
+    expect(dialog).to_be_visible()
+    assert len(state(page)["messages"]) == 1
+    ask(page, "Add web search before the comparison")
+    wait_revision(page, 1)
+    effective = state(page)
+    assert effective["edits"] == empty_edits()
+    assert "research" not in [step["step_id"] for step in effective["plan"]["steps"]]
+    assert effective["plan"]["steps"][0]["arguments"]["document_ids"] == ["doc-b"]
+
+
+def test_add_remove_restore_refine_and_run_only_latest_saved_version(editor_ui):
+    page, api = editor_ui
+    mount(page, api)
+    dialog = open_editor(page)
+    ask(page, "Add web search before the comparison")
+    wait_revision(page, 1)
+    expect(dialog.get_by_text("Search the web", exact=True)).to_be_visible()
+    ask(page, "Remove web search and focus on pricing")
+    wait_revision(page, 2)
+    expect(dialog.get_by_text("Search the web", exact=True)).to_have_count(0)
+    snapshot = state(page)
+    assert len(snapshot["messages"]) == 1 and not snapshot["thoughts"]
+    current_run = snapshot["plan"]["run_id"]
+    dialog.get_by_role("tab", name="History", exact=True).click()
+    dialog.get_by_role("button", name="Load earlier revisions").click()
+    dialog.get_by_role("button", name="Preview revision 0", exact=True).click()
+    expect(dialog.get_by_text("History preview — revision 0", exact=True)).to_be_visible()
+    assert state(page)["plan"]["run_id"] == current_run
+    expect(dialog.get_by_role("button", name="Run saved revision")).to_be_disabled()
+    dialog.get_by_role("button", name="Restore revision 0", exact=True).click()
+    wait_revision(page, 3)
+    assert api.calls("/revisions")[-1]["body"]["source_run_id"].endswith("-run-0")
+    assert state(page)["plan"]["run_id"].endswith("-run-3")
+    ask(page, "Focus the comparison on delivery")
+    wait_revision(page, 4)
+    latest = state(page)["plan"]
+    dialog.get_by_role("button", name="Run saved revision").click()
+    expect(dialog).to_have_count(0)
+    page.wait_for_function("() => window.OrchHarness.stores.chat.useChatStore.getState().messages.length === 2")
+    assert api.successful_runs[0]["run_id"] == latest["run_id"]
+    assert api.successful_runs[0]["expected_version"] == latest["edit_version"]
+    assert len(state(page)["messages"]) == 2
+    expect(page.get_by_text("Ran: Revised: Focus the comparison on delivery", exact=True)).to_be_visible()
+
+
+def test_open_stops_countdown_before_hold_response_and_survives_close_reload(editor_ui):
+    page, api = editor_ui
+    page.clock.install()
+    api.hold_response = "delay"
+    mount(page, api, mode="timed")
+    dialog = open_editor(page)
+    page.clock.fast_forward(10000)
+    assert not api.calls(RUN)
+    expect(dialog.get_by_role("button", name="Run saved revision")).to_be_disabled()
+    dialog.get_by_role("button", name="Close the plan editor").click()
+    api.release()
+    expect(page.get_by_role("button", name="Run the saved plan")).to_be_enabled()
+    page.clock.fast_forward(10000)
+    assert not api.calls(RUN)
+    api.hold_response = "success"
+    page.reload()
+    mount(page, api, resume=True)
+    expect(page.get_by_role("timer")).to_have_count(0)
+    expect(page.get_by_role("button", name="Run the saved plan")).to_be_enabled()
+    assert api.calls("/editor") and not api.calls(RUN)
+    dialog = open_editor(page)
+    dialog.get_by_role("button", name="Close the plan editor").click()
+    assert not api.calls(RUN)
+    page.get_by_role("button", name="Run the saved plan").click()
+    expect(page.get_by_role("button", name="Run the saved plan")).to_have_count(0)
+    assert len(api.successful_runs) == 1
+
+
+@pytest.mark.parametrize("failure", ["error", "lost"])
+def test_failed_or_lost_response_keeps_instruction_and_idempotent_retry(editor_ui, failure):
+    page, api = editor_ui
+    mount(page, api)
+    dialog = open_editor(page)
+    api.next_revision = failure
+    ask(page, "Add web search before the comparison")
+    expect(dialog.get_by_role("alert")).to_be_visible()
+    expect(dialog.get_by_role("textbox", name="Ask planner", exact=True)).to_have_value("Add web search before the comparison")
+    assert state(page)["plan"]["revision"] == 0
+    assert len(state(page)["messages"]) == 1
+    expect(dialog.get_by_role("button", name="Run saved revision")).to_be_enabled()
+    if failure == "error":
+        dialog.get_by_role("button", name="Close the plan editor").click()
+        dialog = open_editor(page)
+        expect(dialog.get_by_role("alert")).to_have_text("Planner unavailable. Your last saved plan is unchanged.")
+        expect(dialog.get_by_role("textbox", name="Ask planner")).to_have_value("Add web search before the comparison")
+    dialog.get_by_role("button", name="Send planner request").click()
+    wait_revision(page, 1)
+    calls = api.calls("/revisions")
+    assert len(calls) == 2 and calls[0]["body"] == calls[1]["body"]
+    assert api.editors["editor-chat"]["plan"]["revision"] == 1
+    assert len(state(page)["messages"]) == 1
+
+
+def test_editor_question_answer_retry_close_and_discard_keep_live_plan(editor_ui):
+    page, api = editor_ui
+    mount(page, api)
+    dialog = open_editor(page)
+    api.next_revision = "question"
+    ask(page, "Change the focus")
+    question = dialog.get_by_role("region", name="Planner edit questions")
+    expect(question).to_be_visible()
+    expect(dialog.get_by_role("button", name="Cancel change", exact=True)).to_be_enabled()
+    question.get_by_role("radio", name="Pricing", exact=True).check()
+    expect(dialog.get_by_role("button", name="Run saved revision")).to_be_disabled()
+    before = state(page)
+    assert before["plan"]["revision"] == 0 and not before["mainQuestions"]
+    dialog.get_by_role("button", name="Close the plan editor").click()
+    expect(page.get_by_role("button", name="Run the saved plan")).to_be_disabled()
+    dialog = open_editor(page)
+    expect(dialog.get_by_role("radio", name="Pricing", exact=True)).to_be_checked()
+    api.next_revision = "error"
+    dialog.get_by_role("button", name="Finish", exact=True).click()
+    expect(dialog.get_by_role("alert")).to_be_visible()
+    expect(dialog.get_by_role("radio", name="Pricing", exact=True)).to_be_checked()
+    dialog.get_by_role("button", name="Finish", exact=True).click()
+    wait_revision(page, 1)
+    answers = [call["body"] for call in api.calls("/revisions") if call["body"]["action"] == "answer"]
+    assert answers[0] == answers[1]
+    assert answers[0]["elicitation_response"] == {"action": "accept", "content": {"focus": "Pricing"}}
+    api.next_revision = "question"
+    ask(page, "Ask about the focus again")
+    expect(dialog.get_by_role("region", name="Planner edit questions")).to_be_visible()
+    dialog.get_by_role("button", name="Cancel edit request and keep current plan").click()
+    expect(dialog.get_by_role("region", name="Planner edit questions")).to_have_count(0)
+    assert state(page)["plan"]["revision"] == 1
+    assert api.calls("/revisions")[-1]["body"]["action"] == "discard"
+    expect(dialog.get_by_role("button", name="Run saved revision")).to_be_enabled()
+    assert len(state(page)["messages"]) == 1
+
+
+def test_late_result_updates_only_its_origin_and_preserves_unsent_draft(editor_ui):
+    page, api = editor_ui
+    mount(page, api)
+    dialog = open_editor(page)
+    api.next_revision = "delay"
+    ask(page, "Add web search to the first plan")
+    expect(dialog.get_by_role("button", name="Run saved revision")).to_be_disabled()
+    dialog.get_by_role("textbox", name="Ask planner", exact=True).fill("Next unsent instruction")
+    mount(page, api, "other-chat", "other-turn", reset=False)
+    expect(page.get_by_role("dialog")).to_have_count(0)
+    other = open_editor(page)
+    api.release()
+    wait_revision(page, 1)
+    expect(other.get_by_text("Compare quarterly reports for other-chat", exact=True)).to_be_visible()
+    assert state(page, "other-chat", "other-turn")["plan"]["revision"] == 0
+    assert all("first plan" not in entry["content"] for entry in state(page)["messages"])
+    other.get_by_role("button", name="Close the plan editor").click()
+    mount(page, api, reset=False)
+    expect(page.get_by_role("dialog")).to_have_count(0)
+    reopened = open_editor(page)
+    expect(reopened.get_by_role("textbox", name="Ask planner", exact=True)).to_have_value("Next unsent instruction")
+    expect(reopened.get_by_text("Revised: Add web search to the first plan", exact=True)).to_be_visible()
+
+
+@pytest.mark.parametrize("code", ["plan_changed", "edit_in_progress"])
+def test_run_conflict_refreshes_canonical_without_completing_or_removing_plan(editor_ui, code):
+    page, api = editor_ui
+    mount(page, api)
+    dialog = open_editor(page)
+    expect(dialog.get_by_role("button", name="Run saved revision")).to_be_enabled()
+    dialog.get_by_role("button", name="Close the plan editor").click()
+    editor = api.editors["editor-chat"]
+    if code == "plan_changed":
+        api.publish(editor, "Focus on the other tab's latest plan")
+    else:
+        editor["busy"] = True
+    page.get_by_role("button", name="Run the saved plan").click()
+    expect(page.get_by_role("alert")).to_contain_text(code)
+    page.wait_for_function("""() => {
+        const H = window.OrchHarness;
+        return !H.stores.orchestration.selectPlanEditor(
+            H.stores.orchestration.useOrchestrationStore.getState(), 'editor-chat', 'editor-turn')?.loading;
+    }""")
+    current = state(page)
+    assert not current["history"] and current["active"] == "editor-turn"
+    assert len(current["messages"]) == 1 and not api.successful_runs
+    assert api.calls("/editor")
+    if code == "edit_in_progress":
+        expect(page.get_by_role("button", name="Run the saved plan")).to_be_disabled()
+        api.publish(editor, "Focus on the completed edit")
+        dialog = open_editor(page)
+        expect(dialog.get_by_role("button", name="Run saved revision")).to_be_enabled()
+        dialog.get_by_role("button", name="Close the plan editor").click()
+    else:
+        assert current["plan"]["run_id"] == editor["plan"]["run_id"]
+    page.get_by_role("button", name="Run the saved plan").click()
+    expect(page.get_by_role("button", name="Run the saved plan")).to_have_count(0)
+    assert api.successful_runs[0]["expected_version"] == editor["version"]
+
+
+def test_failed_hold_stays_paused_and_reports_that_the_server_has_not_confirmed(editor_ui):
+    page, api = editor_ui
+    page.clock.install()
+    api.hold_response = "error"
+    mount(page, api, mode="timed")
+    dialog = open_editor(page)
+    expect(dialog.get_by_role("alert")).to_have_text("The manual hold could not be saved.")
+    expect(dialog.get_by_text("Approval is paused in this tab. The server hold is not yet confirmed.")).to_be_visible()
+    expect(dialog.get_by_role("button", name="Run saved revision")).to_be_disabled()
+    dialog.get_by_role("button", name="Close the plan editor").click()
+    page.clock.fast_forward(10000)
+    assert not api.calls(RUN)
+    expect(page.get_by_role("timer")).to_have_count(0)
+    expect(page.get_by_role("button", name="Run the saved plan")).to_be_disabled()
+    dialog = open_editor(page)
+    expect(dialog.get_by_role("button", name="Run saved revision")).to_be_enabled()
+
+
+@pytest.mark.parametrize("status", ["running", "completed", "cancelled", "failed", "superseded", "archived"])
+def test_nonpending_and_archived_plans_have_no_edit_entry(editor_ui, status):
+    page, api = editor_ui
+    plan = api.add()
+    if status != "archived":
+        plan["status"] = status
+    page.goto(ORIGIN + HARNESS)
+    # Mount manually because the normal setup intentionally waits for an editable card.
+    page.evaluate("""(plan) => {
+        const H = window.OrchHarness;
+        H.reset();
+        H.stores.chat.useChatStore.setState({ activeConversationId: 'editor-chat' });
+        const store = H.stores.orchestration.useOrchestrationStore.getState();
+        store.setPlan('editor-chat', 'editor-turn', plan);
+        store.setActiveTurn('editor-chat', 'editor-turn');
+        H.mount('mount-a', 'OrchestrationPlanCard', { conversationId: 'editor-chat', turnId: 'editor-turn' });
+    }""", plan)
+    if status == "archived":
+        page.evaluate("""() => window.OrchHarness.stores.orchestration.useOrchestrationStore.setState({
+            readOnlyTurns: { ['editor-chat\\u0000editor-turn']: true } })""")
+    expect(page.get_by_role("button", name="Edit the plan", exact=True)).to_have_count(0)
+    page.evaluate("() => window.OrchHarness.mount('mount-b', 'OrchestrationPlanPanel')")
+    expect(page.get_by_role("button", name="Edit the plan", exact=True)).to_have_count(0)
+
+
+def test_mobile_keyboard_focus_and_inert_planner_text(editor_ui):
+    page, api = editor_ui
+    page.set_viewport_size({"width": 390, "height": 844})
+    mount(page, api)
+    opener = page.get_by_role("button", name="Edit the plan", exact=True)
+    dialog = open_editor(page)
+    expect(dialog.get_by_role("button", name="Close the plan editor")).to_be_focused()
+    api.next_revision = "explain"
+    payload = '<img src=x onerror="window.editorInjected=true"> Explain this safely.'
+    ask(page, payload)
+    expect(dialog.get_by_text(f"Kept the saved plan. Your request was: {payload}", exact=True)).to_be_visible()
+    assert page.evaluate("() => window.editorInjected") is None
+    expect(dialog.locator("img")).to_have_count(0)
+    textarea = dialog.get_by_role("textbox", name="Ask planner", exact=True)
+    textarea.fill("Keep this draft")
+    send = dialog.get_by_role("button", name="Send planner request")
+    send.focus()
+    page.keyboard.press("Tab")
+    expect(dialog.get_by_role("button", name="Run saved revision")).to_be_focused()
+    page.keyboard.press("Shift+Tab")
+    expect(send).to_be_focused()
+    preview_box = dialog.get_by_test_id("plan-editor-preview").bounding_box()
+    text_box = textarea.bounding_box()
+    assert preview_box["width"] <= 390 and preview_box["height"] >= 100
+    assert text_box["y"] >= preview_box["y"] + preview_box["height"]
+    assert text_box["x"] >= 0 and text_box["x"] + text_box["width"] <= 390
+    assert text_box["y"] + text_box["height"] <= 844
+    page.keyboard.press("Escape")
+    expect(dialog).to_have_count(0)
+    expect(opener).to_be_focused()
+    assert not api.calls(RUN)
+    dialog = open_editor(page)
+    expect(dialog.get_by_role("textbox", name="Ask planner", exact=True)).to_have_value("Keep this draft")
+    assert len(state(page)["messages"]) == 1
+
+
+def test_late_history_preview_does_not_replace_current_plan(editor_ui):
+    page, api = editor_ui
+    mount(page, api)
+    dialog = open_editor(page)
+    ask(page, "Add web search")
+    wait_revision(page, 1)
+    dialog.get_by_role("tab", name="History", exact=True).click()
+    api.delay_preview = True
+    dialog.get_by_role("button", name="Preview revision 0", exact=True).click()
+    expect(dialog.get_by_text("Loading revision…", exact=True)).to_be_visible()
+    dialog.get_by_role("button", name="Back to current plan").click()
+    api.release()
+    expect(dialog.get_by_text("Current saved plan", exact=True)).to_be_visible()
+    assert state(page)["plan"]["revision"] == 1
+    expect(dialog.get_by_role("button", name="Run saved revision")).to_be_enabled()
+
+
+def test_current_review_draft_survives_reopening_but_stale_edits_adopt_server_overlay(editor_ui):
+    page, api = editor_ui
+    mount(page, api)
+    dialog = open_editor(page)
+    expect(dialog.get_by_role("button", name="Run saved revision")).to_be_enabled()
+    dialog.get_by_role("button", name="Close the plan editor").click()
+    page.get_by_role("button", name="Review the plan in the drawer").click()
+    review = page.get_by_role("complementary", name="Review drawer")
+    review.get_by_role("button", name="Remove document doc-a from this step").click()
+    review.get_by_role("button", name="Edit the plan").click()
+    dialog = page.get_by_role("dialog", name="Edit orchestration plan")
+    expect(dialog.get_by_role("button", name="Run saved revision")).to_be_enabled()
+    assert state(page)["edits"]["removed_document_ids"] == {"read": ["doc-a"]}
+    expect(dialog.get_by_text("Report A", exact=True)).to_have_count(0)
+    dialog.get_by_role("button", name="Close the plan editor").click()
+    server = api.editors["editor-chat"]
+    api.publish(server, "Focus on the remote revision")
+    server["edits"] = {"disabled_step_ids": [], "removed_document_ids": {"read": ["doc-b"]}}
+    api.touch(server)
+    review.get_by_role("button", name="Edit the plan").click()
+    expect(dialog.get_by_role("button", name="Run saved revision")).to_be_enabled()
+    assert state(page)["edits"] == server["edits"]
+    expect(dialog.get_by_text("Report A", exact=True)).to_be_visible()
+    expect(dialog.get_by_text("Report B", exact=True)).to_have_count(0)
+
+
+def test_review_map_can_preview_superseded_revision_without_overwriting_live_plan(editor_ui):
+    page, api = editor_ui
+    mount(page, api)
+    dialog = open_editor(page)
+    ask(page, "Add web search")
+    wait_revision(page, 1)
+    latest = state(page)["plan"]
+    dialog.get_by_role("button", name="Close the plan editor").click()
+    page.get_by_role("button", name="Review the plan in the drawer").click()
+    review = page.get_by_role("complementary", name="Review drawer")
+    review.get_by_role("tab", name="Map", exact=True).click()
+    review.get_by_role("button").filter(has_text="Compare quarterly reports for editor-chat").click()
+    expect(review.get_by_text("Compare quarterly reports for editor-chat", exact=True)).to_be_visible()
+    assert state(page)["plan"] == latest
+    expect(review.get_by_role("button", name="Edit the plan", exact=True)).to_have_count(0)
+    expect(review.get_by_role("checkbox")).to_have_count(0)
+    review.get_by_role("button", name="Back to current", exact=True).click()
+    expect(review.get_by_text("Search the web", exact=True)).to_be_visible()
+    expect(review.get_by_role("button", name="Edit the plan", exact=True)).to_be_visible()
+    assert state(page)["plan"] == latest
+
+
+def test_editor_question_is_hydrated_after_reload_without_becoming_a_main_question(editor_ui):
+    page, api = editor_ui
+    mount(page, api)
+    dialog = open_editor(page)
+    api.next_revision = "question"
+    ask(page, "Change the plan focus")
+    expect(dialog.get_by_role("region", name="Planner edit questions")).to_be_visible()
+    saved_pending = copy.deepcopy(api.editors["editor-chat"]["pending"])
+    page.reload()
+    mount(page, api, resume=True)
+    snapshot = state(page)
+    assert snapshot["editor"]["state"]["pending"] == saved_pending
+    assert snapshot["plan"]["revision"] == 0 and not snapshot["mainQuestions"]
+    expect(page.get_by_role("button", name="Run the saved plan")).to_be_disabled()
+    dialog = open_editor(page)
+    expect(dialog.get_by_text("Change the plan focus", exact=True)).to_be_visible()
+    dialog.get_by_role("radio", name="Delivery", exact=True).check()
+    dialog.get_by_role("button", name="Finish", exact=True).click()
+    wait_revision(page, 1)
+    assert api.calls("/revisions")[-1]["body"]["elicitation_id"] == saved_pending["elicitation_id"]
+    assert len(state(page)["messages"]) == 1
+
+
+def test_concurrent_submissions_and_run_are_blocked_and_changed_instruction_gets_new_id(editor_ui):
+    page, api = editor_ui
+    mount(page, api)
+    dialog = open_editor(page)
+    api.next_revision = "delay"
+    ask(page, "Add web search")
+    expect(dialog.get_by_role("button", name="Run saved revision")).to_be_disabled()
+    page.evaluate("""() => {
+        const H = window.OrchHarness;
+        const target = { conversationId: 'editor-chat', turnId: 'editor-turn' };
+        return Promise.all([
+            H.controller.submitPlanRevision(target, { action: 'ask', instruction: 'Add web search' }),
+            H.controller.approveAndRunPlan(target),
+        ]);
+    }""")
+    assert len(api.calls("/revisions")) == 1 and not api.calls(RUN)
+    api.release()
+    wait_revision(page, 1)
+    api.next_revision = "error"
+    ask(page, "Rework the gathering steps")
+    expect(dialog.get_by_role("alert")).to_be_visible()
+    failed_id = api.calls("/revisions")[-1]["body"]["submission_id"]
+    dialog.get_by_role("textbox", name="Ask planner").fill("Focus on pricing instead")
+    page.keyboard.press("Control+Enter")
+    wait_revision(page, 2)
+    assert api.calls("/revisions")[-1]["body"]["submission_id"] != failed_id
+    assert len(state(page)["messages"]) == 1
+
+
+@pytest.mark.parametrize("response", ["invalid", "foreign"])
+def test_unusable_or_wrong_scope_editor_response_keeps_last_good_plan(editor_ui, response):
+    page, api = editor_ui
+    mount(page, api)
+    dialog = open_editor(page)
+    api.next_revision = response
+    ask(page, "Rework the plan")
+    expect(dialog.get_by_role("alert")).to_contain_text("current plan has been kept")
+    snapshot = state(page)
+    assert snapshot["plan"]["run_id"] == "editor-chat-run-0"
+    assert snapshot["plan"]["conversation_id"] == "editor-chat"
+    expect(dialog.get_by_role("textbox", name="Ask planner")).to_have_value("Rework the plan")
+    assert len(snapshot["messages"]) == 1
+    expect(dialog.get_by_role("button", name="Run saved revision")).to_be_enabled()
+
+
+def test_cancel_change_revokes_inflight_work_without_closing_or_growing_main_thread(editor_ui):
+    page, api = editor_ui
+    mount(page, api)
+    dialog = open_editor(page)
+    expect(dialog.get_by_role("button", name="Run saved revision")).to_be_enabled()
+    original_version = state(page)["plan"]["edit_version"]
+    api.next_revision = "delay"
+    ask(page, "Add web search before the comparison")
+    expect(dialog.get_by_role("button", name="Cancel change", exact=True)).to_be_enabled()
+    dialog.get_by_role("button", name="Close the plan editor").click()
+    assert [call["body"]["action"] for call in api.calls("/revisions")] == ["ask"]
+    assert api.editors["editor-chat"]["busy"] is True
+    dialog = open_editor(page)
+    dialog.get_by_role("button", name="Cancel change", exact=True).click()
+    expect(dialog.get_by_role("button", name="Cancel change", exact=True)).to_have_count(0)
+    expect(dialog.get_by_role("button", name="Run saved revision")).to_be_enabled()
+    snapshot = state(page)
+    cancelled_version = snapshot["plan"]["edit_version"]
+    assert cancelled_version != original_version
+    assert snapshot["plan"]["revision"] == 0 and snapshot["active"] == "editor-turn"
+    assert not snapshot["history"] and not snapshot["streamError"]
+    assert len(snapshot["messages"]) == 1 and not snapshot["thoughts"]
+    expect(dialog.get_by_role("textbox", name="Ask planner")).to_have_value("Add web search before the comparison")
+    discard = api.calls("/revisions")[-1]["body"]
+    assert discard["action"] == "discard" and discard["expected_version"] == original_version
+    assert "edits" not in discard and api.calls("/editor")
+    api.release()
+    assert api.editors["editor-chat"]["plan"]["revision"] == 0
+    assert state(page)["plan"]["edit_version"] == cancelled_version
+    expect(dialog.get_by_role("alert")).to_have_count(0)
+    dialog.get_by_role("button", name="Run saved revision").click()
+    expect(dialog).to_have_count(0)
+    assert api.successful_runs[0]["expected_version"] == cancelled_version
+
+
+def test_cancel_abandoned_busy_change_after_reload_can_retry_without_failing_main_chat(editor_ui):
+    page, api = editor_ui
+    mount(page, api)
+    dialog = open_editor(page)
+    expect(dialog.get_by_role("button", name="Run saved revision")).to_be_enabled()
+    dialog.get_by_role("button", name="Close the plan editor").click()
+    editor = api.editors["editor-chat"]
+    editor["busy"] = True
+    api.touch(editor)
+    busy_version = editor["version"]
+    page.reload()
+    mount(page, api, resume=True)
+    expect(page.get_by_role("button", name="Run the saved plan")).to_be_disabled()
+    dialog = open_editor(page)
+    api.next_revision = "error"
+    dialog.get_by_role("button", name="Cancel change", exact=True).click()
+    expect(dialog.get_by_role("alert")).to_contain_text("Planner unavailable")
+    expect(dialog.get_by_role("button", name="Cancel change", exact=True)).to_have_text("Retry cancel change")
+    expect(dialog.get_by_role("button", name="Run saved revision")).to_be_disabled()
+    failed = state(page)
+    assert failed["editor"]["cancellationStatus"] == "failed"
+    assert failed["plan"]["revision"] == 0 and len(failed["messages"]) == 1
+    assert not failed["streamError"] and not failed["history"]
+    dialog.get_by_role("button", name="Cancel change", exact=True).click()
+    expect(dialog.get_by_role("button", name="Cancel change", exact=True)).to_have_count(0)
+    expect(dialog.get_by_role("button", name="Run saved revision")).to_be_enabled()
+    discards = [call["body"] for call in api.calls("/revisions") if call["body"]["action"] == "discard"]
+    assert len(discards) == 2 and discards[0] == discards[1]
+    assert discards[0]["expected_version"] == busy_version
+    assert state(page)["plan"]["edit_version"] != busy_version
+    assert editor["busy"] is False and len(state(page)["messages"]) == 1
+    dialog.get_by_role("button", name="Close the plan editor").click()
+    assert not api.calls(RUN)
+
+
+def test_finished_change_wins_cancel_race_without_cancelling_new_saved_revision(editor_ui):
+    page, api = editor_ui
+    mount(page, api)
+    dialog = open_editor(page)
+    api.next_revision = "delay"
+    ask(page, "Add web search")
+    expect(dialog.get_by_role("button", name="Cancel change", exact=True)).to_be_enabled()
+    api.publish(api.editors["editor-chat"], "Add web search")
+    dialog.get_by_role("button", name="Cancel change", exact=True).click()
+    expect(dialog.get_by_role("alert")).to_contain_text("No pending change remains")
+    wait_revision(page, 1)
+    assert [call["body"]["action"] for call in api.calls("/revisions")] == ["ask"]
+    assert len(state(page)["messages"]) == 1 and not state(page)["streamError"]
+    expect(dialog.get_by_role("button", name="Run saved revision")).to_be_enabled()
+    api.release()
+    assert state(page)["plan"]["revision"] == 1
+
+
+@pytest.mark.parametrize("replacement", ["question", "busy"])
+def test_stale_cancel_refreshes_without_discarding_a_newer_change(editor_ui, replacement):
+    page, api = editor_ui
+    mount(page, api)
+    dialog = open_editor(page)
+    api.next_revision = "question"
+    ask(page, "Rework the plan")
+    expect(dialog.get_by_role("region", name="Planner edit questions")).to_be_visible()
+    editor = api.editors["editor-chat"]
+    old_question = copy.deepcopy(editor["pending"])
+    api.publish(editor, "A newer plan from another tab")
+    if replacement == "question":
+        editor["pending"] = {
+            **old_question, "elicitation_id": "newer-question", "revision": 2,
+            "message": "Which focus should the newer request use?",
+        }
+    else:
+        editor["busy"] = True
+    api.touch(editor)
+    newest_version = editor["version"]
+
+    dialog.get_by_role("button", name="Cancel change", exact=True).click()
+    expect(dialog.get_by_role("alert")).to_contain_text("Review the current change")
+    assert not [call for call in api.calls("/revisions") if call["body"]["action"] == "discard"]
+    assert editor["pending"] is not None or editor["busy"]
+    assert state(page)["plan"]["edit_version"] == newest_version
+
+    dialog.get_by_role("button", name="Cancel change", exact=True).click()
+    expect(dialog.get_by_role("button", name="Run saved revision")).to_be_enabled()
+    discards = [call["body"] for call in api.calls("/revisions") if call["body"]["action"] == "discard"]
+    assert len(discards) == 1 and discards[0]["expected_version"] == newest_version
+    if replacement == "question":
+        assert discards[0]["elicitation_id"] == "newer-question"
+        assert discards[0]["elicitation_revision"] == 2
+    assert len(state(page)["messages"]) == 1 and not state(page)["streamError"]
+
+
+def test_untouched_immediate_auto_plan_still_runs_without_editor_hold(editor_ui):
+    page, api = editor_ui
+    mount(page, api)
+    page.evaluate("""() => {
+        const H = window.OrchHarness;
+        H.stores.orchestration.useOrchestrationStore.getState().clearPlan('editor-chat', 'editor-turn');
+        return H.controller.startOrchestrationPlan({
+            conversationId: 'editor-chat', message: 'Compare immediately', approvalMode: 'auto',
+        });
+    }""")
+    page.wait_for_function("() => Object.keys(window.OrchHarness.stores.orchestration.useOrchestrationStore.getState().history).length > 0")
+    assert len(api.successful_runs) == 1
+    assert not api.calls("/edit") and not api.calls("/revisions")
+    assert "expected_version" not in api.successful_runs[0]

--- a/ui_tests/test_v2_orchestration_plan_editor_backend.py
+++ b/ui_tests/test_v2_orchestration_plan_editor_backend.py
@@ -1,0 +1,213 @@
+# test_v2_orchestration_plan_editor_backend.py
+"""
+Browser-to-Flask regression for editing and running an orchestration plan.
+Version: 0.261.102
+Implemented in: 0.261.102
+
+The browser's real HTTP requests are forwarded to the actual Flask route test client.
+Unlike the frontend-only suite, no orchestration response is fabricated by the browser
+fixture. Model, source lookup, and Cosmos service boundaries remain deterministic.
+The shared browser fixture supports local Chromium and configured Azure Playwright.
+"""
+
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from urllib.parse import urlsplit
+
+import pytest
+from playwright.sync_api import expect
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / 'functional_tests'))
+
+# Reuse the versioned HTTP fixture and the real-component browser harness.
+import test_orchestration_plan_revision_routes as backend_tests  # noqa: E402
+import test_v2_orchestration_plan_editor as editor_tests  # noqa: E402
+from test_v2_orchestration_plan_editor import (  # noqa: E402, F401
+    connect_options,
+    editor_assets,
+    editor_browser,
+)
+
+
+pytestmark = pytest.mark.ui
+
+
+@pytest.fixture
+def integrated_editor(editor_browser, editor_assets):
+    backend = backend_tests.PlanRevisionRouteTests()
+    backend.setUp()
+    context = editor_browser.new_context(viewport={'width': 1440, 'height': 900})
+    page = context.new_page()
+    errors = []
+    requests = []
+
+    def forward(route):
+        request = route.request
+        url = urlsplit(request.url)
+        if f'{url.scheme}://{url.netloc}' != editor_tests.ORIGIN:
+            errors.append(f'Unexpected browser origin: {request.url}')
+            route.abort()
+            return
+        if request.method == 'GET' and url.path in editor_assets:
+            route.fulfill(path=str(editor_assets[url.path]))
+            return
+        if url.path == '/favicon.ico':
+            route.fulfill(status=204)
+            return
+        if not url.path.startswith('/api/v2/orchestration/'):
+            errors.append(f'Unexpected browser request: {request.method} {url.path}')
+            route.abort()
+            return
+        response = backend.client.open(
+            url.path + (f'?{url.query}' if url.query else ''),
+            method=request.method, data=request.post_data,
+            content_type=request.headers.get('content-type'), buffered=True,
+        )
+        requests.append({
+            'path': url.path, 'status': response.status_code,
+            'body': request.post_data_json if request.post_data else None,
+        })
+        if response.status_code >= 400:
+            errors.append(f'Flask rejected {url.path}: {response.get_data(as_text=True)}')
+        route.fulfill(
+            status=response.status_code, content_type=response.content_type,
+            body=response.get_data(),
+        )
+
+    page.route('**/*', forward)
+    page.on('pageerror', lambda error: errors.append(str(error)))
+    try:
+        plan = backend.planned(approval_mode='timed')
+        seeded = SimpleNamespace(assets=editor_assets, editors={'conv1': {'plan': plan}})
+        editor_tests.mount(page, seeded, 'conv1', 'turn1')
+        record = backend.runs.read_item(plan['run_id'], 'conv1')
+        page.evaluate(
+            """(record) => {
+                const H = window.OrchHarness;
+                H.stores.chat.useChatStore.setState({
+                    messages: [{
+                        id: record.user_message_id, role: 'user', content: record.user_message,
+                        metadata: { orchestration_turn_id: record.turn_id },
+                    }],
+                });
+                H.stores.bootstrap.useBootstrapStore.setState(state => ({
+                    data: { ...state.data, user: { id: 'user1', display_name: 'Plan Tester' } },
+                }));
+            }""",
+            {key: record[key] for key in ('user_message_id', 'user_message', 'turn_id')},
+        )
+        yield page, backend, requests, plan
+    finally:
+        context.close()
+        backend.doCleanups()
+        assert not errors, errors
+
+
+def test_real_editor_add_remove_question_restore_and_run(integrated_editor):
+    page, backend, requests, original = integrated_editor
+    initial_message_count = len(backend.messages.items)
+    dialog = editor_tests.open_editor(page)
+    expect(dialog.get_by_role('button', name='Run saved revision')).to_be_enabled()
+    held = backend.runs.read_item(original['run_id'], 'conv1')
+    assert held['approval']['mode'] == 'manual'
+    assert held['started_at'] is None
+    expect(page.get_by_role('timer')).to_have_count(0)
+
+    backend.edit_responses.append(backend_tests.revised_plan(searches=2))
+    editor_tests.ask(page, 'Add another document search focused on winery prices.')
+    editor_tests.wait_revision(page, 1, 'conv1', 'turn1')
+    assert len(editor_tests.state(page, 'conv1', 'turn1')['plan']['steps']) == 3
+
+    backend.edit_responses.append(backend_tests.revised_plan('Summarize the available comparison.', searches=0))
+    editor_tests.ask(page, 'Remove the searches and summarize the available comparison.')
+    editor_tests.wait_revision(page, 2, 'conv1', 'turn1')
+    assert len(editor_tests.state(page, 'conv1', 'turn1')['plan']['steps']) == 1
+
+    question = backend_tests.question()
+    question['requested_schema']['properties']['day']['enum'] = ['Friday', 'Saturday']
+    backend.edit_responses.append(question)
+    editor_tests.ask(page, 'Compare winery prices on a different weekday.')
+    questions = dialog.get_by_role('region', name='Planner edit questions')
+    expect(questions).to_be_visible()
+    expect(dialog.get_by_role('button', name='Run saved revision')).to_be_disabled()
+    questions.get_by_role('radio', name='Friday', exact=True).check()
+    backend.edit_responses.append(backend_tests.revised_plan('Compare winery prices on Friday.', searches=1))
+    questions.get_by_role('button', name='Finish', exact=True).click()
+    editor_tests.wait_revision(page, 3, 'conv1', 'turn1')
+    expect(questions).to_have_count(0)
+    answer = next(entry['body'] for entry in requests if entry['body'] and entry['body'].get('action') == 'answer')
+    assert answer['elicitation_response']['content']['day'] == 'Friday'
+
+    dialog.get_by_role('tab', name='History', exact=True).click()
+    dialog.get_by_role('button', name='Preview revision 0', exact=True).click()
+    expect(dialog.get_by_role('button', name='Run saved revision')).to_be_disabled()
+    dialog.get_by_role('button', name='Restore revision 0', exact=True).click()
+    editor_tests.wait_revision(page, 4, 'conv1', 'turn1')
+
+    task = 'Compare only Friday prices for the wineries near Grants Pass.'
+    backend.edit_responses.append(backend_tests.revised_plan(task, searches=1))
+    editor_tests.ask(page, task)
+    editor_tests.wait_revision(page, 5, 'conv1', 'turn1')
+    current = editor_tests.state(page, 'conv1', 'turn1')
+    assert len(current['messages']) == 1
+    assert not current['mainQuestions'] and not current['thoughts']
+    assert len(backend.messages.items) == initial_message_count
+
+    backend.search_queries.clear()
+    dialog.get_by_role('button', name='Run saved revision').click()
+    expect(dialog).to_have_count(0)
+    page.wait_for_function(
+        "() => window.OrchHarness.stores.chat.useChatStore.getState().messages.length === 2",
+    )
+    executions = [entry for entry in requests if entry['path'] == '/api/v2/orchestration/run']
+    assert len(executions) == 1
+    assert executions[0]['body']['run_id'] == current['plan']['run_id']
+    assert executions[0]['body']['expected_version'] == current['plan']['edit_version']
+    assert backend.search_queries == [task]
+    assert task in json.dumps(backend.model.calls[-1]['messages'])
+    saved = backend.runs.read_item(current['plan']['run_id'], 'conv1')
+    assert saved['status'] == 'completed'
+    assert len(backend.messages.items) == initial_message_count + 1
+
+
+def test_stale_cancel_does_not_discard_another_tabs_new_question(integrated_editor):
+    page, backend, requests, _original = integrated_editor
+    dialog = editor_tests.open_editor(page)
+    backend.edit_responses.append(backend_tests.question())
+    editor_tests.ask(page, 'Compare on another weekday.')
+    expect(dialog.get_by_role('region', name='Planner edit questions')).to_be_visible()
+    shown = editor_tests.state(page, 'conv1', 'turn1')['editor']['state']
+    old_question = shown['pending']
+
+    updated, _body = backend.revise(
+        shown, backend_tests.revised_plan('Compare prices on Friday.', searches=1),
+        action='answer', elicitation_id=old_question['elicitation_id'],
+        elicitation_revision=old_question['revision'],
+        elicitation_response={'action': 'accept', 'content': {'day': 'Friday'}},
+    )
+    question = backend_tests.question()
+    question['message'] = 'Which weekday should the newer request cover?'
+    newest, _body = backend.revise(updated, question, instruction='Plan another comparison.')
+
+    dialog.get_by_role('button', name='Cancel change', exact=True).click()
+    expect(dialog.get_by_role('alert')).to_contain_text('Review the current change')
+    assert not [
+        entry for entry in requests
+        if entry['body'] and entry['body'].get('action') == 'discard'
+    ]
+    saved = backend.editor(newest['plan']['run_id'])
+    assert saved['pending']['elicitation_id'] == newest['pending']['elicitation_id']
+
+    dialog.get_by_role('button', name='Cancel change', exact=True).click()
+    expect(dialog.get_by_role('button', name='Run saved revision')).to_be_enabled()
+    discard = next(
+        entry['body'] for entry in requests
+        if entry['body'] and entry['body'].get('action') == 'discard'
+    )
+    assert discard['expected_version'] == newest['version']
+    assert discard['elicitation_id'] == newest['pending']['elicitation_id']
+    assert discard['elicitation_id'] != old_question['elicitation_id']
+    assert backend.editor(newest['plan']['run_id'])['pending'] is None


### PR DESCRIPTION
<!-- Thanks for contributing to SimpleChat! Keep this practical and delete sections that truly do not apply. -->

## Summary

<!-- What changed and why? Include the user/admin impact in 2-4 bullets. -->

Base: `paullizer-react-v2-ui`. This change builds on the React V2 integration branch, including the approval-preference persistence fix in #1460.

- Add **Edit** beside **Review**, with a full-screen plan preview, scoped planner chat, and revision history matching the existing visual-editor experience.
- Allow users to add, remove, refine, and restore steps through server-validated plan revisions without adding duplicate messages to the main conversation.
- Hold edited plans for explicit approval; protect against stale approvals, conflicting revisions, and cancellation of newer unseen questions. Running plans remain read-only.
- Preserve account-level approval preferences, document the workflow, and advance the application version to **0.261.102**.

## Linked issue

<!-- Use one when applicable: Fixes #123, Closes #123, Refs #123. -->

N/A — requested directly; no associated issue.

## Release Notes & Latest Features

<!-- Check the most relevant category. Release notes go under the current VERSION from application/single_app/config.py in docs/explanation/release_notes.md. -->

- [x] New Feature
- [ ] Bug Fix
- [x] UI Enhancement
- [ ] Breaking Change
- [ ] Internal only

Is this visible to end users?

- [x] Yes
- [ ] No

Is this admin-facing (Admin Settings, governance, deployment, config)?

- [ ] Yes
- [x] No

Should this become a Latest Feature card?

- [ ] Yes
- [x] No
- [ ] Already added

Screenshot needed for the card?

- [ ] Yes
- [x] No
- [ ] Attached

## Version bump

<!-- Confirm application/single_app/config.py VERSION patch segment was bumped for code changes. If deployers/ changed, also bump deployers/version.txt. -->

- [x] `application/single_app/config.py` `VERSION` third segment bumped, or not needed because this is docs-only
- [x] `deployers/version.txt` bumped, or not needed because `deployers/` was not changed

Application: **0.261.101 → 0.261.102**. No deployer changes.

## Testing / validation

<!-- List commands run and any manual validation. -->

- From `functional_tests`: `python -m unittest -q test_orchestration_plan_revision_routes test_orchestration_conversation_context_routes test_orchestration_plan_revision_store test_orchestration_plan_revision_planner` — **99 passed**.
- `python -m pytest functional_tests/test_v2_orchestration_approval_persistence.py -q` — **17 passed**.
- `python -m pytest ui_tests/test_v2_orchestration_plan_editor_backend.py ui_tests/test_v2_orchestration_plan_editor.py ui_tests/test_v2_orchestration_approval_persistence.py -q` — **55 passed**, including browser-to-Flask editing, clarification, restore, cancellation, and execution workflows.
- `npm --prefix application/v2_ui run build` — passed TypeScript compilation and the production build; the existing large-chunk advisory remains.
- Python compilation, Swagger route validation, changed-line XSS/access-control guardrails, all three route-policy scripts, documentation coverage, and documentation site-quality checks passed.

Model, search, and Cosmos service boundaries are deterministic in automated coverage; no live Azure resources were provisioned.

## Documentation

<!-- Feature docs: docs/explanation/features/. Fix docs: docs/explanation/fixes/. -->

- [ ] Release notes updated, or not needed
- [x] Feature documentation updated, or not needed
- [x] Fix documentation updated, or not needed

Added `docs/explanation/features/V2_ORCHESTRATION_PLAN_EDITING.md` and `docs/guides/review-and-edit-orchestration-plans.md`; updated orchestration and chat-control references. Release notes were left unchanged pending publication approval. The generated application-surface inventory remains current.

## Security checklist

<!-- These are common SimpleChat review requirements. -->

- [x] New Flask routes include `@swagger_route(security=get_auth_security())`
- [x] Settings sent to non-admin frontends use `sanitize_settings_for_user()`
- [x] Browser JavaScript is served from local SimpleChat static assets only; no CDN-hosted JS
- [x] No secrets, keys, connection strings, or local-only artifacts are included

New editor responses use an allowlisted projection rather than returning raw settings or private run context. Ownership, capability/source permissions, revision tokens, and conditional Cosmos writes protect edit and execution operations.